### PR TITLE
Add LOG button to force-log QSO and move on

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1249,6 +1249,29 @@ public class FT8TransmitSignal {
         pendingUserCQ = true;
     }
 
+    /**
+     * Force-log the current QSO and move on to the next caller or CQ.
+     * Called when the user taps "LOG" to skip waiting for a 73 reply.
+     */
+    public void forceLogAndMoveOn() {
+        // Ensure QSO is saved (no-op if already saved at function order 4/5)
+        updateQSlRecordList(4, toCallsign);
+
+        // Mirror the normal QSO-completion path from parseMessageToFunction
+        resetToCQ();
+
+        if (GeneralVariables.autoCQAfterQSO) {
+            GeneralVariables.resetLaunchSupervision();
+        }
+
+        if (!dequeueNextCaller()) {
+            // No queued callers — stay on CQ
+        }
+
+        setCurrentFunctionOrder(functionOrder);
+        mutableFunctionOrder.postValue(functionOrder);
+    }
+
     // ==================== Caller Queue Methods ====================
 
     /**

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1250,10 +1250,13 @@ public class FT8TransmitSignal {
     }
 
     /**
-     * Force-log the current QSO and move on to the next caller or CQ.
+     * Force-log the current QSO and move on.
      * Called when the user taps "LOG" to skip waiting for a 73 reply.
+     *
+     * @param nextCallsign if non-null, dequeue and start this specific caller
+     *                     instead of the head of the queue.
      */
-    public void forceLogAndMoveOn() {
+    public void forceLogAndMoveOn(String nextCallsign) {
         // Ensure QSO is saved (no-op if already saved at function order 4/5)
         updateQSlRecordList(4, toCallsign);
 
@@ -1264,12 +1267,19 @@ public class FT8TransmitSignal {
             GeneralVariables.resetLaunchSupervision();
         }
 
-        if (!dequeueNextCaller()) {
+        if (nextCallsign != null) {
+            dequeueSpecificCaller(nextCallsign);
+        } else if (!dequeueNextCaller()) {
             // No queued callers — stay on CQ
         }
 
         setCurrentFunctionOrder(functionOrder);
         mutableFunctionOrder.postValue(functionOrder);
+    }
+
+    /** Convenience overload: log and move on to the head of the queue. */
+    public void forceLogAndMoveOn() {
+        forceLogAndMoveOn(null);
     }
 
     // ==================== Caller Queue Methods ====================
@@ -1327,6 +1337,30 @@ public class FT8TransmitSignal {
                         GeneralVariables.checkFunOrderByExtraInfo(caller.extraInfo) + 1,
                         caller.extraInfo);
                 return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Remove a specific caller from the queue by callsign and start a QSO with them.
+     * Returns true if the caller was found and started.
+     */
+    public boolean dequeueSpecificCaller(String callsign) {
+        if (callsign == null || callsign.isEmpty()) return false;
+        synchronized (callerQueue) {
+            for (int i = 0; i < callerQueue.size(); i++) {
+                if (callerQueue.get(i).callsign.equals(callsign)) {
+                    QueuedCaller caller = callerQueue.remove(i);
+                    mutableCallerQueue.postValue(new ArrayList<>(callerQueue));
+
+                    resetTargetReport();
+                    setTransmit(new TransmitCallsign(caller.i3, caller.n3, caller.callsign,
+                                    caller.frequency, caller.sequential, caller.snr),
+                            GeneralVariables.checkFunOrderByExtraInfo(caller.extraInfo) + 1,
+                            caller.extraInfo);
+                    return true;
+                }
             }
         }
         return false;

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -245,8 +245,15 @@ fun ActiveQsoPanel(
                 },
             )
 
-            // Caller queue display
-            CallerQueueBar(queue = callerQueue ?: arrayListOf())
+            // Caller queue display — tap a callsign to log current QSO and work them next
+            CallerQueueBar(
+                queue = callerQueue ?: arrayListOf(),
+                onCallerTap = if (displayCallsign != null) { callsign ->
+                    mainViewModel.ft8TransmitSignal.forceLogAndMoveOn(callsign)
+                    mainViewModel.qsoSheetCallsign.postValue(null)
+                    mainViewModel.qsoSheetMinimized.postValue(false)
+                } else null,
+            )
         }
     }
 }
