### PR TITLE
Fix PSKReporter IPFIX field IDs so uploaded spots are recorded

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
@@ -88,6 +88,11 @@ object PskReporterClient {
         }
         if (!force && lastFetchEpochMs != 0L && now - lastFetchEpochMs < COOLDOWN_MS) {
             log("skipped (client cooldown ${(COOLDOWN_MS - (now - lastFetchEpochMs)) / 1000}s remaining)")
+            // A cooldown skip is benign (not a failed attempt), so clear any stale
+            // error — otherwise a caller surfacing lastError (the map overlay) would
+            // keep showing a prior transport/HTTP error during normal throttling.
+            // The rate-limit back-off skip above intentionally keeps lastError set.
+            lastError = null
             return@withContext null
         }
         lastFetchEpochMs = now

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClient.kt
@@ -71,13 +71,22 @@ object PskReporterClient {
     @Volatile
     private var rateLimitedUntilEpochMs: Long = 0L
 
-    suspend fun fetchSpotsForMe(call: String, secondsBack: Int): List<PskReporterSpot>? = withContext(Dispatchers.IO) {
+    /**
+     * Fetch reception reports for [call] over the last [secondsBack] seconds.
+     *
+     * [force] bypasses only the client-side 5-min cooldown — used for the first
+     * fetch when the map overlay is (re)entered so a returning user isn't shown
+     * an empty overlay just because a prior visit's fetch was recent. The 429/503
+     * rate-limit back-off is always honoured, so a forced call never hammers a
+     * server that has asked us to wait.
+     */
+    suspend fun fetchSpotsForMe(call: String, secondsBack: Int, force: Boolean = false): List<PskReporterSpot>? = withContext(Dispatchers.IO) {
         val now = clock()
         if (now < rateLimitedUntilEpochMs) {
             log("skipped (rate-limit back-off ${(rateLimitedUntilEpochMs - now) / 1000}s remaining)")
             return@withContext null
         }
-        if (lastFetchEpochMs != 0L && now - lastFetchEpochMs < COOLDOWN_MS) {
+        if (!force && lastFetchEpochMs != 0L && now - lastFetchEpochMs < COOLDOWN_MS) {
             log("skipped (client cooldown ${(COOLDOWN_MS - (now - lastFetchEpochMs)) / 1000}s remaining)")
             return@withContext null
         }
@@ -93,6 +102,7 @@ object PskReporterClient {
 
         val body = fetch(url) ?: return@withContext null
         val spots = parseSpots(body)
+        lastError = null
         log("fetch ok N=${spots.size}")
         spots
     }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
@@ -52,19 +52,24 @@ object PskReporterSender {
     private const val RECEIVER_DATA_SET_ID = RECEIVER_TEMPLATE_ID
     private const val SENDER_DATA_SET_ID = SENDER_TEMPLATE_ID
 
-    // IPFIX field type IDs (enterprise-specific under 30351)
-    // Receiver fields
-    private const val FT_RX_CALLSIGN = 1       // receiverCallsign
-    private const val FT_RX_LOCATOR = 2        // receiverLocator
-    private const val FT_DECODING_SW = 3       // decodingSoftware
-    // Sender fields
-    private const val FT_TX_CALLSIGN = 1       // senderCallsign
-    private const val FT_FREQUENCY = 2         // frequency
-    private const val FT_SNR = 3               // sNR
-    private const val FT_MODE = 4              // mode
-    private const val FT_TX_LOCATOR = 5        // senderLocator
-    private const val FT_INFO_SOURCE = 6       // informationSource
-    private const val FT_FLOW_START = 7        // flowStartSeconds
+    // IPFIX field type IDs. PSKReporter assigns specific element IDs under
+    // enterprise 30351 (see WSJT-X PSKReporter.cpp / pskreporter.info/pskdev.html);
+    // the collector maps element-ID -> column, so these must match exactly or the
+    // records are parsed structurally but discarded as unrecognized.
+    // Receiver (options) fields — all enterprise-specific under 30351.
+    private const val FT_RX_CALLSIGN = 2       // receiverCallsign  (0x8002)
+    private const val FT_RX_LOCATOR = 4        // receiverLocator   (0x8004)
+    private const val FT_DECODING_SW = 8       // decodingSoftware  (0x8008)
+    // Sender (data) fields — enterprise-specific under 30351, EXCEPT flowStart.
+    private const val FT_TX_CALLSIGN = 1       // senderCallsign    (0x8001)
+    private const val FT_FREQUENCY = 5         // frequency         (0x8005)
+    private const val FT_SNR = 6               // sNR               (0x8006)
+    private const val FT_MODE = 10             // mode              (0x800A)
+    private const val FT_TX_LOCATOR = 3        // senderLocator     (0x8003)
+    private const val FT_INFO_SOURCE = 11      // informationSource (0x800B)
+    // flowStartSeconds is the STANDARD IANA IPFIX element 150 (0x0096): no
+    // enterprise bit, no enterprise number in its template descriptor.
+    private const val FT_FLOW_START = 150      // flowStartSeconds  (0x0096, standard)
 
     data class SpotRecord(
         val senderCallsign: String,
@@ -346,10 +351,14 @@ object PskReporterSender {
 
     private fun encodeSenderTemplate(): ByteArray {
         // Data template set (set ID = 0x0002)
-        // Template ID = 0x50E3, field count = 7
+        // Template ID = 0x50E3, field count = 7. Six fields are enterprise-specific
+        // (8-byte descriptor: type+length+enterprise); flowStartSeconds is the
+        // standard element 0x0096 (4-byte descriptor: type+length, no enterprise).
         val fieldCount = 7
-        val fieldSize = 8 // enterprise fields: type(2) + length(2) + enterprise(4)
-        val templateRecordLen = 2 + 2 + (fieldCount * fieldSize) // templateId + fieldCount + fields
+        val enterpriseFieldSize = 8 // type(2) + length(2) + enterprise(4)
+        val standardFieldSize = 4   // type(2) + length(2)
+        val templateRecordLen =
+            2 + 2 + (6 * enterpriseFieldSize) + standardFieldSize // templateId + fieldCount + fields
         val setLen = 4 + templateRecordLen
         val padding = (4 - (setLen % 4)) % 4
         val totalLen = setLen + padding
@@ -367,8 +376,7 @@ object PskReporterSender {
         buf.putShort(0xFFFF.toShort())
         buf.putInt(ENTERPRISE_NUMBER)
 
-        // Field 2: frequency — uint32 (5 bytes per PSKReporter: 1 len + 4 data? No: fixed 4)
-        // PSKReporter uses uint32 for frequency
+        // Field 2: frequency — uint32 (4 bytes)
         buf.putShort((FT_FREQUENCY or 0x8000).toShort())
         buf.putShort(4.toShort())
         buf.putInt(ENTERPRISE_NUMBER)
@@ -393,10 +401,10 @@ object PskReporterSender {
         buf.putShort(1.toShort())
         buf.putInt(ENTERPRISE_NUMBER)
 
-        // Field 7: flowStartSeconds — uint32 (4 bytes)
-        buf.putShort((FT_FLOW_START or 0x8000).toShort())
+        // Field 7: flowStartSeconds — standard IPFIX element 0x0096, uint32 (4 bytes).
+        // No enterprise bit and no enterprise number (4-byte descriptor).
+        buf.putShort(FT_FLOW_START.toShort())
         buf.putShort(4.toShort())
-        buf.putInt(ENTERPRISE_NUMBER)
 
         repeat(padding) { buf.put(0) }
         return buf.array()

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
@@ -182,6 +182,10 @@ fun MapScreen(mainViewModel: MainViewModel) {
     var viewMode by rememberSaveable { mutableStateOf(MapViewMode.STANDARD) }
     var pskOverlayEnabled by rememberSaveable { mutableStateOf(GeneralVariables.pskOverlayEnabled) }
     var pskSpots by remember { mutableStateOf<List<PskSpotMarker>>(emptyList()) }
+    // Last overlay fetch error (transport/HTTP/rate-limit); null when the last fetch
+    // succeeded or was a benign cooldown skip. Surfaced in the status row so an empty
+    // overlay caused by a failure is distinguishable from "genuinely no spots".
+    var pskError by remember { mutableStateOf<String?>(null) }
 
     // Zoom + pan (issue #51). Scale is clamped to [1, MAX_ZOOM]; pan is clamped so the
     // scaled map can't be dragged entirely off-screen. Both reset whenever the projection
@@ -202,14 +206,21 @@ fun MapScreen(mainViewModel: MainViewModel) {
     LaunchedEffect(pskOverlayEnabled) {
         if (!pskOverlayEnabled) {
             pskSpots = emptyList()
+            pskError = null
             return@LaunchedEffect
         }
+        var firstFetch = true
         while (true) {
             val call = GeneralVariables.myCallsign.trim().uppercase()
             if (call.isEmpty()) {
                 pskSpots = emptyList()
+                pskError = null
             } else {
-                val spots = PskReporterClient.fetchSpotsForMe(call, PSK_OVERLAY_SECONDS_BACK)
+                // force=true only on the first fetch after the overlay is (re)entered so a
+                // recent prior-visit fetch within the 5-min cooldown doesn't leave the
+                // overlay blank; the 429/503 back-off is still honoured.
+                val spots = PskReporterClient.fetchSpotsForMe(call, PSK_OVERLAY_SECONDS_BACK, force = firstFetch)
+                firstFetch = false
                 if (spots != null) {
                     pskSpots = spots.map {
                         PskSpotMarker(
@@ -221,9 +232,13 @@ fun MapScreen(mainViewModel: MainViewModel) {
                             frequencyHz = it.frequencyHz,
                         )
                     }
+                    pskError = null
+                } else {
+                    // null = transport/HTTP error, rate-limit back-off, or cooldown skip.
+                    // Keep prior spots so the overlay doesn't flicker; surface the reason
+                    // (lastError is null for a benign cooldown skip). debug.log has detail.
+                    pskError = PskReporterClient.lastError
                 }
-                // On null (failure / cooldown / rate-limit) keep prior spots so the overlay
-                // doesn't flicker; PskReporterClient logs the reason to debug.log.
             }
             delay(PSK_POLL_INTERVAL_MS)
         }
@@ -465,6 +480,15 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 color = TextMuted,
                 fontSize = 10.5.sp,
             )
+            val overlayError = pskError
+            if (pskOverlayEnabled && overlayError != null) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.map_psk_error, overlayError),
+                    color = StatusNew,
+                    fontSize = 10.5.sp,
+                )
+            }
             Spacer(modifier = Modifier.weight(1f))
             Text(
                 text = if (viewMode == MapViewMode.STANDARD) stringResource(R.string.map_projection_equirectangular) else stringResource(R.string.map_projection_azimuthal),

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -313,6 +313,7 @@
     <string name="map_no_grid_set">No grid set</string>
     <string name="map_station_count">%1$d stations</string>
     <string name="map_station_count_with_heard">%1$d stations · %2$d heard</string>
+    <string name="map_psk_error">PSK Reporter unavailable: %1$s</string>
     <string name="map_projection_equirectangular">Equirectangular</string>
     <string name="map_projection_azimuthal">Azimuthal Equidistant</string>
     <string name="map_mode_standard">STD</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClientTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClientTest.kt
@@ -99,6 +99,24 @@ class PskReporterClientTest {
     }
 
     @Test
+    fun fetchSpots_cooldownSkipClearsStaleError() = runBlocking<Unit> {
+        // First fetch fails with a server error, setting lastError.
+        server.enqueue(MockResponse().setResponseCode(500))
+        val failed = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(failed).isNull()
+        assertThat(PskReporterClient.lastError).isNotNull()
+
+        // A second call within the cooldown is a benign skip (not a failed attempt),
+        // so it must clear lastError — the overlay shouldn't keep showing a stale error.
+        now += 30_000L
+        val skipped = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(skipped).isNull()
+        assertThat(PskReporterClient.lastError).isNull()
+        // Confirm it really was a cooldown skip, not a network call.
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
     fun fetchSpots_forceStillRespectsRateLimitBackoff() = runBlocking<Unit> {
         server.enqueue(MockResponse().setResponseCode(429))
 

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClientTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterClientTest.kt
@@ -83,6 +83,37 @@ class PskReporterClientTest {
     }
 
     @Test
+    fun fetchSpots_forceBypassesClientCooldown() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        val first = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(first).isNotNull()
+
+        // 30s is well inside the 4m50s cooldown, but force=true overrides it
+        // (used for the first overlay fetch when the map is re-entered).
+        now += 30_000L
+        val forced = PskReporterClient.fetchSpotsForMe("W1AW", 900, force = true)
+        assertThat(forced).isNotNull()
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    @Test
+    fun fetchSpots_forceStillRespectsRateLimitBackoff() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setResponseCode(429))
+
+        val rateLimited = PskReporterClient.fetchSpotsForMe("W1AW", 900)
+        assertThat(rateLimited).isNull()
+
+        // Inside the 15-minute back-off: force must NOT override it — we never
+        // hammer a server that returned 429/503.
+        now += 60_000L
+        val forced = PskReporterClient.fetchSpotsForMe("W1AW", 900, force = true)
+        assertThat(forced).isNull()
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
     fun fetchSpots_afterCooldownExpires_callsServerAgain() = runBlocking<Unit> {
         server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
         server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
@@ -459,12 +459,15 @@ class PskReporterSenderTest {
         }
     }
 
-    /** Decode a hex string (whitespace ignored) into bytes for golden-vector comparison. */
+    /** Decode a hex string (all whitespace ignored) into bytes for golden-vector comparison. */
     private fun hex(s: String): ByteArray {
-        val clean = s.replace(" ", "")
+        val clean = s.filterNot { it.isWhitespace() }
         require(clean.length % 2 == 0) { "odd-length hex string" }
         return ByteArray(clean.length / 2) {
-            ((Character.digit(clean[it * 2], 16) shl 4) or Character.digit(clean[it * 2 + 1], 16)).toByte()
+            val hi = Character.digit(clean[it * 2], 16)
+            val lo = Character.digit(clean[it * 2 + 1], 16)
+            require(hi >= 0 && lo >= 0) { "invalid hex digit at index ${it * 2} in: $clean" }
+            ((hi shl 4) or lo).toByte()
         }
     }
 }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
@@ -224,15 +224,13 @@ class PskReporterSenderTest {
     }
 
     @Test
-    fun `template field enterprise numbers are all 30351`() {
+    fun `enterprise fields all carry 30351 except the standard flowStart element`() {
         val data = PskReporterSender.encodeTemplates()
         val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
 
-        // Scan for all 4-byte int values matching enterprise number pattern
-        // Each field is 8 bytes: type(2) + length(2) + enterprise(4)
-        // After set headers and template record headers
         val enterpriseValues = mutableListOf<Int>()
-        // Receiver template: skip set header(4) + templateId(2) + fieldCount(2) + scopeFieldCount(2) = 10
+        // Receiver options template: 3 enterprise fields (8 bytes each).
+        // Skip set header(4) + templateId(2) + fieldCount(2) + scopeFieldCount(2) = 10.
         buf.position(10)
         repeat(3) {
             buf.short // type
@@ -240,16 +238,17 @@ class PskReporterSenderTest {
             enterpriseValues.add(buf.int)
         }
 
-        // Skip padding to next set
         val rxSetLen = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).run {
             short // skip set ID
             short.toInt() and 0xFFFF
         }
-        buf.position(rxSetLen)
 
-        // Sender template: skip set header(4) + templateId(2) + fieldCount(2) = 8
+        // Sender data template: first SIX fields are enterprise (8 bytes each); the
+        // seventh (flowStartSeconds) is standard element 0x0096 with NO enterprise
+        // number, so it is excluded from the scan.
+        // Skip set header(4) + templateId(2) + fieldCount(2) = 8.
         buf.position(rxSetLen + 8)
-        repeat(7) {
+        repeat(6) {
             buf.short // type
             buf.short // length
             enterpriseValues.add(buf.int)
@@ -258,6 +257,84 @@ class PskReporterSenderTest {
         for (en in enterpriseValues) {
             assertThat(en).isEqualTo(30351)
         }
+    }
+
+    @Test
+    fun `receiver template field IDs match PSKReporter spec`() {
+        val data = PskReporterSender.encodeTemplates()
+        val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
+        // Skip set header(4) + templateId(2) + fieldCount(2) + scopeFieldCount(2) = 10.
+        buf.position(10)
+
+        // receiverCallsign 0x8002 / var, receiverLocator 0x8004 / var,
+        // decodingSoftware 0x8008 / var — all enterprise 30351.
+        val expected = listOf(0x8002 to 0xFFFF, 0x8004 to 0xFFFF, 0x8008 to 0xFFFF)
+        for ((type, len) in expected) {
+            assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(type)
+            assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(len)
+            assertThat(buf.int).isEqualTo(30351)
+        }
+    }
+
+    @Test
+    fun `sender template field IDs match PSKReporter spec`() {
+        val data = PskReporterSender.encodeTemplates()
+        val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
+        val rxSetLen = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).run {
+            short // skip set ID
+            short.toInt() and 0xFFFF
+        }
+        // Sender template starts at rxSetLen; skip set header(4) + templateId(2) + fieldCount(2) = 8.
+        buf.position(rxSetLen + 8)
+
+        // First six fields are enterprise-specific under 30351, in encode order:
+        // senderCallsign 0x8001/var, frequency 0x8005/4, sNR 0x8006/1, mode 0x800A/var,
+        // senderLocator 0x8003/var, informationSource 0x800B/1.
+        val enterpriseFields = listOf(
+            0x8001 to 0xFFFF,
+            0x8005 to 4,
+            0x8006 to 1,
+            0x800A to 0xFFFF,
+            0x8003 to 0xFFFF,
+            0x800B to 1,
+        )
+        for ((type, len) in enterpriseFields) {
+            assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(type)
+            assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(len)
+            assertThat(buf.int).isEqualTo(30351)
+        }
+
+        // Seventh field: flowStartSeconds is the STANDARD IPFIX element 0x0096
+        // (4-byte descriptor: type+length, enterprise bit clear, no enterprise number).
+        val flowType = buf.short.toInt() and 0xFFFF
+        assertThat(flowType).isEqualTo(0x0096)
+        assertThat(flowType and 0x8000).isEqualTo(0) // enterprise bit NOT set
+        assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(4)
+    }
+
+    @Test
+    fun `encodeTemplates matches the PSKReporter reference byte layout`() {
+        // Golden vector: exact bytes the PSKReporter collector expects (same element
+        // IDs as WSJT-X PSKReporter.cpp). Pins the layout so a future field-ID drift
+        // fails loudly instead of silently producing discarded packets.
+        val expected = hex(
+            // --- Receiver options template (set 0x0003, len 0x0024 = 36) ---
+            "0003 0024 50E2 0003 0000" +
+                "8002 FFFF 0000768F" + // receiverCallsign  (id 2, var)
+                "8004 FFFF 0000768F" + // receiverLocator   (id 4, var)
+                "8008 FFFF 0000768F" + // decodingSoftware  (id 8, var)
+                "0000" +               // padding to 4-byte boundary
+                // --- Sender data template (set 0x0002, len 0x003C = 60) ---
+                "0002 003C 50E3 0007" +
+                "8001 FFFF 0000768F" + // senderCallsign    (id 1, var)
+                "8005 0004 0000768F" + // frequency         (id 5, u32)
+                "8006 0001 0000768F" + // sNR               (id 6, i8)
+                "800A FFFF 0000768F" + // mode              (id 10, var)
+                "8003 FFFF 0000768F" + // senderLocator     (id 3, var)
+                "800B 0001 0000768F" + // informationSource (id 11, u8)
+                "0096 0004"            // flowStartSeconds  (standard id 150, u32, no enterprise)
+        )
+        assertThat(PskReporterSender.encodeTemplates()).isEqualTo(expected)
     }
 
     // ---------------------------------------------------------------
@@ -379,6 +456,15 @@ class PskReporterSenderTest {
             buf.position(8) // skip version, length, export time
             val seq = buf.int
             assertThat(seq).isEqualTo(i)
+        }
+    }
+
+    /** Decode a hex string (whitespace ignored) into bytes for golden-vector comparison. */
+    private fun hex(s: String): ByteArray {
+        val clean = s.replace(" ", "")
+        require(clean.length % 2 == 0) { "odd-length hex string" }
+        return ByteArray(clean.length / 2) {
+            ((Character.digit(clean[it * 2], 16) shl 4) or Character.digit(clean[it * 2 + 1], 16)).toByte()
         }
     }
 }


### PR DESCRIPTION
## Problem

Users reported pskreporter.info appearing broken in two ways:
1. **Decoded spots never show up on pskreporter.info** ("who I'm hearing" not reported).
2. **The in-app map overlay shows nobody spotting me.**

## Root cause (upload)

`PskReporterSender` invented **sequential** IPFIX information-element IDs (1,2,3…) under enterprise 30351 instead of the **specific** IDs the PSKReporter collector expects. The collector keys element-ID → column, so every record was parsed structurally but discarded as unrecognized — packets were sent every ~5 min and silently dropped.

Corrected to match the spec / WSJT-X `PSKReporter.cpp`:

| Field | Was | Now |
|---|---|---|
| frequency | `0x8002` | `0x8005` |
| sNR | `0x8003` | `0x8006` |
| mode | `0x8004` | `0x800A` |
| senderLocator | `0x8005` | `0x8003` |
| informationSource | `0x8006` | `0x800B` |
| flowStartSeconds | `0x8007` (enterprise) | `0x0096` (**standard** element 150 — no enterprise bit/number, 4-byte descriptor) |
| receiverCallsign | `0x8001` | `0x8002` |
| receiverLocator | `0x8002` | `0x8004` |
| decodingSoftware | `0x8003` | `0x8008` |

(`senderCallsign` `0x8001` was already correct.) The sender template length is recomputed for the 6×8 + 1×4 layout.

## Download / overlay

The download request format and XML parser were **verified correct against the live retrieve API** (HTTP 200, attributes match the parser). To stop silent failures from looking identical to "no spots":
- `fetchSpotsForMe` gains a `force` flag that bypasses **only** the client cooldown (still honouring the 429/503 back-off) for the first fetch when the map is (re)entered.
- `MapScreen` surfaces the last fetch error in the status row.

## Tests

- The old tests only checked the enterprise number + self-consistency, never the field IDs — which is how this shipped. Added **spec-exact field-ID assertions** for both templates and a **golden byte-vector** pinned to the WSJT-X reference layout.
- Fixed the enterprise-scan test for the new standard-`flowStart` layout; added `force`-flag client tests.
- `gradlew testDebugUnitTest` for both PSKReporter classes: **BUILD SUCCESSFUL**.

## On-device verification (pending — no device attached during dev)

- [ ] `installDebug` on the Pixel 8.
- [ ] Decode ~10 min with PSK Reporter enabled; `debug.log` shows `PskReporterSender: sent N packet(s)`; station then appears as a reporter on pskreporter.info.
- [ ] Map overlay populates within one poll with a callsign set; error row distinguishes empty vs. error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)