### PR TITLE
Fix FT2 slot parity so the QSO sequencer advances to RR73 (#205)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -326,26 +326,43 @@ public class Ft8Message {
     }
 
     /**
+     * The slot (cycle) index since the epoch for this message's mode.
+     *
+     * <p>FT8 keeps its legacy 15s math and FT4 its 7.5s; FT2 uses its own 3.8s
+     * slot from {@link ModeProfile}, <em>not</em> FT4's 7.5s. Reusing FT4's
+     * period for FT2 collapsed two adjacent 3.8s slots into a single parity, so
+     * the QSO auto-sequencer ({@link com.bg7yoz.ft8cn.ft8transmit.FT8TransmitSignal})
+     * saw the other station's reply as being in our own slot and skipped it —
+     * stalling after a report instead of advancing to RR73 (issue #205). The
+     * small {@code +slot/20} nudge mirrors the legacy FT8 (+750ms) / FT4 (+370ms)
+     * early-skew correction.
+     *
+     * @return slot index (monotonic, mod into 2 or 4 for the sequence helpers)
+     */
+    private long slotIndex() {
+        if (signalFormat == FT8Common.FT8_MODE) {
+            return (utcTime + 750) / 1000 / 15;
+        } else if (signalFormat == FT8Common.FT2_MODE) {
+            int slot = ModeProfile.FT2.slotMillis; // 3800ms
+            return (utcTime + slot / 20) / slot;
+        } else {
+            return (utcTime + 370) / 100 / 75;
+        }
+    }
+
+    /**
      * Show which time sequence the current message belongs to.
      *
      * @return String Result is the modulo of the time cycle.
      */
     @SuppressLint("DefaultLocale")
     public int getSequence() {
-        if (signalFormat == FT8Common.FT8_MODE) {
-            return (int) ((((utcTime + 750) / 1000) / 15) % 2);
-        } else {
-            return (int) (((utcTime + 370) / 100) / 75) % 2;
-        }
+        return (int) (slotIndex() % 2);
     }
 
     @SuppressLint("DefaultLocale")
     public int getSequence4() {
-        if (signalFormat == FT8Common.FT8_MODE) {
-            return (int) ((((utcTime + 750) / 1000) / 15) % 4);
-        } else {
-            return (int) (((utcTime + 370) / 100) / 75) % 4;
-        }
+        return (int) (slotIndex() % 4);
     }
 
     /**

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
@@ -297,6 +297,69 @@ public class Ft8MessageTest {
         assertThat(msg.getSequence4()).isEqualTo(0);
     }
 
+    @Test
+    public void getSequence_ft4_alternatesEachSevenAndHalfSeconds() {
+        // Unchanged FT4 path: 7.5s slot.
+        Ft8Message msg = new Ft8Message(FT8Common.FT4_MODE);
+        msg.utcTime = 0;
+        assertThat(msg.getSequence()).isEqualTo(0);
+        msg.utcTime = 7500;
+        assertThat(msg.getSequence()).isEqualTo(1);
+        msg.utcTime = 15000;
+        assertThat(msg.getSequence()).isEqualTo(0);
+    }
+
+    @Test
+    public void getSequence_ft2_alternatesEachShortSlot() {
+        // FT2's 3.8s slot — must alternate twice as fast as FT4's 7.5s.
+        Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
+        msg.utcTime = 0;
+        assertThat(msg.getSequence()).isEqualTo(0);
+        msg.utcTime = 3800;
+        assertThat(msg.getSequence()).isEqualTo(1);
+        msg.utcTime = 7600;
+        assertThat(msg.getSequence()).isEqualTo(0);
+        msg.utcTime = 11400;
+        assertThat(msg.getSequence()).isEqualTo(1);
+    }
+
+    @Test
+    public void getSequence_ft2_adjacentSlotsHaveDistinctParity() {
+        // Regression for #205: the old code reused FT4's 7.5s period for FT2, so
+        // two adjacent 3.8s slots (0ms and 3800ms) both mapped to sequence 0.
+        // The QSO sequencer then saw the other station's reply as being in our
+        // own slot and skipped it, stalling on the report instead of sending RR73.
+        Ft8Message slotA = new Ft8Message(FT8Common.FT2_MODE);
+        slotA.utcTime = 0;
+        Ft8Message slotB = new Ft8Message(FT8Common.FT2_MODE);
+        slotB.utcTime = 3800;
+        assertThat(slotA.getSequence()).isNotEqualTo(slotB.getSequence());
+    }
+
+    @Test
+    public void getSequence_ft2_toleratesSlightEarlySkew() {
+        // utcTime is slot-aligned; the +slot/20 nudge keeps a timestamp a touch
+        // early (clock skew) in the correct slot rather than the previous one.
+        Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
+        msg.utcTime = 3800 - 50; // 50ms before slot 1's boundary
+        assertThat(msg.getSequence()).isEqualTo(1);
+    }
+
+    @Test
+    public void getSequence4_ft2_cyclesModuloFourOnShortSlot() {
+        Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
+        msg.utcTime = 0;
+        assertThat(msg.getSequence4()).isEqualTo(0);
+        msg.utcTime = 3800;
+        assertThat(msg.getSequence4()).isEqualTo(1);
+        msg.utcTime = 7600;
+        assertThat(msg.getSequence4()).isEqualTo(2);
+        msg.utcTime = 11400;
+        assertThat(msg.getSequence4()).isEqualTo(3);
+        msg.utcTime = 15200;
+        assertThat(msg.getSequence4()).isEqualTo(0);
+    }
+
     // ---- TransmitCallsign factory methods -----------------------------------
 
     @Test


### PR DESCRIPTION
﻿Closes #205.

## Root cause
`Ft8Message.getSequence()` / `getSequence4()` hardcoded FT4's 7.5 s period for **every** non-FT8 mode, so FT2's 3.8 s slots were measured against the wrong cycle length — two adjacent FT2 slots collapsed into a single parity.

The QSO auto-sequencer (`FT8TransmitSignal.checkFunctionOrdFromMessages`) skips any decode whose `getSequence() == sequential` (our own slot). With FT2 parity collapsed, the other station's **R-report** looked like it was in our slot and was skipped → `newOrder` stayed `-1` → we never advanced and kept re-sending the report instead of **RR73**. (This is why it presents as an FT2-only bug even though the sequencer code is mode-agnostic.)

## Fix
Route slot math through a mode-aware `slotIndex()` using `ModeProfile.FT2.slotMillis` (3800 ms) for FT2, while preserving the **exact** legacy FT8 (15 s) and FT4 (7.5 s) formulas. The `+slot/20` nudge mirrors the existing FT8 (+750 ms) / FT4 (+370 ms) early-skew correction.

## Tests (`Ft8MessageTest`)
- FT2 alternates each 3.8 s slot; `getSequence4` cycles mod 4 on the short slot.
- Adjacent FT2 slots (0 ms vs 3800 ms) have **distinct** parity — direct regression for #205.
- Slight early skew stays in the correct slot.
- FT8 and FT4 sequences unchanged.

`gradlew testDebugUnitTest --tests Ft8MessageTest` passes.

> ⚠️ Unit-verified. Recommend on-air confirmation with a second FT2 station: the QSO should progress grid → report → R-report → **RR73** → 73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
