### PR TITLE
Drop junk/false decodes with garbage sender callsigns

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -27,6 +27,8 @@ import com.google.android.gms.maps.model.LatLng;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class Ft8Message {
     private static String TAG = "Ft8Message";
@@ -431,7 +433,7 @@ t71     Telemetry data, up to 18 hex digits
         if (raw == null) {
             return false;
         }
-        String s = raw.trim().toUpperCase();
+        String s = raw.trim().toUpperCase(Locale.ROOT);
         if (s.isEmpty()) {
             return false;
         }
@@ -441,8 +443,15 @@ t71     Telemetry data, up to 18 hex digits
         if (s.startsWith("<") && s.endsWith(">")) {
             s = s.substring(1, s.length() - 1);// strip the hashed / non-standard wrapper
         }
-        return s.matches("[A-Z0-9/]+");
+        return CALLSIGN_ALPHABET.matcher(s).matches();
     }
+
+    /**
+     * The {@code [A-Z0-9/]} callsign alphabet, precompiled because
+     * {@link #isPlausibleCallsign(String)} runs on the per-cycle decode hot path
+     * (via {@link #isJunkDecode()} -> {@code OwnTxEchoFilter.filter}).
+     */
+    private static final Pattern CALLSIGN_ALPHABET = Pattern.compile("[A-Z0-9/]+");
 
     /**
      * True when this is a structured decode (one that carries real callsign

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -418,6 +418,56 @@ t71     Telemetry data, up to 18 hex digits
     }
 
     /**
+     * Whether {@code raw} is a callsign an FT8 frame can legitimately carry: the
+     * {@code [A-Z0-9/]} callsign alphabet (standard or compound, e.g.
+     * {@code K1ABC} or {@code PJ4/K1ABC}), optionally wrapped in {@code <...>}
+     * for a hashed / non-standard call, plus the bare {@code <...>} placeholder
+     * shown before a hash has been resolved.
+     *
+     * @param raw the callsign field as decoded (may include the {@code <...>} wrapper)
+     * @return true if the field looks like a real callsign field
+     */
+    public static boolean isPlausibleCallsign(String raw) {
+        if (raw == null) {
+            return false;
+        }
+        String s = raw.trim().toUpperCase();
+        if (s.isEmpty()) {
+            return false;
+        }
+        if (s.equals("<...>")) {
+            return true;// unresolved hashed-call placeholder
+        }
+        if (s.startsWith("<") && s.endsWith(">")) {
+            s = s.substring(1, s.length() - 1);// strip the hashed / non-standard wrapper
+        }
+        return s.matches("[A-Z0-9/]+");
+    }
+
+    /**
+     * True when this is a structured decode (one that carries real callsign
+     * fields) whose sender callsign is not a callsign any FT8 frame can hold.
+     *
+     * <p>FT8 guards each frame with only a 14-bit CRC, so on the order of one
+     * noise event in 16k survives as a "valid" decode. Those false frames render
+     * as garbage such as {@code ".<. >"} — stray angle brackets, spaces and dots
+     * that no real callsign field produces — and would otherwise show up as a
+     * bogus station in the decode list, QSO panel and SWL log. Free text
+     * ({@code i3=0,n3=0}) and telemetry ({@code i3=0,n3=5}) legitimately put
+     * non-callsign text in these fields, so they are never treated as junk;
+     * every other type must carry a plausible sender callsign.
+     *
+     * @return true if this decode should be dropped as a false/garbage frame
+     */
+    public boolean isJunkDecode() {
+        boolean freeFormText = i3 == 0 && (n3 == 0 || n3 == 5);
+        if (freeFormText) {
+            return false;
+        }
+        return !isPlausibleCallsign(callsignFrom);
+    }
+
+    /**
      * Get the receiving callsign from the QSO information.
      *
      * @return

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
@@ -4,8 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Splits a freshly decoded FT8 cycle into the messages worth keeping and the
- * own-TX loopback echoes that must be dropped.
+ * Cleans up a freshly decoded FT8 cycle: it splits the messages worth keeping
+ * from the two kinds that must not reach the UI — own-TX loopback echoes and
+ * junk/false decodes.
  *
  * <p>When the transceiver monitors its TX audio back into the app's line-in,
  * the decoder hears and decodes our <em>own</em> transmission. A decode whose
@@ -15,22 +16,31 @@ import java.util.List;
  * The QSO panel already shows what we transmit via its synthesized key-up entry,
  * and PSKReporter / the auto-sequence already ignore own-callsign messages.
  *
- * <p>The result also carries two diagnostic counters used to investigate the
- * separate "missing other station responses" report: how many echoes were
- * dropped and whether any message addressed to us survived this cycle.
+ * <p>FT8's 14-bit CRC also lets roughly one noise event in 16k pass as a "valid"
+ * decode; those false frames render as garbage callsigns like {@code ".<. >"}
+ * (see {@link Ft8Message#isJunkDecode()}) and are dropped here too so a bogus
+ * station never appears in the list.
+ *
+ * <p>The result also carries diagnostic counters used to investigate the
+ * separate "missing other station responses" report: how many echoes and how
+ * much junk were dropped, and whether any message addressed to us survived this
+ * cycle.
  */
 public final class OwnTxEchoFilter {
-    /** Messages to keep — own-TX loopback echoes removed. */
+    /** Messages to keep — own-TX loopback echoes and junk decodes removed. */
     public final ArrayList<Ft8Message> kept;
     /** Number of own-callsign loopback echoes that were dropped. */
     public final int ownEchoCount;
+    /** Number of junk/false decodes (garbage sender callsign) that were dropped. */
+    public final int junkCount;
     /** True if a kept message was addressed to our callsign (a reply to us). */
     public final boolean replyToMePresent;
 
     private OwnTxEchoFilter(ArrayList<Ft8Message> kept, int ownEchoCount,
-                            boolean replyToMePresent) {
+                            int junkCount, boolean replyToMePresent) {
         this.kept = kept;
         this.ownEchoCount = ownEchoCount;
+        this.junkCount = junkCount;
         this.replyToMePresent = replyToMePresent;
     }
 
@@ -42,13 +52,18 @@ public final class OwnTxEchoFilter {
      * Both callsign accessors return "" rather than null, so this is null-safe.
      *
      * @param decoded the raw decode list for one cycle (not modified)
-     * @return the kept messages plus echo/reply diagnostics
+     * @return the kept messages plus echo/junk/reply diagnostics
      */
     public static OwnTxEchoFilter filter(List<Ft8Message> decoded) {
         ArrayList<Ft8Message> kept = new ArrayList<>(decoded.size());
         int ownEcho = 0;
+        int junk = 0;
         boolean replyToMe = false;
         for (Ft8Message m : decoded) {
+            if (m.isJunkDecode()) {// false decode with a garbage sender callsign
+                junk++;
+                continue;
+            }
             if (GeneralVariables.checkIsMyCallsign(m.getCallsignFrom())) {
                 ownEcho++;
                 continue;
@@ -58,20 +73,21 @@ public final class OwnTxEchoFilter {
             }
             kept.add(m);
         }
-        return new OwnTxEchoFilter(kept, ownEcho, replyToMe);
+        return new OwnTxEchoFilter(kept, ownEcho, junk, replyToMe);
     }
 
     /**
      * Format the per-cycle diagnostic line written to debug.log. Recording the
-     * kept count, dropped-echo count, whether a reply addressed to us survived,
-     * and the slot lets us tell "decoded but mis-rendered" from "never decoded"
-     * when investigating the "missing other station responses" report.
+     * kept count, dropped-echo count, dropped-junk count, whether a reply
+     * addressed to us survived, and the slot lets us tell "decoded but
+     * mis-rendered" from "never decoded" when investigating the "missing other
+     * station responses" report.
      *
      * @param sequential the FT8 slot (0/1) of this decode cycle
-     * @return the log line, e.g. {@code "DECODE: kept=3 ownEcho=1 replyToMe=true slot=0"}
+     * @return the log line, e.g. {@code "DECODE: kept=3 ownEcho=1 junk=0 replyToMe=true slot=0"}
      */
     public String decodeLogLine(int sequential) {
-        return String.format("DECODE: kept=%d ownEcho=%d replyToMe=%b slot=%d",
-                kept.size(), ownEchoCount, replyToMePresent, sequential);
+        return String.format("DECODE: kept=%d ownEcho=%d junk=%d replyToMe=%b slot=%d",
+                kept.size(), ownEchoCount, junkCount, replyToMePresent, sequential);
     }
 }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
@@ -245,6 +245,61 @@ public class Ft8MessageTest {
         assertThat(msg.getCallsignTo()).isEqualTo("K1ABC");
     }
 
+    // ---- isPlausibleCallsign / isJunkDecode ---------------------------------
+
+    @Test
+    public void isPlausibleCallsign_acceptsRealCallsigns() {
+        assertThat(Ft8Message.isPlausibleCallsign("K1ABC")).isTrue();
+        assertThat(Ft8Message.isPlausibleCallsign("PJ4/K1ABC")).isTrue();  // compound
+        assertThat(Ft8Message.isPlausibleCallsign("3DA0RS")).isTrue();     // leading digit
+        assertThat(Ft8Message.isPlausibleCallsign("<W9XYZ>")).isTrue();    // hashed wrapper
+        assertThat(Ft8Message.isPlausibleCallsign("<...>")).isTrue();      // unresolved placeholder
+        assertThat(Ft8Message.isPlausibleCallsign(" K1ABC ")).isTrue();    // trimmed
+    }
+
+    @Test
+    public void isPlausibleCallsign_rejectsGarbageAndEmpty() {
+        // The reported false decode: stray brackets, dots and a space.
+        assertThat(Ft8Message.isPlausibleCallsign(".<. >")).isFalse();
+        assertThat(Ft8Message.isPlausibleCallsign("<. .>")).isFalse();
+        assertThat(Ft8Message.isPlausibleCallsign("A B")).isFalse();      // embedded space
+        assertThat(Ft8Message.isPlausibleCallsign("")).isFalse();
+        assertThat(Ft8Message.isPlausibleCallsign("   ")).isFalse();
+        assertThat(Ft8Message.isPlausibleCallsign(null)).isFalse();
+    }
+
+    @Test
+    public void isJunkDecode_structuredMessageWithGarbageSender_isJunk() {
+        Ft8Message msg = new Ft8Message("CQ", ".<. >", "FN42");
+        msg.i3 = 1; // standard message — sender must be a real callsign
+        assertThat(msg.isJunkDecode()).isTrue();
+    }
+
+    @Test
+    public void isJunkDecode_structuredMessageWithRealSender_isNotJunk() {
+        Ft8Message msg = new Ft8Message("CQ", "K1ABC", "FN42");
+        msg.i3 = 1;
+        assertThat(msg.isJunkDecode()).isFalse();
+    }
+
+    @Test
+    public void isJunkDecode_freeTextAndTelemetry_neverJunk() {
+        // i3=0,n3=0 (free text) and i3=0,n3=5 (telemetry) legitimately carry
+        // non-callsign text in the callsign fields, so they are exempt even when
+        // the sender field is not a valid callsign.
+        Ft8Message freeText = new Ft8Message(FT8Common.FT8_MODE);
+        freeText.i3 = 0;
+        freeText.n3 = 0;
+        freeText.callsignFrom = "TNX 73 GL";
+        assertThat(freeText.isJunkDecode()).isFalse();
+
+        Ft8Message telemetry = new Ft8Message(FT8Common.FT8_MODE);
+        telemetry.i3 = 0;
+        telemetry.n3 = 5;
+        telemetry.callsignFrom = "123456789ABCDEF012";
+        assertThat(telemetry.isJunkDecode()).isFalse();
+    }
+
     // ---- simple formatters: getDt / getdB / getFreq_hz ----------------------
 
     @Test

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
@@ -176,7 +176,7 @@ public class OwnTxEchoFilterTest {
         OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
 
         assertThat(result.decodeLogLine(1))
-                .isEqualTo("DECODE: kept=2 ownEcho=1 replyToMe=true slot=1");
+                .isEqualTo("DECODE: kept=2 ownEcho=1 junk=0 replyToMe=true slot=1");
     }
 
     @Test
@@ -187,6 +187,42 @@ public class OwnTxEchoFilterTest {
         OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
 
         assertThat(result.decodeLogLine(0))
-                .isEqualTo("DECODE: kept=1 ownEcho=0 replyToMe=false slot=0");
+                .isEqualTo("DECODE: kept=1 ownEcho=0 junk=0 replyToMe=false slot=0");
+    }
+
+    /**
+     * A junk/false decode (garbage sender callsign such as ".<. >") is dropped
+     * and counted separately from own-TX echoes.
+     */
+    @Test
+    public void filter_dropsJunkDecode() {
+        Ft8Message junk = new Ft8Message("CQ", ".<. >", "FN42");
+        junk.i3 = 1;// standard message type -> sender must be a real callsign
+
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(junk);
+        decoded.add(thirdParty("CQ", "DL1ABC"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.junkCount).isEqualTo(1);
+        assertThat(result.ownEchoCount).isEqualTo(0);
+        assertThat(result.kept).hasSize(1);
+        assertThat(result.kept.get(0).getCallsignFrom()).isEqualTo("DL1ABC");
+    }
+
+    @Test
+    public void decodeLogLine_reportsJunkCount() {
+        Ft8Message junk = new Ft8Message("CQ", ".<. >", "FN42");
+        junk.i3 = 1;
+
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(junk);
+        decoded.add(thirdParty("CQ", "DL1ABC"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.decodeLogLine(0))
+                .isEqualTo("DECODE: kept=1 ownEcho=0 junk=1 replyToMe=false slot=0");
     }
 }


### PR DESCRIPTION
## Problem

A user hit a decode rendered as `.<. >` shown as if it were a station — the false-decode edge case we flagged earlier.

FT8 guards each 77-bit frame with only a **14-bit CRC**, so ~1 noise event in 16k slips through as a "valid" decode. When that garbage lands in a frame type that carries a callsign, the corrupt sender field renders as junk like `.<. >` — stray angle brackets (from the hashed-call `<...>` wrapper), a space, and dots no real callsign can contain. It then appeared in the decode list, QSO panel, and SWL log. The prior handling only matched the *exact* `<...>` placeholder, so these near-misses slipped through.

## Fix

- **`Ft8Message.isPlausibleCallsign(String)`** — a callsign field is real only if it's the `[A-Z0-9/]` alphabet (optionally `<...>`-wrapped for a hashed/non-standard call), or the bare `<...>` placeholder shown before a hash resolves.
- **`Ft8Message.isJunkDecode()`** — true when a *structured* decode's sender callsign isn't plausible. Free text (`i3=0,n3=0`) and telemetry (`i3=0,n3=5`) legitimately carry non-callsign text, so they're exempt.
- **`OwnTxEchoFilter`** — the existing per-cycle decode-cleanup pass now drops junk alongside own-TX echoes, adding a `junk=` counter to the `debug.log` `DECODE:` line.

## Tests

- `Ft8MessageTest`: plausibility (real calls, compound, `<W9XYZ>`, `<...>`) + rejection (`.<. >`, embedded space, empty/null) + `isJunkDecode` (structured junk dropped, real sender kept, free-text/telemetry exempt).
- `OwnTxEchoFilterTest`: junk dropped & counted separately from echoes; updated the existing `DECODE:` log-line assertions for the new `junk=` field.

`gradlew testDebugUnitTest --tests Ft8MessageTest --tests OwnTxEchoFilterTest` passes on the `dev` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)