### PR TITLE
CallingList: highlight worked-before state with left-edge stripe

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -224,6 +225,7 @@ public class GeneralVariables {
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static ArrayList<String> QSL_Callsign_list = new ArrayList<>();//Successfully QSL'd callsigns
     public static ArrayList<String> QSL_Callsign_list_other_band = new ArrayList<>();//Successfully QSL'd callsigns on other bands
+    public static HashSet<String> QSL_Grid_list = new HashSet<>();//Distinct worked 4-char Maidenhead grids (any band)
 
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns
@@ -309,6 +311,15 @@ public class GeneralVariables {
      */
     public static boolean checkQSLCallsign_OtherBand(String callsign) {
         return QSL_Callsign_list_other_band.contains(callsign);
+    }
+
+    /**
+     * Check if a 4-character Maidenhead grid has been previously worked (any band).
+     * Caller should pass the first 4 characters upper-cased.
+     */
+    public static boolean checkQSLGrid(String grid) {
+        if (grid == null || grid.length() < 4) return false;
+        return QSL_Grid_list.contains(grid.substring(0, 4).toUpperCase());
     }
 
     /**

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -1973,6 +1973,21 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             }
             cursor.close();
             GeneralVariables.QSL_Callsign_list_other_band = other_callsigns;
+
+            // Load distinct 4-char worked grids (any band) into in-memory set
+            querySQL = "select distinct upper(substr(gridsquare,1,4)) as g from QSLTable" +
+                    " where gridsquare is not null and length(gridsquare) >= 4";
+            cursor = db.rawQuery(querySQL, null);
+            java.util.HashSet<String> grids = new java.util.HashSet<>();
+            while (cursor.moveToNext()) {
+                @SuppressLint("Range")
+                String g = cursor.getString(cursor.getColumnIndex("g"));
+                if (g != null && g.length() >= 4) {
+                    grids.add(g);
+                }
+            }
+            cursor.close();
+            GeneralVariables.QSL_Grid_list = grids;
         }
 
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/CallingListAdapter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/CallingListAdapter.java
@@ -225,6 +225,9 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
         // Check if this callsign has been contacted before; store result in holder.otherBandIsQso
         setQueryHolderQSL_Callsign(holder);
 
+        // Worked-before highlighting (left-edge stripe). Depends on isQSL_Callsign/otherBandIsQso set above.
+        setWorkedStateStripe(holder);
+
         // Whether the message is related to my callsign
         if (holder.ft8Message.inMyCall()) {
             holder.callListMessageTextView.setTextColor(context.getResources().getColor(
@@ -328,6 +331,38 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
         }
     }
 
+    /**
+     * Color the left-edge stripe of a row based on worked-before state.
+     * Priority: new DXCC > new grid > new band > worked-before > none.
+     */
+    private void setWorkedStateStripe(@NonNull CallingListItemHolder holder) {
+        if (holder.workedStateStripeView == null) return;
+
+        Ft8Message msg = holder.ft8Message;
+        // TX row (synthetic) — no stripe.
+        if (msg == null || msg.freq_hz <= 0.01f) {
+            holder.workedStateStripeView.setBackgroundColor(context.getColor(R.color.stripe_none));
+            return;
+        }
+
+        int colorRes;
+        if (msg.fromDxcc) {
+            colorRes = R.color.stripe_new_dxcc;
+        } else if (msg.maidenGrid != null
+                && msg.maidenGrid.length() >= 4
+                && !GeneralVariables.checkQSLGrid(msg.maidenGrid)) {
+            colorRes = R.color.stripe_new_grid;
+        } else if (!msg.isQSL_Callsign
+                && holder.otherBandIsQso) {
+            colorRes = R.color.stripe_new_band;
+        } else if (msg.isQSL_Callsign) {
+            colorRes = R.color.stripe_worked;
+        } else {
+            colorRes = R.color.stripe_none;
+        }
+        holder.workedStateStripeView.setBackgroundColor(context.getColor(colorRes));
+    }
+
     private void setFromDxcc(@NonNull CallingListItemHolder holder) {
 
         if (holder.ft8Message.fromDxcc && holder.ft8Message.freq_hz > 0.01f) {
@@ -401,6 +436,7 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
                 bandItemTextView, callingUtcTextView;
         ImageView dxccToImageView, ituToImageView, cqToImageView, dxccFromImageView
                 , ituFromImageView, cqFromImageView,isWeakSignalImageView;
+        View workedStateStripeView;
         public Ft8Message ft8Message;
         //boolean showFollow;
         ShowMode showMode;
@@ -431,6 +467,7 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
             ituFromImageView = itemView.findViewById(R.id.ituFromImageView);
             cqFromImageView = itemView.findViewById(R.id.cqFromImageView);
             isWeakSignalImageView=itemView.findViewById(R.id.isWeakSignalImageView);
+            workedStateStripeView=itemView.findViewById(R.id.workedStateStripeView);
 
             dxccToImageView.setVisibility(View.GONE);
             ituToImageView.setVisibility(View.GONE);

--- a/ft8cn/app/src/main/res/layout/call_list_holder_item.xml
+++ b/ft8cn/app/src/main/res/layout/call_list_holder_item.xml
@@ -15,6 +15,15 @@
     android:foreground="?attr/selectableItemBackground"
     tools:ignore="TouchTargetSizeCheck">
 
+    <View
+        android:id="@+id/workedStateStripeView"
+        android:layout_width="6dp"
+        android:layout_height="0dp"
+        android:background="@color/stripe_none"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/callListMessageTextView"
         android:layout_width="0dp"
@@ -96,7 +105,7 @@
         android:layout_marginStart="4dp"
         android:textSize="12sp"
         app:layout_constraintBottom_toBottomOf="@+id/callListMessageTextView"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/workedStateStripeView"
         app:layout_constraintTop_toTopOf="@+id/callListMessageTextView"
         tools:ignore="TextContrastCheck"
         tools:text="0" />
@@ -114,7 +123,7 @@
         android:layout_height="wrap_content"
         android:textSize="10sp"
         app:layout_constraintBottom_toBottomOf="@+id/linearLayout"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/workedStateStripeView"
         app:layout_constraintTop_toTopOf="@+id/linearLayout"
         tools:ignore="SmallSp"
         tools:text="123456" />
@@ -253,7 +262,7 @@
         android:layout_width="10dp"
         android:layout_height="10dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/workedStateStripeView"
         app:layout_constraintTop_toTopOf="@+id/callingListSequenceTextView"
         app:srcCompat="@drawable/is_weak_signal_24"
         tools:ignore="ContentDescription,ImageContrastCheck" />

--- a/ft8cn/app/src/main/res/layout/call_list_holder_simple_item.xml
+++ b/ft8cn/app/src/main/res/layout/call_list_holder_simple_item.xml
@@ -15,6 +15,15 @@
     android:foreground="?attr/selectableItemBackground"
     tools:ignore="TouchTargetSizeCheck">
 
+    <View
+        android:id="@+id/workedStateStripeView"
+        android:layout_width="6dp"
+        android:layout_height="0dp"
+        android:background="@color/stripe_none"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/callListMessageTextView"
         android:layout_width="0dp"
@@ -98,7 +107,7 @@
         android:layout_marginStart="4dp"
         android:textSize="12sp"
         app:layout_constraintBottom_toBottomOf="@+id/callListMessageTextView"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/workedStateStripeView"
         app:layout_constraintTop_toTopOf="@+id/callListMessageTextView"
         tools:ignore="TextContrastCheck"
         tools:text="0" />
@@ -116,7 +125,7 @@
         android:layout_height="wrap_content"
         android:textSize="10sp"
         app:layout_constraintBottom_toBottomOf="@+id/linearLayout"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/workedStateStripeView"
         app:layout_constraintTop_toTopOf="@+id/linearLayout"
         tools:ignore="SmallSp"
         tools:text="123456"
@@ -259,7 +268,7 @@
         android:layout_width="10dp"
         android:layout_height="10dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/workedStateStripeView"
         app:layout_constraintTop_toTopOf="@+id/callingListSequenceTextView"
         app:srcCompat="@drawable/is_weak_signal_24"
         tools:ignore="ContentDescription,ImageContrastCheck" />

--- a/ft8cn/app/src/main/res/values/colors.xml
+++ b/ft8cn/app/src/main/res/values/colors.xml
@@ -178,5 +178,11 @@
     <color name="char_bar_15">#770A8F</color>
     <color name="char_bar_16">#61024D</color>
 
+    <!-- Worked-before highlighting (CallingList row left-edge stripe) -->
+    <color name="stripe_new_dxcc">#FFFF3A3A</color>
+    <color name="stripe_new_grid">#FFFF8C00</color>
+    <color name="stripe_new_band">#FFFFC107</color>
+    <color name="stripe_worked">#80808080</color>
+    <color name="stripe_none">#00000000</color>
 
 </resources>


### PR DESCRIPTION
## Summary
- Adds a 6dp colored stripe on the left edge of each CallingList row, indicating worked-before status: **red** (new DXCC), **orange** (new grid), **yellow** (new band — worked on another band, not this one), **dim gray** (already worked on this band), transparent otherwise.
- Existing 4-minute sequence-window background gradient is untouched — the stripe is a second, independent signal.
- Foundation for later alerting on new DXCC / grids.

## How it works
- `Ft8Message.fromDxcc` is already set to `true` when a decoded callsign's DXCC has not been worked (populated from `cty.dat` via `CallsignDatabase`). Reused as-is for the new-DXCC tier.
- `GeneralVariables.QSL_Callsign_list` / `_other_band` (loaded from `QSLTable` at startup and on band change) drive the new-band and worked-on-this-band tiers.
- New: `GeneralVariables.QSL_Grid_list` (HashSet of distinct 4-char Maidenhead grids), populated from `QSLTable.gridsquare` by extending the existing `DatabaseOpr.GetAllQSLCallsign.get()` loader. Two existing call sites pick it up — no new init paths.
- "New grid" is evaluated only when the decode itself carries a 4-char grid (`Ft8Message.maidenGrid`). Decodes without a grid (most R+/RR73/73 messages) skip that tier — no per-row DB lookups.
- Priority order in `CallingListAdapter.setWorkedStateStripe()`: new DXCC → new grid → new band → worked → none. TX synthetic row (`freq_hz <= 0.01`) always transparent.

## Test plan
- [ ] Build installs cleanly on Pixel 8 (verified locally — `gradlew.bat installDebug` → `Installed on 1 device.`)
- [ ] Open CallingList on a fresh user with no QSO log → most CQs from valid DXCC prefixes show **red** stripes
- [ ] Log a QSO with a callsign on the current band → that callsign's next decode shows **dim gray** stripe, not red
- [ ] Switch to a different band → the just-worked callsign now shows **yellow** (new band) when decoded
- [ ] Decode containing an unworked 4-char grid (e.g. `CQ VK3KE QF22` after logging only DM33 contacts) → shows **orange**
- [ ] TX synthetic row (`freq_hz <= 0.01`) renders with a transparent stripe — no spurious color
- [ ] Existing 4-minute alternating row background colors still alternate as before, behind the stripe
- [ ] Simple list mode (`GeneralVariables.simpleCallItemMode = true`) shows the stripe too

🤖 Generated with [Claude Code](https://claude.com/claude-code)