### PR TITLE
Yaesu3: fix PTT command (MX1/MX0 -> TX1/TX0)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu3RigConstant.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu3RigConstant.java
@@ -25,8 +25,12 @@ public class Yaesu3RigConstant {
     //PTT state
 
     //command set
-    private static final String PTT_ON = "MX1;";
-    private static final String PTT_OFF = "MX0;";
+    // MX1/MX0 is the Monitor function on FT-891/991, not PTT — using it
+    // enabled the rig's speaker monitor but never keyed the transmitter,
+    // so audio was sent to the data jack and nobody on the band heard it.
+    // TX1/TX0 is the actual PTT command (rear/data PTT = TX1).
+    private static final String PTT_ON = "TX1;";
+    private static final String PTT_OFF = "TX0;";
     private static final String USB_MODE = "MD02;";
     private static final String USB_MODE_DATA = "MD09;";
     private static final String DATA_U_MODE = "MD0C;";


### PR DESCRIPTION
## Summary
- `MX1;`/`MX0;` toggles the FT-891/FT-991 Monitor function, not PTT — using it routed input audio to the rig's speaker but never keyed the transmitter, so USB-audio TX produced audible tones at the rig but zero RF and no PSKReporter spots.
- Switch `Yaesu3RigConstant.PTT_ON`/`PTT_OFF` to `TX1;`/`TX0;` (rear/data PTT), which is the documented PTT command on these radios. `Wolf_sdr_450Rig` already calls `setPTT_TX_On()` directly, so leaving the `TX_ON`/`TX_OFF` constants in place keeps that path unchanged.

## Test plan
- [x] Verified with Pixel 8 + FT-891 over the rig's built-in USB CAT: rig now keys on TX1; and unkeys on TX0; (PA bars on the rig, audio actually transmitted).
- [ ] FT-991/991A regression check (anyone with one of these — does PTT still work?)
- [ ] FT-450 unaffected (still uses `setPTT_TX_On()` via Wolf_sdr_450Rig path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)