### PR TITLE
Color slot timer bar by cycle parity again

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -223,8 +223,6 @@ fun FT8USApp(mainViewModel: MainViewModel) {
 
             // Slot timer bar — fills 0→100% across each slot (15s FT8 / 7.5s FT4)
             SlotTimerBar(
-                activeTxSlot = txSlot,
-                isActivated = isActivated,
                 slotMillis = ModeProfile.fromId(operatingMode).slotMillis.toLong(),
             )
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerBar.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -32,8 +33,6 @@ import radio.ks3ckc.ft8us.theme.TextMuted
 
 @Composable
 fun SlotTimerBar(
-    activeTxSlot: Int,
-    isActivated: Boolean,
     slotMillis: Long = 15_000L,
     modifier: Modifier = Modifier,
 ) {
@@ -48,7 +47,7 @@ fun SlotTimerBar(
     }
 
     val state = slotTimerState(nowMs, slotMillis)
-    val fillColor = if (isActivated && state.currentSlot == activeTxSlot) Accent else Signal
+    val fillColor = slotBarColor(state.currentSlot)
 
     Row(
         modifier = modifier
@@ -83,6 +82,17 @@ fun SlotTimerBar(
         )
     }
 }
+
+/**
+ * Color the slot bar by cycle parity, so the two alternating FT8 slots are visually
+ * distinguishable at a glance: the even slot ([UtcTimer.sequential] == 0) is the warm
+ * [Accent] (orange), the odd slot ([UtcTimer.sequential] == 1) is the cool [Signal] (blue).
+ *
+ * Extracted as a pure function so the parity→color mapping can be unit-tested without
+ * Compose, and so it can't silently regress to a single color again.
+ */
+internal fun slotBarColor(currentSlot: Int): Color =
+    if (currentSlot % 2 == 0) Accent else Signal
 
 /** The fill fraction, countdown label, and slot index the bar renders for a given instant. */
 internal data class SlotTimerState(

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
@@ -2,6 +2,8 @@ package radio.ks3ckc.ft8us.ui.components
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import radio.ks3ckc.ft8us.theme.Accent
+import radio.ks3ckc.ft8us.theme.Signal
 
 /**
  * Unit tests for [slotTimerState] — the pure slot-progress math extracted from
@@ -55,6 +57,31 @@ class SlotTimerStateTest {
         val s = slotTimerState(nowMs = 0L, slotMillis = -5L)
         assertThat(s.progress).isEqualTo(0f)
         assertThat(s.secondsRemaining).isEqualTo(15)
+    }
+
+    @Test
+    fun `even slot is orange, odd slot is blue`() {
+        // Regression guard for the parity coloring: the even cycle (sequential == 0) must
+        // be the warm Accent and the odd cycle (sequential == 1) the cool Signal. This
+        // broke once when the bar was tied to the active-TX slot and rendered blue only.
+        assertThat(slotBarColor(0)).isEqualTo(Accent)
+        assertThat(slotBarColor(1)).isEqualTo(Signal)
+    }
+
+    @Test
+    fun `slot color tracks parity for any slot index`() {
+        for (slot in 0..5) {
+            val expected = if (slot % 2 == 0) Accent else Signal
+            assertThat(slotBarColor(slot)).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `slot color drives off the timer state slot index`() {
+        // The bar feeds state.currentSlot into slotBarColor; verify the two stay consistent
+        // so the start of the FT8 slot is orange and the next 15s slot is blue.
+        assertThat(slotBarColor(slotTimerState(0L, 15_000L).currentSlot)).isEqualTo(Accent)
+        assertThat(slotBarColor(slotTimerState(15_000L, 15_000L).currentSlot)).isEqualTo(Signal)
     }
 
     @Test


### PR DESCRIPTION
## What

The slot timer bar's fill color regressed to **blue almost all the time**. It should distinguish the two alternating FT8 slots:

- **Even cycle** (`UtcTimer.sequential == 0`) → warm **Accent** (orange/yellow)
- **Odd cycle** (`sequential == 1`) → cool **Signal** (blue)

The bar had been tied to the *active TX slot* (`if (isActivated && currentSlot == activeTxSlot) Accent else Signal`), so it only went orange during your own transmit slot and rendered blue the rest of the time.

## Change

- Extract a pure `internal fun slotBarColor(currentSlot)` mapping (even → `Accent`, odd → `Signal`) and drive the bar's fill off it.
- Drop the now-unused `activeTxSlot` / `isActivated` params from `SlotTimerBar` and its call site in `FT8USApp`.

## Tests

Added unit tests to `SlotTimerStateTest` for `slotBarColor`:
- even → orange, odd → blue (the regression guard)
- parity holds across several slot indices
- consistency with `slotTimerState.currentSlot`

`gradlew.bat testDebugUnitTest --tests ...SlotTimerStateTest` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)