### PR TITLE
Add TX time slot toggle (TX1/TX2)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1100,7 +1100,7 @@ public class FT8TransmitSignal {
         if (toCallsign == null) {
             //must determine my callsign type to set i3n3 !!!
             int i3 = GenerateFT8.checkI3ByCallsign(GeneralVariables.myCallsign);
-            setTransmit(new TransmitCallsign(i3, 0, "CQ", (UtcTimer.getNowSequential() + 1) % 2)
+            setTransmit(new TransmitCallsign(i3, 0, "CQ", sequential)
                     , 6, "");
         } else {
             functionOrder = 6;

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -36,6 +36,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     // Observe transmit state
     val isTransmitting by mainViewModel.ft8TransmitSignal.mutableIsTransmitting.observeAsState(false)
     val isActivated by mainViewModel.ft8TransmitSignal.mutableIsActivated.observeAsState(false)
+    val txSlot by mainViewModel.ft8TransmitSignal.mutableSequential.observeAsState(mainViewModel.ft8TransmitSignal.sequential)
 
     // Derive band/frequency from GeneralVariables
     val bandIndex by GeneralVariables.mutableBandChange.observeAsState(GeneralVariables.bandListIndex)
@@ -79,6 +80,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
             isActivated = isActivated,
             bandLabel = bandLabel,
             frequencyMhz = frequencyMhz,
+            txSlot = txSlot,
             onCallCQ = {
                 if (GeneralVariables.myCallsign.isNullOrEmpty()) {
                     Toast.makeText(context, "Set your callsign in Settings before calling CQ", Toast.LENGTH_SHORT).show()
@@ -89,6 +91,12 @@ fun FT8USApp(mainViewModel: MainViewModel) {
             },
             onStop = {
                 mainViewModel.ft8TransmitSignal.setActivated(false)
+            },
+            onToggleSlot = {
+                val current = mainViewModel.ft8TransmitSignal.sequential
+                val newSlot = if (current == 0) 1 else 0
+                mainViewModel.ft8TransmitSignal.sequential = newSlot
+                mainViewModel.ft8TransmitSignal.mutableSequential.postValue(newSlot)
             },
         )
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -35,8 +35,10 @@ fun TxStrip(
     isActivated: Boolean,
     bandLabel: String,
     frequencyMhz: String,
+    txSlot: Int,
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
+    onToggleSlot: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val bgColor = if (isTransmitting) {
@@ -116,6 +118,25 @@ fun TxStrip(
                     fontWeight = FontWeight.Bold,
                     fontFamily = GeistMonoFamily,
                     letterSpacing = 0.04.sp,
+                )
+            }
+
+            // TX slot toggle pill
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(BgSurface3)
+                    .clickable { onToggleSlot() }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = if (txSlot == 0) "TX1" else "TX2",
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
                 )
             }
 


### PR DESCRIPTION
## Summary
- Add a TX1/TX2 pill button to TxStrip for explicit time slot selection
- Wire slot state and toggle through FT8USApp to FT8TransmitSignal
- `resetToCQ()` now uses the user's chosen slot instead of auto-calculating from current time

## Test plan
- [ ] TxStrip shows "TX1" or "TX2" pill between CQ/STOP button and frequency
- [ ] Tapping the pill toggles between TX1 and TX2
- [ ] Tap CQ → transmits on the selected slot
- [ ] Toggle slot → tap CQ → transmits on the other slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)