### PR TITLE
Key waterfall label gate on slot length, not just slot index

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
@@ -12,28 +12,51 @@ package com.bg7yoz.ft8cn.ui;
  * {@code utcMs / slotMillis} — 15s FT8, 7.5s FT4, 3.8s FT2), this returns true for only the
  * first stamp of each slot.
  *
+ * <p>The slot length is part of the key as well as the slot index, because a single
+ * {@code WaterfallView} (and its one gate) is reused across mode changes: switching
+ * FT8&rarr;FT4/FT2 changes the divisor, so {@code utcMs / slotMillis} can land on a slot
+ * index already stamped under the previous mode and wrongly suppress the new mode's first
+ * label. Including {@code slotMillis} makes any mode change a distinct key, so the first
+ * slot after the switch always stamps once.
+ *
  * <p>Plain Java (no Android), so the once-per-slot rule can be unit-tested directly.
  */
 public final class WaterfallLabelGate {
 
+    /** Sentinel mode key for the slot-index-only {@link #shouldStamp(long)} overload. */
+    private static final long NO_MODE = Long.MIN_VALUE;
+
+    private long lastSlotMillis = Long.MIN_VALUE;
     private long lastStampedPeriod = Long.MIN_VALUE;
 
     /**
-     * Whether the labels for {@code period} (a decode-slot index — the caller keys it off
-     * the current mode's slot length, e.g. {@code utcMs / slotMillis}, NOT a fixed 15s)
-     * should be stamped now. Returns true once per distinct period and false for any repeat
-     * arming within the same period.
+     * Whether the labels for {@code period} under a mode of slot length {@code slotMillis}
+     * should be stamped now. {@code period} is a decode-slot index the caller keys off the
+     * current mode's slot length (e.g. {@code utcMs / slotMillis}, NOT a fixed 15s). Returns
+     * true once per distinct {@code (slotMillis, period)} pair and false for any repeat
+     * arming of the same pair, so a mode change always stamps even when the new slot index
+     * collides with one already stamped under the old mode.
      */
-    public boolean shouldStamp(long period) {
-        if (period == lastStampedPeriod) {
+    public boolean shouldStamp(long slotMillis, long period) {
+        if (slotMillis == lastSlotMillis && period == lastStampedPeriod) {
             return false;
         }
+        lastSlotMillis = slotMillis;
         lastStampedPeriod = period;
         return true;
     }
 
-    /** Forget the last stamped cycle (e.g. when the bitmap is recreated). */
+    /**
+     * Slot-index-only gate, for callers that never change mode. Equivalent to
+     * {@link #shouldStamp(long, long)} with a fixed mode key.
+     */
+    public boolean shouldStamp(long period) {
+        return shouldStamp(NO_MODE, period);
+    }
+
+    /** Forget the last stamped slot (e.g. when the bitmap is recreated). */
     public void reset() {
+        lastSlotMillis = Long.MIN_VALUE;
         lastStampedPeriod = Long.MIN_VALUE;
     }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -335,10 +335,13 @@ public class WaterfallView extends View {
             // including over the next cycle's not-yet-populated rows where the signal is
             // gone. Stamp at most once per decode slot. Key the gate on the current mode's
             // slot length (NOT a fixed 15s) so FT4 (7.5s) and FT2 (3.8s) each get one stamp
-            // per slot instead of one stamp per two-or-more slots.
+            // per slot instead of one stamp per two-or-more slots. Pass slotMillis as part
+            // of the key too: this view (and its gate) is reused across mode changes, and a
+            // new mode's slotPeriod can collide with one already stamped under the old mode,
+            // which would wrongly suppress the first label after the switch.
             long slotMillis = GeneralVariables.currentMode().slotMillis;
             long slotPeriod = slotMillis > 0 ? utcMs / slotMillis : period;
-            if (messageGate.shouldStamp(slotPeriod)) {
+            if (messageGate.shouldStamp(slotMillis, slotPeriod)) {
                 Log.d(TAG, String.format("Drawing %d messages on waterfall", messages.size()));
                 for (Ft8Message msg : messages) {
 

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGateTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGateTest.java
@@ -52,4 +52,27 @@ public class WaterfallLabelGateTest {
         gate.reset();
         assertThat(gate.shouldStamp(100)).isTrue();   // after a bitmap recreate
     }
+
+    @Test
+    public void modeChangeStampsEvenWhenSlotIndexCollides() {
+        // The view (and its single gate) is reused across mode changes. FT8 (15s) and
+        // FT4 (7.5s) divide utcMs differently, so the new mode's slot index can equal one
+        // already stamped under the old mode. Keying on slotMillis too means the first
+        // slot after the switch still stamps once instead of being suppressed.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(15_000, 5)).isTrue();   // FT8 slot 5
+        assertThat(gate.shouldStamp(15_000, 5)).isFalse();  // deep pass, same slot
+        assertThat(gate.shouldStamp(7_500, 5)).isTrue();    // FT4 slot 5 — same index, new mode
+        assertThat(gate.shouldStamp(7_500, 5)).isFalse();   // deep pass after the switch
+    }
+
+    @Test
+    public void sameModeKeyBehavesLikeTheSingleArgGate() {
+        // With a fixed slotMillis the two-arg gate is once-per-slot, just like the
+        // slot-index-only overload.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(7_500, 100)).isTrue();
+        assertThat(gate.shouldStamp(7_500, 100)).isFalse();
+        assertThat(gate.shouldStamp(7_500, 101)).isTrue();
+    }
 }


### PR DESCRIPTION
## What

Resolves the remaining Copilot review comment on the release PR #188.

`WaterfallLabelGate` was keyed only by `slotPeriod` (= `utcMs / slotMillis`). A single `WaterfallView` (and its one gate) is reused across operating-mode changes, so switching **FT8 → FT4/FT2** changes the divisor and the new mode's slot index can equal one already stamped under the old mode — which wrongly **suppresses the first label-stamp of the new mode**.

## How

- `WaterfallLabelGate.shouldStamp(slotMillis, period)` now stamps once per distinct `(slotMillis, period)` pair, so any mode change is a fresh key and always stamps. The slot-index-only `shouldStamp(period)` overload is kept for mode-agnostic callers/tests. `reset()` clears both fields.
- `WaterfallView` passes the current mode's `slotMillis` into the gate.

## Tests

- `modeChangeStampsEvenWhenSlotIndexCollides` — FT8 slot 5 then FT4 slot 5 (same index, different mode) both stamp; the regression guard for this comment.
- `sameModeKeyBehavesLikeTheSingleArgGate` — fixed mode stays once-per-slot.
- Existing single-arg tests still pass.

`testDebugUnitTest` passes; debug variant compiles.

Targets `dev` per the project workflow; once merged it flows into the dev→main release (#188).

🤖 Generated with [Claude Code](https://claude.com/claude-code)