### PR TITLE
Fix waterfall decode-label smearing and black spectrum strip

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ColumnarView.java
@@ -127,7 +127,11 @@ public class ColumnarView extends View {
             }
             int val = (i + 1 < data.length) ? Math.max(data[i], data[i + 1]) : data[i];
             colRect.top = getHeight() - Math.round(val * rateHeight);
-            colRect.right = colRect.left + width - spacing;
+            // Guarantee at least a 1px-wide bar. With a wide spectrum span the
+            // bin count can exceed the pixel width (e.g. 560 bins across ~1080px
+            // gives width=1), so width - spacing collapses to 0 and every bar
+            // draws as a zero-width rect — the whole strip renders black.
+            colRect.right = colRect.left + Math.max(1, width - spacing);
             colRect.bottom = getHeight();
             newData.add(colRect);
         }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -68,7 +68,6 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
     var touchedFreqHz by remember { mutableIntStateOf(-1) }
     var updateCount by remember { mutableIntStateOf(0) }
 
-    val isDecoding by mainViewModel.mutableIsDecoding.observeAsState(false)
     val isTransmitting by mainViewModel.ft8TransmitSignal.mutableIsTransmitting.observeAsState(false)
     val txFreq by GeneralVariables.mutableBaseFrequency.observeAsState(GeneralVariables.getBaseFrequency())
     val spectrumWidth by GeneralVariables.mutableSpectrumWidth.observeAsState(GeneralVariables.getSpectrumWidth())
@@ -109,9 +108,12 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             }
 
             viewHolder.waterfall?.let { wView ->
-                val currentlyDecoding = mainViewModel.mutableIsDecoding.value ?: false
+                // drawMessage is armed elsewhere, edge-triggered off the
+                // decode-state LiveData (see decodingObserver below). The
+                // view stamps the labels onto its scrolling bitmap on the
+                // first setWaveData after it's armed, then self-resets the
+                // flag, so labels appear exactly once per decode cycle.
                 wView.setSpectrumWidth(GeneralVariables.getSpectrumWidth())
-                wView.setDrawMessage(mainViewModel.markMessage && !currentlyDecoding)
                 wView.setTxFrequency(currentTxFreq)
                 wView.setTxActive(currentTxActive)
                 val messages = if (mainViewModel.markMessage) mainViewModel.currentMessages else null
@@ -119,9 +121,23 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
                 wView.invalidate()
             }
         }
+        // Arm the decode-label draw edge-triggered off the decode-state
+        // LiveData, exactly like the old SpectrumFragment did
+        // (setDrawMessage(!isDecoding)). A decode lasts only ~60ms and can
+        // fall entirely between two ~160ms audio frames, so sampling
+        // isDecoding inside the audio observer misses the transition and the
+        // labels never draw. LiveData delivers every true/false transition on
+        // the main thread regardless of audio cadence. currentMessages is
+        // populated before isDecoding goes false (MainViewModel), so by the
+        // time we arm the draw the labels are ready for the next setWaveData.
+        val decodingObserver = Observer<Boolean> { decoding ->
+            viewHolder.waterfall?.setDrawMessage(!decoding && mainViewModel.markMessage)
+        }
         mainViewModel.spectrumListener.mutableDataBuffer.observeForever(observer)
+        mainViewModel.mutableIsDecoding.observeForever(decodingObserver)
         onDispose {
             mainViewModel.spectrumListener.mutableDataBuffer.removeObserver(observer)
+            mainViewModel.mutableIsDecoding.removeObserver(decodingObserver)
             viewHolder.columnar = null
             viewHolder.waterfall = null
         }
@@ -179,8 +195,6 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
         // Main waterfall display
         WaterfallCanvas(
             spectrumWidth = spectrumWidth,
-            showMessages = showMessages,
-            isDecoding = isDecoding,
             txFrequency = txFreq,
             txActive = isTransmitting,
             onViewCreated = { viewHolder.waterfall = it },
@@ -321,8 +335,6 @@ private fun ColumnarStrip(
 @Composable
 private fun WaterfallCanvas(
     spectrumWidth: Int,
-    showMessages: Boolean,
-    isDecoding: Boolean,
     txFrequency: Float,
     txActive: Boolean,
     onViewCreated: (WaterfallView) -> Unit,
@@ -330,6 +342,10 @@ private fun WaterfallCanvas(
     onTouchUp: (freqHz: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Note: drawMessage is NOT set here. It is armed exclusively by the audio
+    // observer in WaterfallScreen, edge-triggered once per decode cycle.
+    // Re-arming it on recomposition would re-stamp labels onto the scrolling
+    // bitmap and smear them down the waterfall.
     AndroidView(
         factory = { context ->
             WaterfallView(context).apply {
@@ -339,7 +355,6 @@ private fun WaterfallCanvas(
                 )
                 setBackgroundColor(0xFF000000.toInt())
                 setSpectrumWidth(spectrumWidth)
-                setDrawMessage(showMessages && !isDecoding)
                 setTxFrequency(txFrequency)
                 setTxActive(txActive)
 
@@ -363,7 +378,6 @@ private fun WaterfallCanvas(
         },
         update = { view ->
             view.setSpectrumWidth(spectrumWidth)
-            view.setDrawMessage(showMessages && !isDecoding)
             view.setTxFrequency(txFrequency)
             view.setTxActive(txActive)
         },


### PR DESCRIPTION
Fixes two rendering bugs on the Waterfall screen.  Closes issue #109 

## 1. Decode labels smearing down the waterfall

**Symptom:** decoded callsigns rendered as many overlapping copies marching down the fall instead of a single trail.

**Cause:** `WaterfallView` scrolls its bitmap down each audio frame (~160 ms) and *bakes* the labels into it, drawing them once then self-resetting `drawMessage = false` (`WaterfallView.java:325`). It relies on the caller arming `drawMessage` **once per decode cycle**. The original `SpectrumFragment` did this edge-triggered on the decode-state LiveData (`setDrawMessage(!isDecoding)`); the Compose `WaterfallScreen` instead re-armed it every frame in the audio observer and again on every recomposition, so every frame re-stamped the labels.

**Fix:** observe `mutableIsDecoding` directly (`observeForever`) and arm the one-shot draw on the decode-state edge — exactly like the original. Sampling `isDecoding` inside the audio observer is unreliable: a decode lasts only ~60 ms and can fall entirely between two ~160 ms audio frames, so the transition is never seen and labels never draw. `currentMessages` is populated before `isDecoding` goes false (`MainViewModel.java:376`/`:384`), so labels are ready when armed. Removed the per-frame and recomposition `setDrawMessage` calls and the now-dead `showMessages`/`isDecoding` plumbing.

## 2. Top spectrum strip rendering black

**Symptom:** the columnar spectrum strip above the waterfall was solid black at the default 3500 Hz span.

**Cause:** audio frames are 160 ms at 12 kHz = 1920 samples → 960 FFT bins; `binsToShow = round(3500/6000 × 960) = 560`. Bar `width = getWidth()/binsToShow = 1080/560 = 1 px`, and the right edge was `left + width − spacing = left + 1 − 1` — a **zero-width** rect, so every bar drew nothing. (Narrower spans gave `width = 2` and 1 px bars showed, which is why it wasn't always visible.)

**Fix:** clamp bar width to at least 1 px.

## Testing

Built and installed on a Pixel 8. Verified on-device:
- Decode labels now appear as a single row at each 15 s decode boundary and scroll down as one band — no smearing.
- The top spectrum strip now renders bars across the full 0–3500 Hz span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
