### PR TITLE
Fix spurious QSO celebration animation replays

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -61,6 +61,13 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     val isActivated by mainViewModel.ft8TransmitSignal.mutableIsActivated.observeAsState(false)
     val txSlot by mainViewModel.ft8TransmitSignal.mutableSequential.observeAsState(mainViewModel.ft8TransmitSignal.sequential)
     val qsoCompletedAt by mainViewModel.ft8TransmitSignal.mutableQsoCompletedAt.observeAsState()
+    // Consume the one-shot celebration signal so LiveData doesn't replay it
+    // on recomposition / resubscription.
+    LaunchedEffect(qsoCompletedAt) {
+        if (qsoCompletedAt != null) {
+            mainViewModel.ft8TransmitSignal.mutableQsoCompletedAt.postValue(null)
+        }
+    }
 
     // QSO panel expand/collapse state
     var qsoPanelExpanded by rememberSaveable { mutableStateOf(false) }


### PR DESCRIPTION
## Summary
- `mutableQsoCompletedAt` (LiveData) was never reset to null after the celebration animation played, so any recomposition or LiveData resubscription would replay the stale timestamp and re-trigger the firework animation when not in a QSO or transmitting.
- Added a `LaunchedEffect` in `FT8USApp` that consumes the one-shot signal by posting null back to the LiveData immediately after observation.

## Test plan
- [ ] Complete a QSO — celebration should fire once as normal
- [ ] After celebration, switch tabs back and forth — should not replay
- [ ] Rotate device after a completed QSO — should not replay
- [ ] Leave app idle after a QSO for several minutes — no spurious celebrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)