### PR TITLE
Fix blank page on POTA "Sign in with Google" + clearer upload errors

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaClient.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pota/PotaClient.kt
@@ -19,6 +19,14 @@ import java.util.Date
 import java.util.Locale
 
 /**
+ * Thrown by [PotaClient.uploadAdif] when POTA's endpoint returns a non-2xx HTTP
+ * status. Carries the status so the UI can tell a server-side rejection (5xx —
+ * usually a bad park ref or unregistered callsign) from a client/auth problem.
+ */
+class PotaUploadException(val httpCode: Int, val body: String) :
+    Exception("HTTP $httpCode${if (body.isNotBlank()) ": ${body.take(160)}" else ""}")
+
+/**
  * Talks to pota.app's read+write endpoints. Mirrors [radio.ks3ckc.ft8us.pskreporter.PskReporterClient]:
  *   - HttpURLConnection only (no extra deps).
  *   - Coroutine-friendly suspend functions on Dispatchers.IO.
@@ -147,7 +155,7 @@ object PotaClient {
                 if (code !in 200..299) {
                     val err = conn.errorStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() } ?: ""
                     log("uploadAdif $filename -> http $code ${err.take(200)}")
-                    return@withContext Result.failure(IllegalStateException("HTTP $code${if (err.isNotBlank()) ": ${err.take(160)}" else ""}"))
+                    return@withContext Result.failure(PotaUploadException(code, err))
                 }
                 val resp = conn.inputStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() } ?: ""
                 log("uploadAdif ok $filename (${payload.size}B) -> ${resp.take(120)}")

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaOAuthLogin.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaOAuthLogin.kt
@@ -1,9 +1,16 @@
 package radio.ks3ckc.ft8us.ui.pota
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.net.Uri
+import android.os.Message
+import android.util.Log
+import android.webkit.ConsoleMessage
 import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.background
@@ -38,6 +45,11 @@ import radio.ks3ckc.ft8us.theme.Accent
 import radio.ks3ckc.ft8us.theme.BgApp
 import radio.ks3ckc.ft8us.theme.TextMuted
 import radio.ks3ckc.ft8us.theme.TextPrimary
+import java.io.File
+import java.io.FileWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * Full-screen WebView that drives POTA's Cognito hosted-UI OAuth2 flow, so users
@@ -52,9 +64,21 @@ import radio.ks3ckc.ft8us.theme.TextPrimary
  * the code. A WebView lets us watch navigation and lift the `?code=` out the
  * instant Cognito redirects, before pota.app's page loads.
  *
- * The default Android WebView UA contains "; wv", which Google's consent screen
- * rejects (`disallowed_useragent`). We override it with a plain Chrome UA so
- * Google sign-in works; Facebook / Amazon / email work either way.
+ * Getting Google sign-in to actually render inside a WebView takes three things,
+ * all of which used to be missing and produced a blank white page when the user
+ * tapped "Sign in with Google":
+ *  1. A non-"; wv" user-agent ([stripWebViewToken]) — Google's consent screen
+ *     rejects the default WebView UA with `disallowed_useragent`.
+ *  2. Third-party cookies enabled — Google's account chooser / consent set and
+ *     read cookies across google.com; WebView blocks third-party cookies by
+ *     default, which can leave the page blank.
+ *  3. Multi-window handling — Google sometimes opens the account chooser via
+ *     `window.open`; a WebView with no [WebChromeClient.onCreateWindow] silently
+ *     drops the popup, so the user sees nothing happen. We route the popup's
+ *     navigation back into the main WebView instead.
+ *
+ * Every navigation, error, and console message is written to debug.log so a future
+ * "blank page" report carries the failing URL / HTTP status instead of nothing.
  *
  * [onClose] fires exactly once: `true` if a refresh token was obtained and stored
  * (caller can proceed to upload), `false` on cancel / error.
@@ -101,31 +125,48 @@ fun PotaOAuthDialog(onClose: (success: Boolean) -> Unit) {
                         WebView(ctx).apply {
                             settings.javaScriptEnabled = true
                             settings.domStorageEnabled = true
+                            // Google opens its account chooser in a popup window in some
+                            // flows; without these + the onCreateWindow handler below the
+                            // popup is silently dropped (blank screen, "nothing happened").
+                            settings.setSupportMultipleWindows(true)
+                            settings.javaScriptCanOpenWindowsAutomatically = true
                             // Google's consent screen rejects the "; wv" token the default
                             // Android WebView UA carries (disallowed_useragent). Strip just
                             // that token so the UA stays current with the device's real
                             // Chrome/WebView version instead of pinning a version that ages out.
                             settings.userAgentString = stripWebViewToken(settings.userAgentString)
 
+                            // Google sign-in reads/writes cookies across google.com while the
+                            // page lives on the Cognito hosted-UI origin — third-party from
+                            // the WebView's perspective. WebView blocks those by default,
+                            // which can leave the consent page blank.
+                            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+
                             var captured = false
 
                             fun handleRedirect(url: String): Boolean {
-                                if (captured || !url.startsWith(PotaAuth.OAUTH_REDIRECT)) return false
-                                captured = true
-                                val uri = Uri.parse(url)
-                                val code = uri.getQueryParameter("code")
-                                if (code.isNullOrBlank()) {
-                                    // error=… or user bailed at the provider — treat as cancel.
-                                    currentOnClose(false)
-                                    return true
+                                if (captured) return false
+                                return when (val r = classifyRedirect(url, PotaAuth.OAUTH_REDIRECT)) {
+                                    OAuthRedirect.NotRedirect -> false
+                                    OAuthRedirect.NoCode -> {
+                                        // error=… or user bailed at the provider — treat as cancel.
+                                        captured = true
+                                        oauthLog(ctx, "redirect without code -> cancel")
+                                        currentOnClose(false)
+                                        true
+                                    }
+                                    is OAuthRedirect.WithCode -> {
+                                        captured = true
+                                        oauthLog(ctx, "captured auth code, exchanging")
+                                        exchanging = true
+                                        scope.launch {
+                                            val res = PotaAuth.exchangeCode(r.code, pkce.verifier)
+                                            exchanging = false
+                                            currentOnClose(res.isSuccess)
+                                        }
+                                        true
+                                    }
                                 }
-                                exchanging = true
-                                scope.launch {
-                                    val r = PotaAuth.exchangeCode(code, pkce.verifier)
-                                    exchanging = false
-                                    currentOnClose(r.isSuccess)
-                                }
-                                return true
                             }
 
                             webViewClient = object : WebViewClient() {
@@ -139,12 +180,75 @@ fun PotaOAuthDialog(onClose: (success: Boolean) -> Unit) {
                                     view: WebView,
                                     url: String,
                                 ): Boolean = handleRedirect(url)
+
+                                override fun onPageStarted(view: WebView, url: String?, favicon: android.graphics.Bitmap?) {
+                                    oauthLog(ctx, "page start: ${redactUrl(url)}")
+                                }
+
+                                override fun onReceivedError(
+                                    view: WebView,
+                                    request: WebResourceRequest,
+                                    error: WebResourceError,
+                                ) {
+                                    if (request.isForMainFrame) {
+                                        oauthLog(ctx, "load error ${error.errorCode} '${error.description}' for ${redactUrl(request.url.toString())}")
+                                    }
+                                }
+
+                                override fun onReceivedHttpError(
+                                    view: WebView,
+                                    request: WebResourceRequest,
+                                    errorResponse: WebResourceResponse,
+                                ) {
+                                    if (request.isForMainFrame) {
+                                        oauthLog(ctx, "http ${errorResponse.statusCode} for ${redactUrl(request.url.toString())}")
+                                    }
+                                }
+                            }
+
+                            webChromeClient = object : WebChromeClient() {
+                                // Route a popup (window.open / target=_blank) back into this
+                                // WebView so Google's account chooser is actually shown.
+                                override fun onCreateWindow(
+                                    view: WebView,
+                                    isDialog: Boolean,
+                                    isUserGesture: Boolean,
+                                    resultMsg: Message,
+                                ): Boolean {
+                                    oauthLog(ctx, "popup window requested -> routing into main view")
+                                    val popup = WebView(view.context)
+                                    popup.settings.javaScriptEnabled = true
+                                    popup.settings.userAgentString = view.settings.userAgentString
+                                    popup.webViewClient = object : WebViewClient() {
+                                        override fun shouldOverrideUrlLoading(
+                                            v: WebView,
+                                            request: WebResourceRequest,
+                                        ): Boolean = adoptPopupUrl(view, ::handleRedirect, request.url.toString(), popup)
+
+                                        @Deprecated("Deprecated in Java")
+                                        override fun shouldOverrideUrlLoading(
+                                            v: WebView,
+                                            url: String,
+                                        ): Boolean = adoptPopupUrl(view, ::handleRedirect, url, popup)
+                                    }
+                                    (resultMsg.obj as WebView.WebViewTransport).webView = popup
+                                    resultMsg.sendToTarget()
+                                    return true
+                                }
+
+                                override fun onConsoleMessage(message: ConsoleMessage): Boolean {
+                                    if (message.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
+                                        oauthLog(ctx, "console error: ${message.message()}")
+                                    }
+                                    return true
+                                }
                             }
                             // removeAllCookies is async; load the authorize URL from its
                             // callback (fires on the main thread) so navigation only begins
                             // once cookies are cleared — otherwise the page could reuse a
                             // stale session, contradicting the clean-start intent.
                             val authUrl = PotaAuth.authorizeUrl(pkce)
+                            oauthLog(ctx, "starting OAuth flow")
                             CookieManager.getInstance().removeAllCookies { loadUrl(authUrl) }
                         }
                     },
@@ -165,9 +269,75 @@ fun PotaOAuthDialog(onClose: (success: Boolean) -> Unit) {
 }
 
 /**
+ * Where a navigation in the OAuth WebView lands relative to POTA's registered
+ * redirect URI. [classifyRedirect] keeps the URL parsing out of the WebView
+ * callbacks so it can be unit-tested.
+ */
+internal sealed class OAuthRedirect {
+    /** Not the redirect URI — let the WebView load it normally (Google, Cognito, …). */
+    object NotRedirect : OAuthRedirect()
+
+    /** The redirect URI but with no `code` (provider error or user cancelled). */
+    object NoCode : OAuthRedirect()
+
+    /** The redirect URI carrying the authorization `code` to exchange for tokens. */
+    data class WithCode(val code: String) : OAuthRedirect()
+}
+
+/**
+ * Classify a WebView navigation against POTA's hosted-UI [redirectPrefix]
+ * (`https://pota.app/`). Only URLs at that prefix are ours to intercept; a `code`
+ * query parameter means success, its absence means the provider redirected back
+ * with an error or the user bailed.
+ */
+internal fun classifyRedirect(url: String, redirectPrefix: String): OAuthRedirect {
+    if (!url.startsWith(redirectPrefix)) return OAuthRedirect.NotRedirect
+    val code = Uri.parse(url).getQueryParameter("code")
+    return if (code.isNullOrBlank()) OAuthRedirect.NoCode else OAuthRedirect.WithCode(code)
+}
+
+/**
+ * Handle a navigation that arrived in a popup WebView: if it's our redirect URI,
+ * finish the flow via [handleRedirect]; otherwise load it in the visible [main]
+ * WebView. Either way the throwaway [popup] is destroyed. Returns true so the
+ * popup never navigates on its own (it's offscreen and would render nothing).
+ */
+private fun adoptPopupUrl(
+    main: WebView,
+    handleRedirect: (String) -> Boolean,
+    url: String,
+    popup: WebView,
+): Boolean {
+    if (!handleRedirect(url)) main.loadUrl(url)
+    popup.destroy()
+    return true
+}
+
+/**
  * Remove the "; wv" token an Android WebView appends to its user-agent. Google's
  * OAuth consent screen rejects any UA carrying that token with
  * `disallowed_useragent`; stripping it yields a plain Chrome UA that loads, while
  * keeping the device's real (and self-updating) Chrome/WebView version.
  */
 internal fun stripWebViewToken(ua: String): String = ua.replace("; wv", "")
