### PR TITLE
Add manual time correction for offline operating

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -342,6 +342,7 @@ public class GeneralVariables {
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.
+    public static int manualTimeCorrectionMs = 0;//Manual clock correction (ms) applied to UtcTimer.delay; for field use without internet NTP. Range -2000..2000. See TimeSyncSettings.
     public static boolean earlyDecode = true;//Fast turnaround: decode a shorter RX window so CQ decodes appear ~1s before the cycle boundary, enabling a next-slot reply.
     public static int operatingMode = FT8Common.FT8_MODE;//Current operating mode (FT8Common.FT8_MODE / FT4_MODE); persisted as config "operatingMode".
     public static boolean autoCQAfterQSO = false;//Auto-CQ: keep calling CQ after each completed QSO (chain without re-tapping). Refreshes the TX watchdog per QSO and forces pure CQ (ignores Hunt).

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2307,6 +2307,20 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                         GeneralVariables.transmitDelay = FT8Common.FT8_TRANSMIT_DELAY;
                     }
                 }
+                //Manual time correction (ms). Re-applied to UtcTimer.delay at startup so a
+                //field operator's offline clock nudge survives a relaunch. delay is read live
+                //by the running timers, so this takes effect immediately.
+                if (name.equalsIgnoreCase("timeCorrectionMs")) {
+                    int ms;
+                    try {
+                        ms = Integer.parseInt(result.trim());
+                    } catch (NumberFormatException e) {
+                        ms = 0;
+                    }
+                    ms = Math.max(-2000, Math.min(2000, ms));
+                    GeneralVariables.manualTimeCorrectionMs = ms;
+                    UtcTimer.delay = ms;
+                }
 
                 if (name.equalsIgnoreCase("civ")) {
                     GeneralVariables.civAddress = result.equals("") ? 0xa4 : Integer.parseInt(result, 16);

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreen.kt
@@ -66,6 +66,7 @@ import radio.ks3ckc.ft8us.ui.components.TopBar
 private enum class SettingsCategory {
     RADIO_AUDIO,
     TRANSMISSION,
+    TIME_SYNC,
     DECODE_FILTERS,
     LOGGING,
     ADVANCED,
@@ -115,6 +116,8 @@ fun SettingsScreen(
                 RadioAudioSettings(mainViewModel, onBack = { currentCategory = null })
             SettingsCategory.TRANSMISSION ->
                 TransmissionSettings(mainViewModel, onBack = { currentCategory = null })
+            SettingsCategory.TIME_SYNC ->
+                TimeSyncSettings(mainViewModel, onBack = { currentCategory = null })
             SettingsCategory.DECODE_FILTERS ->
                 DecodeFilterSettings(mainViewModel, onBack = { currentCategory = null })
             SettingsCategory.LOGGING ->
@@ -274,6 +277,13 @@ private fun SettingsLanding(
                         label = stringResource(R.string.settings_cat_transmission),
                         showChevron = true,
                         onClick = { onOpenCategory(SettingsCategory.TRANSMISSION) },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_cat_time_sync),
+                        description = stringResource(R.string.settings_cat_time_sync_desc),
+                        showChevron = true,
+                        onClick = { onOpenCategory(SettingsCategory.TIME_SYNC) },
                     )
                     SectionDivider()
                     SettingsRow(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrection.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrection.kt
@@ -1,0 +1,54 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Pure decision/format logic for the manual time-correction control. Kept out of
+ * the Composable so it can be unit-tested directly (Compose/DrawScope code can't).
+ *
+ * The correction is a millisecond offset that drives `UtcTimer.delay`; positive
+ * shifts the app's clock forward. FT8 only tolerates being a second or two off
+ * the 15 s cycle, so the range is intentionally tight.
+ */
+
+/** Inclusive bounds for the manual correction, in milliseconds. */
+internal const val TIME_CORRECTION_MIN_MS = -2000
+internal const val TIME_CORRECTION_MAX_MS = 2000
+
+/** Coerce an arbitrary correction into the allowed range. */
+internal fun clampCorrectionMs(ms: Int): Int =
+    ms.coerceIn(TIME_CORRECTION_MIN_MS, TIME_CORRECTION_MAX_MS)
+
+/** Apply a stepper nudge (e.g. +100 or -500 ms) and clamp to range. */
+internal fun stepCorrectionMs(current: Int, deltaMs: Int): Int =
+    clampCorrectionMs(current + deltaMs)
+
+/**
+ * Suggest a new correction from the average decode DT of the stations we're
+ * hearing — the only time reference available offline.
+ *
+ * `avgDtSec` is WSJT-style DT (seconds): how far into our RX window the decoded
+ * signals landed. If decodes cluster at a positive DT our window opened early
+ * (clock fast), so we subtract that amount; a negative DT means we open late
+ * (clock slow), so we add. The goal is to push the measured DT toward zero.
+ *
+ * Sign is verified on-device (apply, watch the live DT trend toward 0) — if it
+ * worsens, flip the `-` here.
+ */
+internal fun suggestedCorrectionMs(currentDelayMs: Int, avgDtSec: Float): Int =
+    clampCorrectionMs(currentDelayMs - (avgDtSec * 1000f).roundToInt())
+
+/**
+ * Human-readable offset, e.g. "+0.6 s", "-0.3 s", "0.0 s". Used for both the
+ * current correction and the measured/suggested DT.
+ */
+internal fun formatOffsetMs(ms: Int): String {
+    val sign = when {
+        ms > 0 -> "+"
+        ms < 0 -> "-"
+        else -> ""
+    }
+    return String.format(Locale.US, "%s%.1f s", sign, abs(ms) / 1000.0)
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeSyncSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeSyncSettings.kt
@@ -154,7 +154,7 @@ fun TimeSyncSettings(
                             fontSize = 15.sp,
                             fontWeight = FontWeight.SemiBold,
                             modifier = Modifier
-                                .clickable { apply(suggestedCorrectionMs(UtcTimer.delay, dt)) }
+                                .clickable { apply(suggestedCorrectionMs(correctionMs, dt)) }
                                 .padding(vertical = 6.dp),
                         )
                     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeSyncSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeSyncSettings.kt
@@ -1,0 +1,191 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.bg7yoz.ft8cn.MainViewModel
+import com.bg7yoz.ft8cn.R
+import com.bg7yoz.ft8cn.timer.UtcTimer
+import radio.ks3ckc.ft8us.theme.*
+import radio.ks3ckc.ft8us.ui.components.GlassCard
+import kotlin.math.roundToInt
+
+/**
+ * Time Sync settings: a manual clock-correction control for operating offline,
+ * where the NTP auto-sync ("Sync now", needs internet) can't reach a time server.
+ *
+ * The correction drives [UtcTimer.delay] (ms) — the single offset every RX window,
+ * TX start, and the slot-timer bar reads through — and is persisted so it survives
+ * a relaunch. A suggestion is derived from the average decode DT of stations we're
+ * hearing (our only time reference when offline); see [suggestedCorrectionMs].
+ */
+@Composable
+fun TimeSyncSettings(
+    mainViewModel: MainViewModel,
+    onBack: () -> Unit,
+) {
+    // UtcTimer.delay is the live source of truth; seed local state from it.
+    var correctionMs by remember { mutableIntStateOf(UtcTimer.delay) }
+
+    // Latest cycle's average decode DT (seconds), posted in MainViewModel.afterDecode.
+    // Null until the first decode this session.
+    val avgDtSec by mainViewModel.mutableTimerOffset.observeAsState()
+
+    // Apply a new correction everywhere: live timer, in-memory config mirror, and DB.
+    fun apply(newMs: Int) {
+        val clamped = clampCorrectionMs(newMs)
+        correctionMs = clamped
+        UtcTimer.delay = clamped
+        GeneralVariables.manualTimeCorrectionMs = clamped
+        mainViewModel.databaseOpr.writeConfig("timeCorrectionMs", clamped.toString(), null)
+    }
+
+    SettingsDetailScaffold(
+        title = stringResource(R.string.settings_cat_time_sync),
+        onBack = onBack,
+    ) {
+        // =====================================================================
+        // MANUAL CORRECTION
+        // =====================================================================
+        SettingsSection(title = stringResource(R.string.settings_time_correction_section)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_time_current_label),
+                        color = TextMuted,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = formatOffsetMs(correctionMs),
+                        color = if (correctionMs == 0) TextPrimary else Accent,
+                        fontSize = 32.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = GeistMonoFamily,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        StepButton("-0.5", Modifier.weight(1f)) { apply(stepCorrectionMs(correctionMs, -500)) }
+                        StepButton("-0.1", Modifier.weight(1f)) { apply(stepCorrectionMs(correctionMs, -100)) }
+                        StepButton("+0.1", Modifier.weight(1f)) { apply(stepCorrectionMs(correctionMs, 100)) }
+                        StepButton("+0.5", Modifier.weight(1f)) { apply(stepCorrectionMs(correctionMs, 500)) }
+                    }
+                    Text(
+                        text = stringResource(R.string.settings_time_correction_reset),
+                        color = if (correctionMs == 0) TextFaint else Accent,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(enabled = correctionMs != 0) { apply(0) }
+                            .padding(vertical = 6.dp),
+                    )
+                }
+            }
+            Text(
+                text = stringResource(R.string.settings_time_correction_desc),
+                color = TextMuted,
+                fontSize = 13.sp,
+                modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+            )
+        }
+
+        // =====================================================================
+        // SUGGESTION (from decode DT)
+        // =====================================================================
+        SettingsSection(title = stringResource(R.string.settings_time_suggest_section)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    val dt = avgDtSec
+                    if (dt == null) {
+                        Text(
+                            text = stringResource(R.string.settings_time_suggest_none),
+                            color = TextMuted,
+                            fontSize = 14.sp,
+                        )
+                    } else {
+                        val dtMs = (dt * 1000f).roundToInt()
+                        Text(
+                            text = stringResource(
+                                R.string.settings_time_suggest_label,
+                                formatOffsetMs(dtMs),
+                            ),
+                            color = TextPrimary,
+                            fontSize = 15.sp,
+                            fontFamily = GeistMonoFamily,
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_time_suggest_apply),
+                            color = Accent,
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier
+                                .clickable { apply(suggestedCorrectionMs(UtcTimer.delay, dt)) }
+                                .padding(vertical = 6.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A bordered, tappable stepper button (e.g. "-0.1"). Kept local to this screen.
+ */
+@Composable
+private fun StepButton(
+    label: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .border(BorderStroke(1.dp, BorderStrong), RoundedCornerShape(10.dp))
+            .clickable { onClick() }
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            color = Accent,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = GeistMonoFamily,
+        )
+    }
+}

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -342,6 +342,18 @@
     <string name="settings_cat_logging">Logging &amp; Awards</string>
     <string name="settings_cat_advanced">Advanced</string>
     <string name="settings_cat_about">About</string>
+    <string name="settings_cat_time_sync">Time Sync</string>
+    <string name="settings_cat_time_sync_desc">Manual clock correction for offline operating</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Manual Correction</string>
+    <string name="settings_time_current_label">Current correction</string>
+    <string name="settings_time_correction_reset">Reset to 0</string>
+    <string name="settings_time_correction_desc">Nudge the app clock when you have no internet to sync. FT8 needs UTC within about 1 second. Adjust until the DT column on decoded stations centers near 0.</string>
+    <string name="settings_time_suggest_section">Suggested from decodes</string>
+    <string name="settings_time_suggest_none">No decodes yet — start receiving to get a suggestion.</string>
+    <string name="settings_time_suggest_label">Recent average DT: %1$s</string>
+    <string name="settings_time_suggest_apply">Apply suggested correction</string>
 
     <!-- ===== Settings: operator identity ===== -->
     <string name="settings_auto_update_grid">Auto-update Grid (GPS)</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrectionTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrectionTest.kt
@@ -1,0 +1,71 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for the manual time-correction math (no Android/Compose deps,
+ * so no Robolectric runner needed).
+ */
+class TimeCorrectionTest {
+
+    @Test
+    fun clamp_keepsValuesInRange() {
+        assertThat(clampCorrectionMs(0)).isEqualTo(0)
+        assertThat(clampCorrectionMs(500)).isEqualTo(500)
+        assertThat(clampCorrectionMs(-500)).isEqualTo(-500)
+        assertThat(clampCorrectionMs(TIME_CORRECTION_MAX_MS)).isEqualTo(2000)
+        assertThat(clampCorrectionMs(TIME_CORRECTION_MIN_MS)).isEqualTo(-2000)
+    }
+
+    @Test
+    fun clamp_pinsBeyondRange() {
+        assertThat(clampCorrectionMs(5000)).isEqualTo(2000)
+        assertThat(clampCorrectionMs(-5000)).isEqualTo(-2000)
+    }
+
+    @Test
+    fun step_addsAndClamps() {
+        assertThat(stepCorrectionMs(0, 100)).isEqualTo(100)
+        assertThat(stepCorrectionMs(0, -100)).isEqualTo(-100)
+        assertThat(stepCorrectionMs(400, 500)).isEqualTo(900)
+        // +0.5 s past the +2.0 s rail pins to the max.
+        assertThat(stepCorrectionMs(1800, 500)).isEqualTo(2000)
+        // -0.5 s past the -2.0 s rail pins to the min.
+        assertThat(stepCorrectionMs(-1800, -500)).isEqualTo(-2000)
+    }
+
+    @Test
+    fun suggested_subtractsAverageDt() {
+        // Decodes land +0.6 s late in our window (clock fast) -> subtract 600 ms.
+        assertThat(suggestedCorrectionMs(0, 0.6f)).isEqualTo(-600)
+        // Decodes land -0.4 s early (clock slow) -> add 400 ms.
+        assertThat(suggestedCorrectionMs(0, -0.4f)).isEqualTo(400)
+        // Builds on the existing correction.
+        assertThat(suggestedCorrectionMs(200, 0.3f)).isEqualTo(-100)
+        // Already centered -> no change.
+        assertThat(suggestedCorrectionMs(150, 0.0f)).isEqualTo(150)
+    }
+
+    @Test
+    fun suggested_clampsToRange() {
+        assertThat(suggestedCorrectionMs(0, -5.0f)).isEqualTo(2000)
+        assertThat(suggestedCorrectionMs(0, 5.0f)).isEqualTo(-2000)
+    }
+
+    @Test
+    fun format_signsAndZero() {
+        assertThat(formatOffsetMs(0)).isEqualTo("0.0 s")
+        assertThat(formatOffsetMs(600)).isEqualTo("+0.6 s")
+        assertThat(formatOffsetMs(-300)).isEqualTo("-0.3 s")
+        assertThat(formatOffsetMs(2000)).isEqualTo("+2.0 s")
+        assertThat(formatOffsetMs(-2000)).isEqualTo("-2.0 s")
+    }
+
+    @Test
+    fun format_roundsToOneDecimal() {
+        assertThat(formatOffsetMs(640)).isEqualTo("+0.6 s")
+        assertThat(formatOffsetMs(660)).isEqualTo("+0.7 s")
+        assertThat(formatOffsetMs(-660)).isEqualTo("-0.7 s")
+    }
+}


### PR DESCRIPTION
## Why

FT8 only decodes/transmits when the device clock is within ~1 s of UTC on the 15 s cycle. Both existing sync paths fail in the field:

- **NTP auto-sync** (`UtcTimer.syncTime` → `time.windows.com`) needs internet.
- The legacy ±7.5 s spinner lives only in the dead `ConfigFragment` — the active Compose Settings UI had **no time control at all**.

User feedback: *"please add manual time correction, sometimes we operate somewhere without internet connection."*

## What

A new **Time Sync** settings category:

- **±/− stepper** (±0.1 s and ±0.5 s, range ±2.0 s) + **Reset to 0**, driving `UtcTimer.delay` — the single offset every RX window, TX start, and the `SlotTimerBar` already reads through, so corrections take effect live.
- **Persisted** under a new `timeCorrectionMs` config key and re-applied to `UtcTimer.delay` at startup (loaded in `DatabaseOpr.GetAllConfigParameter`), so an offline nudge survives a relaunch.
- **Suggestion card** surfacing the most recent cycle's average decode DT (`mainViewModel.mutableTimerOffset`) — the only time reference available offline — with one-tap apply.

Decision/format logic is extracted into pure, unit-tested functions (`TimeCorrection.kt` / `TimeCorrectionTest.kt`); the Composable is a thin wrapper.

## Files

- `TimeSyncSettings.kt` (new) — the screen
- `TimeCorrection.kt` (new) — pure clamp/step/suggested/format logic
- `TimeCorrectionTest.kt` (new) — JUnit4 + Truth, no Robolectric
- `SettingsScreen.kt` — `TIME_SYNC` category enum + routing + landing row
- `GeneralVariables.java` / `DatabaseOpr.java` — persist + load `timeCorrectionMs`
- `strings_compose.xml` — new strings (default locale; others fall back until translated)

## Testing

- ✅ `gradlew testDebugUnitTest --tests *TimeCorrectionTest` — pure logic (clamp/step/suggested/format).
- ✅ `installDebug` on Pixel 8 — builds, installs, launches without crash.

### Manual verification still recommended (needs a human + live RF)
- Settings → **Time Sync**: tap +0.5 s; confirm the `SlotTimerBar` countdown shifts and the value reads `+0.5 s`. Force-close & relaunch → correction persists.
- With signals decoding, confirm the suggestion shows the recent avg DT; tap **Apply suggested** and watch the live decode **DT** column trend toward 0. **This verifies the suggestion sign** — if DT worsens, flip the `-` in `suggestedCorrectionMs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)