### PR TITLE
Fix USB audio input and CAT serial control in Compose UI

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -957,6 +957,16 @@ public class MainViewModel extends ViewModel {
 
 
     /**
+     * Reinitialize the audio input to pick up newly connected USB audio devices.
+     * Call this after a USB device attach event to switch to USB audio if available.
+     */
+    public void reinitializeAudioInput() {
+        if (hamRecorder != null) {
+            hamRecorder.reinitializeMicRecorder();
+        }
+    }
+
+    /**
      * Check whether the rig is connected. Two cases: rigBaseClass not created, or serial port connection failed.
      *
      * @return whether connected

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/HamRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/HamRecorder.java
@@ -142,6 +142,22 @@ public class HamRecorder {
     }
 
     /**
+     * Reinitialize the mic recorder to pick up newly connected USB audio devices.
+     * Re-wires the data listener after reinit.
+     */
+    public void reinitializeMicRecorder() {
+        micRecorder.reinitialize();
+        if (isMicRecord) {
+            micRecorder.setOnDataListener(new MicRecorder.OnDataListener() {
+                @Override
+                public void onDataReceived(float[] data, int len) {
+                    doOnWaveDataReceived(len, data);
+                }
+            });
+        }
+    }
+
+    /**
      * Method to retrieve recording data, implemented by adding a data monitor (VoiceDataMonitor).
      * Recording data is provided in the OnGetVoiceDataDone callback, triggered when the recording reaches the specified duration (milliseconds).
      * To get recording data, a monitor object is added to the recorder. Data is collected in the monitor's OnReceiveData callback.

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -217,4 +217,56 @@ public class MicRecorder {
     public void setOnDataListener(OnDataListener onDataListener) {
         this.onDataListener = onDataListener;
     }
+
+    /**
+     * Reinitialize the audio input device. Stops current audio capture,
+     * re-checks for USB audio device availability, and restarts if it was running.
+     * This handles the case where a USB audio device is connected after MicRecorder
+     * was originally constructed.
+     */
+    @SuppressLint("MissingPermission")
+    public void reinitialize() {
+        boolean wasRunning = isRunning;
+        OnDataListener savedListener = onDataListener;
+
+        // Stop current capture
+        stopRecord();
+
+        // Reset state
+        useUsbAudio = false;
+        usbAudioDevice = null;
+        audioRecord = null;
+
+        // Re-check for USB audio input
+        if (GeneralVariables.audioInputDeviceId == -1
+                && GeneralVariables.usbAudioInputVendorId != 0) {
+            usbAudioDevice = openUsbAudioInput();
+            if (usbAudioDevice != null) {
+                useUsbAudio = true;
+                UsbAudioDevice.setActiveInputDevice(usbAudioDevice);
+                Log.d(TAG, "reinitialize: Using USB audio input device");
+            } else {
+                Log.w(TAG, "reinitialize: USB audio device not available, falling back to default");
+            }
+        }
+
+        // Set up standard AudioRecord if not using USB audio
+        if (!useUsbAudio) {
+            bufferSize = AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat);
+            audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz,
+                    channelConfig, audioFormat, bufferSize);
+
+            if (GeneralVariables.audioInputDeviceId > 0) {
+                AudioDeviceInfo deviceInfo = findAudioDeviceById(
+                        GeneralVariables.audioInputDeviceId, AudioManager.GET_DEVICES_INPUTS);
+                audioRecord.setPreferredDevice(deviceInfo);
+            }
+        }
+
+        // Restore listener and restart if it was running
+        onDataListener = savedListener;
+        if (wasRunning) {
+            start();
+        }
+    }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -18,9 +18,14 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.Observer
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.bluetooth.BluetoothStateBroadcastReceive
+import com.bg7yoz.ft8cn.connector.CableSerialPort
+import com.bg7yoz.ft8cn.connector.ConnectMode
 import com.bg7yoz.ft8cn.callsign.CallsignDatabase
 import com.bg7yoz.ft8cn.database.DatabaseOpr
 import com.bg7yoz.ft8cn.database.OnAfterQueryConfig
