### PR TITLE
Real-time TX volume: slider takes effect mid-transmission

### DIFF
--- a/ft8cn/app/src/main/cpp/usb_audio_capture.cpp
+++ b/ft8cn/app/src/main/cpp/usb_audio_capture.cpp
@@ -448,6 +448,34 @@ struct OutputSession {
 std::atomic<bool>            g_outputCancel{false};
 std::atomic<libusb_context*> g_outputCtx{nullptr};
 
+// Live TX output gain in [0, 1], applied per-sample as PCM is copied into the
+// iso transfer buffers (both the initial prime in nativeWrite and the refills
+// in onOutputComplete). Updated from Java via nativeSetTxVolume() whenever the
+// volume slider / hardware buttons / ALC auto-volume move, so a level change
+// takes effect within the buffered-ahead window (~32ms) instead of next cycle.
+// This is what lets the operator pull drive down mid-over to protect the rig.
+std::atomic<float>           g_outputVolume{1.0f};
+
+// Scale a block of interleaved little-endian int16 PCM in place by the current
+// g_outputVolume. byteLen must be even (it always is: bytesPerFrame and pcmLen
+// are even). At unity (1.0f) this is a no-op fast path so the common case costs
+// nothing. Reads the atomic once per block — sub-ms blocks, so per-block is
+// effectively per-sample for responsiveness while staying cheap.
+void scalePcm16(uint8_t* buf, int byteLen) {
+    float vol = g_outputVolume.load(std::memory_order_relaxed);
+    if (vol >= 0.999f) return;            // unity: leave bytes untouched
+    if (vol < 0.0f) vol = 0.0f;
+    int samples = byteLen / 2;
+    for (int i = 0; i < samples; ++i) {
+        int16_t s = static_cast<int16_t>(buf[i * 2] | (buf[i * 2 + 1] << 8));
+        int scaled = static_cast<int>(s * vol);
+        if (scaled > 32767) scaled = 32767;
+        else if (scaled < -32768) scaled = -32768;
+        buf[i * 2]     = static_cast<uint8_t>(scaled & 0xFF);
+        buf[i * 2 + 1] = static_cast<uint8_t>((scaled >> 8) & 0xFF);
+    }
+}
+
 void LIBUSB_CALL onOutputComplete(libusb_transfer* xfer) {
     auto* s = static_cast<OutputSession*>(xfer->user_data);
 
@@ -488,6 +516,10 @@ void LIBUSB_CALL onOutputComplete(libusb_transfer* xfer) {
     if (thisChunk < chunkBytes) {
         std::memset(xfer->buffer + thisChunk, 0, chunkBytes - thisChunk);
     }
+    // Apply the live TX gain to the copy (the source PCM is full-scale now;
+    // Java no longer pre-scales). Padding bytes are zero so scaling them is a
+    // no-op; scale the whole chunk for simplicity.
+    scalePcm16(xfer->buffer, thisChunk);
     s->pcmOffset += thisChunk;
 
     int rc = libusb_submit_transfer(xfer);
@@ -606,6 +638,7 @@ Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeWrite(
         if (thisChunk < chunkBytes) {
             std::memset(buf + thisChunk, 0, chunkBytes - thisChunk);
         }
+        scalePcm16(buf, thisChunk);   // live TX gain (source PCM is full-scale)
         s.pcmOffset += thisChunk;
 
         libusb_fill_iso_transfer(
@@ -690,4 +723,16 @@ Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeCancelWrite(
     if (ctx) {
         libusb_interrupt_event_handler(ctx);
     }
+}
+
+// Set the live TX output gain read by nativeWrite's drain loop. Clamped to
+// [0, 1]. Safe to call from any thread at any time (a relaxed store); if no
+// write is in flight it just sets the value the next write starts from.
+extern "C" JNIEXPORT void JNICALL
+Java_com_bg7yoz_ft8cn_wave_UsbAudioNative_nativeSetTxVolume(
+        JNIEnv* /*env*/, jclass /*clazz*/, jfloat volume) {
+    float v = volume;
+    if (v < 0.0f) v = 0.0f;
+    else if (v > 1.0f) v = 1.0f;
+    g_outputVolume.store(v, std::memory_order_relaxed);
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -89,6 +89,14 @@ public class FT8TransmitSignal {
     // so the TX still finishes on the cycle boundary. Set just before playback.
     private volatile int lateStartSkipMs = 0;
 
+    // Set by setTransmitting(false)/STOP to abort the chunked MODE_STREAM
+    // AudioTrack playback loop mid-buffer. The worker thread owns the track's
+    // stop/release (see playFT8Signal); the UI thread only flips this flag and
+    // pauses+flushes the track for immediate silence, avoiding a release race
+    // against the worker blocked in write(). Reset at the start of each cycle's
+    // sound-card playback.
+    private volatile boolean txAudioCancelled = false;
+
     public UtcTimer utcTimer;
 
 
@@ -398,6 +406,28 @@ public class FT8TransmitSignal {
         return temp;
     }
 
+    /**
+     * Convert the first {@code length} float samples to 16-bit, with no trailing
+     * zero padding. Used by the chunked MODE_STREAM playback loop, which writes
+     * many chunks per cycle; the 8-sample QP-7C pad must be appended once at the
+     * very end of the message, not after every chunk (see {@link #float2Short}).
+     * Pure function — covered by unit tests.
+     *
+     * @param buffer source samples
+     * @param length number of samples to convert (≤ buffer.length)
+     * @return new short[length] of clipped, scaled samples
+     */
+    static short[] floatToInt16NoPad(float[] buffer, int length) {
+        short[] out = new short[length];
+        for (int i = 0; i < length; i++) {
+            float x = buffer[i];
+            if (x > 1.0f) x = 1.0f;
+            else if (x < -1.0f) x = -1.0f;
+            out[i] = (short) (x * 32767.0);
+        }
+        return out;
+    }
+
     private void playFT8Signal(Ft8Message msg) {
 
         if (GeneralVariables.connectMode == ConnectMode.NETWORK) {// network mode does not play audio locally
@@ -466,6 +496,11 @@ public class FT8TransmitSignal {
             return;
         }
 
+        // Fresh cancel state for this cycle's playback (consumed by the chunked
+        // AudioTrack loop below; the USB path has its own cancel via
+        // UsbAudioNative.resetCancel/cancelWrite).
+        txAudioCancelled = false;
+
         // USB audio output path. Logged so a dev-screen reader can see
         // which branch was taken — the difference between TX going out
         // the USB radio (this branch) vs. Android's default sink (the
@@ -496,17 +531,28 @@ public class FT8TransmitSignal {
                 .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
                 .build();
 
-        //myFormat = new AudioFormat.Builder().setSampleRate(FT8Common.SAMPLE_RATE)
+        int encoding = GeneralVariables.audioOutput32Bit
+                ? AudioFormat.ENCODING_PCM_FLOAT : AudioFormat.ENCODING_PCM_16BIT;
         myFormat = new AudioFormat.Builder().setSampleRate(GeneralVariables.audioSampleRate)
-                .setEncoding(GeneralVariables.audioOutput32Bit ? // float vs integer
-                        AudioFormat.ENCODING_PCM_FLOAT : AudioFormat.ENCODING_PCM_16BIT)
+                .setEncoding(encoding)
                 .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build();
+
+        // MODE_STREAM (was MODE_STATIC) with a deliberately SMALL buffer so we can
+        // apply TX volume live: we feed the generated waveform out in ~50ms chunks,
+        // re-reading volumePercent for each chunk, and a blocking write only commits
+        // a chunk once the device has room. The buffer depth (~200ms) bounds how much
+        // audio is already queued at the old level, i.e. the worst-case latency from
+        // a slider move to the level changing on air — instant enough to pull drive
+        // down and protect the rig mid-over, which baking volume into a one-shot
+        // MODE_STATIC write could not do (the slider only took effect next cycle).
+        int bytesPerSample = GeneralVariables.audioOutput32Bit ? 4 : 2;
+        int targetBufBytes = (GeneralVariables.audioSampleRate / 5) * bytesPerSample; // ~200ms mono
+        int minBuf = AudioTrack.getMinBufferSize(GeneralVariables.audioSampleRate,
+                AudioFormat.CHANNEL_OUT_MONO, encoding);
+        int bufBytes = Math.max(targetBufBytes, minBuf > 0 ? minBuf : targetBufBytes);
         int mySession = 0;
-        audioTrack = new AudioTrack(attributes, myFormat
-                , GeneralVariables.audioOutput32Bit ? GeneralVariables.audioSampleRate * 15 * 4
-                : GeneralVariables.audioSampleRate * 15 * 2// float vs integer
-                , AudioTrack.MODE_STATIC
-                , mySession);
+        audioTrack = new AudioTrack(attributes, myFormat, bufBytes,
+                AudioTrack.MODE_STREAM, mySession);
 
         // set preferred output device
         if (GeneralVariables.audioOutputDeviceId > 0) {
@@ -521,59 +567,75 @@ public class FT8TransmitSignal {
         if (skipSamples >= buffer.length) skipSamples = 0;
         int playLength = buffer.length - skipSamples;
 
-        // Apply volume in software, exactly like the USB-direct path (playViaUsbAudio).
-        // We do NOT rely on AudioTrack.setVolume() for level control: when the track is
-        // routed to a USB Audio Class device (the rig's sound card), many Android builds
-        // delegate level to the device's hardware volume and the per-track setVolume() is
-        // a no-op, so the samples leave at full scale and the rig overdrives regardless of
-        // the slider (even at 0%). Baking the gain into the samples here makes the slider
-        // behave identically on every output route.
-        float[] volumeAdjusted = applyVolume(buffer, skipSamples, playLength,
-                GeneralVariables.volumePercent);
+        // Keep the track at unity: TX level is carried in the sample values (we scale
+        // each chunk below). On routes where AudioTrack.setVolume() works (phone
+        // speaker) this avoids double-attenuation; on routes where it's a no-op (USB
+        // Audio Class sound cards delegating level to device hardware) the in-sample
+        // gain is what actually controls the rig's drive.
+        audioTrack.play();
+        audioTrack.setVolume(1.0f);
 
-        // distinguish between 32-bit float and integer
-        int writeResult;
-        if (GeneralVariables.audioOutput32Bit) {
-            writeResult = audioTrack.write(volumeAdjusted, 0, playLength
-                    , AudioTrack.WRITE_NON_BLOCKING);
-        } else {
-            short[] audio_data = float2Short(volumeAdjusted);
-            writeResult = audioTrack.write(audio_data, 0, playLength
-                    , AudioTrack.WRITE_NON_BLOCKING);
-        }
+        // Stream the waveform in chunks, re-reading volumePercent each chunk so a
+        // slider move ramps the on-air level within ~1 chunk + buffer depth.
+        final int chunkSamples = Math.max(1, GeneralVariables.audioSampleRate / 20); // ~50ms
+        int framesWritten = 0;
+        boolean writeError = false;
+        int offset = 0;
+        while (offset < playLength) {
+            if (txAudioCancelled || !isTransmitting) break;
+            int chunkLen = Math.min(chunkSamples, playLength - offset);
+            // applyVolume reads volumePercent fresh for this chunk (live gain) and
+            // performs the late-start slice at skipSamples + offset.
+            float[] chunk = applyVolume(buffer, skipSamples + offset, chunkLen,
+                    GeneralVariables.volumePercent);
 
-        if (playLength > writeResult) {
-            Log.e(TAG, String.format("Playback buffer insufficient: %d--->%d", playLength, writeResult));
-        }
-
-        // check write result; if abnormal, release resources immediately
-        if (writeResult == AudioTrack.ERROR_INVALID_OPERATION
-                || writeResult == AudioTrack.ERROR_BAD_VALUE
-                || writeResult == AudioTrack.ERROR_DEAD_OBJECT
-                || writeResult == AudioTrack.ERROR) {
-            // abnormal condition
-            Log.e(TAG, String.format("Playback error: %d", writeResult));
-            afterPlayAudio();
-            return;
-        }
-        audioTrack.setNotificationMarkerPosition(playLength);
-        audioTrack.setPlaybackPositionUpdateListener(new AudioTrack.OnPlaybackPositionUpdateListener() {
-            @Override
-            public void onMarkerReached(AudioTrack audioTrack) {
-                afterPlayAudio();
+            int writeResult;
+            if (GeneralVariables.audioOutput32Bit) {
+                writeResult = audioTrack.write(chunk, 0, chunkLen, AudioTrack.WRITE_BLOCKING);
+            } else {
+                short[] audio_data = floatToInt16NoPad(chunk, chunkLen);
+                writeResult = audioTrack.write(audio_data, 0, chunkLen, AudioTrack.WRITE_BLOCKING);
             }
 
-            @Override
-            public void onPeriodicNotification(AudioTrack audioTrack) {
-
+            if (writeResult < 0) {
+                Log.e(TAG, String.format("Playback error: %d", writeResult));
+                writeError = true;
+                break;
             }
-        });
-        if (audioTrack != null) {
-            audioTrack.play();
-            // Volume is baked into the samples above; keep the track at unity so we don't
-            // double-attenuate on routes where setVolume() does work (e.g. phone speaker).
-            audioTrack.setVolume(1.0f);
+            framesWritten += writeResult;
+            offset += chunkLen;
         }
+
+        // Append the 8-sample zero pad once at the end (QP-7C RP2040 audio
+        // detection compatibility), only for the int16 path — matches the old
+        // float2Short() behavior. Skipped if we errored or were cancelled.
+        if (!writeError && !txAudioCancelled && isTransmitting
+                && !GeneralVariables.audioOutput32Bit) {
+            short[] pad = new short[8];
+            int padResult = audioTrack.write(pad, 0, pad.length, AudioTrack.WRITE_BLOCKING);
+            if (padResult > 0) framesWritten += padResult;
+        }
+
+        // Blocking writes return once data is *buffered*, not played. Wait for the
+        // tail (up to bufBytes) to actually drain before releasing, so we don't
+        // truncate the end of the message. A STOP cancel skips the wait (the UI
+        // thread has already paused+flushed for immediate silence).
+        if (!writeError && !txAudioCancelled) {
+            while (isTransmitting && !txAudioCancelled) {
+                int head = audioTrack.getPlaybackHeadPosition();
+                if (head >= framesWritten) break;
+                try {
+                    Thread.sleep(20);
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        }
+
+        // Worker-thread-owned teardown (drops PTT + releases the track). The UI
+        // thread never releases the streaming track — it only flips txAudioCancelled
+        // and pauses/flushes — so there's no release race against this write loop.
+        afterPlayAudio();
     }
 
     /**
@@ -654,14 +716,17 @@ public class FT8TransmitSignal {
         if (skipSamples >= buffer.length) skipSamples = 0;
         int playLength = buffer.length - skipSamples;
 
-        // Apply volume (shared with the AudioTrack path)
-        float[] volumeAdjusted = applyVolume(buffer, skipSamples, playLength,
-                GeneralVariables.volumePercent);
+        // Pass the full-scale slice; TX volume is applied live as the buffer
+        // drains (native scales each sample in its write loop, the UsbRequest
+        // fallback scales per chunk), so the slider attenuates the in-progress
+        // TX within tens of ms instead of next cycle. applyVolume at unity here
+        // just performs the late-start slice.
+        float[] unscaled = applyVolume(buffer, skipSamples, playLength, 1.0f);
 
         GeneralVariables.fileLog(String.format(
                 "playViaUsbAudio: calling writeAudio playLength=%d rate=%d",
                 playLength, GeneralVariables.audioSampleRate));
-        boolean success = usbDev.writeAudio(volumeAdjusted, GeneralVariables.audioSampleRate);
+        boolean success = usbDev.writeAudio(unscaled, GeneralVariables.audioSampleRate);
         GeneralVariables.fileLog(
                 "playViaUsbAudio: writeAudio returned " + (success ? "OK" : "FAILED"));
 
@@ -1287,18 +1352,27 @@ public class FT8TransmitSignal {
             // bail out. When the writer returns, playViaUsbAudio's afterPlayAudio()
             // drops PTT. No-op when not transmitting over USB audio.
             UsbAudioNative.cancelWrite();
-            if (audioTrack != null) {
-                if (audioTrack.getState() != AudioTrack.STATE_UNINITIALIZED) {
-                    audioTrack.pause();
+
+            // Abort the chunked MODE_STREAM AudioTrack playback. We must NOT release
+            // the track here: the transmit worker thread may be blocked in a
+            // WRITE_BLOCKING call, and releasing it underneath would race/crash.
+            // Instead flip the cancel flag (the write loop checks it each chunk) and
+            // pause()+flush() for immediate silence. flush() also discards the queued
+            // buffer so a blocked write returns at once instead of deadlocking on a
+            // full, paused buffer. The worker then breaks out and its afterPlayAudio()
+            // does the actual stop()/release() + PTT drop.
+            txAudioCancelled = true;
+            AudioTrack t = audioTrack;
+            if (t != null) {
+                try {
+                    if (t.getState() != AudioTrack.STATE_UNINITIALIZED
+                            && t.getPlayState() != AudioTrack.PLAYSTATE_STOPPED) {
+                        t.pause();
+                        t.flush();
+                    }
+                } catch (IllegalStateException ignored) {
+                    // Worker already released the track between our read and here.
                 }
-                if (onDoTransmitted != null) {//notify that transmitting has stopped
-                    onDoTransmitted.onAfterTransmit(getFunctionCommand(functionOrder), functionOrder);
-                }
-                // Release the paused track: its completion marker won't fire once
-                // paused, so afterPlayAudio() would never run for this branch and
-                // the track would leak until the next TX overwrites the field.
-                audioTrack.release();
-                audioTrack = null;
             }
         }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/TrUSDXRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/TrUSDXRig.java
@@ -271,10 +271,10 @@ public class TrUSDXRig extends BaseRig {
             setPTT(false);
             return;
         }
-        //adjust signal strength
-        for (int i = 0; i < wave.length; i++) {
-            wave[i] = wave[i] * GeneralVariables.volumePercent;
-        }
+        // TX volume is applied live in the send loop below (around the 8-bit
+        // midpoint), not baked into the float wave here, so dragging the slider
+        // attenuates the in-progress over instead of only the next one. Real-time
+        // granularity is bounded by the serial buffer depth rather than the cycle.
 
 //
 //        byte[] pcm16 = toWaveFloatToPCM16(wave);
@@ -284,20 +284,31 @@ public class TrUSDXRig extends BaseRig {
 //        txResample.close();
 //        byte[] pcm8 = toWaveSamples16To8(resampled);
 
+        // Full-scale 8-bit unsigned PCM (zero == 128); volume applied per chunk below.
         byte[] pcm8 = FT8Resample.get8Resample32(wave, 24000, txSampling, 1);
 
-
-        for (int i = 0; i < pcm8.length; i++) {
-            if (pcm8[i] == 0x3B) pcm8[i] = 0x3A; // ; to :
-        }
-        while (pcm8.length > 0) {
-            if (pcm8.length <= 256) {
-                getConnector().sendData(pcm8);
-                break;
-            } else {
-                getConnector().sendData(Arrays.copyOfRange(pcm8, 0, 256));
-                pcm8 = Arrays.copyOfRange(pcm8, 256, pcm8.length);
+        // Send in 256-byte chunks, scaling each chunk by the *current* volume so a
+        // mid-over slider move takes effect within a serial-buffer's worth of audio.
+        // Scale around the 8-bit midpoint (128), then re-apply the 0x3B -> 0x3A
+        // escape (';' is the CAT command terminator and must not appear in audio) —
+        // the escape must come after scaling since scaling changes byte values. At
+        // unity (vol == 1) this reproduces the previous output exactly.
+        int sent = 0;
+        while (sent < pcm8.length) {
+            int len = Math.min(256, pcm8.length - sent);
+            byte[] chunk = new byte[len];
+            float vol = GeneralVariables.volumePercent;
+            for (int i = 0; i < len; i++) {
+                int u = pcm8[sent + i] & 0xFF;                 // unsigned 0..255
+                int scaled = 128 + Math.round((u - 128) * vol);
+                if (scaled > 255) scaled = 255;
+                else if (scaled < 0) scaled = 0;
+                byte b = (byte) scaled;
+                if (b == 0x3B) b = 0x3A; // ; to :
+                chunk[i] = b;
             }
+            getConnector().sendData(chunk);
+            sent += len;
         }
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioDevice.java
@@ -472,7 +472,15 @@ public class UsbAudioDevice {
      * Write audio data to the USB output device.
      * Handles sample rate conversion and format conversion.
      *
-     * @param audioData        Float PCM mono data
+     * <p>The {@code audioData} is full-scale (TX volume is no longer baked in by
+     * the caller). Gain is applied live as the buffer drains so a slider move
+     * takes effect mid-over: the native path multiplies each sample in its drain
+     * loop (see {@code nativeSetTxVolume}); the UsbRequest fallback below scales
+     * each chunk by the current {@link GeneralVariables#volumePercent} as it
+     * sends. This is the rig-protection path — pulling the slider down attenuates
+     * the in-progress transmission within tens of ms.
+     *
+     * @param audioData        Float PCM mono data, full-scale (no volume baked in)
      * @param sourceSampleRate Sample rate of the input data
      * @return true if successful
      */
@@ -483,6 +491,10 @@ public class UsbAudioDevice {
         // Start this transmission with a clear cancel flag. STOP sets it (via
         // UsbAudioNative.cancelWrite) to abort either the native or fallback path.
         UsbAudioNative.resetCancel();
+        // Seed the native drain loop with the current level before it starts, so
+        // the first packet is already at the right gain (the live observer keeps
+        // it updated thereafter).
+        UsbAudioNative.setTxVolume(com.bg7yoz.ft8cn.GeneralVariables.volumePercent);
 
         // Resample to device's output rate
         float[] resampled;
@@ -555,7 +567,29 @@ public class UsbAudioDevice {
             int chunkSize = Math.min(packetSize, pcmData.length - offset);
             ByteBuffer buf = ByteBuffer.allocateDirect(chunkSize);
             buf.order(ByteOrder.LITTLE_ENDIAN);
-            buf.put(pcmData, offset, chunkSize);
+            // Apply the current TX gain to this chunk as we copy it (pcmData is
+            // full-scale). Read once per chunk (~1ms of audio) so dragging the
+            // slider attenuates the in-progress TX almost immediately. Unity is
+            // a straight copy.
+            float vol = com.bg7yoz.ft8cn.GeneralVariables.volumePercent;
+            if (vol >= 0.999f) {
+                buf.put(pcmData, offset, chunkSize);
+            } else {
+                int pairs = chunkSize / 2;
+                for (int p = 0; p < pairs; p++) {
+                    int b = offset + p * 2;
+                    short s = (short) ((pcmData[b] & 0xFF) | (pcmData[b + 1] << 8));
+                    int scaled = (int) (s * vol);
+                    if (scaled > 32767) scaled = 32767;
+                    else if (scaled < -32768) scaled = -32768;
+                    buf.put((byte) (scaled & 0xFF));
+                    buf.put((byte) ((scaled >> 8) & 0xFF));
+                }
+                // Odd trailing byte (not expected for 16-bit audio) — copy as-is.
+                if ((chunkSize & 1) == 1) {
+                    buf.put(pcmData[offset + chunkSize - 1]);
+                }
+            }
             buf.flip();
 
             // Whole iteration is guarded: if the underlying USB connection has

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioNative.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/UsbAudioNative.java
@@ -58,6 +58,26 @@ public final class UsbAudioNative {
     }
 
     /**
+     * Set the TX output gain applied live by {@link #nativeWrite} as it drains
+     * the PCM buffer. Unlike the old model (volume baked into the samples in
+     * Java before the write started, so a slider move only took effect next
+     * cycle), the native drain loop multiplies each int16 sample by this value
+     * as it copies it into the iso transfer buffers — so a change here ramps the
+     * on-air level within the buffered-ahead window (~tens of ms), mid-over.
+     * This is the safety-critical path for protecting the rig from overdrive.
+     *
+     * <p>Safe to call from any thread at any time; a no-op if the native lib
+     * isn't loaded. Clamped to [0, 1] on the native side.
+     *
+     * @param volume gain 0.0–1.0
+     */
+    public static void setTxVolume(float volume) {
+        if (LIBRARY_LOADED) {
+            nativeSetTxVolume(volume);
+        }
+    }
+
+    /**
      * Abort an in-progress transmission immediately. Safe to call from the UI
      * thread while a write is blocked on the transmit worker thread: flags the
      * Java fallback loop and, when the native lib is present, signals the libusb
@@ -183,4 +203,14 @@ public final class UsbAudioNative {
      * which also covers the Java fallback path.
      */
     public static native void nativeCancelWrite();
+
+    /**
+     * Set the live TX output gain read by {@link #nativeWrite}'s drain loop.
+     * Stores into a native atomic; takes effect on the next iso packet filled
+     * (~tens of ms). Clamped to [0, 1] natively. Prefer {@link #setTxVolume}
+     * which guards on library availability.
+     *
+     * @param volume gain 0.0–1.0
+     */
+    public static native void nativeSetTxVolume(float volume);
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -93,6 +93,17 @@ class ComposeMainActivity : AppCompatActivity() {
         mainViewModel = MainViewModel.getInstance(this)
         ToastMessage.getInstance()
 
+        // Forward every TX-volume change to the native USB-direct write loop so a
+        // slider move (or hardware-button / ALC auto-volume change) attenuates the
+        // in-progress transmission live, protecting the rig from overdrive. Every
+        // volume mutator posts to mutableVolumePercent, so this single wire covers
+        // them all; the AudioTrack and CAT/UDP paths read volumePercent directly.
+        // Seeded with the current value for the case where no change fires.
+        UsbAudioNative.setTxVolume(GeneralVariables.volumePercent)
+        GeneralVariables.mutableVolumePercent.observeForever { v ->
+            if (v != null) UsbAudioNative.setTxVolume(v)
+        }
+
         // Register back press handler. Priority: dismiss the QSO sheet if
         // it's open, otherwise show exit confirm. Without this, back-from-
         // sheet tries to exit the whole app, which surprises users who

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -99,8 +99,13 @@ class ComposeMainActivity : AppCompatActivity() {
         // volume mutator posts to mutableVolumePercent, so this single wire covers
         // them all; the AudioTrack and CAT/UDP paths read volumePercent directly.
         // Seeded with the current value for the case where no change fires.
+        // Lifecycle-bound (observe(this), not observeForever) so the observer is
+        // removed automatically on destroy — otherwise every activity recreation
+        // (rotation, theme/locale change, process restart) would stack another
+        // observer and fire a redundant native setter per change. TX runs with the
+        // activity foregrounded (STARTED), so STARTED-only delivery loses nothing.
         UsbAudioNative.setTxVolume(GeneralVariables.volumePercent)
-        GeneralVariables.mutableVolumePercent.observeForever { v ->
+        GeneralVariables.mutableVolumePercent.observe(this) { v ->
             if (v != null) UsbAudioNative.setTxVolume(v)
         }
 

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
@@ -112,4 +112,74 @@ public class FT8TransmitSignalTest {
         assertThat((int) out[0]).isEqualTo(32767);   // clipped to +1.0
         assertThat((int) out[1]).isEqualTo(-32767);  // clipped to -1.0
     }
+
+    // ---- floatToInt16NoPad --------------------------------------------------
+    // Used by the chunked MODE_STREAM playback loop: converts each chunk with NO
+    // trailing zero pad (the 8-sample QP-7C pad is appended once at the end of the
+    // message, not per chunk — see float2Short which keeps the pad for other uses).
+
+    @Test
+    public void floatToInt16NoPad_hasNoZeroTail() {
+        short[] out = FT8TransmitSignal.floatToInt16NoPad(new float[]{1.0f, -1.0f}, 2);
+        assertThat(out).hasLength(2);                // exactly length, no +8 pad
+        assertThat((int) out[0]).isEqualTo(32767);
+        assertThat((int) out[1]).isEqualTo(-32767);
+    }
+
+    @Test
+    public void floatToInt16NoPad_honoursLengthShorterThanBuffer() {
+        // The loop passes chunkLen which can be < buffer.length on the last chunk.
+        short[] out = FT8TransmitSignal.floatToInt16NoPad(new float[]{0.5f, 0.5f, 0.5f}, 2);
+        assertThat(out).hasLength(2);
+        assertThat((int) out[0]).isEqualTo(16383);
+        assertThat((int) out[1]).isEqualTo(16383);
+    }
+
+    @Test
+    public void floatToInt16NoPad_clipsOutOfRange() {
+        short[] out = FT8TransmitSignal.floatToInt16NoPad(new float[]{2.0f, -2.0f}, 2);
+        assertThat((int) out[0]).isEqualTo(32767);
+        assertThat((int) out[1]).isEqualTo(-32767);
+    }
+
+    // ---- per-chunk slicing (the real-time volume path) ----------------------
+    // The streaming loop calls applyVolume(buffer, skipSamples + offset, chunkLen,
+    // currentVolume) repeatedly. These prove the offset math is sound and that
+    // changing the volume between chunks attenuates only the later chunks — the
+    // whole point of the feature (pull the slider down mid-over to protect the rig).
+
+    @Test
+    public void chunkedSlicing_concatenatesToWholeBufferAtFixedVolume() {
+        float[] src = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f};
+        int skip = 1;                       // simulate a late-start trim
+        int playLength = src.length - skip; // 6 samples to emit
+        int chunk = 4;
+        float vol = 0.5f;
+
+        float[] whole = FT8TransmitSignal.applyVolume(src, skip, playLength, vol);
+
+        // Re-assemble by chunked slicing the way the playback loop does.
+        float[] assembled = new float[playLength];
+        int pos = 0;
+        for (int offset = 0; offset < playLength; offset += chunk) {
+            int len = Math.min(chunk, playLength - offset);
+            float[] c = FT8TransmitSignal.applyVolume(src, skip + offset, len, vol);
+            System.arraycopy(c, 0, assembled, pos, len);
+            pos += len;
+        }
+        assertThat(assembled).usingTolerance(TOL).containsExactly(whole).inOrder();
+    }
+
+    @Test
+    public void chunkedSlicing_volumeChangeAffectsOnlyLaterChunks() {
+        float[] src = {1.0f, 1.0f, 1.0f, 1.0f};
+        // First two samples at full volume, then slider dropped to 0.25 for the rest.
+        float[] first = FT8TransmitSignal.applyVolume(src, 0, 2, 1.0f);
+        float[] second = FT8TransmitSignal.applyVolume(src, 2, 2, 0.25f);
+
+        assertThat(first).usingTolerance(TOL)
+                .containsExactly(new float[]{1.0f, 1.0f}).inOrder();
+        assertThat(second).usingTolerance(TOL)
+                .containsExactly(new float[]{0.25f, 0.25f}).inOrder();
+    }
 }


### PR DESCRIPTION
## Why

Users reported the TX-volume slider **must** take effect instantly: volume was baked into the per-cycle audio buffer, so a change only applied on the *next* over. If drive was too hot there was no way to pull it down during a transmission — a hardware-damage risk. This moves volume from a once-per-cycle bake to a **live, per-chunk read** on every TX path that streams to a radio, so dragging the slider down ramps the on-air level within tens of ms, mid-over. Smooth ramp (no hard mute / PTT drop at 0%).

## What changed, per path

| Path | Change | Slider latency |
|------|--------|----------------|
| **USB-direct (libusb)** | `g_outputVolume` atomic + `nativeSetTxVolume` JNI in `usb_audio_capture.cpp`; each int16 sample scaled as it's copied into the iso transfer buffers (prime loop + `onOutputComplete`). Java passes full-scale PCM. | ~32 ms (buffered-ahead window) |
| **AudioTrack (Android sink)** | `MODE_STATIC` one-shot → `MODE_STREAM`, ~200 ms buffer, written in ~50 ms chunks each scaled by current `volumePercent`. | ≤ ~250 ms |
| **USB-direct (UsbRequest fallback)** | each ~1 ms chunk scaled live | ~1 chunk |
| **truSDX CAT** | volume around the 8-bit midpoint (128) per 256-byte chunk, `0x3B→0x3A` escape re-applied after scaling | serial-buffer bounded |
| ICOM / XieGu UDP | unchanged — already scaled live per 20 ms packet | — |

Wiring: one `observeForever` in `ComposeMainActivity` forwards every `volumePercent` change (slider, hardware buttons, **and ALC auto-volume**) to the native loop.

The trickiest piece is the **MODE_STREAM stop race**: the worker thread owns `stop()`/`release()`; STOP just flips a cancel flag and `pause()`+`flush()`es for instant silence — `flush()` also unblocks a worker stuck in a blocking write, avoiding a deadlock/release race.

## Verification

- ✅ `testDebugUnitTest` — added tests for `floatToInt16NoPad` (no per-chunk pad) and chunked per-offset slicing (a mid-stream volume change attenuates only later chunks).
- ✅ `assembleDebug` — native lib compiles for all 4 ABIs; full APK assembles; Kotlin/Java clean.
- ⏳ **On-device (pending):** drag slider down mid-over per path → level drops without waiting for next cycle; USB-direct still decodes on PSKReporter at normal level (guards against the pitch-shift / Costas-clip failure modes documented in CLAUDE.md); no AudioTrack underrun gaps; STOP mid-over halts immediately without crash.

## Notes

- truSDX applies gain *after* the 8-bit resample rather than before — mathematically equivalent for a linear scalar, slightly more quantization noise on a QRP path. The one path not verified on hardware yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)