### PR TITLE
Resume POTA activation after app close

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -48,6 +48,7 @@ import com.bg7yoz.ft8cn.wave.UsbAudioNative
 import com.bg7yoz.ft8cn.log.OnShareLogEvents
 import com.bg7yoz.ft8cn.maidenhead.MaidenheadGrid
 import com.bg7yoz.ft8cn.ui.ToastMessage
+import radio.ks3ckc.ft8us.pota.PotaSessionManager
 import radio.ks3ckc.ft8us.theme.FT8USTheme
 import radio.ks3ckc.ft8us.ui.components.ExitConfirmDialog
 import java.io.File
@@ -266,6 +267,9 @@ class ComposeMainActivity : AppCompatActivity() {
                     GridLocationUpdater.refresh(applicationContext, mainViewModel)
                 }
                 mainViewModel.ft8TransmitSignal.setTimer_sec(GeneralVariables.transmitDelay)
+
+                // Resume any POTA activation that was interrupted by app close
+                PotaSessionManager.resume()
 
                 // Scan for USB devices AFTER config is loaded
                 fileLog("initData: scanning USB devices")

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaActivationDao.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaActivationDao.kt
@@ -53,6 +53,14 @@ internal object PotaActivationDao {
         return cursor.use { c -> if (c.moveToFirst()) c.toActivation() else null }
     }
 
+    fun findActiveActivation(): PotaActivation? {
+        val cursor = db().rawQuery(
+            "SELECT * FROM pota_activation WHERE ended_at IS NULL ORDER BY started_at DESC LIMIT 1",
+            null,
+        )
+        return cursor.use { c -> if (c.moveToFirst()) c.toActivation() else null }
+    }
+
     fun history(limit: Int = 50): List<PotaActivation> {
         val cursor = db().rawQuery(
             "SELECT * FROM pota_activation ORDER BY started_at DESC LIMIT ?",

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
@@ -65,6 +65,17 @@ object PotaSessionManager {
     }
 
     @Synchronized
+    fun resume() {
+        if (_currentActivation.value != null) return
+        val active = PotaActivationDao.findActiveActivation() ?: return
+        savedModifier = GeneralVariables.toModifier ?: ""
+        GeneralVariables.toModifier = MY_SIG_POTA
+        _currentActivation.value = active
+        _activationQsos.value = PotaActivationDao.getActivationQsos(active)
+        log("resume ref=${active.parkRef} id=${active.id} qsoCount=${active.qsoCount}")
+    }
+
+    @Synchronized
     fun end() {
         val active = _currentActivation.value ?: run {
             log("end ignored — no activation running")


### PR DESCRIPTION
## Summary
- When the app is killed mid-POTA activation, the `pota_activation` row persists in SQLite with `ended_at IS NULL`, but `PotaSessionManager`'s in-memory state is lost
- On restart, `findActiveActivation()` queries for the unclosed row and `resume()` restores the session — re-setting `toModifier = "POTA"`, reloading the QSO list, and populating the activation card
- Called in `initData()` after config loads so `savedModifier` correctly captures the user's real setting before being overridden

## Test plan
- [ ] Start a POTA activation and make 1-2 contacts
- [ ] Force-close the app (swipe away or `adb shell am force-stop radio.ks3ckc.ft8af`)
- [ ] Reopen the app, navigate to POTA → Activate tab
- [ ] Confirm activation card shows with correct QSO count and elapsed time
- [ ] Confirm "End Activation" works and restores the original CQ modifier
- [ ] Confirm a fresh app start with no unclosed activation behaves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)