### PR TITLE
Fix USB audio death-loop; show real version in splash & About

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GeneralVariables {
     private static final String TAG = "GeneralVariables";
     public static String VERSION = BuildConfig.VERSION_NAME;//Version number "0.62 (Beta 4)";
+    public static int VERSION_CODE = BuildConfig.VERSION_CODE;//Monotonic build number (CI: GITHUB_RUN_NUMBER + 100)
     public static String BUILD_DATE = BuildConfig.apkBuildTime;//Build time
     public static int MESSAGE_COUNT = 3000;//Maximum message cache count
     public static boolean saveSWLMessage = false;//Save decoded messages switch

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -35,6 +35,19 @@ public class MicRecorder {
     private volatile boolean isRunning = false;//whether currently in recording state
     private OnDataListener onDataListener;
 
+    // USB-audio death-loop guard. On some hosts (notably car-dash Android
+    // tablets) UsbRequest.requestWait() returns null on first iteration and
+    // onCaptureStopped() fires immediately. Without this, MicRecorder would
+    // reinitialize() in a ~30ms-per-cycle tight loop. We rate-limit the
+    // self-rebind and after MAX_CONSECUTIVE_USB_FAILURES failed cycles give up
+    // on the raw USB path and fall back to AudioRecord+default mic so the app
+    // keeps running (read-only) instead of spinning the USB bus.
+    private long lastReinitMs = 0;
+    private int consecutiveUsbFailures = 0;
+    private volatile boolean usbAudioSawData = false;
+    private static final long MIN_REINIT_INTERVAL_MS = 2000;
+    private static final int MAX_CONSECUTIVE_USB_FAILURES = 3;
+
     public interface OnDataListener{
         void onDataReceived(float[] data,int len);
     }
@@ -174,9 +187,17 @@ public class MicRecorder {
 
     private void startUsbCapture() {
         final MicRecorder self = this;
+        usbAudioSawData = false;
         usbAudioDevice.startCapture(sampleRateInHz, new UsbAudioDevice.AudioInputCallback() {
             @Override
             public void onAudioData(float[] data, int length) {
+                if (length > 0 && !usbAudioSawData) {
+                    usbAudioSawData = true;
+                    consecutiveUsbFailures = 0;
+                    GeneralVariables.fileLog(
+                            "startUsbCapture: first audio data received, "
+                                    + "USB stream is live");
+                }
                 if (isRunning && onDataListener != null) {
                     onDataListener.onDataReceived(data, length);
                 }
@@ -184,11 +205,54 @@ public class MicRecorder {
 
             @Override
             public void onCaptureStopped() {
-                // The USB audio device died (cable yank, suspend, etc). Without
-                // this, the decode loop's getVoiceData() callback never fires
-                // and the waterfall just stops. reinitialize() either reopens
-                // a fresh USB handle or falls back to the built-in mic.
-                Log.w(TAG, "USB audio capture stopped unexpectedly, reinitializing");
+                // The USB audio capture loop exited without an explicit stop.
+                // Two distinct cases we need to handle differently:
+                //   1. Genuine device-gone / temporary glitch — rebind once,
+                //      hope the next attempt sticks.
+                //   2. Host can't drive isochronous transfers and requestWait()
+                //      returns null on the first iteration — capture dies in
+                //      ~10ms. Without a guard, reinitialize -> open -> start ->
+                //      die -> reinitialize... spins forever at ~30ms per cycle
+                //      (saw this on a car-dash Android 11 tablet).
+                // Strategy: rate-limit to one reinit per MIN_REINIT_INTERVAL_MS,
+                // and after MAX_CONSECUTIVE_USB_FAILURES cycles without ever
+                // seeing audio data, force-fall-back to AudioRecord. The app
+                // can't transmit through USB then but at least stops thrashing.
+                if (!usbAudioSawData) {
+                    consecutiveUsbFailures++;
+                }
+                long now = System.currentTimeMillis();
+                long sinceLast = now - lastReinitMs;
+                GeneralVariables.fileLog(String.format(
+                        "startUsbCapture: capture STOPPED (sawData=%b "
+                                + "consecFailures=%d sinceLastReinit=%dms)",
+                        usbAudioSawData, consecutiveUsbFailures, sinceLast));
+
+                if (consecutiveUsbFailures >= MAX_CONSECUTIVE_USB_FAILURES
+                        && !usbAudioSawData) {
+                    GeneralVariables.fileLog(
+                            "startUsbCapture: giving up on raw USB after "
+                                    + consecutiveUsbFailures
+                                    + " failures, forcing fallback to AudioRecord");
+                    // Temporarily blank the USB selection so reinitialize()
+                    // takes the AudioRecord branch instead of looping.
+                    GeneralVariables.audioInputDeviceId = 0;
+                    self.reinitialize();
+                    return;
+                }
+
+                if (sinceLast < MIN_REINIT_INTERVAL_MS) {
+                    GeneralVariables.fileLog(
+                            "startUsbCapture: throttling reinit (last was "
+                                    + sinceLast + "ms ago)");
+                    try {
+                        Thread.sleep(MIN_REINIT_INTERVAL_MS - sinceLast);
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+                lastReinitMs = System.currentTimeMillis();
                 self.reinitialize();
             }
         });

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
@@ -295,12 +295,23 @@ public class UsbAudioDevice {
             ArrayList<Float> accumulator = new ArrayList<>(inputSampleRate);
             float[] outputBuffer = new float[targetRate]; // 1s max
 
+            int iterations = 0;
             while (capturing) {
                 UsbRequest completed = connection.requestWait();
                 if (completed == null) {
-                    if (capturing) Log.e(TAG, "requestWait returned null");
+                    if (capturing) {
+                        com.bg7yoz.ft8cn.GeneralVariables.fileLog(String.format(
+                                "UsbAudio.captureLoop: requestWait returned null "
+                                        + "after %d iterations (target=%dHz "
+                                        + "input=%dHz channels=%d packetSize=%d "
+                                        + "ratio=%d) — host likely cannot drive "
+                                        + "isochronous transfers via UsbRequest",
+                                iterations, targetRate, inputSampleRate,
+                                inputChannels, packetSize, ratio));
+                    }
                     break;
                 }
+                iterations++;
 
                 int bufIndex = (int) completed.getClientData();
                 ByteBuffer buf = buffers[bufIndex];
@@ -358,7 +369,9 @@ public class UsbAudioDevice {
                 }
             }
         } catch (Exception e) {
-            Log.e(TAG, "Capture loop error: " + e.getMessage());
+            com.bg7yoz.ft8cn.GeneralVariables.fileLog(
+                    "UsbAudio.captureLoop: exception — "
+                            + e.getClass().getSimpleName() + ": " + e.getMessage());
         } finally {
             for (int i = 0; i < NUM_URBS; i++) {
                 if (requests[i] != null) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -1824,12 +1824,12 @@ private fun AboutDialog(
             )
 
             Text(
-                text = "Version ${GeneralVariables.VERSION}\n" +
-                    "Build ${GeneralVariables.BUILD_DATE}\n\n" +
-                    "Based on FT8CN by BG7YOZ\n\n" +
-                    "FT8US is a standalone FT8 transceiver app for Android. " +
-                    "It supports USB, Bluetooth, and network rig control " +
-                    "with automatic sequencing and logging.",
+                text = "Version ${GeneralVariables.VERSION} (build ${GeneralVariables.VERSION_CODE})\n" +
+                    "Build date ${GeneralVariables.BUILD_DATE}\n\n" +
+                    "FT8, made easy.\n\n" +
+                    "A standalone FT8 transceiver app for Android. " +
+                    "USB, Bluetooth, and network rig control with " +
+                    "automatic sequencing and logging.",
                 color = TextMuted,
                 fontSize = 14.sp,
                 lineHeight = 20.sp,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/splash/SplashScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/splash/SplashScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
+import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.R
 import radio.ks3ckc.ft8us.theme.Accent
 import radio.ks3ckc.ft8us.theme.GeistMonoFamily
@@ -150,7 +151,7 @@ fun FT8USplashScreen(
             Spacer(modifier = Modifier.height(14.dp))
 
             Text(
-                text = "v1.0 · Forked from FT8CN",
+                text = "v${GeneralVariables.VERSION} · build ${GeneralVariables.VERSION_CODE}",
                 color = Color(0xFF8A96B1).copy(alpha = 0.5f),
                 fontSize = 10.sp,
                 fontFamily = GeistMonoFamily,


### PR DESCRIPTION
## Summary

Three things bundled because they ship together to the same Play release.

### 1. USB audio death-loop fix (the main one)

The car-dash debug.log from #81 revealed that `openUsbAudioInput` was firing hundreds of times per second on the tablet, each call succeeding. Root cause: `UsbAudioDevice.captureLoop` blocks on `connection.requestWait()`, which returns `null` on the first iteration on that host (the kernel/USB stack apparently can't deliver isochronous URBs to userspace via `UsbRequest`). The capture thread exits, the `finally` block fires `onCaptureStopped()`, MicRecorder unconditionally calls `reinitialize()`, which reopens the USB handle and starts capture again, which dies immediately, ... ~30ms per cycle, forever.

This PR doesn't fix the underlying isochronous-transfer issue (we still need more data to know whether it's worth retrying at a different sample rate or claiming a different alt-setting), but it does stop the spin and produce clear diagnostic output:

- `MicRecorder` rate-limits self-rebind to one per 2s.
- After 3 consecutive failures without ever delivering audio data, it gives up on the raw USB path and force-falls back to `AudioRecord`+mic. App is degraded but stops thrashing the USB bus.
- Tracks `usbAudioSawData` — first valid callback resets the failure counter so intermittent hiccups don't accumulate.
- `UsbAudioDevice.captureLoop` now writes its exit reason to `debug.log` (`requestWait` returned null after N iterations, or exception class + message) plus device params (sample rate, channels, packet size, ratio). The next car-dash repro will tell us exactly when and why the loop dies.

### 2. Splash version is dynamic

Replaces hardcoded `"v1.0 · Forked from FT8CN"` with `"v${VERSION} · build ${VERSION_CODE}"`. CI bumps `versionCode` per release (`GITHUB_RUN_NUMBER + 100`), so each shipped build shows a unique identifier matching what Play displays.

### 3. About dialog tagline

Removed the FT8CN attribution line from the About dialog. The fork credit and BG7YOZ thanks remain in `README.md:5,52` and `LICENSE`. Replaced with `"FT8, made easy."` plus a slightly cleaner description blurb.

## Test plan

- [x] `installDebug` builds + installs clean on Pixel 8.
- [x] Splash shows `v1.0.2 · build 4` (local build; CI will assign the real code).
- [x] About dialog body reflects new tagline.
- [ ] Car-dash Android 11 tablet (after Play update): re-pick `(USB direct)`, open Debug screen, share log. Expected outcome: hundreds of `SUCCESS at 48000 Hz` lines replaced with a single `UsbAudio.captureLoop: requestWait returned null after 0 iterations` + a couple of throttled reinits + final `giving up on raw USB ... forcing fallback to AudioRecord`. App ends up on the mic but stops spinning. The captureLoop log line will tell us the next move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)