### PR TITLE
Address PR #188 review: cancel CAT liveness watchdog in onCleared

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -315,7 +315,7 @@ public class MainViewModel extends ViewModel {
     private volatile long lastRigResponseMs = 0;
     private volatile boolean sawRigResponseSinceConnect = false;
 
-    /** Record that the rig just demonstrably responded (called from onFreqChanged). */
+    /** Record that the rig just demonstrably responded (called from onRigResponded). */
     private void markRigResponded() {
         lastRigResponseMs = System.currentTimeMillis();
         sawRigResponseSinceConnect = true;
@@ -347,8 +347,9 @@ public class MainViewModel extends ViewModel {
         try {
             boolean connected = isRigConnected();
             boolean transmitting = ft8TransmitSignal != null && ft8TransmitSignal.isTransmitting();
-            // Actively probe (a frequency read); the reply lands in onFreqChanged ->
-            // markRigResponded(). On a dead-but-powered BT module the write succeeds but no
+            // Actively probe (a frequency read); the reply lands in onRigResponded ->
+            // markRigResponded() (onFreqChanged only fires on a change, so a stable dial
+            // can't be used). On a dead-but-powered BT module the write succeeds but no
             // reply comes, so the quiet timer below eventually trips.
             if (CatLiveness.shouldProbe(connected, transmitting) && baseRig != null) {
                 baseRig.readFreqFromRig();
@@ -1588,6 +1589,10 @@ public class MainViewModel extends ViewModel {
     @Override
     protected void onCleared() {
         super.onCleared();
+        // The liveness watchdog otherwise only stops on disconnect/error/stale; if the
+        // ViewModel is cleared while still "connected" the Timer thread would keep probing
+        // the rig indefinitely. Tear it down here too.
+        stopCatLivenessWatchdog();
         PskReporterSender.INSTANCE.stop();
     }
 


### PR DESCRIPTION
Addresses the three Copilot review comments on the release PR #188, all in `MainViewModel.java`'s CAT liveness watchdog.

### Fixes
- **Timer leak on ViewModel teardown** — the liveness `Timer` was only stopped on disconnect / `onRunError` / stale-trip. If the ViewModel is cleared while still "connected" (process/background lifecycle), the timer thread kept probing the rig forever. Now also cancelled in `onCleared()`.
- **Stale Javadoc** — `markRigResponded()` said it's "called from onFreqChanged"; it's keyed off `onRigResponded()`.
- **Stale probe comment** — `catLivenessTick()` said the probe reply lands in `onFreqChanged → markRigResponded()`; corrected to `onRigResponded()` (onFreqChanged only fires on an actual dial change, so a stable dial can't be the liveness signal).

### Testing
`gradlew testDebugUnitTest --tests com.bg7yoz.ft8cn.rigs.CatLivenessTest` — BUILD SUCCESSFUL. The `onCleared()` change is lifecycle plumbing that calls the existing `stopCatLivenessWatchdog()`; the watchdog's decision logic (`shouldProbe`/`isRigStale`) is already covered by `CatLivenessTest`, so no new test path is introduced.

Once merged into `dev`, release PR #188 (`dev → main`) picks this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)