### PR TITLE
ci: Discord notifications for merges and Play track promotions

### DIFF
--- a/.github/scripts/play_track_watch.py
+++ b/.github/scripts/play_track_watch.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Poll Google Play Developer API for track contents; post to Discord on changes.
+
+State file is a JSON snapshot of {track_name: [releases]} from the last run.
+On first run (empty state) we snapshot and stay silent so we don't spam every
+existing release. On subsequent runs we diff per-versionCode and emit a Discord
+embed when a versionCode appears in a track it wasn't in before — distinguishing
+"promotion" (was already in a lower-priority track) from "new" (first sighting).
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+from google.auth.transport.requests import Request as GAuthRequest
+from google.oauth2 import service_account
+
+PACKAGE = os.environ["PACKAGE_NAME"]
+WEBHOOK = os.environ["DISCORD_WEBHOOK_URL"]
+SVC_JSON = os.environ["PLAY_SERVICE_ACCOUNT_JSON"]
+
+# Tracks we care about, ordered low → high. "beta" is the API name for closed testing.
+TRACK_ORDER = ["internal", "beta", "production"]
+TRACK_LABEL = {"internal": "Internal testing", "beta": "Closed testing", "production": "Production"}
+TRACK_COLOR = {"internal": 3447003, "beta": 15844367, "production": 3066993}
+TRACK_RANK = {t: i for i, t in enumerate(TRACK_ORDER)}
+
+API = "https://androidpublisher.googleapis.com/androidpublisher/v3"
+
+
+def play_session():
+    creds = service_account.Credentials.from_service_account_info(
+        json.loads(SVC_JSON),
+        scopes=["https://www.googleapis.com/auth/androidpublisher"],
+    )
+    creds.refresh(GAuthRequest())
+    s = requests.Session()
+    s.headers["Authorization"] = f"Bearer {creds.token}"
+    return s
+
+
+def fetch_tracks(s):
+    """Return {track_name: [{name, status, versionCodes:[...]}, ...]} for the watched tracks."""
+    edit = s.post(f"{API}/applications/{PACKAGE}/edits", timeout=30)
+    edit.raise_for_status()
+    edit_id = edit.json()["id"]
+    try:
+        out = {}
+        for t in TRACK_ORDER:
+            r = s.get(f"{API}/applications/{PACKAGE}/edits/{edit_id}/tracks/{t}", timeout=30)
+            if r.status_code == 404:
+                out[t] = []
+                continue
+            r.raise_for_status()
+            releases = []
+            for rel in r.json().get("releases", []):
+                releases.append({
+                    "name": rel.get("name") or "",
+                    "status": rel.get("status") or "",
+                    "versionCodes": sorted(int(v) for v in (rel.get("versionCodes") or [])),
+                })
+            out[t] = releases
+        return out
+    finally:
+        # Delete the edit so we don't leave it hanging — these are read-only ops anyway.
+        s.delete(f"{API}/applications/{PACKAGE}/edits/{edit_id}", timeout=30)
+
+
+def index_by_version(state):
+    """{versionCode: {track: release_name}} for diffing."""
+    idx = {}
+    for track, releases in state.items():
+        for rel in releases:
+            for vc in rel["versionCodes"]:
+                idx.setdefault(vc, {})[track] = rel["name"]
+    return idx
+
+
+def post_discord(embeds):
+    for i in range(0, len(embeds), 10):  # Discord caps at 10 embeds per message
+        r = requests.post(WEBHOOK, json={"embeds": embeds[i:i + 10]}, timeout=15)
+        r.raise_for_status()
+
+
+def build_embeds(prev_idx, curr_idx, current):
+    """Diff prev vs current; emit one embed per (versionCode, newly-entered track)."""
+    # Build a lookup of current release status by (track, versionCode).
+    status_by = {}
+    for t, releases in current.items():
+        for rel in releases:
+            for vc in rel["versionCodes"]:
+                status_by[(t, vc)] = rel.get("status") or "—"
+
+    embeds = []
+    for vc in sorted(curr_idx.keys()):
+        curr_tracks = curr_idx[vc]
+        prev_tracks = prev_idx.get(vc, {})
+        for t, name in curr_tracks.items():
+            if t in prev_tracks:
+                continue  # already known in this track
+            lower = [pt for pt in prev_tracks if TRACK_RANK.get(pt, -1) < TRACK_RANK[t]]
+            if lower:
+                from_t = max(lower, key=lambda x: TRACK_RANK[x])
+                title = f"⬆️ Promoted to {TRACK_LABEL[t]}"
+                desc = (
+                    f"**{name or f'versionCode {vc}'}** "
+                    f"promoted **{TRACK_LABEL[from_t]} → {TRACK_LABEL[t]}**"
+                )
+            else:
+                title = f"🆕 New release in {TRACK_LABEL[t]}"
+                desc = f"**{name or f'versionCode {vc}'}** appeared in **{TRACK_LABEL[t]}**"
+            embeds.append({
+                "title": title,
+                "description": desc,
+                "color": TRACK_COLOR.get(t, 5814783),
+                "fields": [
+                    {"name": "Release", "value": name or "(unnamed)", "inline": True},
+                    {"name": "versionCode", "value": str(vc), "inline": True},
+                    {"name": "Status", "value": status_by.get((t, vc), "—"), "inline": True},
+                ],
+            })
+    return embeds
+
+
+def main(state_path):
+    state_path = Path(state_path)
+    previous = {}
+    if state_path.exists():
+        try:
+            previous = json.loads(state_path.read_text() or "{}")
+        except json.JSONDecodeError:
+            previous = {}
+
+    s = play_session()
+    current = fetch_tracks(s)
+
+    # Always write the new snapshot first so the state branch picks it up regardless of notify outcome.
+    state_path.write_text(json.dumps(current, indent=2, sort_keys=True))
+
+    if not previous:
+        print("First run — snapshotted state, not notifying.")
+        return
+
+    prev_idx = index_by_version(previous)
+    curr_idx = index_by_version(current)
+    embeds = build_embeds(prev_idx, curr_idx, current)
+
+    if not embeds:
+        print("No track changes detected.")
+        return
+
+    print(f"Posting {len(embeds)} Discord embed(s).")
+    post_discord(embeds)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/.github/workflows/discord-merge-notify.yml
+++ b/.github/workflows/discord-merge-notify.yml
@@ -1,0 +1,61 @@
+name: Discord — merge notify
+
+on:
+  push:
+    branches: [dev, main]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # Skip if the head commit message contains [skip discord] (e.g. for state-branch chores)
+    if: ${{ !contains(github.event.head_commit.message, '[skip discord]') }}
+    steps:
+      - name: Post to Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          AUTHOR: ${{ github.event.head_commit.author.name }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          COMPARE_URL: ${{ github.event.compare }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${WEBHOOK_URL:-}" ]]; then
+            echo "::error::DISCORD_WEBHOOK_URL secret is not set"
+            exit 1
+          fi
+          if [[ "$BRANCH" == "main" ]]; then
+            color=3066993   # green
+            emoji="🚀"
+          else
+            color=15105570  # orange
+            emoji="🔧"
+          fi
+          sha_short="${SHA:0:7}"
+          first_line=$(printf '%s' "$COMMIT_MSG" | head -n1)
+          body=$(printf '%s' "$COMMIT_MSG" | tail -n +2 | sed -E '/^[[:space:]]*$/d' || true)
+          payload=$(jq -nc \
+            --arg branch  "$BRANCH" \
+            --arg sha     "$sha_short" \
+            --arg first   "$first_line" \
+            --arg body    "$body" \
+            --arg author  "$AUTHOR" \
+            --arg url     "$COMMIT_URL" \
+            --arg compare "$COMPARE_URL" \
+            --arg repo    "$REPO" \
+            --arg emoji   "$emoji" \
+            --argjson color "$color" \
+            '{embeds:[{
+               title: ($emoji + " " + $repo + " — merged into " + $branch + ": " + $first),
+               url: $url,
+               color: $color,
+               description: (if $body == "" then null else $body end),
+               fields: [
+                 {name:"Commit",  value:("[`"+$sha+"`]("+$url+")"), inline:true},
+                 {name:"Author",  value:$author, inline:true},
+                 {name:"Compare", value:("["+$sha+"]("+$compare+")"), inline:true}
+               ]
+             }]}')
+          curl -fsS -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL"

