### PR TITLE
Tests: expand Compose screen test coverage (issue #64)

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -395,7 +395,7 @@ private fun filterLabel(key: String): String = when (key) {
  *  - Needed: need QSL confirmation (not in QSL callsign list)
  *  - For Me: callsignTo matches operator's callsign
  */
-private fun filterMessages(
+internal fun filterMessages(
     messages: List<Ft8Message>,
     filter: String,
 ): List<Ft8Message> {
@@ -457,7 +457,7 @@ private fun filterMessages(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun EmptyState(
+internal fun EmptyState(
     selectedFilter: String,
     modifier: Modifier = Modifier,
 ) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreen.kt
@@ -117,7 +117,7 @@ private fun bandColor(band: String): Color =
 // Tab enum
 // ---------------------------------------------------------------------------
 
-private enum class LogbookTab(@StringRes val labelRes: Int) {
+internal enum class LogbookTab(@StringRes val labelRes: Int) {
     STATS(R.string.log_tab_stats),
     RECENT(R.string.log_tab_recent),
     AWARDS(R.string.log_tab_awards),
@@ -510,7 +510,7 @@ private fun StatsLoadingPlaceholder() {
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun SegmentedTabRow(
+internal fun SegmentedTabRow(
     tabs: List<LogbookTab>,
     selected: LogbookTab,
     onSelected: (LogbookTab) -> Unit,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/map/MapScreen.kt
@@ -102,13 +102,13 @@ private data class PskSpotMarker(
 private const val PSK_OVERLAY_SECONDS_BACK = 3600
 private const val PSK_POLL_INTERVAL_MS = 5L * 60L * 1000L
 
-private data class ProjectedPoint(
+internal data class ProjectedPoint(
     val x: Float,
     val y: Float,
     val distKm: Double,
 )
 
-private enum class MapViewMode { STANDARD, AZIMUTHAL }
+internal enum class MapViewMode { STANDARD, AZIMUTHAL }
 
 private const val MAP_MIN_ZOOM = 1f
 private const val MAP_MAX_ZOOM = 8f
@@ -118,7 +118,7 @@ private const val MAP_ZOOM_STEP = 2f
 // Great-circle distance (km) — used by both projections
 // ---------------------------------------------------------------------------
 
-private fun greatCircleKm(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+internal fun greatCircleKm(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
     val phi1 = Math.toRadians(lat1)
     val phi2 = Math.toRadians(lat2)
     val dLam = Math.toRadians(lon2 - lon1)
@@ -130,7 +130,7 @@ private fun greatCircleKm(lat1: Double, lon1: Double, lat2: Double, lon2: Double
 // Equirectangular (Plate Carrée) projection — lat/lon -> normalized [-1,1]
 // ---------------------------------------------------------------------------
 
-private fun equirectProject(lat: Double, lon: Double): ProjectedPoint {
+internal fun equirectProject(lat: Double, lon: Double): ProjectedPoint {
     return ProjectedPoint(
         x = (lon / 180.0).toFloat(),
         y = (-lat / 90.0).toFloat(),
@@ -142,7 +142,7 @@ private fun equirectProject(lat: Double, lon: Double): ProjectedPoint {
 // Azimuthal equidistant projection
 // ---------------------------------------------------------------------------
 
-private fun azProject(opLat: Double, opLon: Double, lat: Double, lon: Double): ProjectedPoint {
+internal fun azProject(opLat: Double, opLon: Double, lat: Double, lon: Double): ProjectedPoint {
     val phi1 = Math.toRadians(opLat)
     val lam1 = Math.toRadians(opLon)
     val phi2 = Math.toRadians(lat)
@@ -504,7 +504,7 @@ fun MapScreen(mainViewModel: MainViewModel) {
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun MapViewToggle(
+internal fun MapViewToggle(
     mode: MapViewMode,
     onModeChange: (MapViewMode) -> Unit,
 ) {
@@ -527,7 +527,7 @@ private fun MapViewToggle(
 }
 
 @Composable
-private fun PskOverlayToggle(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+internal fun PskOverlayToggle(enabled: Boolean, onToggle: (Boolean) -> Unit) {
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(8.dp))
@@ -1262,7 +1262,7 @@ private fun InfoChip(value: String, label: String) {
 // Bearing calculation
 // ---------------------------------------------------------------------------
 
-private fun computeBearing(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+internal fun computeBearing(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
     val phi1 = Math.toRadians(lat1)
     val phi2 = Math.toRadians(lat2)
     val dLam = Math.toRadians(lon2 - lon1)

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreen.kt
@@ -412,7 +412,7 @@ private fun WaterfallCanvas(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun FrequencyRuler(spectrumWidth: Int, modifier: Modifier = Modifier) {
+internal fun FrequencyRuler(spectrumWidth: Int, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier.background(BgSurface),
         verticalAlignment = Alignment.CenterVertically,
@@ -442,7 +442,7 @@ private fun FrequencyRuler(spectrumWidth: Int, modifier: Modifier = Modifier) {
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun ToggleChip(
+internal fun ToggleChip(
     label: String,
     active: Boolean,
     onClick: () -> Unit,

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeFilterTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeFilterTest.kt
@@ -1,0 +1,42 @@
+package radio.ks3ckc.ft8us.ui.decode
+
+import com.bg7yoz.ft8cn.Ft8Message
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit-tests the pure [filterMessages] decode-list filter. Robolectric is
+ * needed only because [Ft8Message] reaches android.util.Log on construction.
+ *
+ * These exercise the two chip filters that depend purely on message content
+ * (no operator-specific GeneralVariables state, which stays at its defaults
+ * here): "All" passes everything through, "CQ Calls" keeps only CQ messages.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DecodeFilterTest {
+
+    private fun cq(from: String) = Ft8Message("CQ", from, "FN42")
+    private fun directed(to: String, from: String) = Ft8Message(to, from, "FN42")
+
+    @Test
+    fun all_returnsEveryMessage() {
+        val messages = listOf(cq("K1ABC"), directed("W1AW", "K2DEF"))
+
+        val result = filterMessages(messages, "All")
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.callsignFrom }).containsExactly("K1ABC", "K2DEF")
+    }
+
+    @Test
+    fun cqCalls_keepsOnlyCqMessages() {
+        val cqMsg = cq("K1ABC")
+        val directedMsg = directed("W1AW", "K2DEF")
+
+        val result = filterMessages(listOf(cqMsg, directedMsg), "CQ Calls")
+
+        assertThat(result).containsExactly(cqMsg)
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreenTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreenTest.kt
@@ -1,0 +1,55 @@
+package radio.ks3ckc.ft8us.ui.decode
+
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bg7yoz.ft8cn.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Compose render test for the Decode screen's empty state, run on the JVM via
+ * Robolectric + createComposeRule (no emulator). Verifies the screen renders
+ * filter-specific empty-state copy — the path that breaks silently when a
+ * refactor or theme change drops a string binding.
+ *
+ * The empty state embeds [radio.ks3ckc.ft8us.ui.components.EmptyStateWaves],
+ * which drives an infinite animation, so we freeze the test clock
+ * (autoAdvance = false) to stop waitForIdle from spinning forever waiting for
+ * it to settle.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class DecodeScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun defaultFilter_showsDefaultEmptyCopy() {
+        composeRule.mainClock.autoAdvance = false
+        lateinit var title: String
+        composeRule.setContent {
+            title = stringResource(R.string.decode_empty_default_title)
+            EmptyState(selectedFilter = "All")
+        }
+
+        composeRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
+    fun cqFilter_showsCqEmptyCopy() {
+        composeRule.mainClock.autoAdvance = false
+        lateinit var title: String
+        composeRule.setContent {
+            title = stringResource(R.string.decode_empty_cq_title)
+            EmptyState(selectedFilter = "CQ Calls")
+        }
+
+        composeRule.onNodeWithText(title).assertIsDisplayed()
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreenTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreenTest.kt
@@ -1,9 +1,10 @@
 package radio.ks3ckc.ft8us.ui.decode
 
-import androidx.compose.ui.res.stringResource
+import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.bg7yoz.ft8cn.R
 import org.junit.Rule
@@ -29,12 +30,13 @@ class DecodeScreenTest {
     @get:Rule
     val composeRule = createComposeRule()
 
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
     @Test
     fun defaultFilter_showsDefaultEmptyCopy() {
+        val title = context.getString(R.string.decode_empty_default_title)
         composeRule.mainClock.autoAdvance = false
-        lateinit var title: String
         composeRule.setContent {
-            title = stringResource(R.string.decode_empty_default_title)
             EmptyState(selectedFilter = "All")
         }
 
@@ -43,10 +45,9 @@ class DecodeScreenTest {
 
     @Test
     fun cqFilter_showsCqEmptyCopy() {
+        val title = context.getString(R.string.decode_empty_cq_title)
         composeRule.mainClock.autoAdvance = false
-        lateinit var title: String
         composeRule.setContent {
-            title = stringResource(R.string.decode_empty_cq_title)
             EmptyState(selectedFilter = "CQ Calls")
         }
 

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreenTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreenTest.kt
@@ -1,10 +1,11 @@
 package radio.ks3ckc.ft8us.ui.logbook
 
-import androidx.compose.ui.res.stringResource
+import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
@@ -26,12 +27,16 @@ class LogbookScreenTest {
     @get:Rule
     val composeRule = createComposeRule()
 
+    // Resolve expected labels from a Robolectric context up front rather than
+    // capturing stringResource(...) inside setContent — SegmentedTabRow animates
+    // (animateColorAsState), so a recomposition could re-run any in-composition
+    // capture while the assertions iterate over it.
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private fun tabLabel(tab: LogbookTab): String = context.getString(tab.labelRes)
+
     @Test
     fun segmentedTabRow_rendersEveryTabLabel() {
-        val labels = mutableListOf<String>()
         composeRule.setContent {
-            labels.clear()
-            LogbookTab.entries.forEach { labels.add(stringResource(it.labelRes)) }
             SegmentedTabRow(
                 tabs = LogbookTab.entries,
                 selected = LogbookTab.STATS,
@@ -39,17 +44,15 @@ class LogbookScreenTest {
             )
         }
 
-        labels.forEach { label ->
-            composeRule.onNodeWithText(label).assertIsDisplayed()
+        LogbookTab.entries.forEach { tab ->
+            composeRule.onNodeWithText(tabLabel(tab)).assertIsDisplayed()
         }
     }
 
     @Test
     fun segmentedTabRow_tappingTabReportsThatTab() {
         var picked: LogbookTab? = null
-        lateinit var recentLabel: String
         composeRule.setContent {
-            recentLabel = stringResource(LogbookTab.RECENT.labelRes)
             SegmentedTabRow(
                 tabs = LogbookTab.entries,
                 selected = LogbookTab.STATS,
@@ -57,7 +60,7 @@ class LogbookScreenTest {
             )
         }
 
-        composeRule.onNodeWithText(recentLabel).performClick()
+        composeRule.onNodeWithText(tabLabel(LogbookTab.RECENT)).performClick()
 
         assertThat(picked).isEqualTo(LogbookTab.RECENT)
     }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreenTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/logbook/LogbookScreenTest.kt
@@ -1,0 +1,64 @@
+package radio.ks3ckc.ft8us.ui.logbook
+
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Compose render + interaction tests for the Logbook screen's segmented tab
+ * row (run on the JVM via Robolectric). The Stats/Recent/Awards content is
+ * driven by database queries through the heavyweight MainViewModel and is out
+ * of scope; the tab switcher is the stateless navigation control and its golden
+ * path — render every tab, tapping a tab reports that tab — is what we cover.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class LogbookScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun segmentedTabRow_rendersEveryTabLabel() {
+        val labels = mutableListOf<String>()
+        composeRule.setContent {
+            labels.clear()
+            LogbookTab.entries.forEach { labels.add(stringResource(it.labelRes)) }
+            SegmentedTabRow(
+                tabs = LogbookTab.entries,
+                selected = LogbookTab.STATS,
+                onSelected = {},
+            )
+        }
+
+        labels.forEach { label ->
+            composeRule.onNodeWithText(label).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun segmentedTabRow_tappingTabReportsThatTab() {
+        var picked: LogbookTab? = null
+        lateinit var recentLabel: String
+        composeRule.setContent {
+            recentLabel = stringResource(LogbookTab.RECENT.labelRes)
+            SegmentedTabRow(
+                tabs = LogbookTab.entries,
+                selected = LogbookTab.STATS,
+                onSelected = { picked = it },
+            )
+        }
+
+        composeRule.onNodeWithText(recentLabel).performClick()
+
+        assertThat(picked).isEqualTo(LogbookTab.RECENT)
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/map/MapOverlayToggleTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/map/MapOverlayToggleTest.kt
@@ -1,10 +1,11 @@
 package radio.ks3ckc.ft8us.ui.map
 
-import androidx.compose.ui.res.stringResource
+import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.bg7yoz.ft8cn.R
 import com.google.common.truth.Truth.assertThat
@@ -26,12 +27,13 @@ class MapOverlayToggleTest {
     @get:Rule
     val composeRule = createComposeRule()
 
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
     @Test
     fun pskOverlayToggle_clickEmitsToggledValue() {
+        val label = context.getString(R.string.map_overlay_psk)
         var toggledTo: Boolean? = null
-        lateinit var label: String
         composeRule.setContent {
-            label = stringResource(R.string.map_overlay_psk)
             PskOverlayToggle(enabled = false, onToggle = { toggledTo = it })
         }
 
@@ -43,10 +45,9 @@ class MapOverlayToggleTest {
 
     @Test
     fun mapViewToggle_selectingAzimuthalEmitsThatMode() {
+        val azimuthalLabel = context.getString(R.string.map_mode_azimuthal)
         var selected: MapViewMode? = null
-        lateinit var azimuthalLabel: String
         composeRule.setContent {
-            azimuthalLabel = stringResource(R.string.map_mode_azimuthal)
             MapViewToggle(mode = MapViewMode.STANDARD, onModeChange = { selected = it })
         }
 

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/map/MapOverlayToggleTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/map/MapOverlayToggleTest.kt
@@ -1,0 +1,57 @@
+package radio.ks3ckc.ft8us.ui.map
+
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bg7yoz.ft8cn.R
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Compose render + interaction tests for the Map screen's overlay/mode toggles
+ * (run on the JVM via Robolectric). The Canvas-drawn maps themselves can't
+ * render here; these cover the stateless controls layered over them — the PSK
+ * Reporter overlay toggle and the standard/azimuthal view switch.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class MapOverlayToggleTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun pskOverlayToggle_clickEmitsToggledValue() {
+        var toggledTo: Boolean? = null
+        lateinit var label: String
+        composeRule.setContent {
+            label = stringResource(R.string.map_overlay_psk)
+            PskOverlayToggle(enabled = false, onToggle = { toggledTo = it })
+        }
+
+        composeRule.onNodeWithText(label).assertIsDisplayed()
+        composeRule.onNodeWithText(label).performClick()
+
+        assertThat(toggledTo).isTrue()
+    }
+
+    @Test
+    fun mapViewToggle_selectingAzimuthalEmitsThatMode() {
+        var selected: MapViewMode? = null
+        lateinit var azimuthalLabel: String
+        composeRule.setContent {
+            azimuthalLabel = stringResource(R.string.map_mode_azimuthal)
+            MapViewToggle(mode = MapViewMode.STANDARD, onModeChange = { selected = it })
+        }
+
+        composeRule.onNodeWithText(azimuthalLabel).performClick()
+
+        assertThat(selected).isEqualTo(MapViewMode.AZIMUTHAL)
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/map/MapProjectionTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/map/MapProjectionTest.kt
@@ -1,0 +1,64 @@
+package radio.ks3ckc.ft8us.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for the map's coordinate math: great-circle distance, the two
+ * projections (equirectangular + azimuthal-equidistant), and bearing. No
+ * Android/Compose runtime is touched, so these run as plain JVM tests.
+ *
+ * A quarter of the way around the globe along a meridian/equator is
+ * (PI/2) * 6371 km ≈ 10007.5 km — the reference value used throughout.
+ */
+class MapProjectionTest {
+
+    private val quarterArcKm = 10007.54
+
+    @Test
+    fun greatCircleKm_isZeroForCoincidentPoints() {
+        // acos() of a sin^2+cos^2 sum that rounds just under 1.0 leaves a
+        // sub-meter residue, so assert "within 10 m" rather than exactly 0.
+        assertThat(greatCircleKm(40.0, -75.0, 40.0, -75.0)).isWithin(1e-2).of(0.0)
+    }
+
+    @Test
+    fun greatCircleKm_equatorQuarterTurnIsAQuarterOfTheGlobe() {
+        assertThat(greatCircleKm(0.0, 0.0, 0.0, 90.0)).isWithin(1.0).of(quarterArcKm)
+    }
+
+    @Test
+    fun equirectProject_mapsCornersToNormalizedExtents() {
+        val origin = equirectProject(0.0, 0.0)
+        assertThat(origin.x).isWithin(1e-6f).of(0f)
+        assertThat(origin.y).isWithin(1e-6f).of(0f)
+
+        val corner = equirectProject(90.0, 180.0)
+        assertThat(corner.x).isWithin(1e-6f).of(1f)
+        assertThat(corner.y).isWithin(1e-6f).of(-1f)
+    }
+
+    @Test
+    fun azProject_centerCollapsesToOrigin() {
+        val p = azProject(12.0, 34.0, 12.0, 34.0)
+        assertThat(p.x).isWithin(1e-6f).of(0f)
+        assertThat(p.y).isWithin(1e-6f).of(0f)
+        assertThat(p.distKm).isWithin(1e-6).of(0.0)
+    }
+
+    @Test
+    fun azProject_distanceMatchesGreatCircle() {
+        val p = azProject(0.0, 0.0, 0.0, 90.0)
+        assertThat(p.distKm).isWithin(1.0).of(quarterArcKm)
+    }
+
+    @Test
+    fun computeBearing_dueEastIs90() {
+        assertThat(computeBearing(0.0, 0.0, 0.0, 90.0)).isWithin(1e-6).of(90.0)
+    }
+
+    @Test
+    fun computeBearing_dueNorthIs0() {
+        assertThat(computeBearing(0.0, 0.0, 90.0, 0.0)).isWithin(1e-6).of(0.0)
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreenTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/SettingsScreenTest.kt
@@ -1,0 +1,71 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Compose render + interaction tests for the shared Settings chrome (run on the
+ * JVM via Robolectric). The category detail screens (radio model picker,
+ * control-mode toggle, QRZ test-connection) are wired to the heavyweight
+ * MainViewModel and are out of scope for the first pass; the stateless section
+ * header and drill-down scaffold are the testable golden paths and back out of
+ * the way of the cursor-blink animations that make the editor dialogs
+ * non-deterministic under Robolectric.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class SettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun settingsSection_rendersTitleAndContent() {
+        composeRule.setContent {
+            SettingsSection(title = "RADIO & AUDIO") {
+                Text("Rig model")
+            }
+        }
+
+        composeRule.onNodeWithText("RADIO & AUDIO").assertIsDisplayed()
+        composeRule.onNodeWithText("Rig model").assertIsDisplayed()
+    }
+
+    @Test
+    fun settingsDetailScaffold_rendersTitleAndContent() {
+        composeRule.setContent {
+            SettingsDetailScaffold(title = "Transmission", onBack = {}) {
+                Text("Control mode")
+            }
+        }
+
+        composeRule.onNodeWithText("Transmission").assertIsDisplayed()
+        composeRule.onNodeWithText("Control mode").assertIsDisplayed()
+    }
+
+    @Test
+    fun settingsDetailScaffold_backButtonInvokesOnBack() {
+        var backPressed = false
+        composeRule.setContent {
+            SettingsDetailScaffold(title = "Transmission", onBack = { backPressed = true }) {
+                Text("Control mode")
+            }
+        }
+
+        // The back chevron is the only node with a click action in the scaffold
+        // (TopBar exposes none), so this uniquely targets it.
+        composeRule.onNode(hasClickAction()).performClick()
+
+        assertThat(backPressed).isTrue()
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreenTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/waterfall/WaterfallScreenTest.kt
@@ -1,0 +1,50 @@
+package radio.ks3ckc.ft8us.ui.waterfall
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Compose render + interaction tests for the Waterfall screen's stateless
+ * pieces (run on the JVM via Robolectric). The spectrum/waterfall canvases are
+ * native AndroidViews and out of scope; these cover the pure-Compose frequency
+ * ruler and the bottom-bar toggle chips.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class WaterfallScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun frequencyRuler_rendersTickLabelsEvery500Hz() {
+        composeRule.setContent {
+            FrequencyRuler(spectrumWidth = 1500)
+        }
+
+        listOf("0", "500", "1000", "1500").forEach { label ->
+            composeRule.onNodeWithText(label).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun toggleChip_rendersLabelAndFiresOnClick() {
+        var clicked = false
+        composeRule.setContent {
+            ToggleChip(label = "NR", active = false, onClick = { clicked = true })
+        }
+
+        composeRule.onNodeWithText("NR").assertIsDisplayed()
+        composeRule.onNodeWithText("NR").performClick()
+
+        assertThat(clicked).isTrue()
+    }
+}


### PR DESCRIPTION
Closes #64.

Follow-up to #27 / PR #58. PR #58 added `FilterChipsScreenTest` as the
template for JVM-only screen testing (Robolectric + `createComposeRule()`,
no emulator). This extends that pattern across the remaining major screens.

## Approach

The screen entry points (`DecodeScreen`, `WaterfallScreen`, `SettingsScreen`,
`MapScreen`, `LogbookScreen`) all take the heavyweight `MainViewModel`, so —
consistent with this repo's testing philosophy (extract decision/geometry
logic, test the stateless pieces) — each screen's **stateless sub-composables**
and **pure helpers** are the test surface. Production changes are
visibility-only (`private` → `internal`) test seams.

Goal per the issue: render + golden-path interactions, one or two per screen.

## New tests (20)

| Screen | Test | Covers |
|--------|------|--------|
| Decode | `DecodeScreenTest` | empty-state copy renders per selected filter |
| Decode | `DecodeFilterTest` | `filterMessages` "All" vs "CQ Calls" |
| Waterfall | `WaterfallScreenTest` | `FrequencyRuler` tick labels; `ToggleChip` render + click |
| Settings | `SettingsScreenTest` | `SettingsSection` + `SettingsDetailScaffold` render + back-button click |
| Map | `MapProjectionTest` | `greatCircleKm` / `equirectProject` / `azProject` / `computeBearing` math |
| Map | `MapOverlayToggleTest` | PSK overlay toggle + standard/azimuthal view switch |
| Logbook | `LogbookScreenTest` | `SegmentedTabRow` renders all tabs + reports taps |

## Notes

- The Settings operator-editor and the other category dialogs wrap
  `OutlinedTextField`s whose cursor-blink is an infinite animation that spins
  `waitForIdle` forever under Robolectric (`AppNotIdleException` / OOM). The
  non-dialog Settings chrome is the deterministic golden path instead. The
  Decode empty state embeds `EmptyStateWaves` (also an infinite animation), so
  that test freezes the clock (`autoAdvance = false`).
- The MapViewModel-coupled map canvases and the Logbook/Settings detail screens
  that depend on database queries remain out of scope for this first pass.

## Test plan

- `cd ft8cn && cmd.exe /c "gradlew.bat testDebugUnitTest"` — full suite green,
  including the 20 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)