### PR TITLE
Fix TX marker alignment and frequency display

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -180,6 +180,10 @@ public class GeneralVariables {
     public static boolean alc_switch_on = true;//ALC alarm switch
 
     public static MutableLiveData<Float> mutableBaseFrequency = new MutableLiveData<>();
+
+    private static int spectrumWidth = 3500;//Spectrum display width in Hz
+    public static MutableLiveData<Integer> mutableSpectrumWidth = new MutableLiveData<>();
+
     public static String cloudlogServerAddress = "";//Cloudlog server address
     public static String cloudlogApiKey = "";//Cloudlog API key
     public static String cloudlogStationID = "";//Cloudlog station ID
@@ -237,6 +241,15 @@ public class GeneralVariables {
     public static void setBaseFrequency(float baseFrequency) {
         mutableBaseFrequency.postValue(baseFrequency);
         GeneralVariables.baseFrequency = baseFrequency;
+    }
+
+    public static int getSpectrumWidth() {
+        return spectrumWidth;
+    }
+
+    public static void setSpectrumWidth(int width) {
+        mutableSpectrumWidth.postValue(width);
+        GeneralVariables.spectrumWidth = width;
     }
 
     public static String getCloudlogServerAddress() {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainActivity.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainActivity.java
@@ -29,6 +29,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -553,6 +554,32 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+            float newVol = Math.min(GeneralVariables.volumePercent + 0.05f, 1.0f);
+            GeneralVariables.volumePercent = newVol;
+            GeneralVariables.mutableVolumePercent.postValue(newVol);
+            int intVal = (int) (newVol * 100);
+            mainViewModel.databaseOpr.writeConfig("volumeValue", String.valueOf(intVal), null);
+            if (mainViewModel.baseRig != null && mainViewModel.baseRig.getConnector() != null) {
+                mainViewModel.baseRig.getConnector().setRFVolume(intVal);
+            }
+            return true;
+        } else if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+            float newVol = Math.max(GeneralVariables.volumePercent - 0.05f, 0.0f);
+            GeneralVariables.volumePercent = newVol;
+            GeneralVariables.mutableVolumePercent.postValue(newVol);
+            int intVal = (int) (newVol * 100);
+            mainViewModel.databaseOpr.writeConfig("volumeValue", String.valueOf(intVal), null);
+            if (mainViewModel.baseRig != null && mainViewModel.baseRig.getConnector() != null) {
+                mainViewModel.baseRig.getConnector().setRFVolume(intVal);
+            }
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
+    }
 
     /**
      * Display serial port device list.

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2245,6 +2245,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("alcSwitch")) {
                     GeneralVariables.alc_switch_on = result.equals("1");
                 }
+                if (name.equalsIgnoreCase("spectrumWidth")) {
+                    GeneralVariables.setSpectrumWidth(result.equals("") ? 3500 : Integer.parseInt(result));
+                }
 
             }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/GenerateFT8.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/GenerateFT8.java
@@ -38,6 +38,9 @@ public class GenerateFT8 {
 
 
     public static int checkI3ByCallsign(String callsign) {
+        if (callsign == null || callsign.length() < 2) {
+            return 0;
+        }
         String substring = callsign.substring(callsign.length() - 2);
         if (substring.equals("/P")) {
             if (callsign.length() <= 8) {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
@@ -14,6 +14,8 @@ import android.graphics.Shader;
 import android.util.AttributeSet;
 import android.view.View;
 
+import com.bg7yoz.ft8cn.GeneralVariables;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -84,12 +86,18 @@ public class ColumnarView extends View {
         if (data.length <= 0) {
             return;
         }
-        width = getWidth() / (data.length / 2);// 960/2=480, 480 is reasonable; 906 cannot be displayed.
+        // Calculate how many FFT bins correspond to spectrumWidth Hz.
+        // The full data array covers 0 to Nyquist (sampleRate/2).
+        float nyquist = GeneralVariables.audioSampleRate / 2f;
+        int binsToShow = Math.min(data.length, Math.round((float) spectrumWidth / nyquist * data.length));
+        if (binsToShow <= 0) binsToShow = data.length / 2;
+
+        width = getWidth() / binsToShow;
         if (drawblock) {// Whether to show the peak block
             if (newData.size() > 0) {
                 if (blockData.size() == 0 || newData.size() != blockData.size()) {
                     blockData.clear();
-                    for (int i = 0; i < data.length / 2; i++) {
+                    for (int i = 0; i < binsToShow; i++) {
                         Rect blockRect = new Rect();
                         blockRect.top =getHeight()- blockHeight;
                         blockRect.bottom = getHeight();
@@ -110,14 +118,15 @@ public class ColumnarView extends View {
         }
         newData.clear();
         float rateHeight =  0.95f * getHeight() / 256;// 0.95 is the ratio; max bar height does not exceed 95%
-        for (int i = 0; i < data.length / 2; i++) {
+        for (int i = 0; i < binsToShow; i++) {
             Rect colRect = new Rect();
             if (newData.size() == 0) {
                 colRect.left = 0;
             } else {
-                colRect.left = i * getWidth() / (data.length / 2);
+                colRect.left = i * getWidth() / binsToShow;
             }
-            colRect.top = getHeight() - Math.round(Math.max(data[i], data[i + 1]) * rateHeight);
+            int val = (i + 1 < data.length) ? Math.max(data[i], data[i + 1]) : data[i];
+            colRect.top = getHeight() - Math.round(val * rateHeight);
             colRect.right = colRect.left + width - spacing;
             colRect.bottom = getHeight();
             newData.add(colRect);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
@@ -24,6 +24,8 @@ import java.util.List;
  */
 public class ColumnarView extends View {
     private static final String TAG = "ColumnarView";
+    private static final float FT8_SIGNAL_BANDWIDTH_HZ = 50f;
+
     // Width of each bar
     private int width;
     // Spacing between each bar
@@ -40,12 +42,19 @@ public class ColumnarView extends View {
     private final List<Rect> newData = new ArrayList<>();
     private final List<Rect> blockData = new ArrayList<>();
 
+    private int spectrumWidth = 3500;//Spectrum display width in Hz
+
     private Bitmap lastBitMap=null;
     private Canvas _canvas;
     private Paint linePaint;
     private int touch_x = -1;
     private Paint touchPaint;
     private int freq_hz=-1;
+
+    // TX frequency marker overlay
+    private float txFrequency = -1f;
+    private boolean txActive = false;
+    private final Paint txMarkerPaint = new Paint();
 
     public void setBlockSpeed(int blockSpeed) {
         this.blockSpeed = blockSpeed;
@@ -132,6 +141,9 @@ public class ColumnarView extends View {
         touchPaint = new Paint();
         touchPaint.setColor(0xff00ffff);
         touchPaint.setStrokeWidth(2);
+
+        txMarkerPaint.setStrokeWidth(1.5f * getResources().getDisplayMetrics().density);
+        txMarkerPaint.setStyle(Paint.Style.STROKE);
     }
 
     @Override
@@ -149,9 +161,21 @@ public class ColumnarView extends View {
         canvas.drawBitmap(lastBitMap,0,0,null);
         if (touch_x>0) {
             // Calculate frequency
-            freq_hz = Math.round(3000f * (float) touch_x / (float) getWidth());
+            freq_hz = Math.round((float) spectrumWidth * (float) touch_x / (float) getWidth());
             canvas.drawLine(touch_x, 0, touch_x, getHeight(), touchPaint);
         }
+
+        // Draw TX frequency marker lines
+        if (txFrequency > 0 && getWidth() > 0) {
+            txMarkerPaint.setColor(0xFFEF4444);
+            float freqWidth = (float) getWidth() / spectrumWidth;
+            float halfBw = FT8_SIGNAL_BANDWIDTH_HZ / 2f;
+            float x1 = (txFrequency - halfBw) * freqWidth;
+            float x2 = (txFrequency + halfBw) * freqWidth;
+            canvas.drawLine(x1, 0, x1, getHeight(), txMarkerPaint);
+            canvas.drawLine(x2, 0, x2, getHeight(), txMarkerPaint);
+        }
+
         // Do NOT call invalidate() here — the view is invalidated externally
         // when new data arrives. Self-invalidation causes layout thrashing
         // in Compose's AndroidView.
@@ -162,5 +186,17 @@ public class ColumnarView extends View {
 
     public int getFreq_hz() {
         return freq_hz;
+    }
+
+    public void setTxFrequency(float freq) {
+        this.txFrequency = freq;
+    }
+
+    public void setTxActive(boolean active) {
+        this.txActive = active;
+    }
+
+    public void setSpectrumWidth(int width) {
+        this.spectrumWidth = width;
     }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/SpectrumFragment.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/SpectrumFragment.java
@@ -186,9 +186,9 @@ public class SpectrumFragment extends Fragment {
         }
         binding.columnarView.setWaveData(fft);
         if (mainViewModel.markMessage) {//Whether to mark messages
-            binding.waterfallView.setWaveData(fft, UtcTimer.getNowSequential(), mainViewModel.currentMessages);
+            binding.waterfallView.setWaveData(fft, mainViewModel.currentMessages);
         } else {
-            binding.waterfallView.setWaveData(fft, UtcTimer.getNowSequential(), null);
+            binding.waterfallView.setWaveData(fft, null);
         }
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/SpectrumView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/SpectrumView.java
@@ -190,9 +190,9 @@ public class SpectrumView extends ConstraintLayout {
         }
         columnarView.setWaveData(fft);
         if (mainViewModel.markMessage) {//Whether to mark messages
-            waterfallView.setWaveData(fft, UtcTimer.getNowSequential(), mainViewModel.currentMessages);
+            waterfallView.setWaveData(fft, mainViewModel.currentMessages);
         } else {
-            waterfallView.setWaveData(fft, UtcTimer.getNowSequential(), null);
+            waterfallView.setWaveData(fft, null);
         }
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -27,7 +27,7 @@ import androidx.annotation.Nullable;
 
 import com.bg7yoz.ft8cn.Ft8Message;
 import com.bg7yoz.ft8cn.GeneralVariables;
-import com.bg7yoz.ft8cn.timer.UtcTimer;
+
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,11 +36,13 @@ import java.util.List;
 import java.util.ListIterator;
 
 public class WaterfallView extends View {
+    private static final float FT8_SIGNAL_BANDWIDTH_HZ = 50f;
+
     private int blockHeight = 2;//Color block height
     private float freq_width = 1;//Frequency width
     private final int cycle = 2;
     private final int symbols = 93;
-    private int lastSequential = 0;
+    private int spectrumWidth = 3500;//Spectrum display width in Hz
     private Bitmap lastBitMap = null;
     private Canvas _canvas;
     private final Paint linePaint = new Paint();
@@ -62,6 +64,11 @@ public class WaterfallView extends View {
     // Track the bitmap dimensions to avoid recreating on minor layout changes
     private int bitmapWidth = 0;
     private int bitmapHeight = 0;
+
+    // TX frequency marker overlay
+    private float txFrequency = -1f;
+    private boolean txActive = false;
+    private final Paint txMarkerPaint = new Paint();
 
     public WaterfallView(Context context) {
         super(context);
@@ -104,7 +111,7 @@ public class WaterfallView extends View {
         bitmapHeight = h;
         blockHeight = h / (symbols * cycle);
         if (blockHeight < 1) blockHeight = 1;
-        freq_width = (float) w / 3000f;
+        freq_width = (float) w / spectrumWidth;
         lastBitMap = Bitmap.createBitmap(w, h, ARGB_8888);
         _canvas = new Canvas(lastBitMap);
         Paint blackPaint = new Paint();
@@ -169,6 +176,9 @@ public class WaterfallView extends View {
             pathEnd = 130 * getResources().getDisplayMetrics().density;
         }
 
+        txMarkerPaint.setStrokeWidth(1.5f * getResources().getDisplayMetrics().density);
+        txMarkerPaint.setStyle(Paint.Style.STROKE);
+
         super.onSizeChanged(w, h, oldw, oldh);
 
     }
@@ -180,11 +190,21 @@ public class WaterfallView extends View {
         if (lastBitMap == null) return;
         canvas.drawBitmap(lastBitMap, 0, 0, null);
 
+        // Draw TX frequency marker lines
+        if (txFrequency > 0 && freq_width > 0) {
+            txMarkerPaint.setColor(0xFFEF4444);
+            float halfBw = FT8_SIGNAL_BANDWIDTH_HZ / 2f;
+            float x1 = (txFrequency - halfBw) * freq_width;
+            float x2 = (txFrequency + halfBw) * freq_width;
+            canvas.drawLine(x1, 0, x1, getHeight(), txMarkerPaint);
+            canvas.drawLine(x2, 0, x2, getHeight(), txMarkerPaint);
+        }
+
         //Calculate frequency
         if (touch_x > 0) {//Draw touch line
-            freq_hz = Math.round(3000f * (float) touch_x / (float) getWidth());
-            if (freq_hz > 2900) {
-                freq_hz = 2900;
+            freq_hz = Math.round((float) spectrumWidth * (float) touch_x / (float) getWidth());
+            if (freq_hz > spectrumWidth - 100) {
+                freq_hz = spectrumWidth - 100;
             }
             if (freq_hz < 100) {
                 freq_hz = 100;
@@ -209,7 +229,7 @@ public class WaterfallView extends View {
         // repeatedly and wipe all accumulated waterfall data.
     }
 
-    public void setWaveData(int[] data, int sequential, List<Ft8Message> msgs) {
+    public void setWaveData(int[] data, List<Ft8Message> msgs) {
         if (drawMessage&& msgs!=null){//Copy messages to draw to prevent multi-thread access conflicts
             messages=new ArrayList<>(msgs);
         }else {
@@ -232,20 +252,6 @@ public class WaterfallView extends View {
         int drawHeight = bitmapHeight;
 
         int[] colors = new int[data.length];
-
-        //Draw divider line
-        if (sequential != lastSequential) {
-            Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, drawHeight - blockHeight);
-            _canvas.drawBitmap(bitmap, 0, blockHeight, null);
-            bitmap.recycle();
-            _canvas.drawRect(0, 0, drawWidth, getResources().getDisplayMetrics().density
-                    , linePaint);
-            _canvas.drawText(UtcTimer.getTimeStr(UtcTimer.getSystemTime()), 50
-                    , 15 * getResources().getDisplayMetrics().density, utcPainBack);
-            _canvas.drawText(UtcTimer.getTimeStr(UtcTimer.getSystemTime()), 50
-                    , 15 * getResources().getDisplayMetrics().density, utcPaint);
-        }
-        lastSequential = sequential;
 
         //Color block distribution
         for (int i = 0; i < data.length; i++) {
@@ -318,5 +324,20 @@ public class WaterfallView extends View {
 
     public int getFreq_hz() {
         return freq_hz;
+    }
+
+    public void setTxFrequency(float freq) {
+        this.txFrequency = freq;
+    }
+
+    public void setTxActive(boolean active) {
+        this.txActive = active;
+    }
+
+    public void setSpectrumWidth(int width) {
+        this.spectrumWidth = width;
+        if (bitmapWidth > 0) {
+            freq_width = (float) bitmapWidth / spectrumWidth;
+        }
     }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -266,7 +266,12 @@ public class WaterfallView extends View {
                 colors[i] = 0xff00ffff | (((data[i] - 127)) << 18);//Amplify 4x
             }
         }
-        LinearGradient linearGradient = new LinearGradient(0, 0, drawWidth * 2, 0, colors
+        // Scale gradient so the visible portion (0..drawWidth) maps to 0..spectrumWidth Hz.
+        // The FFT data covers 0 to Nyquist (sampleRate/2). We want spectrumWidth Hz
+        // to fill the view, so the full gradient length = drawWidth * (Nyquist / spectrumWidth).
+        float nyquist = GeneralVariables.audioSampleRate / 2f;
+        float gradientScale = nyquist / spectrumWidth;
+        LinearGradient linearGradient = new LinearGradient(0, 0, drawWidth * gradientScale, 0, colors
                 , null, Shader.TileMode.CLAMP);
         linearPaint.setShader(linearGradient);
         Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, drawHeight - blockHeight);

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -12,6 +12,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
@@ -356,6 +357,30 @@ class ComposeMainActivity : ComponentActivity() {
             File(dir, "debug.log").appendText("$ts $msg\n")
         } catch (_: Exception) {}
         Log.d(TAG, msg)
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        when (keyCode) {
+            KeyEvent.KEYCODE_VOLUME_UP -> {
+                val newVol = (GeneralVariables.volumePercent + 0.05f).coerceAtMost(1.0f)
+                GeneralVariables.volumePercent = newVol
+                GeneralVariables.mutableVolumePercent.postValue(newVol)
+                val intVal = (newVol * 100).toInt()
+                mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
+                mainViewModel.baseRig?.connector?.setRFVolume(intVal)
+                return true
+            }
+            KeyEvent.KEYCODE_VOLUME_DOWN -> {
+                val newVol = (GeneralVariables.volumePercent - 0.05f).coerceAtLeast(0.0f)
+                GeneralVariables.volumePercent = newVol
+                GeneralVariables.mutableVolumePercent.postValue(newVol)
+                val intVal = (newVol * 100).toInt()
+                mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
+                mainViewModel.baseRig?.connector?.setRFVolume(intVal)
+                return true
+            }
+            else -> return super.onKeyDown(keyCode, event)
+        }
     }
 
     private fun closeApp() {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -359,24 +359,30 @@ class ComposeMainActivity : ComponentActivity() {
         Log.d(TAG, msg)
     }
 
+    private var volumeToast: android.widget.Toast? = null
+
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         when (keyCode) {
-            KeyEvent.KEYCODE_VOLUME_UP -> {
-                val newVol = (GeneralVariables.volumePercent + 0.05f).coerceAtMost(1.0f)
+            KeyEvent.KEYCODE_VOLUME_UP, KeyEvent.KEYCODE_VOLUME_DOWN -> {
+                val delta = if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) 0.05f else -0.05f
+                val newVol = (GeneralVariables.volumePercent + delta).coerceIn(0.0f, 1.0f)
                 GeneralVariables.volumePercent = newVol
                 GeneralVariables.mutableVolumePercent.postValue(newVol)
                 val intVal = (newVol * 100).toInt()
                 mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(intVal)
-                return true
-            }
-            KeyEvent.KEYCODE_VOLUME_DOWN -> {
-                val newVol = (GeneralVariables.volumePercent - 0.05f).coerceAtLeast(0.0f)
-                GeneralVariables.volumePercent = newVol
-                GeneralVariables.mutableVolumePercent.postValue(newVol)
-                val intVal = (newVol * 100).toInt()
-                mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
-                mainViewModel.baseRig?.connector?.setRFVolume(intVal)
+
+                // Also adjust system music stream so audio is actually audible
+                val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                val maxVol = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+                val systemVol = (newVol * maxVol).toInt().coerceIn(0, maxVol)
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, systemVol, 0)
+
+                // Show volume toast
+                volumeToast?.cancel()
+                volumeToast = android.widget.Toast.makeText(this, "TX Volume: $intVal%", android.widget.Toast.LENGTH_SHORT)
+                volumeToast?.show()
+
                 return true
             }
             else -> return super.onKeyDown(keyCode, event)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -13,6 +14,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.database.OperationBand
@@ -28,6 +30,7 @@ import radio.ks3ckc.ft8us.ui.waterfall.WaterfallScreen
 
 @Composable
 fun FT8USApp(mainViewModel: MainViewModel) {
+    val context = LocalContext.current
     var activeTab by rememberSaveable { mutableStateOf(FT8USTab.DECODE) }
 
     // Observe transmit state
@@ -76,8 +79,12 @@ fun FT8USApp(mainViewModel: MainViewModel) {
             bandLabel = bandLabel,
             frequencyMhz = frequencyMhz,
             onCallCQ = {
-                mainViewModel.ft8TransmitSignal.resetToCQ()
-                mainViewModel.ft8TransmitSignal.setActivated(true)
+                if (GeneralVariables.myCallsign.isNullOrEmpty()) {
+                    Toast.makeText(context, "Set your callsign in Settings before calling CQ", Toast.LENGTH_SHORT).show()
+                } else {
+                    mainViewModel.ft8TransmitSignal.resetToCQ()
+                    mainViewModel.ft8TransmitSignal.setActivated(true)
+                }
             },
             onStop = {
                 mainViewModel.ft8TransmitSignal.setActivated(false)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -32,6 +32,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
 
     // Observe transmit state
     val isTransmitting by mainViewModel.ft8TransmitSignal.mutableIsTransmitting.observeAsState(false)
+    val isActivated by mainViewModel.ft8TransmitSignal.mutableIsActivated.observeAsState(false)
 
     // Derive band/frequency from GeneralVariables
     val bandIndex by GeneralVariables.mutableBandChange.observeAsState(GeneralVariables.bandListIndex)
@@ -71,8 +72,16 @@ fun FT8USApp(mainViewModel: MainViewModel) {
         // TX status strip — always visible above tab bar
         TxStrip(
             isTransmitting = isTransmitting,
+            isActivated = isActivated,
             bandLabel = bandLabel,
             frequencyMhz = frequencyMhz,
+            onCallCQ = {
+                mainViewModel.ft8TransmitSignal.resetToCQ()
+                mainViewModel.ft8TransmitSignal.setActivated(true)
+            },
+            onStop = {
+                mainViewModel.ft8TransmitSignal.setActivated(false)
+            },
         )
 
         // Bottom tab bar

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -48,7 +48,8 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     } else {
         GeneralVariables.getBandString()
     }
-    val frequencyMhz = GeneralVariables.getBaseFrequencyStr()
+    val baseFreq by GeneralVariables.mutableBaseFrequency.observeAsState(GeneralVariables.getBaseFrequency())
+    val frequencyMhz = String.format("%.0f", baseFreq ?: GeneralVariables.getBaseFrequency())
 
     Column(
         modifier = Modifier

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,8 +32,11 @@ import radio.ks3ckc.ft8us.theme.*
 @Composable
 fun TxStrip(
     isTransmitting: Boolean,
+    isActivated: Boolean,
     bandLabel: String,
     frequencyMhz: String,
+    onCallCQ: () -> Unit,
+    onStop: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val bgColor = if (isTransmitting) {
@@ -86,11 +91,34 @@ fun TxStrip(
             )
         }
 
-        // Right: frequency
+        // Right: CQ/Stop button + frequency
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            // CQ / Stop pill button
+            val buttonBg = if (isActivated) StatusBad.copy(alpha = 0.18f) else AccentSoft
+            val buttonTextColor = if (isActivated) StatusBad else Accent
+            val buttonLabel = if (isActivated) "STOP" else "CQ"
+
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(buttonBg)
+                    .clickable { if (isActivated) onStop() else onCallCQ() }
+                    .padding(horizontal = 28.dp, vertical = 12.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = buttonLabel,
+                    color = buttonTextColor,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.04.sp,
+                )
+            }
+
             Text(
                 text = frequencyMhz,
                 color = Accent,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -124,6 +124,7 @@ fun SettingsScreen(
     var showAudioInputPicker by remember { mutableStateOf(false) }
     var showAudioOutputPicker by remember { mutableStateOf(false) }
     var showBaudRatePicker by remember { mutableStateOf(false) }
+    var showTxVolume by remember { mutableStateOf(false) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -140,6 +141,16 @@ fun SettingsScreen(
     var modelNo by remember { mutableIntStateOf(GeneralVariables.modelNo) }
     var baudRate by remember { mutableIntStateOf(GeneralVariables.baudRate) }
     var spectrumWidth by remember { mutableIntStateOf(GeneralVariables.getSpectrumWidth()) }
+
+    // TX Volume state – observe LiveData so hardware button changes update the UI
+    val volumeLive by GeneralVariables.mutableVolumePercent.observeAsState(
+        GeneralVariables.volumePercent,
+    )
+    var txVolume by remember { mutableIntStateOf((GeneralVariables.volumePercent * 100).toInt()) }
+    // Keep txVolume in sync when hardware buttons (or other sources) update the LiveData
+    LaunchedEffect(volumeLive) {
+        txVolume = ((volumeLive ?: GeneralVariables.volumePercent) * 100).toInt()
+    }
 
     // Derived display strings
     val callsign = callsignState
@@ -407,6 +418,27 @@ fun SettingsScreen(
                 mainViewModel.databaseOpr.writeConfig(
                     "noReplyLimit", index.toString(), null,
                 )
+            },
+        )
+    }
+
+    // -- TX Volume Editor --
+    if (showTxVolume) {
+        NumberInputDialog(
+            title = "TX Volume",
+            suffix = "%",
+            initialValue = txVolume,
+            min = 0,
+            max = 100,
+            onDismiss = { showTxVolume = false },
+            onSave = { value ->
+                showTxVolume = false
+                val clamped = value.coerceIn(0, 100)
+                txVolume = clamped
+                GeneralVariables.volumePercent = clamped / 100f
+                GeneralVariables.mutableVolumePercent.postValue(clamped / 100f)
+                mainViewModel.databaseOpr.writeConfig("volumeValue", clamped.toString(), null)
+                mainViewModel.baseRig?.connector?.setRFVolume(clamped)
             },
         )
     }
@@ -795,6 +827,14 @@ fun SettingsScreen(
                             else "$noReplyLimit tries",
                             showChevron = true,
                             onClick = { showStopAfter = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "TX Volume",
+                            description = "Transmit audio level (hardware buttons ±5%)",
+                            value = "$txVolume%",
+                            showChevron = true,
+                            onClick = { showTxVolume = true },
                         )
                     }
                 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -112,6 +112,7 @@ fun SettingsScreen(
     var showConnectionMode by remember { mutableStateOf(false) }
     var showBandPicker by remember { mutableStateOf(false) }
     var showAudioFreq by remember { mutableStateOf(false) }
+    var showSpectrumWidth by remember { mutableStateOf(false) }
     var showWatchdog by remember { mutableStateOf(false) }
     var showStopAfter by remember { mutableStateOf(false) }
     var showPttDelay by remember { mutableStateOf(false) }
@@ -138,6 +139,7 @@ fun SettingsScreen(
     var controlMode by remember { mutableIntStateOf(GeneralVariables.controlMode) }
     var modelNo by remember { mutableIntStateOf(GeneralVariables.modelNo) }
     var baudRate by remember { mutableIntStateOf(GeneralVariables.baudRate) }
+    var spectrumWidth by remember { mutableIntStateOf(GeneralVariables.getSpectrumWidth()) }
 
     // Derived display strings
     val callsign = callsignState
@@ -321,18 +323,36 @@ fun SettingsScreen(
 
     // -- Audio Frequency Editor --
     if (showAudioFreq) {
+        val audioFreqMax = spectrumWidth - 100
         NumberInputDialog(
             title = "Audio Frequency",
             suffix = "Hz",
             initialValue = GeneralVariables.getBaseFrequency().toInt(),
             min = 100,
-            max = 2900,
+            max = audioFreqMax,
             onDismiss = { showAudioFreq = false },
             onSave = { value ->
                 showAudioFreq = false
-                val clamped = value.toFloat().coerceIn(100f, 2900f)
+                val clamped = value.toFloat().coerceIn(100f, audioFreqMax.toFloat())
                 GeneralVariables.setBaseFrequency(clamped)
                 mainViewModel.databaseOpr.writeConfig("freq", clamped.toInt().toString(), null)
+            },
+        )
+    }
+
+    if (showSpectrumWidth) {
+        NumberInputDialog(
+            title = "Spectrum Width",
+            suffix = "Hz",
+            initialValue = spectrumWidth,
+            min = 2500,
+            max = 5000,
+            onDismiss = { showSpectrumWidth = false },
+            onSave = { value ->
+                showSpectrumWidth = false
+                spectrumWidth = value
+                GeneralVariables.setSpectrumWidth(value)
+                mainViewModel.databaseOpr.writeConfig("spectrumWidth", value.toString(), null)
             },
         )
     }
@@ -700,6 +720,13 @@ fun SettingsScreen(
                             value = audioFreqStr,
                             showChevron = !synFrequency,
                             onClick = if (!synFrequency) {{ showAudioFreq = true }} else null,
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Spectrum Width",
+                            value = "$spectrumWidth Hz",
+                            showChevron = true,
+                            onClick = { showSpectrumWidth = true },
                         )
                     }
                 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -69,6 +69,9 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
     var updateCount by remember { mutableIntStateOf(0) }
 
     val isDecoding by mainViewModel.mutableIsDecoding.observeAsState(false)
+    val isTransmitting by mainViewModel.ft8TransmitSignal.mutableIsTransmitting.observeAsState(false)
+    val txFreq by GeneralVariables.mutableBaseFrequency.observeAsState(GeneralVariables.getBaseFrequency())
+    val spectrumWidth by GeneralVariables.mutableSpectrumWidth.observeAsState(GeneralVariables.getSpectrumWidth())
     var deNoise by remember { mutableStateOf(mainViewModel.deNoise) }
     var showMessages by remember { mutableStateOf(mainViewModel.markMessage) }
 
@@ -86,6 +89,9 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             val fft = IntArray(data.size / 2)
             nativeFFT(data, fft, mainViewModel.deNoise)
 
+            val currentTxFreq = GeneralVariables.getBaseFrequency()
+            val currentTxActive = mainViewModel.ft8TransmitSignal.mutableIsTransmitting.value ?: false
+
             viewHolder.columnar?.let { cView ->
                 if (viewHolder.frequencyLineTimeout > 0) {
                     viewHolder.frequencyLineTimeout--
@@ -95,15 +101,21 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
                     viewHolder.waterfall?.setTouch_x(-1)
                     touchedFreqHz = -1
                 }
+                cView.setSpectrumWidth(GeneralVariables.getSpectrumWidth())
+                cView.setTxFrequency(currentTxFreq)
+                cView.setTxActive(currentTxActive)
                 cView.setWaveData(fft)
                 cView.invalidate()
             }
 
             viewHolder.waterfall?.let { wView ->
                 val currentlyDecoding = mainViewModel.mutableIsDecoding.value ?: false
+                wView.setSpectrumWidth(GeneralVariables.getSpectrumWidth())
                 wView.setDrawMessage(mainViewModel.markMessage && !currentlyDecoding)
+                wView.setTxFrequency(currentTxFreq)
+                wView.setTxActive(currentTxActive)
                 val messages = if (mainViewModel.markMessage) mainViewModel.currentMessages else null
-                wView.setWaveData(fft, UtcTimer.getNowSequential(), messages)
+                wView.setWaveData(fft, messages)
                 wView.invalidate()
             }
         }
@@ -137,6 +149,9 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 
         // Spectrum strip (columnar view)
         ColumnarStrip(
+            spectrumWidth = spectrumWidth,
+            txFrequency = txFreq,
+            txActive = isTransmitting,
             onViewCreated = { viewHolder.columnar = it },
             onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
@@ -154,6 +169,7 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
         )
 
         FrequencyRuler(
+            spectrumWidth = spectrumWidth,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(20.dp)
@@ -162,8 +178,11 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 
         // Main waterfall display
         WaterfallCanvas(
+            spectrumWidth = spectrumWidth,
             showMessages = showMessages,
             isDecoding = isDecoding,
+            txFrequency = txFreq,
+            txActive = isTransmitting,
             onViewCreated = { viewHolder.waterfall = it },
             onTouch = { freqHz, _ ->
                 touchedFreqHz = freqHz
@@ -246,6 +265,9 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
 @SuppressLint("ClickableViewAccessibility")
 @Composable
 private fun ColumnarStrip(
+    spectrumWidth: Int,
+    txFrequency: Float,
+    txActive: Boolean,
     onViewCreated: (ColumnarView) -> Unit,
     onTouch: (freqHz: Int, x: Int) -> Unit,
     onTouchUp: (freqHz: Int) -> Unit,
@@ -260,52 +282,9 @@ private fun ColumnarStrip(
                 )
                 setBackgroundColor(0xFF07090F.toInt())
                 setShowBlock(true)
-
-                setOnTouchListener { _, event ->
-                    when (event.action) {
-                        MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE -> {
-                            setTouch_x(event.x.toInt())
-                            val freq = getFreq_hz()
-                            if (freq > 0) onTouch(freq, event.x.toInt())
-                        }
-                        MotionEvent.ACTION_UP -> {
-                            val freq = getFreq_hz()
-                            if (freq > 0) onTouchUp(freq)
-                        }
-                    }
-                    true
-                }
-
-                onViewCreated(this)
-            }
-        },
-        modifier = modifier,
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Waterfall canvas (AndroidView wrapper)
-// ---------------------------------------------------------------------------
-
-@SuppressLint("ClickableViewAccessibility")
-@Composable
-private fun WaterfallCanvas(
-    showMessages: Boolean,
-    isDecoding: Boolean,
-    onViewCreated: (WaterfallView) -> Unit,
-    onTouch: (freqHz: Int, x: Int) -> Unit,
-    onTouchUp: (freqHz: Int) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AndroidView(
-        factory = { context ->
-            WaterfallView(context).apply {
-                layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                )
-                setBackgroundColor(0xFF000000.toInt())
-                setDrawMessage(showMessages && !isDecoding)
+                setSpectrumWidth(spectrumWidth)
+                setTxFrequency(txFrequency)
+                setTxActive(txActive)
 
                 setOnTouchListener { _, event ->
                     when (event.action) {
@@ -326,7 +305,67 @@ private fun WaterfallCanvas(
             }
         },
         update = { view ->
+            view.setSpectrumWidth(spectrumWidth)
+            view.setTxFrequency(txFrequency)
+            view.setTxActive(txActive)
+        },
+        modifier = modifier,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Waterfall canvas (AndroidView wrapper)
+// ---------------------------------------------------------------------------
+
+@SuppressLint("ClickableViewAccessibility")
+@Composable
+private fun WaterfallCanvas(
+    spectrumWidth: Int,
+    showMessages: Boolean,
+    isDecoding: Boolean,
+    txFrequency: Float,
+    txActive: Boolean,
+    onViewCreated: (WaterfallView) -> Unit,
+    onTouch: (freqHz: Int, x: Int) -> Unit,
+    onTouchUp: (freqHz: Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AndroidView(
+        factory = { context ->
+            WaterfallView(context).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                setBackgroundColor(0xFF000000.toInt())
+                setSpectrumWidth(spectrumWidth)
+                setDrawMessage(showMessages && !isDecoding)
+                setTxFrequency(txFrequency)
+                setTxActive(txActive)
+
+                setOnTouchListener { _, event ->
+                    when (event.action) {
+                        MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE -> {
+                            setTouch_x(event.x.toInt())
+                            val freq = getFreq_hz()
+                            if (freq > 0) onTouch(freq, event.x.toInt())
+                        }
+                        MotionEvent.ACTION_UP -> {
+                            val freq = getFreq_hz()
+                            if (freq > 0) onTouchUp(freq)
+                        }
+                    }
+                    true
+                }
+
+                onViewCreated(this)
+            }
+        },
+        update = { view ->
+            view.setSpectrumWidth(spectrumWidth)
             view.setDrawMessage(showMessages && !isDecoding)
+            view.setTxFrequency(txFrequency)
+            view.setTxActive(txActive)
         },
         modifier = modifier,
     )
@@ -337,12 +376,18 @@ private fun WaterfallCanvas(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun FrequencyRuler(modifier: Modifier = Modifier) {
+private fun FrequencyRuler(spectrumWidth: Int, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier.background(BgSurface),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        val labels = listOf("0", "500", "1000", "1500", "2000", "2500", "3000")
+        val labels = buildList {
+            var freq = 0
+            while (freq <= spectrumWidth) {
+                add(freq.toString())
+                freq += 500
+            }
+        }
         labels.forEachIndexed { index, label ->
             if (index > 0) Spacer(modifier = Modifier.weight(1f))
             Text(


### PR DESCRIPTION
## Summary
- Fix TX marker misalignment on waterfall: the spectrum data rendering hardcoded a factor of 2 (mapping 0–3000 Hz), but the TX marker used `spectrumWidth` (default 3500 Hz). Now both use the same Nyquist-to-spectrumWidth scale so the marker lines up with the actual signal at any spectrum width setting.
- Fix frequency display in TxStrip not updating when tapping the waterfall to change TX offset. `FT8USApp` now observes `mutableBaseFrequency` reactively instead of reading the static value once.

## Test plan
- [ ] Open waterfall, tap CQ → TX marker lines align with the transmitted signal
- [ ] Change spectrum width in settings → marker still tracks correctly
- [ ] Tap waterfall to move TX frequency → TxStrip frequency number updates immediately
- [ ] Columnar spectrum strip markers also align with signal peaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)