### PR TITLE
Map: add PSK Reporter overlay (issue #33)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -190,6 +190,7 @@ public class GeneralVariables {
     public static String qrzApiKey = ""; //QRZ API key
     public static String qrzXmlUsername = ""; //QRZ XML API username (for callsign lookups)
     public static String qrzXmlPassword = ""; //QRZ XML API password
+    public static boolean pskOverlayEnabled = false; //PSK Reporter map overlay (issue #33)
     public static boolean synFrequency = false;//Same-frequency transmit
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2300,6 +2300,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("qrzXmlPassword")) {
                     GeneralVariables.qrzXmlPassword = result;
                 }
+                if (name.equalsIgnoreCase("pskOverlayEnabled")) {
+                    GeneralVariables.pskOverlayEnabled = result.equals("1");
+                }
 
                 if (name.equalsIgnoreCase("swrSwitch")) {
                     GeneralVariables.swr_switch_on = result.equals("1");

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
@@ -1,0 +1,205 @@
+package radio.ks3ckc.ft8us.pskreporter
+
+import android.util.Log
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.bg7yoz.ft8cn.maidenhead.MaidenheadGrid
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.File
+import java.io.FileWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Client for the PSK Reporter retrieval API (issue #33).
+ *
+ * Endpoint: https://retrieve.pskreporter.info/query — returns XML of
+ * <receptionReport ... /> elements describing receivers that have decoded a
+ * transmitter. Per PSK Reporter's docs: do not query more than once per 5
+ * minutes for the same parameter set. The map screen polls every 5 min while
+ * the overlay is enabled; this client adds defense-in-depth via:
+ *   1. A 4m50s client-side cooldown that short-circuits redundant calls.
+ *   2. A 15-minute back-off on HTTP 429/503 (rate-limit signals).
+ *
+ * Returns null on transport/parse failure or while in cooldown — caller keeps
+ * any stale list; empty list means a successful fetch returned zero spots.
+ */
+data class PskReporterSpot(
+    val senderCallsign: String,
+    val receiverCallsign: String,
+    val receiverGrid: String,
+    val receiverLat: Double,
+    val receiverLon: Double,
+    val frequencyHz: Long,
+    val snr: Int,
+    val mode: String,
+    val flowStartSeconds: Long,
+)
+
+object PskReporterClient {
+    private const val TAG = "PskReporterClient"
+    private const val BASE_URL = "https://retrieve.pskreporter.info/query"
+    private const val AGENT = "ft8af-1.0"
+    private const val APP_CONTACT = "ft8af@example.org"
+    private const val COOLDOWN_MS = 290_000L
+    private const val RATE_LIMIT_COOLDOWN_MS = 15L * 60_000L
+    private const val MAX_SPOTS = 500
+    private const val IO_TIMEOUT_MS = 8000
+
+    @Volatile
+    var lastError: String? = null
+        private set
+
+    @Volatile
+    private var lastFetchEpochMs: Long = 0L
+    @Volatile
+    private var rateLimitedUntilEpochMs: Long = 0L
+
+    suspend fun fetchSpotsForMe(call: String, secondsBack: Int): List<PskReporterSpot>? = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        if (now < rateLimitedUntilEpochMs) {
+            log("skipped (rate-limit back-off ${(rateLimitedUntilEpochMs - now) / 1000}s remaining)")
+            return@withContext null
+        }
+        if (lastFetchEpochMs != 0L && now - lastFetchEpochMs < COOLDOWN_MS) {
+            log("skipped (client cooldown ${(COOLDOWN_MS - (now - lastFetchEpochMs)) / 1000}s remaining)")
+            return@withContext null
+        }
+        lastFetchEpochMs = now
+
+        val callUpper = call.uppercase()
+        val url = "$BASE_URL?senderCallsign=${urlEncode(callUpper)}" +
+            "&flowStartSeconds=-$secondsBack" +
+            "&rronly=1" +
+            "&mode=FT8" +
+            "&appcontact=${urlEncode(APP_CONTACT)}"
+        log("fetch start call=$callUpper secondsBack=$secondsBack")
+
+        val body = fetch(url) ?: return@withContext null
+        val spots = parseSpots(body)
+        log("fetch ok N=${spots.size}")
+        spots
+    }
+
+    private fun fetch(url: String): String? {
+        var conn: HttpURLConnection? = null
+        return try {
+            conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = "GET"
+                connectTimeout = IO_TIMEOUT_MS
+                readTimeout = IO_TIMEOUT_MS
+                setRequestProperty("User-Agent", AGENT)
+            }
+            val code = conn.responseCode
+            if (code == 429 || code == 503) {
+                rateLimitedUntilEpochMs = System.currentTimeMillis() + RATE_LIMIT_COOLDOWN_MS
+                log("rate-limited (http $code) — backing off ${RATE_LIMIT_COOLDOWN_MS / 60_000}min")
+                lastError = "rate-limited ($code)"
+                return null
+            }
+            if (code != HttpURLConnection.HTTP_OK) {
+                log("http $code from PSK Reporter")
+                lastError = "http $code"
+                return null
+            }
+            conn.inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+        } catch (e: Exception) {
+            log("transport error: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+            lastError = e.message
+            null
+        } finally {
+            conn?.disconnect()
+        }
+    }
+
+    private fun parseSpots(xml: String): List<PskReporterSpot> {
+        val out = mutableListOf<PskReporterSpot>()
+        var skippedNoGrid = 0
+        var skippedBadGrid = 0
+        var skippedBadAttr = 0
+        try {
+            val parser = XmlPullParserFactory.newInstance().newPullParser().apply {
+                setInput(xml.reader())
+            }
+            var event = parser.eventType
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG && parser.name == "receptionReport") {
+                    val sender = parser.getAttributeValue(null, "senderCallsign") ?: ""
+                    val receiver = parser.getAttributeValue(null, "receiverCallsign") ?: ""
+                    val grid = parser.getAttributeValue(null, "receiverLocator") ?: ""
+                    val freqStr = parser.getAttributeValue(null, "frequency")
+                    val snrStr = parser.getAttributeValue(null, "sNR")
+                    val flowStr = parser.getAttributeValue(null, "flowStartSeconds")
+                    val mode = parser.getAttributeValue(null, "mode") ?: "FT8"
+
+                    if (sender.isEmpty() || receiver.isEmpty()) {
+                        skippedBadAttr++
+                    } else if (grid.isEmpty()) {
+                        skippedNoGrid++
+                    } else {
+                        // MaidenheadGrid.gridToLatLng handles 2/4/6-char grids; wrap in try in
+                        // case of malformed values that slip past PSK Reporter's validation.
+                        val latLng = try { MaidenheadGrid.gridToLatLng(grid) } catch (_: Exception) { null }
+                        val freq = freqStr?.toLongOrNull()
+                        val snr = snrStr?.toIntOrNull()
+                        val flow = flowStr?.toLongOrNull()
+                        if (latLng == null || freq == null || snr == null || flow == null) {
+                            skippedBadGrid++
+                        } else {
+                            out.add(
+                                PskReporterSpot(
+                                    senderCallsign = sender,
+                                    receiverCallsign = receiver,
+                                    receiverGrid = grid,
+                                    receiverLat = latLng.latitude,
+                                    receiverLon = latLng.longitude,
+                                    frequencyHz = freq,
+                                    snr = snr,
+                                    mode = mode,
+                                    flowStartSeconds = flow,
+                                )
+                            )
+                        }
+                    }
+                }
+                event = parser.next()
+            }
+        } catch (e: Exception) {
+            log("parse error: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+            return emptyList()
+        }
+        if (skippedNoGrid + skippedBadGrid + skippedBadAttr > 0) {
+            log("parse: skipped noGrid=$skippedNoGrid badGrid=$skippedBadGrid badAttr=$skippedBadAttr")
+        }
+        return if (out.size > MAX_SPOTS) {
+            log("parse: capped from ${out.size} to $MAX_SPOTS (keeping most recent)")
+            // PSK Reporter returns chronological order — most-recent reports are at the tail.
+            out.takeLast(MAX_SPOTS)
+        } else {
+            out
+        }
+    }
+
+    private fun urlEncode(s: String): String =
+        URLEncoder.encode(s, StandardCharsets.UTF_8.name())
+
+    private fun log(msg: String) {
+        Log.d(TAG, msg)
+        try {
+            val ctx = GeneralVariables.getMainContext() ?: return
+            val dir = ctx.getExternalFilesDir(null) ?: return
+            val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            FileWriter(File(dir, "debug.log"), true).use {
+                it.append("$ts PskReporter: $msg\n")
+            }
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/theme/Color.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/theme/Color.kt
@@ -46,3 +46,7 @@ val Band10m = Color(0xFFC084FC)
 val Band30m = Color(0xFFF472B6)
 val Band17m = Color(0xFFFACC15)
 val Band12m = Color(0xFFFB7185)
+
+// PSK Reporter overlay (red-coral, intentionally absent from the rest of the palette so
+// auxiliary "stations hearing me" spots are visually distinct from decoded FT8 markers).
+val PskSpot = Color(0xFFF87171)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -55,7 +56,9 @@ import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.maidenhead.MaidenheadGrid
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8us.pskreporter.PskReporterClient
 import radio.ks3ckc.ft8us.theme.*
 import radio.ks3ckc.ft8us.ui.components.GlassCard
 import radio.ks3ckc.ft8us.ui.components.TopBar
@@ -82,6 +85,19 @@ private data class StationMarker(
     val color: Color,
     val message: Ft8Message,
 )
+
+// PSK Reporter overlay (issue #33) — a receiver that has decoded the operator's signal.
+private data class PskSpotMarker(
+    val receiverCallsign: String,
+    val grid: String,
+    val lat: Double,
+    val lon: Double,
+    val snr: Int,
+    val frequencyHz: Long,
+)
+
+private const val PSK_OVERLAY_SECONDS_BACK = 3600
+private const val PSK_POLL_INTERVAL_MS = 5L * 60L * 1000L
 
 private data class ProjectedPoint(
     val x: Float,
@@ -157,6 +173,41 @@ fun MapScreen(mainViewModel: MainViewModel) {
 
     var selectedCallsign by remember { mutableStateOf<String?>(null) }
     var viewMode by rememberSaveable { mutableStateOf(MapViewMode.STANDARD) }
+    var pskOverlayEnabled by rememberSaveable { mutableStateOf(GeneralVariables.pskOverlayEnabled) }
+    var pskSpots by remember { mutableStateOf<List<PskSpotMarker>>(emptyList()) }
+
+    // PSK Reporter polling — fires immediately on enter and every 5 min while enabled.
+    // Re-reads myCallsign each cycle so a mid-session change is picked up on the next tick.
+    // Structured concurrency cancels the loop when MapScreen leaves composition.
+    LaunchedEffect(pskOverlayEnabled) {
+        if (!pskOverlayEnabled) {
+            pskSpots = emptyList()
+            return@LaunchedEffect
+        }
+        while (true) {
+            val call = GeneralVariables.myCallsign.trim().uppercase()
+            if (call.isEmpty()) {
+                pskSpots = emptyList()
+            } else {
+                val spots = PskReporterClient.fetchSpotsForMe(call, PSK_OVERLAY_SECONDS_BACK)
+                if (spots != null) {
+                    pskSpots = spots.map {
+                        PskSpotMarker(
+                            receiverCallsign = it.receiverCallsign,
+                            grid = it.receiverGrid,
+                            lat = it.receiverLat,
+                            lon = it.receiverLon,
+                            snr = it.snr,
+                            frequencyHz = it.frequencyHz,
+                        )
+                    }
+                }
+                // On null (failure / cooldown / rate-limit) keep prior spots so the overlay
+                // doesn't flicker; PskReporterClient logs the reason to debug.log.
+            }
+            delay(PSK_POLL_INTERVAL_MS)
+        }
+    }
 
     // Derive operator lat/lon from grid
     val opLatLng = remember(myGrid) {
@@ -229,6 +280,19 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 )
             },
             actions = {
+                PskOverlayToggle(
+                    enabled = pskOverlayEnabled,
+                    onToggle = { newVal ->
+                        pskOverlayEnabled = newVal
+                        GeneralVariables.pskOverlayEnabled = newVal
+                        mainViewModel.databaseOpr.writeConfig(
+                            "pskOverlayEnabled",
+                            if (newVal) "1" else "0",
+                            null,
+                        )
+                    },
+                )
+                Spacer(modifier = Modifier.width(6.dp))
                 MapViewToggle(
                     mode = viewMode,
                     onModeChange = { viewMode = it },
@@ -261,6 +325,7 @@ fun MapScreen(mainViewModel: MainViewModel) {
                     opLat = opLat,
                     opLon = opLon,
                     stations = stations,
+                    pskSpots = pskSpots,
                     selectedCallsign = selectedCallsign,
                     onStationSelected = { selectedCallsign = it },
                     modifier = Modifier
@@ -271,6 +336,7 @@ fun MapScreen(mainViewModel: MainViewModel) {
                     opLat = opLat,
                     opLon = opLon,
                     stations = stations,
+                    pskSpots = pskSpots,
                     selectedCallsign = selectedCallsign,
                     onStationSelected = { selectedCallsign = it },
                     modifier = Modifier
@@ -302,7 +368,11 @@ fun MapScreen(mainViewModel: MainViewModel) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "${stations.size} stations",
+                text = if (pskOverlayEnabled) {
+                    "${stations.size} stations · ${pskSpots.size} heard"
+                } else {
+                    "${stations.size} stations"
+                },
                 color = TextMuted,
                 fontSize = 10.5.sp,
             )
@@ -344,6 +414,26 @@ private fun MapViewToggle(
 }
 
 @Composable
+private fun PskOverlayToggle(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (enabled) PskSpot else BgSurface3)
+            .clickable { onToggle(!enabled) }
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "PSK",
+            color = if (enabled) BgApp else TextMuted,
+            fontFamily = GeistMonoFamily,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
 private fun TogglePill(
     label: String,
     active: Boolean,
@@ -376,6 +466,7 @@ private fun AzimuthalMapCanvas(
     opLat: Double,
     opLon: Double,
     stations: List<StationMarker>,
+    pskSpots: List<PskSpotMarker>,
     selectedCallsign: String?,
     onStationSelected: (String?) -> Unit,
     modifier: Modifier = Modifier,
@@ -425,6 +516,45 @@ private fun AzimuthalMapCanvas(
             radius = 4f,
             center = Offset(cx, cy),
         )
+
+        // PSK Reporter spots — drawn before stations so decoded markers layer on top.
+        // Square shape distinguishes them from circular station markers.
+        for (spot in pskSpots) {
+            val proj = azProject(opLat, opLon, spot.lat, spot.lon)
+            val sx = cx + proj.x * r
+            val sy = cy + proj.y * r
+            val dx = sx - cx
+            val dy = sy - cy
+            if (sqrt(dx * dx + dy * dy) > r) continue
+
+            val half = 2.5f
+            drawRect(
+                color = PskSpot.copy(alpha = 0.7f),
+                topLeft = Offset(sx - half, sy - half),
+                size = Size(half * 2, half * 2),
+            )
+            drawRect(
+                color = BgApp,
+                topLeft = Offset(sx - half, sy - half),
+                size = Size(half * 2, half * 2),
+                style = Stroke(width = 0.8f),
+            )
+            val paint = android.graphics.Paint().apply {
+                color = android.graphics.Color.argb(160, 248, 113, 113)
+                textSize = 14f
+                isAntiAlias = true
+                typeface = android.graphics.Typeface.create(
+                    android.graphics.Typeface.MONOSPACE,
+                    android.graphics.Typeface.NORMAL,
+                )
+            }
+            drawContext.canvas.nativeCanvas.drawText(
+                spot.receiverCallsign,
+                sx + 5f,
+                sy + paint.textSize / 3f,
+                paint,
+            )
+        }
 
         // Station markers
         for ((index, station) in stations.withIndex()) {
@@ -524,6 +654,7 @@ private fun StandardMapCanvas(
     opLat: Double,
     opLon: Double,
     stations: List<StationMarker>,
+    pskSpots: List<PskSpotMarker>,
     selectedCallsign: String?,
     onStationSelected: (String?) -> Unit,
     modifier: Modifier = Modifier,
@@ -573,6 +704,41 @@ private fun StandardMapCanvas(
             radius = 4f,
             center = Offset(opX, opY),
         )
+
+        // PSK Reporter spots — drawn before stations so decoded markers layer on top.
+        for (spot in pskSpots) {
+            val proj = equirectProject(spot.lat, spot.lon)
+            val sx = halfW + proj.x * halfW
+            val sy = halfH + proj.y * halfH
+
+            val half = 2.5f
+            drawRect(
+                color = PskSpot.copy(alpha = 0.7f),
+                topLeft = Offset(sx - half, sy - half),
+                size = Size(half * 2, half * 2),
+            )
+            drawRect(
+                color = BgApp,
+                topLeft = Offset(sx - half, sy - half),
+                size = Size(half * 2, half * 2),
+                style = Stroke(width = 0.8f),
+            )
+            val paint = android.graphics.Paint().apply {
+                color = android.graphics.Color.argb(160, 248, 113, 113)
+                textSize = 14f
+                isAntiAlias = true
+                typeface = android.graphics.Typeface.create(
+                    android.graphics.Typeface.MONOSPACE,
+                    android.graphics.Typeface.NORMAL,
+                )
+            }
+            drawContext.canvas.nativeCanvas.drawText(
+                spot.receiverCallsign,
+                sx + 5f,
+                sy + paint.textSize / 3f,
+                paint,
+            )
+        }
 
         // Station markers
         for ((index, station) in stations.withIndex()) {


### PR DESCRIPTION
## Summary

Resolves #33 — adds a **PSK** toggle to the map top bar that overlays receivers from PSK Reporter who have heard the operator in the past hour.

- New `PskReporterClient` polls `retrieve.pskreporter.info/query?senderCallsign=…&rronly=1&mode=FT8` every 5 min while the toggle is on and the map is visible. Follows the `QrzXmlClient` `HttpURLConnection` pattern; logs to `debug.log` via the existing `fileLog` convention.
- New square red markers render on both equirectangular and azimuthal projections, drawn **before** decoded-station markers so the operator's own decoded signals layer on top.
- Toggle state persists through the existing `DatabaseOpr` config sweep (`pskOverlayEnabled`).
- Footer shows `N stations · M heard` while the overlay is on.

## Scope (MVP per discussion on the issue)

- **Direction:** stations hearing me (`senderCallsign=<call>`).
- **Time window:** hard-coded last 60 minutes.
- **No marker clustering, no MQTT/WebSocket streaming, no in-screen filter UI, no tap interactivity** — those remain as follow-ups.

## Rate-limit handling

PSK Reporter docs say not to query the same parameter set more than once per 5 minutes. The client adds two layers of defence on top of the screen-level poll cadence:
1. A 4m50s client-side cooldown that short-circuits redundant calls.
2. A 15-minute back-off on HTTP 429/503.

## Test plan

- [x] Builds with `cmd.exe /c gradlew.bat installDebug`; no new compile warnings.
- [x] Installs on Pixel 8.
- [ ] Open Map, confirm **PSK** chip appears in top bar (left of STD/AZ).
- [ ] Tap chip → within ~10s, red square markers appear on the map; footer shows `… · N heard`.
- [ ] Swipe STD ↔ AZ; spots render correctly in both projections.
- [ ] Toggle off → markers vanish immediately.
- [ ] Restart app → toggle state persists.
- [ ] With empty callsign in Settings → no fetch, no error UI, no crash.
- [ ] Pull `debug.log` and verify `PskReporter: fetch start … / fetch ok N=…` lines on each 5-min tick.
- [ ] Sanity-check that a 6-char `receiverLocator` (e.g. `IO91wm`) lands at the right lat/lon — `MaidenheadGrid.gridToLatLng` is exercised on 6-char input for the first time here. If wrong, follow-up will apply `grid.take(4)` at the parser site.

## Files changed

| File | Reason |
|---|---|
| `pskreporter/PskReporterClient.kt` | New — HTTP client + XML parser + `PskReporterSpot` data class |
| `ui/map/MapScreen.kt` | Toggle, polling effect, spot rendering in both canvases, footer counter |
| `theme/Color.kt` | New `PskSpot = Color(0xFFF87171)` |
| `GeneralVariables.java` | New `pskOverlayEnabled` boolean field |
| `database/DatabaseOpr.java` | Config-sweep branch for the new key |

## Notes for future follow-ups

- `appcontact` is hard-coded to `ft8af@example.org` — swap for a real project contact before any public release.
- No persistent in-memory cache across Map screen re-entries; quick navigations may show an empty layer for up to 5 min due to the cooldown.
- An interactive filter panel (band/mode/minutes-back) and tap-to-show-SNR are deferred per the MVP scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
