### PR TITLE
Restore radio selection, CAT control & audio device settings to Compose UI

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -25,11 +25,18 @@ package com.bg7yoz.ft8cn;
 import static com.bg7yoz.ft8cn.GeneralVariables.getStringFromResource;
 
 import android.annotation.SuppressLint;
+import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothProfile;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -1101,6 +1108,58 @@ public class MainViewModel extends ViewModel {
                 baseRig.sendWaveData(message);//actual generated data is 12.64+0.04 seconds; 0.04 is zero-padded data
             }
         }
+    }
+
+    private static final String ACTION_USB_AUDIO_PERMISSION =
+            "com.bg7yoz.ft8cn.USB_AUDIO_PERMISSION";
+
+    /**
+     * Request USB audio device permission if not already granted.
+     * Mirrors ConfigFragment.requestUsbPermissionIfNeeded().
+     */
+    public void requestUsbPermissionIfNeeded(UsbDevice device) {
+        if (device == null) return;
+        Context context = GeneralVariables.getMainContext();
+        if (context == null) return;
+        UsbManager usbManager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+        if (usbManager == null) return;
+
+        if (usbManager.hasPermission(device)) {
+            Log.d(TAG, "USB audio device already has permission");
+            return;
+        }
+
+        Log.d(TAG, "Requesting USB permission for audio device: " + device.getProductName());
+        PendingIntent permissionIntent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissionIntent = PendingIntent.getBroadcast(context, 0,
+                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_MUTABLE);
+        } else {
+            permissionIntent = PendingIntent.getBroadcast(context, 0,
+                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+        }
+
+        BroadcastReceiver permReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context ctx, Intent intent) {
+                if (ACTION_USB_AUDIO_PERMISSION.equals(intent.getAction())) {
+                    boolean granted = intent.getBooleanExtra(
+                            UsbManager.EXTRA_PERMISSION_GRANTED, false);
+                    Log.d(TAG, "USB audio permission " + (granted ? "granted" : "denied"));
+                    try { ctx.unregisterReceiver(this); } catch (Exception ignored) {}
+                }
+            }
+        };
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(permReceiver,
+                    new IntentFilter(ACTION_USB_AUDIO_PERMISSION),
+                    Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(permReceiver,
+                    new IntentFilter(ACTION_USB_AUDIO_PERMISSION));
+        }
+        usbManager.requestPermission(device, permissionIntent);
     }
 
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/AudioDeviceSpinnerAdapter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/AudioDeviceSpinnerAdapter.java
@@ -202,7 +202,7 @@ public class AudioDeviceSpinnerAdapter extends BaseAdapter {
         return view;
     }
 
