### PR TITLE
Fix TX volume slider having no effect on USB-routed audio (overdrive at 0%)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -21,7 +21,6 @@ import com.bg7yoz.ft8cn.wave.UsbAudioDevice;
 import com.bg7yoz.ft8cn.wave.UsbAudioNative;
 
 import androidx.lifecycle.MutableLiveData;
-import androidx.lifecycle.Observer;
 
 import com.bg7yoz.ft8cn.FT8Common;
 import com.bg7yoz.ft8cn.Ft8Message;
@@ -141,15 +140,9 @@ public class FT8TransmitSignal {
         setActivated(false);
 
 
-        // observe volume setting changes
-        GeneralVariables.mutableVolumePercent.observeForever(new Observer<Float>() {
-            @Override
-            public void onChanged(Float aFloat) {
-                if (audioTrack != null) {
-                    audioTrack.setVolume(aFloat);
-                }
-            }
-        });
+        // Volume is baked into the TX samples per-cycle (see playFT8Signal / playViaUsbAudio),
+        // so there is no live mid-cycle setVolume() observer here: a volume change takes effect
+        // on the next cycle. This matches the ALC auto-volume model (MeterProtectionController).
 
         utcTimer = new UtcTimer(FT8Common.FT8_SLOT_TIME_M, false, new OnUtcTimer() {
             @Override
@@ -447,10 +440,12 @@ public class FT8TransmitSignal {
         // currently have no way to tell from debug.log which one fired.
         GeneralVariables.fileLog(String.format(
                 "playFT8Signal: TX path branch: audioOutputDeviceId=%d "
-                        + "usbAudioOutputVidPid=%04X:%04X",
+                        + "usbAudioOutputVidPid=%04X:%04X volume=%.0f%% autoVolume=%b",
                 GeneralVariables.audioOutputDeviceId,
                 GeneralVariables.usbAudioOutputVendorId,
-                GeneralVariables.usbAudioOutputProductId));
+                GeneralVariables.usbAudioOutputProductId,
+                GeneralVariables.volumePercent * 100f,
+                GeneralVariables.autoVolumeEnabled));
         if (GeneralVariables.audioOutputDeviceId == -1
                 && GeneralVariables.usbAudioOutputVendorId != 0) {
             GeneralVariables.fileLog("playFT8Signal: using USB audio (direct) output");
@@ -493,14 +488,27 @@ public class FT8TransmitSignal {
         if (skipSamples >= buffer.length) skipSamples = 0;
         int playLength = buffer.length - skipSamples;
 
+        // Apply volume in software, exactly like the USB-direct path (playViaUsbAudio).
+        // We do NOT rely on AudioTrack.setVolume() for level control: when the track is
+        // routed to a USB Audio Class device (the rig's sound card), many Android builds
+        // delegate level to the device's hardware volume and the per-track setVolume() is
+        // a no-op, so the samples leave at full scale and the rig overdrives regardless of
+        // the slider (even at 0%). Baking the gain into the samples here makes the slider
+        // behave identically on every output route.
+        float vol = GeneralVariables.volumePercent;
+        float[] volumeAdjusted = new float[playLength];
+        for (int i = 0; i < playLength; i++) {
+            volumeAdjusted[i] = buffer[skipSamples + i] * vol;
+        }
+
         // distinguish between 32-bit float and integer
         int writeResult;
         if (GeneralVariables.audioOutput32Bit) {
-            writeResult = audioTrack.write(buffer, skipSamples, playLength
+            writeResult = audioTrack.write(volumeAdjusted, 0, playLength
                     , AudioTrack.WRITE_NON_BLOCKING);
         } else {
-            short[] audio_data = float2Short(buffer);
-            writeResult = audioTrack.write(audio_data, skipSamples, playLength
+            short[] audio_data = float2Short(volumeAdjusted);
+            writeResult = audioTrack.write(audio_data, 0, playLength
                     , AudioTrack.WRITE_NON_BLOCKING);
         }
 
@@ -532,7 +540,9 @@ public class FT8TransmitSignal {
         });
         if (audioTrack != null) {
             audioTrack.play();
-            audioTrack.setVolume(GeneralVariables.volumePercent);// set playback volume
+            // Volume is baked into the samples above; keep the track at unity so we don't
+            // double-attenuate on routes where setVolume() does work (e.g. phone speaker).
+            audioTrack.setVolume(1.0f);
         }
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -119,7 +119,15 @@ public class FT8TransmitSignal {
     private final DoTransmitRunnable doTransmitRunnable = new DoTransmitRunnable(this);
 
     static {
-        System.loadLibrary("ft8cn");
+        try {
+            System.loadLibrary("ft8cn");
+        } catch (UnsatisfiedLinkError e) {
+            // Best-effort load: JVM unit tests don't have libft8cn.so on
+            // java.library.path. The native methods themselves will throw if
+            // actually invoked without the library; the pure-Java helpers on
+            // this class (applyVolume, float2Short) stay available either way.
+            Log.w(TAG, "ft8cn native library not loaded: " + e.getMessage());
+        }
     }
 
     /**
@@ -346,13 +354,38 @@ public class FT8TransmitSignal {
     }
 
     /**
+     * Scale a slice of the generated waveform by the TX volume, returning a new
+     * buffer of exactly {@code playLength} samples.
+     *
+     * <p>This is the single source of truth for TX level. Both output paths use
+     * it: the AudioTrack path (because {@code AudioTrack.setVolume()} is a no-op
+     * when the track is routed to a USB Audio Class device, so the gain must be
+     * baked into the samples) and the USB-direct path. Pure function, no Android
+     * or native dependencies — covered by unit tests.
+     *
+     * @param source     full generated waveform
+     * @param skipSamples leading samples to drop (late-start trim); clamped to 0
+     * @param playLength number of samples to emit (source.length - skipSamples)
+     * @param volume     gain 0.0-1.0; 0 yields digital silence
+     * @return new float[playLength] of scaled samples
+     */
+    static float[] applyVolume(float[] source, int skipSamples, int playLength, float volume) {
+        if (skipSamples < 0) skipSamples = 0;
+        float[] out = new float[playLength];
+        for (int i = 0; i < playLength; i++) {
+            out[i] = source[skipSamples + i] * volume;
+        }
+        return out;
+    }
+
+    /**
      * Convert 32-bit float to 16-bit integer for maximum compatibility;
      * some sound cards do not support 32-bit float.
      *
      * @param buffer 32-bit float audio
      * @return 16-bit integer
      */
-    private short[] float2Short(float[] buffer) {
+    static short[] float2Short(float[] buffer) {
         short[] temp = new short[buffer.length + 8];// extra 8 zero-padded samples for QP-7C RP2040 audio detection compatibility
         for (int i = 0; i < buffer.length; i++) {
             float x = buffer[i];
@@ -495,11 +528,8 @@ public class FT8TransmitSignal {
         // a no-op, so the samples leave at full scale and the rig overdrives regardless of
         // the slider (even at 0%). Baking the gain into the samples here makes the slider
         // behave identically on every output route.
-        float vol = GeneralVariables.volumePercent;
-        float[] volumeAdjusted = new float[playLength];
-        for (int i = 0; i < playLength; i++) {
-            volumeAdjusted[i] = buffer[skipSamples + i] * vol;
-        }
+        float[] volumeAdjusted = applyVolume(buffer, skipSamples, playLength,
+                GeneralVariables.volumePercent);
 
         // distinguish between 32-bit float and integer
         int writeResult;
@@ -624,11 +654,9 @@ public class FT8TransmitSignal {
         if (skipSamples >= buffer.length) skipSamples = 0;
         int playLength = buffer.length - skipSamples;
 
-        // Apply volume
-        float[] volumeAdjusted = new float[playLength];
-        for (int i = 0; i < playLength; i++) {
-            volumeAdjusted[i] = buffer[skipSamples + i] * GeneralVariables.volumePercent;
-        }
+        // Apply volume (shared with the AudioTrack path)
+        float[] volumeAdjusted = applyVolume(buffer, skipSamples, playLength,
+                GeneralVariables.volumePercent);
 
         GeneralVariables.fileLog(String.format(
                 "playViaUsbAudio: calling writeAudio playLength=%d rate=%d",

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
@@ -1,0 +1,115 @@
+package com.bg7yoz.ft8cn.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for the two pure audio helpers on {@link FT8TransmitSignal} that
+ * shape the outgoing TX waveform:
+ *   - {@link FT8TransmitSignal#applyVolume(float[], int, int, float)} — the
+ *     software volume scaling that both the AudioTrack and USB-direct output
+ *     paths now share. This is the fix for the rig overdriving regardless of
+ *     the slider (AudioTrack.setVolume() is a no-op on USB audio routes), so a
+ *     volume of 0 MUST produce digital silence.
+ *   - {@link FT8TransmitSignal#float2Short(float[])} — float→16-bit PCM
+ *     conversion with hard clipping and the 8-sample zero tail used for
+ *     RP2040 audio-detection compatibility.
+ *
+ * Plain JUnit: FT8TransmitSignal's static initialiser swallows the
+ * {@code System.loadLibrary("ft8cn")} UnsatisfiedLinkError, so the class loads
+ * on the bare JVM. Neither helper touches JNI or Android framework classes.
+ */
+public class FT8TransmitSignalTest {
+
+    private static final float TOL = 1e-6f;
+
+    // ---- applyVolume --------------------------------------------------------
+
+    @Test
+    public void applyVolume_unityGain_isIdentity() {
+        float[] src = {-1.0f, -0.25f, 0.0f, 0.5f, 1.0f};
+        float[] out = FT8TransmitSignal.applyVolume(src, 0, src.length, 1.0f);
+        assertThat(out).usingTolerance(TOL).containsExactly(src).inOrder();
+    }
+
+    @Test
+    public void applyVolume_zeroGain_isDigitalSilence() {
+        // The whole point of the bug fix: slider at 0% must mute, not overdrive.
+        float[] src = {-1.0f, -0.5f, 0.3f, 0.9f, 1.0f};
+        float[] out = FT8TransmitSignal.applyVolume(src, 0, src.length, 0.0f);
+        for (float v : out) {
+            // Negative inputs * 0 produce -0.0f; isWithin treats +0.0/-0.0 as silence.
+            assertThat(v).isWithin(0.0f).of(0.0f);
+        }
+        assertThat(out).hasLength(src.length);
+    }
+
+    @Test
+    public void applyVolume_halfGain_scalesEverySample() {
+        float[] src = {-1.0f, 0.0f, 0.5f, 1.0f};
+        float[] out = FT8TransmitSignal.applyVolume(src, 0, src.length, 0.5f);
+        assertThat(out).usingTolerance(TOL)
+                .containsExactly(new float[]{-0.5f, 0.0f, 0.25f, 0.5f}).inOrder();
+    }
+
+    @Test
+    public void applyVolume_honoursSkipSamples() {
+        // skipSamples drops leading samples (late-start trim); output is the tail.
+        float[] src = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f};
+        float[] out = FT8TransmitSignal.applyVolume(src, 2, src.length - 2, 1.0f);
+        assertThat(out).usingTolerance(TOL)
+                .containsExactly(new float[]{0.3f, 0.4f, 0.5f}).inOrder();
+    }
+
+    @Test
+    public void applyVolume_negativeSkip_isClampedToZero() {
+        float[] src = {0.1f, 0.2f, 0.3f};
+        float[] out = FT8TransmitSignal.applyVolume(src, -5, src.length, 1.0f);
+        assertThat(out).usingTolerance(TOL)
+                .containsExactly(new float[]{0.1f, 0.2f, 0.3f}).inOrder();
+    }
+
+    @Test
+    public void applyVolume_outputLengthIsPlayLength() {
+        float[] src = new float[10];
+        float[] out = FT8TransmitSignal.applyVolume(src, 3, 7, 0.8f);
+        assertThat(out).hasLength(7);
+    }
+
+    // ---- float2Short --------------------------------------------------------
+
+    @Test
+    public void float2Short_appendsEightZeroSamples() {
+        short[] out = FT8TransmitSignal.float2Short(new float[]{0.0f, 0.0f});
+        assertThat(out).hasLength(2 + 8);
+        for (int i = 2; i < out.length; i++) {
+            assertThat((int) out[i]).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void float2Short_emptyInput_isJustTheZeroTail() {
+        short[] out = FT8TransmitSignal.float2Short(new float[0]);
+        assertThat(out).hasLength(8);
+        for (short s : out) {
+            assertThat((int) s).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void float2Short_scalesFullScaleAndMidScale() {
+        short[] out = FT8TransmitSignal.float2Short(new float[]{1.0f, -1.0f, 0.0f, 0.5f});
+        assertThat((int) out[0]).isEqualTo(32767);   // +1.0 * 32767
+        assertThat((int) out[1]).isEqualTo(-32767);  // -1.0 * 32767
+        assertThat((int) out[2]).isEqualTo(0);
+        assertThat((int) out[3]).isEqualTo(16383);   // (short)(0.5 * 32767.0) truncates
+    }
+
+    @Test
+    public void float2Short_clipsOutOfRangeInput() {
+        short[] out = FT8TransmitSignal.float2Short(new float[]{2.5f, -3.0f});
+        assertThat((int) out[0]).isEqualTo(32767);   // clipped to +1.0
+        assertThat((int) out[1]).isEqualTo(-32767);  // clipped to -1.0
+    }
+}


### PR DESCRIPTION
## Problem

A user reported: *"Volume control doesn't seem to be working on my phone. Slider moves but radio is overdriving at 0%."*

The TX volume slider moves (the UI value changes), but the audio reaching the rig stays at full level — the radio overdrives even with the slider at 0%.

## Root cause

There are two TX output paths and they applied volume differently:

- **USB-direct** (`playViaUsbAudio`) multiplies the float samples by `volumePercent` in software — reliable; 0% = true silence.
- **AudioTrack** wrote the samples **unscaled** and applied volume only via `AudioTrack.setVolume()`.

When an `AudioTrack` is routed to a **USB Audio Class device** (the rig's USB sound card), many Android builds delegate level control to the device's hardware volume, so the per-track `setVolume()` is a no-op and the PCM leaves at full digital scale. Result: the slider updates `volumePercent` → `setVolume()`, but the audio into the rig stays hot ⇒ overdrive that's unaffected by the slider, including at 0%. The `debug.log` `TX path branch` line logged the route but never the applied volume, so this was invisible.

## Fix

Apply volume in **software** on the AudioTrack path, exactly like the USB-direct path, so volume behaves identically on every output route:

1. Multiply the float buffer by `volumePercent` before `audioTrack.write()`.
2. Keep the hardware track volume at unity (`1.0f`) to avoid double-attenuation on routes where `setVolume()` does work (e.g. phone speaker).
3. Remove the now-redundant mid-cycle `setVolume()` observer — volume is fixed per cycle, matching the ALC auto-volume model in `MeterProtectionController`.
4. Add `volume=…%` + `autoVolume=…` to the `TX path branch` log line for diagnosability.

## Verification

- Builds cleanly (Java/Kotlin/native compiled; only on-device `installDebug` was skipped — no device attached at fix time).
- **On-device testing still needed:** with the rig's USB sound card selected as the AudioTrack output, set the slider to 0% and TX → confirm no ALC / no RF; sweep the slider and confirm drive tracks it. Repeat on the USB-direct path to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)