### PR TITLE
Fix waterfall painting decoded labels repeatedly down the cascade

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
@@ -1,23 +1,26 @@
 package com.bg7yoz.ft8cn.ui;
 
 /**
- * Gates the waterfall's decoded-message labels to one stamp per 15-second FT8 cycle.
+ * Gates the waterfall's decoded-message labels to one stamp per decode slot.
  *
  * <p>The waterfall stamps the labels onto its scrolling bitmap as a one-shot, re-armed
- * every time a decode pass finishes. FT8 runs more than one pass per cycle (a normal pass
- * and a slower deep pass), so without a gate the same cycle's labels are stamped several
+ * every time a decode pass finishes. A decode runs more than one pass per slot (a normal
+ * pass and a slower deep pass), so without a gate the same slot's labels are stamped several
  * times, at different scroll offsets, and appear to repeat down the waterfall — including
- * over the next cycle's blank rows where the signal is already gone. Keyed on the UTC
- * 15-second period, this returns true for only the first stamp of each cycle.
+ * over the next slot's blank rows where the signal is already gone. Keyed on a per-slot
+ * index (the caller derives it from the current mode's slot length, e.g.
+ * {@code utcMs / slotMillis} — 15s FT8, 7.5s FT4, 3.8s FT2), this returns true for only the
+ * first stamp of each slot.
  *
- * <p>Plain Java (no Android), so the once-per-cycle rule can be unit-tested directly.
+ * <p>Plain Java (no Android), so the once-per-slot rule can be unit-tested directly.
  */
 public final class WaterfallLabelGate {
 
     private long lastStampedPeriod = Long.MIN_VALUE;
 
     /**
-     * Whether the labels for {@code period} (a UTC 15s cycle index, e.g. {@code utcSec/15})
+     * Whether the labels for {@code period} (a decode-slot index — the caller keys it off
+     * the current mode's slot length, e.g. {@code utcMs / slotMillis}, NOT a fixed 15s)
      * should be stamped now. Returns true once per distinct period and false for any repeat
      * arming within the same period.
      */

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
@@ -1,0 +1,36 @@
+package com.bg7yoz.ft8cn.ui;
+
+/**
+ * Gates the waterfall's decoded-message labels to one stamp per 15-second FT8 cycle.
+ *
+ * <p>The waterfall stamps the labels onto its scrolling bitmap as a one-shot, re-armed
+ * every time a decode pass finishes. FT8 runs more than one pass per cycle (a normal pass
+ * and a slower deep pass), so without a gate the same cycle's labels are stamped several
+ * times, at different scroll offsets, and appear to repeat down the waterfall — including
+ * over the next cycle's blank rows where the signal is already gone. Keyed on the UTC
+ * 15-second period, this returns true for only the first stamp of each cycle.
+ *
+ * <p>Plain Java (no Android), so the once-per-cycle rule can be unit-tested directly.
+ */
+public final class WaterfallLabelGate {
+
+    private long lastStampedPeriod = Long.MIN_VALUE;
+
+    /**
+     * Whether the labels for {@code period} (a UTC 15s cycle index, e.g. {@code utcSec/15})
+     * should be stamped now. Returns true once per distinct period and false for any repeat
+     * arming within the same period.
+     */
+    public boolean shouldStamp(long period) {
+        if (period == lastStampedPeriod) {
+            return false;
+        }
+        lastStampedPeriod = period;
+        return true;
+    }
+
+    /** Forget the last stamped cycle (e.g. when the bitmap is recreated). */
+    public void reset() {
+        lastStampedPeriod = Long.MIN_VALUE;
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -75,8 +75,9 @@ public class WaterfallView extends View {
 
     // FT8 period timestamp tracking
     private long lastTimestampPeriod = -1;
-    // Gates the decoded-label stamp to once per 15s cycle, so a cycle's labels are painted
-    // exactly once even though the decode-done flag re-arms on every decode pass.
+    // Gates the decoded-label stamp to once per decode slot (the current mode's slot
+    // length, not a fixed 15s), so a slot's labels are painted exactly once even though the
+    // decode-done flag re-arms on every decode pass.
     private final WaterfallLabelGate messageGate = new WaterfallLabelGate();
     private final Paint timestampLinePaint = new Paint();
 
@@ -332,8 +333,12 @@ public class WaterfallView extends View {
             // same labels get stamped onto the scrolling bitmap several times per cycle, at
             // different scroll offsets, so they appear to repeat down the waterfall —
             // including over the next cycle's not-yet-populated rows where the signal is
-            // gone. Stamp at most once per 15s UTC period so each cycle is painted once.
-            if (messageGate.shouldStamp(period)) {
+            // gone. Stamp at most once per decode slot. Key the gate on the current mode's
+            // slot length (NOT a fixed 15s) so FT4 (7.5s) and FT2 (3.8s) each get one stamp
+            // per slot instead of one stamp per two-or-more slots.
+            long slotMillis = GeneralVariables.currentMode().slotMillis;
+            long slotPeriod = slotMillis > 0 ? utcMs / slotMillis : period;
+            if (messageGate.shouldStamp(slotPeriod)) {
                 Log.d(TAG, String.format("Drawing %d messages on waterfall", messages.size()));
                 for (Ft8Message msg : messages) {
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -75,6 +75,9 @@ public class WaterfallView extends View {
 
     // FT8 period timestamp tracking
     private long lastTimestampPeriod = -1;
+    // Gates the decoded-label stamp to once per 15s cycle, so a cycle's labels are painted
+    // exactly once even though the decode-done flag re-arms on every decode pass.
+    private final WaterfallLabelGate messageGate = new WaterfallLabelGate();
     private final Paint timestampLinePaint = new Paint();
 
     public WaterfallView(Context context) {
@@ -123,6 +126,8 @@ public class WaterfallView extends View {
         Log.d(TAG, String.format("Bitmap created: %dx%d, blockHeight=%d, freq_width=%.2f, spectrumWidth=%d",
                 w, h, blockHeight, freq_width, spectrumWidth));
         lastBitMap = Bitmap.createBitmap(w, h, ARGB_8888);
+        // Fresh bitmap wiped the stamped labels, so allow the current cycle to re-stamp.
+        messageGate.reset();
         _canvas = new Canvas(lastBitMap);
         Paint blackPaint = new Paint();
         blackPaint.setColor(0xFF000000);
@@ -321,9 +326,16 @@ public class WaterfallView extends View {
 
         //Messages have 3 types: normal, CQ, and involving me
         if (drawMessage && messages != null) {
-            Log.d(TAG, String.format("Drawing %d messages on waterfall", messages.size()));
-            drawMessage = false;//Only draw once
-            for (Ft8Message msg : messages) {
+            drawMessage = false;//Consume the one-shot arming
+            // FT8 decodes in more than one pass per cycle (a normal pass and a slower deep
+            // pass), and every completed pass re-arms drawMessage. Without this guard the
+            // same labels get stamped onto the scrolling bitmap several times per cycle, at
+            // different scroll offsets, so they appear to repeat down the waterfall —
+            // including over the next cycle's not-yet-populated rows where the signal is
+            // gone. Stamp at most once per 15s UTC period so each cycle is painted once.
+            if (messageGate.shouldStamp(period)) {
+                Log.d(TAG, String.format("Drawing %d messages on waterfall", messages.size()));
+                for (Ft8Message msg : messages) {
 
                 if (msg.inMyCall()) {//Related to me
                     messagePaint.setColor(0xffffb2b2);
@@ -353,6 +365,7 @@ public class WaterfallView extends View {
                     float text_high =dpToPixel(4);//messagePaint.getFontSpacing()/2;
                     _canvas.drawLine(msg.freq_hz * freq_width + text_high , text_start
                             , msg.freq_hz * freq_width + text_high, text_len + text_start, textLinePaint);
+                }
                 }
             }
         }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGateTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGateTest.java
@@ -1,0 +1,55 @@
+package com.bg7yoz.ft8cn.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link WaterfallLabelGate}: decoded labels stamp once per 15s cycle even
+ * though FT8's normal + deep decode passes each re-arm the stamp. Pure JUnit, no Android.
+ */
+public class WaterfallLabelGateTest {
+
+    @Test
+    public void firstStampOfACycleIsAllowed() {
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(100)).isTrue();
+    }
+
+    @Test
+    public void repeatedArmingWithinSameCycleIsSuppressed() {
+        // This is the bug: the deep pass re-arms the stamp in the same cycle. The normal
+        // pass stamps; every later pass in the same period must be ignored.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(100)).isTrue();   // normal pass
+        assertThat(gate.shouldStamp(100)).isFalse();  // deep pass, same cycle
+        assertThat(gate.shouldStamp(100)).isFalse();  // any further re-arm
+    }
+
+    @Test
+    public void eachNewCycleStampsExactlyOnce() {
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(100)).isTrue();
+        assertThat(gate.shouldStamp(100)).isFalse();
+        assertThat(gate.shouldStamp(101)).isTrue();   // next cycle
+        assertThat(gate.shouldStamp(101)).isFalse();
+        assertThat(gate.shouldStamp(102)).isTrue();
+    }
+
+    @Test
+    public void periodZeroIsHandled() {
+        // The sentinel is Long.MIN_VALUE, so a real period of 0 must still stamp once.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(0)).isTrue();
+        assertThat(gate.shouldStamp(0)).isFalse();
+    }
+
+    @Test
+    public void resetAllowsTheSameCycleToStampAgain() {
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(100)).isTrue();
+        assertThat(gate.shouldStamp(100)).isFalse();
+        gate.reset();
+        assertThat(gate.shouldStamp(100)).isTrue();   // after a bitmap recreate
+    }
+}


### PR DESCRIPTION
## Report
A operator's screenshot shows the **same decoded message labels repeated in adjacent time bands** of the waterfall — including over a blank region where the signal is already gone.

## Root cause (confirmed in code)
The waterfall stamps a cycle's labels onto its scrolling bitmap as a **one-shot**, re-armed every time the decode-state flips to done (`setDrawMessage(!decoding)` in `WaterfallScreen`). But:
- FT8 runs **more than one decode pass per cycle** (a normal pass + a slower **deep** pass), and
- `MainViewModel.decodingMarkerAfterPass()` **always returns `false`**, so *each* pass posts `mutableIsDecoding = false`.

LiveData fires the observer on every post, so the stamp is re-armed on each pass and the **same `currentMessages` get painted again at a different scroll offset**. Result: labels repeat down the cascade, and the duplicate lands over the next cycle's not-yet-populated rows → "message is there even though the signal is gone." So it's a real bug, not just "showing each decode where it was decoded."

## Fix
Gate the stamp to **once per 15 s UTC cycle** with a small pure-Java `WaterfallLabelGate`, keyed on the period the view already computes for its timestamp line. Reset on bitmap recreate so a resize can re-stamp the current cycle. The decode/auto-sequence logic is untouched — only how often labels are painted.

Unit-tested the once-per-cycle rule (normal+deep re-arm suppressed, cycle rollover, period 0, reset). Tests pass; compiles.

> Not flashed to a device yet (phone disconnected at build time) — worth a quick look on the waterfall to confirm labels now appear once per band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)