### PR TITLE
Decode: target highlight + smarter status badges

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/theme/Color.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/theme/Color.kt
@@ -29,6 +29,13 @@ val AccentGlow = Color(0xFFFFD7A0)
 val Signal = Color(0xFF5CD6E8)
 val SignalSoft = Color(0x245CD6E8)   // rgba(92,214,232, 0.14)
 
+// Target — the station the operator is currently calling. Pink/magenta so it's
+// visually distinct from CQ (amber) and TO YOU (cyan); these often stack on a
+// single row during an active QSO.
+val Target = Color(0xFFF472B6)
+val TargetSoft = Color(0x24F472B6)   // rgba(244,114,182, 0.14)
+val TargetBorder = Color(0x47F472B6) // rgba(244,114,182, 0.28)
+
 // Status
 val StatusNew = Color(0xFFC084FC)
 val StatusNeeded = Color(0xFFFFAF5E)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -59,7 +59,7 @@ private data class QsoLogEntry(
     val messageText: String,
     val snr: Int? = null,
 ) {
-    enum class Direction { TX, RX }
+    enum class Direction { TX, RX, BUSY }
 }
 
 /**
@@ -135,13 +135,30 @@ fun ActiveQsoPanel(
             val from = msg.callsignFrom ?: ""
             val to = msg.callsignTo ?: ""
 
+            val fromIsTarget = from.equals(displayCallsign, ignoreCase = true)
+            val toIsMe = to.equals(myCallsign, ignoreCase = true) ||
+                GeneralVariables.checkIsMyCallsign(to)
+
             when {
                 // RX: target station calling us
-                from.equals(displayCallsign, ignoreCase = true) &&
-                        (to.equals(myCallsign, ignoreCase = true) || GeneralVariables.checkIsMyCallsign(to)) -> {
+                fromIsTarget && toIsMe -> {
                     entries.add(
                         QsoLogEntry(
                             direction = QsoLogEntry.Direction.RX,
+                            utcTime = msg.utcTime,
+                            messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
+                            snr = msg.snr,
+                        )
+                    )
+                }
+                // BUSY: target is transmitting but to someone else — useful so
+                // the hunter can see what their target is doing (calling CQ,
+                // exchanging reports with another station, etc.) instead of
+                // staring at an empty log wondering whether they're still on.
+                fromIsTarget && !toIsMe -> {
+                    entries.add(
+                        QsoLogEntry(
+                            direction = QsoLogEntry.Direction.BUSY,
                             utcTime = msg.utcTime,
                             messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
                             snr = msg.snr,
@@ -343,8 +360,20 @@ private fun MessageLogRow(entry: QsoLogEntry) {
     }
 
     val isTx = entry.direction == QsoLogEntry.Direction.TX
-    val dirColor = if (isTx) Accent else Signal
-    val dirLabel = if (isTx) "TX" else "RX"
+    val isBusy = entry.direction == QsoLogEntry.Direction.BUSY
+    val dirColor = when (entry.direction) {
+        QsoLogEntry.Direction.TX -> Accent
+        QsoLogEntry.Direction.RX -> Signal
+        QsoLogEntry.Direction.BUSY -> TextMuted
+    }
+    val dirLabel = when (entry.direction) {
+        QsoLogEntry.Direction.TX -> "TX"
+        QsoLogEntry.Direction.RX -> "RX"
+        QsoLogEntry.Direction.BUSY -> "BUSY"
+    }
+    // Dim the whole row when the target is talking to someone else — it's
+    // context, not part of our QSO.
+    val rowAlpha = if (isBusy) 0.6f else 1f
 
     Row(
         modifier = Modifier
@@ -356,13 +385,13 @@ private fun MessageLogRow(entry: QsoLogEntry) {
         Box(
             modifier = Modifier
                 .clip(RoundedCornerShape(3.dp))
-                .background(dirColor.copy(alpha = 0.15f))
+                .background(dirColor.copy(alpha = 0.15f * rowAlpha))
                 .padding(horizontal = 4.dp, vertical = 1.dp),
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = dirLabel,
-                color = dirColor,
+                color = dirColor.copy(alpha = rowAlpha),
                 fontSize = 9.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = GeistMonoFamily,
@@ -374,7 +403,7 @@ private fun MessageLogRow(entry: QsoLogEntry) {
         // UTC time
         Text(
             text = timeStr,
-            color = TextFaint,
+            color = TextFaint.copy(alpha = rowAlpha),
             fontSize = 10.sp,
             fontFamily = GeistMonoFamily,
         )
@@ -384,17 +413,17 @@ private fun MessageLogRow(entry: QsoLogEntry) {
         // Message text
         Text(
             text = entry.messageText,
-            color = TextPrimary,
+            color = TextPrimary.copy(alpha = rowAlpha),
             fontSize = 11.sp,
             fontFamily = GeistMonoFamily,
             modifier = Modifier.weight(1f),
         )
 
-        // SNR for RX messages
+        // SNR for received messages (RX or BUSY)
         if (entry.snr != null && !isTx) {
             Text(
                 text = if (entry.snr >= 0) "+${entry.snr}" else "${entry.snr}",
-                color = Signal,
+                color = Signal.copy(alpha = rowAlpha),
                 fontSize = 10.sp,
                 fontFamily = GeistMonoFamily,
             )

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/StatusPill.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/StatusPill.kt
@@ -33,6 +33,30 @@ enum class QsoStatus(
         Color(0x1FC084FC),  // rgba(192,132,252,0.12)
         Color(0x47C084FC),  // rgba(192,132,252,0.28)
     ),
+    NEW_GRID(
+        "NEW GRID",
+        StatusWarn,
+        Color(0x1FFACC15),  // rgba(250,204,21,0.12)
+        Color(0x47FACC15),  // rgba(250,204,21,0.28)
+    ),
+    NEW_BAND(
+        "NEW BAND",
+        Signal,
+        Color(0x1F5CD6E8),  // rgba(92,214,232,0.12)
+        Color(0x475CD6E8),  // rgba(92,214,232,0.28)
+    ),
+    POTA(
+        "POTA",
+        StatusConfirmed,
+        Color(0x1F4ADE80),  // rgba(74,222,128,0.12)
+        Color(0x474ADE80),  // rgba(74,222,128,0.28)
+    ),
+    SOTA(
+        "SOTA",
+        StatusConfirmed,
+        Color(0x1F4ADE80),
+        Color(0x474ADE80),
+    ),
     NEEDED(
         "NEEDED",
         StatusNeeded,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -65,7 +65,9 @@ fun DecodeRow(
 ) {
     val isCQ = message.checkIsCQ()
     val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
-    val isWorked = message.isQSL_Callsign
+    // Dim rows that are clearly mid-QSO with a third party — they're noise
+    // when the operator is scanning for someone to call.
+    val isInQsoWithOther = !isCQ && !isToMe && !isTarget
     val shape = RoundedCornerShape(12.dp)
 
     // Background color based on message type
@@ -102,7 +104,7 @@ fun DecodeRow(
         modifier = modifier
             .fillMaxWidth()
             .graphicsLayer {
-                alpha = entryAnim.value
+                alpha = entryAnim.value * (if (isInQsoWithOther) 0.55f else 1f)
                 translationY = (1f - entryAnim.value) * -12f
             }
             .padding(horizontal = 12.dp, vertical = 3.dp)
@@ -177,9 +179,11 @@ fun DecodeRow(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                // Status pill
+                // Status pill (skipped when there's no useful state to surface)
                 val status = resolveQsoStatus(message)
-                StatusPill(status = status, compact = true)
+                if (status != null) {
+                    StatusPill(status = status, compact = true)
+                }
             }
 
             Spacer(modifier = Modifier.height(6.dp))
@@ -303,17 +307,37 @@ private fun MetaText(text: String) {
 
 /**
  * Resolve the [QsoStatus] for a given [Ft8Message] based on its state.
+ *
+ * Returns null when there is no useful state to surface (e.g. a station
+ * mid-QSO with someone else who isn't new in any dimension) — the caller
+ * should skip rendering the pill in that case.
+ *
+ * Priority (highest first): calling me, POTA/SOTA activation, new DXCC,
+ * new grid, new band, plain CQ, already worked.
  */
