### PR TITLE
Fix CQ auto-answer locking onto stale/abandoned stations

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -875,8 +875,11 @@ public class FT8TransmitSignal {
         }
 
 
-        // exit if auto-call for watched messages is disabled
-        if (!GeneralVariables.autoCallFollow) {
+        // exit if both auto-call modes are off: Hunt (auto-answer any CQ) and
+        // auto-call of followed callsigns. These are now independent — Hunt no
+        // longer requires autoCallFollow — so the on-screen HUNT toggle is
+        // authoritative on its own.
+        if (!GeneralVariables.autoFollowCQ && !GeneralVariables.autoCallFollow) {
             return false;
         }
 
@@ -888,19 +891,25 @@ public class FT8TransmitSignal {
             return false;
         }
 
-        // watched callsigns are secondary priority; search the watched message list
-        // check if watched callsigns are CQing (TO:CQ, and not a callsign that already completed a QSO)
-        for (int i = GeneralVariables.transmitMessages.size() - 1; i >= 0; i--) {
-            Ft8Message msg = GeneralVariables.transmitMessages.get(i);
+        // Auto-answer / auto-call is secondary priority, after stations calling us
+        // directly (the two loops above). Scan ONLY this cycle's fresh decodes —
+        // never the long-lived transmitMessages history. Scanning history would
+        // re-select a CQ heard minutes ago (including the very station the operator
+        // just abandoned by pressing CQ), which made auto-answer "randomly" lock
+        // onto an inactive station and call it forever. Live decodes only, matching
+        // the "calling me" loops.
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            Ft8Message msg = messages.get(i);
             if (isExcludeMessage(msg)) continue;// check if this is an excluded message
 
-            // is CQing, FROM is a watched callsign, and not in the successful QSO list
-            if ((msg.checkIsCQ()// is CQing
-                    && ((GeneralVariables.autoCallFollow && GeneralVariables.autoFollowCQ)// auto-call CQ
-                    || GeneralVariables.callsignInFollow(msg.getCallsignFrom()))// is watched
+            // is CQing, not already worked, not myself, and either Hunt mode is on
+            // (auto-answer any CQ) or this is a followed callsign we auto-call
+            if (msg.checkIsCQ()// is CQing
+                    && (GeneralVariables.autoFollowCQ// Hunt: auto-answer any CQ
+                    || (GeneralVariables.autoCallFollow
+                    && GeneralVariables.callsignInFollow(msg.getCallsignFrom())))// followed callsign
                     && !GeneralVariables.checkQSLCallsign(msg.getCallsignFrom())// not previously contacted successfully
-                    && !GeneralVariables.checkIsMyCallsign(msg.callsignFrom))) {// not myself
-                    //&& !msg.callsignFrom.equals(GeneralVariables.myCallsign))) {// not myself
+                    && !GeneralVariables.checkIsMyCallsign(msg.callsignFrom)) {// not myself
 
                 resetTargetReport();
                 setTransmit(new TransmitCallsign(msg.i3, msg.n3, msg.getCallsignFrom(), msg.freq_hz

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -51,6 +52,10 @@ fun FT8USApp(mainViewModel: MainViewModel) {
 
     // QSO panel expand/collapse state
     var qsoPanelExpanded by rememberSaveable { mutableStateOf(false) }
+
+    // Hunt / auto-answer-CQ mode. Mirrors GeneralVariables.autoFollowCQ (also
+    // editable in Settings, which provides the persisted default at startup).
+    var huntEnabled by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
 
     // Frequency picker sheet state
     var showFrequencyPicker by rememberSaveable { mutableStateOf(false) }
@@ -135,6 +140,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                 isActivated = isActivated,
                 frequencyLabel = frequencyLabel,
                 txSlot = txSlot,
+                huntEnabled = huntEnabled,
                 expanded = qsoPanelExpanded,
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {
@@ -153,6 +159,20 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     val newSlot = if (current == 0) 1 else 0
                     mainViewModel.ft8TransmitSignal.sequential = newSlot
                     mainViewModel.ft8TransmitSignal.mutableSequential.postValue(newSlot)
+                },
+                onToggleHunt = {
+                    val newVal = !huntEnabled
+                    huntEnabled = newVal
+                    GeneralVariables.autoFollowCQ = newVal
+                    mainViewModel.databaseOpr.writeConfig(
+                        "autoFollowCQ", if (newVal) "1" else "0", null,
+                    )
+                    Toast.makeText(
+                        context,
+                        if (newVal) "Hunt on — auto-answering CQs"
+                        else "Hunt off — running CQ, working answers only",
+                        Toast.LENGTH_SHORT,
+                    ).show()
                 },
                 onOpenFrequencyPicker = { showFrequencyPicker = true },
                 onToggleExpand = { qsoPanelExpanded = !qsoPanelExpanded },

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -36,10 +36,12 @@ fun TxStrip(
     isActivated: Boolean,
     frequencyLabel: String,
     txSlot: Int,
+    huntEnabled: Boolean,
     expanded: Boolean = false,
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
     onToggleSlot: () -> Unit,
+    onToggleHunt: () -> Unit,
     onOpenFrequencyPicker: () -> Unit,
     onToggleExpand: () -> Unit = {},
     modifier: Modifier = Modifier,
@@ -134,6 +136,30 @@ fun TxStrip(
                     size = 12.dp,
                     color = TextMuted,
                     strokeWidth = 2f,
+                )
+            }
+
+            // HUNT (auto-answer CQ) toggle pill. On = proactively call stations
+            // calling CQ; off = run CQ and only work stations that answer us.
+            val huntBg = if (huntEnabled) Signal.copy(alpha = 0.18f) else BgSurface3
+            val huntColor = if (huntEnabled) Signal else TextMuted
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(huntBg)
+                    .clickable { onToggleHunt() }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "HUNT",
+                    color = huntColor,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
+                    maxLines = 1,
+                    softWrap = false,
                 )
             }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -928,8 +928,8 @@ fun SettingsScreen(
                 GlassCard(modifier = Modifier.fillMaxWidth()) {
                     Column {
                         SettingsRow(
-                            label = "Auto-call CQ",
-                            description = "Automatically call stations calling CQ",
+                            label = "Hunt (auto-answer CQ)",
+                            description = "Proactively call stations calling CQ. Same as the HUNT button on the TX bar. Off = run CQ and work only stations that answer you.",
                             toggle = autoFollowCQ,
                             onToggleChange = { checked ->
                                 autoFollowCQ = checked


### PR DESCRIPTION
## Problem

After calling CQ, the app would "randomly" pick a station and call it
indefinitely, and that station would stay selected even after pressing
CQ again to start fresh.

## Root cause

The auto-answer ("hunt") branch in `checkCQMeOrFollowCQMessage()` scanned
`GeneralVariables.transmitMessages` — a long-lived accumulator of up to
3000 decoded messages — instead of the current decode cycle. With
`autoFollowCQ` on by default, it would re-select a CQ heard minutes ago.
Because an abandoned (incomplete) QSO never enters the QSL list, the
`checkQSLCallsign` filter never excluded the station the operator had
just dropped by pressing CQ, so it re-locked onto it. The "calling me"
loops directly above it already scan only the fresh cycle — the hunt
loop was the lone inconsistency.

## Changes

- **Fix:** the auto-answer loop now scans only this cycle's fresh
  `messages`, so it reacts only to stations actually CQing right now.
  Pressing CQ to drop a contact now sticks.
- **Decouple modes:** Hunt (`autoFollowCQ`) no longer requires the
  Auto-call-Followed master gate (`autoCallFollow`); the two are now
  independent.
- **UX:** a `HUNT` toggle pill on the TX bar, bound to the same persisted
  `autoFollowCQ` setting (Settings still sets the startup default):
  - **Off** — run CQ: work only stations that answer you, return to CQ
    after each QSO.
  - **On** — hunt: proactively call live CQs.
  - Settings row relabeled "Hunt (auto-answer CQ)" and cross-referenced
    to the on-bar button.

## Testing

Compiles clean (`compileDebugKotlin` + `compileDebugJavaWithJavac`).
Not yet bench-tested on the radio — no device was attached at build
time. On-air checks to run:

- Hunt off, press CQ → calls CQ, works answerers, returns to CQ and
  stays; pressing CQ mid-contact drops the station and does not re-grab
  it.
- Hunt on → answers a CQ live in the current cycle; after a QSO moves to
  the next live CQ, not a stale one.
- Toggle HUNT, reopen Settings → "Hunt (auto-answer CQ)" matches.

## Note (pre-existing, not addressed here)

With the default `noReplyLimit = 0` ("ignore"), a hunted station that
never replies is still called indefinitely with no automatic give-up.
Left as-is; can add an auto-give-up after N unanswered calls as a
follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