@@ -94,8 +99,22 @@ class ComposeMainActivity : ComponentActivity() {
         // Initialize data
         initData()
 
+        // Observe serial port changes for auto-connect (mirrors old MainActivity behavior)
+        mainViewModel.mutableSerialPorts.observe(
+            this,
+            Observer { ports ->
+                autoConnectUsbIfNeeded(ports)
+            },
+        )
+
         // List USB devices
         mainViewModel.getUsbDevice()
+
+        // Delayed audio reinit: handles USB audio device already physically connected
+        // but not ready during ViewModel construction
+        Handler(Looper.getMainLooper()).postDelayed({
+            mainViewModel.reinitializeAudioInput()
+        }, 2000)
 
         // Handle shared file import if needed
         if (mainViewModel.mutableImportShareRunning.value == true) {
@@ -227,6 +246,10 @@ class ComposeMainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         if ("android.hardware.usb.action.USB_DEVICE_ATTACHED" == intent.action) {
             mainViewModel.getUsbDevice()
+            // Reinitialize audio input to pick up newly attached USB audio device
+            Handler(Looper.getMainLooper()).postDelayed({
+                mainViewModel.reinitializeAudioInput()
+            }, 1000)
         } else {
             setIntent(intent)
             doReceiveShareFile(intent)
@@ -262,6 +285,23 @@ class ComposeMainActivity : ComponentActivity() {
     override fun onDestroy() {
         unregisterBluetoothReceiver()
         super.onDestroy()
+    }
+
+    /**
+     * Auto-connect to USB serial rig when ports are detected, rig isn't already connected,
+     * and connect mode is USB Cable. If exactly one port is found, connect automatically.
+     */
+    private fun autoConnectUsbIfNeeded(ports: ArrayList<CableSerialPort.SerialPort>?) {
+        if (ports.isNullOrEmpty()) return
+        if (mainViewModel.isRigConnected()) return
+        if (GeneralVariables.connectMode != ConnectMode.USB_CABLE) return
+
+        if (ports.size == 1) {
+            Log.d(TAG, "Auto-connecting to single USB serial port")
+            mainViewModel.connectCableRig(applicationContext, ports[0])
+        } else {
+            Log.d(TAG, "Multiple USB serial ports detected (${ports.size}), waiting for user selection")
+        }
     }
 
     private fun closeApp() {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
+import com.bg7yoz.ft8cn.connector.CableSerialPort
 import com.bg7yoz.ft8cn.connector.ConnectMode
 import com.bg7yoz.ft8cn.database.ControlMode
 import com.bg7yoz.ft8cn.database.OperationBand
@@ -98,6 +99,10 @@ fun SettingsScreen(
     var enableQRZ by remember { mutableStateOf(GeneralVariables.enableQRZ) }
     var saveSWLMessage by remember { mutableStateOf(GeneralVariables.saveSWLMessage) }
     var saveSWL_QSO by remember { mutableStateOf(GeneralVariables.saveSWL_QSO) }
+
+    // Observe serial ports for USB Cable picker
+    val serialPorts by mainViewModel.mutableSerialPorts.observeAsState()
+    var showSerialPortPicker by remember { mutableStateOf(false) }
 
     // Dialog visibility state
     var showEditOperator by remember { mutableStateOf(false) }
@@ -203,10 +208,34 @@ fun SettingsScreen(
                                 LoginIcomRadioDialog(context, mainViewModel).show()
                         }
                     }
-                    // USB Cable: mode is set, no further dialog needed
+                    ConnectMode.USB_CABLE -> {
+                        mainViewModel.getUsbDevice()
+                        showSerialPortPicker = true
+                    }
                 }
             },
         )
+    }
+
+    // -- Serial Port Picker (USB Cable) --
+    if (showSerialPortPicker) {
+        val ports = serialPorts
+        if (ports.isNullOrEmpty()) {
+            InfoDialog(
+                title = "USB Cable",
+                body = "No USB serial devices detected. Please connect a USB cable to your radio and try again.",
+                onDismiss = { showSerialPortPicker = false },
+            )
+        } else {
+            SerialPortPickerDialog(
+                ports = ports,
+                onDismiss = { showSerialPortPicker = false },
+                onSelect = { port ->
+                    showSerialPortPicker = false
+                    mainViewModel.connectCableRig(context, port)
+                },
+            )
+        }
     }
 
     // -- Band & Frequency Picker --
@@ -1078,6 +1107,67 @@ private fun NumberInputDialog(
                     },
                 ) {
                     Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for selecting a USB serial port to connect to a rig.
+ */
+@Composable
+private fun SerialPortPickerDialog(
+    ports: List<CableSerialPort.SerialPort>,
+    onDismiss: () -> Unit,
+    onSelect: (CableSerialPort.SerialPort) -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(vertical = 24.dp),
+        ) {
+            Text(
+                text = "Select Serial Port",
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp),
+            ) {
+                itemsIndexed(ports) { _, port ->
+                    Text(
+                        text = port.information(),
+                        color = TextPrimary,
+                        fontSize = 14.sp,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(port) }
+                            .padding(horizontal = 24.dp, vertical = 12.dp),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel", color = TextMuted)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- **CAT control**: Add `SerialPortPickerDialog` to `SettingsScreen.kt` so selecting "USB Cable" presents available serial ports and calls `connectCableRig()`. Add auto-connect observer in `ComposeMainActivity` that connects to a single detected port on startup (mirroring old `MainActivity` behavior).
- **USB audio**: Add `MicRecorder.reinitialize()` to re-detect USB audio devices after initial construction. Wire it through `HamRecorder` and `MainViewModel`. Trigger reinit on `USB_DEVICE_ATTACHED` events and with a delayed call on startup for devices already physically connected.

## Files changed
| File | Change |
|------|--------|
| `SettingsScreen.kt` | Add `SerialPortPickerDialog`, wire USB Cable selection to show port picker |
| `ComposeMainActivity.kt` | Add serial port auto-connect observer, audio reinit on USB attach + startup |
| `MicRecorder.java` | Add `reinitialize()` method for USB audio re-detection |
| `HamRecorder.java` | Add `reinitializeMicRecorder()` delegate method |
| `MainViewModel.java` | Add `reinitializeAudioInput()` public API |

## Test plan
- [ ] Build the app and install on device
- [ ] **CAT test**: Plug in USB serial cable to radio, open app, verify serial port picker appears or auto-connects. Verify CAT commands are sent (frequency changes reflected on radio)
- [ ] **Audio test**: Plug in USB audio device (DigiRig or similar), verify the app picks up audio from the radio (waterfall should show signals). If device was plugged in before app launch, verify the delayed reinit catches it
- [ ] **Settings test**: Go to Settings > Connection Mode > USB Cable, verify serial port picker shows available ports
- [ ] **No-device test**: Select USB Cable with no device connected, verify informational dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)