### PR TITLE
Add ALC auto-volume and SWR TX halt protection

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -315,6 +315,13 @@ public class GeneralVariables {
     public static boolean swr_switch_on = true;//SWR alarm switch
     public static boolean alc_switch_on = true;//ALC alarm switch
 
+    // TX Protection: ALC auto-volume and SWR TX halt (MeterProtectionController)
+    public static boolean autoVolumeEnabled = false;  // ALC auto-volume control
+    public static boolean swrHaltEnabled = false;      // SWR TX halt + lockout
+    public static int swrHaltThreshold = 120;          // 0-255 normalized (~3.0:1)
+    public static int alcTargetLow = 60;               // ALC target window low (0-255)
+    public static int alcTargetHigh = 100;             // ALC target window high (0-255)
+
     public static MutableLiveData<Float> mutableBaseFrequency = new MutableLiveData<>();
 
     private static int spectrumWidth = 3500;//Spectrum display width in Hz

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -68,6 +68,7 @@ import com.bg7yoz.ft8cn.flex.RadioTcpClient;
 import com.bg7yoz.ft8cn.ft8listener.FT8SignalListener;
 import com.bg7yoz.ft8cn.ft8listener.OnFt8Listen;
 import com.bg7yoz.ft8cn.ft8transmit.FT8TransmitSignal;
+import com.bg7yoz.ft8cn.ft8transmit.MeterProtectionController;
 import com.bg7yoz.ft8cn.ft8transmit.OnDoTransmitted;
 import com.bg7yoz.ft8cn.ft8transmit.OnTransmitSuccess;
 import com.bg7yoz.ft8cn.html.LogHttpServer;
@@ -195,6 +196,7 @@ public class MainViewModel extends ViewModel {
     public HamRecorder hamRecorder;//recording object
     public FT8SignalListener ft8SignalListener;//object for listening to and decoding FT8 signals
     public FT8TransmitSignal ft8TransmitSignal;//object for transmitting signals
+    public MeterProtectionController meterProtectionController;//ALC auto-volume + SWR halt
     public SpectrumListener spectrumListener;//object for drawing the spectrum
     public boolean markMessage = true;//whether to mark messages toggle
 
@@ -557,6 +559,11 @@ public class MainViewModel extends ViewModel {
             }
         });
 
+
+        //create meter protection controller (ALC auto-volume + SWR halt)
+        meterProtectionController = new MeterProtectionController();
+        meterProtectionController.setTransmitSignal(ft8TransmitSignal);
+        ft8TransmitSignal.setMeterProtectionController(meterProtectionController);
 
         //open HTTP SERVER
         httpServer = new LogHttpServer(this, LogHttpServer.DEFAULT_PORT);
@@ -1068,6 +1075,16 @@ public class MainViewModel extends ViewModel {
             } else {
                 hamRecorder.setDataFromLan();
             }
+        }
+
+        // Wire meter data callback for ALC auto-volume + SWR halt
+        if (baseRig != null && meterProtectionController != null) {
+            baseRig.setOnMeterData(new BaseRig.OnMeterData() {
+                @Override
+                public void onMeterUpdate(int normalizedAlc, int normalizedSwr) {
+                    meterProtectionController.onMeterUpdate(normalizedAlc, normalizedSwr);
+                }
+            });
         }
 
         mutableIsFlexRadio.postValue(GeneralVariables.instructionSet == InstructionSet.FLEX_NETWORK);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2524,6 +2524,22 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("alcSwitch")) {
                     GeneralVariables.alc_switch_on = result.equals("1");
                 }
