### PR TITLE
Sort logbook recent QSO list by date/time, newest first

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2007,10 +2007,20 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             if (!showAll){
                 limitStr="limit 100 offset "+offset;
             }
+            // Normalize time_on to a fixed-width 6-digit HHMMSS before max()/ORDER BY.
+            // time_on is stored as variable-width TEXT (ADIF may carry HHMM; the edit
+            // dialog allows arbitrary input), so a value with a dropped leading zero like
+            // "815" (08:15) would otherwise sort after "103000". Restore the hour's leading
+            // zero on odd-length values, then right-pad seconds. Mirrors normalizeTimeOn()
+            // in LogbookScreen.kt so the DB ordering and the Compose sort agree.
+            String normTimeOn =
+                    "CASE WHEN q.time_on IS NULL OR q.time_on='' THEN '000000'\n" +
+                    " WHEN length(q.time_on)%2=1 THEN substr('0'||q.time_on||'000000',1,6)\n" +
+                    " ELSE substr(q.time_on||'000000',1,6) END";
             String querySQL = "select max(q.id) as id, q.[call] as callsign ,q.gridsquare as grid" +
                     ",q.band||\"(\"||q.freq||\" MHz)\" as band \n" +
                     ",q.qso_date as last_time ,q.mode ,q.isQSL,q.isLotW_QSL\n" +
-                    ",max(q.time_on) as last_time_on\n" +
+                    ",max(" + normTimeOn + ") as last_time_on\n" +
                     ",max(q.synced_cloudlog) as synced_cloudlog\n" +
                     ",max(q.synced_qrz) as synced_qrz\n" +
                     "from QSLTable q inner join QSLTable q2 ON q.id =q2.id \n" +

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2010,6 +2010,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             String querySQL = "select max(q.id) as id, q.[call] as callsign ,q.gridsquare as grid" +
                     ",q.band||\"(\"||q.freq||\" MHz)\" as band \n" +
                     ",q.qso_date as last_time ,q.mode ,q.isQSL,q.isLotW_QSL\n" +
+                    ",max(q.time_on) as last_time_on\n" +
                     ",max(q.synced_cloudlog) as synced_cloudlog\n" +
                     ",max(q.synced_qrz) as synced_qrz\n" +
                     "from QSLTable q inner join QSLTable q2 ON q.id =q2.id \n" +
@@ -2018,7 +2019,8 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     "group by q.[call] ,q.gridsquare,q.freq ,q.qso_date,q.band\n" +
                     ",q.mode,q.isQSL,q.isLotW_QSL\n" +
                     "HAVING q.qso_date =MAX(q2.qso_date) \n" +
-                    "order by q.qso_date desc\n"+
+                    // newest first, by date then time-of-day so same-day QSOs order correctly
+                    "order by q.qso_date desc, last_time_on desc\n"+
                     limitStr;
 
 
@@ -2035,6 +2037,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 record.syncedCloudlog = idxCl >= 0 && cursor.getInt(idxCl) == 1;
                 record.syncedQrz = idxQrz >= 0 && cursor.getInt(idxQrz) == 1;
                 record.setLastTime(cursor.getString(cursor.getColumnIndex("last_time")));
