### PR TITLE
CI: pre-install NDK with retry to stop flaky build failures

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -181,16 +181,20 @@ jobs:
           # that ZipException) if the Android Gradle Plugin is upgraded.
           NDK_VERSION=25.1.8937393
           SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          # sdkmanager writes source.properties last, so its presence marks a
+          # complete install — judge success by that, not the pipeline's exit
+          # code: `yes` dies with SIGPIPE when sdkmanager closes the pipe, which
+          # under `set -o pipefail` would otherwise read as a (false) failure.
+          MARKER="$ANDROID_HOME/ndk/$NDK_VERSION/source.properties"
           for attempt in 1 2 3; do
             echo "::group::NDK install attempt $attempt"
             rm -rf "$ANDROID_HOME/ndk/$NDK_VERSION" "$HOME/.android/cache"
-            if yes | "$SDKMANAGER" --install "ndk;$NDK_VERSION" \
-                && [[ -d "$ANDROID_HOME/ndk/$NDK_VERSION" ]]; then
-              echo "::endgroup::"
+            yes | "$SDKMANAGER" --install "ndk;$NDK_VERSION" || true
+            echo "::endgroup::"
+            if [[ -f "$MARKER" ]]; then
               echo "NDK $NDK_VERSION ready at $ANDROID_HOME/ndk/$NDK_VERSION"
               exit 0
             fi
-            echo "::endgroup::"
             echo "Attempt $attempt failed; retrying in 10s..."
             sleep 10
           done

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -168,6 +168,35 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew
 
+      - name: Pre-install NDK (retry around flaky SDK downloads)
+        run: |
+          set -euo pipefail
+          # AGP auto-downloads this NDK during the native build, but its installer
+          # aborts the whole build on the first corrupt/truncated archive from
+          # Google's SDK server (java.util.zip.ZipException: Archive is not a ZIP
+          # archive) with no retry — which intermittently broke PR builds (#208,
+          # #212). Install it up front with retry and a clean slate between tries
+          # so AGP finds it already present and never runs its fragile downloader.
+          # Keep NDK_VERSION in sync with the AGP-default NDK (the version named in
+          # that ZipException) if the Android Gradle Plugin is upgraded.
+          NDK_VERSION=25.1.8937393
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          for attempt in 1 2 3; do
+            echo "::group::NDK install attempt $attempt"
+            rm -rf "$ANDROID_HOME/ndk/$NDK_VERSION" "$HOME/.android/cache"
+            if yes | "$SDKMANAGER" --install "ndk;$NDK_VERSION" \
+                && [[ -d "$ANDROID_HOME/ndk/$NDK_VERSION" ]]; then
+              echo "::endgroup::"
+              echo "NDK $NDK_VERSION ready at $ANDROID_HOME/ndk/$NDK_VERSION"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Attempt $attempt failed; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Failed to install NDK $NDK_VERSION after 3 attempts"
+          exit 1
+
       - name: Decode keystore (release builds only)
         if: steps.tag.outputs.should_release == 'true'
         env:


### PR DESCRIPTION
## Problem
The **Build APK** job lets the Android Gradle Plugin auto-download NDK `25.1.8937393` during the native build. AGP's installer aborts the entire build on the first corrupt/truncated archive served by Google's SDK mirror:

```
Warning: An error occurred while preparing SDK package NDK (Side by side) 25.1.8937393: Error on ZipFile unknown archive
Caused by: java.util.zip.ZipException: Archive is not a ZIP archive
"Install NDK (Side by side) 25.1.8937393 v.25.1.8937393" failed.
```

It does **not** retry, so one bad download fails the whole PR build. This intermittently broke #208 and #212 — both went green on a plain re-run, confirming the *download*, not the code, was at fault. (The unit-test job is unaffected because `testDebugUnitTest` doesn't build native code, so it never triggers the NDK download.)

## Fix
Add a step before the Gradle build that installs the NDK up front via `sdkmanager` with **three attempts**, wiping any partial/corrupt download between tries. AGP then finds the NDK already present at `$ANDROID_HOME/ndk/25.1.8937393` and never invokes its fragile, no-retry downloader.

`NDK_VERSION` is kept in a single place with a comment to update it if the AGP-default NDK changes on a plugin upgrade (it's the version named in the `ZipException`).

## Note on testing
This is a CI workflow (YAML) change with no app code path, so the unit-test suite doesn't cover it. Validated the YAML parses, and the real proof is the Build APK job going green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)