### PR TITLE
Make decode-list highlights configurable; add NEW POTA highlight

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -265,6 +265,15 @@ public class GeneralVariables {
     public static ArrayList<String> QSL_Callsign_list = new ArrayList<>();//Successfully QSL'd callsigns
     public static ArrayList<String> QSL_Callsign_list_other_band = new ArrayList<>();//Successfully QSL'd callsigns on other bands
     public static HashSet<String> QSL_Grid_list = new HashSet<>();//Distinct worked 4-char Maidenhead grids (any band)
+    public static HashSet<String> QSL_Pota_list = new HashSet<>();//Distinct hunted POTA park refs (UPPER), any band
+
+    // Decode-list highlight toggles (Settings → Decode Highlights). Gate the
+    // status pill shown for each worked-before category in resolveQsoStatus().
+    public static boolean highlightNewDxcc = true;//Highlight stations from an unworked DXCC entity
+    public static boolean highlightNewGrid = false;//Off by default — most grids are "new", so it's noisy
+    public static boolean highlightNewBand = true;//Highlight stations worked only on other bands
+    public static boolean highlightWorked = true;//Tag stations already worked
+    public static boolean highlightPota = true;//Highlight spotted POTA activators (new parks stand out)
 
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns
@@ -359,6 +368,14 @@ public class GeneralVariables {
     public static boolean checkQSLGrid(String grid) {
         if (grid == null || grid.length() < 4) return false;
         return QSL_Grid_list.contains(grid.substring(0, 4).toUpperCase());
+    }
+
+    /**
+     * Check if a POTA park reference (e.g. "K-1234") has been previously hunted (any band).
+     */
+    public static boolean checkQSLPark(String ref) {
+        if (ref == null || ref.isEmpty()) return false;
+        return QSL_Pota_list.contains(ref.toUpperCase());
     }
 
     /**

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2081,6 +2081,25 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             }
             cursor.close();
             GeneralVariables.QSL_Grid_list = grids;
+
+            // Load distinct hunted POTA park refs (any band) into in-memory set.
+            // sig/sig_info may be absent on some upgraded installs (see note in
+            // onUpgrade), so guard the query defensively.
+            try {
+                Cursor potaCursor = db.rawQuery("select distinct upper(sig_info) as p from QSLTable" +
+                        " where sig='POTA' and sig_info is not null and sig_info<>''", null);
+                java.util.HashSet<String> parks = new java.util.HashSet<>();
+                while (potaCursor.moveToNext()) {
+                    String p = potaCursor.getString(0);
+                    if (p != null && !p.isEmpty()) {
+                        parks.add(p);
+                    }
+                }
+                potaCursor.close();
+                GeneralVariables.QSL_Pota_list = parks;
+            } catch (Exception ignored) {
+                GeneralVariables.QSL_Pota_list = new java.util.HashSet<>();
+            }
         }
 
     }
@@ -2436,6 +2455,22 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 if (name.equalsIgnoreCase("spectrumWidth")) {
                     GeneralVariables.setSpectrumWidth(result.equals("") ? 3500 : Integer.parseInt(result));
+                }
+
+                if (name.equalsIgnoreCase("highlightNewDxcc")) {
+                    GeneralVariables.highlightNewDxcc = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("highlightNewGrid")) {
+                    GeneralVariables.highlightNewGrid = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("highlightNewBand")) {
+                    GeneralVariables.highlightNewBand = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("highlightWorked")) {
+                    GeneralVariables.highlightWorked = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("highlightPota")) {
+                    GeneralVariables.highlightPota = result.equals("1");
                 }
 
             }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/CallingListAdapter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/CallingListAdapter.java
@@ -346,16 +346,18 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
         }
 
         int colorRes;
-        if (msg.fromDxcc) {
+        if (GeneralVariables.highlightNewDxcc && msg.fromDxcc) {
             colorRes = R.color.stripe_new_dxcc;
-        } else if (msg.maidenGrid != null
+        } else if (GeneralVariables.highlightNewGrid
+                && msg.maidenGrid != null
                 && msg.maidenGrid.length() >= 4
                 && !GeneralVariables.checkQSLGrid(msg.maidenGrid)) {
             colorRes = R.color.stripe_new_grid;
-        } else if (!msg.isQSL_Callsign
+        } else if (GeneralVariables.highlightNewBand
+                && !msg.isQSL_Callsign
                 && holder.otherBandIsQso) {
             colorRes = R.color.stripe_new_band;
-        } else if (msg.isQSL_Callsign) {
+        } else if (GeneralVariables.highlightWorked && msg.isQSL_Callsign) {
             colorRes = R.color.stripe_worked;
         } else {
             colorRes = R.color.stripe_none;

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/StatusPill.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/StatusPill.kt
@@ -51,6 +51,12 @@ enum class QsoStatus(
         Color(0x1F4ADE80),  // rgba(74,222,128,0.12)
         Color(0x474ADE80),  // rgba(74,222,128,0.28)
     ),
+    NEW_POTA(
+        "NEW POTA",
+        StatusNeeded,
+        Color(0x1FFFAF5E),  // amber — a park you haven't hunted yet
+        Color(0x47FFAF5E),
+    ),
     SOTA(
         "SOTA",
         StatusConfirmed,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -344,18 +344,23 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
 
     // Spotted-on-pota.app activators frequently CQ without the "POTA" suffix
     // because their full call already eats the budget. Treat them as POTA so
-    // hunters can recognise them at a glance.
-    val isSpottedPotaActivator =
-        radio.ks3ckc.ft8us.pota.PotaSpotsRepository.parkRefFor(message.callsignFrom) != null
+    // hunters can recognise them at a glance. When we have the park ref and it's
+    // not in the hunted log, surface it as a distinct NEW POTA.
+    val parkRef = radio.ks3ckc.ft8us.pota.PotaSpotsRepository.parkRefFor(message.callsignFrom)
+    val isPota = isCQ && (modifier == "POTA" || parkRef != null)
+    val newPota = isPota && parkRef != null && !GeneralVariables.checkQSLPark(parkRef)
 
+    // Each worked-before category is gated by a user toggle (Settings → Decode
+    // Highlights). A disabled category falls through to the next in priority.
     return when {
         isToMe -> QsoStatus.PENDING
-        isCQ && (modifier == "POTA" || isSpottedPotaActivator) -> QsoStatus.POTA
+        GeneralVariables.highlightPota && isPota ->
+            if (newPota) QsoStatus.NEW_POTA else QsoStatus.POTA
         isCQ && modifier == "SOTA" -> QsoStatus.SOTA
-        message.fromDxcc -> QsoStatus.NEW
-        newGrid -> QsoStatus.NEW_GRID
-        newBand -> QsoStatus.NEW_BAND
-        isWorked -> QsoStatus.WORKED
+        GeneralVariables.highlightNewDxcc && message.fromDxcc -> QsoStatus.NEW
+        GeneralVariables.highlightNewGrid && newGrid -> QsoStatus.NEW_GRID
+        GeneralVariables.highlightNewBand && newBand -> QsoStatus.NEW_BAND
+        GeneralVariables.highlightWorked && isWorked -> QsoStatus.WORKED
         isCQ -> QsoStatus.CQ
         else -> null
     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -118,6 +118,13 @@ fun SettingsScreen(
     var saveSWLMessage by remember { mutableStateOf(GeneralVariables.saveSWLMessage) }
     var saveSWL_QSO by remember { mutableStateOf(GeneralVariables.saveSWL_QSO) }
 
+    // Decode-list highlight toggles
+    var highlightNewDxcc by remember { mutableStateOf(GeneralVariables.highlightNewDxcc) }
+    var highlightNewGrid by remember { mutableStateOf(GeneralVariables.highlightNewGrid) }
+    var highlightNewBand by remember { mutableStateOf(GeneralVariables.highlightNewBand) }
+    var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
+    var highlightPota by remember { mutableStateOf(GeneralVariables.highlightPota) }
+
     // Observe serial ports for USB Cable picker
     val serialPorts by mainViewModel.mutableSerialPorts.observeAsState()
     var showSerialPortPicker by remember { mutableStateOf(false) }
@@ -986,6 +993,80 @@ fun SettingsScreen(
                                 GeneralVariables.autoCallFollow = checked
                                 mainViewModel.databaseOpr.writeConfig(
                                     "autoCallFollow", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 4b. DECODE HIGHLIGHTS
+            // =====================================================================
+            SettingsSection(title = "DECODE HIGHLIGHTS") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "New DXCC",
+                            description = "Highlight stations from an unworked DXCC entity",
+                            toggle = highlightNewDxcc,
+                            onToggleChange = { checked ->
+                                highlightNewDxcc = checked
+                                GeneralVariables.highlightNewDxcc = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "highlightNewDxcc", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "New Grid",
+                            description = "Highlight not-yet-worked Maidenhead grids",
+                            toggle = highlightNewGrid,
+                            onToggleChange = { checked ->
+                                highlightNewGrid = checked
+                                GeneralVariables.highlightNewGrid = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "highlightNewGrid", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "New Band",
+                            description = "Highlight stations worked only on other bands",
+                            toggle = highlightNewBand,
+                            onToggleChange = { checked ->
+                                highlightNewBand = checked
+                                GeneralVariables.highlightNewBand = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "highlightNewBand", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "POTA Activators",
+                            description = "Highlight spotted POTA activators; new parks stand out",
+                            toggle = highlightPota,
+                            onToggleChange = { checked ->
+                                highlightPota = checked
+                                GeneralVariables.highlightPota = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "highlightPota", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Worked Before",
+                            description = "Tag stations already in your log",
+                            toggle = highlightWorked,
+                            onToggleChange = { checked ->
+                                highlightWorked = checked
+                                GeneralVariables.highlightWorked = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "highlightWorked", if (checked) "1" else "0", null,
                                 )
                             },
                         )


### PR DESCRIPTION
## What

Makes each decode-list **status pill** category user-toggleable, and adds a new **NEW POTA** highlight.

### Configurable highlights (Settings → **Decode Highlights**)
| Toggle | Default |
|---|---|
| New DXCC | ON |
| **New Grid** | **OFF** — noisiest signal, most grids are "new" |
| New Band | ON |
| POTA Activators | ON |
| Worked Before | ON |

Toggles persist as `config` rows (`highlightNewDxcc` / `NewGrid` / `NewBand` / `Worked` / `Pota`) and reload at startup, mirroring the existing settings pattern. A disabled category falls through to the next in priority order.

### New "NEW POTA" pill
A spotted pota.app activator on a park **not yet in the hunted log** now shows a distinct amber **NEW POTA** pill, vs the plain green **POTA** pill for a park already worked. Hunted park refs are loaded into an in-memory set (`GeneralVariables.QSL_Pota_list`) from `QSLTable` `sig`/`sig_info` alongside the existing grid/callsign lists, refreshed via `GetAllQSLCallsign.get()` (startup, band change, after logging). The query is guarded with try/catch since `sig`/`sig_info` may be missing on some upgraded installs.

## Files
- `GeneralVariables.java` — 5 highlight flags, `QSL_Pota_list`, `checkQSLPark()`
- `DatabaseOpr.java` — config loaders + hunted-park population
- `StatusPill.kt` — `NEW_POTA` enum entry
- `DecodeRow.kt` — `resolveQsoStatus()` gated by toggles + new-park split
- `SettingsScreen.kt` — new Decode Highlights section
- `CallingListAdapter.java` — legacy stripe gated by the same flags for consistency

## Testing
- `assembleDebug` → BUILD SUCCESSFUL.
- Manual on-device verification (toggle persistence, NEW POTA pill) pending — no phone was attached during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
