### PR TITLE
fix(qso): truthful CQ header, clear-target button, sheet back press

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -86,12 +86,26 @@ class ComposeMainActivity : ComponentActivity() {
         mainViewModel = MainViewModel.getInstance(this)
         ToastMessage.getInstance()
 
-        // Register back press handler for exit confirmation. The dialog itself
-        // is rendered in the Compose tree below; the back press just flips a
-        // state flag so the UI can show our styled ExitConfirmDialog rather
-        // than the stock platform AlertDialog.
+        // Register back press handler. Priority: dismiss the QSO sheet if
+        // it's open, otherwise show exit confirm. Without this, back-from-
+        // sheet tries to exit the whole app, which surprises users who
+        // expect back to peel off the foreground overlay first.
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
+                val sheetCs = mainViewModel.qsoSheetCallsign.value
+                val sheetMinimized = mainViewModel.qsoSheetMinimized.value == true
+                if (sheetCs != null && !sheetMinimized) {
+                    // Mirror DecodeScreen.onDismiss: minimize when a QSO is
+                    // live so the panel header stays reopenable; fully clear
+                    // otherwise.
+                    if (mainViewModel.ft8TransmitSignal.isActivated) {
+                        mainViewModel.qsoSheetMinimized.postValue(true)
+                    } else {
+                        mainViewModel.qsoSheetCallsign.postValue(null)
+                        mainViewModel.qsoSheetMinimized.postValue(false)
+                    }
+                    return
+                }
                 showExitConfirm.value = true
             }
         })

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -28,9 +28,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -86,23 +84,14 @@ fun ActiveQsoPanel(
 
     val liveCallsign = toCallsign?.callsign ?: "CQ"
 
-    // Remember the last real (non-CQ) callsign so the panel stays visible
-    // after resetToCQ() until isActivated goes false
-    var rememberedCallsign by remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(liveCallsign) {
-        if (liveCallsign != "CQ" && liveCallsign.isNotEmpty()) {
-            rememberedCallsign = liveCallsign
-        }
-    }
-    LaunchedEffect(isActivated) {
-        if (!isActivated) {
-            rememberedCallsign = null
-        }
-    }
-
-    // Use the live callsign if it's a real target, otherwise fall back to remembered
-    val displayCallsign = if (liveCallsign != "CQ" && liveCallsign.isNotEmpty()) liveCallsign else rememberedCallsign
+    // displayCallsign is the live target when one is set, null when calling CQ.
+    // We used to remember the last non-CQ callsign across resetToCQ() so the
+    // panel "stayed visible" after a QSO completed — but that made the panel
+    // lie ("Waiting for W1XYZ" while we were actually back to CQ). Now we
+    // just show real state: either a real target or the CQ state below.
+    val displayCallsign = liveCallsign.takeIf { it != "CQ" && it.isNotEmpty() }
     val hasTarget = displayCallsign != null
+    val isCallingCq = isActivated && !hasTarget
 
     // Synthesized TX log: append the message we're currently transmitting
     // the moment TX begins, so the operator sees it in the log without
@@ -212,12 +201,20 @@ fun ActiveQsoPanel(
             // minimized it, the header acts as the "reopen" affordance.
             StationHeader(
                 targetCallsign = when {
+                    isCallingCq -> "Calling CQ"
                     displayCallsign == null -> "Searching..."
                     isTransmitting -> "QSOing with $displayCallsign"
                     else -> "Waiting for $displayCallsign"
                 },
                 snr = if (displayCallsign != null) toCallsign?.snr else null,
                 onClick = if (displayCallsign != null) onReopenSheet else null,
+                onClear = if (displayCallsign != null) {
+                    {
+                        mainViewModel.ft8TransmitSignal.userResetToCQ()
+                        mainViewModel.qsoSheetCallsign.postValue(null)
+                        mainViewModel.qsoSheetMinimized.postValue(false)
+                    }
+                } else null,
             )
 
             Spacer(modifier = Modifier.height(6.dp))
@@ -248,7 +245,12 @@ fun ActiveQsoPanel(
 }
 
 @Composable
-private fun StationHeader(targetCallsign: String, snr: Int?, onClick: (() -> Unit)? = null) {
+private fun StationHeader(
+    targetCallsign: String,
+    snr: Int?,
+    onClick: (() -> Unit)? = null,
+    onClear: (() -> Unit)? = null,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -260,6 +262,7 @@ private fun StationHeader(targetCallsign: String, snr: Int?, onClick: (() -> Uni
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.weight(1f, fill = false),
         ) {
             Text(
                 text = "QSO",
@@ -285,14 +288,32 @@ private fun StationHeader(targetCallsign: String, snr: Int?, onClick: (() -> Uni
                 )
             }
         }
-        if (onClick != null) {
-            Text(
-                text = "tap to view ↗",
-                color = Accent,
-                fontSize = 10.sp,
-                fontFamily = GeistMonoFamily,
-                fontWeight = FontWeight.SemiBold,
-            )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            if (onClick != null) {
+                Text(
+                    text = "tap to view ↗",
+                    color = Accent,
+                    fontSize = 10.sp,
+                    fontFamily = GeistMonoFamily,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            if (onClear != null) {
+                // Tap target uses its own Box so the parent header's reopen
+                // clickable doesn't swallow this gesture.
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .clickable(onClick = onClear)
+                        .padding(horizontal = 6.dp, vertical = 4.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    FT8USIcons.Close(color = TextMuted, size = 14.dp)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Three small UX fixes around the active QSO panel and bottom sheet:

- **Header tells the truth about CQ state.** `ActiveQsoPanel` was remembering the last non-CQ callsign and keeping the header at "Waiting for W1XYZ" until `isActivated` flipped false — but `FT8TransmitSignal.resetToCQ()` had already moved the system back to CQ after the QSO completed. The header was lying. Now: when `liveCallsign == "CQ"` and we're activated, the header reads **"Calling CQ"**.
- **Clear-target (x) button** in the panel header. Tapping it calls `userResetToCQ()` (drops the target, clears the caller queue, leaves you activated) and dismisses any open sheet, so the operator can abandon a QSO mid-sequence without waiting it out.
- **Back press dismisses the QSO sheet first.** Previously back fired the exit-app confirm dialog from anywhere. Now back mirrors the sheet's own `onDismiss`: minimize when a QSO is live (so the panel reopen affordance survives), full-clear otherwise; only fall through to exit confirm when no sheet is open.

## Test plan

- [ ] Tap a decode -> "Call X". During the QSO, press back -> sheet minimizes, panel still reachable via the header; press back again -> exit dialog.
- [ ] Let the QSO complete through 73. Header flips from "QSOing/Waiting for X" to **"Calling CQ"** once `resetToCQ()` fires (no more lingering "Waiting for ..." after the contact).
- [ ] Tap a decode, then tap the x in the panel header before the sequence finishes -> target clears, system goes back to calling CQ, sheet closes.
- [ ] No regressions on the existing "tap to view" reopen affordance — clear and reopen taps don't swallow each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)