### PR TITLE
feat(pota): activator + hunter UX with self-spot and ADIF tagging

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -54,7 +54,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
     public static synchronized DatabaseOpr getInstance(@Nullable Context context, @Nullable String databaseName) {
         if (instance == null) {
-            instance = new DatabaseOpr(context, databaseName, null, 16);
+            instance = new DatabaseOpr(context, databaseName, null, 17);
         }
         return instance;
     }
@@ -96,6 +96,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         //Create SWL-related tables
         createSWLTables(sqLiteDatabase);
 
+        //Create POTA activation history table
+        createPotaTables(sqLiteDatabase);
+
         //Create indexes
         createIndex(sqLiteDatabase);
 
@@ -120,6 +123,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
         //Create SWL-related tables
         createSWLTables(sqLiteDatabase);
+
+        //Create POTA activation history table
+        createPotaTables(sqLiteDatabase);
 
         //Create indexes
         createIndex(sqLiteDatabase);
@@ -227,6 +233,16 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     , "synced_cloudlog INTEGER DEFAULT 0");
             alterTable(sqLiteDatabase, "QSLTable", "synced_qrz"
                     , "synced_qrz INTEGER DEFAULT 0");
+            // POTA ADIF fields. MY_SIG/MY_SIG_INFO are the activator's program/park ref;
+            // SIG/SIG_INFO are the worked station's. Empty for non-POTA contacts.
+            alterTable(sqLiteDatabase, "QSLTable", "my_sig"
+                    , "my_sig TEXT");
+            alterTable(sqLiteDatabase, "QSLTable", "my_sig_info"
+                    , "my_sig_info TEXT");
+            alterTable(sqLiteDatabase, "QSLTable", "sig"
+                    , "sig TEXT");
+            alterTable(sqLiteDatabase, "QSLTable", "sig_info"
+                    , "sig_info TEXT");
 
         } else {
             sqLiteDatabase.execSQL("CREATE TABLE QSLTable (\n" +
@@ -251,7 +267,11 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     "freq TEXT,\n" +
                     "station_callsign TEXT,\n" +
                     "my_gridsquare TEXT,\n" +
-                    "comment TEXT)");
+                    "comment TEXT,\n" +
+                    "my_sig TEXT,\n" +//POTA: activator's program ("POTA")
+                    "my_sig_info TEXT,\n" +//POTA: activator's park ref
+                    "sig TEXT,\n" +//POTA: worked station's program
+                    "sig_info TEXT)");//POTA: worked station's park ref
         }
 
 
@@ -431,6 +451,23 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         }
     }
 
+
+    /**
+     * Create POTA activation history table. Each row is one activation session
+     * (start to end) so users can re-export a single activation's ADIF later.
+     */
+    private void createPotaTables(SQLiteDatabase sqLiteDatabase) {
+        if (!checkTableExists(sqLiteDatabase, "pota_activation")) {
+            sqLiteDatabase.execSQL("CREATE TABLE pota_activation (\n" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
+                    "park_ref TEXT NOT NULL,\n" +
+                    "operator TEXT,\n" +
+                    "started_at INTEGER NOT NULL,\n" +//epoch millis
+                    "ended_at INTEGER,\n" +//null while in progress
+                    "qso_count INTEGER DEFAULT 0,\n" +
+                    "notes TEXT)");
+        }
+    }
 
     /**
      * Create indexes to improve import speed
@@ -1042,6 +1079,13 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
             }
 
+            // POTA ADIF fields — emitted only when populated so non-POTA rows
+            // remain byte-identical to the prior upload format.
+            appendPotaField(logStr, cursor, "my_sig", "MY_SIG");
+            appendPotaField(logStr, cursor, "my_sig_info", "MY_SIG_INFO");
+            appendPotaField(logStr, cursor, "sig", "SIG");
+            appendPotaField(logStr, cursor, "sig_info", "SIG_INFO");
+
             String comment = cursor.getString(cursor.getColumnIndex("comment"));
 
             //<comment:15>Distance: 99 km <eor>
@@ -1053,6 +1097,15 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
         cursor.close();
         return logStr.toString();
+    }
+
+    /** Append a POTA ADIF field if the column exists and is non-empty. */
+    private static void appendPotaField(StringBuilder sb, Cursor cursor, String column, String adifName) {
+        int idx = cursor.getColumnIndex(column);
+        if (idx < 0) return;
+        String value = cursor.getString(idx);
+        if (value == null || value.isEmpty()) return;
+        sb.append(String.format("<%s:%d>%s ", adifName, value.length(), value));
     }
 
     /**
@@ -1175,6 +1228,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             }
             return false;
         }
+        // POTA: if an activation is running, stamp MY_SIG/MY_SIG_INFO; if the worked
+        // station is currently spotted on pota.app, stamp SIG/SIG_INFO too (P2P case).
+        // No-op when no activation/spot, so non-POTA contacts are unaffected.
+        radio.ks3ckc.ft8us.pota.PotaSessionManager.stampQso(
+                record,
+                radio.ks3ckc.ft8us.pota.PotaSpotsRepository.parkRefFor(record.getToCallsign()));
 
         String querySQL;
         if (!checkQSLCallsign(record)) {//If record doesn't exist, add it
@@ -1225,7 +1284,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         if (!checkIsQSL(record)) {//If log data doesn't exist, add it
             querySQL = "INSERT INTO QSLTable(call, isQSL,isLotW_import,isLotW_QSL,gridsquare, mode, rst_sent, rst_rcvd, qso_date, " +
                     "time_on, qso_date_off, time_off, band, freq, station_callsign, my_gridsquare," +
-                    "comment)VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+                    "comment,my_sig,my_sig_info,sig,sig_info)VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
             db.execSQL(querySQL, new String[]{record.getToCallsign()
                     , String.valueOf(record.isQSL ? 1 : 0)
@@ -1244,7 +1303,17 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     , BaseRigOperation.getFrequencyFloat(record.getBandFreq())
                     , record.getMyCallsign()
                     , record.getMyMaidenGrid()
-                    , record.getComment()});
+                    , record.getComment()
+                    , record.getMySig()
+                    , record.getMySigInfo()
+                    , record.getSig()
+                    , record.getSigInfo()});
+            // If this QSO was logged during an active POTA activation, bump its qso_count.
+            if (record.getMySigInfo() != null && !record.getMySigInfo().isEmpty()) {
+                db.execSQL("UPDATE pota_activation SET qso_count = qso_count + 1 "
+                        + "WHERE park_ref = ? AND ended_at IS NULL"
+                        , new Object[]{record.getMySigInfo()});
+            }
             if (afterInsertQSLData!=null){
                 afterInsertQSLData.doAfterInsert(false,true);//New QSL
             }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -54,7 +54,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
     public static synchronized DatabaseOpr getInstance(@Nullable Context context, @Nullable String databaseName) {
         if (instance == null) {
-            instance = new DatabaseOpr(context, databaseName, null, 17);
+            instance = new DatabaseOpr(context, databaseName, null, 18);
         }
         return instance;
     }
@@ -162,18 +162,32 @@ public class DatabaseOpr extends SQLiteOpenHelper {
      * @param sql       column definition SQL
      */
     private void alterTable(SQLiteDatabase db, String tableName, String fieldName, String sql) {
-        // Identifiers are interpolated into ALTER TABLE because SQLite cannot bind them; restrict
-        // to simple SQL identifiers so a stray caller can never inject statements.
+        // Identifiers are interpolated into ALTER TABLE and PRAGMA because SQLite cannot bind them;
+        // restrict to simple SQL identifiers so a stray caller can never inject statements.
         if (!SQL_IDENTIFIER.matcher(tableName).matches()
                 || !SQL_IDENTIFIER.matcher(fieldName).matches()) {
             throw new IllegalArgumentException("Invalid SQL identifier");
         }
-        Cursor cursor = db.rawQuery("select * from sqlite_master where name=? and sql like ?"
-                , new String[]{tableName, "%" + fieldName + "%"});
-        if (!cursor.moveToNext()) {
+        // Query the live schema. The previous LIKE-on-sqlite_master.sql approach was broken
+        // two ways: sqlite_master.sql freezes the original CREATE TABLE text and never
+        // reflects ALTER TABLE ADD COLUMN, and the unanchored substring match treated
+        // `sig` as already present whenever `my_sig` was in the original CREATE — so the
+        // `sig`/`sig_info` columns were never added on upgraded installs and POTA QSO
+        // inserts crashed with "no column named sig".
+        boolean exists = false;
+        try (Cursor cursor = db.rawQuery(
+                String.format("PRAGMA table_info(%s)", tableName), null)) {
+            int nameIdx = cursor.getColumnIndex("name");
+            while (cursor.moveToNext()) {
+                if (fieldName.equals(cursor.getString(nameIdx))) {
+                    exists = true;
+                    break;
+                }
+            }
+        }
+        if (!exists) {
             db.execSQL(String.format("ALTER TABLE %s ADD COLUMN %s", tableName, sql));
         }
-        cursor.close();
     }
 
     private static final java.util.regex.Pattern SQL_IDENTIFIER =

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/QSLRecord.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/QSLRecord.java
@@ -42,6 +42,12 @@ public class QSLRecord {
     private long bandFreq;//Transmit band frequency
     private int wavFrequency;//Transmit audio frequency
     private String comment;
+    // POTA ADIF fields. mySig/mySigInfo describe my own activation (e.g. "POTA"/"K-1234");
+    // sig/sigInfo describe the worked station's activation if it was a hunt or P2P.
+    private String mySig;
+    private String mySigInfo;
+    private String sig;
+    private String sigInfo;
     public boolean isQSL = false;//Manual confirmation
     public boolean isLotW_import = false;//Whether imported from external data; requires database comparison to determine
     public boolean isLotW_QSL = false;//Whether confirmed via LoTW
@@ -226,6 +232,11 @@ public class QSLRecord {
                     , UtcTimer.getDatetimeStr(UtcTimer.getSystemTime()));
         }
 
+        // POTA activation/hunt metadata on import. pota.app exports use these field names.
+        if (map.containsKey("MY_SIG")) mySig = map.get("MY_SIG");
+        if (map.containsKey("MY_SIG_INFO")) mySigInfo = map.get("MY_SIG_INFO");
+        if (map.containsKey("SIG")) sig = map.get("SIG");
+        if (map.containsKey("SIG_INFO")) sigInfo = map.get("SIG_INFO");
 
     }
 