+                // TX Protection: ALC auto-volume + SWR halt
+                if (name.equalsIgnoreCase("autoVolumeEnabled")) {
+                    GeneralVariables.autoVolumeEnabled = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("swrHaltEnabled")) {
+                    GeneralVariables.swrHaltEnabled = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("swrHaltThreshold")) {
+                    GeneralVariables.swrHaltThreshold = result.equals("") ? 120 : Integer.parseInt(result);
+                }
+                if (name.equalsIgnoreCase("alcTargetLow")) {
+                    GeneralVariables.alcTargetLow = result.equals("") ? 60 : Integer.parseInt(result);
+                }
+                if (name.equalsIgnoreCase("alcTargetHigh")) {
+                    GeneralVariables.alcTargetHigh = result.equals("") ? 100 : Integer.parseInt(result);
+                }
                 if (name.equalsIgnoreCase("spectrumWidth")) {
                     GeneralVariables.setSpectrumWidth(result.equals("") ? 3500 : Integer.parseInt(result));
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -101,6 +101,12 @@ public class FT8TransmitSignal {
     private final ArrayList<QueuedCaller> callerQueue = new ArrayList<>();
     public MutableLiveData<ArrayList<QueuedCaller>> mutableCallerQueue = new MutableLiveData<>();
 
+    private MeterProtectionController meterProtectionController;// ALC auto-volume + SWR halt
+
+    public void setMeterProtectionController(MeterProtectionController controller) {
+        this.meterProtectionController = controller;
+    }
+
     private final OnDoTransmitted onDoTransmitted;// typically used for opening/closing PTT
     private final ExecutorService doTransmitThreadPool = Executors.newCachedThreadPool();
     private final DoTransmitRunnable doTransmitRunnable = new DoTransmitRunnable(this);
@@ -617,6 +623,10 @@ public class FT8TransmitSignal {
     private void afterPlayAudio() {
         if (onDoTransmitted != null) {
             onDoTransmitted.onAfterTransmit(getFunctionCommand(functionOrder), functionOrder);
+        }
+        // Notify meter protection controller that the TX cycle ended (between-cycle ALC adjust)
+        if (meterProtectionController != null) {
+            meterProtectionController.onTxCycleEnd();
         }
         isTransmitting = false;
         mutableIsTransmitting.postValue(false);
@@ -1151,6 +1161,12 @@ public class FT8TransmitSignal {
     }
 
     public void setActivated(boolean activated) {
+        // Block activation if SWR lockout is active
+        if (activated && meterProtectionController != null
+                && meterProtectionController.isSwrLocked()) {
+            ToastMessage.show("TX blocked — SWR lockout active. Dismiss the lockout banner first.");
+            return;
+        }
         this.activated = activated;
         if (!this.activated) {//force stop transmitting
             setTransmitting(false);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionController.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionController.java
@@ -1,0 +1,233 @@
+package com.bg7yoz.ft8cn.ft8transmit;
+
+import android.util.Log;
+
+import androidx.lifecycle.MutableLiveData;
+
+import com.bg7yoz.ft8cn.GeneralVariables;
+
+/**
+ * Protocol-agnostic controller that receives normalized ALC and SWR meter
+ * values during TX and takes protective action:
+ *   - ALC auto-volume: adjusts {@link GeneralVariables#volumePercent} to keep
+ *     ALC in a target window, reducing overdrive distortion.
+ *   - SWR TX halt + lockout: immediately stops TX and prevents re-activation
+ *     when SWR exceeds a threshold, protecting the PA/feedline.
+ *
+ * Rig classes call {@link #onMeterUpdate(int, int)} from their showAlert()
+ * methods, passing values already normalized to 0-255.
+ */
+public class MeterProtectionController {
+    private static final String TAG = "MeterProtection";
+
+    // Reference to the transmit signal — set after construction
+    private FT8TransmitSignal transmitSignal;
+
+    // ALC auto-volume tuning constants
+    private static final float VOLUME_STEP_DOWN = 0.02f;  // 2% per adjustment
+    private static final float VOLUME_STEP_UP = 0.01f;    // 1% per adjustment
+    private static final float VOLUME_MIN = 0.05f;        // never below 5%
+    private static final float VOLUME_MAX = 1.0f;
+
+    // ALC running-average window (last N samples within a TX cycle)
+    private static final int ALC_WINDOW_SIZE = 5;
+    private final int[] alcWindow = new int[ALC_WINDOW_SIZE];
+    private int alcWindowIndex = 0;
+    private int alcWindowCount = 0;
+
+    // Track whether we adjusted down mid-TX this cycle (suppress up-adjust mid-TX)
+    private boolean adjustedDownThisCycle = false;
+
+    // Observable state for UI
+    public final MutableLiveData<Boolean> swrLockout = new MutableLiveData<>(false);
+    public final MutableLiveData<Integer> lastAlc = new MutableLiveData<>(0);
+    public final MutableLiveData<Integer> lastSwr = new MutableLiveData<>(0);
+    // Holds the SWR ratio string (e.g. "3.2:1") that triggered lockout, for the banner.
+    public final MutableLiveData<String> lockoutSwrRatio = new MutableLiveData<>("");
+
+    public void setTransmitSignal(FT8TransmitSignal signal) {
+        this.transmitSignal = signal;
+    }
+
+    /**
+     * Called by each rig's showAlert() with normalized 0-255 meter values.
+     * A value of -1 means the rig does not report that meter.
+     */
+    public void onMeterUpdate(int normalizedAlc, int normalizedSwr) {
+        // Publish for optional UI display
+        if (normalizedAlc >= 0) lastAlc.postValue(normalizedAlc);
+        if (normalizedSwr >= 0) lastSwr.postValue(normalizedSwr);
+
+        // --- SWR halt check ---
+        if (normalizedSwr >= 0 && GeneralVariables.swrHaltEnabled
+                && normalizedSwr > GeneralVariables.swrHaltThreshold) {
+            haltForSwr(normalizedSwr);
+            return; // no point adjusting volume if we just killed TX
+        }
+
+        // --- ALC auto-volume (only when enabled and we have a valid reading) ---
+        if (normalizedAlc >= 0 && GeneralVariables.autoVolumeEnabled) {
+            accumulateAlc(normalizedAlc);
+            int avg = getAlcAverage();
+            if (avg < 0) return; // not enough samples yet
+
+            if (avg > GeneralVariables.alcTargetHigh) {
+                // Too hot — reduce volume immediately (mid-TX for AudioTrack path)
+                float newVol = GeneralVariables.volumePercent - VOLUME_STEP_DOWN;
+                if (newVol < VOLUME_MIN) newVol = VOLUME_MIN;
+                GeneralVariables.volumePercent = newVol;
+                GeneralVariables.mutableVolumePercent.postValue(newVol);
+                adjustedDownThisCycle = true;
+                GeneralVariables.fileLog(String.format(
+                        "MeterProtection: ALC high (avg=%d > %d), vol down to %.0f%%",
+                        avg, GeneralVariables.alcTargetHigh, newVol * 100));
+            }
+            // Up-adjust is deferred to onTxCycleEnd() to avoid oscillation
+        }
+    }
+
+    /**
+     * Called after each TX cycle completes (from afterPlayAudio or onAfterTransmit).
+     * Applies between-cycle ALC volume increase if ALC was consistently low.
+     */
+    public void onTxCycleEnd() {
+        if (!GeneralVariables.autoVolumeEnabled) {
+            resetAccumulators();
+            return;
+        }
+
+        int avg = getAlcAverage();
+        if (avg >= 0 && avg < GeneralVariables.alcTargetLow && !adjustedDownThisCycle) {
+            // ALC consistently low — nudge volume up for next cycle
+            float newVol = GeneralVariables.volumePercent + VOLUME_STEP_UP;
+            if (newVol > VOLUME_MAX) newVol = VOLUME_MAX;
+            GeneralVariables.volumePercent = newVol;
+            GeneralVariables.mutableVolumePercent.postValue(newVol);
+            GeneralVariables.fileLog(String.format(
+                    "MeterProtection: ALC low (avg=%d < %d), vol up to %.0f%%",
+                    avg, GeneralVariables.alcTargetLow, newVol * 100));
+        }
+
+        // Persist updated volume to DB (fire-and-forget)
+        if (alcWindowCount > 0) {
+            persistVolume();
+        }
+
+        resetAccumulators();
+    }
+
+    /**
+     * Halt TX and set lockout due to high SWR.
+     */
+    private void haltForSwr(int normalizedSwr) {
+        Log.w(TAG, "SWR halt triggered: normalized=" + normalizedSwr);
+        GeneralVariables.fileLog("MeterProtection: SWR HALT triggered, swr=" + normalizedSwr);
+
+        String ratio = normalizedSwrToRatio(normalizedSwr);
+        lockoutSwrRatio.postValue(ratio);
+        swrLockout.postValue(true);
+
+        if (transmitSignal != null) {
+            transmitSignal.setActivated(false);
+        }
+    }
+
+    /**
+     * User dismisses the SWR lockout banner, allowing TX again.
+     */
+    public void clearSwrLockout() {
+        swrLockout.postValue(false);
+        lockoutSwrRatio.postValue("");
+        GeneralVariables.fileLog("MeterProtection: SWR lockout cleared by user");
+    }
+
+    /**
+     * Check whether SWR lockout is currently active.
+     */
+    public boolean isSwrLocked() {
+        Boolean locked = swrLockout.getValue();
+        return locked != null && locked;
+    }
+
+    /**
+     * Reset all accumulators. Called on rig disconnect or TX mode change.
+     */
+    public void reset() {
+        resetAccumulators();
+    }
+
+    private void accumulateAlc(int value) {
+        alcWindow[alcWindowIndex] = value;
+        alcWindowIndex = (alcWindowIndex + 1) % ALC_WINDOW_SIZE;
+        if (alcWindowCount < ALC_WINDOW_SIZE) alcWindowCount++;
+    }
+
+    /**
+     * @return running average of ALC samples, or -1 if no samples yet.
+     */
+    private int getAlcAverage() {
+        if (alcWindowCount == 0) return -1;
+        int sum = 0;
+        for (int i = 0; i < alcWindowCount; i++) {
+            sum += alcWindow[i];
+        }
+        return sum / alcWindowCount;
+    }
+
+    private void resetAccumulators() {
+        alcWindowIndex = 0;
+        alcWindowCount = 0;
+        adjustedDownThisCycle = false;
+    }
+
+    private void persistVolume() {
+        try {
+            android.content.Context ctx = GeneralVariables.getMainContext();
+            if (ctx == null) return;
+            com.bg7yoz.ft8cn.database.DatabaseOpr db =
+                    com.bg7yoz.ft8cn.database.DatabaseOpr.getInstance(ctx, "data.db");
+            if (db != null) {
+                int pct = Math.round(GeneralVariables.volumePercent * 100);
+                db.writeConfig("volumeValue", String.valueOf(pct), null);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to persist volume", e);
+        }
+    }
+
+    /**
+     * Approximate mapping of normalized 0-255 SWR value to a human-readable ratio string.
+     * The mapping is intentionally coarse — the exact curve varies by rig manufacturer,
+     * but the general shape (roughly quadratic) is similar across Yaesu/Icom/Kenwood:
+     *   0 = 1.0:1, ~60 = 1.5:1, ~120 = 3.0:1, 200+ = high/infinity.
+     */
+    public static String normalizedSwrToRatio(int normalized) {
+        if (normalized <= 0) return "1.0:1";
+        if (normalized >= 255) return ">10:1";
+        // Piecewise linear approximation
+        float ratio;
+        if (normalized <= 60) {
+            ratio = 1.0f + (normalized / 60f) * 0.5f;       // 0→1.0, 60→1.5
+        } else if (normalized <= 120) {
+            ratio = 1.5f + ((normalized - 60) / 60f) * 1.5f; // 60→1.5, 120→3.0
+        } else if (normalized <= 200) {
+            ratio = 3.0f + ((normalized - 120) / 80f) * 4.0f; // 120→3.0, 200→7.0
+        } else {
+            ratio = 7.0f + ((normalized - 200) / 55f) * 3.0f; // 200→7.0, 255→10.0
+        }
+        return String.format("%.1f:1", ratio);
+    }
+
+    /**
+     * Convert a human-readable SWR ratio (e.g. 3.0) back to the approximate normalized
+     * 0-255 value. Used by the settings slider.
+     */
+    public static int swrRatioToNormalized(float ratio) {
+        if (ratio <= 1.0f) return 0;
+        if (ratio <= 1.5f) return Math.round((ratio - 1.0f) / 0.5f * 60);
+        if (ratio <= 3.0f) return 60 + Math.round((ratio - 1.5f) / 1.5f * 60);
+        if (ratio <= 7.0f) return 120 + Math.round((ratio - 3.0f) / 4.0f * 80);
+        if (ratio <= 10.0f) return 200 + Math.round((ratio - 7.0f) / 3.0f * 55);
+        return 255;
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/BaseRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/BaseRig.java
@@ -142,4 +142,14 @@ public abstract class BaseRig {
     public void onDisconnecting() {
     }
 
+    // Meter data callback for MeterProtectionController (ALC auto-volume, SWR halt)
+    public interface OnMeterData {
+        void onMeterUpdate(int normalizedAlc, int normalizedSwr);
+    }
+    private OnMeterData onMeterData;
+    public void setOnMeterData(OnMeterData listener) { this.onMeterData = listener; }
+    protected void notifyMeterData(int alc, int swr) {
+        if (onMeterData != null) onMeterData.onMeterUpdate(alc, swr);
+    }
+
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/ElecraftRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/ElecraftRig.java
@@ -149,6 +149,7 @@ public class ElecraftRig extends BaseRig {
                 }
 
                 showAlert();
+                notifyMeterData(-1, Math.min(swr * 4, 255));
             }
 
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/IcomRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/IcomRig.java
@@ -186,6 +186,7 @@ public class IcomRig extends BaseRig {
                     swr = IcomRigConstant.twoByteBcdToInt(icomCommand.getData(true));
                 }
                 showAlert();//check if meter value is in alert range
+                notifyMeterData(alc, swr);
                 break;
             case IcomRigConstant.CMD_CONNECTORS:
                 break;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/KenwoodTS2000Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/KenwoodTS2000Rig.java
@@ -143,6 +143,7 @@ public class KenwoodTS2000Rig extends BaseRig {
                     alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
                 }
                 showAlert();
+                notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
             }
 
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/KenwoodTS570Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/KenwoodTS570Rig.java
@@ -142,6 +142,7 @@ public class KenwoodTS570Rig extends BaseRig {
                     alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
                 }
                 showAlert();
+                notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
             }
 
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/KenwoodTS590Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/KenwoodTS590Rig.java
@@ -142,6 +142,7 @@ public class KenwoodTS590Rig extends BaseRig {
                     alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
                 }
                 showAlert();
+                notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
             }
 
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/XieGu6100Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/XieGu6100Rig.java
@@ -181,6 +181,7 @@ public class XieGu6100Rig extends BaseRig {
                     }
                 }
                 showAlert();//check if meter value is in alert range
+                notifyMeterData(alc, swr);
 
                 break;
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/XieGuRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/XieGuRig.java
@@ -171,6 +171,7 @@ public class XieGuRig extends BaseRig {
                     }
                 }
                 showAlert();//check if meter value is in alert range
+                notifyMeterData(alc, swr);
 
                 break;
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu2Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu2Rig.java
@@ -102,6 +102,7 @@ public class Yaesu2Rig extends BaseRig {
             alc = (data[0] & 0x0f);
             swr = (data[1] & 0x0f0) >> 4;
             showAlert();
+            notifyMeterData(alc * 17, swr * 17);
         }
 
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu2_847Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu2_847Rig.java
@@ -109,6 +109,7 @@ public class Yaesu2_847Rig extends BaseRig {
             alc = (data[0] & 0x0f);
             swr = (data[1] & 0x0f0) >> 4;
             showAlert();
+            notifyMeterData(alc * 17, swr * 17);
         }
 
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu38Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu38Rig.java
@@ -166,6 +166,7 @@ public class Yaesu38Rig extends BaseRig {
                     alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
                 }
                 showAlert();
+                notifyMeterData(alc, swr);
             }
 
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu39Rig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/Yaesu39Rig.java
@@ -200,6 +200,7 @@ public class Yaesu39Rig extends BaseRig {
                     alc = Yaesu3Command.getSWROrALC39(yaesu3Command);
                 }
                 showAlert();
+                notifyMeterData(alc, swr);
             } else {
                 fileLog("rig.parsed: cmd=" + yaesu3Command.getCommandID()
                         + " data=" + yaesu3Command.getData());

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -1,10 +1,17 @@
 package radio.ks3ckc.ft8us
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -16,7 +23,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.R
@@ -95,10 +106,52 @@ fun FT8USApp(mainViewModel: MainViewModel) {
             append(bandName)
         }
     }
+    // Observe SWR lockout state
+    val swrLocked by mainViewModel.meterProtectionController.swrLockout.observeAsState(false)
+    val lockoutSwrRatio by mainViewModel.meterProtectionController.lockoutSwrRatio.observeAsState("")
+
     Box(modifier = Modifier.fillMaxSize().background(BgApp)) {
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
+            // SWR lockout banner — red warning at top when SWR halt triggered
+            if (swrLocked) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFFCC2222))
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "TX HALTED — High SWR detected ($lockoutSwrRatio)",
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 13.sp,
+                        )
+                        Text(
+                            text = "Check antenna / feedline before transmitting.",
+                            color = Color.White.copy(alpha = 0.85f),
+                            fontSize = 11.sp,
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    TextButton(
+                        onClick = {
+                            mainViewModel.meterProtectionController.clearSwrLockout()
+                        },
+                    ) {
+                        Text(
+                            "DISMISS",
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 12.sp,
+                        )
+                    }
+                }
+            }
+
             // Main content area (takes remaining space).
             // Note: AndroidView-wrapped legacy views (waterfall/columnar) interact badly with
             // AnimatedContent's graphicsLayer translations during enter/exit, so tab switching

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -74,6 +74,7 @@ import com.bg7yoz.ft8cn.database.ControlMode
 import com.bg7yoz.ft8cn.database.OperationBand
 import com.bg7yoz.ft8cn.database.RigNameList
 import com.bg7yoz.ft8cn.ft8signal.FT8Package
