### PR TITLE
Taller waterfall spectrum strip + float the QSO panel so it keeps its height (#206)

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -56,6 +56,18 @@ import radio.ks3ckc.ft8us.ui.pota.PotaScreen
 import radio.ks3ckc.ft8us.ui.settings.SettingsScreen
 import radio.ks3ckc.ft8us.ui.waterfall.WaterfallScreen
 
+/**
+ * Whether the active QSO panel should float over the screen content (true)
+ * rather than dock below it in the main column (false).
+ *
+ * The Waterfall tab overlays it: docking the panel shrinks the content area,
+ * and resizing the waterfall's AndroidView rescales it and wipes its
+ * accumulated history (see WaterfallView.onSizeChanged). Floating keeps the
+ * waterfall at a constant height. List-style screens (decode, log, settings,
+ * POTA, map) dock it, where pushing their content up is harmless.
+ */
+internal fun qsoPanelOverlaysContent(tab: FT8USTab): Boolean = tab == FT8USTab.WATERFALL
+
 @Composable
 fun FT8USApp(mainViewModel: MainViewModel) {
     val context = LocalContext.current
@@ -140,6 +152,31 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     val swrLocked by mainViewModel.meterProtectionController.swrLockout.observeAsState(false)
     val lockoutSwrRatio by mainViewModel.meterProtectionController.lockoutSwrRatio.observeAsState("")
 
+    // Reopen the full QSO sheet from the panel header: jump to the Decode tab,
+    // bind the current TX target, and clear the minimized flag.
+    val reopenQsoSheet: () -> Unit = {
+        activeTab = FT8USTab.DECODE
+        val target = mainViewModel.ft8TransmitSignal.mutableToCallsign.value?.callsign
+        if (!target.isNullOrEmpty() && target != "CQ") {
+            if (mainViewModel.qsoSheetCallsign.value != target) {
+                mainViewModel.qsoSheetCallsign.postValue(target)
+            }
+        }
+        mainViewModel.qsoSheetMinimized.postValue(false)
+    }
+
+    // Single definition of the panel, placed either docked in the column or
+    // floated over the content (see qsoPanelOverlaysContent).
+    val qsoPanel: @Composable (Modifier) -> Unit = { panelModifier ->
+        ActiveQsoPanel(
+            mainViewModel = mainViewModel,
+            expanded = qsoPanelExpanded,
+            onCollapse = { qsoPanelExpanded = false },
+            onReopenSheet = reopenQsoSheet,
+            modifier = panelModifier,
+        )
+    }
+
     Box(modifier = Modifier.fillMaxSize().background(BgApp)) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -199,27 +236,25 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     FT8USTab.LOG -> LogbookScreen(mainViewModel)
                     FT8USTab.SETTINGS -> SettingsScreen(mainViewModel)
                 }
+
+                // On the Waterfall tab the QSO panel floats over the bottom of
+                // the waterfall instead of docking below it, so the waterfall
+                // keeps its full height (docking would resize the AndroidView,
+                // rescaling and wiping it). The panel sits flush with the bottom
+                // of the content area, directly above the slot/TX/tab bars —
+                // visually the same place as when docked.
+                if (qsoPanelOverlaysContent(activeTab)) {
+                    qsoPanel(Modifier.align(Alignment.BottomCenter))
+                }
             }
 
