### PR TITLE
fix: bug bash — FlexRadio crashes, TCP hang, dead audio pad, charset

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/FlexRadio.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/FlexRadio.java
@@ -1074,7 +1074,15 @@ public class FlexRadio {
                     getHeadAndContent(line, "\\|");
                     try {
                         seq_number = Integer.parseInt(head.substring(1));//Parse command sequence number
-                        flexCommand = FlexCommand.values()[seq_number % 1000];
+                        int cmdIdx = seq_number % 1000;
+                        // Modulo 1000 doesn't bound the index by enum size — an out-of-range
+                        // sequence number used to crash the parser. Treat as unknown command.
+                        if (cmdIdx < 0 || cmdIdx >= FlexCommand.values().length) {
+                            Log.w(TAG, "FlexResponse seq_number=" + seq_number
+                                    + " -> unknown command index " + cmdIdx);
+                            break;
+                        }
+                        flexCommand = FlexCommand.values()[cmdIdx];
                         switch (flexCommand) {
                             case STREAM_CREATE_DAX_RX:
                                 this.daxStreamId = getStreamId(line);
@@ -1169,13 +1177,15 @@ public class FlexRadio {
          */
         private void getHeadAndContent(String line, String split) {
             String[] temp = line.split(split);
-            if (line.length() > 1) {
+            // The old guard was `line.length() > 1`, which has nothing to do with how many
+            // fields `split` produced — a single-token response (no delimiter) crashed the
+            // CAT parser thread with ArrayIndexOutOfBoundsException on `temp[1]`.
+            if (temp.length >= 2) {
                 head = temp[0];
                 content = temp[1];
             } else {
-                head = "";
+                head = temp.length == 1 ? temp[0] : "";
                 content = "";
-
             }
 
             if (temp.length > 2) {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/RadioTcpClient.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/RadioTcpClient.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.Arrays;
@@ -96,7 +97,12 @@ public class RadioTcpClient {
                     mSocket = null;
                 }
                 InetAddress ipAddress = InetAddress.getByName(ip);
-                mSocket = new Socket(ipAddress, port);
+                // The old `new Socket(addr, port)` form used the OS default connect timeout
+                // (~75 s on Linux). When the Flex was unreachable the UI gave no feedback
+                // for that whole window. Use the two-step pattern with explicit timeouts.
+                mSocket = new Socket();
+                mSocket.connect(new InetSocketAddress(ipAddress, port), 5000);
+                mSocket.setSoTimeout(15000);
                 //Set no-delay sending
                 //mSocket.setTcpNoDelay(true);
                 //Set input/output buffer stream size

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -339,7 +339,11 @@ public class FT8TransmitSignal {
      * @return 16-bit integer
      */
     private short[] float2Short(float[] buffer) {
-        short[] temp = new short[buffer.length + 8];// extra 8 zero-padded samples for QP-7C RP2040 audio detection compatibility
+        // Previously this allocated `buffer.length + 8` shorts "for QP-7C RP2040 audio
+        // detection compatibility", but the 16-bit AudioTrack.write below uses
+        // `playLength = buffer.length - skipSamples` and never writes the trailing pad.
+        // The float path didn't include the pad either. Drop the dead allocation.
+        short[] temp = new short[buffer.length];
         for (int i = 0; i < buffer.length; i++) {
             float x = buffer[i];
             if (x > 1.0)

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
@@ -550,7 +550,7 @@ public class ThirdPartyService {
             // Get server response
             int responseCode = conn.getResponseCode();
             if (responseCode == HttpURLConnection.HTTP_OK) {
-                reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
                 StringBuilder response = new StringBuilder();
                 String line;
                 while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
## Summary
Four independent latent bugs surfaced during a bug-bash sweep across FlexRadio, the Flex TCP client, the FT8 TX path, and the QRZ/Cloudlog HTTP client. None are regressions from a recent change.

- **FlexRadio.getHeadAndContent** (\`FlexRadio.java:1170\`) — guarded \`temp[1]\` with \`line.length() > 1\`, which is unrelated to the split-array length. A no-delimiter response crashes the CAT parser thread with \`ArrayIndexOutOfBoundsException\`. Now checks \`temp.length >= 2\`.
- **FlexRadio command dispatch** (\`FlexRadio.java:1077\`) — \`FlexCommand.values()[seq_number % 1000]\` assumed the enum had ≥1000 entries; an out-of-range sequence number crashed with AIOOBE. Now bounds-checked, unknown commands are logged and skipped.
- **RadioTcpClient TCP connect** (\`RadioTcpClient.java:99\`) — \`new Socket(addr, port)\` used the OS default connect timeout (~75 s on Linux), so an unreachable Flex hangs the connect thread that long with no UI feedback. Replaced with the two-step \`connect(InetSocketAddress, 5000)\` + \`setSoTimeout(15000)\` pattern.
- **FT8TransmitSignal.float2Short** (\`FT8TransmitSignal.java:341\`) — allocated \`short[buffer.length + 8]\` "for QP-7C RP2040 audio detection compatibility", but the 16-bit \`AudioTrack.write\` uses \`playLength = buffer.length - skipSamples\` and never includes those 8 trailing samples. The 32-bit float path doesn't add the pad at all. Dropped the dead allocation and the misleading comment.
- **ThirdPartyService.sendGetRequest** (\`ThirdPartyService.java:553\`) — \`InputStreamReader\` without an explicit charset reads QRZ/Cloudlog responses with the platform default. The sibling reader near line 443 already uses UTF-8; this one-line divergence corrupts non-ASCII responses on non-UTF-8 default locales.

## Test plan
- [x] Builds clean on \`fix/bug-bash\` (verified during full \`gradlew installDebug\` from the parent branch with the same edits)
- [ ] FlexRadio bounds fixes — synthetic test feeding a no-delimiter line and a high-\`seq\` response to the parser (no Flex on hand to exercise live)
- [ ] TCP timeout — point Flex IP at \`192.0.2.1\` (TEST-NET-1), confirm connect attempt fails in ~5 s with visible error
- [ ] \`float2Short\` change is a no-op for non-QP-7C TX — confirm TX'd FT8 still decodes on a second receiver
- [ ] UTF-8 charset on QRZ reader — code-review parity with line-443 reader; full validation needs a non-UTF-8 locale device

## Related
Companion fixes that touch POTA-only files (DatabaseOpr migration repair, POTA self-spot frequency, POTA ADIF exporter UTF-8 length) were pushed to PR #96 since they only apply where the POTA branch's files exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)