### PR TITLE
Add caller queue and fix QSO panel visibility

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -87,6 +87,11 @@ public class FT8TransmitSignal {
     public ArrayList<FunctionOfTransmit> functionList = new ArrayList<>();
     public MutableLiveData<ArrayList<FunctionOfTransmit>> mutableFunctions = new MutableLiveData<>();
 
+    // Caller queue: stations that called us while we're in an active QSO
+    private static final int MAX_QUEUE_SIZE = 10;
+    private final ArrayList<QueuedCaller> callerQueue = new ArrayList<>();
+    public MutableLiveData<ArrayList<QueuedCaller>> mutableCallerQueue = new MutableLiveData<>();
+
     private final OnDoTransmitted onDoTransmitted;// typically used for opening/closing PTT
     private final ExecutorService doTransmitThreadPool = Executors.newCachedThreadPool();
     private final DoTransmitRunnable doTransmitRunnable = new DoTransmitRunnable(this);
@@ -793,6 +798,14 @@ public class FT8TransmitSignal {
             //if ((msg.getCallsignTo().equals(GeneralVariables.myCallsign)
             if ((GeneralVariables.checkIsMyCallsign(msg.getCallsignTo())
                     && !GeneralVariables.checkFun5(msg.extraInfo))) {// CQ me, not 73
+
+                // Guard: if we're in an active QSO (not CQ), queue the caller instead of switching
+                if (functionOrder != 6 && toCallsign != null && toCallsign.haveTargetCallsign()
+                        && !msg.getCallsignFrom().equals(toCallsign.callsign)) {
+                    enqueueCaller(msg);
+                    continue;
+                }
+
                 // before setting transmit, determine message sequence to avoid starting from the beginning
                 setTransmit(new TransmitCallsign(msg.i3, msg.n3, msg.getCallsignFrom(), msg.freq_hz
                                 , msg.getSequence(), msg.snr)
@@ -937,8 +950,10 @@ public class FT8TransmitSignal {
             // enter CQ state
             resetToCQ();
 
-            // check if any messages are calling me, or if watched callsigns are CQing
-            checkCQMeOrFollowCQMessage(messages);
+            // try queued callers first, then check for new callers
+            if (!dequeueNextCaller()) {
+                checkCQMeOrFollowCQMessage(messages);
+            }
             setCurrentFunctionOrder(functionOrder);// set current message
             mutableFunctionOrder.postValue(functionOrder);
             return;
@@ -970,7 +985,9 @@ public class FT8TransmitSignal {
         // at this point, no reply messages were received
         // if I am in CQ state, newOrder must be -1
         if (functionOrder == 6) {// I am in CQ state
-            checkCQMeOrFollowCQMessage(messages);
+            if (!dequeueNextCaller()) {
+                checkCQMeOrFollowCQMessage(messages);
+            }
             return;
         }
 
@@ -981,10 +998,12 @@ public class FT8TransmitSignal {
         }
         // if no-reply limit exceeded, reset to CQ state
         if ((GeneralVariables.noReplyCount > GeneralVariables.noReplyLimit) && (GeneralVariables.noReplyLimit > 0)) {
-            // check watched message list; if no new CQ, enter CQ state; if found, switch to calling the new target
-            if (!getNewTargetCallsign(messages)) {//check CQ messages in watch list; returns true if a new target is found
-                functionOrder = 6;
-                toCallsign.callsign = "CQ";
+            // try queued callers first, then check watched messages, then fall back to CQ
+            if (!dequeueNextCaller()) {
+                if (!getNewTargetCallsign(messages)) {//check CQ messages in watch list; returns true if a new target is found
+                    functionOrder = 6;
+                    toCallsign.callsign = "CQ";
+                }
             }
             generateFun();
             setCurrentFunctionOrder(functionOrder);// set current message
@@ -1047,6 +1066,7 @@ public class FT8TransmitSignal {
         this.activated = activated;
         if (!this.activated) {//force stop transmitting
             setTransmitting(false);
+            clearCallerQueue();
         }
         mutableIsActivated.postValue(activated);
     }
@@ -1084,6 +1104,7 @@ public class FT8TransmitSignal {
         if (GeneralVariables.myCallsign.length() < 3) {
             return;
         }
+        clearCallerQueue();
         //must determine my callsign type to set i3n3 !!!
         int i3 = GenerateFT8.checkI3ByCallsign(GeneralVariables.myCallsign);
         setTransmit(new TransmitCallsign(i3, 0, "CQ", UtcTimer.getNowSequential())
@@ -1117,6 +1138,78 @@ public class FT8TransmitSignal {
             generateFun();
         }
     }
+
+    // ==================== Caller Queue Methods ====================
+
+    /**
+     * Add a caller to the queue. Deduplicates by callsign (updates SNR/freq if already present).
+     * Skips callers that are excluded, already QSL'd, or our own callsign.
+     */
+    public void enqueueCaller(Ft8Message msg) {
+        String callsign = msg.getCallsignFrom();
+        if (callsign == null || callsign.isEmpty()) return;
+        if (GeneralVariables.checkIsMyCallsign(callsign)) return;
+        if (GeneralVariables.checkIsExcludeCallsign(callsign)) return;
+        if (GeneralVariables.checkQSLCallsign(callsign)) return;
+
+        synchronized (callerQueue) {
+            // Update existing entry if callsign already queued
+            for (int i = 0; i < callerQueue.size(); i++) {
+                if (callerQueue.get(i).callsign.equals(callsign)) {
+                    QueuedCaller existing = callerQueue.get(i);
+                    existing.snr = msg.snr;
+                    existing.queuedTimeMs = System.currentTimeMillis();
+                    mutableCallerQueue.postValue(new ArrayList<>(callerQueue));
+                    return;
+                }
+            }
+            // Add new entry if not at capacity
+            if (callerQueue.size() < MAX_QUEUE_SIZE) {
+                callerQueue.add(new QueuedCaller(
+                        callsign, msg.freq_hz, msg.getSequence(), msg.snr,
+                        msg.i3, msg.n3, msg.extraInfo));
+                mutableCallerQueue.postValue(new ArrayList<>(callerQueue));
+            }
+        }
+    }
+
+    /**
+     * Dequeue the next caller and start a QSO with them via setTransmit().
+     * Skips stale or excluded callers. Returns true if a caller was started.
+     */
+    public boolean dequeueNextCaller() {
+        synchronized (callerQueue) {
+            while (!callerQueue.isEmpty()) {
+                QueuedCaller caller = callerQueue.remove(0);
+                mutableCallerQueue.postValue(new ArrayList<>(callerQueue));
+
+                // Skip if caller is now excluded or already worked
+                if (GeneralVariables.checkIsExcludeCallsign(caller.callsign)) continue;
+                if (GeneralVariables.checkQSLCallsign(caller.callsign)) continue;
+
+                // Start QSO with this caller
+                resetTargetReport();
+                setTransmit(new TransmitCallsign(caller.i3, caller.n3, caller.callsign,
+                                caller.frequency, caller.sequential, caller.snr),
+                        GeneralVariables.checkFunOrderByExtraInfo(caller.extraInfo) + 1,
+                        caller.extraInfo);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Clear the entire caller queue.
+     */
+    public void clearCallerQueue() {
+        synchronized (callerQueue) {
+            callerQueue.clear();
+            mutableCallerQueue.postValue(new ArrayList<>(callerQueue));
+        }
+    }
+
+    // ==================== End Caller Queue Methods ====================
 
     /**
      * Set transmit time delay; this delay also provides decoding time for the previous cycle.

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/QueuedCaller.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/QueuedCaller.java
@@ -1,0 +1,27 @@
+package com.bg7yoz.ft8cn.ft8transmit;
+
+/**
+ * Data class representing a caller queued for response after the current QSO completes.
+ */
+public class QueuedCaller {
+    public final String callsign;
+    public final float frequency;
+    public final int sequential;
+    public int snr;
+    public final int i3;
+    public final int n3;
+    public final String extraInfo;
+    public long queuedTimeMs;
+
+    public QueuedCaller(String callsign, float frequency, int sequential, int snr,
+                        int i3, int n3, String extraInfo) {
+        this.callsign = callsign;
+        this.frequency = frequency;
+        this.sequential = sequential;
+        this.snr = snr;
+        this.i3 = i3;
+        this.n3 = n3;
+        this.extraInfo = extraInfo;
+        this.queuedTimeMs = System.currentTimeMillis();
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -26,7 +27,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +42,7 @@ import com.bg7yoz.ft8cn.Ft8Message
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.ft8transmit.FunctionOfTransmit
+import com.bg7yoz.ft8cn.ft8transmit.QueuedCaller
 import radio.ks3ckc.ft8us.theme.*
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -70,17 +74,36 @@ fun ActiveQsoPanel(
     modifier: Modifier = Modifier,
 ) {
     val toCallsign by mainViewModel.ft8TransmitSignal.mutableToCallsign.observeAsState()
+    val isActivated by mainViewModel.ft8TransmitSignal.mutableIsActivated.observeAsState(false)
     val functions by mainViewModel.ft8TransmitSignal.mutableFunctions.observeAsState(arrayListOf())
     val functionOrder by mainViewModel.ft8TransmitSignal.mutableFunctionOrder.observeAsState(6)
     val messageList by mainViewModel.mutableFt8MessageList.observeAsState(arrayListOf())
     val transmittingMessage by mainViewModel.ft8TransmitSignal.mutableTransmittingMessage.observeAsState("")
+    val callerQueue by mainViewModel.ft8TransmitSignal.mutableCallerQueue.observeAsState(arrayListOf())
 
-    val targetCallsign = toCallsign?.callsign ?: "CQ"
-    val hasTarget = targetCallsign != "CQ" && targetCallsign.isNotEmpty()
+    val liveCallsign = toCallsign?.callsign ?: "CQ"
+
+    // Remember the last real (non-CQ) callsign so the panel stays visible
+    // after resetToCQ() until isActivated goes false
+    var rememberedCallsign by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(liveCallsign) {
+        if (liveCallsign != "CQ" && liveCallsign.isNotEmpty()) {
+            rememberedCallsign = liveCallsign
+        }
+    }
+    LaunchedEffect(isActivated) {
+        if (!isActivated) {
+            rememberedCallsign = null
+        }
+    }
+
+    // Use the live callsign if it's a real target, otherwise fall back to remembered
+    val displayCallsign = if (liveCallsign != "CQ" && liveCallsign.isNotEmpty()) liveCallsign else rememberedCallsign
+    val hasTarget = displayCallsign != null
 
     // Filter messages to/from the target station
-    val qsoMessages: List<QsoLogEntry> = remember(messageList, messageList?.size, targetCallsign, transmittingMessage) {
-        if (!hasTarget) return@remember emptyList()
+    val qsoMessages: List<QsoLogEntry> = remember(messageList, messageList?.size, displayCallsign, transmittingMessage) {
+        if (!hasTarget || displayCallsign == null) return@remember emptyList()
 
         val entries = mutableListOf<QsoLogEntry>()
 
@@ -92,7 +115,7 @@ fun ActiveQsoPanel(
 
             when {
                 // RX: target station calling us
-                from.equals(targetCallsign, ignoreCase = true) &&
+                from.equals(displayCallsign, ignoreCase = true) &&
                         (to.equals(myCallsign, ignoreCase = true) || GeneralVariables.checkIsMyCallsign(to)) -> {
                     entries.add(
                         QsoLogEntry(
@@ -104,7 +127,7 @@ fun ActiveQsoPanel(
                     )
                 }
                 // TX: us calling the target station (messages from us in the decoded list)
-                from.equals(myCallsign, ignoreCase = true) && to.equals(targetCallsign, ignoreCase = true) -> {
+                from.equals(myCallsign, ignoreCase = true) && to.equals(displayCallsign, ignoreCase = true) -> {
                     entries.add(
                         QsoLogEntry(
                             direction = QsoLogEntry.Direction.TX,
@@ -119,7 +142,7 @@ fun ActiveQsoPanel(
     }
 
     AnimatedVisibility(
-        visible = expanded && hasTarget,
+        visible = expanded && (hasTarget || isActivated),
         enter = expandVertically(expandFrom = Alignment.Bottom),
         exit = shrinkVertically(shrinkTowards = Alignment.Bottom),
         modifier = modifier,
@@ -139,7 +162,10 @@ fun ActiveQsoPanel(
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         ) {
             // Station header
-            StationHeader(targetCallsign = targetCallsign, snr = toCallsign?.snr)
+            StationHeader(
+                targetCallsign = displayCallsign ?: "Searching...",
+                snr = if (displayCallsign != null) toCallsign?.snr else null,
+            )
 
             Spacer(modifier = Modifier.height(6.dp))
 
@@ -157,6 +183,9 @@ fun ActiveQsoPanel(
                     mainViewModel.ft8TransmitSignal.mutableFunctionOrder.postValue(order)
                 },
             )
+
+            // Caller queue display
+            CallerQueueBar(queue = callerQueue ?: arrayListOf())
         }
     }
 }
@@ -384,6 +413,52 @@ private fun TxSelector(
                     fontFamily = GeistMonoFamily,
                     letterSpacing = 0.02.sp,
                 )
+            }
+        }
+    }
+}
+
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+@Composable
+private fun CallerQueueBar(queue: ArrayList<QueuedCaller>) {
+    if (queue.isEmpty()) return
+
+    Spacer(modifier = Modifier.height(6.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = "QUEUE",
+            color = TextFaint,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = GeistMonoFamily,
+            letterSpacing = 0.04.sp,
+        )
+
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            queue.forEach { caller ->
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(SignalSoft)
+                        .padding(horizontal = 6.dp, vertical = 2.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = caller.callsign,
+                        color = Signal,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Medium,
+                        fontFamily = GeistMonoFamily,
+                    )
+                }
             }
         }
     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -68,7 +68,6 @@ fun QsoSheet(
             QsoSheetContent(
                 message = message,
                 mainViewModel = mainViewModel,
-                onDismiss = onDismiss,
             )
         }
     }
@@ -78,7 +77,6 @@ fun QsoSheet(
 private fun QsoSheetContent(
     message: Ft8Message,
     mainViewModel: MainViewModel,
-    onDismiss: () -> Unit,
 ) {
     val callsign = message.callsignFrom ?: ""
     val status = resolveQsoStatus(message)
@@ -145,8 +143,8 @@ private fun QsoSheetContent(
             Button(
                 onClick = {
                     mainViewModel.addFollowCallsign(callsign)
+                    GeneralVariables.transmitMessages.add(message)
                     mainViewModel.ft8TransmitSignal.setActivated(true)
-                    onDismiss()
                 },
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
## Summary
- Adds a FIFO caller queue so the app stays locked on the current target during an active QSO instead of switching to new callers mid-sequence
- Queued callers are auto-dequeued after QSO completion, no-reply timeout, or when entering CQ state
- Fixes QSO panel not appearing when calling a station (panel now shows whenever activated)
- Fixes station card auto-dismissing when pressing the Call button
- Fixes Call button not adding message to `transmitMessages` (target was never picked up by transmit engine)

## Test plan
- [ ] Call Station A → have Station B call you → verify B appears in queue, QSO with A continues
- [ ] Complete QSO with A → verify auto-dequeue starts QSO with B
- [ ] Have A not reply until timeout → verify B is dequeued instead of CQ
- [ ] Have B call multiple cycles → verify single queue entry with updated SNR
- [ ] Hit STOP → verify queue clears
- [ ] In CQ mode → verify callers are immediately answered (not queued)
- [ ] Tap station in decode list → press Call → verify card stays visible
- [ ] Verify QSO panel appears immediately after pressing Call

🤖 Generated with [Claude Code](https://claude.com/claude-code)