### PR TITLE
Address PR #165 review: guard SlotTimerBar, localize Hound dialog

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/HoundSetupSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/HoundSetupSheet.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.text.KeyboardOptions
+import com.bg7yoz.ft8cn.R
 
 /**
  * Setup dialog for FT8 DXpedition "Hound" mode. The user tunes the rig to the
@@ -38,26 +40,24 @@ fun HoundSetupSheet(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Work a DXpedition (Hound)") },
+        title = { Text(stringResource(R.string.hound_title)) },
         text = {
             Column {
-                Text(
-                    "Tune the rig to the Fox's published dial frequency first. " +
-                        "You call high (1000–4000 Hz); the app auto-QSYs you " +
-                        "down to where the Fox answers and replies with your report.",
-                )
+                Text(stringResource(R.string.hound_help))
                 Spacer(Modifier.height(12.dp))
                 OutlinedTextField(
                     value = foxCall,
+                    // uppercase() (no Locale arg) is locale-invariant, so callsigns are
+                    // normalized the same way regardless of the device locale.
                     onValueChange = { foxCall = it.uppercase().trim() },
-                    label = { Text("Fox callsign") },
+                    label = { Text(stringResource(R.string.hound_fox_callsign)) },
                     singleLine = true,
                 )
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = callFreq,
                     onValueChange = { v -> callFreq = v.filter { it.isDigit() }.take(4) },
-                    label = { Text("Call frequency (Hz, 1000–4000)") },
+                    label = { Text(stringResource(R.string.hound_call_frequency)) },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 )
@@ -69,10 +69,10 @@ fun HoundSetupSheet(
                     val f = (callFreq.toFloatOrNull() ?: 2500f).coerceIn(1000f, 4000f)
                     if (foxCall.trim().length >= 3) onStart(foxCall.trim(), f)
                 },
-            ) { Text("Start") }
+            ) { Text(stringResource(R.string.hound_start)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerBar.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerBar.kt
@@ -47,16 +47,8 @@ fun SlotTimerBar(
         }
     }
 
-    val slotMs = ((nowMs % slotMillis) + slotMillis) % slotMillis
-    val progress = slotMs / slotMillis.toFloat()
-    // Round the slot length UP so a 7.5s FT4 slot peaks at 8s, not 7 (integer
-    // division would truncate the half-second).
-    val maxSeconds = ((slotMillis + 999L) / 1000L).toInt()
-    val secondsRemaining = (((slotMillis - slotMs) + 999L) / 1000L).toInt().coerceIn(0, maxSeconds)
-    // Derive the slot index from the same slot length the bar is rendering, so
-    // they can't disagree if the bar is ever driven by a non-global slot.
-    val currentSlot = UtcTimer.sequential(nowMs, slotMillis.toInt())
-    val fillColor = if (isActivated && currentSlot == activeTxSlot) Accent else Signal
+    val state = slotTimerState(nowMs, slotMillis)
+    val fillColor = if (isActivated && state.currentSlot == activeTxSlot) Accent else Signal
 
     Row(
         modifier = modifier
@@ -73,12 +65,12 @@ fun SlotTimerBar(
                     drawRect(color = Border, size = Size(size.width, size.height))
                     drawRect(
                         color = fillColor,
-                        size = Size(size.width * progress, size.height),
+                        size = Size(size.width * state.progress, size.height),
                     )
                 },
         )
         Text(
-            text = "${secondsRemaining}s",
+            text = "${state.secondsRemaining}s",
             color = TextMuted,
             fontSize = 11.sp,
             fontWeight = FontWeight.SemiBold,
@@ -90,4 +82,32 @@ fun SlotTimerBar(
             modifier = Modifier.width(26.dp),
         )
     }
+}
+
+/** The fill fraction, countdown label, and slot index the bar renders for a given instant. */
+internal data class SlotTimerState(
+    val progress: Float,
+    val secondsRemaining: Int,
+    val currentSlot: Int,
+)
+
+/**
+ * Pure slot-progress math, extracted so it can be unit-tested without Compose.
+ *
+ * [slotMillis] is a public composable parameter, so guard it: a 0 or negative value would
+ * crash the modulo/division below (e.g. `nowMs % 0`). Fall back to the FT8 default so an
+ * unexpected value can never take the UI down — the bar just renders a 15 s cycle instead.
+ */
+internal fun slotTimerState(nowMs: Long, slotMillis: Long): SlotTimerState {
+    val slot = if (slotMillis > 0L) slotMillis else 15_000L
+    val slotMs = ((nowMs % slot) + slot) % slot
+    val progress = slotMs / slot.toFloat()
+    // Round the slot length UP so a 7.5s FT4 slot peaks at 8s, not 7 (integer division
+    // would truncate the half-second).
+    val maxSeconds = ((slot + 999L) / 1000L).toInt()
+    val secondsRemaining = (((slot - slotMs) + 999L) / 1000L).toInt().coerceIn(0, maxSeconds)
+    // Derive the slot index from the same slot length the bar is rendering, so they can't
+    // disagree if the bar is ever driven by a non-global slot.
+    val currentSlot = UtcTimer.sequential(nowMs, slot.toInt())
+    return SlotTimerState(progress, secondsRemaining, currentSlot)
 }

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -463,6 +463,11 @@
     <string name="tx_hunt">Caza</string>
     <string name="tx_call_cq">Llamar CQ</string>
     <string name="tx_stop">Detener</string>
