### PR TITLE
Redesign TX strip: two-row layout with large primary action buttons

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
@@ -338,6 +338,31 @@ object FT8USIcons {
         }
     }
 
+    /** Upward arrow — the TX time-slot button (we key up / transmit). */
+    @Composable
+    fun ArrowUp(
+        modifier: Modifier = Modifier,
+        color: Color = Color.Unspecified,
+        size: Dp = 22.dp,
+        strokeWidth: Float = 1.6f,
+    ) {
+        val tint = if (color == Color.Unspecified) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else color
+        Canvas(modifier = modifier.then(Modifier.sizeOf(size))) {
+            val s = this.size.width / 24f
+            val stroke = strokeStyle(strokeWidth * s)
+            // Shaft
+            drawLine(tint, Offset(12f * s, 19f * s), Offset(12f * s, 5f * s),
+                strokeWidth * s, StrokeCap.Round)
+            // Head
+            val head = Path().apply {
+                moveTo(6f * s, 11f * s)
+                lineTo(12f * s, 5f * s)
+                lineTo(18f * s, 11f * s)
+            }
+            drawPath(head, tint, style = stroke)
+        }
+    }
+
     /** Three tightly-spaced horizontal lines — switch to compact decode list. */
     @Composable
     fun ViewCompact(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -221,7 +221,7 @@ fun TxStrip(
             // HUNT — stacked icon + label. Locked off during an active CQ/QSO.
             StackedActionButton(
                 modifier = Modifier.weight(1f),
-                label = "Hunt",
+                label = stringResource(R.string.tx_hunt),
                 background = when {
                     actions.huntDisabled -> BgSurface3.copy(alpha = 0.4f)
                     actions.huntActive -> Signal.copy(alpha = 0.18f)
@@ -242,7 +242,7 @@ fun TxStrip(
             val cqIsStop = actions.cqIsStop
             PrimaryActionButton(
                 modifier = Modifier.weight(1.7f),
-                label = if (cqIsStop) "Stop" else "Call CQ",
+                label = if (cqIsStop) stringResource(R.string.tx_stop) else stringResource(R.string.tx_call_cq),
                 background = when {
                     cqIsStop -> StatusBad
                     actions.cqDisabled -> Accent.copy(alpha = 0.35f)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -6,13 +6,14 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -36,7 +37,30 @@ import com.bg7yoz.ft8cn.R
 import com.bg7yoz.ft8cn.rigs.CatConnectionState
 import radio.ks3ckc.ft8us.theme.*
 
-@OptIn(ExperimentalLayoutApi::class)
+/**
+ * The enabled/disabled state of the two mutually-exclusive action buttons (HUNT and
+ * CQ/STOP), derived purely from the activation + hunt flags so the rule can be unit-tested
+ * without Compose.
+ *
+ * HUNT (auto-answer the stations calling CQ) and running your own CQ can't both be on:
+ *  - While a CQ/QSO is active ([isActivated]) the HUNT toggle is locked off.
+ *  - While HUNT is armed (and no QSO yet) the CQ button is locked off.
+ * Once activated, the CQ button becomes the STOP button.
+ */
+internal data class TxStripActionState(
+    val huntDisabled: Boolean,
+    val huntActive: Boolean,
+    val cqDisabled: Boolean,
+    val cqIsStop: Boolean,
+)
+
+internal fun txStripActionState(isActivated: Boolean, huntEnabled: Boolean) = TxStripActionState(
+    huntDisabled = isActivated && !huntEnabled,
+    huntActive = huntEnabled,
+    cqDisabled = huntEnabled && !isActivated,
+    cqIsStop = isActivated,
+)
+
 @Composable
 fun TxStrip(
     isTransmitting: Boolean,
@@ -72,16 +96,17 @@ fun TxStrip(
         Brush.horizontalGradient(listOf(BgSurface, BgSurface))
     }
 
-    // Seven controls live here: status, mode, frequency, DX, HUNT, CQ/STOP, and TX slot.
-    // They don't all fit on one row in portrait, so use a FlowRow that wraps overflow onto
-    // a second line instead of pushing CQ/TX off the right edge.
-    // Each item is vertically centered within its wrapped line via Modifier.align(Alignment.CenterVertically).
-    FlowRow(
+    val actions = txStripActionState(isActivated, huntEnabled)
+
+    // Two stacked rows (vs. the old single cramped FlowRow): an info line with the small
+    // status/mode/frequency/DX chips, and a row of three large primary buttons
+    // (HUNT · CQ/STOP · TX slot) sized like the design prototype so the main action is a
+    // comfortable tap target on a phone.
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .background(bgColor)
             .drawBehind {
-                // Top border
                 drawLine(
                     color = Border,
                     start = androidx.compose.ui.geometry.Offset(0f, 0f),
@@ -89,229 +114,268 @@ fun TxStrip(
                     strokeWidth = 1f,
                 )
             }
-            .padding(horizontal = 16.dp, vertical = 6.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        // Status: expand/collapse chevron (when QSO active) + pulse dot + state text
+        // ---- Info row: status (left) · mode / frequency / DX chips (right) ----
         Row(
-            modifier = Modifier.align(Alignment.CenterVertically),
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            // Expand/collapse chevron — only shown when QSO is active
-            if (isActivated) {
-                Box(
-                    modifier = Modifier
-                        .size(20.dp)
-                        .clip(RoundedCornerShape(4.dp))
-                        .clickable { onToggleExpand() }
-                        .rotate(if (expanded) 0f else 180f),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    FT8USIcons.ChevronDown(
-                        size = 14.dp,
-                        color = TextMuted,
-                        strokeWidth = 2f,
-                    )
+            // Left: expand chevron (when QSO active) + pulse dot + state + CAT chip.
+            // weight(1f, fill=false) lets the status label ellipsize before it can shove
+            // the right-hand chips off screen on a narrow device.
+            Row(
+                modifier = Modifier.weight(1f, fill = false),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                if (isActivated) {
+                    Box(
+                        modifier = Modifier
+                            .size(20.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable { onToggleExpand() }
+                            .rotate(if (expanded) 0f else 180f),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        FT8USIcons.ChevronDown(size = 14.dp, color = TextMuted, strokeWidth = 2f)
+                    }
+                }
+                PulseDot(color = if (isTransmitting) Accent else Signal)
+                Text(
+                    text = if (isTransmitting) stringResource(R.string.tx_transmitting)
+                    else stringResource(R.string.tx_listening),
+                    color = TextPrimary,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (showCatChip) {
+                    CatStatusChip(state = catState, onReconnect = onReconnectCat)
                 }
             }
-            PulseDot(color = if (isTransmitting) Accent else Signal)
-            Text(
-                text = if (isTransmitting) stringResource(R.string.tx_transmitting)
-                else stringResource(R.string.tx_listening),
-                color = TextPrimary,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.02.sp,
-                // Keep the status on a single line so a long (localized) label
-                // can't balloon this item to two lines inside the FlowRow.
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            // CAT connection status — tap to reconnect (Bluetooth often needs a
-            // second attempt). Hidden for VOX / audio-only setups.
-            if (showCatChip) {
-                CatStatusChip(state = catState, onReconnect = onReconnectCat)
+
+            // Right: mode pill, frequency/band pill, DX pill.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                // Mode pill (FT8/FT4/FT2) — taps cycle the operating mode. Disabled
+                // mid-transmit so we never switch the cycle out from under a live TX.
+                TxChip(
+                    label = modeName,
+                    background = if (modeSwitchEnabled) Accent.copy(alpha = 0.18f) else BgSurface3,
+                    textColor = if (modeSwitchEnabled) Accent else TextFaint,
+                    bold = true,
+                    enabled = modeSwitchEnabled,
+                    onClick = onCycleMode,
+                )
+
+                // Frequency / band pill — opens the frequency picker.
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(BgSurface3)
+                        .clickable { onOpenFrequencyPicker() }
+                        .padding(horizontal = 10.dp, vertical = 7.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(
+                        text = frequencyLabel,
+                        color = TextPrimary,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        fontFamily = GeistMonoFamily,
+                        letterSpacing = 0.02.sp,
+                        maxLines = 1,
+                        softWrap = false,
+                    )
+                    FT8USIcons.ChevronDown(size = 12.dp, color = TextMuted, strokeWidth = 2f)
+                }
+
+                // DX (DXpedition Hound) toggle pill. On = working a Fox (call high,
+                // auto-QSY when answered). Mutually exclusive with HUNT/CQ.
+                TxChip(
+                    label = "DX",
+                    background = if (dxEnabled) Accent.copy(alpha = 0.18f) else BgSurface3,
+                    textColor = if (dxEnabled) Accent else TextMuted,
+                    bold = false,
+                    enabled = true,
+                    onClick = onToggleDx,
+                )
             }
         }
 
-        // Mode pill (FT8/FT4) — taps cycle the operating mode. Disabled mid-transmit
-        // so we never switch the cycle out from under an in-progress TX.
-        val modeBg = if (modeSwitchEnabled) Accent.copy(alpha = 0.18f) else BgSurface3
-        val modeColor = if (modeSwitchEnabled) Accent else TextFaint
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .clip(RoundedCornerShape(6.dp))
-                .background(modeBg)
-                .clickable(enabled = modeSwitchEnabled) { onCycleMode() }
-                .padding(horizontal = 8.dp, vertical = 4.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = modeName,
-                color = modeColor,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.Bold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.02.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
-
-        // Frequency / band pill — opens the frequency picker
+        // ---- Action row: HUNT · CQ/STOP · TX slot ----
         Row(
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .clip(RoundedCornerShape(8.dp))
-                .background(BgSurface3)
-                .clickable { onOpenFrequencyPicker() }
-                .padding(horizontal = 10.dp, vertical = 7.dp),
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            Text(
-                text = frequencyLabel,
-                color = TextPrimary,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.02.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-            FT8USIcons.ChevronDown(
-                size = 12.dp,
-                color = TextMuted,
-                strokeWidth = 2f,
-            )
-        }
+            // HUNT — stacked icon + label. Locked off during an active CQ/QSO.
+            StackedActionButton(
+                modifier = Modifier.weight(1f),
+                label = "Hunt",
+                background = when {
+                    actions.huntDisabled -> BgSurface3.copy(alpha = 0.4f)
+                    actions.huntActive -> Signal.copy(alpha = 0.18f)
+                    else -> BgSurface3
+                },
+                contentColor = when {
+                    actions.huntDisabled -> TextMuted.copy(alpha = 0.4f)
+                    actions.huntActive -> Signal
+                    else -> TextMuted
+                },
+                borderColor = if (actions.huntActive) Signal.copy(alpha = 0.5f) else Border,
+                enabled = !actions.huntDisabled,
+                onClick = onToggleHunt,
+            ) { color -> FT8USIcons.Target(size = 18.dp, color = color, strokeWidth = 1.8f) }
 
-        // DX (DXpedition Hound) toggle pill. On = working a Fox/DXpedition
-        // (call high, auto-QSY when answered). Mutually exclusive with HUNT/CQ.
-        val dxBg = if (dxEnabled) Accent.copy(alpha = 0.18f) else BgSurface3
-        val dxColor = if (dxEnabled) Accent else TextMuted
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .clip(RoundedCornerShape(6.dp))
-                .background(dxBg)
-                .clickable { onToggleDx() }
-                .padding(horizontal = 8.dp, vertical = 4.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = "DX",
-                color = dxColor,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.02.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
+            // CQ / STOP — the primary action. Filled amber to call CQ, red to stop.
+            // Locked off while HUNT is armed (and no QSO yet).
+            val cqIsStop = actions.cqIsStop
+            PrimaryActionButton(
+                modifier = Modifier.weight(1.7f),
+                label = if (cqIsStop) "Stop" else "Call CQ",
+                background = when {
+                    cqIsStop -> StatusBad
+                    actions.cqDisabled -> Accent.copy(alpha = 0.35f)
+                    else -> Accent
+                },
+                contentColor = if (cqIsStop) Color.White else BgApp,
+                enabled = !actions.cqDisabled,
+                onClick = { if (cqIsStop) onStop() else onCallCQ() },
+            ) { color ->
+                if (cqIsStop) {
+                    FT8USIcons.Close(size = 18.dp, color = color, strokeWidth = 2f)
+                } else {
+                    FT8USIcons.Transmit(size = 18.dp, color = color, strokeWidth = 1.8f)
+                }
+            }
 
-        // HUNT (auto-answer CQ) toggle pill. On = proactively call stations
-        // calling CQ; off = run CQ. Mutually exclusive with CQ: disabled while
-        // you're actively running CQ so the two modes never overlap.
-        val huntDisabled = isActivated && !huntEnabled
-        val huntBg = when {
-            huntDisabled -> BgSurface3.copy(alpha = 0.4f)
-            huntEnabled -> Signal.copy(alpha = 0.18f)
-            else -> BgSurface3
+            // TX time-slot toggle — stacked arrow + TX1/TX2.
+            StackedActionButton(
+                modifier = Modifier.weight(1f),
+                label = if (txSlot == 0) "TX1" else "TX2",
+                background = BgSurface3,
+                contentColor = TextMuted,
+                borderColor = Border,
+                enabled = true,
+                onClick = onToggleSlot,
+            ) { color -> FT8USIcons.ArrowUp(size = 18.dp, color = color, strokeWidth = 1.8f) }
         }
-        val huntColor = when {
-            huntDisabled -> TextMuted.copy(alpha = 0.4f)
-            huntEnabled -> Signal
-            else -> TextMuted
-        }
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .clip(RoundedCornerShape(6.dp))
-                .background(huntBg)
-                // Disable via clickable(enabled=…) rather than dropping the modifier, so
-                // the pill keeps its button semantics and TalkBack still announces it as a
-                // disabled control instead of it vanishing from accessibility entirely.
-                .clickable(enabled = !huntDisabled) { onToggleHunt() }
-                .padding(horizontal = 8.dp, vertical = 4.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = "HUNT",
-                color = huntColor,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.02.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
+    }
+}
 
-        // CQ / Stop pill button. Mutually exclusive with HUNT: disabled while
-        // HUNT mode is on, so you can't run CQ and hunt at the same time.
-        val cqDisabled = huntEnabled && !isActivated
-        val buttonBg = when {
-            isActivated -> StatusBad.copy(alpha = 0.18f)
-            cqDisabled -> AccentSoft.copy(alpha = 0.4f)
-            else -> AccentSoft
-        }
-        val buttonTextColor = when {
-            isActivated -> StatusBad
-            cqDisabled -> Accent.copy(alpha = 0.4f)
-            else -> Accent
-        }
-        val buttonLabel = if (isActivated) "STOP" else "CQ"
+/** A small rounded text chip (mode / DX). Keeps button semantics when disabled. */
+@Composable
+private fun TxChip(
+    label: String,
+    background: Color,
+    textColor: Color,
+    bold: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(background)
+            // Disable via clickable(enabled=…) rather than dropping the modifier, so the
+            // chip keeps its button semantics and TalkBack still announces it as a disabled
+            // control instead of vanishing from accessibility entirely.
+            .clickable(enabled = enabled) { onClick() }
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            color = textColor,
+            fontSize = 11.sp,
+            fontWeight = if (bold) FontWeight.Bold else FontWeight.SemiBold,
+            fontFamily = GeistMonoFamily,
+            letterSpacing = 0.02.sp,
+            maxLines = 1,
+            softWrap = false,
+        )
+    }
+}
 
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .clip(RoundedCornerShape(8.dp))
-                .background(buttonBg)
-                // Keep button semantics when disabled (see HUNT pill above) so the
-                // CQ/STOP control stays exposed to TalkBack as a disabled button.
-                .clickable(enabled = !cqDisabled) { if (isActivated) onStop() else onCallCQ() }
-                .padding(horizontal = 18.dp, vertical = 9.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = buttonLabel,
-                color = buttonTextColor,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Bold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.04.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
+/** A large secondary button with the icon stacked above the label (HUNT, TX slot). */
+@Composable
+private fun StackedActionButton(
+    label: String,
+    background: Color,
+    contentColor: Color,
+    borderColor: Color,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: @Composable (Color) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .height(54.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(background)
+            .border(1.dp, borderColor, RoundedCornerShape(12.dp))
+            .clickable(enabled = enabled) { onClick() }
+            .padding(vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(3.dp, Alignment.CenterVertically),
+    ) {
+        icon(contentColor)
+        Text(
+            text = label,
+            color = contentColor,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = GeistMonoFamily,
+            letterSpacing = 0.02.sp,
+            maxLines = 1,
+            softWrap = false,
+        )
+    }
+}
 
-        // TX slot toggle pill
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .clip(RoundedCornerShape(6.dp))
-                .background(BgSurface3)
-                .clickable { onToggleSlot() }
-                .padding(horizontal = 8.dp, vertical = 4.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = if (txSlot == 0) "TX1" else "TX2",
-                color = TextMuted,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.02.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
+/** The large primary button with the icon beside the label (CQ / STOP). */
+@Composable
+private fun PrimaryActionButton(
+    label: String,
+    background: Color,
+    contentColor: Color,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: @Composable (Color) -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .height(54.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(background)
+            .clickable(enabled = enabled) { onClick() }
+            .padding(horizontal = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        icon(contentColor)
+        Text(
+            text = label,
+            color = contentColor,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = GeistMonoFamily,
+            letterSpacing = 0.04.sp,
+            maxLines = 1,
+            softWrap = false,
+        )
     }
 }
 

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -460,6 +460,9 @@
 
     <string name="tx_transmitting">TRANSMITIENDO</string>
     <string name="tx_listening">ESCUCHANDO</string>
+    <string name="tx_hunt">Caza</string>
+    <string name="tx_call_cq">Llamar CQ</string>
+    <string name="tx_stop">Detener</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -460,6 +460,9 @@
 
     <string name="tx_transmitting">ÉMISSION</string>
     <string name="tx_listening">ÉCOUTE</string>
+    <string name="tx_hunt">Chasse</string>
+    <string name="tx_call_cq">Appel CQ</string>
+    <string name="tx_stop">Arrêter</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -460,6 +460,9 @@
 
     <string name="tx_transmitting">送信中</string>
     <string name="tx_listening">受信中</string>
+    <string name="tx_hunt">ハント</string>
+    <string name="tx_call_cq">CQを出す</string>
+    <string name="tx_stop">停止</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -460,6 +460,9 @@
 
     <string name="tx_transmitting">ПЕРЕДАЧА</string>
     <string name="tx_listening">ПРИЁМ</string>
+    <string name="tx_hunt">Охота</string>
+    <string name="tx_call_cq">Вызов CQ</string>
+    <string name="tx_stop">Стоп</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -460,6 +460,9 @@
 
     <string name="tx_transmitting">发射中</string>
     <string name="tx_listening">监听中</string>
+    <string name="tx_hunt">猎台</string>
+    <string name="tx_call_cq">呼叫CQ</string>
+    <string name="tx_stop">停止</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -460,6 +460,9 @@
 
     <string name="tx_transmitting">發射中</string>
     <string name="tx_listening">監聽中</string>
+    <string name="tx_hunt">獵取</string>
+    <string name="tx_call_cq">呼叫CQ</string>
+    <string name="tx_stop">停止</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -108,6 +108,9 @@
     <!-- ===== TX strip ===== -->
     <string name="tx_transmitting">TRANSMITTING</string>
     <string name="tx_listening">LISTENING</string>
+    <string name="tx_hunt">Hunt</string>
+    <string name="tx_call_cq">Call CQ</string>
+    <string name="tx_stop">Stop</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxStripActionStateTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxStripActionStateTest.kt
@@ -53,21 +53,37 @@ class TxStripActionStateTest {
     }
 
     @Test
-    fun `CQ and HUNT are never both enabled at once when idle-armed or active`() {
-        // The whole point of the rule: you can't be running CQ and hunting simultaneously.
+    fun `full truth table — every (isActivated, huntEnabled) combination`() {
+        // Exhaustive, both-directions assertion of the whole 2x2 space, so a regression in
+        // any field of any cell fails here. Tuple order:
+        //   isActivated, huntEnabled -> huntDisabled, huntActive, cqDisabled, cqIsStop
+        val expected = mapOf(
+            (false to false) to TxStripActionState(
+                huntDisabled = false, huntActive = false, cqDisabled = false, cqIsStop = false),
+            (false to true) to TxStripActionState(
+                huntDisabled = false, huntActive = true, cqDisabled = true, cqIsStop = false),
+            (true to false) to TxStripActionState(
+                huntDisabled = true, huntActive = false, cqDisabled = false, cqIsStop = true),
+            (true to true) to TxStripActionState(
+                huntDisabled = false, huntActive = true, cqDisabled = false, cqIsStop = true),
+        )
+        for ((input, want) in expected) {
+            val (activated, hunt) = input
+            assertThat(txStripActionState(activated, hunt)).isEqualTo(want)
+        }
+    }
+
+    @Test
+    fun `the two calling modes are mutually exclusive in every cell`() {
+        // The rule's purpose: you can never be set up to run CQ and to hunt at the same
+        // time. "Able to call CQ" = the CQ button is enabled and not already STOP; "hunting"
+        // = HUNT is the active calling mode and not locked. These must never both hold.
         for (activated in listOf(false, true)) {
             for (hunt in listOf(false, true)) {
                 val s = txStripActionState(activated, hunt)
-                val cqEnabled = !s.cqDisabled
-                val huntEnabledForCalling = s.huntActive && !s.huntDisabled
-                // If CQ is being actively run (activated, not stop-disabled) it's exclusive
-                // with hunt being the *calling* mode.
-                if (activated && !hunt) {
-                    assertThat(huntEnabledForCalling).isFalse()
-                }
-                if (!activated && hunt) {
-                    assertThat(cqEnabled).isFalse()
-                }
+                val canCallCq = !s.cqDisabled && !s.cqIsStop
+                val isHunting = s.huntActive && !s.huntDisabled
+                assertThat(canCallCq && isHunting).isFalse()
             }
         }
     }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxStripActionStateTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxStripActionStateTest.kt
@@ -1,0 +1,74 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [txStripActionState] — the pure HUNT vs CQ/STOP mutual-exclusion rule
+ * extracted from TxStrip so the Composable stays a thin wrapper. No Android runtime is
+ * needed: the inputs and outputs are plain booleans.
+ */
+class TxStripActionStateTest {
+
+    @Test
+    fun `idle, hunt off — CQ callable, hunt callable`() {
+        val s = txStripActionState(isActivated = false, huntEnabled = false)
+        assertThat(s.cqDisabled).isFalse()
+        assertThat(s.cqIsStop).isFalse()
+        assertThat(s.huntDisabled).isFalse()
+        assertThat(s.huntActive).isFalse()
+    }
+
+    @Test
+    fun `idle, hunt armed — CQ locked off, hunt highlighted and still toggleable`() {
+        val s = txStripActionState(isActivated = false, huntEnabled = true)
+        // HUNT armed but no QSO yet: CQ is locked so the two modes never overlap.
+        assertThat(s.cqDisabled).isTrue()
+        assertThat(s.cqIsStop).isFalse()
+        assertThat(s.huntActive).isTrue()
+        // Still enabled so the user can turn HUNT back off.
+        assertThat(s.huntDisabled).isFalse()
+    }
+
+    @Test
+    fun `active CQ, hunt off — button is STOP, hunt locked off`() {
+        val s = txStripActionState(isActivated = true, huntEnabled = false)
+        assertThat(s.cqIsStop).isTrue()
+        // STOP must always be tappable to end the QSO.
+        assertThat(s.cqDisabled).isFalse()
+        // Can't arm HUNT while a CQ/QSO is running.
+        assertThat(s.huntDisabled).isTrue()
+        assertThat(s.huntActive).isFalse()
+    }
+
+    @Test
+    fun `active while hunt enabled — STOP stays tappable, hunt stays enabled`() {
+        // Hunt-driven QSO: activated AND huntEnabled. STOP must work, and HUNT
+        // shouldn't be locked (huntDisabled requires hunt to be OFF).
+        val s = txStripActionState(isActivated = true, huntEnabled = true)
+        assertThat(s.cqIsStop).isTrue()
+        assertThat(s.cqDisabled).isFalse()
+        assertThat(s.huntDisabled).isFalse()
+        assertThat(s.huntActive).isTrue()
+    }
+
+    @Test
+    fun `CQ and HUNT are never both enabled at once when idle-armed or active`() {
+        // The whole point of the rule: you can't be running CQ and hunting simultaneously.
+        for (activated in listOf(false, true)) {
+            for (hunt in listOf(false, true)) {
+                val s = txStripActionState(activated, hunt)
+                val cqEnabled = !s.cqDisabled
+                val huntEnabledForCalling = s.huntActive && !s.huntDisabled
+                // If CQ is being actively run (activated, not stop-disabled) it's exclusive
+                // with hunt being the *calling* mode.
+                if (activated && !hunt) {
+                    assertThat(huntEnabledForCalling).isFalse()
+                }
+                if (!activated && hunt) {
+                    assertThat(cqEnabled).isFalse()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Restores the design-prototype TX strip layout and folds in the controls added since (mode pill, DX/Hound, CAT status chip).

**Before:** seven controls crammed into one wrapping `FlowRow` of tiny pills — `CQ`, the main action, was the same small tap target as `DX` or `TX1`, and the row wraps unpredictably in portrait.

**After:** two rows —
- **Info line:** status dot + `LISTENING`/`TRANSMITTING` + CAT chip (left) · mode / frequency / DX chips (right)
- **Action row:** three large buttons — **Hunt** (target icon) · **Call CQ / Stop** (wide, filled amber → red) · **TX1/TX2** (arrow icon)

The slot-timer/progress bar already sits directly above and reads as the top of the card (matches the screenshot's `2s` countdown bar).

## Behavior preserved

- HUNT vs CQ mutual-exclusion (can't run CQ and hunt at once)
- Mode pill locked mid-transmit
- DX (Hound) toggle, tappable CAT status chip, QSO expand chevron
- Disabled controls keep button semantics via `clickable(enabled=…)` so TalkBack still announces them

## Tests

Extracted the mutual-exclusion rule into the pure, testable `txStripActionState` (mirroring the existing `catChipVisuals` pattern) and added `TxStripActionStateTest` covering all four (activated × huntEnabled) combinations plus the never-both-enabled invariant. Added an `ArrowUp` icon for the TX-slot button.

`gradlew testDebugUnitTest --tests …TxStripActionStateTest` ✅, `installDebug` deployed to the Pixel 8.

> Note: the device was locked when I went to grab an in-app screenshot, so the visual hasn't been eyeballed on-device yet — verifying next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)