### PR TITLE
ADIF export: strip < > from hash-rendered callsigns so LoTW accepts them

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -997,9 +997,8 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         logStr.append("FT8AF ADIF Export<eoh>\n");
         cursor.moveToPosition(-1);
         while (cursor.moveToNext()) {
-            logStr.append(String.format("<call:%d>%s "
-                    , cursor.getString(cursor.getColumnIndex("call")).length()
-                    , cursor.getString(cursor.getColumnIndex("call"))));
+            logStr.append(com.bg7yoz.ft8cn.log.AdifFormat.callField(
+                    cursor.getString(cursor.getColumnIndex("call"))));
             if (!isSWL) {
                 if (cursor.getInt(cursor.getColumnIndex("isLotW_QSL")) == 1) {
                     logStr.append("<QSL_RCVD:1>Y ");

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/AdifFormat.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/AdifFormat.java
@@ -1,0 +1,37 @@
+package com.bg7yoz.ft8cn.log;
+
+import java.util.Locale;
+
+/**
+ * Small helpers for writing ADIF fields safely.
+ *
+ * <p>FT8 renders a callsign that was only carried as a 22-bit hash with angle brackets
+ * (e.g. {@code <DK4RH>}, or {@code <...>} when unresolved). If such a value reaches the ADIF
+ * {@code CALL} field verbatim, the brackets are part of the value and the declared length is
+ * wrong — ARRL LoTW (and eQSL) reject the record. Strip the brackets on the way out so the
+ * exported call is bare.
+ */
+public final class AdifFormat {
+
+    private AdifFormat() {}
+
+    /**
+     * Strip the hash-marker angle brackets from a callsign so the ADIF value is a bare call
+     * ({@code "<DK4RH>"} → {@code "DK4RH"}). Null or all-bracket input becomes {@code ""}.
+     */
+    public static String sanitizeCallsign(String raw) {
+        if (raw == null) {
+            return "";
+        }
+        return raw.replace("<", "").replace(">", "").trim();
+    }
+
+    /**
+     * The ADIF {@code <call:len>VALUE } field for a (possibly bracketed) callsign, with the
+     * length computed from the sanitized value.
+     */
+    public static String callField(String rawCall) {
+        String c = sanitizeCallsign(rawCall);
+        return String.format(Locale.US, "<call:%d>%s ", c.length(), c);
+    }
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ShareLogs.java
@@ -133,10 +133,7 @@ public class ShareLogs {
                    };
                 }
                 String call = cursor.getString(cursor.getColumnIndex("call"));
-                if (call == null) call = "";
-                fileOutputStream.write(String.format("<call:%d>%s "
-                        , call.length()
-                        , call).getBytes());
+                fileOutputStream.write(AdifFormat.callField(call).getBytes());
                 if (!isSWL) {
                     if (cursor.getInt(cursor.getColumnIndex("isLotW_QSL")) == 1) {
                         fileOutputStream.write("<QSL_RCVD:1>Y ".getBytes());

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/ThirdPartyService.java
@@ -97,9 +97,7 @@ public class ThirdPartyService {
 
     private static String QSLRecordToADIF(QSLRecord qslRecord, ServiceType serv){
         StringBuilder logStr = new StringBuilder();
-        logStr.append(String.format("<call:%d>%s "
-                , qslRecord.getToCallsign().length()
-                , qslRecord.getToCallsign()));
+        logStr.append(AdifFormat.callField(qslRecord.getToCallsign()));
 
         if (qslRecord.getToMaidenGrid() != null) {
             logStr.append(String.format("<gridsquare:%d>%s "

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/log/AdifFormatTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/log/AdifFormatTest.java
@@ -1,0 +1,51 @@
+package com.bg7yoz.ft8cn.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AdifFormat}: hash-marker angle brackets must be stripped from the
+ * ADIF CALL field, with the declared length matching the bare value (ARRL LoTW rejects
+ * bracketed callsigns). Pure JUnit.
+ */
+public class AdifFormatTest {
+
+    @Test
+    public void sanitize_stripsBracketsFromResolvedHashCall() {
+        assertThat(AdifFormat.sanitizeCallsign("<DK4RH>")).isEqualTo("DK4RH");
+        assertThat(AdifFormat.sanitizeCallsign("DK4RH")).isEqualTo("DK4RH");
+    }
+
+    @Test
+    public void sanitize_handlesNullAndBlank() {
+        assertThat(AdifFormat.sanitizeCallsign(null)).isEqualTo("");
+        assertThat(AdifFormat.sanitizeCallsign("  ")).isEqualTo("");
+    }
+
+    @Test
+    public void callField_usesBareCallAndCorrectLength() {
+        // The bug: "<call:7><DK4RH>" — brackets in the value, length 7 not 5. Fixed:
+        assertThat(AdifFormat.callField("<DK4RH>")).isEqualTo("<call:5>DK4RH ");
+        assertThat(AdifFormat.callField("K1ABC")).isEqualTo("<call:5>K1ABC ");
+    }
+
+    @Test
+    public void callField_nullBecomesEmptyField() {
+        assertThat(AdifFormat.callField(null)).isEqualTo("<call:0> ");
+    }
+
+    @Test
+    public void callField_lengthAlwaysMatchesValue() {
+        for (String c : new String[] { "<DK4RH>", "W1AW", "<VP2E/W1ABC>", "", null }) {
+            String field = AdifFormat.callField(c);
+            // Parse "<call:LEN>VALUE " and assert LEN == VALUE.length().
+            int gt = field.indexOf('>');
+            int len = Integer.parseInt(field.substring("<call:".length(), gt));
+            String value = field.substring(gt + 1).trim();
+            assertThat(value.length()).isEqualTo(len);
+            assertThat(value).doesNotContain("<");
+            assertThat(value).doesNotContain(">");
+        }
+    }
+}


### PR DESCRIPTION
## Report
*"one of QSO had < > around callsign in log file and was not accepted by ARRL. good that i did notice it."*

## Root cause
FT8 renders a callsign that was only carried as a 22-bit hash with angle brackets — e.g. `<DK4RH>`. The three ADIF export paths wrote `String.format("<call:%d>%s ", call.length(), call)` straight from the stored value, so a bracketed call produced **`<call:7><DK4RH>`** — brackets inside the value *and* a wrong declared length (7 vs 5). ARRL LoTW (and eQSL) reject that.

## Fix
New `AdifFormat.callField()` / `sanitizeCallsign()` strips the brackets and computes the length from the bare call. All three export sites now go through it:
- `DatabaseOpr.downQSLTable`
- `ShareLogs`
- `ThirdPartyService`

Because it sanitizes **on export**, it also fixes records already logged with brackets. Unit-tested: resolved hash (`<DK4RH>`→`DK4RH`), null/blank, and a `len == value.length()` + no-brackets invariant across cases.

> Note: a *fully unresolved* hash (`<...>`) sanitizes to `...`, which LoTW still won't accept — but that's a rare case (a completed QSO shouldn't have an unresolved call), and at least the ADIF is now syntactically valid. The real-world case (a real call in brackets) is fixed.

Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)