### PR TITLE
Tests: bootstrap unit + Robolectric infrastructure (issue #27)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -72,6 +72,19 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew
 
+      - name: Run unit tests
+        working-directory: ft8cn
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-reports
+          path: |
+            ft8cn/app/build/reports/tests/
+            ft8cn/app/build/test-results/
+
       - name: Build APK
         working-directory: ft8cn
         run: ./gradlew assembleRelease

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -86,6 +86,15 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion '1.5.8'
     }
+    testOptions {
+        unitTests {
+            // Robolectric needs the merged manifest + resources to bring up an
+            // Android runtime; returnDefaultValues keeps unmocked framework
+            // calls (e.g. android.util.Log) from throwing in pure-JVM tests.
+            includeAndroidResources = true
+            returnDefaultValues = true
+        }
+    }
 //    externalNativeBuild {
 //        cmake {
 //            path file('src/main/cpp/CMakeLists.txt')
@@ -98,6 +107,15 @@ android {
             java.srcDirs = ['src/main/java']
             kotlin.srcDirs = ['src/main/kotlin']
             jniLibs.srcDirs = ['libs']
+        }
+        test {
+            java.srcDirs = ['src/test/java']
+            kotlin.srcDirs = ['src/test/kotlin']
+            resources.srcDirs = ['src/test/resources']
+        }
+        androidTest {
+            java.srcDirs = ['src/androidTest/java']
+            kotlin.srcDirs = ['src/androidTest/kotlin']
         }
     }
     namespace 'com.bg7yoz.ft8cn'
@@ -139,4 +157,24 @@ dependencies {
 
     // Image loading for QRZ profile avatars
     implementation 'io.coil-kt:coil-compose:2.6.0'
+
+    // --- JVM unit + Robolectric tests ---
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation 'com.google.truth:truth:1.4.2'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
+    testImplementation 'androidx.compose.ui:ui-test-junit4'
+
+    // ui-test-manifest must be debug-scoped: the merged debug manifest is what
+    // hosts ComponentActivity for createComposeRule(). testImplementation
+    // wouldn't surface it during the unit-test build.
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
+    // --- Connected (instrumented) tests ---
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
 }