+    <string name="hound_title">Trabajar una DXpedición (Hound)</string>
+    <string name="hound_help">Primero sintoniza el equipo en la frecuencia de dial publicada del Fox. Tú llamas alto (1000–4000 Hz); la app te hace QSY automáticamente a donde responde el Fox y envía tu informe.</string>
+    <string name="hound_fox_callsign">Indicativo del Fox</string>
+    <string name="hound_call_frequency">Frecuencia de llamada (Hz, 1000–4000)</string>
+    <string name="hound_start">Iniciar</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -463,6 +463,11 @@
     <string name="tx_hunt">Chasse</string>
     <string name="tx_call_cq">Appel CQ</string>
     <string name="tx_stop">Arrêter</string>
+    <string name="hound_title">Contacter une DXpédition (Hound)</string>
+    <string name="hound_help">Réglez d\'abord la radio sur la fréquence d\'affichage publiée du Fox. Vous appelez haut (1000–4000 Hz) ; l\'app vous fait QSY automatiquement là où le Fox répond et envoie votre report.</string>
+    <string name="hound_fox_callsign">Indicatif du Fox</string>
+    <string name="hound_call_frequency">Fréquence d\'appel (Hz, 1000–4000)</string>
+    <string name="hound_start">Démarrer</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -463,6 +463,11 @@
     <string name="tx_hunt">ハント</string>
     <string name="tx_call_cq">CQを出す</string>
     <string name="tx_stop">停止</string>
+    <string name="hound_title">DXペディションと交信（Hound）</string>
+    <string name="hound_help">まず無線機を Fox の公開ダイヤル周波数に合わせます。高い周波数（1000〜4000 Hz）で呼び出すと、アプリが自動的に Fox が応答する周波数へ QSY し、レポートを送信します。</string>
+    <string name="hound_fox_callsign">Fox のコールサイン</string>
+    <string name="hound_call_frequency">呼び出し周波数（Hz、1000〜4000）</string>
+    <string name="hound_start">開始</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -463,6 +463,11 @@
     <string name="tx_hunt">Охота</string>
     <string name="tx_call_cq">Вызов CQ</string>
     <string name="tx_stop">Стоп</string>
+    <string name="hound_title">Работа с DX-экспедицией (Hound)</string>
+    <string name="hound_help">Сначала настройте трансивер на опубликованную частоту Fox. Вы вызываете на высокой частоте (1000–4000 Гц); приложение автоматически переходит (QSY) туда, где отвечает Fox, и отправляет ваш рапорт.</string>
+    <string name="hound_fox_callsign">Позывной Fox</string>
+    <string name="hound_call_frequency">Частота вызова (Гц, 1000–4000)</string>
+    <string name="hound_start">Старт</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -463,6 +463,11 @@
     <string name="tx_hunt">猎台</string>
     <string name="tx_call_cq">呼叫CQ</string>
     <string name="tx_stop">停止</string>
+    <string name="hound_title">工作 DX 远征（Hound）</string>
+    <string name="hound_help">请先将电台调到 Fox 公布的拨盘频率。你在高频处呼叫（1000–4000 Hz）；应用会自动将你 QSY 到 Fox 应答的频率并回复你的报告。</string>
+    <string name="hound_fox_callsign">Fox 呼号</string>
+    <string name="hound_call_frequency">呼叫频率（Hz，1000–4000）</string>
+    <string name="hound_start">开始</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -463,6 +463,11 @@
     <string name="tx_hunt">獵取</string>
     <string name="tx_call_cq">呼叫CQ</string>
     <string name="tx_stop">停止</string>
+    <string name="hound_title">工作 DX 遠征（Hound）</string>
+    <string name="hound_help">請先將電台調到 Fox 公佈的撥盤頻率。你在高頻處呼叫（1000–4000 Hz）；應用會自動將你 QSY 到 Fox 回應的頻率並回覆你的報告。</string>
+    <string name="hound_fox_callsign">Fox 呼號</string>
+    <string name="hound_call_frequency">呼叫頻率（Hz，1000–4000）</string>
+    <string name="hound_start">開始</string>
 
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -112,6 +112,13 @@
     <string name="tx_call_cq">Call CQ</string>
     <string name="tx_stop">Stop</string>
 
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Work a DXpedition (Hound)</string>
+    <string name="hound_help">Tune the rig to the Fox\'s published dial frequency first. You call high (1000–4000 Hz); the app auto-QSYs you down to where the Fox answers and replies with your report.</string>
+    <string name="hound_fox_callsign">Fox callsign</string>
+    <string name="hound_call_frequency">Call frequency (Hz, 1000–4000)</string>
+    <string name="hound_start">Start</string>
+
     <!-- ===== CAT status chip ===== -->
     <string name="cat_status_chip_label">CAT</string>
     <string name="cat_status_connected">CAT connected — tap to reconnect</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
