### PR TITLE
CI: sign release APK from repo secrets

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -72,8 +72,28 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew
 
+      - name: Decode signing keystore
+        if: steps.tag.outputs.should_release == 'true'
+        env:
+          RELEASE_STORE_FILE_BASE64: ${{ secrets.RELEASE_STORE_FILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RELEASE_STORE_FILE_BASE64:-}" ]]; then
+            echo "::error::RELEASE_STORE_FILE_BASE64 secret is not configured." >&2
+            echo "::error::Add base64-encoded keystore (and RELEASE_STORE_PASSWORD," >&2
+            echo "::error::RELEASE_KEY_ALIAS, RELEASE_KEY_PASSWORD) under Settings → Secrets." >&2
+            exit 1
+          fi
+          keystore_path="$RUNNER_TEMP/release.keystore"
+          echo "$RELEASE_STORE_FILE_BASE64" | base64 -d > "$keystore_path"
+          echo "ORG_GRADLE_PROJECT_RELEASE_STORE_FILE=$keystore_path" >> "$GITHUB_ENV"
+
       - name: Build APK
         working-directory: ft8cn
+        env:
+          ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          ORG_GRADLE_PROJECT_RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: ./gradlew assembleRelease
 
       - name: Rename APK


### PR DESCRIPTION
## Summary

The "Build & Release APK" workflow has been failing on every push to `main` since #42 — including the most recent merge of #46 — because it tries to `mv app-release.apk → FT8CN-vX.Y.apk` but Gradle was producing `app-release-unsigned.apk` (no signing config was being passed to `assembleRelease`).

This PR wires the existing `signingConfigs.release` block in `app/build.gradle:41` up to GitHub repo secrets:

- New **Decode signing keystore** step (only runs when `should_release == 'true'`) base64-decodes the keystore into `$RUNNER_TEMP/release.keystore` and exports its path as `ORG_GRADLE_PROJECT_RELEASE_STORE_FILE`.
- The **Build APK** step now passes the keystore/key passwords and alias as `ORG_GRADLE_PROJECT_*` env vars so Gradle reads them as project properties via its env-var convention.
- PR builds skip the decode step, so `project.hasProperty('RELEASE_STORE_FILE')` stays false and they keep producing unsigned APKs — no change to PR validation.

## Required repo secrets

Before this merges, add these under **Settings → Secrets and variables → Actions → New repository secret**:

| Secret | Value |
| --- | --- |
| `RELEASE_STORE_FILE_BASE64` | `base64 -w 0 release.keystore` output (no line wrap) |
| `RELEASE_STORE_PASSWORD` | keystore password |
| `RELEASE_KEY_ALIAS` | the key alias inside the keystore |
| `RELEASE_KEY_PASSWORD` | key password (often same as the keystore password) |

If `RELEASE_STORE_FILE_BASE64` is missing when a release build runs, the workflow now fails fast with a clear `::error::` message pointing at the secrets page.

## Test plan

- [ ] Add the four secrets above
- [ ] Merge this PR — the resulting auto-tag push to `main` should produce a signed `FT8CN-v0.106.apk` (or whatever the bumped tag is) and create a GitHub Release
- [ ] Verify the released APK is signed: `apksigner verify --print-certs FT8CN-v0.106.apk`
- [ ] Open a follow-up PR to confirm PR builds still pass (they should — they skip the new decode step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
