### PR TITLE
FT8 TX: stop chopping leading Costas off every transmission

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1381,9 +1381,26 @@ public class FT8TransmitSignal {
                 e.printStackTrace();
             }
 
-            // Compute how late we are into this 15-second cycle; leading audio will be clipped
-            // so transmission still ends on the cycle boundary.
-            int msLate = (int) (UtcTimer.getSystemTime() % 15000);
+            // Compute how late we are *vs. when FT8 audio should start*, and only
+            // clip leading audio if we'd overrun the 15-second cycle otherwise.
+            //
+            // FT8 = 79 GFSK symbols at 0.16s each = 12.64s of audio. The spec
+            // expects audio to start ~+0.5s into each 15s cycle, so any start
+            // between 0 and (15.00 - 12.64) = 2.36s into the cycle fits without
+            // clipping. The original `msLate = position % 15000` treated every
+            // millisecond past the cycle boundary as lateness — so a normal
+            // on-time TX that fires ~500-800ms into the cycle (totally fine)
+            // would chop 500-800ms off the *start* of the audio buffer, which
+            // is exactly where the leading Costas sync array lives (symbols
+            // 0-6, the first 1.12s). Receivers couldn't lock, and the signal
+            // came across as audible-but-undecodable.
+            //
+            // New behavior: skip only the excess past 2.36s. On-time and
+            // mildly-late TXs send the full waveform; only genuinely late
+            // starts (over ~2.4s into cycle) start clipping leading audio.
+            int msIntoCycle = (int) (UtcTimer.getSystemTime() % 15000);
+            int msMaxStart = 15000 - 12640; // 2360ms — last moment we can start without overrunning
+            int msLate = msIntoCycle - msMaxStart;
             if (msLate < 0) msLate = 0;
             if (msLate >= 15000) msLate = 14999;
             transmitSignal.lateStartSkipMs = msLate;


### PR DESCRIPTION
## Summary
`FT8TransmitSignal.java`'s `lateStartSkipMs` calculation treated every millisecond past the cycle boundary as lateness, so a perfectly on-time TX firing ~500–800 ms into the 15 s cycle (totally normal for UI thread → native generate → USB open latency) would chop 500–800 ms off the **start** of the audio buffer. That start is exactly where the leading Costas sync array lives (symbols 0–6, the first 1.12 s of the message). With a damaged leading Costas, receivers can't lock on, and the signal comes across as audible-but-undecodable.

## Why
FT8 audio is 79 × 0.16 = 12.64 s; cycle is 15 s; we have 2.36 s of slack between the cycle boundary and the latest moment we can still fit the message inside the cycle. Compute `msLate` against *that* threshold (2.36 s), not against the cycle boundary, so on-time and mildly-late TXs send the full waveform with Costas intact. Genuinely late TXs (>2.4 s into the cycle) still clip leading audio to keep the message ending inside the 15 s window.

## Test plan
- [x] Pixel 8 + FT-891 + C-Media USB CODEC: previously `playLength` was ~144,300 of 151,680 samples (~7,400 chopped, 616 ms gone from the front). After this change `playLength == 151,680` on a normal-timing TX (no clipping).
- [ ] Verify signal now decodes for other stations (PSKReporter spot, or HF buddy).
- [ ] Sanity-check that a genuinely late TX (>2.4 s in — possible if the device wakes mid-cycle) still clips correctly so it doesn't overrun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)