### PR TITLE
ci: sign release builds and publish AAB to Play internal

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -118,18 +118,43 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew
 
-      - name: Build APK
+      - name: Decode keystore (release builds only)
+        if: steps.tag.outputs.should_release == 'true'
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+          echo "RELEASE_STORE_FILE=$RUNNER_TEMP/release.jks" >> "$GITHUB_ENV"
+
+      - name: Build APK & AAB
         working-directory: ft8cn
-        run: ./gradlew assembleRelease
+        env:
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          args=(assembleRelease)
+          # Sign + produce AAB only on release builds — PR builds stay unsigned
+          # because the keystore secret isn't available (and shouldn't be) for
+          # fork PRs.
+          if [[ -n "${RELEASE_STORE_FILE:-}" ]]; then
+            args+=(bundleRelease \
+              "-PRELEASE_STORE_FILE=$RELEASE_STORE_FILE" \
+              "-PRELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD" \
+              "-PRELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS" \
+              "-PRELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD")
+          fi
+          ./gradlew "${args[@]}"
 
       - name: Rename APK
         if: steps.tag.outputs.should_release == 'true'
         run: |
           set -euo pipefail
           cd ft8cn/app/build/outputs/apk/release
-          # No signing config is wired up (see app/build.gradle:46), so the
-          # release task emits app-release-unsigned.apk. Handle either name so
-          # adding RELEASE_STORE_FILE later will Just Work.
+          # Signed builds emit app-release.apk; unsigned emit app-release-unsigned.apk.
+          # Keep the fallback so the rename works either way.
           if [[ -f app-release.apk ]]; then
             src=app-release.apk
           elif [[ -f app-release-unsigned.apk ]]; then
@@ -147,6 +172,13 @@ jobs:
           name: ft8cn-release
           path: ft8cn/app/build/outputs/apk/release/*.apk
 
+      - name: Upload AAB artifact
+        if: steps.tag.outputs.should_release == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ft8cn-release-aab
+          path: ft8cn/app/build/outputs/bundle/release/*.aab
+
       - name: Create GitHub Release
         if: steps.tag.outputs.should_release == 'true'
         uses: softprops/action-gh-release@v2
@@ -161,3 +193,14 @@ jobs:
             Vibecoded with spite on I-70 enroute to Dayton Hamvention.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish AAB to Play Internal track
+        if: steps.tag.outputs.should_release == 'true'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: radio.ks3ckc.ft8af
+          releaseFiles: ft8cn/app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
+          releaseName: ${{ steps.tag.outputs.release_tag }}

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -22,7 +22,14 @@ android {
         applicationId "radio.ks3ckc.ft8af"
         minSdk 23
         targetSdk 35
-        versionCode 4
+        // CI builds derive versionCode from GITHUB_RUN_NUMBER + offset, so each
+        // run gets a unique, monotonically increasing value Play Console will
+        // accept. Offset clears the manual-upload history (current max in
+        // internal track is 4). Local builds without the env var keep the
+        // static fallback so debug/release builds run unchanged from a dev
+        // machine.
+        def ciRunNumber = System.getenv("GITHUB_RUN_NUMBER")
+        versionCode ciRunNumber ? (ciRunNumber.toInteger() + 100) : 4
         versionName '1.0.2'
 
 


### PR DESCRIPTION
## Summary

Extend the existing `build-release.yml` workflow so the same job that ships APKs to GitHub Releases also signs the build and uploads a signed AAB to the Google Play **internal testing** track.

- **Decode keystore** from `RELEASE_KEYSTORE_BASE64` into `$RUNNER_TEMP/release.jks`, gated on `should_release == 'true'` so PR builds (which don't have access to the keystore secret) stay unsigned.
- **Build both** `assembleRelease` (APK for GitHub Releases) and `bundleRelease` (AAB for Play). Signing properties are forwarded as `-PRELEASE_*` Gradle properties; the existing `signingConfigs` block in `app/build.gradle` already picks them up.
- **Publish step** uses `r0adkll/upload-google-play@v1` with `track: internal`, `status: completed`, and `releaseName` set to the auto-bumped `v*` tag.
- **AAB artifact** also uploaded to the workflow run for diagnostic download.

`app/build.gradle` — `versionCode` now derives from `GITHUB_RUN_NUMBER + 100` under CI so each run gets a unique, monotonically increasing code that clears the current Play max (4). Local builds without the env var keep the static fallback so dev workflow is unchanged.

## Required secrets (set in Repo Settings → Secrets and variables → Actions)

| Secret | Source |
|---|---|
| `RELEASE_KEYSTORE_BASE64` | base64 of `C:\Users\burns\ft8af-upload-keystore.jks` |
| `RELEASE_STORE_PASSWORD` | from `~/.gradle/gradle.properties` |
| `RELEASE_KEY_ALIAS` | from `~/.gradle/gradle.properties` |
| `RELEASE_KEY_PASSWORD` | from `~/.gradle/gradle.properties` |
| `PLAY_SERVICE_ACCOUNT_JSON` | full JSON of the service account, granted "Release manager" on FT8AF via Users and permissions |

## Test plan

- [ ] All five secrets configured in repo settings
- [ ] Local debug build still succeeds (`./gradlew assembleDebug`) — confirmed
- [ ] PR build (this PR) succeeds without secrets — produces unsigned APK only
- [ ] After merge to main: workflow signs the APK, signs the AAB, creates GitHub Release with signed APK, uploads AAB to Play internal track
- [ ] Play Console internal track shows the new build under release name matching the auto-bumped `v*` tag
- [ ] Internal testers receive the update via Play Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)