### PR TITLE
Decode: add Clear button to empty the decode list (issue #57)

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -13,6 +13,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -150,6 +154,18 @@ fun DecodeScreen(
                     TopBarSubtitle(
                         text = "$utcString  \u2022  $decodedCount decoded this cycle",
                     )
+                },
+                actions = {
+                    IconButton(
+                        onClick = { mainViewModel.clearFt8MessageList() },
+                        enabled = messageList?.isNotEmpty() == true,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = "Clear decode list",
+                            tint = TextMuted,
+                        )
+                    }
                 },
             )
 


### PR DESCRIPTION
## Summary

- Adds a trash IconButton to the Decode screen's TopBar that calls the existing `MainViewModel.clearFt8MessageList()` (resets the list, the decoded counter, and triggers the empty-state UI).
- Button is disabled when the list is already empty so there's no spurious tap target.
- No confirmation dialog — single explicit tap, per design preference. Decoding is unaffected.

Closes #57.

## Test plan

- [ ] Open Decode tab, wait for several FT8 cycles, confirm trash icon is enabled in top-right of TopBar.
- [ ] Tap trash icon → list empties immediately, subtitle shows `0 decoded this cycle`, empty-state illustration renders.
- [ ] Confirm new decodes still arrive afterward (decoder is not affected).
- [ ] Verify the trash icon is disabled (greyed) when the list is empty.

Generated with Claude Code
