### PR TITLE
Directional CQ awareness (skip/hide CQs aimed elsewhere)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import androidx.lifecycle.MutableLiveData;
 
 import com.bg7yoz.ft8cn.callsign.CallsignDatabase;
+import com.bg7yoz.ft8cn.callsign.CallsignInfo;
 import com.bg7yoz.ft8cn.connector.ConnectMode;
 import com.bg7yoz.ft8cn.database.ControlMode;
 import com.bg7yoz.ft8cn.database.DatabaseOpr;
@@ -384,6 +385,63 @@ public class GeneralVariables {
     // The operator's own continent abbreviation, derived once from the callsign
     // (CallsignDatabase.getContinent). Used by the DX filter. Null until resolved.
     public static String myContinent = null;
+
+    // The operator's own DXCC, derived once from the callsign alongside myContinent
+    // (CallsignDatabase.getMessagesLocation). Used by the directional-CQ matcher to
+    // match country/region tokens (e.g. "CQ JA"). Null until resolved → fail-open.
+    public static String myDxcc = null;
+
+    // Directional CQ awareness (Settings → Decode Filters). Both opt-in, default off.
+    //   - respectDirectionalCQ: suppress AUTO-replies to directional CQs (CQ DX/EU/JA…)
+    //     not aimed at my station. Does not affect manual taps or stations calling me.
+    //   - filterDirectionalCQ: hide those same CQs from the decode list.
+    public static boolean respectDirectionalCQ = false;
+    public static boolean filterDirectionalCQ = false;
+
+    // Geographic continent-directed CQ tokens — matched against myContinent.
+    private static final java.util.Set<String> CONTINENT_CODES =
+            new java.util.HashSet<>(java.util.Arrays.asList("NA", "SA", "EU", "AF", "AS", "OC", "AN"));
+    // Non-geographic activity calls — always answerable. Easily extended.
+    private static final java.util.Set<String> ACTIVITY_TOKENS =
+            new java.util.HashSet<>(java.util.Arrays.asList(
+                    "DX", "POTA", "SOTA", "WWFF", "IOTA", "TEST", "FD", "QRP", "WW"));
+
+    /**
+     * The directional token after CQ/DE/QRZ in a decoded callsignTo (e.g. "DX" from
+     * "CQ DX"), or null for a plain CQ / non-CQ message.
+     */
+    public static String getDirectionalCQToken(String callsignTo) {
+        if (callsignTo == null) return null;
+        String[] p = callsignTo.trim().toUpperCase().split("\\s+");
+        if (p.length < 2) return null;
+        if (!(p[0].equals("CQ") || p[0].equals("DE") || p[0].equals("QRZ"))) return null;
+        return p[1];
+    }
+
+    /**
+     * Whether a (possibly directional) CQ is answerable by my station. Continent-code
+     * tokens are matched against {@link #myContinent}; country/region prefixes against
+     * {@link #myDxcc} via the callsign database. Fail-open: plain CQ, "CQ DX",
+     * 3-digit zone CQs, known activity calls, and anything we can't positively resolve
+     * to a different DXCC/continent are all treated as answerable.
+     *
+     * @param callsignTo the decoded message's callsignTo field
+     * @return true if answerable (or not a CQ at all)
+     */
+    public static synchronized boolean directionalCQIsForMe(String callsignTo) {
+        String token = getDirectionalCQToken(callsignTo);
+        if (token == null) return true;                       // plain CQ / not a CQ
+        if (token.matches("[0-9]{3}")) return true;           // zone-directed CQ nnn
+        if (ACTIVITY_TOKENS.contains(token)) return true;     // DX / POTA / TEST / ...
+        if (CONTINENT_CODES.contains(token)) {                // continent-directed
+            return myContinent == null || token.equalsIgnoreCase(myContinent);
+        }
+        // country/region prefix (e.g. JA) — match by DXCC
+        if (callsignDatabase == null || myDxcc == null) return true;
+        CallsignInfo info = callsignDatabase.getCallInfo(token);
+        if (info == null || info.DXCC == null) return true;   // unresolved → fail-open
+        return info.DXCC.equalsIgnoreCase(myDxcc);
+    }
 
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -127,14 +127,16 @@ public class CallsignDatabase extends SQLiteOpenHelper {
                     msg.fromLatLng = new LatLng(fromCallsignInfo.Latitude, fromCallsignInfo.Longitude * -1);
             }
 
-            // Resolve the operator's own continent once (for the DX decode filter).
-            if (GeneralVariables.myContinent == null
+            // Resolve the operator's own continent + DXCC once (continent for the DX
+            // decode filter, DXCC for the directional-CQ matcher).
+            if ((GeneralVariables.myContinent == null || GeneralVariables.myDxcc == null)
                     && GeneralVariables.myCallsign != null
                     && GeneralVariables.myCallsign.length() > 0) {
                 CallsignInfo myInfo = getCallsignInfo(db,
                         GeneralVariables.myCallsign.replace("<", "").replace(">", ""));
                 if (myInfo != null) {
                     GeneralVariables.myContinent = myInfo.Continent;
+                    GeneralVariables.myDxcc = myInfo.DXCC;
                 }
             }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2387,6 +2387,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                         GeneralVariables.filterContinent = result;
                     }
                 }