+                int idxTimeOn = cursor.getColumnIndex("last_time_on");
+                if (idxTimeOn >= 0) {
+                    record.setTimeOn(cursor.getString(idxTimeOn));
+                }
                 record.setMode(cursor.getString(cursor.getColumnIndex("mode")));
                 record.setGrid(cursor.getString(cursor.getColumnIndex("grid")));
                 record.setBand(cursor.getString(cursor.getColumnIndex("band")));

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/QSLCallsignRecord.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/QSLCallsignRecord.java
@@ -15,6 +15,10 @@ public class QSLCallsignRecord {
     private String grid;
     private String band;
     private String lastTime;
+    // Latest UTC time (HHMMSS) of the underlying QSO for this grouped row. Paired
+    // with lastTime (YYYYMMDD) it gives a sortable date+time so the recent list can
+    // order same-day QSOs by time. Empty when unknown (e.g. legacy/ADIF rows).
+    private String timeOn = "";
     public String where=null;
     public String dxccStr="";
     public boolean isQSL=false;//Whether manually confirmed
@@ -44,6 +48,14 @@ public class QSLCallsignRecord {
         }else {
             this.lastTime="";
         }
+    }
+
+    public String getTimeOn() {
+        return timeOn;
+    }
+
+    public void setTimeOn(String timeOn) {
+        this.timeOn = timeOn != null ? timeOn : "";
     }
 
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
@@ -1064,8 +1064,29 @@ internal fun sortQsosByDateTimeDesc(
 
 internal fun qsoSortKey(record: QSLCallsignRecord): String {
     val date = (record.lastTime ?: "").padEnd(8, '0')
-    val time = (record.timeOn ?: "").padEnd(6, '0')
-    return date + time
+    return date + normalizeTimeOn(record.timeOn)
+}
+
+/**
+ * Normalize a stored time-of-day to a fixed-width 6-digit HHMMSS string so it sorts
+ * lexicographically against any other time on the same day. Handles every shape that
+ * can reach the logbook:
+ *  - "" / null            -> "000000" (no recorded time; sorts to the start of its day)
+ *  - HHMMSS ("143005")    -> unchanged
+ *  - HHMM   ("1430")      -> "143000" (append the missing seconds)
+ *  - dropped leading zero ("815" = 08:15, "81500" = 08:15:00) -> restore the hour's
+ *    leading zero first, then append seconds: "081500"
+ *
+ * Plain `padEnd(6, '0')` only fixes missing *trailing* digits, so "815" would become
+ * "815000" (81:50:00) and sort after a real "103000". Restoring the leading zero on an
+ * odd-length value fixes that. Mirrors the normalization the grouped SQL query applies,
+ * so the DB ordering and this in-memory sort agree.
+ */
+internal fun normalizeTimeOn(timeOn: String?): String {
+    val digits = (timeOn ?: "").filter { it.isDigit() }
+    if (digits.isEmpty()) return "000000"
+    val evened = if (digits.length % 2 == 1) "0$digits" else digits
+    return evened.padEnd(6, '0').substring(0, 6)
 }
 
 @Composable

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
@@ -1046,6 +1046,28 @@ private fun gridSquaresWorked(records: List<QSLCallsignRecord>): Int =
 // RECENT TAB
 // ===========================================================================
 
+/**
+ * Order the recent QSO list newest-first by full date + time.
+ *
+ * [QSLCallsignRecord.lastTime] is the QSO date (YYYYMMDD) and
+ * [QSLCallsignRecord.timeOn] is the UTC time of day (HHMMSS); concatenated they
+ * form a lexicographically sortable timestamp, so same-day QSOs order by time
+ * rather than by the database's grouping order. Short/missing values are padded
+ * so a row without a recorded time still sorts within its day. The sort is
+ * stable, so genuine ties keep their incoming order.
+ *
+ * Extracted from [RecentTab] so the ordering can be unit-tested.
+ */
+internal fun sortQsosByDateTimeDesc(
+    records: List<QSLCallsignRecord>,
+): List<QSLCallsignRecord> = records.sortedByDescending { qsoSortKey(it) }
+
+internal fun qsoSortKey(record: QSLCallsignRecord): String {
+    val date = (record.lastTime ?: "").padEnd(8, '0')
+    val time = (record.timeOn ?: "").padEnd(6, '0')
+    return date + time
+}
+
 @Composable
 private fun RecentTab(
     records: List<QSLCallsignRecord>,
@@ -1076,7 +1098,7 @@ private fun RecentTab(
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         items(
-            items = records.reversed(),
+            items = sortQsosByDateTimeDesc(records),
             // Include id so an edit that changes other fields still maps to a stable key,
             // and so two grouped rows with otherwise identical display fields don't collide.
             key = { "${it.id}_${it.callsign}_${it.lastTime}_${it.band}" },

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookSortTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookSortTest.kt
@@ -1,0 +1,98 @@
+package radio.ks3ckc.ft8us.ui.logbook
+
+import com.bg7yoz.ft8cn.log.QSLCallsignRecord
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [sortQsosByDateTimeDesc], the pure ordering extracted from
+ * RecentTab so the logbook's recent QSO list shows newest contacts first.
+ *
+ * The records expose [QSLCallsignRecord.lastTime] (YYYYMMDD) and
+ * [QSLCallsignRecord.timeOn] (HHMMSS); the sort must order by the combined
+ * date+time descending, so same-day QSOs order by time of day. QSLCallsignRecord
+ * is a plain POJO, so these run on the bare JVM with no Robolectric.
+ */
+class LogbookSortTest {
+
+    private fun record(callsign: String, date: String, time: String): QSLCallsignRecord {
+        val r = QSLCallsignRecord()
+        r.setCallsign(callsign)
+        r.lastTime = date
+        r.timeOn = time
+        return r
+    }
+
+    private fun calls(records: List<QSLCallsignRecord>): List<String?> =
+        records.map { it.callsign }
+
+    @Test
+    fun sortsByDateNewestFirst() {
+        val sorted = sortQsosByDateTimeDesc(
+            listOf(
+                record("OLD", "20230101", "120000"),
+                record("NEW", "20240615", "120000"),
+                record("MID", "20231231", "120000"),
+            ),
+        )
+        assertThat(calls(sorted)).containsExactly("NEW", "MID", "OLD").inOrder()
+    }
+
+    @Test
+    fun sameDaySortsByTimeNewestFirst() {
+        // The whole point of carrying time_on: a busy day must order by time.
+        val sorted = sortQsosByDateTimeDesc(
+            listOf(
+                record("MORNING", "20240615", "081500"),
+                record("EVENING", "20240615", "231000"),
+                record("NOON", "20240615", "120000"),
+            ),
+        )
+        assertThat(calls(sorted)).containsExactly("EVENING", "NOON", "MORNING").inOrder()
+    }
+
+    @Test
+    fun missingTimeSortsAtStartOfDayButAfterPriorDay() {
+        // A row with no recorded time pads to 000000 — earliest within its own
+        // day, but still ahead of every QSO on an older day.
+        val sorted = sortQsosByDateTimeDesc(
+            listOf(
+                record("PREV_DAY_LATE", "20240614", "235900"),
+                record("NO_TIME", "20240615", ""),
+                record("SAME_DAY_EARLY", "20240615", "000500"),
+            ),
+        )
+        assertThat(calls(sorted))
+            .containsExactly("SAME_DAY_EARLY", "NO_TIME", "PREV_DAY_LATE").inOrder()
+    }
+
+    @Test
+    fun shortAdifTimeIsPaddedConsistently() {
+        // ADIF imports may carry HHMM (4 digits); it must pad to HHMM00 so it
+        // compares correctly against full HHMMSS values on the same day.
+        val sorted = sortQsosByDateTimeDesc(
+            listOf(
+                record("HHMMSS_LATER", "20240615", "143005"),
+                record("HHMM_EARLIER", "20240615", "1430"),
+            ),
+        )
+        assertThat(calls(sorted)).containsExactly("HHMMSS_LATER", "HHMM_EARLIER").inOrder()
+    }
+
+    @Test
+    fun emptyListReturnsEmpty() {
+        assertThat(sortQsosByDateTimeDesc(emptyList())).isEmpty()
+    }
+
+    @Test
+    fun sortIsStableForIdenticalTimestamps() {
+        // Genuine ties (same date+time) keep their incoming order.
+        val sorted = sortQsosByDateTimeDesc(
+            listOf(
+                record("FIRST", "20240615", "120000"),
+                record("SECOND", "20240615", "120000"),
+            ),
+        )
+        assertThat(calls(sorted)).containsExactly("FIRST", "SECOND").inOrder()
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookSortTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookSortTest.kt
@@ -80,6 +80,31 @@ class LogbookSortTest {
     }
 
     @Test
+    fun missingLeadingZeroTimeSortsAsMorning() {
+        // A manually-edited or imported time that dropped its leading hour zero
+        // ("815" = 08:15) must normalize to 081500 — it should sort as a morning QSO,
+        // not after midday ones. Plain padEnd would make it "815000" (81:50) and sort last.
+        val sorted = sortQsosByDateTimeDesc(
+            listOf(
+                record("NOON", "20240615", "120000"),
+                record("MORNING_SHORT", "20240615", "815"),
+                record("EVENING", "20240615", "2030"),
+            ),
+        )
+        assertThat(calls(sorted)).containsExactly("EVENING", "NOON", "MORNING_SHORT").inOrder()
+    }
+
+    @Test
+    fun normalizeTimeOnHandlesEveryShape() {
+        assertThat(normalizeTimeOn(null)).isEqualTo("000000")
+        assertThat(normalizeTimeOn("")).isEqualTo("000000")
+        assertThat(normalizeTimeOn("143005")).isEqualTo("143005") // HHMMSS unchanged
+        assertThat(normalizeTimeOn("1430")).isEqualTo("143000")   // HHMM -> append seconds
+        assertThat(normalizeTimeOn("815")).isEqualTo("081500")    // dropped leading zero (H MM)
+        assertThat(normalizeTimeOn("81500")).isEqualTo("081500")  // dropped leading zero (H MM SS)
+    }
+
+    @Test
     fun emptyListReturnsEmpty() {
         assertThat(sortQsosByDateTimeDesc(emptyList())).isEmpty()
     }


### PR DESCRIPTION
## What

The logbook's **Recent** tab now lists QSOs **newest-first by full date and time**.

## Why

Two bugs in the recent list ordering:

1. The UI applied `records.reversed()` on top of the database's `qso_date desc` query, so the list actually showed the **oldest** QSOs first.
2. The query only ordered by `qso_date` (a date, `YYYYMMDD`) — it never looked at the time of day, so multiple contacts on the **same day** came back in an arbitrary grouping order.

## How

- **`DatabaseOpr.java`** — the grouped query now also selects `max(q.time_on) as last_time_on` and orders by `qso_date desc, last_time_on desc`.
- **`QSLCallsignRecord.java`** — new `timeOn` field (UTC `HHMMSS`) carrying that value; defaults to empty for legacy/ADIF rows.
- **`LogbookScreen.kt`** — `RecentTab` replaces `records.reversed()` with the new pure `sortQsosByDateTimeDesc()` helper, which sorts newest-first on the combined `lastTime + timeOn` key (padded so short/missing times still sort sensibly; stable for genuine ties).

The query is shared with the legacy (non-Compose) log list, which consumes the record list via callback — adding a column/field is backward compatible and the legacy list also gets the improved time ordering.

## Tests

New `LogbookSortTest` (6 cases) covers `sortQsosByDateTimeDesc`: newest date first, same-day ordering by time, missing time padding, short ADIF (`HHMM`) times, empty list, and stability for identical timestamps. `testDebugUnitTest` passes and the full debug variant compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
