### PR TITLE
Add GitHub and Discord links to FAQ & Support dialog

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -2933,6 +2933,29 @@ private fun AboutDialog(
             )
 
             Text(
+                text = stringResource(R.string.settings_community),
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+            )
+            Text(
+                text = "github.com/patrickrb/FT8AF",
+                color = Accent,
+                fontSize = 14.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uriHandler.openUri("https://github.com/patrickrb/FT8AF") },
+            )
+            Text(
+                text = "discord.gg/UeE3ZpwRG",
+                color = Accent,
+                fontSize = 14.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uriHandler.openUri("https://discord.gg/UeE3ZpwRG") },
+            )
+
+            Text(
                 text = stringResource(R.string.settings_built_by),
                 color = TextPrimary,
                 fontWeight = FontWeight.SemiBold,

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -398,6 +398,7 @@
     <string name="settings_debug_desc">Ver / compartir debug.log</string>
     <string name="settings_about_body">Versión %1$s (compilación %2$s)\nFecha de compilación %3$s\n\nFT8, fácil.\n\nUna app de transceptor FT8 independiente para Android. Control de RIG por USB, Bluetooth y red con secuenciado y registro automáticos.</string>
     <string name="settings_website">Sitio web</string>
+    <string name="settings_community">Comunidad</string>
     <string name="settings_built_by">Creado por</string>
 
     <!-- ===== Settings: dialogs ===== -->

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -398,6 +398,7 @@
     <string name="settings_debug_desc">Afficher / partager debug.log</string>
     <string name="settings_about_body">Version %1$s (build %2$s)\nDate de build %3$s\n\nFT8, en toute simplicité.\n\nUne application de transceiver FT8 autonome pour Android. Contrôle de rig par USB, Bluetooth et réseau avec séquençage et journalisation automatiques.</string>
     <string name="settings_website">Site web</string>
+    <string name="settings_community">Communauté</string>
     <string name="settings_built_by">Développé par</string>
 
     <!-- ===== Settings: dialogs ===== -->

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -398,6 +398,7 @@
     <string name="settings_debug_desc">debug.log を表示 / 共有</string>
     <string name="settings_about_body">バージョン %1$s (ビルド %2$s)\nビルド日 %3$s\n\nFT8 を、もっと手軽に。\n\nAndroid 向けのスタンドアロン FT8 トランシーバーアプリ。USB、Bluetooth、ネットワークでの無線機制御に対応し、自動シーケンスとログ記録を備えています。</string>
     <string name="settings_website">ウェブサイト</string>
+    <string name="settings_community">コミュニティ</string>
     <string name="settings_built_by">制作</string>
 
     <!-- ===== Settings: dialogs ===== -->

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -398,6 +398,7 @@
     <string name="settings_debug_desc">Просмотр / отправка debug.log</string>
     <string name="settings_about_body">Версия %1$s (сборка %2$s)\nДата сборки %3$s\n\nFT8 — это просто.\n\nАвтономное приложение FT8-трансивера для Android. Управление трансивером по USB, Bluetooth и сети с автопоследовательностью и журналированием.</string>
     <string name="settings_website">Веб-сайт</string>
+    <string name="settings_community">Сообщество</string>
     <string name="settings_built_by">Разработано</string>
 
     <!-- ===== Settings: dialogs ===== -->

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -398,6 +398,7 @@
     <string name="settings_debug_desc">查看 / 分享 debug.log</string>
     <string name="settings_about_body">版本 %1$s（构建 %2$s）\n构建日期 %3$s\n\nFT8，轻松上手。\n\n一款用于 Android 的独立 FT8 收发应用。支持 USB、Bluetooth 及网络电台控制，具备自动流程与日志记录功能。</string>
     <string name="settings_website">网站</string>
+    <string name="settings_community">社区</string>
     <string name="settings_built_by">开发者</string>
 
     <!-- ===== 设置：对话框 ===== -->

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -398,6 +398,7 @@
     <string name="settings_debug_desc">檢視／分享 debug.log</string>
     <string name="settings_about_body">版本 %1$s（build %2$s）\n建置日期 %3$s\n\nFT8，輕鬆上手。\n\n一款適用於 Android 的獨立 FT8 收發器應用程式。支援 USB、Bluetooth 與網路電台控制，並具備自動序列與日誌功能。</string>
     <string name="settings_website">網站</string>
+    <string name="settings_community">社群</string>
     <string name="settings_built_by">開發者</string>
 
     <!-- ===== Settings: dialogs ===== -->

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -414,6 +414,7 @@
     <string name="settings_debug_desc">View / share debug.log</string>
     <string name="settings_about_body">Version %1$s (build %2$s)\nBuild date %3$s\n\nFT8, made easy.\n\nA standalone FT8 transceiver app for Android. USB, Bluetooth, and network rig control with automatic sequencing and logging.</string>
     <string name="settings_website">Website</string>
+    <string name="settings_community">Community</string>
     <string name="settings_built_by">Built by</string>
     <string name="settings_author_k1af" translatable="false">K1AF — Patrick Burns (QRZ)</string>
     <string name="settings_author_n0rc" translatable="false">N0RC — Reid (QRZ)</string>


### PR DESCRIPTION
## Summary
- Adds a "Community" section to the About dialog with clickable GitHub and Discord links
- Uses existing `uriHandler.openUri()` pattern and `Accent` color styling
- Adds `settings_community` string resource with translations for all 7 locales (EN, RU, ZH-CN, ZH-TW, JA, FR, ES)

## Test plan
- [ ] Build and install on device
- [ ] Open Settings > scroll to About > tap "FAQ & Support"
- [ ] Confirm "Community" label appears between "Website" and "Built by"
- [ ] Tap GitHub link — opens `https://github.com/patrickrb/FT8AF`
- [ ] Tap Discord link — opens `https://discord.gg/UeE3ZpwRG`
- [ ] Switch language and verify translated "Community" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)