### PR TITLE
Needed-DX alerts: sound + notification for new DXCC / US state

### DIFF
--- a/ft8cn/app/src/main/AndroidManifest.xml
+++ b/ft8cn/app/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Needed-DX alerts: post notifications (Android 13+) and vibrate. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:allowBackup="false"

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -84,6 +84,11 @@ public class Ft8Message {
     public boolean toItu = false;
     public boolean toCq = false;
 
+    // US state of the sender, derived from maidenGrid via GeneralVariables.stateForGrid
+    // (null when not a US grid). fromNewState = that state is not yet in the worked set.
+    public String fromState = null;
+    public boolean fromNewState = false;
+
     public LatLng fromLatLng = null;
     public LatLng toLatLng = null;
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -104,6 +104,14 @@ public class GeneralVariables {
     public static final Map<String, String> dxccMap = new ConcurrentHashMap<>();
     public static final Map<Integer, Integer> cqMap = new ConcurrentHashMap<>();
     public static final Map<Integer, Integer> ituMap = new ConcurrentHashMap<>();
+    // Already-contacted US states (USPS code, e.g. "ND"). Populated at startup from the
+    // logbook by DatabaseOpr.getQslDxccToMap(), deriving each QSO's state from its grid.
+    public static final java.util.Set<String> workedStates =
+            java.util.Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    // 4-char Maidenhead field -> US state code, lazily loaded from the bundled
+    // assets/us_grid_states.json (the same map the Compose UI reads via UsStateLookup).
+    private static volatile Map<String, String> gridStateMap = null;
 
     // Callsign blocklist (Settings → Callsign Blocklist). Three independent match
     // modes, generalizing the original prefix-only "excluded callsigns" feature. A
@@ -398,6 +406,14 @@ public class GeneralVariables {
     //   - filterDirectionalCQ: hide those same CQs from the decode list.
     public static boolean respectDirectionalCQ = false;
     public static boolean filterDirectionalCQ = false;
+
+    // Needed-DX alerts (Settings → Needed-DX Alerts). Opt-in, default off. When enabled,
+    // a station calling CQ that is a NEW unworked entity/state triggers a sound + vibrate
+    // notification (DxAlertNotifier). Categories are independent.
+    //   - alertNewDxcc:  alert on a new (unworked) DXCC entity   (uses Ft8Message.fromDxcc)
+    //   - alertNewState: alert on a new (unworked) US state       (uses Ft8Message.fromNewState)
+    public static boolean alertNewDxcc = false;
+    public static boolean alertNewState = false;
 
     // Geographic continent-directed CQ tokens — matched against myContinent.
     private static final java.util.Set<String> CONTINENT_CODES =
@@ -819,6 +835,73 @@ public class GeneralVariables {
      */
     public static boolean getItuZoneById(int itu) {
         return ituMap.containsKey(itu);
+    }
+
+    /**
+     * Add an already-contacted US state to the set.
+     *
+     * @param state USPS state code (e.g. "ND")
+     */
+    public static void addState(String state) {
+        if (state == null || state.isEmpty()) return;
+        workedStates.add(state.toUpperCase());
+    }
+
+    /**
+     * Check if this US state has already been contacted.
+     *
+     * @param state USPS state code
+     * @return whether it is in the worked set
+     */
+    public static boolean getStateWorked(String state) {
+        return state != null && workedStates.contains(state.toUpperCase());
+    }
+
+    /**
+     * Resolve a 4-character Maidenhead field to a US state code, or null if it is not a
+     * US grid (the bundled table is US-only, so non-US grids return null naturally).
+     *
+     * <p>Backed by the same {@code assets/us_grid_states.json} the Compose UI reads via
+     * {@code UsStateLookup}; loaded once on first use. Used both for live-decode "new
+     * state" detection (CallsignDatabase) and worked-state import (DatabaseOpr).
+     *
+     * @param grid the station's Maidenhead grid (4+ chars); shorter/empty returns null
+     * @return USPS state code, or null
+     */
+    public static String stateForGrid(String grid) {
+        if (grid == null || grid.length() < 4) return null;
+        Map<String, String> m = gridStateMap;
+        if (m == null) {
+            m = loadGridStateMap();
+            gridStateMap = m;
+        }
+        return m.get(grid.substring(0, 4).toUpperCase());
+    }
+
+    private static synchronized Map<String, String> loadGridStateMap() {
+        if (gridStateMap != null) return gridStateMap;
+        Map<String, String> out = new HashMap<>();
+        Context ctx = getMainContext();
+        if (ctx != null) {
+            try {
+                java.io.InputStream is = ctx.getAssets().open("us_grid_states.json");
+                java.io.BufferedReader reader = new java.io.BufferedReader(
+                        new java.io.InputStreamReader(is));
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) sb.append(line);
+                reader.close();
+                org.json.JSONObject obj = new org.json.JSONObject(sb.toString());
+                Iterator<String> keys = obj.keys();
+                while (keys.hasNext()) {
+                    String k = keys.next();
+                    out.put(k.toUpperCase(), obj.getString(k));
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "loadGridStateMap: failed to load us_grid_states.json", e);
+            }
+        }
+        return out;
     }
 
     //used to trigger new grid

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -155,6 +155,12 @@ public class MainViewModel extends ViewModel {
     public MutableLiveData<Integer> mutable_Decoded_Counter = new MutableLiveData<>();//total decoded count
     public int currentDecodeCount = 0;//number of decoded items in this cycle
     public MutableLiveData<ArrayList<Ft8Message>> mutableFt8MessageList = new MutableLiveData<>();//message list
+    // Needed-DX alerts: posts sound+vibrate notifications for new DXCC/state CQ stations.
+    public final com.bg7yoz.ft8cn.alert.DxAlertNotifier dxAlertNotifier =
+            new com.bg7yoz.ft8cn.alert.DxAlertNotifier(GeneralVariables.getMainContext());
+    // Callsign from a tapped Needed-DX notification; the Decode screen observes this to
+    // scroll to + highlight that station (pre-select). Set by ComposeMainActivity.
+    public MutableLiveData<String> mutablePreselectCallsign = new MutableLiveData<>();
     public MutableLiveData<Long> timerSec = new MutableLiveData<>();//current UTC time. Update frequency determined by UtcTimer, ~100ms when not triggered.
     public MutableLiveData<Boolean> mutableIsRecording = new MutableLiveData<>();//whether currently recording
     public MutableLiveData<Boolean> mutableHamRecordIsRunning = new MutableLiveData<>();//whether HamRecord is running
@@ -1215,6 +1221,8 @@ public class MainViewModel extends ViewModel {
         public void run() {
             CallsignDatabase.getMessagesLocation(
                     GeneralVariables.callsignDatabase.getDb(), messages);
+            // Entity/state flags are now populated — fire Needed-DX alerts before the UI refresh.
+            mainViewModel.dxAlertNotifier.processDecodes(messages);
             mainViewModel.mutableFt8MessageList.postValue(mainViewModel.ft8Messages);
         }
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/alert/DxAlertNotifier.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/alert/DxAlertNotifier.java
@@ -1,0 +1,149 @@
+package com.bg7yoz.ft8cn.alert;
+
+import android.Manifest;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.core.content.ContextCompat;
+
+import com.bg7yoz.ft8cn.Ft8Message;
+import com.bg7yoz.ft8cn.GeneralVariables;
+import com.bg7yoz.ft8cn.R;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Needed-DX alerts: plays a sound + vibrates and posts a notification when a station
+ * calling CQ is a NEW (unworked) one in a user-enabled category — a new DXCC entity
+ * ({@link GeneralVariables#alertNewDxcc}) or a new US state
+ * ({@link GeneralVariables#alertNewState}).
+ *
+ * <p>Driven from {@code MainViewModel.GetQTHRunnable.run()} after
+ * {@code CallsignDatabase.getMessagesLocation} has populated the {@code from*} flags,
+ * so this just reads {@link Ft8Message#fromDxcc} / {@link Ft8Message#fromNewState}.
+ *
+ * <p>Sound + vibration are handled by a high-importance notification channel, so they
+ * respect Do-Not-Disturb and the user's per-channel system settings. Alerts are
+ * de-duplicated per (category + identifier) for the lifetime of the process, so a
+ * station calling CQ every cycle — or several stations from the same needed entity —
+ * only alert once.
+ */
+public class DxAlertNotifier {
+    private static final String CHANNEL_ID = "dx_alerts";
+    public static final String EXTRA_CALLSIGN = "alert_callsign";
+    public static final String EXTRA_BAND = "alert_band";
+
+    private final Context appContext;
+    // Already-alerted keys this session: "DXCC:<country>" / "STATE:<code>".
+    private final Set<String> alerted = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    public DxAlertNotifier(Context context) {
+        this.appContext = context != null ? context.getApplicationContext() : null;
+        createChannel();
+    }
+
+    private void createChannel() {
+        if (appContext == null) return;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        NotificationManager nm = (NotificationManager)
+                appContext.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm == null) return;
+        if (nm.getNotificationChannel(CHANNEL_ID) != null) return;
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID, "Needed-DX alerts", NotificationManager.IMPORTANCE_HIGH);
+        channel.setDescription("New DXCC / US state stations calling CQ");
+        channel.enableVibration(true);
+        channel.setVibrationPattern(new long[]{0, 250, 150, 250});
+        Uri sound = android.media.RingtoneManager
+                .getDefaultUri(android.media.RingtoneManager.TYPE_NOTIFICATION);
+        if (sound != null) {
+            channel.setSound(sound, new android.media.AudioAttributes.Builder()
+                    .setUsage(android.media.AudioAttributes.USAGE_NOTIFICATION)
+                    .setContentType(android.media.AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build());
+        }
+        nm.createNotificationChannel(channel);
+    }
+
+    /**
+     * Inspect a freshly-decoded batch and fire alerts for newly-needed CQ stations.
+     */
+    public void processDecodes(List<Ft8Message> messages) {
+        if (appContext == null || messages == null) return;
+        if (!GeneralVariables.alertNewDxcc && !GeneralVariables.alertNewState) return;
+
+        for (Ft8Message msg : messages) {
+            if (msg == null || !msg.checkIsCQ()) continue;          // workable stations only
+            if (GeneralVariables.checkIsBlockedMessage(msg)) continue;
+
+            if (GeneralVariables.alertNewDxcc && msg.fromDxcc) {
+                String country = (msg.fromWhere == null || msg.fromWhere.isEmpty())
+                        ? msg.getCallsignFrom() : msg.fromWhere;
+                fireOnce("DXCC:" + country, "New DXCC: " + country, msg);
+            }
+            if (GeneralVariables.alertNewState && msg.fromNewState && msg.fromState != null) {
+                fireOnce("STATE:" + msg.fromState, "New state: " + msg.fromState, msg);
+            }
+        }
+    }
+
+    private void fireOnce(String dedupKey, String title, Ft8Message msg) {
+        if (!alerted.add(dedupKey)) return;                         // already alerted this session
+
+        StringBuilder body = new StringBuilder(msg.getCallsignFrom());
+        if (msg.maidenGrid != null && !msg.maidenGrid.isEmpty()) {
+            body.append("  ").append(msg.maidenGrid);
+        }
+        body.append("  ").append(msg.snr).append(" dB");
+
+        GeneralVariables.fileLog("DX_ALERT fire key=[" + dedupKey + "] "
+                + title + " call=" + msg.getCallsignFrom());
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && ContextCompat.checkSelfPermission(appContext,
+                        Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            return;                                                 // no permission → skip silently
+        }
+
+        int id = dedupKey.hashCode();
+
+        Intent intent = new Intent(appContext,
+                radio.ks3ckc.ft8us.ComposeMainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP
+                | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra(EXTRA_CALLSIGN, msg.getCallsignFrom());
+        intent.putExtra(EXTRA_BAND, msg.band);
+
+        int piFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            piFlags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+        PendingIntent pi = PendingIntent.getActivity(appContext, id, intent, piFlags);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(appContext, CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle(title)
+                .setContentText(body.toString())
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_EVENT)
+                .setAutoCancel(true)
+                .setContentIntent(pi);
+
+        try {
+            NotificationManagerCompat.from(appContext).notify(id, builder.build());
+        } catch (SecurityException ignored) {
+            // Permission revoked between the check and notify(); ignore.
+        }
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -127,6 +127,12 @@ public class CallsignDatabase extends SQLiteOpenHelper {
                     msg.fromLatLng = new LatLng(fromCallsignInfo.Latitude, fromCallsignInfo.Longitude * -1);
             }
 
+            // US state from the sender's grid (US-only table → null for non-US grids).
+            // fromNewState mirrors fromDxcc: true when the state is not yet worked.
+            msg.fromState = GeneralVariables.stateForGrid(msg.maidenGrid);
+            msg.fromNewState = msg.fromState != null
+                    && !GeneralVariables.getStateWorked(msg.fromState);
+
             // Resolve the operator's own continent + DXCC once (continent for the DX
             // decode filter, DXCC for the directional-CQ matcher).
             if ((GeneralVariables.myContinent == null || GeneralVariables.myDxcc == null)

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -1174,7 +1174,27 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 cursor.close();
 
-                Log.d(TAG, "run: zone import complete, resolved " + count + " logged callsigns");
+                // Worked US states: derive each logged QSO's state from its grid square,
+                // using the same grid->state table the decode/display paths use. Keeps the
+                // "new state" alert consistent with what the UI shows on each row.
+                Cursor gridCursor = db.rawQuery(
+                        "SELECT DISTINCT gridsquare FROM QSLTable "
+                                + "WHERE gridsquare IS NOT NULL AND gridsquare <> ''",
+                        null);
+                int stateCount = 0;
+                while (gridCursor.moveToNext()) {
+                    String grid = gridCursor.getString(gridCursor.getColumnIndex("gridsquare"));
+                    String state = GeneralVariables.stateForGrid(grid);
+                    if (state != null) {
+                        GeneralVariables.addState(state);
+                        stateCount++;
+                    }
+                }
+                gridCursor.close();
+
+                Log.d(TAG, "run: zone import complete, resolved " + count + " logged callsigns, "
+                        + stateCount + " gridded QSOs -> " + GeneralVariables.workedStates.size()
+                        + " worked states");
             }
         }).start();
 
@@ -2395,6 +2415,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 if (name.equalsIgnoreCase("filterDirectionalCQ")) {//Directional CQ: hide from decode list
                     GeneralVariables.filterDirectionalCQ = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("alertNewDxcc")) {//Needed-DX alert: new DXCC entity
+                    GeneralVariables.alertNewDxcc = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("alertNewState")) {//Needed-DX alert: new US state
+                    GeneralVariables.alertNewState = result.equals("1");
                 }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -182,6 +182,22 @@ class ComposeMainActivity : ComponentActivity() {
         } else {
             doReceiveShareFile(intent)
         }
+
+        // Handle a tapped Needed-DX alert (cold start).
+        handleAlertIntent(intent)
+    }
+
+    /**
+     * If [intent] came from a tapped Needed-DX notification, publish the alerted callsign
+     * so the Decode screen can switch to itself and scroll to + highlight that station.
+     */
+    private fun handleAlertIntent(intent: Intent?) {
+        val callsign = intent?.getStringExtra(
+            com.bg7yoz.ft8cn.alert.DxAlertNotifier.EXTRA_CALLSIGN,
+        ) ?: return
+        if (callsign.isBlank()) return
+        fileLog("handleAlertIntent: preselect $callsign")
+        mainViewModel.mutablePreselectCallsign.postValue(callsign)
     }
 
     private fun buildPermissionsList(): Array<String> {
@@ -197,6 +213,9 @@ class ComposeMainActivity : ComponentActivity() {
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             base.add(Manifest.permission.BLUETOOTH_CONNECT)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            base.add(Manifest.permission.POST_NOTIFICATIONS)
         }
         return base.toTypedArray()
     }
@@ -351,6 +370,8 @@ class ComposeMainActivity : ComponentActivity() {
         } else {
             setIntent(intent)
             doReceiveShareFile(intent)
+            // Handle a tapped Needed-DX alert (app already running).
+            handleAlertIntent(intent)
         }
     }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -60,6 +60,15 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     // Frequency picker sheet state
     var showFrequencyPicker by rememberSaveable { mutableStateOf(false) }
 
+    // A tapped Needed-DX notification asks us to jump to the Decode tab (DecodeScreen
+    // then scrolls to + highlights the alerted station).
+    val preselectCallsign by mainViewModel.mutablePreselectCallsign.observeAsState()
+    LaunchedEffect(preselectCallsign) {
+        if (!preselectCallsign.isNullOrBlank()) {
+            activeTab = FT8USTab.DECODE
+        }
+    }
+
     // Auto-expand when activated, auto-collapse when deactivated
     LaunchedEffect(isActivated) {
         if (isActivated) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -143,6 +143,22 @@ fun DecodeScreen(
         previousCount = filteredMessages.size
     }
 
+    // A tapped Needed-DX notification asks us to pre-select that station: reset to the
+    // "All" filter so it's visible, scroll to its latest decode, and open the QSO sheet
+    // (which shows the station detail + a Call button). We do NOT auto-transmit.
+    val preselectCallsign by mainViewModel.mutablePreselectCallsign.observeAsState()
+    LaunchedEffect(preselectCallsign, messageList?.size) {
+        val cs = preselectCallsign
+        if (cs.isNullOrBlank()) return@LaunchedEffect
+        val present = (messageList ?: arrayListOf())
+            .any { it.callsignFrom.equals(cs, ignoreCase = true) }
+        if (!present) return@LaunchedEffect          // wait until the station is in the list
+        selectedFilter = "All"
+        mainViewModel.qsoSheetCallsign.postValue(cs)
+        mainViewModel.qsoSheetMinimized.postValue(false)
+        mainViewModel.mutablePreselectCallsign.postValue(null)   // consume (allow re-trigger)
+    }
+
     // Format UTC time for the subtitle
     val utcString = if (utcTime > 0L) {
         UtcTimer.getTimeStr(utcTime)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -137,6 +137,8 @@ fun SettingsScreen(
     var filterContinent by remember { mutableStateOf(GeneralVariables.filterContinent) }
     var respectDirectionalCQ by remember { mutableStateOf(GeneralVariables.respectDirectionalCQ) }
     var filterDirectionalCQ by remember { mutableStateOf(GeneralVariables.filterDirectionalCQ) }
+    var alertNewDxcc by remember { mutableStateOf(GeneralVariables.alertNewDxcc) }
+    var alertNewState by remember { mutableStateOf(GeneralVariables.alertNewState) }
 
     // Continent codes (stored on the message) and their display names, parallel lists.
     val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
@@ -1314,6 +1316,41 @@ fun SettingsScreen(
                                 GeneralVariables.filterDirectionalCQ = checked
                                 mainViewModel.databaseOpr.writeConfig(
                                     "filterDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 4e. NEEDED-DX ALERTS
+            // =====================================================================
+            SettingsSection(title = "NEEDED-DX ALERTS") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "New DXCC",
+                            description = "Sound + vibrate + notify when an unworked DXCC entity calls CQ",
+                            toggle = alertNewDxcc,
+                            onToggleChange = { checked ->
+                                alertNewDxcc = checked
+                                GeneralVariables.alertNewDxcc = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "alertNewDxcc", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "New US State",
+                            description = "Sound + vibrate + notify when a station from an unworked US state calls CQ (state from grid)",
+                            toggle = alertNewState,
+                            onToggleChange = { checked ->
+                                alertNewState = checked
+                                GeneralVariables.alertNewState = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "alertNewState", if (checked) "1" else "0", null,
                                 )
                             },
                         )


### PR DESCRIPTION
## What

Active **Needed-DX alerts**: when a station calling CQ is a *new* (unworked) **DXCC entity** or **US state**, the app plays a sound + vibrates and posts a notification — so the operator doesn't have to be watching the decode list to catch a needed one. Tapping the notification opens the app and **pre-selects** that station (opens its QSO sheet, ready to call).

Builds on the existing per-decode "new entity" flags, decode filters, and the bundled grid→state table.

## Categories (opt-in, independent)

Settings → **NEEDED-DX ALERTS**:
- **New DXCC** — reuses the existing `Ft8Message.fromDxcc` flag.
- **New US State** — adds a parallel `fromNewState` flag, derived from the sender's gridsquare via the already-bundled `us_grid_states.json` (the same map the decode rows already display). Worked states are imported at startup from the logbook's gridsquares, alongside the existing DXCC/zone import in `getQslDxccToMap()`.

Both default **off**.

## How it works

- Alerts fire from `MainViewModel.GetQTHRunnable.run()`, right after `CallsignDatabase.getMessagesLocation` populates the entity/state flags.
- `DxAlertNotifier` posts via a high-importance `dx_alerts` notification channel → **sound + vibrate** handled by the channel (respects DND / per-channel system settings).
- Fires on **CQ** messages only (workable stations), respects the callsign blocklist, and **de-dups per entity/state** for the session (a station calling CQ every cycle alerts once).
- Tap → `ComposeMainActivity` routes to the Decode tab and pre-selects the station. It does **not** auto-transmit.
- Adds `POST_NOTIFICATIONS` (runtime, Android 13+) + `VIBRATE`.

## Verification

- Builds clean (`assembleDebug`); installed on a Pixel 8 (Android 14), launches without crash.
- Settings section renders with both toggles; toggling persists via the existing `writeConfig` path.
- Notification channel verified registered: `mImportance=4` (HIGH), notification sound set, `mVibrationEnabled=true` with pattern `[0,250,150,250]`.
- State display on decode rows already uses the same `us_grid_states.json` table.

## Notes / limitations

- State is grid-derived (4-char field); border grids resolve to a single state — best-effort, matching existing display behavior.
- Worked DXCC/state sets are in-memory, rebuilt at startup from the logbook (consistent with the current zone-import design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)