### PR TITLE
Document git worktree workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,26 @@ After finishing the code for any feature, open a pull request targeting the `dev
 branch (do the work on a feature branch, then `gh pr create --base dev`). Don't
 merge straight to `main`.
 
+**Use a git worktree for every separate line of work.** Don't switch branches in
+the primary checkout (`C:\Users\burns\Projects\NEXT-FT8CN`) — branch-switching
+there collides with anything else in flight (a running build, an `adb install`, a
+different task). Instead spin up an isolated worktree per task:
+
+```
+git worktree add ../NEXT-FT8CN-<short-task-name> -b feat/<task>
+```
+
+Two gotchas for a fresh worktree:
+
+- The `ft8cn/app/src/main/cpp/` native sources (`ft8_lib`, `ft8cn_glue`,
+  `libsamplerate`) are **untracked** (see `git status` / memory
+  `ft8af-untracked-native-sources.md`), so a new worktree won't have them and the
+  NDK build fails. Copy them over from the primary checkout before building.
+- Build/install still uses the Windows wrapper from inside the worktree's `ft8cn`
+  dir (`cmd.exe /c "gradlew.bat installDebug"`).
+
+Remove the worktree when the branch is merged: `git worktree remove <path>`.
+
 ## Build & Deploy
 
 After making code changes, always build and install on the connected device.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,13 @@
 
 ## Workflow
 
-After finishing the code for any feature, open a pull request targeting the `dev`
-branch (do the work on a feature branch, then `gh pr create --base dev`). Don't
-merge straight to `main`.
+**Every work item requires a pull request — no direct commits to `dev` or
+`main`.** Even a one-line docs or config change goes through a feature branch and
+a PR.
+
+**All PRs target the `dev` branch.** After finishing the code for any work item,
+open a pull request against `dev` (do the work on a feature branch, then
+`gh pr create --base dev`). Don't merge straight to `main`.
 
 **Use a git worktree for every separate line of work.** Don't switch branches in
 the primary checkout (`C:\Users\burns\Projects\NEXT-FT8CN`) — branch-switching


### PR DESCRIPTION
## Summary
Adds a Workflow note to `CLAUDE.md` directing every separate line of work to its own git worktree instead of branch-switching the primary checkout — branch-switching there collides with anything in flight (a running build, an `adb install`, another task).

Includes the two fresh-worktree gotchas:
- The untracked `ft8cn/app/src/main/cpp/` native sources (`ft8_lib`, `ft8cn_glue`, `libsamplerate`) must be copied over or the NDK build fails.
- Build/install still goes through the Windows `gradlew.bat` wrapper from inside the worktree.

## Why
Doing things simultaneously in the single checkout keeps causing collisions; this codifies the worktree-per-task workflow so it actually gets followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)