### PR TITLE
Support multi-park POTA activations

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaSessionManager.kt
@@ -41,26 +41,31 @@ object PotaSessionManager {
     private var savedModifier: String = ""
 
     val isActive: Boolean get() = _currentActivation.value != null
-    val currentParkRef: String? get() = _currentActivation.value?.parkRef
+    val currentParkRefs: List<String> get() = _currentActivation.value?.parkRefs ?: emptyList()
 
     @Synchronized
-    fun start(parkRef: String, notes: String?): PotaActivation? {
+    fun start(parkRefs: List<String>, notes: String?): PotaActivation? {
         if (_currentActivation.value != null) {
-            log("start ignored — activation already running for ${currentParkRef}")
+            log("start ignored — activation already running for ${currentParkRefs}")
             return _currentActivation.value
         }
-        val ref = parkRef.trim().uppercase()
-        if (ref.isEmpty()) {
-            log("start rejected — empty park ref")
+        val refs = parkRefs
+            .map { it.trim().uppercase() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .take(10)
+        if (refs.isEmpty()) {
+            log("start rejected — no valid park refs")
             return null
         }
+        val joined = refs.joinToString(",")
         savedModifier = GeneralVariables.toModifier ?: ""
         GeneralVariables.toModifier = MY_SIG_POTA
         val operator = GeneralVariables.myCallsign?.takeIf { it.isNotBlank() }
-        val activation = PotaActivationDao.startActivation(ref, operator, notes)
+        val activation = PotaActivationDao.startActivation(joined, operator, notes)
         _currentActivation.value = activation
         _activationQsos.value = emptyList()
-        log("start ref=$ref id=${activation.id} priorModifier='${savedModifier}'")
+        log("start refs=$joined id=${activation.id} priorModifier='${savedModifier}'")
         return activation
     }
 
@@ -111,7 +116,7 @@ object PotaSessionManager {
      */
     @JvmStatic
     fun stampQso(record: com.bg7yoz.ft8cn.log.QSLRecord, spottedParkRef: String?) {
-        currentParkRef?.let {
+        _currentActivation.value?.parkRef?.let {
             record.mySig = MY_SIG_POTA
             record.mySigInfo = it
         }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/model/PotaModels.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/model/PotaModels.kt
@@ -48,4 +48,12 @@ data class PotaActivation(
     val notes: String?,
 ) {
     val isActive: Boolean get() = endedAtMs == null
+
+    /** Individual park references (splits comma-separated `parkRef`). */
+    val parkRefs: List<String>
+        get() = parkRef.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+
+    /** Human-readable display: "K-1234 + K-5678". */
+    val parkRefsDisplay: String
+        get() = parkRefs.joinToString(" + ")
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
@@ -2,6 +2,7 @@ package radio.ks3ckc.ft8us.ui.pota
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.core.content.FileProvider
 import com.bg7yoz.ft8cn.MainViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -15,12 +16,12 @@ import java.util.Date
 import java.util.Locale
 
 /**
- * Writes an ADIF file for a single POTA activation and shares it via system intent.
+ * Writes ADIF files for a POTA activation and shares them via system intent.
  *
  * pota.app's website upload (https://pota.app/#/user/upload) expects an ADIF where each
- * QSO carries MY_SIG=POTA / MY_SIG_INFO=<park ref>. SIG/SIG_INFO are filled for P2P
- * (Park-to-Park) contacts. We pull rows from QSLTable that fall inside the activation's
- * time window AND match the park ref so the file contains only the activation's QSOs.
+ * QSO carries MY_SIG=POTA / MY_SIG_INFO=<park ref>. For multi-park activations (two-fers,
+ * three-fers, etc.) we generate one ADIF file per park — each containing the same QSOs but
+ * with MY_SIG_INFO set to that single park — and share all files in one intent.
  */
 object PotaAdifExporter {
 
@@ -39,16 +40,24 @@ object PotaAdifExporter {
         }
         scope.launch {
             try {
+                // Read all QSO rows for this activation. The DB stores the full
+                // comma-separated park string in my_sig_info, so we match on that.
                 val cursor = db.rawQuery(
                     "SELECT * FROM QSLTable WHERE my_sig = 'POTA' AND my_sig_info = ? " +
                         "ORDER BY qso_date, time_on",
                     arrayOf(activation.parkRef),
                 )
-                val sb = StringBuilder()
-                sb.append("FT8AF POTA Activation ${activation.parkRef}\n")
-                sb.append("<ADIF_VER:5>3.1.4 ")
-                sb.append("<PROGRAMID:5>FT8AF ")
-                sb.append("<EOH>\n")
+
+                // Collect QSO field values so we can write them into multiple files.
+                data class QsoRow(
+                    val call: String?, val grid: String?, val mode: String?,
+                    val band: String?, val freq: String?, val rstSent: String?,
+                    val rstRcvd: String?, val date: String?, val timeOn: String?,
+                    val timeOff: String?, val station: String?, val myGrid: String?,
+                    val mySig: String?, val sig: String?, val sigInfo: String?,
+                )
+
+                val rows = mutableListOf<QsoRow>()
                 cursor.use { c ->
                     val callIdx = c.getColumnIndex("call")
                     val gridIdx = c.getColumnIndex("gridsquare")
@@ -63,27 +72,21 @@ object PotaAdifExporter {
                     val stationIdx = c.getColumnIndex("station_callsign")
                     val myGridIdx = c.getColumnIndex("my_gridsquare")
                     val mySigIdx = c.getColumnIndex("my_sig")
-                    val mySigInfoIdx = c.getColumnIndex("my_sig_info")
                     val sigIdx = c.getColumnIndex("sig")
                     val sigInfoIdx = c.getColumnIndex("sig_info")
                     while (c.moveToNext()) {
-                        adifField(sb, "CALL", c.getString(callIdx))
-                        adifField(sb, "GRIDSQUARE", c.getString(gridIdx))
-                        adifField(sb, "MODE", c.getString(modeIdx))
-                        adifField(sb, "BAND", c.getString(bandIdx))
-                        adifField(sb, "FREQ", c.getString(freqIdx))
-                        adifField(sb, "RST_SENT", c.getString(rstSentIdx))
-                        adifField(sb, "RST_RCVD", c.getString(rstRcvdIdx))
-                        adifField(sb, "QSO_DATE", c.getString(dateIdx))
-                        adifField(sb, "TIME_ON", c.getString(timeOnIdx))
-                        adifField(sb, "TIME_OFF", c.getString(timeOffIdx))
-                        adifField(sb, "STATION_CALLSIGN", c.getString(stationIdx))
-                        adifField(sb, "MY_GRIDSQUARE", c.getString(myGridIdx))
-                        adifField(sb, "MY_SIG", c.getString(mySigIdx))
-                        adifField(sb, "MY_SIG_INFO", c.getString(mySigInfoIdx))
-                        adifField(sb, "SIG", c.getString(sigIdx))
-                        adifField(sb, "SIG_INFO", c.getString(sigInfoIdx))
-                        sb.append("<EOR>\n")
+                        rows.add(
+                            QsoRow(
+                                call = c.getString(callIdx), grid = c.getString(gridIdx),
+                                mode = c.getString(modeIdx), band = c.getString(bandIdx),
+                                freq = c.getString(freqIdx), rstSent = c.getString(rstSentIdx),
+                                rstRcvd = c.getString(rstRcvdIdx), date = c.getString(dateIdx),
+                                timeOn = c.getString(timeOnIdx), timeOff = c.getString(timeOffIdx),
+                                station = c.getString(stationIdx), myGrid = c.getString(myGridIdx),
+                                mySig = c.getString(mySigIdx), sig = c.getString(sigIdx),
+                                sigInfo = c.getString(sigInfoIdx),
+                            ),
+                        )
                     }
                 }
 
@@ -92,15 +95,58 @@ object PotaAdifExporter {
                     return@launch
                 }
                 val ts = SimpleDateFormat("yyyyMMdd-HHmm", Locale.US).format(Date(activation.startedAtMs))
-                val file = File(dir, "pota-${activation.parkRef}-$ts.adi")
-                file.writeText(sb.toString())
+                val parks = activation.parkRefs
 
-                val uri = FileProvider.getUriForFile(context, AUTHORITY, file)
-                val send = Intent(Intent.ACTION_SEND).apply {
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_STREAM, uri)
-                    putExtra(Intent.EXTRA_SUBJECT, "POTA activation ${activation.parkRef}")
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                // Write one ADIF file per park reference.
+                val files = parks.map { parkRef ->
+                    val sb = StringBuilder()
+                    sb.append("FT8AF POTA Activation $parkRef\n")
+                    sb.append("<ADIF_VER:5>3.1.4 ")
+                    sb.append("<PROGRAMID:5>FT8AF ")
+                    sb.append("<EOH>\n")
+                    for (r in rows) {
+                        adifField(sb, "CALL", r.call)
+                        adifField(sb, "GRIDSQUARE", r.grid)
+                        adifField(sb, "MODE", r.mode)
+                        adifField(sb, "BAND", r.band)
+                        adifField(sb, "FREQ", r.freq)
+                        adifField(sb, "RST_SENT", r.rstSent)
+                        adifField(sb, "RST_RCVD", r.rstRcvd)
+                        adifField(sb, "QSO_DATE", r.date)
+                        adifField(sb, "TIME_ON", r.timeOn)
+                        adifField(sb, "TIME_OFF", r.timeOff)
+                        adifField(sb, "STATION_CALLSIGN", r.station)
+                        adifField(sb, "MY_GRIDSQUARE", r.myGrid)
+                        adifField(sb, "MY_SIG", r.mySig)
+                        // Override MY_SIG_INFO to this single park (not the comma-separated value from DB).
+                        adifField(sb, "MY_SIG_INFO", parkRef)
+                        adifField(sb, "SIG", r.sig)
+                        adifField(sb, "SIG_INFO", r.sigInfo)
+                        sb.append("<EOR>\n")
+                    }
+                    val file = File(dir, "pota-$parkRef-$ts.adi")
+                    file.writeText(sb.toString())
+                    file
+                }
+
+                val uris = ArrayList(
+                    files.map { FileProvider.getUriForFile(context, AUTHORITY, it) },
+                )
+
+                val send = if (uris.size == 1) {
+                    Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_STREAM, uris[0])
+                        putExtra(Intent.EXTRA_SUBJECT, "POTA activation ${parks.first()}")
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                } else {
+                    Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+                        type = "text/plain"
+                        putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+                        putExtra(Intent.EXTRA_SUBJECT, "POTA activation ${activation.parkRefsDisplay}")
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
                 }
                 val chooser = Intent.createChooser(send, "Share POTA ADIF").apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -22,9 +23,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
@@ -38,6 +42,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -157,7 +162,7 @@ private fun ActivateTab() {
     val contacts by PotaSessionManager.activationQsos.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    var parkRef by rememberSaveable { mutableStateOf("") }
+    val parkRefs = remember { mutableStateListOf("") }
     var notes by rememberSaveable { mutableStateOf("") }
     var refreshKey by remember { mutableIntStateOf(0) }
 
@@ -179,15 +184,52 @@ private fun ActivateTab() {
             Card {
                 SectionTitle(stringResource(R.string.pota_start_activation))
                 Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = parkRef,
-                    onValueChange = { parkRef = it.uppercase().take(10) },
-                    label = { Text(stringResource(R.string.pota_park_reference_label)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
-                    colors = textFieldColors(),
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                parkRefs.forEachIndexed { index, ref ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        OutlinedTextField(
+                            value = ref,
+                            onValueChange = { parkRefs[index] = it.uppercase().take(10) },
+                            label = { Text(stringResource(R.string.pota_park_reference_label)) },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
+                            colors = textFieldColors(),
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (parkRefs.size > 1) {
+                            IconButton(onClick = { parkRefs.removeAt(index) }) {
+                                Icon(
+                                    Icons.Filled.Close,
+                                    contentDescription = stringResource(R.string.pota_remove_park),
+                                    tint = TextMuted,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            }
+                        }
+                    }
+                    if (index < parkRefs.lastIndex) Spacer(Modifier.height(4.dp))
+                }
+                if (parkRefs.size < 10) {
+                    Spacer(Modifier.height(4.dp))
+                    OutlinedButton(
+                        onClick = { parkRefs.add("") },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text(stringResource(R.string.pota_add_park), color = TextPrimary, fontSize = 13.sp)
+                    }
+                } else {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        stringResource(R.string.pota_max_parks_reached),
+                        color = TextMuted,
+                        fontSize = 11.sp,
+                        modifier = Modifier.padding(start = 4.dp),
+                    )
+                }
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = notes,
@@ -200,11 +242,11 @@ private fun ActivateTab() {
                 Spacer(Modifier.height(12.dp))
                 Button(
                     onClick = {
-                        val started = PotaSessionManager.start(parkRef, notes.ifBlank { null })
+                        val started = PotaSessionManager.start(parkRefs, notes.ifBlank { null })
                         if (started == null) {
                             Toast.makeText(context, context.getString(R.string.pota_enter_park_reference_first), Toast.LENGTH_SHORT).show()
                         } else {
-                            Toast.makeText(context, context.getString(R.string.pota_activating, started.parkRef), Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, context.getString(R.string.pota_activating, started.parkRefsDisplay), Toast.LENGTH_SHORT).show()
                         }
                     },
                     colors = ButtonDefaults.buttonColors(containerColor = Accent, contentColor = BgApp),
@@ -229,20 +271,27 @@ private fun ActivateTab() {
                         if (myCall.isBlank()) {
                             Toast.makeText(context, context.getString(R.string.pota_set_callsign_first), Toast.LENGTH_SHORT).show()
                         } else {
+                            val refs = activation!!.parkRefs
                             scope.launch {
-                                val ok = PotaClient.selfSpot(
-                                    activator = myCall,
-                                    spotter = myCall,
-                                    frequencyKhz = GeneralVariables.getBaseFrequency() / 1000.0,
-                                    mode = "FT8",
-                                    reference = activation!!.parkRef,
-                                    comments = "CQ POTA via FT8AF",
-                                )
-                                Toast.makeText(
-                                    context,
-                                    context.getString(if (ok) R.string.pota_self_spot_posted else R.string.pota_self_spot_failed),
-                                    Toast.LENGTH_SHORT,
-                                ).show()
+                                var successCount = 0
+                                for (ref in refs) {
+                                    val ok = PotaClient.selfSpot(
+                                        activator = myCall,
+                                        spotter = myCall,
+                                        frequencyKhz = GeneralVariables.getBaseFrequency() / 1000.0,
+                                        mode = "FT8",
+                                        reference = ref,
+                                        comments = "CQ POTA via FT8AF",
+                                    )
+                                    if (ok) successCount++
+                                }
+                                val msg = if (successCount == refs.size) {
+                                    if (refs.size == 1) context.getString(R.string.pota_self_spot_posted)
+                                    else context.getString(R.string.pota_spotted_n_parks, successCount)
+                                } else {
+                                    context.getString(R.string.pota_self_spot_failed)
+                                }
+                                Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
                             }
                         }
                     },
@@ -272,7 +321,42 @@ private fun ActiveActivationCard(
     onSelfSpot: () -> Unit,
 ) {
     Card {
-        SectionTitle(stringResource(R.string.pota_active_park, activation.parkRef))
+        val parks = activation.parkRefs
+        if (parks.size <= 3) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    stringResource(R.string.pota_status_active).uppercase(),
+                    color = Accent,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                )
+                for (ref in parks) ParkPill(ref)
+            }
+        } else {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    stringResource(R.string.pota_status_active).uppercase(),
+                    color = Accent,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                )
+                for (ref in parks.take(3)) ParkPill(ref)
+                Text(
+                    stringResource(R.string.pota_parks_more, parks.size - 3),
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                )
+            }
+        }
         Spacer(Modifier.height(8.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -544,7 +628,13 @@ private fun HistoryRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                ParkPill(row.parkRef)
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.weight(1f, fill = false),
+                ) {
+                    for (ref in row.parkRefs) ParkPill(ref)
+                }
                 Spacer(Modifier.width(6.dp))
                 Text(
                     if (row.isActive) stringResource(R.string.pota_status_active) else stringResource(R.string.pota_qso_count, row.qsoCount),

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
@@ -314,6 +314,7 @@ private fun ActivateTab() {
     }
 }
 
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
 @Composable
 private fun ActiveActivationCard(
     activation: PotaActivation,
@@ -597,6 +598,7 @@ private fun HistoryTab(mainViewModel: MainViewModel) {
     }
 }
 
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
 @Composable
 private fun HistoryRow(
     row: PotaActivation,

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -249,6 +249,11 @@
     <string name="pota_qso_count">%1$d QSO</string>
     <string name="pota_share_adif">Share ADIF</string>
     <string name="pota_open_pota_app">Open pota.app</string>
+    <string name="pota_add_park">Add park</string>
+    <string name="pota_remove_park">Remove</string>
+    <string name="pota_max_parks_reached">Maximum of 10 parks reached</string>
+    <string name="pota_spotted_n_parks">Spotted at %1$d parks</string>
+    <string name="pota_parks_more">+%1$d more</string>
 
     <!-- ===== Debug log / Map / Waterfall ===== -->
     <string name="debug_title">Debug</string>
@@ -356,6 +361,8 @@
     <string name="settings_highlight_pota_desc">Highlight spotted POTA activators; new parks stand out</string>
     <string name="settings_highlight_worked">Worked Before</string>
     <string name="settings_highlight_worked_desc">Tag stations already in your log</string>
+    <string name="settings_distance_unit">Distance in Miles</string>
+    <string name="settings_distance_unit_desc">Show distances in miles instead of kilometers</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">Exact Callsigns</string>


### PR DESCRIPTION
## Summary
- Activators can now enter up to 10 park references for overlapping parks (two-fers, three-fers, etc.)
- ADIF export generates one `.adi` file per park, each with the correct `MY_SIG_INFO`, shared in a single intent
- Self-spots are posted once per park reference

## Changes
- **PotaModels.kt**: Added `parkRefs` and `parkRefsDisplay` computed properties to `PotaActivation`
- **PotaSessionManager.kt**: `start()` now accepts `List<String>`, validates/deduplicates/limits to 10, stores comma-joined in DB
- **PotaAdifExporter.kt**: Generates one ADIF per park with `ACTION_SEND_MULTIPLE`; single-park behavior unchanged
- **PotaScreen.kt**: Multi-park form with add/remove buttons, `FlowRow` park pills on active card and history, per-park self-spotting
- **strings_compose.xml**: Added `pota_add_park`, `pota_remove_park`, `pota_max_parks_reached`, `pota_spotted_n_parks`, `pota_parks_more`

No database schema migration needed — `park_ref TEXT` already stores any string.

## Test plan
- [ ] Start activation with 1 park — behavior identical to before
- [ ] Start activation with 2-3 parks — all parks shown as pills in active card
- [ ] Make QSOs — verify `my_sig_info` in DB contains comma-separated parks
- [ ] Self-spot — verify one API call per park
- [ ] End activation & share ADIF — one `.adi` file per park, each with correct `MY_SIG_INFO`
- [ ] History tab — multi-park activations show all park pills
- [ ] Resume — kill app during multi-park activation, reopen, verify all parks restored
- [ ] Max limit — UI prevents adding more than 10 parks

🤖 Generated with [Claude Code](https://claude.com/claude-code)