### PR TITLE
Add POTA activation contacts list

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaActivationDao.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaActivationDao.kt
@@ -4,6 +4,10 @@ import android.database.sqlite.SQLiteDatabase
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.database.DatabaseOpr
 import radio.ks3ckc.ft8us.pota.model.PotaActivation
+import radio.ks3ckc.ft8us.pota.model.PotaQso
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * Thin DAO over the pota_activation SQLite table. Single-threaded callers from the
@@ -57,6 +61,50 @@ internal object PotaActivationDao {
         val out = mutableListOf<PotaActivation>()
         cursor.use { c ->
             while (c.moveToNext()) out.add(c.toActivation())
+        }
+        return out
+    }
+
+    /**
+     * Return QSOs belonging to [activation] by matching my_sig = 'POTA' and
+     * my_sig_info = parkRef, filtered to the activation's time window so repeat
+     * activations at the same park don't bleed into each other.
+     */
+    fun getActivationQsos(activation: PotaActivation): List<PotaQso> {
+        val fmt = SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
+        val startStamp = fmt.format(Date(activation.startedAtMs))
+        val endStamp = activation.endedAtMs?.let { fmt.format(Date(it)) } ?: "99991231235959"
+        val cursor = db().rawQuery(
+            """
+            SELECT id, call, gridsquare, band, mode, rst_sent, rst_rcvd,
+                   qso_date, time_on, sig, sig_info
+              FROM QSLTable
+             WHERE my_sig = 'POTA' AND my_sig_info = ?
+               AND (qso_date || time_on) >= ?
+               AND (qso_date || time_on) <= ?
+             ORDER BY qso_date DESC, time_on DESC
+            """.trimIndent(),
+            arrayOf(activation.parkRef, startStamp, endStamp),
+        )
+        val out = mutableListOf<PotaQso>()
+        cursor.use { c ->
+            while (c.moveToNext()) {
+                out.add(
+                    PotaQso(
+                        id = c.getLong(0),
+                        callsign = c.getString(1) ?: "",
+                        grid = c.getString(2) ?: "",
+                        band = c.getString(3) ?: "",
+                        mode = c.getString(4) ?: "",
+                        rstSent = c.getString(5) ?: "",
+                        rstRcvd = c.getString(6) ?: "",
+                        qsoDate = c.getString(7) ?: "",
+                        timeOn = c.getString(8) ?: "",
+                        sig = c.getString(9),
+                        sigInfo = c.getString(10),
+                    ),
+                )
+            }
         }
         return out
     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import radio.ks3ckc.ft8us.pota.model.PotaActivation
+import radio.ks3ckc.ft8us.pota.model.PotaQso
 import java.io.File
 import java.io.FileWriter
 import java.text.SimpleDateFormat
@@ -33,6 +34,9 @@ object PotaSessionManager {
     private val _currentActivation = MutableStateFlow<PotaActivation?>(null)
     val currentActivation: StateFlow<PotaActivation?> = _currentActivation.asStateFlow()
 
+    private val _activationQsos = MutableStateFlow<List<PotaQso>>(emptyList())
+    val activationQsos: StateFlow<List<PotaQso>> = _activationQsos.asStateFlow()
+
     @Volatile
     private var savedModifier: String = ""
 
@@ -55,6 +59,7 @@ object PotaSessionManager {
         val operator = GeneralVariables.myCallsign?.takeIf { it.isNotBlank() }
         val activation = PotaActivationDao.startActivation(ref, operator, notes)
         _currentActivation.value = activation
+        _activationQsos.value = emptyList()
         log("start ref=$ref id=${activation.id} priorModifier='${savedModifier}'")
         return activation
     }
@@ -70,15 +75,22 @@ object PotaSessionManager {
         savedModifier = ""
         log("end ref=${active.parkRef} id=${active.id} qsoCount=${active.qsoCount} restoredModifier='${GeneralVariables.toModifier}'")
         _currentActivation.value = null
+        _activationQsos.value = emptyList()
     }
 
-    /** Pull the latest qso_count from the DB so the UI counter stays accurate. */
+    /** Pull the latest qso_count and contacts from the DB so the UI stays accurate. */
     fun refreshCounter() {
         val active = _currentActivation.value ?: return
-        PotaActivationDao.reload(active.id)?.let { _currentActivation.value = it }
+        PotaActivationDao.reload(active.id)?.let {
+            _currentActivation.value = it
+            _activationQsos.value = PotaActivationDao.getActivationQsos(it)
+        }
     }
 
     fun history(): List<PotaActivation> = PotaActivationDao.history()
+
+    fun getQsosForActivation(activation: PotaActivation): List<PotaQso> =
+        PotaActivationDao.getActivationQsos(activation)
 
     /**
      * Stamp POTA ADIF fields onto a QSO record about to be inserted. Mutates

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/model/PotaModels.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/model/PotaModels.kt
@@ -22,6 +22,21 @@ data class PotaPark(
     val locationDesc: String,
 )
 
+/** A single QSO row for the activation contacts list. */
+data class PotaQso(
+    val id: Long,
+    val callsign: String,
+    val grid: String,
+    val band: String,
+    val mode: String,
+    val rstSent: String,
+    val rstRcvd: String,
+    val qsoDate: String,
+    val timeOn: String,
+    val sig: String?,
+    val sigInfo: String?,
+)
+
 /** A logged activation session (row from pota_activation). */
 data class PotaActivation(
     val id: Long,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
@@ -21,6 +21,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Icon
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
@@ -58,7 +62,9 @@ import radio.ks3ckc.ft8us.pota.PotaClient
 import radio.ks3ckc.ft8us.pota.PotaSessionManager
 import radio.ks3ckc.ft8us.pota.PotaSpotsRepository
 import radio.ks3ckc.ft8us.pota.model.PotaActivation
+import radio.ks3ckc.ft8us.pota.model.PotaQso
 import radio.ks3ckc.ft8us.pota.model.PotaSpot
+import radio.ks3ckc.ft8us.ui.decode.QrzAvatar
 import radio.ks3ckc.ft8us.theme.Accent
 import radio.ks3ckc.ft8us.theme.AccentSoft
 import radio.ks3ckc.ft8us.theme.BgApp
@@ -148,6 +154,7 @@ private fun PotaTabHeader(subTab: PotaSubTab, onTabSelected: (PotaSubTab) -> Uni
 @Composable
 private fun ActivateTab() {
     val activation by PotaSessionManager.currentActivation.collectAsStateWithLifecycle()
+    val contacts by PotaSessionManager.activationQsos.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var parkRef by rememberSaveable { mutableStateOf("") }
@@ -164,11 +171,11 @@ private fun ActivateTab() {
         }
     }
 
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        if (activation == null) {
+    if (activation == null) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
             Card {
                 SectionTitle(stringResource(R.string.pota_start_activation))
                 Spacer(Modifier.height(8.dp))
@@ -204,39 +211,56 @@ private fun ActivateTab() {
                     modifier = Modifier.fillMaxWidth(),
                 ) { Text(stringResource(R.string.pota_start_activation), fontWeight = FontWeight.SemiBold) }
             }
-        } else {
-            ActiveActivationCard(
-                activation = activation!!,
-                onStop = {
-                    PotaSessionManager.end()
-                    Toast.makeText(context, context.getString(R.string.pota_activation_ended), Toast.LENGTH_SHORT).show()
-                },
-                onSelfSpot = {
-                    val myCall = GeneralVariables.myCallsign ?: ""
-                    if (myCall.isBlank()) {
-                        Toast.makeText(context, context.getString(R.string.pota_set_callsign_first), Toast.LENGTH_SHORT).show()
-                    } else {
-                        scope.launch {
-                            val ok = PotaClient.selfSpot(
-                                activator = myCall,
-                                spotter = myCall,
-                                // getBaseFrequency() = carrier + audio offset, in Hz — the
-                                // actual TX QRG. Using band/1000 here posted the band
-                                // centre and put hunters off-frequency by the audio offset.
-                                frequencyKhz = GeneralVariables.getBaseFrequency() / 1000.0,
-                                mode = "FT8",
-                                reference = activation!!.parkRef,
-                                comments = "CQ POTA via FT8AF",
-                            )
-                            Toast.makeText(
-                                context,
-                                context.getString(if (ok) R.string.pota_self_spot_posted else R.string.pota_self_spot_failed),
-                                Toast.LENGTH_SHORT,
-                            ).show()
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            item(key = "activation-card") {
+                ActiveActivationCard(
+                    activation = activation!!,
+                    onStop = {
+                        PotaSessionManager.end()
+                        Toast.makeText(context, context.getString(R.string.pota_activation_ended), Toast.LENGTH_SHORT).show()
+                    },
+                    onSelfSpot = {
+                        val myCall = GeneralVariables.myCallsign ?: ""
+                        if (myCall.isBlank()) {
+                            Toast.makeText(context, context.getString(R.string.pota_set_callsign_first), Toast.LENGTH_SHORT).show()
+                        } else {
+                            scope.launch {
+                                val ok = PotaClient.selfSpot(
+                                    activator = myCall,
+                                    spotter = myCall,
+                                    frequencyKhz = GeneralVariables.getBaseFrequency() / 1000.0,
+                                    mode = "FT8",
+                                    reference = activation!!.parkRef,
+                                    comments = "CQ POTA via FT8AF",
+                                )
+                                Toast.makeText(
+                                    context,
+                                    context.getString(if (ok) R.string.pota_self_spot_posted else R.string.pota_self_spot_failed),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                            }
                         }
-                    }
-                },
-            )
+                    },
+                )
+            }
+            if (contacts.isNotEmpty()) {
+                item(key = "contacts-header") {
+                    Text(
+                        stringResource(R.string.pota_qsos),
+                        color = TextMuted,
+                        fontSize = 12.sp,
+                        modifier = Modifier.padding(start = 4.dp, top = 4.dp),
+                    )
+                }
+                items(contacts, key = { it.id }) { qso ->
+                    PotaContactRow(qso)
+                }
+            }
         }
     }
 }
@@ -295,6 +319,65 @@ private fun ActiveActivationCard(
             color = TextMuted,
             fontSize = 11.sp,
         )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Contact row
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun PotaContactRow(qso: PotaQso) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BgSurface, RoundedCornerShape(10.dp))
+            .border(1.dp, Border, RoundedCornerShape(10.dp))
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        QrzAvatar(callsign = qso.callsign, size = 32.dp, fallbackText = qso.callsign.take(2))
+        Spacer(Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    qso.callsign,
+                    color = TextPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 13.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+                if (qso.sigInfo != null) {
+                    Spacer(Modifier.width(6.dp))
+                    ParkPill(qso.sigInfo)
+                }
+            }
+            Row {
+                Text(
+                    listOfNotNull(
+                        qso.grid.ifBlank { null },
+                        qso.band.ifBlank { null },
+                    ).joinToString(" · "),
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                )
+            }
+        }
+        Spacer(Modifier.width(6.dp))
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                formatQsoTime(qso.timeOn),
+                color = TextMuted,
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+            )
+            Text(
+                "${qso.rstRcvd} dB",
+                color = Accent,
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
     }
 }
 
