### PR TITLE
Release: decode workflow features (fast reply, blocklist, directional CQ, auto-CQ, Needed-DX alerts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # FT8AF Project Instructions
 
+## Workflow
+
+After finishing the code for any feature, open a pull request targeting the `dev`
+branch (do the work on a feature branch, then `gh pr create --base dev`). Don't
+merge straight to `main`.
+
 ## Build & Deploy
 
 After making code changes, always build and install on the connected device.

--- a/ft8cn/app/src/main/AndroidManifest.xml
+++ b/ft8cn/app/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Needed-DX alerts: post notifications (Android 13+) and vibrate. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:allowBackup="false"

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
@@ -11,6 +11,10 @@ public final class FT8Common {
     public static final int SAMPLE_RATE=12000;
     public static final int FT8_SLOT_TIME=15;
     public static final int FT8_SLOT_TIME_MILLISECOND=15000;//milliseconds per cycle
+    //Shorter RX window used when GeneralVariables.earlyDecode is on. The FT8 message is
+    //12.64s; 13500ms captures it plus ~0.86s of positive-DT margin and lets the decode
+    //finish ~1s before the cycle boundary, so a CQ can be answered on the next slot.
+    public static final int FT8_EARLY_DECODE_MILLISECOND=13500;
     public static final int FT4_SLOT_TIME_MILLISECOND=7500;
     public static final int FT8_5_SYMBOLS_MILLISECOND=800;//time needed for 5 symbols
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -70,6 +70,8 @@ public class Ft8Message {
     public String fromWhere = null;//used for displaying address/location
     public String toWhere = null;//used for displaying address/location
 
+    public String continent = null;//sender's continent abbrev (NA/SA/EU/AF/AS/OC/AN); used by decode filters
+
     public boolean isQSL_Callsign = false;//whether this callsign has been previously contacted
 
     public static MessageHashMap hashList = new MessageHashMap();

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -84,6 +84,11 @@ public class Ft8Message {
     public boolean toItu = false;
     public boolean toCq = false;
 
+    // US state of the sender, derived from maidenGrid via GeneralVariables.stateForGrid
+    // (null when not a US grid). fromNewState = that state is not yet in the worked set.
+    public String fromState = null;
+    public boolean fromNewState = false;
+
     public LatLng fromLatLng = null;
     public LatLng toLatLng = null;
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -104,6 +104,14 @@ public class GeneralVariables {
     public static final Map<String, String> dxccMap = new ConcurrentHashMap<>();
     public static final Map<Integer, Integer> cqMap = new ConcurrentHashMap<>();
     public static final Map<Integer, Integer> ituMap = new ConcurrentHashMap<>();
+    // Already-contacted US states (USPS code, e.g. "ND"). Populated at startup from the
+    // logbook by DatabaseOpr.getQslDxccToMap(), deriving each QSO's state from its grid.
+    public static final java.util.Set<String> workedStates =
+            java.util.Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    // 4-char Maidenhead field -> US state code, lazily loaded from the bundled
+    // assets/us_grid_states.json (the same map the Compose UI reads via UsStateLookup).
+    private static volatile Map<String, String> gridStateMap = null;
 
     // Callsign blocklist (Settings → Callsign Blocklist). Three independent match
     // modes, generalizing the original prefix-only "excluded callsigns" feature. A
@@ -398,6 +406,14 @@ public class GeneralVariables {
     //   - filterDirectionalCQ: hide those same CQs from the decode list.
     public static boolean respectDirectionalCQ = false;
     public static boolean filterDirectionalCQ = false;
+
+    // Needed-DX alerts (Settings → Needed-DX Alerts). Opt-in, default off. When enabled,
+    // a station calling CQ that is a NEW unworked entity/state triggers a sound + vibrate
+    // notification (DxAlertNotifier). Categories are independent.
+    //   - alertNewDxcc:  alert on a new (unworked) DXCC entity   (uses Ft8Message.fromDxcc)
+    //   - alertNewState: alert on a new (unworked) US state       (uses Ft8Message.fromNewState)
+    public static boolean alertNewDxcc = false;
+    public static boolean alertNewState = false;
 
     // Geographic continent-directed CQ tokens — matched against myContinent.
     private static final java.util.Set<String> CONTINENT_CODES =
@@ -819,6 +835,73 @@ public class GeneralVariables {
      */
     public static boolean getItuZoneById(int itu) {
         return ituMap.containsKey(itu);
+    }
+
+    /**
+     * Add an already-contacted US state to the set.
+     *
+     * @param state USPS state code (e.g. "ND")
+     */
+    public static void addState(String state) {
+        if (state == null || state.isEmpty()) return;
+        workedStates.add(state.toUpperCase());
+    }
+
+    /**
+     * Check if this US state has already been contacted.
+     *
+     * @param state USPS state code
+     * @return whether it is in the worked set
+     */
+    public static boolean getStateWorked(String state) {
+        return state != null && workedStates.contains(state.toUpperCase());
+    }
+
+    /**
+     * Resolve a 4-character Maidenhead field to a US state code, or null if it is not a
+     * US grid (the bundled table is US-only, so non-US grids return null naturally).
+     *
+     * <p>Backed by the same {@code assets/us_grid_states.json} the Compose UI reads via
+     * {@code UsStateLookup}; loaded once on first use. Used both for live-decode "new
+     * state" detection (CallsignDatabase) and worked-state import (DatabaseOpr).
+     *
+     * @param grid the station's Maidenhead grid (4+ chars); shorter/empty returns null
+     * @return USPS state code, or null
+     */
+    public static String stateForGrid(String grid) {
+        if (grid == null || grid.length() < 4) return null;
+        Map<String, String> m = gridStateMap;
+        if (m == null) {
+            m = loadGridStateMap();
+            gridStateMap = m;
+        }
+        return m.get(grid.substring(0, 4).toUpperCase());
+    }
+
+    private static synchronized Map<String, String> loadGridStateMap() {
+        if (gridStateMap != null) return gridStateMap;
+        Map<String, String> out = new HashMap<>();
+        Context ctx = getMainContext();
+        if (ctx != null) {
+            try {
+                java.io.InputStream is = ctx.getAssets().open("us_grid_states.json");
+                java.io.BufferedReader reader = new java.io.BufferedReader(
+                        new java.io.InputStreamReader(is));
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) sb.append(line);
+                reader.close();
+                org.json.JSONObject obj = new org.json.JSONObject(sb.toString());
+                Iterator<String> keys = obj.keys();
+                while (keys.hasNext()) {
+                    String k = keys.next();
+                    out.put(k.toUpperCase(), obj.getString(k));
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "loadGridStateMap: failed to load us_grid_states.json", e);
+            }
+        }
+        return out;
     }
 
     //used to trigger new grid

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -224,6 +224,7 @@ public class GeneralVariables {
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.
+    public static boolean earlyDecode = true;//Fast turnaround: decode a shorter RX window so CQ decodes appear ~1s before the cycle boundary, enabling a next-slot reply.
     public static int civAddress = 0xa4;//CI-V address
     public static int baudRate = 19200;//Baud rate
     public static long band = 14074000;//Carrier frequency band

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -104,36 +104,115 @@ public class GeneralVariables {
     public static final Map<Integer, Integer> cqMap = new ConcurrentHashMap<>();
     public static final Map<Integer, Integer> ituMap = new ConcurrentHashMap<>();
 
+    // Callsign blocklist (Settings → Callsign Blocklist). Three independent match
+    // modes, generalizing the original prefix-only "excluded callsigns" feature. A
+    // blocked station is hidden from the decode list AND excluded from TX/auto-seq.
+    //   - excludedCallsigns: callsign PREFIX match (e.g. "RA" blocks RA0..RA9..).
+    //     Reuses the legacy "excludedCallsigns" config key for backward compat.
+    //   - blockedExactCallsigns: whole-call EXACT match.
+    //   - blockedKeywords: SUBSTRING match (against the call, and the full message
+    //     text via checkIsBlockedMessage) — catches POTA, /P, QRP, contest junk.
     private static final Map<String, Integer> excludedCallsigns = new HashMap<>();
+    private static final java.util.LinkedHashSet<String> blockedExactCallsigns = new java.util.LinkedHashSet<>();
+    private static final java.util.LinkedHashSet<String> blockedKeywords = new java.util.LinkedHashSet<>();
 
     /**
-     * Add excluded callsign prefixes
-     *
-     * @param callsigns callsigns
+     * Split a user-entered list on comma / space / pipe / Chinese comma and
+     * collect the non-empty, upper-cased tokens into {@code target}.
      */
-    public static synchronized void addExcludedCallsigns(String callsigns) {
-        excludedCallsigns.clear();
-        String[] s = callsigns.toUpperCase().replace(" ", ",")
+    private static void parseBlockTokens(String text, java.util.Collection<String> target) {
+        target.clear();
+        if (text == null) return;
+        String[] s = text.toUpperCase().replace(" ", ",")
                 .replace("|", ",")
                 .replace("，", ",").split(",");
-        for (int i = 0; i < s.length; i++) {
-            if (s[i].length() > 0) {
-                excludedCallsigns.put(s[i], 0);
+        for (String token : s) {
+            if (token.length() > 0) {
+                target.add(token);
             }
         }
     }
 
     /**
-     * Check if a callsign matches an excluded prefix
+     * Join a token collection back into the canonical comma-separated form used
+     * for persistence and for display in the Settings text field.
+     */
+    private static String joinBlockTokens(java.util.Collection<String> tokens) {
+        StringBuilder calls = new StringBuilder();
+        int i = 0;
+        for (String token : tokens) {
+            if (i++ == 0) {
+                calls.append(token);
+            } else {
+                calls.append(",").append(token);
+            }
+        }
+        return calls.toString();
+    }
+
+    /**
+     * Add excluded callsign prefixes (legacy name kept; this is the PREFIX list).
+     *
+     * @param callsigns callsigns
+     */
+    public static synchronized void addExcludedCallsigns(String callsigns) {
+        excludedCallsigns.clear();
+        if (callsigns == null) return;
+        String[] s = callsigns.toUpperCase().replace(" ", ",")
+                .replace("|", ",")
+                .replace("，", ",").split(",");
+        for (String token : s) {
+            if (token.length() > 0) {
+                excludedCallsigns.put(token, 0);
+            }
+        }
+    }
+
+    public static synchronized void addBlockedExactCallsigns(String callsigns) {
+        parseBlockTokens(callsigns, blockedExactCallsigns);
+    }
+
+    public static synchronized void addBlockedKeywords(String keywords) {
+        parseBlockTokens(keywords, blockedKeywords);
+    }
+
+    /**
+     * Get the list of excluded callsign prefixes (the PREFIX list).
+     *
+     * @return the list as a comma-separated string
+     */
+    public static synchronized String getExcludeCallsigns() {
+        return joinBlockTokens(excludedCallsigns.keySet());
+    }
+
+    public static synchronized String getBlockedExactCallsigns() {
+        return joinBlockTokens(blockedExactCallsigns);
+    }
+
+    public static synchronized String getBlockedKeywords() {
+        return joinBlockTokens(blockedKeywords);
+    }
+
+    /**
+     * Check whether a callsign is blocked by any match mode: exact whole-call,
+     * prefix, or keyword substring (against the callsign itself).
      *
      * @param callsign callsign
-     * @return whether it matches
+     * @return whether it is blocked
      */
-    public static synchronized boolean checkIsExcludeCallsign(String callsign) {
-        Iterator<String> iterator = excludedCallsigns.keySet().iterator();
-        while (iterator.hasNext()) {
-            String key = iterator.next();
-            if (callsign.toUpperCase().indexOf(key) == 0) {
+    public static synchronized boolean checkIsBlocked(String callsign) {
+        if (callsign == null) return false;
+        String up = callsign.toUpperCase();
+        if (blockedExactCallsigns.contains(up)) {
+            return true;
+        }
+        for (String prefix : excludedCallsigns.keySet()) {
+            if (up.indexOf(prefix) == 0) {
+                return true;
+            }
+        }
+        for (String keyword : blockedKeywords) {
+            if (up.contains(keyword)) {
                 return true;
             }
         }
@@ -141,24 +220,41 @@ public class GeneralVariables {
     }
 
     /**
-     * Get the list of excluded callsign prefixes
+     * Decode-list block check: blocked if the sender's callsign is blocked, or any
+     * keyword appears anywhere in the rendered message text (so keywords can match
+     * message content like "POTA", not just the callsign).
      *
-     * @return the list as a string
+     * @param msg the decoded message
+     * @return whether it is blocked
      */
-    public static synchronized String getExcludeCallsigns() {
-        StringBuilder calls = new StringBuilder();
-        Iterator<String> iterator = excludedCallsigns.keySet().iterator();
-        int i = 0;
-        while (iterator.hasNext()) {
-            String key = iterator.next();
-            if (i == 0) {
-                calls.append(key);
-            } else {
-                calls.append(",").append(key);
-            }
-            i++;
+    public static synchronized boolean checkIsBlockedMessage(Ft8Message msg) {
+        if (msg == null) return false;
+        if (checkIsBlocked(msg.callsignFrom)) {
+            return true;
         }
-        return calls.toString();
+        if (!blockedKeywords.isEmpty()) {
+            String text = msg.getMessageText();
+            if (text != null) {
+                String up = text.toUpperCase();
+                for (String keyword : blockedKeywords) {
+                    if (up.contains(keyword)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Backward-compatible alias. Existing TX-side call sites call this; it now
+     * covers all three blocklist match modes via {@link #checkIsBlocked}.
+     *
+     * @param callsign callsign
+     * @return whether it matches
+     */
+    public static synchronized boolean checkIsExcludeCallsign(String callsign) {
+        return checkIsBlocked(callsign);
     }
 
 
@@ -275,6 +371,19 @@ public class GeneralVariables {
     public static boolean highlightNewBand = true;//Highlight stations worked only on other bands
     public static boolean highlightWorked = true;//Tag stations already worked
     public static boolean highlightPota = true;//Highlight spotted POTA activators (new parks stand out)
+
+    // Decode-list display filters (Settings → Decode Filters). Persistent
+    // "show only" filters applied to the decode list in DecodeScreen.filterMessages().
+    // Multiple enabled filters AND together.
+    public static boolean filterShowOnlyCQ = false;//Show only CQ-type messages
+    public static boolean filterDxOnly = false;//Show only stations outside my own continent
+    public static boolean filterNeededOnly = false;//Show only not-yet-QSL'd stations
+    public static boolean filterByContinent = false;//Show only stations from filterContinent
+    public static String filterContinent = "EU";//Target continent for filterByContinent (NA/SA/EU/AF/AS/OC/AN)
+
+    // The operator's own continent abbreviation, derived once from the callsign
+    // (CallsignDatabase.getContinent). Used by the DX filter. Null until resolved.
+    public static String myContinent = null;
 
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -322,6 +322,7 @@ public class GeneralVariables {
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.
     public static boolean earlyDecode = true;//Fast turnaround: decode a shorter RX window so CQ decodes appear ~1s before the cycle boundary, enabling a next-slot reply.
+    public static boolean autoCQAfterQSO = false;//Auto-CQ: keep calling CQ after each completed QSO (chain without re-tapping). Refreshes the TX watchdog per QSO and forces pure CQ (ignores Hunt).
     public static int civAddress = 0xa4;//CI-V address
     public static int baudRate = 19200;//Baud rate
     public static long band = 14074000;//Carrier frequency band

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import androidx.lifecycle.MutableLiveData;
 
 import com.bg7yoz.ft8cn.callsign.CallsignDatabase;
+import com.bg7yoz.ft8cn.callsign.CallsignInfo;
 import com.bg7yoz.ft8cn.connector.ConnectMode;
 import com.bg7yoz.ft8cn.database.ControlMode;
 import com.bg7yoz.ft8cn.database.DatabaseOpr;
@@ -384,6 +385,63 @@ public class GeneralVariables {
     // The operator's own continent abbreviation, derived once from the callsign
     // (CallsignDatabase.getContinent). Used by the DX filter. Null until resolved.
     public static String myContinent = null;
+
+    // The operator's own DXCC, derived once from the callsign alongside myContinent
+    // (CallsignDatabase.getMessagesLocation). Used by the directional-CQ matcher to
+    // match country/region tokens (e.g. "CQ JA"). Null until resolved → fail-open.
+    public static String myDxcc = null;
+
+    // Directional CQ awareness (Settings → Decode Filters). Both opt-in, default off.
+    //   - respectDirectionalCQ: suppress AUTO-replies to directional CQs (CQ DX/EU/JA…)
+    //     not aimed at my station. Does not affect manual taps or stations calling me.
+    //   - filterDirectionalCQ: hide those same CQs from the decode list.
+    public static boolean respectDirectionalCQ = false;
+    public static boolean filterDirectionalCQ = false;
+
+    // Geographic continent-directed CQ tokens — matched against myContinent.
+    private static final java.util.Set<String> CONTINENT_CODES =
+            new java.util.HashSet<>(java.util.Arrays.asList("NA", "SA", "EU", "AF", "AS", "OC", "AN"));
+    // Non-geographic activity calls — always answerable. Easily extended.
+    private static final java.util.Set<String> ACTIVITY_TOKENS =
+            new java.util.HashSet<>(java.util.Arrays.asList(
+                    "DX", "POTA", "SOTA", "WWFF", "IOTA", "TEST", "FD", "QRP", "WW"));
+
+    /**
+     * The directional token after CQ/DE/QRZ in a decoded callsignTo (e.g. "DX" from
+     * "CQ DX"), or null for a plain CQ / non-CQ message.
+     */
+    public static String getDirectionalCQToken(String callsignTo) {
+        if (callsignTo == null) return null;
+        String[] p = callsignTo.trim().toUpperCase().split("\\s+");
+        if (p.length < 2) return null;
+        if (!(p[0].equals("CQ") || p[0].equals("DE") || p[0].equals("QRZ"))) return null;
+        return p[1];
+    }
+
+    /**
+     * Whether a (possibly directional) CQ is answerable by my station. Continent-code
+     * tokens are matched against {@link #myContinent}; country/region prefixes against
+     * {@link #myDxcc} via the callsign database. Fail-open: plain CQ, "CQ DX",
+     * 3-digit zone CQs, known activity calls, and anything we can't positively resolve
+     * to a different DXCC/continent are all treated as answerable.
+     *
+     * @param callsignTo the decoded message's callsignTo field
+     * @return true if answerable (or not a CQ at all)
+     */
+    public static synchronized boolean directionalCQIsForMe(String callsignTo) {
+        String token = getDirectionalCQToken(callsignTo);
+        if (token == null) return true;                       // plain CQ / not a CQ
+        if (token.matches("[0-9]{3}")) return true;           // zone-directed CQ nnn
+        if (ACTIVITY_TOKENS.contains(token)) return true;     // DX / POTA / TEST / ...
+        if (CONTINENT_CODES.contains(token)) {                // continent-directed
+            return myContinent == null || token.equalsIgnoreCase(myContinent);
+        }
+        // country/region prefix (e.g. JA) — match by DXCC
+        if (callsignDatabase == null || myDxcc == null) return true;
+        CallsignInfo info = callsignDatabase.getCallInfo(token);
+        if (info == null || info.DXCC == null) return true;   // unresolved → fail-open
+        return info.DXCC.equalsIgnoreCase(myDxcc);
+    }
 
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -155,6 +155,12 @@ public class MainViewModel extends ViewModel {
     public MutableLiveData<Integer> mutable_Decoded_Counter = new MutableLiveData<>();//total decoded count
     public int currentDecodeCount = 0;//number of decoded items in this cycle
     public MutableLiveData<ArrayList<Ft8Message>> mutableFt8MessageList = new MutableLiveData<>();//message list
+    // Needed-DX alerts: posts sound+vibrate notifications for new DXCC/state CQ stations.
+    public final com.bg7yoz.ft8cn.alert.DxAlertNotifier dxAlertNotifier =
+            new com.bg7yoz.ft8cn.alert.DxAlertNotifier(GeneralVariables.getMainContext());
+    // Callsign from a tapped Needed-DX notification; the Decode screen observes this to
+    // scroll to + highlight that station (pre-select). Set by ComposeMainActivity.
+    public MutableLiveData<String> mutablePreselectCallsign = new MutableLiveData<>();
     public MutableLiveData<Long> timerSec = new MutableLiveData<>();//current UTC time. Update frequency determined by UtcTimer, ~100ms when not triggered.
     public MutableLiveData<Boolean> mutableIsRecording = new MutableLiveData<>();//whether currently recording
     public MutableLiveData<Boolean> mutableHamRecordIsRunning = new MutableLiveData<>();//whether HamRecord is running
@@ -1215,6 +1221,8 @@ public class MainViewModel extends ViewModel {
         public void run() {
             CallsignDatabase.getMessagesLocation(
                     GeneralVariables.callsignDatabase.getDb(), messages);
+            // Entity/state flags are now populated — fire Needed-DX alerts before the UI refresh.
+            mainViewModel.dxAlertNotifier.processDecodes(messages);
             mainViewModel.mutableFt8MessageList.postValue(mainViewModel.ft8Messages);
         }
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -671,6 +671,44 @@ public class MainViewModel extends ViewModel {
 
 
     /**
+     * Start calling the station that sent {@code message} (e.g. a station calling CQ).
+     * This is the single entry point shared by the decode-list row tap and the
+     * QsoSheet "Call" button: it follows the callsign, activates TX if idle, sets up
+     * the QSO sequence, and requests an immediate transmit (which fires this slot if
+     * we are still inside the late-start window, otherwise at the next matching slot).
+     *
+     * @param message the decoded message whose sender we want to call
+     */
+    public void callStation(Ft8Message message) {
+        if (message == null || ft8TransmitSignal == null) {
+            return;
+        }
+        // Don't hijack an in-progress transmission, and ignore rows with no usable
+        // sender or our own decoded callsign (avoids accidentally "calling" ourselves).
+        if (ft8TransmitSignal.isTransmitting()) {
+            return;
+        }
+        String from = message.callsignFrom;
+        if (from == null || from.trim().isEmpty()
+                || from.equalsIgnoreCase(GeneralVariables.myCallsign)) {
+            return;
+        }
+
+        addFollowCallsign(from);
+        if (!ft8TransmitSignal.isActivated()) {
+            ft8TransmitSignal.setActivated(true);
+            GeneralVariables.transmitMessages.add(message);
+            GeneralVariables.resetLaunchSupervision();
+        }
+        ft8TransmitSignal.setTransmit(
+                message.getFromCallTransmitCallsign(),
+                1,
+                message.extraInfo);
+        ft8TransmitSignal.transmitNow();
+    }
+
+
+    /**
      * Get the followed callsign list from the database
      */
     public void getFollowCallsignsFromDataBase() {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/alert/DxAlertNotifier.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/alert/DxAlertNotifier.java
@@ -1,0 +1,149 @@
+package com.bg7yoz.ft8cn.alert;
+
+import android.Manifest;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.core.content.ContextCompat;
+
+import com.bg7yoz.ft8cn.Ft8Message;
+import com.bg7yoz.ft8cn.GeneralVariables;
+import com.bg7yoz.ft8cn.R;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Needed-DX alerts: plays a sound + vibrates and posts a notification when a station
+ * calling CQ is a NEW (unworked) one in a user-enabled category — a new DXCC entity
+ * ({@link GeneralVariables#alertNewDxcc}) or a new US state
+ * ({@link GeneralVariables#alertNewState}).
+ *
+ * <p>Driven from {@code MainViewModel.GetQTHRunnable.run()} after
+ * {@code CallsignDatabase.getMessagesLocation} has populated the {@code from*} flags,
+ * so this just reads {@link Ft8Message#fromDxcc} / {@link Ft8Message#fromNewState}.
+ *
+ * <p>Sound + vibration are handled by a high-importance notification channel, so they
+ * respect Do-Not-Disturb and the user's per-channel system settings. Alerts are
+ * de-duplicated per (category + identifier) for the lifetime of the process, so a
+ * station calling CQ every cycle — or several stations from the same needed entity —
+ * only alert once.
+ */
+public class DxAlertNotifier {
+    private static final String CHANNEL_ID = "dx_alerts";
+    public static final String EXTRA_CALLSIGN = "alert_callsign";
+    public static final String EXTRA_BAND = "alert_band";
+
+    private final Context appContext;
+    // Already-alerted keys this session: "DXCC:<country>" / "STATE:<code>".
+    private final Set<String> alerted = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    public DxAlertNotifier(Context context) {
+        this.appContext = context != null ? context.getApplicationContext() : null;
+        createChannel();
+    }
+
+    private void createChannel() {
+        if (appContext == null) return;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        NotificationManager nm = (NotificationManager)
+                appContext.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm == null) return;
+        if (nm.getNotificationChannel(CHANNEL_ID) != null) return;
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID, "Needed-DX alerts", NotificationManager.IMPORTANCE_HIGH);
+        channel.setDescription("New DXCC / US state stations calling CQ");
+        channel.enableVibration(true);
+        channel.setVibrationPattern(new long[]{0, 250, 150, 250});
+        Uri sound = android.media.RingtoneManager
+                .getDefaultUri(android.media.RingtoneManager.TYPE_NOTIFICATION);
+        if (sound != null) {
+            channel.setSound(sound, new android.media.AudioAttributes.Builder()
+                    .setUsage(android.media.AudioAttributes.USAGE_NOTIFICATION)
+                    .setContentType(android.media.AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build());
+        }
+        nm.createNotificationChannel(channel);
+    }
+
+    /**
+     * Inspect a freshly-decoded batch and fire alerts for newly-needed CQ stations.
+     */
+    public void processDecodes(List<Ft8Message> messages) {
+        if (appContext == null || messages == null) return;
+        if (!GeneralVariables.alertNewDxcc && !GeneralVariables.alertNewState) return;
+
+        for (Ft8Message msg : messages) {
+            if (msg == null || !msg.checkIsCQ()) continue;          // workable stations only
+            if (GeneralVariables.checkIsBlockedMessage(msg)) continue;
+
+            if (GeneralVariables.alertNewDxcc && msg.fromDxcc) {
+                String country = (msg.fromWhere == null || msg.fromWhere.isEmpty())
+                        ? msg.getCallsignFrom() : msg.fromWhere;
+                fireOnce("DXCC:" + country, "New DXCC: " + country, msg);
+            }
+            if (GeneralVariables.alertNewState && msg.fromNewState && msg.fromState != null) {
+                fireOnce("STATE:" + msg.fromState, "New state: " + msg.fromState, msg);
+            }
+        }
+    }
+
+    private void fireOnce(String dedupKey, String title, Ft8Message msg) {
+        if (!alerted.add(dedupKey)) return;                         // already alerted this session
+
+        StringBuilder body = new StringBuilder(msg.getCallsignFrom());
+        if (msg.maidenGrid != null && !msg.maidenGrid.isEmpty()) {
+            body.append("  ").append(msg.maidenGrid);
+        }
+        body.append("  ").append(msg.snr).append(" dB");
+
+        GeneralVariables.fileLog("DX_ALERT fire key=[" + dedupKey + "] "
+                + title + " call=" + msg.getCallsignFrom());
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && ContextCompat.checkSelfPermission(appContext,
+                        Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            return;                                                 // no permission → skip silently
+        }
+
+        int id = dedupKey.hashCode();
+
+        Intent intent = new Intent(appContext,
+                radio.ks3ckc.ft8us.ComposeMainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP
+                | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra(EXTRA_CALLSIGN, msg.getCallsignFrom());
+        intent.putExtra(EXTRA_BAND, msg.band);
+
+        int piFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            piFlags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+        PendingIntent pi = PendingIntent.getActivity(appContext, id, intent, piFlags);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(appContext, CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle(title)
+                .setContentText(body.toString())
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_EVENT)
+                .setAutoCancel(true)
+                .setContentIntent(pi);
+
+        try {
+            NotificationManagerCompat.from(appContext).notify(id, builder.build());
+        } catch (SecurityException ignored) {
+            // Permission revoked between the check and notify(); ignore.
+        }
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -127,6 +127,12 @@ public class CallsignDatabase extends SQLiteOpenHelper {
                     msg.fromLatLng = new LatLng(fromCallsignInfo.Latitude, fromCallsignInfo.Longitude * -1);
             }
 
+            // US state from the sender's grid (US-only table → null for non-US grids).
+            // fromNewState mirrors fromDxcc: true when the state is not yet worked.
+            msg.fromState = GeneralVariables.stateForGrid(msg.maidenGrid);
+            msg.fromNewState = msg.fromState != null
+                    && !GeneralVariables.getStateWorked(msg.fromState);
+
             // Resolve the operator's own continent + DXCC once (continent for the DX
             // decode filter, DXCC for the directional-CQ matcher).
             if ((GeneralVariables.myContinent == null || GeneralVariables.myDxcc == null)

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -127,14 +127,16 @@ public class CallsignDatabase extends SQLiteOpenHelper {
                     msg.fromLatLng = new LatLng(fromCallsignInfo.Latitude, fromCallsignInfo.Longitude * -1);
             }
 
-            // Resolve the operator's own continent once (for the DX decode filter).
-            if (GeneralVariables.myContinent == null
+            // Resolve the operator's own continent + DXCC once (continent for the DX
+            // decode filter, DXCC for the directional-CQ matcher).
+            if ((GeneralVariables.myContinent == null || GeneralVariables.myDxcc == null)
                     && GeneralVariables.myCallsign != null
                     && GeneralVariables.myCallsign.length() > 0) {
                 CallsignInfo myInfo = getCallsignInfo(db,
                         GeneralVariables.myCallsign.replace("<", "").replace(">", ""));
                 if (myInfo != null) {
                     GeneralVariables.myContinent = myInfo.Continent;
+                    GeneralVariables.myDxcc = myInfo.DXCC;
                 }
             }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -123,7 +123,19 @@ public class CallsignDatabase extends SQLiteOpenHelper {
                     msg.fromItu = !GeneralVariables.getItuZoneById(fromCallsignInfo.ITUZone);
                     msg.fromCq = !GeneralVariables.getCqZoneById(fromCallsignInfo.CQZone);
                     msg.fromWhere = fromCallsignInfo.CountryNameEn;
+                    msg.continent = fromCallsignInfo.Continent;
                     msg.fromLatLng = new LatLng(fromCallsignInfo.Latitude, fromCallsignInfo.Longitude * -1);
+            }
+
+            // Resolve the operator's own continent once (for the DX decode filter).
+            if (GeneralVariables.myContinent == null
+                    && GeneralVariables.myCallsign != null
+                    && GeneralVariables.myCallsign.length() > 0) {
+                CallsignInfo myInfo = getCallsignInfo(db,
+                        GeneralVariables.myCallsign.replace("<", "").replace(">", ""));
+                if (myInfo != null) {
+                    GeneralVariables.myContinent = myInfo.Continent;
+                }
             }
 
             if (msg.checkIsCQ() || msg.getCallsignTo().contains("...")) { // Skip CQ messages

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2343,6 +2343,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                         GeneralVariables.lateStartTolerance = 2000;
                     }
                 }
+                if (name.equalsIgnoreCase("earlyDecode")) {//Fast turnaround: shorter RX window, defaults on
+                    GeneralVariables.earlyDecode = (result.equals("") || result.equals("1"));
+                }
                 if (name.equalsIgnoreCase("icomIp")) {//ICOM IP address
                     GeneralVariables.icomIp = result.equals("") ? "255.255.255.255" : result;
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -1174,7 +1174,27 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 cursor.close();
 
-                Log.d(TAG, "run: zone import complete, resolved " + count + " logged callsigns");
+                // Worked US states: derive each logged QSO's state from its grid square,
+                // using the same grid->state table the decode/display paths use. Keeps the
+                // "new state" alert consistent with what the UI shows on each row.
+                Cursor gridCursor = db.rawQuery(
+                        "SELECT DISTINCT gridsquare FROM QSLTable "
+                                + "WHERE gridsquare IS NOT NULL AND gridsquare <> ''",
+                        null);
+                int stateCount = 0;
+                while (gridCursor.moveToNext()) {
+                    String grid = gridCursor.getString(gridCursor.getColumnIndex("gridsquare"));
+                    String state = GeneralVariables.stateForGrid(grid);
+                    if (state != null) {
+                        GeneralVariables.addState(state);
+                        stateCount++;
+                    }
+                }
+                gridCursor.close();
+
+                Log.d(TAG, "run: zone import complete, resolved " + count + " logged callsigns, "
+                        + stateCount + " gridded QSOs -> " + GeneralVariables.workedStates.size()
+                        + " worked states");
             }
         }).start();
 
@@ -2395,6 +2415,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 if (name.equalsIgnoreCase("filterDirectionalCQ")) {//Directional CQ: hide from decode list
                     GeneralVariables.filterDirectionalCQ = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("alertNewDxcc")) {//Needed-DX alert: new DXCC entity
+                    GeneralVariables.alertNewDxcc = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("alertNewState")) {//Needed-DX alert: new US state
+                    GeneralVariables.alertNewState = result.equals("1");
                 }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2361,8 +2361,31 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("volumeValue")) {//Output volume level
                     GeneralVariables.volumePercent = result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
                 }
-                if (name.equalsIgnoreCase("excludedCallsigns")) {//Excluded callsigns
+                if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
+                }
+                if (name.equalsIgnoreCase("blockedExactCallsigns")) {//Blocklist: whole-call exact
+                    GeneralVariables.addBlockedExactCallsigns(result);
+                }
+                if (name.equalsIgnoreCase("blockedKeywords")) {//Blocklist: keyword substrings
+                    GeneralVariables.addBlockedKeywords(result);
+                }
+                if (name.equalsIgnoreCase("filterShowOnlyCQ")) {//Decode filter: CQ only
+                    GeneralVariables.filterShowOnlyCQ = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterDxOnly")) {//Decode filter: DX (other continents) only
+                    GeneralVariables.filterDxOnly = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterNeededOnly")) {//Decode filter: needed only
+                    GeneralVariables.filterNeededOnly = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterByContinent")) {//Decode filter: by continent
+                    GeneralVariables.filterByContinent = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterContinent")) {//Decode filter: target continent
+                    if (result != null && result.length() > 0) {
+                        GeneralVariables.filterContinent = result;
+                    }
                 }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2387,6 +2387,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                         GeneralVariables.filterContinent = result;
                     }
                 }
+                if (name.equalsIgnoreCase("respectDirectionalCQ")) {//Directional CQ: suppress auto-reply
+                    GeneralVariables.respectDirectionalCQ = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("filterDirectionalCQ")) {//Directional CQ: hide from decode list
+                    GeneralVariables.filterDirectionalCQ = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2346,6 +2346,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("earlyDecode")) {//Fast turnaround: shorter RX window, defaults on
                     GeneralVariables.earlyDecode = (result.equals("") || result.equals("1"));
                 }
+                if (name.equalsIgnoreCase("autoCQAfterQSO")) {//Auto-CQ after each completed QSO, defaults off
+                    GeneralVariables.autoCQAfterQSO = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("icomIp")) {//ICOM IP address
                     GeneralVariables.icomIp = result.equals("") ? "255.255.255.255" : result;
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
@@ -101,7 +101,13 @@ public class FT8SignalListener {
         Log.d(TAG, "Starting recording...");
 
         if (onWaveDataListener != null) {
-            onWaveDataListener.getVoiceData(FT8Common.FT8_SLOT_TIME_MILLISECOND, true
+            // Fast turnaround: collect a shorter window so decoding finishes (and CQ
+            // decodes appear) ~1s before the cycle boundary, leaving time to answer
+            // on the next slot. Off = full 15s window (max sensitivity).
+            int recordMs = GeneralVariables.earlyDecode
+                    ? FT8Common.FT8_EARLY_DECODE_MILLISECOND
+                    : FT8Common.FT8_SLOT_TIME_MILLISECOND;
+            onWaveDataListener.getVoiceData(recordMs, true
                     , new OnGetVoiceDataDone() {
                         @Override
                         public void onGetDone(float[] data) {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -909,6 +909,9 @@ public class FT8TransmitSignal {
                     && (GeneralVariables.autoFollowCQ// Hunt: auto-answer any CQ
                     || (GeneralVariables.autoCallFollow
                     && GeneralVariables.callsignInFollow(msg.getCallsignFrom())))// followed callsign
+                    // skip directional CQs aimed at a different DXCC/continent (opt-in)
+                    && (!GeneralVariables.respectDirectionalCQ
+                    || GeneralVariables.directionalCQIsForMe(msg.callsignTo))
                     && !GeneralVariables.checkQSLCallsign(msg.getCallsignFrom())// not previously contacted successfully
                     && !GeneralVariables.checkIsMyCallsign(msg.callsignFrom)) {// not myself
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -829,6 +829,10 @@ public class FT8TransmitSignal {
      */
     //@RequiresApi(api = Build.VERSION_CODES.N)
     private boolean checkCQMeOrFollowCQMessage(ArrayList<Ft8Message> messages) {
+        return checkCQMeOrFollowCQMessage(messages, false);
+    }
+
+    private boolean checkCQMeOrFollowCQMessage(ArrayList<Ft8Message> messages, boolean suppressHunt) {
         // these messages are freshly decoded
         // both loops check for CQ-me messages. The first loop prioritizes checking for my target callsign,
         // to prevent replying inconsistently when multiple targets are calling me.
@@ -880,7 +884,9 @@ public class FT8TransmitSignal {
         // auto-call of followed callsigns. These are now independent — Hunt no
         // longer requires autoCallFollow — so the on-screen HUNT toggle is
         // authoritative on its own.
-        if (!GeneralVariables.autoFollowCQ && !GeneralVariables.autoCallFollow) {
+        // suppressHunt: Auto-CQ forces pure CQ — answer direct callers (loops
+        // above) but never auto-follow another station's CQ.
+        if (suppressHunt || (!GeneralVariables.autoFollowCQ && !GeneralVariables.autoCallFollow)) {
             return false;
         }
 
@@ -1022,9 +1028,17 @@ public class FT8TransmitSignal {
             // enter CQ state
             resetToCQ();
 
-            // try queued callers first, then check for new callers
+            // Auto-CQ: refresh the watchdog on each completed QSO so the run
+            // keeps going without a re-tap. An idle CQ (no answers) still times out.
+            if (GeneralVariables.autoCQAfterQSO) {
+                GeneralVariables.resetLaunchSupervision();
+            }
+
+            // try queued callers first, then answer direct callers. When Auto-CQ
+            // is on, suppress Hunt so we stay on our run frequency calling CQ
+            // instead of chasing someone else's CQ.
             if (!dequeueNextCaller()) {
-                checkCQMeOrFollowCQMessage(messages);
+                checkCQMeOrFollowCQMessage(messages, GeneralVariables.autoCQAfterQSO);
             }
             setCurrentFunctionOrder(functionOrder);// set current message
             mutableFunctionOrder.postValue(functionOrder);

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -182,6 +182,22 @@ class ComposeMainActivity : ComponentActivity() {
         } else {
             doReceiveShareFile(intent)
         }
+
+        // Handle a tapped Needed-DX alert (cold start).
+        handleAlertIntent(intent)
+    }
+
+    /**
+     * If [intent] came from a tapped Needed-DX notification, publish the alerted callsign
+     * so the Decode screen can switch to itself and scroll to + highlight that station.
+     */
+    private fun handleAlertIntent(intent: Intent?) {
+        val callsign = intent?.getStringExtra(
+            com.bg7yoz.ft8cn.alert.DxAlertNotifier.EXTRA_CALLSIGN,
+        ) ?: return
+        if (callsign.isBlank()) return
+        fileLog("handleAlertIntent: preselect $callsign")
+        mainViewModel.mutablePreselectCallsign.postValue(callsign)
     }
 
     private fun buildPermissionsList(): Array<String> {
@@ -197,6 +213,9 @@ class ComposeMainActivity : ComponentActivity() {
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             base.add(Manifest.permission.BLUETOOTH_CONNECT)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            base.add(Manifest.permission.POST_NOTIFICATIONS)
         }
         return base.toTypedArray()
     }
@@ -351,6 +370,8 @@ class ComposeMainActivity : ComponentActivity() {
         } else {
             setIntent(intent)
             doReceiveShareFile(intent)
+            // Handle a tapped Needed-DX alert (app already running).
+            handleAlertIntent(intent)
         }
     }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -60,6 +60,15 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     // Frequency picker sheet state
     var showFrequencyPicker by rememberSaveable { mutableStateOf(false) }
 
+    // A tapped Needed-DX notification asks us to jump to the Decode tab (DecodeScreen
+    // then scrolls to + highlights the alerted station).
+    val preselectCallsign by mainViewModel.mutablePreselectCallsign.observeAsState()
+    LaunchedEffect(preselectCallsign) {
+        if (!preselectCallsign.isNullOrBlank()) {
+            activeTab = FT8USTab.DECODE
+        }
+    }
+
     // Auto-expand when activated, auto-collapse when deactivated
     LaunchedEffect(isActivated) {
         if (isActivated) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -1,8 +1,9 @@
 package radio.ks3ckc.ft8us.ui.decode
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,11 +55,13 @@ import radio.ks3ckc.ft8us.ui.motion.MotionTokens
  *  - Surface tint for CQ messages
  *  - Transparent for others
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun DecodeRow(
     message: Ft8Message,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
     animateEntry: Boolean = false,
     nowMillis: Long = 0L,
     isTarget: Boolean = false,
@@ -111,7 +114,7 @@ fun DecodeRow(
             .clip(shape)
             .background(bgColor, shape)
             .border(1.dp, borderColor, shape)
-            .clickable { onClick() }
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
             .padding(start = 0.dp, end = 12.dp, top = 10.dp, bottom = 10.dp),
         verticalAlignment = Alignment.Top,
     ) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -143,6 +143,22 @@ fun DecodeScreen(
         previousCount = filteredMessages.size
     }
 
+    // A tapped Needed-DX notification asks us to pre-select that station: reset to the
+    // "All" filter so it's visible, scroll to its latest decode, and open the QSO sheet
+    // (which shows the station detail + a Call button). We do NOT auto-transmit.
+    val preselectCallsign by mainViewModel.mutablePreselectCallsign.observeAsState()
+    LaunchedEffect(preselectCallsign, messageList?.size) {
+        val cs = preselectCallsign
+        if (cs.isNullOrBlank()) return@LaunchedEffect
+        val present = (messageList ?: arrayListOf())
+            .any { it.callsignFrom.equals(cs, ignoreCase = true) }
+        if (!present) return@LaunchedEffect          // wait until the station is in the list
+        selectedFilter = "All"
+        mainViewModel.qsoSheetCallsign.postValue(cs)
+        mainViewModel.qsoSheetMinimized.postValue(false)
+        mainViewModel.mutablePreselectCallsign.postValue(null)   // consume (allow re-trigger)
+    }
+
     // Format UTC time for the subtitle
     val utcString = if (utcTime > 0L) {
         UtcTimer.getTimeStr(utcTime)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -319,9 +319,34 @@ private fun filterMessages(
     messages: List<Ft8Message>,
     filter: String,
 ): List<Ft8Message> {
+    // Base stage: always-on blocklist + settings-driven "show only" filters.
+    // Applied before the chip switch so they AND with whatever chip is selected.
+    var base = messages.filterNot { GeneralVariables.checkIsBlockedMessage(it) }
+    if (GeneralVariables.filterShowOnlyCQ) {
+        base = base.filter { it.checkIsCQ() }
+    }
+    if (GeneralVariables.filterDxOnly) {
+        base = base.filter {
+            it.continent != null && GeneralVariables.myContinent != null &&
+                !it.continent.equals(GeneralVariables.myContinent, ignoreCase = true)
+        }
+    }
+    if (GeneralVariables.filterNeededOnly) {
+        base = base.filter {
+            !it.isQSL_Callsign &&
+                !GeneralVariables.checkQSLCallsign(it.callsignFrom ?: "")
+        }
+    }
+    if (GeneralVariables.filterByContinent) {
+        base = base.filter {
+            it.continent != null &&
+                it.continent.equals(GeneralVariables.filterContinent, ignoreCase = true)
+        }
+    }
+
     return when (filter) {
-        "CQ Calls" -> messages.filter { it.checkIsCQ() }
-        "CQ POTA" -> messages.filter {
+        "CQ Calls" -> base.filter { it.checkIsCQ() }
+        "CQ POTA" -> base.filter {
             // Match three signals: (1) explicit "POTA" suffix on a CQ, (2) any CQ from a
             // station currently spotted on pota.app (activators often drop the suffix to
             // save chars), (3) free-text fragments like "CQ POT" that decoders garble
@@ -332,15 +357,15 @@ private fun filterMessages(
                     (it.callsignTo?.startsWith("CQ POT", ignoreCase = true) == true)
                 )
         }
-        "New DXCC" -> messages.filter { it.checkIsCQ() && it.fromDxcc }
-        "Needed" -> messages.filter {
+        "New DXCC" -> base.filter { it.checkIsCQ() && it.fromDxcc }
+        "Needed" -> base.filter {
             !it.isQSL_Callsign &&
                 !GeneralVariables.checkQSLCallsign(it.callsignFrom ?: "")
         }
-        "For Me" -> messages.filter {
+        "For Me" -> base.filter {
             GeneralVariables.checkIsMyCallsign(it.callsignTo ?: "")
         }
-        else -> messages // "All"
+        else -> base // "All"
     }
 }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -343,6 +343,9 @@ private fun filterMessages(
                 it.continent.equals(GeneralVariables.filterContinent, ignoreCase = true)
         }
     }
+    if (GeneralVariables.filterDirectionalCQ) {
+        base = base.filter { GeneralVariables.directionalCQIsForMe(it.callsignTo) }
+    }
 
     return when (filter) {
         "CQ Calls" -> base.filter { it.checkIsCQ() }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -230,7 +230,12 @@ fun DecodeScreen(
                             animateEntry = rowKey in newKeys,
                             nowMillis = utcTime,
                             isTarget = isTarget,
+                            // Single tap = immediately call this station (fast reply to
+                            // a CQ). Long-press opens the info sheet (QRZ, country, etc.).
                             onClick = {
+                                mainViewModel.callStation(message)
+                            },
+                            onLongClick = {
                                 mainViewModel.qsoSheetCallsign.postValue(message.callsignFrom)
                                 mainViewModel.qsoSheetMinimized.postValue(false)
                             },

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -189,18 +189,7 @@ private fun QsoSheetContent(
         } else {
             Button(
                 onClick = {
-                    mainViewModel.addFollowCallsign(callsign)
-                    if (!mainViewModel.ft8TransmitSignal.isActivated) {
-                        mainViewModel.ft8TransmitSignal.setActivated(true)
-                        GeneralVariables.transmitMessages.add(message)
-                        GeneralVariables.resetLaunchSupervision()
-                    }
-                    mainViewModel.ft8TransmitSignal.setTransmit(
-                        message.fromCallTransmitCallsign,
-                        1,
-                        message.extraInfo,
-                    )
-                    mainViewModel.ft8TransmitSignal.transmitNow()
+                    mainViewModel.callStation(message)
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -135,6 +135,8 @@ fun SettingsScreen(
     var filterNeededOnly by remember { mutableStateOf(GeneralVariables.filterNeededOnly) }
     var filterByContinent by remember { mutableStateOf(GeneralVariables.filterByContinent) }
     var filterContinent by remember { mutableStateOf(GeneralVariables.filterContinent) }
+    var respectDirectionalCQ by remember { mutableStateOf(GeneralVariables.respectDirectionalCQ) }
+    var filterDirectionalCQ by remember { mutableStateOf(GeneralVariables.filterDirectionalCQ) }
 
     // Continent codes (stored on the message) and their display names, parallel lists.
     val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
@@ -1275,6 +1277,32 @@ fun SettingsScreen(
                                 onClick = { showContinentPicker = true },
                             )
                         }
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Skip Directional CQs (auto-reply)",
+                            description = "Don't auto-answer CQ DX/EU/JA… aimed at a different DXCC",
+                            toggle = respectDirectionalCQ,
+                            onToggleChange = { checked ->
+                                respectDirectionalCQ = checked
+                                GeneralVariables.respectDirectionalCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "respectDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Hide Directional CQs Not For Me",
+                            description = "Hide region-directed CQs that don't target your DXCC",
+                            toggle = filterDirectionalCQ,
+                            onToggleChange = { checked ->
+                                filterDirectionalCQ = checked
+                                GeneralVariables.filterDirectionalCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
                     }
                 }
             }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -137,6 +137,8 @@ fun SettingsScreen(
     var filterContinent by remember { mutableStateOf(GeneralVariables.filterContinent) }
     var respectDirectionalCQ by remember { mutableStateOf(GeneralVariables.respectDirectionalCQ) }
     var filterDirectionalCQ by remember { mutableStateOf(GeneralVariables.filterDirectionalCQ) }
+    var alertNewDxcc by remember { mutableStateOf(GeneralVariables.alertNewDxcc) }
+    var alertNewState by remember { mutableStateOf(GeneralVariables.alertNewState) }
 
     // Continent codes (stored on the message) and their display names, parallel lists.
     val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
@@ -1314,6 +1316,41 @@ fun SettingsScreen(
                                 GeneralVariables.filterDirectionalCQ = checked
                                 mainViewModel.databaseOpr.writeConfig(
                                     "filterDirectionalCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 4e. NEEDED-DX ALERTS
+            // =====================================================================
+            SettingsSection(title = "NEEDED-DX ALERTS") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "New DXCC",
+                            description = "Sound + vibrate + notify when an unworked DXCC entity calls CQ",
+                            toggle = alertNewDxcc,
+                            onToggleChange = { checked ->
+                                alertNewDxcc = checked
+                                GeneralVariables.alertNewDxcc = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "alertNewDxcc", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "New US State",
+                            description = "Sound + vibrate + notify when a station from an unworked US state calls CQ (state from grid)",
+                            toggle = alertNewState,
+                            onToggleChange = { checked ->
+                                alertNewState = checked
+                                GeneralVariables.alertNewState = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "alertNewState", if (checked) "1" else "0", null,
                                 )
                             },
                         )

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -126,6 +126,22 @@ fun SettingsScreen(
     var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
     var highlightPota by remember { mutableStateOf(GeneralVariables.highlightPota) }
 
+    // Callsign blocklist (comma-separated entries) + decode display filters
+    var blockedExact by remember { mutableStateOf(GeneralVariables.getBlockedExactCallsigns()) }
+    var blockedPrefixes by remember { mutableStateOf(GeneralVariables.getExcludeCallsigns()) }
+    var blockedKeywords by remember { mutableStateOf(GeneralVariables.getBlockedKeywords()) }
+    var filterShowOnlyCQ by remember { mutableStateOf(GeneralVariables.filterShowOnlyCQ) }
+    var filterDxOnly by remember { mutableStateOf(GeneralVariables.filterDxOnly) }
+    var filterNeededOnly by remember { mutableStateOf(GeneralVariables.filterNeededOnly) }
+    var filterByContinent by remember { mutableStateOf(GeneralVariables.filterByContinent) }
+    var filterContinent by remember { mutableStateOf(GeneralVariables.filterContinent) }
+
+    // Continent codes (stored on the message) and their display names, parallel lists.
+    val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
+    val continentNames = listOf(
+        "North America", "South America", "Europe", "Africa", "Asia", "Oceania", "Antarctica",
+    )
+
     // Observe serial ports for USB Cable picker
     val serialPorts by mainViewModel.mutableSerialPorts.observeAsState()
     var showSerialPortPicker by remember { mutableStateOf(false) }
@@ -158,6 +174,10 @@ fun SettingsScreen(
     var showAudioOutputPicker by remember { mutableStateOf(false) }
     var showBaudRatePicker by remember { mutableStateOf(false) }
     var showTxVolume by remember { mutableStateOf(false) }
+    var showBlockExactDialog by remember { mutableStateOf(false) }
+    var showBlockPrefixDialog by remember { mutableStateOf(false) }
+    var showBlockKeywordDialog by remember { mutableStateOf(false) }
+    var showContinentPicker by remember { mutableStateOf(false) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -263,6 +283,72 @@ fun SettingsScreen(
                 mainViewModel.databaseOpr.writeConfig("grid", formattedGrid, null)
 
                 showEditOperator = false
+            },
+        )
+    }
+
+    // -- Blocklist: exact whole-call dialog --
+    if (showBlockExactDialog) {
+        TextListDialog(
+            title = "Block Exact Callsigns",
+            description = "Whole-call match. Comma- or space-separated, e.g. W1AW, K1ABC.",
+            initialValue = blockedExact,
+            onDismiss = { showBlockExactDialog = false },
+            onSave = { text ->
+                GeneralVariables.addBlockedExactCallsigns(text)
+                blockedExact = GeneralVariables.getBlockedExactCallsigns()
+                mainViewModel.databaseOpr.writeConfig("blockedExactCallsigns", blockedExact, null)
+                showBlockExactDialog = false
+            },
+        )
+    }
+
+    // -- Blocklist: prefix dialog (legacy excludedCallsigns key) --
+    if (showBlockPrefixDialog) {
+        TextListDialog(
+            title = "Block Callsign Prefixes",
+            description = "Prefix match, e.g. RA blocks RA0AA..RA9ZZ. Comma- or space-separated.",
+            initialValue = blockedPrefixes,
+            onDismiss = { showBlockPrefixDialog = false },
+            onSave = { text ->
+                GeneralVariables.addExcludedCallsigns(text)
+                blockedPrefixes = GeneralVariables.getExcludeCallsigns()
+                mainViewModel.databaseOpr.writeConfig("excludedCallsigns", blockedPrefixes, null)
+                showBlockPrefixDialog = false
+            },
+        )
+    }
+
+    // -- Blocklist: keyword dialog --
+    if (showBlockKeywordDialog) {
+        TextListDialog(
+            title = "Block Keywords",
+            description = "Substring match against the call and message text, e.g. POTA, /P, QRP.",
+            initialValue = blockedKeywords,
+            onDismiss = { showBlockKeywordDialog = false },
+            onSave = { text ->
+                GeneralVariables.addBlockedKeywords(text)
+                blockedKeywords = GeneralVariables.getBlockedKeywords()
+                mainViewModel.databaseOpr.writeConfig("blockedKeywords", blockedKeywords, null)
+                showBlockKeywordDialog = false
+            },
+        )
+    }
+
+    // -- Decode filter: continent picker --
+    if (showContinentPicker) {
+        val currentIndex = continentCodes.indexOf(filterContinent).coerceAtLeast(0)
+        ListPickerDialog(
+            title = "Filter Continent",
+            items = continentNames,
+            selectedIndex = currentIndex,
+            onDismiss = { showContinentPicker = false },
+            onSelect = { index ->
+                showContinentPicker = false
+                val code = continentCodes[index]
+                filterContinent = code
+                GeneralVariables.filterContinent = code
+                mainViewModel.databaseOpr.writeConfig("filterContinent", code, null)
             },
         )
     }
@@ -1089,6 +1175,111 @@ fun SettingsScreen(
             }
 
             // =====================================================================
+            // 4c. CALLSIGN BLOCKLIST
+            // =====================================================================
+            SettingsSection(title = "CALLSIGN BLOCKLIST") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "Exact Callsigns",
+                            description = "Block whole-call matches",
+                            value = blockedExact.ifBlank { "None" },
+                            showChevron = true,
+                            onClick = { showBlockExactDialog = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Prefixes",
+                            description = "Block by callsign prefix (e.g. RA)",
+                            value = blockedPrefixes.ifBlank { "None" },
+                            showChevron = true,
+                            onClick = { showBlockPrefixDialog = true },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Keywords",
+                            description = "Block by substring in call or message (e.g. POTA, /P)",
+                            value = blockedKeywords.ifBlank { "None" },
+                            showChevron = true,
+                            onClick = { showBlockKeywordDialog = true },
+                        )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 4d. DECODE FILTERS
+            // =====================================================================
+            SettingsSection(title = "DECODE FILTERS") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "Show Only CQ",
+                            description = "Hide everything except CQ-type messages",
+                            toggle = filterShowOnlyCQ,
+                            onToggleChange = { checked ->
+                                filterShowOnlyCQ = checked
+                                GeneralVariables.filterShowOnlyCQ = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterShowOnlyCQ", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "DX Only",
+                            description = "Show only stations outside your own continent",
+                            toggle = filterDxOnly,
+                            onToggleChange = { checked ->
+                                filterDxOnly = checked
+                                GeneralVariables.filterDxOnly = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterDxOnly", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Needed Only",
+                            description = "Show only stations not yet confirmed (QSL)",
+                            toggle = filterNeededOnly,
+                            onToggleChange = { checked ->
+                                filterNeededOnly = checked
+                                GeneralVariables.filterNeededOnly = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterNeededOnly", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Filter By Continent",
+                            description = "Show only stations from a chosen continent",
+                            toggle = filterByContinent,
+                            onToggleChange = { checked ->
+                                filterByContinent = checked
+                                GeneralVariables.filterByContinent = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "filterByContinent", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        if (filterByContinent) {
+                            SectionDivider()
+                            SettingsRow(
+                                label = "Continent",
+                                value = continentNames.getOrElse(
+                                    continentCodes.indexOf(filterContinent),
+                                ) { filterContinent },
+                                showChevron = true,
+                                onClick = { showContinentPicker = true },
+                            )
+                        }
+                    }
+                }
+            }
+
+            // =====================================================================
             // 5. LOGGING & AWARDS
             // =====================================================================
             SettingsSection(title = "LOGGING & AWARDS") {
@@ -1366,6 +1557,82 @@ private fun EditOperatorDialog(
                 TextButton(
                     onClick = { onSave(callsignInput.text, gridInput.text) },
                 ) {
+                    Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for editing a comma/space-separated list of tokens (blocklist entries).
+ * One multi-line text field; the caller parses + persists the saved string.
+ */
+@Composable
+private fun TextListDialog(
+    title: String,
+    description: String,
+    initialValue: String,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
+    var input by remember { mutableStateOf(TextFieldValue(initialValue)) }
+
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = TextPrimary,
+        unfocusedTextColor = TextPrimary,
+        cursorColor = Accent,
+        focusedBorderColor = Accent,
+        unfocusedBorderColor = BorderStrong,
+        focusedLabelColor = Accent,
+        unfocusedLabelColor = TextMuted,
+    )
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = title,
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+            )
+
+            Text(
+                text = description,
+                color = TextMuted,
+                fontSize = 13.sp,
+            )
+
+            OutlinedTextField(
+                value = input,
+                onValueChange = { input = it },
+                placeholder = { Text("e.g. W1AW, RA, /P", color = TextFaint) },
+                singleLine = false,
+                minLines = 2,
+                colors = fieldColors,
+                textStyle = TextStyle(
+                    fontFamily = GeistMonoFamily,
+                    fontSize = 15.sp,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel", color = TextMuted)
+                }
+                TextButton(onClick = { onSave(input.text) }) {
                     Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
                 }
             }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -187,6 +187,7 @@ fun SettingsScreen(
 
     // Mutable state for settings that need to trigger recomposition on change
     var watchdogMs by remember { mutableIntStateOf(GeneralVariables.launchSupervision) }
+    var autoCQAfterQSO by remember { mutableStateOf(GeneralVariables.autoCQAfterQSO) }
     var noReplyLimit by remember { mutableIntStateOf(GeneralVariables.noReplyLimit) }
     var pttDelay by remember { mutableIntStateOf(GeneralVariables.pttDelay) }
     var txDelay by remember { mutableIntStateOf(GeneralVariables.transmitDelay) }
@@ -1095,6 +1096,19 @@ fun SettingsScreen(
                                 GeneralVariables.earlyDecode = checked
                                 mainViewModel.databaseOpr.writeConfig(
                                     "earlyDecode", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Auto-CQ after QSO",
+                            description = "Keep calling CQ automatically after each completed contact — no re-tap. Stays on your frequency (ignores Hunt). Runs until you stop or the TX Watchdog times out with no answers.",
+                            toggle = autoCQAfterQSO,
+                            onToggleChange = { checked ->
+                                autoCQAfterQSO = checked
+                                GeneralVariables.autoCQAfterQSO = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "autoCQAfterQSO", if (checked) "1" else "0", null,
                                 )
                             },
                         )

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -111,6 +111,7 @@ fun SettingsScreen(
     var synFrequency by remember { mutableStateOf(GeneralVariables.synFrequency) }
     var autoFollowCQ by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
     var autoCallFollow by remember { mutableStateOf(GeneralVariables.autoCallFollow) }
+    var earlyDecode by remember { mutableStateOf(GeneralVariables.earlyDecode) }
     var autoUpdateGridFromGPS by remember { mutableStateOf(GeneralVariables.autoUpdateGridFromGPS) }
     var enableCloudlog by remember { mutableStateOf(GeneralVariables.enableCloudlog) }
     var enableQRZ by remember { mutableStateOf(GeneralVariables.enableQRZ) }
@@ -993,6 +994,19 @@ fun SettingsScreen(
                                 GeneralVariables.autoCallFollow = checked
                                 mainViewModel.databaseOpr.writeConfig(
                                     "autoCallFollow", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Fast turnaround",
+                            description = "Decode ~1s earlier so you can answer a CQ on the next slot instead of waiting. May miss stations with a large clock offset.",
+                            toggle = earlyDecode,
+                            onToggleChange = { checked ->
+                                earlyDecode = checked
+                                GeneralVariables.earlyDecode = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "earlyDecode", if (checked) "1" else "0", null,
                                 )
                             },
                         )


### PR DESCRIPTION
Promotes the current `dev` line to `main`. Five operating-workflow features have landed since the last release, all centered on making the decode list faster to act on and more relevant.

## Changelog

### ⚡ Fast reply to a CQ (#121)
- Single-tap a decode row to immediately call that station (long-press still opens the info sheet).
- Decode slightly before the cycle boundary so a CQ is in hand ~1s earlier, leaving time to answer in the same cycle.

### 🚫 Callsign blocklist + decode display filters (#122)
- Block callsigns by **exact** match, **prefix**, or **keyword** (matched against call + message text). Blocked stations are hidden from the list and excluded from TX/auto-sequence.
- New decode filters: **Show Only CQ**, **DX Only** (other continents), **Needed Only** (unconfirmed QSL), and **By Continent**.

### 🧭 Directional CQ awareness (#123)
- **Skip auto-reply** to directional CQs aimed elsewhere (e.g. CQ DX/EU/JA not matching your continent/DXCC) — manual taps and stations calling you are unaffected.
- Optionally **hide** those region-directed CQs from the decode list.

### 🔁 Auto-CQ after QSO (#124)
- After a QSO completes, automatically resume calling CQ — chain contacts without re-tapping.

### 🔔 Needed-DX alerts (#125)
- Sound + vibrate + notification when a station calling CQ is a **new (unworked) DXCC entity** or **new US state**.
- Opt-in per category in **Settings → Needed-DX Alerts** (default off). DXCC reuses the existing per-decode "new entity" flag; US state is derived from the sender's gridsquare and worked-states are imported from the logbook at startup.
- Fires on CQ messages only, respects the callsign blocklist, and de-dups per entity/state for the session. Tapping the notification opens the app and pre-selects the station, ready to call.

## Verification
- Each feature merged via its own reviewed PR into `dev`.
- Latest `dev` builds clean (`assembleDebug`) and installs/runs on a Pixel 8 (Android 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)