### PR TITLE
Survive USB audio disconnect during TX and decode

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -141,12 +141,23 @@ public class MicRecorder {
     }
 
     private void startUsbCapture() {
+        final MicRecorder self = this;
         usbAudioDevice.startCapture(sampleRateInHz, new UsbAudioDevice.AudioInputCallback() {
             @Override
             public void onAudioData(float[] data, int length) {
                 if (isRunning && onDataListener != null) {
                     onDataListener.onDataReceived(data, length);
                 }
+            }
+
+            @Override
+            public void onCaptureStopped() {
+                // The USB audio device died (cable yank, suspend, etc). Without
+                // this, the decode loop's getVoiceData() callback never fires
+                // and the waterfall just stops. reinitialize() either reopens
+                // a fresh USB handle or falls back to the built-in mic.
+                Log.w(TAG, "USB audio capture stopped unexpectedly, reinitializing");
+                self.reinitialize();
             }
         });
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
@@ -56,6 +56,13 @@ public class UsbAudioDevice {
 
     public interface AudioInputCallback {
         void onAudioData(float[] data, int length);
+        /**
+         * Fired on a worker thread when the capture loop exits without
+         * stopCapture() being called — e.g. the USB device was disconnected
+         * or the kernel returned a null URB. Default is a no-op so existing
+         * callers compile unchanged.
+         */
+        default void onCaptureStopped() {}
     }
 
     /**
@@ -359,6 +366,18 @@ public class UsbAudioDevice {
                     try { requests[i].close(); } catch (Exception ignored) {}
                 }
             }
+            // If `capturing` is still true here, we exited without an explicit
+            // stopCapture() — the device died on us. Notify upstream so the
+            // recorder can rebind (e.g. fall back to the built-in mic) instead
+            // of stalling on a dead handle forever.
+            boolean abnormalExit = capturing;
+            capturing = false;
+            if (abnormalExit && callback != null) {
+                final AudioInputCallback cb = callback;
+                new Thread(() -> {
+                    try { cb.onCaptureStopped(); } catch (Exception ignored) {}
+                }, "USB-Audio-Capture-Stopped").start();
+            }
         }
     }
 
@@ -411,23 +430,40 @@ public class UsbAudioDevice {
             buf.put(pcmData, offset, chunkSize);
             buf.flip();
 
+            // Whole iteration is guarded: if the underlying USB connection has
+            // been torn down (cable yanked, kernel renumeration, selective
+            // suspend), initialize() returns false and queue()/requestWait()
+            // throw IllegalStateException. Catching here turns a fatal process
+            // crash into a clean TX abort that the caller already handles.
             UsbRequest request = new UsbRequest();
-            request.initialize(connection, endpointOut);
-            boolean queued;
-            if (android.os.Build.VERSION.SDK_INT >= 26) {
-                queued = request.queue(buf);
-            } else {
-                queued = request.queue(buf, chunkSize);
-            }
-            if (!queued) {
-                Log.e(TAG, "Failed to queue output URB at offset " + offset);
-                request.close();
-                return false;
-            }
+            try {
+                if (!request.initialize(connection, endpointOut)) {
+                    Log.e(TAG, "request.initialize returned false at offset " + offset
+                            + " (USB connection likely closed)");
+                    try { request.close(); } catch (Exception ignored) {}
+                    return false;
+                }
 
-            UsbRequest completed = connection.requestWait();
-            if (completed != null) {
-                completed.close();
+                boolean queued;
+                if (android.os.Build.VERSION.SDK_INT >= 26) {
+                    queued = request.queue(buf);
+                } else {
+                    queued = request.queue(buf, chunkSize);
+                }
+                if (!queued) {
+                    Log.e(TAG, "Failed to queue output URB at offset " + offset);
+                    try { request.close(); } catch (Exception ignored) {}
+                    return false;
+                }
+
+                UsbRequest completed = connection.requestWait();
+                if (completed != null) {
+                    try { completed.close(); } catch (Exception ignored) {}
+                }
+            } catch (IllegalStateException | NullPointerException e) {
+                Log.e(TAG, "writeAudio aborting at offset " + offset + ": " + e.getMessage());
+                try { request.close(); } catch (Exception ignored) {}
+                return false;
             }
 
             offset += chunkSize;

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -3,10 +3,13 @@ package radio.ks3ckc.ft8us
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbManager
 import android.media.AudioManager
 import android.net.Uri
 import android.os.Build
@@ -52,6 +55,7 @@ import java.util.Locale
 class ComposeMainActivity : ComponentActivity() {
 
     private var bluetoothReceiver: BluetoothStateBroadcastReceive? = null
+    private var usbDetachReceiver: BroadcastReceiver? = null
     private lateinit var mainViewModel: MainViewModel
 
     companion object {
@@ -100,6 +104,12 @@ class ComposeMainActivity : ComponentActivity() {
         if (mainViewModel.isBTConnected()) {
             mainViewModel.setBlueToothOn()
         }
+
+        // Register USB detach receiver — without this, a cable yank leaves the
+        // recorder waiting on a dead handle and TX still pointing at a closed
+        // UsbDeviceConnection. We tear down those handles here so the next
+        // ATTACH event can rebind cleanly.
+        registerUsbDetachReceiver()
 
         // Set Compose UI — splash plays once per cold start, then crossfades into the app.
         setContent {
@@ -337,8 +347,47 @@ class ComposeMainActivity : ComponentActivity() {
         }
     }
 
+    private fun registerUsbDetachReceiver() {
+        if (usbDetachReceiver != null) return
+        usbDetachReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.action != UsbManager.ACTION_USB_DEVICE_DETACHED) return
+                val device: UsbDevice? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+                }
+                fileLog("usbDetach: vid=${device?.vendorId?.toString(16)} " +
+                    "pid=${device?.productId?.toString(16)}")
+                // Drop the recorder's USB audio handle. reinitialize() handles
+                // both "device gone -> fall back to built-in mic" and
+                // "device returned -> reopen". Idempotent and safe to call.
+                try {
+                    mainViewModel.reinitializeAudioInput()
+                } catch (e: Exception) {
+                    fileLog("usbDetach: reinitializeAudioInput threw: ${e.message}")
+                }
+            }
+        }
+        val filter = IntentFilter(UsbManager.ACTION_USB_DEVICE_DETACHED)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(usbDetachReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(usbDetachReceiver, filter)
+        }
+    }
+
+    private fun unregisterUsbDetachReceiver() {
+        usbDetachReceiver?.let {
+            try { unregisterReceiver(it) } catch (_: Exception) {}
+            usbDetachReceiver = null
+        }
+    }
+
     override fun onDestroy() {
         unregisterBluetoothReceiver()
+        unregisterUsbDetachReceiver()
         super.onDestroy()
     }
 


### PR DESCRIPTION
## Summary

Three related bugs that all trip when the USB OTG cable to the radio loses contact briefly. Combined, they turn a momentary USB hiccup into either an app crash (during TX) or a silently stalled waterfall (during decode). After this PR the app degrades to a missed TX or a skipped decode cycle instead.

### 1. TX no longer crashes the whole process when the USB connection has been torn down
\`UsbAudioDevice.writeAudio()\` called \`UsbRequest.initialize()\` and \`.queue()\` without guards. When the cable was yanked between FT8 slots the underlying \`UsbDeviceConnection\` was closed, so \`queue()\` threw \`IllegalStateException: request is not initialized\` on \`pool-9-thread-1\` — and that uncaught exception killed the process mid-transmit. PTT had already been raised by then, so the user saw a hot carrier with no audio. Stack from the field:
\`\`\`
E/AndroidRuntime: java.lang.IllegalStateException: request is not initialized
    at android.hardware.usb.UsbRequest.queue(UsbRequest.java:278)
    at com.bg7yoz.ft8cn.wave.UsbAudioDevice.writeAudio(UsbAudioDevice.java:418)
    at com.bg7yoz.ft8cn.ft8transmit.FT8TransmitSignal.playViaUsbAudio(FT8TransmitSignal.java:569)
\`\`\`
The inner loop now checks \`initialize()\`'s return value and catches \`IllegalStateException\` / \`NullPointerException\`, returning false. \`playViaUsbAudio\` already handles a false return by dropping PTT and tearing down the audio device cleanly.

### 2. Decode loop unblocks when the USB audio device disappears
The capture-loop thread in \`UsbAudioDevice.captureLoop()\` exited silently when \`requestWait()\` returned null, leaving \`MicRecorder\` pointing at a dead handle. \`FT8SignalListener.getVoiceData()\`'s \`onGetDone\` callback then never fired — visible in logs as every slot logging \`Starting recording...\` with no matching \`Starting decode...\`. \`AudioInputCallback\` now has a default \`onCaptureStopped()\` method invoked from \`captureLoop\`'s finally block on abnormal exit. \`MicRecorder\` uses it to call its existing \`reinitialize()\`, which either reopens a fresh USB handle or falls back to the built-in mic.

### 3. The app actually notices USB_DEVICE_DETACHED now
The manifest only registers for \`USB_DEVICE_ATTACHED\`, so a disconnect previously left stale audio and serial handles in place until the next attach. \`ComposeMainActivity\` now registers a dynamic \`BroadcastReceiver\` for \`ACTION_USB_DEVICE_DETACHED\` that calls \`reinitializeAudioInput()\`. This complements the capture-loop callback above — the capture callback handles device deaths that don't generate a system DETACHED event (e.g. selective suspend).

## Context
Found while debugging an FT-891 owner whose Pixel 8 OTG cable cycled four full disconnect/reconnect events in 60 seconds. After this PR, the same flaky hardware still drops audio (no software fix for a bad cable) but the app stays alive and recovers when the cable comes back, instead of crashing or freezing.

## Test plan
- [ ] On a stable USB connection: TX still works normally end to end; decode loop produces \`Starting decode...\` / \`Decode took:\` lines every cycle as before.
- [ ] Mid-TX, physically yank the OTG cable: app does not crash. Expect \`writeAudio aborting at offset N: request is not initialized\` in logcat and a clean PTT release.
- [ ] Mid-decode, yank the OTG cable: expect \`USB audio capture stopped unexpectedly, reinitializing\` in logcat, then \`Starting decode...\` resumes (against the built-in mic) within one slot.
- [ ] Detach event in debug.log: should see \`usbDetach: vid=10c4 pid=ea70\` style lines whenever a device leaves.
- [ ] On reattach: existing \`onNewIntent USB_DEVICE_ATTACHED\` path takes over and reopens the USB audio + serial as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)