@@ -558,7 +565,10 @@ private fun TxSelector(
 
 @OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
 @Composable
-private fun CallerQueueBar(queue: ArrayList<QueuedCaller>) {
+private fun CallerQueueBar(
+    queue: ArrayList<QueuedCaller>,
+    onCallerTap: ((String) -> Unit)? = null,
+) {
     if (queue.isEmpty()) return
 
     Spacer(modifier = Modifier.height(6.dp))
@@ -586,6 +596,10 @@ private fun CallerQueueBar(queue: ArrayList<QueuedCaller>) {
                     modifier = Modifier
                         .clip(RoundedCornerShape(4.dp))
                         .background(SignalSoft)
+                        .then(
+                            if (onCallerTap != null) Modifier.clickable { onCallerTap(caller.callsign) }
+                            else Modifier
+                        )
                         .padding(horizontal = 6.dp, vertical = 2.dp),
                     contentAlignment = Alignment.Center,
                 ) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -208,6 +208,13 @@ fun ActiveQsoPanel(
                 },
                 snr = if (displayCallsign != null) toCallsign?.snr else null,
                 onClick = if (displayCallsign != null) onReopenSheet else null,
+                onLog = if (displayCallsign != null) {
+                    {
+                        mainViewModel.ft8TransmitSignal.forceLogAndMoveOn()
+                        mainViewModel.qsoSheetCallsign.postValue(null)
+                        mainViewModel.qsoSheetMinimized.postValue(false)
+                    }
+                } else null,
                 onClear = if (displayCallsign != null) {
                     {
                         mainViewModel.ft8TransmitSignal.userResetToCQ()
@@ -249,6 +256,7 @@ private fun StationHeader(
     targetCallsign: String,
     snr: Int?,
     onClick: (() -> Unit)? = null,
+    onLog: (() -> Unit)? = null,
     onClear: (() -> Unit)? = null,
 ) {
     Row(
@@ -290,7 +298,7 @@ private fun StationHeader(
         }
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             if (onClick != null) {
                 Text(
@@ -300,6 +308,25 @@ private fun StationHeader(
                     fontFamily = GeistMonoFamily,
                     fontWeight = FontWeight.SemiBold,
                 )
+            }
+            if (onLog != null) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(SignalSoft)
+                        .clickable(onClick = onLog)
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "LOG",
+                        color = Signal,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = GeistMonoFamily,
+                        letterSpacing = 0.04.sp,
+                    )
+                }
             }
             if (onClear != null) {
                 // Tap target uses its own Box so the parent header's reopen

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
@@ -338,6 +338,42 @@ object FT8USIcons {
         }
     }
 
+    /** Three tightly-spaced horizontal lines — switch to compact decode list. */
+    @Composable
+    fun ViewCompact(
+        modifier: Modifier = Modifier,
+        color: Color = Color.Unspecified,
+        size: Dp = 22.dp,
+        strokeWidth: Float = 1.6f,
+    ) {
+        val tint = if (color == Color.Unspecified) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else color
+        Canvas(modifier = modifier.then(Modifier.sizeOf(size))) {
+            val s = this.size.width / 24f
+            val stroke = strokeStyle(strokeWidth * s)
+            drawLine(tint, Offset(4f * s, 8f * s), Offset(20f * s, 8f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 12f * s), Offset(20f * s, 12f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 16f * s), Offset(20f * s, 16f * s), stroke.width, StrokeCap.Round)
+        }
+    }
+
+    /** Three widely-spaced horizontal lines — switch to expanded decode list. */
+    @Composable
+    fun ViewExpanded(
+        modifier: Modifier = Modifier,
+        color: Color = Color.Unspecified,
+        size: Dp = 22.dp,
+        strokeWidth: Float = 1.6f,
+    ) {
+        val tint = if (color == Color.Unspecified) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else color
+        Canvas(modifier = modifier.then(Modifier.sizeOf(size))) {
+            val s = this.size.width / 24f
+            val stroke = strokeStyle(strokeWidth * s)
+            drawLine(tint, Offset(4f * s, 5f * s), Offset(20f * s, 5f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 12f * s), Offset(20f * s, 12f * s), stroke.width, StrokeCap.Round)
+            drawLine(tint, Offset(4f * s, 19f * s), Offset(20f * s, 19f * s), stroke.width, StrokeCap.Round)
+        }
+    }
+
     /** Triangular pine tree on a small trunk — POTA tab. */
     @Composable
     fun Tree(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -65,6 +65,7 @@ fun DecodeRow(
     animateEntry: Boolean = false,
     nowMillis: Long = 0L,
     isTarget: Boolean = false,
+    compact: Boolean = false,
 ) {
     val isCQ = message.checkIsCQ()
     val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
@@ -115,7 +116,7 @@ fun DecodeRow(
             .background(bgColor, shape)
             .border(1.dp, borderColor, shape)
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-            .padding(start = 0.dp, end = 12.dp, top = 10.dp, bottom = 10.dp),
+            .padding(start = 0.dp, end = 12.dp, top = if (compact) 6.dp else 10.dp, bottom = if (compact) 6.dp else 10.dp),
         verticalAlignment = Alignment.Top,
     ) {
         // Left accent bar — pink for the current call target, amber for CQ.
@@ -129,7 +130,7 @@ fun DecodeRow(
             Box(
                 modifier = Modifier
                     .width(3.dp)
-                    .height(52.dp)
+                    .height(if (compact) 32.dp else 52.dp)
                     .background(accentColor, RoundedCornerShape(99.dp))
             )
             Spacer(modifier = Modifier.width(10.dp))
@@ -189,20 +190,22 @@ fun DecodeRow(
                 }
             }
 
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(if (compact) 2.dp else 4.dp))
 
             // Full decoded message text (canonical FT8 frame, e.g. "K1ABC W9XYZ EN37"
             // or "CQ POTA W1ABC FN42"). This is what was actually transmitted.
-            val msgText = message.getMessageText()?.trim().orEmpty()
-            if (msgText.isNotEmpty()) {
-                Text(
-                    text = msgText,
-                    color = TextMuted,
-                    fontFamily = GeistMonoFamily,
-                    fontSize = 12.sp,
-                    letterSpacing = 0.02.sp,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
+            if (!compact) {
+                val msgText = message.getMessageText()?.trim().orEmpty()
+                if (msgText.isNotEmpty()) {
+                    Text(
+                        text = msgText,
+                        color = TextMuted,
+                        fontFamily = GeistMonoFamily,
+                        fontSize = 12.sp,
+                        letterSpacing = 0.02.sp,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
             }
 
             // Metadata row: signal bar, SNR, frequency, distance, UTC time
@@ -211,7 +214,7 @@ fun DecodeRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                SignalBar(snr = message.snr, width = 28.dp, height = 12.dp)
+                SignalBar(snr = message.snr, width = if (compact) 22.dp else 28.dp, height = if (compact) 10.dp else 12.dp)
 
                 MetaText("${message.snr} dB")
                 MetaText("${message.getFreq_hz()} Hz")
@@ -234,24 +237,26 @@ fun DecodeRow(
             }
 
             // State / DX entity location line (shown on every row when known)
-            val context = LocalContext.current
-            val locationText = resolveLocationText(context, message)
-            if (!locationText.isNullOrEmpty()) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    radio.ks3ckc.ft8us.ui.components.FT8USIcons.Globe(
-                        color = TextDim,
-                        size = 12.dp,
-                    )
-                    Text(
-                        text = locationText,
-                        color = TextDim,
-                        fontSize = 10.5.sp,
-                        fontWeight = FontWeight.Medium,
-                    )
+            if (!compact) {
+                val context = LocalContext.current
+                val locationText = resolveLocationText(context, message)
+                if (!locationText.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        radio.ks3ckc.ft8us.ui.components.FT8USIcons.Globe(
+                            color = TextDim,
+                            size = 12.dp,
+                        )
+                        Text(
+                            text = locationText,
+                            color = TextDim,
+                            fontSize = 10.5.sp,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
                 }
             }
         }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -159,6 +159,9 @@ fun DecodeScreen(
         mainViewModel.mutablePreselectCallsign.postValue(null)   // consume (allow re-trigger)
     }
 
+    // Compact mode — persisted via GeneralVariables.simpleCallItemMode / DB key "msgMode"
+    var compactMode by rememberSaveable { mutableStateOf(GeneralVariables.simpleCallItemMode) }
+
     // Format UTC time for the subtitle
     val utcString = if (utcTime > 0L) {
         UtcTimer.getTimeStr(utcTime)
@@ -181,6 +184,19 @@ fun DecodeScreen(
                     )
                 },
                 actions = {
+                    IconButton(
+                        onClick = {
+                            compactMode = !compactMode
+                            GeneralVariables.simpleCallItemMode = compactMode
+                            mainViewModel.databaseOpr.writeConfig("msgMode", if (compactMode) "1" else "0", null)
+                        },
+                    ) {
+                        if (compactMode) {
+                            radio.ks3ckc.ft8us.ui.components.FT8USIcons.ViewExpanded(color = TextMuted)
+                        } else {
+                            radio.ks3ckc.ft8us.ui.components.FT8USIcons.ViewCompact(color = TextMuted)
+                        }
+                    }
                     IconButton(
                         onClick = { mainViewModel.clearFt8MessageList() },
                         enabled = messageList?.isNotEmpty() == true,
@@ -229,7 +245,7 @@ fun DecodeScreen(
                         val prevSlot = if (index > 0) filteredMessages[index - 1].utcTime / 15000L else null
                         val thisSlot = message.utcTime / 15000L
                         if (prevSlot == null || prevSlot != thisSlot) {
-                            TimeGroupDivider(utcTime = message.utcTime)
+                            TimeGroupDivider(utcTime = message.utcTime, compact = compactMode)
                         }
 
                         // Target highlight: this row is from the station the
@@ -246,6 +262,7 @@ fun DecodeScreen(
                             animateEntry = rowKey in newKeys,
                             nowMillis = utcTime,
                             isTarget = isTarget,
+                            compact = compactMode,
                             // Single tap = immediately call this station (fast reply to
                             // a CQ). Long-press opens the info sheet (QRZ, country, etc.).
                             onClick = {
@@ -285,12 +302,12 @@ fun DecodeScreen(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun TimeGroupDivider(utcTime: Long) {
+private fun TimeGroupDivider(utcTime: Long, compact: Boolean = false) {
     val timeStr = remember(utcTime) { UtcTimer.getTimeHHMMSS(utcTime) }
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .padding(horizontal = 12.dp, vertical = if (compact) 3.dp else 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(


### PR DESCRIPTION
## Summary
- Adds a **LOG** pill button in the `ActiveQsoPanel` header (next to the X/close button) that force-saves the current QSO and immediately moves on to the next queued caller or CQ
- Eliminates the need to wait for a 73 reply or the no-reply timeout when the QSO is effectively complete (RR73 stage)
- Works at any QSO stage — saves whatever info is available, then resets

## Test plan
- [ ] Start a QSO and advance to RR73 stage (function order 4)
- [ ] Tap LOG button — verify QSO appears in Logbook, TX resets to CQ or picks up next queued caller
- [ ] Test tapping LOG at earlier stages (function order 2/3) — should still log and reset
- [ ] Verify the LOG button only appears when there's an active QSO target (not during CQ)
- [ ] Verify auto-CQ-after-QSO behavior is preserved when LOG is tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)