### PR TITLE
Update CI workflow branches from release to main

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,11 +2,11 @@ name: Build & Release APK
 
 on:
   push:
-    branches: [release, Dev]
+    branches: [main, Dev]
     tags:
       - 'v*'
   pull_request:
-    branches: [release]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Updated GitHub Actions workflow trigger branches from `release` to `main` to match the new default branch

## Test plan
- [ ] Verify CI triggers on push to `main`
- [ ] Verify CI triggers on PRs targeting `main`
- [ ] Verify tag-based releases still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)