### PR TITLE
Drop junk/false decodes with garbage sender callsigns (#200)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -478,6 +478,59 @@ t71     Telemetry data, up to 18 hex digits
     }
 
     /**
+     * Decide whether a callsign field could be a real callsign.
+     *
+     * <p>A real callsign field uses only the {@code [A-Z0-9/]} alphabet,
+     * optionally wrapped in {@code <...>} (a hashed / non-standard call), or is
+     * the bare {@code <...>} placeholder shown before a hash resolves. Anything
+     * else — stray angle brackets, embedded spaces, dots — is the junk a
+     * CRC-collision false decode renders into the sender field (e.g. {@code .<. >}).
+     *
+     * @param callsign the raw sender field (may be null, may be {@code <...>}-wrapped)
+     * @return true if it could be a real callsign or the unresolved-hash placeholder
+     */
+    public static boolean isPlausibleCallsign(String callsign) {
+        if (callsign == null) {
+            return false;
+        }
+        String s = callsign.trim();
+        if (s.isEmpty()) {
+            return false;
+        }
+        if (s.equals("<...>")) {//unresolved hashed-call placeholder
+            return true;
+        }
+        //Strip a single matching <...> wrapper around a hashed / non-standard call.
+        if (s.startsWith("<") && s.endsWith(">") && s.length() > 2) {
+            s = s.substring(1, s.length() - 1);
+        }
+        //No leftover angle brackets, spaces, or dots — just the call alphabet.
+        return s.matches("[A-Z0-9/]+");
+    }
+
+    /**
+     * Detect a junk/false decode by its sender callsign.
+     *
+     * <p>FT8 guards each 77-bit frame with only a 14-bit CRC, so roughly one
+     * noise event in 16k slips through as a "valid" decode. When that garbage
+     * lands in a callsign-bearing frame, the corrupt sender field renders as
+     * junk like {@code .<. >}. A structured decode is junk when its sender isn't
+     * a {@link #isPlausibleCallsign plausible callsign}. Free text
+     * ({@code i3=0,n3=0}) and telemetry ({@code i3=0,n3=5}) legitimately carry
+     * non-callsign text in that field, so they are never treated as junk here.
+     *
+     * @return true if this decode should be dropped as garbage
+     */
+    public boolean isJunkDecode() {
+        boolean freeText = (i3 == 0 && n3 == 0);
+        boolean telemetry = (i3 == 0 && n3 == 5);
+        if (freeText || telemetry) {
+            return false;
+        }
+        return !isPlausibleCallsign(callsignFrom);
+    }
+
+    /**
      * Get the message type (i3.n3).
      *
      * @return Message type

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/OwnTxEchoFilter.java
@@ -15,40 +15,51 @@ import java.util.List;
  * The QSO panel already shows what we transmit via its synthesized key-up entry,
  * and PSKReporter / the auto-sequence already ignore own-callsign messages.
  *
- * <p>The result also carries two diagnostic counters used to investigate the
- * separate "missing other station responses" report: how many echoes were
- * dropped and whether any message addressed to us survived this cycle.
+ * <p>The result also carries diagnostic counters used to investigate the
+ * separate "missing other station responses" report: how many echoes and junk
+ * decodes were dropped and whether any message addressed to us survived this
+ * cycle.
  */
 public final class OwnTxEchoFilter {
-    /** Messages to keep — own-TX loopback echoes removed. */
+    /** Messages to keep — own-TX loopback echoes and junk decodes removed. */
     public final ArrayList<Ft8Message> kept;
     /** Number of own-callsign loopback echoes that were dropped. */
     public final int ownEchoCount;
+    /** Number of junk/false decodes (garbage sender callsign) that were dropped. */
+    public final int junkCount;
     /** True if a kept message was addressed to our callsign (a reply to us). */
     public final boolean replyToMePresent;
 
     private OwnTxEchoFilter(ArrayList<Ft8Message> kept, int ownEchoCount,
-                            boolean replyToMePresent) {
+                            int junkCount, boolean replyToMePresent) {
         this.kept = kept;
         this.ownEchoCount = ownEchoCount;
+        this.junkCount = junkCount;
         this.replyToMePresent = replyToMePresent;
     }
 
     /**
      * Filter one cycle's decode list.
      *
-     * <p>A message is dropped when its sender ({@link Ft8Message#getCallsignFrom()})
-     * matches our own callsign per {@link GeneralVariables#checkIsMyCallsign}.
-     * Both callsign accessors return "" rather than null, so this is null-safe.
+     * <p>A message is dropped when it is a {@link Ft8Message#isJunkDecode() junk
+     * decode} (CRC-collision garbage with an implausible sender), or when its
+     * sender ({@link Ft8Message#getCallsignFrom()}) matches our own callsign per
+     * {@link GeneralVariables#checkIsMyCallsign}. Both callsign accessors return
+     * "" rather than null, so this is null-safe.
      *
      * @param decoded the raw decode list for one cycle (not modified)
-     * @return the kept messages plus echo/reply diagnostics
+     * @return the kept messages plus echo/junk/reply diagnostics
      */
     public static OwnTxEchoFilter filter(List<Ft8Message> decoded) {
         ArrayList<Ft8Message> kept = new ArrayList<>(decoded.size());
         int ownEcho = 0;
+        int junk = 0;
         boolean replyToMe = false;
         for (Ft8Message m : decoded) {
+            if (m.isJunkDecode()) {
+                junk++;
+                continue;
+            }
             if (GeneralVariables.checkIsMyCallsign(m.getCallsignFrom())) {
                 ownEcho++;
                 continue;
@@ -58,7 +69,7 @@ public final class OwnTxEchoFilter {
             }
             kept.add(m);
         }
-        return new OwnTxEchoFilter(kept, ownEcho, replyToMe);
+        return new OwnTxEchoFilter(kept, ownEcho, junk, replyToMe);
     }
 
     /**
@@ -68,10 +79,10 @@ public final class OwnTxEchoFilter {
      * when investigating the "missing other station responses" report.
      *
      * @param sequential the FT8 slot (0/1) of this decode cycle
-     * @return the log line, e.g. {@code "DECODE: kept=3 ownEcho=1 replyToMe=true slot=0"}
+     * @return the log line, e.g. {@code "DECODE: kept=3 ownEcho=1 junk=0 replyToMe=true slot=0"}
      */
     public String decodeLogLine(int sequential) {
-        return String.format("DECODE: kept=%d ownEcho=%d replyToMe=%b slot=%d",
-                kept.size(), ownEchoCount, replyToMePresent, sequential);
+        return String.format("DECODE: kept=%d ownEcho=%d junk=%d replyToMe=%b slot=%d",
+                kept.size(), ownEchoCount, junkCount, replyToMePresent, sequential);
     }
 }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
@@ -335,4 +335,70 @@ public class Ft8MessageTest {
         assertThat(tc.snr).isEqualTo(5);
         assertThat(tc.sequential).isEqualTo(0);
     }
+
+    // ---- isPlausibleCallsign / isJunkDecode (false-decode guard) ------------
+
+    @Test
+    public void isPlausibleCallsign_acceptsRealCalls() {
+        assertThat(Ft8Message.isPlausibleCallsign("K1ABC")).isTrue();
+        assertThat(Ft8Message.isPlausibleCallsign("W9XYZ")).isTrue();
+    }
+
+    @Test
+    public void isPlausibleCallsign_acceptsCompoundCall() {
+        assertThat(Ft8Message.isPlausibleCallsign("PJ4/K1ABC")).isTrue();
+    }
+
+    @Test
+    public void isPlausibleCallsign_acceptsHashedWrappedCall() {
+        assertThat(Ft8Message.isPlausibleCallsign("<W9XYZ>")).isTrue();
+    }
+
+    @Test
+    public void isPlausibleCallsign_acceptsUnresolvedHashPlaceholder() {
+        assertThat(Ft8Message.isPlausibleCallsign("<...>")).isTrue();
+    }
+
+    @Test
+    public void isPlausibleCallsign_rejectsCrcCollisionJunk() {
+        assertThat(Ft8Message.isPlausibleCallsign(".<. >")).isFalse();
+    }
+
+    @Test
+    public void isPlausibleCallsign_rejectsEmbeddedSpace() {
+        assertThat(Ft8Message.isPlausibleCallsign("K1 ABC")).isFalse();
+    }
+
+    @Test
+    public void isPlausibleCallsign_rejectsEmptyAndNull() {
+        assertThat(Ft8Message.isPlausibleCallsign("")).isFalse();
+        assertThat(Ft8Message.isPlausibleCallsign("   ")).isFalse();
+        assertThat(Ft8Message.isPlausibleCallsign(null)).isFalse();
+    }
+
+    @Test
+    public void isJunkDecode_structuredWithJunkSender_isJunk() {
+        Ft8Message msg = new Ft8Message(1, 0, "K1ABC", ".<. >", "EN37");
+        assertThat(msg.isJunkDecode()).isTrue();
+    }
+
+    @Test
+    public void isJunkDecode_structuredWithRealSender_isNotJunk() {
+        Ft8Message msg = new Ft8Message(1, 0, "K1ABC", "W9XYZ", "EN37");
+        assertThat(msg.isJunkDecode()).isFalse();
+    }
+
+    @Test
+    public void isJunkDecode_freeText_isExempt() {
+        // i3=0,n3=0 carries free text in the sender field — never junk.
+        Ft8Message msg = new Ft8Message(0, 0, "CQ", ".<. >", "TNX 73");
+        assertThat(msg.isJunkDecode()).isFalse();
+    }
+
+    @Test
+    public void isJunkDecode_telemetry_isExempt() {
+        // i3=0,n3=5 telemetry carries hex digits, not a callsign — never junk.
+        Ft8Message msg = new Ft8Message(0, 5, "CQ", "123456789ABCDEF012", "");
+        assertThat(msg.isJunkDecode()).isFalse();
+    }
 }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/OwnTxEchoFilterTest.java
