### PR TITLE
Mini-log: show every repeated TX, not just the first

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1525,6 +1525,12 @@ public class FT8TransmitSignal {
                     // Worker already released the track between our read and here.
                 }
             }
+            // Clear the "currently transmitting" message on TX end. It's only shown while
+            // transmitting (banner), and clearing it means the next transmission's rising
+            // edge starts from empty rather than the previous over's text — so the mini-log
+            // logs each transmission's REAL message instead of, on a new-and-different over,
+            // the stale prior one. (mutableTransmittingMessage is posted fresh at TX start.)
+            mutableTransmittingMessage.postValue("");
         }
 
         mutableIsTransmitting.postValue(transmitting);

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -28,7 +28,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -116,6 +118,55 @@ internal fun buildQsoLog(
 }
 
 /**
+ * Outcome of one evaluation of the synthesized-TX-log effect.
+ *
+ * @property shouldLog            append a TX row now (with the current transmit message)
+ * @property pendingAfter         carry a "still owe a log for this transmission" flag forward
+ * @property wasTransmittingAfter the transmitting state to remember for the next evaluation
+ */
+internal data class TxLogDecision(
+    val shouldLog: Boolean,
+    val pendingAfter: Boolean,
+    val wasTransmittingAfter: Boolean,
+)
+
+/**
+ * Decide whether to append one TX row to the mini-log, given the previous and current
+ * transmit state. We log exactly **one row per transmission** — keyed off the rising edge
+ * of [isTransmitting] — rather than de-duplicating by message text. That's the fix for
+ * "repeated RR73s only showed once": each time a (possibly identical) message is sent in a
+ * new cycle it is a fresh transmission and gets its own row.
+ *
+ * A "pending" flag bridges the case where [isTransmitting] flips true a frame before the
+ * transmit-message string is populated: the rising edge arms a pending log, and we emit the
+ * row on the first subsequent evaluation that actually has a non-empty message (and a live
+ * target). The pending flag clears when the row is logged or when transmit ends, so it can
+ * never leak a duplicate into the next transmission.
+ *
+ * @param wasTransmitting transmitting state at the previous evaluation
+ * @param isTransmitting  transmitting state now
+ * @param pending         whether a log is already owed for the in-flight transmission
+ * @param message         the current transmit-message text (empty until populated)
+ * @param hasTarget       whether a real target callsign is set (CQ has no mini-log)
+ */
+internal fun decideTxLog(
+    wasTransmitting: Boolean,
+    isTransmitting: Boolean,
+    pending: Boolean,
+    message: String,
+    hasTarget: Boolean,
+): TxLogDecision {
+    val armed = pending || (isTransmitting && !wasTransmitting) // rising edge arms a new log
+    val shouldLog = armed && isTransmitting && message.isNotEmpty() && hasTarget
+    val pendingAfter = when {
+        !isTransmitting -> false   // transmit ended — drop any unfulfilled pending log
+        shouldLog -> false         // just logged this transmission
+        else -> armed              // armed but message not ready yet; keep waiting
+    }
+    return TxLogDecision(shouldLog, pendingAfter, isTransmitting)
+}
+
+/**
  * Collapsible panel showing the active QSO with live RX/TX message history
  * and TX message selector buttons.
  */
