### PR TITLE
Prepare app for Google Play Store publishing

### DIFF
--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -16,14 +16,14 @@ static def getCurrentTime() {
 
 android {
 
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
-        applicationId "com.bg7yoz.ft8cn"
+        applicationId "radio.ks3ckc.ft8af"
         minSdk 23
-        targetSdk 34
-        versionCode 1
-        versionName '1.0'
+        targetSdk 35
+        versionCode 3
+        versionName '1.0.1'
 
 
         dataBinding{

--- a/ft8cn/app/src/main/AndroidManifest.xml
+++ b/ft8cn/app/src/main/AndroidManifest.xml
@@ -77,7 +77,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.bg7yoz.ft8cn.fileprovider"
+            android:authorities="radio.ks3ckc.ft8af.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
@@ -323,7 +323,7 @@ public class ShareLogs {
                 if (!isCancel) {
                     Intent sharingIntent = new Intent(Intent.ACTION_SEND);
                     Uri fileUri = FileProvider.getUriForFile(context.getApplicationContext()
-                            , "com.bg7yoz.ft8cn.fileprovider", file);
+                            , "radio.ks3ckc.ft8af.fileprovider", file);
                     sharingIntent.setType("application/octet-stream");
                     sharingIntent.putExtra(Intent.EXTRA_STREAM, fileUri);
                     sharingIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);


### PR DESCRIPTION
## Summary
- Change `applicationId` from `com.bg7yoz.ft8cn` to `radio.ks3ckc.ft8af` (required by Play Store)
- Update `FileProvider` authority to `radio.ks3ckc.ft8af.fileprovider` in both the manifest and the Java code reference in `ShareLogs.java` (old authority was claimed by the original FT8CN app)
- Bump `compileSdk` and `targetSdk` from 34 to 35 (Play Store now requires API 35 minimum)
- Bump `versionCode` to 3 and `versionName` to 1.0.1

## Test plan
- [ ] Build release bundle: `./gradlew bundleRelease`
- [ ] Verify the APK/AAB package name is `radio.ks3ckc.ft8af`
- [ ] Test log export sharing (uses FileProvider) still works
- [ ] Upload to Play Console without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)