### PR TITLE
Rebind USB audio input when permission is granted

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -59,6 +59,27 @@ public class GeneralVariables {
     public static int usbAudioOutputVendorId = 0;
     public static int usbAudioOutputProductId = 0;
 
+    /**
+     * Whether the given USB VID:PID is the device the user picked for direct
+     * USB audio <em>input</em> (audioInputDeviceId == -1 means "USB direct").
+     * Used on a USB-attach event to decide whether a freshly-plugged device
+     * needs an audio permission request so the recorder can rebind to it
+     * instead of staying on the built-in mic.
+     */
+    public static boolean isConfiguredUsbAudioInput(int vid, int pid) {
+        return audioInputDeviceId == -1 && usbAudioInputVendorId != 0
+                && usbAudioInputVendorId == vid && usbAudioInputProductId == pid;
+    }
+
+    /**
+     * Whether the given USB VID:PID is the device the user picked for direct
+     * USB audio <em>output</em> (audioOutputDeviceId == -1 means "USB direct").
+     */
+    public static boolean isConfiguredUsbAudioOutput(int vid, int pid) {
+        return audioOutputDeviceId == -1 && usbAudioOutputVendorId != 0
+                && usbAudioOutputVendorId == vid && usbAudioOutputProductId == pid;
+    }
+
     public static MutableLiveData<Float> mutableVolumePercent = new MutableLiveData<>();
     public static float volumePercent = 0.8f;//Audio playback volume, as a percentage
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -1539,7 +1539,19 @@ public class MainViewModel extends ViewModel {
                     boolean granted = intent.getBooleanExtra(
                             UsbManager.EXTRA_PERMISSION_GRANTED, false);
                     Log.d(TAG, "USB audio permission " + (granted ? "granted" : "denied"));
+                    GeneralVariables.fileLog("USB audio permission "
+                            + (granted ? "granted" : "denied"));
                     try { ctx.unregisterReceiver(this); } catch (Exception ignored) {}
+                    if (granted) {
+                        // The recorder was constructed before this permission
+                        // existed and fell back to the built-in mic (see
+                        // MicRecorder.openUsbAudioInput's hasPermission check).
+                        // Now that we're allowed to open the device, rebind the
+                        // input so RX actually uses the USB sound card. TX is
+                        // immune to this bug because it opens the device lazily
+                        // at transmit time, always after this grant.
+                        reinitializeAudioInput();
+                    }
                 }
             }
         };

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -381,6 +381,26 @@ class ComposeMainActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         if ("android.hardware.usb.action.USB_DEVICE_ATTACHED" == intent.action) {
             fileLog("onNewIntent: USB_DEVICE_ATTACHED")
+            // If the attached device is the one the user picked for direct USB
+            // audio, make sure we hold permission before the delayed reinit
+            // below tries to open it. USB permission can be dropped across an
+            // unplug/replug; without this, the recorder reopens, finds no
+            // permission, and silently falls back to the built-in mic. The
+            // grant callback (MainViewModel.requestUsbPermissionIfNeeded) then
+            // rebinds the input once the user allows it.
+            val attached: UsbDevice? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+            }
+            if (attached != null
+                && (GeneralVariables.isConfiguredUsbAudioInput(attached.vendorId, attached.productId)
+                    || GeneralVariables.isConfiguredUsbAudioOutput(attached.vendorId, attached.productId))
+            ) {
+                fileLog("onNewIntent: attached device is configured USB audio; ensuring permission")
+                mainViewModel.requestUsbPermissionIfNeeded(attached)
+            }
             // Immediate scan
             mainViewModel.getUsbDevice()
             val ports = mainViewModel.mutableSerialPorts.value

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/UsbAudioSelectionTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/UsbAudioSelectionTest.java
@@ -1,0 +1,111 @@
+package com.bg7yoz.ft8cn;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Unit tests for {@link GeneralVariables#isConfiguredUsbAudioInput(int, int)}
+ * and {@link GeneralVariables#isConfiguredUsbAudioOutput(int, int)}.
+ *
+ * <p>These decide, on a USB-attach event, whether a freshly-plugged device is
+ * the one the user picked for the direct USB audio path and therefore needs an
+ * audio-permission request so the recorder rebinds to it instead of silently
+ * staying on the built-in mic. "USB direct" is encoded as deviceId == -1 with a
+ * non-zero saved VID/PID; anything else (0 = system default, a positive
+ * AudioManager id, or a zero VID) must NOT match.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class UsbAudioSelectionTest {
+
+    // A representative C-Media CM108-style dongle (the DigiRig case).
+    private static final int VID = 0x0D8C;
+    private static final int PID = 0x0012;
+
+    @Before
+    public void setUp() {
+        GeneralVariables.audioInputDeviceId = 0;
+        GeneralVariables.usbAudioInputVendorId = 0;
+        GeneralVariables.usbAudioInputProductId = 0;
+        GeneralVariables.audioOutputDeviceId = 0;
+        GeneralVariables.usbAudioOutputVendorId = 0;
+        GeneralVariables.usbAudioOutputProductId = 0;
+    }
+
+    @After
+    public void tearDown() {
+        setUp();
+    }
+
+    @Test
+    public void input_matchesWhenSelectedAsUsbDirectWithSameVidPid() {
+        GeneralVariables.audioInputDeviceId = -1;
+        GeneralVariables.usbAudioInputVendorId = VID;
+        GeneralVariables.usbAudioInputProductId = PID;
+
+        assertThat(GeneralVariables.isConfiguredUsbAudioInput(VID, PID)).isTrue();
+    }
+
+    @Test
+    public void input_doesNotMatchWhenDeviceIsSystemDefault() {
+        // deviceId 0 = system default mic; never the direct USB path even if a
+        // stale VID/PID lingers.
+        GeneralVariables.audioInputDeviceId = 0;
+        GeneralVariables.usbAudioInputVendorId = VID;
+        GeneralVariables.usbAudioInputProductId = PID;
+
+        assertThat(GeneralVariables.isConfiguredUsbAudioInput(VID, PID)).isFalse();
+    }
+
+    @Test
+    public void input_doesNotMatchWhenDeviceIsAudioManagerDevice() {
+        GeneralVariables.audioInputDeviceId = 7; // a positive AudioManager id
+        GeneralVariables.usbAudioInputVendorId = VID;
+        GeneralVariables.usbAudioInputProductId = PID;
+
+        assertThat(GeneralVariables.isConfiguredUsbAudioInput(VID, PID)).isFalse();
+    }
+
+    @Test
+    public void input_doesNotMatchADifferentDevice() {
+        GeneralVariables.audioInputDeviceId = -1;
+        GeneralVariables.usbAudioInputVendorId = VID;
+        GeneralVariables.usbAudioInputProductId = PID;
+
+        assertThat(GeneralVariables.isConfiguredUsbAudioInput(0x1234, 0x5678)).isFalse();
+    }
+
+    @Test
+    public void input_doesNotMatchWhenNoVidSaved() {
+        // USB direct selected but VID never persisted (0) — can't match anything.
+        GeneralVariables.audioInputDeviceId = -1;
+        GeneralVariables.usbAudioInputVendorId = 0;
+        GeneralVariables.usbAudioInputProductId = 0;
+
+        assertThat(GeneralVariables.isConfiguredUsbAudioInput(0, 0)).isFalse();
+    }
+
+    @Test
+    public void inputAndOutputAreIndependent() {
+        // Output is USB-direct; input is the default mic. Only output matches.
+        GeneralVariables.audioOutputDeviceId = -1;
+        GeneralVariables.usbAudioOutputVendorId = VID;
+        GeneralVariables.usbAudioOutputProductId = PID;
+
+        assertThat(GeneralVariables.isConfiguredUsbAudioOutput(VID, PID)).isTrue();
+        assertThat(GeneralVariables.isConfiguredUsbAudioInput(VID, PID)).isFalse();
+    }
+
+    @Test
+    public void output_matchesWhenSelectedAsUsbDirectWithSameVidPid() {
+        GeneralVariables.audioOutputDeviceId = -1;
+        GeneralVariables.usbAudioOutputVendorId = VID;
+        GeneralVariables.usbAudioOutputProductId = PID;
+
+        assertThat(GeneralVariables.isConfiguredUsbAudioOutput(VID, PID)).isTrue();
+    }
+}


### PR DESCRIPTION
## Problem

USB **direct audio input** silently falls back to the **built-in mic** even when it's selected in Settings — while USB **output (TX) works fine**. That asymmetry is the whole tell.

Diagnosed from `debug.log`: when the CM108 dongle was present, both USB in and out worked simultaneously. But on a fresh selection/plug, the recorder ends up on `AudioRecord(DEFAULT)` (the mic).

## Root cause

`MicRecorder` is constructed **eagerly at app startup**, before the user grants USB permission. `openUsbAudioInput()` bails at its `hasPermission()` check and falls back to the default mic. When the user then taps **Allow** on the permission dialog, the grant receiver in `MainViewModel.requestUsbPermissionIfNeeded()` only **logged** the result and unregistered — **nothing rebound the recorder**, so RX stayed on the mic until the next app restart.

TX is immune because `playFT8Signal` opens the USB device **lazily at transmit time**, always *after* the grant — which is exactly why output worked and input didn't.

## Fix

- **`MainViewModel`** — on a *granted* USB permission result, call `reinitializeAudioInput()` so the recorder reopens the now-permitted device immediately.
- **`ComposeMainActivity.onNewIntent`** — on `USB_DEVICE_ATTACHED`, request audio permission for the configured USB audio device (permission can be dropped across an unplug/replug); the grant callback then rebinds.
- **`GeneralVariables.isConfiguredUsbAudioInput/Output(vid, pid)`** — pure predicates gating the attach-time request, covered by `UsbAudioSelectionTest` (7 cases).

## Testing

- `testDebugUnitTest --tests com.bg7yoz.ft8cn.UsbAudioSelectionTest` ✅
- Full `installDebug` on a Pixel 8 ✅

⚠️ **Not yet hardware-verified** with the USB sound card connected — needs a dongle that reaches both the radio and the phone. The logic is sound and the change is low-risk, but final confirmation (select USB input → grant → RX uses USB) should happen on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)