+import com.bg7yoz.ft8cn.ft8transmit.MeterProtectionController
 import com.bg7yoz.ft8cn.rigs.BaseRigOperation
 import com.bg7yoz.ft8cn.rigs.InstructionSet
 import com.bg7yoz.ft8cn.ui.AudioDeviceSpinnerAdapter
@@ -200,6 +201,13 @@ fun SettingsScreen(
     var showBlockKeywordDialog by remember { mutableStateOf(false) }
     var showContinentPicker by remember { mutableStateOf(false) }
     var showLanguagePicker by remember { mutableStateOf(false) }
+
+    // TX Protection state
+    var autoVolumeEnabled by remember { mutableStateOf(GeneralVariables.autoVolumeEnabled) }
+    var swrHaltEnabled by remember { mutableStateOf(GeneralVariables.swrHaltEnabled) }
+    var swrHaltThreshold by remember { mutableIntStateOf(GeneralVariables.swrHaltThreshold) }
+    var alcTargetLow by remember { mutableIntStateOf(GeneralVariables.alcTargetLow) }
+    var alcTargetHigh by remember { mutableIntStateOf(GeneralVariables.alcTargetHigh) }
 
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
@@ -1139,6 +1147,158 @@ fun SettingsScreen(
                             showChevron = true,
                             onClick = { showStopAfter = true },
                         )
+                    }
+                }
+            }
+
+            // =====================================================================
+            // 3b. TX PROTECTION
+            // =====================================================================
+            SettingsSection(title = "TX PROTECTION") {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        SettingsRow(
+                            label = "Auto Volume (ALC)",
+                            description = "Automatically adjust TX volume to keep ALC in target range",
+                            toggle = autoVolumeEnabled,
+                            onToggleChange = { checked ->
+                                autoVolumeEnabled = checked
+                                GeneralVariables.autoVolumeEnabled = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "autoVolumeEnabled", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        if (autoVolumeEnabled) {
+                            SectionDivider()
+                            // ALC target range — two values displayed as a label row
+                            SettingsRow(
+                                label = "ALC Target Range",
+                                description = "Low: $alcTargetLow  High: $alcTargetHigh  (0-255 normalized)",
+                                value = "$alcTargetLow – $alcTargetHigh",
+                            )
+                            // Low slider
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    "Low",
+                                    style = TextStyle(fontSize = 12.sp, color = TextMuted),
+                                    modifier = Modifier.width(32.dp),
+                                )
+                                Slider(
+                                    value = alcTargetLow.toFloat(),
+                                    onValueChange = { v ->
+                                        val clamped = v.toInt().coerceIn(10, alcTargetHigh - 10)
+                                        alcTargetLow = clamped
+                                        GeneralVariables.alcTargetLow = clamped
+                                    },
+                                    onValueChangeFinished = {
+                                        mainViewModel.databaseOpr.writeConfig(
+                                            "alcTargetLow", alcTargetLow.toString(), null,
+                                        )
+                                    },
+                                    valueRange = 10f..200f,
+                                    modifier = Modifier.weight(1f),
+                                    colors = SliderDefaults.colors(
+                                        thumbColor = Accent,
+                                        activeTrackColor = Accent,
+                                    ),
+                                )
+                            }
+                            // High slider
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp)
+                                    .padding(bottom = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    "High",
+                                    style = TextStyle(fontSize = 12.sp, color = TextMuted),
+                                    modifier = Modifier.width(32.dp),
+                                )
+                                Slider(
+                                    value = alcTargetHigh.toFloat(),
+                                    onValueChange = { v ->
+                                        val clamped = v.toInt().coerceIn(alcTargetLow + 10, 250)
+                                        alcTargetHigh = clamped
+                                        GeneralVariables.alcTargetHigh = clamped
+                                    },
+                                    onValueChangeFinished = {
+                                        mainViewModel.databaseOpr.writeConfig(
+                                            "alcTargetHigh", alcTargetHigh.toString(), null,
+                                        )
+                                    },
+                                    valueRange = 20f..250f,
+                                    modifier = Modifier.weight(1f),
+                                    colors = SliderDefaults.colors(
+                                        thumbColor = Accent,
+                                        activeTrackColor = Accent,
+                                    ),
+                                )
+                            }
+                        }
+                        SectionDivider()
+                        SettingsRow(
+                            label = "SWR Protection",
+                            description = "Stop transmitting and lock TX if SWR exceeds threshold",
+                            toggle = swrHaltEnabled,
+                            onToggleChange = { checked ->
+                                swrHaltEnabled = checked
+                                GeneralVariables.swrHaltEnabled = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "swrHaltEnabled", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        if (swrHaltEnabled) {
+                            SectionDivider()
+                            val swrRatioStr = MeterProtectionController.normalizedSwrToRatio(swrHaltThreshold)
+                            SettingsRow(
+                                label = "SWR Threshold",
+                                description = "TX halts when SWR exceeds this value",
+                                value = swrRatioStr,
+                            )
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp)
+                                    .padding(bottom = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    "1.5:1",
+                                    style = TextStyle(fontSize = 12.sp, color = TextMuted),
+                                )
+                                Slider(
+                                    value = swrHaltThreshold.toFloat(),
+                                    onValueChange = { v ->
+                                        swrHaltThreshold = v.toInt()
+                                        GeneralVariables.swrHaltThreshold = v.toInt()
+                                    },
+                                    onValueChangeFinished = {
+                                        mainViewModel.databaseOpr.writeConfig(
+                                            "swrHaltThreshold", swrHaltThreshold.toString(), null,
+                                        )
+                                    },
+                                    valueRange = 30f..200f, // ~1.3:1 to ~7.0:1
+                                    modifier = Modifier.weight(1f),
+                                    colors = SliderDefaults.colors(
+                                        thumbColor = Accent,
+                                        activeTrackColor = Accent,
+                                    ),
+                                )
+                                Text(
+                                    "7:1",
+                                    style = TextStyle(fontSize = 12.sp, color = TextMuted),
+                                )
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- **ALC auto-volume**: Automatically adjusts TX volume to keep ALC in a configurable target window (default 60–100 / 255). Fast step-down mid-TX (2%), slow step-up between cycles (1%) — asymmetric control prevents oscillation and prioritizes protecting the radio over maximizing power.
- **SWR TX halt + lockout**: Immediately stops TX and blocks re-activation when SWR exceeds a configurable threshold (default ≈ 3.0:1). A red banner appears at the top of the screen with a DISMISS button to clear the lockout. Protects PA/feedline from antenna problems.
- **New `MeterProtectionController`**: Protocol-agnostic controller receives normalized 0–255 meter values from all 11 rig classes via a new `OnMeterData` callback on `BaseRig`. Each rig normalizes its native range before forwarding.
- **Settings UI**: New "TX Protection" section in Settings with toggles for both features, ALC target range sliders, and SWR threshold slider (displayed as human-readable ratio like 3.0:1).
- **Persistence**: All settings saved to config DB and restored on startup.
- Both features are **off by default** — opt-in via Settings > TX Protection.

## Test plan

- [ ] Build and install: `cd ft8cn && cmd.exe /c "gradlew.bat installDebug"`
- [ ] Open Settings > TX Protection — verify both toggles appear with sliders
- [ ] Enable Auto Volume, set TX volume to 100%, TX on FT-891/991 — observe volume automatically decreasing over 2–3 cycles
- [ ] Enable SWR Protection with low threshold (1.5:1) — verify TX halts immediately on high SWR, red banner appears, TX button blocked until Dismiss tapped
- [ ] Verify settings persist across app restart
- [ ] Connect a rig without meter support (VOX/DTR mode) — features should be inert with no errors
- [ ] Check `debug.log` for `MeterProtection:` entries during TX with features enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)