### PR TITLE
Add FT8 DXpedition Hound mode (work a Fox)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -250,13 +250,15 @@ public class Ft8Message {
         }
 
         if (i3 == 0 && (n3 == 1)) {//this is DXpedition
-
+            // Fox combo: "<acked> RR73; <invited> <foxHash> <report>". The report
+            // is already signed, so format its magnitude after the sign char —
+            // otherwise a negative report renders a double minus ("--18").
             return String.format("%s RR73; %s %s %s%d"
                     ,callsignTo
                     ,dx_call_to2
                     ,hashList.getCallsign(new long[]{callFromHash10})
                     ,report > 0 ? "+" : "-"
-                    ,report
+                    ,Math.abs(report)
             );
         }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -252,12 +252,13 @@ public class Ft8Message {
         if (i3 == 0 && (n3 == 1)) {//this is DXpedition
             // Fox combo: "<acked> RR73; <invited> <foxHash> <report>". The report
             // is already signed, so format its magnitude after the sign char —
-            // otherwise a negative report renders a double minus ("--18").
+            // otherwise a negative report renders a double minus ("--18"). A zero
+            // report formats as "+0" (>= 0), matching WSJT-X, not "-0".
             return String.format("%s RR73; %s %s %s%d"
                     ,callsignTo
                     ,dx_call_to2
                     ,hashList.getCallsign(new long[]{callFromHash10})
-                    ,report > 0 ? "+" : "-"
+                    ,report >= 0 ? "+" : "-"
                     ,Math.abs(report)
             );
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -485,6 +485,14 @@ public class GeneralVariables {
         return myMaidenheadGrid;
     }
 
+    // ===== FT8 DXpedition "Hound" mode =====
+    // When true, the TX engine runs the Hound QSO variant (call Fox high at
+    // 1000-4000 Hz, auto-QSY down to where Fox calls us, reply R+rpt, log on
+    // RR73) instead of the standard auto-sequencer. Mutually exclusive with the
+    // Hunt auto-answer-CQ mode. houndFoxCall is the Fox's base callsign.
+    public static boolean houndMode = false;
+    public static String houndFoxCall = "";
+
     public static float getBaseFrequency() {
         return baseFrequency;
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -742,6 +742,35 @@ public class MainViewModel extends ViewModel {
         ft8TransmitSignal.transmitNow();
     }
 
+    // ===== FT8 DXpedition Hound mode =====
+
+    /**
+     * Enter DXpedition Hound mode and start calling the Fox. Mutually exclusive
+     * with Hunt (auto-answer-CQ), which is disabled here. The rig should already
+     * be tuned to the Fox's published dial frequency.
+     *
+     * @param foxCall    the Fox's base callsign (the DXpedition)
+     * @param callFreqHz initial Hound TX audio frequency, 1000-4000 Hz
+     */
+    public void startHoundMode(String foxCall, float callFreqHz) {
+        if (foxCall == null || foxCall.trim().length() < 3) return;
+        if (GeneralVariables.myCallsign == null
+                || GeneralVariables.myCallsign.length() < 3) return;
+        GeneralVariables.houndMode = true;
+        GeneralVariables.houndFoxCall = foxCall.trim().toUpperCase();
+        GeneralVariables.autoFollowCQ = false;// Hound and Hunt are mutually exclusive
+        GeneralVariables.resetLaunchSupervision();
+        ft8TransmitSignal.startHound(GeneralVariables.houndFoxCall, callFreqHz);
+    }
+
+    /** Leave Hound mode and return to the normal idle/CQ state. */
+    public void stopHoundMode() {
+        GeneralVariables.houndMode = false;
+        GeneralVariables.houndFoxCall = "";
+        ft8TransmitSignal.setActivated(false);
+        ft8TransmitSignal.resetToCQ();
+    }
+
 
     /**
      * Get the followed callsign list from the database

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1065,6 +1065,10 @@ public class FT8TransmitSignal {
         }
         ArrayList<Ft8Message> messages = new ArrayList<>(msgList);// prevent thread conflicts
 
+        if (GeneralVariables.houndMode) {// DXpedition Hound: dedicated QSO handler
+            handleHoundCycle(messages);
+            return;
+        }
 
         int newOrder = checkFunctionOrdFromMessages(messages);// check reply message sequence from the other party; -1 means not received
         // Per-cycle spine of the QSO trace: current state, what (if anything) the
@@ -1206,6 +1210,104 @@ public class FT8TransmitSignal {
         }
 
     }
+
+    // ==================== FT8 DXpedition Hound ====================
+
+    /**
+     * Begin DXpedition Hound operation: call the Fox high (1000-4000 Hz) and let
+     * {@link #handleHoundCycle} auto-QSY and sequence the QSO. The caller sets
+     * {@code GeneralVariables.houndMode = true} first.
+     *
+     * @param foxCall    the Fox's base callsign
+     * @param callFreqHz initial Hound TX audio frequency (1000-4000 Hz)
+     */
+    public void startHound(String foxCall, float callFreqHz) {
+        int i3 = GenerateFT8.checkI3ByCallsign(GeneralVariables.myCallsign);
+        // Fox transmits in the even/1st slot (sequential 0); setTransmit derives
+        // our slot as (fox.sequential + 1) % 2 = 1 (odd), which is where Hounds
+        // are required to transmit.
+        resetTargetReport();
+        setTransmit(new TransmitCallsign(i3, 0, foxCall, callFreqHz, 0, 0), 1, "");
+        setBaseFrequency(callFreqHz);// call Fox at the chosen high frequency
+        setActivated(true);
+        GeneralVariables.fileLog("HOUND: start, fox=" + foxCall
+                + " callFreq=" + Math.round(callFreqHz) + "Hz slot=" + sequential);
+    }
+
+    /**
+     * DXpedition Hound per-cycle handler. Reacts to the Fox's reply to us:
+     * <ul>
+     *   <li>RR73 to me (combo where I'm the acknowledged call, or an explicit
+     *       standard RR73 from Fox) -&gt; log + complete.</li>
+     *   <li>Report/invite to me (combo where I'm the invited second call, or a
+     *       standard "&lt;me&gt; &lt;fox&gt; -rpt") -&gt; QSY to the frequency Fox
+     *       called me on and reply "&lt;fox&gt; &lt;me&gt; R-rpt".</li>
+     *   <li>Otherwise keep calling at the current order (grid-call or R+rpt).</li>
+     * </ul>
+     */
+    private void handleHoundCycle(ArrayList<Ft8Message> messages) {
+        if (toCallsign == null || !toCallsign.haveTargetCallsign()) return;
+        String fox = toCallsign.callsign;
+
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            Ft8Message msg = messages.get(i);
+            if (msg.getSequence() == sequential) continue;// our own slot
+            if (msg.band != GeneralVariables.band) continue;
+
+            boolean combo = (msg.i3 == 0 && msg.n3 == 1);// Fox DXpedition combo
+            boolean toMe = GeneralVariables.checkIsMyCallsign(msg.getCallsignTo());
+
+            // 1) RR73 to me => QSO complete & logged. Combo: I'm the acknowledged
+            //    (first) call. Standard: an explicit RR73 addressed to me by Fox.
+            if ((combo && toMe)
+                    || (msg.i3 == 1 && toMe
+                        && checkCallsignIsCallTo(msg.getCallsignFrom(), fox)
+                        && GeneralVariables.checkFun4(msg.extraInfo))) {
+                GeneralVariables.fileLog("HOUND: RR73 from " + fox + " -> complete");
+                houndComplete();
+                return;
+            }
+
+            // 2) Fox reported / invited me => reply R+rpt at Fox's frequency.
+            //    Combo: I'm the invited second call (dx_call_to2), report = msg.report.
+            //    Standard: "<me> <fox> -rpt" or "<me> <fox> R-rpt".
+            String invited = msg.dx_call_to2 == null ? ""
+                    : msg.dx_call_to2.replace("<", "").replace(">", "");
+            boolean invitedByCombo = combo && GeneralVariables.checkIsMyCallsign(invited);
+            boolean reportStd = msg.i3 == 1 && toMe
+                    && checkCallsignIsCallTo(msg.getCallsignFrom(), fox)
+                    && (GeneralVariables.checkFun2(msg.extraInfo)
+                        || GeneralVariables.checkFun3(msg.extraInfo));
+            if (invitedByCombo || reportStd) {
+                int rpt = invitedByCombo ? msg.report : getReportFromExtraInfo(msg.extraInfo);
+                if (rpt != -100) {
+                    receivedReport = rpt;
+                    receiveTargetReport = rpt;
+                }
+                toCallsign.snr = msg.snr;// Fox's SNR as I hear it -> goes in my R+rpt
+                setBaseFrequency(msg.freq_hz);// auto-QSY to where Fox called me
+                functionOrder = 3;// "<fox> <me> R-rpt"
+                generateFun();
+                setCurrentFunctionOrder(functionOrder);
+                mutableFunctionOrder.postValue(functionOrder);
+                GeneralVariables.fileLog(String.format(
+                        "HOUND: report from %s rpt=%d -> QSY %.0fHz, send R%s",
+                        fox, rpt, msg.freq_hz, toCallsign.getSnr()));
+                return;
+            }
+        }
+        // Nothing relevant this cycle: keep calling at the current order.
+    }
+
+    /** Hound QSO complete: log it, fire the celebration, and stop transmitting. */
+    private void houndComplete() {
+        if (toCallsign == null) return;
+        doComplete();// saves the QSL record + posts mutableQsoCompletedAt
+        setActivated(false);// worked the Fox; stop calling
+        GeneralVariables.fileLog("HOUND: QSO logged with " + toCallsign.callsign);
+    }
+
+    // ==================== End FT8 DXpedition Hound ====================
 
     /**
      * Check watch list for active CQ messages that are not my current target callsign.

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -24,6 +24,7 @@ import androidx.lifecycle.MutableLiveData;
 
 import com.bg7yoz.ft8cn.FT8Common;
 import com.bg7yoz.ft8cn.Ft8Message;
+import com.bg7yoz.ft8cn.ft8signal.FT8Package;
 import com.bg7yoz.ft8cn.GeneralVariables;
 import com.bg7yoz.ft8cn.R;
 import com.bg7yoz.ft8cn.connector.ConnectMode;
@@ -1223,6 +1224,14 @@ public class FT8TransmitSignal {
      */
     public void startHound(String foxCall, float callFreqHz) {
         int i3 = GenerateFT8.checkI3ByCallsign(GeneralVariables.myCallsign);
+        // Seed the Fox callsign's hashes. DXpedition combo messages carry the Fox
+        // only as a 10-bit hash, so without this the combo renders "<...>" in the
+        // UI and handleHoundCycle can't tell whose combo it is. (No-op for a
+        // compound Fox whose combo hashes its full call while the user enters the
+        // base call — handleHoundCycle degrades gracefully in that case.)
+        Ft8Message.hashList.addHash(FT8Package.getHash22(foxCall), foxCall);
+        Ft8Message.hashList.addHash(FT8Package.getHash12(foxCall), foxCall);
+        Ft8Message.hashList.addHash(FT8Package.getHash10(foxCall), foxCall);
         // Fox transmits in the even/1st slot (sequential 0); setTransmit derives
         // our slot as (fox.sequential + 1) % 2 = 1 (odd), which is where Hounds
         // are required to transmit.
@@ -1256,6 +1265,11 @@ public class FT8TransmitSignal {
 
             boolean combo = (msg.i3 == 0 && msg.n3 == 1);// Fox DXpedition combo
             boolean toMe = GeneralVariables.checkIsMyCallsign(msg.getCallsignTo());
+
+            // A combo names the Fox only by a 10-bit hash. If that hash resolves
+            // to a known callsign that isn't our Fox, it belongs to a different
+            // Fox's pileup — skip it so we don't QSY/log against the wrong station.
+            if (combo && !comboFromOurFox(msg, fox)) continue;
 
             // 1) RR73 to me => QSO complete & logged. Combo: I'm the acknowledged
             //    (first) call. Standard: an explicit RR73 addressed to me by Fox.
@@ -1305,6 +1319,21 @@ public class FT8TransmitSignal {
         doComplete();// saves the QSL record + posts mutableQsoCompletedAt
         setActivated(false);// worked the Fox; stop calling
         GeneralVariables.fileLog("HOUND: QSO logged with " + toCallsign.callsign);
+    }
+
+    /**
+     * Whether a DXpedition combo can be attributed to our Fox. The combo names
+     * the Fox only by a 10-bit hash; if that hash resolves to a known callsign
+     * that doesn't match our Fox (base or compound), it's a different Fox's combo.
+     * Returns true when the hash is unknown/unresolved, so we never reject a valid
+     * QSO just because the Fox's (possibly compound) call hasn't been hashed yet.
+     */
+    private boolean comboFromOurFox(Ft8Message msg, String fox) {
+        String resolved = Ft8Message.hashList
+                .getCallsign(new long[]{msg.callFromHash10})
+                .replace("<", "").replace(">", "");
+        if (resolved.isEmpty() || resolved.equals("...")) return true;// unknown -> allow
+        return resolved.equals(fox) || resolved.contains(fox) || fox.contains(resolved);
     }
 
     // ==================== End FT8 DXpedition Hound ====================

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -38,6 +38,7 @@ import radio.ks3ckc.ft8us.theme.BgApp
 import radio.ks3ckc.ft8us.ui.components.ActiveQsoPanel
 import radio.ks3ckc.ft8us.ui.components.FT8USTab
 import radio.ks3ckc.ft8us.ui.components.FrequencyPickerSheet
+import radio.ks3ckc.ft8us.ui.components.HoundSetupSheet
 import radio.ks3ckc.ft8us.ui.components.formatMhz
 import radio.ks3ckc.ft8us.ui.components.QsoCelebration
 import radio.ks3ckc.ft8us.ui.components.SlotTimerBar
@@ -76,6 +77,11 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     // Hunt / auto-answer-CQ mode. Mirrors GeneralVariables.autoFollowCQ (also
     // editable in Settings, which provides the persisted default at startup).
     var huntEnabled by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
+
+    // DXpedition Hound mode. Mirrors GeneralVariables.houndMode; the setup sheet
+    // collects the Fox call + call frequency before starting.
+    var dxEnabled by remember { mutableStateOf(GeneralVariables.houndMode) }
+    var showHoundSetup by remember { mutableStateOf(false) }
 
     // Frequency picker sheet state
     var showFrequencyPicker by rememberSaveable { mutableStateOf(false) }
@@ -212,6 +218,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                 frequencyLabel = frequencyLabel,
                 txSlot = txSlot,
                 huntEnabled = huntEnabled,
+                dxEnabled = dxEnabled,
                 expanded = qsoPanelExpanded,
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {
@@ -223,7 +230,22 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     }
                 },
                 onStop = {
-                    mainViewModel.ft8TransmitSignal.setActivated(false)
+                    // In Hound mode the STOP button leaves Hound entirely;
+                    // otherwise it just deactivates the normal sequencer.
+                    if (GeneralVariables.houndMode) {
+                        mainViewModel.stopHoundMode()
+                        dxEnabled = false
+                    } else {
+                        mainViewModel.ft8TransmitSignal.setActivated(false)
+                    }
+                },
+                onToggleDx = {
+                    if (dxEnabled || GeneralVariables.houndMode) {
+                        mainViewModel.stopHoundMode()
+                        dxEnabled = false
+                    } else {
+                        showHoundSetup = true
+                    }
                 },
                 onToggleSlot = {
                     val current = mainViewModel.ft8TransmitSignal.sequential
@@ -272,6 +294,24 @@ fun FT8USApp(mainViewModel: MainViewModel) {
             onSelect = { idx ->
                 selectBandIndex(mainViewModel, context, idx)
                 showFrequencyPicker = false
+            },
+        )
+
+        // DXpedition Hound setup — collects the Fox call + call frequency, then
+        // starts calling (disabling Hunt, which is mutually exclusive).
+        HoundSetupSheet(
+            visible = showHoundSetup,
+            initialFoxCall = GeneralVariables.houndFoxCall,
+            onDismiss = { showHoundSetup = false },
+            onStart = { foxCall, callFreqHz ->
+                if (GeneralVariables.myCallsign.isNullOrEmpty()) {
+                    Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()
+                } else {
+                    mainViewModel.startHoundMode(foxCall, callFreqHz)
+                    dxEnabled = true
+                    huntEnabled = false
+                    showHoundSetup = false
+                }
             },
         )
     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/HoundSetupSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/HoundSetupSheet.kt
@@ -1,0 +1,78 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+
+/**
+ * Setup dialog for FT8 DXpedition "Hound" mode. The user tunes the rig to the
+ * Fox's published dial frequency (via the normal frequency picker), then enters
+ * the Fox's base callsign here and an initial call frequency in the 1000-4000 Hz
+ * Hound band. On Start, the app begins calling the Fox and auto-QSYs down when
+ * answered.
+ */
+@Composable
+fun HoundSetupSheet(
+    visible: Boolean,
+    initialFoxCall: String,
+    onDismiss: () -> Unit,
+    onStart: (foxCall: String, callFreqHz: Float) -> Unit,
+) {
+    if (!visible) return
+
+    var foxCall by remember { mutableStateOf(initialFoxCall) }
+    var callFreq by remember { mutableStateOf("2500") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Work a DXpedition (Hound)") },
+        text = {
+            Column {
+                Text(
+                    "Tune the rig to the Fox's published dial frequency first. " +
+                        "You call high (1000–4000 Hz); the app auto-QSYs you " +
+                        "down to where the Fox answers and replies with your report.",
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = foxCall,
+                    onValueChange = { foxCall = it.uppercase().trim() },
+                    label = { Text("Fox callsign") },
+                    singleLine = true,
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = callFreq,
+                    onValueChange = { v -> callFreq = v.filter { it.isDigit() }.take(4) },
+                    label = { Text("Call frequency (Hz, 1000–4000)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val f = (callFreq.toFloatOrNull() ?: 2500f).coerceIn(1000f, 4000f)
+                    if (foxCall.trim().length >= 3) onStart(foxCall.trim(), f)
+                },
+            ) { Text("Start") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -39,11 +39,13 @@ fun TxStrip(
     frequencyLabel: String,
     txSlot: Int,
     huntEnabled: Boolean,
+    dxEnabled: Boolean = false,
     expanded: Boolean = false,
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
     onToggleSlot: () -> Unit,
     onToggleHunt: () -> Unit,
+    onToggleDx: () -> Unit = {},
     onOpenFrequencyPicker: () -> Unit,
     onToggleExpand: () -> Unit = {},
     modifier: Modifier = Modifier,
@@ -139,6 +141,30 @@ fun TxStrip(
                     size = 12.dp,
                     color = TextMuted,
                     strokeWidth = 2f,
+                )
+            }
+
+            // DX (DXpedition Hound) toggle pill. On = working a Fox/DXpedition
+            // (call high, auto-QSY when answered). Mutually exclusive with HUNT/CQ.
+            val dxBg = if (dxEnabled) Accent.copy(alpha = 0.18f) else BgSurface3
+            val dxColor = if (dxEnabled) Accent else TextMuted
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(dxBg)
+                    .clickable { onToggleDx() }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "DX",
+                    color = dxColor,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
+                    maxLines = 1,
+                    softWrap = false,
                 )
             }
 

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
@@ -185,6 +185,34 @@ public class Ft8MessageTest {
         assertThat(msg.getMessageText()).isEqualTo("<G4ABC> <PA9XYZ> R 570007 JO22DB");
     }
 
+    @Test
+    public void getMessageText_dxpeditionCombo_negativeReportSingleSign() {
+        // i3=0, n3=1 DXpedition combo: "<acked> RR73; <invited> <foxHash> <rpt>".
+        // An unseeded Fox hash resolves to "<...>"; a negative report must render a
+        // single minus (regression: the magnitude is formatted after the sign char).
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        msg.i3 = 0;
+        msg.n3 = 1;
+        msg.callsignTo = "K1ABC";
+        msg.dx_call_to2 = "W9XYZ";
+        msg.callFromHash10 = 0;
+        msg.report = -18;
+        assertThat(msg.getMessageText()).isEqualTo("K1ABC RR73; W9XYZ <...> -18");
+    }
+
+    @Test
+    public void getMessageText_dxpeditionCombo_zeroReportIsPlusZero() {
+        // A zero report formats as "+0" (>= 0), matching WSJT-X, not "-0".
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        msg.i3 = 0;
+        msg.n3 = 1;
+        msg.callsignTo = "K1ABC";
+        msg.dx_call_to2 = "W9XYZ";
+        msg.callFromHash10 = 0;
+        msg.report = 0;
+        assertThat(msg.getMessageText()).isEqualTo("K1ABC RR73; W9XYZ <...> +0");
+    }
+
     // ---- getCallsignFrom / getCallsignTo ------------------------------------
 
     @Test


### PR DESCRIPTION
## FT8 DXpedition "Hound" mode

Adds the **Hound** side of FT8 DXpedition (Fox/Hound) mode — the high-value path that lets a phone user work a rare DXpedition "Fox." Protocol verified against K1JT's official *FT8 DXpedition Mode User Guide* (WSJT-X 1.9).

### How it works
1. Tune the rig to the Fox's published dial frequency, tap the new **DX** chip in the TX strip, enter the Fox's callsign, and Start.
2. The app calls the Fox **high (1000–4000 Hz)** with a standard grid-call, locked to the **odd** slot.
3. When the Fox answers (either a standard `<me> <fox> -rpt` or the DXpedition **combo** `<other> RR73; <me> <hash> -rpt`), the app **auto-QSYs** down to the frequency the Fox called us on and replies `<fox> <me> R-rpt`.
4. On **RR73** (the combo where our call is the acknowledged one), the QSO is logged and TX stops.

### Why this is small / low-risk
A decode spike (against a WSJT-X `ft8code`-generated reference frame, played through the app's decoder on-device) proved the Fox **combo message (`i3=0/n3=1`) already decodes and surfaces to Java** with `callsignTo` / `dx_call_to2` / `report` / Fox-hash populated. And the Hound only ever *transmits* standard `i3=1` messages (grid-call + R+rpt), which already encode. So:
- **No native/DSP changes.** No decoder work, no message-codec work, no multi-signal mixing.
- The Hound QSO handler is **gated behind `houndMode`** — the existing standard auto-sequencer is untouched.

### Changes
- `Ft8Message` — fix a cosmetic double-sign (`--18`) in the existing `i3=0/n3=1` formatter.
- `GeneralVariables` — `houndMode` + `houndFoxCall` flags.
- `FT8TransmitSignal` — `startHound()` + `handleHoundCycle()`; reuses `getFunctionCommand` orders 1/3 and the proven `doComplete()` logging.
- `MainViewModel` — `startHoundMode()` / `stopHoundMode()` (disables Hunt; the two are mutually exclusive).
- `TxStrip` — new **DX** chip; `FT8USApp` — `HoundSetupSheet` (Fox call + call frequency).

### Verification
- ✅ Builds, installs, launches on a Pixel 8 without crash.
- ✅ DX chip renders and opens the setup sheet; entering a Fox call + Start logs `HOUND: start … slot=1`.
- ✅ Transmits the grid-call **in the odd slot** every cycle (`QSO: TX slot=1 order=1 msg=[<fox> K1AF EM28]`), with Hunt auto-disabled.
- ⏳ **Full QSO sequencing** (invite → auto-QSY → R+rpt → RR73 → log) reuses proven primitives and the spike-verified decode path, but **awaits on-air validation against a live Fox** (can't be exercised without a real DXpedition or a callsign-matched injection harness).

### Follow-ups (intentionally out of scope)
- Polish: decoding-✓-gated CALL button, auto-QSY waterfall animation, 2-min re-arm countdown chip, directed-CQ guard, ±300 Hz R+rpt retry.
- **Fox mode** (run a pileup) — designed but deferred; needs the combo *encoder* + multi-signal mixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