-internal fun resolveQsoStatus(message: Ft8Message): QsoStatus {
+internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
     val isCQ = message.checkIsCQ()
     val isWorked = message.isQSL_Callsign
+    val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
+    val modifier = message.modifier
+    val grid = message.maidenGrid
+
+    val newGrid = !grid.isNullOrEmpty() &&
+        grid.length >= 4 &&
+        !GeneralVariables.checkQSLGrid(grid)
+    val newBand = !isWorked &&
+        GeneralVariables.checkQSLCallsign_OtherBand(message.callsignFrom ?: "")
 
     return when {
-        isCQ && !isWorked -> QsoStatus.CQ
-        isCQ && isWorked -> QsoStatus.WORKED
-        GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "") -> QsoStatus.PENDING
+        isToMe -> QsoStatus.PENDING
+        isCQ && modifier == "POTA" -> QsoStatus.POTA
+        isCQ && modifier == "SOTA" -> QsoStatus.SOTA
+        message.fromDxcc -> QsoStatus.NEW
+        newGrid -> QsoStatus.NEW_GRID
+        newBand -> QsoStatus.NEW_BAND
         isWorked -> QsoStatus.WORKED
-        else -> QsoStatus.NEW
+        isCQ -> QsoStatus.CQ
+        else -> null
     }
 }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -61,6 +61,7 @@ fun DecodeRow(
     modifier: Modifier = Modifier,
     animateEntry: Boolean = false,
     nowMillis: Long = 0L,
+    isTarget: Boolean = false,
 ) {
     val isCQ = message.checkIsCQ()
     val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
@@ -70,11 +71,13 @@ fun DecodeRow(
     // Background color based on message type
     val bgColor = when {
         isToMe -> Color(0x145CD6E8)   // cyan glow rgba(92,214,232,0.08)
+        isTarget -> TargetSoft         // pink — current call target's transmissions
         isCQ -> BgSurface              // surface card
         else -> Color.Transparent
     }
     val borderColor = when {
         isToMe -> Color(0x385CD6E8)   // rgba(92,214,232,0.22)
+        isTarget -> TargetBorder       // pink border for target rows
         isCQ -> Border
         else -> Color.Transparent
     }
@@ -110,13 +113,19 @@ fun DecodeRow(
             .padding(start = 0.dp, end = 12.dp, top = 10.dp, bottom = 10.dp),
         verticalAlignment = Alignment.Top,
     ) {
-        // Left accent bar for CQ messages
-        if (isCQ) {
+        // Left accent bar — pink for the current call target, amber for CQ.
+        // Target wins because it's the more actionable signal for the operator.
+        val accentColor = when {
+            isTarget -> Target
+            isCQ -> Accent
+            else -> null
+        }
+        if (accentColor != null) {
             Box(
                 modifier = Modifier
                     .width(3.dp)
                     .height(52.dp)
-                    .background(Accent, RoundedCornerShape(99.dp))
+                    .background(accentColor, RoundedCornerShape(99.dp))
             )
             Spacer(modifier = Modifier.width(10.dp))
         } else {
@@ -130,7 +139,11 @@ fun DecodeRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                // CQ or "TO YOU" label
+                // CALLING / TO YOU / CQ labels (can stack \u2014 e.g. target station
+                // calling CQ shows both CALLING and CQ).
+                if (isTarget) {
+                    MessageLabel(text = "\u2192 CALLING", color = Target, bgColor = TargetSoft)
+                }
                 if (isCQ) {
                     MessageLabel(text = "CQ", color = Accent, bgColor = AccentSoft)
                 } else if (isToMe) {
@@ -140,7 +153,11 @@ fun DecodeRow(
                 // Callsign
                 Text(
                     text = message.callsignFrom ?: "",
-                    color = if (isToMe) Signal else TextPrimary,
+                    color = when {
+                        isToMe -> Signal
+                        isTarget -> Target
+                        else -> TextPrimary
+                    },
                     fontFamily = GeistMonoFamily,
                     fontWeight = FontWeight.Bold,
                     fontSize = 15.sp,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -186,7 +186,21 @@ fun DecodeRow(
                 }
             }
 
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // Full decoded message text (canonical FT8 frame, e.g. "K1ABC W9XYZ EN37"
+            // or "CQ POTA W1ABC FN42"). This is what was actually transmitted.
+            val msgText = message.getMessageText()?.trim().orEmpty()
+            if (msgText.isNotEmpty()) {
+                Text(
+                    text = msgText,
+                    color = TextMuted,
+                    fontFamily = GeistMonoFamily,
+                    fontSize = 12.sp,
+                    letterSpacing = 0.02.sp,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+            }
 
             // Metadata row: signal bar, SNR, frequency, distance, UTC time
             Row(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -297,7 +297,7 @@ private fun TimeGroupDivider(utcTime: Long) {
  * Filters:
  *  - All: no filtering
  *  - CQ Calls: only CQ messages
- *  - New DXCC: never-worked entity (!isQSL_Callsign on CQ calls)
+ *  - New DXCC: CQ from a DXCC entity not yet in the operator's worked list
  *  - Needed: need QSL confirmation (not in QSL callsign list)
  *  - For Me: callsignTo matches operator's callsign
  */
@@ -307,7 +307,7 @@ private fun filterMessages(
 ): List<Ft8Message> {
     return when (filter) {
         "CQ Calls" -> messages.filter { it.checkIsCQ() }
-        "New DXCC" -> messages.filter { it.checkIsCQ() && !it.isQSL_Callsign }
+        "New DXCC" -> messages.filter { it.checkIsCQ() && it.fromDxcc }
         "Needed" -> messages.filter {
             !it.isQSL_Callsign &&
                 !GeneralVariables.checkQSLCallsign(it.callsignFrom ?: "")

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -207,10 +207,20 @@ fun DecodeScreen(
                             TimeGroupDivider(utcTime = message.utcTime)
                         }
 
+                        // Target highlight: this row is from the station the
+                        // operator is currently calling. Ignore the idle "CQ"
+                        // sentinel that lives in txToCallsign between QSOs.
+                        val targetCs = txToCallsign?.callsign?.takeIf {
+                            it.isNotEmpty() && !it.equals("CQ", ignoreCase = true)
+                        }
+                        val isTarget = targetCs != null &&
+                            message.callsignFrom?.equals(targetCs, ignoreCase = true) == true
+
                         DecodeRow(
                             message = message,
                             animateEntry = rowKey in newKeys,
                             nowMillis = utcTime,
+                            isTarget = isTarget,
                             onClick = {
                                 mainViewModel.qsoSheetCallsign.postValue(message.callsignFrom)
                                 mainViewModel.qsoSheetMinimized.postValue(false)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -233,7 +233,7 @@ private fun QsoSheetContent(
 @Composable
 private fun StationHeader(
     callsign: String,
-    status: QsoStatus,
+    status: QsoStatus?,
     country: String?,
     state: String?,
     grid: String?,
@@ -264,7 +264,9 @@ private fun StationHeader(
                     fontWeight = FontWeight.Bold,
                     fontSize = 20.sp,
                 )
-                StatusPill(status = status, compact = true)
+                if (status != null) {
+                    StatusPill(status = status, compact = true)
+                }
             }
 
             // Location info: combine state + country + grid into a single sentence


### PR DESCRIPTION
## Summary

Two related improvements to the Compose decode list:

- **Target station highlight** (c543aa3): pink accent + "CALLING" label on rows from the station the operator is currently calling, so it's obvious which decode is theirs.
- **Smarter status badges**: the purple "NEW DXCC" badge no longer appears on every unworked station. It now reads `Ft8Message.fromDxcc` (the real new-DXCC flag), so a US station you've worked on other bands stops claiming to be a new entity. Adds **POTA** (green), **SOTA** (green), **NEW GRID** (yellow), and **NEW BAND** (cyan) variants.
- **Mid-QSO dim**: rows that aren't CQ, aren't to you, and aren't your current target render at 55% opacity so they don't crowd out actionable signals.
- **"New DXCC" filter chip** updated to use the same `fromDxcc` signal as the badge.

Badge priority (highest first): PENDING → POTA → SOTA → NEW DXCC → NEW GRID → NEW BAND → WORKED → CQ → no pill.

## Test plan

- [ ] US/Canada stations on a band where you've never worked them no longer show "NEW DXCC".
- [ ] A station from a genuinely unworked DXCC entity still shows the purple NEW DXCC pill.
- [ ] A \`CQ POTA <call> <grid>\` decode shows the green POTA pill. (Cross-check \`CQ_DEBUG\` lines in \`/sdcard/Android/data/com.bg7yoz.ft8cn/files/debug.log\` to confirm the decoder is populating \`modifier\`.)
- [ ] An unworked Maidenhead square shows the yellow NEW GRID pill.
- [ ] A callsign previously worked on another band shows the cyan NEW BAND pill on the current band.
- [ ] Watch a CQ get answered: once the responder transmits, their row dims to ~55% opacity. Target rows and rows addressed to you stay bright.
- [ ] The pink CALLING highlight still appears for the current target's transmissions; the cyan TO YOU glow still appears for messages directed at the operator.
- [ ] "New DXCC" filter chip lists only CQs from unworked DXCC entities (not just unworked callsigns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)