### PR TITLE
CI: handle unsigned release APK filename in rename step

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -78,7 +78,22 @@ jobs:
 
       - name: Rename APK
         if: steps.tag.outputs.should_release == 'true'
-        run: mv ft8cn/app/build/outputs/apk/release/app-release.apk ft8cn/app/build/outputs/apk/release/FT8CN-${{ steps.tag.outputs.release_tag }}.apk
+        run: |
+          set -euo pipefail
+          cd ft8cn/app/build/outputs/apk/release
+          # No signing config is wired up (see app/build.gradle:46), so the
+          # release task emits app-release-unsigned.apk. Handle either name so
+          # adding RELEASE_STORE_FILE later will Just Work.
+          if [[ -f app-release.apk ]]; then
+            src=app-release.apk
+          elif [[ -f app-release-unsigned.apk ]]; then
+            src=app-release-unsigned.apk
+          else
+            echo "::error::No release APK found in $(pwd):" >&2
+            ls -la >&2
+            exit 1
+          fi
+          mv "$src" "FT8CN-${{ steps.tag.outputs.release_tag }}.apk"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

`assembleRelease` emits **`app-release-unsigned.apk`** when no signing config is wired up (`app/build.gradle:46` only enables the signing block when `RELEASE_STORE_FILE` is set as a Gradle property — and CI never sets it). But the rename step has always looked for `app-release.apk`, so every push-to-main release run has been failing at the rename with `mv: cannot stat 'app-release.apk': No such file or directory` — visible on the merge runs for PR #42 and PR #46.

Make the rename step pick whichever filename actually exists:

```bash
if [[ -f app-release.apk ]]; then
  src=app-release.apk
elif [[ -f app-release-unsigned.apk ]]; then
  src=app-release-unsigned.apk
else
  ...error...
fi
mv "$src" "FT8CN-vX.Y.apk"
```

So the unsigned APK gets renamed and published as the release asset. The branch on the signed filename keeps working unchanged if you later set up the keystore secrets (see closed PR #48 for that direction).

Supersedes #48 (the signing approach) — that one's being closed since you don't have a keystore yet.

## Test plan

- [ ] Merge this PR — the auto-tag push to `main` should produce `FT8CN-vX.Y.apk` (renamed from `app-release-unsigned.apk`) and create the GitHub Release without the `mv: cannot stat` failure
- [ ] If you do set up a keystore + secrets later, the same workflow still works — it just falls through to the `app-release.apk` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
