### PR TITLE
Add French, Russian, and Chinese localizations

### DIFF
--- a/ft8cn/app/src/main/res/values-fr/strings.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,560 @@
+<resources>
+    <string name="app_name">FT8AF</string>
+    <string name="nav_menu_title_call_list">Contenu</string>
+    <string name="nav_menu_title_decode_list">Décodage</string>
+    <string name="nav_menu_title_my_calling">Appel</string>
+    <string name="nav_menu_title_history">Journaux QSO</string>
+    <string name="nav_menu_title_config">Paramètres</string>
+    <string name="map_name" translatable="false">nightUSGS4Layer.sqlite</string>
+
+
+    <string name="run_decode">Lancer le décodage</string>
+    <string name="db">dB</string>
+    <string name="dt">Δt</string>
+    <string name="locate">Position</string>
+    <string name="message">Message</string>
+    <string name="freq">Fréq</string>
+    <string name="decode">Décoder</string>
+    <string name="delete">Supprimer</string>
+    <string name="sequence">S.</string>
+    <string name="dist">Distance</string>
+    <string name="location">Emplacement</string>
+    <string name="mycall">Indicatif</string>
+    <string name="pl_mycall">Veuillez entrer votre indicatif</string>
+    <string name="headGrid">Locator</string>
+    <string name="pl_grid">Veuillez entrer votre locator Maidenhead</string>
+    <string name="decoding">Décodage…</string>
+    <string name="send">TX</string>
+    <string name="check">Vérifier</string>
+    <string name="sendFreq">Fréq TX</string>
+    <string name="sendDefaultFreq">Fréq audio</string>
+    <string name="pl_sendFreq">Plage de fréq audio 0~2900</string>
+    <string name="transmitting">TX …</string>
+    <string name="synFrequency">Verrouillé TX=RX</string>
+    <string name="spectrum">Spectre</string>
+    <string name="pl_trans_delay">Délai de transmission (MS)</string>
+    <string name="tran_delay">Délai TX</string>
+
+    <string name="timeOffset">Décalage horaire</string>
+    <string name="help">Aide</string>
+    <string name="scroll_down">▾</string>
+    <string name="about_me">À propos de FT8AF</string>
+
+    <string name="connectMode">Contrôle</string>
+    <string name="VOX">VOX</string>
+    <string name="CAT">CAT</string>
+    <string name="operationBand">Fréquence</string>
+    <string name="civ_address">CI-V</string>
+    <string name="pl_civ_address">Adresse CI-V de la radio</string>
+    <string name="serial_port">Port série</string>
+    <string name="bau_rate">Débit en bauds</string>
+    <string name="pl_select_serial_port">Veuillez sélectionner le port série</string>
+    <string name="close">Fermer</string>
+    <string name="rig_name">Radio</string>
+    <string name="debug">Débogage</string>
+    <string name="logo_image">FT8AF</string>
+    <string name="RTS">RTS</string>
+    <string name="FAQ">FAQ</string>
+    <string name="launch_supervision">Minuterie TX</string>
+    <string name="no_response_count">Sans réponse</string>
+    <string name="break_launch">arrêté</string>
+    <string name="follow_cq">Suivi auto des CQ</string>
+    <string name="auto_call_follow">Suivi automatique des appels</string>
+    <string name="DTR">DTR</string>
+    <string name="launch">TX</string>
+    <string name="export">Exporter</string>
+    <string name="view_style">Mode d\'affichage</string>
+    <string name="ptt_delay">Délai PTT</string>
+    <string name="filter">Filtre</string>
+    <string name="pl_filter">Veuillez sélectionner le filtre</string>
+    <string name="filter_all">Tout afficher</string>
+    <string name="filter_is_qsl">Afficher les confirmés</string>
+    <string name="filter_none_qsl">Afficher les non confirmés</string>
+    <string name="cable_connect">USB</string>
+    <string name="bluetooth_connect">Bluetooth</string>
+    <string name="cable_mode">Type de connexion</string>
+    <string name="pl_select_bluetooth">Veuillez sélectionner un appareil Bluetooth disponible</string>
+    <string name="bluetooth_set">Paramètres Bluetooth</string>
+    <string name="spp_device">Appareil Bluetooth SPP</string>
+    <string name="headset_device">Casque Bluetooth</string>>
+    <string name="disconnect_rig">La connexion à la radio est interrompue</string>>
+    <string name="connected_rig">Connexion à la radio réussie.</string>>
+    <string name="current_frequency">Fréquence actuelle : %s</string>>
+    <string name="radio_communication_error">Erreur de communication avec la radio : %s</string>>
+    <string name="does_not_support_recording">L\'appareil Bluetooth ne prend pas en charge l\'enregistrement</string>>
+    <string name="bluetooth_headset_mode">Mode casque Bluetooth activé</string>>
+    <string name="bluetooth_Headset_mode_cancelled">Mode casque Bluetooth désactivé</string>>
+
+    <string name="version_info">FT8AF Ver %s\nKS3CKC\n%s</string>>
+
+
+    <string name="exit">Quitter</string>>
+    <string name="cancel">Annuler</string>>
+    <string name="exit_confirmation">Voulez-vous vraiment quitter ?</string>>
+
+    <!--   FT8Message-->
+    <string name="std_msg">Msg standard</string>>
+    <string name="none_std_msg">Appel non std</string>>
+    <string name="free_text">Texte libre</string>>
+    <string name="dXpedition">DXpedition</string>>
+    <string name="field_day">Field Day</string>>
+    <string name="telemetry">Télémétrie</string>>
+    <string name="rtty_ru_msg">RTTY RU</string>>
+
+
+    <!--   Settings bar-->
+    <string name="offset_time_sec">%.1f sec</string>>
+
+    <!--   Spectrum chart-->
+    <string name="decoding_takes_milliseconds">Décodé : %d ms</string>>
+    <string name="sound_frequency_is_set_to">La fréquence audio est de %d Hz</string>>
+    <string name="de_noise">Réduction bruit</string>
+    <string name="raw_spectrum_data">Original</string>
+    <string name="markMessage">Afficher msg</string>
+    <string name="unMarkMessage">Masquer msg</string>
+
+    <!--   Select Bluetooth device dialog-->
+    <string name="select_bluetooth_device">Sélectionner l\'appareil Bluetooth : %s</string>
+
+    <!--   PTT delay in milliseconds-->
+    <string name="milliseconds">%d ms</string>
+    <!--   No-reply count-->
+    <string name="ignore">Ignorer</string>
+    <string name="times">%d appels</string>
+
+    <!--   Calling bar-->
+    <string name="sound_frequency_is">Fréq : %.0f Hz</string>
+    <string name="target_callsign">Cible : %s</string>
+    <string name="transmission_sequence">Séquence : %d</string>
+    <string name="message_count">Messages(%d)</string>
+
+    <!--   Log export bar-->
+    <string name="export_info">Veuillez utiliser le navigateur web d\'un autre appareil sur le même réseau local pour exporter.\nEntrez l\'URL dans le navigateur :\nhttp://%s:%d</string>
+    <!--   TX watchdog-->
+    <string name="minutes">%d min</string>
+
+    <!--   TX watchdog-->
+    <string name="freq_syn">Verrouillé TX=RX</string>
+    <string name="freq_asyn">TX/RX séparés</string>
+    <string name="auto_follow_cq">Suivi auto des CQ</string>
+    <string name="not_concerned_about_CQ">Pas de suivi CQ</string>
+    <string name="automatic_call_following">Suivi auto des appels</string>
+    <string name="do_not_call_the_following_callsign">Pas de suivi d\'appel</string>
+
+    <!--   Decode bar-->
+    <string name="message_count_count">Messages(%d/%d)</string>
+    <string name="average_offset_seconds">Décalage moy : %.2f sec</string>
+    <string name="my_grid">Locator : %s</string>
+
+    <!--   Decode list-->
+    <string name="tracking_receiver">Suivi du récepteur %s(%s)</string>
+    <string name="calling_receiver">Appel du récepteur %s(%s)</string>
+    <string name="reply_to">Répondre à %s(%s)</string>
+    <string name="tracking">Suivi de %s(%s)</string>
+    <string name="calling">Appel de %s(%s)</string>
+
+    <!--   Grid distance calculation-->
+    <string name="distance">%.0f km</string>
+
+    <!--   Log list-->
+    <string name="confirmed">Confirmé</string>
+    <string name="unconfirmed">Non confirmé</string>
+    <string name="lotw_confirmation">Confirmé par LoTW</string>
+    <string name="manual_confirmation">Confirmé manuellement</string>
+    <string name="log_start_time">Début : %s</string>
+    <string name="log_end_time">Fin : %s</string>
+    <string name="log_last_time">Dernier QSO : %s</string>
+    <string name="log_grid">Locator : %s</string>
+    <string name="log_mode">Mode : %s</string>
+    <string name="log_cancel_confirmation">Annuler la confirmation (%s)</string>
+    <string name="log_manual_confirmation">Confirmation manuelle (%s)</string>
+
+    <!--   QSL log list-->
+    <string name="qsl_grid">Locator : %s</string>
+    <string name="qsl_start_time">Début : %s</string>
+    <string name="qsl_end_time">Fin : %s</string>
+    <string name="qsl_rst_rcvd">RST reçu : %s</string>
+    <string name="html_rst_rcvd">RST reçu</string>
+    <string name="qsl_rst_sent">RST envoyé : %s</string>
+    <string name="html_rst_sent">RST envoyé</string>
+    <string name="qsl_band">Bande : %s</string>
+    <string name="qsl_freq">Fréq : %s</string>
+    <string name="qsl_mode">Mode : %s</string>
+    <string name="qsl_lotw_confirmation">Confirmé par LoTW</string>
+    <string name="qsl_manual_confirmation">Confirmé manuellement</string>
+    <string name="qsl_unconfirmed">Non confirmé</string>
+    <string name="qsl_cancel_confirmation">Annuler la confirmation (%s)</string>
+    <string name="qsl_manual_confirmation_s">Confirmation manuelle (%s)</string>
+    <string name="qsl_qrz_confirmation_s">QRZ (%s)</string>
+
+    <!--   QSL record-->
+    <string name="qsl_record_import_time">Date d\'importation : %s</string>
+
+    <!--   HTML -->
+    <string name="html_track_operation_information">Informations de surveillance</string>
+    <string name="html_track_callsign_hash_table">Table de hachage des indicatifs surveillés</string>
+    <string name="html_trace_parsed_messages">Surveiller les messages analysés</string>
+    <string name="html_trace_callsign_and_grid_correspondence_table">Surveiller la correspondance entre indicatifs et locators</string>
+    <string name="html_query_communication_message">Rechercher les QSO</string>
+    <string name="html_query_configuration_information">Consulter la configuration</string>
+    <string name="html_query_all_table">Consulter toutes les tables de données</string>
+    <string name="html_manage_tracking_callsign">Gérer les indicatifs suivis</string>
+    <string name="html_manage_communication_callsigns">Gérer les indicatifs QSO</string>
+    <string name="html_show_communication_callsigns">Afficher les indicatifs QSO</string>
+    <string name="html_export_log">Exporter le journal</string>
+    <string name="html_import_log">Importer le journal</string>
+    <string name="html_to_the_third_party">Exporter le journal (pour sauvegarde et envoi vers une plateforme tierce pour confirmation)</string>
+    <string name="html_from_jtdx_lotw">Exporter les journaux (pour sauvegarde, envoi vers une plateforme tierce pour confirmation, synchronisation des journaux JTDX et synchronisation LoTW pour confirmation. Il est recommandé d\'utiliser les données ADI de JTDX, LoTW, Log32 et N1mm pour la synchronisation)</string>
+    <string name="html_return">Retour</string>
+
+
+    <string name="html_import_count">Le fichier ADI contient %d enregistrements et %d ont été importés. Le format de %d journaux est incorrect.</string>
+    <string name="html_import_failed">Échec de l\'importation ! %s</string>
+    <string name="html_illegal_command">Commande invalide, échec du téléversement !</string>
+    <string name="html_callsign">Indicatif</string>
+    <string name="html_operation">Opération</string>
+    <string name="html_delete">Supprimer</string>
+    <string name="html_qsl_start_time">Heure de début du QSO</string>
+    <string name="html_qsl_start_day">Date de début du QSO</string>
+    <string name="html_qsl_end_time">Heure de fin du QSO</string>
+    <string name="html_qsl_end_date">Date de fin du QSO</string>
+    <string name="html_qsl_mode">Mode</string>
+    <string name="html_qsl_grid">Locator</string>
+    <string name="html_qsl_band">Bande</string>
+    <string name="html_qsl_freq">Fréq</string>
+    <string name="html_qsl_manual_confirmation">Confirmé manuellement</string>
+    <string name="html_qsl_lotw_confirmation">Confirmé par LoTW</string>
+    <string name="html_qsl_data_source">Source de données</string>
+    <string name="html_qsl_import_data_from_external">Externe</string>
+    <string name="html_qsl_native_data">Local</string>
+    <string name="html_variable">Variables</string>
+    <string name="html_value">Valeurs</string>
+    <string name="html_my_callsign">Indicatif</string>
+    <string name="html_my_grid">Locator</string>
+    <string name="html_decodes_in_this_cycle">Nombre de décodages dans ce cycle</string>
+    <string name="html_total_number_of_decodes">Nombre total de décodages</string>
+    <string name="html_in_recording_state">État d\'enregistrement</string>
+    <string name="html_recording">Enregistrement en cours</string>
+    <string name="html_no_recording">Pas d\'enregistrement</string>
+    <string name="html_time_consuming_for_this_decoding">Durée de ce décodage</string>
+    <string name="html_milliseconds">%d millisecondes</string>
+    <string name="html_average_delay_time_of_this_cycle">Délai moyen de cette période</string>
+    <string name="html_seconds">%.3f secondes</string>
+    <string name="html_sound_frequency">Fréquence audio du signal</string>
+    <string name="html_transmission_delay_time">Délai TX</string>
+    <string name="html_launch_supervision">Minuterie TX</string>
+    <string name="html_automatic_program_run_time">Durée d\'exécution automatique du programme</string>
+    <string name="html_no_reply_limit">Limite sans réponse</string>
+    <string name="html_no_reply_count">Compteur sans réponse</string>
+    <string name="html_mark_message">Marquer les messages sur le diagramme en cascade</string>
+    <string name="html_marking_message">Messages marqués</string>
+    <string name="html_do_not_mark_message">Messages non marqués</string>
+    <string name="html_operation_mode">Mode de fonctionnement</string>
+    <string name="html_civ_address">Adresse CI-V</string>
+    <string name="html_baud_rate">Débit en bauds</string>
+    <string name="html_connect_mode">Mode de connexion</string>
+    <string name="html_available_serial_ports">Ports série disponibles</string>
+    <string name="html_serial_port_in_use">Port série en cours d\'utilisation</string>
+    <string name="html_instruction_set">Jeu d\'instructions</string>
+    <string name="html_target_callsign">Indicatif cible</string>
+    <string name="html_sequential">Séquence</string>
+
+
+    <string name="html_carrier_frequency_band">Bande</string>
+    <string name="html_radio_frequency">Fréquence de la radio</string>
+    <string name="html_successful_callsign">Indicatifs QSO réussis en %s</string>
+    <string name="html_tracking_callsign">Indicatif suivi</string>
+    <string name="html_tracking_qso_information">Informations de suivi QSO</string>
+
+    <string name="html_hash_value">Hash</string>
+    <string name="html_please_select">Veuillez sélectionner</string>
+    <string name="html_adi_format">Fichier journal au format ADI</string>
+    <string name="html_file_in_other_format">et les fichiers dans d\'autres formats pourraient ne pas être analysés et importés correctement.</string>
+    <string name="html_time">Heure</string>
+    <string name="html_total">Total</string>
+    <string name="html_all_logs">Tous les journaux</string>
+    <string name="html_download">Télécharger</string>
+    <string name="html_today_log">Journaux du jour</string>
+    <string name="html_download_all">Tout télécharger</string>
+    <string name="html_download_unconfirmed">Télécharger les non confirmés</string>
+    <string name="callsign_error">L\'indicatif est incorrect !</string>
+    <string name="adjust_call_target">Cible d\'appel ajustée : %s</string>
+    <string name="use_wspr2_error">La fréquence actuellement utilisée %s est la fréquence utilisée par WSPR-2. Il est interdit de transmettre des signaux FT8 !</string>
+    <string name="none">Aucun</string>
+    <string name="connect_bluetooth_spp">Connexion au port série Bluetooth %s …</string>
+    <string name="bluetooth_is_connected">L\'appareil Bluetooth %s est connecté.</string>
+    <string name="bluetooth_is_diconnected">L\'appareil Bluetooth %s est déconnecté.</string>
+    <string name="sound_source_switched">La source audio a été changée.</string>
+    <string name="bluetooth_turn_off">Le Bluetooth est désactivé.</string>
+    <string name="bluetooth_turn_on">Le Bluetooth est activé.</string>
+    <string name="can_not_location">Impossible de localiser. Veuillez vérifier que vous avez autorisé la localisation.</string>
+    <string name="statistical">Statistiques</string>
+    <string name="count_up">Haut</string>
+    <string name="count_down">Bas</string>
+    <string name="band_statistics">Statistiques par bande</string>
+    <string name="count_total">Total : %d</string>
+    <string name="confirmation_statistics">Statistiques de confirmation des journaux</string>
+    <string name="count_confirmed">Confirmé</string>
+    <string name="count_unconfirmed">Non confirmé</string>
+    <string name="count_total_logs">Total : %d</string>
+    <string name="count_confirmed_log">Confirmé : %d</string>
+    <string name="count_lotw_confirmed">Confirmé par LoTW : %d</string>
+    <string name="count_manually_confirmed">Confirmé manuellement : %d</string>
+    <string name="count_confirmed_proportion">Proportion confirmée : %.1f%%</string>
+    <string name="count_tota_callsigns">Nombre total d\'indicatifs : %d</string>
+    <string name="count_zone">Zone %s</string>
+    <string name="itu_completion_statistics">Statistiques de complétion ITU</string>
+    <string name="count_incomplete">Incomplet</string>
+    <string name="count_completed">Complété</string>
+    <string name="count_total_itu">Total ITU : %d\nComplétés %d(%.1f%%)</string>
+    <string name="count_itu_completed_scale">Statistiques ITU</string>
+    <string name="count_cqzone_completed">Statistiques des zones CQ</string>
+    <string name="count_total_cqzone">Total zones CQ : %d \n Complétées : %d(%.1f%%)</string>
+    <string name="count_cqzone_proportion">Statistiques des zones CQ</string>
+    <string name="dxcc_completion_statistics">Statistiques DXCC</string>
+    <string name="count_total_dxcc">Total DXCC : %d \nComplétés : %d(%.1f%%)</string>
+    <string name="count_dxcc_proportion">Statistiques DXCC</string>
+    <string name="callsign_info">Indicatif : %s\nEmplacement : %s\nZone CQ : %d\nZone ITU : %d\nContinent : %s\nLongitude et latitude : %.2f,%.2f\nFuseau horaire : %.0f\nPréfixe DXCC : %s</string>
+    <string name="maximum_distance">Distance maximale\n\n%s</string>
+    <string name="minimum_distance">Distance minimale\n\n%s</string>
+    <string name="count_distance_info">Distance maximale : %.0f km (%s)\nDistance minimale : %.0f km (%s)</string>
+    <string name="distance_statistics">Statistiques de distance</string>
+    <string name="dxcc_image">dxcc</string>
+    <string name="cqzone">cq zone</string>
+    <string name="itu_image">itu zone</string>
+    <string name="recorder_cannot_record">Impossible d\'enregistrer, veuillez vérifier les autorisations. %s</string>
+    <string name="recorder_stop_record_error">Erreur à l\'arrêt de l\'enregistrement ! %s</string>
+    <string name="delete_confirmation">Confirmation de suppression</string>
+    <string name="are_you_sure_delete">Voulez-vous vraiment supprimer ?</string>
+    <string name="ok_confirmed">OK</string>
+    <string name="network_connect">Réseau</string>
+    <string name="pl_select_flex_radio">Veuillez sélectionner une FlexRadio disponible</string>
+    <string name="select_flex_device">Sélectionner l\'appareil FlexRadio : %s</string>
+    <string name="select_xiegu_device">Sélectionner l\'appareil XIEGU : %s</string>
+    <string name="only_flex_supported">Seules les séries FlexRadio ou ICom sont prises en charge !</string>
+    <string name="flex_connect_failed">Échec de la connexion à la FlexRadio %s !</string>
+    <string name="xiegu_connect_failed">Échec de la connexion à la XIEGU %s !</string>
+    <string name="init_flex_operation">%s est en cours d\'initialisation.</string>
+    <string name="html_max_message_cache">Nombre maximum de messages en cache</string>
+    <string name="instruction_failed">L\'instruction %s n\'a pas pu être exécutée. Message : %s</string>
+    <string name="instruction_success">L\'instruction %s a été exécutée avec succès.</string>
+    <string name="flex_ip_addr">IP</string>
+    <string name="pl_input_flex_ip">Veuillez entrer l\'adresse IP</string>
+    <string name="connect_flex">Connecter FlexRadio</string>
+    <string name="connect_flex_ip">Connexion à la FlexRadio %s …</string>
+    <string name="get_new_version">Obtenir la dernière version</string>
+    <string name="login_icom_help">Connexion à la ICom</string>
+    <string name="pl_input_icom_port">Port de contrôle (UDP)</string>
+    <string name="icom_port">Port</string>
+    <string name="icom_user_name">Utilisateur</string>
+    <string name="pl_icom_user">Veuillez entrer le nom d\'utilisateur</string>
+    <string name="icom_password">Mot de passe</string>
+    <string name="pl_icom_password">Veuillez entrer le mot de passe</string>
+    <string name="icom_login_button">Connexion</string>
+    <string name="show_password">Mot de passe visible</string>
+    <string name="connect_icom_ip">Connexion à la radio ICom %s …</string>
+    <string name="connect_xiegu_ip">Connexion à la radio XIEGU %s …</string>
+    <string name="network_exception">%s : Exception de transmission réseau : %s</string>
+    <string name="login_succeed">Connexion réussie !</string>
+    <string name="loging_failed">Échec de la connexion, nom d\'utilisateur ou mot de passe invalide.</string>
+    <string name="data_stream">Flux de données</string>
+    <string name="control_stream">Flux de contrôle</string>
+    <string name="civ_stream">Flux CI-V</string>
+    <string name="audio_stream">Flux audio</string>
+    <string name="alc_high_alert">Attention ! L\'ALC est trop élevé.</string>
+
+    <string name="swr_high_alert">Attention ! Le SWR est trop élevé.</string>
+    <string name="volume_percent">Puissance du signal en sortie %.0f %%</string>
+    <string name="signal_strength">Puissance du signal en sortie</string>
+    <string name="html_distance">Distance</string>
+    <string name="html_callsign_qth">QTH de l\'indicatif</string>
+    <string name="html_update_time">Heure de mise à jour</string>
+    <string name="grid_tracker_new_grid">Nouveau locator trouvé : %s</string>
+    <string name="tracker_open_messages">Ouvrir les messages</string>
+    <string name="tracker_close_messages">Fermer les messages</string>
+    <string name="tracker_decoded_new">%d messages décodés.</string>
+    <string name="tracker_call_this">Appeler cet indicatif</string>
+    <string name="tracker_show_info_mode">Mode info-bulles</string>
+    <string name="tracker_tips_all">Tout</string>
+    <string name="tracker_tips_new">Nouveau</string>
+    <string name="tracker_tips_none">Aucun</string>
+    <string name="tracker_show_cq_tips">Afficher les info-bulles CQ</string>
+    <string name="tracker_hide_cq_tips">Masquer les info-bulles CQ</string>
+    <string name="tracker_show_qsx_tips">Afficher les info-bulles QSX</string>
+    <string name="tracker_hide_qsx_tips">Masquer les info-bulles QSX</string>
+    <string name="track_sample_text_qsl">QSL</string>
+    <string name="tracker_sample_qso_text">QSO</string>
+    <string name="tracker_sample_qsx_text">QSX</string>
+    <string name="tracker_cq_text">CQ</string>
+    <string name="tracker_qso_text">QSO</string>
+    <string name="tracker_new_zone_found">Nouvelle zone trouvée : %s</string>
+    <string name="transmit_freeText">Veuillez entrer le texte libre</string>
+    <string name="trans_free_text_mode">Mode texte libre</string>
+    <string name="trans_standard_messge_mode">Mode message standard</string>
+    <string name="launch_supervision_ignore">Ignorer</string>
+    <string name="be_excluded_callsigns">Préfixes d\'indicatifs exclus</string>
+    <string name="pl_callsing_prefix">Veuillez entrer les préfixes d\'indicatifs</string>
+    <string name="cache_clear">Effacer</string>
+    <string name="cache_clear_title">Effacer le cache</string>
+    <string name="follow_callsign_data">Indicatifs suivis</string>
+    <string name="cancel_clear_cache">Annuler</string>
+    <string name="log_statistics_cache">Nombre de journaux en cache</string>
+    <string name="logs_cache">Msg décodés</string>
+    <string name="band_total">Bande \t Total</string>
+    <string name="modifier_editor">Modificateur CQ</string>
+    <string name="pl_input_modifier">Veuillez entrer le modificateur</string>
+    <string name="flex_start_atu">Démarrer l\'ATU</string>
+    <string name="flex_max_tx_power">Puissance TX maximale à %d W</string>
+    <string name="flex_tune_power">Puissance d\'accord ATU %d W</string>
+    <string name="html_flex_max_rf_power">Puissance TX maximale</string>
+    <string name="html_atu_tune_power">Puissance d\'accord ATU</string>
+    <string name="flex_atu_tune_off">ACCORD ARRÊT</string>
+    <string name="flex_atu_tune_on">ACCORD MARCHE</string>
+    <string name="flex_logo_text">FlexRadio</string>
+    <string name="map_location_image">Localiser sur la carte</string>
+    <string name="log_menu_location">Emplacement</string>
+    <string name="tracker_query_qso_info">Interrogation des données QSO…</string>
+    <string name="html_callsign_grid_total">Total : %d</string>
+    <string name="html_message_page_count">Nombre de pages : %d</string>
+    <string name="html_message_page_size">Taille de page :</string>
+    <string name="html_message_query">Rechercher</string>
+    <string name="config_save_swl">Sauvegarder les décodages</string>
+    <string name="config_donot_save_swl">Ne pas sauvegarder les décodages</string>
+    <string name="config_save_swl_qso">Sauvegarder les QSO pour SWL</string>
+    <string name="config_donot_save_swl_qso">Ne pas sauvegarder les QSO pour SWL</string>
+    <string name="html_query_swl_message">Consulter les messages décodés (SWL)</string>
+    <string name="log_statistics_decode_msg">Nombre total de messages décodés</string>
+    <string name="config_Syn_time">Synchroniser l\'heure</string>
+    <string name="utc_time_sync_delay_slow">Synchronisé. L\'horloge locale est en retard de %d millisecondes</string>
+    <string name="utc_time_sync_delay_faster">Synchronisé. L\'horloge locale est en avance de %d millisecondes</string>
+    <string name="config_clock_is_accurate">L\'horloge locale est exacte !</string>
+    <string name="html_start_date_swl_message">Date de début</string>
+    <string name="html_end_date_swl_message">Date de fin</string>
+    <string name="html_query_qso_swl">Consulter les QSO de SWL</string>
+    <string name="html_export_csv">Exporter en fichier CSV</string>
+    <string name="html_export_text">Exporter en fichier texte</string>
+    <string name="html_export_adi">Exporter en fichier ADIF</string>
+    <string name="log_statistics_swl_qso">Nombre total de QSO décodés</string>
+    <string name="config_clear_swl_qso">QSO décodés</string>
+    <string name="audioOutput">Sortie audio</string>
+    <string name="audio_input_device">Entrée audio</string>
+    <string name="audio_output_device">Périphérique de sortie audio</string>
+    <string name="audio_device_default">Par défaut</string>
+    <string name="audio_device_help">audio_device_help_en.txt</string>
+    <string name="audio16_bit">16 bits entier</string>
+    <string name="audio32_bit">32 bits flottant</string>
+    <string name="html_audio_bits">Audio - profondeur de bits</string>
+    <string name="audio_rate_12k">12kHz</string>
+    <string name="audio_rate_24k">24kHz</string>
+    <string name="audio_rate_48k">48kHz</string>
+    <string name="audio_rate">Taux d\'échantillonnage</string>
+    <string name="html_audio_rate">Audio - taux d\'échantillonnage</string>
+    <string name="audio_bit_depth">Profondeur de bits</string>
+    <string name="callsign_help">callsign_en.txt</string>
+    <string name="maidenhead_help">maidenhead_en.txt</string>
+    <string name="frequency_help">frequency_en.txt</string>
+    <string name="transDelay_help">transDelay_en.txt</string>
+    <string name="timeoffset_help">timeoffset_en.txt</string>
+    <string name="pttdelay_help">pttdelay_en.txt</string>
+    <string name="operationBand_help">operationBand_en.txt</string>
+    <string name="controlMode_help">controlMode_en.txt</string>
+    <string name="civ_help">civ_help_en.txt</string>
+    <string name="rig_model_help">rig_model_help_en.txt</string>
+    <string name="launch_supervision_help">launch_supervision_en.txt</string>
+    <string name="no_response_help">no_response_help_en.txt</string>
+    <string name="auto_follow_help">auto_follow_help_en.txt</string>
+    <string name="connectMode_help">connectMode_en.txt</string>
+    <string name="excludeCallsign_help">excludeCallsign_en.txt</string>
+    <string name="swlMode_help">swlMode_en.txt</string>
+    <string name="audio_output_help">audio_output_help_en.txt</string>
+    <string name="deep_mode_help">decode_help_en.txt</string>
+    <string name="clear_cache_data_help">clear_cache_data_en.txt</string>
+    <string name="html_query_logs">Consulter les journaux</string>
+    <string name="html_qso_all">Tout</string>
+    <string name="html_qso_source">Sources de données</string>
+    <string name="html_qso_unconfirmed">Non confirmé</string>
+    <string name="html_qso_confirmed">Confirmé</string>
+    <string name="html_qso_raw_log">Journaux locaux</string>
+    <string name="html_qso_external_logs">Journaux externes</string>
+    <string name="html_qso_external">Externe</string>
+    <string name="html_qso_raw">Journal local</string>
+    <string name="html_protocol">Protocole</string>
+    <string name="html_comment">Commentaire</string>
+    <string name="decode_mode_text">Mode de décodage</string>
+    <string name="fast_mode">Décodage rapide</string>
+    <string name="deep_mode">Décodage approfondi</string>
+    <string name="export_null">Exporter depuis l\'interface web via un navigateur sur un autre appareil connecté au même réseau local\n Veuillez vous connecter à un Wi-Fi valide</string>
+    <string name="null_task_html">La tâche n\'existe pas !</string>
+    <string name="log_importing_html">Importation en cours...</string>
+    <string name="log_import_finished_html">Terminé !</string>
+    <string name="import_read_error_count_html">Lignes en erreur : %d</string>
+    <string name="import_new_count_html">QSL ajoutées : %d</string>
+    <string name="import_update_count_html">QSL mises à jour : %d</string>
+    <string name="import_invalid_count_html">QSL invalides : %d</string>
+    <string name="import_progress_html">"Progression : "</string>
+    <string name="import_readed_html">QSL validées : %d</string>
+    <string name="import_canceled_html">Annulé !</string>
+    <string name="import_cancel_button">Arrêter</string>
+    <string name="qsl_query_log_menu">Journal (%s)</string>
+    <string name="message_list_simple_mode">Mode liste compact</string>
+    <string name="message_list_standard_mode">Mode liste standard</string>
+    <string name="config_msg_mode">Mode de message</string>
+    <string name="config_msg_std_mode">Standard</string>
+    <string name="config_msg_simple_mode">Simple</string>
+    <string name="message_mode_help">messageMode_en.txt</string>
+    <string name="pl_select_xiegu_radio">Veuillez sélectionner une radio XIEGU disponible</string>
+    <string name="x6100_packet_lost">Perte de paquets : %d</string>
+    <string name="xiegu_name_label">XIEGU</string>
+    <string name="xiegu_ping_value">Ping : %d ms</string>
+    <string name="xiegu_start_atu">Démarrer l\'ATU</string>
+    <string name="xiegu_atu_on">ATU activé</string>
+    <string name="xiegu_atu_off">ATU désactivé</string>
+    <string name="xiegu_band_str">Bande : %s</string>
+    <string name="alc_low_alert">Attention ! L\'ALC est trop faible.</string>
+    <string name="xiegu_meter_info">S.Meter : %.1f dBm\nSWR : %s\nALC : %.1f\nTension : %.1fV\nPuissance TX : %.1f W\nPuissance TX max : %.1f\nVolume TX : %d%%</string>
+    <string name="serial_connect_no_access">Impossible de se connecter au port série, veuillez vérifier que vous avez accès au périphérique USB !</string>
+    <string name="serial_connect_failed">Échec de l\'ouverture du port série !</string>
+    <string name="serial_no_driver">Impossible de se connecter au port série, port série introuvable !</string>
+    <string name="serial_data_bits">Bits de données</string>
+    <string name="serial_parity">Parité</string>
+    <string name="serial_parity_none">Aucune</string>
+    <string name="serial_parity_odd">Impaire</string>
+    <string name="serial_parity_even">Paire</string>
+    <string name="serial_parity_mark">Marque</string>
+    <string name="serial_parity_space">Espace</string>
+    <string name="serial_stop_bits">Bits d\'arrêt</string>
+    <string name="serial_default">Par défaut</string>
+    <string name="serial_setting_help">serial_help_en.txt</string>
+    <string name="tcp_connect_closed">La connexion réseau a été interrompue.</string>
+    <string name="share_logs">Partager les journaux</string>
+    <string name="config_clear_share_data">Supprimer les fichiers en cache</string>
+    <string name="preparing_log_data">Préparation des données du journal…</string>
+    <string name="total_logs">Il y a un total de %d journaux.</string>
+    <string name="get_log_no">%d journaux ont été téléchargés.</string>
+    <string name="write_file_error">Erreur lors de l\'écriture du fichier : %s</string>
+    <string name="import_share_failed">Échec de l\'importation des données du journal ! %s</string>
+    <string name="preparing_import_logs">Préparation de l\'importation des journaux…</string>
+    <string name="share_logs_been_read">%d journaux ont été lus.</string>
+    <string name="share_import_log_data">Importation des données du journal…</string>
+    <string name="cloudlog_settings">Paramètres Cloudlog</string>
+    <string name="config_enable_cloudlog">Activer la synchronisation Cloudlog</string>
+    <string name="cloudlog_addr">Adresse du serveur</string>
+    <string name="cloudlog_api_key">Clé API</string>
+    <string name="test_cloudlog_config">TEST</string>
+    <string name="cloudlog_station_id">ID de station</string>
+    <string name="cloudlog_help">cloudlog_en.txt</string>
+    <string name="pass">Réussi !</string>
+    <string name="fail">Échoué !</string>
+    <string name="testing">Test en cours…</string>
+    <string name="test">Test</string>
+    <string name="qrz_settings">Paramètres QRZ.com</string>
+    <string name="qrz_api_key">Clé API</string>
+    <string name="config_enable_qrz">Activer la synchronisation QRZ</string>
+    <string name="qrz_help">qrz_en.txt</string>
+    <string name="alram_switch">Interrupteur d\'alarme</string>
+    <string name="swr_switch_on" translatable="false">SWR On</string>
+    <string name="swr_switch_off" translatable="false">SWR Off</string>
+    <string name="alc_switch_on" translatable="false">ALC On</string>
+    <string name="alc_switch_off" translatable="false">ALC Off</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-ru/strings.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,560 @@
+<resources>
+    <string name="app_name">FT8AF</string>
+    <string name="nav_menu_title_call_list">Содержание</string>
+    <string name="nav_menu_title_decode_list">Декодирование</string>
+    <string name="nav_menu_title_my_calling">Вызов</string>
+    <string name="nav_menu_title_history">Журнал QSO</string>
+    <string name="nav_menu_title_config">Настройки</string>
+    <string name="map_name" translatable="false">nightUSGS4Layer.sqlite</string>
+
+
+    <string name="run_decode">Начать декодирование</string>
+    <string name="db">dB</string>
+    <string name="dt">Δt</string>
+    <string name="locate">Позиция</string>
+    <string name="message">Сообщение</string>
+    <string name="freq">Частота</string>
+    <string name="decode">Декодировать</string>
+    <string name="delete">Удалить</string>
+    <string name="sequence">S.</string>
+    <string name="dist">Расстояние</string>
+    <string name="location">Местоположение</string>
+    <string name="mycall">Позывной</string>
+    <string name="pl_mycall">Введите позывной</string>
+    <string name="headGrid">Квадрат сетки</string>
+    <string name="pl_grid">Введите Maidenhead-локатор</string>
+    <string name="decoding">Декодирование…</string>
+    <string name="send">TX</string>
+    <string name="check">Проверка</string>
+    <string name="sendFreq">Частота TX</string>
+    <string name="sendDefaultFreq">Звуковая частота</string>
+    <string name="pl_sendFreq">Диапазон звуковой частоты 0~2900</string>
+    <string name="transmitting">TX …</string>
+    <string name="synFrequency">Блок. TX=RX</string>
+    <string name="spectrum">Спектр</string>
+    <string name="pl_trans_delay">Задержка передачи (мс)</string>
+    <string name="tran_delay">Задержка TX</string>
+
+    <string name="timeOffset">Смещение времени</string>
+    <string name="help">Справка</string>
+    <string name="scroll_down">▾</string>
+    <string name="about_me">О программе FT8AF</string>
+
+    <string name="connectMode">Управление</string>
+    <string name="VOX">VOX</string>
+    <string name="CAT">CAT</string>
+    <string name="operationBand">Частота</string>
+    <string name="civ_address">CI-V</string>
+    <string name="pl_civ_address">CI-V адрес трансивера</string>
+    <string name="serial_port">Последовательный порт</string>
+    <string name="bau_rate">Скорость (бод)</string>
+    <string name="pl_select_serial_port">Выберите последовательный порт</string>
+    <string name="close">Закрыть</string>
+    <string name="rig_name">Трансивер</string>
+    <string name="debug">Отладка</string>
+    <string name="logo_image">FT8AF</string>
+    <string name="RTS">RTS</string>
+    <string name="FAQ">FAQ</string>
+    <string name="launch_supervision">Сторожевой таймер TX</string>
+    <string name="no_response_count">Нет ответа</string>
+    <string name="break_launch">остановлено</string>
+    <string name="follow_cq">Автослежение за CQ</string>
+    <string name="auto_call_follow">Автоматическое отслеживание вызова</string>
+    <string name="DTR">DTR</string>
+    <string name="launch">TX</string>
+    <string name="export">Экспорт</string>
+    <string name="view_style">Режим отображения</string>
+    <string name="ptt_delay">Задержка PTT</string>
+    <string name="filter">Фильтр</string>
+    <string name="pl_filter">Выберите фильтр</string>
+    <string name="filter_all">Показать все</string>
+    <string name="filter_is_qsl">Показать подтверждённые</string>
+    <string name="filter_none_qsl">Показать неподтверждённые</string>
+    <string name="cable_connect">USB</string>
+    <string name="bluetooth_connect">Bluetooth</string>
+    <string name="cable_mode">Тип подключения</string>
+    <string name="pl_select_bluetooth">Выберите доступное Bluetooth-устройство</string>
+    <string name="bluetooth_set">Настройки Bluetooth</string>
+    <string name="spp_device">Bluetooth SPP-устройство</string>
+    <string name="headset_device">Bluetooth-гарнитура</string>>
+    <string name="disconnect_rig">Соединение с трансивером разорвано</string>>
+    <string name="connected_rig">Подключение к трансиверу выполнено.</string>>
+    <string name="current_frequency">Текущая частота: %s</string>>
+    <string name="radio_communication_error">Ошибка связи с трансивером: %s</string>>
+    <string name="does_not_support_recording">Bluetooth-устройство не поддерживает запись</string>>
+    <string name="bluetooth_headset_mode">Включён режим Bluetooth-гарнитуры</string>>
+    <string name="bluetooth_Headset_mode_cancelled">Выключен режим Bluetooth-гарнитуры</string>>
+
+    <string name="version_info">FT8AF Ver %s\nKS3CKC\n%s</string>>
+
+
+    <string name="exit">Выход</string>>
+    <string name="cancel">Отмена</string>>
+    <string name="exit_confirmation">Вы уверены, что хотите выйти?</string>>
+
+    <!--   FT8Message-->
+    <string name="std_msg">Стд. сообщение</string>>
+    <string name="none_std_msg">Нестд. позывной</string>>
+    <string name="free_text">Свободный текст</string>>
+    <string name="dXpedition">DXpedition</string>>
+    <string name="field_day">Field Day</string>>
+    <string name="telemetry">Телеметрия</string>>
+    <string name="rtty_ru_msg">RTTY RU</string>>
+
+
+    <!--   Settings bar-->
+    <string name="offset_time_sec">%.1f сек</string>>
+
+    <!--   Spectrum chart-->
+    <string name="decoding_takes_milliseconds">Декодировано: %d мс</string>>
+    <string name="sound_frequency_is_set_to">Звуковая частота: %d Гц</string>>
+    <string name="de_noise">Шумоподавление</string>
+    <string name="raw_spectrum_data">Исходный</string>
+    <string name="markMessage">Показать сообщ.</string>
+    <string name="unMarkMessage">Скрыть сообщ.</string>
+
+    <!--   Select Bluetooth device dialog-->
+    <string name="select_bluetooth_device">Выберите Bluetooth-устройство: %s</string>
+
+    <!--   PTT delay in milliseconds-->
+    <string name="milliseconds">%d мс</string>
+    <!--   No-reply count-->
+    <string name="ignore">Игнорировать</string>
+    <string name="times">%d вызовов</string>
+
+    <!--   Calling bar-->
+    <string name="sound_frequency_is">Частота: %.0f Гц</string>
+    <string name="target_callsign">Цель: %s</string>
+    <string name="transmission_sequence">Последовательность: %d</string>
+    <string name="message_count">Сообщения(%d)</string>
+
+    <!--   Log export bar-->
+    <string name="export_info">Для экспорта используйте веб-браузер на другом устройстве в той же локальной сети.\nВведите URL в браузере:\nhttp://%s:%d</string>
+    <!--   TX watchdog-->
+    <string name="minutes">%d мин</string>
+
+    <!--   TX watchdog-->
+    <string name="freq_syn">Блок. TX=RX</string>
+    <string name="freq_asyn">Tx/Rx раздельно</string>
+    <string name="auto_follow_cq">Автослежение за CQ</string>
+    <string name="not_concerned_about_CQ">Без слежения за CQ</string>
+    <string name="automatic_call_following">Автослежение за вызовом</string>
+    <string name="do_not_call_the_following_callsign">Без слежения за вызовом</string>
+
+    <!--   Decode bar-->
+    <string name="message_count_count">Сообщения(%d/%d)</string>
+    <string name="average_offset_seconds">Смещение ср.: %.2f сек</string>
+    <string name="my_grid">Локатор: %s</string>
+
+    <!--   Decode list-->
+    <string name="tracking_receiver">Слежение за приёмником %s(%s)</string>
+    <string name="calling_receiver">Вызов приёмника %s(%s)</string>
+    <string name="reply_to">Ответ %s(%s)</string>
+    <string name="tracking">Слежение %s(%s)</string>
+    <string name="calling">Вызов %s(%s)</string>
+
+    <!--   Grid distance calculation-->
+    <string name="distance">%.0f км</string>
+
+    <!--   Log list-->
+    <string name="confirmed">Подтверждено</string>
+    <string name="unconfirmed">Не подтверждено</string>
+    <string name="lotw_confirmation">Подтверждено LoTW</string>
+    <string name="manual_confirmation">Подтверждено вручную</string>
+    <string name="log_start_time">Начало: %s</string>
+    <string name="log_end_time">Окончание: %s</string>
+    <string name="log_last_time">Последнее QSO: %s</string>
+    <string name="log_grid">Локатор: %s</string>
+    <string name="log_mode">Режим: %s</string>
+    <string name="log_cancel_confirmation">Отменить подтверждение (%s)</string>
+    <string name="log_manual_confirmation">Подтвердить вручную (%s)</string>
+
+    <!--   QSL log list-->
+    <string name="qsl_grid">Локатор:%s</string>
+    <string name="qsl_start_time">Начало: %s</string>
+    <string name="qsl_end_time">Окончание: %s</string>
+    <string name="qsl_rst_rcvd">RST принято: %s</string>
+    <string name="html_rst_rcvd">RST принято</string>
+    <string name="qsl_rst_sent">RST передано: %s</string>
+    <string name="html_rst_sent">RST передано</string>
+    <string name="qsl_band">Диапазон: %s</string>
+    <string name="qsl_freq">Частота: %s</string>
+    <string name="qsl_mode">Режим: %s</string>
+    <string name="qsl_lotw_confirmation">Подтверждено LoTW</string>
+    <string name="qsl_manual_confirmation">Подтверждено вручную</string>
+    <string name="qsl_unconfirmed">Не подтверждено</string>
+    <string name="qsl_cancel_confirmation">Отменить подтверждение (%s)</string>
+    <string name="qsl_manual_confirmation_s">Подтвердить вручную (%s)</string>
+    <string name="qsl_qrz_confirmation_s">QRZ (%s)</string>
+
+    <!--   QSL record-->
+    <string name="qsl_record_import_time">Время импорта:%s</string>
+
+    <!--   HTML -->
+    <string name="html_track_operation_information">Мониторинг операционной информации</string>
+    <string name="html_track_callsign_hash_table">Мониторинг хеш-таблицы позывных</string>
+    <string name="html_trace_parsed_messages">Мониторинг разобранных сообщений</string>
+    <string name="html_trace_callsign_and_grid_correspondence_table">Мониторинг соответствия позывных и локаторов</string>
+    <string name="html_query_communication_message">Запрос QSO</string>
+    <string name="html_query_configuration_information">Запрос информации о конфигурации</string>
+    <string name="html_query_all_table">Запрос всех таблиц данных</string>
+    <string name="html_manage_tracking_callsign">Управление отслеживаемыми позывными</string>
+    <string name="html_manage_communication_callsigns">Управление позывными QSO</string>
+    <string name="html_show_communication_callsigns">Показать позывные QSO</string>
+    <string name="html_export_log">Экспорт журнала</string>
+    <string name="html_import_log">Импорт журнала</string>
+    <string name="html_to_the_third_party">Экспорт журнала (для резервного копирования и загрузки на стороннюю платформу для подтверждения)</string>
+    <string name="html_from_jtdx_lotw">Экспорт журналов (для резервного копирования, загрузки на стороннюю платформу для подтверждения, синхронизации журналов JTDX и подтверждения LoTW. Рекомендуется использовать ADI-данные JTDX, LoTW, Log32 и N1mm для синхронизации)</string>
+    <string name="html_return">Назад</string>
+
+
+    <string name="html_import_count">В ADI-файле %d записей, импортировано %d записей. Формат %d записей некорректен.</string>
+    <string name="html_import_failed">Импорт не удался! %s</string>
+    <string name="html_illegal_command">Недопустимая команда, загрузка не удалась!</string>
+    <string name="html_callsign">Позывной</string>
+    <string name="html_operation">Операция</string>
+    <string name="html_delete">Удалить</string>
+    <string name="html_qsl_start_time">Время начала QSO</string>
+    <string name="html_qsl_start_day">Дата начала QSO</string>
+    <string name="html_qsl_end_time">Время окончания QSO</string>
+    <string name="html_qsl_end_date">Дата окончания QSO</string>
+    <string name="html_qsl_mode">Режим</string>
+    <string name="html_qsl_grid">Локатор</string>
+    <string name="html_qsl_band">Диапазон</string>
+    <string name="html_qsl_freq">Частота</string>
+    <string name="html_qsl_manual_confirmation">Подтверждено вручную</string>
+    <string name="html_qsl_lotw_confirmation">Подтверждено LoTW</string>
+    <string name="html_qsl_data_source">Источник данных</string>
+    <string name="html_qsl_import_data_from_external">Из внешнего источника</string>
+    <string name="html_qsl_native_data">Локальные</string>
+    <string name="html_variable">Переменные</string>
+    <string name="html_value">Значения</string>
+    <string name="html_my_callsign">Позывной</string>
+    <string name="html_my_grid">Локатор</string>
+    <string name="html_decodes_in_this_cycle">Декодировано в этом цикле</string>
+    <string name="html_total_number_of_decodes">Всего декодировано</string>
+    <string name="html_in_recording_state">Состояние записи</string>
+    <string name="html_recording">Запись</string>
+    <string name="html_no_recording">Нет записи</string>
+    <string name="html_time_consuming_for_this_decoding">Время декодирования</string>
+    <string name="html_milliseconds">%d миллисекунд</string>
+    <string name="html_average_delay_time_of_this_cycle">Средняя задержка за период</string>
+    <string name="html_seconds">%.3f секунд</string>
+    <string name="html_sound_frequency">Звуковая частота сигнала</string>
+    <string name="html_transmission_delay_time">Задержка TX</string>
+    <string name="html_launch_supervision">Сторожевой таймер TX</string>
+    <string name="html_automatic_program_run_time">Время работы автоматической программы</string>
+    <string name="html_no_reply_limit">Лимит без ответа</string>
+    <string name="html_no_reply_count">Счётчик без ответа</string>
+    <string name="html_mark_message">Отметки сообщений на водопаде</string>
+    <string name="html_marking_message">Показать отметки</string>
+    <string name="html_do_not_mark_message">Скрыть отметки</string>
+    <string name="html_operation_mode">Режим работы</string>
+    <string name="html_civ_address">Адрес CI-V</string>
+    <string name="html_baud_rate">Скорость (бод)</string>
+    <string name="html_connect_mode">Режим подключения</string>
+    <string name="html_available_serial_ports">Доступные порты</string>
+    <string name="html_serial_port_in_use">Используемый порт</string>
+    <string name="html_instruction_set">Набор команд</string>
+    <string name="html_target_callsign">Целевой позывной</string>
+    <string name="html_sequential">Последовательность</string>
+
+
+    <string name="html_carrier_frequency_band">Диапазон</string>
+    <string name="html_radio_frequency">Частота трансивера</string>
+    <string name="html_successful_callsign">Успешные QSO-позывные в %s</string>
+    <string name="html_tracking_callsign">Отслеживаемый позывной</string>
+    <string name="html_tracking_qso_information">Отслеживание информации QSO</string>
+
+    <string name="html_hash_value">Хеш</string>
+    <string name="html_please_select">Выберите</string>
+    <string name="html_adi_format">Файл журнала в формате ADI</string>
+    <string name="html_file_in_other_format">файлы в других форматах могут быть некорректно разобраны и импортированы.</string>
+    <string name="html_time">Время</string>
+    <string name="html_total">Всего</string>
+    <string name="html_all_logs">Все записи</string>
+    <string name="html_download">Скачать</string>
+    <string name="html_today_log">Записи за сегодня</string>
+    <string name="html_download_all">Скачать все</string>
+    <string name="html_download_unconfirmed">Скачать неподтверждённые</string>
+    <string name="callsign_error">Позывной указан неверно!</string>
+    <string name="adjust_call_target">Изменение цели вызова: %s</string>
+    <string name="use_wspr2_error">Текущая частота %s используется для WSPR-2. Передача FT8-сигналов запрещена!</string>
+    <string name="none">Нет</string>
+    <string name="connect_bluetooth_spp">Подключение Bluetooth-порта %s …</string>
+    <string name="bluetooth_is_connected">Bluetooth-устройство %s подключено.</string>
+    <string name="bluetooth_is_diconnected">Bluetooth-устройство %s отключено.</string>
+    <string name="sound_source_switched">Источник звука переключён.</string>
+    <string name="bluetooth_turn_off">Bluetooth выключен.</string>
+    <string name="bluetooth_turn_on">Bluetooth включён.</string>
+    <string name="can_not_location">Не удалось определить местоположение. Проверьте разрешения на определение местоположения.</string>
+    <string name="statistical">Статистика</string>
+    <string name="count_up">Вверх</string>
+    <string name="count_down">Вниз</string>
+    <string name="band_statistics">Статистика по диапазонам</string>
+    <string name="count_total">Всего: %d</string>
+    <string name="confirmation_statistics">Статистика подтверждений журнала</string>
+    <string name="count_confirmed">Подтверждено</string>
+    <string name="count_unconfirmed">Не подтверждено</string>
+    <string name="count_total_logs">Всего: %d</string>
+    <string name="count_confirmed_log">Подтверждено: %d</string>
+    <string name="count_lotw_confirmed">Подтверждено LoTW: %d</string>
+    <string name="count_manually_confirmed">Подтверждено вручную: %d</string>
+    <string name="count_confirmed_proportion">Доля подтверждённых: %.1f%%</string>
+    <string name="count_tota_callsigns">Всего позывных: %d</string>
+    <string name="count_zone">Зона %s</string>
+    <string name="itu_completion_statistics">Статистика заполнения ITU</string>
+    <string name="count_incomplete">Не завершено</string>
+    <string name="count_completed">Завершено</string>
+    <string name="count_total_itu">Всего ITU: %d\nЗавершено %d(%.1f%%)</string>
+    <string name="count_itu_completed_scale">Статистика ITU</string>
+    <string name="count_cqzone_completed">Статистика CQ-зон</string>
+    <string name="count_total_cqzone">Всего CQ-зон: %d \n Завершено: %d(%.1f%%)</string>
+    <string name="count_cqzone_proportion">Статистика CQ-зон</string>
+    <string name="dxcc_completion_statistics">Статистика DXCC</string>
+    <string name="count_total_dxcc">Всего DXCC: %d \nЗавершено: %d(%.1f%%)</string>
+    <string name="count_dxcc_proportion">Статистика DXCC</string>
+    <string name="callsign_info">Позывной:%s\nМестоположение:%s\nCQ-зона:%d\nITU-зона:%d\nКонтинент:%s\nШирота и долгота:%.2f,%.2f\nЧасовой пояс:%.0f\nПрефикс DXCC:%s</string>
+    <string name="maximum_distance">Максимальное расстояние\n\n%s</string>
+    <string name="minimum_distance">Минимальное расстояние\n\n%s</string>
+    <string name="count_distance_info">Максимальное расстояние:%.0f км (%s)\nМинимальное расстояние:%.0f км (%s)</string>
+    <string name="distance_statistics">Статистика расстояний</string>
+    <string name="dxcc_image">dxcc</string>
+    <string name="cqzone">cq zone</string>
+    <string name="itu_image">itu zone</string>
+    <string name="recorder_cannot_record">Невозможно записать. Проверьте разрешения. %s</string>
+    <string name="recorder_stop_record_error">Ошибка остановки записи! %s</string>
+    <string name="delete_confirmation">Подтверждение удаления</string>
+    <string name="are_you_sure_delete">Вы уверены, что хотите удалить?</string>
+    <string name="ok_confirmed">OK</string>
+    <string name="network_connect">Сеть</string>
+    <string name="pl_select_flex_radio">Выберите доступный FlexRadio</string>
+    <string name="select_flex_device">Выберите FlexRadio: %s</string>
+    <string name="select_xiegu_device">Выберите XIEGU: %s</string>
+    <string name="only_flex_supported">В настоящее время поддерживаются только FlexRadio и ICom!</string>
+    <string name="flex_connect_failed">Подключение к FlexRadio %s не удалось!</string>
+    <string name="xiegu_connect_failed">Подключение к XIEGU %s не удалось!</string>
+    <string name="init_flex_operation">%s — инициализация операции.</string>
+    <string name="html_max_message_cache">Максимальное количество кешированных сообщений</string>
+    <string name="instruction_failed">Команда %s не выполнена. Сообщение: %s</string>
+    <string name="instruction_success">Команда %s выполнена успешно.</string>
+    <string name="flex_ip_addr">IP</string>
+    <string name="pl_input_flex_ip">Введите IP-адрес</string>
+    <string name="connect_flex">Подключить FlexRadio</string>
+    <string name="connect_flex_ip">Подключение к FlexRadio %s …</string>
+    <string name="get_new_version">Получить последнюю версию</string>
+    <string name="login_icom_help">Вход в ICom</string>
+    <string name="pl_input_icom_port">Порт управления (UDP)</string>
+    <string name="icom_port">Порт</string>
+    <string name="icom_user_name">Пользователь</string>
+    <string name="pl_icom_user">Введите имя пользователя</string>
+    <string name="icom_password">Пароль</string>
+    <string name="pl_icom_password">Введите пароль</string>
+    <string name="icom_login_button">Войти</string>
+    <string name="show_password">Показать пароль</string>
+    <string name="connect_icom_ip">Подключение к ICom %s …</string>
+    <string name="connect_xiegu_ip">Подключение к XIEGU %s …</string>
+    <string name="network_exception">%s: Ошибка сетевой передачи: %s</string>
+    <string name="login_succeed">Вход выполнен!</string>
+    <string name="loging_failed">Вход не удался, неверное имя пользователя или пароль.</string>
+    <string name="data_stream">Поток данных</string>
+    <string name="control_stream">Поток управления</string>
+    <string name="civ_stream">Поток CI-V</string>
+    <string name="audio_stream">Аудиопоток</string>
+    <string name="alc_high_alert">Внимание! ALC слишком высок.</string>
+
+    <string name="swr_high_alert">Внимание! SWR слишком высок.</string>
+    <string name="volume_percent">Мощность выходного сигнала %.0f %%</string>
+    <string name="signal_strength">Мощность выходного сигнала</string>
+    <string name="html_distance">Расстояние</string>
+    <string name="html_callsign_qth">QTH позывного</string>
+    <string name="html_update_time">Время обновления</string>
+    <string name="grid_tracker_new_grid">Обнаружен новый локатор: %s</string>
+    <string name="tracker_open_messages">Открыть сообщения</string>
+    <string name="tracker_close_messages">Закрыть сообщения</string>
+    <string name="tracker_decoded_new">Декодировано %d сообщений.</string>
+    <string name="tracker_call_this">Вызвать этот позывной</string>
+    <string name="tracker_show_info_mode">Режим подсказок</string>
+    <string name="tracker_tips_all">Все</string>
+    <string name="tracker_tips_new">Новые</string>
+    <string name="tracker_tips_none">Нет</string>
+    <string name="tracker_show_cq_tips">Показать подсказки CQ</string>
+    <string name="tracker_hide_cq_tips">Скрыть подсказки CQ</string>
+    <string name="tracker_show_qsx_tips">Показать подсказки QSX</string>
+    <string name="tracker_hide_qsx_tips">Скрыть подсказки QSX</string>
+    <string name="track_sample_text_qsl">QSL</string>
+    <string name="tracker_sample_qso_text">QSO</string>
+    <string name="tracker_sample_qsx_text">QSX</string>
+    <string name="tracker_cq_text">CQ</string>
+    <string name="tracker_qso_text">QSO</string>
+    <string name="tracker_new_zone_found">Обнаружена новая зона: %s</string>
+    <string name="transmit_freeText">Введите свободный текст</string>
+    <string name="trans_free_text_mode">Режим свободного текста</string>
+    <string name="trans_standard_messge_mode">Режим стандартного сообщения</string>
+    <string name="launch_supervision_ignore">Игнорировать</string>
+    <string name="be_excluded_callsigns">Исключённые префиксы позывных</string>
+    <string name="pl_callsing_prefix">Введите префиксы позывных</string>
+    <string name="cache_clear">Очистить</string>
+    <string name="cache_clear_title">Очистка кеша</string>
+    <string name="follow_callsign_data">Отслеживаемые позывные</string>
+    <string name="cancel_clear_cache">Отмена</string>
+    <string name="log_statistics_cache">Кешировано записей журнала</string>
+    <string name="logs_cache">Декодированные сообщения</string>
+    <string name="band_total">Диапазон \t Всего</string>
+    <string name="modifier_editor">Модификатор CQ</string>
+    <string name="pl_input_modifier">Введите модификатор</string>
+    <string name="flex_start_atu">Запуск ATU</string>
+    <string name="flex_max_tx_power">Макс. мощность TX: %d Вт</string>
+    <string name="flex_tune_power">Мощность настройки ATU: %d Вт</string>
+    <string name="html_flex_max_rf_power">Макс. мощность TX</string>
+    <string name="html_atu_tune_power">Мощность настройки ATU</string>
+    <string name="flex_atu_tune_off">TUNE OFF</string>
+    <string name="flex_atu_tune_on">TUNE ON</string>
+    <string name="flex_logo_text">FlexRadio</string>
+    <string name="map_location_image">Показать на карте</string>
+    <string name="log_menu_location">Местоположение</string>
+    <string name="tracker_query_qso_info">Запрос данных QSO…</string>
+    <string name="html_callsign_grid_total">Всего: %d</string>
+    <string name="html_message_page_count">Количество страниц: %d</string>
+    <string name="html_message_page_size">Размер страницы:</string>
+    <string name="html_message_query">Поиск</string>
+    <string name="config_save_swl">Сохранять декодированные</string>
+    <string name="config_donot_save_swl">Не сохранять декодированные</string>
+    <string name="config_save_swl_qso">Сохранять QSO для SWL</string>
+    <string name="config_donot_save_swl_qso">Не сохранять QSO для SWL</string>
+    <string name="html_query_swl_message">Запрос декодированных сообщений (SWL)</string>
+    <string name="log_statistics_decode_msg">Всего декодировано сообщений</string>
+    <string name="config_Syn_time">Синхронизация времени</string>
+    <string name="utc_time_sync_delay_slow">Синхронизировано. Местные часы отстают на %d мс</string>
+    <string name="utc_time_sync_delay_faster">Синхронизировано. Местные часы спешат на %d мс</string>
+    <string name="config_clock_is_accurate">Местные часы точны!</string>
+    <string name="html_start_date_swl_message">Дата начала</string>
+    <string name="html_end_date_swl_message">Дата окончания</string>
+    <string name="html_query_qso_swl">Запрос QSO для SWL</string>
+    <string name="html_export_csv">Экспорт в CSV-файл</string>
+    <string name="html_export_text">Экспорт в текстовый файл</string>
+    <string name="html_export_adi">Экспорт в ADIF-файл</string>
+    <string name="log_statistics_swl_qso">Всего декодировано QSO</string>
+    <string name="config_clear_swl_qso">Декодированные QSO</string>
+    <string name="audioOutput">Аудиовыход</string>
+    <string name="audio_input_device">Аудиовход</string>
+    <string name="audio_output_device">Устройство аудиовыхода</string>
+    <string name="audio_device_default">По умолчанию</string>
+    <string name="audio_device_help">audio_device_help_en.txt</string>
+    <string name="audio16_bit">16-bit int</string>
+    <string name="audio32_bit">32-bit float</string>
+    <string name="html_audio_bits">Аудио — разрядность</string>
+    <string name="audio_rate_12k">12kHz</string>
+    <string name="audio_rate_24k">24kHz</string>
+    <string name="audio_rate_48k">48kHz</string>
+    <string name="audio_rate">Частота дискретизации</string>
+    <string name="html_audio_rate">Аудио — частота дискретизации</string>
+    <string name="audio_bit_depth">Разрядность</string>
+    <string name="callsign_help">callsign_en.txt</string>
+    <string name="maidenhead_help">maidenhead_en.txt</string>
+    <string name="frequency_help">frequency_en.txt</string>
+    <string name="transDelay_help">transDelay_en.txt</string>
+    <string name="timeoffset_help">timeoffset_en.txt</string>
+    <string name="pttdelay_help">pttdelay_en.txt</string>
+    <string name="operationBand_help">operationBand_en.txt</string>
+    <string name="controlMode_help">controlMode_en.txt</string>
+    <string name="civ_help">civ_help_en.txt</string>
+    <string name="rig_model_help">rig_model_help_en.txt</string>
+    <string name="launch_supervision_help">launch_supervision_en.txt</string>
+    <string name="no_response_help">no_response_help_en.txt</string>
+    <string name="auto_follow_help">auto_follow_help_en.txt</string>
+    <string name="connectMode_help">connectMode_en.txt</string>
+    <string name="excludeCallsign_help">excludeCallsign_en.txt</string>
+    <string name="swlMode_help">swlMode_en.txt</string>
+    <string name="audio_output_help">audio_output_help_en.txt</string>
+    <string name="deep_mode_help">decode_help_en.txt</string>
+    <string name="clear_cache_data_help">clear_cache_data_en.txt</string>
+    <string name="html_query_logs">Запрос журнала</string>
+    <string name="html_qso_all">Все</string>
+    <string name="html_qso_source">Источники данных</string>
+    <string name="html_qso_unconfirmed">Не подтверждено</string>
+    <string name="html_qso_confirmed">Подтверждено</string>
+    <string name="html_qso_raw_log">Локальные записи</string>
+    <string name="html_qso_external_logs">Внешние записи</string>
+    <string name="html_qso_external">Внешние</string>
+    <string name="html_qso_raw">Локальная запись</string>
+    <string name="html_protocol">Протокол</string>
+    <string name="html_comment">Комментарий</string>
+    <string name="decode_mode_text">Режим декодирования</string>
+    <string name="fast_mode">Быстрое декодирование</string>
+    <string name="deep_mode">Глубокое декодирование</string>
+    <string name="export_null">Экспортируйте через веб-браузер на другом устройстве в той же локальной сети.\nПодключитесь к Wi-Fi</string>
+    <string name="null_task_html">Задача не существует!</string>
+    <string name="log_importing_html">Импорт...</string>
+    <string name="log_import_finished_html">Готово!</string>
+    <string name="import_read_error_count_html">Ошибочных строк: %d</string>
+    <string name="import_new_count_html">Добавлено QSL: %d</string>
+    <string name="import_update_count_html">Обновлено QSL: %d</string>
+    <string name="import_invalid_count_html">Недействительных QSL: %d</string>
+    <string name="import_progress_html">"Прогресс: "</string>
+    <string name="import_readed_html">Проверено QSL: %d</string>
+    <string name="import_canceled_html">Отменено!</string>
+    <string name="import_cancel_button">Стоп</string>
+    <string name="qsl_query_log_menu">Журнал (%s)</string>
+    <string name="message_list_simple_mode">Компактный режим списка</string>
+    <string name="message_list_standard_mode">Стандартный режим списка</string>
+    <string name="config_msg_mode">Режим сообщений</string>
+    <string name="config_msg_std_mode">Стандартный</string>
+    <string name="config_msg_simple_mode">Компактный</string>
+    <string name="message_mode_help">messageMode_en.txt</string>
+    <string name="pl_select_xiegu_radio">Выберите доступный XIEGU</string>
+    <string name="x6100_packet_lost">Потеря пакетов: %d</string>
+    <string name="xiegu_name_label">XIEGU</string>
+    <string name="xiegu_ping_value">Пинг: %d мс</string>
+    <string name="xiegu_start_atu">Запуск ATU</string>
+    <string name="xiegu_atu_on">ATU включён</string>
+    <string name="xiegu_atu_off">ATU выключен</string>
+    <string name="xiegu_band_str">Диапазон: %s</string>
+    <string name="alc_low_alert">Внимание! ALC слишком низок.</string>
+    <string name="xiegu_meter_info">S-метр: %.1f dBm\nSWR: %s\nALC: %.1f\nНапряжение: %.1fV\nМощность TX: %.1f Вт\nМакс. мощность TX: %.1f\nГромкость TX:%d%%</string>
+    <string name="serial_connect_no_access">Невозможно подключиться к последовательному порту. Проверьте доступ к USB-устройству!</string>
+    <string name="serial_connect_failed">Не удалось открыть последовательный порт!</string>
+    <string name="serial_no_driver">Невозможно подключиться к последовательному порту, порт не найден!</string>
+    <string name="serial_data_bits">Биты данных</string>
+    <string name="serial_parity">Контроль чётности</string>
+    <string name="serial_parity_none">Нет</string>
+    <string name="serial_parity_odd">Нечётный</string>
+    <string name="serial_parity_even">Чётный</string>
+    <string name="serial_parity_mark">Маркер</string>
+    <string name="serial_parity_space">Пробел</string>
+    <string name="serial_stop_bits">Стоп-биты</string>
+    <string name="serial_default">По умолчанию</string>
+    <string name="serial_setting_help">serial_help_en.txt</string>
+    <string name="tcp_connect_closed">Сетевое соединение разорвано.</string>
+    <string name="share_logs">Поделиться журналом</string>
+    <string name="config_clear_share_data">Удалить файлы кеша</string>
+    <string name="preparing_log_data">Подготовка данных журнала…</string>
+    <string name="total_logs">Всего %d записей в журнале.</string>
+    <string name="get_log_no">Скачано %d записей.</string>
+    <string name="write_file_error">Ошибка записи файла: %s</string>
+    <string name="import_share_failed">Импорт данных журнала не удался! %s</string>
+    <string name="preparing_import_logs">Подготовка к импорту журнала…</string>
+    <string name="share_logs_been_read">Прочитано %d записей.</string>
+    <string name="share_import_log_data">Импорт данных журнала…</string>
+    <string name="cloudlog_settings">Настройки Cloudlog</string>
+    <string name="config_enable_cloudlog">Включить синхронизацию Cloudlog</string>
+    <string name="cloudlog_addr">Адрес сервера</string>
+    <string name="cloudlog_api_key">API-ключ</string>
+    <string name="test_cloudlog_config">ТЕСТ</string>
+    <string name="cloudlog_station_id">ID станции</string>
+    <string name="cloudlog_help">cloudlog_en.txt</string>
+    <string name="pass">Успешно!</string>
+    <string name="fail">Ошибка!</string>
+    <string name="testing">Проверка…</string>
+    <string name="test">Тест</string>
+    <string name="qrz_settings">Настройки QRZ.com</string>
+    <string name="qrz_api_key">API KEY</string>
+    <string name="config_enable_qrz">Включить синхронизацию QRZ</string>
+    <string name="qrz_help">qrz_en.txt</string>
+    <string name="alram_switch">Переключатель оповещений</string>
+    <string name="swr_switch_on" translatable="false">SWR On</string>
+    <string name="swr_switch_off" translatable="false">SWR Off</string>
+    <string name="alc_switch_on" translatable="false">ALC On</string>
+    <string name="alc_switch_off" translatable="false">ALC Off</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,560 @@
+<resources>
+    <string name="app_name">FT8AF</string>
+    <string name="nav_menu_title_call_list">内容</string>
+    <string name="nav_menu_title_decode_list">解码</string>
+    <string name="nav_menu_title_my_calling">呼叫</string>
+    <string name="nav_menu_title_history">QSO 日志</string>
+    <string name="nav_menu_title_config">设置</string>
+    <string name="map_name" translatable="false">nightUSGS4Layer.sqlite</string>
+
+
+    <string name="run_decode">开始解码</string>
+    <string name="db">dB</string>
+    <string name="dt">Δt</string>
+    <string name="locate">位置</string>
+    <string name="message">消息</string>
+    <string name="freq">频率</string>
+    <string name="decode">解码</string>
+    <string name="delete">删除</string>
+    <string name="sequence">S.</string>
+    <string name="dist">距离</string>
+    <string name="location">地点</string>
+    <string name="mycall">呼号</string>
+    <string name="pl_mycall">请输入呼号</string>
+    <string name="headGrid">网格坐标</string>
+    <string name="pl_grid">请输入梅登黑德网格</string>
+    <string name="decoding">解码中…</string>
+    <string name="send">发射</string>
+    <string name="check">检查</string>
+    <string name="sendFreq">发射频率</string>
+    <string name="sendDefaultFreq">音频频率</string>
+    <string name="pl_sendFreq">音频频率范围 0~2900</string>
+    <string name="transmitting">发射中…</string>
+    <string name="synFrequency">锁定 TX=RX</string>
+    <string name="spectrum">频谱</string>
+    <string name="pl_trans_delay">发射延迟时间（毫秒）</string>
+    <string name="tran_delay">发射延迟</string>
+
+    <string name="timeOffset">时间偏移</string>
+    <string name="help">帮助</string>
+    <string name="scroll_down">▾</string>
+    <string name="about_me">关于 FT8AF</string>
+
+    <string name="connectMode">控制方式</string>
+    <string name="VOX">VOX</string>
+    <string name="CAT">CAT</string>
+    <string name="operationBand">频率</string>
+    <string name="civ_address">CI-V</string>
+    <string name="pl_civ_address">电台的 CI-V 地址</string>
+    <string name="serial_port">串口</string>
+    <string name="bau_rate">波特率</string>
+    <string name="pl_select_serial_port">请选择串口</string>
+    <string name="close">关闭</string>
+    <string name="rig_name">电台</string>
+    <string name="debug">调试</string>
+    <string name="logo_image">FT8AF</string>
+    <string name="RTS">RTS</string>
+    <string name="FAQ">FAQ</string>
+    <string name="launch_supervision">发射看门狗</string>
+    <string name="no_response_count">无应答</string>
+    <string name="break_launch">已停止</string>
+    <string name="follow_cq">自动跟踪 CQ</string>
+    <string name="auto_call_follow">自动呼叫跟踪</string>
+    <string name="DTR">DTR</string>
+    <string name="launch">发射</string>
+    <string name="export">导出</string>
+    <string name="view_style">显示模式</string>
+    <string name="ptt_delay">PTT 延迟</string>
+    <string name="filter">筛选</string>
+    <string name="pl_filter">请选择筛选条件</string>
+    <string name="filter_all">显示全部</string>
+    <string name="filter_is_qsl">显示已确认</string>
+    <string name="filter_none_qsl">显示未确认</string>
+    <string name="cable_connect">USB</string>
+    <string name="bluetooth_connect">Bluetooth</string>
+    <string name="cable_mode">连接方式</string>
+    <string name="pl_select_bluetooth">请选择可用的 Bluetooth 设备</string>
+    <string name="bluetooth_set">Bluetooth 设置</string>
+    <string name="spp_device">Bluetooth SPP 设备</string>
+    <string name="headset_device">Bluetooth 耳机</string>>
+    <string name="disconnect_rig">电台连接已断开</string>>
+    <string name="connected_rig">电台连接成功。</string>>
+    <string name="current_frequency">当前频率：%s</string>>
+    <string name="radio_communication_error">与电台通信出错：%s</string>>
+    <string name="does_not_support_recording">Bluetooth 设备不支持录音</string>>
+    <string name="bluetooth_headset_mode">进入 Bluetooth 耳机模式</string>>
+    <string name="bluetooth_Headset_mode_cancelled">退出 Bluetooth 耳机模式</string>>
+
+    <string name="version_info">FT8AF Ver %s\nKS3CKC\n%s</string>>
+
+
+    <string name="exit">退出</string>>
+    <string name="cancel">取消</string>>
+    <string name="exit_confirmation">确定要退出吗？</string>>
+
+    <!--   FT8Message-->
+    <string name="std_msg">标准消息</string>>
+    <string name="none_std_msg">非标准呼号</string>>
+    <string name="free_text">自由文本</string>>
+    <string name="dXpedition">DXpedition</string>>
+    <string name="field_day">Field Day</string>>
+    <string name="telemetry">遥测</string>>
+    <string name="rtty_ru_msg">RTTY RU</string>>
+
+
+    <!--   Settings bar-->
+    <string name="offset_time_sec">%.1f 秒</string>>
+
+    <!--   Spectrum chart-->
+    <string name="decoding_takes_milliseconds">解码耗时：%d 毫秒</string>>
+    <string name="sound_frequency_is_set_to">音频频率已设为 %d Hz</string>>
+    <string name="de_noise">降噪</string>
+    <string name="raw_spectrum_data">原始数据</string>
+    <string name="markMessage">显示消息</string>
+    <string name="unMarkMessage">隐藏消息</string>
+
+    <!--   Select Bluetooth device dialog-->
+    <string name="select_bluetooth_device">选择 Bluetooth 设备：%s</string>
+
+    <!--   PTT delay in milliseconds-->
+    <string name="milliseconds">%d 毫秒</string>
+    <!--   No-reply count-->
+    <string name="ignore">忽略</string>
+    <string name="times">%d 次呼叫</string>
+
+    <!--   Calling bar-->
+    <string name="sound_frequency_is">频率：%.0f Hz</string>
+    <string name="target_callsign">目标：%s</string>
+    <string name="transmission_sequence">序列：%d</string>
+    <string name="message_count">消息(%d)</string>
+
+    <!--   Log export bar-->
+    <string name="export_info">请在同一局域网下使用其他设备的浏览器进行导出。\n在浏览器中输入网址：\nhttp://%s:%d</string>
+    <!--   TX watchdog-->
+    <string name="minutes">%d 分钟</string>
+
+    <!--   TX watchdog-->
+    <string name="freq_syn">锁定 TX=RX</string>
+    <string name="freq_asyn">收发分离</string>
+    <string name="auto_follow_cq">自动跟踪 CQ</string>
+    <string name="not_concerned_about_CQ">不跟踪 CQ</string>
+    <string name="automatic_call_following">已启用自动呼叫跟踪</string>
+    <string name="do_not_call_the_following_callsign">未启用呼叫跟踪</string>
+
+    <!--   Decode bar-->
+    <string name="message_count_count">消息(%d/%d)</string>
+    <string name="average_offset_seconds">平均偏移：%.2f 秒</string>
+    <string name="my_grid">网格：%s</string>
+
+    <!--   Decode list-->
+    <string name="tracking_receiver">跟踪接收方 %s(%s)</string>
+    <string name="calling_receiver">呼叫接收方 %s(%s)</string>
+    <string name="reply_to">回复 %s(%s)</string>
+    <string name="tracking">跟踪 %s(%s)</string>
+    <string name="calling">呼叫 %s(%s)</string>
+
+    <!--   Grid distance calculation-->
+    <string name="distance">%.0f 公里</string>
+
+    <!--   Log list-->
+    <string name="confirmed">已确认</string>
+    <string name="unconfirmed">未确认</string>
+    <string name="lotw_confirmation">LoTW 已确认</string>
+    <string name="manual_confirmation">手动确认</string>
+    <string name="log_start_time">开始时间：%s</string>
+    <string name="log_end_time">结束时间：%s</string>
+    <string name="log_last_time">最近 QSO：%s</string>
+    <string name="log_grid">网格：%s</string>
+    <string name="log_mode">模式：%s</string>
+    <string name="log_cancel_confirmation">取消确认 (%s)</string>
+    <string name="log_manual_confirmation">手动确认 (%s)</string>
+
+    <!--   QSL log list-->
+    <string name="qsl_grid">网格：%s</string>
+    <string name="qsl_start_time">开始时间：%s</string>
+    <string name="qsl_end_time">结束时间：%s</string>
+    <string name="qsl_rst_rcvd">接收 RST：%s</string>
+    <string name="html_rst_rcvd">接收 RST</string>
+    <string name="qsl_rst_sent">发送 RST：%s</string>
+    <string name="html_rst_sent">发送 RST</string>
+    <string name="qsl_band">波段：%s</string>
+    <string name="qsl_freq">频率：%s</string>
+    <string name="qsl_mode">模式：%s</string>
+    <string name="qsl_lotw_confirmation">LoTW 已确认</string>
+    <string name="qsl_manual_confirmation">手动确认</string>
+    <string name="qsl_unconfirmed">未确认</string>
+    <string name="qsl_cancel_confirmation">取消确认 (%s)</string>
+    <string name="qsl_manual_confirmation_s">手动确认 (%s)</string>
+    <string name="qsl_qrz_confirmation_s">QRZ (%s)</string>
+
+    <!--   QSL record-->
+    <string name="qsl_record_import_time">导入时间：%s</string>
+
+    <!--   HTML -->
+    <string name="html_track_operation_information">监控运行信息</string>
+    <string name="html_track_callsign_hash_table">监控呼号哈希表</string>
+    <string name="html_trace_parsed_messages">监控已解析消息</string>
+    <string name="html_trace_callsign_and_grid_correspondence_table">监控呼号与网格对应关系</string>
+    <string name="html_query_communication_message">查询 QSO</string>
+    <string name="html_query_configuration_information">查询配置信息</string>
+    <string name="html_query_all_table">查询所有数据表</string>
+    <string name="html_manage_tracking_callsign">管理跟踪呼号</string>
+    <string name="html_manage_communication_callsigns">管理 QSO 呼号</string>
+    <string name="html_show_communication_callsigns">显示 QSO 呼号</string>
+    <string name="html_export_log">导出日志</string>
+    <string name="html_import_log">导入日志</string>
+    <string name="html_to_the_third_party">导出日志（用于备份和上传至第三方平台进行确认）</string>
+    <string name="html_from_jtdx_lotw">导入日志（用于备份、上传至第三方平台进行确认、同步 JTDX 日志及同步 LoTW 确认。建议使用 JTDX、LoTW、Log32 和 N1mm 的 ADI 数据进行同步）</string>
+    <string name="html_return">返回</string>
+
+
+    <string name="html_import_count">ADI 文件中共有 %d 条记录，已导入 %d 条。%d 条日志格式不正确。</string>
+    <string name="html_import_failed">导入失败！%s</string>
+    <string name="html_illegal_command">非法命令，上传失败！</string>
+    <string name="html_callsign">呼号</string>
+    <string name="html_operation">操作</string>
+    <string name="html_delete">删除</string>
+    <string name="html_qsl_start_time">QSO 开始时间</string>
+    <string name="html_qsl_start_day">QSO 开始日期</string>
+    <string name="html_qsl_end_time">QSO 结束时间</string>
+    <string name="html_qsl_end_date">QSO 结束日期</string>
+    <string name="html_qsl_mode">模式</string>
+    <string name="html_qsl_grid">网格</string>
+    <string name="html_qsl_band">波段</string>
+    <string name="html_qsl_freq">频率</string>
+    <string name="html_qsl_manual_confirmation">手动确认</string>
+    <string name="html_qsl_lotw_confirmation">LoTW 已确认</string>
+    <string name="html_qsl_data_source">数据来源</string>
+    <string name="html_qsl_import_data_from_external">来自外部</string>
+    <string name="html_qsl_native_data">本地数据</string>
+    <string name="html_variable">变量</string>
+    <string name="html_value">值</string>
+    <string name="html_my_callsign">呼号</string>
+    <string name="html_my_grid">网格</string>
+    <string name="html_decodes_in_this_cycle">本周期解码数</string>
+    <string name="html_total_number_of_decodes">解码总数</string>
+    <string name="html_in_recording_state">录音状态</string>
+    <string name="html_recording">录音中</string>
+    <string name="html_no_recording">未录音</string>
+    <string name="html_time_consuming_for_this_decoding">本次解码耗时</string>
+    <string name="html_milliseconds">%d 毫秒</string>
+    <string name="html_average_delay_time_of_this_cycle">本周期平均延迟</string>
+    <string name="html_seconds">%.3f 秒</string>
+    <string name="html_sound_frequency">信号音频频率</string>
+    <string name="html_transmission_delay_time">发射延迟</string>
+    <string name="html_launch_supervision">发射看门狗</string>
+    <string name="html_automatic_program_run_time">自动程序运行时间</string>
+    <string name="html_no_reply_limit">无应答上限</string>
+    <string name="html_no_reply_count">无应答计数</string>
+    <string name="html_mark_message">在瀑布图上标记消息</string>
+    <string name="html_marking_message">标记消息</string>
+    <string name="html_do_not_mark_message">不标记消息</string>
+    <string name="html_operation_mode">操作模式</string>
+    <string name="html_civ_address">CI-V 地址</string>
+    <string name="html_baud_rate">波特率</string>
+    <string name="html_connect_mode">连接模式</string>
+    <string name="html_available_serial_ports">可用串口</string>
+    <string name="html_serial_port_in_use">正在使用的串口</string>
+    <string name="html_instruction_set">指令集</string>
+    <string name="html_target_callsign">目标呼号</string>
+    <string name="html_sequential">序列</string>
+
+
+    <string name="html_carrier_frequency_band">波段</string>
+    <string name="html_radio_frequency">电台频率</string>
+    <string name="html_successful_callsign">%s 中成功通联的呼号</string>
+    <string name="html_tracking_callsign">跟踪呼号</string>
+    <string name="html_tracking_qso_information">跟踪 QSO 信息</string>
+
+    <string name="html_hash_value">哈希值</string>
+    <string name="html_please_select">请选择</string>
+    <string name="html_adi_format">ADI 格式的日志文件</string>
+    <string name="html_file_in_other_format">其他格式的文件可能无法正常解析和导入。</string>
+    <string name="html_time">时间</string>
+    <string name="html_total">合计</string>
+    <string name="html_all_logs">全部日志</string>
+    <string name="html_download">下载</string>
+    <string name="html_today_log">今日日志</string>
+    <string name="html_download_all">下载全部</string>
+    <string name="html_download_unconfirmed">下载未确认</string>
+    <string name="callsign_error">呼号不正确！</string>
+    <string name="adjust_call_target">调整呼叫目标：%s</string>
+    <string name="use_wspr2_error">当前使用的频率 %s 是 WSPR-2 使用的频率，禁止发射 FT8 信号！</string>
+    <string name="none">无</string>
+    <string name="connect_bluetooth_spp">正在连接 Bluetooth 串口 %s …</string>
+    <string name="bluetooth_is_connected">Bluetooth 设备 %s 已连接。</string>
+    <string name="bluetooth_is_diconnected">Bluetooth 设备 %s 已断开。</string>
+    <string name="sound_source_switched">音频源已切换。</string>
+    <string name="bluetooth_turn_off">Bluetooth 已关闭。</string>
+    <string name="bluetooth_turn_on">Bluetooth 已开启。</string>
+    <string name="can_not_location">无法定位。请确认是否已授予定位权限。</string>
+    <string name="statistical">统计</string>
+    <string name="count_up">升序</string>
+    <string name="count_down">降序</string>
+    <string name="band_statistics">波段统计</string>
+    <string name="count_total">合计：%d</string>
+    <string name="confirmation_statistics">日志确认统计</string>
+    <string name="count_confirmed">已确认</string>
+    <string name="count_unconfirmed">未确认</string>
+    <string name="count_total_logs">总计：%d</string>
+    <string name="count_confirmed_log">已确认：%d</string>
+    <string name="count_lotw_confirmed">LoTW 已确认：%d</string>
+    <string name="count_manually_confirmed">手动确认：%d</string>
+    <string name="count_confirmed_proportion">确认比例：%.1f%%</string>
+    <string name="count_tota_callsigns">呼号总数：%d</string>
+    <string name="count_zone">%s 区</string>
+    <string name="itu_completion_statistics">ITU 完成统计</string>
+    <string name="count_incomplete">未完成</string>
+    <string name="count_completed">已完成</string>
+    <string name="count_total_itu">ITU 区总数：%d\n已完成 %d(%.1f%%)</string>
+    <string name="count_itu_completed_scale">ITU 统计</string>
+    <string name="count_cqzone_completed">CQ 区统计</string>
+    <string name="count_total_cqzone">CQ 区总数：%d \n 已完成：%d(%.1f%%)</string>
+    <string name="count_cqzone_proportion">CQ 区统计</string>
+    <string name="dxcc_completion_statistics">DXCC 统计</string>
+    <string name="count_total_dxcc">DXCC 总数：%d \n已完成：%d(%.1f%%)</string>
+    <string name="count_dxcc_proportion">DXCC 统计</string>
+    <string name="callsign_info">呼号：%s\n地点：%s\nCQ 区：%d\nITU 区：%d\n洲：%s\n经纬度：%.2f,%.2f\n时区：%.0f\nDXCC 前缀：%s</string>
+    <string name="maximum_distance">最远距离\n\n%s</string>
+    <string name="minimum_distance">最近距离\n\n%s</string>
+    <string name="count_distance_info">最远距离：%.0f 公里 (%s)\n最近距离：%.0f 公里 (%s)</string>
+    <string name="distance_statistics">距离统计</string>
+    <string name="dxcc_image">DXCC</string>
+    <string name="cqzone">CQ Zone</string>
+    <string name="itu_image">ITU Zone</string>
+    <string name="recorder_cannot_record">无法录音，请检查权限。%s</string>
+    <string name="recorder_stop_record_error">停止录音出错！%s</string>
+    <string name="delete_confirmation">删除确认</string>
+    <string name="are_you_sure_delete">确定要删除吗？</string>
+    <string name="ok_confirmed">确定</string>
+    <string name="network_connect">网络</string>
+    <string name="pl_select_flex_radio">请选择可用的 FlexRadio</string>
+    <string name="select_flex_device">选择 FlexRadio 设备：%s</string>
+    <string name="select_xiegu_device">选择 XIEGU 设备：%s</string>
+    <string name="only_flex_supported">目前仅支持 FlexRadio 或 ICom 系列！</string>
+    <string name="flex_connect_failed">FlexRadio %s 连接失败！</string>
+    <string name="xiegu_connect_failed">XIEGU %s 连接失败！</string>
+    <string name="init_flex_operation">%s 正在初始化操作。</string>
+    <string name="html_max_message_cache">最大缓存消息数</string>
+    <string name="instruction_failed">指令 %s 执行失败。消息：%s</string>
+    <string name="instruction_success">指令 %s 已成功执行。</string>
+    <string name="flex_ip_addr">IP</string>
+    <string name="pl_input_flex_ip">请输入 IP 地址</string>
+    <string name="connect_flex">连接 FlexRadio</string>
+    <string name="connect_flex_ip">正在连接 FlexRadio %s …</string>
+    <string name="get_new_version">获取最新版本</string>
+    <string name="login_icom_help">登录 ICom 电台</string>
+    <string name="pl_input_icom_port">控制端口(UDP)</string>
+    <string name="icom_port">端口</string>
+    <string name="icom_user_name">用户名</string>
+    <string name="pl_icom_user">请输入用户名</string>
+    <string name="icom_password">密码</string>
+    <string name="pl_icom_password">请输入密码</string>
+    <string name="icom_login_button">登录</string>
+    <string name="show_password">显示密码</string>
+    <string name="connect_icom_ip">正在连接 ICom 电台 %s …</string>
+    <string name="connect_xiegu_ip">正在连接 XIEGU 电台 %s …</string>
+    <string name="network_exception">%s：网络传输异常：%s</string>
+    <string name="login_succeed">登录成功！</string>
+    <string name="loging_failed">登录失败，用户名或密码无效。</string>
+    <string name="data_stream">数据流</string>
+    <string name="control_stream">控制流</string>
+    <string name="civ_stream">CI-V 流</string>
+    <string name="audio_stream">音频流</string>
+    <string name="alc_high_alert">警告！ALC 过高。</string>
+
+    <string name="swr_high_alert">警告！SWR 过高。</string>
+    <string name="volume_percent">信号输出强度 %.0f %%</string>
+    <string name="signal_strength">信号输出强度</string>
+    <string name="html_distance">距离</string>
+    <string name="html_callsign_qth">呼号所在地</string>
+    <string name="html_update_time">更新时间</string>
+    <string name="grid_tracker_new_grid">发现新网格：%s</string>
+    <string name="tracker_open_messages">打开消息</string>
+    <string name="tracker_close_messages">关闭消息</string>
+    <string name="tracker_decoded_new">解码了 %d 条消息。</string>
+    <string name="tracker_call_this">呼叫该呼号</string>
+    <string name="tracker_show_info_mode">提示模式</string>
+    <string name="tracker_tips_all">全部</string>
+    <string name="tracker_tips_new">新增</string>
+    <string name="tracker_tips_none">无</string>
+    <string name="tracker_show_cq_tips">显示 CQ 提示</string>
+    <string name="tracker_hide_cq_tips">隐藏 CQ 提示</string>
+    <string name="tracker_show_qsx_tips">显示 QSX 提示</string>
+    <string name="tracker_hide_qsx_tips">隐藏 QSX 提示</string>
+    <string name="track_sample_text_qsl">QSL</string>
+    <string name="tracker_sample_qso_text">QSO</string>
+    <string name="tracker_sample_qsx_text">QSX</string>
+    <string name="tracker_cq_text">CQ</string>
+    <string name="tracker_qso_text">QSO</string>
+    <string name="tracker_new_zone_found">发现新区域：%s</string>
+    <string name="transmit_freeText">请输入自由文本</string>
+    <string name="trans_free_text_mode">自由文本模式</string>
+    <string name="trans_standard_messge_mode">标准消息模式</string>
+    <string name="launch_supervision_ignore">忽略</string>
+    <string name="be_excluded_callsigns">排除的呼号前缀</string>
+    <string name="pl_callsing_prefix">请输入呼号前缀</string>
+    <string name="cache_clear">清除</string>
+    <string name="cache_clear_title">清除缓存</string>
+    <string name="follow_callsign_data">已关注的呼号</string>
+    <string name="cancel_clear_cache">取消</string>
+    <string name="log_statistics_cache">已缓存日志数</string>
+    <string name="logs_cache">已解码消息</string>
+    <string name="band_total">波段 \t 合计</string>
+    <string name="modifier_editor">CQ 修饰符</string>
+    <string name="pl_input_modifier">请输入修饰符</string>
+    <string name="flex_start_atu">启动 ATU</string>
+    <string name="flex_max_tx_power">最大发射功率 %d W</string>
+    <string name="flex_tune_power">ATU 调谐功率 %d W</string>
+    <string name="html_flex_max_rf_power">最大发射功率</string>
+    <string name="html_atu_tune_power">ATU 调谐功率</string>
+    <string name="flex_atu_tune_off">调谐关闭</string>
+    <string name="flex_atu_tune_on">调谐开启</string>
+    <string name="flex_logo_text">FlexRadio</string>
+    <string name="map_location_image">在地图上定位</string>
+    <string name="log_menu_location">位置</string>
+    <string name="tracker_query_qso_info">正在查询 QSO 数据…</string>
+    <string name="html_callsign_grid_total">合计：%d</string>
+    <string name="html_message_page_count">总页数：%d</string>
+    <string name="html_message_page_size">每页条数：</string>
+    <string name="html_message_query">搜索</string>
+    <string name="config_save_swl">保存已解码</string>
+    <string name="config_donot_save_swl">不保存已解码</string>
+    <string name="config_save_swl_qso">保存 SWL 的 QSO</string>
+    <string name="config_donot_save_swl_qso">不保存 SWL 的 QSO</string>
+    <string name="html_query_swl_message">查询已解码消息(SWL)</string>
+    <string name="log_statistics_decode_msg">已解码消息总数</string>
+    <string name="config_Syn_time">同步时间</string>
+    <string name="utc_time_sync_delay_slow">已同步。本地时钟落后 %d 毫秒</string>
+    <string name="utc_time_sync_delay_faster">已同步。本地时钟超前 %d 毫秒</string>
+    <string name="config_clock_is_accurate">本地时钟准确！</string>
+    <string name="html_start_date_swl_message">开始日期</string>
+    <string name="html_end_date_swl_message">结束日期</string>
+    <string name="html_query_qso_swl">查询 SWL 的 QSO</string>
+    <string name="html_export_csv">导出为 CSV 文件</string>
+    <string name="html_export_text">导出为 TEXT 文件</string>
+    <string name="html_export_adi">导出为 ADIF 文件</string>
+    <string name="log_statistics_swl_qso">已解码 QSO 总数</string>
+    <string name="config_clear_swl_qso">已解码的 QSO</string>
+    <string name="audioOutput">音频输出</string>
+    <string name="audio_input_device">音频输入</string>
+    <string name="audio_output_device">音频输出设备</string>
+    <string name="audio_device_default">默认</string>
+    <string name="audio_device_help">audio_device_help_en.txt</string>
+    <string name="audio16_bit">16-bit int</string>
+    <string name="audio32_bit">32-bit float</string>
+    <string name="html_audio_bits">音频 - 位深度</string>
+    <string name="audio_rate_12k">12kHz</string>
+    <string name="audio_rate_24k">24kHz</string>
+    <string name="audio_rate_48k">48kHz</string>
+    <string name="audio_rate">采样率</string>
+    <string name="html_audio_rate">音频 - 采样率</string>
+    <string name="audio_bit_depth">位深度</string>
+    <string name="callsign_help">callsign_en.txt</string>
+    <string name="maidenhead_help">maidenhead_en.txt</string>
+    <string name="frequency_help">frequency_en.txt</string>
+    <string name="transDelay_help">transDelay_en.txt</string>
+    <string name="timeoffset_help">timeoffset_en.txt</string>
+    <string name="pttdelay_help">pttdelay_en.txt</string>
+    <string name="operationBand_help">operationBand_en.txt</string>
+    <string name="controlMode_help">controlMode_en.txt</string>
+    <string name="civ_help">civ_help_en.txt</string>
+    <string name="rig_model_help">rig_model_help_en.txt</string>
+    <string name="launch_supervision_help">launch_supervision_en.txt</string>
+    <string name="no_response_help">no_response_help_en.txt</string>
+    <string name="auto_follow_help">auto_follow_help_en.txt</string>
+    <string name="connectMode_help">connectMode_en.txt</string>
+    <string name="excludeCallsign_help">excludeCallsign_en.txt</string>
+    <string name="swlMode_help">swlMode_en.txt</string>
+    <string name="audio_output_help">audio_output_help_en.txt</string>
+    <string name="deep_mode_help">decode_help_en.txt</string>
+    <string name="clear_cache_data_help">clear_cache_data_en.txt</string>
+    <string name="html_query_logs">查询日志</string>
+    <string name="html_qso_all">全部</string>
+    <string name="html_qso_source">数据来源</string>
+    <string name="html_qso_unconfirmed">未确认</string>
+    <string name="html_qso_confirmed">已确认</string>
+    <string name="html_qso_raw_log">本地日志</string>
+    <string name="html_qso_external_logs">外部日志</string>
+    <string name="html_qso_external">外部</string>
+    <string name="html_qso_raw">本地日志</string>
+    <string name="html_protocol">协议</string>
+    <string name="html_comment">备注</string>
+    <string name="decode_mode_text">解码模式</string>
+    <string name="fast_mode">快速解码</string>
+    <string name="deep_mode">深度解码</string>
+    <string name="export_null">请在同一局域网下通过其他设备的浏览器从 WebUI 导出\n请连接有效的 Wi-Fi</string>
+    <string name="null_task_html">任务不存在！</string>
+    <string name="log_importing_html">导入中...</string>
+    <string name="log_import_finished_html">已完成！</string>
+    <string name="import_read_error_count_html">错误行数：%d</string>
+    <string name="import_new_count_html">新增 QSL：%d</string>
+    <string name="import_update_count_html">更新 QSL：%d</string>
+    <string name="import_invalid_count_html">无效 QSL：%d</string>
+    <string name="import_progress_html">"进度："</string>
+    <string name="import_readed_html">已验证 QSL：%d</string>
+    <string name="import_canceled_html">已取消！</string>
+    <string name="import_cancel_button">停止</string>
+    <string name="qsl_query_log_menu">日志 (%s)</string>
+    <string name="message_list_simple_mode">简洁列表模式</string>
+    <string name="message_list_standard_mode">标准列表模式</string>
+    <string name="config_msg_mode">消息模式</string>
+    <string name="config_msg_std_mode">标准</string>
+    <string name="config_msg_simple_mode">简洁</string>
+    <string name="message_mode_help">messageMode_en.txt</string>
+    <string name="pl_select_xiegu_radio">请选择可用的 XIEGU 电台</string>
+    <string name="x6100_packet_lost">丢包数：%d</string>
+    <string name="xiegu_name_label">XIEGU</string>
+    <string name="xiegu_ping_value">Ping: %d ms</string>
+    <string name="xiegu_start_atu">启动 ATU</string>
+    <string name="xiegu_atu_on">ATU 开启</string>
+    <string name="xiegu_atu_off">ATU 关闭</string>
+    <string name="xiegu_band_str">波段：%s</string>
+    <string name="alc_low_alert">警告！ALC 过低。</string>
+    <string name="xiegu_meter_info">S.Meter: %.1f dBm\nSWR: %s\nALC: %.1f\nVolt: %.1fV\nTX power: %.1f W\nMax tx power: %.1f\nTX volume:%d%%</string>
+    <string name="serial_connect_no_access">无法连接串口，请确认是否拥有 USB 设备的访问权限！</string>
+    <string name="serial_connect_failed">串口打开失败！</string>
+    <string name="serial_no_driver">无法连接串口，未找到串口！</string>
+    <string name="serial_data_bits">数据位</string>
+    <string name="serial_parity">校验位</string>
+    <string name="serial_parity_none">无</string>
+    <string name="serial_parity_odd">奇校验</string>
+    <string name="serial_parity_even">偶校验</string>
+    <string name="serial_parity_mark">标记</string>
+    <string name="serial_parity_space">空格</string>
+    <string name="serial_stop_bits">停止位</string>
+    <string name="serial_default">默认</string>
+    <string name="serial_setting_help">serial_help_en.txt</string>
+    <string name="tcp_connect_closed">网络连接已断开。</string>
+    <string name="share_logs">共享日志</string>
+    <string name="config_clear_share_data">删除缓存文件</string>
+    <string name="preparing_log_data">正在准备日志数据…</string>
+    <string name="total_logs">共有 %d 条日志。</string>
+    <string name="get_log_no">已下载 %d 条日志。</string>
+    <string name="write_file_error">写入文件时发生错误：%s</string>
+    <string name="import_share_failed">导入日志数据失败！%s</string>
+    <string name="preparing_import_logs">正在准备导入日志…</string>
+    <string name="share_logs_been_read">已读入 %d 条日志。</string>
+    <string name="share_import_log_data">正在导入日志数据…</string>
+    <string name="cloudlog_settings">Cloudlog 设置</string>
+    <string name="config_enable_cloudlog">启用 Cloudlog 同步</string>
+    <string name="cloudlog_addr">服务器地址</string>
+    <string name="cloudlog_api_key">API 密钥</string>
+    <string name="test_cloudlog_config">测试</string>
+    <string name="cloudlog_station_id">电台 ID</string>
+    <string name="cloudlog_help">cloudlog_en.txt</string>
+    <string name="pass">通过！</string>
+    <string name="fail">失败！</string>
+    <string name="testing">测试中…</string>
+    <string name="test">测试</string>
+    <string name="qrz_settings">QRZ.com 设置</string>
+    <string name="qrz_api_key">API KEY</string>
+    <string name="config_enable_qrz">启用 QRZ 同步</string>
+    <string name="qrz_help">qrz_en.txt</string>
+    <string name="alram_switch">报警开关</string>
+    <string name="swr_switch_on" translatable="false">SWR On</string>
+    <string name="swr_switch_off" translatable="false">SWR Off</string>
+    <string name="alc_switch_on" translatable="false">ALC On</string>
+    <string name="alc_switch_off" translatable="false">ALC Off</string>
+
+</resources>


### PR DESCRIPTION
## Summary
- Adds French (`values-fr`), Russian (`values-ru`), and Simplified Chinese (`values-zh-rCN`) string resource translations
- All 511 strings translated from English source for each language
- Technical ham radio terms, format specifiers, and help file references preserved unchanged

## Test plan
- [ ] Set device language to French and verify UI strings render correctly
- [ ] Set device language to Russian and verify UI strings render correctly
- [ ] Set device language to Chinese (Simplified) and verify UI strings render correctly
- [ ] Verify no crashes on locale switch
- [ ] Spot-check format strings (e.g. frequency display, distance, log counts) for correct placeholder usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)