### PR TITLE
Serialize Play publishing to prevent edit-expired races

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,6 +11,25 @@ on:
 permissions:
   contents: write
 
+# Google Play allows only one active "edit" per app, so two release builds
+# publishing at once make the second fail with "This edit has expired, please
+# create a new Edit." Serialize the release-publishing runs (pushes to dev/main
+# and v* tags) into a single queue so they never overlap on the Play API.
+# cancel-in-progress is false so an in-flight publish finishes rather than being
+# killed mid-upload. Everything else (PRs, feature-branch pushes) gets a unique
+# group keyed to its run id and is never queued.
+concurrency:
+  group: >-
+    ${{
+      (github.event_name == 'push'
+        && (github.ref == 'refs/heads/main'
+          || github.ref == 'refs/heads/dev'
+          || startsWith(github.ref, 'refs/tags/v')))
+      && 'play-publish'
+      || format('build-{0}', github.run_id)
+    }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Unit tests & coverage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,8 +16,8 @@ permissions:
 # create a new Edit." Serialize the release-publishing runs (pushes to dev/main
 # and v* tags) into a single queue so they never overlap on the Play API.
 # cancel-in-progress is false so an in-flight publish finishes rather than being
-# killed mid-upload. Everything else (PRs, feature-branch pushes) gets a unique
-# group keyed to its run id and is never queued.
+# killed mid-upload. Pull request runs get a unique group keyed to run id, so
+# they never queue and CI stays fast.
 concurrency:
   group: >-
     ${{


### PR DESCRIPTION
## Problem

The `Build APK` check on the dev→main release PR (#165) went red. The APK and AAB built fine — the failure was in the final **Publish AAB to Play Internal track** step:

```
##[error]This edit has expired, please create a new Edit.
```

## Root cause

Two pushes to `dev` landed **19 seconds apart** and both reached the Play publish step concurrently:

| Run | Trigger | Started | Result |
|-----|---------|---------|--------|
| `27165014434` | Merge #161 | 20:29:25Z | ✅ published `dev-333` |
| `27165030095` | Merge #163 | 20:29:44Z | ❌ `dev-334` — edit expired |

The Google Play Developer API allows only **one active "edit" per app**. When the second run opened its edit while the first still held one, the first commit invalidated the second → `This edit has expired`. Nothing was wrong with the build.

## Fix

Add a workflow-level `concurrency` group so all release-*publishing* runs (pushes to `main`/`dev` and `v*` tags) share a single `play-publish` queue and run one-at-a-time:

```yaml
concurrency:
  group: >-
    ${{ (github.event_name == 'push'
          && (github.ref == 'refs/heads/main'
            || github.ref == 'refs/heads/dev'
            || startsWith(github.ref, 'refs/tags/v')))
        && 'play-publish'
        || format('build-{0}', github.run_id) }}
  cancel-in-progress: false
```

- `cancel-in-progress: false` — an in-flight upload finishes instead of being killed mid-publish.
- PRs and feature-branch pushes get a unique per-run group (`build-<run_id>`) so they're **never** queued and CI stays fast.

## Notes

- No app code changed, so there's no unit test to add — this is CI orchestration config only. Validated that the workflow YAML parses.
- The already-failed `dev-334` run will be re-run separately to clear the red check on #165; with no concurrent edit live, it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
