### PR TITLE
Don't auto-answer other CQs after a manual QSO gives up (Hunt off)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1429,8 +1429,28 @@ public class FT8TransmitSignal {
      * @param messages watched message list
      * @return true if new target found, false otherwise
      */
+    /**
+     * Whether we're allowed to auto-call a station that's calling CQ, given the auto-call
+     * settings. Hunt ({@code autoFollowCQ}) answers any CQ; with Hunt off, auto-call-follow
+     * answers only CQs from {@code isFollowed} callsigns; with both off we never auto-call.
+     * Shared rule so the give-up fallback ({@link #getNewTargetCallsign}) and the live
+     * auto-answer scan agree on who we'll call.
+     */
+    static boolean mayAutoCall(boolean autoFollowCQ, boolean autoCallFollow, boolean isFollowed) {
+        if (autoFollowCQ) return true;
+        return autoCallFollow && isFollowed;
+    }
+
     public boolean getNewTargetCallsign(ArrayList<Ft8Message> messages) {
         if (toCallsign == null) return false;
+        // Only auto-pick a fresh CQ target when an auto-call mode is on. With Hunt
+        // (autoFollowCQ) and auto-call-follow both off, a manually-started QSO that gets no
+        // reply must fall back to idle/CQ — it must NOT start answering some other station's
+        // CQ. (This is the give-up fallback after the no-reply limit; it previously chased
+        // any CQ regardless of the Hunt toggle.)
+        if (!GeneralVariables.autoFollowCQ && !GeneralVariables.autoCallFollow) {
+            return false;
+        }
         for (int i = messages.size() - 1; i >= 0; i--) {
             Ft8Message ft8Message = messages.get(i);
             if (ft8Message.band != GeneralVariables.band) {//ignore messages not on the same band
@@ -1438,6 +1458,12 @@ public class FT8TransmitSignal {
             }
             // not CQ, ignore
             if (!ft8Message.checkIsCQ()) {
+                continue;
+            }
+            // With Hunt off but auto-call-follow on, only auto-call *followed* callsigns —
+            // mirror checkCQMeOrFollowCQMessage so the two paths agree on who we'll call.
+            if (!mayAutoCall(GeneralVariables.autoFollowCQ, GeneralVariables.autoCallFollow,
+                    GeneralVariables.callsignInFollow(ft8Message.getCallsignFrom()))) {
                 continue;
             }
             // not the current target callsign, and no previous successful QSO

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1099,9 +1099,8 @@ public class FT8TransmitSignal {
             // is CQing, not already worked, not myself, and either Hunt mode is on
             // (auto-answer any CQ) or this is a followed callsign we auto-call
             if (msg.checkIsCQ()// is CQing
-                    && (GeneralVariables.autoFollowCQ// Hunt: auto-answer any CQ
-                    || (GeneralVariables.autoCallFollow
-                    && GeneralVariables.callsignInFollow(msg.getCallsignFrom())))// followed callsign
+                    && mayAutoCall(GeneralVariables.autoFollowCQ, GeneralVariables.autoCallFollow,
+                    GeneralVariables.callsignInFollow(msg.getCallsignFrom()))// Hunt or followed callsign
                     // skip directional CQs aimed at a different DXCC/continent (opt-in)
                     && (!GeneralVariables.respectDirectionalCQ
                     || GeneralVariables.directionalCQIsForMe(msg.callsignTo))
@@ -1463,23 +1462,23 @@ public class FT8TransmitSignal {
     // ==================== End FT8 DXpedition Hound ====================
 
     /**
-     * Check watch list for active CQ messages that are not my current target callsign.
-     *
-     * @param messages watched message list
-     * @return true if new target found, false otherwise
-     */
-    /**
      * Whether we're allowed to auto-call a station that's calling CQ, given the auto-call
      * settings. Hunt ({@code autoFollowCQ}) answers any CQ; with Hunt off, auto-call-follow
      * answers only CQs from {@code isFollowed} callsigns; with both off we never auto-call.
      * Shared rule so the give-up fallback ({@link #getNewTargetCallsign}) and the live
-     * auto-answer scan agree on who we'll call.
+     * auto-answer scan ({@link #checkCQMeOrFollowCQMessage}) agree on who we'll call.
      */
     static boolean mayAutoCall(boolean autoFollowCQ, boolean autoCallFollow, boolean isFollowed) {
         if (autoFollowCQ) return true;
         return autoCallFollow && isFollowed;
     }
 
+    /**
+     * Check watch list for active CQ messages that are not my current target callsign.
+     *
+     * @param messages watched message list
+     * @return true if new target found, false otherwise
+     */
     public boolean getNewTargetCallsign(ArrayList<Ft8Message> messages) {
         if (toCallsign == null) return false;
         // Only auto-pick a fresh CQ target when an auto-call mode is on. With Hunt

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignalTest.java
@@ -182,4 +182,27 @@ public class FT8TransmitSignalTest {
         assertThat(second).usingTolerance(TOL)
                 .containsExactly(new float[]{0.25f, 0.25f}).inOrder();
     }
+
+    // ---- mayAutoCall --------------------------------------------------------
+    // The give-up fallback after a no-reply manual QSO must not chase other CQs unless an
+    // auto-call mode is on.
+
+    @Test
+    public void mayAutoCall_huntOn_answersAnyCq() {
+        assertThat(FT8TransmitSignal.mayAutoCall(true, false, false)).isTrue();
+        assertThat(FT8TransmitSignal.mayAutoCall(true, false, true)).isTrue();
+    }
+
+    @Test
+    public void mayAutoCall_huntOff_followOn_onlyFollowed() {
+        assertThat(FT8TransmitSignal.mayAutoCall(false, true, true)).isTrue();
+        assertThat(FT8TransmitSignal.mayAutoCall(false, true, false)).isFalse();
+    }
+
+    @Test
+    public void mayAutoCall_bothOff_neverAnswers() {
+        // The reported bug: manual QSO, no reply, Hunt off -> must NOT answer other CQs.
+        assertThat(FT8TransmitSignal.mayAutoCall(false, false, false)).isFalse();
+        assertThat(FT8TransmitSignal.mayAutoCall(false, false, true)).isFalse();
+    }
 }


### PR DESCRIPTION
## Report
*"if i manually answer CQ and there is no answer after N attempts and hunt is off — it still answers other CQs."*

## Root cause
`getNewTargetCallsign` is the give-up fallback invoked when a station we're calling stops replying past the no-reply limit. It scanned the fresh decodes and switched to **any** CQ caller, with **no check of the Hunt / auto-call settings**. So a manually-started QSO that got no reply would, with Hunt off, start calling another station's CQ by itself.

## Fix
Gate it on the auto-call modes via a new shared, unit-tested `mayAutoCall(autoFollowCQ, autoCallFollow, isFollowed)` — the same rule `checkCQMeOrFollowCQMessage` uses:
- Hunt (`autoFollowCQ`) → answer any CQ
- Hunt off + auto-call-follow → answer only *followed* callsigns
- both off → never auto-pick; the QSO falls back to idle/CQ

Tests cover all three cases (incl. the reported both-off case). Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)