### PR TITLE
Callsign blocklist & per-message-type decode filters (JTDX-style)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -70,6 +70,8 @@ public class Ft8Message {
     public String fromWhere = null;//used for displaying address/location
     public String toWhere = null;//used for displaying address/location
 
+    public String continent = null;//sender's continent abbrev (NA/SA/EU/AF/AS/OC/AN); used by decode filters
+
     public boolean isQSL_Callsign = false;//whether this callsign has been previously contacted
 
     public static MessageHashMap hashList = new MessageHashMap();

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -104,36 +104,115 @@ public class GeneralVariables {
     public static final Map<Integer, Integer> cqMap = new ConcurrentHashMap<>();
     public static final Map<Integer, Integer> ituMap = new ConcurrentHashMap<>();
 
+    // Callsign blocklist (Settings → Callsign Blocklist). Three independent match
+    // modes, generalizing the original prefix-only "excluded callsigns" feature. A
+    // blocked station is hidden from the decode list AND excluded from TX/auto-seq.
+    //   - excludedCallsigns: callsign PREFIX match (e.g. "RA" blocks RA0..RA9..).
+    //     Reuses the legacy "excludedCallsigns" config key for backward compat.
+    //   - blockedExactCallsigns: whole-call EXACT match.
+    //   - blockedKeywords: SUBSTRING match (against the call, and the full message
+    //     text via checkIsBlockedMessage) — catches POTA, /P, QRP, contest junk.
     private static final Map<String, Integer> excludedCallsigns = new HashMap<>();
+    private static final java.util.LinkedHashSet<String> blockedExactCallsigns = new java.util.LinkedHashSet<>();
+    private static final java.util.LinkedHashSet<String> blockedKeywords = new java.util.LinkedHashSet<>();
 
     /**
-     * Add excluded callsign prefixes
-     *
-     * @param callsigns callsigns
+     * Split a user-entered list on comma / space / pipe / Chinese comma and
+     * collect the non-empty, upper-cased tokens into {@code target}.
      */
-    public static synchronized void addExcludedCallsigns(String callsigns) {
-        excludedCallsigns.clear();
-        String[] s = callsigns.toUpperCase().replace(" ", ",")
+    private static void parseBlockTokens(String text, java.util.Collection<String> target) {
+        target.clear();
+        if (text == null) return;
+        String[] s = text.toUpperCase().replace(" ", ",")
                 .replace("|", ",")
                 .replace("，", ",").split(",");
-        for (int i = 0; i < s.length; i++) {
-            if (s[i].length() > 0) {
-                excludedCallsigns.put(s[i], 0);
+        for (String token : s) {
+            if (token.length() > 0) {
+                target.add(token);
             }
         }
     }
 
     /**
-     * Check if a callsign matches an excluded prefix
+     * Join a token collection back into the canonical comma-separated form used
+     * for persistence and for display in the Settings text field.
+     */
+    private static String joinBlockTokens(java.util.Collection<String> tokens) {
+        StringBuilder calls = new StringBuilder();
+        int i = 0;
+        for (String token : tokens) {
+            if (i++ == 0) {
+                calls.append(token);
+            } else {
+                calls.append(",").append(token);
+            }
+        }
+        return calls.toString();
+    }
+
+    /**
+     * Add excluded callsign prefixes (legacy name kept; this is the PREFIX list).
+     *
+     * @param callsigns callsigns
+     */
+    public static synchronized void addExcludedCallsigns(String callsigns) {
+        excludedCallsigns.clear();
+        if (callsigns == null) return;
+        String[] s = callsigns.toUpperCase().replace(" ", ",")
+                .replace("|", ",")
+                .replace("，", ",").split(",");
+        for (String token : s) {
+            if (token.length() > 0) {
+                excludedCallsigns.put(token, 0);
+            }
+        }
+    }
+
+    public static synchronized void addBlockedExactCallsigns(String callsigns) {
+        parseBlockTokens(callsigns, blockedExactCallsigns);
+    }
+
+    public static synchronized void addBlockedKeywords(String keywords) {
+        parseBlockTokens(keywords, blockedKeywords);
+    }
+
+    /**
+     * Get the list of excluded callsign prefixes (the PREFIX list).
+     *
+     * @return the list as a comma-separated string
+     */
+    public static synchronized String getExcludeCallsigns() {
+        return joinBlockTokens(excludedCallsigns.keySet());
+    }
+
+    public static synchronized String getBlockedExactCallsigns() {
+        return joinBlockTokens(blockedExactCallsigns);
+    }
+
+    public static synchronized String getBlockedKeywords() {
+        return joinBlockTokens(blockedKeywords);
+    }
+
+    /**
+     * Check whether a callsign is blocked by any match mode: exact whole-call,
+     * prefix, or keyword substring (against the callsign itself).
      *
      * @param callsign callsign
-     * @return whether it matches
+     * @return whether it is blocked
      */
-    public static synchronized boolean checkIsExcludeCallsign(String callsign) {
-        Iterator<String> iterator = excludedCallsigns.keySet().iterator();
-        while (iterator.hasNext()) {
-            String key = iterator.next();
-            if (callsign.toUpperCase().indexOf(key) == 0) {
+    public static synchronized boolean checkIsBlocked(String callsign) {
+        if (callsign == null) return false;
+        String up = callsign.toUpperCase();
+        if (blockedExactCallsigns.contains(up)) {
+            return true;
+        }
+        for (String prefix : excludedCallsigns.keySet()) {
+            if (up.indexOf(prefix) == 0) {
+                return true;
+            }
+        }
+        for (String keyword : blockedKeywords) {
+            if (up.contains(keyword)) {
                 return true;
             }
         }
@@ -141,24 +220,41 @@ public class GeneralVariables {
     }
 
     /**
-     * Get the list of excluded callsign prefixes
+     * Decode-list block check: blocked if the sender's callsign is blocked, or any
+     * keyword appears anywhere in the rendered message text (so keywords can match
+     * message content like "POTA", not just the callsign).
      *
-     * @return the list as a string
+     * @param msg the decoded message
+     * @return whether it is blocked
      */
-    public static synchronized String getExcludeCallsigns() {
-        StringBuilder calls = new StringBuilder();
-        Iterator<String> iterator = excludedCallsigns.keySet().iterator();
-        int i = 0;
-        while (iterator.hasNext()) {
-            String key = iterator.next();
-            if (i == 0) {
-                calls.append(key);
-            } else {
-                calls.append(",").append(key);
-            }
-            i++;
+    public static synchronized boolean checkIsBlockedMessage(Ft8Message msg) {
+        if (msg == null) return false;
+        if (checkIsBlocked(msg.callsignFrom)) {
+            return true;
         }
-        return calls.toString();
+        if (!blockedKeywords.isEmpty()) {
+            String text = msg.getMessageText();
+            if (text != null) {
+                String up = text.toUpperCase();
+                for (String keyword : blockedKeywords) {
+                    if (up.contains(keyword)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Backward-compatible alias. Existing TX-side call sites call this; it now
+     * covers all three blocklist match modes via {@link #checkIsBlocked}.
+     *
+     * @param callsign callsign
+     * @return whether it matches
+     */
+    public static synchronized boolean checkIsExcludeCallsign(String callsign) {
+        return checkIsBlocked(callsign);
     }
 
 
@@ -275,6 +371,19 @@ public class GeneralVariables {
     public static boolean highlightNewBand = true;//Highlight stations worked only on other bands
     public static boolean highlightWorked = true;//Tag stations already worked
     public static boolean highlightPota = true;//Highlight spotted POTA activators (new parks stand out)
+
+    // Decode-list display filters (Settings → Decode Filters). Persistent
+    // "show only" filters applied to the decode list in DecodeScreen.filterMessages().
+    // Multiple enabled filters AND together.
+    public static boolean filterShowOnlyCQ = false;//Show only CQ-type messages
+    public static boolean filterDxOnly = false;//Show only stations outside my own continent
+    public static boolean filterNeededOnly = false;//Show only not-yet-QSL'd stations
+    public static boolean filterByContinent = false;//Show only stations from filterContinent
+    public static String filterContinent = "EU";//Target continent for filterByContinent (NA/SA/EU/AF/AS/OC/AN)
+
+    // The operator's own continent abbreviation, derived once from the callsign
+    // (CallsignDatabase.getContinent). Used by the DX filter. Null until resolved.
+    public static String myContinent = null;
 
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import androidx.lifecycle.MutableLiveData;
 
 import com.bg7yoz.ft8cn.callsign.CallsignDatabase;
+import com.bg7yoz.ft8cn.callsign.CallsignInfo;
 import com.bg7yoz.ft8cn.connector.ConnectMode;
 import com.bg7yoz.ft8cn.database.ControlMode;
 import com.bg7yoz.ft8cn.database.DatabaseOpr;
@@ -384,6 +385,63 @@ public class GeneralVariables {
     // The operator's own continent abbreviation, derived once from the callsign
     // (CallsignDatabase.getContinent). Used by the DX filter. Null until resolved.
     public static String myContinent = null;
+
+    // The operator's own DXCC, derived once from the callsign alongside myContinent
+    // (CallsignDatabase.getMessagesLocation). Used by the directional-CQ matcher to
+    // match country/region tokens (e.g. "CQ JA"). Null until resolved → fail-open.
+    public static String myDxcc = null;
+
+    // Directional CQ awareness (Settings → Decode Filters). Both opt-in, default off.
+    //   - respectDirectionalCQ: suppress AUTO-replies to directional CQs (CQ DX/EU/JA…)
+    //     not aimed at my station. Does not affect manual taps or stations calling me.
+    //   - filterDirectionalCQ: hide those same CQs from the decode list.
+    public static boolean respectDirectionalCQ = false;
+    public static boolean filterDirectionalCQ = false;
+
+    // Geographic continent-directed CQ tokens — matched against myContinent.
+    private static final java.util.Set<String> CONTINENT_CODES =
+            new java.util.HashSet<>(java.util.Arrays.asList("NA", "SA", "EU", "AF", "AS", "OC", "AN"));
+    // Non-geographic activity calls — always answerable. Easily extended.
+    private static final java.util.Set<String> ACTIVITY_TOKENS =
+            new java.util.HashSet<>(java.util.Arrays.asList(
+                    "DX", "POTA", "SOTA", "WWFF", "IOTA", "TEST", "FD", "QRP", "WW"));
+
+    /**
+     * The directional token after CQ/DE/QRZ in a decoded callsignTo (e.g. "DX" from
+     * "CQ DX"), or null for a plain CQ / non-CQ message.
+     */
+    public static String getDirectionalCQToken(String callsignTo) {
+        if (callsignTo == null) return null;
+        String[] p = callsignTo.trim().toUpperCase().split("\\s+");
+        if (p.length < 2) return null;
+        if (!(p[0].equals("CQ") || p[0].equals("DE") || p[0].equals("QRZ"))) return null;
+        return p[1];
+    }
+
+    /**
+     * Whether a (possibly directional) CQ is answerable by my station. Continent-code
+     * tokens are matched against {@link #myContinent}; country/region prefixes against
+     * {@link #myDxcc} via the callsign database. Fail-open: plain CQ, "CQ DX",
+     * 3-digit zone CQs, known activity calls, and anything we can't positively resolve
+     * to a different DXCC/continent are all treated as answerable.
+     *
+     * @param callsignTo the decoded message's callsignTo field
+     * @return true if answerable (or not a CQ at all)
+     */
+    public static synchronized boolean directionalCQIsForMe(String callsignTo) {
+        String token = getDirectionalCQToken(callsignTo);
+        if (token == null) return true;                       // plain CQ / not a CQ
+        if (token.matches("[0-9]{3}")) return true;           // zone-directed CQ nnn
+        if (ACTIVITY_TOKENS.contains(token)) return true;     // DX / POTA / TEST / ...
+        if (CONTINENT_CODES.contains(token)) {                // continent-directed
+            return myContinent == null || token.equalsIgnoreCase(myContinent);
+        }
+        // country/region prefix (e.g. JA) — match by DXCC
+        if (callsignDatabase == null || myDxcc == null) return true;
+        CallsignInfo info = callsignDatabase.getCallInfo(token);
+        if (info == null || info.DXCC == null) return true;   // unresolved → fail-open
+        return info.DXCC.equalsIgnoreCase(myDxcc);
+    }
 
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -127,14 +127,16 @@ public class CallsignDatabase extends SQLiteOpenHelper {
                     msg.fromLatLng = new LatLng(fromCallsignInfo.Latitude, fromCallsignInfo.Longitude * -1);
             }
 
-            // Resolve the operator's own continent once (for the DX decode filter).
-            if (GeneralVariables.myContinent == null
+            // Resolve the operator's own continent + DXCC once (continent for the DX
+            // decode filter, DXCC for the directional-CQ matcher).
+            if ((GeneralVariables.myContinent == null || GeneralVariables.myDxcc == null)
                     && GeneralVariables.myCallsign != null
                     && GeneralVariables.myCallsign.length() > 0) {
                 CallsignInfo myInfo = getCallsignInfo(db,
                         GeneralVariables.myCallsign.replace("<", "").replace(">", ""));
                 if (myInfo != null) {
                     GeneralVariables.myContinent = myInfo.Continent;
+                    GeneralVariables.myDxcc = myInfo.DXCC;
                 }
             }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -123,7 +123,19 @@ public class CallsignDatabase extends SQLiteOpenHelper {
                     msg.fromItu = !GeneralVariables.getItuZoneById(fromCallsignInfo.ITUZone);
                     msg.fromCq = !GeneralVariables.getCqZoneById(fromCallsignInfo.CQZone);
                     msg.fromWhere = fromCallsignInfo.CountryNameEn;
+                    msg.continent = fromCallsignInfo.Continent;
                     msg.fromLatLng = new LatLng(fromCallsignInfo.Latitude, fromCallsignInfo.Longitude * -1);
+            }
+
+            // Resolve the operator's own continent once (for the DX decode filter).
+            if (GeneralVariables.myContinent == null
+                    && GeneralVariables.myCallsign != null
+                    && GeneralVariables.myCallsign.length() > 0) {
+                CallsignInfo myInfo = getCallsignInfo(db,
+                        GeneralVariables.myCallsign.replace("<", "").replace(">", ""));
+                if (myInfo != null) {
+                    GeneralVariables.myContinent = myInfo.Continent;
+                }
             }
 
             if (msg.checkIsCQ() || msg.getCallsignTo().contains("...")) { // Skip CQ messages

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2361,8 +2361,31 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("volumeValue")) {//Output volume level
                     GeneralVariables.volumePercent = result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
                 }
-                if (name.equalsIgnoreCase("excludedCallsigns")) {//Excluded callsigns
+                if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
+                }
+                if (name.equalsIgnoreCase("blockedExactCallsigns")) {//Blocklist: whole-call exact
+                    GeneralVariables.addBlockedExactCallsigns(result);
+                }
+                if (name.equalsIgnoreCase("blockedKeywords")) {//Blocklist: keyword substrings
+                    GeneralVariables.addBlockedKeywords(result);
+                }
+                if (name.equalsIgnoreCase("filterShowOnlyCQ")) {//Decode filter: CQ only
+                    GeneralVariables.filterShowOnlyCQ = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterDxOnly")) {//Decode filter: DX (other continents) only
+                    GeneralVariables.filterDxOnly = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterNeededOnly")) {//Decode filter: needed only
+                    GeneralVariables.filterNeededOnly = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterByContinent")) {//Decode filter: by continent
+                    GeneralVariables.filterByContinent = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterContinent")) {//Decode filter: target continent
+                    if (result != null && result.length() > 0) {
+                        GeneralVariables.filterContinent = result;
+                    }
                 }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2387,6 +2387,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                         GeneralVariables.filterContinent = result;
                     }
                 }
+                if (name.equalsIgnoreCase("respectDirectionalCQ")) {//Directional CQ: suppress auto-reply
+                    GeneralVariables.respectDirectionalCQ = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterDirectionalCQ")) {//Directional CQ: hide from decode list
+                    GeneralVariables.filterDirectionalCQ = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -909,6 +909,9 @@ public class FT8TransmitSignal {
                     && (GeneralVariables.autoFollowCQ// Hunt: auto-answer any CQ
                     || (GeneralVariables.autoCallFollow
                     && GeneralVariables.callsignInFollow(msg.getCallsignFrom())))// followed callsign
+                    // skip directional CQs aimed at a different DXCC/continent (opt-in)
+                    && (!GeneralVariables.respectDirectionalCQ
+                    || GeneralVariables.directionalCQIsForMe(msg.callsignTo))
                     && !GeneralVariables.checkQSLCallsign(msg.getCallsignFrom())// not previously contacted successfully
                     && !GeneralVariables.checkIsMyCallsign(msg.callsignFrom)) {// not myself
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -319,9 +319,34 @@ private fun filterMessages(
     messages: List<Ft8Message>,
     filter: String,
 ): List<Ft8Message> {
+    // Base stage: always-on blocklist + settings-driven "show only" filters.
+    // Applied before the chip switch so they AND with whatever chip is selected.
+    var base = messages.filterNot { GeneralVariables.checkIsBlockedMessage(it) }
+    if (GeneralVariables.filterShowOnlyCQ) {
+        base = base.filter { it.checkIsCQ() }
+    }
+    if (GeneralVariables.filterDxOnly) {
+        base = base.filter {
+            it.continent != null && GeneralVariables.myContinent != null &&
+                !it.continent.equals(GeneralVariables.myContinent, ignoreCase = true)
+        }
+    }
+    if (GeneralVariables.filterNeededOnly) {
+        base = base.filter {
+            !it.isQSL_Callsign &&
+                !GeneralVariables.checkQSLCallsign(it.callsignFrom ?: "")
+        }
+    }
+    if (GeneralVariables.filterByContinent) {
+        base = base.filter {
+            it.continent != null &&
+                it.continent.equals(GeneralVariables.filterContinent, ignoreCase = true)
+        }
+    }
+
     return when (filter) {
-        "CQ Calls" -> messages.filter { it.checkIsCQ() }
-        "CQ POTA" -> messages.filter {
+        "CQ Calls" -> base.filter { it.checkIsCQ() }
+        "CQ POTA" -> base.filter {
             // Match three signals: (1) explicit "POTA" suffix on a CQ, (2) any CQ from a
             // station currently spotted on pota.app (activators often drop the suffix to
             // save chars), (3) free-text fragments like "CQ POT" that decoders garble
@@ -332,15 +357,15 @@ private fun filterMessages(
                     (it.callsignTo?.startsWith("CQ POT", ignoreCase = true) == true)
                 )
         }
-        "New DXCC" -> messages.filter { it.checkIsCQ() && it.fromDxcc }
-        "Needed" -> messages.filter {
+        "New DXCC" -> base.filter { it.checkIsCQ() && it.fromDxcc }
+        "Needed" -> base.filter {
             !it.isQSL_Callsign &&
                 !GeneralVariables.checkQSLCallsign(it.callsignFrom ?: "")
         }
-        "For Me" -> messages.filter {
+        "For Me" -> base.filter {
             GeneralVariables.checkIsMyCallsign(it.callsignTo ?: "")
         }
-        else -> messages // "All"
+        else -> base // "All"
     }
 }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -343,6 +343,9 @@ private fun filterMessages(
                 it.continent.equals(GeneralVariables.filterContinent, ignoreCase = true)
         }
     }
+    if (GeneralVariables.filterDirectionalCQ) {
+        base = base.filter { GeneralVariables.directionalCQIsForMe(it.callsignTo) }
+    }
 
     return when (filter) {
         "CQ Calls" -> base.filter { it.checkIsCQ() }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -135,6 +135,8 @@ fun SettingsScreen(
     var filterNeededOnly by remember { mutableStateOf(GeneralVariables.filterNeededOnly) }
     var filterByContinent by remember { mutableStateOf(GeneralVariables.filterByContinent) }
     var filterContinent by remember { mutableStateOf(GeneralVariables.filterContinent) }
+    var respectDirectionalCQ by remember { mutableStateOf(GeneralVariables.respectDirectionalCQ) }
+    var filterDirectionalCQ by remember { mutableStateOf(GeneralVariables.filterDirectionalCQ) }
 
     // Continent codes (stored on the message) and their display names, parallel lists.
     val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
@@ -1275,6 +1277,32 @@ fun SettingsScreen(
                                 onClick = { showContinentPicker = true },
                             )
                         }
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Skip Directional CQs (auto-reply)",
+                            description = "Don't auto-answer CQ DX/EU/JA… aimed at a different DXCC",
+                            toggle = respectDirectionalCQ,
+                            onToggleChange = { checked ->
+                                respectDirectionalCQ = checked
+                                GeneralVariables.respectDirectionalCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "respectDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Hide Directional CQs Not For Me",
+                            description = "Hide region-directed CQs that don't target your DXCC",
+                            toggle = filterDirectionalCQ,
+                            onToggleChange = { checked ->
+                                filterDirectionalCQ = checked
+                                GeneralVariables.filterDirectionalCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
                     }
                 }
             }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -126,6 +126,22 @@ fun SettingsScreen(
     var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
     var highlightPota by remember { mutableStateOf(GeneralVariables.highlightPota) }
 
+    // Callsign blocklist (comma-separated entries) + decode display filters
+    var blockedExact by remember { mutableStateOf(GeneralVariables.getBlockedExactCallsigns()) }
+    var blockedPrefixes by remember { mutableStateOf(GeneralVariables.getExcludeCallsigns()) }
+    var blockedKeywords by remember { mutableStateOf(GeneralVariables.getBlockedKeywords()) }
+    var filterShowOnlyCQ by remember { mutableStateOf(GeneralVariables.filterShowOnlyCQ) }
+    var filterDxOnly by remember { mutableStateOf(GeneralVariables.filterDxOnly) }
+    var filterNeededOnly by remember { mutableStateOf(GeneralVariables.filterNeededOnly) }
+    var filterByContinent by remember { mutableStateOf(GeneralVariables.filterByContinent) }
+    var filterContinent by remember { mutableStateOf(GeneralVariables.filterContinent) }
+
+    // Continent codes (stored on the message) and their display names, parallel lists.
+    val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
+    val continentNames = listOf(
+        "North America", "South America", "Europe", "Africa", "Asia", "Oceania", "Antarctica",
+    )
+
     // Observe serial ports for USB Cable picker
     val serialPorts by mainViewModel.mutableSerialPorts.observeAsState()
     var showSerialPortPicker by remember { mutableStateOf(false) }
@@ -158,6 +174,10 @@ fun SettingsScreen(
     var showAudioOutputPicker by remember { mutableStateOf(false) }
     var showBaudRatePicker by remember { mutableStateOf(false) }
     var showTxVolume by remember { mutableStateOf(false) }
+    var showBlockExactDialog by remember { mutableStateOf(false) }
+    var showBlockPrefixDialog by remember { mutableStateOf(false) }
+    var showBlockKeywordDialog by remember { mutableStateOf(false) }
+    var showContinentPicker by remember { mutableStateOf(false) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -263,6 +283,72 @@ fun SettingsScreen(
                 mainViewModel.databaseOpr.writeConfig("grid", formattedGrid, null)
 
                 showEditOperator = false
+            },
+        )
+    }
+
+    // -- Blocklist: exact whole-call dialog --
+    if (showBlockExactDialog) {
+        TextListDialog(
+            title = "Block Exact Callsigns",
+            description = "Whole-call match. Comma- or space-separated, e.g. W1AW, K1ABC.",
+            initialValue = blockedExact,
+            onDismiss = { showBlockExactDialog = false },
+            onSave = { text ->
+                GeneralVariables.addBlockedExactCallsigns(text)
+                blockedExact = GeneralVariables.getBlockedExactCallsigns()
+                mainViewModel.databaseOpr.writeConfig("blockedExactCallsigns", blockedExact, null)
+                showBlockExactDialog = false
+            },
+        )
+    }
+
+    // -- Blocklist: prefix dialog (legacy excludedCallsigns key) --
+    if (showBlockPrefixDialog) {
+        TextListDialog(
+            title = "Block Callsign Prefixes",
+            description = "Prefix match, e.g. RA blocks RA0AA..RA9ZZ. Comma- or space-separated.",
+            initialValue = blockedPrefixes,
+            onDismiss = { showBlockPrefixDialog = false },
+            onSave = { text ->
+                GeneralVariables.addExcludedCallsigns(text)
+                blockedPrefixes = GeneralVariables.getExcludeCallsigns()
+                mainViewModel.databaseOpr.writeConfig("excludedCallsigns", blockedPrefixes, null)
+                showBlockPrefixDialog = false
+            },
+        )
+    }
+
+    // -- Blocklist: keyword dialog --
+    if (showBlockKeywordDialog) {
+        TextListDialog(
+            title = "Block Keywords",
+            description = "Substring match against the call and message text, e.g. POTA, /P, QRP.",
+            initialValue = blockedKeywords,
+            onDismiss = { showBlockKeywordDialog = false },
+            onSave = { text ->
+                GeneralVariables.addBlockedKeywords(text)
+                blockedKeywords = GeneralVariables.getBlockedKeywords()
+                mainViewModel.databaseOpr.writeConfig("blockedKeywords", blockedKeywords, null)
+                showBlockKeywordDialog = false
+            },
+        )
+    }
+
+    // -- Decode filter: continent picker --
+    if (showContinentPicker) {
+        val currentIndex = continentCodes.indexOf(filterContinent).coerceAtLeast(0)
+        ListPickerDialog(
+            title = "Filter Continent",
+            items = continentNames,
+            selectedIndex = currentIndex,
+            onDismiss = { showContinentPicker = false },
+            onSelect = { index ->
+                showContinentPicker = false
+                val code = continentCodes[index]
+                filterContinent = code
+                GeneralVariables.filterContinent = code
+                mainViewModel.databaseOpr.writeConfig("filterContinent", code, null)
             },
         )
     }
@@ -1089,6 +1175,111 @@ fun SettingsScreen(
             }
 
             // =====================================================================
+            // 4c. CALLSIGN BLOCKLIST
+            // =====================================================================
+            SettingsSection(title = "CALLSIGN BLOCKLIST") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "Exact Callsigns",
+                            description = "Block whole-call matches",
+                            value = blockedExact.ifBlank { "None" },
+                            showChevron = true,
+                            onClick = { showBlockExactDialog = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Prefixes",
+                            description = "Block by callsign prefix (e.g. RA)",
+                            value = blockedPrefixes.ifBlank { "None" },
+                            showChevron = true,
+                            onClick = { showBlockPrefixDialog = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Keywords",
+                            description = "Block by substring in call or message (e.g. POTA, /P)",
+                            value = blockedKeywords.ifBlank { "None" },
+                            showChevron = true,
+                            onClick = { showBlockKeywordDialog = true },
+                        )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 4d. DECODE FILTERS
+            // =====================================================================
+            SettingsSection(title = "DECODE FILTERS") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "Show Only CQ",
+                            description = "Hide everything except CQ-type messages",
+                            toggle = filterShowOnlyCQ,
+                            onToggleChange = { checked ->
+                                filterShowOnlyCQ = checked
+                                GeneralVariables.filterShowOnlyCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterShowOnlyCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "DX Only",
+                            description = "Show only stations outside your own continent",
+                            toggle = filterDxOnly,
+                            onToggleChange = { checked ->
+                                filterDxOnly = checked
+                                GeneralVariables.filterDxOnly = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterDxOnly", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Needed Only",
+                            description = "Show only stations not yet confirmed (QSL)",
+                            toggle = filterNeededOnly,
+                            onToggleChange = { checked ->
+                                filterNeededOnly = checked
+                                GeneralVariables.filterNeededOnly = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterNeededOnly", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Filter By Continent",
+                            description = "Show only stations from a chosen continent",
+                            toggle = filterByContinent,
+                            onToggleChange = { checked ->
+                                filterByContinent = checked
+                                GeneralVariables.filterByContinent = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterByContinent", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        if (filterByContinent) {
+                            SectionDivider()
+                            SettingsRow(
+                                label = "Continent",
+                                value = continentNames.getOrElse(
+                                    continentCodes.indexOf(filterContinent),
+                                ) { filterContinent },
+                                showChevron = true,
+                                onClick = { showContinentPicker = true },
+                            )
+                        }
+                    }
+                }
+            }
+
+            // =====================================================================
             // 5. LOGGING & AWARDS
             // =====================================================================
             SettingsSection(title = "LOGGING & AWARDS") {
@@ -1366,6 +1557,82 @@ private fun EditOperatorDialog(
                 TextButton(
                     onClick = { onSave(callsignInput.text, gridInput.text) },
                 ) {
+                    Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for editing a comma/space-separated list of tokens (blocklist entries).
+ * One multi-line text field; the caller parses + persists the saved string.
+ */
+@Composable
+private fun TextListDialog(
+    title: String,
+    description: String,
+    initialValue: String,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
+    var input by remember { mutableStateOf(TextFieldValue(initialValue)) }
+
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = TextPrimary,
+        unfocusedTextColor = TextPrimary,
+        cursorColor = Accent,
+        focusedBorderColor = Accent,
+        unfocusedBorderColor = BorderStrong,
+        focusedLabelColor = Accent,
+        unfocusedLabelColor = TextMuted,
+    )
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = title,
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+            )
+
+            Text(
+                text = description,
+                color = TextMuted,
+                fontSize = 13.sp,
+            )
+
+            OutlinedTextField(
+                value = input,
+                onValueChange = { input = it },
+                placeholder = { Text("e.g. W1AW, RA, /P", color = TextFaint) },
+                singleLine = false,
+                minLines = 2,
+                colors = fieldColors,
+                textStyle = TextStyle(
+                    fontFamily = GeistMonoFamily,
+                    fontSize = 15.sp,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel", color = TextMuted)
+                }
+                TextButton(onClick = { onSave(input.text) }) {
                     Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
                 }
             }


### PR DESCRIPTION
## What

Generalizes the prefix-only, TX-only **excluded callsigns** mechanism into a JTDX-style filtering system with two parts.

### 1. Callsign blocklist — three independent match modes
- **Exact** whole-call match
- **Prefix** match (reuses the legacy `excludedCallsigns` config key, so existing lists keep working)
- **Keyword** substring match — checks both the callsign and the **full decoded message text** (catches `POTA`, `/P`, `QRP`, contest fragments)

A blocked station is now **hidden from the decode list** *and* **excluded from TX / auto-sequence**. The four existing TX-side call sites funnel through `checkIsExcludeCallsign`, which now delegates to the unified `checkIsBlocked`, so they automatically gain exact + keyword matching with no edits.

### 2. Settings-driven decode display filters
Persistent "show only" filters configured in **Settings → Decode Filters** (the decode-screen chips are intentionally left untouched):
- **Show Only CQ**
- **DX Only** — stations outside your own continent
- **Needed Only** — not-yet-confirmed (QSL)
- **Filter By Continent** — picker (NA/SA/EU/AF/AS/OC/AN)

Applied as a base stage in `DecodeScreen.filterMessages()`, ANDed with whatever chip is selected.

### Supporting change
Each station's **continent** (previously looked up in `CallsignDatabase.getMessagesLocation()` then discarded) is now stored on `Ft8Message`, and the operator's own continent is derived once for the DX filter.

## Files
- `GeneralVariables.java` — three block lists, `checkIsBlocked` / `checkIsBlockedMessage`, filter fields, `myContinent`
- `Ft8Message.java` — `continent` field
- `CallsignDatabase.java` — store continent + resolve own continent
- `DatabaseOpr.java` — config load cases for the new keys
- `DecodeScreen.kt` — blocklist + settings-filter base stage
- `SettingsScreen.kt` — Callsign Blocklist + Decode Filters sections + `TextListDialog`

## Testing
- Builds and installs cleanly on a Pixel 8 (`gradlew.bat installDebug`, Kotlin + Java compile, app launches without crash).
- Functional verification against live decodes (block by exact/prefix/keyword, each display filter, persistence across relaunch) still to be exercised manually — see the plan's verification checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)