### PR TITLE
Audio picker: always expose raw USB audio path for car-dash compatibility

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/AudioDeviceSpinnerAdapter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/AudioDeviceSpinnerAdapter.java
@@ -57,37 +57,19 @@ public class AudioDeviceSpinnerAdapter extends BaseAdapter {
             }
         }
 
-        // 2. Scan for USB Audio Class devices not recognized by AudioManager
+        // 2. Scan for USB Audio Class devices and list them as a separate "direct" entry.
+        // We intentionally do NOT dedupe against AudioManager-listed USB devices: on
+        // automotive Android skins the AudioManager entry routes through AudioRecord +
+        // setPreferredDevice(), which the in-car audio policy silently overrides back to
+        // the built-in mic. The raw USB path bypasses that policy entirely, so users on
+        // those systems need both entries visible and labeled distinctly.
         try {
             List<UsbAudioDevice.UsbAudioDeviceInfo> usbDevices =
                     UsbAudioDevice.findUsbAudioDevices(mContext);
             for (UsbAudioDevice.UsbAudioDeviceInfo usbDev : usbDevices) {
                 boolean matchesDirection = isInput ? usbDev.hasInput : usbDev.hasOutput;
                 if (!matchesDirection) continue;
-
-                // Check if this device is already listed by AudioManager (by matching type)
-                boolean alreadyListed = false;
-                for (AudioDeviceInfo adi : audioDeviceList) {
-                    if (adi.getType() == AudioDeviceInfo.TYPE_USB_DEVICE
-                            || adi.getType() == AudioDeviceInfo.TYPE_USB_ACCESSORY
-                            || adi.getType() == AudioDeviceInfo.TYPE_USB_HEADSET) {
-                        // AudioManager already has a USB audio device — might be the same one
-                        // Compare product name if available
-                        String adName = adi.getProductName() != null
-                                ? adi.getProductName().toString() : "";
-                        String usbName = usbDev.device.getProductName() != null
-                                ? usbDev.device.getProductName() : "";
-                        if (!adName.isEmpty() && !usbName.isEmpty()
-                                && adName.equals(usbName)) {
-                            alreadyListed = true;
-                            break;
-                        }
-                    }
-                }
-
-                if (!alreadyListed) {
-                    usbAudioDeviceList.add(usbDev);
-                }
+                usbAudioDeviceList.add(usbDev);
             }
         } catch (Exception e) {
             // Ignore USB enumeration errors

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
@@ -573,7 +573,7 @@ public class UsbAudioDevice {
                 name = String.format("USB Audio [%04X:%04X]",
                         device.getVendorId(), device.getProductId());
             }
-            return name + " (USB)";
+            return name + " (USB direct)";
         }
     }
 }


### PR DESCRIPTION
## Summary

- On car-dash / automotive Android skins, the AudioManager-listed USB-audio entry routes through `AudioRecord` + `setPreferredDevice()`, which the in-car audio policy silently overrides back to the built-in mic. The waterfall keeps showing cabin noise no matter what device the user picks.
- The codebase already has a raw USB Audio Class path (`UsbAudioDevice`) that opens the interface directly via `UsbManager` and bypasses Android's audio policy entirely. It was being hidden whenever AudioManager also listed the same device.
- This PR removes the dedup in `AudioDeviceSpinnerAdapter.refreshDevices()` so both entries appear, and labels the raw one `(USB direct)` so users on broken HALs know which to pick.

## Test plan

- [x] Pixel 8 (Android 14): both `(USB Audio)` and `(USB direct)` entries now appear for the connected radio; existing AudioManager-routed path still works.
- [ ] Car-dash Android 11 tablet: install via Play internal, pick `(USB direct)` entry in Settings → Audio Input, confirm waterfall shows RF instead of cabin mic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)