-    private String getDeviceDisplayName(int position) {
+    public String getDeviceDisplayName(int position) {
         if (position == 0) {
             return mContext.getString(R.string.audio_device_default);
         }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -50,15 +50,18 @@ import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
+import android.media.AudioManager
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.connector.CableSerialPort
 import com.bg7yoz.ft8cn.connector.ConnectMode
 import com.bg7yoz.ft8cn.database.ControlMode
 import com.bg7yoz.ft8cn.database.OperationBand
+import com.bg7yoz.ft8cn.database.RigNameList
 import com.bg7yoz.ft8cn.ft8signal.FT8Package
 import com.bg7yoz.ft8cn.rigs.BaseRigOperation
 import com.bg7yoz.ft8cn.rigs.InstructionSet
+import com.bg7yoz.ft8cn.ui.AudioDeviceSpinnerAdapter
 import com.bg7yoz.ft8cn.ui.LoginIcomRadioDialog
 import com.bg7yoz.ft8cn.ui.SelectBluetoothDialog
 import com.bg7yoz.ft8cn.ui.SelectFlexRadioDialog
@@ -115,6 +118,10 @@ fun SettingsScreen(
     var showTxDelay by remember { mutableStateOf(false) }
     var showAbout by remember { mutableStateOf(false) }
     var showCloudlog by remember { mutableStateOf(false) }
+    var showRigModelPicker by remember { mutableStateOf(false) }
+    var showControlModePicker by remember { mutableStateOf(false) }
+    var showAudioInputPicker by remember { mutableStateOf(false) }
+    var showAudioOutputPicker by remember { mutableStateOf(false) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -127,6 +134,8 @@ fun SettingsScreen(
     var txDelay by remember { mutableIntStateOf(GeneralVariables.transmitDelay) }
     var connectMode by remember { mutableIntStateOf(GeneralVariables.connectMode) }
     var cloudlogAddress by remember { mutableStateOf(GeneralVariables.cloudlogServerAddress.orEmpty()) }
+    var controlMode by remember { mutableIntStateOf(GeneralVariables.controlMode) }
+    var modelNo by remember { mutableIntStateOf(GeneralVariables.modelNo) }
 
     // Derived display strings
     val callsign = callsignState
@@ -144,7 +153,35 @@ fun SettingsScreen(
     } else {
         "Not connected"
     }
-    val isCatMode = GeneralVariables.controlMode == ControlMode.CAT
+    val isCatMode = controlMode == ControlMode.CAT
+        || controlMode == ControlMode.RTS
+        || controlMode == ControlMode.DTR
+
+    // Rig model list
+    val rigNameList = remember { RigNameList.getInstance(context) }
+    val rigModelStr = remember(modelNo) {
+        rigNameList.getRigNameByIndex(modelNo).name
+    }
+
+    // Control mode display
+    val controlModeStr = when (controlMode) {
+        ControlMode.CAT -> "CAT"
+        ControlMode.RTS -> "RTS"
+        ControlMode.DTR -> "DTR"
+        else -> "VOX"
+    }
+
+    // Audio device display names
+    val audioInputAdapter = remember { AudioDeviceSpinnerAdapter(context, AudioManager.GET_DEVICES_INPUTS) }
+    val audioOutputAdapter = remember { AudioDeviceSpinnerAdapter(context, AudioManager.GET_DEVICES_OUTPUTS) }
+    val audioInputPos = remember(GeneralVariables.audioInputDeviceId) {
+        audioInputAdapter.getPositionByDeviceId(GeneralVariables.audioInputDeviceId)
+    }
+    val audioOutputPos = remember(GeneralVariables.audioOutputDeviceId) {
+        audioOutputAdapter.getPositionByDeviceId(GeneralVariables.audioOutputDeviceId)
+    }
+    var audioInputName by remember { mutableStateOf(audioInputAdapter.getDeviceDisplayName(audioInputPos)) }
+    var audioOutputName by remember { mutableStateOf(audioOutputAdapter.getDeviceDisplayName(audioOutputPos)) }
 
     // =====================================================================
     // DIALOGS
@@ -412,6 +449,144 @@ fun SettingsScreen(
         )
     }
 
+    // -- Rig Model Picker --
+    if (showRigModelPicker) {
+        val rigItems = rigNameList.rigList
+            .mapIndexed { index, rig -> index to rig }
+            .filter { (_, rig) -> !rig.modelName.startsWith("#") }
+        val rigDisplayNames = rigItems.map { (_, rig) -> rig.name }
+        val currentRigIndex = rigItems.indexOfFirst { (index, _) -> index == modelNo }
+            .coerceAtLeast(0)
+        ListPickerDialog(
+            title = "Rig Model",
+            items = rigDisplayNames,
+            selectedIndex = currentRigIndex,
+            onDismiss = { showRigModelPicker = false },
+            onSelect = { selectedDisplayIndex ->
+                showRigModelPicker = false
+                val (actualIndex, selectedRig) = rigItems[selectedDisplayIndex]
+                GeneralVariables.modelNo = actualIndex
+                modelNo = actualIndex
+                GeneralVariables.instructionSet = selectedRig.instructionSet
+                GeneralVariables.civAddress = selectedRig.address
+                GeneralVariables.baudRate = selectedRig.bauRate
+                mainViewModel.setCivAddress()
+                mainViewModel.databaseOpr.writeConfig("model", actualIndex.toString(), null)
+                mainViewModel.databaseOpr.writeConfig(
+                    "instruction", GeneralVariables.instructionSet.toString(), null,
+                )
+                mainViewModel.databaseOpr.writeConfig(
+                    "baudRate", GeneralVariables.baudRate.toString(), null,
+                )
+                mainViewModel.databaseOpr.writeConfig(
+                    "civ", GeneralVariables.civAddress.toString(), null,
+                )
+            },
+        )
+    }
+
+    // -- Control Mode Picker --
+    if (showControlModePicker) {
+        val controlModeOptions = listOf("VOX", "CAT", "RTS", "DTR")
+        val controlModeValues = listOf(ControlMode.VOX, ControlMode.CAT, ControlMode.RTS, ControlMode.DTR)
+        val currentControlIndex = controlModeValues.indexOf(controlMode).coerceAtLeast(0)
+        ListPickerDialog(
+            title = "Control Mode",
+            items = controlModeOptions,
+            selectedIndex = currentControlIndex,
+            onDismiss = { showControlModePicker = false },
+            onSelect = { index ->
+                showControlModePicker = false
+                val newMode = controlModeValues[index]
+                GeneralVariables.controlMode = newMode
+                controlMode = newMode
+                mainViewModel.setControlMode()
+                mainViewModel.databaseOpr.writeConfig("ctrMode", newMode.toString(), null)
+                if (newMode == ControlMode.CAT
+                    || newMode == ControlMode.RTS
+                    || newMode == ControlMode.DTR
+                ) {
+                    if (!mainViewModel.isRigConnected()) {
+                        mainViewModel.getUsbDevice()
+                        showSerialPortPicker = true
+                    } else {
+                        mainViewModel.setOperationBand()
+                    }
+                }
+            },
+        )
+    }
+
+    // -- Audio Input Device Picker --
+    if (showAudioInputPicker) {
+        AudioDevicePickerDialog(
+            title = "Audio Input",
+            adapter = audioInputAdapter,
+            currentDeviceId = GeneralVariables.audioInputDeviceId,
+            onDismiss = { showAudioInputPicker = false },
+            onSelect = { position ->
+                showAudioInputPicker = false
+                val deviceId = audioInputAdapter.getDeviceId(position)
+                GeneralVariables.audioInputDeviceId = deviceId
+                mainViewModel.databaseOpr.writeConfig("audioInputDevice", deviceId.toString(), null)
+
+                val usbInfo = audioInputAdapter.getUsbAudioDeviceInfo(position)
+                if (usbInfo != null) {
+                    GeneralVariables.usbAudioInputVendorId = usbInfo.device.vendorId
+                    GeneralVariables.usbAudioInputProductId = usbInfo.device.productId
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioInputVid", GeneralVariables.usbAudioInputVendorId.toString(), null,
+                    )
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioInputPid", GeneralVariables.usbAudioInputProductId.toString(), null,
+                    )
+                    mainViewModel.requestUsbPermissionIfNeeded(usbInfo.device)
+                } else if (deviceId != -1) {
+                    GeneralVariables.usbAudioInputVendorId = 0
+                    GeneralVariables.usbAudioInputProductId = 0
+                    mainViewModel.databaseOpr.writeConfig("usbAudioInputVid", "0", null)
+                    mainViewModel.databaseOpr.writeConfig("usbAudioInputPid", "0", null)
+                }
+                audioInputName = audioInputAdapter.getDeviceDisplayName(position)
+            },
+        )
+    }
+
+    // -- Audio Output Device Picker --
+    if (showAudioOutputPicker) {
+        AudioDevicePickerDialog(
+            title = "Audio Output",
+            adapter = audioOutputAdapter,
+            currentDeviceId = GeneralVariables.audioOutputDeviceId,
+            onDismiss = { showAudioOutputPicker = false },
+            onSelect = { position ->
+                showAudioOutputPicker = false
+                val deviceId = audioOutputAdapter.getDeviceId(position)
+                GeneralVariables.audioOutputDeviceId = deviceId
+                mainViewModel.databaseOpr.writeConfig("audioOutputDevice", deviceId.toString(), null)
+
+                val usbInfo = audioOutputAdapter.getUsbAudioDeviceInfo(position)
+                if (usbInfo != null) {
+                    GeneralVariables.usbAudioOutputVendorId = usbInfo.device.vendorId
+                    GeneralVariables.usbAudioOutputProductId = usbInfo.device.productId
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioOutputVid", GeneralVariables.usbAudioOutputVendorId.toString(), null,
+                    )
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioOutputPid", GeneralVariables.usbAudioOutputProductId.toString(), null,
+                    )
+                    mainViewModel.requestUsbPermissionIfNeeded(usbInfo.device)
+                } else if (deviceId != -1) {
+                    GeneralVariables.usbAudioOutputVendorId = 0
+                    GeneralVariables.usbAudioOutputProductId = 0
+                    mainViewModel.databaseOpr.writeConfig("usbAudioOutputVid", "0", null)
+                    mainViewModel.databaseOpr.writeConfig("usbAudioOutputPid", "0", null)
+                }
+                audioOutputName = audioOutputAdapter.getDeviceDisplayName(position)
+            },
+        )
+    }
+
     // =====================================================================
     // SCREEN CONTENT
     // =====================================================================