-            // Active QSO panel — slides up above TxStrip when a QSO is in progress
-            ActiveQsoPanel(
-                mainViewModel = mainViewModel,
-                expanded = qsoPanelExpanded,
-                onCollapse = { qsoPanelExpanded = false },
-                onReopenSheet = {
-                    // Switch to the Decode tab so the bottom sheet is visible,
-                    // then expand it (clears minimized flag, ensures a callsign
-                    // is bound to the current TX target).
-                    activeTab = FT8USTab.DECODE
-                    val target = mainViewModel.ft8TransmitSignal.mutableToCallsign.value?.callsign
-                    if (!target.isNullOrEmpty() && target != "CQ") {
-                        if (mainViewModel.qsoSheetCallsign.value != target) {
-                            mainViewModel.qsoSheetCallsign.postValue(target)
-                        }
-                    }
-                    mainViewModel.qsoSheetMinimized.postValue(false)
-                },
-            )
+            // Active QSO panel (docked) — slides up above TxStrip when a QSO is
+            // in progress. On the Waterfall tab it is floated over the content
+            // above instead (see qsoPanelOverlaysContent) so it never resizes
+            // the waterfall.
+            if (!qsoPanelOverlaysContent(activeTab)) {
+                qsoPanel(Modifier)
+            }
 
             // Slot timer bar — fills 0→100% across each slot (15s FT8 / 7.5s FT4)
             SlotTimerBar(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -54,6 +54,7 @@ import radio.ks3ckc.ft8us.ui.logbook.LogbookScreen
 import radio.ks3ckc.ft8us.ui.map.MapScreen
 import radio.ks3ckc.ft8us.ui.pota.PotaScreen
 import radio.ks3ckc.ft8us.ui.settings.SettingsScreen
+import radio.ks3ckc.ft8us.ui.waterfall.WaterfallBottomStripHeight
 import radio.ks3ckc.ft8us.ui.waterfall.WaterfallScreen
 
 /**
@@ -240,11 +241,16 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                 // On the Waterfall tab the QSO panel floats over the bottom of
                 // the waterfall instead of docking below it, so the waterfall
                 // keeps its full height (docking would resize the AndroidView,
-                // rescaling and wiping it). The panel sits flush with the bottom
-                // of the content area, directly above the slot/TX/tab bars —
-                // visually the same place as when docked.
+                // rescaling and wiping it). It sits directly above the waterfall's
+                // own bottom info/toggle strip (offset by WaterfallBottomStripHeight)
+                // so those controls stay reachable during an active QSO instead of
+                // being covered — still without resizing the AndroidView.
                 if (qsoPanelOverlaysContent(activeTab)) {
-                    qsoPanel(Modifier.align(Alignment.BottomCenter))
+                    qsoPanel(
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = WaterfallBottomStripHeight),
+                    )
                 }
             }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -47,6 +47,15 @@ import radio.ks3ckc.ft8us.theme.*
 import radio.ks3ckc.ft8us.ui.components.TopBar
 
 /**
+ * Height of the columnar spectrum strip above the waterfall canvas. Taller than
+ * the original 56.dp so peaks have more vertical room to read at a glance
+ * (issue #206). The strip's [ColumnarView] is MATCH_PARENT, so it scales to
+ * whatever height this modifier gives it; the waterfall canvas below keeps the
+ * remaining space via weight(1f).
+ */
+internal val SpectrumStripHeight = 96.dp
+
+/**
  * Holder for view references using plain @Volatile fields.
  * Avoids Compose snapshot system overhead when accessed from callbacks.
  */
@@ -183,7 +192,7 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .height(SpectrumStripHeight),
         )
 
         FrequencyRuler(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -56,6 +56,15 @@ import radio.ks3ckc.ft8us.ui.components.TopBar
 internal val SpectrumStripHeight = 96.dp
 
 /**
+ * Height of the bottom info/toggle strip (clock, NR/MSG toggles, live status)
+ * at the bottom of the waterfall screen. Fixed so the floating QSO panel can
+ * offset itself by exactly this much (see FT8USApp.qsoPanelOverlaysContent) and
+ * leave the strip's controls reachable during an active QSO instead of covering
+ * them — all without resizing the waterfall AndroidView.
+ */
+internal val WaterfallBottomStripHeight = 34.dp
+
+/**
  * Holder for view references using plain @Volatile fields.
  * Avoids Compose snapshot system overhead when accessed from callbacks.
  */
@@ -224,12 +233,14 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
                 .fillMaxWidth(),
         )
 
-        // Bottom info strip
+        // Bottom info strip. Fixed height (WaterfallBottomStripHeight) so the
+        // floating QSO panel can sit just above it instead of covering it.
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .height(WaterfallBottomStripHeight)
                 .background(BgSurface)
