### PR TITLE
Start GPS grid updater after first permission grant (#59)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/location/GridLocationUpdater.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/location/GridLocationUpdater.java
@@ -145,15 +145,27 @@ public class GridLocationUpdater {
     }
 
     private void applyGridFromLatLng(double lat, double lon, MainViewModel mainViewModel) {
-        LatLng latLng = new LatLng(lat, lon);
-        String grid = MaidenheadGrid.getGridSquare(latLng);
-        if (grid == null || grid.isEmpty()) return;
-        String current = GeneralVariables.getMyMaidenheadGrid();
-        if (grid.equals(current)) return;
+        String grid = gridUpdateFor(lat, lon, GeneralVariables.getMyMaidenheadGrid());
+        if (grid == null) return;
         GeneralVariables.setMyMaidenheadGrid(grid);
         if (mainViewModel != null && mainViewModel.databaseOpr != null) {
             mainViewModel.databaseOpr.writeConfig("grid", grid, null);
         }
         Log.d(TAG, "Updated grid from GPS: " + grid);
+    }
+
+    /**
+     * Decide the grid to write for a GPS fix: the Maidenhead grid at
+     * (lat, lon) if it is valid and differs from {@code currentGrid},
+     * otherwise {@code null} (meaning "no change, don't write").
+     *
+     * Extracted from {@link #applyGridFromLatLng} so the update-decision
+     * logic can be unit-tested without a {@link LocationManager}.
+     */
+    static String gridUpdateFor(double lat, double lon, String currentGrid) {
+        String grid = MaidenheadGrid.getGridSquare(new LatLng(lat, lon));
+        if (grid == null || grid.isEmpty()) return null;
+        if (grid.equals(currentGrid)) return null;
+        return grid;
     }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -258,7 +258,25 @@ class ComposeMainActivity : AppCompatActivity() {
         grantResults: IntArray,
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        // Proceed regardless; same behavior as original
+        // Proceed regardless; same behavior as original.
+
+        // GPS grid auto-update: the toggle in Settings (and the cold-start path)
+        // requests ACCESS_FINE_LOCATION *asynchronously* and then immediately calls
+        // GridLocationUpdater.refresh(). On the very first enable the permission is
+        // still ungranted at that point, so start() bails and the subscription never
+        // begins until the next app launch. Once the user grants location here, kick
+        // refresh() again so updates start in the same session (issue #59).
+        if (locationGrantedIn(permissions, grantResults)
+            && GeneralVariables.autoUpdateGridFromGPS
+        ) {
+            fileLog("onRequestPermissionsResult: location granted, starting GPS grid updater")
+            val grid = MaidenheadGrid.getMyMaidenheadGrid(applicationContext)
+            if (grid.isNotEmpty()) {
+                GeneralVariables.setMyMaidenheadGrid(grid)
+                mainViewModel.databaseOpr.writeConfig("grid", grid, null)
+            }
+            GridLocationUpdater.refresh(applicationContext, mainViewModel)
+        }
     }
 
     private fun initData() {
@@ -573,4 +591,26 @@ class ComposeMainActivity : AppCompatActivity() {
         mainViewModel.utcTimer?.delete()
         System.exit(0)
     }
+}
+
+/**
+ * True if this permission result granted either fine or coarse location.
+ * Top-level + [internal] so the GPS-grid restart decision (issue #59) can be
+ * unit-tested without constructing the Activity.
+ */
+internal fun locationGrantedIn(
+    permissions: Array<out String>,
+    grantResults: IntArray,
+): Boolean {
+    for (i in permissions.indices) {
+        if (i >= grantResults.size) break
+        val p = permissions[i]
+        if ((p == Manifest.permission.ACCESS_FINE_LOCATION ||
+                p == Manifest.permission.ACCESS_COARSE_LOCATION) &&
+            grantResults[i] == PackageManager.PERMISSION_GRANTED
+        ) {
+            return true
+        }
+    }
+    return false
 }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/location/GridLocationUpdaterTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/location/GridLocationUpdaterTest.java
@@ -1,0 +1,64 @@
+package com.bg7yoz.ft8cn.location;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.bg7yoz.ft8cn.maidenhead.MaidenheadGrid;
+import com.google.android.gms.maps.model.LatLng;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Covers {@link GridLocationUpdater#gridUpdateFor} — the GPS-grid update
+ * decision extracted from {@code applyGridFromLatLng} (issue #59). Robolectric
+ * is required because the method reaches Play-Services {@link LatLng} via
+ * {@link MaidenheadGrid#getGridSquare}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GridLocationUpdaterTest {
+
+    // Boston, MA. MaidenheadGridTest cross-checks that this maps to FN42.
+    private static final double BOSTON_LAT = 42.5;
+    private static final double BOSTON_LON = -71.0;
+
+    @Test
+    public void gridUpdateFor_returnsNewGrid_whenDifferentFromCurrent() {
+        // Driving into FN42 while the stored grid is something else => update to FN42.
+        String result = GridLocationUpdater.gridUpdateFor(BOSTON_LAT, BOSTON_LON, "AA00");
+        assertThat(result).isEqualTo("FN42");
+    }
+
+    @Test
+    public void gridUpdateFor_returnsNull_whenGridUnchanged() {
+        // Already in FN42 => no write, so a fresh fix in the same square is a no-op.
+        String result = GridLocationUpdater.gridUpdateFor(BOSTON_LAT, BOSTON_LON, "FN42");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void gridUpdateFor_returnsNull_whenCurrentMatchesComputed() {
+        // The decision must match exactly what getGridSquare would produce for the
+        // fix — guards against the "stored 6-char vs computed 4-char" mismatch.
+        String computed = MaidenheadGrid.getGridSquare(new LatLng(BOSTON_LAT, BOSTON_LON));
+        assertThat(GridLocationUpdater.gridUpdateFor(BOSTON_LAT, BOSTON_LON, computed)).isNull();
+    }
+
+    @Test
+    public void gridUpdateFor_detectsGridBoundaryCrossing() {
+        // Simulate a vehicle crossing from one grid square into a far-away one:
+        // the transmitted grid must follow GPS. Boston (FN42) -> central Europe.
+        double euLat = 48.5;
+        double euLon = 9.0;
+        String startGrid = MaidenheadGrid.getGridSquare(new LatLng(BOSTON_LAT, BOSTON_LON));
+        String endGrid = MaidenheadGrid.getGridSquare(new LatLng(euLat, euLon));
+
+        // Sanity: the two locations really are in different grids.
+        assertThat(endGrid).isNotEqualTo(startGrid);
+
+        // Standing still in the start square => no change.
+        assertThat(GridLocationUpdater.gridUpdateFor(BOSTON_LAT, BOSTON_LON, startGrid)).isNull();
+        // After the boundary crossing => update to the new square.
+        assertThat(GridLocationUpdater.gridUpdateFor(euLat, euLon, startGrid)).isEqualTo(endGrid);
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/LocationPermissionResultTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/LocationPermissionResultTest.kt
@@ -1,0 +1,74 @@
+package radio.ks3ckc.ft8us
+
+import android.Manifest
+import android.content.pm.PackageManager
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Covers [locationGrantedIn] — the gate that decides whether a permission
+ * result should (re)start the GPS grid updater (issue #59). The first time a
+ * user enables the toggle, the permission dialog resolves *after* the initial
+ * refresh() call, so this is the path that actually starts location updates in
+ * the same session.
+ *
+ * Manifest permission strings and PERMISSION_GRANTED/DENIED are compile-time
+ * constants, so a bare JUnit runner suffices — no Android runtime needed.
+ */
+class LocationPermissionResultTest {
+
+    @Test
+    fun granted_whenFineLocationGranted() {
+        val perms = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        val grants = intArrayOf(PackageManager.PERMISSION_GRANTED)
+        assertThat(locationGrantedIn(perms, grants)).isTrue()
+    }
+
+    @Test
+    fun granted_whenCoarseLocationGranted() {
+        val perms = arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+        val grants = intArrayOf(PackageManager.PERMISSION_GRANTED)
+        assertThat(locationGrantedIn(perms, grants)).isTrue()
+    }
+
+    @Test
+    fun notGranted_whenLocationDenied() {
+        val perms = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        val grants = intArrayOf(PackageManager.PERMISSION_DENIED)
+        assertThat(locationGrantedIn(perms, grants)).isFalse()
+    }
+
+    @Test
+    fun notGranted_whenNoLocationPermissionInResult() {
+        // A result for an unrelated permission (e.g. notifications) must not
+        // trigger a GPS restart.
+        val perms = arrayOf(Manifest.permission.RECORD_AUDIO)
+        val grants = intArrayOf(PackageManager.PERMISSION_GRANTED)
+        assertThat(locationGrantedIn(perms, grants)).isFalse()
+    }
+
+    @Test
+    fun granted_whenLocationIsOneOfSeveralPermissions() {
+        // Cold-start path requests a whole batch at once; the location grant must
+        // be found regardless of its position in the array.
+        val perms = arrayOf(
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.WAKE_LOCK,
+        )
+        val grants = intArrayOf(
+            PackageManager.PERMISSION_DENIED,
+            PackageManager.PERMISSION_GRANTED,
+            PackageManager.PERMISSION_GRANTED,
+        )
+        assertThat(locationGrantedIn(perms, grants)).isTrue()
+    }
+
+    @Test
+    fun notGranted_whenGrantResultsShorterThanPermissions() {
+        // Defensive: a truncated grantResults array must not throw.
+        val perms = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        val grants = intArrayOf()
+        assertThat(locationGrantedIn(perms, grants)).isFalse()
+    }
+}


### PR DESCRIPTION
## Audit + fix for #59 (auto-update grid from GPS)

I traced the full chain **GPS fix → grid computation → `GeneralVariables` → transmitted FT8 message**.

### Transmit side is correct ✅
The on-air message is regenerated **fresh every TX cycle** — `DoTransmitRunnable.run()` calls `getFunctionCommand(functionOrder)` (`FT8TransmitSignal.java:1700`) right before encoding, which reads `GeneralVariables.getMyMaidenhead4Grid()` live (CQ case 6 / grid case 1). So once the stored grid changes, the **next** TX slot carries it — even mid-QSO. No stale caching. This half of the feature works.

### Bug: first enable does nothing until app restart 🐞
In `SettingsScreen.kt` the toggle requests `ACCESS_FINE_LOCATION` **asynchronously**, then immediately calls `GridLocationUpdater.refresh()` while permission is still ungranted → `start()` bails on its permission check → `running` stays false. `onRequestPermissionsResult` was a no-op, so nothing restarted it. The GPS subscription only began on the *next* app launch (cold-start path re-runs `refresh()` with permission now granted).

**Repro:** fresh install → enable "auto-update grid from GPS", grant location → drive → grid never updates that session. Kill + relaunch → it works.

### Fix
- `onRequestPermissionsResult` (`ComposeMainActivity.kt`): when the result grants fine/coarse location and the toggle is on, seed the grid from last-known location and re-run `GridLocationUpdater.refresh()` so updates start in the same session.

### Tests (per CLAUDE.md test policy)
Extracted the two decision points into testable units and covered them:
- `GridLocationUpdater.gridUpdateFor(lat, lon, current)` — returns the new grid only when it is valid and differs; includes a grid-boundary-crossing case. (`GridLocationUpdaterTest`, Robolectric)
- top-level `locationGrantedIn(permissions, grantResults)` — the restart gate, incl. batched-request and truncated-array cases. (`LocationPermissionResultTest`)

Both new classes pass (`testDebugUnitTest`). Debug Kotlin+Java compile clean. No device was attached so on-device install/drive-test was not run; the acceptance-criteria drive test still needs a real-world pass.

### Notes (not changed)
- Update cadence (5 min / 1 km) is adequate: the TX grid is 4-char (~111×150 km squares), so worst-case lag is a few km past a boundary.
- Foreground-only: no `ACCESS_BACKGROUND_LOCATION`; fine for a car-mounted foreground app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
