### PR TITLE
Add tappable CAT connection status chip to TX strip

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -366,6 +366,10 @@ public class GeneralVariables {
         return android.text.TextUtils.join(",", excludedBands);
     }
     public static int controlMode = ControlMode.VOX;
+    //Control-mode change signal so Compose can react when the user switches
+    //VOX <-> CAT/RTS/DTR (e.g. to show/hide the CAT status chip). No initial
+    //value: observers seed from the current controlMode until a change posts.
+    public static MutableLiveData<Integer> mutableControlMode = new MutableLiveData<>();
     public static int modelNo = 0;
     public static int launchSupervision = DEFAULT_LAUNCH_SUPERVISION;//Transmit supervision
     public static long launchSupervisionStart = UtcTimer.getSystemTime();//Auto-transmit start time

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -216,28 +216,40 @@ public class MainViewModel extends ViewModel {
     public MutableLiveData<ArrayList<CableSerialPort.SerialPort>> mutableSerialPorts = new MutableLiveData<>();
     private ArrayList<CableSerialPort.SerialPort> serialPorts;//serial port list
     public BaseRig baseRig;//rig
-    //Observable CAT connection state for the UI status chip. Updated off the UI
-    //thread by the connector callbacks below, so use postValue everywhere.
+    //Observable CAT connection state for the UI status chip. The callbacks below
+    //fire off the UI thread, so LiveData is updated via postValue. catConnectionState
+    //is a synchronous mirror of the same value: a failed Bluetooth connect calls
+    //onRunError() immediately followed by onDisconnected(), and reading LiveData's
+    //value across those two posts would race — so the ERROR-preserving guard reads
+    //the synchronous field instead.
     public final MutableLiveData<CatConnectionState> mutableCatConnectionState =
             new MutableLiveData<>(CatConnectionState.DISCONNECTED);
+    private volatile CatConnectionState catConnectionState = CatConnectionState.DISCONNECTED;
+
+    private void setCatConnectionState(CatConnectionState state) {
+        catConnectionState = state;
+        mutableCatConnectionState.postValue(state);
+    }
     private final OnRigStateChanged onRigStateChanged = new OnRigStateChanged() {
         @Override
         public void onDisconnected() {
-            //disconnected from rig
-            mutableCatConnectionState.postValue(CatConnectionState.DISCONNECTED);
+            //disconnected from rig. A failed connect fires onRunError() then
+            //onDisconnected(); afterDisconnect() preserves ERROR so the chip can
+            //stay red until the next connect attempt (onConnecting) or a success.
+            setCatConnectionState(CatConnectionState.afterDisconnect(catConnectionState));
             ToastMessage.show(getStringFromResource(R.string.disconnect_rig));
         }
 
         @Override
         public void onConnecting() {
             //connection attempt started
-            mutableCatConnectionState.postValue(CatConnectionState.CONNECTING);
+            setCatConnectionState(CatConnectionState.CONNECTING);
         }
 
         @Override
         public void onConnected() {
             //connected to rig
-            mutableCatConnectionState.postValue(CatConnectionState.CONNECTED);
+            setCatConnectionState(CatConnectionState.CONNECTED);
             ToastMessage.show(getStringFromResource(R.string.connected_rig));
         }
 
@@ -263,7 +275,7 @@ public class MainViewModel extends ViewModel {
         @Override
         public void onRunError(String message) {
             //rig communication error
-            mutableCatConnectionState.postValue(CatConnectionState.ERROR);
+            setCatConnectionState(CatConnectionState.ERROR);
             ToastMessage.show(String.format(getStringFromResource(R.string.radio_communication_error)
                     , message));
         }
@@ -963,6 +975,8 @@ public class MainViewModel extends ViewModel {
         if (baseRig != null) {
             baseRig.setControlMode(GeneralVariables.controlMode);
         }
+        //Notify observers (CAT status chip visibility) of the mode change.
+        GeneralVariables.mutableControlMode.postValue(GeneralVariables.controlMode);
     }
 
 
@@ -976,6 +990,7 @@ public class MainViewModel extends ViewModel {
         if (GeneralVariables.controlMode == ControlMode.VOX) {//if currently VOX, switch to CAT mode
             GeneralVariables.controlMode = ControlMode.CAT;
             databaseOpr.writeConfig("ctrMode", String.valueOf(ControlMode.CAT), null);
+            GeneralVariables.mutableControlMode.postValue(GeneralVariables.controlMode);
         }
         connectRig();
 
@@ -1012,6 +1027,7 @@ public class MainViewModel extends ViewModel {
 
     public void connectBluetoothRig(Context context, BluetoothDevice device) {
         GeneralVariables.controlMode = ControlMode.CAT;//Bluetooth control mode, only CAT control is supported
+        GeneralVariables.mutableControlMode.postValue(GeneralVariables.controlMode);
         connectRig();
         if (baseRig == null) {
             return;
@@ -1315,7 +1331,7 @@ public class MainViewModel extends ViewModel {
         if (baseRig == null || baseRig.getConnector() == null) {
             return;
         }
-        mutableCatConnectionState.postValue(CatConnectionState.CONNECTING);
+        setCatConnectionState(CatConnectionState.CONNECTING);
         baseRig.getConnector().connect();
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -79,6 +79,7 @@ import com.bg7yoz.ft8cn.log.SWLQsoList;
 import com.bg7yoz.ft8cn.log.ThirdPartyService;
 import com.bg7yoz.ft8cn.rigs.BaseRig;
 import com.bg7yoz.ft8cn.rigs.BaseRigOperation;
+import com.bg7yoz.ft8cn.rigs.CatConnectionState;
 import com.bg7yoz.ft8cn.rigs.DiscoveryTX500Rig;
 import com.bg7yoz.ft8cn.rigs.ElecraftRig;
 import com.bg7yoz.ft8cn.rigs.Flex6000Rig;
@@ -215,16 +216,28 @@ public class MainViewModel extends ViewModel {
     public MutableLiveData<ArrayList<CableSerialPort.SerialPort>> mutableSerialPorts = new MutableLiveData<>();
     private ArrayList<CableSerialPort.SerialPort> serialPorts;//serial port list
     public BaseRig baseRig;//rig
+    //Observable CAT connection state for the UI status chip. Updated off the UI
+    //thread by the connector callbacks below, so use postValue everywhere.
+    public final MutableLiveData<CatConnectionState> mutableCatConnectionState =
+            new MutableLiveData<>(CatConnectionState.DISCONNECTED);
     private final OnRigStateChanged onRigStateChanged = new OnRigStateChanged() {
         @Override
         public void onDisconnected() {
             //disconnected from rig
+            mutableCatConnectionState.postValue(CatConnectionState.DISCONNECTED);
             ToastMessage.show(getStringFromResource(R.string.disconnect_rig));
+        }
+
+        @Override
+        public void onConnecting() {
+            //connection attempt started
+            mutableCatConnectionState.postValue(CatConnectionState.CONNECTING);
         }
 
         @Override
         public void onConnected() {
             //connected to rig
+            mutableCatConnectionState.postValue(CatConnectionState.CONNECTED);
             ToastMessage.show(getStringFromResource(R.string.connected_rig));
         }
 
@@ -250,6 +263,7 @@ public class MainViewModel extends ViewModel {
         @Override
         public void onRunError(String message) {
             //rig communication error
+            mutableCatConnectionState.postValue(CatConnectionState.ERROR);
             ToastMessage.show(String.format(getStringFromResource(R.string.radio_communication_error)
                     , message));
         }
@@ -1289,6 +1303,20 @@ public class MainViewModel extends ViewModel {
         } else {
             return baseRig.isConnected();
         }
+    }
+
+    /**
+     * Re-trigger the current rig's CAT connection. Backs the tap-to-reconnect
+     * status chip: Bluetooth often only connects on the second attempt, so this
+     * reuses the connector's existing connect() path (which, for Bluetooth, runs
+     * socketConnect() again). No-op when no rig/connector is configured.
+     */
+    public void reconnectRig() {
+        if (baseRig == null || baseRig.getConnector() == null) {
+            return;
+        }
+        mutableCatConnectionState.postValue(CatConnectionState.CONNECTING);
+        baseRig.getConnector().connect();
     }
 
     /**

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BaseRigConnector.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BaseRigConnector.java
@@ -34,6 +34,13 @@ public class BaseRigConnector {
         }
 
         @Override
+        public void onConnecting() {
+            if (onRigStateChanged!=null){
+                onRigStateChanged.onConnecting();
+            }
+        }
+
+        @Override
         public void onRunError(String message) {
             if (onRigStateChanged!=null){
                 onRigStateChanged.onRunError(message);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BluetoothRigConnector.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BluetoothRigConnector.java
@@ -139,6 +139,7 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
             BluetoothDevice device = bluetoothAdapter.getRemoteDevice(deviceAddress);
             Log.d(TAG, "connecting...");
             connected = Connected.Pending;
+            getOnConnectorStateChanged().onConnecting();
             BluetoothSerialSocket socket = new BluetoothSerialSocket(context, device);
             service.connect(socket);
         } catch (Exception e) {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/CableConnector.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/CableConnector.java
@@ -106,6 +106,7 @@ public class CableConnector extends BaseRigConnector {
     @Override
     public void connect() {
         super.connect();
+        getOnConnectorStateChanged().onConnecting();
         cableSerialPort.connect();
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/OnConnectorStateChanged.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/OnConnectorStateChanged.java
@@ -9,4 +9,10 @@ public interface OnConnectorStateChanged {
     void onDisconnected();
     void onConnected();
     void onRunError(String message);
+
+    /**
+     * Called when a connection attempt has started but not yet succeeded or
+     * failed. Default no-op so existing implementers don't need to change.
+     */
+    default void onConnecting() {}
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatConnectionState.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatConnectionState.java
@@ -1,0 +1,17 @@
+package com.bg7yoz.ft8cn.rigs;
+
+/**
+ * Observable CAT (rig control) connection state, surfaced to the Compose UI so
+ * the operator can see at a glance whether the radio is connected and, when it
+ * isn't, tap to retry. Bluetooth in particular often only connects on the second
+ * attempt (see BluetoothRigConnector), so a persistent indicator beats the
+ * transient connect/disconnect Toasts that were the only feedback before.
+ *
+ * @author Patrick Burns
+ */
+public enum CatConnectionState {
+    DISCONNECTED,
+    CONNECTING,
+    CONNECTED,
+    ERROR
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatConnectionState.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatConnectionState.java
@@ -13,5 +13,18 @@ public enum CatConnectionState {
     DISCONNECTED,
     CONNECTING,
     CONNECTED,
-    ERROR
+    ERROR;
+
+    /**
+     * Resulting state after a disconnect event. A failed connect emits
+     * onRunError() (ERROR) immediately followed by onDisconnected(); keep ERROR
+     * in that case so the status chip stays red until the next connect attempt,
+     * otherwise fall to DISCONNECTED.
+     *
+     * @param current the current connection state
+     * @return ERROR if {@code current} is ERROR, otherwise DISCONNECTED
+     */
+    public static CatConnectionState afterDisconnect(CatConnectionState current) {
+        return current == ERROR ? ERROR : DISCONNECTED;
+    }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/OnRigStateChanged.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/OnRigStateChanged.java
@@ -11,4 +11,10 @@ public interface OnRigStateChanged {
     void onPttChanged(boolean isOn);
     void onFreqChanged(long freq);
     void onRunError(String message);
+
+    /**
+     * Called when a connection attempt has started but not yet succeeded or
+     * failed. Default no-op so existing implementers don't need to change.
+     */
+    default void onConnecting() {}
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -35,9 +35,11 @@ import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.ModeProfile
 import com.bg7yoz.ft8cn.R
 import com.bg7yoz.ft8cn.database.OperationBand
+import com.bg7yoz.ft8cn.rigs.CatConnectionState
 import com.bg7yoz.ft8cn.rigs.BaseRigOperation
 import radio.ks3ckc.ft8us.theme.BgApp
 import radio.ks3ckc.ft8us.ui.components.ActiveQsoPanel
+import radio.ks3ckc.ft8us.ui.components.shouldShowCatChip
 import radio.ks3ckc.ft8us.ui.components.FT8USTab
 import radio.ks3ckc.ft8us.ui.components.FrequencyPickerSheet
 import radio.ks3ckc.ft8us.ui.components.HoundSetupSheet
@@ -65,6 +67,11 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     val isActivated by mainViewModel.ft8TransmitSignal.mutableIsActivated.observeAsState(false)
     val txSlot by mainViewModel.ft8TransmitSignal.mutableSequential.observeAsState(mainViewModel.ft8TransmitSignal.sequential)
     val qsoCompletedAt by mainViewModel.ft8TransmitSignal.mutableQsoCompletedAt.observeAsState()
+    // CAT connection status for the TX-strip chip. Hidden for VOX / audio-only
+    // setups (see shouldShowCatChip); tap reconnects (handy for Bluetooth, which
+    // often only connects on the second attempt).
+    val catState by mainViewModel.mutableCatConnectionState.observeAsState(CatConnectionState.DISCONNECTED)
+    val showCatChip = shouldShowCatChip(GeneralVariables.controlMode, catState)
     // Consume the one-shot celebration signal so LiveData doesn't replay it
     // on recomposition / resubscription.
     LaunchedEffect(qsoCompletedAt) {
@@ -229,6 +236,8 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                 modeName = modeName,
                 modeSwitchEnabled = !isTransmitting,
                 dxEnabled = dxEnabled,
+                catState = catState,
+                showCatChip = showCatChip,
                 expanded = qsoPanelExpanded,
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {
@@ -296,6 +305,7 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                         ).show()
                     }
                 },
+                onReconnectCat = { mainViewModel.reconnectRig() },
                 onOpenFrequencyPicker = { showFrequencyPicker = true },
                 onToggleExpand = { qsoPanelExpanded = !qsoPanelExpanded },
             )

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -71,7 +71,10 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     // setups (see shouldShowCatChip); tap reconnects (handy for Bluetooth, which
     // often only connects on the second attempt).
     val catState by mainViewModel.mutableCatConnectionState.observeAsState(CatConnectionState.DISCONNECTED)
-    val showCatChip = shouldShowCatChip(GeneralVariables.controlMode, catState)
+    // Observe control mode so the chip shows/hides immediately when the user
+    // switches VOX <-> CAT/RTS/DTR in Settings (seeds from the current value).
+    val controlMode by GeneralVariables.mutableControlMode.observeAsState(GeneralVariables.controlMode)
+    val showCatChip = shouldShowCatChip(controlMode, catState)
     // Consume the one-shot celebration signal so LiveData doesn't replay it
     // on recomposition / resubscription.
     LaunchedEffect(qsoCompletedAt) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/CatStatusChip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/CatStatusChip.kt
@@ -1,0 +1,143 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.bg7yoz.ft8cn.R
+import com.bg7yoz.ft8cn.database.ControlMode
+import com.bg7yoz.ft8cn.rigs.CatConnectionState
+import radio.ks3ckc.ft8us.theme.*
+
+/**
+ * Visual treatment for the CAT status dot, derived purely from connection state
+ * so it can be unit-tested without Compose. The visible label is always "CAT";
+ * [contentDescriptionRes] is the TalkBack description that varies by state.
+ */
+internal data class CatChipVisuals(
+    val dotColor: Color,
+    val pulsing: Boolean,
+    val contentDescriptionRes: Int,
+)
+
+/**
+ * Map a CAT connection state to its dot color / pulse / accessibility label.
+ * grey = disconnected, amber pulsing = connecting, green = connected, red = error.
+ */
+internal fun catChipVisuals(state: CatConnectionState): CatChipVisuals = when (state) {
+    CatConnectionState.DISCONNECTED -> CatChipVisuals(
+        dotColor = TextMuted,
+        pulsing = false,
+        contentDescriptionRes = R.string.cat_status_disconnected,
+    )
+    CatConnectionState.CONNECTING -> CatChipVisuals(
+        dotColor = Accent,
+        pulsing = true,
+        contentDescriptionRes = R.string.cat_status_connecting,
+    )
+    CatConnectionState.CONNECTED -> CatChipVisuals(
+        dotColor = StatusConfirmed,
+        pulsing = false,
+        contentDescriptionRes = R.string.cat_status_connected,
+    )
+    CatConnectionState.ERROR -> CatChipVisuals(
+        dotColor = StatusBad,
+        pulsing = false,
+        contentDescriptionRes = R.string.cat_status_error,
+    )
+}
+
+/**
+ * Whether the CAT status chip should be shown. Shown when a rig-control mode is
+ * configured (anything other than VOX, which keys via audio and has no CAT link)
+ * or while a connection is in progress / connected / errored — so audio-only
+ * setups aren't cluttered with an irrelevant indicator.
+ */
+internal fun shouldShowCatChip(controlMode: Int, state: CatConnectionState): Boolean =
+    controlMode != ControlMode.VOX || state != CatConnectionState.DISCONNECTED
+
+/**
+ * A small CAT (rig control) connection indicator for the TX strip. Tappable to
+ * re-trigger the connection — Bluetooth often only connects on the second try,
+ * so a one-tap retry beats digging back into Settings.
+ */
+@Composable
+fun CatStatusChip(
+    state: CatConnectionState,
+    onReconnect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val visuals = catChipVisuals(state)
+    val description = stringResource(visuals.contentDescriptionRes)
+
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(BgSurface3)
+            .clickable(onClickLabel = description) { onReconnect() }
+            .semantics { contentDescription = description }
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        StatusDot(color = visuals.dotColor, pulsing = visuals.pulsing)
+        Text(
+            text = stringResource(R.string.cat_status_chip_label),
+            color = TextMuted,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = GeistMonoFamily,
+            letterSpacing = 0.02.sp,
+            maxLines = 1,
+            softWrap = false,
+        )
+    }
+}
+
+@Composable
+private fun StatusDot(color: Color, pulsing: Boolean) {
+    val alpha = if (pulsing) {
+        val transition = rememberInfiniteTransition(label = "catPulse")
+        val animated by transition.animateFloat(
+            initialValue = 1f,
+            targetValue = 0.3f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(800),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "catPulseAlpha",
+        )
+        animated
+    } else {
+        1f
+    }
+    Box(
+        modifier = Modifier
+            .size(7.dp)
+            .clip(CircleShape)
+            .background(color.copy(alpha = alpha)),
+    )
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bg7yoz.ft8cn.R
+import com.bg7yoz.ft8cn.rigs.CatConnectionState
 import radio.ks3ckc.ft8us.theme.*
 
 @Composable
@@ -42,6 +43,8 @@ fun TxStrip(
     modeName: String,
     modeSwitchEnabled: Boolean,
     dxEnabled: Boolean = false,
+    catState: CatConnectionState = CatConnectionState.DISCONNECTED,
+    showCatChip: Boolean = false,
     expanded: Boolean = false,
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
@@ -49,6 +52,7 @@ fun TxStrip(
     onToggleHunt: () -> Unit,
     onCycleMode: () -> Unit,
     onToggleDx: () -> Unit = {},
+    onReconnectCat: () -> Unit = {},
     onOpenFrequencyPicker: () -> Unit,
     onToggleExpand: () -> Unit = {},
     modifier: Modifier = Modifier,
@@ -113,6 +117,11 @@ fun TxStrip(
                 fontFamily = GeistMonoFamily,
                 letterSpacing = 0.02.sp,
             )
+            // CAT connection status — tap to reconnect (Bluetooth often needs a
+            // second attempt). Hidden for VOX / audio-only setups.
+            if (showCatChip) {
+                CatStatusChip(state = catState, onReconnect = onReconnectCat)
+            }
         }
 
         // Right: CQ/Stop button + frequency

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -458,6 +458,13 @@
 
     <string name="tx_transmitting">TRANSMITIENDO</string>
     <string name="tx_listening">ESCUCHANDO</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT conectado — toca para reconectar</string>
+    <string name="cat_status_connecting">Conectando CAT…</string>
+    <string name="cat_status_disconnected">CAT desconectado — toca para conectar</string>
+    <string name="cat_status_error">Error de conexión CAT — toca para reintentar</string>
     <string name="qsopanel_log_action">LOG</string>
     <string name="qsopanel_queue">COLA</string>
     <string name="swr_lockout_title">TX DETENIDO — SWR alto detectado (%1$s)</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -458,6 +458,13 @@
 
     <string name="tx_transmitting">ÉMISSION</string>
     <string name="tx_listening">ÉCOUTE</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT connecté — appuyez pour reconnecter</string>
+    <string name="cat_status_connecting">Connexion CAT…</string>
+    <string name="cat_status_disconnected">CAT déconnecté — appuyez pour connecter</string>
+    <string name="cat_status_error">Erreur de connexion CAT — appuyez pour réessayer</string>
     <string name="qsopanel_log_action">LOG</string>
     <string name="qsopanel_queue">FILE</string>
     <string name="swr_lockout_title">TX ARRÊTÉ — SWR élevé détecté (%1$s)</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -458,6 +458,13 @@
 
     <string name="tx_transmitting">送信中</string>
     <string name="tx_listening">受信中</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT接続済み — タップで再接続</string>
+    <string name="cat_status_connecting">CAT接続中…</string>
+    <string name="cat_status_disconnected">CAT未接続 — タップで接続</string>
+    <string name="cat_status_error">CAT接続エラー — タップで再試行</string>
     <string name="qsopanel_log_action">LOG</string>
     <string name="qsopanel_queue">キュー</string>
     <string name="swr_lockout_title">送信停止 — 高SWR検出 (%1$s)</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -458,6 +458,13 @@
 
     <string name="tx_transmitting">ПЕРЕДАЧА</string>
     <string name="tx_listening">ПРИЁМ</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT подключён — нажмите для переподключения</string>
+    <string name="cat_status_connecting">Подключение CAT…</string>
+    <string name="cat_status_disconnected">CAT отключён — нажмите для подключения</string>
+    <string name="cat_status_error">Ошибка подключения CAT — нажмите для повтора</string>
     <string name="qsopanel_log_action">LOG</string>
     <string name="qsopanel_queue">ОЧЕРЕДЬ</string>
     <string name="swr_lockout_title">TX ОСТАНОВЛЕН — Высокий КСВ (%1$s)</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -458,6 +458,13 @@
 
     <string name="tx_transmitting">发射中</string>
     <string name="tx_listening">监听中</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT 已连接 — 点按重新连接</string>
+    <string name="cat_status_connecting">CAT 连接中…</string>
+    <string name="cat_status_disconnected">CAT 未连接 — 点按连接</string>
+    <string name="cat_status_error">CAT 连接错误 — 点按重试</string>
     <string name="qsopanel_log_action">LOG</string>
     <string name="qsopanel_queue">队列</string>
     <string name="swr_lockout_title">发射已停止 — 检测到高驻波比 (%1$s)</string>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -458,6 +458,13 @@
 
     <string name="tx_transmitting">發射中</string>
     <string name="tx_listening">監聽中</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT 已連線 — 點按重新連線</string>
+    <string name="cat_status_connecting">CAT 連線中…</string>
+    <string name="cat_status_disconnected">CAT 未連線 — 點按連線</string>
+    <string name="cat_status_error">CAT 連線錯誤 — 點按重試</string>
     <string name="qsopanel_log_action">LOG</string>
     <string name="qsopanel_queue">佇列</string>
     <string name="swr_lockout_title">發射已停止 — 偵測到高駐波比 (%1$s)</string>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -109,6 +109,13 @@
     <string name="tx_transmitting">TRANSMITTING</string>
     <string name="tx_listening">LISTENING</string>
 
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT connected — tap to reconnect</string>
+    <string name="cat_status_connecting">CAT connecting…</string>
+    <string name="cat_status_disconnected">CAT disconnected — tap to connect</string>
+    <string name="cat_status_error">CAT connection error — tap to retry</string>
+
     <!-- ===== SWR lockout banner ===== -->
     <string name="swr_lockout_title">TX HALTED — High SWR detected (%1$s)</string>
     <string name="swr_lockout_body">Check antenna / feedline before transmitting.</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/CatStatusChipLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/CatStatusChipLogicTest.kt
@@ -69,4 +69,22 @@ class CatStatusChipLogicTest {
         assertThat(shouldShowCatChip(ControlMode.VOX, CatConnectionState.CONNECTED)).isTrue()
         assertThat(shouldShowCatChip(ControlMode.VOX, CatConnectionState.ERROR)).isTrue()
     }
+
+    @Test
+    fun `afterDisconnect preserves ERROR so the chip stays red`() {
+        // A failed connect emits ERROR then immediately DISCONNECTED; the latter
+        // must not clobber the error.
+        assertThat(CatConnectionState.afterDisconnect(CatConnectionState.ERROR))
+            .isEqualTo(CatConnectionState.ERROR)
+    }
+
+    @Test
+    fun `afterDisconnect falls to DISCONNECTED from non-error states`() {
+        assertThat(CatConnectionState.afterDisconnect(CatConnectionState.CONNECTED))
+            .isEqualTo(CatConnectionState.DISCONNECTED)
+        assertThat(CatConnectionState.afterDisconnect(CatConnectionState.CONNECTING))
+            .isEqualTo(CatConnectionState.DISCONNECTED)
+        assertThat(CatConnectionState.afterDisconnect(CatConnectionState.DISCONNECTED))
+            .isEqualTo(CatConnectionState.DISCONNECTED)
+    }
 }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/CatStatusChipLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/CatStatusChipLogicTest.kt
@@ -1,0 +1,72 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.bg7yoz.ft8cn.R
+import com.bg7yoz.ft8cn.database.ControlMode
+import com.bg7yoz.ft8cn.rigs.CatConnectionState
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import radio.ks3ckc.ft8us.theme.Accent
+import radio.ks3ckc.ft8us.theme.StatusBad
+import radio.ks3ckc.ft8us.theme.StatusConfirmed
+import radio.ks3ckc.ft8us.theme.TextMuted
+
+/**
+ * Unit tests for the pure CAT-status-chip logic ([catChipVisuals] and
+ * [shouldShowCatChip]) extracted from CatStatusChip so the Composable stays a
+ * thin wrapper. No Android runtime needed: CatConnectionState is a plain enum,
+ * ControlMode is int constants, and Compose Color is a JVM value class.
+ */
+class CatStatusChipLogicTest {
+
+    @Test
+    fun `disconnected is muted, not pulsing`() {
+        val v = catChipVisuals(CatConnectionState.DISCONNECTED)
+        assertThat(v.dotColor).isEqualTo(TextMuted)
+        assertThat(v.pulsing).isFalse()
+        assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_disconnected)
+    }
+
+    @Test
+    fun `connecting is amber and pulsing`() {
+        val v = catChipVisuals(CatConnectionState.CONNECTING)
+        assertThat(v.dotColor).isEqualTo(Accent)
+        assertThat(v.pulsing).isTrue()
+        assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_connecting)
+    }
+
+    @Test
+    fun `connected is green, not pulsing`() {
+        val v = catChipVisuals(CatConnectionState.CONNECTED)
+        assertThat(v.dotColor).isEqualTo(StatusConfirmed)
+        assertThat(v.pulsing).isFalse()
+        assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_connected)
+    }
+
+    @Test
+    fun `error is red, not pulsing`() {
+        val v = catChipVisuals(CatConnectionState.ERROR)
+        assertThat(v.dotColor).isEqualTo(StatusBad)
+        assertThat(v.pulsing).isFalse()
+        assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_error)
+    }
+
+    @Test
+    fun `chip shown for any CAT-control mode even when disconnected`() {
+        assertThat(shouldShowCatChip(ControlMode.CAT, CatConnectionState.DISCONNECTED)).isTrue()
+        assertThat(shouldShowCatChip(ControlMode.BLUETOOTH, CatConnectionState.DISCONNECTED)).isTrue()
+        assertThat(shouldShowCatChip(ControlMode.RTS, CatConnectionState.DISCONNECTED)).isTrue()
+        assertThat(shouldShowCatChip(ControlMode.DTR, CatConnectionState.DISCONNECTED)).isTrue()
+    }
+
+    @Test
+    fun `chip hidden for VOX while disconnected`() {
+        assertThat(shouldShowCatChip(ControlMode.VOX, CatConnectionState.DISCONNECTED)).isFalse()
+    }
+
+    @Test
+    fun `chip shown for VOX once a connection is in progress or active`() {
+        assertThat(shouldShowCatChip(ControlMode.VOX, CatConnectionState.CONNECTING)).isTrue()
+        assertThat(shouldShowCatChip(ControlMode.VOX, CatConnectionState.CONNECTED)).isTrue()
+        assertThat(shouldShowCatChip(ControlMode.VOX, CatConnectionState.ERROR)).isTrue()
+    }
+}


### PR DESCRIPTION
## What

Adds an always-visible **CAT connection status chip** to the bottom TX strip, **tappable to reconnect**.

- **grey** = disconnected · **amber pulsing** = connecting · **green** = connected · **red** = error
- Hidden for VOX / audio-only setups (`shouldShowCatChip`)

## Why

CAT connection state previously surfaced only as transient Toasts — no persistent indicator. Bluetooth in particular usually only connects on the **second attempt**: the first `socketConnect()` fails and silently drops back to disconnected, then a later CAT command auto-retries. It works eventually, but the operator gets no signal in between. The chip makes the state visible and turns the retry into a single tap.

## How

- New `CatConnectionState` enum exposed as `LiveData` on `MainViewModel`, driven from the existing rig-state callbacks plus a new `onConnecting()` **default-method** callback on `OnRigStateChanged`/`OnConnectorStateChanged` (no existing implementer needs to change).
- `BluetoothRigConnector.socketConnect()` and `CableConnector.connect()` fire `onConnecting()` — this covers both the initial connect and the silent `sendCommand` auto-retry path.
- `MainViewModel.reconnectRig()` re-runs the current connector's `connect()` path on tap.
- `CatStatusChip.kt` keeps the Composable a thin wrapper over pure, unit-tested `catChipVisuals()` / `shouldShowCatChip()`; wired into `TxStrip` + `FT8USApp`.
- Strings added across all 6 locales.

## Testing

- `CatStatusChipLogicTest` (7 tests) — covers each state's visuals and the show/hide gating. **testDebugUnitTest: BUILD SUCCESSFUL**.
- `installDebug` (incl. NDK native build) — **Installed on Pixel 8**.
- Manual hardware check (chip amber→green on BT connect, tap-to-retry after first-attempt failure) still recommended on a real rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)