### PR TITLE
SWR halt: log every reading so "not working" reports are diagnosable

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionController.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionController.java
@@ -47,8 +47,20 @@ public class MeterProtectionController {
     // Holds the SWR ratio string (e.g. "3.2:1") that triggered lockout, for the banner.
     public final MutableLiveData<String> lockoutSwrRatio = new MutableLiveData<>("");
 
+    // Throttle for the per-reading SWR diagnostic log line (meter polls ~every 2s).
+    private static final long SWR_LOG_THROTTLE_MS = 1500;
+    private long lastSwrLogMs = 0;
+
     public void setTransmitSignal(FT8TransmitSignal signal) {
         this.transmitSignal = signal;
+    }
+
+    /**
+     * Whether SWR is high enough to halt TX: protection enabled, a valid reading, and over
+     * the threshold. Pure so the rule is unit-tested independent of the rig meter plumbing.
+     */
+    public static boolean shouldHaltForSwr(int normalizedSwr, boolean enabled, int threshold) {
+        return normalizedSwr >= 0 && enabled && normalizedSwr > threshold;
     }
 
     /**
@@ -60,9 +72,26 @@ public class MeterProtectionController {
         if (normalizedAlc >= 0) lastAlc.postValue(normalizedAlc);
         if (normalizedSwr >= 0) lastSwr.postValue(normalizedSwr);
 
+        // Diagnostics: when SWR protection is on, record each SWR reading we actually
+        // receive (throttled) so the debug.log shows whether meter data even reaches here
+        // during TX, the values, and the halt decision. Without this a halt that never
+        // fires leaves no trace — we can't tell "no meter data" from "value below threshold"
+        // from a wiring problem. (Reported: "SWR protection not working".)
+        if (GeneralVariables.swrHaltEnabled && normalizedSwr >= 0) {
+            long now = System.currentTimeMillis();
+            if (now - lastSwrLogMs >= SWR_LOG_THROTTLE_MS) {
+                lastSwrLogMs = now;
+                GeneralVariables.fileLog(String.format(
+                        "MeterProtection: SWR reading swr=%d threshold=%d -> %s",
+                        normalizedSwr, GeneralVariables.swrHaltThreshold,
+                        shouldHaltForSwr(normalizedSwr, true, GeneralVariables.swrHaltThreshold)
+                                ? "HALT" : "ok"));
+            }
+        }
+
         // --- SWR halt check ---
-        if (normalizedSwr >= 0 && GeneralVariables.swrHaltEnabled
-                && normalizedSwr > GeneralVariables.swrHaltThreshold) {
+        if (shouldHaltForSwr(normalizedSwr, GeneralVariables.swrHaltEnabled,
+                GeneralVariables.swrHaltThreshold)) {
             haltForSwr(normalizedSwr);
             return; // no point adjusting volume if we just killed TX
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionController.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionController.java
@@ -50,6 +50,7 @@ public class MeterProtectionController {
     // Throttle for the per-reading SWR diagnostic log line (meter polls ~every 2s).
     private static final long SWR_LOG_THROTTLE_MS = 1500;
     private long lastSwrLogMs = 0;
+    private int lastLoggedSwr = -1;
 
     public void setTransmitSignal(FT8TransmitSignal signal) {
         this.transmitSignal = signal;
@@ -73,19 +74,23 @@ public class MeterProtectionController {
         if (normalizedSwr >= 0) lastSwr.postValue(normalizedSwr);
 
         // Diagnostics: when SWR protection is on, record each SWR reading we actually
-        // receive (throttled) so the debug.log shows whether meter data even reaches here
-        // during TX, the values, and the halt decision. Without this a halt that never
-        // fires leaves no trace — we can't tell "no meter data" from "value below threshold"
-        // from a wiring problem. (Reported: "SWR protection not working".)
+        // receive so the debug.log shows whether meter data even reaches here during TX, the
+        // values, and the halt decision. Without this a halt that never fires leaves no trace
+        // — we can't tell "no meter data" from "value below threshold" from a wiring problem.
+        // (Reported: "SWR protection not working".) Log whenever the SWR value CHANGES (so a
+        // real SWR update isn't suppressed when ALC and SWR arrive as separate callbacks
+        // close together), plus a periodic time-throttled line for a stable value.
         if (GeneralVariables.swrHaltEnabled && normalizedSwr >= 0) {
             long now = System.currentTimeMillis();
-            if (now - lastSwrLogMs >= SWR_LOG_THROTTLE_MS) {
+            boolean changed = normalizedSwr != lastLoggedSwr;
+            if (changed || now - lastSwrLogMs >= SWR_LOG_THROTTLE_MS) {
                 lastSwrLogMs = now;
+                lastLoggedSwr = normalizedSwr;
                 GeneralVariables.fileLog(String.format(
                         "MeterProtection: SWR reading swr=%d threshold=%d -> %s",
                         normalizedSwr, GeneralVariables.swrHaltThreshold,
-                        shouldHaltForSwr(normalizedSwr, true, GeneralVariables.swrHaltThreshold)
-                                ? "HALT" : "ok"));
+                        shouldHaltForSwr(normalizedSwr, GeneralVariables.swrHaltEnabled,
+                                GeneralVariables.swrHaltThreshold) ? "HALT" : "ok"));
             }
         }
 

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionControllerTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/MeterProtectionControllerTest.java
@@ -90,4 +90,19 @@ public class MeterProtectionControllerTest {
         int n = MeterProtectionController.swrRatioToNormalized(3.0f); // 120
         assertThat(MeterProtectionController.normalizedSwrToRatio(n)).isEqualTo("3.0:1");
     }
+
+    // ---- shouldHaltForSwr ---------------------------------------------------
+
+    @Test
+    public void shouldHalt_onlyWhenEnabledValidAndOverThreshold() {
+        // Over threshold with protection on -> halt.
+        assertThat(MeterProtectionController.shouldHaltForSwr(150, true, 120)).isTrue();
+        // At/under threshold -> no halt (strictly greater-than).
+        assertThat(MeterProtectionController.shouldHaltForSwr(120, true, 120)).isFalse();
+        assertThat(MeterProtectionController.shouldHaltForSwr(90, true, 120)).isFalse();
+        // Protection off -> never halt, even at high SWR.
+        assertThat(MeterProtectionController.shouldHaltForSwr(200, false, 120)).isFalse();
+        // No reading from the rig (-1) -> never halt.
+        assertThat(MeterProtectionController.shouldHaltForSwr(-1, true, 120)).isFalse();
+    }
 }


### PR DESCRIPTION
## Context
A user reports **SWR protection not halting TX** with the toggle on. I traced the whole path for his rig (**Yaesu39Rig**, instructionSet 19 — FT‑991A/FTDX10/FT‑891 class) and it's **correct on paper**:
- meter read fires during PTT (`readMeters()` sends `RM` ALC+SWR),
- SWR parsed 0–255 (`getSWROrALC39`),
- `notifyMeterData → onMeterUpdate`, listener wired in `connectRig()`,
- threshold 120 (~3:1) matches the rig's 0–255 SWR scale.

So the failure is **runtime** — is RM/SWR data actually arriving during TX, and at what values? But `onMeterUpdate` logged **nothing** about received SWR, so a halt that never fires leaves no trace: we can't distinguish "no meter data reached the controller" from "value below threshold" from a wiring/rig issue.

## Change (instrument-first, no behavior change)
- Throttled diagnostic per reading: `MeterProtection: SWR reading swr=X threshold=Y -> ok/HALT` (when protection is on).
- Extracted the halt rule into the pure, unit-tested `shouldHaltForSwr(swr, enabled, threshold)`; `onMeterUpdate` now calls it (same condition as before).

## Next step for the reporter
With this in, his TX `debug.log` will show one of:
1. **No `SWR reading` lines during TX** → meter data never reaches the controller (rig not answering `RM` during TX / read loop paused over Bluetooth / timer not polling). That's the real bug to fix next.
2. **`SWR reading swr=… -> ok`** with low values → his SWR genuinely isn't crossing the threshold, or the threshold's too high.
3. **`-> HALT`** but TX continues → a halt-action problem.

Tests pass. I deliberately didn't blind-"fix" a path that's correct on paper — this makes the actual failure point visible first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)