### PR TITLE
Show state and pulsating QSO sequence in decode sheet

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -1,7 +1,15 @@
 package radio.ks3ckc.ft8us.ui.decode
 
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,9 +31,12 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bg7yoz.ft8cn.Ft8Message
@@ -80,8 +91,13 @@ private fun QsoSheetContent(
 ) {
     val callsign = message.callsignFrom ?: ""
     val status = resolveQsoStatus(message)
+    val context = LocalContext.current
     val isTransmitting by mainViewModel.ft8TransmitSignal.mutableIsTransmitting.observeAsState(false)
     val isActivated by mainViewModel.ft8TransmitSignal.mutableIsActivated.observeAsState(false)
+    val toCallsign by mainViewModel.ft8TransmitSignal.mutableToCallsign.observeAsState()
+    val txFunctionOrder by mainViewModel.ft8TransmitSignal.mutableFunctionOrder.observeAsState(6)
+
+    val usState = UsStateLookup.stateFromGrid(context, message.maidenGrid)
 
     Column(
         modifier = Modifier
@@ -92,8 +108,19 @@ private fun QsoSheetContent(
         StationHeader(
             callsign = callsign,
             status = status,
-            location = message.fromWhere,
+            country = message.fromWhere,
+            state = usState,
             grid = message.maidenGrid,
+            onQrzClick = {
+                try {
+                    val intent = Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse("https://www.qrz.com/db/${Uri.encode(callsign)}"),
+                    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    context.startActivity(intent)
+                } catch (_: Exception) {
+                }
+            },
         )
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -104,10 +131,14 @@ private fun QsoSheetContent(
         Spacer(modifier = Modifier.height(20.dp))
 
         // -- QSO sequence visualizer --
+        val liveQsoIsThisCallsign =
+            isActivated && toCallsign?.callsign?.equals(callsign, ignoreCase = true) == true
         QsoSequenceVisualizer(
             callsign = callsign,
             message = message,
-            isActivated = isActivated,
+            isLiveQso = liveQsoIsThisCallsign,
+            liveFunctionOrder = txFunctionOrder ?: 6,
+            isTransmitting = isTransmitting,
         )
 
         // -- Current TX banner: always shows what's queued to transmit next --
@@ -185,8 +216,10 @@ private fun QsoSheetContent(
 private fun StationHeader(
     callsign: String,
     status: QsoStatus,
-    location: String?,
+    country: String?,
+    state: String?,
     grid: String?,
+    onQrzClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -226,12 +259,9 @@ private fun StationHeader(
                 StatusPill(status = status, compact = true)
             }
 
-            // Location info
-            val locationParts = buildList {
-                if (!location.isNullOrEmpty()) add(location)
-                if (!grid.isNullOrEmpty()) add(grid)
-            }
-            if (locationParts.isNotEmpty()) {
+            // Location info: combine state + country + grid into a single sentence
+            val locationText = formatLocationLine(state = state, country = country, grid = grid)
+            if (!locationText.isNullOrEmpty()) {
                 Row(
                     modifier = Modifier.padding(top = 2.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -239,14 +269,65 @@ private fun StationHeader(
                 ) {
                     FT8USIcons.Globe(color = TextFaint, size = 12.dp)
                     Text(
-                        text = locationParts.joinToString(" \u2022 "),
+                        text = locationText,
                         color = TextMuted,
                         fontSize = 12.sp,
                     )
                 }
             }
+
+            // QRZ link
+            Row(
+                modifier = Modifier
+                    .padding(top = 4.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable(onClick = onQrzClick)
+                    .padding(vertical = 2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = "QRZ \u2197",
+                    color = Signal,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    textDecoration = TextDecoration.Underline,
+                    letterSpacing = 0.04.sp,
+                )
+            }
         }
     }
+}
+
+/**
+ * Build a human-readable single-line location label combining (in order):
+ *   state, country (collapsed when redundant with state), grid.
+ * Returns null when none of the inputs are usable.
+ */
+private fun formatLocationLine(
+    state: String?,
+    country: String?,
+    grid: String?,
+): String? {
+    val countryClean = country?.trim()
+    val isUs = countryClean?.contains("United States", ignoreCase = true) == true ||
+        countryClean.equals("USA", ignoreCase = true)
+
+    val placeText = when {
+        !state.isNullOrEmpty() && isUs -> "$state, USA"
+        !state.isNullOrEmpty() && countryClean.isNullOrEmpty() -> "$state, USA"
+        !state.isNullOrEmpty() -> "$state, $countryClean"
+        countryClean.isNullOrEmpty() -> null
+        countryClean == "United States of America" -> "USA"
+        countryClean == "United Kingdom" -> "UK"
+        else -> countryClean
+    }
+
+    val parts = buildList {
+        if (!placeText.isNullOrEmpty()) add(placeText)
+        if (!grid.isNullOrEmpty()) add(grid)
+    }
+    return if (parts.isEmpty()) null else parts.joinToString(" \u2022 ")
 }
 
 // ---------------------------------------------------------------------------
@@ -340,14 +421,12 @@ private data class QsoStep(
 private fun QsoSequenceVisualizer(
     callsign: String,
     message: Ft8Message,
-    isActivated: Boolean,
+    isLiveQso: Boolean,
+    liveFunctionOrder: Int,
+    isTransmitting: Boolean,
 ) {
     val myCall = GeneralVariables.myCallsign ?: ""
-    val grid = message.maidenGrid ?: ""
     val myGrid = GeneralVariables.getMyMaidenhead4Grid() ?: ""
-
-    // Determine current QSO step based on extraInfo
-    val currentFunOrder = GeneralVariables.checkFunOrder(message)
 
     val steps = listOf(
         QsoStep(
@@ -377,19 +456,26 @@ private fun QsoSequenceVisualizer(
         ),
     )
 
-    // Map fun order to completed step count
-    val completedSteps = when {
-        currentFunOrder >= 5 -> 5  // 73 sent -> all done
-        currentFunOrder == 4 -> 4  // RR73/RRR received
-        currentFunOrder == 3 -> 3  // R-report sent
-        currentFunOrder == 2 -> 2  // Report received
-        currentFunOrder == 1 -> 1  // Grid / initial call
-        isActivated -> 0           // Activated but not started
-        else -> -1                 // Not started
-    }
+    // Determine current step (0-based index, or -1 for "not started"). For a live
+    // QSO we use the operator's transmit function order; otherwise fall back to
+    // historical message state or the worked/confirmed flag.
+    val historicalFunOrder = GeneralVariables.checkFunOrder(message)
+    val isFullyComplete = message.isQSL_Callsign && !isLiveQso
 
-    val visibleSteps = steps.take((completedSteps + 1).coerceAtLeast(0))
-    if (visibleSteps.isEmpty()) return
+    val currentStepIndex = when {
+        isFullyComplete -> 5  // QSO complete -> all 5 done
+        isLiveQso -> when (liveFunctionOrder) {
+            1 -> 0   // sending grid call
+            2 -> 1   // they replied with grid, we're sending report
+            3 -> 2   // they sent report, we're sending R-report
+            4 -> 3   // they sent R-report, we're sending RR73
+            5 -> 4   // we're sending 73 -> all logged
+            else -> -1
+        }
+        historicalFunOrder == 5 -> 5
+        historicalFunOrder in 1..4 -> historicalFunOrder
+        else -> -1
+    }
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -404,16 +490,18 @@ private fun QsoSequenceVisualizer(
             modifier = Modifier.padding(bottom = 10.dp),
         )
 
-        visibleSteps.forEachIndexed { index, step ->
-            val isComplete = index < completedSteps
-            val isCurrent = index == completedSteps
+        // Always render every step; state is per-step.
+        steps.forEachIndexed { index, step ->
+            val isComplete = index < currentStepIndex
+            val isCurrent = index == currentStepIndex && currentStepIndex in 0..4
 
             QsoStepRow(
                 stepNumber = index + 1,
                 step = step,
                 isComplete = isComplete,
                 isCurrent = isCurrent,
-                isLast = index == visibleSteps.lastIndex,
+                pulse = isCurrent && (isLiveQso || isTransmitting),
+                isLast = index == steps.lastIndex,
             )
         }
     }
@@ -425,6 +513,7 @@ private fun QsoStepRow(
     step: QsoStep,
     isComplete: Boolean,
     isCurrent: Boolean,
+    pulse: Boolean,
     isLast: Boolean,
 ) {
     val stepColor = when {
@@ -438,9 +527,37 @@ private fun QsoStepRow(
         else -> TextDim
     }
     val txRxColor = when (step.txRxLabel) {
-        "TX" -> StatusBad
-        "RX" -> Signal
+        "TX" -> if (isComplete || isCurrent) StatusBad else TextDim
+        "RX" -> if (isComplete || isCurrent) Signal else TextDim
         else -> TextDim
+    }
+
+    // Pulse animation: only when this is the active step in a live QSO.
+    val pulseScale: Float
+    val pulseAlpha: Float
+    if (pulse) {
+        val transition = rememberInfiniteTransition(label = "qso-step-pulse")
+        pulseScale = transition.animateFloat(
+            initialValue = 1f,
+            targetValue = 1.18f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 900),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "pulse-scale",
+        ).value
+        pulseAlpha = transition.animateFloat(
+            initialValue = 0.25f,
+            targetValue = 0.55f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 900),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "pulse-alpha",
+        ).value
+    } else {
+        pulseScale = 1f
+        pulseAlpha = 0f
     }
 
     Row(
@@ -449,38 +566,57 @@ private fun QsoStepRow(
             .padding(vertical = 6.dp),
         verticalAlignment = Alignment.Top,
     ) {
-        // Step indicator (number or check)
+        // Step indicator (number, pulsing dot, or check)
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.width(28.dp),
         ) {
             Box(
-                modifier = Modifier
-                    .size(22.dp)
-                    .clip(CircleShape)
-                    .background(
-                        if (isComplete) StatusConfirmed.copy(alpha = 0.15f)
-                        else if (isCurrent) Accent.copy(alpha = 0.15f)
-                        else BgSurface3
-                    )
-                    .border(
-                        1.dp,
-                        if (isComplete) StatusConfirmed.copy(alpha = 0.4f)
-                        else if (isCurrent) Accent.copy(alpha = 0.4f)
-                        else Border,
-                        CircleShape,
-                    ),
+                modifier = Modifier.size(22.dp),
                 contentAlignment = Alignment.Center,
             ) {
-                if (isComplete) {
-                    FT8USIcons.Check(color = StatusConfirmed, size = 12.dp)
-                } else {
-                    Text(
-                        text = "$stepNumber",
-                        color = stepColor,
-                        fontSize = 10.sp,
-                        fontWeight = FontWeight.Bold,
+                // Pulse halo behind the indicator while active.
+                if (pulse) {
+                    Box(
+                        modifier = Modifier
+                            .size(22.dp)
+                            .scale(pulseScale)
+                            .clip(CircleShape)
+                            .background(Accent.copy(alpha = pulseAlpha)),
                     )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(22.dp)
+                        .clip(CircleShape)
+                        .background(
+                            when {
+                                isComplete -> StatusConfirmed.copy(alpha = 0.18f)
+                                isCurrent -> Accent.copy(alpha = 0.18f)
+                                else -> BgSurface3
+                            },
+                        )
+                        .border(
+                            1.dp,
+                            when {
+                                isComplete -> StatusConfirmed.copy(alpha = 0.5f)
+                                isCurrent -> Accent.copy(alpha = 0.6f)
+                                else -> Border
+                            },
+                            CircleShape,
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (isComplete) {
+                        FT8USIcons.Check(color = StatusConfirmed, size = 12.dp)
+                    } else {
+                        Text(
+                            text = "$stepNumber",
+                            color = stepColor,
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 }
             }
 
@@ -490,7 +626,9 @@ private fun QsoStepRow(
                     modifier = Modifier
                         .width(1.dp)
                         .height(12.dp)
-                        .background(if (isComplete) StatusConfirmed.copy(alpha = 0.3f) else Border)
+                        .background(
+                            if (isComplete) StatusConfirmed.copy(alpha = 0.3f) else Border,
+                        ),
                 )
             }
         }
@@ -525,10 +663,10 @@ private fun QsoStepRow(
                     )
                 }
             }
-            // Message preview
+            // Message preview (dimmer when neither current nor complete).
             Text(
                 text = step.messagePreview,
-                color = TextDim,
+                color = if (isComplete || isCurrent) TextDim else TextDim.copy(alpha = 0.55f),
                 fontFamily = GeistMonoFamily,
                 fontSize = 10.sp,
                 modifier = Modifier.padding(top = 1.dp),

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
@@ -72,6 +72,7 @@ import radio.ks3ckc.ft8us.ui.components.ShimmerBox
 import radio.ks3ckc.ft8us.ui.components.StatusPill
 import radio.ks3ckc.ft8us.ui.components.TopBar
 import radio.ks3ckc.ft8us.ui.components.TopBarSubtitle
+import radio.ks3ckc.ft8us.ui.decode.UsStateLookup
 import kotlin.coroutines.resume
 
 // ---------------------------------------------------------------------------
@@ -916,11 +917,25 @@ private fun QsoRow(record: QSLCallsignRecord) {
     val band = record.band ?: ""
     val time = record.lastTime ?: ""
     val dxcc = record.dxccStr ?: ""
+    val context = LocalContext.current
+    val state = UsStateLookup.stateFromGrid(context, grid)
 
     val status = when {
         record.isLotW_QSL -> QsoStatus.CONFIRMED
         record.isQSL -> QsoStatus.WORKED
         else -> QsoStatus.PENDING
+    }
+
+    // Build the secondary line entries (state takes precedence over DXCC when present
+    // because for US contacts the DXCC string is always just "United States" and the
+    // state is the more useful information).
+    val secondaryParts = buildList {
+        if (grid.isNotBlank()) add(grid to Signal)
+        if (!state.isNullOrBlank()) {
+            add("$state, USA" to TextMuted)
+        } else if (dxcc.isNotBlank()) {
+            add(dxcc to TextFaint)
+        }
     }
 
     GlassCard(modifier = Modifier.fillMaxWidth()) {
@@ -953,7 +968,7 @@ private fun QsoRow(record: QSLCallsignRecord) {
 
             Spacer(modifier = Modifier.width(8.dp))
 
-            // Callsign + grid + DX entity
+            // Callsign + grid + state/DX entity
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = callsign,
@@ -965,19 +980,12 @@ private fun QsoRow(record: QSLCallsignRecord) {
                     overflow = TextOverflow.Ellipsis,
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    if (grid.isNotBlank()) {
+                    secondaryParts.forEach { (text, color) ->
                         Text(
-                            text = grid,
-                            color = Signal,
+                            text = text,
+                            color = color,
                             fontSize = 10.sp,
                             fontFamily = GeistMonoFamily,
-                        )
-                    }
-                    if (dxcc.isNotBlank()) {
-                        Text(
-                            text = dxcc,
-                            color = TextFaint,
-                            fontSize = 10.sp,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )


### PR DESCRIPTION
## Summary

- Show US state on every decode row, on the QSO sheet header, and on each logbook entry, derived from the station's Maidenhead grid.
- Add a QRZ link under the callsign in the QSO sheet that opens the station's QRZ.com page in the browser.
- Rework the QSO Sequence visualizer: always render all 5 steps so the path is visible from the start. Future steps are grayed, the active step pulsates, and completed steps get the green check. The active step is driven by the operator's live transmit function order when the sheet matches the current TX target.

## Test plan

- [ ] Open a US station's CQ from the decode list and confirm the state is shown on the row and on the sheet header.
- [ ] Tap the QRZ link in the sheet and confirm it opens qrz.com/db/CALL.
- [ ] Click Call on a CQ and watch the QSO Sequence — step 1 pulsates, fills in green on each handoff, and the next step pulsates in turn.
- [ ] Open the Logbook → Recent tab and verify US contacts show "<state>, USA" on the secondary line.

Generated with Claude Code
