### PR TITLE
Fix wrong time and clean up logbook Recent rows

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
@@ -1185,31 +1185,37 @@ private fun QsoRow(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Time column
-            Column(modifier = Modifier.width(52.dp)) {
+            // Band chip — color-coded per band, with the frequency moved to the
+            // meta line below so it never clips the way the old packed column did.
+            val meter = parseBandMeter(band)
+            val freqLabel = parseFreqMhz(band)
+            val chipColor = bandColor(meter)
+            Box(
+                modifier = Modifier
+                    .width(46.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(chipColor.copy(alpha = 0.14f))
+                    .border(1.dp, chipColor.copy(alpha = 0.34f), RoundedCornerShape(6.dp))
+                    .padding(vertical = 6.dp),
+                contentAlignment = Alignment.Center,
+            ) {
                 Text(
-                    text = formatTime(time),
-                    color = TextMuted,
-                    fontSize = 10.sp,
+                    text = meter.ifBlank { "—" },
+                    color = chipColor,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
                     fontFamily = GeistMonoFamily,
                     maxLines = 1,
                 )
-                if (band.isNotBlank()) {
-                    Text(
-                        text = band.uppercase(),
-                        color = bandColor(band),
-                        fontSize = 10.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        fontFamily = GeistMonoFamily,
-                        maxLines = 1,
-                    )
-                }
             }
 
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(10.dp))
 
-            // Callsign + grid + state/DX entity
-            Column(modifier = Modifier.weight(1f)) {
+            // Callsign, then grid/state/DX, then a muted "freq · time · date" meta line.
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
                 Text(
                     text = callsign,
                     color = TextPrimary,
@@ -1219,17 +1225,36 @@ private fun QsoRow(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    secondaryParts.forEach { (text, color) ->
-                        Text(
-                            text = text,
-                            color = color,
-                            fontSize = 10.sp,
-                            fontFamily = GeistMonoFamily,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                if (secondaryParts.isNotEmpty()) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        secondaryParts.forEach { (text, color) ->
+                            Text(
+                                text = text,
+                                color = color,
+                                fontSize = 10.sp,
+                                fontFamily = GeistMonoFamily,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     }
+                }
+                val metaLine = buildList {
+                    if (freqLabel.isNotBlank()) add(freqLabel)
+                    val t = formatQsoTime(record.timeOn)
+                    if (t != "--:--") add("${t}z")
+                    val d = formatQsoDate(time)
+                    if (d.isNotBlank()) add(d)
+                }.joinToString(" · ")
+                if (metaLine.isNotBlank()) {
+                    Text(
+                        text = metaLine,
+                        color = TextFaint,
+                        fontSize = 10.sp,
+                        fontFamily = GeistMonoFamily,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
 
@@ -1349,18 +1374,53 @@ private fun SyncChip(label: String) {
 }
 
 // ---------------------------------------------------------------------------
-// Format time helper: "20230320-143000" -> "14:30"
+// Row display helpers (extracted as internal top-level funs so they're unit-testable)
 // ---------------------------------------------------------------------------
 
-private fun formatTime(raw: String): String {
-    if (raw.isBlank()) return "--:--"
-    // Try to extract HH:MM from various formats
-    val timepart = if ("-" in raw) raw.substringAfter("-") else raw
-    return if (timepart.length >= 4) {
-        "${timepart.substring(0, 2)}:${timepart.substring(2, 4)}"
-    } else {
-        raw.take(5)
-    }
+/**
+ * Format a stored time-of-day (`time_on`, UTC) as "HH:MM". The SQL query already
+ * normalizes `time_on` to 6-digit HHMMSS, but we route through [normalizeTimeOn]
+ * anyway so odd-width inputs (HHMM, or a dropped leading zero) still render right.
+ * Blank / non-numeric input → "--:--".
+ */
+internal fun formatQsoTime(timeOn: String): String {
+    if (timeOn.none { it.isDigit() }) return "--:--"
+    val norm = normalizeTimeOn(timeOn)
+    return "${norm.substring(0, 2)}:${norm.substring(2, 4)}"
+}
+
+/**
+ * Format a stored `qso_date` ("yyyyMMdd", UTC) as a short "11 Jun". Blank or
+ * malformed (anything that isn't a valid 8-digit yyyyMMdd) → "".
+ */
+internal fun formatQsoDate(qsoDate: String): String {
+    val digits = qsoDate.filter { it.isDigit() }
+    if (digits.length < 8) return ""
+    val month = digits.substring(4, 6).toIntOrNull() ?: return ""
+    val day = digits.substring(6, 8).toIntOrNull() ?: return ""
+    if (month !in 1..12 || day !in 1..31) return ""
+    val months = arrayOf(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    )
+    return "$day ${months[month - 1]}"
+}
+
+/**
+ * The grouped logbook query packs band + frequency into one column as
+ * "20M(14.084 MHz)". Pull out just the band meter ("20M") so it can be
+ * color-coded; a plain "20M" passes through unchanged.
+ */
+internal fun parseBandMeter(band: String): String =
+    band.substringBefore("(").trim()
+
+/**
+ * Pull the "14.084 MHz" frequency out of the packed "20M(14.084 MHz)" band column.
+ * Returns "" when the column carries no parenthesized frequency.
+ */
+internal fun parseFreqMhz(band: String): String {
+    if (!band.contains("(")) return ""
+    return band.substringAfter("(").substringBefore(")").trim()
 }
 
 // ===========================================================================

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
@@ -1384,7 +1384,11 @@ private fun SyncChip(label: String) {
  * Blank / non-numeric input → "--:--".
  */
 internal fun formatQsoTime(timeOn: String): String {
-    if (timeOn.none { it.isDigit() }) return "--:--"
+    // Reject anything that isn't purely numeric, not just the all-non-digit case:
+    // a partial like "12:30" or "12ab" would otherwise be silently stripped to digits
+    // by normalizeTimeOn and rendered as a real time, masking malformed data. Legit
+    // inputs are pure-digit strings of varying width (HHMMSS / HHMM / dropped zero).
+    if (timeOn.isEmpty() || timeOn.any { !it.isDigit() }) return "--:--"
     val norm = normalizeTimeOn(timeOn)
     return "${norm.substring(0, 2)}:${norm.substring(2, 4)}"
 }
@@ -1394,10 +1398,12 @@ internal fun formatQsoTime(timeOn: String): String {
  * malformed (anything that isn't a valid 8-digit yyyyMMdd) → "".
  */
 internal fun formatQsoDate(qsoDate: String): String {
-    val digits = qsoDate.filter { it.isDigit() }
-    if (digits.length < 8) return ""
-    val month = digits.substring(4, 6).toIntOrNull() ?: return ""
-    val day = digits.substring(6, 8).toIntOrNull() ?: return ""
+    // Require exactly 8 digits, not merely "contains ≥8 digits": stripping non-digits
+    // and taking the first 8 would render a date from malformed input like
+    // "20260611xxx" or "2026-06-11", contradicting the documented yyyyMMdd contract.
+    if (qsoDate.length != 8 || qsoDate.any { !it.isDigit() }) return ""
+    val month = qsoDate.substring(4, 6).toIntOrNull() ?: return ""
+    val day = qsoDate.substring(6, 8).toIntOrNull() ?: return ""
     if (month !in 1..12 || day !in 1..31) return ""
     val months = arrayOf(
         "Jan", "Feb", "Mar", "Apr", "May", "Jun",

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookRowLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookRowLogicTest.kt
@@ -1,0 +1,64 @@
+package radio.ks3ckc.ft8us.ui.logbook
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for the pure display helpers extracted from [QsoRow] so the logbook's
+ * recent entries render the real UTC time, a short date, a color-coded band meter,
+ * and an un-clipped frequency. These are plain string transforms, so they run on the
+ * bare JVM with no Robolectric.
+ *
+ * [formatQsoTime] previously sliced the date column (showing "20:26" from the year
+ * 2026's "2026"); it now reads the normalized `time_on`.
+ */
+class LogbookRowLogicTest {
+
+    @Test
+    fun formatQsoTime_rendersHoursAndMinutes() {
+        assertThat(formatQsoTime("202600")).isEqualTo("20:26")
+        assertThat(formatQsoTime("2026")).isEqualTo("20:26")
+        assertThat(formatQsoTime("083015")).isEqualTo("08:30")
+    }
+
+    @Test
+    fun formatQsoTime_restoresDroppedLeadingZero() {
+        // "81500" is 08:15:00 with the hour's leading zero dropped — normalizeTimeOn
+        // must restore it rather than read "81" as the hour.
+        assertThat(formatQsoTime("81500")).isEqualTo("08:15")
+    }
+
+    @Test
+    fun formatQsoTime_blankOrNonNumericIsPlaceholder() {
+        assertThat(formatQsoTime("")).isEqualTo("--:--")
+        assertThat(formatQsoTime("abc")).isEqualTo("--:--")
+    }
+
+    @Test
+    fun formatQsoDate_rendersShortDate() {
+        assertThat(formatQsoDate("20260611")).isEqualTo("11 Jun")
+        assertThat(formatQsoDate("20260101")).isEqualTo("1 Jan")
+        assertThat(formatQsoDate("20251231")).isEqualTo("31 Dec")
+    }
+
+    @Test
+    fun formatQsoDate_blankOrMalformedIsEmpty() {
+        assertThat(formatQsoDate("")).isEqualTo("")
+        assertThat(formatQsoDate("2026")).isEqualTo("")
+        assertThat(formatQsoDate("20261301")).isEqualTo("") // month 13
+    }
+
+    @Test
+    fun parseBandMeter_extractsMeterFromPackedColumn() {
+        assertThat(parseBandMeter("20M(14.084 MHz)")).isEqualTo("20M")
+        assertThat(parseBandMeter("20M")).isEqualTo("20M")
+        assertThat(parseBandMeter("")).isEqualTo("")
+    }
+
+    @Test
+    fun parseFreqMhz_extractsFrequencyFromPackedColumn() {
+        assertThat(parseFreqMhz("20M(14.084 MHz)")).isEqualTo("14.084 MHz")
+        assertThat(parseFreqMhz("20M")).isEqualTo("")
+        assertThat(parseFreqMhz("")).isEqualTo("")
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookRowLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookRowLogicTest.kt
@@ -32,6 +32,10 @@ class LogbookRowLogicTest {
     fun formatQsoTime_blankOrNonNumericIsPlaceholder() {
         assertThat(formatQsoTime("")).isEqualTo("--:--")
         assertThat(formatQsoTime("abc")).isEqualTo("--:--")
+        // Partially-numeric input must be rejected, not silently stripped to digits
+        // and rendered as a real time.
+        assertThat(formatQsoTime("12ab")).isEqualTo("--:--")
+        assertThat(formatQsoTime("12:30")).isEqualTo("--:--")
     }
 
     @Test
@@ -46,6 +50,10 @@ class LogbookRowLogicTest {
         assertThat(formatQsoDate("")).isEqualTo("")
         assertThat(formatQsoDate("2026")).isEqualTo("")
         assertThat(formatQsoDate("20261301")).isEqualTo("") // month 13
+        // Must require exactly 8 digits, not merely "contains ≥8 digits": trailing
+        // junk or separators are malformed, not a valid yyyyMMdd.
+        assertThat(formatQsoDate("20260611xxx")).isEqualTo("")
+        assertThat(formatQsoDate("2026-06-11")).isEqualTo("")
     }
 
     @Test


### PR DESCRIPTION
## Problem

The Logbook → Recent (Недавние) tab showed the **same wrong time on every row** and a clipped, cramped band column (screenshot: every row read `20:26`, band showed `20M(14.084`).

- **Wrong time:** `formatTime()` sliced the `qso_date` column (`20260611`) characters 0–1 / 2–3 → `20:26`, i.e. the year+month of the *date*, not a time of day. The real `time_on` is already loaded into `QSLCallsignRecord` and sorted on by `dev` — only the display was wrong.
- **Clipped band:** the `band` field is the SQL concatenation `20M(14.084 MHz)`, rendered in a 52dp column with `maxLines=1` and no ellipsis, so it hard-clipped to `20M(14.084`. The packed string also isn't a `BandColorMap` key, so `bandColor()` fell through to muted gray.

## Change

- Replace the broken `formatTime()` with four testable `internal` helpers:
  - `formatQsoTime()` — renders normalized `time_on` as `HH:MM` (reuses existing `normalizeTimeOn`).
  - `formatQsoDate()` — `yyyyMMdd` → short `"11 Jun"`.
  - `parseBandMeter()` / `parseFreqMhz()` — split the packed `"20M(14.084 MHz)"` column.
- Rewrite `QsoRow` to a **band-chip-lead** layout: a color-coded band chip on the left, callsign + grid/country, and a muted `14.084 MHz · 20:26z · 11 Jun` meta line (UTC time + short date). Removes the clipping 52dp column.

Backend is untouched — `time_on` was already wired up on `dev`; this is a display-only fix.

```
┌────────────────────────────────────────┐
│ ╔════╗  UB6C             ✓  ↑QRZ      ⋮ │
│ ║20M ║  KN94 · United States            │
│ ╚════╝  14.084 MHz · 20:26z · 11 Jun    │
└────────────────────────────────────────┘
```

## Tests

New `LogbookRowLogicTest` covers all four helpers, including the dropped-leading-zero time and malformed-date edge cases. Passes alongside the existing `LogbookSortTest`:

```
gradlew.bat testDebugUnitTest --tests *LogbookRowLogicTest --tests *LogbookSortTest  → BUILD SUCCESSFUL
```

## Verification status

APK builds cleanly. On-device visual check is **still pending** — no phone was connected at build time (`installDebug` → "No connected devices!"). Needs a quick look on the Pixel 8: Journal → Недавние should show distinct real UTC times, the colored band chip, and an un-clipped frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)