### PR TITLE
Reply with 73 before completing QSO after receiving RR73

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1019,11 +1019,21 @@ public class FT8TransmitSignal {
         // update the QSO list; if not already recorded, save it
         updateQSlRecordList(newOrder, toCallsign);
 
+        // FT8 protocol: when we receive RR73/RRR (order 4), always reply with
+        // 73 (order 5) before completing the QSO. This handler fires before
+        // the completion check so that we never skip the 73 reply.
+        if (newOrder == 4) {
+            functionOrder = 5;
+            mutableFunctions.postValue(functionList);
+            mutableFunctionOrder.postValue(functionOrder);
+            setCurrentFunctionOrder(functionOrder);
+            return;
+        }
 
         // determine QSO success: other party replied 73 (5) || I am at 73 (5) and other party did not reply (-1)
         // or I am at RR73 (4) and no-reply threshold reached with no-reply limit enabled
         // or I am at RR73 (4) and the other party started calling someone else, to prevent RR73 deadlock
-        if (newOrder == 5// target replied RR73 to me
+        if (newOrder == 5// target replied 73 to me
                 || (functionOrder == 5 && newOrder == -1)// QSO success: other party replied 73 (5) || I am at 73 (5) and no reply (-1)
                 || (functionOrder == 4 &&
                 (GeneralVariables.noReplyCount > GeneralVariables.noReplyLimit * 2)


### PR DESCRIPTION
## Summary
- When the other station sends RR73, the app now always replies with 73 before completing the QSO and moving on to the next queued caller or CQ
- Adds an explicit handler in `parseMessageToFunction` that fires **before** the completion check, guaranteeing `functionOrder` advances to 5 (73) so the courtesy reply is transmitted
- Fixes a misleading comment that said "target replied RR73" when the condition actually checks for 73 (order 5)

## Test plan
- [ ] Answer someone's CQ, complete exchange through R+report, verify app sends 73 after receiving their RR73
- [ ] CQ and complete a QSO — when the answering station sends RR73, verify app sends 73 before dequeuing the next caller
- [ ] Verify QSO is still logged correctly (updateQSlRecordList runs before the new handler)
- [ ] Verify the QSO completes normally on the next cycle after 73 is sent (functionOrder == 5 && newOrder == -1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)