### PR TITLE
Fix waterfall display and USB audio/CAT control

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -957,6 +957,16 @@ public class MainViewModel extends ViewModel {
 
 
     /**
+     * Reinitialize the audio input to pick up newly connected USB audio devices.
+     * Call this after a USB device attach event to switch to USB audio if available.
+     */
+    public void reinitializeAudioInput() {
+        if (hamRecorder != null) {
+            hamRecorder.reinitializeMicRecorder();
+        }
+    }
+
+    /**
      * Check whether the rig is connected. Two cases: rigBaseClass not created, or serial port connection failed.
      *
      * @return whether connected

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -117,6 +117,21 @@ public class MainViewModel extends ViewModel {
     String TAG = "ft8cn MainViewModel";
     public boolean configIsLoaded = false;
 
+    /** Write debug line to the app's external files debug.log */
+    private void fileLog(String msg) {
+        try {
+            android.content.Context ctx = GeneralVariables.getMainContext();
+            if (ctx == null) return;
+            java.io.File dir = ctx.getExternalFilesDir(null);
+            if (dir == null) return;
+            String ts = new java.text.SimpleDateFormat("HH:mm:ss.SSS", java.util.Locale.US)
+                    .format(new java.util.Date());
+            new java.io.FileWriter(new java.io.File(dir, "debug.log"), true)
+                    .append(ts + " " + msg + "\n").close();
+        } catch (Exception ignored) {}
+        Log.d(TAG, msg);
+    }
+
     private static MainViewModel viewModel = null;//current existing instance.
     //public static Application application;
 
@@ -638,9 +653,12 @@ public class MainViewModel extends ViewModel {
      */
     public void setOperationBand() {
         if (!isRigConnected()) {
+            fileLog("setOperationBand: rig not connected, skipping");
             return;
         }
 
+        fileLog("setOperationBand: sending USB mode, then freq=" + GeneralVariables.band
+                + " in 800ms (controlMode=" + GeneralVariables.controlMode + ")");
         //set USB mode first, then set frequency
         baseRig.setUsbModeToRig();//set USB mode
 
@@ -648,6 +666,8 @@ public class MainViewModel extends ViewModel {
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
             @Override
             public void run() {
+                fileLog("setOperationBand: setting freq=" + GeneralVariables.band
+                        + " (rig.getFreq=" + baseRig.getFreq() + ")");
                 baseRig.setFreq(GeneralVariables.band);//set frequency
                 baseRig.setFreqToRig();
             }
@@ -676,6 +696,7 @@ public class MainViewModel extends ViewModel {
     public void connectCableRig(Context context, CableSerialPort.SerialPort port) {
         if (GeneralVariables.controlMode == ControlMode.VOX) {//if currently VOX, switch to CAT mode
             GeneralVariables.controlMode = ControlMode.CAT;
+            databaseOpr.writeConfig("ctrMode", String.valueOf(ControlMode.CAT), null);
         }
         connectRig();
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -25,11 +25,18 @@ package com.bg7yoz.ft8cn;
 import static com.bg7yoz.ft8cn.GeneralVariables.getStringFromResource;
 
 import android.annotation.SuppressLint;
+import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothProfile;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -1101,6 +1108,58 @@ public class MainViewModel extends ViewModel {
                 baseRig.sendWaveData(message);//actual generated data is 12.64+0.04 seconds; 0.04 is zero-padded data
             }
         }
+    }
+
+    private static final String ACTION_USB_AUDIO_PERMISSION =
+            "com.bg7yoz.ft8cn.USB_AUDIO_PERMISSION";
+
+    /**
+     * Request USB audio device permission if not already granted.
+     * Mirrors ConfigFragment.requestUsbPermissionIfNeeded().
+     */
+    public void requestUsbPermissionIfNeeded(UsbDevice device) {
+        if (device == null) return;
+        Context context = GeneralVariables.getMainContext();
+        if (context == null) return;
+        UsbManager usbManager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+        if (usbManager == null) return;
+
+        if (usbManager.hasPermission(device)) {
+            Log.d(TAG, "USB audio device already has permission");
+            return;
+        }
+
+        Log.d(TAG, "Requesting USB permission for audio device: " + device.getProductName());
+        PendingIntent permissionIntent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissionIntent = PendingIntent.getBroadcast(context, 0,
+                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_MUTABLE);
+        } else {
+            permissionIntent = PendingIntent.getBroadcast(context, 0,
+                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+        }
+
+        BroadcastReceiver permReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context ctx, Intent intent) {
+                if (ACTION_USB_AUDIO_PERMISSION.equals(intent.getAction())) {
+                    boolean granted = intent.getBooleanExtra(
+                            UsbManager.EXTRA_PERMISSION_GRANTED, false);
+                    Log.d(TAG, "USB audio permission " + (granted ? "granted" : "denied"));
+                    try { ctx.unregisterReceiver(this); } catch (Exception ignored) {}
+                }
+            }
+        };
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(permReceiver,
+                    new IntentFilter(ACTION_USB_AUDIO_PERMISSION),
+                    Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(permReceiver,
+                    new IntentFilter(ACTION_USB_AUDIO_PERMISSION));
+        }
+        usbManager.requestPermission(device, permissionIntent);
     }
 
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/CableSerialPort.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/CableSerialPort.java
@@ -223,18 +223,42 @@ public class CableSerialPort {
         return true;
     }
 
+    private void fileLog(String msg) {
+        try {
+            android.content.Context ctx = GeneralVariables.getMainContext();
+            if (ctx == null) return;
+            java.io.File dir = ctx.getExternalFilesDir(null);
+            if (dir == null) return;
+            String ts = new java.text.SimpleDateFormat("HH:mm:ss.SSS", java.util.Locale.US)
+                    .format(new java.util.Date());
+            new java.io.FileWriter(new java.io.File(dir, "debug.log"), true)
+                    .append(ts + " " + msg + "\n").close();
+        } catch (Exception ignored) {}
+        Log.d(TAG, msg);
+    }
+
     public boolean sendData(final byte[] src) {
         if (usbSerialPort != null) {
             try {
+                String preview = new String(src).replace("\r", "\\r").replace("\n", "\\n");
+                // Only log non-periodic commands (skip FA; reads to avoid log spam)
+                if (!preview.equals("FA;") && !preview.startsWith("RM")) {
+                    StringBuilder hex = new StringBuilder();
+                    for (byte b : src) hex.append(String.format("%02X ", b));
+                    fileLog("serial.send[" + src.length + "]: " + preview + " | hex: " + hex.toString().trim());
+                }
                 usbSerialPort.write(src, SEND_TIMEOUT);
+                if (!preview.equals("FA;") && !preview.startsWith("RM")) {
+                    fileLog("serial.send: write completed OK");
+                }
             } catch (IOException e) {
                 e.printStackTrace();
-                Log.e(TAG, "Error sending data: " + e.getMessage());
+                fileLog("serial.send ERROR: " + e.getMessage());
                 return false;
             }
             return true;
         } else {
-            Log.e(TAG, "Cannot send data, serial port is not open.");
+            fileLog("serial.send: port not open!");
             return false;
         }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -22,6 +22,7 @@ import com.bg7yoz.ft8cn.FT8Common;
 import com.bg7yoz.ft8cn.Ft8Message;
 import com.bg7yoz.ft8cn.GeneralVariables;
 import com.bg7yoz.ft8cn.R;
+import com.bg7yoz.ft8cn.connector.ConnectMode;
 import com.bg7yoz.ft8cn.ft8signal.FT8Package;
 import com.bg7yoz.ft8cn.log.OnQueryQSLCallsign;
 import com.bg7yoz.ft8cn.log.OnQueryQSLRecordCallsign;
@@ -2123,6 +2124,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
                 if (name.equalsIgnoreCase("ctrMode")) {
                     GeneralVariables.controlMode = result.equals("") ? ControlMode.VOX : Integer.parseInt(result);
+                }
+                if (name.equalsIgnoreCase("connectMode")) {
+                    GeneralVariables.connectMode = result.equals("") ? ConnectMode.USB_CABLE : Integer.parseInt(result);
                 }
                 if (name.equalsIgnoreCase("model")) {//Radio model
                     GeneralVariables.modelNo = result.equals("") ? 0 : Integer.parseInt(result);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu39Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu39Rig.java
@@ -10,6 +10,11 @@ import com.bg7yoz.ft8cn.R;
 import com.bg7yoz.ft8cn.database.ControlMode;
 import com.bg7yoz.ft8cn.ui.ToastMessage;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -120,6 +125,7 @@ public class Yaesu39Rig extends BaseRig {
         if (getConnector() != null) {
             if (isDataUsb) {//use DATA-USB mode
                 getConnector().sendData(Yaesu3RigConstant.setOperationUSB_Data_Mode());
+                getConnector().sendData(Yaesu3RigConstant.setMaxDataWidth());
             } else {
                 getConnector().sendData(Yaesu3RigConstant.setOperationUSBMode());
             }
@@ -133,9 +139,27 @@ public class Yaesu39Rig extends BaseRig {
         }
     }
 
+    private void fileLog(String msg) {
+        try {
+            android.content.Context ctx = GeneralVariables.getMainContext();
+            if (ctx == null) return;
+            File dir = ctx.getExternalFilesDir(null);
+            if (dir == null) return;
+            String ts = new SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(new Date());
+            new FileWriter(new File(dir, "debug.log"), true)
+                    .append(ts + " " + msg + "\n").close();
+        } catch (Exception ignored) {}
+        Log.d(TAG, msg);
+    }
+
     @Override
     public void onReceiveData(byte[] data) {
         String s = new String(data);
+        // Log all non-FA/RM responses (skip periodic polling to avoid spam)
+        String preview = s.replace("\r", "\\r").replace("\n", "\\n");
+        if (!preview.startsWith("FA") && !preview.startsWith("RM")) {
+            fileLog("rig.recv[" + data.length + "]: " + preview);
+        }
 
         if (!s.contains(";")) {
             buffer.append(s);
@@ -147,12 +171,16 @@ public class Yaesu39Rig extends BaseRig {
             }
 
             //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
+            String bufStr = buffer.toString();
+            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(bufStr);
             clearBufferData();//clear buffer
             //put remaining data into buffer
             buffer.append(s.substring(s.indexOf(";") + 1));
 
             if (yaesu3Command == null) {
+                if (bufStr.length() > 0) {
+                    fileLog("rig.parse: unknown command: " + bufStr);
+                }
                 return;
             }
             if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
@@ -169,6 +197,9 @@ public class Yaesu39Rig extends BaseRig {
                     alc = Yaesu3Command.getSWROrALC39(yaesu3Command);
                 }
                 showAlert();
+            } else {
+                fileLog("rig.parsed: cmd=" + yaesu3Command.getCommandID()
+                        + " data=" + yaesu3Command.getData());
             }
 
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu3RigConstant.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu3RigConstant.java
@@ -30,6 +30,7 @@ public class Yaesu3RigConstant {
     private static final String USB_MODE = "MD02;";
     private static final String USB_MODE_DATA = "MD09;";
     private static final String DATA_U_MODE = "MD0C;";
+    private static final String WIDTH_MAX_DATA = "SH0120;"; // Width ON, 3000 Hz (max for DATA mode)
     private static final String READ_FREQ = "FA;";
     private static final String READ_39METER_ALC = "RM4;";//commands for 38 and 39 are the same
     private static final String READ_39METER_SWR = "RM6;";//commands for 38 and 39 are the same
@@ -102,6 +103,9 @@ public class Yaesu3RigConstant {
 
     public static byte[] setOperationDATA_U_Mode() {
         return DATA_U_MODE.getBytes();
+    }
+    public static byte[] setMaxDataWidth() {
+        return WIDTH_MAX_DATA.getBytes();
     }
 
     @SuppressLint("DefaultLocale")

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/spectrum/SpectrumListener.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/spectrum/SpectrumListener.java
@@ -5,6 +5,9 @@ package com.bg7yoz.ft8cn.spectrum;
  * @date 2023-03-20
  */
 
+import android.os.Handler;
+import android.os.Looper;
+
 import androidx.lifecycle.MutableLiveData;
 
 import com.bg7yoz.ft8cn.wave.HamRecorder;
@@ -17,11 +20,22 @@ public class SpectrumListener {
     private float[] dataBuffer=new float[0];
     public MutableLiveData<float[]> mutableDataBuffer = new MutableLiveData<>();
 
+    // Post each update individually to the main thread.
+    // LiveData.postValue() coalesces: if a new value arrives before the main
+    // thread processes the previous one, the earlier value is silently dropped.
+    // At ~6 updates/sec this causes most waterfall frames to be lost when the
+    // main thread is busy with Compose layout or view rendering.
+    // Handler.post + setValue bypasses this — each update gets its own message.
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
 
     private final OnGetVoiceDataDone onGetVoiceDataDone=new OnGetVoiceDataDone() {
         @Override
         public void onGetDone(float[] data) {
-                    mutableDataBuffer.postValue(data);
+            // Clone because VoiceDataMonitor reuses the same float[] buffer.
+            // Without the clone, the main thread observer would read partially-
+            // overwritten data from the next recording cycle.
+            float[] copy = data.clone();
+            mainHandler.post(() -> mutableDataBuffer.setValue(copy));
         }
     };
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/AudioDeviceSpinnerAdapter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/AudioDeviceSpinnerAdapter.java
@@ -202,7 +202,7 @@ public class AudioDeviceSpinnerAdapter extends BaseAdapter {
         return view;
     }
 
-    private String getDeviceDisplayName(int position) {
+    public String getDeviceDisplayName(int position) {
         if (position == 0) {
             return mContext.getString(R.string.audio_device_default);
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
@@ -152,7 +152,9 @@ public class ColumnarView extends View {
             freq_hz = Math.round(3000f * (float) touch_x / (float) getWidth());
             canvas.drawLine(touch_x, 0, touch_x, getHeight(), touchPaint);
         }
-        invalidate();
+        // Do NOT call invalidate() here — the view is invalidated externally
+        // when new data arrives. Self-invalidation causes layout thrashing
+        // in Compose's AndroidView.
     }
     public void setTouch_x(int touch_x) {
         this.touch_x = touch_x;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -59,6 +59,10 @@ public class WaterfallView extends View {
     private int freq_hz = -1;
     private boolean drawMessage = false;//Whether to draw message content
 
+    // Track the bitmap dimensions to avoid recreating on minor layout changes
+    private int bitmapWidth = 0;
+    private int bitmapHeight = 0;
+
     public WaterfallView(Context context) {
         super(context);
     }
@@ -86,9 +90,21 @@ public class WaterfallView extends View {
 
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        if (w <= 0 || h <= 0) return;
+
+        // Skip bitmap recreation if the size hasn't meaningfully changed.
+        // Compose layout can cause small oscillations in the view size;
+        // recreating the bitmap each time wipes all accumulated waterfall data.
+        if (lastBitMap != null && w == bitmapWidth && Math.abs(h - bitmapHeight) < 20) {
+            return;
+        }
+
         setClickable(true);
-        blockHeight = getHeight() / (symbols * cycle);
-        freq_width = (float) getWidth() / 3000f;
+        bitmapWidth = w;
+        bitmapHeight = h;
+        blockHeight = h / (symbols * cycle);
+        if (blockHeight < 1) blockHeight = 1;
+        freq_width = (float) w / 3000f;
         lastBitMap = Bitmap.createBitmap(w, h, ARGB_8888);
         _canvas = new Canvas(lastBitMap);
         Paint blackPaint = new Paint();
@@ -127,16 +143,6 @@ public class WaterfallView extends View {
         messagePaint.setTextAlign(Paint.Align.CENTER);
         messagePaint.setShadowLayer(10,5,5,Color.BLACK);
 
-        //messagePaintBack = new Paint();
-//        messagePaintBack.setTextSize(dpToPixel(11));
-//        messagePaintBack.setColor(0xff000000);//Opaque background
-//        messagePaintBack.setAntiAlias(true);
-//        messagePaintBack.setDither(true);
-//        messagePaintBack.setStrokeWidth(dpToPixel(3));
-//        messagePaintBack.setFakeBoldText(true);
-//        messagePaintBack.setStyle(Paint.Style.FILL_AND_STROKE);
-//        messagePaintBack.setTextAlign(Paint.Align.CENTER);
-
         //utcPaint = new Paint();
         utcPaint.setTextSize(dpToPixel(10));
         utcPaint.setColor(0xff00ffff);//
@@ -171,6 +177,7 @@ public class WaterfallView extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
+        if (lastBitMap == null) return;
         canvas.drawBitmap(lastBitMap, 0, 0, null);
 
         //Calculate frequency
@@ -195,7 +202,11 @@ public class WaterfallView extends View {
             canvas.drawLine(touch_x, 0, touch_x, getHeight(), touchPaint);
 
         }
-        invalidate();
+        // Do NOT call invalidate() here. The view is invalidated externally
+        // when new data arrives via setWaveData(). Calling invalidate() from
+        // onDraw() creates a continuous redraw loop that triggers layout
+        // thrashing in Compose's AndroidView, causing onSizeChanged to fire
+        // repeatedly and wipe all accumulated waterfall data.
     }
 
     public void setWaveData(int[] data, int sequential, List<Ft8Message> msgs) {
@@ -215,14 +226,19 @@ public class WaterfallView extends View {
             return;
         }
 
+        // Use bitmap dimensions for drawing, not getWidth()/getHeight() which
+        // may differ from the bitmap size during Compose layout transitions.
+        int drawWidth = bitmapWidth;
+        int drawHeight = bitmapHeight;
+
         int[] colors = new int[data.length];
 
         //Draw divider line
         if (sequential != lastSequential) {
-            Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, getWidth(), getHeight() - blockHeight);
-            _canvas.drawBitmap(bitmap, 0, blockHeight, linePaint);
+            Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, drawHeight - blockHeight);
+            _canvas.drawBitmap(bitmap, 0, blockHeight, null);
             bitmap.recycle();
-            _canvas.drawRect(0, 0, getWidth(), getResources().getDisplayMetrics().density
+            _canvas.drawRect(0, 0, drawWidth, getResources().getDisplayMetrics().density
                     , linePaint);
             _canvas.drawText(UtcTimer.getTimeStr(UtcTimer.getSystemTime()), 50
                     , 15 * getResources().getDisplayMetrics().density, utcPainBack);
@@ -244,20 +260,17 @@ public class WaterfallView extends View {
                 colors[i] = 0xff00ffff | (((data[i] - 127)) << 18);//Amplify 4x
             }
         }
-        LinearGradient linearGradient = new LinearGradient(0, 0, getWidth() * 2, 0, colors
+        LinearGradient linearGradient = new LinearGradient(0, 0, drawWidth * 2, 0, colors
                 , null, Shader.TileMode.CLAMP);
-        //Paint linearPaint = new Paint();
         linearPaint.setShader(linearGradient);
-        Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, getWidth(), getHeight() - blockHeight);
-        _canvas.drawBitmap(bitmap, 0, blockHeight, linearPaint);
+        Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, drawHeight - blockHeight);
+        _canvas.drawBitmap(bitmap, 0, blockHeight, null);
         bitmap.recycle();
-        _canvas.drawRect(0, 0, getWidth(), blockHeight, linearPaint);
+        _canvas.drawRect(0, 0, drawWidth, blockHeight, linearPaint);
 
         //Messages have 3 types: normal, CQ, and involving me
         if (drawMessage && messages != null) {
             drawMessage = false;//Only draw once
-            //fontPaint.setTextAlign(Paint.Align.LEFT);
-            //fontPaint.setStrikeThruText(true);
             for (Ft8Message msg : messages) {
 
                 if (msg.inMyCall()) {//Related to me

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/HamRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/HamRecorder.java
@@ -142,6 +142,22 @@ public class HamRecorder {
     }
 
     /**
+     * Reinitialize the mic recorder to pick up newly connected USB audio devices.
+     * Re-wires the data listener after reinit.
+     */
+    public void reinitializeMicRecorder() {
+        micRecorder.reinitialize();
+        if (isMicRecord) {
+            micRecorder.setOnDataListener(new MicRecorder.OnDataListener() {
+                @Override
+                public void onDataReceived(float[] data, int len) {
+                    doOnWaveDataReceived(len, data);
+                }
+            });
+        }
+    }
+
+    /**
      * Method to retrieve recording data, implemented by adding a data monitor (VoiceDataMonitor).
      * Recording data is provided in the OnGetVoiceDataDone callback, triggered when the recording reaches the specified duration (milliseconds).
      * To get recording data, a monitor object is added to the recorder. Data is collected in the monitor's OnReceiveData callback.

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -217,4 +217,56 @@ public class MicRecorder {
     public void setOnDataListener(OnDataListener onDataListener) {
         this.onDataListener = onDataListener;
     }
+
+    /**
+     * Reinitialize the audio input device. Stops current audio capture,
+     * re-checks for USB audio device availability, and restarts if it was running.
+     * This handles the case where a USB audio device is connected after MicRecorder
+     * was originally constructed.
+     */
+    @SuppressLint("MissingPermission")
+    public void reinitialize() {
+        boolean wasRunning = isRunning;
+        OnDataListener savedListener = onDataListener;
+
+        // Stop current capture
+        stopRecord();
+
+        // Reset state
+        useUsbAudio = false;
+        usbAudioDevice = null;
+        audioRecord = null;
+
+        // Re-check for USB audio input
+        if (GeneralVariables.audioInputDeviceId == -1
+                && GeneralVariables.usbAudioInputVendorId != 0) {
+            usbAudioDevice = openUsbAudioInput();
+            if (usbAudioDevice != null) {
+                useUsbAudio = true;
+                UsbAudioDevice.setActiveInputDevice(usbAudioDevice);
+                Log.d(TAG, "reinitialize: Using USB audio input device");
+            } else {
+                Log.w(TAG, "reinitialize: USB audio device not available, falling back to default");
+            }
+        }
+
+        // Set up standard AudioRecord if not using USB audio
+        if (!useUsbAudio) {
+            bufferSize = AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat);
+            audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz,
+                    channelConfig, audioFormat, bufferSize);
+
+            if (GeneralVariables.audioInputDeviceId > 0) {
+                AudioDeviceInfo deviceInfo = findAudioDeviceById(
+                        GeneralVariables.audioInputDeviceId, AudioManager.GET_DEVICES_INPUTS);
+                audioRecord.setPreferredDevice(deviceInfo);
+            }
+        }
+
+        // Restore listener and restart if it was running
+        onDataListener = savedListener;
+        if (wasRunning) {
+            start();
+        }
+    }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -200,14 +200,6 @@ public class MicRecorder {
         if (useUsbAudio && usbAudioDevice != null) {
             usbAudioDevice.stopCapture();
         }
-        if (audioRecord != null) {
-            try {
-                audioRecord.release();
-            } catch (Exception e) {
-                Log.d(TAG, "Error releasing AudioRecord: " + e.getMessage());
-            }
-            audioRecord = null;
-        }
     }
 
     public OnDataListener getOnDataListener() {
@@ -232,10 +224,28 @@ public class MicRecorder {
         // Stop current capture
         stopRecord();
 
+        // Release old AudioRecord (stopRecord only sets isRunning=false)
+        if (audioRecord != null) {
+            try {
+                audioRecord.release();
+            } catch (Exception e) {
+                Log.d(TAG, "reinitialize: error releasing AudioRecord: " + e.getMessage());
+            }
+            audioRecord = null;
+        }
+
+        // Close old USB audio device
+        if (usbAudioDevice != null) {
+            try {
+                usbAudioDevice.close();
+            } catch (Exception e) {
+                Log.d(TAG, "reinitialize: error closing USB audio device: " + e.getMessage());
+            }
+        }
+
         // Reset state
         useUsbAudio = false;
         usbAudioDevice = null;
-        audioRecord = null;
 
         // Re-check for USB audio input
         if (GeneralVariables.audioInputDeviceId == -1

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -107,15 +107,6 @@ class ComposeMainActivity : ComponentActivity() {
             },
         )
 
-        // List USB devices
-        mainViewModel.getUsbDevice()
-
-        // Delayed audio reinit: handles USB audio device already physically connected
-        // but not ready during ViewModel construction
-        Handler(Looper.getMainLooper()).postDelayed({
-            mainViewModel.reinitializeAudioInput()
-        }, 2000)
-
         // Handle shared file import if needed
         if (mainViewModel.mutableImportShareRunning.value == true) {
             // Import is already running; UI will show progress
@@ -179,6 +170,17 @@ class ComposeMainActivity : ComponentActivity() {
                     mainViewModel.databaseOpr.writeConfig("grid", grid, null)
                 }
                 mainViewModel.ft8TransmitSignal.setTimer_sec(GeneralVariables.transmitDelay)
+
+                // Scan for USB devices AFTER config is loaded so that controlMode,
+                // instructionSet, baudRate, civAddress, audioInputDeviceId etc.
+                // are all populated before auto-connect fires.
+                mainViewModel.getUsbDevice()
+
+                // Delayed audio reinit: handles USB audio device already physically
+                // connected but not ready during ViewModel construction
+                Handler(Looper.getMainLooper()).postDelayed({
+                    mainViewModel.reinitializeAudioInput()
+                }, 2000)
             }
         })
 
@@ -289,19 +291,17 @@ class ComposeMainActivity : ComponentActivity() {
 
     /**
      * Auto-connect to USB serial rig when ports are detected, rig isn't already connected,
-     * and connect mode is USB Cable. If exactly one port is found, connect automatically.
+     * and connect mode is USB Cable with a non-VOX control mode.
+     * Connects to the first detected port (most radios expose CAT as the first port).
      */
     private fun autoConnectUsbIfNeeded(ports: ArrayList<CableSerialPort.SerialPort>?) {
         if (ports.isNullOrEmpty()) return
         if (mainViewModel.isRigConnected()) return
         if (GeneralVariables.connectMode != ConnectMode.USB_CABLE) return
+        if (!mainViewModel.configIsLoaded) return
 
-        if (ports.size == 1) {
-            Log.d(TAG, "Auto-connecting to single USB serial port")
-            mainViewModel.connectCableRig(applicationContext, ports[0])
-        } else {
-            Log.d(TAG, "Multiple USB serial ports detected (${ports.size}), waiting for user selection")
-        }
+        Log.d(TAG, "Auto-connecting to USB serial port (${ports.size} port(s) detected)")
+        mainViewModel.connectCableRig(applicationContext, ports[0])
     }
 
     private fun closeApp() {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -35,7 +35,11 @@ import com.bg7yoz.ft8cn.log.OnShareLogEvents
 import com.bg7yoz.ft8cn.maidenhead.MaidenheadGrid
 import com.bg7yoz.ft8cn.ui.ToastMessage
 import radio.ks3ckc.ft8us.theme.FT8USTheme
+import java.io.File
 import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class ComposeMainActivity : ComponentActivity() {
 
@@ -97,6 +101,7 @@ class ComposeMainActivity : ComponentActivity() {
         }
 
         // Initialize data
+        fileLog("=== APP START ===")
         initData()
 
         // Observe serial port changes for auto-connect (mirrors old MainActivity behavior)
@@ -164,6 +169,10 @@ class ComposeMainActivity : ComponentActivity() {
 
             override fun doOnAfterQueryConfig(keyName: String?, value: String?) {
                 mainViewModel.configIsLoaded = true
+                fileLog("configLoaded: instructionSet=${GeneralVariables.instructionSet}, " +
+                    "baudRate=${GeneralVariables.baudRate}, " +
+                    "controlMode=${GeneralVariables.controlMode}, " +
+                    "connectMode=${GeneralVariables.connectMode}")
                 val grid = MaidenheadGrid.getMyMaidenheadGrid(applicationContext)
                 if (grid.isNotEmpty()) {
                     GeneralVariables.setMyMaidenheadGrid(grid)
@@ -171,16 +180,24 @@ class ComposeMainActivity : ComponentActivity() {
                 }
                 mainViewModel.ft8TransmitSignal.setTimer_sec(GeneralVariables.transmitDelay)
 
-                // Scan for USB devices AFTER config is loaded so that controlMode,
-                // instructionSet, baudRate, civAddress, audioInputDeviceId etc.
-                // are all populated before auto-connect fires.
+                // Scan for USB devices AFTER config is loaded
+                fileLog("initData: scanning USB devices")
                 mainViewModel.getUsbDevice()
+                val ports = mainViewModel.mutableSerialPorts.value
+                fileLog("initData: found ${ports?.size ?: 0} serial port(s)")
+                mainViewModel.reinitializeAudioInput()
 
-                // Delayed audio reinit: handles USB audio device already physically
-                // connected but not ready during ViewModel construction
+                // Delayed re-scan for slow USB enumeration
                 Handler(Looper.getMainLooper()).postDelayed({
+                    val connected = mainViewModel.isRigConnected()
+                    fileLog("initData delayed: rigConnected=$connected")
+                    if (!connected) {
+                        mainViewModel.getUsbDevice()
+                        val delayedPorts = mainViewModel.mutableSerialPorts.value
+                        fileLog("initData delayed: found ${delayedPorts?.size ?: 0} serial port(s)")
+                    }
                     mainViewModel.reinitializeAudioInput()
-                }, 2000)
+                }, 3000)
             }
         })
 
@@ -247,11 +264,23 @@ class ComposeMainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         if ("android.hardware.usb.action.USB_DEVICE_ATTACHED" == intent.action) {
+            fileLog("onNewIntent: USB_DEVICE_ATTACHED")
+            // Immediate scan
             mainViewModel.getUsbDevice()
-            // Reinitialize audio input to pick up newly attached USB audio device
+            val ports = mainViewModel.mutableSerialPorts.value
+            fileLog("onNewIntent: immediate scan found ${ports?.size ?: 0} port(s)")
+
+            // Delayed re-scan and audio reinit (USB needs time to enumerate)
             Handler(Looper.getMainLooper()).postDelayed({
+                val connected = mainViewModel.isRigConnected()
+                fileLog("onNewIntent delayed: rigConnected=$connected")
+                if (!connected) {
+                    mainViewModel.getUsbDevice()
+                    val delayedPorts = mainViewModel.mutableSerialPorts.value
+                    fileLog("onNewIntent delayed: re-scan found ${delayedPorts?.size ?: 0} port(s)")
+                }
                 mainViewModel.reinitializeAudioInput()
-            }, 1000)
+            }, 2000)
         } else {
             setIntent(intent)
             doReceiveShareFile(intent)
@@ -295,13 +324,38 @@ class ComposeMainActivity : ComponentActivity() {
      * Connects to the first detected port (most radios expose CAT as the first port).
      */
     private fun autoConnectUsbIfNeeded(ports: ArrayList<CableSerialPort.SerialPort>?) {
-        if (ports.isNullOrEmpty()) return
-        if (mainViewModel.isRigConnected()) return
-        if (GeneralVariables.connectMode != ConnectMode.USB_CABLE) return
-        if (!mainViewModel.configIsLoaded) return
+        if (ports.isNullOrEmpty()) {
+            fileLog("autoConnect: no serial ports detected")
+            return
+        }
+        if (mainViewModel.isRigConnected()) {
+            fileLog("autoConnect: rig already connected, skipping")
+            return
+        }
+        if (GeneralVariables.connectMode != ConnectMode.USB_CABLE) {
+            fileLog("autoConnect: connectMode=${GeneralVariables.connectMode}, not USB_CABLE")
+            return
+        }
+        if (!mainViewModel.configIsLoaded) {
+            fileLog("autoConnect: config not loaded yet, skipping")
+            return
+        }
 
-        Log.d(TAG, "Auto-connecting to USB serial port (${ports.size} port(s) detected)")
+        fileLog("autoConnect: connecting to port 0 of ${ports.size} " +
+            "(instructionSet=${GeneralVariables.instructionSet}, " +
+            "baudRate=${GeneralVariables.baudRate}, " +
+            "controlMode=${GeneralVariables.controlMode})")
         mainViewModel.connectCableRig(applicationContext, ports[0])
+    }
+
+    /** Write a line to /sdcard/Android/data/com.bg7yoz.ft8cn/files/debug.log */
+    private fun fileLog(msg: String) {
+        try {
+            val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            val dir = getExternalFilesDir(null) ?: return
+            File(dir, "debug.log").appendText("$ts $msg\n")
+        } catch (_: Exception) {}
+        Log.d(TAG, msg)
     }
 
     private fun closeApp() {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -18,9 +18,14 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.Observer
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.bluetooth.BluetoothStateBroadcastReceive
+import com.bg7yoz.ft8cn.connector.CableSerialPort
+import com.bg7yoz.ft8cn.connector.ConnectMode
 import com.bg7yoz.ft8cn.callsign.CallsignDatabase
 import com.bg7yoz.ft8cn.database.DatabaseOpr
 import com.bg7yoz.ft8cn.database.OnAfterQueryConfig
@@ -94,8 +99,22 @@ class ComposeMainActivity : ComponentActivity() {
         // Initialize data
         initData()
 
+        // Observe serial port changes for auto-connect (mirrors old MainActivity behavior)
+        mainViewModel.mutableSerialPorts.observe(
+            this,
+            Observer { ports ->
+                autoConnectUsbIfNeeded(ports)
+            },
+        )
+
         // List USB devices
         mainViewModel.getUsbDevice()
+
+        // Delayed audio reinit: handles USB audio device already physically connected
+        // but not ready during ViewModel construction
+        Handler(Looper.getMainLooper()).postDelayed({
+            mainViewModel.reinitializeAudioInput()
+        }, 2000)
 
         // Handle shared file import if needed
         if (mainViewModel.mutableImportShareRunning.value == true) {
@@ -227,6 +246,10 @@ class ComposeMainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         if ("android.hardware.usb.action.USB_DEVICE_ATTACHED" == intent.action) {
             mainViewModel.getUsbDevice()
+            // Reinitialize audio input to pick up newly attached USB audio device
+            Handler(Looper.getMainLooper()).postDelayed({
+                mainViewModel.reinitializeAudioInput()
+            }, 1000)
         } else {
             setIntent(intent)
             doReceiveShareFile(intent)
@@ -262,6 +285,23 @@ class ComposeMainActivity : ComponentActivity() {
     override fun onDestroy() {
         unregisterBluetoothReceiver()
         super.onDestroy()
+    }
+
+    /**
+     * Auto-connect to USB serial rig when ports are detected, rig isn't already connected,
+     * and connect mode is USB Cable. If exactly one port is found, connect automatically.
+     */
+    private fun autoConnectUsbIfNeeded(ports: ArrayList<CableSerialPort.SerialPort>?) {
+        if (ports.isNullOrEmpty()) return
+        if (mainViewModel.isRigConnected()) return
+        if (GeneralVariables.connectMode != ConnectMode.USB_CABLE) return
+
+        if (ports.size == 1) {
+            Log.d(TAG, "Auto-connecting to single USB serial port")
+            mainViewModel.connectCableRig(applicationContext, ports[0])
+        } else {
+            Log.d(TAG, "Multiple USB serial ports detected (${ports.size}), waiting for user selection")
+        }
     }
 
     private fun closeApp() {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
+import com.bg7yoz.ft8cn.connector.CableSerialPort
 import com.bg7yoz.ft8cn.connector.ConnectMode
 import com.bg7yoz.ft8cn.database.ControlMode
 import com.bg7yoz.ft8cn.database.OperationBand
@@ -98,6 +99,10 @@ fun SettingsScreen(
     var enableQRZ by remember { mutableStateOf(GeneralVariables.enableQRZ) }
     var saveSWLMessage by remember { mutableStateOf(GeneralVariables.saveSWLMessage) }
     var saveSWL_QSO by remember { mutableStateOf(GeneralVariables.saveSWL_QSO) }
+
+    // Observe serial ports for USB Cable picker
+    val serialPorts by mainViewModel.mutableSerialPorts.observeAsState()
+    var showSerialPortPicker by remember { mutableStateOf(false) }
 
     // Dialog visibility state
     var showEditOperator by remember { mutableStateOf(false) }
@@ -203,10 +208,34 @@ fun SettingsScreen(
                                 LoginIcomRadioDialog(context, mainViewModel).show()
                         }
                     }
-                    // USB Cable: mode is set, no further dialog needed
+                    ConnectMode.USB_CABLE -> {
+                        mainViewModel.getUsbDevice()
+                        showSerialPortPicker = true
+                    }
                 }
             },
         )
+    }
+
+    // -- Serial Port Picker (USB Cable) --
+    if (showSerialPortPicker) {
+        val ports = serialPorts
+        if (ports.isNullOrEmpty()) {
+            InfoDialog(
+                title = "USB Cable",
+                body = "No USB serial devices detected. Please connect a USB cable to your radio and try again.",
+                onDismiss = { showSerialPortPicker = false },
+            )
+        } else {
+            SerialPortPickerDialog(
+                ports = ports,
+                onDismiss = { showSerialPortPicker = false },
+                onSelect = { port ->
+                    showSerialPortPicker = false
+                    mainViewModel.connectCableRig(context, port)
+                },
+            )
+        }
     }
 
     // -- Band & Frequency Picker --
@@ -1078,6 +1107,67 @@ private fun NumberInputDialog(
                     },
                 ) {
                     Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for selecting a USB serial port to connect to a rig.
+ */
+@Composable
+private fun SerialPortPickerDialog(
+    ports: List<CableSerialPort.SerialPort>,
+    onDismiss: () -> Unit,
+    onSelect: (CableSerialPort.SerialPort) -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(vertical = 24.dp),
+        ) {
+            Text(
+                text = "Select Serial Port",
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp),
+            ) {
+                itemsIndexed(ports) { _, port ->
+                    Text(
+                        text = port.information(),
+                        color = TextPrimary,
+                        fontSize = 14.sp,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(port) }
+                            .padding(horizontal = 24.dp, vertical = 12.dp),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel", color = TextMuted)
                 }
             }
         }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -50,15 +50,18 @@ import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
+import android.media.AudioManager
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.connector.CableSerialPort
 import com.bg7yoz.ft8cn.connector.ConnectMode
 import com.bg7yoz.ft8cn.database.ControlMode
 import com.bg7yoz.ft8cn.database.OperationBand
+import com.bg7yoz.ft8cn.database.RigNameList
 import com.bg7yoz.ft8cn.ft8signal.FT8Package
 import com.bg7yoz.ft8cn.rigs.BaseRigOperation
 import com.bg7yoz.ft8cn.rigs.InstructionSet
+import com.bg7yoz.ft8cn.ui.AudioDeviceSpinnerAdapter
 import com.bg7yoz.ft8cn.ui.LoginIcomRadioDialog
 import com.bg7yoz.ft8cn.ui.SelectBluetoothDialog
 import com.bg7yoz.ft8cn.ui.SelectFlexRadioDialog
@@ -115,6 +118,10 @@ fun SettingsScreen(
     var showTxDelay by remember { mutableStateOf(false) }
     var showAbout by remember { mutableStateOf(false) }
     var showCloudlog by remember { mutableStateOf(false) }
+    var showRigModelPicker by remember { mutableStateOf(false) }
+    var showControlModePicker by remember { mutableStateOf(false) }
+    var showAudioInputPicker by remember { mutableStateOf(false) }
+    var showAudioOutputPicker by remember { mutableStateOf(false) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -127,6 +134,8 @@ fun SettingsScreen(
     var txDelay by remember { mutableIntStateOf(GeneralVariables.transmitDelay) }
     var connectMode by remember { mutableIntStateOf(GeneralVariables.connectMode) }
     var cloudlogAddress by remember { mutableStateOf(GeneralVariables.cloudlogServerAddress.orEmpty()) }
+    var controlMode by remember { mutableIntStateOf(GeneralVariables.controlMode) }
+    var modelNo by remember { mutableIntStateOf(GeneralVariables.modelNo) }
 
     // Derived display strings
     val callsign = callsignState
@@ -144,7 +153,35 @@ fun SettingsScreen(
     } else {
         "Not connected"
     }
-    val isCatMode = GeneralVariables.controlMode == ControlMode.CAT
+    val isCatMode = controlMode == ControlMode.CAT
+        || controlMode == ControlMode.RTS
+        || controlMode == ControlMode.DTR
+
+    // Rig model list
+    val rigNameList = remember { RigNameList.getInstance(context) }
+    val rigModelStr = remember(modelNo) {
+        rigNameList.getRigNameByIndex(modelNo).name
+    }
+
+    // Control mode display
+    val controlModeStr = when (controlMode) {
+        ControlMode.CAT -> "CAT"
+        ControlMode.RTS -> "RTS"
+        ControlMode.DTR -> "DTR"
+        else -> "VOX"
+    }
+
+    // Audio device display names
+    val audioInputAdapter = remember { AudioDeviceSpinnerAdapter(context, AudioManager.GET_DEVICES_INPUTS) }
+    val audioOutputAdapter = remember { AudioDeviceSpinnerAdapter(context, AudioManager.GET_DEVICES_OUTPUTS) }
+    val audioInputPos = remember(GeneralVariables.audioInputDeviceId) {
+        audioInputAdapter.getPositionByDeviceId(GeneralVariables.audioInputDeviceId)
+    }
+    val audioOutputPos = remember(GeneralVariables.audioOutputDeviceId) {
+        audioOutputAdapter.getPositionByDeviceId(GeneralVariables.audioOutputDeviceId)
+    }
+    var audioInputName by remember { mutableStateOf(audioInputAdapter.getDeviceDisplayName(audioInputPos)) }
+    var audioOutputName by remember { mutableStateOf(audioOutputAdapter.getDeviceDisplayName(audioOutputPos)) }
 
     // =====================================================================
     // DIALOGS
@@ -412,6 +449,144 @@ fun SettingsScreen(
         )
     }
 
+    // -- Rig Model Picker --
+    if (showRigModelPicker) {
+        val rigItems = rigNameList.rigList
+            .mapIndexed { index, rig -> index to rig }
+            .filter { (_, rig) -> !rig.modelName.startsWith("#") }
+        val rigDisplayNames = rigItems.map { (_, rig) -> rig.name }
+        val currentRigIndex = rigItems.indexOfFirst { (index, _) -> index == modelNo }
+            .coerceAtLeast(0)
+        ListPickerDialog(
+            title = "Rig Model",
+            items = rigDisplayNames,
+            selectedIndex = currentRigIndex,
+            onDismiss = { showRigModelPicker = false },
+            onSelect = { selectedDisplayIndex ->
+                showRigModelPicker = false
+                val (actualIndex, selectedRig) = rigItems[selectedDisplayIndex]
+                GeneralVariables.modelNo = actualIndex
+                modelNo = actualIndex
+                GeneralVariables.instructionSet = selectedRig.instructionSet
+                GeneralVariables.civAddress = selectedRig.address
+                GeneralVariables.baudRate = selectedRig.bauRate
+                mainViewModel.setCivAddress()
+                mainViewModel.databaseOpr.writeConfig("model", actualIndex.toString(), null)
+                mainViewModel.databaseOpr.writeConfig(
+                    "instruction", GeneralVariables.instructionSet.toString(), null,
+                )
+                mainViewModel.databaseOpr.writeConfig(
+                    "baudRate", GeneralVariables.baudRate.toString(), null,
+                )
+                mainViewModel.databaseOpr.writeConfig(
+                    "civ", GeneralVariables.civAddress.toString(), null,
+                )
+            },
+        )
+    }
+
+    // -- Control Mode Picker --
+    if (showControlModePicker) {
+        val controlModeOptions = listOf("VOX", "CAT", "RTS", "DTR")
+        val controlModeValues = listOf(ControlMode.VOX, ControlMode.CAT, ControlMode.RTS, ControlMode.DTR)
+        val currentControlIndex = controlModeValues.indexOf(controlMode).coerceAtLeast(0)
+        ListPickerDialog(
+            title = "Control Mode",
+            items = controlModeOptions,
+            selectedIndex = currentControlIndex,
+            onDismiss = { showControlModePicker = false },
+            onSelect = { index ->
+                showControlModePicker = false
+                val newMode = controlModeValues[index]
+                GeneralVariables.controlMode = newMode
+                controlMode = newMode
+                mainViewModel.setControlMode()
+                mainViewModel.databaseOpr.writeConfig("ctrMode", newMode.toString(), null)
+                if (newMode == ControlMode.CAT
+                    || newMode == ControlMode.RTS
+                    || newMode == ControlMode.DTR
+                ) {
+                    if (!mainViewModel.isRigConnected()) {
+                        mainViewModel.getUsbDevice()
+                        showSerialPortPicker = true
+                    } else {
+                        mainViewModel.setOperationBand()
+                    }
+                }
+            },
+        )
+    }
+
+    // -- Audio Input Device Picker --
+    if (showAudioInputPicker) {
+        AudioDevicePickerDialog(
+            title = "Audio Input",
+            adapter = audioInputAdapter,
+            currentDeviceId = GeneralVariables.audioInputDeviceId,
+            onDismiss = { showAudioInputPicker = false },
+            onSelect = { position ->
+                showAudioInputPicker = false
+                val deviceId = audioInputAdapter.getDeviceId(position)
+                GeneralVariables.audioInputDeviceId = deviceId
+                mainViewModel.databaseOpr.writeConfig("audioInputDevice", deviceId.toString(), null)
+
+                val usbInfo = audioInputAdapter.getUsbAudioDeviceInfo(position)
+                if (usbInfo != null) {
+                    GeneralVariables.usbAudioInputVendorId = usbInfo.device.vendorId
+                    GeneralVariables.usbAudioInputProductId = usbInfo.device.productId
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioInputVid", GeneralVariables.usbAudioInputVendorId.toString(), null,
+                    )
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioInputPid", GeneralVariables.usbAudioInputProductId.toString(), null,
+                    )
+                    mainViewModel.requestUsbPermissionIfNeeded(usbInfo.device)
+                } else if (deviceId != -1) {
+                    GeneralVariables.usbAudioInputVendorId = 0
+                    GeneralVariables.usbAudioInputProductId = 0
+                    mainViewModel.databaseOpr.writeConfig("usbAudioInputVid", "0", null)
+                    mainViewModel.databaseOpr.writeConfig("usbAudioInputPid", "0", null)
+                }
+                audioInputName = audioInputAdapter.getDeviceDisplayName(position)
+            },
+        )
+    }
+
+    // -- Audio Output Device Picker --
+    if (showAudioOutputPicker) {
+        AudioDevicePickerDialog(
+            title = "Audio Output",
+            adapter = audioOutputAdapter,
+            currentDeviceId = GeneralVariables.audioOutputDeviceId,
+            onDismiss = { showAudioOutputPicker = false },
+            onSelect = { position ->
+                showAudioOutputPicker = false
+                val deviceId = audioOutputAdapter.getDeviceId(position)
+                GeneralVariables.audioOutputDeviceId = deviceId
+                mainViewModel.databaseOpr.writeConfig("audioOutputDevice", deviceId.toString(), null)
+
+                val usbInfo = audioOutputAdapter.getUsbAudioDeviceInfo(position)
+                if (usbInfo != null) {
+                    GeneralVariables.usbAudioOutputVendorId = usbInfo.device.vendorId
+                    GeneralVariables.usbAudioOutputProductId = usbInfo.device.productId
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioOutputVid", GeneralVariables.usbAudioOutputVendorId.toString(), null,
+                    )
+                    mainViewModel.databaseOpr.writeConfig(
+                        "usbAudioOutputPid", GeneralVariables.usbAudioOutputProductId.toString(), null,
+                    )
+                    mainViewModel.requestUsbPermissionIfNeeded(usbInfo.device)
+                } else if (deviceId != -1) {
+                    GeneralVariables.usbAudioOutputVendorId = 0
+                    GeneralVariables.usbAudioOutputProductId = 0
+                    mainViewModel.databaseOpr.writeConfig("usbAudioOutputVid", "0", null)
+                    mainViewModel.databaseOpr.writeConfig("usbAudioOutputPid", "0", null)
+                }
+                audioOutputName = audioOutputAdapter.getDeviceDisplayName(position)
+            },
+        )
+    }
+
     // =====================================================================
     // SCREEN CONTENT
     // =====================================================================
@@ -450,6 +625,20 @@ fun SettingsScreen(
                 GlassCard(modifier = Modifier.fillMaxWidth()) {
                     Column {
                         SettingsRow(
+                            label = "Rig Model",
+                            value = rigModelStr,
+                            showChevron = true,
+                            onClick = { showRigModelPicker = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Control Mode",
+                            value = controlModeStr,
+                            showChevron = true,
+                            onClick = { showControlModePicker = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
                             label = "Connection Mode",
                             value = connectModeStr,
                             showChevron = isCatMode,
@@ -468,6 +657,35 @@ fun SettingsScreen(
                             value = audioFreqStr,
                             showChevron = !synFrequency,
                             onClick = if (!synFrequency) {{ showAudioFreq = true }} else null,
+                        )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 2b. AUDIO
+            // =====================================================================
+            SettingsSection(title = "AUDIO") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "Audio Input",
+                            value = audioInputName,
+                            showChevron = true,
+                            onClick = {
+                                audioInputAdapter.refreshDevices()
+                                showAudioInputPicker = true
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Audio Output",
+                            value = audioOutputName,
+                            showChevron = true,
+                            onClick = {
+                                audioOutputAdapter.refreshDevices()
+                                showAudioOutputPicker = true
+                            },
                         )
                     }
                 }
@@ -1216,4 +1434,28 @@ private fun InfoDialog(
             }
         }
     }
+}
+
+/**
+ * Dialog for selecting an audio input or output device from [AudioDeviceSpinnerAdapter].
+ */
+@Composable
+private fun AudioDevicePickerDialog(
+    title: String,
+    adapter: AudioDeviceSpinnerAdapter,
+    currentDeviceId: Int,
+    onDismiss: () -> Unit,
+    onSelect: (position: Int) -> Unit,
+) {
+    val count = adapter.count
+    val items = (0 until count).map { adapter.getDeviceDisplayName(it) }
+    val selectedIndex = adapter.getPositionByDeviceId(currentDeviceId).coerceIn(0, count - 1)
+
+    ListPickerDialog(
+        title = title,
+        items = items,
+        selectedIndex = selectedIndex,
+        onDismiss = onDismiss,
+        onSelect = onSelect,
+    )
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -122,6 +122,7 @@ fun SettingsScreen(
     var showControlModePicker by remember { mutableStateOf(false) }
     var showAudioInputPicker by remember { mutableStateOf(false) }
     var showAudioOutputPicker by remember { mutableStateOf(false) }
+    var showBaudRatePicker by remember { mutableStateOf(false) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -136,6 +137,7 @@ fun SettingsScreen(
     var cloudlogAddress by remember { mutableStateOf(GeneralVariables.cloudlogServerAddress.orEmpty()) }
     var controlMode by remember { mutableIntStateOf(GeneralVariables.controlMode) }
     var modelNo by remember { mutableIntStateOf(GeneralVariables.modelNo) }
+    var baudRate by remember { mutableIntStateOf(GeneralVariables.baudRate) }
 
     // Derived display strings
     val callsign = callsignState
@@ -153,6 +155,7 @@ fun SettingsScreen(
     } else {
         "Not connected"
     }
+    val baudRateStr = "$baudRate"
     val isCatMode = controlMode == ControlMode.CAT
         || controlMode == ControlMode.RTS
         || controlMode == ControlMode.DTR
@@ -294,10 +297,22 @@ fun SettingsScreen(
                     "bandFreq", GeneralVariables.band.toString(), null,
                 )
                 mainViewModel.databaseOpr.getAllQSLCallsigns()
-                if (GeneralVariables.controlMode == ControlMode.CAT
-                    || GeneralVariables.controlMode == ControlMode.RTS
-                    || GeneralVariables.controlMode == ControlMode.DTR
-                ) {
+                val cm = GeneralVariables.controlMode
+                val connected = mainViewModel.isRigConnected()
+                android.util.Log.d("SettingsScreen",
+                    "bandSelect: index=$index, band=${GeneralVariables.band}, " +
+                    "controlMode=$cm, rigConnected=$connected")
+                try {
+                    val dir = context.getExternalFilesDir(null)
+                    if (dir != null) {
+                        val ts = java.text.SimpleDateFormat("HH:mm:ss.SSS", java.util.Locale.US)
+                            .format(java.util.Date())
+                        java.io.File(dir, "debug.log").appendText(
+                            "$ts bandSelect: index=$index, band=${GeneralVariables.band}, " +
+                            "controlMode=$cm, rigConnected=$connected\n")
+                    }
+                } catch (_: Exception) {}
+                if (cm == ControlMode.CAT || cm == ControlMode.RTS || cm == ControlMode.DTR) {
                     mainViewModel.setOperationBand()
                 }
             },
@@ -470,6 +485,7 @@ fun SettingsScreen(
                 GeneralVariables.instructionSet = selectedRig.instructionSet
                 GeneralVariables.civAddress = selectedRig.address
                 GeneralVariables.baudRate = selectedRig.bauRate
+                baudRate = selectedRig.bauRate
                 mainViewModel.setCivAddress()
                 mainViewModel.databaseOpr.writeConfig("model", actualIndex.toString(), null)
                 mainViewModel.databaseOpr.writeConfig(
@@ -513,6 +529,26 @@ fun SettingsScreen(
                         mainViewModel.setOperationBand()
                     }
                 }
+            },
+        )
+    }
+
+    // -- Baud Rate Picker --
+    if (showBaudRatePicker) {
+        val baudRateOptions = listOf(4800, 9600, 14400, 19200, 38400, 43000, 56000, 57600, 115200)
+        val baudRateLabels = baudRateOptions.map { it.toString() }
+        val currentBaudIndex = baudRateOptions.indexOf(baudRate).coerceAtLeast(0)
+        ListPickerDialog(
+            title = "Baud Rate",
+            items = baudRateLabels,
+            selectedIndex = currentBaudIndex,
+            onDismiss = { showBaudRatePicker = false },
+            onSelect = { index ->
+                showBaudRatePicker = false
+                val newBaudRate = baudRateOptions[index]
+                GeneralVariables.baudRate = newBaudRate
+                baudRate = newBaudRate
+                mainViewModel.databaseOpr.writeConfig("baudRate", newBaudRate.toString(), null)
             },
         )
     }
@@ -643,6 +679,13 @@ fun SettingsScreen(
                             value = connectModeStr,
                             showChevron = isCatMode,
                             onClick = if (isCatMode) {{ showConnectionMode = true }} else null,
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Baud Rate",
+                            value = baudRateStr,
+                            showChevron = isCatMode,
+                            onClick = if (isCatMode) {{ showBaudRatePicker = true }} else null,
                         )
                         SectionDivider()
                         SettingsRow(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -51,6 +51,7 @@ import radio.ks3ckc.ft8us.ui.components.TopBar
 private class ViewHolder {
     @Volatile var columnar: ColumnarView? = null
     @Volatile var waterfall: WaterfallView? = null
+    var frequencyLineTimeout: Int = 0 // plain field, only accessed from main thread
 }
 
 /**
@@ -65,7 +66,7 @@ private class ViewHolder {
 @Composable
 fun WaterfallScreen(mainViewModel: MainViewModel) {
     var touchedFreqHz by remember { mutableIntStateOf(-1) }
-    var frequencyLineTimeout by remember { mutableIntStateOf(0) }
+    var updateCount by remember { mutableIntStateOf(0) }
 
     val isDecoding by mainViewModel.mutableIsDecoding.observeAsState(false)
     var deNoise by remember { mutableStateOf(mainViewModel.deNoise) }
@@ -80,14 +81,16 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
     //   spectrumListener.mutableDataBuffer.observe(...) { drawSpectrum(it) }
     DisposableEffect(Unit) {
         val observer = Observer<FloatArray> { data ->
-            // Runs on MAIN THREAD (LiveData dispatches postValue via Handler)
+            // Runs on MAIN THREAD (setValue dispatched via Handler.post)
+            updateCount++
             val fft = IntArray(data.size / 2)
             nativeFFT(data, fft, mainViewModel.deNoise)
 
             viewHolder.columnar?.let { cView ->
-                frequencyLineTimeout--
-                if (frequencyLineTimeout < 0) frequencyLineTimeout = 0
-                if (frequencyLineTimeout == 0) {
+                if (viewHolder.frequencyLineTimeout > 0) {
+                    viewHolder.frequencyLineTimeout--
+                }
+                if (viewHolder.frequencyLineTimeout == 0) {
                     cView.setTouch_x(-1)
                     viewHolder.waterfall?.setTouch_x(-1)
                     touchedFreqHz = -1
@@ -137,7 +140,7 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             onViewCreated = { viewHolder.columnar = it },
             onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
-                frequencyLineTimeout = 60
+                viewHolder.frequencyLineTimeout = 60
             },
             onTouchUp = { freqHz ->
                 if (freqHz > 0 && !GeneralVariables.synFrequency) {
@@ -164,7 +167,7 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             onViewCreated = { viewHolder.waterfall = it },
             onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
-                frequencyLineTimeout = 60
+                viewHolder.frequencyLineTimeout = 60
             },
             onTouchUp = { freqHz ->
                 if (freqHz > 0 && !GeneralVariables.synFrequency) {
@@ -215,6 +218,15 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             )
 
             Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = "$updateCount",
+                color = TextDim,
+                fontFamily = GeistMonoFamily,
+                fontSize = 9.sp,
+            )
+
+            Spacer(modifier = Modifier.width(6.dp))
 
             Text(
                 text = "LIVE",

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Observer
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -32,6 +34,10 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import com.bg7yoz.ft8cn.timer.UtcTimer
 import com.bg7yoz.ft8cn.ui.ColumnarView
 import com.bg7yoz.ft8cn.ui.SpectrumFragment
@@ -50,8 +56,22 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
     var touchedFreqHz by remember { mutableIntStateOf(-1) }
     var frequencyLineTimeout by remember { mutableIntStateOf(0) }
 
-    // Observe spectrum data from the recorder
-    val spectrumData by mainViewModel.spectrumListener.mutableDataBuffer.observeAsState()
+    // Observe spectrum data from the recorder.
+    // VoiceDataMonitor reuses the same float[] buffer, so LiveData posts the same
+    // reference each cycle. Compose's observeAsState() uses reference equality for
+    // FloatArray and would skip recomposition. We manually observe and copyOf() to
+    // ensure a new reference triggers recomposition every time.
+    var spectrumData by remember { mutableStateOf<FloatArray?>(null) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = Observer<FloatArray> { data ->
+            spectrumData = data.copyOf()
+        }
+        mainViewModel.spectrumListener.mutableDataBuffer.observe(lifecycleOwner, observer)
+        onDispose {
+            mainViewModel.spectrumListener.mutableDataBuffer.removeObserver(observer)
+        }
+    }
 
     // Observe decode state to control message overlay
     val isDecoding by mainViewModel.mutableIsDecoding.observeAsState(false)
@@ -257,7 +277,7 @@ private fun ColumnarStrip(
         },
         update = { view ->
             spectrumData?.let { data ->
-                val fft = IntArray(data.size)
+                val fft = IntArray(data.size / 2)
                 nativeFFT(data, fft, deNoise)
 
                 var timeout = frequencyLineTimeout - 1
@@ -280,6 +300,15 @@ private fun ColumnarStrip(
             columnarViewRef = null
         }
     }
+}
+
+private fun wfLog(msg: String) {
+    try {
+        val ctx = GeneralVariables.getMainContext() ?: return
+        val dir = ctx.getExternalFilesDir(null) ?: return
+        val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+        File(dir, "debug.log").appendText("$ts $msg\n")
+    } catch (_: Exception) {}
 }
 
 // ---------------------------------------------------------------------------
@@ -334,9 +363,10 @@ private fun WaterfallCanvas(
         update = { view ->
             view.setDrawMessage(showMessages && !isDecoding)
 
-            spectrumData?.let { data ->
-                val fft = IntArray(data.size)
-                nativeFFT(data, fft, mainViewModel.deNoise)
+            val sd = spectrumData
+            if (sd != null) {
+                val fft = IntArray(sd.size / 2)
+                nativeFFT(sd, fft, mainViewModel.deNoise)
 
                 val messages = if (showMessages) mainViewModel.currentMessages else null
                 view.setWaveData(fft, UtcTimer.getNowSequential(), messages)
@@ -425,8 +455,8 @@ private object FFTBridge {
             } else {
                 fragment.getFFTDataRawFloat(audioData, fftOut)
             }
-        } catch (_: UnsatisfiedLinkError) {
-            // Native library not loaded; leave fftOut zeroed
+        } catch (e: UnsatisfiedLinkError) {
+            wfLog("waterfall.FFT ERROR: native library not loaded! ${e.message}")
         }
     }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Observer
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import java.io.File
@@ -44,52 +45,58 @@ import radio.ks3ckc.ft8us.theme.*
 import radio.ks3ckc.ft8us.ui.components.TopBar
 
 /**
+ * Holder for view references using plain @Volatile fields.
+ * Avoids Compose snapshot system overhead when accessed from callbacks.
+ */
+private class ViewHolder {
+    @Volatile var columnar: ColumnarView? = null
+    @Volatile var waterfall: WaterfallView? = null
+}
+
+/**
  * Waterfall screen wrapping the existing Java WaterfallView and ColumnarView
- * via AndroidView. This preserves the optimized bitmap scrolling and JNI FFT
- * rendering while providing a Compose-native chrome around it.
+ * via AndroidView.
  *
- * Audio data is fed to the views via a direct VoiceDataMonitor callback
- * registered with HamRecorder, bypassing LiveData and Compose state. This
- * mirrors how the old SpectrumFragment's LiveData observer directly called
- * drawSpectrum(). Going through Compose state doesn't work reliably because
- * VoiceDataMonitor reuses the same float[] buffer and Compose's equality
- * checks can silently suppress updates.
+ * Audio data is fed to the views via observeForever on the existing
+ * SpectrumListener LiveData. The observer runs on the main thread (LiveData
+ * dispatches via Handler) and directly calls setWaveData + invalidate on the
+ * views — exactly matching the old SpectrumFragment's drawSpectrum() pattern.
  */
 @Composable
 fun WaterfallScreen(mainViewModel: MainViewModel) {
-    // Track frequency touch state
     var touchedFreqHz by remember { mutableIntStateOf(-1) }
     var frequencyLineTimeout by remember { mutableIntStateOf(0) }
 
-    // Observe decode state to control message overlay
     val isDecoding by mainViewModel.mutableIsDecoding.observeAsState(false)
-
-    // Noise suppression and message display toggles
     var deNoise by remember { mutableStateOf(mainViewModel.deNoise) }
     var showMessages by remember { mutableStateOf(mainViewModel.markMessage) }
 
-    // View references — set by factory callbacks, read by the audio monitor
-    var columnarViewRef by remember { mutableStateOf<ColumnarView?>(null) }
-    var waterfallViewRef by remember { mutableStateOf<WaterfallView?>(null) }
+    // Plain volatile refs — no Compose snapshot overhead
+    val viewHolder = remember { ViewHolder() }
 
-    // Register a direct VoiceDataMonitor with HamRecorder. The callback runs on
-    // the recording thread, computes FFT, then posts view updates to the main
-    // thread via view.post {}. This is the same pattern the old SpectrumFragment
-    // used (LiveData observer → drawSpectrum) but without LiveData in the middle.
+    // Observe SpectrumListener's LiveData with observeForever.
+    // The observer fires on the main thread every ~160ms, directly updating
+    // both views. This is the exact same pattern as the old SpectrumFragment:
+    //   spectrumListener.mutableDataBuffer.observe(...) { drawSpectrum(it) }
     DisposableEffect(Unit) {
-        mainViewModel.hamRecorder?.getVoiceData(160, false) { data ->
-            val audioCopy = data.copyOf()
-            val fft = IntArray(audioCopy.size / 2)
-            nativeFFT(audioCopy, fft, mainViewModel.deNoise)
+        val observer = Observer<FloatArray> { data ->
+            // Runs on MAIN THREAD (LiveData dispatches postValue via Handler)
+            val fft = IntArray(data.size / 2)
+            nativeFFT(data, fft, mainViewModel.deNoise)
 
-            columnarViewRef?.post {
-                val cView = columnarViewRef ?: return@post
+            viewHolder.columnar?.let { cView ->
+                frequencyLineTimeout--
+                if (frequencyLineTimeout < 0) frequencyLineTimeout = 0
+                if (frequencyLineTimeout == 0) {
+                    cView.setTouch_x(-1)
+                    viewHolder.waterfall?.setTouch_x(-1)
+                    touchedFreqHz = -1
+                }
                 cView.setWaveData(fft)
                 cView.invalidate()
             }
 
-            waterfallViewRef?.post {
-                val wView = waterfallViewRef ?: return@post
+            viewHolder.waterfall?.let { wView ->
                 val currentlyDecoding = mainViewModel.mutableIsDecoding.value ?: false
                 wView.setDrawMessage(mainViewModel.markMessage && !currentlyDecoding)
                 val messages = if (mainViewModel.markMessage) mainViewModel.currentMessages else null
@@ -97,10 +104,11 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
                 wView.invalidate()
             }
         }
+        mainViewModel.spectrumListener.mutableDataBuffer.observeForever(observer)
         onDispose {
-            // Null out view refs so the callback becomes a no-op
-            columnarViewRef = null
-            waterfallViewRef = null
+            mainViewModel.spectrumListener.mutableDataBuffer.removeObserver(observer)
+            viewHolder.columnar = null
+            viewHolder.waterfall = null
         }
     }
 
@@ -109,9 +117,7 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             .fillMaxSize()
             .background(BgApp),
     ) {
-        // Header
         TopBar(title = "Waterfall") {
-            // Frequency display
             val freqText = if (touchedFreqHz > 0) {
                 "$touchedFreqHz Hz"
             } else {
@@ -126,9 +132,9 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             )
         }
 
-        // Spectrum strip (columnar view) — live bar chart
+        // Spectrum strip (columnar view)
         ColumnarStrip(
-            onViewCreated = { columnarViewRef = it },
+            onViewCreated = { viewHolder.columnar = it },
             onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
                 frequencyLineTimeout = 60
@@ -144,7 +150,6 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
                 .height(56.dp),
         )
 
-        // Frequency ruler labels
         FrequencyRuler(
             modifier = Modifier
                 .fillMaxWidth()
@@ -156,7 +161,7 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
         WaterfallCanvas(
             showMessages = showMessages,
             isDecoding = isDecoding,
-            onViewCreated = { waterfallViewRef = it },
+            onViewCreated = { viewHolder.waterfall = it },
             onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
                 frequencyLineTimeout = 60
@@ -180,7 +185,6 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
                 .padding(horizontal = 12.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // UTC time
             Text(
                 text = UtcTimer.getTimeStr(UtcTimer.getSystemTime()),
                 color = TextMuted,
@@ -190,7 +194,6 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 
             Spacer(modifier = Modifier.width(12.dp))
 
-            // Noise filter toggle chip
             ToggleChip(
                 label = "NR",
                 active = deNoise,
@@ -202,7 +205,6 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 
             Spacer(modifier = Modifier.width(8.dp))
 
-            // Message overlay toggle chip
             ToggleChip(
                 label = "MSG",
                 active = showMessages,
@@ -214,7 +216,6 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 
             Spacer(modifier = Modifier.weight(1f))
 
-            // Live indicator
             Text(
                 text = "LIVE",
                 color = StatusConfirmed,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -25,8 +25,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Observer
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,6 +47,13 @@ import radio.ks3ckc.ft8us.ui.components.TopBar
  * Waterfall screen wrapping the existing Java WaterfallView and ColumnarView
  * via AndroidView. This preserves the optimized bitmap scrolling and JNI FFT
  * rendering while providing a Compose-native chrome around it.
+ *
+ * Audio data is fed to the views via a direct VoiceDataMonitor callback
+ * registered with HamRecorder, bypassing LiveData and Compose state. This
+ * mirrors how the old SpectrumFragment's LiveData observer directly called
+ * drawSpectrum(). Going through Compose state doesn't work reliably because
+ * VoiceDataMonitor reuses the same float[] buffer and Compose's equality
+ * checks can silently suppress updates.
  */
 @Composable
 fun WaterfallScreen(mainViewModel: MainViewModel) {
@@ -56,29 +61,48 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
     var touchedFreqHz by remember { mutableIntStateOf(-1) }
     var frequencyLineTimeout by remember { mutableIntStateOf(0) }
 
-    // Observe spectrum data from the recorder.
-    // VoiceDataMonitor reuses the same float[] buffer, so LiveData posts the same
-    // reference each cycle. Compose's observeAsState() uses reference equality for
-    // FloatArray and would skip recomposition. We manually observe and copyOf() to
-    // ensure a new reference triggers recomposition every time.
-    var spectrumData by remember { mutableStateOf<FloatArray?>(null) }
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = Observer<FloatArray> { data ->
-            spectrumData = data.copyOf()
-        }
-        mainViewModel.spectrumListener.mutableDataBuffer.observe(lifecycleOwner, observer)
-        onDispose {
-            mainViewModel.spectrumListener.mutableDataBuffer.removeObserver(observer)
-        }
-    }
-
     // Observe decode state to control message overlay
     val isDecoding by mainViewModel.mutableIsDecoding.observeAsState(false)
 
     // Noise suppression and message display toggles
     var deNoise by remember { mutableStateOf(mainViewModel.deNoise) }
     var showMessages by remember { mutableStateOf(mainViewModel.markMessage) }
+
+    // View references — set by factory callbacks, read by the audio monitor
+    var columnarViewRef by remember { mutableStateOf<ColumnarView?>(null) }
+    var waterfallViewRef by remember { mutableStateOf<WaterfallView?>(null) }
+
+    // Register a direct VoiceDataMonitor with HamRecorder. The callback runs on
+    // the recording thread, computes FFT, then posts view updates to the main
+    // thread via view.post {}. This is the same pattern the old SpectrumFragment
+    // used (LiveData observer → drawSpectrum) but without LiveData in the middle.
+    DisposableEffect(Unit) {
+        mainViewModel.hamRecorder?.getVoiceData(160, false) { data ->
+            val audioCopy = data.copyOf()
+            val fft = IntArray(audioCopy.size / 2)
+            nativeFFT(audioCopy, fft, mainViewModel.deNoise)
+
+            columnarViewRef?.post {
+                val cView = columnarViewRef ?: return@post
+                cView.setWaveData(fft)
+                cView.invalidate()
+            }
+
+            waterfallViewRef?.post {
+                val wView = waterfallViewRef ?: return@post
+                val currentlyDecoding = mainViewModel.mutableIsDecoding.value ?: false
+                wView.setDrawMessage(mainViewModel.markMessage && !currentlyDecoding)
+                val messages = if (mainViewModel.markMessage) mainViewModel.currentMessages else null
+                wView.setWaveData(fft, UtcTimer.getNowSequential(), messages)
+                wView.invalidate()
+            }
+        }
+        onDispose {
+            // Null out view refs so the callback becomes a no-op
+            columnarViewRef = null
+            waterfallViewRef = null
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -104,30 +128,17 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 
         // Spectrum strip (columnar view) — live bar chart
         ColumnarStrip(
-            mainViewModel = mainViewModel,
-            spectrumData = spectrumData,
-            deNoise = deNoise,
-            touchedFreqHz = touchedFreqHz,
-            frequencyLineTimeout = frequencyLineTimeout,
-            onTouch = { freqHz, x ->
+            onViewCreated = { columnarViewRef = it },
+            onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
                 frequencyLineTimeout = 60
             },
             onTouchUp = { freqHz ->
                 if (freqHz > 0 && !GeneralVariables.synFrequency) {
-                    mainViewModel.databaseOpr.writeConfig(
-                        "freq",
-                        freqHz.toString(),
-                        null,
-                    )
+                    mainViewModel.databaseOpr.writeConfig("freq", freqHz.toString(), null)
                     GeneralVariables.setBaseFrequency(freqHz.toFloat())
                 }
             },
-            onFrequencyTimeout = {
-                touchedFreqHz = -1
-                frequencyLineTimeout = 0
-            },
-            onTimeoutTick = { frequencyLineTimeout = it },
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp),
@@ -143,31 +154,19 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 
         // Main waterfall display
         WaterfallCanvas(
-            mainViewModel = mainViewModel,
-            spectrumData = spectrumData,
-            isDecoding = isDecoding,
             showMessages = showMessages,
-            touchedFreqHz = touchedFreqHz,
-            frequencyLineTimeout = frequencyLineTimeout,
-            onTouch = { freqHz, x ->
+            isDecoding = isDecoding,
+            onViewCreated = { waterfallViewRef = it },
+            onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
                 frequencyLineTimeout = 60
             },
             onTouchUp = { freqHz ->
                 if (freqHz > 0 && !GeneralVariables.synFrequency) {
-                    mainViewModel.databaseOpr.writeConfig(
-                        "freq",
-                        freqHz.toString(),
-                        null,
-                    )
+                    mainViewModel.databaseOpr.writeConfig("freq", freqHz.toString(), null)
                     GeneralVariables.setBaseFrequency(freqHz.toFloat())
                 }
             },
-            onFrequencyTimeout = {
-                touchedFreqHz = -1
-                frequencyLineTimeout = 0
-            },
-            onTimeoutTick = { frequencyLineTimeout = it },
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
@@ -234,19 +233,11 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 @SuppressLint("ClickableViewAccessibility")
 @Composable
 private fun ColumnarStrip(
-    mainViewModel: MainViewModel,
-    spectrumData: FloatArray?,
-    deNoise: Boolean,
-    touchedFreqHz: Int,
-    frequencyLineTimeout: Int,
+    onViewCreated: (ColumnarView) -> Unit,
     onTouch: (freqHz: Int, x: Int) -> Unit,
     onTouchUp: (freqHz: Int) -> Unit,
-    onFrequencyTimeout: () -> Unit,
-    onTimeoutTick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var columnarViewRef by remember { mutableStateOf<ColumnarView?>(null) }
-
     AndroidView(
         factory = { context ->
             ColumnarView(context).apply {
@@ -272,43 +263,11 @@ private fun ColumnarStrip(
                     true
                 }
 
-                columnarViewRef = this
-            }
-        },
-        update = { view ->
-            spectrumData?.let { data ->
-                val fft = IntArray(data.size / 2)
-                nativeFFT(data, fft, deNoise)
-
-                var timeout = frequencyLineTimeout - 1
-                if (timeout < 0) timeout = 0
-                onTimeoutTick(timeout)
-                if (timeout == 0) {
-                    view.setTouch_x(-1)
-                    onFrequencyTimeout()
-                }
-
-                view.setWaveData(fft)
-                view.invalidate()
+                onViewCreated(this)
             }
         },
         modifier = modifier,
     )
-
-    DisposableEffect(Unit) {
-        onDispose {
-            columnarViewRef = null
-        }
-    }
-}
-
-private fun wfLog(msg: String) {
-    try {
-        val ctx = GeneralVariables.getMainContext() ?: return
-        val dir = ctx.getExternalFilesDir(null) ?: return
-        val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
-        File(dir, "debug.log").appendText("$ts $msg\n")
-    } catch (_: Exception) {}
 }
 
 // ---------------------------------------------------------------------------
@@ -318,20 +277,13 @@ private fun wfLog(msg: String) {
 @SuppressLint("ClickableViewAccessibility")
 @Composable
 private fun WaterfallCanvas(
-    mainViewModel: MainViewModel,
-    spectrumData: FloatArray?,
-    isDecoding: Boolean,
     showMessages: Boolean,
-    touchedFreqHz: Int,
-    frequencyLineTimeout: Int,
+    isDecoding: Boolean,
+    onViewCreated: (WaterfallView) -> Unit,
     onTouch: (freqHz: Int, x: Int) -> Unit,
     onTouchUp: (freqHz: Int) -> Unit,
-    onFrequencyTimeout: () -> Unit,
-    onTimeoutTick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var waterfallViewRef by remember { mutableStateOf<WaterfallView?>(null) }
-
     AndroidView(
         factory = { context ->
             WaterfallView(context).apply {
@@ -357,30 +309,14 @@ private fun WaterfallCanvas(
                     true
                 }
 
-                waterfallViewRef = this
+                onViewCreated(this)
             }
         },
         update = { view ->
             view.setDrawMessage(showMessages && !isDecoding)
-
-            val sd = spectrumData
-            if (sd != null) {
-                val fft = IntArray(sd.size / 2)
-                nativeFFT(sd, fft, mainViewModel.deNoise)
-
-                val messages = if (showMessages) mainViewModel.currentMessages else null
-                view.setWaveData(fft, UtcTimer.getNowSequential(), messages)
-                view.invalidate()
-            }
         },
         modifier = modifier,
     )
-
-    DisposableEffect(Unit) {
-        onDispose {
-            waterfallViewRef = null
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -437,6 +373,15 @@ private fun ToggleChip(
 // ---------------------------------------------------------------------------
 // Native FFT bridge — delegates to SpectrumFragment's JNI methods
 // ---------------------------------------------------------------------------
+
+private fun wfLog(msg: String) {
+    try {
+        val ctx = GeneralVariables.getMainContext() ?: return
+        val dir = ctx.getExternalFilesDir(null) ?: return
+        val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+        File(dir, "debug.log").appendText("$ts $msg\n")
+    } catch (_: Exception) {}
+}
 
 /**
  * Singleton FFT bridge. The native methods are bound to SpectrumFragment's


### PR DESCRIPTION
## Summary

- **Fix waterfall rendering** by eliminating Compose layout thrashing — `invalidate()` in `onDraw()` caused `onSizeChanged` to fire ~170 times in 10 seconds, wiping the bitmap on every call
- **Fix waterfall update rate** by replacing LiveData `postValue()` (which coalesces updates) with `Handler.post + setValue` for guaranteed ~6 Hz delivery
- **Fix spectrum data flow** by using `observeForever` on SpectrumListener LiveData, bypassing Compose state/recomposition overhead
- **Fix USB audio input** with proper device enumeration, reinitialize lifecycle, and PCM format handling
- **Fix CAT serial control** for FT-891 data mode configuration
- **Add rig/audio device pickers** to Compose Settings screen

## Test plan
- [ ] Launch app, switch to Waterfall tab — verify spectrum bars and scrolling waterfall render correctly
- [ ] Verify waterfall accumulates data over time (not blank/black)
- [ ] Verify FT8 message overlays appear on waterfall when MSG is toggled on
- [ ] Test USB audio input with external radio
- [ ] Test CAT control with FT-891 or similar rig
- [ ] Verify Settings screen rig model and audio device pickers work

🤖 Generated with [Claude Code](https://claude.com/claude-code)