### PR TITLE
feat(settings): station ID dropdown for logging server

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import com.bg7yoz.ft8cn.GeneralVariables;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONStringer;
 import org.xmlpull.v1.XmlPullParser;
@@ -19,7 +20,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 enum ServiceType{
     Cloudlog,
@@ -28,6 +31,69 @@ enum ServiceType{
 
 public class ThirdPartyService {
     public static String TAG = "ThirdPartyService";
+
+    public static class StationProfile {
+        public final String stationId;
+        public final String profileName;
+        public final String callsign;
+        public final String gridsquare;
+
+        public StationProfile(String stationId, String profileName,
+                              String callsign, String gridsquare) {
+            this.stationId = stationId;
+            this.profileName = profileName;
+            this.callsign = callsign;
+            this.gridsquare = gridsquare;
+        }
+
+        public String displayLabel() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(stationId);
+            if (profileName != null && !profileName.isEmpty()) {
+                sb.append(" - ").append(profileName);
+            }
+            if (callsign != null && !callsign.isEmpty()) {
+                sb.append(" (").append(callsign);
+                if (gridsquare != null && !gridsquare.isEmpty()) {
+                    sb.append(", ").append(gridsquare);
+                }
+                sb.append(")");
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Fetches station profiles from a Cloudlog/Wavelog/Nextlog server.
+     * Returns an empty list on any failure (network, bad JSON, 404, etc.) — never null.
+     */
+    public static List<StationProfile> FetchCloudlogStations(String address, String apiKey) {
+        List<StationProfile> stations = new ArrayList<>();
+        if (address == null || address.isEmpty() || apiKey == null || apiKey.isEmpty()) {
+            return stations;
+        }
+        if (!address.endsWith("/")) {
+            address += "/";
+        }
+        try {
+            String url = address + "api/station_info/" + apiKey;
+            String result = sendGetRequest(url);
+            if (result == null || result.isEmpty()) return stations;
+            JSONArray arr = new JSONArray(result);
+            for (int i = 0; i < arr.length(); i++) {
+                JSONObject obj = arr.getJSONObject(i);
+                stations.add(new StationProfile(
+                        obj.optString("station_id", ""),
+                        obj.optString("station_profile_name", ""),
+                        obj.optString("station_callsign", ""),
+                        obj.optString("station_gridsquare", "")
+                ));
+            }
+        } catch (Exception e) {
+            Log.d(TAG, "FetchCloudlogStations error: " + e.getClass().getSimpleName());
+        }
+        return stations;
+    }
 
     private static String QSLRecordToADIF(QSLRecord qslRecord, ServiceType serv){
         StringBuilder logStr = new StringBuilder();

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -1248,6 +1248,26 @@ private fun CloudlogSettingsDialog(
     var isTesting by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
+    // Station picker state
+    var stationList by remember { mutableStateOf<List<ThirdPartyService.StationProfile>>(emptyList()) }
+    var isFetchingStations by remember { mutableStateOf(false) }
+    var manualStationEntry by remember { mutableStateOf(false) }
+    var showStationPicker by remember { mutableStateOf(false) }
+
+    // Auto-fetch stations on dialog open if credentials are present
+    LaunchedEffect(Unit) {
+        val addr = initialAddress.trim()
+        val key = initialApiKey.trim()
+        if (addr.isNotBlank() && key.isNotBlank()) {
+            isFetchingStations = true
+            val result = withContext(Dispatchers.IO) {
+                ThirdPartyService.FetchCloudlogStations(addr, key)
+            }
+            stationList = result
+            isFetchingStations = false
+        }
+    }
+
     val fieldColors = OutlinedTextFieldDefaults.colors(
         focusedTextColor = TextPrimary,
         unfocusedTextColor = TextPrimary,
@@ -1286,6 +1306,7 @@ private fun CloudlogSettingsDialog(
                 onValueChange = {
                     addressInput = it
                     testResult = null
+                    stationList = emptyList()
                 },
                 label = { Text("Server Address") },
                 placeholder = { Text("https://log.example.com/", color = TextFaint) },
@@ -1301,6 +1322,7 @@ private fun CloudlogSettingsDialog(
                 onValueChange = {
                     apiKeyInput = it
                     testResult = null
+                    stationList = emptyList()
                 },
                 label = { Text("API Key") },
                 placeholder = { Text("Your Cloudlog API key", color = TextFaint) },
@@ -1310,19 +1332,79 @@ private fun CloudlogSettingsDialog(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            OutlinedTextField(
-                value = stationIdInput,
-                onValueChange = {
-                    stationIdInput = it
-                    testResult = null
-                },
-                label = { Text("Station ID") },
-                placeholder = { Text("e.g. 1", color = TextFaint) },
-                singleLine = true,
-                colors = fieldColors,
-                textStyle = TextStyle(fontSize = 14.sp),
-                modifier = Modifier.fillMaxWidth(),
-            )
+            // Station ID: picker when stations are loaded, manual entry otherwise
+            if (isFetchingStations) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(vertical = 4.dp),
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.width(16.dp).height(16.dp),
+                        strokeWidth = 2.dp,
+                        color = Accent,
+                    )
+                    Text(
+                        text = "Loading stations...",
+                        color = TextMuted,
+                        fontSize = 13.sp,
+                    )
+                }
+            } else if (stationList.isNotEmpty() && !manualStationEntry) {
+                // Picker mode: show selected station as a clickable read-only field
+                val selectedLabel = stationList
+                    .firstOrNull { it.stationId == stationIdInput.text }
+                    ?.displayLabel()
+                    ?: stationIdInput.text.ifBlank { "Select a station" }
+
+                Column {
+                    Text(
+                        text = "Station ID",
+                        color = TextMuted,
+                        fontSize = 12.sp,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = selectedLabel,
+                        color = TextPrimary,
+                        fontSize = 14.sp,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(BgSurface3)
+                            .clickable { showStationPicker = true }
+                            .padding(12.dp),
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Enter manually",
+                        color = Accent,
+                        fontSize = 12.sp,
+                        modifier = Modifier.clickable { manualStationEntry = true },
+                    )
+                }
+            } else {
+                // Manual entry mode
+                OutlinedTextField(
+                    value = stationIdInput,
+                    onValueChange = { stationIdInput = it },
+                    label = { Text("Station ID") },
+                    placeholder = { Text("e.g. 1", color = TextFaint) },
+                    singleLine = true,
+                    colors = fieldColors,
+                    textStyle = TextStyle(fontSize = 14.sp),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (stationList.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Choose from server",
+                        color = Accent,
+                        fontSize = 12.sp,
+                        modifier = Modifier.clickable { manualStationEntry = false },
+                    )
+                }
+            }
 
             // Test Connection button
             Row(
@@ -1343,6 +1425,18 @@ private fun CloudlogSettingsDialog(
                             }
                             testResult = result
                             isTesting = false
+                            // On success, also fetch station profiles
+                            if (result) {
+                                isFetchingStations = true
+                                val stations = withContext(Dispatchers.IO) {
+                                    ThirdPartyService.FetchCloudlogStations(
+                                        addressInput.text.trim(),
+                                        apiKeyInput.text.trim(),
+                                    )
+                                }
+                                stationList = stations
+                                isFetchingStations = false
+                            }
                         }
                     },
                     enabled = !isTesting,
@@ -1393,6 +1487,22 @@ private fun CloudlogSettingsDialog(
                 }
             }
         }
+    }
+
+    // Station picker dialog
+    if (showStationPicker && stationList.isNotEmpty()) {
+        val items = stationList.map { it.displayLabel() }
+        val selectedIdx = stationList.indexOfFirst { it.stationId == stationIdInput.text }
+        ListPickerDialog(
+            title = "Station Profile",
+            items = items,
+            selectedIndex = selectedIdx.coerceAtLeast(0),
+            onDismiss = { showStationPicker = false },
+            onSelect = { index ->
+                stationIdInput = TextFieldValue(stationList[index].stationId)
+                showStationPicker = false
+            },
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

- Fetch station profiles from the Cloudlog/Wavelog `/api/station_info` endpoint and present them in a picker dialog instead of requiring manual numeric ID entry
- Auto-fetches stations when the dialog opens with existing credentials, and after a successful Test Connection
- Falls back gracefully to manual text entry when the server doesn't support the endpoint or returns an empty list
- Toggle between picker and manual entry modes via "Enter manually" / "Choose from server" links

Closes #77

## Test plan

- [x] Open Settings > Logging Server with existing Wavelog/Cloudlog config — verify stations auto-load
- [x] With fresh config: enter address + API key, click Test Connection — verify stations populate after "Pass"
- [ ] Select a station from the picker, save, verify the correct numeric ID persists
- [ ] Test "Enter manually" / "Choose from server" toggle
- [ ] Test with a server that doesn't have the endpoint — should fall back to manual entry
- [ ] Changing address or API key clears the station list

🤖 Generated with [Claude Code](https://claude.com/claude-code)