### PR TITLE
Hidden Debug screen + diagnostic logging for USB audio path

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -60,7 +60,33 @@ public class GeneralVariables {
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power
 
+    // Hidden debug mode (unlocked by tapping the version 7 times in About).
+    // When true, Settings exposes the Debug screen for log viewing/sharing.
+    public static boolean debugModeEnabled = false;
+
     private Context mainContext;
+
+    /**
+     * Append a timestamped line to the app's external-files-dir debug.log.
+     * Safe to call from any thread; failures are swallowed so logging can never
+     * crash the caller. This is the structured app-event log surfaced by the
+     * in-app Debug screen and `adb pull` workflows.
+     */
+    public static void fileLog(String msg) {
+        try {
+            Context ctx = getMainContext();
+            if (ctx == null) return;
+            File dir = ctx.getExternalFilesDir(null);
+            if (dir == null) return;
+            String ts = new java.text.SimpleDateFormat(
+                    "HH:mm:ss.SSS", java.util.Locale.US).format(new java.util.Date());
+            try (FileOutputStream fos = new FileOutputStream(new File(dir, "debug.log"), true)) {
+                fos.write((ts + " " + msg + "\n").getBytes());
+            }
+        } catch (Exception ignored) {
+        }
+        Log.d(TAG, msg);
+    }
     public static CallsignDatabase callsignDatabase = null;
 
     public void setMainContext(Context context) {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2278,6 +2278,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("deepMode")) {//Deep decode mode
                     GeneralVariables.deepDecodeMode =result.equals("1");
                 }
+                if (name.equalsIgnoreCase("debugModeEnabled")) {//Hidden debug screen unlock
+                    GeneralVariables.debugModeEnabled = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("dataBits")) {//Serial data bits
                     GeneralVariables.serialDataBits =Integer.parseInt(result);
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -41,6 +41,12 @@ public class MicRecorder {
 
     @SuppressLint("MissingPermission")
     public MicRecorder(){
+        GeneralVariables.fileLog(String.format(
+                "MicRecorder: init audioInputDeviceId=%d usbVidPid=%04X:%04X",
+                GeneralVariables.audioInputDeviceId,
+                GeneralVariables.usbAudioInputVendorId,
+                GeneralVariables.usbAudioInputProductId));
+
         // Check if USB audio input is selected
         if (GeneralVariables.audioInputDeviceId == -1
                 && GeneralVariables.usbAudioInputVendorId != 0) {
@@ -48,10 +54,11 @@ public class MicRecorder {
             if (usbAudioDevice != null) {
                 useUsbAudio = true;
                 UsbAudioDevice.setActiveInputDevice(usbAudioDevice);
-                Log.d(TAG, "Using USB audio input device");
+                GeneralVariables.fileLog("MicRecorder: using USB audio (direct) input");
                 return; // Skip AudioRecord setup
             }
-            Log.w(TAG, "USB audio device not available, falling back to default");
+            GeneralVariables.fileLog(
+                    "MicRecorder: USB audio open FAILED, falling back to AudioRecord");
         }
 
         //calculate minimum buffer size
@@ -64,7 +71,12 @@ public class MicRecorder {
         if (GeneralVariables.audioInputDeviceId > 0) {
             AudioDeviceInfo deviceInfo = findAudioDeviceById(
                     GeneralVariables.audioInputDeviceId, AudioManager.GET_DEVICES_INPUTS);
-            audioRecord.setPreferredDevice(deviceInfo); // null resets to default
+            boolean ok = audioRecord.setPreferredDevice(deviceInfo); // null resets to default
+            GeneralVariables.fileLog(String.format(
+                    "MicRecorder: AudioRecord(DEFAULT) preferredDevice id=%d ok=%b deviceFound=%b",
+                    GeneralVariables.audioInputDeviceId, ok, deviceInfo != null));
+        } else {
+            GeneralVariables.fileLog("MicRecorder: AudioRecord(DEFAULT) using system default mic");
         }
     }
 
@@ -73,42 +85,62 @@ public class MicRecorder {
      */
     private UsbAudioDevice openUsbAudioInput() {
         Context context = GeneralVariables.getMainContext();
-        if (context == null) return null;
+        if (context == null) {
+            GeneralVariables.fileLog("openUsbAudioInput: no main context");
+            return null;
+        }
 
         UsbDevice device = UsbAudioDevice.findDeviceByVidPid(context,
                 GeneralVariables.usbAudioInputVendorId,
                 GeneralVariables.usbAudioInputProductId);
         if (device == null) {
-            Log.w(TAG, String.format("USB audio device not found: %04X:%04X",
+            GeneralVariables.fileLog(String.format(
+                    "openUsbAudioInput: device not found by VID:PID %04X:%04X",
                     GeneralVariables.usbAudioInputVendorId,
                     GeneralVariables.usbAudioInputProductId));
             return null;
         }
+        GeneralVariables.fileLog(String.format(
+                "openUsbAudioInput: found device %04X:%04X name=%s",
+                device.getVendorId(), device.getProductId(),
+                device.getProductName()));
 
         UsbManager usbManager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
-        if (usbManager == null || !usbManager.hasPermission(device)) {
-            Log.w(TAG, "No USB permission for audio device");
+        if (usbManager == null) {
+            GeneralVariables.fileLog("openUsbAudioInput: UsbManager is null");
+            return null;
+        }
+        if (!usbManager.hasPermission(device)) {
+            GeneralVariables.fileLog(
+                    "openUsbAudioInput: NO USB permission for audio device "
+                            + "(grant via unplug/replug or re-select in Settings)");
             return null;
         }
 
         UsbAudioDevice usbDev = new UsbAudioDevice();
         if (!usbDev.open(context, device)) {
-            Log.e(TAG, "Failed to open USB audio device");
+            GeneralVariables.fileLog(
+                    "openUsbAudioInput: UsbAudioDevice.open() FAILED "
+                            + "(descriptor parse or claimInterface failed)");
             return null;
         }
 
         if (!usbDev.hasInput()) {
-            Log.e(TAG, "USB audio device has no input endpoint");
+            GeneralVariables.fileLog(
+                    "openUsbAudioInput: device has no input endpoint after open");
             usbDev.close();
             return null;
         }
 
         if (!usbDev.activateInput(48000)) {
-            Log.e(TAG, "Failed to activate USB audio input");
+            GeneralVariables.fileLog(
+                    "openUsbAudioInput: activateInput(48000) FAILED "
+                            + "(alt-setting select or endpoint setup failed)");
             usbDev.close();
             return null;
         }
 
+        GeneralVariables.fileLog("openUsbAudioInput: SUCCESS at 48000 Hz");
         return usbDev;
     }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/DebugLogScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/DebugLogScreen.kt
@@ -1,0 +1,240 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8us.theme.Accent
+import radio.ks3ckc.ft8us.theme.BgApp
+import radio.ks3ckc.ft8us.theme.BgSurface2
+import radio.ks3ckc.ft8us.theme.TextFaint
+import radio.ks3ckc.ft8us.theme.TextMuted
+import radio.ks3ckc.ft8us.theme.TextPrimary
+import java.io.File
+
+/**
+ * In-app log viewer surfaced from Settings -> About -> Debug (only visible
+ * after the user taps the version 7 times to unlock debug mode).
+ *
+ * Default content is the tail of /Android/data/.../files/debug.log, which the
+ * app writes via GeneralVariables.fileLog(). The Logcat toggle additionally
+ * captures the running app's own logcat output for richer diagnostics during
+ * an active repro.
+ */
+@Composable
+fun DebugLogScreen(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val debugLogFile = remember {
+        context.getExternalFilesDir(null)?.let { File(it, "debug.log") }
+    }
+
+    var lines by remember { mutableStateOf<List<String>>(emptyList()) }
+    var captureLogcat by remember { mutableStateOf(false) }
+    var statusMsg by remember { mutableStateOf<String?>(null) }
+
+    // Tail loop: re-read debug.log (and logcat if toggled) every 2s.
+    LaunchedEffect(captureLogcat) {
+        while (true) {
+            val newLines = withContext(Dispatchers.IO) {
+                buildLogLines(debugLogFile, captureLogcat)
+            }
+            lines = newLines
+            delay(2_000)
+        }
+    }
+
+    val listState = rememberLazyListState()
+    // Auto-scroll to bottom when new lines arrive (only if user hasn't scrolled up).
+    LaunchedEffect(lines.size) {
+        if (lines.isNotEmpty()) {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val total = listState.layoutInfo.totalItemsCount
+            // If we were within 5 lines of the bottom, stick to the bottom.
+            if (total == 0 || lastVisible >= total - 5) {
+                listState.scrollToItem((lines.size - 1).coerceAtLeast(0))
+            }
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(BgApp),
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                // Header
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column {
+                        Text(
+                            text = "Debug",
+                            color = TextPrimary,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 20.sp,
+                        )
+                        Text(
+                            text = "${lines.size} lines" +
+                                if (captureLogcat) " · logcat ON" else "",
+                            color = TextFaint,
+                            fontSize = 12.sp,
+                        )
+                    }
+                    TextButton(onClick = onDismiss) {
+                        Text("Close", color = Accent, fontWeight = FontWeight.SemiBold)
+                    }
+                }
+
+                // Action row
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    TextButton(onClick = {
+                        debugLogFile?.let { shareDebugLog(context, it) }
+                            ?: run { statusMsg = "no log file" }
+                    }) { Text("Share", color = Accent) }
+                    TextButton(onClick = {
+                        debugLogFile?.takeIf { it.exists() }?.delete()
+                        statusMsg = "log cleared"
+                    }) { Text("Clear", color = Accent) }
+                    TextButton(onClick = { captureLogcat = !captureLogcat }) {
+                        Text(
+                            if (captureLogcat) "Logcat: ON" else "Logcat: OFF",
+                            color = Accent,
+                        )
+                    }
+                }
+
+                statusMsg?.let {
+                    Text(
+                        text = it,
+                        color = TextMuted,
+                        fontSize = 12.sp,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    )
+                }
+
+                // Log tail
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 8.dp, vertical = 8.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(BgSurface2),
+                ) {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(8.dp),
+                    ) {
+                        items(lines) { line ->
+                            Text(
+                                text = line,
+                                color = TextPrimary,
+                                fontSize = 11.sp,
+                                fontFamily = FontFamily.Monospace,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Build the log tail: last ~500 lines of debug.log, optionally interleaved
+ * with the most recent app-pid logcat output. Runs on IO.
+ */
+private fun buildLogLines(debugLogFile: File?, captureLogcat: Boolean): List<String> {
+    val MAX_LINES = 500
+    val fileLines: List<String> = debugLogFile
+        ?.takeIf { it.exists() }
+        ?.runCatching { readLines().takeLast(MAX_LINES) }
+        ?.getOrNull()
+        ?: emptyList()
+
+    if (!captureLogcat) return fileLines
+
+    val pid = android.os.Process.myPid()
+    val logcatLines: List<String> = runCatching {
+        val proc = ProcessBuilder("logcat", "-d", "-v", "threadtime", "--pid=$pid")
+            .redirectErrorStream(true)
+            .start()
+        proc.inputStream.bufferedReader().useLines { seq ->
+            seq.toList().takeLast(MAX_LINES)
+        }
+    }.getOrElse { emptyList() }
+
+    // Crude merge: file lines first, then a separator and logcat. Not chronological
+    // across the two streams, but each is internally ordered and they capture
+    // different signal (structured app events vs. raw runtime).
+    return buildList {
+        addAll(fileLines)
+        if (logcatLines.isNotEmpty()) {
+            add("--- logcat (--pid=$pid) ---")
+            addAll(logcatLines)
+        }
+    }
+}
+
+private fun shareDebugLog(context: android.content.Context, debugLogFile: File) {
+    if (!debugLogFile.exists()) return
+    val uri = FileProvider.getUriForFile(
+        context, "radio.ks3ckc.ft8af.fileprovider", debugLogFile,
+    )
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        putExtra(Intent.EXTRA_SUBJECT, "FT8AF debug.log")
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(
+        Intent.createChooser(send, "Share debug.log").apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        },
+    )
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
 import android.media.AudioManager
+import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.bg7yoz.ft8cn.GeneralVariables
@@ -129,6 +130,8 @@ fun SettingsScreen(
     var showTxDelay by remember { mutableStateOf(false) }
     var showLateStart by remember { mutableStateOf(false) }
     var showAbout by remember { mutableStateOf(false) }
+    var showDebugScreen by remember { mutableStateOf(false) }
+    var debugEnabled by remember { mutableStateOf(GeneralVariables.debugModeEnabled) }
     var showCloudlog by remember { mutableStateOf(false) }
     var showQrzCreds by remember { mutableStateOf(false) }
     var qrzXmlUser by remember { mutableStateOf(GeneralVariables.qrzXmlUsername.orEmpty()) }
@@ -495,7 +498,27 @@ fun SettingsScreen(
 
     // -- About / FAQ Dialog --
     if (showAbout) {
-        AboutDialog(onDismiss = { showAbout = false })
+        AboutDialog(
+            onDismiss = { showAbout = false },
+            onToggleDebug = {
+                val next = !debugEnabled
+                GeneralVariables.debugModeEnabled = next
+                debugEnabled = next
+                mainViewModel.databaseOpr.writeConfig(
+                    "debugModeEnabled", if (next) "1" else "0", null,
+                )
+                Toast.makeText(
+                    context,
+                    if (next) "Debug mode enabled" else "Debug mode disabled",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            },
+        )
+    }
+
+    // -- Debug log viewer --
+    if (showDebugScreen) {
+        DebugLogScreen(onDismiss = { showDebugScreen = false })
     }
 
     // -- QRZ Credentials Dialog --
@@ -1055,6 +1078,15 @@ fun SettingsScreen(
                             showChevron = true,
                             onClick = { showAbout = true },
                         )
+                        if (debugEnabled) {
+                            SectionDivider()
+                            SettingsRow(
+                                label = "Debug",
+                                description = "View / share debug.log",
+                                showChevron = true,
+                                onClick = { showDebugScreen = true },
+                            )
+                        }
                     }
                 }
             }
@@ -1766,8 +1798,15 @@ private fun InfoDialog(
  * About dialog with version info, credits, and tappable QRZ links for the authors.
  */
 @Composable
-private fun AboutDialog(onDismiss: () -> Unit) {
+private fun AboutDialog(
+    onDismiss: () -> Unit,
+    onToggleDebug: () -> Unit = {},
+) {
     val uriHandler = LocalUriHandler.current
+    // Hidden debug-mode unlock: 7 consecutive taps on the version block flips
+    // GeneralVariables.debugModeEnabled (and persists it). Counter resets when
+    // the dialog re-opens, matching Android's developer-options UX.
+    var versionTaps by remember { mutableIntStateOf(0) }
     Dialog(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
@@ -1794,6 +1833,13 @@ private fun AboutDialog(onDismiss: () -> Unit) {
                 color = TextMuted,
                 fontSize = 14.sp,
                 lineHeight = 20.sp,
+                modifier = Modifier.clickable {
+                    versionTaps += 1
+                    if (versionTaps >= 7) {
+                        versionTaps = 0
+                        onToggleDebug()
+                    }
+                },
             )
 
             Text(

--- a/ft8cn/app/src/main/res/xml/filepaths.xml
+++ b/ft8cn/app/src/main/res/xml/filepaths.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <external-cache-path path="." name="files_path" />
+    <!-- Debug screen shares debug.log out of getExternalFilesDir(null). -->
+    <external-files-path path="." name="external_files" />
 </paths>
 


### PR DESCRIPTION
## Summary

Adds a hidden in-app Debug screen so users can diagnose problems (especially the car-dash USB audio routing issue from #80) without needing adb. Unlocked Android-developer-options style: tap the version row in Settings → About 7 times.

While we're at it, this also wires the USB audio open path into `debug.log` so the screen actually has useful signal. Previously those failures only went to logcat.

## What's in it

- `GeneralVariables.fileLog()` — static helper any class can call. Same format as existing per-class loggers.
- `MicRecorder.openUsbAudioInput()` — every step now logs success/failure with context (device found, USB permission, `open()`, `hasInput()`, `activateInput(48000)`). The constructor logs the final routing decision (USB direct vs `AudioRecord` with mic fallback, including whether `setPreferredDevice` returned true).
- Persistence: `debugModeEnabled` boolean in `GeneralVariables`, loaded by `DatabaseOpr` like other config flags.
- `AboutDialog`: tap-counter on the version text. 7 taps → flips the flag, persists, toasts confirmation.
- `SettingsScreen`: conditional **Debug** row under FAQ & Support, visible only when unlocked.
- `DebugLogScreen` (new): full-screen Dialog with auto-refreshing tail (last 500 lines, every 2s), **Share** via FileProvider, **Clear**, and a **Logcat: ON/OFF** toggle that appends `logcat -d --pid=<self>` output for richer runtime detail during an active repro.
- `filepaths.xml`: exposes `external-files-path` so the share intent can hand `debug.log` to the chooser.

## Test plan

- [x] `assembleDebug` compiles clean.
- [ ] Pixel 8: tap version 7x → toast appears, Debug row shows up in settings, screen opens, debug.log tail visible, Share opens chooser with debug.log, Clear empties the log, Logcat toggle adds new lines.
- [ ] Car-dash Android 11 tablet: after Play update, pick `(USB direct)` in Audio Input, open Debug screen, share `debug.log`. Lines like `openUsbAudioInput: NO USB permission...` or `activateInput(48000) FAILED ...` should tell us exactly where the raw USB path is dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)