### PR TITLE
Fix FT-891 bandwidth not set to 3000Hz in DATA-USB mode

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu39Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu39Rig.java
@@ -126,8 +126,11 @@ public class Yaesu39Rig extends BaseRig {
             if (isDataUsb) {//use DATA-USB mode
                 getConnector().sendData(Yaesu3RigConstant.setOperationUSB_Data_Mode());
                 getConnector().sendData(Yaesu3RigConstant.setMaxDataWidth());
+                fileLog("setUsbModeToRig: mode=DATA-USB, sent NA00;SH0117 (3000Hz)");
             } else {
                 getConnector().sendData(Yaesu3RigConstant.setOperationUSBMode());
+                getConnector().sendData(Yaesu3RigConstant.setMaxSsbWidth());
+                fileLog("setUsbModeToRig: mode=USB, sent NA00;SH0120 (3000Hz)");
             }
         }
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu3RigConstant.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu3RigConstant.java
@@ -30,7 +30,8 @@ public class Yaesu3RigConstant {
     private static final String USB_MODE = "MD02;";
     private static final String USB_MODE_DATA = "MD09;";
     private static final String DATA_U_MODE = "MD0C;";
-    private static final String WIDTH_MAX_DATA = "SH0120;"; // Width ON, 3000 Hz (max for DATA mode)
+    private static final String WIDTH_MAX_SSB = "NA00;SH0120;"; // Narrow OFF + Width 3000 Hz (SSB index 20)
+    private static final String WIDTH_MAX_DATA = "NA00;SH0117;"; // Narrow OFF + Width 3000 Hz (DATA index 17)
     private static final String READ_FREQ = "FA;";
     private static final String READ_39METER_ALC = "RM4;";//commands for 38 and 39 are the same
     private static final String READ_39METER_SWR = "RM6;";//commands for 38 and 39 are the same
@@ -103,6 +104,9 @@ public class Yaesu3RigConstant {
 
     public static byte[] setOperationDATA_U_Mode() {
         return DATA_U_MODE.getBytes();
+    }
+    public static byte[] setMaxSsbWidth() {
+        return WIDTH_MAX_SSB.getBytes();
     }
     public static byte[] setMaxDataWidth() {
         return WIDTH_MAX_DATA.getBytes();


### PR DESCRIPTION
## Summary
- The SH (WIDTH) CAT command uses different index tables per mode on the FT-891. The original `SH0120` used SSB's index for 3000Hz, but DATA mode maps 3000Hz to index 17 (`SH0117`)
- Now sends `NA00;` (NARROW OFF) before the SH command, matching how Flrig handles FT-891 bandwidth
- Both USB and DATA-USB modes correctly set 3000Hz bandwidth on connect

## Test plan
- [x] Build and install on device
- [x] Connect to FT-891 in DATA-USB mode and verify bandwidth is set to 3000Hz
- [x] Verify no `?;` error responses in debug log

🤖 Generated with [Claude Code](https://claude.com/claude-code)