@@ -176,7 +176,7 @@ public class OwnTxEchoFilterTest {
         OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
 
         assertThat(result.decodeLogLine(1))
-                .isEqualTo("DECODE: kept=2 ownEcho=1 replyToMe=true slot=1");
+                .isEqualTo("DECODE: kept=2 ownEcho=1 junk=0 replyToMe=true slot=1");
     }
 
     @Test
@@ -187,6 +187,69 @@ public class OwnTxEchoFilterTest {
         OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
 
         assertThat(result.decodeLogLine(0))
-                .isEqualTo("DECODE: kept=1 ownEcho=0 replyToMe=false slot=0");
+                .isEqualTo("DECODE: kept=1 ownEcho=0 junk=0 replyToMe=false slot=0");
+    }
+
+    /** A structured decode whose sender renders as junk (e.g. ".<. >") is dropped. */
+    private Ft8Message structuredJunk() {
+        // i3=1 standard message; sender field is CRC-collision garbage.
+        return new Ft8Message(1, 0, "K1ABC", ".<. >", "EN37");
+    }
+
+    /** A structured decode with a real sender callsign. */
+    private Ft8Message structuredReal(String fromCall) {
+        return new Ft8Message(1, 0, "K1ABC", fromCall, "EN37");
+    }
+
+    @Test
+    public void filter_dropsJunkDecode_keepsReal() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(structuredJunk());
+        decoded.add(structuredReal("W9XYZ"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.junkCount).isEqualTo(1);
+        assertThat(result.kept).hasSize(1);
+        assertThat(result.kept.get(0).getCallsignFrom()).isEqualTo("W9XYZ");
+    }
+
+    @Test
+    public void filter_junkCountedSeparatelyFromEchoes() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(structuredJunk());          // dropped as junk
+        decoded.add(ownEcho("RA3XYZ"));          // dropped as echo (free text)
+        decoded.add(structuredReal("DL1ABC"));   // kept
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.junkCount).isEqualTo(1);
+        assertThat(result.ownEchoCount).isEqualTo(1);
+        assertThat(result.kept).hasSize(1);
+    }
+
+    @Test
+    public void filter_freeTextWithNonCallsignSender_notJunk() {
+        // Free text (i3=0,n3=0) legitimately carries non-callsign text, so it is
+        // exempt from junk filtering even when the sender field isn't a callsign.
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(new Ft8Message(0, 0, "CQ", "TNX 73 GL", "FN42"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.junkCount).isEqualTo(0);
+        assertThat(result.kept).hasSize(1);
+    }
+
+    @Test
+    public void filter_junkAppearsInLogLine() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(structuredJunk());
+        decoded.add(structuredReal("DL1ABC"));
+
+        OwnTxEchoFilter result = OwnTxEchoFilter.filter(decoded);
+
+        assertThat(result.decodeLogLine(0))
+                .isEqualTo("DECODE: kept=1 ownEcho=0 junk=1 replyToMe=false slot=0");
     }
 }


