### PR TITLE
Add compact decode list mode

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
@@ -338,6 +338,42 @@ object FT8USIcons {
         }
     }
 
+    /** Three tightly-spaced horizontal lines — switch to compact decode list. */
+    @Composable
+    fun ViewCompact(
+        modifier: Modifier = Modifier,
+        color: Color = Color.Unspecified,
+        size: Dp = 22.dp,
+        strokeWidth: Float = 1.6f,
+    ) {
+        val tint = if (color == Color.Unspecified) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else color
+        Canvas(modifier = modifier.then(Modifier.sizeOf(size))) {
+            val s = this.size.width / 24f
+            val stroke = strokeStyle(strokeWidth * s)
+            drawLine(tint, Offset(4f * s, 8f * s), Offset(20f * s, 8f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 12f * s), Offset(20f * s, 12f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 16f * s), Offset(20f * s, 16f * s), stroke.width, StrokeCap.Round)
+        }
+    }
+
+    /** Three widely-spaced horizontal lines — switch to expanded decode list. */
+    @Composable
+    fun ViewExpanded(
+        modifier: Modifier = Modifier,
+        color: Color = Color.Unspecified,
+        size: Dp = 22.dp,
+        strokeWidth: Float = 1.6f,
+    ) {
+        val tint = if (color == Color.Unspecified) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else color
+        Canvas(modifier = modifier.then(Modifier.sizeOf(size))) {
+            val s = this.size.width / 24f
+            val stroke = strokeStyle(strokeWidth * s)
+            drawLine(tint, Offset(4f * s, 5f * s), Offset(20f * s, 5f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 12f * s), Offset(20f * s, 12f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 19f * s), Offset(20f * s, 19f * s), stroke.width, StrokeCap.Round)
+        }
+    }
+
     /** Triangular pine tree on a small trunk — POTA tab. */
     @Composable
     fun Tree(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -65,6 +65,7 @@ fun DecodeRow(
     animateEntry: Boolean = false,
     nowMillis: Long = 0L,
     isTarget: Boolean = false,
+    compact: Boolean = false,
 ) {
     val isCQ = message.checkIsCQ()
     val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
@@ -115,7 +116,7 @@ fun DecodeRow(
             .background(bgColor, shape)
             .border(1.dp, borderColor, shape)
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-            .padding(start = 0.dp, end = 12.dp, top = 10.dp, bottom = 10.dp),
+            .padding(start = 0.dp, end = 12.dp, top = if (compact) 6.dp else 10.dp, bottom = if (compact) 6.dp else 10.dp),
         verticalAlignment = Alignment.Top,
     ) {
         // Left accent bar — pink for the current call target, amber for CQ.
@@ -129,7 +130,7 @@ fun DecodeRow(
             Box(
                 modifier = Modifier
                     .width(3.dp)
-                    .height(52.dp)
+                    .height(if (compact) 32.dp else 52.dp)
                     .background(accentColor, RoundedCornerShape(99.dp))
             )
             Spacer(modifier = Modifier.width(10.dp))
@@ -189,20 +190,22 @@ fun DecodeRow(
                 }
             }
 
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(if (compact) 2.dp else 4.dp))
 
             // Full decoded message text (canonical FT8 frame, e.g. "K1ABC W9XYZ EN37"
             // or "CQ POTA W1ABC FN42"). This is what was actually transmitted.
-            val msgText = message.getMessageText()?.trim().orEmpty()
-            if (msgText.isNotEmpty()) {
-                Text(
-                    text = msgText,
-                    color = TextMuted,
-                    fontFamily = GeistMonoFamily,
-                    fontSize = 12.sp,
-                    letterSpacing = 0.02.sp,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
+            if (!compact) {
+                val msgText = message.getMessageText()?.trim().orEmpty()
+                if (msgText.isNotEmpty()) {
+                    Text(
+                        text = msgText,
+                        color = TextMuted,
+                        fontFamily = GeistMonoFamily,
+                        fontSize = 12.sp,
+                        letterSpacing = 0.02.sp,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
             }
 
             // Metadata row: signal bar, SNR, frequency, distance, UTC time
@@ -211,7 +214,7 @@ fun DecodeRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                SignalBar(snr = message.snr, width = 28.dp, height = 12.dp)
+                SignalBar(snr = message.snr, width = if (compact) 22.dp else 28.dp, height = if (compact) 10.dp else 12.dp)
 
                 MetaText("${message.snr} dB")
                 MetaText("${message.getFreq_hz()} Hz")
@@ -234,24 +237,26 @@ fun DecodeRow(
             }
 
             // State / DX entity location line (shown on every row when known)
-            val context = LocalContext.current
-            val locationText = resolveLocationText(context, message)
-            if (!locationText.isNullOrEmpty()) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    radio.ks3ckc.ft8us.ui.components.FT8USIcons.Globe(
-                        color = TextDim,
-                        size = 12.dp,
-                    )
-                    Text(
-                        text = locationText,
-                        color = TextDim,
-                        fontSize = 10.5.sp,
-                        fontWeight = FontWeight.Medium,
-                    )
+            if (!compact) {
+                val context = LocalContext.current
+                val locationText = resolveLocationText(context, message)
+                if (!locationText.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        radio.ks3ckc.ft8us.ui.components.FT8USIcons.Globe(
+                            color = TextDim,
+                            size = 12.dp,
+                        )
+                        Text(
+                            text = locationText,
+                            color = TextDim,
+                            fontSize = 10.5.sp,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
                 }
             }
         }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -159,6 +159,9 @@ fun DecodeScreen(
         mainViewModel.mutablePreselectCallsign.postValue(null)   // consume (allow re-trigger)
     }
 
+    // Compact mode — persisted via GeneralVariables.simpleCallItemMode / DB key "msgMode"
+    var compactMode by rememberSaveable { mutableStateOf(GeneralVariables.simpleCallItemMode) }
+
     // Format UTC time for the subtitle
     val utcString = if (utcTime > 0L) {
         UtcTimer.getTimeStr(utcTime)
@@ -181,6 +184,19 @@ fun DecodeScreen(
                     )
                 },
                 actions = {
+                    IconButton(
+                        onClick = {
+                            compactMode = !compactMode
+                            GeneralVariables.simpleCallItemMode = compactMode
+                            mainViewModel.databaseOpr.writeConfig("msgMode", if (compactMode) "1" else "0", null)
+                        },
+                    ) {
+                        if (compactMode) {
+                            radio.ks3ckc.ft8us.ui.components.FT8USIcons.ViewExpanded(color = TextMuted)
+                        } else {
+                            radio.ks3ckc.ft8us.ui.components.FT8USIcons.ViewCompact(color = TextMuted)
+                        }
+                    }
                     IconButton(
                         onClick = { mainViewModel.clearFt8MessageList() },
                         enabled = messageList?.isNotEmpty() == true,
@@ -229,7 +245,7 @@ fun DecodeScreen(
                         val prevSlot = if (index > 0) filteredMessages[index - 1].utcTime / 15000L else null
                         val thisSlot = message.utcTime / 15000L
                         if (prevSlot == null || prevSlot != thisSlot) {
-                            TimeGroupDivider(utcTime = message.utcTime)
+                            TimeGroupDivider(utcTime = message.utcTime, compact = compactMode)
                         }
 
                         // Target highlight: this row is from the station the
@@ -246,6 +262,7 @@ fun DecodeScreen(
                             animateEntry = rowKey in newKeys,
                             nowMillis = utcTime,
                             isTarget = isTarget,
+                            compact = compactMode,
                             // Single tap = immediately call this station (fast reply to
                             // a CQ). Long-press opens the info sheet (QRZ, country, etc.).
                             onClick = {
@@ -285,12 +302,12 @@ fun DecodeScreen(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun TimeGroupDivider(utcTime: Long) {
+private fun TimeGroupDivider(utcTime: Long, compact: Boolean = false) {
     val timeStr = remember(utcTime) { UtcTimer.getTimeHHMMSS(utcTime) }
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .padding(horizontal = 12.dp, vertical = if (compact) 3.dp else 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(


### PR DESCRIPTION
## Summary
- Adds a density toggle icon in the Decode top bar (left of the delete button) that switches between normal and compact row layout
- Compact mode hides the full message text line and location line, reduces inner padding, shrinks the accent bar and signal bar — roughly doubling visible decode entries
- Persists across restarts via the existing `GeneralVariables.simpleCallItemMode` / DB key `"msgMode"`

## Test plan
- [ ] Confirm new icon appears to the left of the trash icon on the Decode tab
- [ ] Tap icon → rows visibly shrink (no message text, no location, tighter spacing)
- [ ] Tap again → normal layout returns
- [ ] Kill and relaunch → confirm setting persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)