### PR TITLE
Fix CQ button not always starting with a fresh CQ

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -55,6 +55,7 @@ public class FT8TransmitSignal {
     public MutableLiveData<Boolean> mutableIsActivated = new MutableLiveData<>();
     public volatile int sequential;// transmit sequence
     public MutableLiveData<Integer> mutableSequential = new MutableLiveData<>();
+    private volatile boolean pendingUserCQ = false;
     private volatile boolean isTransmitting = false;
     public MutableLiveData<Boolean> mutableIsTransmitting = new MutableLiveData<>();// whether currently transmitting
     public MutableLiveData<String> mutableTransmittingMessage = new MutableLiveData<>();// current message content
@@ -1001,7 +1002,7 @@ public class FT8TransmitSignal {
 
         // at this point I am not yet in message 6 state; check if anyone is calling me
         // 2022-09-22 if someone is calling me or auto-follow is active, set up a new transmit message list
-        if (checkCQMeOrFollowCQMessage(messages)) {
+        if (!pendingUserCQ && checkCQMeOrFollowCQMessage(messages)) {
             return;
         }
 
@@ -1009,7 +1010,9 @@ public class FT8TransmitSignal {
         // at this point, no reply messages were received
         // if I am in CQ state, newOrder must be -1
         if (functionOrder == 6) {// I am in CQ state
-            if (!dequeueNextCaller()) {
+            if (pendingUserCQ) {
+                pendingUserCQ = false;
+            } else if (!dequeueNextCaller()) {
                 checkCQMeOrFollowCQMessage(messages);
             }
             return;
@@ -1161,6 +1164,17 @@ public class FT8TransmitSignal {
             mutableToCallsign.postValue(toCallsign);// set the call target
             generateFun();
         }
+    }
+
+    /**
+     * Called when the user explicitly presses CQ. Clears the caller queue and
+     * sets a flag so that the first decode cycle after pressing CQ will not
+     * auto-follow or dequeue — the CQ message transmits cleanly first.
+     */
+    public void userResetToCQ() {
+        resetToCQ();
+        clearCallerQueue();
+        pendingUserCQ = true;
     }
 
     // ==================== Caller Queue Methods ====================

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/MyCallingFragment.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/MyCallingFragment.java
@@ -385,7 +385,7 @@ public class MyCallingFragment extends Fragment {
             //@RequiresApi(api = Build.VERSION_CODES.N)
             @Override
             public void onClick(View view) {
-                mainViewModel.ft8TransmitSignal.resetToCQ();
+                mainViewModel.ft8TransmitSignal.userResetToCQ();
                 GeneralVariables.resetLaunchSupervision();//Reset automatic supervision
             }
         });

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -131,7 +131,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {
                         Toast.makeText(context, "Set your callsign in Settings before calling CQ", Toast.LENGTH_SHORT).show()
                     } else {
-                        mainViewModel.ft8TransmitSignal.resetToCQ()
+                        mainViewModel.ft8TransmitSignal.userResetToCQ()
                         mainViewModel.ft8TransmitSignal.setActivated(true)
                     }
                 },


### PR DESCRIPTION
## Summary
- After calling another station, pressing CQ could send a directed call instead of "CQ MYCALL GRID" because `parseMessageToFunction()` ran auto-follow and caller-queue logic on the first decode cycle before the CQ message was transmitted
- Adds a `pendingUserCQ` flag that suppresses auto-follow and caller dequeue for one decode cycle when the user explicitly presses CQ
- Internal `resetToCQ()` calls (e.g. after QSO completion) are unaffected — caller queue and auto-follow work normally in those flows

## Test plan
- [ ] Press CQ → tap a decoded callsign → press Call → press Stop → press CQ again → verify the app sends "CQ MYCALL GRID" on the first TX cycle, not a directed call
- [ ] After the first CQ cycle, verify the app responds normally if someone calls you
- [ ] Complete a full QSO and verify the caller queue dequeue still works after QSO finishes
- [ ] Verify followed stations are still auto-targeted after the first CQ cycle completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)