### PR DESCRIPTION
﻿Closes #200.

## Problem
FT8 guards each 77-bit frame with only a 14-bit CRC, so ~1 noise event in 16k slips through as a "valid" decode. When that garbage lands in a callsign-bearing frame, the corrupt sender field renders as junk like `.<. >` and leaks into the decode list, QSO panel, and SWL log. The prior handling only matched the exact `<...>` placeholder, so these near-misses slipped through.

## Fix
- **`Ft8Message.isPlausibleCallsign(String)`** — a callsign field is real only if it is the `[A-Z0-9/]` alphabet (optionally `<...>`-wrapped for a hashed/non-standard call), or the bare `<...>` placeholder shown before a hash resolves.
- **`Ft8Message.isJunkDecode()`** — true when a structured decode's sender callsign isn't plausible. Free text (`i3=0,n3=0`) and telemetry (`i3=0,n3=5`) legitimately carry non-callsign text, so they are exempt.
- **`OwnTxEchoFilter`** — the existing per-cycle decode-cleanup pass now drops junk alongside own-TX echoes, adding a `junk=` counter to the debug.log `DECODE:` line.

## Tests
- `Ft8MessageTest`: plausibility accept (real/compound/`<W9XYZ>`/`<...>`) + reject (`.<. >`, embedded space, empty/null) + `isJunkDecode` (structured junk dropped, real sender kept, free-text/telemetry exempt).
- `OwnTxEchoFilterTest`: junk dropped & counted separately from echoes; updated existing `DECODE:` log-line assertions for the new `junk=` field.

`gradlew testDebugUnitTest --tests Ft8MessageTest --tests OwnTxEchoFilterTest` passes (BUILD SUCCESSFUL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
