### PR TITLE
Fast reply to a CQ: single-tap call + decode-before-boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # FT8AF Project Instructions
 
+## Workflow
+
+After finishing the code for any feature, open a pull request targeting the `dev`
+branch (do the work on a feature branch, then `gh pr create --base dev`). Don't
+merge straight to `main`.
+
 ## Build & Deploy
 
 After making code changes, always build and install on the connected device.

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
@@ -11,6 +11,10 @@ public final class FT8Common {
     public static final int SAMPLE_RATE=12000;
     public static final int FT8_SLOT_TIME=15;
     public static final int FT8_SLOT_TIME_MILLISECOND=15000;//milliseconds per cycle
+    //Shorter RX window used when GeneralVariables.earlyDecode is on. The FT8 message is
+    //12.64s; 13500ms captures it plus ~0.86s of positive-DT margin and lets the decode
+    //finish ~1s before the cycle boundary, so a CQ can be answered on the next slot.
+    public static final int FT8_EARLY_DECODE_MILLISECOND=13500;
     public static final int FT4_SLOT_TIME_MILLISECOND=7500;
     public static final int FT8_5_SYMBOLS_MILLISECOND=800;//time needed for 5 symbols
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -224,6 +224,7 @@ public class GeneralVariables {
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.
+    public static boolean earlyDecode = true;//Fast turnaround: decode a shorter RX window so CQ decodes appear ~1s before the cycle boundary, enabling a next-slot reply.
     public static int civAddress = 0xa4;//CI-V address
     public static int baudRate = 19200;//Baud rate
     public static long band = 14074000;//Carrier frequency band

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -671,6 +671,44 @@ public class MainViewModel extends ViewModel {
 
 
     /**
+     * Start calling the station that sent {@code message} (e.g. a station calling CQ).
+     * This is the single entry point shared by the decode-list row tap and the
+     * QsoSheet "Call" button: it follows the callsign, activates TX if idle, sets up
+     * the QSO sequence, and requests an immediate transmit (which fires this slot if
+     * we are still inside the late-start window, otherwise at the next matching slot).
+     *
+     * @param message the decoded message whose sender we want to call
+     */
+    public void callStation(Ft8Message message) {
+        if (message == null || ft8TransmitSignal == null) {
+            return;
+        }
+        // Don't hijack an in-progress transmission, and ignore rows with no usable
+        // sender or our own decoded callsign (avoids accidentally "calling" ourselves).
+        if (ft8TransmitSignal.isTransmitting()) {
+            return;
+        }
+        String from = message.callsignFrom;
+        if (from == null || from.trim().isEmpty()
+                || from.equalsIgnoreCase(GeneralVariables.myCallsign)) {
+            return;
+        }
+
+        addFollowCallsign(from);
+        if (!ft8TransmitSignal.isActivated()) {
+            ft8TransmitSignal.setActivated(true);
+            GeneralVariables.transmitMessages.add(message);
+            GeneralVariables.resetLaunchSupervision();
+        }
+        ft8TransmitSignal.setTransmit(
+                message.getFromCallTransmitCallsign(),
+                1,
+                message.extraInfo);
+        ft8TransmitSignal.transmitNow();
+    }
+
+
+    /**
      * Get the followed callsign list from the database
      */
     public void getFollowCallsignsFromDataBase() {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2343,6 +2343,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                         GeneralVariables.lateStartTolerance = 2000;
                     }
                 }
+                if (name.equalsIgnoreCase("earlyDecode")) {//Fast turnaround: shorter RX window, defaults on
+                    GeneralVariables.earlyDecode = (result.equals("") || result.equals("1"));
+                }
                 if (name.equalsIgnoreCase("icomIp")) {//ICOM IP address
                     GeneralVariables.icomIp = result.equals("") ? "255.255.255.255" : result;
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
@@ -101,7 +101,13 @@ public class FT8SignalListener {
         Log.d(TAG, "Starting recording...");
 
         if (onWaveDataListener != null) {
-            onWaveDataListener.getVoiceData(FT8Common.FT8_SLOT_TIME_MILLISECOND, true
+            // Fast turnaround: collect a shorter window so decoding finishes (and CQ
+            // decodes appear) ~1s before the cycle boundary, leaving time to answer
+            // on the next slot. Off = full 15s window (max sensitivity).
+            int recordMs = GeneralVariables.earlyDecode
+                    ? FT8Common.FT8_EARLY_DECODE_MILLISECOND
+                    : FT8Common.FT8_SLOT_TIME_MILLISECOND;
+            onWaveDataListener.getVoiceData(recordMs, true
                     , new OnGetVoiceDataDone() {
                         @Override
                         public void onGetDone(float[] data) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -1,8 +1,9 @@
 package radio.ks3ckc.ft8us.ui.decode
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,11 +55,13 @@ import radio.ks3ckc.ft8us.ui.motion.MotionTokens
  *  - Surface tint for CQ messages
  *  - Transparent for others
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun DecodeRow(
     message: Ft8Message,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
     animateEntry: Boolean = false,
     nowMillis: Long = 0L,
     isTarget: Boolean = false,
@@ -111,7 +114,7 @@ fun DecodeRow(
             .clip(shape)
             .background(bgColor, shape)
             .border(1.dp, borderColor, shape)
-            .clickable { onClick() }
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
             .padding(start = 0.dp, end = 12.dp, top = 10.dp, bottom = 10.dp),
         verticalAlignment = Alignment.Top,
     ) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -230,7 +230,12 @@ fun DecodeScreen(
                             animateEntry = rowKey in newKeys,
                             nowMillis = utcTime,
                             isTarget = isTarget,
+                            // Single tap = immediately call this station (fast reply to
+                            // a CQ). Long-press opens the info sheet (QRZ, country, etc.).
                             onClick = {
+                                mainViewModel.callStation(message)
+                            },
+                            onLongClick = {
                                 mainViewModel.qsoSheetCallsign.postValue(message.callsignFrom)
                                 mainViewModel.qsoSheetMinimized.postValue(false)
                             },

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -189,18 +189,7 @@ private fun QsoSheetContent(
         } else {
             Button(
                 onClick = {
-                    mainViewModel.addFollowCallsign(callsign)
-                    if (!mainViewModel.ft8TransmitSignal.isActivated) {
-                        mainViewModel.ft8TransmitSignal.setActivated(true)
-                        GeneralVariables.transmitMessages.add(message)
-                        GeneralVariables.resetLaunchSupervision()
-                    }
-                    mainViewModel.ft8TransmitSignal.setTransmit(
-                        message.fromCallTransmitCallsign,
-                        1,
-                        message.extraInfo,
-                    )
-                    mainViewModel.ft8TransmitSignal.transmitNow()
+                    mainViewModel.callStation(message)
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -111,6 +111,7 @@ fun SettingsScreen(
     var synFrequency by remember { mutableStateOf(GeneralVariables.synFrequency) }
     var autoFollowCQ by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
     var autoCallFollow by remember { mutableStateOf(GeneralVariables.autoCallFollow) }
+    var earlyDecode by remember { mutableStateOf(GeneralVariables.earlyDecode) }
     var autoUpdateGridFromGPS by remember { mutableStateOf(GeneralVariables.autoUpdateGridFromGPS) }
     var enableCloudlog by remember { mutableStateOf(GeneralVariables.enableCloudlog) }
     var enableQRZ by remember { mutableStateOf(GeneralVariables.enableQRZ) }
@@ -993,6 +994,19 @@ fun SettingsScreen(
                                 GeneralVariables.autoCallFollow = checked
                                 mainViewModel.databaseOpr.writeConfig(
                                     "autoCallFollow", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Fast turnaround",
+                            description = "Decode ~1s earlier so you can answer a CQ on the next slot instead of waiting. May miss stations with a large clock offset.",
+                            toggle = earlyDecode,
+                            onToggleChange = { checked ->
+                                earlyDecode = checked
+                                GeneralVariables.earlyDecode = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "earlyDecode", if (checked) "1" else "0", null,
                                 )
                             },
                         )


### PR DESCRIPTION
## Problem

Tapping a station that just called CQ used to wait ~2 cycles (~30s) before the reply went out — by which point they'd often worked someone else.

Two compounding causes:
1. **Decodes landed after the cycle boundary.** Recording asked for a full 15s of audio, so a slot's decode posted ~0.5s into the *next* slot, leaving only a ~1.5s window before the late-start cutoff.
2. **The UI burned that window** — tap row → open sheet → tap "Call" (two taps + animation).

Miss the window and the reply could only fire at the next *same-parity* slot, +30s. WSJT-X avoids this by presenting decodes *before* the boundary so the operator arms TX in time.

## Changes

**Single-tap = call immediately.** A new shared `MainViewModel.callStation(message)` (guards against in-progress TX, empty/own callsign) is invoked by a single tap on a decode row. The info sheet (QRZ/country) moves to **long-press**. `DecodeRow` switches to `combinedClickable`; the QsoSheet "Call" button reuses the same method.

**"Fast turnaround" option (default ON).** Shortens the RX window to 13.5s (`FT8_EARLY_DECODE_MILLISECOND`) so CQ decodes appear ~1s *before* the boundary, letting the reply arm in time and fire cleanly on the next slot via the existing boundary timer (zero clipping). Toggle in **Settings → Auto-sequence**, persisted via the `earlyDecode` config key. Off = prior full-15s behavior.

Also adds a CLAUDE.md note documenting the dev-branch PR workflow.

## Trade-off

The 13.5s window sacrifices a little sensitivity to stations with a large positive clock offset (DT > ~0.9s — tail gets truncated). Toggle Fast turnaround off to restore the full window.

## Testing

- Builds clean and installs on the Pixel 8 (`Installed on 1 device.`).
- On-air verification still needed: confirm single-tap fires on the next slot (not +30s) and produces a clean PSKReporter spot; confirm long-press opens the info sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
