### PR TITLE
Add slot timer bar showing time remaining in 15s FT8 slot

### DIFF
--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -160,7 +160,9 @@ dependencies {
 
     // --- JVM unit + Robolectric tests ---
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.11.1'
+    // 4.14.1 ships android-all for SDK 35; older versions fail with
+    // IllegalArgumentException during RobolectricTestRunner init.
+    testImplementation 'org.robolectric:robolectric:4.14.1'
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'androidx.test.ext:junit:1.1.5'
     testImplementation 'com.google.truth:truth:1.4.2'

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -26,6 +26,7 @@ import radio.ks3ckc.ft8us.ui.components.FT8USTab
 import radio.ks3ckc.ft8us.ui.components.FrequencyPickerSheet
 import radio.ks3ckc.ft8us.ui.components.formatMhz
 import radio.ks3ckc.ft8us.ui.components.QsoCelebration
+import radio.ks3ckc.ft8us.ui.components.SlotTimerBar
 import radio.ks3ckc.ft8us.ui.components.TabBar
 import radio.ks3ckc.ft8us.ui.components.TransmitGlow
 import radio.ks3ckc.ft8us.ui.components.TxStrip
@@ -118,6 +119,12 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     }
                     mainViewModel.qsoSheetMinimized.postValue(false)
                 },
+            )
+
+            // Slot timer bar — fills 0→100% across each 15s FT8 slot
+            SlotTimerBar(
+                activeTxSlot = txSlot,
+                isActivated = isActivated,
             )
 
             // TX status strip — always visible above tab bar

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerBar.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerBar.kt
@@ -1,0 +1,89 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.geometry.Size
+import androidx.compose.runtime.withFrameMillis
+import com.bg7yoz.ft8cn.timer.UtcTimer
+import radio.ks3ckc.ft8us.theme.Accent
+import radio.ks3ckc.ft8us.theme.Border
+import radio.ks3ckc.ft8us.theme.GeistMonoFamily
+import radio.ks3ckc.ft8us.theme.Signal
+import radio.ks3ckc.ft8us.theme.TextMuted
+
+private const val SLOT_MILLIS = 15_000L
+
+@Composable
+fun SlotTimerBar(
+    activeTxSlot: Int,
+    isActivated: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var nowMs by remember { mutableLongStateOf(UtcTimer.getSystemTime()) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            withFrameMillis {
+                nowMs = UtcTimer.getSystemTime()
+            }
+        }
+    }
+
+    val slotMs = ((nowMs % SLOT_MILLIS) + SLOT_MILLIS) % SLOT_MILLIS
+    val progress = slotMs / SLOT_MILLIS.toFloat()
+    val secondsRemaining = (((SLOT_MILLIS - slotMs) + 999L) / 1000L).toInt().coerceIn(0, 15)
+    val currentSlot = UtcTimer.sequential(nowMs)
+    val fillColor = if (isActivated && currentSlot == activeTxSlot) Accent else Signal
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(3.dp)
+                .drawBehind {
+                    drawRect(color = Border, size = Size(size.width, size.height))
+                    drawRect(
+                        color = fillColor,
+                        size = Size(size.width * progress, size.height),
+                    )
+                },
+        )
+        Text(
+            text = "${secondsRemaining}s",
+            color = TextMuted,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = GeistMonoFamily,
+            letterSpacing = 0.02.sp,
+            textAlign = TextAlign.End,
+            maxLines = 1,
+            softWrap = false,
+            modifier = Modifier.width(26.dp),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a thin progress bar above the TxStrip that fills 0→100% across each 15-second FT8 slot, with a monospace seconds-remaining readout (`15s` … `0s`).
- Driven per-frame off `UtcTimer.getSystemTime()` (which already includes the NTP-synced offset) rather than `MainViewModel.timerSec` LiveData — that only ticks once per second and would give a jerky bar.
- Cyan (`Signal`) by default; turns amber (`Accent`) when CQ/QSO is active **and** the current slot matches the selected TX slot, matching the existing TX-vs-RX color language used by `PulseDot` in TxStrip.

## Test plan
- [x] Builds clean (`gradlew.bat installDebug`)
- [x] Installed on Pixel 8
- [ ] Bar appears as a 3dp line directly above the LISTENING/TRANSMITTING row
- [ ] Bar fills smoothly left→right over 15 seconds (no visible stepping)
- [ ] Bar resets at :00, :15, :30, :45 against the system clock
- [ ] `15s`…`0s` countdown is visible on the right
- [ ] Bar turns amber on the selected TX slot when CQ is active; flips when toggling TX1/TX2
- [ ] Bar continues animating across tab switches (Decode → Map → Waterfall) and with the QSO panel expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)