### PR TITLE
security: hardening pass across manifest, ADIF import, credentials, and signing

### DIFF
--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -36,7 +36,21 @@ android {
 
             }
         }
-        signingConfig signingConfigs.debug
+    }
+
+    signingConfigs {
+        // Release signing is opt-in via project properties (typically declared in
+        // ~/.gradle/gradle.properties or via -P flags on the command line). If those
+        // properties are absent the release build produces an unsigned APK rather than
+        // silently falling back to the debug key.
+        if (project.hasProperty('RELEASE_STORE_FILE')) {
+            release {
+                storeFile file(RELEASE_STORE_FILE)
+                storePassword RELEASE_STORE_PASSWORD
+                keyAlias RELEASE_KEY_ALIAS
+                keyPassword RELEASE_KEY_PASSWORD
+            }
+        }
     }
 
     buildTypes {
@@ -45,8 +59,13 @@ android {
             buildConfigField("String", "apkBuildTime", "\"${currentTime}\"")
         }
         release {
+            if (project.hasProperty('RELEASE_STORE_FILE')) {
+                signingConfig signingConfigs.release
+            }
+            // TODO: enable R8 once we have a proguard-rules.pro that keeps the JNI entry
+            // points in FT8SignalListener/FT8Package/etc and the reflection-driven
+            // SQLite mappers. Shipping with minify off until that work is done.
             minifyEnabled false
-            signingConfig signingConfigs.debug
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField("String", "apkBuildTime", "\"${currentTime}\"")
 

--- a/ft8cn/app/src/main/AndroidManifest.xml
+++ b/ft8cn/app/src/main/AndroidManifest.xml
@@ -21,8 +21,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
-        android:allowBackup="true"
-        android:usesCleartextTraffic="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -56,7 +57,6 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\.adi" />
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="application/octet-stream" />
-                <data android:mimeType="*/*" />
             </intent-filter>
             <meta-data
                 android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FAQActivity.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FAQActivity.java
@@ -7,6 +7,7 @@ package com.bg7yoz.ft8cn;
 
 import android.annotation.SuppressLint;
 import android.os.Bundle;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -22,8 +23,15 @@ public class FAQActivity extends AppCompatActivity {
 
 
         WebView webView = (WebView) findViewById(R.id.faqWebView);
-        webView.getSettings().setJavaScriptEnabled(true);
-        webView.getSettings().setDomStorageEnabled(true);       // This needs to be enabled
+        WebSettings faqSettings = webView.getSettings();
+        faqSettings.setJavaScriptEnabled(true);
+        faqSettings.setDomStorageEnabled(true);       // This needs to be enabled
+        // Block local file / content URI access so a compromised support.qq.com page
+        // can't read app cache or FileProvider contents via the WebView.
+        faqSettings.setAllowFileAccess(false);
+        faqSettings.setAllowContentAccess(false);
+        faqSettings.setAllowFileAccessFromFileURLs(false);
+        faqSettings.setAllowUniversalAccessFromFileURLs(false);
 
         /* Get the webview url. Note the word is "product" not "products"; "products" is an old parameter and using the wrong address will prevent successful submission */
         //String url = "https://www.qrz.com/db/BG7YOZ";

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -156,6 +156,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
      * @param sql       column definition SQL
      */
     private void alterTable(SQLiteDatabase db, String tableName, String fieldName, String sql) {
+        // Identifiers are interpolated into ALTER TABLE because SQLite cannot bind them; restrict
+        // to simple SQL identifiers so a stray caller can never inject statements.
+        if (!SQL_IDENTIFIER.matcher(tableName).matches()
+                || !SQL_IDENTIFIER.matcher(fieldName).matches()) {
+            throw new IllegalArgumentException("Invalid SQL identifier");
+        }
         Cursor cursor = db.rawQuery("select * from sqlite_master where name=? and sql like ?"
                 , new String[]{tableName, "%" + fieldName + "%"});
         if (!cursor.moveToNext()) {
@@ -163,6 +169,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         }
         cursor.close();
     }
+
+    private static final java.util.regex.Pattern SQL_IDENTIFIER =
+            java.util.regex.Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
 
     /**
      * Check if a table exists

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ImportSharedLogs.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ImportSharedLogs.java
@@ -4,13 +4,21 @@ import com.bg7yoz.ft8cn.GeneralVariables;
 import com.bg7yoz.ft8cn.MainViewModel;
 import com.bg7yoz.ft8cn.R;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class ImportSharedLogs {
     private static final String TAG = "ImportSharedLogs";
+    // Cap shared file size so a hostile (or just oversized) .adi opened via the VIEW intent
+    // cannot OOM the app. 50 MB comfortably fits a real-world lifetime ADIF log.
+    private static final int MAX_IMPORT_BYTES = 50 * 1024 * 1024;
+    // Reject individual ADIF field lengths above this to avoid pathological allocations in
+    // substring() when a record claims a multi-megabyte field.
+    private static final int MAX_ADIF_FIELD_LEN = 64 * 1024;
     //private final Uri uri;
     private String fileContext;
     private final MainViewModel mainViewModel;
@@ -22,26 +30,37 @@ public class ImportSharedLogs {
     }
 
     private boolean loadData(OnShareLogEvents onShareLogEvents) {
-        if (logFileStream != null) {
-            byte[] bytes = new byte[0];
-            try {
-                bytes = new byte[logFileStream.available()];
-                logFileStream.read(bytes);
-                fileContext = new String(bytes);
-            } catch (IOException e) {
-                if (onShareLogEvents != null) {
-                    onShareLogEvents.onShareFailed(String.format(
-                            GeneralVariables.getStringFromResource(R.string.import_share_failed)
-                            , e.getMessage()));
-                }
-                return false;
-            }
-            return true;
-
-        } else {
+        if (logFileStream == null) {
             fileContext = "";
             return false;
         }
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        int total = 0;
+        try {
+            int n;
+            while ((n = logFileStream.read(chunk)) > 0) {
+                total += n;
+                if (total > MAX_IMPORT_BYTES) {
+                    if (onShareLogEvents != null) {
+                        onShareLogEvents.onShareFailed(String.format(
+                                GeneralVariables.getStringFromResource(R.string.import_share_failed)
+                                , "file exceeds " + (MAX_IMPORT_BYTES / (1024 * 1024)) + " MB limit"));
+                    }
+                    return false;
+                }
+                buffer.write(chunk, 0, n);
+            }
+            fileContext = buffer.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            if (onShareLogEvents != null) {
+                onShareLogEvents.onShareFailed(String.format(
+                        GeneralVariables.getStringFromResource(R.string.import_share_failed)
+                        , e.getMessage()));
+            }
+            return false;
+        }
+        return true;
     }
 
     public String getLogBody() {
@@ -82,6 +101,9 @@ public class ImportSharedLogs {
                                 if (ttt.length > 1) {
                                     String name = ttt[0];//Field name
                                     int valueLen = Integer.parseInt(ttt[1]);//Field length
+                                    if (valueLen > MAX_ADIF_FIELD_LEN) {
+                                        continue;//Skip pathological field lengths
+                                    }
                                     if (valueLen > 0) {
                                         if (values[1].length() < valueLen) {
                                             valueLen = values[1].length() - 1;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
@@ -15,6 +15,8 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 enum ServiceType{
@@ -121,25 +123,18 @@ public class ThirdPartyService {
     public static void UploadToCloudLog(QSLRecord qslRecord){
         // Convert to ADIF format
         String logStr = QSLRecordToADIF(qslRecord,ServiceType.Cloudlog);
-        Log.d(TAG,logStr);
         String address = GeneralVariables.getCloudlogServerAddress();
         if (!address.endsWith("/")){
             address+="/";
         }
-        HashMap<String,String> json = new HashMap<>();
-        json.put("key", GeneralVariables.getCloudlogServerApiKey());
-        json.put("station_profile_id", GeneralVariables.getCloudlogStationID());
-        json.put("type","adif");
-        json.put("string", logStr);
-
         JSONStringer js = new JSONStringer();
         try {
             String result = js.object().key("key").value(GeneralVariables.getCloudlogServerApiKey()).key("station_profile_id").value(GeneralVariables.getCloudlogStationID())
                     .key("type").value("adif").key("string").value(logStr).endObject().toString();
             String clRes = sendPostRequest(address+"api/qso/",result);
-            Log.d(TAG,"Updated to Cloudlog successfully. result:"+clRes);
+            Log.d(TAG, "Cloudlog upload " + (clRes != null ? "succeeded" : "failed"));
         }catch (Exception k){
-            Log.d(TAG, k.toString());
+            Log.d(TAG, "Cloudlog upload error: " + k.getClass().getSimpleName());
         }
     }
     public static boolean CheckCloudlogConnection(){
@@ -150,14 +145,14 @@ public class ThirdPartyService {
             address+="/";
         }
         try{
+            // The Cloudlog auth endpoint takes the key as a path segment, so the constructed
+            // URL is unavoidably credential-bearing. Do not log it.
             String url = address + "api/auth/"+ apiKey;
-            Log.d(TAG, "URL: "+url);
             String result = sendGetRequest(url);
             if (result == null) {
                 Log.d(TAG, "Cloudlog connection failed: no response");
                 return false;
             }
-            Log.d(TAG, result);
             // Nextlog and Wavelog both implement /api/auth but return slightly different shapes
             // (XML declaration, extra whitespace, etc.). Match on the meaningful markers so all
             // three Cloudlog-compatible backends report Pass.
@@ -165,7 +160,7 @@ public class ThirdPartyService {
             return compact.contains("<status>Valid</status>")
                     && compact.contains("<rights>rw</rights>");
         }catch (Exception e){
-            Log.d(TAG, e.toString());
+            Log.d(TAG, "Cloudlog auth error: " + e.getClass().getSimpleName());
             return false;
         }
     }
@@ -173,26 +168,27 @@ public class ThirdPartyService {
     public static boolean CheckQRZConnection(){
         String apiKey = GeneralVariables.getQrzApiKey();
         try{
-            String url = "https://logbook.qrz.com/api?KEY="+apiKey+"&ACTION=STATUS";
-            String result = sendGetRequest(url);
+            // POST so the API key is in the body rather than the URL, where it could leak
+            // via proxies, server access logs, or our own logcat.
+            String body = "KEY=" + URLEncoder.encode(apiKey, StandardCharsets.UTF_8.name())
+                    + "&ACTION=STATUS";
+            String result = sendPostFormRequest("https://logbook.qrz.com/api", body);
             if (result == null) {
                 Log.d(TAG, "QRZ connection failed: no response");
                 return false;
             }
-            HashMap<String,String> status = new HashMap<>();
+            String qrzResult = null;
             for (String s : result.split("&")) {
-                String[] split = s.split("=");
-                if (split.length>1){
-                    status.put(split[0],split[1]);
+                String[] split = s.split("=", 2);
+                if (split.length > 1 && "RESULT".equals(split[0])) {
+                    qrzResult = split[1];
+                    break;
                 }
             }
-            Log.d(TAG, status.toString());
-            if (!"OK".equals(status.get("RESULT"))){
-                return false;
-            }
-            return true;
+            Log.d(TAG, "QRZ status RESULT=" + qrzResult);
+            return "OK".equals(qrzResult);
         }catch (Exception e){
-            Log.d(TAG, e.toString());
+            Log.d(TAG, "QRZ status error: " + e.getClass().getSimpleName());
             return false;
         }
     }
@@ -200,17 +196,16 @@ public class ThirdPartyService {
     public static void UploadToQRZ(QSLRecord qslRecord){
         // Convert to ADIF format
         String logStr = QSLRecordToADIF(qslRecord, ServiceType.QRZ);
-        Log.d(TAG,logStr);
         String apikey = GeneralVariables.getQrzApiKey();
-        HashMap<String,String> json = new HashMap<>();
-
-        String url = String.format("https://logbook.qrz.com/api/KEY=%s&ACTION=INSERT&ADIF=%s",apikey,logStr);
-
         try {
-            String result = sendGetRequest(url);
-            Log.d(TAG,"Updated to QRZ successfully. result:" + result);
+            // POST keeps both the API key and the ADIF payload out of the URL.
+            String body = "KEY=" + URLEncoder.encode(apikey, StandardCharsets.UTF_8.name())
+                    + "&ACTION=INSERT"
+                    + "&ADIF=" + URLEncoder.encode(logStr, StandardCharsets.UTF_8.name());
+            String result = sendPostFormRequest("https://logbook.qrz.com/api", body);
+            Log.d(TAG, "QRZ upload " + (result != null ? "succeeded" : "failed"));
         }catch (Exception k){
-            Log.d(TAG, k.toString());
+            Log.d(TAG, "QRZ upload error: " + k.getClass().getSimpleName());
         }
     }
 
@@ -255,6 +250,44 @@ public class ThirdPartyService {
 
         return null;
     }
+    public static String sendPostFormRequest(String url, String formBody) throws IOException {
+        HttpURLConnection conn = null;
+        BufferedReader reader = null;
+        try {
+            URL urlObj = new URL(url);
+            conn = (HttpURLConnection) urlObj.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            conn.setDoOutput(true);
+
+            OutputStream os = conn.getOutputStream();
+            os.write(formBody.getBytes(StandardCharsets.UTF_8));
+            os.flush();
+            os.close();
+
+            int responseCode = conn.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK
+                    || responseCode == HttpURLConnection.HTTP_CREATED) {
+                reader = new BufferedReader(new InputStreamReader(conn.getInputStream(),
+                        StandardCharsets.UTF_8));
+                StringBuilder response = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    response.append(line);
+                }
+                return response.toString();
+            }
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+            if (reader != null) {
+                reader.close();
+            }
+        }
+        return null;
+    }
+
     public static String sendGetRequest(String url) throws IOException {
         HttpURLConnection conn = null;
         BufferedReader reader = null;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/QRZ_Fragment.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/QRZ_Fragment.java
@@ -42,10 +42,19 @@ public class QRZ_Fragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         binding=FragmentQrzBinding.inflate(inflater, container, false);
-        binding.qrzWebView.getSettings().setJavaScriptEnabled(true);
+        WebSettings qrzSettings = binding.qrzWebView.getSettings();
+        qrzSettings.setJavaScriptEnabled(true);
+        // Block access to local files and content:// URIs from inside this WebView so a
+        // compromised qrz.com page (or a stored XSS) can't pivot to reading our cache or
+        // FileProvider contents. setAllowFileAccessFromFileURLs / Universal default false on
+        // API 30+ but set them explicitly for older devices we still support (minSdk 23).
+        qrzSettings.setAllowFileAccess(false);
+        qrzSettings.setAllowContentAccess(false);
+        qrzSettings.setAllowFileAccessFromFileURLs(false);
+        qrzSettings.setAllowUniversalAccessFromFileURLs(false);
         //binding.qrzWebView.getSettings().setDomStorageEnabled(true);       // This needs to be added
-        binding.qrzWebView.getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.SINGLE_COLUMN);
-        binding.qrzWebView.getSettings().setUseWideViewPort(true);
+        qrzSettings.setLayoutAlgorithm(WebSettings.LayoutAlgorithm.SINGLE_COLUMN);
+        qrzSettings.setUseWideViewPort(true);
 
         binding.qrzWebView.getSettings().setLoadWithOverviewMode(true);
         binding.qrzWebView.getSettings().setSupportZoom(true);

--- a/ft8cn/app/src/main/res/xml/data_extraction_rules.xml
+++ b/ft8cn/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true" />
+    <device-transfer />
+</data-extraction-rules>

--- a/ft8cn/app/src/main/res/xml/filepaths.xml
+++ b/ft8cn/app/src/main/res/xml/filepaths.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-path path="." name="files_path" />
+    <external-cache-path path="." name="files_path" />
 </paths>
 

--- a/ft8cn/app/src/main/res/xml/network_security_config.xml
+++ b/ft8cn/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/ft8cn/build.gradle
+++ b/ft8cn/build.gradle
@@ -4,12 +4,6 @@ plugins {
     id 'com.android.library' version '8.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
 }
-ext {
-    var3 = 'G:\\coding\\ft8CN\\ft8CN.jks'
-    var = var3
-    var1 = '/Users/mymac/Desktop/coding/ft8CN/ft8CN.jks'
-    var2 = var
-}
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## Summary

Audit + fix pass across the app. Four themed commits, smallest blast-radius first, build/signing last.

- **`98286ad` — manifest, FileProvider, network config.** `allowBackup=false`; add `networkSecurityConfig` (blocks cleartext app-wide) and `dataExtractionRules`; drop `*/*` MIME from the VIEW intent-filter; narrow FileProvider from `<external-path path=".">` to `<external-cache-path path=".">` (matches where `writeToTempFile` actually writes); validate identifiers before interpolating them into `ALTER TABLE` in `DatabaseOpr.alterTable` (defense-in-depth — current callers all pass literals).
- **`a65c834` — ADIF import hardening.** `ImportSharedLogs.loadData` previously sized a single `byte[]` from `InputStream.available()`, so a hostile or oversized `.adi` opened via the VIEW intent could OOM. Stream through an 8 KB buffer into a `ByteArrayOutputStream`, abort at 50 MB, decode as UTF-8 explicitly. Reject ADIF field lengths above 64 KB before `substring()`.
- **`79295ee` — credentials + WebViews.** QRZ `STATUS`/`INSERT` switched from `GET` (api key in URL) to `application/x-www-form-urlencoded` POST. Stop logging the Cloudlog auth URL and full HTTP response bodies; only class names on exceptions. QRZ + FAQ WebViews: `setAllowFileAccess(false)`, `setAllowContentAccess(false)`, file-URL cross-origin flags off.
- **`c958ff9` — build/signing.** Remove `signingConfig signingConfigs.debug` from both `defaultConfig` and the release block — `assembleRelease` was producing APKs signed with the per-machine debug key. Add a `signingConfigs.release` block guarded on `project.hasProperty('RELEASE_STORE_FILE')`; without those properties release now produces `app-release-unsigned.apk` (fail-loud default). Drop dead `ext { var3 = 'G:\\coding...' }` keystore-path block from the root `build.gradle`. `minifyEnabled` stays `false` with a `TODO` — R8 enablement needs JNI/SQLite keep rules + smoke testing and should be its own change.

`assembleDebug` and `assembleRelease` both green. Release APK now lands as `app-release-unsigned.apk` as intended.

## Deferred (documented but not fixed here)

- API keys stored unencrypted in SQLite — needs `EncryptedSharedPreferences` / Keystore migration; touches schema + every read site.
- CAT serial buffer growth in `IcomRig.java` / `Yaesu38Rig.java` — only exploitable by a malicious USB rig.
- WebView navigation host allowlist — needs a product call on which QRZ/QQ domains are legitimate.
- R8/ProGuard enablement.
- Native `libft8cn.so` audit — no C/C++ source in the repo.

## Test plan

- [x] `cd ft8cn && cmd.exe /c "gradlew.bat installDebug"` on the Pixel 8; app launches, decode/transmit still work.
- [x] Settings → Apps → FT8AF → confirm Backup is `Not allowed`; `adb backup -apk com.bg7yoz.ft8cn` returns empty/refused.
- [x] `dd if=/dev/urandom of=/tmp/big.adi bs=1M count=100`, `adb push`, open via picker → graceful "import failed" toast, no OOM. Confirm `debug.log` shows the abort path.
- [ ] With a real QRZ API key, trigger an upload. `adb logcat --pid=$(adb shell pidof com.bg7yoz.ft8cn) | grep ThirdPartyService` shows no key, no URL, only `QRZ upload succeeded/failed` and `QRZ status RESULT=OK`. Upload actually lands in the QRZ logbook.
- [x] Configure a `http://` Cloudlog endpoint → connection now fails (expected, network-security-config blocks cleartext). HTTPS Cloudlog + QRZ still work.
- [ ] Trigger ADIF export → share sheet still works and the file is reachable (FileProvider narrowing didn't break it).
- [ ] Open QRZ tab on a known callsign → page loads. FAQ tab loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)