### PR TITLE
Fix FT2 transmit: anchor cycle timer to the epoch, not the UTC minute

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
@@ -156,6 +156,31 @@ public class UtcTimer {
         };
     }
 
+    /**
+     * Whether {@code utc} lands on a cycle (slot) boundary for a slot of {@code sec} tenths
+     * of a second, anchored to the Unix epoch.
+     *
+     * <p>The original test was {@code (((utc - offsetMs) / 100) % 600) % sec == 0}, which
+     * anchored the slot grid to each UTC minute (600 tenths of a second). That is identical
+     * to this epoch-anchored form only when {@code sec} evenly divides 600 — true for FT8
+     * (150) and FT4 (75), but NOT FT2 (38, since 600 / 38 is not whole). For FT2 the
+     * minute-anchored grid drifted off the absolute 3.8 s slot grid that
+     * {@link #sequential(long, int)} and the transmit late-start clip math both use, so a
+     * normal FT2 transmit fired part-way into its slot and had its leading Costas sync
+     * array clipped — audible on the air but undecodable. Anchoring to the epoch keeps the
+     * FT8/FT4 firing instants byte-for-byte identical while making every slot length
+     * internally consistent.
+     *
+     * @param utc      system time in ms (epoch + {@link #delay})
+     * @param offsetMs manual time offset in ms (see {@link #setTime_sec(int)})
+     * @param sec      slot period in tenths of a second (see ModeProfile.slotTenths)
+     * @return true exactly on the 100 ms tick that opens a slot
+     */
+    public static boolean isCycleBoundary(long utc, int offsetMs, int sec) {
+        if (sec <= 0) return false;
+        return (((utc - offsetMs) / 100) % sec) == 0;
+    }
+
     private TimerTask secTask() {
         return new TimerTask() {
 
@@ -165,11 +190,9 @@ public class UtcTimer {
 
                 try {
                     utc = getSystemTime();//get current UTC time
-                    //utc/100 is in tenths of a second, so modulo should be 600, not 60, remember!
                     //running determines whether to trigger cycle actions
-                    //+80 is time compensation for some action delays after triggering
                     //time_sec is the time offset
-                    if (running && (((utc - time_sec) / 100) % 600) % sec == 0) {
+                    if (running && isCycleBoundary(utc, time_sec, sec)) {
                         //cycle action
                         //IMPORTANT! doHeartBeatTimer must not perform time-consuming operations and must complete within the heartbeat interval, otherwise thread backlog may occur and affect performance.
                         cachedThreadPool.execute(doSomething);//use thread pool for invocation to reduce system overhead

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
@@ -97,6 +97,91 @@ public class UtcTimerTest {
         assertThat(UtcTimer.sequential(29_999L)).isEqualTo(1);
     }
 
+    /** The legacy minute-anchored predicate, kept here to prove equivalence for FT8/FT4. */
+    private static boolean legacyBoundary(long utc, int offsetMs, int sec) {
+        return (((utc - offsetMs) / 100) % 600) % sec == 0;
+    }
+
+    @Test
+    public void isCycleBoundary_ft8MatchesLegacyMinuteAnchoredFormula() {
+        // 150 tenths (15s) divides 600, so the new epoch-anchored test must agree with the
+        // old minute-anchored one at every 100ms tick across a full minute.
+        for (long ms = 0; ms < 60_000; ms += 100) {
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 150))
+                    .isEqualTo(legacyBoundary(ms, 0, 150));
+        }
+    }
+
+    @Test
+    public void isCycleBoundary_ft4MatchesLegacyMinuteAnchoredFormula() {
+        // 75 tenths (7.5s) also divides 600 — behaviour is unchanged for FT4.
+        for (long ms = 0; ms < 60_000; ms += 100) {
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 75))
+                    .isEqualTo(legacyBoundary(ms, 0, 75));
+        }
+    }
+
+    @Test
+    public void isCycleBoundary_ft8FiresOnAbsoluteSlotGrid() {
+        assertThat(UtcTimer.isCycleBoundary(0L, 0, 150)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(15_000L, 0, 150)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(7_500L, 0, 150)).isFalse();
+        // Real-world instant: a boundary iff systemTime % 15000 == 0.
+        assertThat(UtcTimer.isCycleBoundary(T_2023, 0, 150))
+                .isEqualTo(T_2023 % 15_000 == 0);
+    }
+
+    @Test
+    public void isCycleBoundary_ft2FiresOnAbsolute3point8sGrid() {
+        // FT2 (38 tenths) does NOT divide 600, so this is where old and new diverge.
+        // The new predicate fires exactly on multiples of 3.8s from the epoch...
+        assertThat(UtcTimer.isCycleBoundary(0L, 0, 38)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(3_800L, 0, 38)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(7_600L, 0, 38)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(3_700L, 0, 38)).isFalse();
+        assertThat(UtcTimer.isCycleBoundary(3_900L, 0, 38)).isFalse();
+    }
+
+    @Test
+    public void isCycleBoundary_ft2EveryFireOpensASlotSoLateStartNeverClips() {
+        // The transmit late-start math clips leading audio by (systemTime % slotMillis)
+        // beyond the slack. The FT2 regression was that the timer fired when
+        // systemTime % 3800 was large (up to ~3.0s), clipping the leading Costas sync.
+        // With the epoch-anchored predicate, every fire lands within one 100ms tick of a
+        // real 3800ms slot boundary, so msIntoCycle is always < 100 and nothing is clipped.
+        int slotMillis = 3_800;
+        int fires = 0;
+        for (long ms = 0; ms < 600_000; ms += 100) { // 10 minutes of ticks
+            if (UtcTimer.isCycleBoundary(ms, 0, 38)) {
+                fires++;
+                long msIntoCycle = ms % slotMillis;
+                assertThat(msIntoCycle).isLessThan(100L);
+            }
+        }
+        // Sanity: ~ one fire per 3.8s over 10 minutes.
+        assertThat(fires).isEqualTo(600_000 / slotMillis + 1);
+    }
+
+    @Test
+    public void isCycleBoundary_legacyFormulaWouldHaveClippedFt2() {
+        // Guard the regression: the OLD predicate fired off the absolute slot grid for
+        // FT2, landing where systemTime % 3800 was large — that is the clip that broke TX.
+        boolean sawLargeOffset = false;
+        for (long ms = 0; ms < 600_000; ms += 100) {
+            if (legacyBoundary(ms, 0, 38) && (ms % 3_800) >= 1_280) {
+                sawLargeOffset = true; // >= FT2 audio slack -> leading audio clipped
+                break;
+            }
+        }
+        assertThat(sawLargeOffset).isTrue();
+    }
+
+    @Test
+    public void isCycleBoundary_nonPositivePeriodNeverFires() {
+        assertThat(UtcTimer.isCycleBoundary(0L, 0, 0)).isFalse();
+        assertThat(UtcTimer.isCycleBoundary(15_000L, 0, -5)).isFalse();
+    }
+
     @Test
     public void getTimeStr_wrapsHoursAtMidnight() {
         // 24h exactly -> back to 00:00:00 (hour is modulo 24).


### PR DESCRIPTION
## Problem

Pressing **CQ on FT2 does nothing** — the rig keys but no station ever answers, because the transmitted signal is undecodable.

## Root cause

FT2's 3.8 s slot is the first operating mode whose period does **not** divide 60 s. `UtcTimer`'s cycle trigger tested:

```java
(((utc - offset) / 100) % 600) % sec == 0   // 600 tenths = one UTC minute
```

This anchors the slot grid to each UTC minute. It only equals the epoch-anchored `(tenths % sec) == 0` when `sec` divides 600 — true for FT8 (150) and FT4 (75), **false for FT2 (38)**.

For FT2 the minute-anchored grid drifts off the absolute 3.8 s grid that `UtcTimer.sequential()` and the transmit **late-start clip math** both use. The timer fires part-way into each slot (`systemTime % 3800` up to ~3.0 s), so the late-start logic clips **1.4–2.5 s of leading audio** — exactly the leading Costas sync array. Receivers can't lock → audible-but-undecodable (the same failure class documented in `CLAUDE.md`).

| Mode | `msIntoCycle` at fire (old) | Leading audio clipped |
|------|------------------------------|-----------------------|
| FT8  | 0 ms                         | none |
| FT4  | 0 ms                         | none |
| FT2  | 1400 / 2200 / 3000 ms (varies per minute) | up to ~2.5 s |

## Fix

Drop the `% 600` so the trigger is **epoch-anchored**. Extracted into the testable static `UtcTimer.isCycleBoundary(utc, offsetMs, sec)`.

- **FT8/FT4: byte-for-byte identical** — tests sweep a full minute of 100 ms ticks and assert the new predicate matches the old minute-anchored formula at every tick.
- **FT2: every fire now lands within one 100 ms tick of a real 3.8 s slot boundary**, so `msIntoCycle < 100 ms` and the full waveform (with its Costas sync) is transmitted.

## Tests

Added to `UtcTimerTest`:
- FT8/FT4 equivalence to the legacy formula across a full minute
- FT2 fires on the absolute 3.8 s grid; every fire opens a slot (late-start never clips)
- Regression guard: the legacy formula *would* have clipped FT2
- Non-positive period never fires

`gradlew testDebugUnitTest --tests com.bg7yoz.ft8cn.timer.UtcTimerTest` ✅, and `installDebug` deployed to the Pixel 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)