### PR TITLE
Persist decode-screen filter across navigation

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -192,6 +192,11 @@ public class MainViewModel extends ViewModel {
     public MutableLiveData<String> qsoSheetCallsign = new MutableLiveData<>(null);
     public MutableLiveData<Boolean> qsoSheetMinimized = new MutableLiveData<>(false);
 
+    // Decode-screen filter selection (Compose UI). Lives in the ViewModel so
+    // the chosen filter survives navigation away from Decode and back, rather
+    // than resetting to "All" each time the screen is recreated.
+    public MutableLiveData<String> decodeFilter = new MutableLiveData<>("All");
+
 
     public HamRecorder hamRecorder;//recording object
     public FT8SignalListener ft8SignalListener;//object for listening to and decoding FT8 signals

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -60,9 +60,11 @@ fun DecodeScreen(
     val decodedCount by mainViewModel.mutable_Decoded_Counter.observeAsState(0)
     val utcTime by mainViewModel.timerSec.observeAsState(0L)
 
-    // Filter state
+    // Filter state. Backed by the ViewModel so the chosen filter survives
+    // navigation away from Decode and back (the screen is recreated by the
+    // tab switch, which would otherwise reset a local rememberSaveable).
     val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "Needed", "For Me")
-    var selectedFilter by rememberSaveable { mutableStateOf("All") }
+    val selectedFilter by mainViewModel.decodeFilter.observeAsState("All")
 
     // Keep the POTA spots cache warm while the user is browsing decodes so the
     // CQ POTA filter and the green POTA pill on spotted activators work even
@@ -155,7 +157,7 @@ fun DecodeScreen(
         val present = (messageList ?: arrayListOf())
             .any { it.callsignFrom.equals(cs, ignoreCase = true) }
         if (!present) return@LaunchedEffect          // wait until the station is in the list
-        selectedFilter = "All"
+        mainViewModel.decodeFilter.postValue("All")
         mainViewModel.qsoSheetCallsign.postValue(cs)
         mainViewModel.qsoSheetMinimized.postValue(false)
         mainViewModel.mutablePreselectCallsign.postValue(null)   // consume (allow re-trigger)
@@ -221,7 +223,7 @@ fun DecodeScreen(
             FilterChips(
                 options = localizedLabels,
                 selected = filterLabel(selectedFilter),
-                onSelected = { label -> selectedFilter = labelToKey[label] ?: selectedFilter },
+                onSelected = { label -> mainViewModel.decodeFilter.postValue(labelToKey[label] ?: selectedFilter) },
                 modifier = Modifier.padding(bottom = 8.dp),
             )
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -217,7 +217,8 @@ fun DecodeScreen(
             // Filter chips. FilterChips renders each option string AND passes it
             // back through onSelected, so we feed it localized labels for display
             // but translate the tapped label back to its stable English key before
-            // storing it in selectedFilter (which the filter logic switches on).
+            // writing it to mainViewModel.decodeFilter, which selectedFilter
+            // observes and the filter logic switches on.
             val localizedLabels = filterOptions.map { filterLabel(it) }
             val labelToKey = filterOptions.indices.associate { localizedLabels[it] to filterOptions[it] }
             FilterChips(


### PR DESCRIPTION
## Problem

The filter at the top of the Decode page (All / CQ Calls / CQ POTA / New DXCC / Needed / For Me) resets to **All** whenever you switch to another tab and come back.

## Cause

The selection lived in a composable-local `rememberSaveable` in `DecodeScreen`. Tab navigation in `FT8USApp` swaps screens with a `when` block, which disposes and recreates `DecodeScreen` — discarding composable-local state. `rememberSaveable` only survives recomposition and config changes, not disposal.

## Fix

Hoist the selection into `MainViewModel.decodeFilter` (`MutableLiveData<String>`), exactly mirroring how the QSO bottom-sheet state (`qsoSheetCallsign` / `qsoSheetMinimized`) already survives navigation. `DecodeScreen` now `observeAsState`s it and writes through `postValue`. Because the ViewModel outlives any individual screen, the chosen filter persists across tab switches.

## Files
- `MainViewModel.java` — add `decodeFilter` LiveData
- `DecodeScreen.kt` — observe it; route the filter-chip tap and the Needed-DX preselect reset through `postValue`

## Testing
- Built and installed on the Pixel 8 (`installDebug` → `Installed on 1 device.`).
- Manual: set a filter on Decode, switch to another tab, return — the filter is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)