@@ -1,0 +1,70 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [slotTimerState] — the pure slot-progress math extracted from
+ * SlotTimerBar. No Android runtime needed: UtcTimer.sequential is plain modular
+ * arithmetic and the rest is integer/float math.
+ */
+class SlotTimerStateTest {
+
+    @Test
+    fun `ft8 slot start — empty bar, full countdown, slot 0`() {
+        val s = slotTimerState(nowMs = 0L, slotMillis = 15_000L)
+        assertThat(s.progress).isEqualTo(0f)
+        assertThat(s.secondsRemaining).isEqualTo(15)
+        assertThat(s.currentSlot).isEqualTo(0)
+    }
+
+    @Test
+    fun `ft8 mid-slot — half full, slot flips after the boundary`() {
+        val s = slotTimerState(nowMs = 7_500L, slotMillis = 15_000L)
+        assertThat(s.progress).isWithin(1e-4f).of(0.5f)
+        // 7.5s left, rounded up.
+        assertThat(s.secondsRemaining).isEqualTo(8)
+        assertThat(s.currentSlot).isEqualTo(0)
+        assertThat(slotTimerState(15_000L, 15_000L).currentSlot).isEqualTo(1)
+    }
+
+    @Test
+    fun `ft4 slot rounds the 7point5s length up to 8`() {
+        val s = slotTimerState(nowMs = 0L, slotMillis = 7_500L)
+        assertThat(s.secondsRemaining).isEqualTo(8)
+        assertThat(s.progress).isEqualTo(0f)
+    }
+
+    @Test
+    fun `ft2 slot — 3point8s peaks at 4 seconds`() {
+        val s = slotTimerState(nowMs = 0L, slotMillis = 3_800L)
+        assertThat(s.secondsRemaining).isEqualTo(4)
+    }
+
+    @Test
+    fun `zero slotMillis falls back to 15s instead of crashing`() {
+        // The regression guard: a 0 slot length used to crash on nowMs % 0.
+        val s = slotTimerState(nowMs = 3_000L, slotMillis = 0L)
+        assertThat(s.progress).isWithin(1e-4f).of(0.2f)
+        assertThat(s.secondsRemaining).isEqualTo(12)
+        assertThat(s.currentSlot).isEqualTo(0)
+    }
+
+    @Test
+    fun `negative slotMillis also falls back to 15s`() {
+        val s = slotTimerState(nowMs = 0L, slotMillis = -5L)
+        assertThat(s.progress).isEqualTo(0f)
+        assertThat(s.secondsRemaining).isEqualTo(15)
+    }
+
+    @Test
+    fun `progress and countdown stay in range across a whole slot`() {
+        for (ms in 0 until 15_000 step 250) {
+            val s = slotTimerState(ms.toLong(), 15_000L)
+            assertThat(s.progress).isAtLeast(0f)
+            assertThat(s.progress).isLessThan(1f)
+            assertThat(s.secondsRemaining).isAtLeast(0)
+            assertThat(s.secondsRemaining).isAtMost(15)
+        }
+    }
+}


### PR DESCRIPTION
Resolves the still-live findings from the Copilot review on the dev→main release PR #165.

## Fixes
- **SlotTimerBar divide-by-zero** — `slotMillis` is a public composable parameter fed straight into `nowMs % slotMillis` and `/ slotMillis`; a `0`/negative value would crash the UI. Extracted the slot math into a pure, testable `slotTimerState()` that guards the value and falls back to the FT8 15 s default. (`SlotTimerStateTest` covers normal FT8/FT4/FT2 plus the zero/negative cases.)
- **HoundSetupSheet localization** — moved the hard-coded title / help / field labels / Start into string resources (reusing `action_cancel` for Cancel) and added translations to all six locales, matching the rest of the Compose UI.

## Already fixed in dev (no change needed)
- *MainViewModel empty-decode flag* and *FT8TransmitSignal TX-volume comment* were both addressed by the merged `fix/decode-flag-tx-volume-comment` branch.

## Not a bug (documented, no change)
- *Callsign `uppercase()`* — Kotlin's no-arg `String.uppercase()` is locale-invariant (the recommended replacement for the locale-sensitive `toUpperCase()`), so the Turkish-i concern doesn't apply. Added a clarifying comment.

`gradlew testDebugUnitTest --tests …SlotTimerStateTest` ✅ and full debug resources compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)