### PR TITLE
Time sync: localize all locales + widen manual correction to ±5s

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrection.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrection.kt
@@ -9,13 +9,17 @@ import kotlin.math.roundToInt
  * the Composable so it can be unit-tested directly (Compose/DrawScope code can't).
  *
  * The correction is a millisecond offset that drives `UtcTimer.delay`; positive
- * shifts the app's clock forward. FT8 only tolerates being a second or two off
- * the 15 s cycle, so the range is intentionally tight.
+ * shifts the app's clock forward.
+ *
+ * The range has to cover the *device clock error*, not FT8's much tighter decode
+ * tolerance: a phone that's been offline for a while (no NTP) can drift several
+ * seconds, and the correction is what pulls that back toward 0. A field report of
+ * a Samsung A50 needing over 3 s while offline is why this is ±5 s, not ±2 s.
  */
 
 /** Inclusive bounds for the manual correction, in milliseconds. */
-internal const val TIME_CORRECTION_MIN_MS = -2000
-internal const val TIME_CORRECTION_MAX_MS = 2000
+internal const val TIME_CORRECTION_MIN_MS = -5000
+internal const val TIME_CORRECTION_MAX_MS = 5000
 
 /** Coerce an arbitrary correction into the allowed range. */
 internal fun clampCorrectionMs(ms: Int): Int =

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -481,4 +481,15 @@
     <string name="swr_lockout_body">Verifique la antena / línea de alimentación antes de transmitir.</string>
     <string name="swr_lockout_dismiss">DESCARTAR</string>
     <string name="swr_lockout_toast">TX bloqueado — bloqueo por SWR activo. Descarte el aviso primero.</string>
+
+    <!-- ===== Time sync / manual correction ===== -->
+    <string name="settings_cat_time_sync">Sincronización de hora</string>
+    <string name="settings_time_correction_section">Corrección manual</string>
+    <string name="settings_time_correction_desc">Ajusta el reloj de la app cuando no tienes internet para sincronizar. FT8 necesita UTC con una precisión de aproximadamente 1 segundo. Ajusta hasta que la columna DT de las estaciones decodificadas se centre cerca de 0.</string>
+    <string name="settings_time_current_label">Corrección actual</string>
+    <string name="settings_time_correction_reset">Restablecer a 0</string>
+    <string name="settings_time_suggest_section">Sugerido a partir de decodificaciones</string>
+    <string name="settings_time_suggest_label">DT promedio reciente: %1$s</string>
+    <string name="settings_time_suggest_none">Aún no hay decodificaciones — empieza a recibir para obtener una sugerencia.</string>
+    <string name="settings_time_suggest_apply">Aplicar corrección sugerida</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -484,6 +484,7 @@
 
     <!-- ===== Time sync / manual correction ===== -->
     <string name="settings_cat_time_sync">Sincronización de hora</string>
+    <string name="settings_cat_time_sync_desc">Corrección manual del reloj para operar sin conexión</string>
     <string name="settings_time_correction_section">Corrección manual</string>
     <string name="settings_time_correction_desc">Ajusta el reloj de la app cuando no tienes internet para sincronizar. FT8 necesita UTC con una precisión de aproximadamente 1 segundo. Ajusta hasta que la columna DT de las estaciones decodificadas se centre cerca de 0.</string>
     <string name="settings_time_current_label">Corrección actual</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -481,4 +481,15 @@
     <string name="swr_lockout_body">Vérifiez l\'antenne / le câble avant d\'émettre.</string>
     <string name="swr_lockout_dismiss">IGNORER</string>
     <string name="swr_lockout_toast">TX bloqué — verrouillage SWR actif. Fermez la bannière d\'abord.</string>
+
+    <!-- ===== Time sync / manual correction ===== -->
+    <string name="settings_cat_time_sync">Synchronisation de l\'heure</string>
+    <string name="settings_time_correction_section">Correction manuelle</string>
+    <string name="settings_time_correction_desc">Ajustez l\'horloge de l\'app quand vous n\'avez pas d\'Internet pour synchroniser. FT8 a besoin de l\'UTC à environ 1 seconde près. Ajustez jusqu\'à ce que la colonne DT des stations décodées soit proche de 0.</string>
+    <string name="settings_time_current_label">Correction actuelle</string>
+    <string name="settings_time_correction_reset">Réinitialiser à 0</string>
+    <string name="settings_time_suggest_section">Suggéré d\'après les décodages</string>
+    <string name="settings_time_suggest_label">DT moyen récent : %1$s</string>
+    <string name="settings_time_suggest_none">Aucun décodage pour l\'instant — commencez à recevoir pour obtenir une suggestion.</string>
+    <string name="settings_time_suggest_apply">Appliquer la correction suggérée</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -484,6 +484,7 @@
 
     <!-- ===== Time sync / manual correction ===== -->
     <string name="settings_cat_time_sync">Synchronisation de l\'heure</string>
+    <string name="settings_cat_time_sync_desc">Correction manuelle de l\'horloge pour le trafic hors ligne</string>
     <string name="settings_time_correction_section">Correction manuelle</string>
     <string name="settings_time_correction_desc">Ajustez l\'horloge de l\'app quand vous n\'avez pas d\'Internet pour synchroniser. FT8 a besoin de l\'UTC à environ 1 seconde près. Ajustez jusqu\'à ce que la colonne DT des stations décodées soit proche de 0.</string>
     <string name="settings_time_current_label">Correction actuelle</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -481,4 +481,15 @@
     <string name="swr_lockout_body">送信前にアンテナ / 給電線を確認してください。</string>
     <string name="swr_lockout_dismiss">解除</string>
     <string name="swr_lockout_toast">送信ブロック — SWRロック中。先にロックバナーを解除してください。</string>
+
+    <!-- ===== Time sync / manual correction ===== -->
+    <string name="settings_cat_time_sync">時刻同期</string>
+    <string name="settings_time_correction_section">手動補正</string>
+    <string name="settings_time_correction_desc">同期できるインターネットがないときにアプリの時計を微調整します。FT8 には約1秒以内の UTC が必要です。デコードした局の DT 列が 0 付近になるまで調整してください。</string>
+    <string name="settings_time_current_label">現在の補正</string>
+    <string name="settings_time_correction_reset">0 にリセット</string>
+    <string name="settings_time_suggest_section">デコードからの提案</string>
+    <string name="settings_time_suggest_label">最近の平均 DT: %1$s</string>
+    <string name="settings_time_suggest_none">まだデコードがありません — 受信を開始すると提案が表示されます。</string>
+    <string name="settings_time_suggest_apply">提案された補正を適用</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -484,6 +484,7 @@
 
     <!-- ===== Time sync / manual correction ===== -->
     <string name="settings_cat_time_sync">時刻同期</string>
+    <string name="settings_cat_time_sync_desc">オフライン運用のための手動時刻補正</string>
     <string name="settings_time_correction_section">手動補正</string>
     <string name="settings_time_correction_desc">同期できるインターネットがないときにアプリの時計を微調整します。FT8 には約1秒以内の UTC が必要です。デコードした局の DT 列が 0 付近になるまで調整してください。</string>
     <string name="settings_time_current_label">現在の補正</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -481,4 +481,15 @@
     <string name="swr_lockout_body">Проверьте антенну / фидер перед передачей.</string>
     <string name="swr_lockout_dismiss">ЗАКРЫТЬ</string>
     <string name="swr_lockout_toast">TX заблокирован — блокировка КСВ активна. Сначала закройте баннер.</string>
+
+    <!-- ===== Time sync / manual correction ===== -->
+    <string name="settings_cat_time_sync">Синхронизация времени</string>
+    <string name="settings_time_correction_section">Ручная коррекция</string>
+    <string name="settings_time_correction_desc">Подстройка часов приложения, когда нет интернета для синхронизации. Для FT8 нужно UTC с точностью около 1 секунды. Регулируйте, пока столбец DT у декодированных станций не будет около 0.</string>
+    <string name="settings_time_current_label">Текущая коррекция</string>
+    <string name="settings_time_correction_reset">Сбросить на 0</string>
+    <string name="settings_time_suggest_section">Предложение по декодированиям</string>
+    <string name="settings_time_suggest_label">Средний DT за последнее время: %1$s</string>
+    <string name="settings_time_suggest_none">Пока нет декодирований — включите приём, чтобы получить рекомендацию.</string>
+    <string name="settings_time_suggest_apply">Применить предложенную коррекцию</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -484,6 +484,7 @@
 
     <!-- ===== Time sync / manual correction ===== -->
     <string name="settings_cat_time_sync">Синхронизация времени</string>
+    <string name="settings_cat_time_sync_desc">Ручная коррекция часов для работы офлайн</string>
     <string name="settings_time_correction_section">Ручная коррекция</string>
     <string name="settings_time_correction_desc">Подстройка часов приложения, когда нет интернета для синхронизации. Для FT8 нужно UTC с точностью около 1 секунды. Регулируйте, пока столбец DT у декодированных станций не будет около 0.</string>
     <string name="settings_time_current_label">Текущая коррекция</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -484,6 +484,7 @@
 
     <!-- ===== Time sync / manual correction ===== -->
     <string name="settings_cat_time_sync">时间同步</string>
+    <string name="settings_cat_time_sync_desc">离线操作的手动时钟校正</string>
     <string name="settings_time_correction_section">手动校正</string>
     <string name="settings_time_correction_desc">在没有网络同步时微调应用时钟。FT8 需要 UTC 精确到约 1 秒。请调整到解码站点的 DT 列接近 0。</string>
     <string name="settings_time_current_label">当前校正</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -481,4 +481,15 @@
     <string name="swr_lockout_body">发射前请检查天线 / 馈线。</string>
     <string name="swr_lockout_dismiss">关闭</string>
     <string name="swr_lockout_toast">发射已阻止 — 驻波比锁定中，请先关闭锁定横幅。</string>
+
+    <!-- ===== Time sync / manual correction ===== -->
+    <string name="settings_cat_time_sync">时间同步</string>
+    <string name="settings_time_correction_section">手动校正</string>
+    <string name="settings_time_correction_desc">在没有网络同步时微调应用时钟。FT8 需要 UTC 精确到约 1 秒。请调整到解码站点的 DT 列接近 0。</string>
+    <string name="settings_time_current_label">当前校正</string>
+    <string name="settings_time_correction_reset">重置为 0</string>
+    <string name="settings_time_suggest_section">根据解码建议</string>
+    <string name="settings_time_suggest_label">近期平均 DT：%1$s</string>
+    <string name="settings_time_suggest_none">暂无解码 — 开始接收以获取建议。</string>
+    <string name="settings_time_suggest_apply">应用建议的校正</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -481,4 +481,15 @@
     <string name="swr_lockout_body">發射前請檢查天線 / 饋線。</string>
     <string name="swr_lockout_dismiss">關閉</string>
     <string name="swr_lockout_toast">發射已阻止 — 駐波比鎖定中，請先關閉鎖定橫幅。</string>
+
+    <!-- ===== Time sync / manual correction ===== -->
+    <string name="settings_cat_time_sync">時間同步</string>
+    <string name="settings_time_correction_section">手動校正</string>
+    <string name="settings_time_correction_desc">在沒有網路同步時微調應用時鐘。FT8 需要 UTC 精確到約 1 秒。請調整到解碼站台的 DT 欄接近 0。</string>
+    <string name="settings_time_current_label">目前校正</string>
+    <string name="settings_time_correction_reset">重設為 0</string>
+    <string name="settings_time_suggest_section">根據解碼建議</string>
+    <string name="settings_time_suggest_label">近期平均 DT：%1$s</string>
+    <string name="settings_time_suggest_none">尚無解碼 — 開始接收以取得建議。</string>
+    <string name="settings_time_suggest_apply">套用建議的校正</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -484,6 +484,7 @@
 
     <!-- ===== Time sync / manual correction ===== -->
     <string name="settings_cat_time_sync">時間同步</string>
+    <string name="settings_cat_time_sync_desc">離線操作的手動時鐘校正</string>
     <string name="settings_time_correction_section">手動校正</string>
     <string name="settings_time_correction_desc">在沒有網路同步時微調應用時鐘。FT8 需要 UTC 精確到約 1 秒。請調整到解碼站台的 DT 欄接近 0。</string>
     <string name="settings_time_current_label">目前校正</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrectionTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/TimeCorrectionTest.kt
@@ -14,14 +14,16 @@ class TimeCorrectionTest {
         assertThat(clampCorrectionMs(0)).isEqualTo(0)
         assertThat(clampCorrectionMs(500)).isEqualTo(500)
         assertThat(clampCorrectionMs(-500)).isEqualTo(-500)
-        assertThat(clampCorrectionMs(TIME_CORRECTION_MAX_MS)).isEqualTo(2000)
-        assertThat(clampCorrectionMs(TIME_CORRECTION_MIN_MS)).isEqualTo(-2000)
+        assertThat(clampCorrectionMs(TIME_CORRECTION_MAX_MS)).isEqualTo(5000)
+        assertThat(clampCorrectionMs(TIME_CORRECTION_MIN_MS)).isEqualTo(-5000)
+        // The reported real-world case: an offline phone needing ~3.4 s is now in range.
+        assertThat(clampCorrectionMs(3400)).isEqualTo(3400)
     }
 
     @Test
     fun clamp_pinsBeyondRange() {
-        assertThat(clampCorrectionMs(5000)).isEqualTo(2000)
-        assertThat(clampCorrectionMs(-5000)).isEqualTo(-2000)
+        assertThat(clampCorrectionMs(9000)).isEqualTo(5000)
+        assertThat(clampCorrectionMs(-9000)).isEqualTo(-5000)
     }
 
     @Test
@@ -29,10 +31,10 @@ class TimeCorrectionTest {
         assertThat(stepCorrectionMs(0, 100)).isEqualTo(100)
         assertThat(stepCorrectionMs(0, -100)).isEqualTo(-100)
         assertThat(stepCorrectionMs(400, 500)).isEqualTo(900)
-        // +0.5 s past the +2.0 s rail pins to the max.
-        assertThat(stepCorrectionMs(1800, 500)).isEqualTo(2000)
-        // -0.5 s past the -2.0 s rail pins to the min.
-        assertThat(stepCorrectionMs(-1800, -500)).isEqualTo(-2000)
+        // +0.5 s past the +5.0 s rail pins to the max.
+        assertThat(stepCorrectionMs(4800, 500)).isEqualTo(5000)
+        // -0.5 s past the -5.0 s rail pins to the min.
+        assertThat(stepCorrectionMs(-4800, -500)).isEqualTo(-5000)
     }
 
     @Test
@@ -49,8 +51,11 @@ class TimeCorrectionTest {
 
     @Test
     fun suggested_clampsToRange() {
-        assertThat(suggestedCorrectionMs(0, -5.0f)).isEqualTo(2000)
-        assertThat(suggestedCorrectionMs(0, 5.0f)).isEqualTo(-2000)
+        // Within ±5 s the suggestion passes through unclamped...
+        assertThat(suggestedCorrectionMs(0, -3.4f)).isEqualTo(3400)
+        // ...and only a larger-than-range DT pins to the rail.
+        assertThat(suggestedCorrectionMs(0, -7.0f)).isEqualTo(5000)
+        assertThat(suggestedCorrectionMs(0, 7.0f)).isEqualTo(-5000)
     }
 
     @Test


### PR DESCRIPTION
Addresses two field reports from a Russian operator (Samsung A50).

## 1. "time sync: missing translation"
The manual time-correction feature (PR #169) shipped with **no translations** — all 9 `settings_time_*` / time-sync strings existed only in `values/`, so non-English users saw raw English. Added translations to all six locales: **es, fr, ja, ru, zh-rCN, zh-rTW**.

## 2. "2 sec is not enough"
Offline (no NTP) he needed **over 3 s** of correction, but the range was clamped to **±2000 ms**. The correction has to absorb the *device clock error* — a phone offline a while can drift several seconds — not FT8's tighter decode tolerance. Widened `TIME_CORRECTION_MIN/MAX_MS` to **±5000 ms**.

`TimeCorrectionTest` updated for the new rails (incl. the ~3.4 s real-world case). Tests pass; all six locale resources compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)