### PR TITLE
Add in-app bug reporting from Settings -> About

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/AboutSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/AboutSettings.kt
@@ -47,6 +47,7 @@ fun AboutSettings(
     var debugEnabled by remember { mutableStateOf(GeneralVariables.debugModeEnabled) }
     var showAbout by remember { mutableStateOf(false) }
     var showDebugScreen by remember { mutableStateOf(false) }
+    var showBugReport by remember { mutableStateOf(false) }
 
     // -- About / FAQ Dialog --
     if (showAbout) {
@@ -74,6 +75,11 @@ fun AboutSettings(
         DebugLogScreen(onDismiss = { showDebugScreen = false })
     }
 
+    // -- Report a bug --
+    if (showBugReport) {
+        BugReportDialog(onDismiss = { showBugReport = false })
+    }
+
     SettingsDetailScaffold(
         title = stringResource(R.string.settings_cat_about),
         onBack = onBack,
@@ -97,6 +103,12 @@ fun AboutSettings(
                         label = stringResource(R.string.settings_faq_support),
                         showChevron = true,
                         onClick = { showAbout = true },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_report_bug),
+                        showChevron = true,
+                        onClick = { showBugReport = true },
                     )
                     if (debugEnabled) {
                         SectionDivider()

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportDialog.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportDialog.kt
@@ -1,0 +1,161 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.core.content.FileProvider
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.bg7yoz.ft8cn.R
+import radio.ks3ckc.ft8us.theme.Accent
+import radio.ks3ckc.ft8us.theme.BgSurface2
+import radio.ks3ckc.ft8us.theme.BorderStrong
+import radio.ks3ckc.ft8us.theme.TextFaint
+import radio.ks3ckc.ft8us.theme.TextMuted
+import radio.ks3ckc.ft8us.theme.TextPrimary
+import java.io.File
+
+/**
+ * "Report a Bug" dialog surfaced from Settings -> About. The user types a short
+ * description, then either emails it (with app/device context + the debug.log
+ * attached) or opens a prefilled GitHub issue. All text formatting lives in the
+ * testable [BugReportLogic] helpers; this Composable just collects input and fires
+ * the intents.
+ */
+@Composable
+fun BugReportDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    var description by remember { mutableStateOf("") }
+
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = TextPrimary,
+        unfocusedTextColor = TextPrimary,
+        cursorColor = Accent,
+        focusedBorderColor = Accent,
+        unfocusedBorderColor = BorderStrong,
+        focusedLabelColor = Accent,
+        unfocusedLabelColor = TextMuted,
+    )
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_report_bug),
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+            )
+
+            OutlinedTextField(
+                value = description,
+                onValueChange = { description = it },
+                placeholder = {
+                    Text(stringResource(R.string.bug_report_description_hint), color = TextFaint)
+                },
+                singleLine = false,
+                minLines = 3,
+                colors = fieldColors,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.action_cancel), color = TextMuted)
+                }
+                TextButton(onClick = {
+                    uriHandler.openUri(buildGithubIssueUrl(description, gatherInfo()))
+                    onDismiss()
+                }) {
+                    Text(stringResource(R.string.bug_report_open_github), color = Accent)
+                }
+                TextButton(onClick = {
+                    sendBugReportEmail(context, description)
+                    onDismiss()
+                }) {
+                    Text(
+                        stringResource(R.string.bug_report_send_email),
+                        color = Accent,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Snapshot the current app/device/operator context into a [BugReportInfo]. */
+private fun gatherInfo(): BugReportInfo = BugReportInfo(
+    appVersion = GeneralVariables.VERSION,
+    versionCode = GeneralVariables.VERSION_CODE,
+    buildDate = GeneralVariables.BUILD_DATE,
+    manufacturer = Build.MANUFACTURER ?: "",
+    deviceModel = Build.MODEL ?: "",
+    androidRelease = Build.VERSION.RELEASE ?: "",
+    sdkInt = Build.VERSION.SDK_INT,
+    callsign = GeneralVariables.myCallsign,
+)
+
+/**
+ * Fire an email intent prefilled with the report body, addressed to the maintainer,
+ * attaching debug.log when it exists. Mirrors the FileProvider/flags handling in
+ * [DebugLogScreen.shareDebugLog].
+ */
+private fun sendBugReportEmail(context: Context, description: String) {
+    val info = gatherInfo()
+    val logFile = context.getExternalFilesDir(null)?.let { File(it, "debug.log") }
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_EMAIL, arrayOf(context.getString(R.string.bug_report_email)))
+        putExtra(Intent.EXTRA_SUBJECT, buildBugReportTitle(info))
+        putExtra(Intent.EXTRA_TEXT, buildBugReportBody(description, info))
+        if (logFile != null && logFile.exists()) {
+            val uri = FileProvider.getUriForFile(
+                context, "radio.ks3ckc.ft8af.fileprovider", logFile,
+            )
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+    context.startActivity(
+        Intent.createChooser(intent, context.getString(R.string.settings_report_bug)).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        },
+    )
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportDialog.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportDialog.kt
@@ -2,6 +2,7 @@ package radio.ks3ckc.ft8us.ui.settings
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -136,12 +137,21 @@ private fun gatherInfo(): BugReportInfo = BugReportInfo(
  * Fire an email intent prefilled with the report body, addressed to the maintainer,
  * attaching debug.log when it exists. Mirrors the FileProvider/flags handling in
  * [DebugLogScreen.shareDebugLog].
+ *
+ * Uses an ACTION_SEND intent (so the debug.log attachment rides along via
+ * EXTRA_STREAM) narrowed with a `mailto:` selector. The selector restricts the
+ * candidate apps to email handlers, so the report — which carries the operator's
+ * callsign and device info — can't be sent to an arbitrary share target like a
+ * messaging or social app.
  */
 private fun sendBugReportEmail(context: Context, description: String) {
     val info = gatherInfo()
     val logFile = context.getExternalFilesDir(null)?.let { File(it, "debug.log") }
     val intent = Intent(Intent.ACTION_SEND).apply {
         type = "text/plain"
+        // Narrow the chooser to email apps only; a bare ACTION_SEND would let any
+        // share target (messaging, social, etc.) receive the callsign/device block.
+        selector = Intent(Intent.ACTION_SENDTO).apply { data = Uri.parse("mailto:") }
         putExtra(Intent.EXTRA_EMAIL, arrayOf(context.getString(R.string.bug_report_email)))
         putExtra(Intent.EXTRA_SUBJECT, buildBugReportTitle(info))
         putExtra(Intent.EXTRA_TEXT, buildBugReportBody(description, info))
@@ -152,10 +162,7 @@ private fun sendBugReportEmail(context: Context, description: String) {
             putExtra(Intent.EXTRA_STREAM, uri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
-    context.startActivity(
-        Intent.createChooser(intent, context.getString(R.string.settings_report_bug)).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        },
-    )
+    context.startActivity(intent)
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportLogic.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportLogic.kt
@@ -1,0 +1,63 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import java.net.URLEncoder
+
+/**
+ * Pure, testable logic for the in-app bug reporter. The Composable
+ * ([BugReportDialog]) gathers the runtime values into [BugReportInfo] and fires
+ * the email / GitHub intents; everything that formats text lives here so it can be
+ * unit-tested without Android or Compose.
+ */
+
+/** GitHub `owner/repo` for issue submission — matches the link in [AboutSettings]. */
+internal const val BUG_REPORT_REPO = "patrickrb/FT8AF"
+
+/** App + device context auto-attached to every report. Plain data, no Android types. */
+internal data class BugReportInfo(
+    val appVersion: String,
+    val versionCode: Int,
+    val buildDate: String,
+    val manufacturer: String,
+    val deviceModel: String,
+    val androidRelease: String,
+    val sdkInt: Int,
+    val callsign: String,
+)
+
+/**
+ * Developer-facing report body: the user's description followed by an app/device
+ * block. Intentionally English (diagnostic text for the maintainer, not localized).
+ */
+internal fun buildBugReportBody(description: String, info: BugReportInfo): String {
+    val callsign = info.callsign.ifBlank { "(not set)" }
+    return buildString {
+        append("Describe the problem:\n")
+        append(description.ifBlank { "(no description provided)" })
+        append("\n\n")
+        append("--- App / device info ---\n")
+        append("App version: ${info.appVersion} (build ${info.versionCode})\n")
+        append("Build date: ${info.buildDate}\n")
+        append("Device: ${info.manufacturer} ${info.deviceModel}\n")
+        append("Android: ${info.androidRelease} (API ${info.sdkInt})\n")
+        append("Callsign: $callsign\n")
+    }
+}
+
+/** Short issue/email title, e.g. `Bug report (v1.0.2)`. */
+internal fun buildBugReportTitle(info: BugReportInfo): String =
+    "Bug report (v${info.appVersion})"
+
+/**
+ * Prefilled GitHub "new issue" URL. GitHub issues can't carry a file attachment, so
+ * the body includes the inline device block plus a note to attach `debug.log` from
+ * Settings -> About -> Debug if the maintainer asks.
+ */
+internal fun buildGithubIssueUrl(description: String, info: BugReportInfo): String {
+    val title = buildBugReportTitle(info)
+    val body = buildBugReportBody(description, info) +
+        "\n(If asked, attach debug.log from Settings -> About -> Debug.)"
+    return "https://github.com/$BUG_REPORT_REPO/issues/new" +
+        "?title=${enc(title)}&body=${enc(body)}"
+}
+
+private fun enc(s: String): String = URLEncoder.encode(s, "UTF-8")

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -404,6 +404,10 @@
 
     <!-- ===== Settings: about ===== -->
     <string name="settings_faq_support">FAQ y soporte</string>
+    <string name="settings_report_bug">Informar de un error</string>
+    <string name="bug_report_description_hint">Describe qué salió mal…</string>
+    <string name="bug_report_send_email">Enviar correo</string>
+    <string name="bug_report_open_github">Abrir incidencia en GitHub</string>
     <string name="settings_debug">Depuración</string>
     <string name="settings_debug_desc">Ver / compartir debug.log</string>
     <string name="settings_about_body">Versión %1$s (compilación %2$s)\nFecha de compilación %3$s\n\nFT8, fácil.\n\nUna app de transceptor FT8 independiente para Android. Control de RIG por USB, Bluetooth y red con secuenciado y registro automáticos.</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -404,6 +404,10 @@
 
     <!-- ===== Settings: about ===== -->
     <string name="settings_faq_support">FAQ &amp; assistance</string>
+    <string name="settings_report_bug">Signaler un bug</string>
+    <string name="bug_report_description_hint">Décrivez le problème…</string>
+    <string name="bug_report_send_email">Envoyer un e-mail</string>
+    <string name="bug_report_open_github">Ouvrir un ticket GitHub</string>
     <string name="settings_debug">Débogage</string>
     <string name="settings_debug_desc">Afficher / partager debug.log</string>
     <string name="settings_about_body">Version %1$s (build %2$s)\nDate de build %3$s\n\nFT8, en toute simplicité.\n\nUne application de transceiver FT8 autonome pour Android. Contrôle de rig par USB, Bluetooth et réseau avec séquençage et journalisation automatiques.</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -404,6 +404,10 @@
 
     <!-- ===== Settings: about ===== -->
     <string name="settings_faq_support">FAQ &amp; サポート</string>
+    <string name="settings_report_bug">バグを報告</string>
+    <string name="bug_report_description_hint">問題の内容を説明してください…</string>
+    <string name="bug_report_send_email">メールを送信</string>
+    <string name="bug_report_open_github">GitHub Issue を開く</string>
     <string name="settings_debug">デバッグ</string>
     <string name="settings_debug_desc">debug.log を表示 / 共有</string>
     <string name="settings_about_body">バージョン %1$s (ビルド %2$s)\nビルド日 %3$s\n\nFT8 を、もっと手軽に。\n\nAndroid 向けのスタンドアロン FT8 トランシーバーアプリ。USB、Bluetooth、ネットワークでの無線機制御に対応し、自動シーケンスとログ記録を備えています。</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -404,6 +404,10 @@
 
     <!-- ===== Settings: about ===== -->
     <string name="settings_faq_support">FAQ и поддержка</string>
+    <string name="settings_report_bug">Сообщить об ошибке</string>
+    <string name="bug_report_description_hint">Опишите, что пошло не так…</string>
+    <string name="bug_report_send_email">Отправить письмо</string>
+    <string name="bug_report_open_github">Открыть issue на GitHub</string>
     <string name="settings_debug">Отладка</string>
     <string name="settings_debug_desc">Просмотр / отправка debug.log</string>
     <string name="settings_about_body">Версия %1$s (сборка %2$s)\nДата сборки %3$s\n\nFT8 — это просто.\n\nАвтономное приложение FT8-трансивера для Android. Управление трансивером по USB, Bluetooth и сети с автопоследовательностью и журналированием.</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -404,6 +404,10 @@
 
     <!-- ===== 设置：关于 ===== -->
     <string name="settings_faq_support">FAQ 与支持</string>
+    <string name="settings_report_bug">报告问题</string>
+    <string name="bug_report_description_hint">描述出现的问题…</string>
+    <string name="bug_report_send_email">发送邮件</string>
+    <string name="bug_report_open_github">打开 GitHub issue</string>
     <string name="settings_debug">调试</string>
     <string name="settings_debug_desc">查看 / 分享 debug.log</string>
     <string name="settings_about_body">版本 %1$s（构建 %2$s）\n构建日期 %3$s\n\nFT8，轻松上手。\n\n一款用于 Android 的独立 FT8 收发应用。支持 USB、Bluetooth 及网络电台控制，具备自动流程与日志记录功能。</string>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -404,6 +404,10 @@
 
     <!-- ===== Settings: about ===== -->
     <string name="settings_faq_support">常見問題與支援</string>
+    <string name="settings_report_bug">回報問題</string>
+    <string name="bug_report_description_hint">描述發生的問題…</string>
+    <string name="bug_report_send_email">傳送郵件</string>
+    <string name="bug_report_open_github">開啟 GitHub issue</string>
     <string name="settings_debug">除錯</string>
     <string name="settings_debug_desc">檢視／分享 debug.log</string>
     <string name="settings_about_body">版本 %1$s（build %2$s）\n建置日期 %3$s\n\nFT8，輕鬆上手。\n\n一款適用於 Android 的獨立 FT8 收發器應用程式。支援 USB、Bluetooth 與網路電台控制，並具備自動序列與日誌功能。</string>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -433,6 +433,11 @@
 
     <!-- ===== Settings: about ===== -->
     <string name="settings_faq_support">FAQ &amp; Support</string>
+    <string name="settings_report_bug">Report a Bug</string>
+    <string name="bug_report_description_hint">Describe what went wrong…</string>
+    <string name="bug_report_send_email">Send email</string>
+    <string name="bug_report_open_github">Open GitHub issue</string>
+    <string name="bug_report_email" translatable="false">k1af@FT8AF.app</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_desc">View / share debug.log</string>
     <string name="settings_about_body">Version %1$s (build %2$s)\nBuild date %3$s\n\nFT8, made easy.\n\nA standalone FT8 transceiver app for Android. USB, Bluetooth, and network rig control with automatic sequencing and logging.</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/BugReportLogicTest.kt
@@ -1,0 +1,68 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.net.URLDecoder
+
+/**
+ * Pure-logic tests for the in-app bug reporter. No Android types are touched, so
+ * these run without Robolectric.
+ */
+class BugReportLogicTest {
+
+    private fun info(callsign: String = "K1AF") = BugReportInfo(
+        appVersion = "1.0.2",
+        versionCode = 104,
+        buildDate = "2026-06-11",
+        manufacturer = "Google",
+        deviceModel = "Pixel 8",
+        androidRelease = "15",
+        sdkInt = 35,
+        callsign = callsign,
+    )
+
+    @Test
+    fun `body includes the description and every context field`() {
+        val body = buildBugReportBody("Decode freezes on 20m", info())
+        assertThat(body).contains("Decode freezes on 20m")
+        assertThat(body).contains("1.0.2")
+        assertThat(body).contains("104")
+        assertThat(body).contains("2026-06-11")
+        assertThat(body).contains("Google Pixel 8")
+        assertThat(body).contains("15")
+        assertThat(body).contains("API 35")
+        assertThat(body).contains("K1AF")
+    }
+
+    @Test
+    fun `body shows placeholders when description and callsign are blank`() {
+        val body = buildBugReportBody("   ", info(callsign = ""))
+        assertThat(body).contains("(no description provided)")
+        assertThat(body).contains("(not set)")
+    }
+
+    @Test
+    fun `title carries the version`() {
+        assertThat(buildBugReportTitle(info())).isEqualTo("Bug report (v1.0.2)")
+    }
+
+    @Test
+    fun `github url targets the FT8AF new-issue endpoint`() {
+        val url = buildGithubIssueUrl("hello world", info())
+        assertThat(url).startsWith("https://github.com/patrickrb/FT8AF/issues/new")
+        assertThat(url).contains("title=")
+        assertThat(url).contains("body=")
+    }
+
+    @Test
+    fun `github url percent-encodes the body so it carries no raw spaces`() {
+        val url = buildGithubIssueUrl("two words\nnext line", info())
+        val query = url.substringAfter("?")
+        assertThat(query).doesNotContain(" ")
+
+        val bodyParam = query.substringAfter("body=")
+        val decoded = URLDecoder.decode(bodyParam, "UTF-8")
+        assertThat(decoded).contains("two words")
+        assertThat(decoded).contains("next line")
+    }
+}


### PR DESCRIPTION
## What

Adds an in-app **Report a Bug** entry under **Settings → About** (between FAQ & Support and the hidden Debug entry). Users previously had no way to report a bug from inside the app.

Tapping it opens a dialog with a description field and two submit options:

- **Send email** — opens the user's mail app addressed to `k1af@FT8AF.app`, subject `Bug report (v<version>)`, body prefilled with their description plus an app/device/callsign block, and `debug.log` attached via the existing `radio.ks3ckc.ft8af.fileprovider` (same pattern as `DebugLogScreen.shareDebugLog`).
- **Open GitHub issue** — opens `github.com/patrickrb/FT8AF/issues/new` with title + body prefilled. GitHub can't take a file attachment, so the body notes how to attach `debug.log` manually.

## How

Per the project's testability rule, all text formatting lives in a pure `internal` file with unit tests; the Composable is a thin wrapper.

- **`BugReportLogic.kt`** (new) — `BugReportInfo` data class + `buildBugReportBody` / `buildBugReportTitle` / `buildGithubIssueUrl`. No Android/Compose types, so tested with plain JUnit (no Robolectric).
- **`BugReportDialog.kt`** (new) — gathers `BuildConfig`/`android.os.Build`/`GeneralVariables` values and fires the email / GitHub intents.
- **`AboutSettings.kt`** — adds the row + dialog wiring.
- **`BugReportLogicTest.kt`** (new) — 5 tests: body field coverage, blank-input placeholders, title, GitHub endpoint, and percent-encoding round-trip.
- **strings** — `settings_report_bug`, `bug_report_description_hint`, `bug_report_send_email`, `bug_report_open_github` translated across all 6 locales; `bug_report_email` is `translatable="false"` (base only) so the recipient is easy to change.

No manifest/FileProvider/Gradle changes needed — the existing FileProvider authority and `filepaths.xml` already cover `debug.log`.

## Testing

- `testDebugUnitTest --tests …BugReportLogicTest` → green.
- `installDebug` → `Installed on 1 device.` (Pixel 8).
- Manual: open Settings → About → Report a Bug, type a description, confirm **Send email** opens the composer addressed to `k1af@FT8AF.app` with `debug.log` attached, and **Open GitHub issue** opens the prefilled new-issue page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