--- a/ft8cn/app/src/androidTest/kotlin/com/bg7yoz/ft8cn/AppSmokeTest.kt
+++ b/ft8cn/app/src/androidTest/kotlin/com/bg7yoz/ft8cn/AppSmokeTest.kt
@@ -1,0 +1,32 @@
+package com.bg7yoz.ft8cn
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import radio.ks3ckc.ft8us.ComposeMainActivity
+
+/**
+ * Instrumented smoke test. Launches the real ComposeMainActivity on a device
+ * (or emulator) and asserts it reaches RESUMED without throwing.
+ *
+ * Not run in CI yet — the GitHub Actions workflow has no emulator wired up.
+ * Local invocation:
+ *   cd ft8cn && cmd.exe /c "gradlew.bat connectedDebugAndroidTest"
+ */
+@RunWith(AndroidJUnit4::class)
+class AppSmokeTest {
+
+    @Test
+    fun composeMainActivity_launchesAndReachesResumed() {
+        ActivityScenario.launch(ComposeMainActivity::class.java).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                assertThat(activity).isNotNull()
+                assertThat(activity.isFinishing).isFalse()
+            }
+        }
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/GenerateFT8.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/GenerateFT8.java
@@ -33,7 +33,15 @@ public class GenerateFT8 {
 
 
     static {
-        System.loadLibrary("ft8cn");
+        try {
+            System.loadLibrary("ft8cn");
+        } catch (UnsatisfiedLinkError e) {
+            // Best-effort load: JVM unit tests don't have libft8cn.so on
+            // java.library.path. The native methods themselves will throw if
+            // actually invoked without the library; the pure-Java helpers on
+            // this class stay available either way.
+            Log.w(TAG, "ft8cn native library not loaded: " + e.getMessage());
+        }
     }
 
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
@@ -1,6 +1,7 @@
 package radio.ks3ckc.ft8us.pskreporter
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.maidenhead.MaidenheadGrid
 import kotlinx.coroutines.Dispatchers
@@ -45,13 +46,21 @@ data class PskReporterSpot(
 
 object PskReporterClient {
     private const val TAG = "PskReporterClient"
-    private const val BASE_URL = "https://retrieve.pskreporter.info/query"
+    private const val DEFAULT_BASE_URL = "https://retrieve.pskreporter.info/query"
     private const val AGENT = "ft8af-1.0"
     private const val APP_CONTACT = "ft8af@example.org"
     private const val COOLDOWN_MS = 290_000L
     private const val RATE_LIMIT_COOLDOWN_MS = 15L * 60_000L
     private const val MAX_SPOTS = 500
     private const val IO_TIMEOUT_MS = 8000
+
+    @VisibleForTesting
+    @JvmField
+    internal var baseUrl: String = DEFAULT_BASE_URL
+
+    @VisibleForTesting
+    @JvmField
+    internal var clock: () -> Long = { System.currentTimeMillis() }
 
     @Volatile
     var lastError: String? = null
@@ -63,7 +72,7 @@ object PskReporterClient {
     private var rateLimitedUntilEpochMs: Long = 0L
 
     suspend fun fetchSpotsForMe(call: String, secondsBack: Int): List<PskReporterSpot>? = withContext(Dispatchers.IO) {
-        val now = System.currentTimeMillis()
+        val now = clock()
         if (now < rateLimitedUntilEpochMs) {
             log("skipped (rate-limit back-off ${(rateLimitedUntilEpochMs - now) / 1000}s remaining)")
             return@withContext null
@@ -75,7 +84,7 @@ object PskReporterClient {
         lastFetchEpochMs = now
 
         val callUpper = call.uppercase()
-        val url = "$BASE_URL?senderCallsign=${urlEncode(callUpper)}" +
+        val url = "$baseUrl?senderCallsign=${urlEncode(callUpper)}" +
             "&flowStartSeconds=-$secondsBack" +
             "&rronly=1" +
             "&mode=FT8" +
@@ -99,7 +108,7 @@ object PskReporterClient {
             }
             val code = conn.responseCode
             if (code == 429 || code == 503) {
-                rateLimitedUntilEpochMs = System.currentTimeMillis() + RATE_LIMIT_COOLDOWN_MS
+                rateLimitedUntilEpochMs = clock() + RATE_LIMIT_COOLDOWN_MS
                 log("rate-limited (http $code) — backing off ${RATE_LIMIT_COOLDOWN_MS / 60_000}min")
                 lastError = "rate-limited ($code)"
                 return null
@@ -185,6 +194,15 @@ object PskReporterClient {
         } else {
             out
         }
+    }
+
+    @VisibleForTesting
+    internal fun resetForTests() {
+        lastError = null
+        lastFetchEpochMs = 0L
+        rateLimitedUntilEpochMs = 0L
+        baseUrl = DEFAULT_BASE_URL
+        clock = { System.currentTimeMillis() }
     }
 
     private fun urlEncode(s: String): String =

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/qrz/QrzXmlClient.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/qrz/QrzXmlClient.kt
@@ -1,6 +1,7 @@
 package radio.ks3ckc.ft8us.qrz
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.bg7yoz.ft8cn.GeneralVariables
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -33,9 +34,13 @@ import java.util.Locale
  */
 object QrzXmlClient {
     private const val TAG = "QrzXmlClient"
-    private const val BASE_URL = "https://xmldata.qrz.com/xml/current/"
+    private const val DEFAULT_BASE_URL = "https://xmldata.qrz.com/xml/current/"
     private const val AGENT = "ft8af-1.0"
     private const val CACHE_MAX = 200
+
+    @VisibleForTesting
+    @JvmField
+    internal var baseUrl: String = DEFAULT_BASE_URL
 
     private val sessionMutex = Mutex()
     @Volatile private var sessionKey: String? = null
@@ -163,7 +168,7 @@ object QrzXmlClient {
     private fun fetch(query: String): String? {
         var conn: HttpURLConnection? = null
         return try {
-            val url = URL("$BASE_URL?$query")
+            val url = URL("$baseUrl?$query")
             conn = (url.openConnection() as HttpURLConnection).apply {
                 requestMethod = "GET"
                 connectTimeout = 8000
@@ -184,7 +189,8 @@ object QrzXmlClient {
         }
     }
 
-    private fun parseTag(xml: String, tagName: String): String? {
+    @VisibleForTesting
+    internal fun parseTag(xml: String, tagName: String): String? {
         return try {
             val parser = XmlPullParserFactory.newInstance().newPullParser().apply {
                 setInput(xml.reader())
@@ -201,6 +207,14 @@ object QrzXmlClient {
         } catch (_: Exception) {
             null
         }
+    }
+
+    @VisibleForTesting
+    internal fun resetForTests() {
+        sessionKey = null
+        cache.clear()
+        lastError = null
+        baseUrl = DEFAULT_BASE_URL
     }
 
     private fun urlEncode(s: String): String =

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
@@ -1,0 +1,73 @@
+package com.bg7yoz.ft8cn;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Exercise the constructors and simple formatters on {@link Ft8Message}.
+ * The complex copy-constructor (which touches the native libft8cn hash
+ * helpers via FT8Package.getHashNN) is deliberately out of scope; the JNI
+ * side belongs to a separate test layer.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class Ft8MessageTest {
+
+    @Test
+    public void singleArgConstructor_setsSignalFormat() {
+        Ft8Message msg = new Ft8Message(FT8Common.FT4_MODE);
+        assertThat(msg.signalFormat).isEqualTo(FT8Common.FT4_MODE);
+    }
+
+    @Test
+    public void threeArgConstructor_uppercasesAllStrings() {
+        Ft8Message msg = new Ft8Message("cq", "k1abc", "fn42");
+        assertThat(msg.callsignTo).isEqualTo("CQ");
+        assertThat(msg.callsignFrom).isEqualTo("K1ABC");
+        assertThat(msg.extraInfo).isEqualTo("FN42");
+    }
+
+    @Test
+    public void threeArgConstructor_preservesAlreadyUppercase() {
+        Ft8Message msg = new Ft8Message("CQ", "VE3XY", "EN85");
+        assertThat(msg.callsignTo).isEqualTo("CQ");
+        assertThat(msg.callsignFrom).isEqualTo("VE3XY");
+        assertThat(msg.extraInfo).isEqualTo("EN85");
+    }
+
+    @Test
+    public void defaultReport_isSentinelMinus100() {
+        // -100 is the "no signal report" sentinel checked throughout the
+        // decode UI; assert the field initialiser matches what callers expect.
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        assertThat(msg.report).isEqualTo(-100);
+    }
+
+    @Test
+    public void getFreq_hz_formatsWithLeadingZeros() {
+        // %04.0f for an audio-frequency display; rounds to integer and pads
+        // to a minimum of four characters (e.g. 750 Hz -> "0750").
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        msg.freq_hz = 750.4f;
+        assertThat(msg.getFreq_hz()).isEqualTo("0750");
+    }
+
+    @Test
+    public void getFreq_hz_handlesFourDigitFrequencies() {
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        msg.freq_hz = 2375.0f;
+        assertThat(msg.getFreq_hz()).isEqualTo("2375");
+    }
+
+    @Test
+    public void defaultsForOtherFlagFields() {
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        assertThat(msg.isValid).isFalse();
+        assertThat(msg.isQSL_Callsign).isFalse();
+        assertThat(msg.isWeakSignal).isFalse();
+        assertThat(msg.snr).isEqualTo(0);
+        assertThat(msg.score).isEqualTo(0);
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/MessageHashMapTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/MessageHashMapTest.java
@@ -1,0 +1,75 @@
+package com.bg7yoz.ft8cn;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Exercise {@link MessageHashMap}'s callsign-hash bookkeeping. The class
+ * extends HashMap and adds three guards on top of {@code put}: it filters the
+ * reserved meta-callsigns CQ/QRZ/DE, it rejects entries whose callsign is a
+ * hash placeholder like {@code <...>}, and it ignores hash code 0.
+ */
+public class MessageHashMapTest {
+
+    @Test
+    public void addHash_storesCallsignAndIsLookupable() {
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(0xABCDL, "K1ABC");
+        assertThat(map.checkHash(0xABCDL)).isTrue();
+        assertThat(map.get(0xABCDL)).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void addHash_skipsReservedCallsigns() {
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(1L, "CQ");
+        map.addHash(2L, "QRZ");
+        map.addHash(3L, "DE");
+        assertThat(map.checkHash(1L)).isFalse();
+        assertThat(map.checkHash(2L)).isFalse();
+        assertThat(map.checkHash(3L)).isFalse();
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    public void addHash_rejectsZeroHashCode() {
+        // Hash 0 is the sentinel for "no hash known yet"; never store it.
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(0L, "W1AW");
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    public void addHash_rejectsPlaceholderCallsign() {
+        // Callsigns rendered as <...> are the unresolved-placeholder form that
+        // getCallsign() emits; never let one round-trip back into the map.
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(99L, "<...>");
+        assertThat(map.checkHash(99L)).isFalse();
+    }
+
+    @Test
+    public void addHash_isIdempotentForSameKey() {
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(7L, "VE3XYZ");
+        map.addHash(7L, "VE3XYZ");
+        assertThat(map).hasSize(1);
+    }
+
+    @Test
+    public void getCallsign_returnsAngleWrappedMatch() {
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(0x10L, "K1ABC");
+        // getCallsign walks the array in order, returning the first match.
+        String result = map.getCallsign(new long[]{0x99L, 0x10L, 0x77L});
+        assertThat(result).isEqualTo("<K1ABC>");
+    }
+
+    @Test
+    public void getCallsign_returnsPlaceholderWhenNoMatch() {
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(0x10L, "K1ABC");
+        assertThat(map.getCallsign(new long[]{1L, 2L, 3L})).isEqualTo("<...>");
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/callsign/CallsignInfoTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/callsign/CallsignInfoTest.java
@@ -1,0 +1,86 @@
+package com.bg7yoz.ft8cn.callsign;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Exercise {@link CallsignInfo}'s data-model constructors. The 10-arg
+ * constructor is a plain field-assigner; the single-arg String form parses
+ * cty.dat-style colon-delimited records.
+ *
+ * Robolectric is needed because the class imports android.util.Log for its
+ * error-path logging.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CallsignInfoTest {
+
+    @Test
+    public void argConstructor_assignsAllFields() {
+        CallsignInfo info = new CallsignInfo(
+                "K1ABC", "United States", "美国", 5, 8,
+                "NA", 42.5f, -71.0f, -5.0f, "K");
+
+        assertThat(info.CallSign).isEqualTo("K1ABC");
+        assertThat(info.CountryNameEn).isEqualTo("United States");
+        assertThat(info.CountryNameCN).isEqualTo("美国");
+        assertThat(info.CQZone).isEqualTo(5);
+        assertThat(info.ITUZone).isEqualTo(8);
+        assertThat(info.Continent).isEqualTo("NA");
+        assertThat(info.Latitude).isEqualTo(42.5f);
+        assertThat(info.Longitude).isEqualTo(-71.0f);
+        assertThat(info.GMT_offset).isEqualTo(-5.0f);
+        assertThat(info.DXCC).isEqualTo("K");
+    }
+
+    @Test
+    public void stringConstructor_parsesColonDelimitedRecord() {
+        // cty.dat-style row: country:cq:itu:continent:lat:lon:gmtOffset:dxcc:callsign
+        CallsignInfo info = new CallsignInfo(
+                "United States:5:8:NA:42.5:-71.0:-5.0:K:K1ABC");
+
+        assertThat(info.CountryNameEn).isEqualTo("United States");
+        assertThat(info.CQZone).isEqualTo(5);
+        assertThat(info.ITUZone).isEqualTo(8);
+        assertThat(info.Continent).isEqualTo("NA");
+        assertThat(info.Latitude).isEqualTo(42.5f);
+        assertThat(info.Longitude).isEqualTo(-71.0f);
+        assertThat(info.GMT_offset).isEqualTo(-5.0f);
+        assertThat(info.DXCC).isEqualTo("K");
+        assertThat(info.CallSign).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void stringConstructor_stripsWhitespaceFromNumericFields() {
+        // Real cty.dat input has leading spaces around the numeric columns.
+        CallsignInfo info = new CallsignInfo(
+                "Canada: 5: 8:NA: 45.0: -75.0: -5.0:VE:VE3XYZ");
+
+        assertThat(info.CQZone).isEqualTo(5);
+        assertThat(info.ITUZone).isEqualTo(8);
+        assertThat(info.Latitude).isEqualTo(45.0f);
+        assertThat(info.Longitude).isEqualTo(-75.0f);
+    }
+
+    @Test
+    public void stringConstructor_belowMinFieldCount_doesNotThrow() {
+        // Fewer than 9 fields logs an error and bails without populating; we
+        // assert it doesn't throw and that the default-initialised fields stay
+        // at their zero values rather than triggering a NumberFormatException.
+        CallsignInfo info = new CallsignInfo("too:few:fields");
+        assertThat(info.CallSign).isNull();
+        assertThat(info.CountryNameEn).isNull();
+        assertThat(info.CQZone).isEqualTo(0);
+    }
+
+    @Test
+    public void stringConstructor_stripsNewlinesFromCountryName() {
+        // CountryNameEn keeps interior spaces but strips leading/trailing
+        // newlines (replace("\n","").trim()).
+        CallsignInfo info = new CallsignInfo(
+                "United States\n:5:8:NA:42.5:-71.0:-5.0:K:K1ABC");
+        assertThat(info.CountryNameEn).isEqualTo("United States");
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/GenerateFT8MessageTypeTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/GenerateFT8MessageTypeTest.java
@@ -1,0 +1,99 @@
+package com.bg7yoz.ft8cn.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Exercise the pure static helpers in {@link GenerateFT8} that classify a
+ * callsign into FT8's i3 message-type buckets and recognise the standard
+ * amateur-radio callsign shape.
+ *
+ * Runs under Robolectric (rather than plain JUnit) only because the GenerateFT8
+ * class's static initialiser calls {@code System.loadLibrary("ft8cn")}; the
+ * Robolectric runner no-ops that call so we can hit the Java-side methods
+ * without the native library on the JVM library path.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GenerateFT8MessageTypeTest {
+
+    // i3 codes used by FT8 (see GenerateFT8.checkI3ByCallsign):
+    //   0 = free text / empty
+    //   1 = standard callsign
+    //   2 = /P suffix (portable, short callsign)
+    //   4 = non-standard / hashed
+
+    @Test
+    public void standardCallsign_returnsI3_1() {
+        assertThat(GenerateFT8.checkI3ByCallsign("K1ABC")).isEqualTo(1);
+        assertThat(GenerateFT8.checkI3ByCallsign("VE3XY")).isEqualTo(1);
+    }
+
+    @Test
+    public void portableSuffix_returnsI3_2_whenShort() {
+        // /P on a callsign <=8 chars total is the standard portable form.
+        assertThat(GenerateFT8.checkI3ByCallsign("K1ABC/P")).isEqualTo(2);
+    }
+
+    @Test
+    public void rovingSuffix_returnsI3_1_whenShort() {
+        // /R is treated as i3=1 by the encoder (see line 53-55).
+        assertThat(GenerateFT8.checkI3ByCallsign("K1ABC/R")).isEqualTo(1);
+    }
+
+    @Test
+    public void longPortableCallsign_returnsI3_4_nonstandard() {
+        // A /P call longer than 8 chars overflows the standard slot and must
+        // be encoded as a non-standard (hashed) callsign.
+        assertThat(GenerateFT8.checkI3ByCallsign("VE2ABCD/P")).isEqualTo(4);
+    }
+
+    @Test
+    public void slashInCallsign_returnsI3_4() {
+        // Anything with a '/' that isn't /P or /R is non-standard.
+        assertThat(GenerateFT8.checkI3ByCallsign("DL/W1AW")).isEqualTo(4);
+    }
+
+    @Test
+    public void overlyLongCallsign_returnsI3_4() {
+        // >6 chars (without /P or /R) is also non-standard.
+        assertThat(GenerateFT8.checkI3ByCallsign("ABCDEFG")).isEqualTo(4);
+    }
+
+    @Test
+    public void emptyCallsign_returnsZero_freeText() {
+        // Length < 2 short-circuits to 0 (free-text).
+        assertThat(GenerateFT8.checkI3ByCallsign("")).isEqualTo(0);
+        assertThat(GenerateFT8.checkI3ByCallsign("X")).isEqualTo(0);
+    }
+
+    @Test
+    public void nullCallsign_returnsZero() {
+        assertThat(GenerateFT8.checkI3ByCallsign(null)).isEqualTo(0);
+    }
+
+    @Test
+    public void checkIsStandardCallsign_acceptsCanonicalShapes() {
+        // ITU-shape examples; regex requires prefix(1-2 alphanumeric, includes digit)
+        // + digit + 1-3 letter suffix.
+        assertThat(GenerateFT8.checkIsStandardCallsign("K1ABC")).isTrue();
+        assertThat(GenerateFT8.checkIsStandardCallsign("VE3XY")).isTrue();
+        assertThat(GenerateFT8.checkIsStandardCallsign("W1AW")).isTrue();
+    }
+
+    @Test
+    public void checkIsStandardCallsign_stripsPortableRoverSuffix() {
+        // /P and /R are stripped before the regex check (line 99-103).
+        assertThat(GenerateFT8.checkIsStandardCallsign("K1ABC/P")).isTrue();
+        assertThat(GenerateFT8.checkIsStandardCallsign("K1ABC/R")).isTrue();
+    }
+
+    @Test
+    public void checkIsStandardCallsign_rejectsNonStandard() {
+        assertThat(GenerateFT8.checkIsStandardCallsign("DL/W1AW")).isFalse();
+        assertThat(GenerateFT8.checkIsStandardCallsign("123")).isFalse();
+        assertThat(GenerateFT8.checkIsStandardCallsign("LONGCALL")).isFalse();
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/log/LogFileImportTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/log/LogFileImportTest.java
@@ -1,0 +1,125 @@
+package com.bg7yoz.ft8cn.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.bg7yoz.ft8cn.html.ImportTaskList;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Drive {@link LogFileImport} against on-disk ADIF fixtures. The production
+ * constructor takes a file path (it reads via FileInputStream), so we copy
+ * each classpath resource into a TemporaryFolder file and feed the path in.
+ *
+ * Robolectric is here for {@code android.util.Log}; the import code itself
+ * is plain Java.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LogFileImportTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private ImportTaskList.ImportTask task;
+
+    @Before
+    public void setUp() {
+        // Session id is opaque to the import path; any value works.
+        task = new ImportTaskList.ImportTask(0);
+    }
+
+    @Test
+    public void wellFormedAdif_parsesAllRecords() throws IOException {
+        File f = fixture("adif/sample-wsjtx.adi");
+        LogFileImport imp = new LogFileImport(task, f.getAbsolutePath());
+        ArrayList<HashMap<String, String>> records = imp.getLogRecords();
+        assertThat(records).hasSize(3);
+    }
+
+    @Test
+    public void wellFormedAdif_uppercasesFieldKeys() throws IOException {
+        File f = fixture("adif/sample-wsjtx.adi");
+        LogFileImport imp = new LogFileImport(task, f.getAbsolutePath());
+        HashMap<String, String> first = imp.getLogRecords().get(0);
+        // Production code uppercases the field name before put() (line 96).
+        assertThat(first).containsKey("CALL");
+        assertThat(first).containsKey("MODE");
+        assertThat(first).containsKey("BAND");
+        // Lowercase keys should not exist.
+        assertThat(first).doesNotContainKey("call");
+    }
+
+    @Test
+    public void wellFormedAdif_extractsValuesUsingDeclaredLength() throws IOException {
+        File f = fixture("adif/sample-wsjtx.adi");
+        LogFileImport imp = new LogFileImport(task, f.getAbsolutePath());
+        HashMap<String, String> first = imp.getLogRecords().get(0);
+        assertThat(first.get("CALL")).isEqualTo("K1ABC");
+        assertThat(first.get("GRIDSQUARE")).isEqualTo("FN42");
+        assertThat(first.get("MODE")).isEqualTo("FT8");
+    }
+
+    @Test
+    public void getLogBody_returnsContentAfterEoh() throws IOException {
+        File f = fixture("adif/sample-wsjtx.adi");
+        LogFileImport imp = new LogFileImport(task, f.getAbsolutePath());
+        String body = imp.getLogBody();
+        // The header is stripped; first surviving content should be the
+        // first record marker.
+        assertThat(body).doesNotContain("<adif_ver");
+        assertThat(body).contains("<call:5>K1ABC");
+    }
+
+    @Test
+    public void malformedAdif_skipsBadRecordsAndReportsErrorCount() throws IOException {
+        File f = fixture("adif/sample-malformed.adi");
+        LogFileImport imp = new LogFileImport(task, f.getAbsolutePath());
+        ArrayList<HashMap<String, String>> records = imp.getLogRecords();
+
+        // The fixture has 4 pieces between <eor> markers:
+        //   1. a valid K1ABC record               -> should be parsed
+        //   2. a free-text line with no '<' tag   -> short-circuits at `s.contains("<")`
+        //   3. <call:notanumber>BADREC...         -> NumberFormatException, counted in errorLines
+        //   4. a valid W1AW record                -> should be parsed
+        // The K1ABC record is added before iteration even reaches the bad
+        // record, so the good records on either side survive.
+        assertThat(records).hasSize(2);
+        assertThat(records.get(0).get("CALL")).isEqualTo("K1ABC");
+        assertThat(records.get(1).get("CALL")).isEqualTo("W1AW");
+        assertThat(imp.getErrorCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void emptyFile_returnsEmptyRecordList() throws IOException {
+        File empty = tmp.newFile("empty.adi");
+        // Write a header-only file with no <eoh> — getLogBody returns "".
+        try (FileOutputStream out = new FileOutputStream(empty)) {
+            out.write("header only, no eoh marker".getBytes(StandardCharsets.UTF_8));
+        }
+        LogFileImport imp = new LogFileImport(task, empty.getAbsolutePath());
+        assertThat(imp.getLogRecords()).isEmpty();
+    }
+
+    private File fixture(String resource) throws IOException {
+        File out = tmp.newFile(new File(resource).getName());
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
+            assertThat(in).isNotNull();
+            Files.copy(in, out.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+        return out;
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/maidenhead/MaidenheadGridTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/maidenhead/MaidenheadGridTest.java
@@ -1,0 +1,152 @@
+package com.bg7yoz.ft8cn.maidenhead;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.android.gms.maps.model.LatLng;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Exercise the Maidenhead grid math: grid->LatLng, LatLng->grid, distance,
+ * and the format validator. Robolectric is required because the production
+ * class uses Google Play Services {@code LatLng} and Android framework types
+ * elsewhere in the file.
+ *
+ * Reference values were cross-checked against the published Maidenhead
+ * locator system definition and HamWaves' online calculator.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class MaidenheadGridTest {
+
+    private static final double POS_TOL = 0.05;   // degrees
+    private static final double DIST_TOL = 5.0;   // kilometres
+
+    // ---------- gridToLatLng ----------
+
+    @Test
+    public void gridToLatLng_fourChar_returnsCenterOfSquare() {
+        // FN42 is roughly Boston, MA — center should fall around 42.5N, -71.0W.
+        LatLng p = MaidenheadGrid.gridToLatLng("FN42");
+        assertThat(p).isNotNull();
+        assertThat(p.latitude).isWithin(POS_TOL).of(42.5);
+        assertThat(p.longitude).isWithin(POS_TOL).of(-71.0);
+    }
+
+    @Test
+    public void gridToLatLng_sixChar_narrowsToSubsquare() {
+        // FN42aa: south-west corner of FN42.
+        LatLng p = MaidenheadGrid.gridToLatLng("FN42aa");
+        assertThat(p).isNotNull();
+        // Sub-square centroid lat: 42 + (0.5 * 1/18) ≈ 42.0278
+        assertThat(p.latitude).isWithin(POS_TOL).of(42.028);
+        // Sub-square centroid lng: -72 + (0.5 * 2/18) ≈ -71.944
+        assertThat(p.longitude).isWithin(POS_TOL).of(-71.944);
+    }
+
+    @Test
+    public void gridToLatLng_clampsAboveEightyFiveDegrees() {
+        // Anything past lat ±85° is clamped to ±85° so the map projection
+        // (Mercator-style) doesn't blow up.
+        LatLng p = MaidenheadGrid.gridToLatLng("JR99");
+        assertThat(p).isNotNull();
+        assertThat(p.latitude).isAtMost(85.0);
+    }
+
+    @Test
+    public void gridToLatLng_rr73IsRejected() {
+        // "RR73" is a 73-greeting collision with the locator parser; the
+        // production code explicitly rejects it (line 36) to avoid plotting
+        // a fake grid for the sign-off greeting.
+        assertThat(MaidenheadGrid.gridToLatLng("RR73")).isNull();
+    }
+
+    @Test
+    public void gridToLatLng_emptyOrNull_returnsNull() {
+        assertThat(MaidenheadGrid.gridToLatLng(null)).isNull();
+        assertThat(MaidenheadGrid.gridToLatLng("")).isNull();
+    }
+
+    @Test
+    public void gridToLatLng_badLength_returnsNull() {
+        // Valid Maidenhead lengths are 2/4/6; anything else is rejected.
+        assertThat(MaidenheadGrid.gridToLatLng("ABC")).isNull();
+        assertThat(MaidenheadGrid.gridToLatLng("ABCDE")).isNull();
+        assertThat(MaidenheadGrid.gridToLatLng("ABCDEFG")).isNull();
+    }
+
+    // ---------- getGridSquare ----------
+
+    @Test
+    public void getGridSquare_roundTripsFourCharCenter() {
+        // Convert FN42 center to LatLng, then back; should land in FN42.
+        LatLng p = MaidenheadGrid.gridToLatLng("FN42");
+        String grid = MaidenheadGrid.getGridSquare(p);
+        assertThat(grid).isEqualTo("FN42");
+    }
+
+    @Test
+    public void getGridSquare_roundTripsKnownLocation() {
+        // Boston-ish coordinates.
+        String grid = MaidenheadGrid.getGridSquare(new LatLng(42.5, -71.0));
+        assertThat(grid).isEqualTo("FN42");
+    }
+
+    // ---------- getDist ----------
+
+    @Test
+    public void getDist_zeroForSamePoint() {
+        LatLng p = new LatLng(40.0, -75.0);
+        assertThat(MaidenheadGrid.getDist(p, p)).isWithin(DIST_TOL).of(0.0);
+    }
+
+    @Test
+    public void getDist_knownGreatCircleBaseline() {
+        // London (51.5074, -0.1278) to New York (40.7128, -74.0060):
+        // canonical great-circle distance is ~5570 km.
+        LatLng london = new LatLng(51.5074, -0.1278);
+        LatLng newYork = new LatLng(40.7128, -74.0060);
+        double dist = MaidenheadGrid.getDist(london, newYork);
+        assertThat(dist).isWithin(20.0).of(5570.0);
+    }
+
+    @Test
+    public void getDist_betweenGridsMatchesLatLngFormula() {
+        // FN42 (Boston ~42N/-71W) <-> IO91 (London ~51N/0W); a well-known
+        // transatlantic baseline of ~5300 km.
+        double dist = MaidenheadGrid.getDist("FN42", "IO91");
+        assertThat(dist).isGreaterThan(5000.0);
+        assertThat(dist).isLessThan(5800.0);
+    }
+
+    @Test
+    public void getDist_invalidGridReturnsZero() {
+        // Per the production contract: if either grid fails to parse, return 0.
+        // Grids of an unsupported length (3, 5, 7+) are rejected outright;
+        // gridToLatLng will not coerce them.
+        assertThat(MaidenheadGrid.getDist("FN42", "ABC")).isEqualTo(0.0);
+    }
+
+    // ---------- checkMaidenhead ----------
+
+    @Test
+    public void checkMaidenhead_acceptsCanonicalFourChar() {
+        assertThat(MaidenheadGrid.checkMaidenhead("FN42")).isTrue();
+        assertThat(MaidenheadGrid.checkMaidenhead("JN58")).isTrue();
+    }
+
+    @Test
+    public void checkMaidenhead_rejectsRR73() {
+        // Same protection as gridToLatLng — "RR73" looks structurally valid
+        // but is the sign-off greeting, not a locator.
+        assertThat(MaidenheadGrid.checkMaidenhead("RR73")).isFalse();
+    }
+
+    @Test
+    public void checkMaidenhead_rejectsBadShapes() {
+        assertThat(MaidenheadGrid.checkMaidenhead("12AB")).isFalse(); // digits first
+        assertThat(MaidenheadGrid.checkMaidenhead("FNXX")).isFalse(); // letters in digit slot
+        assertThat(MaidenheadGrid.checkMaidenhead("FN4")).isFalse();  // wrong length
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/rigs/CRC16Test.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/rigs/CRC16Test.java
@@ -1,0 +1,72 @@
+package com.bg7yoz.ft8cn.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * CRC-16/CCITT-FALSE reference vectors. The canonical test vector from the
+ * CRC catalogue is ASCII "123456789" -> 0x29B1; everything else here exercises
+ * the three overloads and the byte-vs-short return surfaces against each other.
+ */
+public class CRC16Test {
+
+    private static final byte[] CHECK = "123456789".getBytes(StandardCharsets.US_ASCII);
+
+    @Test
+    public void canonicalCheckVector() {
+        assertThat(CRC16.crc16(CHECK)).isEqualTo(0x29B1);
+    }
+
+    @Test
+    public void emptyInput_returnsSeed() {
+        // CCITT-FALSE seed is 0xFFFF; no bytes mixed in means the seed survives.
+        assertThat(CRC16.crc16(new byte[0])).isEqualTo(0xFFFF);
+    }
+
+    @Test
+    public void allZeros_8bytes_isStableAcrossOverloads() {
+        // Don't pin a specific magic number here (the canonical "123456789"
+        // vector above proves correctness of the algorithm). Instead lock in
+        // that all three overloads agree on the same input — a regression
+        // guard against accidental divergence between the byte[]-only,
+        // (bytes, len), and (bytes, start, len) code paths.
+        byte[] zeros = new byte[]{0, 0, 0, 0, 0, 0, 0, 0};
+        int full = CRC16.crc16(zeros);
+        int withLen = CRC16.crc16(zeros, zeros.length);
+        int withStartLen = CRC16.crc16(zeros, 0, zeros.length);
+        assertThat(withLen).isEqualTo(full);
+        assertThat(withStartLen).isEqualTo(full);
+        // Bytes of zero should not leave the seed unchanged — the polynomial
+        // mixes the register on every iteration even with zero input.
+        assertThat(full).isNotEqualTo(0xFFFF);
+    }
+
+    @Test
+    public void allOnes_4bytes() {
+        byte[] in = {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+        // The same value computed by the explicit-length overload should match.
+        int full = CRC16.crc16(in);
+        int withLen = CRC16.crc16(in, in.length);
+        assertThat(full).isEqualTo(withLen);
+    }
+
+    @Test
+    public void startLenOverload_agreesWithFullForFullRange() {
+        byte[] in = "the quick brown fox".getBytes(StandardCharsets.US_ASCII);
+        // crc16(bytes, start, len) treats `len` as the stop index (loop is
+        // `for (; start < len; start++)`), so calling with start=0 and
+        // len=bytes.length must reproduce the full-array result.
+        assertThat(CRC16.crc16(in, 0, in.length)).isEqualTo(CRC16.crc16(in));
+    }
+
+    @Test
+    public void shortOverload_truncatesIntCorrectly() {
+        // crc16_short downcasts the int via (short); the bit pattern should match
+        // the low 16 bits of the int form (which itself is already masked to 16).
+        short s = CRC16.crc16_short(CHECK);
+        assertThat(s & 0xFFFF).isEqualTo(CRC16.crc16(CHECK));
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClientTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClientTest.kt
@@ -1,0 +1,154 @@
+package radio.ks3ckc.ft8us.pskreporter
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Drive the PSK Reporter client against a MockWebServer with a controllable
+ * clock. The production singleton enforces a 4m50s client-side cooldown and
+ * a 15-minute back-off on 429/503; both are time-driven, so the test injects
+ * `clock` via the @VisibleForTesting seam to fast-forward without sleeping.
+ */
+@RunWith(RobolectricTestRunner::class)
+class PskReporterClientTest {
+
+    private lateinit var server: MockWebServer
+    private var now: Long = 1_000_000_000_000L  // arbitrary epoch ms
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().also { it.start() }
+        PskReporterClient.resetForTests()
+        PskReporterClient.baseUrl = server.url("/query").toString()
+        PskReporterClient.clock = { now }
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        PskReporterClient.resetForTests()
+    }
+
+    @Test
+    fun fetchSpots_happyPath_parsesAllValidReceptionReports() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        val spots = PskReporterClient.fetchSpotsForMe("W1AW", secondsBack = 900)
+
+        assertThat(spots).isNotNull()
+        // Fixture has 4 reception reports; two are dropped: JA1XX has an
+        // empty receiverLocator (skippedNoGrid path), and VK2YY has a
+        // non-numeric frequency (skippedBadGrid path).
+        assertThat(spots!!).hasSize(2)
+        assertThat(spots.map { it.receiverCallsign })
+            .containsExactly("VE3XY", "DL1AA")
+    }
+
+    @Test
+    fun fetchSpots_populatesLatLngFromReceiverLocator() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        val spots = PskReporterClient.fetchSpotsForMe("W1AW", secondsBack = 900)!!
+        val ve3xy = spots.first { it.receiverCallsign == "VE3XY" }
+
+        // FN03ab decodes to roughly 43.08N / -79.94W (Niagara peninsula).
+        assertThat(ve3xy.receiverLat).isWithin(0.5).of(43.08)
+        assertThat(ve3xy.receiverLon).isWithin(0.5).of(-79.94)
+        // Plus the metadata we passed through verbatim.
+        assertThat(ve3xy.frequencyHz).isEqualTo(14076234L)
+        assertThat(ve3xy.snr).isEqualTo(-8)
+        assertThat(ve3xy.mode).isEqualTo("FT8")
+    }
+
+    @Test
+    fun fetchSpots_secondCallWithinCooldown_returnsNullAndDoesNotHitNetwork() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        val first = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(first).isNotNull()
+
+        // Advance only 30 seconds (well inside the 4m50s cooldown).
+        now += 30_000L
+        val second = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(second).isNull()
+        // Only the first request reached the server.
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun fetchSpots_afterCooldownExpires_callsServerAgain() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        val first = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(first).isNotNull()
+
+        // 5 minutes is past the 4m50s cooldown threshold.
+        now += 5L * 60_000L
+        val second = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(second).isNotNull()
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    @Test
+    fun fetchSpots_http429_triggers15MinuteBackoff() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setResponseCode(429))
+
+        val first = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(first).isNull()
+        assertThat(PskReporterClient.lastError).contains("429")
+
+        // Advance 10 minutes — still inside the 15-minute back-off window.
+        now += 10L * 60_000L
+        val second = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(second).isNull()
+        // Only the original 429 hit the server; the second attempt
+        // short-circuited on the in-memory back-off.
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun fetchSpots_http503_triggersSameBackoffPath() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setResponseCode(503))
+
+        val first = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(first).isNull()
+        assertThat(PskReporterClient.lastError).contains("503")
+    }
+
+    @Test
+    fun fetchSpots_recoversAfterRateLimitWindowExpires() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        val rateLimited = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(rateLimited).isNull()
+
+        // Past both the 15-minute rate-limit window AND the 4m50s cooldown.
+        now += 16L * 60_000L
+        val recovered = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(recovered).isNotNull()
+    }
+
+    @Test
+    fun fetchSpots_uppercasesCallsignInQueryString() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        PskReporterClient.fetchSpotsForMe("w1aw", 900)
+
+        val req = server.takeRequest()
+        assertThat(req.path).contains("senderCallsign=W1AW")
+    }
+
+    private fun fixture(path: String): String =
+        checkNotNull(javaClass.classLoader?.getResourceAsStream(path)) {
+            "missing test resource: $path"
+        }.bufferedReader().use { it.readText() }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/qrz/QrzXmlClientTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/qrz/QrzXmlClientTest.kt
@@ -1,0 +1,196 @@
+package radio.ks3ckc.ft8us.qrz
+
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Drive the QrzXmlClient singleton against a MockWebServer. The production
+ * client hard-codes its endpoint as DEFAULT_BASE_URL but exposes an
+ * @VisibleForTesting `baseUrl` seam; resetForTests() clears the in-memory
+ * session, cache, lastError, and restores the production URL.
+ *
+ * Robolectric is required for android.util.Log (used by the client's
+ * file/stderr logger).
+ */
+@RunWith(RobolectricTestRunner::class)
+class QrzXmlClientTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().also { it.start() }
+        QrzXmlClient.resetForTests()
+        QrzXmlClient.baseUrl = server.url("/xml/current/").toString()
+        // Production reads credentials from GeneralVariables; default to a
+        // configured pair for happy-path tests. Individual tests override.
+        GeneralVariables.qrzXmlUsername = "testuser"
+        GeneralVariables.qrzXmlPassword = "testpass"
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        QrzXmlClient.resetForTests()
+        GeneralVariables.qrzXmlUsername = ""
+        GeneralVariables.qrzXmlPassword = ""
+    }
+
+    @Test
+    fun lookup_happyPath_returnsImageUrl() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-ok.xml")))
+        server.enqueue(MockResponse().setBody(fixture("qrz/lookup-with-image.xml")))
+
+        val result = QrzXmlClient.lookup("K1ABC")
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.imageUrl).isEqualTo("https://cdn.qrz.com/k1abc/photo.jpg")
+        // Two requests: auth + lookup
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    @Test
+    fun lookup_missingCredentials_returnsNullAndSetsLastError() = runBlocking<Unit> {
+        GeneralVariables.qrzXmlUsername = ""
+        GeneralVariables.qrzXmlPassword = ""
+
+        val result = QrzXmlClient.lookup("K1ABC")
+
+        assertThat(result).isNull()
+        assertThat(QrzXmlClient.lastError).contains("not configured")
+        // No HTTP traffic should have occurred — we short-circuit before
+        // reaching the network.
+        assertThat(server.requestCount).isEqualTo(0)
+    }
+
+    @Test
+    fun lookup_authFailure_setsLastErrorFromErrorTag() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-bad.xml")))
+
+        val result = QrzXmlClient.lookup("K1ABC")
+
+        assertThat(result).isNull()
+        assertThat(QrzXmlClient.lastError).isEqualTo("Username/password incorrect")
+    }
+
+    @Test
+    fun lookup_http500_returnsNull() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        val result = QrzXmlClient.lookup("K1ABC")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun lookup_noImageInResponse_returnsNullAndDoesNotCache() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-ok.xml")))
+        server.enqueue(MockResponse().setBody(fixture("qrz/lookup-no-image.xml")))
+        // Second lookup re-uses the session, so only the lookup response.
+        server.enqueue(MockResponse().setBody(fixture("qrz/lookup-no-image.xml")))
+
+        val first = QrzXmlClient.lookup("W1AW")
+        val second = QrzXmlClient.lookup("W1AW")
+
+        assertThat(first).isNull()
+        assertThat(second).isNull()
+        // Three requests: auth + two lookups (no caching of negative results).
+        assertThat(server.requestCount).isEqualTo(3)
+    }
+
+    @Test
+    fun lookup_cachesPositiveResultOnSecondCall() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-ok.xml")))
+        server.enqueue(MockResponse().setBody(fixture("qrz/lookup-with-image.xml")))
+
+        val first = QrzXmlClient.lookup("K1ABC")
+        val second = QrzXmlClient.lookup("K1ABC")
+
+        assertThat(first).isNotNull()
+        assertThat(second).isNotNull()
+        assertThat(second!!.imageUrl).isEqualTo(first!!.imageUrl)
+        // Cache hit means no third request to the server.
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    @Test
+    fun lookup_isCaseInsensitiveOnCallsign() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-ok.xml")))
+        server.enqueue(MockResponse().setBody(fixture("qrz/lookup-with-image.xml")))
+
+        val upper = QrzXmlClient.lookup("K1ABC")
+        val lower = QrzXmlClient.lookup("k1abc")
+
+        // Lookup normalises to uppercase before the cache check; the lowercase
+        // call should hit the cache and not generate a new HTTP request.
+        assertThat(upper).isNotNull()
+        assertThat(lower).isNotNull()
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    @Test
+    fun lookup_sessionExpired_reAuthenticatesAndRetries() = runBlocking<Unit> {
+        // Order of responses the client will see:
+        //   1. auth -> session key SESSION-OK-...
+        //   2. lookup -> "Invalid session key" error (forces re-auth)
+        //   3. re-auth -> fresh session
+        //   4. lookup retry -> success with image
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-ok.xml")))
+        server.enqueue(MockResponse().setBody(fixture("qrz/session-expired.xml")))
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-ok.xml")))
+        server.enqueue(MockResponse().setBody(fixture("qrz/lookup-with-image.xml")))
+
+        val result = QrzXmlClient.lookup("K1ABC")
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.imageUrl).isEqualTo("https://cdn.qrz.com/k1abc/photo.jpg")
+        assertThat(server.requestCount).isEqualTo(4)
+    }
+
+    @Test
+    fun testConnection_happyPath_returnsOk() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-ok.xml")))
+
+        assertThat(QrzXmlClient.testConnection()).isEqualTo("OK")
+    }
+
+    @Test
+    fun testConnection_badCreds_returnsErrorMessage() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-bad.xml")))
+
+        val msg = QrzXmlClient.testConnection()
+        assertThat(msg).isEqualTo("Username/password incorrect")
+    }
+
+    @Test
+    fun testConnection_missingCredentials_returnsMissingMessage() = runBlocking<Unit> {
+        GeneralVariables.qrzXmlUsername = ""
+        GeneralVariables.qrzXmlPassword = ""
+
+        assertThat(QrzXmlClient.testConnection()).isEqualTo("Missing username or password")
+    }
+
+    @Test
+    fun clearCache_resetsLastError() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("qrz/auth-bad.xml")))
+        QrzXmlClient.lookup("K1ABC") // sets lastError
+        assertThat(QrzXmlClient.lastError).isNotNull()
+
+        QrzXmlClient.clearCache()
+
+        assertThat(QrzXmlClient.lastError).isNull()
+    }
+
+    private fun fixture(path: String): String =
+        checkNotNull(javaClass.classLoader?.getResourceAsStream(path)) {
+            "missing test resource: $path"
+        }.bufferedReader().use { it.readText() }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/qrz/QrzXmlParseTagTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/qrz/QrzXmlParseTagTest.kt
@@ -1,0 +1,54 @@
+package radio.ks3ckc.ft8us.qrz
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Focused tests on QrzXmlClient.parseTag — a small XmlPullParser-based tag
+ * scanner that the lookup/auth paths share. Lives in the same package as the
+ * production class so it can call the @VisibleForTesting internal helper.
+ */
+@RunWith(RobolectricTestRunner::class)
+class QrzXmlParseTagTest {
+
+    @Test
+    fun parseTag_returnsFirstMatchingTagText() {
+        val xml = """
+            <root>
+                <Key>abc123</Key>
+                <Count>42</Count>
+            </root>
+        """.trimIndent()
+        assertThat(QrzXmlClient.parseTag(xml, "Key")).isEqualTo("abc123")
+    }
+
+    @Test
+    fun parseTag_isCaseInsensitive() {
+        // parseTag does a case-insensitive name comparison so QRZ's mixed-case
+        // tags (e.g. <Key> vs <key>) all match.
+        val xml = "<r><KEY>abc</KEY></r>"
+        assertThat(QrzXmlClient.parseTag(xml, "key")).isEqualTo("abc")
+    }
+
+    @Test
+    fun parseTag_returnsNullWhenTagAbsent() {
+        val xml = "<r><other>x</other></r>"
+        assertThat(QrzXmlClient.parseTag(xml, "Key")).isNull()
+    }
+
+    @Test
+    fun parseTag_returnsNullForEmptyTagText() {
+        // parseTag explicitly filters empty/null text so callers can rely on
+        // a non-null return meaning "real value present".
+        val xml = "<r><Key></Key></r>"
+        assertThat(QrzXmlClient.parseTag(xml, "Key")).isNull()
+    }
+
+    @Test
+    fun parseTag_returnsNullForMalformedXml() {
+        // Any XmlPullParser exception is swallowed and surfaces as null.
+        assertThat(QrzXmlClient.parseTag("not really xml <<<>>>", "Key")).isNull()
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/FilterChipsScreenTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/FilterChipsScreenTest.kt
@@ -1,0 +1,74 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Compose UI test running on the JVM via Robolectric. Smoke-covers the
+ * stateless FilterChips composable: it renders each option, and clicking a
+ * chip invokes the `onSelected` callback with that option's value.
+ *
+ * Establishes the pattern for future screen-level tests; not exhaustive.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class FilterChipsScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val options = listOf("All", "CQ", "QSL", "Active")
+
+    @Test
+    fun rendersAllOptionLabels() {
+        composeRule.setContent {
+            FilterChips(options = options, selected = "All", onSelected = {})
+        }
+
+        options.forEach { label ->
+            composeRule.onNodeWithText(label).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun clickingChip_invokesOnSelectedWithThatOption() {
+        var picked: String? = null
+        composeRule.setContent {
+            FilterChips(
+                options = options,
+                selected = "All",
+                onSelected = { picked = it },
+            )
+        }
+
+        composeRule.onNodeWithText("CQ").performClick()
+
+        assertThat(picked).isEqualTo("CQ")
+    }
+
+    @Test
+    fun selectedChip_doesNotErrorWhenClicked() {
+        // Tapping the already-selected chip should still fire the callback
+        // (it's the caller's job to decide if that's a no-op).
+        var picked: String? = null
+        composeRule.setContent {
+            FilterChips(
+                options = options,
+                selected = "All",
+                onSelected = { picked = it },
+            )
+        }
+
+        composeRule.onNodeWithText("All").performClick()
+
+        assertThat(picked).isEqualTo("All")
+    }
+}

--- a/ft8cn/app/src/test/resources/adif/sample-malformed.adi
+++ b/ft8cn/app/src/test/resources/adif/sample-malformed.adi
@@ -1,0 +1,6 @@
+Header without proper EOH
+<eoh>
+<call:5>K1ABC<mode:3>FT8<eor>
+this record has no tags at all, parser should skip it<eor>
+<call:notanumber>BADREC<mode:3>FT8<eor>
+<call:4>W1AW<mode:3>FT8<eor>

--- a/ft8cn/app/src/test/resources/adif/sample-wsjtx.adi
+++ b/ft8cn/app/src/test/resources/adif/sample-wsjtx.adi
@@ -1,0 +1,7 @@
+ADIF Export from FT8AF test fixture
+<adif_ver:5>3.1.0
+<programid:6>FT8CN
+<eoh>
+<call:5>K1ABC<gridsquare:4>FN42<mode:3>FT8<rst_sent:3>-08<rst_rcvd:3>-12<qso_date:8>20260518<time_on:6>120000<qso_date_off:8>20260518<time_off:6>120100<band:3>20m<freq:8>14.07415<station_callsign:5>W1AW<my_gridsquare:4>FN31<eor>
+<call:5>VE3XY<gridsquare:4>FN03<mode:3>FT8<rst_sent:3>+05<rst_rcvd:3>-03<qso_date:8>20260518<time_on:6>120300<qso_date_off:8>20260518<time_off:6>120400<band:3>20m<freq:8>14.07415<station_callsign:5>W1AW<my_gridsquare:4>FN31<eor>
+<call:5>DL1AA<gridsquare:4>JO62<mode:3>FT8<rst_sent:3>-15<rst_rcvd:3>-09<qso_date:8>20260518<time_on:6>120600<qso_date_off:8>20260518<time_off:6>120700<band:3>20m<freq:8>14.07415<station_callsign:5>W1AW<my_gridsquare:4>FN31<eor>

--- a/ft8cn/app/src/test/resources/pskreporter/reception-report.xml
+++ b/ft8cn/app/src/test/resources/pskreporter/reception-report.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<receptionReports currentSeconds="1747756800">
+    <activeReceiver callsign="VE3XY" locator="FN03" frequency="14076000"/>
+    <receptionReport
+        receiverCallsign="VE3XY"
+        receiverLocator="FN03ab"
+        senderCallsign="W1AW"
+        senderLocator="FN31"
+        frequency="14076234"
+        flowStartSeconds="1747756700"
+        mode="FT8"
+        isSender="0"
+        sNR="-08"/>
+    <receptionReport
+        receiverCallsign="DL1AA"
+        receiverLocator="JO62"
+        senderCallsign="W1AW"
+        senderLocator="FN31"
+        frequency="14076150"
+        flowStartSeconds="1747756500"
+        mode="FT8"
+        isSender="0"
+        sNR="-15"/>
+    <receptionReport
+        receiverCallsign="JA1XX"
+        receiverLocator=""
+        senderCallsign="W1AW"
+        senderLocator="FN31"
+        frequency="14076000"
+        flowStartSeconds="1747756400"
+        mode="FT8"
+        isSender="0"
+        sNR="-20"/>
+    <receptionReport
+        receiverCallsign="VK2YY"
+        receiverLocator="QF56"
+        senderCallsign="W1AW"
+        senderLocator="FN31"
+        frequency="not-a-number"
+        flowStartSeconds="1747756300"
+        mode="FT8"
+        isSender="0"
+        sNR="-22"/>
+</receptionReports>

--- a/ft8cn/app/src/test/resources/qrz/auth-bad.xml
+++ b/ft8cn/app/src/test/resources/qrz/auth-bad.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<QRZDatabase version="1.34">
+    <Session>
+        <Error>Username/password incorrect</Error>
+    </Session>
+</QRZDatabase>

--- a/ft8cn/app/src/test/resources/qrz/auth-ok.xml
+++ b/ft8cn/app/src/test/resources/qrz/auth-ok.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<QRZDatabase version="1.34">
+    <Session>
+        <Key>SESSION-OK-1234567890ABCDEF</Key>
+        <Count>1</Count>
+        <SubExp>Sun Jan 1 12:34:03 2027</SubExp>
+    </Session>
+</QRZDatabase>

--- a/ft8cn/app/src/test/resources/qrz/lookup-no-image.xml
+++ b/ft8cn/app/src/test/resources/qrz/lookup-no-image.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<QRZDatabase version="1.34">
+    <Callsign>
+        <call>W1AW</call>
+    </Callsign>
+    <Session>
+        <Key>SESSION-OK-1234567890ABCDEF</Key>
+    </Session>
+</QRZDatabase>

--- a/ft8cn/app/src/test/resources/qrz/lookup-with-image.xml
+++ b/ft8cn/app/src/test/resources/qrz/lookup-with-image.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<QRZDatabase version="1.34">
+    <Callsign>
+        <call>K1ABC</call>
+        <image>https://cdn.qrz.com/k1abc/photo.jpg</image>
+    </Callsign>
+    <Session>
+        <Key>SESSION-OK-1234567890ABCDEF</Key>
+    </Session>
+</QRZDatabase>

--- a/ft8cn/app/src/test/resources/qrz/session-expired.xml
+++ b/ft8cn/app/src/test/resources/qrz/session-expired.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<QRZDatabase version="1.34">
+    <Session>
+        <Error>Invalid session key</Error>
+    </Session>
+</QRZDatabase>


### PR DESCRIPTION
Closes #27.

## Summary
- Bootstraps a JVM-only test stack (JUnit 4, Robolectric 4.11.1, MockWebServer, Truth, Compose `ui-test-junit4`) plus a single `androidTest` smoke for `ComposeMainActivity`.
- **85 unit tests, 0 failures**, covering: Maidenhead grid math, ADIF import, FT8 message classifiers, CRC16, MessageHashMap, `Ft8Message`, `CallsignInfo`, the QRZ XML and PSK Reporter HTTP clients (rate-limit back-off, 4m50s cooldown, session-expiry re-auth, LRU cache, case-insensitive lookups), and the `FilterChips` composable rendered under Robolectric.
- CI now runs `./gradlew testDebugUnitTest` before `assembleRelease` and uploads HTML+XML reports on failure.

## Production changes (test seams only)
- `QrzXmlClient.kt` / `PskReporterClient.kt`: `@VisibleForTesting internal var baseUrl` so MockWebServer can intercept; `internal fun resetForTests()` to clear in-memory state between tests. `PskReporterClient` gets an injectable `clock: () -> Long` so cooldown/back-off tests don't sleep five minutes.
- `GenerateFT8.java`: wraps `System.loadLibrary(\"ft8cn\")` in `try/catch (UnsatisfiedLinkError)` with a warning log. Production still loads the native lib normally; JVM tests can now reach the pure-Java helpers (`checkI3ByCallsign`, `checkIsStandardCallsign`). Native methods themselves still throw `UnsatisfiedLinkError` if invoked without the .so.

## Architecture
- **Pure JVM**: `CRC16Test`, `MessageHashMapTest`.
- **Robolectric** (for `android.util.Log`, Google Maps `LatLng`, etc.): `MaidenheadGridTest`, `CallsignInfoTest`, `Ft8MessageTest`, `LogFileImportTest`, `GenerateFT8MessageTypeTest`.
- **MockWebServer**: `QrzXmlClientTest` (12), `QrzXmlParseTagTest` (5), `PskReporterClientTest` (8). All fixtures are in `src/test/resources/{adif,qrz,pskreporter}/`.
- **Compose UI under Robolectric**: `FilterChipsScreenTest` — `createComposeRule()`, click assertions.
- **Instrumented** (`androidTest`, not in CI): `AppSmokeTest` launches `ComposeMainActivity` via `ActivityScenario`. Run locally with \`cd ft8cn && cmd.exe /c \"gradlew.bat connectedDebugAndroidTest\"\`.

## Out of scope (follow-ups to file)
- Emulator setup in CI for `connectedAndroidTest`.
- LDPC encoder coverage (lives in `libft8cn.so`, JNI-only).
- JaCoCo coverage measurement.
- Lint/Detekt/ktlint in CI.
- Exhaustive screen tests for every Compose screen (this PR sets the pattern with one example).

## Test plan
- [x] \`cmd.exe /c \"gradlew.bat testDebugUnitTest\"\` — **85 tests, 0 failures**
- [x] \`cmd.exe /c \"gradlew.bat assembleRelease\"\` — release APK build still green
- [x] CI: \`Run unit tests\` step passes on this PR
- [x] (manual, not blocking) \`cmd.exe /c \"gradlew.bat connectedDebugAndroidTest\"\` on the Pixel 8 confirms \`AppSmokeTest\` launches \`ComposeMainActivity\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)