+                if (name.equalsIgnoreCase("respectDirectionalCQ")) {//Directional CQ: suppress auto-reply
+                    GeneralVariables.respectDirectionalCQ = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterDirectionalCQ")) {//Directional CQ: hide from decode list
+                    GeneralVariables.filterDirectionalCQ = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -909,6 +909,9 @@ public class FT8TransmitSignal {
                     && (GeneralVariables.autoFollowCQ// Hunt: auto-answer any CQ
                     || (GeneralVariables.autoCallFollow
                     && GeneralVariables.callsignInFollow(msg.getCallsignFrom())))// followed callsign
+                    // skip directional CQs aimed at a different DXCC/continent (opt-in)
+                    && (!GeneralVariables.respectDirectionalCQ
+                    || GeneralVariables.directionalCQIsForMe(msg.callsignTo))
                     && !GeneralVariables.checkQSLCallsign(msg.getCallsignFrom())// not previously contacted successfully
                     && !GeneralVariables.checkIsMyCallsign(msg.callsignFrom)) {// not myself
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -343,6 +343,9 @@ private fun filterMessages(
                 it.continent.equals(GeneralVariables.filterContinent, ignoreCase = true)
         }
     }
+    if (GeneralVariables.filterDirectionalCQ) {
+        base = base.filter { GeneralVariables.directionalCQIsForMe(it.callsignTo) }
+    }
 
     return when (filter) {
         "CQ Calls" -> base.filter { it.checkIsCQ() }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -135,6 +135,8 @@ fun SettingsScreen(
     var filterNeededOnly by remember { mutableStateOf(GeneralVariables.filterNeededOnly) }
     var filterByContinent by remember { mutableStateOf(GeneralVariables.filterByContinent) }
     var filterContinent by remember { mutableStateOf(GeneralVariables.filterContinent) }
+    var respectDirectionalCQ by remember { mutableStateOf(GeneralVariables.respectDirectionalCQ) }
+    var filterDirectionalCQ by remember { mutableStateOf(GeneralVariables.filterDirectionalCQ) }
 
     // Continent codes (stored on the message) and their display names, parallel lists.
     val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
@@ -1275,6 +1277,32 @@ fun SettingsScreen(
                                 onClick = { showContinentPicker = true },
                             )
                         }
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Skip Directional CQs (auto-reply)",
+                            description = "Don't auto-answer CQ DX/EU/JA… aimed at a different DXCC",
+                            toggle = respectDirectionalCQ,
+                            onToggleChange = { checked ->
+                                respectDirectionalCQ = checked
+                                GeneralVariables.respectDirectionalCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "respectDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Hide Directional CQs Not For Me",
+                            description = "Hide region-directed CQs that don't target your DXCC",
+                            toggle = filterDirectionalCQ,
+                            onToggleChange = { checked ->
+                                filterDirectionalCQ = checked
+                                GeneralVariables.filterDirectionalCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## What

Parses the directional token in decoded CQs (`CQ DX/EU/NA/JA/POTA/075…`) so the operator can avoid auto-replying to — and optionally hide — CQs aimed at a different region. A W4 station no longer auto-answers `CQ JA`.

## How it matches

`GeneralVariables.directionalCQIsForMe(callsignTo)`:
- **Continent codes** (NA/SA/EU/AF/AS/OC/AN) → compared to `myContinent`.
- **Country/region prefixes** (e.g. `JA`) → resolved via CTY.DAT and compared to the new cached `myDxcc`.
- **Fail-open**: plain `CQ`, `CQ DX`, 3-digit zone CQs (`CQ 075`), activity calls (POTA/SOTA/TEST/FD/QRP/WW/IOTA/WWFF), and anything unresolvable stay answerable — only suppresses when it positively knows the target is a different DXCC/continent.

The directional token is read from `callsignTo` (where the decoder puts it); `modifier` is null on RX.

## Toggles (Settings → Decode Filters, both OFF by default)

- **Skip Directional CQs (auto-reply)** — `respectDirectionalCQ`: gates the Hunt phase-3 auto-answer loop. Manual taps and stations calling you are unaffected.
- **Hide Directional CQs Not For Me** — `filterDirectionalCQ`: hides them from the decode list.

## Files

- `GeneralVariables.java` — matcher, `myDxcc`, two toggle fields
- `CallsignDatabase.java` — cache `myDxcc` alongside `myContinent`
- `FT8TransmitSignal.java` — phase-3 auto-reply gate
- `DecodeScreen.kt` — decode-list display filter
- `DatabaseOpr.java` — persist both config keys
- `SettingsScreen.kt` — two toggle rows

## Notes

- Stacked on `feature/callsign-blocklist-filters` (PR #122), which it builds on. **Retarget this PR to `dev` once #122 merges.**
- Builds clean (`gradlew installDebug`) and installed/launched on a Pixel 8 without crash. On-air behavioral test (watching a `CQ JA` get skipped) needs live signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)