### PR TITLE
Add distance unit setting (miles / kilometers)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -43,6 +43,8 @@ public class GeneralVariables {
     public static boolean enableQRZ = false;//Whether QRZ auto-sync is enabled
     public static boolean enablePskReporter = true;//Whether PSKReporter spot upload is enabled
 
+    public static boolean distanceInMiles = true;//Display distances in miles (true) or kilometers (false)
+
     public static boolean deepDecodeMode = false;//Whether deep decode mode is enabled
 
     public static boolean audioOutput32Bit = true;//Audio output type: true=float, false=int16

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/count/CountDbOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/count/CountDbOpr.java
@@ -116,17 +116,18 @@ public class CountDbOpr {
                 cursor.close();
 
                 if ((max>-1)&&(min<6553500f)){
-                    values.add(new CountValue((int) Math.round(max),String.format(
+                    values.add(new CountValue((int) Math.round(MaidenheadGrid.convertDist(max)),String.format(
                             GeneralVariables.getStringFromResource(R.string.maximum_distance)
                             ,getQSLInfo(maxGrid))));
-                    values.add(new CountValue((int) Math.round(min),String.format(
+                    values.add(new CountValue((int) Math.round(MaidenheadGrid.convertDist(min)),String.format(
                             GeneralVariables.getStringFromResource(R.string.minimum_distance)
                             ,getQSLInfo(minGrid))));
                 }
             }
 
            String info=String.format(GeneralVariables.getStringFromResource(R.string.count_distance_info)
-                   ,maxDistance,maxDistanceGrid,minDistance,minDistanceGrid);
+                   ,MaidenheadGrid.convertDist(maxDistance),MaidenheadGrid.getDistUnitLabel(),maxDistanceGrid
+                   ,MaidenheadGrid.convertDist(minDistance),MaidenheadGrid.getDistUnitLabel(),minDistanceGrid);
 
             if (afterCount!=null &&(maxDistance>0)&&(minDistance<6553500f)){
                 afterCount.countInformation(new CountInfo(info

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2560,6 +2560,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.highlightPota = result.equals("1");
                 }
 
+                if (name.equalsIgnoreCase("distanceInMiles")) {
+                    GeneralVariables.distanceInMiles = !result.equals("0");
+                }
+
             }
 
             cursor.close();

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/maidenhead/MaidenheadGrid.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/maidenhead/MaidenheadGrid.java
@@ -292,29 +292,45 @@ public class MaidenheadGrid {
         }
     }
 
+    private static final double KM_TO_MILES = 0.621371;
+
     /**
-     * Calculate distance between two grids
-     *
-     * @param mGrid1 grid
-     * @param mGrid2 grid
-     * @return distance
+     * Convert a distance in km to the user's preferred unit (miles or km).
      */
+    public static double convertDist(double distKm) {
+        return GeneralVariables.distanceInMiles ? distKm * KM_TO_MILES : distKm;
+    }
+
+    /**
+     * Return the abbreviated unit label for the current distance setting.
+     */
+    public static String getDistUnitLabel() {
+        return GeneralVariables.distanceInMiles ? "mi" : "km";
+    }
+
+    /**
+     * Format a distance (given in km) as a rounded string with the user's preferred unit.
+     */
+    @SuppressLint("DefaultLocale")
+    public static String formatDist(double distKm) {
+        return String.format("%.0f %s", convertDist(distKm), getDistUnitLabel());
+    }
+
     @SuppressLint("DefaultLocale")
     public static String getDistStr(String mGrid1, String mGrid2) {
         double dist = getDist(mGrid1, mGrid2);
         if (dist == 0) {
             return "";
         } else {
-            return String.format(GeneralVariables.getStringFromResource(R.string.distance), dist);
+            return formatDist(dist);
         }
     }
     public static String getDistLatLngStr(LatLng latLng1,LatLng latLng2){
-        return String.format(GeneralVariables.getStringFromResource(R.string.distance), getDist(latLng1,latLng2));
-
+        return formatDist(getDist(latLng1,latLng2));
     }
 
     /**
-     * Calculate distance between two grids, displaying kilometers in English
+     * Calculate distance between two grids, displaying in user's preferred unit
      *
      * @param mGrid1 grid
      * @param mGrid2 grid
@@ -326,7 +342,7 @@ public class MaidenheadGrid {
         if (dist == 0) {
             return "";
         } else {
-            return String.format("%.0f km", dist);
+            return formatDist(dist);
         }
     }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -386,7 +386,7 @@ private fun computeDistanceText(message: Ft8Message): String {
     if (myGrid.isNullOrEmpty() || theirGrid.isNullOrEmpty()) return ""
     return try {
         val dist = MaidenheadGrid.getDist(myGrid, theirGrid)
-        if (dist > 0) "${String.format("%.0f", dist)} km" else ""
+        if (dist > 0) MaidenheadGrid.formatDist(dist) else ""
     } catch (_: Exception) {
         ""
     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
@@ -1208,7 +1208,7 @@ private fun SelectedStationCard(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                InfoChip("${String.format("%.0f", distKm)} km", stringResource(R.string.map_info_distance))
+                InfoChip(MaidenheadGrid.formatDist(distKm), stringResource(R.string.map_info_distance))
                 InfoChip("${String.format("%.0f", bearing)}\u00B0", stringResource(R.string.map_info_bearing))
                 InfoChip("${station.snr} dB", stringResource(R.string.map_info_snr))
             }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -137,6 +137,7 @@ fun SettingsScreen(
     var highlightNewBand by remember { mutableStateOf(GeneralVariables.highlightNewBand) }
     var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
     var highlightPota by remember { mutableStateOf(GeneralVariables.highlightPota) }
+    var distanceInMiles by remember { mutableStateOf(GeneralVariables.distanceInMiles) }
 
     // Callsign blocklist (comma-separated entries) + decode display filters
     var blockedExact by remember { mutableStateOf(GeneralVariables.getBlockedExactCallsigns()) }
@@ -1431,6 +1432,19 @@ fun SettingsScreen(
                                 GeneralVariables.highlightWorked = checked
                                 mainViewModel.databaseOpr.writeConfig(
                                     "highlightWorked", if (checked) "1" else "0", null,
+                                )
+                            },
+                        )
+                        SectionDivider()
+                        SettingsRow(
+                            label = stringResource(R.string.settings_distance_unit),
+                            description = stringResource(R.string.settings_distance_unit_desc),
+                            toggle = distanceInMiles,
+                            onToggleChange = { checked ->
+                                distanceInMiles = checked
+                                GeneralVariables.distanceInMiles = checked
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "distanceInMiles", if (checked) "1" else "0", null,
                                 )
                             },
                         )

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -340,6 +340,8 @@
     <string name="settings_highlight_pota_desc">Resalta activadores POTA reportados; los parques nuevos destacan</string>
     <string name="settings_highlight_worked">Trabajado antes</string>
     <string name="settings_highlight_worked_desc">Marca estaciones que ya están en tu diario</string>
+    <string name="settings_distance_unit">Distancia en millas</string>
+    <string name="settings_distance_unit_desc">Mostrar distancias en millas en lugar de kilómetros</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">Indicativos exactos</string>

--- a/ft8cn/app/src/main/res/values-fr/strings.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings.xml
@@ -317,7 +317,7 @@
     <string name="callsign_info">Indicatif : %s\nEmplacement : %s\nZone CQ : %d\nZone ITU : %d\nContinent : %s\nLongitude et latitude : %.2f,%.2f\nFuseau horaire : %.0f\nPréfixe DXCC : %s</string>
     <string name="maximum_distance">Distance maximale\n\n%s</string>
     <string name="minimum_distance">Distance minimale\n\n%s</string>
-    <string name="count_distance_info">Distance maximale : %.0f km (%s)\nDistance minimale : %.0f km (%s)</string>
+    <string name="count_distance_info">Distance maximale : %.0f %s (%s)\nDistance minimale : %.0f %s (%s)</string>
     <string name="distance_statistics">Statistiques de distance</string>
     <string name="dxcc_image">dxcc</string>
     <string name="cqzone">cq zone</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -340,6 +340,8 @@
     <string name="settings_highlight_pota_desc">Mettre en évidence les activateurs POTA repérés ; les nouveaux parcs ressortent</string>
     <string name="settings_highlight_worked">Déjà contacté</string>
     <string name="settings_highlight_worked_desc">Marquer les stations déjà présentes dans votre journal</string>
+    <string name="settings_distance_unit">Distance en miles</string>
+    <string name="settings_distance_unit_desc">Afficher les distances en miles au lieu de kilomètres</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">Indicatifs exacts</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -340,6 +340,8 @@
     <string name="settings_highlight_pota_desc">スポットされた POTA アクティベーターをハイライト。新規公園を目立たせます</string>
     <string name="settings_highlight_worked">交信済</string>
     <string name="settings_highlight_worked_desc">すでにログにある局にタグを付けます</string>
+    <string name="settings_distance_unit">マイル表示</string>
+    <string name="settings_distance_unit_desc">キロメートルの代わりにマイルで距離を表示</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">完全一致コールサイン</string>

--- a/ft8cn/app/src/main/res/values-ru/strings.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings.xml
@@ -317,7 +317,7 @@
     <string name="callsign_info">Позывной:%s\nМестоположение:%s\nCQ-зона:%d\nITU-зона:%d\nКонтинент:%s\nШирота и долгота:%.2f,%.2f\nЧасовой пояс:%.0f\nПрефикс DXCC:%s</string>
     <string name="maximum_distance">Максимальное расстояние\n\n%s</string>
     <string name="minimum_distance">Минимальное расстояние\n\n%s</string>
-    <string name="count_distance_info">Максимальное расстояние:%.0f км (%s)\nМинимальное расстояние:%.0f км (%s)</string>
+    <string name="count_distance_info">Максимальное расстояние:%.0f %s (%s)\nМинимальное расстояние:%.0f %s (%s)</string>
     <string name="distance_statistics">Статистика расстояний</string>
     <string name="dxcc_image">dxcc</string>
     <string name="cqzone">cq zone</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -340,6 +340,8 @@
     <string name="settings_highlight_pota_desc">Подсвечивать заспоченных активаторов POTA; новые парки выделяются</string>
     <string name="settings_highlight_worked">Уже проведён</string>
     <string name="settings_highlight_worked_desc">Отмечать станции, уже имеющиеся в журнале</string>
+    <string name="settings_distance_unit">Расстояние в милях</string>
+    <string name="settings_distance_unit_desc">Показывать расстояния в милях вместо километров</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">Точные позывные</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings.xml
@@ -317,7 +317,7 @@
     <string name="callsign_info">呼号：%s\n地点：%s\nCQ 区：%d\nITU 区：%d\n洲：%s\n经纬度：%.2f,%.2f\n时区：%.0f\nDXCC 前缀：%s</string>
     <string name="maximum_distance">最远距离\n\n%s</string>
     <string name="minimum_distance">最近距离\n\n%s</string>
-    <string name="count_distance_info">最远距离：%.0f 公里 (%s)\n最近距离：%.0f 公里 (%s)</string>
+    <string name="count_distance_info">最远距离：%.0f %s (%s)\n最近距离：%.0f %s (%s)</string>
     <string name="distance_statistics">距离统计</string>
     <string name="dxcc_image">DXCC</string>
     <string name="cqzone">CQ Zone</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -340,6 +340,8 @@
     <string name="settings_highlight_pota_desc">高亮显示被点位的 POTA 激活者；新公园更醒目</string>
     <string name="settings_highlight_worked">此前已通联</string>
     <string name="settings_highlight_worked_desc">标记已在您日志中的电台</string>
+    <string name="settings_distance_unit">以英里显示距离</string>
+    <string name="settings_distance_unit_desc">以英里代替公里显示距离</string>
 
     <!-- ===== 设置：呼号屏蔽列表 ===== -->
     <string name="settings_exact_callsigns">精确呼号</string>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -340,6 +340,8 @@
     <string name="settings_highlight_pota_desc">醒目標示被點位的 POTA 啟動者；新公園特別突顯</string>
     <string name="settings_highlight_worked">先前通聯過</string>
     <string name="settings_highlight_worked_desc">標記已在您日誌中的電台</string>
+    <string name="settings_distance_unit">以英里顯示距離</string>
+    <string name="settings_distance_unit_desc">以英里代替公里顯示距離</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">完整呼號</string>

--- a/ft8cn/app/src/main/res/values/strings.xml
+++ b/ft8cn/app/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="callsign_info">Callsign:%s\nLocation:%s\nCQ zone:%d\nITU zone:%d\nContinent:%s\nLongitude and latitude:%.2f,%.2f\nTime zone:%.0f\nDxcc prefix:%s</string>
     <string name="maximum_distance">Maximum distance\n\n%s</string>
     <string name="minimum_distance">Nearest distance\n\n%s</string>
-    <string name="count_distance_info">Maximum distance:%.0f km (%s)\nNearest distance:%.0f km (%s)</string>
+    <string name="count_distance_info">Maximum distance:%.0f %s (%s)\nNearest distance:%.0f %s (%s)</string>
     <string name="distance_statistics">Distance statistics</string>
     <string name="dxcc_image">dxcc</string>
     <string name="cqzone">cq zone</string>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -356,6 +356,8 @@
     <string name="settings_highlight_pota_desc">Highlight spotted POTA activators; new parks stand out</string>
     <string name="settings_highlight_worked">Worked Before</string>
     <string name="settings_highlight_worked_desc">Tag stations already in your log</string>
+    <string name="settings_distance_unit">Distance in Miles</string>
+    <string name="settings_distance_unit_desc">Show distances in miles instead of kilometers</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">Exact Callsigns</string>


### PR DESCRIPTION
## Summary
- Adds a **Distance in Miles** toggle to Settings > Decode Highlights (defaults to ON)
- All internal calculations remain in km; conversion to miles happens at display time via new `MaidenheadGrid.formatDist()` / `convertDist()` helpers
- Updates all distance display sites: decode list, map popup, statistics charts, ADIF export, and legacy XML adapters

## Changed files
- `GeneralVariables.java` — new `distanceInMiles` boolean
- `MaidenheadGrid.java` — `KM_TO_MILES`, `convertDist()`, `getDistUnitLabel()`, `formatDist()`; updated `getDistStr`/`getDistLatLngStr`/`getDistStrEN`
- `DecodeRow.kt`, `MapScreen.kt` — use `formatDist()` instead of hardcoded "km"
- `CountDbOpr.java` — convert chart values + dynamic unit label in info string
- `DatabaseOpr.java` — persist/restore setting
- `SettingsScreen.kt` — new toggle row
- String resources for en, zh-CN, zh-TW, fr, ru, es, ja

## Test plan
- [ ] Open Settings — confirm "Distance in Miles" toggle appears, defaulted ON
- [ ] View decode list — distances show "mi"
- [ ] Toggle OFF — distances switch to "km"
- [ ] Check map popup — distance respects setting
- [ ] View statistics — max/min distances use correct unit
- [ ] Restart app — setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)