### PR TITLE
CI: lint, detekt, and ktlint on PRs (warn-only) — closes #63

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,9 +42,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}--
+            gradle-${{ runner.os }}-
 
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,82 @@
+name: Static analysis
+
+# Issue #63: run Android lint, detekt, and ktlint on PRs.
+#
+# ROLLOUT IS PHASED — every analysis step below is currently WARN-ONLY
+# (`continue-on-error: true`). CI runs the tool and uploads its report, but a
+# violation does NOT fail the check. This lets the team see a few PRs' worth of
+# output before any of these gate merges.
+#
+# To FLIP A TOOL TO BLOCKING: delete its `continue-on-error: true` line. Do them
+# one at a time, not all three at once.
+#
+# Notes on what already gates new code even in warn-only mode:
+#   - detekt runs against config/detekt/baseline.xml, so it only reports NEW
+#     correctness findings; the baseline holds the existing ones.
+#   - ktlint has no baseline yet — the existing codebase isn't formatted, so it
+#     will report many violations until a formatting pass lands. That's why it
+#     stays warn-only here.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  static-analysis:
+    name: lint / detekt / ktlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('ft8cn/**/*.gradle*', 'ft8cn/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}--
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ft8cn/gradlew
+
+      # --- WARN-ONLY during rollout: remove continue-on-error to make blocking ---
+
+      - name: Android lint (debug)
+        id: lint
+        continue-on-error: true
+        working-directory: ft8cn
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: detekt
+        id: detekt
+        continue-on-error: true
+        working-directory: ft8cn
+        run: ./gradlew detekt --stacktrace
+
+      - name: ktlint
+        id: ktlint
+        continue-on-error: true
+        working-directory: ft8cn
+        run: ./gradlew ktlintCheck --stacktrace
+
+      - name: Upload analysis reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: static-analysis-reports
+          path: |
+            ft8cn/app/build/reports/lint-results-debug.html
+            ft8cn/app/build/reports/lint-results-debug.xml
+            ft8cn/app/build/reports/detekt/
+            ft8cn/app/build/reports/ktlint/
+          if-no-files-found: ignore

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -5,6 +5,9 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'jacoco'
+    // Static analysis (issue #63).
+    id 'io.gitlab.arturbosch.detekt'
+    id 'org.jlleitschuh.gradle.ktlint'
 }
 
 def currentTime = getCurrentTime()
