### PR TITLE
Stop TX audio immediately when STOP is pressed

### DIFF
--- a/ft8cn/app/src/main/cpp/usb_audio_capture.cpp
+++ b/ft8cn/app/src/main/cpp/usb_audio_capture.cpp
@@ -437,8 +437,27 @@ struct OutputSession {
     std::atomic<int>      firstError{0};   // non-zero = first libusb error code seen
 };
 
+// Cancel signal for an in-progress nativeWrite. Set from the main thread via
+// nativeCancelWrite() when the user presses STOP; observed by the transmit
+// worker thread blocked in nativeWrite's drain loop and by onOutputComplete,
+// which together stop resubmitting iso transfers and cancel the in-flight ones
+// so audio to the device halts (well under 100ms later). g_outputCtx lets the
+// cancel JNI wake the drain loop immediately instead of waiting out its 50ms
+// timeout. There is only ever one nativeWrite in flight (one TX per cycle), so
+// a single global pair is sufficient.
+std::atomic<bool>            g_outputCancel{false};
+std::atomic<libusb_context*> g_outputCtx{nullptr};
+
 void LIBUSB_CALL onOutputComplete(libusb_transfer* xfer) {
     auto* s = static_cast<OutputSession*>(xfer->user_data);
+
+    // User pressed STOP: retire this transfer instead of refilling it. Once all
+    // in-flight transfers retire this way, nativeWrite's drain loop exits and
+    // its cleanup cancels anything still pending.
+    if (g_outputCancel.load(std::memory_order_acquire)) {
+        s->inFlight.fetch_sub(1, std::memory_order_acq_rel);
+        return;
+    }
 
     if (xfer->status != LIBUSB_TRANSFER_COMPLETED) {
         int expect = 0;
@@ -498,6 +517,10 @@ Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeWrite(
     if (!pcmArray) return LIBUSB_ERROR_INVALID_PARAM;
     if (maxPacketSize <= 0) return LIBUSB_ERROR_INVALID_PARAM;
 
+    // Clear any stale cancel from a prior TX so this transmission isn't
+    // immediately aborted before it starts.
+    g_outputCancel.store(false, std::memory_order_release);
+
     // USB full-speed iso = 1 packet per 1ms frame. The amount of audio data
     // per packet must equal the *negotiated* sample rate × channels × bytes,
     // not the endpoint's wMaxPacketSize. The previous code used maxPktSize
@@ -526,6 +549,8 @@ Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeWrite(
         LOGE("nativeWrite: libusb_init: %s", libusb_error_name(rc));
         return rc;
     }
+    // Publish the context so nativeCancelWrite() can wake our drain loop.
+    g_outputCtx.store(ctx, std::memory_order_release);
 
     libusb_device_handle* handle = nullptr;
     rc = libusb_wrap_sys_device(ctx, (intptr_t)fd, &handle);
@@ -616,6 +641,10 @@ Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeWrite(
     // Drain. Iso transfers are paced by the device's bandwidth allocation,
     // so this naturally takes ~ pcmLen / (sampleRate * channels * 2) seconds.
     while (s.inFlight.load(std::memory_order_acquire) > 0) {
+        if (g_outputCancel.load(std::memory_order_acquire)) {
+            LOGI("nativeWrite: cancel requested, aborting TX");
+            break;  // cleanup below cancels the still-in-flight transfers
+        }
         timeval tv{0, 50000};  // 50ms
         rc = libusb_handle_events_timeout_completed(ctx, &tv, nullptr);
         if (rc != 0 && rc != LIBUSB_ERROR_INTERRUPTED) {
@@ -639,6 +668,8 @@ Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeWrite(
     }
 
     env->ReleaseByteArrayElements(pcmArray, pcmBytes, JNI_ABORT);
+    // Unpublish before exit so a late cancel can't poke a freed context.
+    g_outputCtx.store(nullptr, std::memory_order_release);
     libusb_close(handle);
     libusb_exit(ctx);
 
@@ -646,4 +677,17 @@ Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeWrite(
     LOGI("nativeWrite: done, firstError=%d (%s)",
          err, err == 0 ? "OK" : libusb_error_name(err));
     return err;
+}
+
+// Abort an in-progress nativeWrite as fast as possible. Safe to call from any
+// thread (and a no-op if no write is running). Sets the cancel flag, then nudges
+// the event loop so the drain loop notices now rather than after its 50ms tick.
+extern "C" JNIEXPORT void JNICALL
+Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeCancelWrite(
+        JNIEnv* /*env*/, jclass /*clazz*/) {
+    g_outputCancel.store(true, std::memory_order_release);
+    libusb_context* ctx = g_outputCtx.load(std::memory_order_acquire);
+    if (ctx) {
+        libusb_interrupt_event_handler(ctx);
+    }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -18,6 +18,7 @@ import android.media.AudioTrack;
 import android.util.Log;
 
 import com.bg7yoz.ft8cn.wave.UsbAudioDevice;
+import com.bg7yoz.ft8cn.wave.UsbAudioNative;
 
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Observer;
@@ -1143,6 +1144,12 @@ public class FT8TransmitSignal {
         }
 
         if (!transmitting) {//stop transmitting
+            // Abort any in-progress USB-audio write so TX audio stops immediately.
+            // The native/fallback writers run on the transmit worker thread and
+            // would otherwise drain the full ~12.6s message; this signals them to
+            // bail out. When the writer returns, playViaUsbAudio's afterPlayAudio()
+            // drops PTT. No-op when not transmitting over USB audio.
+            UsbAudioNative.cancelWrite();
             if (audioTrack != null) {
                 if (audioTrack.getState() != AudioTrack.STATE_UNINITIALIZED) {
                     audioTrack.pause();
@@ -1150,6 +1157,11 @@ public class FT8TransmitSignal {
                 if (onDoTransmitted != null) {//notify that transmitting has stopped
                     onDoTransmitted.onAfterTransmit(getFunctionCommand(functionOrder), functionOrder);
                 }
+                // Release the paused track: its completion marker won't fire once
+                // paused, so afterPlayAudio() would never run for this branch and
+                // the track would leak until the next TX overwrites the field.
+                audioTrack.release();
+                audioTrack = null;
             }
         }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
@@ -480,6 +480,10 @@ public class UsbAudioDevice {
     public boolean writeAudio(float[] audioData, int sourceSampleRate) {
         if (endpointOut == null || connection == null) return false;
 
+        // Start this transmission with a clear cancel flag. STOP sets it (via
+        // UsbAudioNative.cancelWrite) to abort either the native or fallback path.
+        UsbAudioNative.resetCancel();
+
         // Resample to device's output rate
         float[] resampled;
         if (sourceSampleRate != outputSampleRate) {
@@ -542,6 +546,12 @@ public class UsbAudioDevice {
         int offset = 0;
 
         while (offset < pcmData.length) {
+            // STOP pressed mid-transmission: abort between chunks so audio halts
+            // immediately instead of draining the full ~12.6s message.
+            if (UsbAudioNative.writeCancelled) {
+                Log.d(TAG, "writeAudio cancelled at offset " + offset);
+                return false;
+            }
             int chunkSize = Math.min(packetSize, pcmData.length - offset);
             ByteBuffer buf = ByteBuffer.allocateDirect(chunkSize);
             buf.order(ByteOrder.LITTLE_ENDIAN);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioNative.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioNative.java
@@ -38,9 +38,37 @@ public final class UsbAudioNative {
 
     private UsbAudioNative() {}
 
+    /**
+     * Set true by {@link #cancelWrite()} when the user presses STOP, cleared by
+     * {@link #resetCancel()} at the start of each transmission. Read by the
+     * {@code UsbRequest} fallback loop in {@link UsbAudioDevice#writeAudio} so it
+     * can break out between chunks. The libusb path uses the native cancel flag
+     * instead (see {@link #nativeCancelWrite()}).
+     */
+    public static volatile boolean writeCancelled = false;
+
     /** Whether {@code libft8af_usb.so} was loaded at process start. */
     public static boolean isAvailable() {
         return LIBRARY_LOADED;
+    }
+
+    /** Clear the cancel flag before a new transmission. */
+    public static void resetCancel() {
+        writeCancelled = false;
+    }
+
+    /**
+     * Abort an in-progress transmission immediately. Safe to call from the UI
+     * thread while a write is blocked on the transmit worker thread: flags the
+     * Java fallback loop and, when the native lib is present, signals the libusb
+     * drain loop to cancel its in-flight iso transfers. No-op if nothing is
+     * transmitting.
+     */
+    public static void cancelWrite() {
+        writeCancelled = true;
+        if (LIBRARY_LOADED) {
+            nativeCancelWrite();
+        }
     }
 
     /**
@@ -146,4 +174,13 @@ public final class UsbAudioNative {
             int outputChannels,
             int outputBytesPerSample,
             byte[] pcmData);
+
+    /**
+     * Request that an in-progress {@link #nativeWrite} abort. Sets a native
+     * cancel flag and wakes the libusb event loop so the blocked write returns
+     * within ~tens of ms, cancelling its in-flight iso transfers. Safe to call
+     * from any thread; a no-op if no write is running. Prefer {@link #cancelWrite()}
+     * which also covers the Java fallback path.
+     */
+    public static native void nativeCancelWrite();
 }


### PR DESCRIPTION
## Problem

Pressing **STOP** mid-transmission did not stop TX on the USB-direct audio path (the path the app uses with USB radios). STOP flows `setActivated(false)` → `setTransmitting(false)`, which only called `audioTrack.pause()`. On the USB path `audioTrack` is `null` and the transmit worker thread is blocked inside the native `nativeWrite` libusb drain loop with **no cancellation path**, so audio and PTT kept going for the full ~12.6 s message.

## Fix

Add a cancel signal that reaches all local-audio TX paths, fired from `setTransmitting(false)`:

- **`usb_audio_capture.cpp`** — `g_outputCancel` atomic + `g_outputCtx`. `nativeWrite` clears the flag on entry and publishes its libusb context; `onOutputComplete` retires transfers instead of refilling when cancelled; the drain loop breaks on the flag (the existing cleanup then cancels the in-flight iso transfers, which is what silences the device). New `nativeCancelWrite()` sets the flag and calls `libusb_interrupt_event_handler()` to wake the loop immediately rather than waiting out its 50 ms tick.
- **`UsbAudioNative.java`** — `nativeCancelWrite()` declaration, `writeCancelled` flag, and `cancelWrite()` / `resetCancel()` helpers covering both the native and Java-fallback paths.
- **`UsbAudioDevice.writeAudio`** — `resetCancel()` on entry; the `UsbRequest` fallback loop bails out between chunks when cancelled.
- **`FT8TransmitSignal.setTransmitting(false)`** — calls `UsbAudioNative.cancelWrite()` (its return triggers `afterPlayAudio()` → PTT drop) and releases the paused `AudioTrack` to avoid leaking it on the default-sink path.

Net stop latency is well under 100 ms (interrupt wakes the loop now; only the ~32 ms already buffered in-flight remains).

## Testing

- Builds clean for all four ABIs; installed on a Pixel 8.
- On-device verification to do: start a CQ TX, press STOP mid-transmission, confirm audio/PTT stop within a fraction of a second. `debug.log` shows `playViaUsbAudio: writeAudio returned` right after STOP; logcat tag `ft8af_usb_capture` logs `cancel requested, aborting TX`. Regression: a TX left to run still sends the full message and decodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)