+
+/**
+ * Strip the query string from a URL before logging it. OAuth URLs carry the
+ * authorization `code`, PKCE challenge, and (on the token endpoint) tokens —
+ * none of which belong in debug.log.
+ */
+internal fun redactUrl(url: String?): String {
+    if (url.isNullOrEmpty()) return "?"
+    val q = url.indexOf('?')
+    return if (q >= 0) url.substring(0, q) + "?…" else url
+}
+
+private fun oauthLog(ctx: Context, msg: String) {
+    Log.d("PotaOAuth", msg)
+    try {
+        val dir = ctx.getExternalFilesDir(null) ?: return
+        val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+        FileWriter(File(dir, "debug.log"), true).use { it.append("$ts PotaOAuth: $msg\n") }
+    } catch (_: Exception) {
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaOAuthLogin.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaOAuthLogin.kt
@@ -145,7 +145,11 @@ fun PotaOAuthDialog(onClose: (success: Boolean) -> Unit) {
                             var captured = false
 
                             fun handleRedirect(url: String): Boolean {
-                                if (captured) return false
+                                // Once we've captured (or rejected) the redirect, swallow every
+                                // later navigation: the code exchange is in flight or the dialog
+                                // is closing, and letting the WebView load pota.app (or anything
+                                // else) on top of that serves no purpose.
+                                if (captured) return true
                                 return when (val r = classifyRedirect(url, PotaAuth.OAUTH_REDIRECT)) {
                                     OAuthRedirect.NotRedirect -> false
                                     OAuthRedirect.NoCode -> {
@@ -240,7 +244,10 @@ fun PotaOAuthDialog(onClose: (success: Boolean) -> Unit) {
                                     if (message.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
                                         oauthLog(ctx, "console error: ${message.message()}")
                                     }
-                                    return true
+                                    // Returning false lets WebView keep its default console
+                                    // logging for warnings/info — useful when troubleshooting a
+                                    // blank page — while we still capture errors above.
+                                    return false
                                 }
                             }
                             // removeAllCookies is async; load the authorize URL from its
@@ -289,10 +296,21 @@ internal sealed class OAuthRedirect {
  * (`https://pota.app/`). Only URLs at that prefix are ours to intercept; a `code`
  * query parameter means success, its absence means the provider redirected back
  * with an error or the user bailed.
+ *
+ * Origin is compared on parsed scheme/host/port — not a raw `startsWith` — so a
+ * lookalike host like `https://pota.app.evil.example/?code=…` can't masquerade as
+ * the redirect and trick us into exchanging an attacker-supplied code.
  */
 internal fun classifyRedirect(url: String, redirectPrefix: String): OAuthRedirect {
-    if (!url.startsWith(redirectPrefix)) return OAuthRedirect.NotRedirect
-    val code = Uri.parse(url).getQueryParameter("code")
+    val target = Uri.parse(url)
+    val expected = Uri.parse(redirectPrefix)
+    val sameOrigin = target.scheme.equals(expected.scheme, ignoreCase = true) &&
+        target.host.equals(expected.host, ignoreCase = true) &&
+        target.port == expected.port
+    val expectedPath = expected.path?.ifEmpty { "/" } ?: "/"
+    val targetPath = target.path?.ifEmpty { "/" } ?: "/"
+    if (!sameOrigin || !targetPath.startsWith(expectedPath)) return OAuthRedirect.NotRedirect
+    val code = target.getQueryParameter("code")
     return if (code.isNullOrBlank()) OAuthRedirect.NoCode else OAuthRedirect.WithCode(code)
 }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
@@ -640,18 +640,18 @@ private suspend fun uploadActivation(
     val docs = withContext(Dispatchers.IO) { PotaAdifExporter.buildActivationAdif(db, activation) }
     if (docs.isEmpty()) return Result.failure(IllegalStateException("no QSOs to upload"))
     var ok = 0
-    var lastError: Throwable? = null
+    var firstError: Throwable? = null
     for (doc in docs) {
         PotaClient.uploadAdif(token, doc.filename, doc.content)
             .onSuccess { ok++ }
-            .onFailure { lastError = it }
+            .onFailure { if (firstError == null) firstError = it }
     }
     return if (ok == docs.size) {
         Result.success(ok)
     } else {
         // Preserve the original throwable (e.g. PotaUploadException) so the caller
         // can classify it for a useful message rather than a raw HTTP dump.
-        Result.failure(lastError ?: IllegalStateException("uploaded $ok of ${docs.size}"))
+        Result.failure(firstError ?: IllegalStateException("uploaded $ok of ${docs.size}"))
     }
 }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/pota/PotaScreen.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import radio.ks3ckc.ft8us.pota.PotaAuth
 import radio.ks3ckc.ft8us.pota.PotaClient
+import radio.ks3ckc.ft8us.pota.PotaUploadException
 import radio.ks3ckc.ft8us.pota.PotaSessionManager
 import radio.ks3ckc.ft8us.pota.PotaSpotsRepository
 import radio.ks3ckc.ft8us.pota.model.PotaActivation
@@ -639,17 +640,34 @@ private suspend fun uploadActivation(
     val docs = withContext(Dispatchers.IO) { PotaAdifExporter.buildActivationAdif(db, activation) }
     if (docs.isEmpty()) return Result.failure(IllegalStateException("no QSOs to upload"))
     var ok = 0
-    var lastErr: String? = null
+    var lastError: Throwable? = null
     for (doc in docs) {
         PotaClient.uploadAdif(token, doc.filename, doc.content)
             .onSuccess { ok++ }
-            .onFailure { lastErr = it.message }
+            .onFailure { lastError = it }
     }
     return if (ok == docs.size) {
         Result.success(ok)
     } else {
-        Result.failure(IllegalStateException(lastErr ?: "uploaded $ok of ${docs.size}"))
+        // Preserve the original throwable (e.g. PotaUploadException) so the caller
+        // can classify it for a useful message rather than a raw HTTP dump.
+        Result.failure(lastError ?: IllegalStateException("uploaded $ok of ${docs.size}"))
     }
+}
+
+/** How an upload failed, mapped to a user-facing message in [startUpload]. */
+internal enum class UploadFailureKind { SERVER, NETWORK, OTHER }
+
+/**
+ * Classify an upload failure so the UI can explain it. A 5xx is POTA's backend
+ * rejecting the log (almost always a bad park ref or a callsign not registered to
+ * the account); an [java.io.IOException] is a connectivity problem; anything else
+ * falls back to the raw message.
+ */
+internal fun classifyUploadFailure(error: Throwable?): UploadFailureKind = when {
+    error is PotaUploadException && error.httpCode in 500..599 -> UploadFailureKind.SERVER
+    error is java.io.IOException -> UploadFailureKind.NETWORK
+    else -> UploadFailureKind.OTHER
 }
 
 @Composable
@@ -853,7 +871,12 @@ private fun ActivationDetailScreen(
                 if (e is NotSignedInException) {
                     loginPending = true
                 } else {
-                    Toast.makeText(context, context.getString(R.string.pota_upload_failed, e.message ?: "?"), Toast.LENGTH_LONG).show()
+                    val msg = when (classifyUploadFailure(e)) {
+                        UploadFailureKind.SERVER -> context.getString(R.string.pota_upload_server_error)
+                        UploadFailureKind.NETWORK -> context.getString(R.string.pota_upload_network_error)
+                        UploadFailureKind.OTHER -> context.getString(R.string.pota_upload_failed, e.message ?: "?")
+                    }
+                    Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
                 }
             }
         }

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -281,6 +281,8 @@
     <string name="pota_upload_to_pota">Upload to POTA</string>
     <string name="pota_upload_success">Uploaded %1$d park log(s) to POTA</string>
     <string name="pota_upload_failed">Upload failed: %1$s</string>
+    <string name="pota_upload_server_error">POTA couldn\'t process the upload. Check that the park reference is valid and your callsign is registered with POTA, then try again.</string>
+    <string name="pota_upload_network_error">Couldn\'t reach POTA. Check your internet connection and try again.</string>
     <string name="pota_login_title">Sign in to POTA</string>
     <string name="pota_login_desc">Use your pota.app account email and password.</string>
     <string name="pota_login_email">Email</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/ClassifyUploadFailureTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/ClassifyUploadFailureTest.kt
@@ -1,0 +1,51 @@
+package radio.ks3ckc.ft8us.ui.pota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import radio.ks3ckc.ft8us.pota.PotaUploadException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+/**
+ * Coverage for [classifyUploadFailure], which turns an upload failure into the
+ * category [startUpload] uses to pick a user-facing message. Pure JVM logic — no
+ * Android types, so no Robolectric runner.
+ */
+class ClassifyUploadFailureTest {
+
+    @Test
+    fun `5xx from POTA is a server rejection`() {
+        assertThat(classifyUploadFailure(PotaUploadException(502, "Internal server error")))
+            .isEqualTo(UploadFailureKind.SERVER)
+        assertThat(classifyUploadFailure(PotaUploadException(500, "")))
+            .isEqualTo(UploadFailureKind.SERVER)
+        assertThat(classifyUploadFailure(PotaUploadException(599, "")))
+            .isEqualTo(UploadFailureKind.SERVER)
+    }
+
+    @Test
+    fun `4xx is not treated as a server error`() {
+        assertThat(classifyUploadFailure(PotaUploadException(400, "bad request")))
+            .isEqualTo(UploadFailureKind.OTHER)
+        assertThat(classifyUploadFailure(PotaUploadException(403, "forbidden")))
+            .isEqualTo(UploadFailureKind.OTHER)
+    }
+
+    @Test
+    fun `connectivity exceptions are network failures`() {
+        assertThat(classifyUploadFailure(UnknownHostException("api.pota.app")))
+            .isEqualTo(UploadFailureKind.NETWORK)
+        assertThat(classifyUploadFailure(SocketTimeoutException("timeout")))
+            .isEqualTo(UploadFailureKind.NETWORK)
+        assertThat(classifyUploadFailure(IOException("broken pipe")))
+            .isEqualTo(UploadFailureKind.NETWORK)
+    }
+
+    @Test
+    fun `null and unrecognized errors fall back to OTHER`() {
+        assertThat(classifyUploadFailure(null)).isEqualTo(UploadFailureKind.OTHER)
+        assertThat(classifyUploadFailure(IllegalStateException("no database")))
+            .isEqualTo(UploadFailureKind.OTHER)
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/OAuthRedirectTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/OAuthRedirectTest.kt
@@ -47,6 +47,26 @@ class OAuthRedirectTest {
     }
 
     @Test
+    fun `a lookalike host carrying a code is not the redirect`() {
+        // Raw startsWith would have matched this on the "https://pota.app" prefix
+        // and tried to exchange the attacker-supplied code; parsed-host compare rejects it.
+        assertThat(classifyRedirect("https://pota.app.evil.example/?code=abc123", redirect))
+            .isEqualTo(OAuthRedirect.NotRedirect)
+    }
+
+    @Test
+    fun `a different scheme is not the redirect`() {
+        assertThat(classifyRedirect("http://pota.app/?code=abc123", redirect))
+            .isEqualTo(OAuthRedirect.NotRedirect)
+    }
+
+    @Test
+    fun `host comparison ignores case`() {
+        assertThat(classifyRedirect("https://POTA.app/?code=abc123", redirect))
+            .isEqualTo(OAuthRedirect.WithCode("abc123"))
+    }
+
+    @Test
     fun `redactUrl drops the query string`() {
         assertThat(redactUrl("https://pota.app/?code=secret&state=xyz")).isEqualTo("https://pota.app/?…")
     }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/OAuthRedirectTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/pota/OAuthRedirectTest.kt
@@ -1,0 +1,64 @@
+package radio.ks3ckc.ft8us.ui.pota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Coverage for the OAuth WebView's navigation classification and URL redaction —
+ * the bug-prone, non-Composable logic lifted out of [PotaOAuthDialog] so it can be
+ * tested without a WebView. [classifyRedirect] uses android.net.Uri, so the suite
+ * runs under Robolectric.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OAuthRedirectTest {
+
+    private val redirect = "https://pota.app/"
+
+    @Test
+    fun `redirect carrying a code yields WithCode`() {
+        val r = classifyRedirect("https://pota.app/?code=abc123&state=x", redirect)
+        assertThat(r).isEqualTo(OAuthRedirect.WithCode("abc123"))
+    }
+
+    @Test
+    fun `redirect with an error and no code yields NoCode`() {
+        val r = classifyRedirect("https://pota.app/?error=access_denied", redirect)
+        assertThat(r).isEqualTo(OAuthRedirect.NoCode)
+    }
+
+    @Test
+    fun `bare redirect with no query yields NoCode`() {
+        assertThat(classifyRedirect("https://pota.app/", redirect)).isEqualTo(OAuthRedirect.NoCode)
+    }
+
+    @Test
+    fun `an empty code parameter is treated as NoCode`() {
+        assertThat(classifyRedirect("https://pota.app/?code=", redirect)).isEqualTo(OAuthRedirect.NoCode)
+    }
+
+    @Test
+    fun `provider and cognito urls are not the redirect`() {
+        assertThat(classifyRedirect("https://accounts.google.com/o/oauth2/auth?x=1", redirect))
+            .isEqualTo(OAuthRedirect.NotRedirect)
+        assertThat(classifyRedirect("https://parksontheair.auth.us-east-2.amazoncognito.com/login", redirect))
+            .isEqualTo(OAuthRedirect.NotRedirect)
+    }
+
+    @Test
+    fun `redactUrl drops the query string`() {
+        assertThat(redactUrl("https://pota.app/?code=secret&state=xyz")).isEqualTo("https://pota.app/?…")
+    }
+
+    @Test
+    fun `redactUrl leaves a query-less url intact`() {
+        assertThat(redactUrl("https://accounts.google.com/signin")).isEqualTo("https://accounts.google.com/signin")
+    }
+
+    @Test
+    fun `redactUrl tolerates null and empty`() {
+        assertThat(redactUrl(null)).isEqualTo("?")
+        assertThat(redactUrl("")).isEqualTo("?")
+    }
+}


### PR DESCRIPTION
## Problem

Tapping **Sign in with Google** in the POTA upload flow (`PotaOAuthDialog` WebView) showed a **blank white page** — nothing happened. The email/password path worked, but federated (Google) accounts had no usable way in.

## Root cause

The WebView was missing things Google sign-in needs inside a WebView:
- **Third-party cookies** were blocked (WebView default) — Google's cross-origin account chooser/consent couldn't set cookies.
- **Popup windows** (`window.open`) were silently dropped (no `onCreateWindow`), so a popup-based provider button did nothing.
- **No diagnostics** — a blank page produced zero signal to debug from.

## Changes

**Fix the WebView** (`PotaOAuthLogin.kt`)
- Enable third-party cookies (`setAcceptThirdPartyCookies`).
- Support multiple windows + route any popup's navigation into the main WebView.
- Log every navigation (query-redacted so codes/tokens never hit the log), load/HTTP errors, and JS console errors to `debug.log`.
- Extract `classifyRedirect` / `redactUrl` as pure helpers with unit tests.

**Clearer upload errors** (`PotaClient.kt`, `PotaScreen.kt`)
- `uploadAdif` now fails with a typed `PotaUploadException` carrying the HTTP status.
- A 5xx (POTA rejecting the log — usually a bad park ref or unregistered callsign) and network failures now get explanatory messages instead of a raw `HTTP 502: {"message": "Internal server error"}` dump. `classifyUploadFailure` is unit-tested.

## Tests

- `OAuthRedirectTest` (8 cases, Robolectric) — redirect classification + URL redaction.
- `ClassifyUploadFailureTest` (pure JVM) — 5xx/4xx/network/unknown mapping.
- `StripWebViewTokenTest` — unchanged, still green.

## On-device verification (Pixel 8)

Built, installed, and reproduced with a throwaway activation. `debug.log` confirms the previously-blank path now works end to end:

```
PotaOAuth: starting OAuth flow
PotaOAuth: page start: cognito .../login
PotaOAuth: page start: accounts.google.com/v3/signin/identifier   <- Google rendered (was blank)
PotaOAuth: captured auth code, exchanging
PotaAuth: oauth login ok (refresh stored)
Pota: uploadAdif ... -> http 502 {"message": "Internal server error"}   <- expected: deliberately-invalid test park
```

The 502 is POTA's backend rejecting the intentionally-bogus test park ref (request authenticated and reached the backend — no 4xx), which motivated the clearer-error change above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)