@@ -211,6 +214,32 @@ dependencies {
 
 jacoco {
     toolVersion = '0.8.12'
+}
+
+// --- Static analysis (issue #63) ---
+//
+// Both tools fail their own task on a NEW violation so a developer running
+// them locally gets a clear signal. CI keeps them warn-only during the rollout
+// (see .github/workflows/static-analysis.yml) by not gating on the step; the
+// flip to blocking is a one-line change there.
+
+detekt {
+    // Layer our correctness-only overrides on top of detekt's bundled defaults.
+    buildUponDefaultConfig = true
+    config.setFrom(files("$projectDir/config/detekt/detekt.yml"))
+    // Existing findings are recorded here so only new code is policed.
+    baseline = file("$projectDir/config/detekt/baseline.xml")
+    parallel = true
+}
+
+ktlint {
+    version = '1.2.1'
+    android = true
+    // Reports for CI to upload as artifacts.
+    reporters {
+        reporter org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN
+        reporter org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML
+    }
 }
 
 // Robolectric loads app classes through its own classloader, which JaCoCo's

--- a/ft8cn/app/config/detekt/baseline.xml
+++ b/ft8cn/app/config/detekt/baseline.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>ImplicitDefaultLocale:MapScreen.kt$String.format("%.0f", bearing)</ID>
+    <ID>ImplicitDefaultLocale:QsoSheet.kt$String.format("%.0f", bearing)</ID>
+    <ID>TooGenericExceptionCaught:ComposeMainActivity.kt$ComposeMainActivity$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:ComposeMainActivity.kt$ComposeMainActivity.&lt;no name provided&gt;$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PotaAdifExporter.kt$PotaAdifExporter$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PotaAuth.kt$PotaAuth$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PotaClient.kt$PotaClient$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PskReporterClient.kt$PskReporterClient$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PskReporterSender.kt$PskReporterSender$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:QrzWebClient.kt$QrzWebClient$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:QrzXmlClient.kt$QrzXmlClient$e: Exception</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/ft8cn/app/config/detekt/detekt.yml
+++ b/ft8cn/app/config/detekt/detekt.yml
@@ -1,0 +1,41 @@
+# detekt configuration — issue #63.
+#
+# Scope is deliberately narrow: CORRECTNESS rules only. Style, naming, and
+# formatting are ktlint's job; complexity/comments metrics are noise for this
+# codebase. We layer on top of detekt's bundled defaults
+# (buildUponDefaultConfig = true in app/build.gradle) and switch off every
+# ruleset that isn't about catching bugs.
+
+build:
+  # Any finding above the baseline fails the `detekt` task. Existing findings
+  # are recorded in config/detekt/baseline.xml so only NEW code is policed.
+  # (Warn-only at the CI level during rollout — see static-analysis.yml.)
+  maxIssues: 0
+  excludeCorrectable: false
+
+config:
+  validation: true
+  warningsAsErrors: false
+  checkExhaustiveness: false
+
+# --- Correctness rulesets: ON ---
+coroutines:
+  active: true
+exceptions:
+  active: true
+potential-bugs:
+  active: true
+
+# --- Everything else: OFF (owned by ktlint or just noise) ---
+comments:
+  active: false
+complexity:
+  active: false
+empty-blocks:
+  active: false
+naming:
+  active: false
+performance:
+  active: false
+style:
+  active: false

--- a/ft8cn/build.gradle
+++ b/ft8cn/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'com.android.application' version '8.2.2' apply false
     id 'com.android.library' version '8.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
+    // Static analysis (issue #63). Applied in app/build.gradle; declared here
+    // with apply false so the versions resolve once for the whole build.
+    id 'io.gitlab.arturbosch.detekt' version '1.23.6' apply false
+    id 'org.jlleitschuh.gradle.ktlint' version '12.1.1' apply false
 }
 task clean(type: Delete) {
     delete rootProject.buildDir


### PR DESCRIPTION
Closes #63.

Adds a **Static analysis** GitHub Actions workflow (`.github/workflows/static-analysis.yml`) that runs on PRs to `main`/`dev`, plus the Gradle wiring for detekt and ktlint.

## What's added

- **Android lint** — `lintDebug` (broader than the `lintVitalRelease` that runs inside `assembleRelease`).
- **detekt** — correctness-focused config (`ft8cn/app/config/detekt/detekt.yml`): `potential-bugs`, `exceptions`, `coroutines` on; `style`/`naming`/`complexity`/`comments`/`performance`/`empty-blocks` off (ktlint owns style; the rest are noise). A generated **baseline** (`config/detekt/baseline.xml`) records existing findings so only *new* code is policed.
- **ktlint** — standard Kotlin style rules (`android = true`), PLAIN + HTML reporters for the CI artifact.

## Phased rollout (per the issue)

All three steps are **warn-only** (`continue-on-error: true`): CI runs each tool and uploads its report, but a violation does **not** fail the check. Flipping a tool to blocking is a one-line deletion in the workflow — the header comment documents the procedure and says to flip **one at a time**, not all three at once.

## Verification (local, Windows wrapper)

- `gradlew detektBaseline` → generated the baseline (11 existing findings: `ImplicitDefaultLocale`, `TooGenericExceptionCaught`).
- `gradlew detekt` → **BUILD SUCCESSFUL** against the baseline (0 new findings).
- `gradlew ktlintCheck` → plugin configures and runs; fails on the unformatted existing tree, which is exactly why it stays warn-only until a formatting pass lands.

Android `lintDebug` is a standard AGP task and not run locally (full native build); it's covered by `continue-on-error` during the warn-only phase regardless.

## Testing note

No unit test accompanies this change — it's Gradle/CI configuration with no new Kotlin/Java code path to cover.

## Follow-ups

- After a few PRs' worth of output: flip detekt → blocking (one line).
- Land a ktlint auto-format pass, then flip ktlint → blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)