### PR TITLE
CAT: push frequency on (re)connect + connection liveness watchdog

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -80,6 +80,7 @@ import com.bg7yoz.ft8cn.log.ThirdPartyService;
 import com.bg7yoz.ft8cn.rigs.BaseRig;
 import com.bg7yoz.ft8cn.rigs.BaseRigOperation;
 import com.bg7yoz.ft8cn.rigs.CatConnectionState;
+import com.bg7yoz.ft8cn.rigs.CatLiveness;
 import com.bg7yoz.ft8cn.rigs.DiscoveryTX500Rig;
 import com.bg7yoz.ft8cn.rigs.ElecraftRig;
 import com.bg7yoz.ft8cn.rigs.Flex6000Rig;
@@ -118,6 +119,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -236,6 +239,7 @@ public class MainViewModel extends ViewModel {
             //disconnected from rig. A failed connect fires onRunError() then
             //onDisconnected(); afterDisconnect() preserves ERROR so the chip can
             //stay red until the next connect attempt (onConnecting) or a success.
+            stopCatLivenessWatchdog();
             setCatConnectionState(CatConnectionState.afterDisconnect(catConnectionState));
             ToastMessage.show(getStringFromResource(R.string.disconnect_rig));
         }
@@ -251,6 +255,15 @@ public class MainViewModel extends ViewModel {
             //connected to rig
             setCatConnectionState(CatConnectionState.CONNECTED);
             ToastMessage.show(getStringFromResource(R.string.connected_rig));
+            // Push the app's current band/frequency to the rig on every connect —
+            // including an automatic reconnect, which previously left the rig on
+            // whatever frequency it powered up on ("no frequency set after connecting").
+            // setOperationBand() no-ops if the rig isn't actually connected and has its
+            // own settle delay, so a short post keeps us off the connect-callback thread
+            // without racing the link coming up.
+            new Handler(Looper.getMainLooper()).postDelayed(MainViewModel.this::setOperationBand, 1500);
+            // (Re)start the liveness watchdog for this connection.
+            startCatLivenessWatchdog();
         }
 
         @Override
@@ -260,6 +273,8 @@ public class MainViewModel extends ViewModel {
 
         @Override
         public void onFreqChanged(long freq) {
+            //the rig answered a frequency query — proof the link is alive (liveness watchdog)
+            markRigResponded();
             //current frequency: %s
             ToastMessage.show(String.format(getStringFromResource(R.string.current_frequency)
                     , BaseRigOperation.getFrequencyAllInfo(freq)));
@@ -275,11 +290,77 @@ public class MainViewModel extends ViewModel {
         @Override
         public void onRunError(String message) {
             //rig communication error
+            stopCatLivenessWatchdog();
             setCatConnectionState(CatConnectionState.ERROR);
             ToastMessage.show(String.format(getStringFromResource(R.string.radio_communication_error)
                     , message));
         }
     };
+
+    // ===== CAT liveness watchdog =====
+    // A Bluetooth/serial CAT link can stay "connected" after the radio is powered off (the
+    // BT module keeps the socket up), so the chip stayed green and frequency writes went
+    // nowhere. This watchdog periodically reads the rig's frequency and, if a previously-
+    // responsive rig goes quiet for too long, flips the chip to error. See CatLiveness for
+    // the guard logic (never judges during TX; only arms after the first reply, so a rig
+    // that doesn't echo frequency reads is never falsely marked dead).
+    private static final long CAT_LIVENESS_TICK_MS = 3000;
+    private Timer catLivenessTimer;
+    private volatile long lastRigResponseMs = 0;
+    private volatile boolean sawRigResponseSinceConnect = false;
+
+    /** Record that the rig just demonstrably responded (called from onFreqChanged). */
+    private void markRigResponded() {
+        lastRigResponseMs = System.currentTimeMillis();
+        sawRigResponseSinceConnect = true;
+    }
+
+    private synchronized void startCatLivenessWatchdog() {
+        stopCatLivenessWatchdog();
+        lastRigResponseMs = System.currentTimeMillis();
+        sawRigResponseSinceConnect = false;
+        catLivenessTimer = new Timer("cat-liveness");
+        catLivenessTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                catLivenessTick();
+            }
+        }, CAT_LIVENESS_TICK_MS, CAT_LIVENESS_TICK_MS);
+    }
+
+    private synchronized void stopCatLivenessWatchdog() {
+        if (catLivenessTimer != null) {
+            catLivenessTimer.cancel();
+            catLivenessTimer.purge();
+            catLivenessTimer = null;
+        }
+    }
+
+    /** One watchdog tick: probe the rig, then declare it dead if it's gone quiet too long. */
+    private void catLivenessTick() {
+        try {
+            boolean connected = isRigConnected();
+            boolean transmitting = ft8TransmitSignal != null && ft8TransmitSignal.isTransmitting();
+            // Actively probe (a frequency read); the reply lands in onFreqChanged ->
+            // markRigResponded(). On a dead-but-powered BT module the write succeeds but no
+            // reply comes, so the quiet timer below eventually trips.
+            if (CatLiveness.shouldProbe(connected, transmitting) && baseRig != null) {
+                baseRig.readFreqFromRig();
+            }
+            if (CatLiveness.isRigStale(connected, transmitting, sawRigResponseSinceConnect,
+                    System.currentTimeMillis(), lastRigResponseMs, CatLiveness.DEFAULT_TIMEOUT_MS)) {
+                stopCatLivenessWatchdog();
+                setCatConnectionState(CatConnectionState.ERROR);
+                ToastMessage.show(String.format(
+                        getStringFromResource(R.string.radio_communication_error),
+                        getStringFromResource(R.string.disconnect_rig)));
+            }
+        } catch (Exception e) {
+            // Never let a probe failure crash the timer thread; a real I/O error already
+            // surfaces via onRunError().
+            Log.w(TAG, "cat liveness tick: " + e.getMessage());
+        }
+    }
 
     //message list for signal transmission
     //public ArrayList<Ft8Message> transmitMessages = new ArrayList<>();

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -272,9 +272,15 @@ public class MainViewModel extends ViewModel {
         }
 
         @Override
