### PR TITLE
CI: run instrumented tests on an emulator (issue #60)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -127,6 +127,26 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      # Pre-build the app + androidTest APKs (and resolve all dependencies)
+      # BEFORE booting the emulator. The androidTest classpath pulls espresso /
+      # hamcrest from Maven Central, which rate-limits the shared GitHub runner
+      # IPs (transient HTTP 429). Doing it here, with a retry+backoff, means a
+      # 429 is retried cheaply instead of wasting a full emulator boot; the
+      # emulator step then runs against already-cached dependencies.
+      - name: Assemble instrumented test APKs
+        working-directory: ft8cn
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if ./gradlew assembleDebug assembleDebugAndroidTest --stacktrace; then
+              exit 0
+            fi
+            echo "::warning::Gradle assemble failed (attempt ${attempt}/3) — retrying after backoff"
+            sleep $((attempt * 30))
+          done
+          echo "::error::Gradle assemble failed after 3 attempts (likely Maven Central 429)"
+          exit 1
+
       # google_apis image (not plain default) so Google Play services types the
       # app links against — play-services-maps — resolve at runtime and the
       # activity reaches RESUMED. API 30 matches the Compose UI test floor.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -85,6 +85,72 @@ jobs:
             ft8cn/app/build/test-results/
             ft8cn/app/build/reports/jacoco/
 
+  instrumented:
+    name: Instrumented tests (emulator)
+    # Exercises the androidTest suite (AppSmokeTest launches the real
+    # ComposeMainActivity) on an emulator. Same trigger as the unit-test job:
+    # every PR plus pushes to main. This job is intentionally NOT a dependency
+    # of `build` and is left out of branch protection's required checks while it
+    # stabilises (issue #60) — a flaky emulator must never block a release.
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}--
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ft8cn/gradlew
+
+      # Hardware acceleration (KVM) is required for a usable x86_64 emulator on
+      # the GitHub-hosted Ubuntu runners; without it the AVD falls back to slow
+      # software rendering and connectedAndroidTest reliably times out.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # google_apis image (not plain default) so Google Play services types the
+      # app links against — play-services-maps — resolve at runtime and the
+      # activity reaches RESUMED. API 30 matches the Compose UI test floor.
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          arch: x86_64
+          target: google_apis
+          profile: Nexus 6
+          working-directory: ft8cn
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew connectedDebugAndroidTest --stacktrace
+
+      - name: Upload instrumented test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: instrumented-test-reports
+          path: |
+            ft8cn/app/build/reports/androidTests/
+            ft8cn/app/build/outputs/androidTest-results/
+
   build:
     name: Build APK
     needs: test

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,9 +52,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}--
+            gradle-${{ runner.os }}-
 
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew
@@ -111,9 +111,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}--
+            gradle-${{ runner.os }}-
 
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew
@@ -247,9 +247,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}--
+            gradle-${{ runner.os }}-
 
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -204,6 +204,11 @@ dependencies {
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
     // --- Connected (instrumented) tests ---
+    // The compose BOM is on `implementation`, which does NOT flow into the
+    // androidTest classpath (unlike testImplementation), so the versionless
+    // ui-test-junit4 below resolves to no version and fails. Apply the BOM here
+    // too so it gets the same managed version the main + unit-test classpaths do.
+    androidTestImplementation composeBom
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -212,6 +212,11 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    // AppSmokeTest asserts with Truth (assertThat). Truth is on testImplementation
+    // for the JVM unit tests but does not flow into the androidTest classpath, so
+    // the instrumented build needs its own copy or compileDebugAndroidTestKotlin
+    // fails with "Unresolved reference: truth".
+    androidTestImplementation 'com.google.truth:truth:1.4.2'
 }
 
 jacoco {


### PR DESCRIPTION
Closes #60.

## What

Adds an `instrumented` job to `.github/workflows/build-release.yml` that boots an Android emulator and runs the instrumented suite, so `AppSmokeTest` (which launches the real `ComposeMainActivity` via `ActivityScenario`) is finally exercised in CI instead of only when a dev remembers to run it locally.

## How

- **Emulator** via `reactivecircus/android-emulator-runner@v2`: API 30, `x86_64`, `google_apis` target, `Nexus 6` profile. API 30 matches the Compose UI-test floor; the `google_apis` image (not plain `default`) so the `play-services-maps` types the app links against resolve at runtime and the activity reaches `RESUMED`.
- **Enable KVM** step so the x86_64 emulator is hardware-accelerated — without it the AVD falls back to software rendering and `connectedAndroidTest` reliably times out on the hosted runner.
- **Run step**: `./gradlew connectedDebugAndroidTest --stacktrace` (`working-directory: ft8cn`).
- **Artifacts**: uploads `app/build/reports/androidTests/` and `app/build/outputs/androidTest-results/` on failure, mirroring the unit-test report upload.
- **Trigger**: same as the unit-test job — every PR plus pushes to `main`.

## Required-for-merge?

Per the issue, **non-required while it stabilises**. The job is intentionally *not* a dependency of `build`, so a flaky emulator never blocks a release. Branch protection is configured in GitHub Settings (not in-repo); once the job proves stable, add `Instrumented tests (emulator)` to the required checks for `dev`/`main`.

## Testing note

This is a CI-config change with no new app code path; the "new test" it covers is `AppSmokeTest` itself, which this PR wires into CI. The real validation is the job result on this PR — please watch the `Instrumented tests (emulator)` check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
