### PR TITLE
Fix Hunt: actually answer CQs (arm the sequencer, stay silent when idle)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -182,12 +182,27 @@ public class FT8TransmitSignal {
             //@RequiresApi(api = Build.VERSION_CODES.N)
             @Override
             public void doOnSecTimer(long utc) {
+                // Hunt (auto-answer) is armed via setActivated(true) so it CAN reply, but it
+                // only answers other stations' CQs — it never calls CQ itself. While no
+                // caller is locked yet it's just listening, so keep the TX watchdog fresh;
+                // otherwise an idle hunt would auto-stop after the timeout even though it's
+                // behaving correctly. A stuck *active* QSO still ages the watchdog (this is
+                // false once a real target is locked).
+                if (isHuntListeningIdle(GeneralVariables.autoFollowCQ, functionOrder, toCallsign)) {
+                    GeneralVariables.resetLaunchSupervision();
+                }
                 // stop if auto-supervision timeout exceeded
                 if (GeneralVariables.isLaunchSupervisionTimeout()) {
                     setActivated(false);
                     return;
                 }
                 if (UtcTimer.getNowSequential() == sequential && activated) {
+                    // Idle hunt: stay silent this slot and keep listening rather than keying
+                    // up a CQ. Once parseMessageToFunction locks a caller (order advances,
+                    // target becomes a real callsign) this is false and the reply transmits.
+                    if (isHuntListeningIdle(GeneralVariables.autoFollowCQ, functionOrder, toCallsign)) {
+                        return;
+                    }
                     if (GeneralVariables.myCallsign.length() < 3) {
                         // my callsign is invalid, cannot transmit!
                         ToastMessage.show(GeneralVariables.getStringFromResource(R.string.callsign_error));
@@ -978,6 +993,30 @@ public class FT8TransmitSignal {
     //@RequiresApi(api = Build.VERSION_CODES.N)
     private boolean checkCQMeOrFollowCQMessage(ArrayList<Ft8Message> messages) {
         return checkCQMeOrFollowCQMessage(messages, false);
+    }
+
+    /**
+     * Whether Hunt (auto-answer) is armed but still idle — i.e. we are in the CQ baseline
+     * state ({@code functionOrder == 6}, target null/"CQ") with no station locked to answer.
+     *
+     * <p>Hunt arms the sequencer with {@code setActivated(true)} so it can reply, but it
+     * answers other stations' CQs and must never call CQ itself. In this idle state the
+     * transmit slot stays silent and we just keep listening; once
+     * {@link #checkCQMeOrFollowCQMessage} locks a caller (order advances past 6 and the
+     * target becomes a real callsign) this returns false and the reply transmits normally.
+     * When Hunt is off ({@code autoFollowCQ == false}) this is always false, so a normal
+     * user CQ run is unaffected.
+     *
+     * @param autoFollowCQ  the Hunt flag (GeneralVariables.autoFollowCQ)
+     * @param functionOrder the current TX sequence step (6 == CQ baseline)
+     * @param toCallsign    the current TX target, if any
+     */
+    static boolean isHuntListeningIdle(boolean autoFollowCQ, int functionOrder,
+                                       TransmitCallsign toCallsign) {
+        if (!autoFollowCQ) return false;
+        if (functionOrder != 6) return false;
+        // "no target" == null or the CQ placeholder (see TransmitCallsign.haveTargetCallsign).
+        return toCallsign == null || !toCallsign.haveTargetCallsign();
     }
 
     private boolean checkCQMeOrFollowCQMessage(ArrayList<Ft8Message> messages, boolean suppressHunt) {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1625,6 +1625,18 @@ public class FT8TransmitSignal {
     }
 
     /**
+     * Arm the sequencer for Hunt: enter the CQ baseline and clear the caller queue, but do
+     * NOT set {@code pendingUserCQ}. Unlike {@link #userResetToCQ()} (a user-initiated CQ,
+     * which deliberately skips one cycle so the CQ transmits cleanly first), Hunt should be
+     * able to lock onto and answer a CQ on the very next decode cycle, so it must not
+     * suppress the first {@code checkCQMeOrFollowCQMessage} pass.
+     */
+    public void armForHunt() {
+        resetToCQ();
+        clearCallerQueue();
+    }
+
+    /**
      * Force-log the current QSO and move on.
      * Called when the user taps "LOG" to skip waiting for a 73 reply.
      *

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -295,7 +295,9 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                         if (newVal) {
                             // Arm the sequencer so Hunt actually answers CQs. It stays silent
                             // (transmit path suppresses calling CQ) until it hears a CQ to work.
-                            mainViewModel.ft8TransmitSignal.userResetToCQ()
+                            // armForHunt (not userResetToCQ) so Hunt can answer on the very next
+                            // cycle instead of skipping one via pendingUserCQ.
+                            mainViewModel.ft8TransmitSignal.armForHunt()
                             mainViewModel.ft8TransmitSignal.setActivated(true)
                             GeneralVariables.resetLaunchSupervision()
                         } else {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -258,6 +258,13 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                         dxEnabled = false
                     } else {
                         mainViewModel.ft8TransmitSignal.setActivated(false)
+                        // If Hunt armed this run, STOP ends Hunt too, so the buttons can't be
+                        // left showing Hunt "on" while the sequencer is stopped (and idle).
+                        if (huntEnabled) {
+                            huntEnabled = false
+                            GeneralVariables.autoFollowCQ = false
+                            mainViewModel.databaseOpr.writeConfig("autoFollowCQ", "0", null)
+                        }
                     }
                 },
                 onToggleDx = {
@@ -276,17 +283,31 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                 },
                 onToggleHunt = {
                     val newVal = !huntEnabled
-                    huntEnabled = newVal
-                    GeneralVariables.autoFollowCQ = newVal
-                    mainViewModel.databaseOpr.writeConfig(
-                        "autoFollowCQ", if (newVal) "1" else "0", null,
-                    )
-                    Toast.makeText(
-                        context,
-                        if (newVal) context.getString(R.string.app_hunt_on)
-                        else context.getString(R.string.app_hunt_off),
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    if (newVal && GeneralVariables.myCallsign.isNullOrEmpty()) {
+                        // Hunt transmits replies, so it needs a callsign just like CQ does.
+                        Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()
+                    } else {
+                        huntEnabled = newVal
+                        GeneralVariables.autoFollowCQ = newVal
+                        mainViewModel.databaseOpr.writeConfig(
+                            "autoFollowCQ", if (newVal) "1" else "0", null,
+                        )
+                        if (newVal) {
+                            // Arm the sequencer so Hunt actually answers CQs. It stays silent
+                            // (transmit path suppresses calling CQ) until it hears a CQ to work.
+                            mainViewModel.ft8TransmitSignal.userResetToCQ()
+                            mainViewModel.ft8TransmitSignal.setActivated(true)
+                            GeneralVariables.resetLaunchSupervision()
+                        } else {
+                            mainViewModel.ft8TransmitSignal.setActivated(false)
+                        }
+                        Toast.makeText(
+                            context,
+                            if (newVal) context.getString(R.string.app_hunt_on)
+                            else context.getString(R.string.app_hunt_off),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
                 },
                 onCycleMode = {
                     // Cycle through the shipped ModeProfile entries in declaration order

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
@@ -182,4 +182,40 @@ public class FT8TransmitSignalTest {
         assertThat(second).usingTolerance(TOL)
                 .containsExactly(new float[]{0.25f, 0.25f}).inOrder();
     }
+
+    // ---- isHuntListeningIdle ------------------------------------------------
+    // Hunt arms the sequencer so it CAN reply, but it answers others' CQs and never calls
+    // CQ itself: while idle (CQ baseline, no target locked) the TX slot must stay silent.
+
+    private static TransmitCallsign cqBaseline() {
+        return new TransmitCallsign(1, 0, "CQ", 0);
+    }
+
+    private static TransmitCallsign station(String call) {
+        return new TransmitCallsign(1, 0, call, 0);
+    }
+
+    @Test
+    public void huntIdle_armedWithCqBaseline_isListeningOnly() {
+        // Hunt on, CQ state (order 6), target is the CQ placeholder -> stay silent.
+        assertThat(FT8TransmitSignal.isHuntListeningIdle(true, 6, cqBaseline())).isTrue();
+        // Null target (never set) is also idle.
+        assertThat(FT8TransmitSignal.isHuntListeningIdle(true, 6, null)).isTrue();
+    }
+
+    @Test
+    public void huntIdle_lockedOntoStation_transmitsReply() {
+        // A real caller is locked: order advanced and target is a station -> not idle.
+        assertThat(FT8TransmitSignal.isHuntListeningIdle(true, 1, station("K1ABC"))).isFalse();
+        // Even at order 6, a real target means we're answering, not idle-listening.
+        assertThat(FT8TransmitSignal.isHuntListeningIdle(true, 6, station("K1ABC"))).isFalse();
+    }
+
+    @Test
+    public void huntIdle_huntOff_neverSuppresses() {
+        // Hunt off: a normal user CQ run (order 6, "CQ") must transmit as usual.
+        assertThat(FT8TransmitSignal.isHuntListeningIdle(false, 6, cqBaseline())).isFalse();
+        assertThat(FT8TransmitSignal.isHuntListeningIdle(false, 6, null)).isFalse();
+        assertThat(FT8TransmitSignal.isHuntListeningIdle(false, 1, station("K1ABC"))).isFalse();
+    }
 }


### PR DESCRIPTION
## Bug
Field report: *"enabling hunt button blocks cq button but not starting to answer cq."*

**Root cause:** the Hunt toggle only set `GeneralVariables.autoFollowCQ`; it never armed the transmit sequencer. The decode loop *would* pick a CQ caller and prepare a reply, but with `activated == false` the radio never keyed. Hunt looked on (and correctly disabled the CQ button) but was inert.

## Fix
Hunt now actually runs, matching its "auto-answering CQs" contract — **answer others' CQs, never call CQ yourself**:

- **`onToggleHunt`** arms the sequencer when enabled (`userResetToCQ` + `setActivated(true)` + reset the TX watchdog) and deactivates when disabled; requires a callsign like CQ does.
- **`FT8TransmitSignal.isHuntListeningIdle()`** — while Hunt is armed but no caller is locked yet (CQ baseline: order 6, target null/"CQ"), the TX slot **stays silent and just listens**, so Hunt never calls CQ. Once `parseMessageToFunction` locks a caller (order advances, real target), the reply transmits normally. Returns false when Hunt is off, so a normal CQ run is untouched.
- The idle-listen branch keeps the TX watchdog fresh so an idle hunt can listen indefinitely, while a *stuck active QSO* still times out.
- **STOP** now also clears Hunt, so the buttons can't show Hunt "on" while the sequencer is stopped.

## Tests
`isHuntListeningIdle` covered for armed-idle (silent), locked-onto-station (transmits), and hunt-off (never suppresses). Unit tests pass; compiles.

> Not yet flashed to a device (phone was disconnected at build time) — wants an on-air check: toggle Hunt, confirm it answers a CQ and doesn't call CQ on idle cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)