--- a/.github/workflows/discord-play-track-watch.yml
+++ b/.github/workflows/discord-play-track-watch.yml
@@ -1,0 +1,81 @@
+name: Discord — Play track watch
+
+# Poll the Play Developer API for track contents (internal / closed-testing / production)
+# and post to Discord when a versionCode appears in a new track — i.e. a promotion or
+# a fresh internal upload. Google Play has no webhooks for this, so we poll every 10
+# minutes. Previous state is stored as tracks.json on an orphan branch `state/play-tracks`
+# so we can diff across runs.
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write   # needed to push state to the orphan branch
+
+concurrency:
+  group: discord-play-track-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo (for the script)
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: pip install --quiet google-auth requests
+
+      - name: Restore state branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir state
+          cd state
+          git init -q
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          if git fetch --depth 1 origin state/play-tracks 2>/dev/null; then
+            git checkout -q -B state/play-tracks FETCH_HEAD
+            echo "HAS_BRANCH=true" >> "$GITHUB_ENV"
+          else
+            git checkout --orphan state/play-tracks
+            git rm -rf . 2>/dev/null || true
+            : > tracks.json
+            echo "HAS_BRANCH=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Watch + notify
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PACKAGE_NAME: radio.ks3ckc.ft8af
+        run: python .github/scripts/play_track_watch.py state/tracks.json
+
+      - name: Push updated state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd state
+          git add tracks.json
+          if git diff --cached --quiet; then
+            echo "No state changes."
+            exit 0
+          fi
+          if [[ "$HAS_BRANCH" == "true" ]]; then
+            git commit -q -m "Update play track state [skip discord]"
+          else
+            git commit -q -m "Initialize play track state [skip discord]"
+          fi
+          git push origin HEAD:refs/heads/state/play-tracks


