### PR TITLE
docs: surface ft8af.app site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **FT8 on Android — modernized.**
 
+🌐 **[ft8af.app](https://ft8af.app)**
+
 A fork of [FT8CN](https://github.com/N0BOY/FT8CN) that takes the excellent original and brings it forward: a Jetpack Compose UI, full English localization, dozens of bug fixes, and a pile of new operating features built for real on-the-air use.
 
 Run FT8 natively on your Android phone or tablet, drive your radio over USB CAT, decode the band, and work the world from anywhere.

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -1843,6 +1843,21 @@ private fun AboutDialog(
             )
 
             Text(
+                text = "Website",
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+            )
+            Text(
+                text = "ft8af.app",
+                color = Accent,
+                fontSize = 14.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uriHandler.openUri("https://ft8af.app") },
+            )
+
+            Text(
                 text = "Built by",
                 color = TextPrimary,
                 fontWeight = FontWeight.SemiBold,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/splash/SplashScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/splash/SplashScreen.kt
@@ -158,6 +158,16 @@ fun FT8USplashScreen(
                 letterSpacing = 0.08.em,
             )
 
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = "ft8af.app",
+                color = Color(0xFF8A96B1).copy(alpha = 0.45f),
+                fontSize = 10.sp,
+                fontFamily = GeistMonoFamily,
+                letterSpacing = 0.08.em,
+            )
+
             Spacer(modifier = Modifier.height(96.dp))
         }
     }


### PR DESCRIPTION
## Summary

Adds the new project site (https://ft8af.app) in three places where users naturally land.

## What's where

| Surface | Treatment | Behavior |
|---|---|---|
| **README.md** | 🌐 **[ft8af.app](https://ft8af.app)** prominently at the top under the tagline | Clickable on GitHub |
| **About dialog** | New "Website" section above "Built by", with `ft8af.app` styled like the existing QRZ links | Tap opens browser via `LocalUriHandler` |
| **Splash screen** | Small subtle `ft8af.app` line right under `v1.0.2 · build N` — same monospace font, slightly fainter | Decorative only — splash is transient, no tap target |

## What I left alone

The "FT8 · MOBILE COMPANION" subtitle on the splash. Three URLs near the top of the splash would be loud; the version footer is the natural place for the domain.

## Test plan

- [x] `assembleDebug` builds clean.
- [ ] Pixel 8 smoke check (not yet — was unplugged at build time). Confirm: About dialog shows "Website" → "ft8af.app" above "Built by", tap opens browser to https://ft8af.app; splash shows "ft8af.app" under the version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)