@@ -436,6 +519,16 @@ private fun HistoryRow(
     onOpenUploadPage: () -> Unit,
     onShareAdif: () -> Unit,
 ) {
+    var expanded by remember { mutableStateOf(false) }
+    var contacts by remember { mutableStateOf<List<PotaQso>?>(null) }
+
+    // Load contacts lazily on first expansion.
+    LaunchedEffect(expanded) {
+        if (expanded && contacts == null) {
+            contacts = PotaSessionManager.getQsosForActivation(row)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -444,7 +537,9 @@ private fun HistoryRow(
             .padding(horizontal = 12.dp, vertical = 10.dp),
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = !expanded },
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -458,7 +553,18 @@ private fun HistoryRow(
                     fontSize = 13.sp,
                 )
             }
-            Text(formatDateRange(row), color = TextMuted, fontSize = 11.sp)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(formatDateRange(row), color = TextMuted, fontSize = 11.sp)
+                if (row.qsoCount > 0) {
+                    Spacer(Modifier.width(4.dp))
+                    Icon(
+                        imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                        tint = TextMuted,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
         }
         if (!row.notes.isNullOrBlank()) {
             Spacer(Modifier.height(2.dp))
@@ -471,6 +577,13 @@ private fun HistoryRow(
             }
             OutlinedButton(onClick = onOpenUploadPage, modifier = Modifier.weight(1f)) {
                 Text(stringResource(R.string.pota_open_pota_app), color = TextPrimary, fontSize = 12.sp)
+            }
+        }
+        if (expanded && contacts != null) {
+            Spacer(Modifier.height(8.dp))
+            contacts!!.forEach { qso ->
+                PotaContactRow(qso)
+                Spacer(Modifier.height(4.dp))
             }
         }
     }
@@ -540,6 +653,11 @@ private fun formatElapsed(ms: Long): String {
     val h = totalSec / 3600
     val m = (totalSec % 3600) / 60
     return if (h > 0) "${h}h ${m}m" else "${m}m"
+}
+
+private fun formatQsoTime(timeOn: String): String {
+    if (timeOn.length < 4) return timeOn
+    return "${timeOn.substring(0, 2)}:${timeOn.substring(2, 4)}z"
 }
 
 private fun formatDateRange(row: PotaActivation): String {


### PR DESCRIPTION
## Summary
- Display worked stations below the activation card during an active POTA activation, with QRZ profile avatars, callsign, grid/band, UTC time, signal report, and park-to-park pills
- Contacts refresh every 3 seconds alongside the existing QSO counter
- History tab rows are now expandable — tap to reveal contacts from past activations (loaded lazily on first expansion)

## Test plan
- [ ] Start a POTA activation, make QSOs, verify contacts appear and auto-refresh
- [ ] Check QRZ avatars load (or show initials fallback)
- [ ] Check P2P pill appears when the worked station is another activator
- [ ] End activation, go to History tab, tap a row to expand contacts
- [ ] Verify scroll behavior with 10+ contacts in both Activate and History tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)