### PR TITLE
Add privacy policy

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,55 @@
+# Privacy Policy
+
+**FT8AF**
+Last updated: May 20, 2026
+
+## Overview
+
+FT8AF is an open-source amateur radio application. Your privacy is important to us. This policy explains what data the app collects, how it is used, and what choices you have.
+
+## Data Collection
+
+FT8AF does **not** collect, transmit, or sell personal information to third parties for advertising or analytics purposes. The app contains no ads, no tracking SDKs, and no telemetry.
+
+### Data You Provide
+
+- **Operator identity**: Your callsign and Maidenhead grid square, entered in Settings. This information is stored locally on your device and is only transmitted over the air as part of normal FT8 radio operation.
+- **QSO logs**: Contact records are stored in a local database on your device.
+
+### Data Shared with Third-Party Services
+
+If you choose to configure integrations, the app will transmit QSO data to the services you enable:
+
+- **Cloudlog / Wavelog** — self-hosted or cloud logging platforms
+- **QRZ.com** — online callsign and logbook database
+- **PSK Reporter** — propagation reporting network
+
+These transmissions only occur when you explicitly configure and enable them. The data sent is limited to standard amateur radio contact information (callsigns, grids, signal reports, frequency, mode, and time). Each service is governed by its own privacy policy.
+
+### Location Data
+
+If you enable "Auto-update Grid (GPS)" in Settings, the app accesses your device's GPS to calculate your Maidenhead grid square. This location data is not transmitted to any server — it is only used locally to set your grid and calculate distances to other stations.
+
+## Data Storage
+
+All data is stored locally on your device in the app's private storage. No data is stored on external servers operated by FT8AF.
+
+## Data Sharing
+
+FT8AF does not share your data with any party except the third-party logging services listed above, and only when you explicitly configure them.
+
+## Children's Privacy
+
+FT8AF does not knowingly collect information from children under 13. The app is intended for licensed amateur radio operators.
+
+## Open Source
+
+FT8AF is open-source software licensed under the MIT License. You can review the complete source code at [github.com/patrickrb/FT8AF](https://github.com/patrickrb/FT8AF).
+
+## Changes to This Policy
+
+If this policy is updated, the revised version will be posted to this page with an updated date.
+
+## Contact
+
+If you have questions about this privacy policy, please open an issue on the [GitHub repository](https://github.com/patrickrb/FT8AF/issues).


### PR DESCRIPTION
## Summary
- Adds `privacy.md` to the repo root for the Google Play Store listing
- Covers: no ads/tracking/telemetry, local-only storage, optional third-party logging integrations (Cloudlog, QRZ, Wavelog, PSK Reporter), GPS usage disclosure

## Test plan
- [ ] Verify the policy renders correctly at https://github.com/patrickrb/FT8AF/blob/main/privacy.md after merge
- [ ] Link it from Google Play Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)