-        public void onFreqChanged(long freq) {
-            //the rig answered a frequency query — proof the link is alive (liveness watchdog)
+        public void onRigResponded() {
+            // The rig answered with a valid frequency (changed or not) — the liveness signal.
+            // onFreqChanged only fires on a change, so it can't be used here (a stable dial
+            // would look dead and falsely trip the watchdog).
             markRigResponded();
+        }
+
+        @Override
+        public void onFreqChanged(long freq) {
             //current frequency: %s
             ToastMessage.show(String.format(getStringFromResource(R.string.current_frequency)
                     , BaseRigOperation.getFrequencyAllInfo(freq)));
@@ -357,8 +363,9 @@ public class MainViewModel extends ViewModel {
             }
         } catch (Exception e) {
             // Never let a probe failure crash the timer thread; a real I/O error already
-            // surfaces via onRunError().
-            Log.w(TAG, "cat liveness tick: " + e.getMessage());
+            // surfaces via onRunError(). Log the exception object (not just getMessage(),
+            // which can be null) so the stack trace is preserved.
+            Log.w(TAG, "cat liveness tick failed", e);
         }
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/BaseRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/BaseRig.java
@@ -58,9 +58,16 @@ public abstract class BaseRig {
     }
 
     public void setFreq(long freq) {
-        if (freq == this.freq) return;
         if (freq == 0) return;
         if (freq == -1) return;
+        // The rig answered with a valid frequency — proof the link is alive even if the dial
+        // didn't move. Fire this BEFORE the unchanged-frequency early return below so the CAT
+        // liveness watchdog (which keys off onRigResponded, not onFreqChanged) sees every
+        // reply and doesn't falsely trip on a stable dial.
+        if (onRigStateChanged != null) {
+            onRigStateChanged.onRigResponded();
+        }
+        if (freq == this.freq) return;
         mutableFrequency.postValue(freq);
         this.freq = freq;
         if (onRigStateChanged != null) {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatLiveness.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatLiveness.java
@@ -13,10 +13,11 @@ package com.bg7yoz.ft8cn.rigs;
  * <p>Two guards keep it from crying wolf:
  * <ul>
  *   <li>It never judges during transmit (we don't poll while keyed).</li>
- *   <li>It only arms once the rig has answered at least once since connecting
- *       ({@code sawResponse}). A rig that never echoes a frequency read (or a transport that
- *       doesn't support it) therefore can't be falsely marked dead — the watchdog simply
- *       stays dormant for it.</li>
+ *   <li>The <em>stale</em> decision only arms once the rig has answered at least once since
+ *       connecting ({@code sawResponse}). Probes are still sent every tick (see
+ *       {@link #shouldProbe}); it's only the "declare dead" judgement that waits for a first
+ *       reply, so a rig that never answers a frequency read (or a transport that doesn't
+ *       support it) can't be falsely marked dead.</li>
  * </ul>
  */
 public final class CatLiveness {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatLiveness.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/CatLiveness.java
@@ -1,0 +1,56 @@
+package com.bg7yoz.ft8cn.rigs;
+
+/**
+ * Pure decision logic for the CAT connection liveness watchdog, kept separate from
+ * MainViewModel so it can be unit-tested without Android.
+ *
+ * <p>The problem it solves: a Bluetooth (or other) CAT link can stay "connected" at the
+ * transport level after the radio itself is powered off — the BT module keeps the socket
+ * up, so no I/O error ever fires and the status chip stays green while frequency writes
+ * silently go nowhere. The watchdog actively probes the rig (a periodic frequency read) and
+ * watches for replies; if the rig has gone quiet for too long it flips the chip to error.
+ *
+ * <p>Two guards keep it from crying wolf:
+ * <ul>
+ *   <li>It never judges during transmit (we don't poll while keyed).</li>
+ *   <li>It only arms once the rig has answered at least once since connecting
+ *       ({@code sawResponse}). A rig that never echoes a frequency read (or a transport that
+ *       doesn't support it) therefore can't be falsely marked dead — the watchdog simply
+ *       stays dormant for it.</li>
+ * </ul>
+ */
+public final class CatLiveness {
+
+    private CatLiveness() {}
+
+    /** Default quiet period after which a previously-responsive rig is considered dead. */
+    public static final long DEFAULT_TIMEOUT_MS = 8000;
+
+    /**
+     * Whether we should send a liveness probe (a frequency read) this tick: only when
+     * connected and not transmitting.
+     */
+    public static boolean shouldProbe(boolean connected, boolean transmitting) {
+        return connected && !transmitting;
+    }
+
+    /**
+     * Whether the rig should now be treated as stale (unresponsive) and the chip flipped to
+     * error.
+     *
+     * @param connected      whether the transport still reports connected
+     * @param transmitting   whether we are mid-transmit (never judge during TX)
+     * @param sawResponse    whether the rig has replied at least once since connecting
+     * @param nowMs          current time (ms)
+     * @param lastResponseMs time of the last reply from the rig (ms)
+     * @param timeoutMs      allowed quiet period before declaring the rig dead
+     */
+    public static boolean isRigStale(boolean connected, boolean transmitting,
+                                     boolean sawResponse, long nowMs,
+                                     long lastResponseMs, long timeoutMs) {
+        if (!connected) return false;     // not connected -> nothing to police
+        if (transmitting) return false;   // don't judge during TX (no polling then)
+        if (!sawResponse) return false;   // never armed -> can't false-positive a quiet rig
+        return (nowMs - lastResponseMs) > timeoutMs;
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/OnRigStateChanged.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/OnRigStateChanged.java
@@ -17,4 +17,13 @@ public interface OnRigStateChanged {
      * failed. Default no-op so existing implementers don't need to change.
      */
     default void onConnecting() {}
+
+    /**
+     * Called whenever the rig answers with a valid frequency, even if the dial hasn't
+     * moved. {@link #onFreqChanged(long)} only fires on an actual change, so it can't be
+     * used as a liveness signal — a rig parked on one frequency would look dead. The CAT
+     * liveness watchdog keys off this instead. Default no-op so existing implementers don't
+     * need to change.
+     */
+    default void onRigResponded() {}
 }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/rigs/CatLivenessTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/rigs/CatLivenessTest.java
@@ -1,0 +1,63 @@
+package com.bg7yoz.ft8cn.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the CAT liveness watchdog decision logic. Pure JUnit — no Android.
+ */
+public class CatLivenessTest {
+
+    private static final long TIMEOUT = CatLiveness.DEFAULT_TIMEOUT_MS;
+
+    // ---- shouldProbe --------------------------------------------------------
+
+    @Test
+    public void probe_onlyWhenConnectedAndNotTransmitting() {
+        assertThat(CatLiveness.shouldProbe(true, false)).isTrue();
+        assertThat(CatLiveness.shouldProbe(false, false)).isFalse(); // not connected
+        assertThat(CatLiveness.shouldProbe(true, true)).isFalse();   // mid-transmit
+        assertThat(CatLiveness.shouldProbe(false, true)).isFalse();
+    }
+
+    // ---- isRigStale ---------------------------------------------------------
+
+    @Test
+    public void stale_whenResponsiveRigGoesQuietPastTimeout() {
+        // Armed (saw a reply), connected, idle, and silent for longer than the timeout.
+        assertThat(CatLiveness.isRigStale(true, false, true,
+                100_000, 100_000 - (TIMEOUT + 1), TIMEOUT)).isTrue();
+    }
+
+    @Test
+    public void notStale_withinTimeout() {
+        assertThat(CatLiveness.isRigStale(true, false, true,
+                100_000, 100_000 - (TIMEOUT - 1), TIMEOUT)).isFalse();
+        // Exactly at the boundary is not yet stale (strictly greater-than).
+        assertThat(CatLiveness.isRigStale(true, false, true,
+                100_000, 100_000 - TIMEOUT, TIMEOUT)).isFalse();
+    }
+
+    @Test
+    public void neverStale_beforeFirstResponse() {
+        // The arming guard: a rig that has never echoed a frequency read (sawResponse=false)
+        // must not be flagged dead, even after a long silence. This is what stops the
+        // watchdog from false-positiving rigs/transports that don't answer freq queries.
+        assertThat(CatLiveness.isRigStale(true, false, false,
+                100_000, 0, TIMEOUT)).isFalse();
+    }
+
+    @Test
+    public void neverStale_whileTransmitting() {
+        // We don't poll during TX, so we must not judge silence as death then.
+        assertThat(CatLiveness.isRigStale(true, true, true,
+                100_000, 0, TIMEOUT)).isFalse();
+    }
+
+    @Test
+    public void neverStale_whenDisconnected() {
+        assertThat(CatLiveness.isRigStale(false, false, true,
+                100_000, 0, TIMEOUT)).isFalse();
+    }
+}


### PR DESCRIPTION
Two field reports from a Bluetooth-CAT operator.

## 1. "no frequency set after connecting"
`onConnected()` only set the chip green; the frequency was pushed **only** by the per-transport delayed callback inside each connect method, so an **automatic reconnect** left the rig on whatever frequency it powered up on. Now `onConnected()` pushes the app's current band/frequency on **every** connect (short settle delay; `setOperationBand()` already no-ops when not connected).

## 2. "no connection check — rig off but Bluetooth stays green"
A BT/serial link can stay connected at the transport level after the radio is powered off (the module keeps the socket up), so no I/O error fires — the chip stayed green and frequency writes went nowhere.

Added a **liveness watchdog**: while connected and not transmitting it periodically reads the rig's frequency; a reply (`onFreqChanged`) marks the link alive, and if a previously-responsive rig goes quiet past an 8 s timeout the chip flips to **error**.

The guard logic is in the pure, unit-tested `CatLiveness`:
- **never judges during TX** (we don't poll while keyed), and
- **only arms after the first reply**, so a rig/transport that doesn't echo frequency reads can't be falsely marked dead — the watchdog just stays dormant for it.

## ⚠️ Needs on-rig testing
The connection-layer wiring (probe timing, watchdog lifecycle) is **untested on hardware** — I can't drive a real rig from here. Please validate on the Bluetooth rig before merge:
1. Connect → confirm the rig retunes to the app frequency.
2. With the app connected, power **off** the radio (leave BT on) → the chip should go **red** within ~10 s (today it stays green).
3. Normal RX/TX on a working rig → chip stays green, no false reds, no TX interference.

Pure decision logic (`CatLivenessTest`) passes; full debug build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)