-                .padding(horizontal = 12.dp, vertical = 6.dp),
+                .padding(horizontal = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/QsoPanelLayoutTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/QsoPanelLayoutTest.kt
@@ -1,0 +1,30 @@
+package radio.ks3ckc.ft8us
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import radio.ks3ckc.ft8us.ui.components.FT8USTab
+
+/**
+ * Unit test for [qsoPanelOverlaysContent], the rule that decides whether the
+ * active QSO panel floats over the screen content or docks below it.
+ *
+ * The Waterfall tab must overlay the panel: docking shrinks the content area,
+ * which resizes the waterfall AndroidView and wipes its accumulated history.
+ * Every other (list-style) tab docks it.
+ */
+class QsoPanelLayoutTest {
+
+    @Test
+    fun waterfallTab_floatsThePanelOverContent() {
+        assertThat(qsoPanelOverlaysContent(FT8USTab.WATERFALL)).isTrue()
+    }
+
+    @Test
+    fun allOtherTabs_dockThePanel() {
+        FT8USTab.values()
+            .filter { it != FT8USTab.WATERFALL }
+            .forEach { tab ->
+                assertThat(qsoPanelOverlaysContent(tab)).isFalse()
+            }
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreenLayoutTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreenLayoutTest.kt
@@ -10,11 +10,18 @@ import org.junit.Test
 class WaterfallScreenLayoutTest {
 
     @Test
-    fun spectrumStrip_isTallerThanOriginalAndTheRulerBelowIt() {
+    fun spectrumStrip_isTallerThanOriginal() {
         // #206: the spectrum strip was enlarged from the original 56.dp. Guard
-        // against a regression that shrinks it back below that legible height,
-        // and keep it clearly taller than the 20.dp frequency ruler beneath it.
+        // against a regression that shrinks it back below that legible height.
         assertThat(SpectrumStripHeight.value).isAtLeast(56f)
-        assertThat(SpectrumStripHeight.value).isGreaterThan(20f)
+    }
+
+    @Test
+    fun bottomStripHeight_isAPositiveOffset() {
+        // The floating QSO panel offsets itself up by this much so the waterfall's
+        // bottom info/toggle strip stays reachable during a QSO. It must be a real
+        // (positive) reservation, and a thin strip rather than a full-height panel.
+        assertThat(WaterfallBottomStripHeight.value).isGreaterThan(0f)
+        assertThat(WaterfallBottomStripHeight.value).isLessThan(SpectrumStripHeight.value)
     }
 }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreenLayoutTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreenLayoutTest.kt
@@ -1,0 +1,20 @@
+package radio.ks3ckc.ft8us.ui.waterfall
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Guards the waterfall layout geometry constants. [SpectrumStripHeight] is a
+ * pure Compose Dp value (no Android runtime needed), so this is a plain JVM test.
+ */
+class WaterfallScreenLayoutTest {
+
+    @Test
+    fun spectrumStrip_isTallerThanOriginalAndTheRulerBelowIt() {
+        // #206: the spectrum strip was enlarged from the original 56.dp. Guard
+        // against a regression that shrinks it back below that legible height,
+        // and keep it clearly taller than the 20.dp frequency ruler beneath it.
+        assertThat(SpectrumStripHeight.value).isAtLeast(56f)
+        assertThat(SpectrumStripHeight.value).isGreaterThan(20f)
+    }
+}


### PR DESCRIPTION
Closes #206.

## Scope
This PR makes two related changes to the **Waterfall** screen. They're kept
together because the second is a layout fix for a regression that the first
would otherwise expose on the same screen.

### 1. Taller spectrum strip
The columnar spectrum strip above the waterfall canvas was a fixed `56.dp`,
which felt cramped for reading signal peaks. Extracted the height into an
`internal SpectrumStripHeight` constant and bumped it to `96.dp`.

The strip's `ColumnarView` is `MATCH_PARENT` so it scales to the new height;
the waterfall canvas below keeps the remaining space via `weight(1f)`, so only
the strip grows (the canvas is unaffected).

> On #206: the issue is worded as "waterfall/decode list height," but per the
> reporter's clarification the element they actually meant was the spectrum
> strip — so `Closes #206` is intentional.

### 2. Float the QSO panel over the Waterfall tab (no rescale)
With the strip reshaped, docking the Active QSO panel below the content would
shrink the content area, which resizes the waterfall `AndroidView` and rescales
/ wipes its accumulated history (see `WaterfallView.onSizeChanged`). So on the
Waterfall tab the panel now **floats** over the bottom of the content instead of
docking — the waterfall keeps a constant height. Every other (list-style) tab
still docks it, where pushing content up is harmless. The rule is the new
`internal qsoPanelOverlaysContent(tab)`.

To keep the waterfall's own bottom info/toggle strip (clock, NR/MSG toggles,
live status) reachable during a QSO, that strip is given a fixed
`WaterfallBottomStripHeight` and the floating panel is offset up by exactly that
much (`padding(bottom = WaterfallBottomStripHeight)`), so it sits just above the
controls rather than covering them — still without resizing the AndroidView.

## Tests
- `WaterfallScreenLayoutTest` — guards `SpectrumStripHeight` against a regression
  below the legible 56.dp floor, and that `WaterfallBottomStripHeight` is a
  positive offset thinner than the strip.
- `QsoPanelLayoutTest` — `qsoPanelOverlaysContent` floats on `WATERFALL` and
  docks on every other tab.

`gradlew testDebugUnitTest --tests WaterfallScreenLayoutTest --tests QsoPanelLayoutTest` passes.

> ⚠️ Unit-verified. On-air confirmation recommended: the QSO panel should float
> over the waterfall without rescaling/wiping it, and the bottom strip controls
> should stay tappable during a QSO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
