### PR TITLE
Fix CQ button stopping immediately after waiting one time slot

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -133,6 +133,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     } else {
                         mainViewModel.ft8TransmitSignal.userResetToCQ()
                         mainViewModel.ft8TransmitSignal.setActivated(true)
+                        GeneralVariables.resetLaunchSupervision()
                     }
                 },
                 onStop = {


### PR DESCRIPTION
## Summary
- The Compose CQ button (`TxStrip` `onCallCQ` in `FT8USApp.kt`) called `userResetToCQ()` and `setActivated(true)` but never reset the launch-supervision timer.
- Default supervision is **10 minutes** from app start (`GeneralVariables.DEFAULT_LAUNCH_SUPERVISION`). Once it has expired, `FT8TransmitSignal`'s per-second timer (`FT8TransmitSignal.java:148-152`) sees `isLaunchSupervisionTimeout() == true` and calls `setActivated(false)` *before* the next transmit — so pressing CQ after the app has been running for >10 minutes waits for the time slot, then immediately stops without ever calling `doTransmit()`.
- Every other transmit-start path already pairs `setActivated(true)` with `resetLaunchSupervision()` (`MyCallingFragment.java:74/82`, `CallingListFragment.java:317/324`, `QsoSheet.kt:194/196`). The CQ button was the only one missing it.

This was a regression that #66 drew attention to — the call was renamed from `resetToCQ()` to `userResetToCQ()` but the missing supervision reset wasn't noticed at the time.

## Test plan
- [ ] Leave the app running for >10 minutes without transmitting, then press CQ — verify it actually transmits on the next time slot instead of stopping.
- [ ] Press CQ shortly after app start — verify behavior is unchanged.
- [ ] Verify other transmit triggers (Reply from QsoSheet, MyCallingFragment, CallingListFragment) still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)