### PR TITLE
Add frequency picker to the Listening Bar

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -22,10 +22,12 @@ import com.bg7yoz.ft8cn.database.OperationBand
 import radio.ks3ckc.ft8us.theme.BgApp
 import radio.ks3ckc.ft8us.ui.components.ActiveQsoPanel
 import radio.ks3ckc.ft8us.ui.components.FT8USTab
+import radio.ks3ckc.ft8us.ui.components.FrequencyPickerSheet
 import radio.ks3ckc.ft8us.ui.components.QsoCelebration
 import radio.ks3ckc.ft8us.ui.components.TabBar
 import radio.ks3ckc.ft8us.ui.components.TransmitGlow
 import radio.ks3ckc.ft8us.ui.components.TxStrip
+import radio.ks3ckc.ft8us.ui.components.selectBandIndex
 import radio.ks3ckc.ft8us.ui.decode.DecodeScreen
 import radio.ks3ckc.ft8us.ui.logbook.LogbookScreen
 import radio.ks3ckc.ft8us.ui.map.MapScreen
@@ -46,6 +48,9 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     // QSO panel expand/collapse state
     var qsoPanelExpanded by rememberSaveable { mutableStateOf(false) }
 
+    // Frequency picker sheet state
+    var showFrequencyPicker by rememberSaveable { mutableStateOf(false) }
+
     // Auto-expand when activated, auto-collapse when deactivated
     LaunchedEffect(isActivated) {
         if (isActivated) {
@@ -65,6 +70,12 @@ fun FT8USApp(mainViewModel: MainViewModel) {
         }
     } else {
         GeneralVariables.getBandString()
+    }
+    // Short pill label for the TxStrip frequency button — just the band (e.g. "20m").
+    val frequencyLabel = if (bandIndex >= 0 && bandIndex < OperationBand.bandList.size) {
+        OperationBand.bandList[bandIndex].waveLength
+    } else {
+        "—"
     }
     Box(modifier = Modifier.fillMaxSize().background(BgApp)) {
         Column(
@@ -100,6 +111,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                 isTransmitting = isTransmitting,
                 isActivated = isActivated,
                 bandLabel = bandLabel,
+                frequencyLabel = frequencyLabel,
                 txSlot = txSlot,
                 expanded = qsoPanelExpanded,
                 onCallCQ = {
@@ -119,6 +131,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     mainViewModel.ft8TransmitSignal.sequential = newSlot
                     mainViewModel.ft8TransmitSignal.mutableSequential.postValue(newSlot)
                 },
+                onOpenFrequencyPicker = { showFrequencyPicker = true },
                 onToggleExpand = { qsoPanelExpanded = !qsoPanelExpanded },
             )
 
@@ -135,5 +148,17 @@ fun FT8USApp(mainViewModel: MainViewModel) {
 
         // One-shot particle burst when a QSO completes.
         QsoCelebration(triggerAt = qsoCompletedAt)
+
+        // Frequency picker — sibling overlay so the scrim and sheet sit above the
+        // tab bar and TxStrip.
+        FrequencyPickerSheet(
+            visible = showFrequencyPicker,
+            currentBandIndex = bandIndex,
+            onDismiss = { showFrequencyPicker = false },
+            onSelect = { idx ->
+                selectBandIndex(mainViewModel, context, idx)
+                showFrequencyPicker = false
+            },
+        )
     }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -73,10 +73,15 @@ fun FT8USApp(mainViewModel: MainViewModel) {
         GeneralVariables.getBandString()
     }
     // Short pill label for the TxStrip frequency button — just the band (e.g. "20m").
-    // Derived from the current frequency so it's correct even before bandListIndex
-    // has been set (e.g. on first launch, when index is -1).
-    val frequencyLabel = (BaseRigOperation.getMeterFromFreq(GeneralVariables.band) ?: "")
-        .ifBlank { "—" }
+    // Looked up by frequency from bands.txt so the conventional band name is used
+    // (e.g. 40.68 MHz is "8m" by convention, not the computed wavelength). Falls
+    // back to the computed wavelength if the freq isn't in the band list.
+    val frequencyLabel = run {
+        val freq = GeneralVariables.band
+        OperationBand.bandList.firstOrNull { it.band == freq }?.waveLength
+            ?: BaseRigOperation.getMeterFromFreq(freq)
+            ?: ""
+    }.ifBlank { "—" }
     // Trim the band parenthetical and any marker prefix from the status label, since
     // the band is shown in the new pill on the right.
     val bandLabelTrimmed = bandLabel

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.database.OperationBand
+import com.bg7yoz.ft8cn.rigs.BaseRigOperation
 import radio.ks3ckc.ft8us.theme.BgApp
 import radio.ks3ckc.ft8us.ui.components.ActiveQsoPanel
 import radio.ks3ckc.ft8us.ui.components.FT8USTab
@@ -72,11 +73,17 @@ fun FT8USApp(mainViewModel: MainViewModel) {
         GeneralVariables.getBandString()
     }
     // Short pill label for the TxStrip frequency button — just the band (e.g. "20m").
-    val frequencyLabel = if (bandIndex >= 0 && bandIndex < OperationBand.bandList.size) {
-        OperationBand.bandList[bandIndex].waveLength
-    } else {
-        "—"
-    }
+    // Derived from the current frequency so it's correct even before bandListIndex
+    // has been set (e.g. on first launch, when index is -1).
+    val frequencyLabel = (BaseRigOperation.getMeterFromFreq(GeneralVariables.band) ?: "")
+        .ifBlank { "—" }
+    // Trim the band parenthetical and any marker prefix from the status label, since
+    // the band is shown in the new pill on the right.
+    val bandLabelTrimmed = bandLabel
+        .substringBefore('(')
+        .trim()
+        .removePrefix("*")
+        .trim()
     Box(modifier = Modifier.fillMaxSize().background(BgApp)) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -110,7 +117,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
             TxStrip(
                 isTransmitting = isTransmitting,
                 isActivated = isActivated,
-                bandLabel = bandLabel,
+                bandLabel = bandLabelTrimmed,
                 frequencyLabel = frequencyLabel,
                 txSlot = txSlot,
                 expanded = qsoPanelExpanded,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FrequencyPickerSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FrequencyPickerSheet.kt
@@ -1,0 +1,305 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.bg7yoz.ft8cn.MainViewModel
+import com.bg7yoz.ft8cn.database.ControlMode
+import com.bg7yoz.ft8cn.database.OperationBand
+import radio.ks3ckc.ft8us.theme.*
+
+/**
+ * Applies a band selection (by index into [OperationBand.bandList]) to the app: updates
+ * GeneralVariables, persists the new bandFreq in config, refreshes QSL callsigns, and
+ * pushes the new frequency to the rig when CAT/RTS/DTR control is active.
+ *
+ * Shared between the Settings band picker and the TxStrip frequency picker.
+ */
+fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) {
+    GeneralVariables.bandListIndex = index
+    GeneralVariables.band = OperationBand.getBandFreq(index)
+    mainViewModel.databaseOpr.writeConfig(
+        "bandFreq", GeneralVariables.band.toString(), null,
+    )
+    mainViewModel.databaseOpr.getAllQSLCallsigns()
+
+    val cm = GeneralVariables.controlMode
+    val connected = mainViewModel.isRigConnected()
+    android.util.Log.d(
+        "FrequencyPicker",
+        "bandSelect: index=$index, band=${GeneralVariables.band}, " +
+            "controlMode=$cm, rigConnected=$connected",
+    )
+    try {
+        val dir = context.getExternalFilesDir(null)
+        if (dir != null) {
+            val ts = java.text.SimpleDateFormat("HH:mm:ss.SSS", java.util.Locale.US)
+                .format(java.util.Date())
+            java.io.File(dir, "debug.log").appendText(
+                "$ts bandSelect: index=$index, band=${GeneralVariables.band}, " +
+                    "controlMode=$cm, rigConnected=$connected\n",
+            )
+        }
+    } catch (_: Exception) {
+    }
+
+    if (cm == ControlMode.CAT || cm == ControlMode.RTS || cm == ControlMode.DTR) {
+        mainViewModel.setOperationBand()
+    }
+}
+
+private data class BandGroup(
+    val waveLength: String,
+    val primaryIndex: Int,
+    val primaryFreqHz: Long,
+    val alternates: List<Pair<Int, Long>>,
+)
+
+/**
+ * Build the band model from OperationBand.bandList:
+ *   - Group entries by waveLength (file order preserved).
+ *   - Primary = first entry with marked == true; fall back to first entry in group.
+ *   - Alternates = every other entry in the group, in file order.
+ */
+private fun buildBandGroups(): List<BandGroup> {
+    val order = LinkedHashMap<String, MutableList<Pair<Int, OperationBand.Band>>>()
+    for (i in 0 until OperationBand.bandList.size) {
+        val b = OperationBand.bandList[i]
+        order.getOrPut(b.waveLength) { mutableListOf() }.add(i to b)
+    }
+    return order.map { (wave, entries) ->
+        val primary = entries.firstOrNull { it.second.marked } ?: entries.first()
+        val alternates = entries.filter { it.first != primary.first }
+            .map { it.first to it.second.band }
+        BandGroup(
+            waveLength = wave,
+            primaryIndex = primary.first,
+            primaryFreqHz = primary.second.band,
+            alternates = alternates,
+        )
+    }
+}
+
+private fun formatMhz(freqHz: Long): String {
+    val mhz = freqHz / 1_000_000.0
+    return String.format(java.util.Locale.US, "%.3f", mhz)
+}
+
+@Composable
+fun FrequencyPickerSheet(
+    visible: Boolean,
+    currentBandIndex: Int,
+    onDismiss: () -> Unit,
+    onSelect: (Int) -> Unit,
+) {
+    FT8USBottomSheet(visible = visible, onDismiss = onDismiss) {
+        val groups = remember { buildBandGroups() }
+        var showAlternates by remember { mutableStateOf(false) }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(top = 8.dp, bottom = 24.dp),
+        ) {
+            Text(
+                text = "SELECT FREQUENCY",
+                color = TextPrimary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
+                letterSpacing = 0.06.sp,
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+
+            BandTileGrid(
+                groups = groups,
+                currentBandIndex = currentBandIndex,
+                onTileClick = onSelect,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Show / hide alternates toggle
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { showAlternates = !showAlternates }
+                    .padding(vertical = 10.dp, horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = if (showAlternates) "HIDE ALTERNATES" else "SHOW ALTERNATES",
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.08.sp,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = if (showAlternates) "△" else "▽",
+                    color = TextFaint,
+                    fontSize = 11.sp,
+                )
+            }
+
+            if (showAlternates) {
+                Spacer(modifier = Modifier.height(4.dp))
+                AlternatesList(
+                    groups = groups,
+                    currentBandIndex = currentBandIndex,
+                    onChipClick = onSelect,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BandTileGrid(
+    groups: List<BandGroup>,
+    currentBandIndex: Int,
+    onTileClick: (Int) -> Unit,
+) {
+    val columns = 3
+    val rows = groups.chunked(columns)
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        for (row in rows) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                for (g in row) {
+                    BandTile(
+                        group = g,
+                        isSelected = g.primaryIndex == currentBandIndex ||
+                            g.alternates.any { it.first == currentBandIndex },
+                        modifier = Modifier.weight(1f),
+                        onClick = { onTileClick(g.primaryIndex) },
+                    )
+                }
+                // Pad incomplete row with empty weights so tiles stay sized consistently.
+                repeat(columns - row.size) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BandTile(
+    group: BandGroup,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val bg = if (isSelected) AccentSoft else BgSurface3
+    val bandColor = if (isSelected) Accent else TextPrimary
+    val freqColor = if (isSelected) Accent else TextMuted
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(bg)
+            .clickable { onClick() }
+            .padding(vertical = 12.dp, horizontal = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = group.waveLength,
+                color = bandColor,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = GeistMonoFamily,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = formatMhz(group.primaryFreqHz),
+                color = freqColor,
+                fontSize = 11.sp,
+                fontFamily = GeistMonoFamily,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlternatesList(
+    groups: List<BandGroup>,
+    currentBandIndex: Int,
+    onChipClick: (Int) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        for (g in groups) {
+            if (g.alternates.isEmpty()) continue
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = g.waveLength,
+                    color = TextMuted,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    modifier = Modifier.width(44.dp),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    for (alt in g.alternates) {
+                        AlternateChip(
+                            label = formatMhz(alt.second),
+                            isSelected = alt.first == currentBandIndex,
+                            onClick = { onChipClick(alt.first) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlternateChip(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val bg = if (isSelected) AccentSoft else BgSurface3
+    val fg = if (isSelected) Accent else TextMuted
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(bg)
+            .clickable { onClick() }
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+    ) {
+        Text(
+            text = label,
+            color = fg,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = GeistMonoFamily,
+        )
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -35,11 +35,13 @@ fun TxStrip(
     isTransmitting: Boolean,
     isActivated: Boolean,
     bandLabel: String,
+    frequencyLabel: String,
     txSlot: Int,
     expanded: Boolean = false,
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
     onToggleSlot: () -> Unit,
+    onOpenFrequencyPicker: () -> Unit,
     onToggleExpand: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -117,6 +119,27 @@ fun TxStrip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            // Frequency / band pill — opens the frequency picker
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(BgSurface3)
+                    .clickable { onOpenFrequencyPicker() }
+                    .padding(horizontal = 10.dp, vertical = 7.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = frequencyLabel,
+                    color = TextMuted,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            }
+
             // CQ / Stop pill button
             val buttonBg = if (isActivated) StatusBad.copy(alpha = 0.18f) else AccentSoft
             val buttonTextColor = if (isActivated) StatusBad else Accent

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -76,6 +76,7 @@ import radio.ks3ckc.ft8us.theme.*
 import radio.ks3ckc.ft8us.ui.components.GlassCard
 import radio.ks3ckc.ft8us.ui.components.SettingsRow
 import radio.ks3ckc.ft8us.ui.components.TopBar
+import radio.ks3ckc.ft8us.ui.components.selectBandIndex
 
 /**
  * Settings screen that replaces the legacy ConfigFragment.
@@ -313,30 +314,7 @@ fun SettingsScreen(
             onDismiss = { showBandPicker = false },
             onSelect = { index ->
                 showBandPicker = false
-                GeneralVariables.bandListIndex = index
-                GeneralVariables.band = OperationBand.getBandFreq(index)
-                mainViewModel.databaseOpr.writeConfig(
-                    "bandFreq", GeneralVariables.band.toString(), null,
-                )
-                mainViewModel.databaseOpr.getAllQSLCallsigns()
-                val cm = GeneralVariables.controlMode
-                val connected = mainViewModel.isRigConnected()
-                android.util.Log.d("SettingsScreen",
-                    "bandSelect: index=$index, band=${GeneralVariables.band}, " +
-                    "controlMode=$cm, rigConnected=$connected")
-                try {
-                    val dir = context.getExternalFilesDir(null)
-                    if (dir != null) {
-                        val ts = java.text.SimpleDateFormat("HH:mm:ss.SSS", java.util.Locale.US)
-                            .format(java.util.Date())
-                        java.io.File(dir, "debug.log").appendText(
-                            "$ts bandSelect: index=$index, band=${GeneralVariables.band}, " +
-                            "controlMode=$cm, rigConnected=$connected\n")
-                    }
-                } catch (_: Exception) {}
-                if (cm == ControlMode.CAT || cm == ControlMode.RTS || cm == ControlMode.DTR) {
-                    mainViewModel.setOperationBand()
-                }
+                selectBandIndex(mainViewModel, context, index)
             },
         )
     }


### PR DESCRIPTION
## Summary
- Adds a compact band pill (e.g. `20m`) to the right side of the TxStrip, immediately left of the CQ/STOP button. Tapping it opens a bottom-sheet frequency picker.
- The picker shows a 3-column grid of band tiles, each labeled with the band and its primary FT8 frequency. A `SHOW ALTERNATES` toggle reveals chip rows of non-primary entries (FT4, regional, DXpedition slots) per band — driven by the existing `*` marker in `assets/bands.txt`.
- Extracts the Settings band-picker `onSelect` body into a shared `selectBandIndex(...)` helper so both entry points share one path for persistence, debug logging, and CAT/RTS/DTR retune.

## Test plan
- [x] Launch the app and confirm the TxStrip shows three right-side pills: band, CQ, TX1/TX2 — without clipping.
- [x] Tap the band pill, bottom sheet slides up; the currently selected band is highlighted.
- [ ] Tap a different band tile (e.g. `40m`), sheet dismisses, pill updates to `40m`, status line updates to `40m FT8`.
- [ ] With a CAT/RTS/DTR-connected rig, confirm `debug.log` shows the `bandSelect` line and `setFreq` follows (e.g. `7074000`).
- [ ] Tap `SHOW ALTERNATES` and pick an alternate chip (e.g. 20m `14.090`), sheet dismisses, frequency updates accordingly.
- [ ] Open Settings → Band & Frequency picker. Pick a band — behavior identical to before (shared helper path).
- [ ] Kill and relaunch the app, last selected frequency is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
