### PR TITLE
Hide own-TX loopback echoes from QSO panel and decode log

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -344,8 +344,43 @@ public class MainViewModel extends ViewModel {
 
             @Override
             public void afterDecode(long utc, float time_sec, int sequential
-                    , ArrayList<Ft8Message> messages, boolean isDeep) {
-                if (messages.size() == 0) return;//no messages decoded, don't trigger action
+                    , ArrayList<Ft8Message> decoded, boolean isDeep) {
+                if (decoded.size() == 0) return;//no messages decoded, don't trigger action
+
+                // Filter out own-TX loopback echoes. When the rig monitors TX audio to
+                // line-out the decoder hears our own transmission and decodes it. A decode
+                // whose *sender* is our own callsign can only be that loopback (you never
+                // legitimately receive your own callsign in the "from" field), so drop it
+                // before it reaches the message list, QSO panel, or SWL database. The QSO
+                // panel already shows what we send via its synthesized TX entry, and
+                // PSKReporter / the auto-sequence already ignore own-callsign messages.
+                ArrayList<Ft8Message> messages = new ArrayList<>(decoded.size());
+                int ownEchoCount = 0;
+                boolean replyToMePresent = false;
+                for (Ft8Message m : decoded) {
+                    if (GeneralVariables.checkIsMyCallsign(m.getCallsignFrom())) {
+                        ownEchoCount++;
+                        continue;
+                    }
+                    if (GeneralVariables.checkIsMyCallsign(m.getCallsignTo())) {
+                        replyToMePresent = true;
+                    }
+                    messages.add(m);
+                }
+                // Diagnostic for the "missing other station responses" report: record how
+                // many decodes survived, how many own-echoes were dropped, and whether any
+                // message addressed to us was decoded this cycle. Lets us tell "decoded but
+                // mis-rendered" from "never decoded" from a pulled debug.log. Skip deep
+                // passes to avoid log spam (they re-report the same cycle).
+                if (!isDeep) {
+                    fileLog(String.format(
+                            "DECODE: kept=%d ownEcho=%d replyToMe=%b slot=%d",
+                            messages.size(), ownEchoCount, replyToMePresent, sequential));
+                }
+                if (messages.size() == 0) {
+                    mutableIsDecoding.postValue(false);//nothing left after filtering own echoes
+                    return;
+                }
 
                 // Diagnostic: log every CQ message so we can see what the JNI decoder
                 // populates for "CQ DX" / "CQ POTA" style broadcasts.

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -362,10 +362,7 @@ public class MainViewModel extends ViewModel {
                 // mis-rendered" from "never decoded" from a pulled debug.log. Skip deep
                 // passes to avoid log spam (they re-report the same cycle).
                 if (!isDeep) {
-                    fileLog(String.format(
-                            "DECODE: kept=%d ownEcho=%d replyToMe=%b slot=%d",
-                            messages.size(), filtered.ownEchoCount,
-                            filtered.replyToMePresent, sequential));
+                    fileLog(filtered.decodeLogLine(sequential));
                 }
                 if (messages.size() == 0) {
                     mutableIsDecoding.postValue(false);//nothing left after filtering own echoes

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -348,25 +348,14 @@ public class MainViewModel extends ViewModel {
                 if (decoded.size() == 0) return;//no messages decoded, don't trigger action
 
                 // Filter out own-TX loopback echoes. When the rig monitors TX audio to
-                // line-out the decoder hears our own transmission and decodes it. A decode
-                // whose *sender* is our own callsign can only be that loopback (you never
-                // legitimately receive your own callsign in the "from" field), so drop it
-                // before it reaches the message list, QSO panel, or SWL database. The QSO
-                // panel already shows what we send via its synthesized TX entry, and
-                // PSKReporter / the auto-sequence already ignore own-callsign messages.
-                ArrayList<Ft8Message> messages = new ArrayList<>(decoded.size());
-                int ownEchoCount = 0;
-                boolean replyToMePresent = false;
-                for (Ft8Message m : decoded) {
-                    if (GeneralVariables.checkIsMyCallsign(m.getCallsignFrom())) {
-                        ownEchoCount++;
-                        continue;
-                    }
-                    if (GeneralVariables.checkIsMyCallsign(m.getCallsignTo())) {
-                        replyToMePresent = true;
-                    }
-                    messages.add(m);
-                }
+                // line-out the decoder hears our own transmission and decodes it; a decode
+                // whose sender is our own callsign can only be that loopback, so it must
+                // not reach the message list, QSO panel, or SWL database. See
+                // OwnTxEchoFilter for the rationale. The QSO panel already shows what we
+                // send via its synthesized TX entry, and PSKReporter / the auto-sequence
+                // already ignore own-callsign messages.
+                OwnTxEchoFilter filtered = OwnTxEchoFilter.filter(decoded);
+                ArrayList<Ft8Message> messages = filtered.kept;
                 // Diagnostic for the "missing other station responses" report: record how
                 // many decodes survived, how many own-echoes were dropped, and whether any
                 // message addressed to us was decoded this cycle. Lets us tell "decoded but
@@ -375,7 +364,8 @@ public class MainViewModel extends ViewModel {
                 if (!isDeep) {
                     fileLog(String.format(
                             "DECODE: kept=%d ownEcho=%d replyToMe=%b slot=%d",
-                            messages.size(), ownEchoCount, replyToMePresent, sequential));
+                            messages.size(), filtered.ownEchoCount,
+                            filtered.replyToMePresent, sequential));
                 }
                 if (messages.size() == 0) {
                     mutableIsDecoding.postValue(false);//nothing left after filtering own echoes

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
@@ -1,0 +1,63 @@
+package com.bg7yoz.ft8cn;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits a freshly decoded FT8 cycle into the messages worth keeping and the
+ * own-TX loopback echoes that must be dropped.
+ *
+ * <p>When the transceiver monitors its TX audio back into the app's line-in,
+ * the decoder hears and decodes our <em>own</em> transmission. A decode whose
+ * sender is our own callsign can only be that loopback — you never legitimately
+ * receive your own callsign in the "from" field — so it has to be removed before
+ * it reaches the message list, the QSO conversation panel, or the SWL database.
+ * The QSO panel already shows what we transmit via its synthesized key-up entry,
+ * and PSKReporter / the auto-sequence already ignore own-callsign messages.
+ *
+ * <p>The result also carries two diagnostic counters used to investigate the
+ * separate "missing other station responses" report: how many echoes were
+ * dropped and whether any message addressed to us survived this cycle.
+ */
+public final class OwnTxEchoFilter {
+    /** Messages to keep — own-TX loopback echoes removed. */
+    public final ArrayList<Ft8Message> kept;
+    /** Number of own-callsign loopback echoes that were dropped. */
+    public final int ownEchoCount;
+    /** True if a kept message was addressed to our callsign (a reply to us). */
+    public final boolean replyToMePresent;
+
+    private OwnTxEchoFilter(ArrayList<Ft8Message> kept, int ownEchoCount,
+                            boolean replyToMePresent) {
+        this.kept = kept;
+        this.ownEchoCount = ownEchoCount;
+        this.replyToMePresent = replyToMePresent;
+    }
+
+    /**
+     * Filter one cycle's decode list.
+     *
+     * <p>A message is dropped when its sender ({@link Ft8Message#getCallsignFrom()})
+     * matches our own callsign per {@link GeneralVariables#checkIsMyCallsign}.
+     * Both callsign accessors return "" rather than null, so this is null-safe.
+     *
+     * @param decoded the raw decode list for one cycle (not modified)
+     * @return the kept messages plus echo/reply diagnostics
+     */
+    public static OwnTxEchoFilter filter(List<Ft8Message> decoded) {
+        ArrayList<Ft8Message> kept = new ArrayList<>(decoded.size());
+        int ownEcho = 0;
+        boolean replyToMe = false;
+        for (Ft8Message m : decoded) {
+            if (GeneralVariables.checkIsMyCallsign(m.getCallsignFrom())) {
+                ownEcho++;
+                continue;
+            }
+            if (GeneralVariables.checkIsMyCallsign(m.getCallsignTo())) {
+                replyToMe = true;
+            }
+            kept.add(m);
+        }
+        return new OwnTxEchoFilter(kept, ownEcho, replyToMe);
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
@@ -60,4 +60,18 @@ public final class OwnTxEchoFilter {
         }
         return new OwnTxEchoFilter(kept, ownEcho, replyToMe);
     }
+
+    /**
+     * Format the per-cycle diagnostic line written to debug.log. Recording the
+     * kept count, dropped-echo count, whether a reply addressed to us survived,
+     * and the slot lets us tell "decoded but mis-rendered" from "never decoded"
+     * when investigating the "missing other station responses" report.
+     *
+     * @param sequential the FT8 slot (0/1) of this decode cycle
+     * @return the log line, e.g. {@code "DECODE: kept=3 ownEcho=1 replyToMe=true slot=0"}
+     */
+    public String decodeLogLine(int sequential) {
+        return String.format("DECODE: kept=%d ownEcho=%d replyToMe=%b slot=%d",
+                kept.size(), ownEchoCount, replyToMePresent, sequential);
+    }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -53,13 +53,72 @@ import java.util.TimeZone
 /**
  * Data class representing a single message in the QSO log.
  */
-private data class QsoLogEntry(
+internal data class QsoLogEntry(
     val direction: Direction,
     val utcTime: Long,
     val messageText: String,
     val snr: Int? = null,
 ) {
     enum class Direction { TX, RX, BUSY }
+}
+
+/**
+ * Build the ordered QSO conversation log for [displayCallsign] from the decoded
+ * [messageList] plus our own synthesized TX entries ([synthTx]).
+ *
+ * Classification:
+ *  - RX   — from the target, addressed to us.
+ *  - BUSY — from the target, addressed to someone else (context for the hunter).
+ *  - TX   — our own transmissions, sourced *solely* from [synthTx]. Own-callsign
+ *           loopback echoes never appear here because they are filtered upstream
+ *           in MainViewModel.afterDecode (see OwnTxEchoFilter), so there is no
+ *           decoded-list TX branch and no de-dup against loopback to do.
+ *
+ * Extracted from the composable so the (pure) classification/ordering is unit
+ * testable. Entries are returned sorted ascending by [QsoLogEntry.utcTime].
+ */
+internal fun buildQsoLog(
+    messageList: List<Ft8Message>?,
+    displayCallsign: String,
+    myCallsign: String,
+    synthTx: List<QsoLogEntry>,
+): List<QsoLogEntry> {
+    if (displayCallsign.isEmpty()) return emptyList()
+
+    val entries = mutableListOf<QsoLogEntry>()
+    messageList?.forEach { msg ->
+        val from = msg.callsignFrom ?: ""
+        val to = msg.callsignTo ?: ""
+
+        val fromIsTarget = from.equals(displayCallsign, ignoreCase = true)
+        val toIsMe = to.equals(myCallsign, ignoreCase = true) ||
+            GeneralVariables.checkIsMyCallsign(to)
+
+        when {
+            fromIsTarget && toIsMe -> entries.add(
+                QsoLogEntry(
+                    direction = QsoLogEntry.Direction.RX,
+                    utcTime = msg.utcTime,
+                    messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
+                    snr = msg.snr,
+                )
+            )
+            fromIsTarget && !toIsMe -> entries.add(
+                QsoLogEntry(
+                    direction = QsoLogEntry.Direction.BUSY,
+                    utcTime = msg.utcTime,
+                    messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
+                    snr = msg.snr,
+                )
+            )
+            // No TX branch: own transmissions come solely from synthTx below.
+        }
+    }
+
+    // Our own transmissions — the sole source of TX rows.
+    entries.addAll(synthTx)
+
+    return entries.sortedBy { it.utcTime }
 }
 
 /**
@@ -114,63 +173,15 @@ fun ActiveQsoPanel(
         }
     }
 
-    // Filter messages to/from the target station
+    // Build the conversation log to/from the target station. The classification
+    // and ordering live in buildQsoLog() so they can be unit tested.
     val qsoMessages: List<QsoLogEntry> = remember(messageList, messageList?.size, displayCallsign, transmittingMessage, synthTxLog.size) {
-        if (!hasTarget || displayCallsign == null) return@remember emptyList()
-
-        val entries = mutableListOf<QsoLogEntry>()
-
-        // RX messages from the target station directed at us, or from us to the target
-        val myCallsign = GeneralVariables.myCallsign ?: ""
-        messageList?.forEach { msg ->
-            val from = msg.callsignFrom ?: ""
-            val to = msg.callsignTo ?: ""
-
-            val fromIsTarget = from.equals(displayCallsign, ignoreCase = true)
-            val toIsMe = to.equals(myCallsign, ignoreCase = true) ||
-                GeneralVariables.checkIsMyCallsign(to)
-
-            when {
-                // RX: target station calling us
-                fromIsTarget && toIsMe -> {
-                    entries.add(
-                        QsoLogEntry(
-                            direction = QsoLogEntry.Direction.RX,
-                            utcTime = msg.utcTime,
-                            messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
-                            snr = msg.snr,
-                        )
-                    )
-                }
-                // BUSY: target is transmitting but to someone else — useful so
-                // the hunter can see what their target is doing (calling CQ,
-                // exchanging reports with another station, etc.) instead of
-                // staring at an empty log wondering whether they're still on.
-                fromIsTarget && !toIsMe -> {
-                    entries.add(
-                        QsoLogEntry(
-                            direction = QsoLogEntry.Direction.BUSY,
-                            utcTime = msg.utcTime,
-                            messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
-                            snr = msg.snr,
-                        )
-                    )
-                }
-                // (No TX branch here.) Our own transmissions are never sourced from the
-                // decoded list: own-callsign loopback echoes are filtered out upstream in
-                // MainViewModel.afterDecode (so the rig monitoring TX audio back to line-in
-                // doesn't produce a phantom "received" copy of what we sent). TX rows come
-                // solely from synthTxLog below, which is added at key-up with the correct
-                // timestamp.
-            }
-        }
-
-        // Our own transmissions — the sole source of TX rows. Each distinct TX string is
-        // added once at key-up (see synthTxLog above); no de-dup against the decoded list
-        // is needed because own-TX loopback never reaches it.
-        entries.addAll(synthTxLog)
-
-        entries.sortedBy { it.utcTime }
+        buildQsoLog(
+            messageList = messageList,
+            displayCallsign = displayCallsign ?: "",
+            myCallsign = GeneralVariables.myCallsign ?: "",
+            synthTx = synthTxLog.toList(),
+        )
     }
 
     AnimatedVisibility(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -88,31 +88,25 @@ internal fun buildQsoLog(
     val entries = mutableListOf<QsoLogEntry>()
     messageList?.forEach { msg ->
         val from = msg.callsignFrom ?: ""
-        val to = msg.callsignTo ?: ""
+        // Only the target station's traffic appears in this panel. Own-callsign
+        // loopback (from == us) is filtered upstream (OwnTxEchoFilter) and there
+        // is deliberately no decoded-list TX branch, so anything not from the
+        // target is skipped here — TX rows come solely from synthTx below.
+        if (!from.equals(displayCallsign, ignoreCase = true)) return@forEach
 
-        val fromIsTarget = from.equals(displayCallsign, ignoreCase = true)
+        val to = msg.callsignTo ?: ""
         val toIsMe = to.equals(myCallsign, ignoreCase = true) ||
             GeneralVariables.checkIsMyCallsign(to)
 
-        when {
-            fromIsTarget && toIsMe -> entries.add(
-                QsoLogEntry(
-                    direction = QsoLogEntry.Direction.RX,
-                    utcTime = msg.utcTime,
-                    messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
-                    snr = msg.snr,
-                )
+        // RX when the target is calling us, BUSY when it's working someone else.
+        entries.add(
+            QsoLogEntry(
+                direction = if (toIsMe) QsoLogEntry.Direction.RX else QsoLogEntry.Direction.BUSY,
+                utcTime = msg.utcTime,
+                messageText = msg.getMessageText(),
+                snr = msg.snr,
             )
-            fromIsTarget && !toIsMe -> entries.add(
-                QsoLogEntry(
-                    direction = QsoLogEntry.Direction.BUSY,
-                    utcTime = msg.utcTime,
-                    messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
-                    snr = msg.snr,
-                )
-            )
-            // No TX branch: own transmissions come solely from synthTx below.
-        }
+        )
     }
 
     // Our own transmissions — the sole source of TX rows.

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -156,25 +156,19 @@ fun ActiveQsoPanel(
                         )
                     )
                 }
-                // TX: us calling the target station (messages from us in the decoded list)
-                from.equals(myCallsign, ignoreCase = true) && to.equals(displayCallsign, ignoreCase = true) -> {
-                    entries.add(
-                        QsoLogEntry(
-                            direction = QsoLogEntry.Direction.TX,
-                            utcTime = msg.utcTime,
-                            messageText = msg.getMessageText() ?: "$from $to ${msg.extraInfo ?: ""}",
-                        )
-                    )
-                }
+                // (No TX branch here.) Our own transmissions are never sourced from the
+                // decoded list: own-callsign loopback echoes are filtered out upstream in
+                // MainViewModel.afterDecode (so the rig monitoring TX audio back to line-in
+                // doesn't produce a phantom "received" copy of what we sent). TX rows come
+                // solely from synthTxLog below, which is added at key-up with the correct
+                // timestamp.
             }
         }
 
-        // Add synthesized TX entries (skip duplicates already present from decode loopback).
-        synthTxLog.forEach { synth ->
-            if (entries.none { it.messageText == synth.messageText && it.direction == QsoLogEntry.Direction.TX }) {
-                entries.add(synth)
-            }
-        }
+        // Our own transmissions — the sole source of TX rows. Each distinct TX string is
+        // added once at key-up (see synthTxLog above); no de-dup against the decoded list
+        // is needed because own-TX loopback never reaches it.
+        entries.addAll(synthTxLog)
 
         entries.sortedBy { it.utcTime }
     }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
@@ -1,0 +1,168 @@
+package com.bg7yoz.ft8cn;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Unit tests for {@link OwnTxEchoFilter}, which drops own-TX loopback echoes
+ * (decodes whose sender is our own callsign) from a decode cycle. This is the
+ * core of the fix for the QSO panel showing our own transmissions twice when
+ * the rig monitors TX audio back to line-in.
+ *
+ * <p>{@link Ft8Message}'s three-arg constructor takes (to, from, extra) and
+ * upper-cases each, so {@code new Ft8Message("RA3XYZ", "UB8CSJ", "R-10")} is a
+ * message we sent (from = UB8CSJ) to RA3XYZ — i.e. a loopback echo.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class OwnTxEchoFilterTest {
+
+    private static final String MY_CALL = "UB8CSJ";
+
+    @Before
+    public void setUp() {
+        GeneralVariables.myCallsign = MY_CALL;
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.myCallsign = "";
+    }
+
+    /** A message we transmitted (from == my callsign) is a loopback echo. */
+    private Ft8Message ownEcho(String toCall) {
+        return new Ft8Message(toCall, MY_CALL, "R-10");
+    }
+
+    /** A message another station sent to us (a reply). */
+    private Ft8Message replyToMe(String fromCall) {
+        return new Ft8Message(MY_CALL, fromCall, "-12");
+    }
+
+    /** Traffic between two other stations / a CQ — unrelated to us. */
+    private Ft8Message thirdParty(String toCall, String fromCall) {
+        return new Ft8Message(toCall, fromCall, "RR73");
+    }
+
+    @Test
+    public void filter_dropsOwnTxEcho_keepsOthers() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(ownEcho("RA3XYZ"));
+        decoded.add(thirdParty("CQ", "DL1ABC"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.kept).hasSize(1);
+        assertThat(result.kept.get(0).getCallsignFrom()).isEqualTo("DL1ABC");
+        assertThat(result.ownEchoCount).isEqualTo(1);
+    }
+
+    @Test
+    public void filter_countsMultipleEchoes() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(ownEcho("RA3XYZ"));
+        decoded.add(ownEcho("DL1ABC"));
+        decoded.add(thirdParty("CQ", "JA1XYZ"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.ownEchoCount).isEqualTo(2);
+        assertThat(result.kept).hasSize(1);
+    }
+
+    @Test
+    public void filter_flagsReplyToMePresent() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(replyToMe("RA3XYZ"));
+        decoded.add(thirdParty("CQ", "DL1ABC"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.replyToMePresent).isTrue();
+        assertThat(result.kept).hasSize(2); // reply to me is kept, not an echo
+        assertThat(result.ownEchoCount).isEqualTo(0);
+    }
+
+    @Test
+    public void filter_replyToMeFalse_whenNoneAddressedToUs() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(thirdParty("CQ", "DL1ABC"));
+        decoded.add(thirdParty("JA1XYZ", "VK2DEF"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.replyToMePresent).isFalse();
+        assertThat(result.kept).hasSize(2);
+    }
+
+    @Test
+    public void filter_emptyInput_returnsEmpty() {
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(Collections.<Ft8Message>emptyList());
+
+        assertThat(result.kept).isEmpty();
+        assertThat(result.ownEchoCount).isEqualTo(0);
+        assertThat(result.replyToMePresent).isFalse();
+    }
+
+    @Test
+    public void filter_allEchoes_keptIsEmpty() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(ownEcho("RA3XYZ"));
+        decoded.add(ownEcho("DL1ABC"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.kept).isEmpty();
+        assertThat(result.ownEchoCount).isEqualTo(2);
+    }
+
+    @Test
+    public void filter_noMyCallsignSet_dropsNothing() {
+        // With no callsign configured, checkIsMyCallsign() returns false for
+        // everything, so a message that *would* be ours must not be dropped.
+        GeneralVariables.myCallsign = "";
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(new Ft8Message("RA3XYZ", "UB8CSJ", "R-10"));
+        decoded.add(new Ft8Message("CQ", "DL1ABC", "JO31"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.kept).hasSize(2);
+        assertThat(result.ownEchoCount).isEqualTo(0);
+    }
+
+    @Test
+    public void filter_compoundCallsign_dropsBaseCallEcho() {
+        // checkIsMyCallsign() reduces a compound call to its longest token, so
+        // an echo decoded as the base call must still be recognised as ours.
+        GeneralVariables.myCallsign = "UB8CSJ/P";
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(new Ft8Message("RA3XYZ", "UB8CSJ", "R-10")); // echo, base call
+        decoded.add(new Ft8Message("CQ", "DL1ABC", "JO31"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.ownEchoCount).isEqualTo(1);
+        assertThat(result.kept).hasSize(1);
+        assertThat(result.kept.get(0).getCallsignFrom()).isEqualTo("DL1ABC");
+    }
+
+    @Test
+    public void filter_doesNotMutateInput() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(ownEcho("RA3XYZ"));
+        decoded.add(thirdParty("CQ", "DL1ABC"));
+
+        OwnTxEchoFilter.filter(decoded);
+
+        assertThat(decoded).hasSize(2); // original list untouched
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
@@ -165,4 +165,28 @@ public class OwnTxEchoFilterTest {
 
         assertThat(decoded).hasSize(2); // original list untouched
     }
+
+    @Test
+    public void decodeLogLine_reportsKeptEchoReplyAndSlot() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(ownEcho("RA3XYZ"));        // dropped
+        decoded.add(replyToMe("DL1ABC"));      // kept, reply to me
+        decoded.add(thirdParty("CQ", "JA1XYZ")); // kept
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.decodeLogLine(1))
+                .isEqualTo("DECODE: kept=2 ownEcho=1 replyToMe=true slot=1");
+    }
+
+    @Test
+    public void decodeLogLine_noEchoesNoReply() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(thirdParty("CQ", "DL1ABC"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.decodeLogLine(0))
+                .isEqualTo("DECODE: kept=1 ownEcho=0 replyToMe=false slot=0");
+    }
 }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
@@ -1,5 +1,6 @@
 package radio.ks3ckc.ft8us.ui.components
 
+import com.bg7yoz.ft8cn.FT8Common
 import com.bg7yoz.ft8cn.Ft8Message
 import com.bg7yoz.ft8cn.GeneralVariables
 import com.google.common.truth.Truth.assertThat
@@ -37,6 +38,15 @@ class ActiveQsoPanelLogicTest {
         Ft8Message(to, from, "-10").apply {
             utcTime = utc
             this.snr = snr
+        }
+
+    /** Build a message with raw (possibly null) callsign fields. */
+    private fun rawMsg(to: String?, from: String?, utc: Long): Ft8Message =
+        Ft8Message(FT8Common.FT8_MODE).apply {
+            callsignTo = to
+            callsignFrom = from
+            extraInfo = "RR73"
+            utcTime = utc
         }
 
     @Test
@@ -114,6 +124,42 @@ class ActiveQsoPanelLogicTest {
     @Test
     fun `target match is case insensitive`() {
         val list = listOf(msg(myCall, "ra3xyz", 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).hasSize(1)
+        assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.RX)
+    }
+
+    @Test
+    fun `null message list yields only synthesized TX rows`() {
+        val synth = listOf(
+            QsoLogEntry(QsoLogEntry.Direction.TX, utcTime = 1_000L, messageText = "RA3XYZ UB8CSJ 73")
+        )
+        val result = buildQsoLog(null, target, myCall, synth)
+        assertThat(result).hasSize(1)
+        assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.TX)
+    }
+
+    @Test
+    fun `null sender callsign is ignored`() {
+        val list = listOf(rawMsg(to = myCall, from = null, utc = 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `target with null recipient is BUSY`() {
+        // from == target, to == null -> not addressed to us -> BUSY.
+        val list = listOf(rawMsg(to = null, from = target, utc = 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).hasSize(1)
+        assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.BUSY)
+    }
+
+    @Test
+    fun `recipient matched via checkIsMyCallsign is RX`() {
+        // to is our compound form, not an exact equals() of myCallsign, so the
+        // RX classification must come from the checkIsMyCallsign() operand.
+        val list = listOf(msg("UB8CSJ/P", target, 1_000L))
         val result = buildQsoLog(list, target, myCall, emptyList())
         assertThat(result).hasSize(1)
         assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.RX)

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
@@ -1,0 +1,121 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.bg7yoz.ft8cn.Ft8Message
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for [buildQsoLog], the (pure) QSO-panel classification/ordering
+ * extracted from ActiveQsoPanel. Covers the fix that own-TX loopback never
+ * produces a panel row from the decoded list — TX rows come solely from the
+ * synthesized key-up entries.
+ *
+ * Ft8Message's three-arg constructor is (to, from, extra), upper-cased.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ActiveQsoPanelLogicTest {
+
+    private val myCall = "UB8CSJ"
+    private val target = "RA3XYZ"
+
+    @Before
+    fun setUp() {
+        GeneralVariables.myCallsign = myCall
+    }
+
+    @After
+    fun tearDown() {
+        GeneralVariables.myCallsign = ""
+    }
+
+    private fun msg(to: String, from: String, utc: Long, snr: Int = -10): Ft8Message =
+        Ft8Message(to, from, "-10").apply {
+            utcTime = utc
+            this.snr = snr
+        }
+
+    @Test
+    fun `empty target returns empty list`() {
+        val list = listOf(msg(myCall, target, 1_000L))
+        val result = buildQsoLog(list, displayCallsign = "", myCallsign = myCall, synthTx = emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `message from target to me is RX with snr`() {
+        val list = listOf(msg(myCall, target, 1_000L, snr = -7))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.RX)
+        assertThat(result[0].snr).isEqualTo(-7)
+        assertThat(result[0].utcTime).isEqualTo(1_000L)
+    }
+
+    @Test
+    fun `message from target to someone else is BUSY`() {
+        val list = listOf(msg("DL1ABC", target, 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.BUSY)
+    }
+
+    @Test
+    fun `unrelated traffic is ignored`() {
+        val list = listOf(msg("DL1ABC", "JA1XYZ", 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `own loopback in the decoded list never becomes a TX row`() {
+        // A message we sent (from = my call, to = target). Even if such an echo
+        // reached the message list it must not render — there is no TX branch.
+        val list = listOf(msg(target, myCall, 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `synthesized TX entries are the sole source of TX rows`() {
+        val synth = listOf(
+            QsoLogEntry(QsoLogEntry.Direction.TX, utcTime = 2_000L, messageText = "RA3XYZ UB8CSJ -10")
+        )
+        val list = listOf(msg(myCall, target, 1_000L)) // one RX
+        val result = buildQsoLog(list, target, myCall, synth)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.count { it.direction == QsoLogEntry.Direction.TX }).isEqualTo(1)
+        assertThat(result.count { it.direction == QsoLogEntry.Direction.RX }).isEqualTo(1)
+    }
+
+    @Test
+    fun `entries are sorted ascending by utc time`() {
+        val synth = listOf(
+            QsoLogEntry(QsoLogEntry.Direction.TX, utcTime = 3_000L, messageText = "TX later")
+        )
+        val list = listOf(
+            msg(myCall, target, 1_000L),   // RX earliest
+            msg("DL1ABC", target, 2_000L), // BUSY middle
+        )
+        val result = buildQsoLog(list, target, myCall, synth)
+
+        assertThat(result.map { it.utcTime }).isInOrder()
+        assertThat(result.first().direction).isEqualTo(QsoLogEntry.Direction.RX)
+        assertThat(result.last().direction).isEqualTo(QsoLogEntry.Direction.TX)
+    }
+
+    @Test
+    fun `target match is case insensitive`() {
+        val list = listOf(msg(myCall, "ra3xyz", 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).hasSize(1)
+        assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.RX)
+    }
+}


### PR DESCRIPTION
## Problem

User UB8CSJ reported that the **QSO conversation panel** sometimes shows their own
action **twice**, with timestamps one second apart inside the same 15-second FT8 cycle
(e.g. `14:14:15`/`14:14:16`, `14:14:45`/`14:14:46`), and that the exchange sometimes
looks **out of order**. Their transceiver monitors TX audio to line-out, so the app
hears its own transmissions on line-in ("I do hear myself on TX").

## Root cause

The panel sourced TX rows from **two** places:

1. A synthesized key-up entry (`ActiveQsoPanel`), text `" (NNNNHz) MSG"` (from
   `mutableTransmittingMessage`, formatted with a frequency prefix in
   `FT8TransmitSignal:1578`), timestamped at real key-up time.
2. The **loopback decode** of our own transmission, which `MainViewModel.afterDecode`
   added to `ft8Messages` with no own-callsign filter; the panel's TX branch then turned
   it into a second TX row, text `getMessageText()` (no Hz prefix), timestamped at the
   cycle boundary.

The de-dup that should have collapsed them compared the two strings with `==`, which
never matched because of the `" (NNNNHz) "` prefix → both rendered ~1s apart, and the
stray cycle-boundary row interleaved into the exchange (the "out of order" look).

## Fix

- **`MainViewModel.afterDecode`**: drop decodes whose *sender* is our own callsign
  (own callsign in the `from` field can only be loopback) before they reach the message
  list, QSO panel, or SWL database. Reuses the existing
  `GeneralVariables.checkIsMyCallsign(...)`.
- **`ActiveQsoPanel`**: remove the now-dead loopback TX branch; TX rows come solely from
  the synthesized key-up entry.
- PSKReporter spotting and the auto-sequence already ignored own-callsign messages, so
  behavior there is unchanged.

Also adds a per-cycle `DECODE` diagnostic line (`kept/ownEcho/replyToMe/slot`) to help
confirm the separate, **unverified** "missing other station responses" report from a
pulled `debug.log` (the panel already renders any decoded reply addressed to us, so a
missing reply most likely means it was never decoded — RX desense — rather than dropped
in software).

## Testing

- `gradlew.bat assembleDebug` → BUILD SUCCESSFUL.
- On-device verification still pending (no phone attached at build time). With the rig's
  TX monitor enabled, confirm each own TX shows exactly one panel row, rows stay in
  chronological order, and worked stations' replies still appear as RX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