### PR DESCRIPTION
## Summary

Two new GitHub Actions workflows post to a Discord releases channel:

- **`discord-merge-notify.yml`** — fires on push to `dev`/`main`, posts a branch-colored embed with short SHA, author, commit message, and compare link.
- **`discord-play-track-watch.yml`** — cron `*/10 * * * *` polls the Play Developer API (reusing `PLAY_SERVICE_ACCOUNT_JSON`) and posts when a `versionCode` appears in a new track. "Promotion" vs "new" is decided by whether the same `versionCode` was previously seen in a lower-rank track. Diff state is stored as `tracks.json` on an orphan branch `state/play-tracks`.

Google Play has no webhooks for track promotions, so polling is the only option that catches manual promotions done in the Play Console UI.

## Required setup before merging

1. In Discord: *Channel → Edit Channel → Integrations → Webhooks → New Webhook* in the releases channel (`1511813761701515544`). Copy the URL.
2. In GitHub repo settings: *Secrets and variables → Actions → New repository secret*, name `DISCORD_WEBHOOK_URL`, value = the webhook URL.

If `DISCORD_WEBHOOK_URL` is missing, both workflows fail loudly (won't silently no-op).

## Behavior notes

- **First watcher run is silent** — it snapshots current track state without notifying. Otherwise the first tick would post a Discord burst for every release currently in internal/closed/production. Real notifications start on the second tick.
- **Cron drift**: GitHub schedules can lag several minutes under load — expect promotion pings 10–20 min after clicking in the Play Console.
- **Idempotency**: if Discord posts succeed but state push fails, the next tick will re-emit the same diffs. Duplicate ping > missed ping.
- The state branch's commit messages are tagged `[skip discord]` as a belt-and-suspenders measure, though the merge-notify workflow only triggers on `dev`/`main` so state branch pushes wouldn't fire it anyway.

## Test plan

- [ ] Add `DISCORD_WEBHOOK_URL` secret
- [ ] Merge this PR into `dev`; verify a merge embed appears in Discord (orange `:wrench:` for dev)
- [ ] Manually trigger `Discord — Play track watch` via *Actions → Run workflow*; first run should log `First run — snapshotted state, not notifying.` and create `state/play-tracks` branch
- [ ] Trigger it again; should log `No track changes detected.`
- [ ] After the next Play Internal upload via `build-release.yml`, watch for a "New in Internal testing" embed within ~10–20 min
- [ ] Promote that release internal → closed in Play Console; watch for "Promoted Internal → Closed testing" embed
- [ ] Promote closed → production; watch for the final embed
- [ ] Eventually: `dev → main` PR merges should post a green `:rocket:` embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)