@@ -382,5 +393,37 @@ public class QSLRecord {
 
     public void setTime_on(String time_on) {
         this.time_on = time_on;
+    }
+
+    public String getMySig() {
+        return mySig;
+    }
+
+    public void setMySig(String mySig) {
+        this.mySig = mySig;
+    }
+
+    public String getMySigInfo() {
+        return mySigInfo;
+    }
+
+    public void setMySigInfo(String mySigInfo) {
+        this.mySigInfo = mySigInfo;
+    }
+
+    public String getSig() {
+        return sig;
+    }
+
+    public void setSig(String sig) {
+        this.sig = sig;
+    }
+
+    public String getSigInfo() {
+        return sigInfo;
+    }
+
+    public void setSigInfo(String sigInfo) {
+        this.sigInfo = sigInfo;
     }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
@@ -231,6 +231,12 @@ public class ShareLogs {
                                 , cursor.getString(cursor.getColumnIndex("operator"))).getBytes());
                     }
                 }
+                // POTA fields. Only emit when populated so non-POTA QSOs stay
+                // byte-identical to the prior export format.
+                writePotaField(fileOutputStream, cursor, "my_sig", "MY_SIG");
+                writePotaField(fileOutputStream, cursor, "my_sig_info", "MY_SIG_INFO");
+                writePotaField(fileOutputStream, cursor, "sig", "SIG");
+                writePotaField(fileOutputStream, cursor, "sig_info", "SIG_INFO");
                 String comment = cursor.getString(cursor.getColumnIndex("comment"));
                 if (comment == null) comment = "";
 
@@ -395,5 +401,20 @@ public class ShareLogs {
             out.write(buf, 0, n);
         }
         out.flush();
+    }
+
+    /**
+     * Emit a single ADIF field from a cursor column. Silently skips when the
+     * column doesn't exist (pre-migration DB) or the value is null/empty so
+     * POTA fields stay invisible for ordinary non-POTA contacts.
+     */
+    private static void writePotaField(
+            FileOutputStream out, android.database.Cursor cursor,
+            String column, String adifName) throws IOException {
+        int idx = cursor.getColumnIndex(column);
+        if (idx < 0) return;
+        String value = cursor.getString(idx);
+        if (value == null || value.isEmpty()) return;
+        out.write(String.format("<%s:%d>%s ", adifName, value.length(), value).getBytes());
     }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
@@ -415,6 +415,10 @@ public class ShareLogs {
         if (idx < 0) return;
         String value = cursor.getString(idx);
         if (value == null || value.isEmpty()) return;
-        out.write(String.format("<%s:%d>%s ", adifName, value.length(), value).getBytes());
+        // ADIF length is in bytes; value.length() (UTF-16 code units) would mis-tag any
+        // non-ASCII content and misalign the following field.
+        byte[] valueBytes = value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        out.write(String.format("<%s:%d>%s ", adifName, valueBytes.length, value)
+                .getBytes(java.nio.charset.StandardCharsets.UTF_8));
     }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -34,6 +34,7 @@ import radio.ks3ckc.ft8us.ui.components.selectBandIndex
 import radio.ks3ckc.ft8us.ui.decode.DecodeScreen
 import radio.ks3ckc.ft8us.ui.logbook.LogbookScreen
 import radio.ks3ckc.ft8us.ui.map.MapScreen
+import radio.ks3ckc.ft8us.ui.pota.PotaScreen
 import radio.ks3ckc.ft8us.ui.settings.SettingsScreen
 import radio.ks3ckc.ft8us.ui.waterfall.WaterfallScreen
 
@@ -96,6 +97,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     FT8USTab.DECODE -> DecodeScreen(mainViewModel)
                     FT8USTab.MAP -> MapScreen(mainViewModel)
                     FT8USTab.WATERFALL -> WaterfallScreen(mainViewModel)
+                    FT8USTab.POTA -> PotaScreen(mainViewModel)
                     FT8USTab.LOG -> LogbookScreen(mainViewModel)
                     FT8USTab.SETTINGS -> SettingsScreen(mainViewModel)
                 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaActivationDao.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaActivationDao.kt