@@ -148,22 +199,33 @@ fun ActiveQsoPanel(
     val hasTarget = displayCallsign != null
     val isCallingCq = isActivated && !hasTarget
 
-    // Synthesized TX log: append the message we're currently transmitting
-    // the moment TX begins, so the operator sees it in the log without
-    // waiting for the loopback decode (15–30s) to catch up.
+    // Synthesized TX log: append the message we're currently transmitting the moment TX
+    // begins, so the operator sees it without waiting for the loopback decode (15–30s) to
+    // catch up. We log one row per transmission (the rising edge of isTransmitting) rather
+    // than de-duplicating by text, so repeated messages — e.g. several unanswered RR73s —
+    // each get their own row. State resets per target. See decideTxLog for the rule.
     val synthTxLog = remember(displayCallsign) { mutableStateListOf<QsoLogEntry>() }
+    var wasTransmitting by remember(displayCallsign) { mutableStateOf(false) }
+    var pendingTxLog by remember(displayCallsign) { mutableStateOf(false) }
     LaunchedEffect(isTransmitting, transmittingMessage, displayCallsign) {
         val msg = transmittingMessage.orEmpty()
-        if (isTransmitting && msg.isNotEmpty() && displayCallsign != null) {
-            if (synthTxLog.none { it.messageText == msg }) {
-                synthTxLog.add(
-                    QsoLogEntry(
-                        direction = QsoLogEntry.Direction.TX,
-                        utcTime = System.currentTimeMillis(),
-                        messageText = msg,
-                    )
+        val decision = decideTxLog(
+            wasTransmitting = wasTransmitting,
+            isTransmitting = isTransmitting,
+            pending = pendingTxLog,
+            message = msg,
+            hasTarget = displayCallsign != null,
+        )
+        wasTransmitting = decision.wasTransmittingAfter
+        pendingTxLog = decision.pendingAfter
+        if (decision.shouldLog) {
+            synthTxLog.add(
+                QsoLogEntry(
+                    direction = QsoLogEntry.Direction.TX,
+                    utcTime = System.currentTimeMillis(),
+                    messageText = msg,
                 )
-            }
+            )
         }
     }
 

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxLogDecisionTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxLogDecisionTest.kt
@@ -1,0 +1,92 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [decideTxLog] — the rule that appends one mini-log row per transmission.
+ * Pure (booleans + a string), so no Android runtime is needed.
+ *
+ * The bug being fixed: repeated transmissions of the same message (e.g. several unanswered
+ * RR73s) used to collapse into a single row because rows were de-duplicated by text. Now
+ * each transmission (rising edge of isTransmitting) logs its own row.
+ */
+class TxLogDecisionTest {
+
+    /** Drive a sequence of (isTransmitting, message) frames and return how many rows were logged. */
+    private fun runFrames(frames: List<Pair<Boolean, String>>, hasTarget: Boolean = true): Int {
+        var was = false
+        var pending = false
+        var logged = 0
+        for ((tx, msg) in frames) {
+            val d = decideTxLog(was, tx, pending, msg, hasTarget)
+            was = d.wasTransmittingAfter
+            pending = d.pendingAfter
+            if (d.shouldLog) logged++
+        }
+        return logged
+    }
+
+    @Test
+    fun idle_logsNothing() {
+        assertThat(runFrames(listOf(false to "", false to ""))).isEqualTo(0)
+    }
+
+    @Test
+    fun singleTransmission_logsOnce() {
+        // TX rises with the message ready, then ends.
+        val n = runFrames(listOf(false to "", true to "RA3XYZ UB8CSJ RR73", false to ""))
+        assertThat(n).isEqualTo(1)
+    }
+
+    @Test
+    fun sameTransmissionAcrossRecompositions_logsOnce() {
+        // isTransmitting stays true across several frames (recompositions) within one cycle:
+        // only the rising edge logs.
+        val msg = "RA3XYZ UB8CSJ RR73"
+        val n = runFrames(listOf(false to "", true to msg, true to msg, true to msg, false to ""))
+        assertThat(n).isEqualTo(1)
+    }
+
+    @Test
+    fun repeatedIdenticalMessages_logEachTransmission() {
+        // THE BUG: three unanswered RR73s in three separate cycles -> three rows.
+        val msg = "RA3XYZ UB8CSJ RR73"
+        val n = runFrames(
+            listOf(
+                false to "", true to msg, false to "",   // 1st RR73
+                true to msg, false to "",                // 2nd RR73
+                true to msg, false to "",                // 3rd RR73
+            )
+        )
+        assertThat(n).isEqualTo(3)
+    }
+
+    @Test
+    fun risingEdgeBeforeMessageReady_logsWhenMessageArrives() {
+        // isTransmitting flips true one frame before the message string is populated:
+        // the pending flag bridges it, logging exactly once when the text arrives.
+        val n = runFrames(listOf(false to "", true to "", true to "RA3XYZ UB8CSJ R-12", true to "RA3XYZ UB8CSJ R-12"))
+        assertThat(n).isEqualTo(1)
+    }
+
+    @Test
+    fun pendingDoesNotLeakAcrossTransmitEnd() {
+        // TX rises but no message ever arrives, then TX ends: nothing logged, and the next
+        // real transmission still logs exactly once (pending didn't leak).
+        val n = runFrames(
+            listOf(
+                false to "", true to "", false to "",            // armed but no text, then ended
+                true to "RA3XYZ UB8CSJ 73", false to "",         // a real transmission
+            )
+        )
+        assertThat(n).isEqualTo(1)
+    }
+
+    @Test
+    fun noTarget_logsNothing() {
+        // Calling CQ (no target) has no mini-log.
+        val n = runFrames(listOf(false to "", true to "CQ UB8CSJ MO07"), hasTarget = false)
+        assertThat(n).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## Report
While working a QSO, sending the **same message several times** (e.g. a few unanswered **RR73s**) showed up as only **one** row in the QSO panel ("mini-log"). *"i send few rr73 messages that was not answered, i saw only the first one of those repeated rr73."*

## Root cause
The synthesized TX rows were de-duplicated by message text:
```kotlin
if (synthTxLog.none { it.messageText == msg }) { synthTxLog.add(...) }
```
That guard was meant to avoid double-logging a single transmission across recompositions, but it also collapses *legitimately repeated* transmissions into one row. (RX/BUSY rows come from decodes and were never affected.)

## Fix
Log **one row per transmission**, keyed off the **rising edge of `isTransmitting`**, instead of de-duplicating by text — so each message sent in a new cycle gets its own row, even when identical. A small `pending` flag bridges the frame where `isTransmitting` flips true just before the transmit-message string is populated, and clears on transmit-end so it can't leak a duplicate into the next over.

The rule is extracted into the pure, unit-tested `decideTxLog`. Tests cover: single TX, same TX across recompositions (once), **repeated identical messages (one row each)**, message-not-ready-yet bridging, no-leak across TX end, and CQ/no-target.

Tests pass; compiles.

> Not flashed yet (phone disconnected at build time) — worth confirming on-air: send an unanswered message a couple of times and check each shows as its own mini-log row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)