### PR TITLE
Log decoded CQ messages for modifier diagnostics

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -335,6 +335,19 @@ public class MainViewModel extends ViewModel {
                     , ArrayList<Ft8Message> messages, boolean isDeep) {
                 if (messages.size() == 0) return;//no messages decoded, don't trigger action
 
+                // Diagnostic: log every CQ message so we can see what the JNI decoder
+                // populates for "CQ DX" / "CQ POTA" style broadcasts.
+                for (Ft8Message m : messages) {
+                    if (m.checkIsCQ()) {
+                        fileLog(String.format(
+                                "CQ_DEBUG i3=%d n3=%d to=[%s] from=[%s] extra=[%s] modifier=[%s] msgText=[%s]",
+                                m.i3, m.n3,
+                                m.callsignTo, m.callsignFrom, m.extraInfo,
+                                m.modifier == null ? "null" : m.modifier,
+                                m.getMessageText()));
+                    }
+                }
+
                 synchronized (ft8Messages) {
                     ft8Messages.addAll(messages);//add messages to list
                 }


### PR DESCRIPTION
## Summary
- Add a fileLog line in `MainViewModel.afterDecode` that, for every decoded CQ message, dumps the raw `callsignTo`, `callsignFrom`, `extraInfo`, `modifier`, and `getMessageText()` to `debug.log`.
- Goal: confirm what the JNI decoder actually puts in `callsignTo` for "CQ DX" / "CQ POTA" style broadcasts, so we can tell whether the modifier survives the decode path or gets dropped before display.
- Diagnostic only — safe to revert once we have data.

## Test plan
- [ ] Install on device, decode a few cycles on a band with CQ DX / CQ POTA / CQ NA / CQ EU traffic.
- [ ] `adb pull /sdcard/Android/data/com.bg7yoz.ft8cn/files/debug.log` and grep for `CQ_DEBUG`.
- [ ] Verify the lines show modifier info (either in `to=[...]` or `modifier=[...]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
