### PR TITLE
Add QRZ profile photo, antenna, and power to operator card

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -305,6 +305,8 @@ public class GeneralVariables {
     //private static final Map<String,String> callsignAndGrids=new HashMap<>();
 
     public static String myCallsign = "";//My callsign
+    public static String myAntenna = "";
+    public static int myPowerWatts = 0;    // 0 = not set, displays as "--"
     public static String toModifier = "";//Call modifier
     private static float baseFrequency = 1000;//Audio frequency
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2276,6 +2276,16 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("toModifier")) {
                     GeneralVariables.toModifier = result;
                 }
+                if (name.equalsIgnoreCase("antenna")) {
+                    GeneralVariables.myAntenna = result;
+                }
+                if (name.equalsIgnoreCase("powerWatts")) {
+                    try {
+                        GeneralVariables.myPowerWatts = result.isEmpty() ? 0 : Integer.parseInt(result);
+                    } catch (NumberFormatException e) {
+                        GeneralVariables.myPowerWatts = 0;
+                    }
+                }
                 if (name.equalsIgnoreCase("freq")) {
                     float freq = 1000;
                     try {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/OperatorCard.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/OperatorCard.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -26,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import radio.ks3ckc.ft8us.theme.*
+import radio.ks3ckc.ft8us.ui.decode.QrzAvatar
 
 /**
  * Operator identity card with amber gradient background, callsign avatar,
@@ -88,27 +87,8 @@ fun OperatorCard(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                // Callsign initials avatar
-                Box(
-                    modifier = Modifier
-                        .size(56.dp)
-                        .clip(CircleShape)
-                        .background(
-                            brush = Brush.linearGradient(
-                                colors = listOf(Accent, AccentGlow),
-                            ),
-                            shape = CircleShape,
-                        ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = initials,
-                        color = BgApp,
-                        fontFamily = GeistMonoFamily,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 20.sp,
-                    )
-                }
+                // Callsign avatar (QRZ photo with initials fallback)
+                QrzAvatar(callsign = callsign, size = 56.dp, fallbackText = initials)
 
                 // Callsign + grid
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -186,6 +186,8 @@ fun SettingsScreen(
     // Operator identity edit state
     var callsignState by remember { mutableStateOf(GeneralVariables.myCallsign.orEmpty()) }
     var gridState by remember { mutableStateOf(GeneralVariables.getMyMaidenheadGrid().orEmpty()) }
+    var antennaState by remember { mutableStateOf(GeneralVariables.myAntenna.orEmpty()) }
+    var powerWattsState by remember { mutableIntStateOf(GeneralVariables.myPowerWatts) }
 
     // Mutable state for settings that need to trigger recomposition on change
     var watchdogMs by remember { mutableIntStateOf(GeneralVariables.launchSupervision) }
@@ -227,6 +229,8 @@ fun SettingsScreen(
     } else {
         "Not connected"
     }
+    val antennaDisplay = antennaState.ifEmpty { "--" }
+    val powerDisplay = if (powerWattsState > 0) "${powerWattsState}W" else "--"
     val baudRateStr = "$baudRate"
     val isCatMode = controlMode == ControlMode.CAT
         || controlMode == ControlMode.RTS
@@ -267,8 +271,10 @@ fun SettingsScreen(
         EditOperatorDialog(
             initialCallsign = callsign,
             initialGrid = grid,
+            initialAntenna = antennaState,
+            initialPowerWatts = powerWattsState,
             onDismiss = { showEditOperator = false },
-            onSave = { newCallsign, newGrid ->
+            onSave = { newCallsign, newGrid, newAntenna, newPowerWatts ->
                 val trimmedCall = newCallsign.uppercase().trim()
                 callsignState = trimmedCall
                 GeneralVariables.myCallsign = trimmedCall
@@ -286,6 +292,15 @@ fun SettingsScreen(
                 }
                 GeneralVariables.setMyMaidenheadGrid(formattedGrid)
                 mainViewModel.databaseOpr.writeConfig("grid", formattedGrid, null)
+
+                val trimmedAntenna = newAntenna.trim()
+                antennaState = trimmedAntenna
+                GeneralVariables.myAntenna = trimmedAntenna
+                mainViewModel.databaseOpr.writeConfig("antenna", trimmedAntenna, null)
+
+                powerWattsState = newPowerWatts
+                GeneralVariables.myPowerWatts = newPowerWatts
+                mainViewModel.databaseOpr.writeConfig("powerWatts", newPowerWatts.toString(), null)
 
                 showEditOperator = false
             },
@@ -878,6 +893,8 @@ fun SettingsScreen(
                     callsign = callsign,
                     grid = grid,
                     rigName = rigName,
+                    antenna = antennaDisplay,
+                    power = powerDisplay,
                     modifier = Modifier.padding(bottom = 4.dp),
                     onClick = { showEditOperator = true },
                 )
@@ -1558,17 +1575,23 @@ private fun SectionDivider() {
 // ---------------------------------------------------------------------------
 
 /**
- * Dialog for editing callsign and grid locator.
+ * Dialog for editing callsign, grid locator, antenna, and power.
  */
 @Composable
 private fun EditOperatorDialog(
     initialCallsign: String,
     initialGrid: String,
+    initialAntenna: String = "",
+    initialPowerWatts: Int = 0,
     onDismiss: () -> Unit,
-    onSave: (callsign: String, grid: String) -> Unit,
+    onSave: (callsign: String, grid: String, antenna: String, powerWatts: Int) -> Unit,
 ) {
     var callsignInput by remember { mutableStateOf(TextFieldValue(initialCallsign)) }
     var gridInput by remember { mutableStateOf(TextFieldValue(initialGrid)) }
+    var antennaInput by remember { mutableStateOf(TextFieldValue(initialAntenna)) }
+    var powerInput by remember {
+        mutableStateOf(TextFieldValue(if (initialPowerWatts > 0) initialPowerWatts.toString() else ""))
+    }
 
     val fieldColors = OutlinedTextFieldDefaults.colors(
         focusedTextColor = TextPrimary,
@@ -1625,6 +1648,31 @@ private fun EditOperatorDialog(
                 modifier = Modifier.fillMaxWidth(),
             )
 
+            OutlinedTextField(
+                value = antennaInput,
+                onValueChange = { antennaInput = it },
+                label = { Text("Antenna") },
+                placeholder = { Text("e.g. EFHW 40-10m", color = TextFaint) },
+                singleLine = true,
+                colors = fieldColors,
+                textStyle = TextStyle(fontSize = 14.sp),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value = powerInput,
+                onValueChange = { new ->
+                    if (new.text.all { it.isDigit() }) powerInput = new
+                },
+                label = { Text("Power (watts)") },
+                placeholder = { Text("e.g. 100", color = TextFaint) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                colors = fieldColors,
+                textStyle = TextStyle(fontSize = 14.sp),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
@@ -1634,7 +1682,10 @@ private fun EditOperatorDialog(
                     Text("Cancel", color = TextMuted)
                 }
                 TextButton(
-                    onClick = { onSave(callsignInput.text, gridInput.text) },
+                    onClick = {
+                        val watts = powerInput.text.toIntOrNull() ?: 0
+                        onSave(callsignInput.text, gridInput.text, antennaInput.text, watts)
+                    },
                 ) {
                     Text("Save", color = Accent, fontWeight = FontWeight.SemiBold)
                 }


### PR DESCRIPTION
## Summary
- Replace initials avatar in OperatorCard with QrzAvatar (fetches QRZ profile photo, falls back to initials)
- Add user-editable antenna and power fields to the Edit Operator dialog (persisted via config DB)
- OperatorCard mini stats now display real antenna/power values instead of hardcoded "--"

## Test plan
- [ ] Open Settings — OperatorCard should show QRZ photo (or initials fallback)
- [ ] Tap to edit — dialog should show 4 fields: callsign, grid, antenna, power
- [ ] Enter antenna + power, save — card should display values instead of "--"
- [ ] Kill and reopen app — values should persist
- [ ] Power field should only accept digits

🤖 Generated with [Claude Code](https://claude.com/claude-code)