### PR TITLE
Reject POTA activations with no matching QSOs (no empty ADIF)

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaAdifExporter.kt
@@ -90,6 +90,12 @@ object PotaAdifExporter {
             }
         }
 
+        // No matching QSO rows → no documents. Without this we'd emit header-only
+        // ADIF files (one per park), which the upload path would happily POST and the
+        // share path would attach as empty logs. Callers treat an empty list as
+        // "nothing to upload/share".
+        if (rows.isEmpty()) return emptyList()
+
         val ts = SimpleDateFormat("yyyyMMdd-HHmm", Locale.US).format(Date(activation.startedAtMs))
         return activation.parkRefs.map { parkRef ->
             val sb = StringBuilder()
@@ -134,6 +140,11 @@ object PotaAdifExporter {
         scope.launch {
             try {
                 val docs = buildActivationAdif(db, activation)
+                if (docs.isEmpty()) {
+                    // No QSOs matched this activation — nothing to share.
+                    onResult(false)
+                    return@launch
+                }
                 val dir = context.getExternalFilesDir(null) ?: run {
                     onResult(false)
                     return@launch

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/BuildActivationAdifTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/BuildActivationAdifTest.kt
@@ -166,6 +166,24 @@ class BuildActivationAdifTest {
     }
 
     @Test
+    fun noMatchingQsos_returnsEmptyList_notHeaderOnlyDocs() {
+        // A row exists, but for a different park — so this activation has no QSOs.
+        insertQso("OTHER", "20240601", "1230", mySigInfo = "K-9999")
+
+        val docs = PotaAdifExporter.buildActivationAdif(db, activation("K-1234"))
+
+        // Must be empty (so callers reject it), not one header-only doc per park.
+        assertThat(docs).isEmpty()
+    }
+
+    @Test
+    fun noRowsAtAll_returnsEmptyList() {
+        val docs = PotaAdifExporter.buildActivationAdif(db, activation("K-1234,K-5678"))
+
+        assertThat(docs).isEmpty()
+    }
+
+    @Test
     fun onlyPotaRowsMatchingTheParkAreIncluded() {
         insertQso("INPARK", "20240601", "1230", mySigInfo = "K-1234")
         // Different park — must not bleed into K-1234's document.


### PR DESCRIPTION
## What

Follow-up to #154 (merged). Fixes an edge case I flagged during that review.

`PotaAdifExporter.buildActivationAdif` returned one ADIF document **per park
regardless of whether any QSO rows matched** the activation. So an activation
whose `my_sig_info` didn't line up (e.g. mismatched park string) produced
**header-only ADIF files** — the in-app upload path would happily `POST` them,
and the share path would attach empty logs.

## Fix

- `buildActivationAdif` returns an **empty list** when no QSO rows match.
- The upload guard (`docs.isEmpty()` → "no QSOs to upload") now fires correctly.
- `shareActivationAdif` bails with `onResult(false)` on an empty result.

## Tests

Two new cases in `BuildActivationAdifTest`:
- a row exists but for a different park → empty list (not header-only docs)
- no rows at all → empty list

All green; `testDebugUnitTest` passes on top of `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)