### PR TITLE
Add Cloudlog settings, fix QSO initiation, and fix decode layout shift

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -219,7 +219,7 @@ public class GeneralVariables {
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns
 
-    public static ArrayList<Ft8Message> transmitMessages = new ArrayList<>();//List for the calling UI, followed entries
+    public static java.util.List<Ft8Message> transmitMessages = new java.util.concurrent.CopyOnWriteArrayList<>();//List for the calling UI, followed entries
 
     public static void setMyMaidenheadGrid(String grid) {
         myMaidenheadGrid = grid;
@@ -634,7 +634,7 @@ public class GeneralVariables {
         return result.toString();
     }
 
-    public static synchronized void deleteArrayListMore(ArrayList<Ft8Message> list) {
+    public static synchronized void deleteArrayListMore(java.util.List<Ft8Message> list) {
         if (list.size() > GeneralVariables.MESSAGE_COUNT) {
             while (list.size() > GeneralVariables.MESSAGE_COUNT) {
                 list.remove(0);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -603,7 +603,7 @@ public class FT8TransmitSignal {
 
 
         messageEndTime = UtcTimer.getSystemTime();
-        if (onDoTransmitted != null) {// for saving QSO records
+        if (onTransmitSuccess != null) {// for saving QSO records
             onTransmitSuccess.doAfterTransmit(new QSLRecord(
                     messageStartTime,
                     messageEndTime,

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/CallingListAdapter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/CallingListAdapter.java
@@ -35,7 +35,7 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
     public enum ShowMode{CALLING_LIST,MY_CALLING,TRACKER}
     private static final String TAG = "CallingListAdapter";
     private final MainViewModel mainViewModel;
-    private final ArrayList<Ft8Message> ft8MessageArrayList;
+    private final java.util.List<Ft8Message> ft8MessageArrayList;
     private final Context context;
 
     private final ShowMode showMode;
@@ -124,7 +124,7 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
 
 
     public CallingListAdapter(Context context, MainViewModel mainViewModel
-            , ArrayList<Ft8Message> messages, ShowMode showMode) {
+            , java.util.List<Ft8Message> messages, ShowMode showMode) {
         this.mainViewModel = mainViewModel;
         this.context = context;
         this.showMode=showMode;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/HamRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/HamRecorder.java
@@ -34,7 +34,7 @@ public class HamRecorder {
     //private AudioRecord audioRecord = null;//AudioRecord object
     private volatile boolean isRunning = false;//whether currently in recording state
 
-    private final ArrayList<VoiceDataMonitor> voiceDataMonitorList = new ArrayList<>();//listener callback list, data is retrieved in listener callbacks
+    private final java.util.concurrent.CopyOnWriteArrayList<VoiceDataMonitor> voiceDataMonitorList = new java.util.concurrent.CopyOnWriteArrayList<>();//listener callback list, data is retrieved in listener callbacks
     private OnVoiceMonitorChanged onVoiceMonitorChanged=null;
 
     private boolean isMicRecord=true;
@@ -129,7 +129,7 @@ public class HamRecorder {
      * Get the list of monitors
      * @return monitor list
      */
-    public ArrayList<VoiceDataMonitor> getVoiceDataMonitors(){
+    public java.util.List<VoiceDataMonitor> getVoiceDataMonitors(){
         return this.voiceDataMonitorList;
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -201,6 +201,18 @@ public class MicRecorder {
             usbAudioDevice.stopCapture();
         }
         if (audioRecord != null) {
+            // Wait briefly for the recording thread to exit its read() call
+            // before releasing the AudioRecord, to avoid IllegalStateException.
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ignored) {}
+            try {
+                if (audioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
+                    audioRecord.stop();
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "Error stopping AudioRecord: " + e.getMessage());
+            }
             try {
                 audioRecord.release();
             } catch (Exception e) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -130,7 +130,10 @@ private fun PulseDot(color: Color) {
         label = "pulseSize",
     )
 
-    Box(contentAlignment = Alignment.Center) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.size(22.dp),
+    ) {
         // Pulse ring
         Box(
             modifier = Modifier

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -145,7 +145,15 @@ private fun QsoSheetContent(
             Button(
                 onClick = {
                     mainViewModel.addFollowCallsign(callsign)
-                    mainViewModel.ft8TransmitSignal.setActivated(true)
+                    if (!mainViewModel.ft8TransmitSignal.isActivated) {
+                        mainViewModel.ft8TransmitSignal.setActivated(true)
+                        GeneralVariables.transmitMessages.add(message)
+                    }
+                    mainViewModel.ft8TransmitSignal.setTransmit(
+                        message.fromCallTransmitCallsign, 1, message.extraInfo
+                    )
+                    mainViewModel.ft8TransmitSignal.transmitNow()
+                    GeneralVariables.resetLaunchSupervision()
                     onDismiss()
                 },
                 modifier = Modifier

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -43,6 +43,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.bg7yoz.ft8cn.Ft8Message
+import com.bg7yoz.ft8cn.log.ThirdPartyService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.connector.ConnectMode
@@ -102,6 +109,7 @@ fun SettingsScreen(
     var showPttDelay by remember { mutableStateOf(false) }
     var showTxDelay by remember { mutableStateOf(false) }
     var showAbout by remember { mutableStateOf(false) }
+    var showCloudlog by remember { mutableStateOf(false) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -113,6 +121,7 @@ fun SettingsScreen(
     var pttDelay by remember { mutableIntStateOf(GeneralVariables.pttDelay) }
     var txDelay by remember { mutableIntStateOf(GeneralVariables.transmitDelay) }
     var connectMode by remember { mutableIntStateOf(GeneralVariables.connectMode) }
+    var cloudlogAddress by remember { mutableStateOf(GeneralVariables.cloudlogServerAddress.orEmpty()) }
 
     // Derived display strings
     val callsign = callsignState
@@ -354,6 +363,26 @@ fun SettingsScreen(
         )
     }
 
+    // -- Cloudlog Settings Dialog --
+    if (showCloudlog) {
+        CloudlogSettingsDialog(
+            initialAddress = GeneralVariables.cloudlogServerAddress.orEmpty(),
+            initialApiKey = GeneralVariables.cloudlogApiKey.orEmpty(),
+            initialStationId = GeneralVariables.cloudlogStationID.orEmpty(),
+            onDismiss = { showCloudlog = false },
+            onSave = { address, apiKey, stationId ->
+                GeneralVariables.cloudlogServerAddress = address
+                GeneralVariables.cloudlogApiKey = apiKey
+                GeneralVariables.cloudlogStationID = stationId
+                cloudlogAddress = address
+                mainViewModel.databaseOpr.writeConfig("cloudlogServerAddress", address, null)
+                mainViewModel.databaseOpr.writeConfig("cloudlogApiKey", apiKey, null)
+                mainViewModel.databaseOpr.writeConfig("cloudlogStationID", stationId, null)
+                showCloudlog = false
+            },
+        )
+    }
+
     // =====================================================================
     // SCREEN CONTENT
     // =====================================================================
@@ -537,6 +566,7 @@ fun SettingsScreen(
                         SettingsRow(
                             label = "Cloudlog",
                             description = "Auto-upload QSOs to a Cloudlog instance",
+                            value = cloudlogAddress.ifEmpty { "Not configured" },
                             toggle = enableCloudlog,
                             onToggleChange = { checked ->
                                 enableCloudlog = checked
@@ -545,6 +575,8 @@ fun SettingsScreen(
                                     "enableCloudlog", if (checked) "1" else "0", null,
                                 )
                             },
+                            showChevron = true,
+                            onClick = { showCloudlog = true },
                         )
                     }
                 }
@@ -721,6 +753,168 @@ private fun EditOperatorDialog(
                 }
                 TextButton(
                     onClick = { onSave(callsignInput.text, gridInput.text) },
+                ) {
+                    Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for configuring Cloudlog server address, API key, and station ID.
+ * Includes a Test Connection button that calls [ThirdPartyService.CheckCloudlogConnection].
+ */
+@Composable
+private fun CloudlogSettingsDialog(
+    initialAddress: String,
+    initialApiKey: String,
+    initialStationId: String,
+    onDismiss: () -> Unit,
+    onSave: (address: String, apiKey: String, stationId: String) -> Unit,
+) {
+    var addressInput by remember { mutableStateOf(TextFieldValue(initialAddress)) }
+    var apiKeyInput by remember { mutableStateOf(TextFieldValue(initialApiKey)) }
+    var stationIdInput by remember { mutableStateOf(TextFieldValue(initialStationId)) }
+
+    // Test connection state: null = idle, true = pass, false = fail
+    var testResult by remember { mutableStateOf<Boolean?>(null) }
+    var isTesting by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = TextPrimary,
+        unfocusedTextColor = TextPrimary,
+        cursorColor = Accent,
+        focusedBorderColor = Accent,
+        unfocusedBorderColor = BorderStrong,
+        focusedLabelColor = Accent,
+        unfocusedLabelColor = TextMuted,
+    )
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "Cloudlog Settings",
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+            )
+
+            OutlinedTextField(
+                value = addressInput,
+                onValueChange = {
+                    addressInput = it
+                    testResult = null
+                },
+                label = { Text("Server Address") },
+                placeholder = { Text("https://log.example.com/", color = TextFaint) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                colors = fieldColors,
+                textStyle = TextStyle(fontSize = 14.sp),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value = apiKeyInput,
+                onValueChange = {
+                    apiKeyInput = it
+                    testResult = null
+                },
+                label = { Text("API Key") },
+                placeholder = { Text("Your Cloudlog API key", color = TextFaint) },
+                singleLine = true,
+                colors = fieldColors,
+                textStyle = TextStyle(fontSize = 14.sp),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value = stationIdInput,
+                onValueChange = {
+                    stationIdInput = it
+                    testResult = null
+                },
+                label = { Text("Station ID") },
+                placeholder = { Text("e.g. 1", color = TextFaint) },
+                singleLine = true,
+                colors = fieldColors,
+                textStyle = TextStyle(fontSize = 14.sp),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // Test Connection button
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                TextButton(
+                    onClick = {
+                        // Write current input values to GeneralVariables so the test uses them
+                        GeneralVariables.cloudlogServerAddress = addressInput.text
+                        GeneralVariables.cloudlogApiKey = apiKeyInput.text
+                        GeneralVariables.cloudlogStationID = stationIdInput.text
+                        isTesting = true
+                        testResult = null
+                        scope.launch {
+                            val result = withContext(Dispatchers.IO) {
+                                ThirdPartyService.CheckCloudlogConnection()
+                            }
+                            testResult = result
+                            isTesting = false
+                        }
+                    },
+                    enabled = !isTesting,
+                ) {
+                    Text(
+                        text = "Test Connection",
+                        color = if (isTesting) TextFaint else Accent,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                if (isTesting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .width(16.dp)
+                            .height(16.dp),
+                        strokeWidth = 2.dp,
+                        color = Accent,
+                    )
+                }
+                if (testResult != null) {
+                    Text(
+                        text = if (testResult == true) "Pass" else "Fail",
+                        color = if (testResult == true) StatusConfirmed else StatusBad,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 14.sp,
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel", color = TextMuted)
+                }
+                TextButton(
+                    onClick = {
+                        onSave(
+                            addressInput.text.trim(),
+                            apiKeyInput.text.trim(),
+                            stationIdInput.text.trim(),
+                        )
+                    },
                 ) {
                     Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
                 }


### PR DESCRIPTION
## Summary
- **Cloudlog configuration dialog** in Compose Settings with server address, API key, station ID fields and a Test Connection button
- **Fix QSO initiation** from the Compose decode screen bottom sheet — properly calls `setTransmit()` and `transmitNow()` with thread safety improvements (`CopyOnWriteArrayList` for shared message lists)
- **Fix decode page layout shift** caused by the PulseDot animation in TxStrip — the animated pulse ring had no fixed-size container, so its size changes (6dp → 22dp) caused the TxStrip height to oscillate, shifting the entire decode page up and down

## Test plan
- [ ] Open the decode page and verify it no longer shifts/animates when the "LISTENING" pulse dot animates
- [ ] Verify the pulse dot animation still renders correctly in the TxStrip
- [ ] Open Settings → Cloudlog, configure server/API key/station ID, test connection
- [ ] Tap a CQ call in the decode list and verify QSO initiation works from the bottom sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)