### PR TITLE
Add Discord invite link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **FT8 on Android — modernized.**
 
-🌐 **[ft8af.app](https://ft8af.app)**
+🌐 **[ft8af.app](https://ft8af.app)** · 💬 **[Join the Discord](https://discord.gg/tz4spm5nWB)**
 
 A fork of [FT8CN](https://github.com/N0BOY/FT8CN) that takes the excellent original and brings it forward: a Jetpack Compose UI, full English localization, dozens of bug fixes, and a pile of new operating features built for real on-the-air use.
 


### PR DESCRIPTION
@
Adds a Discord community invite link next to the website link at the top of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@