### PR TITLE
Fix leftover celebration ring/dot after QSO animation

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/QsoCelebration.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/QsoCelebration.kt
@@ -47,19 +47,35 @@ fun QsoCelebration(
     // 0f = idle, (0,1] = playing
     var progress by remember { mutableStateOf(0f) }
 
+    // `triggerAt` mirrors a LiveData that a sibling effect resets to null right after
+    // a QSO completes. Keying the animation directly on `triggerAt` lets that null
+    // transition cancel the coroutine mid-flight, freezing a partial frame (the
+    // starting ring + centered particle cluster) painted on screen forever — the
+    // reported "leftover circle and dot" bug. Translate non-null triggers into a
+    // monotonic token instead, so the null reset neither cancels nor restarts a play.
+    var playToken by remember { mutableStateOf(0) }
     LaunchedEffect(triggerAt) {
-        if (triggerAt == null) return@LaunchedEffect
-        haptics.success()
-        progress = 0.0001f
-        val start = withFrameNanos { it }
-        while (true) {
-            val now = withFrameNanos { it }
-            val elapsed = (now - start) / 1_000_000L
-            val p = (elapsed.toFloat() / DURATION_MS.toFloat()).coerceIn(0f, 1f)
-            progress = p
-            if (p >= 1f) break
+        if (triggerAt != null) playToken++
+    }
+
+    LaunchedEffect(playToken) {
+        if (playToken == 0) return@LaunchedEffect
+        // Reset in a finally so a restart (or any cancellation) can never leave a
+        // frozen frame on screen.
+        try {
+            haptics.success()
+            progress = 0.0001f
+            val start = withFrameNanos { it }
+            while (true) {
+                val now = withFrameNanos { it }
+                val elapsed = (now - start) / 1_000_000L
+                val p = (elapsed.toFloat() / DURATION_MS.toFloat()).coerceIn(0f, 1f)
+                progress = p
+                if (p >= 1f) break
+            }
+        } finally {
+            progress = 0f
         }
-        progress = 0f
     }
 
     if (progress <= 0f) return


### PR DESCRIPTION
## Problem

After the QSO celebration animation plays, a faint **ring and a dot remain painted in the center** of the Decode screen (reported by a user, and reproduced locally). It's intermittent.

![bug](leftover circle and dot in center)

## Root cause

`QsoCelebration`'s animation was a `LaunchedEffect(triggerAt)`, and `triggerAt` mirrors the `qsoCompletedAt` LiveData. A sibling effect in `FT8USApp.kt` resets that LiveData to `null` immediately after a QSO completes (to stop replay on recomposition). That null transition changes the `LaunchedEffect` key, which **cancels the running animation coroutine mid-flight**. Cancellation throws out of the `while` frame loop *before* the `progress = 0f` cleanup line runs, so `progress` freezes at a tiny value.

The Canvas then keeps redrawing the starting frame forever:
- the **circle** = the ring stroke at its starting radius (`0.12 * minDimension`)
- the **dot** = the 12 particles still bunched at center (`easeOutCubic(p) ≈ 0`)

It's intermittent because it depends on whether the null lands before or after the 900 ms animation finishes on its own.

## Fix

1. Translate non-null triggers into a monotonic `playToken` and key the animation on that instead of `triggerAt`. The null reset now neither cancels nor restarts a play, so the celebration reliably runs its full duration.
2. Wrap the animation in `try/finally` so `progress` always resets to `0` on any cancellation/restart — making a frozen leftover frame impossible.

## Testing

- `:app:compileDebugKotlin` — BUILD SUCCESSFUL.
- Not yet installed on a device (none connected at PR time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)