@@ -450,6 +625,20 @@ fun SettingsScreen(
                 GlassCard(modifier = Modifier.fillMaxWidth()) {
                     Column {
                         SettingsRow(
+                            label = "Rig Model",
+                            value = rigModelStr,
+                            showChevron = true,
+                            onClick = { showRigModelPicker = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Control Mode",
+                            value = controlModeStr,
+                            showChevron = true,
+                            onClick = { showControlModePicker = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
                             label = "Connection Mode",
                             value = connectModeStr,
                             showChevron = isCatMode,
@@ -468,6 +657,35 @@ fun SettingsScreen(
                             value = audioFreqStr,
                             showChevron = !synFrequency,
                             onClick = if (!synFrequency) {{ showAudioFreq = true }} else null,
+                        )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 2b. AUDIO
+            // =====================================================================
+            SettingsSection(title = "AUDIO") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "Audio Input",
+                            value = audioInputName,
+                            showChevron = true,
+                            onClick = {
+                                audioInputAdapter.refreshDevices()
+                                showAudioInputPicker = true
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Audio Output",
+                            value = audioOutputName,
+                            showChevron = true,
+                            onClick = {
+                                audioOutputAdapter.refreshDevices()
+                                showAudioOutputPicker = true
+                            },
                         )
                     }
                 }
@@ -1216,4 +1434,28 @@ private fun InfoDialog(
             }
         }
     }
+}
+
+/**
+ * Dialog for selecting an audio input or output device from [AudioDeviceSpinnerAdapter].
+ */
+@Composable
+private fun AudioDevicePickerDialog(
+    title: String,
+    adapter: AudioDeviceSpinnerAdapter,
+    currentDeviceId: Int,
+    onDismiss: () -> Unit,
+    onSelect: (position: Int) -> Unit,
+) {
+    val count = adapter.count
+    val items = (0 until count).map { adapter.getDeviceDisplayName(it) }
+    val selectedIndex = adapter.getPositionByDeviceId(currentDeviceId).coerceIn(0, count - 1)
+
+    ListPickerDialog(
+        title = title,
+        items = items,
+        selectedIndex = selectedIndex,
+        onDismiss = onDismiss,
+        onSelect = onSelect,
+    )
 }


### PR DESCRIPTION
## Summary
- Adds **Rig Model** picker to Settings (populated from `RigNameList`, updates baud rate, CI-V address, and instruction set on selection)
- Adds **Control Mode** picker (VOX/CAT/RTS/DTR) that triggers serial port scanning and rig connection when switching to non-VOX modes
- Adds **Audio Input/Output** device pickers in a new AUDIO section, with USB audio VID/PID persistence and automatic USB permission requests
- Fixes **Connection Mode** row gating to be clickable for RTS and DTR modes (not just CAT)
- Adds `requestUsbPermissionIfNeeded(UsbDevice)` to `MainViewModel` so Compose UI can request USB permissions without Fragment context
- Makes `AudioDeviceSpinnerAdapter.getDeviceDisplayName()` public for Compose UI access

## Test plan
- [ ] Open Settings and verify "Rig Model" shows full radio list; selecting one updates baud rate and CI-V
- [ ] Verify "Control Mode" shows VOX/CAT/RTS/DTR; selecting CAT/RTS/DTR enables Connection Mode row
- [ ] Verify "Connection Mode" → "USB Cable" shows serial port picker with connected radio
- [ ] Verify "Audio Input" picker shows Default + connected USB audio devices
- [ ] Verify selecting a USB audio device stores VID/PID and requests USB permission
- [ ] After configuring all settings, verify CAT control works (frequency changes on radio)
- [ ] Verify audio input from USB audio device is received (waterfall shows signals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)