@@ -1,0 +1,76 @@
+package radio.ks3ckc.ft8us.pota
+
+import android.database.sqlite.SQLiteDatabase
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.bg7yoz.ft8cn.database.DatabaseOpr
+import radio.ks3ckc.ft8us.pota.model.PotaActivation
+
+/**
+ * Thin DAO over the pota_activation SQLite table. Single-threaded callers from the
+ * session manager — no locking beyond what SQLite gives us.
+ */
+internal object PotaActivationDao {
+
+    private fun db(): SQLiteDatabase =
+        DatabaseOpr.getInstance(GeneralVariables.getMainContext(), null).db
+
+    fun startActivation(parkRef: String, operator: String?, notes: String?): PotaActivation {
+        val now = System.currentTimeMillis()
+        val db = db()
+        db.execSQL(
+            "INSERT INTO pota_activation(park_ref, operator, started_at, qso_count, notes) " +
+                "VALUES (?, ?, ?, 0, ?)",
+            arrayOf<Any?>(parkRef, operator, now, notes),
+        )
+        val cursor = db.rawQuery("SELECT last_insert_rowid()", null)
+        val id = if (cursor.moveToFirst()) cursor.getLong(0) else -1L
+        cursor.close()
+        return PotaActivation(
+            id = id,
+            parkRef = parkRef,
+            operator = operator,
+            startedAtMs = now,
+            endedAtMs = null,
+            qsoCount = 0,
+            notes = notes,
+        )
+    }
+
+    fun endActivation(id: Long) {
+        db().execSQL(
+            "UPDATE pota_activation SET ended_at = ? WHERE id = ?",
+            arrayOf<Any?>(System.currentTimeMillis(), id),
+        )
+    }
+
+    /** Refresh a single row (used to pick up the qso_count bumps DatabaseOpr writes). */
+    fun reload(id: Long): PotaActivation? {
+        val cursor = db().rawQuery("SELECT * FROM pota_activation WHERE id = ?", arrayOf(id.toString()))
+        return cursor.use { c -> if (c.moveToFirst()) c.toActivation() else null }
+    }
+
+    fun history(limit: Int = 50): List<PotaActivation> {
+        val cursor = db().rawQuery(
+            "SELECT * FROM pota_activation ORDER BY started_at DESC LIMIT ?",
+            arrayOf(limit.toString()),
+        )
+        val out = mutableListOf<PotaActivation>()
+        cursor.use { c ->
+            while (c.moveToNext()) out.add(c.toActivation())
+        }
+        return out
+    }
+
+    private fun android.database.Cursor.toActivation(): PotaActivation {
+        val endedIdx = getColumnIndex("ended_at")
+        return PotaActivation(
+            id = getLong(getColumnIndex("id")),
+            parkRef = getString(getColumnIndex("park_ref")) ?: "",
+            operator = getString(getColumnIndex("operator")),
+            startedAtMs = getLong(getColumnIndex("started_at")),
+            endedAtMs = if (isNull(endedIdx)) null else getLong(endedIdx),
+            qsoCount = getInt(getColumnIndex("qso_count")),
+            notes = getString(getColumnIndex("notes")),
+        )
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaClient.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaClient.kt
@@ -1,0 +1,175 @@
+package radio.ks3ckc.ft8us.pota
+
+import android.util.Log
+import com.bg7yoz.ft8cn.GeneralVariables
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import radio.ks3ckc.ft8us.pota.model.PotaPark
+import radio.ks3ckc.ft8us.pota.model.PotaSpot
+import java.io.File
+import java.io.FileWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Talks to pota.app's read+write endpoints. Mirrors [radio.ks3ckc.ft8us.pskreporter.PskReporterClient]:
+ *   - HttpURLConnection only (no extra deps).
+ *   - Coroutine-friendly suspend functions on Dispatchers.IO.
+ *   - Logs every call into debug.log alongside the rest of the network layer.
+ *
+ * Endpoints:
+ *   GET  https://api.pota.app/spot/activator       -> JSON array of live spots
+ *   POST https://api.pota.app/spot                 -> self-spot
+ *   GET  https://api.pota.app/park/<reference>     -> park details (optional / fallback)
+ */
+object PotaClient {
+    private const val TAG = "PotaClient"
+    private const val BASE_URL = "https://api.pota.app"
+    private const val USER_AGENT = "ft8af-1.0"
+    private const val IO_TIMEOUT_MS = 10_000
+
+    suspend fun getActiveSpots(modeFilter: String? = "FT8"): List<PotaSpot>? =
+        withContext(Dispatchers.IO) {
+            val body = httpGet("$BASE_URL/spot/activator") ?: return@withContext null
+            try {
+                val arr = JSONArray(body)
+                val out = ArrayList<PotaSpot>(arr.length())
+                for (i in 0 until arr.length()) {
+                    val o = arr.getJSONObject(i)
+                    val mode = o.optString("mode", "")
+                    if (modeFilter != null && !mode.equals(modeFilter, ignoreCase = true)) continue
+                    val freqKhz = o.optString("frequency", "0").toDoubleOrNull() ?: 0.0
+                    out.add(
+                        PotaSpot(
+                            activator = o.optString("activator", "").uppercase(),
+                            frequencyKhz = freqKhz,
+                            mode = mode,
+                            reference = o.optString("reference", ""),
+                            parkName = o.optString("name", ""),
+                            locationDesc = o.optString("locationDesc", ""),
+                            spotter = o.optString("spotter", ""),
+                            spotTimeUtc = o.optString("spotTime", ""),
+                            comments = o.optString("comments", ""),
+                        ),
+                    )
+                }
+                log("spots ok N=${out.size} (filter=${modeFilter ?: "any"})")
+                out
+            } catch (e: Exception) {
+                log("spots parse error: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+                null
+            }
+        }
+
+    suspend fun selfSpot(
+        activator: String,
+        spotter: String,
+        frequencyKhz: Double,
+        mode: String,
+        reference: String,
+        comments: String,
+    ): Boolean = withContext(Dispatchers.IO) {
+        val body = JSONObject().apply {
+            put("activator", activator.uppercase())
+            put("spotter", spotter.uppercase())
+            put("frequency", String.format(Locale.US, "%.1f", frequencyKhz))
+            put("reference", reference.uppercase())
+            put("mode", mode)
+            put("source", "FT8AF")
+            put("comments", comments)
+        }.toString()
+        val ok = httpPost("$BASE_URL/spot", body) != null
+        log("selfSpot ${if (ok) "ok" else "FAILED"} ref=$reference freq=${frequencyKhz}kHz mode=$mode")
+        ok
+    }
+
+    suspend fun lookupPark(reference: String): PotaPark? = withContext(Dispatchers.IO) {
+        val ref = reference.trim().uppercase()
+        if (ref.isEmpty()) return@withContext null
+        val body = httpGet("$BASE_URL/park/${urlEncode(ref)}") ?: return@withContext null
+        try {
+            val o = JSONObject(body)
+            PotaPark(
+                reference = ref,
+                name = o.optString("name", ""),
+                locationDesc = o.optString("locationDesc", ""),
+            )
+        } catch (e: Exception) {
+            log("park parse error: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+            null
+        }
+    }
+
+    private fun httpGet(url: String): String? {
+        var conn: HttpURLConnection? = null
+        return try {
+            conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = "GET"
+                connectTimeout = IO_TIMEOUT_MS
+                readTimeout = IO_TIMEOUT_MS
+                setRequestProperty("User-Agent", USER_AGENT)
+                setRequestProperty("Accept", "application/json")
+            }
+            val code = conn.responseCode
+            if (code != HttpURLConnection.HTTP_OK) {
+                log("GET $url -> http $code")
+                return null
+            }
+            conn.inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+        } catch (e: Exception) {
+            log("GET $url failed: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+            null
+        } finally {
+            conn?.disconnect()
+        }
+    }
+
+    private fun httpPost(url: String, jsonBody: String): String? {
+        var conn: HttpURLConnection? = null
+        return try {
+            conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                connectTimeout = IO_TIMEOUT_MS
+                readTimeout = IO_TIMEOUT_MS
+                doOutput = true
+                setRequestProperty("User-Agent", USER_AGENT)
+                setRequestProperty("Content-Type", "application/json; charset=utf-8")
+                setRequestProperty("Accept", "application/json")
+            }
+            conn.outputStream.use { it.write(jsonBody.toByteArray(StandardCharsets.UTF_8)) }
+            val code = conn.responseCode
+            if (code !in 200..299) {
+                log("POST $url -> http $code")
+                return null
+            }
+            val stream = conn.inputStream ?: return ""
+            stream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+        } catch (e: Exception) {
+            log("POST $url failed: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+            null
+        } finally {
+            conn?.disconnect()
+        }
+    }
+
+    private fun urlEncode(s: String): String =
+        URLEncoder.encode(s, StandardCharsets.UTF_8.name())
+
+    private fun log(msg: String) {
+        Log.d(TAG, msg)
+        try {
+            val ctx = GeneralVariables.getMainContext() ?: return
+            val dir = ctx.getExternalFilesDir(null) ?: return
+            val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            FileWriter(File(dir, "debug.log"), true).use { it.append("$ts Pota: $msg\n") }
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
@@ -1,0 +1,111 @@
+package radio.ks3ckc.ft8us.pota
+
+import android.util.Log
+import com.bg7yoz.ft8cn.GeneralVariables
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import radio.ks3ckc.ft8us.pota.model.PotaActivation
+import java.io.File
+import java.io.FileWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Tracks the user's current POTA activation. While an activation is running we
+ * force `GeneralVariables.toModifier = "POTA"` so generated CQs come out as
+ * "CQ POTA <call> <grid>" via the existing message-formatting path
+ * (Ft8Message.java:277). On stop we restore whatever modifier was set before
+ * the activation started — so a user can still send "CQ NA …" etc. without
+ * losing their preference.
+ *
+ * The activator UI and the QSO save path both consult this manager:
+ * - UI binds to [currentActivation] to drive counter/buttons/etc.
+ * - The QSO save path calls [stampQso] to attach MY_SIG/MY_SIG_INFO so the
+ *   ADIF export can identify the contact as part of an activation. The
+ *   matching pota_activation row's qso_count is bumped inside DatabaseOpr.
+ */
+object PotaSessionManager {
+    private const val TAG = "PotaSessionManager"
+    private const val MY_SIG_POTA = "POTA"
+
+    private val _currentActivation = MutableStateFlow<PotaActivation?>(null)
+    val currentActivation: StateFlow<PotaActivation?> = _currentActivation.asStateFlow()
+
+    @Volatile
+    private var savedModifier: String = ""
+
+    val isActive: Boolean get() = _currentActivation.value != null
+    val currentParkRef: String? get() = _currentActivation.value?.parkRef
+
+    @Synchronized
+    fun start(parkRef: String, notes: String?): PotaActivation? {
+        if (_currentActivation.value != null) {
+            log("start ignored — activation already running for ${currentParkRef}")
+            return _currentActivation.value
+        }
+        val ref = parkRef.trim().uppercase()
+        if (ref.isEmpty()) {
+            log("start rejected — empty park ref")
+            return null
+        }
+        savedModifier = GeneralVariables.toModifier ?: ""
+        GeneralVariables.toModifier = MY_SIG_POTA
+        val operator = GeneralVariables.myCallsign?.takeIf { it.isNotBlank() }
+        val activation = PotaActivationDao.startActivation(ref, operator, notes)
+        _currentActivation.value = activation
+        log("start ref=$ref id=${activation.id} priorModifier='${savedModifier}'")
+        return activation
+    }
+
+    @Synchronized
+    fun end() {
+        val active = _currentActivation.value ?: run {
+            log("end ignored — no activation running")
+            return
+        }
+        PotaActivationDao.endActivation(active.id)
+        GeneralVariables.toModifier = savedModifier
+        savedModifier = ""
+        log("end ref=${active.parkRef} id=${active.id} qsoCount=${active.qsoCount} restoredModifier='${GeneralVariables.toModifier}'")
+        _currentActivation.value = null
+    }
+
+    /** Pull the latest qso_count from the DB so the UI counter stays accurate. */
+    fun refreshCounter() {
+        val active = _currentActivation.value ?: return
+        PotaActivationDao.reload(active.id)?.let { _currentActivation.value = it }
+    }
+
+    fun history(): List<PotaActivation> = PotaActivationDao.history()
+
+    /**
+     * Stamp POTA ADIF fields onto a QSO record about to be inserted. Mutates
+     * [record] in place — called from the QSO save path with the latest spots
+     * cache so we can also auto-fill SIG/SIG_INFO when the worked station is
+     * itself activating (Park-to-Park).
+     */
+    @JvmStatic
+    fun stampQso(record: com.bg7yoz.ft8cn.log.QSLRecord, spottedParkRef: String?) {
+        currentParkRef?.let {
+            record.mySig = MY_SIG_POTA
+            record.mySigInfo = it
+        }
+        spottedParkRef?.let {
+            record.sig = MY_SIG_POTA
+            record.sigInfo = it
+        }
+    }
+
+    private fun log(msg: String) {
+        Log.d(TAG, msg)
+        try {
+            val ctx = GeneralVariables.getMainContext() ?: return
+            val dir = ctx.getExternalFilesDir(null) ?: return
+            val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            FileWriter(File(dir, "debug.log"), true).use { it.append("$ts Pota: $msg\n") }
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSpotsRepository.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSpotsRepository.kt
@@ -1,0 +1,84 @@
+package radio.ks3ckc.ft8us.pota
+
+import android.util.Log
+import com.bg7yoz.ft8cn.GeneralVariables
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import radio.ks3ckc.ft8us.pota.model.PotaSpot
+import java.io.File
+import java.io.FileWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * In-memory cache of active POTA spots keyed by uppercased activator callsign.
+ * Refreshed every [REFRESH_INTERVAL_MS] while [start] is active.
+ *
+ * Multiple subscribers can call [start] — internally we ref-count and only the
+ * last [stop] cancels the polling job. The decode screen and the POTA hunter
+ * tab both subscribe; either keeps the poller alive.
+ */
+object PotaSpotsRepository {
+    private const val TAG = "PotaSpotsRepository"
+    private const val REFRESH_INTERVAL_MS = 60_000L
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var job: Job? = null
+    private var subscribers = 0
+
+    private val _spotsByCall = MutableStateFlow<Map<String, PotaSpot>>(emptyMap())
+    val spotsByCall: StateFlow<Map<String, PotaSpot>> = _spotsByCall.asStateFlow()
+
+    @Synchronized
+    fun start() {
+        subscribers++
+        if (job != null) return
+        log("polling started (subscribers=$subscribers)")
+        job = scope.launch {
+            while (isActive) {
+                val fresh = PotaClient.getActiveSpots(modeFilter = "FT8")
+                if (fresh != null) {
+                    _spotsByCall.value = fresh.associateBy { it.activator }
+                }
+                delay(REFRESH_INTERVAL_MS)
+            }
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        if (subscribers > 0) subscribers--
+        if (subscribers > 0) return
+        log("polling stopped")
+        job?.cancel()
+        job = null
+    }
+
+    /** Lookup helper used by QSO save path + decode-row enrichment. */
+    @JvmStatic
+    fun parkRefFor(callsign: String?): String? {
+        val key = callsign?.uppercase() ?: return null
+        return _spotsByCall.value[key]?.reference?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun log(msg: String) {
+        Log.d(TAG, msg)
+        try {
+            val ctx = GeneralVariables.getMainContext() ?: return
+            val dir = ctx.getExternalFilesDir(null) ?: return
+            val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            FileWriter(File(dir, "debug.log"), true).use { it.append("$ts Pota: $msg\n") }
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/model/PotaModels.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/model/PotaModels.kt
@@ -1,0 +1,36 @@
+package radio.ks3ckc.ft8us.pota.model
+
+/** One row from the live POTA spots feed (api.pota.app/spot/activator). */
+data class PotaSpot(
+    val activator: String,
+    val frequencyKhz: Double,
+    val mode: String,
+    val reference: String,
+    val parkName: String,
+    val locationDesc: String,
+    val spotter: String,
+    val spotTimeUtc: String,
+    val comments: String,
+) {
+    val frequencyHz: Long get() = (frequencyKhz * 1000).toLong()
+}
+
+/** Park metadata. Mostly we fill this from spot rows; the lookup endpoint is optional. */
+data class PotaPark(
+    val reference: String,
+    val name: String,
+    val locationDesc: String,
+)
+
+/** A logged activation session (row from pota_activation). */
+data class PotaActivation(
+    val id: Long,
+    val parkRef: String,
+    val operator: String?,
+    val startedAtMs: Long,
+    val endedAtMs: Long?,
+    val qsoCount: Int,
+    val notes: String?,
+) {
+    val isActive: Boolean get() = endedAtMs == null
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
@@ -337,6 +337,35 @@ object FT8USIcons {
             drawCircle(tint, 1.5f * s, Offset(12f * s, 12f * s)) // filled
         }
     }
+
+    /** Triangular pine tree on a small trunk — POTA tab. */
+    @Composable
+    fun Tree(
+        modifier: Modifier = Modifier,
+        color: Color = Color.Unspecified,
+        size: Dp = 22.dp,
+        strokeWidth: Float = 1.6f,
+    ) {
+        val tint = if (color == Color.Unspecified) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else color
+        Canvas(modifier = modifier.then(Modifier.sizeOf(size))) {
+            val s = this.size.width / 24f
+            val stroke = strokeStyle(strokeWidth * s)
+            // Trunk
+            drawLine(tint, Offset(12f * s, 19f * s), Offset(12f * s, 17f * s), stroke.width, StrokeCap.Round)
+            // Three stacked triangles (foliage)
+            val crown = Path().apply {
+                moveTo(12f * s, 3f * s)
+                lineTo(6f * s, 11f * s)
+                lineTo(9f * s, 11f * s)
+                lineTo(5f * s, 17f * s)
+                lineTo(19f * s, 17f * s)
+                lineTo(15f * s, 11f * s)
+                lineTo(18f * s, 11f * s)
+                close()
+            }
+            drawPath(crown, tint, style = stroke)
+        }
+    }
 }
 
 // Extension to apply a dp size uniformly

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TabBar.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TabBar.kt
@@ -41,6 +41,7 @@ enum class FT8USTab(val label: String) {
     DECODE("Decode"),
     MAP("Map"),
     WATERFALL("Waterfall"),
+    POTA("POTA"),
     LOG("Logbook"),
     SETTINGS("Settings"),
 }
@@ -163,6 +164,7 @@ fun TabBar(
                         FT8USTab.DECODE -> FT8USIcons.Decode(color = color, strokeWidth = strokeWidth)
                         FT8USTab.MAP -> FT8USIcons.Globe(color = color, strokeWidth = strokeWidth)
                         FT8USTab.WATERFALL -> FT8USIcons.Waterfall(color = color, strokeWidth = strokeWidth)
+                        FT8USTab.POTA -> FT8USIcons.Tree(color = color, strokeWidth = strokeWidth)
                         FT8USTab.LOG -> FT8USIcons.Book(color = color, strokeWidth = strokeWidth)
                         FT8USTab.SETTINGS -> FT8USIcons.Cog(color = color, strokeWidth = strokeWidth)
                     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -342,9 +342,15 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
     val newBand = !isWorked &&
         GeneralVariables.checkQSLCallsign_OtherBand(message.callsignFrom ?: "")
 
+    // Spotted-on-pota.app activators frequently CQ without the "POTA" suffix
+    // because their full call already eats the budget. Treat them as POTA so
+    // hunters can recognise them at a glance.
+    val isSpottedPotaActivator =
+        radio.ks3ckc.ft8us.pota.PotaSpotsRepository.parkRefFor(message.callsignFrom) != null
+
     return when {
         isToMe -> QsoStatus.PENDING
-        isCQ && modifier == "POTA" -> QsoStatus.POTA
+        isCQ && (modifier == "POTA" || isSpottedPotaActivator) -> QsoStatus.POTA
         isCQ && modifier == "SOTA" -> QsoStatus.SOTA
         message.fromDxcc -> QsoStatus.NEW
         newGrid -> QsoStatus.NEW_GRID

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -58,8 +59,16 @@ fun DecodeScreen(
     val utcTime by mainViewModel.timerSec.observeAsState(0L)
 
     // Filter state
-    val filterOptions = listOf("All", "CQ Calls", "New DXCC", "Needed", "For Me")
+    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "Needed", "For Me")
     var selectedFilter by rememberSaveable { mutableStateOf("All") }
+
+    // Keep the POTA spots cache warm while the user is browsing decodes so the
+    // CQ POTA filter and the green POTA pill on spotted activators work even
+    // without visiting the POTA tab. Ref-counted with the POTA screen.
+    DisposableEffect(Unit) {
+        radio.ks3ckc.ft8us.pota.PotaSpotsRepository.start()
+        onDispose { radio.ks3ckc.ft8us.pota.PotaSpotsRepository.stop() }
+    }
 
     // Bottom-sheet state lives in the ViewModel so it survives navigation
     // away from this screen during an active QSO.
@@ -307,6 +316,17 @@ private fun filterMessages(
 ): List<Ft8Message> {
     return when (filter) {
         "CQ Calls" -> messages.filter { it.checkIsCQ() }
+        "CQ POTA" -> messages.filter {
+            // Match three signals: (1) explicit "POTA" suffix on a CQ, (2) any CQ from a
+            // station currently spotted on pota.app (activators often drop the suffix to
+            // save chars), (3) free-text fragments like "CQ POT" that decoders garble
+            // when the activator's call is long.
+            it.checkIsCQ() && (
+                it.modifier == "POTA" ||
+                    radio.ks3ckc.ft8us.pota.PotaSpotsRepository.parkRefFor(it.callsignFrom) != null ||
+                    (it.callsignTo?.startsWith("CQ POT", ignoreCase = true) == true)
+                )
+        }
         "New DXCC" -> messages.filter { it.checkIsCQ() && it.fromDxcc }
         "Needed" -> messages.filter {
             !it.isQSL_Callsign &&
@@ -330,7 +350,8 @@ private fun EmptyState(
 ) {
     val (title, subtitle) = when (selectedFilter) {
         "CQ Calls" -> "No CQ calls" to "No stations are calling CQ on this band right now."
-        "New DXCC" -> "No new DXCC" to "No unworked DXCC entities have been decoded yet."
+        "CQ POTA" -> "No POTA spots" to "No park activations decoded on this band yet — open POTA → Hunt for the spot list."
+    "New DXCC" -> "No new DXCC" to "No unworked DXCC entities have been decoded yet."
         "Needed" -> "Nothing needed" to "No stations needing confirmation found."
         "For Me" -> "No calls for you" to "No stations are calling your callsign right now."
         else -> "No signals decoded" to "Waiting for FT8 signals to appear..."

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
@@ -116,6 +116,9 @@ object PotaAdifExporter {
 
     private fun adifField(sb: StringBuilder, name: String, value: String?) {
         if (value.isNullOrEmpty()) return
-        sb.append("<").append(name).append(":").append(value.length).append(">").append(value).append(" ")
+        // ADIF length is in bytes, not characters — `value.length` (UTF-16 code units)
+        // would mis-tag any non-ASCII content and misalign the following field.
+        val bytes = value.toByteArray(Charsets.UTF_8).size
+        sb.append("<").append(name).append(":").append(bytes).append(">").append(value).append(" ")
     }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
@@ -1,0 +1,121 @@
+package radio.ks3ckc.ft8us.ui.pota
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import com.bg7yoz.ft8cn.MainViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import radio.ks3ckc.ft8us.pota.model.PotaActivation
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Writes an ADIF file for a single POTA activation and shares it via system intent.
+ *
+ * pota.app's website upload (https://pota.app/#/user/upload) expects an ADIF where each
+ * QSO carries MY_SIG=POTA / MY_SIG_INFO=<park ref>. SIG/SIG_INFO are filled for P2P
+ * (Park-to-Park) contacts. We pull rows from QSLTable that fall inside the activation's
+ * time window AND match the park ref so the file contains only the activation's QSOs.
+ */
+object PotaAdifExporter {
+
+    private const val AUTHORITY = "radio.ks3ckc.ft8af.fileprovider"
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun shareActivationAdif(
+        context: Context,
+        mainViewModel: MainViewModel,
+        activation: PotaActivation,
+        onResult: (Boolean) -> Unit,
+    ) {
+        val db = mainViewModel.databaseOpr?.db ?: run {
+            onResult(false)
+            return
+        }
+        scope.launch {
+            try {
+                val cursor = db.rawQuery(
+                    "SELECT * FROM QSLTable WHERE my_sig = 'POTA' AND my_sig_info = ? " +
+                        "ORDER BY qso_date, time_on",
+                    arrayOf(activation.parkRef),
+                )
+                val sb = StringBuilder()
+                sb.append("FT8AF POTA Activation ${activation.parkRef}\n")
+                sb.append("<ADIF_VER:5>3.1.4 ")
+                sb.append("<PROGRAMID:5>FT8AF ")
+                sb.append("<EOH>\n")
+                cursor.use { c ->
+                    val callIdx = c.getColumnIndex("call")
+                    val gridIdx = c.getColumnIndex("gridsquare")
+                    val modeIdx = c.getColumnIndex("mode")
+                    val bandIdx = c.getColumnIndex("band")
+                    val freqIdx = c.getColumnIndex("freq")
+                    val rstSentIdx = c.getColumnIndex("rst_sent")
+                    val rstRcvdIdx = c.getColumnIndex("rst_rcvd")
+                    val dateIdx = c.getColumnIndex("qso_date")
+                    val timeOnIdx = c.getColumnIndex("time_on")
+                    val timeOffIdx = c.getColumnIndex("time_off")
+                    val stationIdx = c.getColumnIndex("station_callsign")
+                    val myGridIdx = c.getColumnIndex("my_gridsquare")
+                    val mySigIdx = c.getColumnIndex("my_sig")
+                    val mySigInfoIdx = c.getColumnIndex("my_sig_info")
+                    val sigIdx = c.getColumnIndex("sig")
+                    val sigInfoIdx = c.getColumnIndex("sig_info")
+                    while (c.moveToNext()) {
+                        adifField(sb, "CALL", c.getString(callIdx))
+                        adifField(sb, "GRIDSQUARE", c.getString(gridIdx))
+                        adifField(sb, "MODE", c.getString(modeIdx))
+                        adifField(sb, "BAND", c.getString(bandIdx))
+                        adifField(sb, "FREQ", c.getString(freqIdx))
+                        adifField(sb, "RST_SENT", c.getString(rstSentIdx))
+                        adifField(sb, "RST_RCVD", c.getString(rstRcvdIdx))
+                        adifField(sb, "QSO_DATE", c.getString(dateIdx))
+                        adifField(sb, "TIME_ON", c.getString(timeOnIdx))
+                        adifField(sb, "TIME_OFF", c.getString(timeOffIdx))
+                        adifField(sb, "STATION_CALLSIGN", c.getString(stationIdx))
+                        adifField(sb, "MY_GRIDSQUARE", c.getString(myGridIdx))
+                        adifField(sb, "MY_SIG", c.getString(mySigIdx))
+                        adifField(sb, "MY_SIG_INFO", c.getString(mySigInfoIdx))
+                        adifField(sb, "SIG", c.getString(sigIdx))
+                        adifField(sb, "SIG_INFO", c.getString(sigInfoIdx))
+                        sb.append("<EOR>\n")
+                    }
+                }
+
+                val dir = context.getExternalFilesDir(null) ?: run {
+                    onResult(false)
+                    return@launch
+                }
+                val ts = SimpleDateFormat("yyyyMMdd-HHmm", Locale.US).format(Date(activation.startedAtMs))
+                val file = File(dir, "pota-${activation.parkRef}-$ts.adi")
+                file.writeText(sb.toString())
+
+                val uri = FileProvider.getUriForFile(context, AUTHORITY, file)
+                val send = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    putExtra(Intent.EXTRA_SUBJECT, "POTA activation ${activation.parkRef}")
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                val chooser = Intent.createChooser(send, "Share POTA ADIF").apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(chooser)
+                onResult(true)
+            } catch (e: Exception) {
+                e.printStackTrace()
+                onResult(false)
+            }
+        }
+    }
+
+    private fun adifField(sb: StringBuilder, name: String, value: String?) {
+        if (value.isNullOrEmpty()) return
+        sb.append("<").append(name).append(":").append(value.length).append(">").append(value).append(" ")
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
@@ -217,7 +217,10 @@ private fun ActivateTab() {
                             val ok = PotaClient.selfSpot(
                                 activator = myCall,
                                 spotter = myCall,
-                                frequencyKhz = GeneralVariables.band / 1000.0,
+                                // getBaseFrequency() = carrier + audio offset, in Hz — the
+                                // actual TX QRG. Using band/1000 here posted the band
+                                // centre and put hunters off-frequency by the audio offset.
+                                frequencyKhz = GeneralVariables.getBaseFrequency() / 1000.0,
                                 mode = "FT8",
                                 reference = activation!!.parkRef,
                                 comments = "CQ POTA via FT8AF",

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
@@ -1,0 +1,544 @@
+package radio.ks3ckc.ft8us.ui.pota
+
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.bg7yoz.ft8cn.MainViewModel
+import kotlinx.coroutines.launch
+import radio.ks3ckc.ft8us.pota.PotaClient
+import radio.ks3ckc.ft8us.pota.PotaSessionManager
+import radio.ks3ckc.ft8us.pota.PotaSpotsRepository
+import radio.ks3ckc.ft8us.pota.model.PotaActivation
+import radio.ks3ckc.ft8us.pota.model.PotaSpot
+import radio.ks3ckc.ft8us.theme.Accent
+import radio.ks3ckc.ft8us.theme.AccentSoft
+import radio.ks3ckc.ft8us.theme.BgApp
+import radio.ks3ckc.ft8us.theme.BgSurface
+import radio.ks3ckc.ft8us.theme.BgSurface2
+import radio.ks3ckc.ft8us.theme.Border
+import radio.ks3ckc.ft8us.theme.BorderStrong
+import radio.ks3ckc.ft8us.theme.StatusConfirmed
+import radio.ks3ckc.ft8us.theme.TextMuted
+import radio.ks3ckc.ft8us.theme.TextPrimary
+
+private enum class PotaSubTab(val label: String) {
+    ACTIVATE("Activate"),
+    HUNT("Hunt"),
+    HISTORY("History"),
+}
+
+@Composable
+fun PotaScreen(mainViewModel: MainViewModel) {
+    var subTab by rememberSaveable { mutableStateOf(PotaSubTab.ACTIVATE) }
+
+    // Hunter tab and an active activation both rely on fresh spots — start
+    // polling whenever the POTA screen is mounted.
+    DisposableEffect(Unit) {
+        PotaSpotsRepository.start()
+        onDispose { PotaSpotsRepository.stop() }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BgApp)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        PotaTabHeader(subTab = subTab, onTabSelected = { subTab = it })
+        Spacer(Modifier.height(10.dp))
+        when (subTab) {
+            PotaSubTab.ACTIVATE -> ActivateTab()
+            PotaSubTab.HUNT -> HuntTab(mainViewModel)
+            PotaSubTab.HISTORY -> HistoryTab(mainViewModel)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-tab chip header
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun PotaTabHeader(subTab: PotaSubTab, onTabSelected: (PotaSubTab) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BgSurface, RoundedCornerShape(10.dp))
+            .border(1.dp, Border, RoundedCornerShape(10.dp))
+            .padding(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        for (tab in PotaSubTab.entries) {
+            val selected = tab == subTab
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .background(
+                        if (selected) AccentSoft else Color.Transparent,
+                        RoundedCornerShape(8.dp),
+                    )
+                    .clickable { onTabSelected(tab) }
+                    .padding(vertical = 9.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = tab.label,
+                    color = if (selected) Accent else TextMuted,
+                    fontSize = 13.sp,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Activate tab
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun ActivateTab() {
+    val activation by PotaSessionManager.currentActivation.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var parkRef by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var refreshKey by remember { mutableIntStateOf(0) }
+
+    // Refresh the activation's QSO counter periodically while one is running so
+    // the on-screen tally reflects QSOs added by the TX/RX path.
+    LaunchedEffect(activation?.id, refreshKey) {
+        if (activation != null) {
+            kotlinx.coroutines.delay(3000)
+            PotaSessionManager.refreshCounter()
+            refreshKey++
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (activation == null) {
+            Card {
+                SectionTitle("Start activation")
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = parkRef,
+                    onValueChange = { parkRef = it.uppercase().take(10) },
+                    label = { Text("Park reference (e.g. K-1234)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
+                    colors = textFieldColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = notes,
+                    onValueChange = { notes = it.take(120) },
+                    label = { Text("Notes (optional)") },
+                    singleLine = true,
+                    colors = textFieldColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                Button(
+                    onClick = {
+                        val started = PotaSessionManager.start(parkRef, notes.ifBlank { null })
+                        if (started == null) {
+                            Toast.makeText(context, "Enter a park reference first", Toast.LENGTH_SHORT).show()
+                        } else {
+                            Toast.makeText(context, "Activating ${started.parkRef}", Toast.LENGTH_SHORT).show()
+                        }
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Accent, contentColor = BgApp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Start activation", fontWeight = FontWeight.SemiBold) }
+            }
+        } else {
+            ActiveActivationCard(
+                activation = activation!!,
+                onStop = {
+                    PotaSessionManager.end()
+                    Toast.makeText(context, "Activation ended", Toast.LENGTH_SHORT).show()
+                },
+                onSelfSpot = {
+                    val myCall = GeneralVariables.myCallsign ?: ""
+                    if (myCall.isBlank()) {
+                        Toast.makeText(context, "Set your callsign in Settings first", Toast.LENGTH_SHORT).show()
+                    } else {
+                        scope.launch {
+                            val ok = PotaClient.selfSpot(
+                                activator = myCall,
+                                spotter = myCall,
+                                frequencyKhz = GeneralVariables.band / 1000.0,
+                                mode = "FT8",
+                                reference = activation!!.parkRef,
+                                comments = "CQ POTA via FT8AF",
+                            )
+                            Toast.makeText(
+                                context,
+                                if (ok) "Self-spot posted" else "Self-spot failed — check log",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActiveActivationCard(
+    activation: PotaActivation,
+    onStop: () -> Unit,
+    onSelfSpot: () -> Unit,
+) {
+    Card {
+        SectionTitle("ACTIVE — ${activation.parkRef}")
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            StatBlock(
+                label = "QSOs",
+                value = activation.qsoCount.toString(),
+                hint = if (activation.qsoCount >= 10) "valid activation" else "${10 - activation.qsoCount} to valid",
+                valueColor = if (activation.qsoCount >= 10) StatusConfirmed else Accent,
+            )
+            StatBlock(
+                label = "Elapsed",
+                value = formatElapsed(System.currentTimeMillis() - activation.startedAtMs),
+                hint = "since start",
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Button(
+                onClick = onSelfSpot,
+                colors = ButtonDefaults.buttonColors(containerColor = Accent, contentColor = BgApp),
+                modifier = Modifier.weight(1f),
+            ) { Text("Self-spot", fontWeight = FontWeight.SemiBold) }
+            OutlinedButton(
+                onClick = onStop,
+                modifier = Modifier.weight(1f),
+            ) { Text("End activation", color = TextPrimary) }
+        }
+        if (!activation.notes.isNullOrBlank()) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "“${activation.notes}”",
+                color = TextMuted,
+                fontSize = 12.sp,
+            )
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(
+            "TX CQ will go out as “CQ POTA ${GeneralVariables.myCallsign ?: ""} ${GeneralVariables.getMyMaidenhead4Grid()}”.",
+            color = TextMuted,
+            fontSize = 11.sp,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hunt tab
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun HuntTab(mainViewModel: MainViewModel) {
+    val spotsMap by PotaSpotsRepository.spotsByCall.collectAsStateWithLifecycle()
+    val spots = remember(spotsMap) { spotsMap.values.sortedBy { it.frequencyKhz } }
+    val context = LocalContext.current
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = if (spots.isEmpty()) "No FT8 POTA spots right now." else "${spots.size} active FT8 spots",
+            color = TextMuted,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
+        )
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            contentPadding = PaddingValues(vertical = 2.dp),
+        ) {
+            items(spots, key = { "${it.activator}-${it.reference}-${it.frequencyKhz}" }) { spot ->
+                SpotRow(spot = spot, onClick = {
+                    // Open the QSO sheet pre-filled with this activator's callsign. Tuning the
+                    // radio is the operator's job — most rigs aren't CAT-controlled by FT8AF
+                    // for frequency changes during a session.
+                    mainViewModel.qsoSheetCallsign.postValue(spot.activator)
+                    Toast.makeText(
+                        context,
+                        "Targeting ${spot.activator} @ ${"%.1f".format(spot.frequencyKhz)} kHz (${spot.reference}) — switch to Decode to call",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                })
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpotRow(spot: PotaSpot, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BgSurface, RoundedCornerShape(10.dp))
+            .border(1.dp, Border, RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    spot.activator,
+                    color = TextPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Spacer(Modifier.width(8.dp))
+                ParkPill(spot.reference)
+            }
+            if (spot.parkName.isNotBlank()) {
+                Text(
+                    spot.parkName + if (spot.locationDesc.isNotBlank()) " · ${spot.locationDesc}" else "",
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                )
+            }
+            if (spot.comments.isNotBlank()) {
+                Text("“${spot.comments}”", color = TextMuted, fontSize = 11.sp)
+            }
+        }
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = "%.1f kHz".format(spot.frequencyKhz),
+            color = Accent,
+            fontSize = 12.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// History tab
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun HistoryTab(mainViewModel: MainViewModel) {
+    val context = LocalContext.current
+    var history by remember { mutableStateOf<List<PotaActivation>>(emptyList()) }
+    var refreshKey by remember { mutableIntStateOf(0) }
+    val activation by PotaSessionManager.currentActivation.collectAsStateWithLifecycle()
+
+    // Reload whenever activation state changes (start/end will appear here).
+    LaunchedEffect(refreshKey, activation?.id, activation?.endedAtMs) {
+        history = PotaSessionManager.history()
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (history.isEmpty()) {
+            Text(
+                "No past activations yet.",
+                color = TextMuted,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            items(history, key = { it.id }) { row ->
+                HistoryRow(
+                    row = row,
+                    onOpenUploadPage = {
+                        runCatching {
+                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://pota.app/#/user/upload"))
+                            context.startActivity(intent)
+                        }.onFailure {
+                            Toast.makeText(context, "No browser available", Toast.LENGTH_SHORT).show()
+                        }
+                    },
+                    onShareAdif = {
+                        PotaAdifExporter.shareActivationAdif(context, mainViewModel, row) { ok ->
+                            if (!ok) Toast.makeText(context, "Export failed — check log", Toast.LENGTH_SHORT).show()
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryRow(
+    row: PotaActivation,
+    onOpenUploadPage: () -> Unit,
+    onShareAdif: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BgSurface, RoundedCornerShape(10.dp))
+            .border(1.dp, Border, RoundedCornerShape(10.dp))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ParkPill(row.parkRef)
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    if (row.isActive) "active" else "${row.qsoCount} QSO",
+                    color = if (row.isActive) Accent else TextPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 13.sp,
+                )
+            }
+            Text(formatDateRange(row), color = TextMuted, fontSize = 11.sp)
+        }
+        if (!row.notes.isNullOrBlank()) {
+            Spacer(Modifier.height(2.dp))
+            Text("“${row.notes}”", color = TextMuted, fontSize = 11.sp)
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            OutlinedButton(onClick = onShareAdif, modifier = Modifier.weight(1f)) {
+                Text("Share ADIF", color = TextPrimary, fontSize = 12.sp)
+            }
+            OutlinedButton(onClick = onOpenUploadPage, modifier = Modifier.weight(1f)) {
+                Text("Open pota.app", color = TextPrimary, fontSize = 12.sp)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun Card(content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BgSurface, RoundedCornerShape(12.dp))
+            .border(1.dp, BorderStrong, RoundedCornerShape(12.dp))
+            .padding(14.dp),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(text, color = TextPrimary, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+}
+
+@Composable
+private fun StatBlock(label: String, value: String, hint: String, valueColor: Color = TextPrimary) {
+    Column(horizontalAlignment = Alignment.Start) {
+        Text(label, color = TextMuted, fontSize = 11.sp)
+        Text(value, color = valueColor, fontSize = 24.sp, fontWeight = FontWeight.Bold, fontFamily = FontFamily.Monospace)
+        Text(hint, color = TextMuted, fontSize = 11.sp)
+    }
+}
+
+@Composable
+private fun ParkPill(ref: String) {
+    Text(
+        ref,
+        color = StatusConfirmed,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier
+            .background(BgSurface2, RoundedCornerShape(6.dp))
+            .border(1.dp, Border, RoundedCornerShape(6.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        fontFamily = FontFamily.Monospace,
+    )
+}
+
+@Composable
+private fun textFieldColors() = TextFieldDefaults.colors(
+    focusedTextColor = TextPrimary,
+    unfocusedTextColor = TextPrimary,
+    focusedContainerColor = BgSurface2,
+    unfocusedContainerColor = BgSurface2,
+    focusedLabelColor = Accent,
+    unfocusedLabelColor = TextMuted,
+    focusedIndicatorColor = Accent,
+    unfocusedIndicatorColor = Border,
+    cursorColor = Accent,
+)
+
+private fun formatElapsed(ms: Long): String {
+    val totalSec = (ms / 1000).coerceAtLeast(0)
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    return if (h > 0) "${h}h ${m}m" else "${m}m"
+}
+
+private fun formatDateRange(row: PotaActivation): String {
+    val fmt = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.US)
+    val start = fmt.format(java.util.Date(row.startedAtMs))
+    val end = row.endedAtMs?.let { fmt.format(java.util.Date(it)) } ?: "—"
+    return "$start → $end"
+}


### PR DESCRIPTION
## Summary
- **Activator**: new POTA tab with start/end activation flow, live QSO counter toward the 10-QSO validation threshold, self-spot to `api.pota.app/spot`, and a History sub-tab that re-shares any past activation's ADIF.
- **Hunter**: 60s-polled spots cache feeding a new "CQ POTA" decode filter chip and extending the existing green POTA pill to spotted activators who CQ without the suffix. Hunt tab lists current spots; tap to pre-fill the QSO sheet.
- **Logging**: QSLTable gains MY_SIG/MY_SIG_INFO/SIG/SIG_INFO; the QSO insert path auto-stamps these from the active activation + spots cache so Park-to-Park works without operator intervention. ADIF emit writes the new fields when populated and is byte-identical otherwise.

## Architecture notes
- TX uses the existing CQ-with-suffix code path — \`PotaSessionManager.start()\` just flips \`GeneralVariables.toModifier = \"POTA\"\` and the encoder produces \"CQ POTA <call> <grid>\" as a structured i3=1 frame. No changes to libft8cn.so or the audio pipeline.
- Spots cache is ref-counted; both the decode screen and the POTA screen start it, last \`stop()\` cancels polling.
- Schema migration bumps to v17 with \`alterTable\` calls — matches the existing pattern in \`createQSLTable\`.
- pota.app has no public log-upload API, so the History tab generates ADIF + opens https://pota.app/#/user/upload via \`ACTION_VIEW\` — operator picks the file in the browser.

## Test plan
- [ ] Install on Pixel 8 (currently blocked locally — device storage at 100%; \`gradlew installDebug\` after freeing space)
- [ ] Activator: start activation with \`K-TEST\`, press Call CQ on the Decode tab, pull \`debug.log\` and confirm the generated message string is \"CQ POTA <call> <grid>\"
- [ ] Cross-check with WSJT-X or a second receiver — should decode as \"CQ POTA …\" not garbled / not free-text
- [ ] Press Self-spot — verify HTTP 2xx in debug.log and a corresponding entry on https://pota.app/#/activations
- [ ] Log a QSO during the session — confirm \`my_sig=POTA, my_sig_info=K-TEST\` in QSLTable (\`adb shell run-as radio.ks3ckc.ft8af sqlite3 …\`) and that \`pota_activation.qso_count\` was bumped
- [ ] Hunter: open Decode tab, confirm spots-cache poller fires every ~60s (debug.log); verify a known active POTA station gets the green POTA pill even without the suffix
- [ ] Filter chip: \"CQ POTA\" shows only CQ-POTA and spotted activators; other chips unaffected
- [ ] ADIF: from History tab, re-share a past activation; inspect the \`.adi\` for \`<MY_SIG:4>POTA\` and \`<MY_SIG_INFO:N>K-TEST\`; verify \"Open pota.app upload\" launches the browser to the correct page
- [ ] Regression: existing non-POTA CQ still produces \"CQ <call> <grid>\" after ending activation (toModifier is restored to its prior value)
- [ ] Regression: existing ADIF export for non-POTA QSOs is unchanged

## Known gaps to verify on-air
- Self-spot endpoint body shape: I'm using \`POST /spot\` with \`{activator, spotter, frequency (kHz string), reference, mode, source, comments}\`. pota.app's docs aren't fully public — verify against debug.log on first use; may need tweaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)