### PR TITLE
Dismiss bottom sheets on Android Back instead of exiting app (#201)

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USBottomSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USBottomSheet.kt
@@ -1,5 +1,6 @@
 package radio.ks3ckc.ft8us.ui.components
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -45,6 +46,12 @@ fun FT8USBottomSheet(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
+    // Hardware / gesture back dismisses the sheet while it is shown, instead of
+    // falling through to the activity's back handler (which would try to exit
+    // the app — the bug behind the band picker not closing on Back). Disabled
+    // when hidden so Back still propagates to the app handler then.
+    BackHandler(enabled = visible) { onDismiss() }
+
     val density = LocalDensity.current
     val dismissThresholdPx = with(density) { 120.dp.toPx() }
     var dragOffset by remember { mutableFloatStateOf(0f) }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USBottomSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USBottomSheet.kt
@@ -2,6 +2,7 @@ package radio.ks3ckc.ft8us.ui.components
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -46,11 +47,21 @@ fun FT8USBottomSheet(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    // Hardware / gesture back dismisses the sheet while it is shown, instead of
-    // falling through to the activity's back handler (which would try to exit
-    // the app — the bug behind the band picker not closing on Back). Disabled
-    // when hidden so Back still propagates to the app handler then.
-    BackHandler(enabled = visible) { onDismiss() }
+    // A MutableTransitionState lets the exit animation keep the Back handler
+    // installed: currentState stays true until the sheet's slide-out completes,
+    // even after targetState (visible) has already flipped to false.
+    val sheetState = remember { MutableTransitionState(visible) }
+    sheetState.targetState = visible
+
+    // Hardware / gesture Back dismisses the sheet while it is on-screen, instead
+    // of falling through to the activity's back handler (which would try to exit
+    // the app — the bug behind the band picker not closing on Back, #201). The
+    // handler stays active through the exit animation so a second Back press
+    // during slide-out can't slip past to the app-exit path while the sheet is
+    // still visible; once fully hidden it propagates to the app handler again.
+    BackHandler(enabled = sheetBackHandlerActive(sheetState.currentState, sheetState.targetState)) {
+        onDismiss()
+    }
 
     val density = LocalDensity.current
     val dismissThresholdPx = with(density) { 120.dp.toPx() }
@@ -87,7 +98,7 @@ fun FT8USBottomSheet(
     }
 
     AnimatedVisibility(
-        visible = visible,
+        visibleState = sheetState,
         enter = slideInVertically(initialOffsetY = { it }),
         exit = slideOutVertically(targetOffsetY = { it }),
     ) {
@@ -152,3 +163,18 @@ fun FT8USBottomSheet(
         }
     }
 }
+
+/**
+ * Whether the sheet's Android-Back handler should be enabled, given the sheet's
+ * [MutableTransitionState] components.
+ *
+ * The handler must stay active not only while the sheet is shown ([targetState])
+ * but throughout its exit animation: [currentState] remains true until the
+ * slide-out completes. Gating on `currentState || targetState` therefore keeps
+ * Back captured during the exit window, so a second press can't fall through to
+ * the activity's app-exit handler while the sheet is still on-screen (the
+ * follow-up to issue #201). Only once the sheet is fully hidden — both states
+ * false — does Back propagate to the app handler again.
+ */
+internal fun sheetBackHandlerActive(currentState: Boolean, targetState: Boolean): Boolean =
+    currentState || targetState

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USBottomSheetBackTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USBottomSheetBackTest.kt
@@ -1,0 +1,80 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Compose UI test (JVM via Robolectric) for the back-press behaviour of
+ * [FT8USBottomSheet] — the fix for the band picker not closing on Android Back
+ * (issue #201).
+ *
+ * The sheet installs a [androidx.activity.compose.BackHandler] that is enabled
+ * only while the sheet is visible. We register a sentinel "app-level" back
+ * callback first (lower priority) to stand in for the activity's exit handler,
+ * then assert that:
+ *   - while visible, Back dismisses the sheet and never reaches the app handler;
+ *   - while hidden, the sheet ignores Back and it propagates to the app handler.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class FT8USBottomSheetBackTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun pressBack() = composeRule.runOnUiThread {
+        composeRule.activity.onBackPressedDispatcher.onBackPressed()
+    }
+
+    /** Stand-in for the activity's own back handler (added before the sheet, so
+     * lower priority than the sheet's BackHandler). */
+    private fun addAppHandler(onBack: () -> Unit) = composeRule.runOnUiThread {
+        composeRule.activity.onBackPressedDispatcher.addCallback(
+            composeRule.activity,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() = onBack()
+            },
+        )
+    }
+
+    @Test
+    fun backPress_whenVisible_dismissesSheet_andDoesNotReachAppHandler() {
+        var dismissed = false
+        var appHandled = false
+        addAppHandler { appHandled = true }
+        composeRule.setContent {
+            FT8USBottomSheet(visible = true, onDismiss = { dismissed = true }) {}
+        }
+        composeRule.waitForIdle()
+
+        pressBack()
+        composeRule.waitForIdle()
+
+        assertThat(dismissed).isTrue()
+        assertThat(appHandled).isFalse()
+    }
+
+    @Test
+    fun backPress_whenHidden_propagatesToAppHandler_notSheet() {
+        var dismissed = false
+        var appHandled = false
+        addAppHandler { appHandled = true }
+        composeRule.setContent {
+            FT8USBottomSheet(visible = false, onDismiss = { dismissed = true }) {}
+        }
+        composeRule.waitForIdle()
+
+        pressBack()
+        composeRule.waitForIdle()
+
+        assertThat(dismissed).isFalse()
+        assertThat(appHandled).isTrue()
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SheetBackHandlerActiveTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SheetBackHandlerActiveTest.kt
@@ -1,0 +1,39 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [sheetBackHandlerActive], the gate that keeps [FT8USBottomSheet]'s
+ * Android-Back handler installed throughout the sheet's exit animation (the
+ * follow-up to issue #201, so a Back press during slide-out can't reach the
+ * activity's app-exit path while the sheet is still on-screen).
+ */
+class SheetBackHandlerActiveTest {
+
+    @Test
+    fun active_whenFullyShown() {
+        // Settled, visible: target and current both true.
+        assertThat(sheetBackHandlerActive(currentState = true, targetState = true)).isTrue()
+    }
+
+    @Test
+    fun active_whileExiting_targetHiddenButStillOnScreen() {
+        // The exit window the fix exists for: visible flipped to false
+        // (targetState), but the slide-out hasn't finished so currentState is
+        // still true and Back must remain captured.
+        assertThat(sheetBackHandlerActive(currentState = true, targetState = false)).isTrue()
+    }
+
+    @Test
+    fun active_whileEntering() {
+        // Opening: target true, current not yet true.
+        assertThat(sheetBackHandlerActive(currentState = false, targetState = true)).isTrue()
+    }
+
+    @Test
+    fun inactive_whenFullyHidden() {
+        // Settled, hidden: Back propagates to the app handler.
+        assertThat(sheetBackHandlerActive(currentState = false, targetState = false)).isFalse()
+    }
+}


### PR DESCRIPTION
﻿Closes #201.

## Problem
Pressing Android Back while the band selection sheet is open tried to exit the app. `FT8USBottomSheet` had no back handler, so the press fell through to the activity's `OnBackPressedCallback` (which only knows about the QSO sheet) and on to the exit-confirm path.

## Fix
Add a `BackHandler` to the shared `FT8USBottomSheet`, enabled only while the sheet is `visible`, calling `onDismiss()`. This fixes the band picker (`FrequencyPickerSheet`) and the export-log sheet, and unifies the QSO sheet's Back behaviour with its existing `onDismiss` (the same minimize/clear logic the activity already mirrors). When the sheet is hidden the handler is disabled, so Back still propagates to the app-level handler as before.

## Test
`FT8USBottomSheetBackTest` (Robolectric Compose UI):
- Back while visible dismisses the sheet and does **not** reach a lower-priority app handler.
- Back while hidden propagates to the app handler and leaves the sheet's `onDismiss` untouched.

`gradlew testDebugUnitTest --tests FT8USBottomSheetBackTest` passes (BUILD SUCCESSFUL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
