### PR TITLE
Make the FT2 slot a true 3.75s (not 3.8s)

### DIFF
--- a/ft8cn/app/src/main/cpp/ft8_lib/ft8/constants.h
+++ b/ft8cn/app/src/main/cpp/ft8_lib/ft8/constants.h
@@ -16,9 +16,10 @@ extern "C"
 
 // FT2: same channel structure as FT4 (4-GFSK, 4 Costas blocks, 105 symbols, same LDPC),
 // but double the baud — half the FT4 symbol period. ~41.67 Hz tone spacing, ~167 Hz BW,
-// 3.8s T/R cycle. Reuses every FT4_* symbol constant below; only the period/slot differ.
+// 3.75s T/R cycle (exactly half FT4's 7.5s). Reuses every FT4_* symbol constant below;
+// only the period/slot differ.
 #define FT2_SYMBOL_PERIOD (0.024f) ///< FT2 symbol duration (NSPS 288 @ 12kHz)
-#define FT2_SLOT_TIME     (3.8f)   ///< FT2 slot period
+#define FT2_SLOT_TIME     (3.75f)  ///< FT2 slot period
 
 // Define FT8 symbol counts
 // FT8 message structure:

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
@@ -9,7 +9,7 @@ public final class FT8Common {
     public static final int FT8_MODE=0;
     public static final int FT4_MODE=1;
     //FT2: same 4-GFSK/Costas/LDPC structure as FT4 but double the baud (0.024s symbol
-    //period, 167Hz BW, 3.8s T/R cycle). Receive uses the from-source FT2 decoder; the
+    //period, 167Hz BW, 3.75s T/R cycle). Receive uses the from-source FT2 decoder; the
     //closed prebuilt libft8cn.so only knows FT8/FT4.
     public static final int FT2_MODE=2;
     public static final int SAMPLE_RATE=12000;
@@ -20,16 +20,17 @@ public final class FT8Common {
     //finish ~1s before the cycle boundary, so a CQ can be answered on the next slot.
     public static final int FT8_EARLY_DECODE_MILLISECOND=13500;
     public static final int FT4_SLOT_TIME_MILLISECOND=7500;
-    public static final int FT2_SLOT_TIME_MILLISECOND=3800;
+    public static final int FT2_SLOT_TIME_MILLISECOND=3750;
     public static final int FT8_5_SYMBOLS_MILLISECOND=800;//time needed for 5 symbols
 
 
     public static final float FT4_SLOT_TIME=7.5f;
-    public static final float FT2_SLOT_TIME=3.8f;
+    public static final float FT2_SLOT_TIME=3.75f;
     public static final int FT8_SLOT_TIME_M=150;//15 seconds
     public static final int FT8_5_SYMBOLS_TIME_M =8;//duration of 5 symbols: 0.8 seconds
     public static final int FT4_SLOT_TIME_M=75;//7.5 seconds
-    public static final int FT2_SLOT_TIME_M=38;//3.8 seconds
+    // FT2's 3.75s slot is 37.5 tenths — not a whole number, so it has no tenths-of-a-second
+    // form. Timing uses FT2_SLOT_TIME_MILLISECOND (3750) directly; see ModeProfile.slotMillis.
     public static final int FT8_TRANSMIT_DELAY=500;//default transmit delay duration in milliseconds
     public static final long DEEP_DECODE_TIMEOUT=7*1000;//maximum time range for deep decode
     public static final int DECODE_MAX_ITERATIONS=1;//number of iterations

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -330,9 +330,9 @@ public class Ft8Message {
     /**
      * The slot (cycle) index since the epoch for this message's mode.
      *
-     * <p>FT8 keeps its legacy 15s math and FT4 its 7.5s; FT2 uses its own 3.8s
+     * <p>FT8 keeps its legacy 15s math and FT4 its 7.5s; FT2 uses its own 3.75s
      * slot from {@link ModeProfile}, <em>not</em> FT4's 7.5s. Reusing FT4's
-     * period for FT2 collapsed two adjacent 3.8s slots into a single parity, so
+     * period for FT2 collapsed two adjacent 3.75s slots into a single parity, so
      * the QSO auto-sequencer ({@link com.bg7yoz.ft8cn.ft8transmit.FT8TransmitSignal})
      * saw the other station's reply as being in our own slot and skipped it —
      * stalling after a report instead of advancing to RR73 (issue #205). The
@@ -345,7 +345,7 @@ public class Ft8Message {
         if (signalFormat == FT8Common.FT8_MODE) {
             return (utcTime + 750) / 1000 / 15;
         } else if (signalFormat == FT8Common.FT2_MODE) {
-            int slot = ModeProfile.FT2.slotMillis; // 3800ms
+            int slot = ModeProfile.FT2.slotMillis; // 3750ms
             return (utcTime + slot / 20) / slot;
         } else {
             return (utcTime + 370) / 100 / 75;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -448,8 +448,8 @@ public class MainViewModel extends ViewModel {
         mutableIsFlexRadio.setValue(false);
         mutableIsXieguRadio.setValue(false);
 
-        //create timer for displaying time
-        utcTimer = new UtcTimer(10, false, new OnUtcTimer() {
+        //create timer for displaying time — a 1-second (1000ms) tick, just to refresh the clock.
+        utcTimer = new UtcTimer(1000, false, new OnUtcTimer() {
             @Override
             public void doHeartBeatTimer(long utc) {//clock info when not triggered
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ModeProfile.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ModeProfile.java
@@ -15,23 +15,22 @@ import com.bg7yoz.ft8cn.ft8transmit.GenerateFT8;
  * @see FT8Common#FT4_MODE
  */
 public enum ModeProfile {
-    // id, name, slotMs, slotTenths, earlyDecodeMs, symPeriod, symBt, numTones, isFt8
-    FT8(FT8Common.FT8_MODE, "FT8", 15000, 150, 13500, 0.160f, 2.0f, 79, true),
-    FT4(FT8Common.FT4_MODE, "FT4", 7500, 75, 6500, 0.048f, 1.0f, 105, false),
+    // id, name, slotMs, earlyDecodeMs, symPeriod, symBt, numTones, isFt8
+    FT8(FT8Common.FT8_MODE, "FT8", 15000, 13500, 0.160f, 2.0f, 79, true),
+    FT4(FT8Common.FT4_MODE, "FT4", 7500, 6500, 0.048f, 1.0f, 105, false),
     // FT2 reuses FT4's tone layout (4-GFSK, 4 Costas, 105 symbols, same LDPC/encoder) at
-    // double the baud: 0.024s symbol period -> ~2.52s audio, 3.8s slot. isFt8=false so
-    // encode() dispatches to the shared ft4Encode; decode routes to the from-source
-    // decoder (see usesFromSourceDecoder) since the prebuilt has no FT2 protocol.
-    FT2(FT8Common.FT2_MODE, "FT2", 3800, 38, 3000, 0.024f, 1.0f, 105, false);
+    // double the baud: 0.024s symbol period -> ~2.52s audio, 3.75s slot (exactly half FT4's
+    // 7.5s). isFt8=false so encode() dispatches to the shared ft4Encode; decode routes to the
+    // from-source decoder (see usesFromSourceDecoder) since the prebuilt has no FT2 protocol.
+    FT2(FT8Common.FT2_MODE, "FT2", 3750, 3000, 0.024f, 1.0f, 105, false);
 
     /** Mode id, matching the {@code FT8Common.*_MODE} ints (also stored in config + Ft8Message). */
     public final int id;
     /** Human/protocol-facing name ("FT8"/"FT4"), used for logs, PSKReporter, POTA, ADIF. */
     public final String displayName;
-    /** TX/RX cycle length in milliseconds (15000 FT8, 7500 FT4). */
+    /** TX/RX cycle length in milliseconds (15000 FT8, 7500 FT4, 3750 FT2); the
+     * {@link com.bg7yoz.ft8cn.timer.UtcTimer} fires a slot boundary on this grid. */
     public final int slotMillis;
-    /** Cycle length in tenths of a second, as the {@link com.bg7yoz.ft8cn.timer.UtcTimer} expects. */
-    public final int slotTenths;
     /** Shorter RX capture window used when fast/early decode is on. */
     public final int earlyDecodeMillis;
     /** GFSK symbol period in seconds (0.160 FT8, 0.048 FT4). */
@@ -51,13 +50,12 @@ public enum ModeProfile {
      */
     public final int audioSlackMillis;
 
-    ModeProfile(int id, String displayName, int slotMillis, int slotTenths,
+    ModeProfile(int id, String displayName, int slotMillis,
                 int earlyDecodeMillis, float symbolPeriod, float symbolBt,
                 int numTones, boolean isFt8) {
         this.id = id;
         this.displayName = displayName;
         this.slotMillis = slotMillis;
-        this.slotTenths = slotTenths;
         this.earlyDecodeMillis = earlyDecodeMillis;
         this.symbolPeriod = symbolPeriod;
         this.symbolBt = symbolBt;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
@@ -69,8 +69,8 @@ public class FT8SignalListener {
         this.db = db;
 
         // Create action trigger, synchronized with UTC time, on the current mode's cycle
-        // (FT8 = 15s/150, FT4 = 7.5s/75). DoOnSecTimer fires at the start of each cycle.
-        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotTenths, false, makeTimerCallback());
+        // (FT8 = 15000ms, FT4 = 7500ms, FT2 = 3750ms). DoOnSecTimer fires at the start of each cycle.
+        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotMillis, false, makeTimerCallback());
     }
 
     /** The cycle-trigger callback, shared between the constructor and {@link #rebuildTimer}. */
@@ -96,7 +96,7 @@ public class FT8SignalListener {
     public void rebuildTimer(ModeProfile mode) {
         boolean wasListening = utcTimer.isRunning();
         utcTimer.delete();
-        utcTimer = new UtcTimer(mode.slotTenths, false, makeTimerCallback());
+        utcTimer = new UtcTimer(mode.slotMillis, false, makeTimerCallback());
         if (wasListening) {
             utcTimer.start();
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -170,8 +170,8 @@ public class FT8TransmitSignal {
         // change therefore takes effect within the current cycle, so no per-cycle setVolume()
         // observer is needed here.
 
-        // Cycle timer on the current mode's period (FT8 = 15s/150, FT4 = 7.5s/75).
-        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotTenths, false, makeTimerCallback());
+        // Cycle timer on the current mode's period (FT8 = 15000ms, FT4 = 7500ms, FT2 = 3750ms).
+        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotMillis, false, makeTimerCallback());
 
         utcTimer.start();
 
@@ -227,7 +227,7 @@ public class FT8TransmitSignal {
      */
     public void rebuildTimer(ModeProfile mode) {
         utcTimer.delete();
-        utcTimer = new UtcTimer(mode.slotTenths, false, makeTimerCallback());
+        utcTimer = new UtcTimer(mode.slotMillis, false, makeTimerCallback());
         utcTimer.start();
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
@@ -32,7 +32,8 @@ import java.util.concurrent.Executors;
 
 
 public class UtcTimer {
-    private final int sec;
+    /** Slot (cycle) length in milliseconds: 15000 FT8, 7500 FT4, 3750 FT2. */
+    private final int slotMillis;
     private final boolean doOnce;
     private final OnUtcTimer onUtcTimer;
 
@@ -112,18 +113,18 @@ public class UtcTimer {
 
     /**
      * Constructor for the clock trigger. Requires specifying the clock cycle period, typically 15 seconds or 7.5 seconds.
-     * Since the cycle parameter is an int, the unit is tenths of a second.
+     * The cycle parameter is an int in milliseconds.
      * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
      * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
      * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
      * This trigger requires calling the delete function to fully stop (heartbeat actions also stop).
      *
-     * @param sec        clock cycle period in tenths of a second, e.g.: 15 seconds = 150, 7.5 seconds = 75
+     * @param slotMillis clock cycle period in milliseconds, e.g.: 15 seconds = 15000, 7.5 seconds = 7500, FT2 = 3750
      * @param doOnce     whether to trigger only once
      * @param onUtcTimer callback functions, including heartbeat callback and cycle start action callback
      */
-    public UtcTimer(int sec, boolean doOnce, OnUtcTimer onUtcTimer) {
-        this.sec = sec;
+    public UtcTimer(int slotMillis, boolean doOnce, OnUtcTimer onUtcTimer) {
+        this.slotMillis = slotMillis;
         this.doOnce = doOnce;
         this.onUtcTimer = onUtcTimer;
 
@@ -137,7 +138,7 @@ public class UtcTimer {
 
     /**
      * Define the clock-triggered action.
-     * The clock cycle is typically 15 seconds or 7.5 seconds; since the cycle parameter is an int, the unit is tenths of a second.
+     * The clock cycle is typically 15 seconds or 7.5 seconds; the cycle parameter is an int in milliseconds.
      * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
      * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
      * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
@@ -156,29 +157,37 @@ public class UtcTimer {
         };
     }
 
+    /** Detection window (ms) for opening a slot — see {@link #isCycleBoundary}. */
+    private static final int SLOT_OPEN_WINDOW_MS = 100;
+
     /**
-     * Whether {@code utc} lands on a cycle (slot) boundary for a slot of {@code sec} tenths
-     * of a second, anchored to the Unix epoch.
+     * Whether {@code utc} lands on a cycle (slot) boundary for a slot of {@code slotMillis}
+     * milliseconds, anchored to the Unix epoch.
      *
-     * <p>The original test was {@code (((utc - offsetMs) / 100) % 600) % sec == 0}, which
-     * anchored the slot grid to each UTC minute (600 tenths of a second). That is identical
-     * to this epoch-anchored form only when {@code sec} evenly divides 600 — true for FT8
-     * (150) and FT4 (75), but NOT FT2 (38, since 600 / 38 is not whole). For FT2 the
-     * minute-anchored grid drifted off the absolute 3.8 s slot grid that
-     * {@link #sequential(long, int)} and the transmit late-start clip math both use, so a
-     * normal FT2 transmit fired part-way into its slot and had its leading Costas sync
-     * array clipped — audible on the air but undecodable. Anchoring to the epoch keeps the
-     * FT8/FT4 firing instants byte-for-byte identical while making every slot length
-     * internally consistent.
+     * <p>A slot opens in the {@link #SLOT_OPEN_WINDOW_MS}-millisecond window that starts at
+     * each epoch-anchored multiple of {@code slotMillis}. The 100 ms window is wide enough
+     * that the 10 ms heartbeat reliably lands at least one tick inside it, and the 1 s
+     * post-fire pause in {@link #secTask()} prevents a second fire within the same slot.
      *
-     * @param utc      system time in ms (epoch + {@link #delay})
-     * @param offsetMs manual time offset in ms (see {@link #setTime_sec(int)})
-     * @param sec      slot period in tenths of a second (see ModeProfile.slotTenths)
-     * @return true exactly on the 100 ms tick that opens a slot
+     * <p>This works in milliseconds rather than tenths of a second so a slot length that
+     * isn't a whole number of tenths — FT2's 3750 ms — sits on a clean grid. For FT8
+     * (15000) and FT4 (7500) the firing instants are byte-for-byte identical to the old
+     * tenths predicate {@code (utc/100) % (slotMillis/100) == 0}: both fire exactly in
+     * {@code [k*slotMillis, k*slotMillis + 99]}. The earlier tenths form rounded FT2 to a
+     * 3.8 s grid (37.5 tenths isn't an integer), which drifted off the absolute 3.75 s slot
+     * grid that {@link #sequential(long, int)} and the transmit late-start clip math use, so
+     * a normal FT2 transmit fired part-way into its slot and had its leading Costas sync
+     * array clipped — audible on the air but undecodable.
+     *
+     * @param utc        system time in ms (epoch + {@link #delay})
+     * @param offsetMs   manual time offset in ms (see {@link #setTime_sec(int)})
+     * @param slotMillis slot period in milliseconds (see ModeProfile.slotMillis)
+     * @return true on the heartbeat ticks that open a slot
      */
-    public static boolean isCycleBoundary(long utc, int offsetMs, int sec) {
-        if (sec <= 0) return false;
-        return (((utc - offsetMs) / 100) % sec) == 0;
+    public static boolean isCycleBoundary(long utc, int offsetMs, int slotMillis) {
+        if (slotMillis <= 0) return false;
+        long intoSlot = ((utc - offsetMs) % slotMillis + slotMillis) % slotMillis;
+        return intoSlot < SLOT_OPEN_WINDOW_MS;
     }
 
     private TimerTask secTask() {
@@ -192,7 +201,7 @@ public class UtcTimer {
                     utc = getSystemTime();//get current UTC time
                     //running determines whether to trigger cycle actions
                     //time_sec is the time offset
-                    if (running && isCycleBoundary(utc, time_sec, sec)) {
+                    if (running && isCycleBoundary(utc, time_sec, slotMillis)) {
                         //cycle action
                         //IMPORTANT! doHeartBeatTimer must not perform time-consuming operations and must complete within the heartbeat interval, otherwise thread backlog may occur and affect performance.
                         cachedThreadPool.execute(doSomething);//use thread pool for invocation to reduce system overhead

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
@@ -114,9 +114,10 @@ public class UtcTimer {
     /**
      * Constructor for the clock trigger. Requires specifying the clock cycle period, typically 15 seconds or 7.5 seconds.
      * The cycle parameter is an int in milliseconds.
-     * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
-     * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
-     * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
+     * The cycle-boundary check runs on a fast 10ms task, so cycle (doOnSecTimer) callbacks should be as concise as
+     * possible and must complete before the next tick, to prevent thread stacking and performance impact.
+     * The heartbeat callback (doHeartBeatTimer) runs on a separate 1000ms task and is independent of whether cycle
+     * actions are triggering (running==false); as long as the UtcTimer instance exists it runs (convenient for displaying clock data).
      * This trigger requires calling the delete function to fully stop (heartbeat actions also stop).
      *
      * @param slotMillis clock cycle period in milliseconds, e.g.: 15 seconds = 15000, 7.5 seconds = 7500, FT2 = 3750
@@ -129,8 +130,7 @@ public class UtcTimer {
         this.onUtcTimer = onUtcTimer;
 
         //initialize Timer tasks
-        //TimerTask timerTask = initTask();
-        //execute timer, 0 delay, 100ms period
+        //secTask checks the cycle boundary every 10ms; heartBeatTask fires the display callback every 1000ms.
 
         secTimer.schedule(secTask(), 0, 10);
         heartBeatTimer.schedule(heartBeatTask(), 0, 1000);
@@ -139,9 +139,10 @@ public class UtcTimer {
     /**
      * Define the clock-triggered action.
      * The clock cycle is typically 15 seconds or 7.5 seconds; the cycle parameter is an int in milliseconds.
-     * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
-     * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
-     * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
+     * The cycle-boundary check runs on a fast 10ms task, so callbacks should be as concise as possible
+     * and must complete before the next tick, to prevent thread stacking and performance impact.
+     * The heartbeat callback runs on a separate 1000ms task and is independent of whether cycle actions are
+     * triggering (running==false); as long as the UtcTimer instance exists it runs (convenient for displaying clock data).
      *
      * @return TimerTask the action instance
      */

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
@@ -9,7 +9,7 @@ package com.bg7yoz.ft8cn.ui;
  * times, at different scroll offsets, and appear to repeat down the waterfall — including
  * over the next slot's blank rows where the signal is already gone. Keyed on a per-slot
  * index (the caller derives it from the current mode's slot length, e.g.
- * {@code utcMs / slotMillis} — 15s FT8, 7.5s FT4, 3.8s FT2), this returns true for only the
+ * {@code utcMs / slotMillis} — 15s FT8, 7.5s FT4, 3.75s FT2), this returns true for only the
  * first stamp of each slot.
  *
  * <p>The slot length is part of the key as well as the slot index, because a single

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelMessages.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelMessages.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
  * the overlay on a non-empty decode, so a silent slot left the previous slot's
  * messages in place and they were re-stamped onto the waterfall each cycle,
  * appearing to repeat and never disappear. The effect is worst on FT4 (7.5s) and
- * especially FT2 (3.8s), whose short, often-empty slots re-stamp far more often
+ * especially FT2 (3.75s), whose short, often-empty slots re-stamp far more often
  * than FT8's 15s slots.
  */
 public final class WaterfallLabelMessages {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -334,7 +334,7 @@ public class WaterfallView extends View {
             // different scroll offsets, so they appear to repeat down the waterfall —
             // including over the next cycle's not-yet-populated rows where the signal is
             // gone. Stamp at most once per decode slot. Key the gate on the current mode's
-            // slot length (NOT a fixed 15s) so FT4 (7.5s) and FT2 (3.8s) each get one stamp
+            // slot length (NOT a fixed 15s) so FT4 (7.5s) and FT2 (3.75s) each get one stamp
             // per slot instead of one stamp per two-or-more slots. Pass slotMillis as part
             // of the key too: this view (and its gate) is reused across mode changes, and a
             // new mode's slotPeriod can collide with one already stamped under the old mode,

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
@@ -366,28 +366,28 @@ public class Ft8MessageTest {
 
     @Test
     public void getSequence_ft2_alternatesEachShortSlot() {
-        // FT2's 3.8s slot — must alternate twice as fast as FT4's 7.5s.
+        // FT2's 3.75s slot — must alternate twice as fast as FT4's 7.5s.
         Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
         msg.utcTime = 0;
         assertThat(msg.getSequence()).isEqualTo(0);
-        msg.utcTime = 3800;
+        msg.utcTime = 3750;
         assertThat(msg.getSequence()).isEqualTo(1);
-        msg.utcTime = 7600;
+        msg.utcTime = 7500;
         assertThat(msg.getSequence()).isEqualTo(0);
-        msg.utcTime = 11400;
+        msg.utcTime = 11250;
         assertThat(msg.getSequence()).isEqualTo(1);
     }
 
     @Test
     public void getSequence_ft2_adjacentSlotsHaveDistinctParity() {
         // Regression for #205: the old code reused FT4's 7.5s period for FT2, so
-        // two adjacent 3.8s slots (0ms and 3800ms) both mapped to sequence 0.
+        // two adjacent 3.75s slots (0ms and 3750ms) both mapped to sequence 0.
         // The QSO sequencer then saw the other station's reply as being in our
         // own slot and skipped it, stalling on the report instead of sending RR73.
         Ft8Message slotA = new Ft8Message(FT8Common.FT2_MODE);
         slotA.utcTime = 0;
         Ft8Message slotB = new Ft8Message(FT8Common.FT2_MODE);
-        slotB.utcTime = 3800;
+        slotB.utcTime = 3750;
         assertThat(slotA.getSequence()).isNotEqualTo(slotB.getSequence());
     }
 
@@ -396,7 +396,7 @@ public class Ft8MessageTest {
         // utcTime is slot-aligned; the +slot/20 nudge keeps a timestamp a touch
         // early (clock skew) in the correct slot rather than the previous one.
         Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
-        msg.utcTime = 3800 - 50; // 50ms before slot 1's boundary
+        msg.utcTime = 3750 - 50; // 50ms before slot 1's boundary
         assertThat(msg.getSequence()).isEqualTo(1);
     }
 
@@ -405,13 +405,13 @@ public class Ft8MessageTest {
         Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
         msg.utcTime = 0;
         assertThat(msg.getSequence4()).isEqualTo(0);
-        msg.utcTime = 3800;
+        msg.utcTime = 3750;
         assertThat(msg.getSequence4()).isEqualTo(1);
-        msg.utcTime = 7600;
+        msg.utcTime = 7500;
         assertThat(msg.getSequence4()).isEqualTo(2);
-        msg.utcTime = 11400;
+        msg.utcTime = 11250;
         assertThat(msg.getSequence4()).isEqualTo(3);
-        msg.utcTime = 15200;
+        msg.utcTime = 15000;
         assertThat(msg.getSequence4()).isEqualTo(0);
     }
 

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ModeProfileTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ModeProfileTest.java
@@ -17,7 +17,6 @@ public class ModeProfileTest {
         assertThat(m.id).isEqualTo(FT8Common.FT8_MODE);
         assertThat(m.displayName).isEqualTo("FT8");
         assertThat(m.slotMillis).isEqualTo(15_000);
-        assertThat(m.slotTenths).isEqualTo(150);
         assertThat(m.numTones).isEqualTo(79);
         assertThat(m.isFt8).isTrue();
         // 79 * 0.160 * 1000 = 12640ms audio; slack = 15000 - 12640.
@@ -31,7 +30,6 @@ public class ModeProfileTest {
         assertThat(m.id).isEqualTo(FT8Common.FT4_MODE);
         assertThat(m.displayName).isEqualTo("FT4");
         assertThat(m.slotMillis).isEqualTo(7_500);
-        assertThat(m.slotTenths).isEqualTo(75);
         assertThat(m.numTones).isEqualTo(105);
         assertThat(m.isFt8).isFalse();
         // 105 * 0.048 * 1000 = 5040ms audio; slack = 7500 - 5040.
@@ -44,17 +42,18 @@ public class ModeProfileTest {
         ModeProfile m = ModeProfile.FT2;
         assertThat(m.id).isEqualTo(FT8Common.FT2_MODE);
         assertThat(m.displayName).isEqualTo("FT2");
-        assertThat(m.slotMillis).isEqualTo(3_800);
-        assertThat(m.slotTenths).isEqualTo(38);
+        // FT2's slot is exactly half FT4's 7.5s, so 3750ms.
+        assertThat(m.slotMillis).isEqualTo(3_750);
+        assertThat(m.slotMillis).isEqualTo(ModeProfile.FT4.slotMillis / 2);
         // FT2 reuses FT4's 105-symbol layout (same encoder/tones).
         assertThat(m.numTones).isEqualTo(105);
         // FT2 decodes as FT4-family (isFt8 false), but receives on the from-source decoder.
         assertThat(m.isFt8).isFalse();
         // Half FT4's symbol period -> double baud.
         assertThat(m.symbolPeriod).isEqualTo(0.024f);
-        // 105 * 0.024 * 1000 = 2520ms audio; slack = 3800 - 2520.
+        // 105 * 0.024 * 1000 = 2520ms audio; slack = 3750 - 2520.
         assertThat(m.audioMillis).isEqualTo(2_520);
-        assertThat(m.audioSlackMillis).isEqualTo(1_280);
+        assertThat(m.audioSlackMillis).isEqualTo(1_230);
     }
 
     @Test

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
@@ -171,6 +171,19 @@ public class UtcTimerTest {
     }
 
     @Test
+    public void isCycleBoundary_oneSecondTickFiresOnSecondGrid() {
+        // MainViewModel's clock-display timer is a 1-second tick. It used to pass the
+        // tenths value 10 (= 1s); under the millisecond API it must pass 1000. Both forms
+        // fire once per second, second-aligned — guard against the unit regression.
+        for (long ms = 0; ms < 10_000; ms += 100) {
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 1_000))
+                    .isEqualTo(tenthsBoundary(ms, 0, 10));
+        }
+        assertThat(UtcTimer.isCycleBoundary(1_000L, 0, 1_000)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(500L, 0, 1_000)).isFalse();
+    }
+
+    @Test
     public void isCycleBoundary_nonPositivePeriodNeverFires() {
         assertThat(UtcTimer.isCycleBoundary(0L, 0, 0)).isFalse();
         assertThat(UtcTimer.isCycleBoundary(15_000L, 0, -5)).isFalse();

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
@@ -77,14 +77,14 @@ public class UtcTimerTest {
     }
 
     @Test
-    public void sequential_withSlotMillis_ft2AlternatesEvery3point8s() {
-        // FT2's 3800ms slot isn't a whole number of seconds; sequential() works in ms
-        // directly so the boundary lands exactly on each 3.8s multiple.
-        assertThat(UtcTimer.sequential(0L, 3_800)).isEqualTo(0);
-        assertThat(UtcTimer.sequential(3_799L, 3_800)).isEqualTo(0);
-        assertThat(UtcTimer.sequential(3_800L, 3_800)).isEqualTo(1);
-        assertThat(UtcTimer.sequential(7_600L, 3_800)).isEqualTo(0);
-        assertThat(UtcTimer.sequential(11_400L, 3_800)).isEqualTo(1);
+    public void sequential_withSlotMillis_ft2AlternatesEvery3point75s() {
+        // FT2's 3750ms slot isn't a whole number of seconds; sequential() works in ms
+        // directly so the boundary lands exactly on each 3.75s multiple.
+        assertThat(UtcTimer.sequential(0L, 3_750)).isEqualTo(0);
+        assertThat(UtcTimer.sequential(3_749L, 3_750)).isEqualTo(0);
+        assertThat(UtcTimer.sequential(3_750L, 3_750)).isEqualTo(1);
+        assertThat(UtcTimer.sequential(7_500L, 3_750)).isEqualTo(0);
+        assertThat(UtcTimer.sequential(11_250L, 3_750)).isEqualTo(1);
     }
 
     @Test
@@ -97,83 +97,77 @@ public class UtcTimerTest {
         assertThat(UtcTimer.sequential(29_999L)).isEqualTo(1);
     }
 
-    /** The legacy minute-anchored predicate, kept here to prove equivalence for FT8/FT4. */
-    private static boolean legacyBoundary(long utc, int offsetMs, int sec) {
-        return (((utc - offsetMs) / 100) % 600) % sec == 0;
+    /**
+     * The slot-boundary predicate before this change worked in tenths of a second
+     * ({@code (utc/100) % tenths == 0}). Kept here to prove the new millisecond-window
+     * predicate fires on exactly the same 100ms ticks for FT8 and FT4 — whose slot lengths
+     * are whole tenths (150, 75) — so only FT2 (3.75s, not a whole tenth) changes.
+     */
+    private static boolean tenthsBoundary(long utc, int offsetMs, int tenths) {
+        return (((utc - offsetMs) / 100) % tenths) == 0;
     }
 
     @Test
-    public void isCycleBoundary_ft8MatchesLegacyMinuteAnchoredFormula() {
-        // 150 tenths (15s) divides 600, so the new epoch-anchored test must agree with the
-        // old minute-anchored one at every 100ms tick across a full minute.
+    public void isCycleBoundary_ft8MatchesPreviousTenthsPredicate() {
         for (long ms = 0; ms < 60_000; ms += 100) {
-            assertThat(UtcTimer.isCycleBoundary(ms, 0, 150))
-                    .isEqualTo(legacyBoundary(ms, 0, 150));
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 15_000))
+                    .isEqualTo(tenthsBoundary(ms, 0, 150));
         }
     }
 
     @Test
-    public void isCycleBoundary_ft4MatchesLegacyMinuteAnchoredFormula() {
-        // 75 tenths (7.5s) also divides 600 — behaviour is unchanged for FT4.
+    public void isCycleBoundary_ft4MatchesPreviousTenthsPredicate() {
         for (long ms = 0; ms < 60_000; ms += 100) {
-            assertThat(UtcTimer.isCycleBoundary(ms, 0, 75))
-                    .isEqualTo(legacyBoundary(ms, 0, 75));
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 7_500))
+                    .isEqualTo(tenthsBoundary(ms, 0, 75));
         }
     }
 
     @Test
     public void isCycleBoundary_ft8FiresOnAbsoluteSlotGrid() {
-        assertThat(UtcTimer.isCycleBoundary(0L, 0, 150)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(15_000L, 0, 150)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(7_500L, 0, 150)).isFalse();
-        // Real-world instant: a boundary iff systemTime % 15000 == 0.
-        assertThat(UtcTimer.isCycleBoundary(T_2023, 0, 150))
-                .isEqualTo(T_2023 % 15_000 == 0);
+        assertThat(UtcTimer.isCycleBoundary(0L, 0, 15_000)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(15_000L, 0, 15_000)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(7_500L, 0, 15_000)).isFalse();
+        // Real-world instant: a boundary iff systemTime % 15000 is inside the open window.
+        assertThat(UtcTimer.isCycleBoundary(T_2023, 0, 15_000))
+                .isEqualTo(T_2023 % 15_000 < 100);
     }
 
     @Test
-    public void isCycleBoundary_ft2FiresOnAbsolute3point8sGrid() {
-        // FT2 (38 tenths) does NOT divide 600, so this is where old and new diverge.
-        // The new predicate fires exactly on multiples of 3.8s from the epoch...
-        assertThat(UtcTimer.isCycleBoundary(0L, 0, 38)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(3_800L, 0, 38)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(7_600L, 0, 38)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(3_700L, 0, 38)).isFalse();
-        assertThat(UtcTimer.isCycleBoundary(3_900L, 0, 38)).isFalse();
+    public void isCycleBoundary_ft2FiresOnAbsolute3point75sGrid() {
+        // FT2's 3750ms slot has no tenths-of-a-second form (37.5 tenths), so the
+        // millisecond predicate is what puts it on a clean grid. Fires in the 100ms
+        // window opening each slot.
+        assertThat(UtcTimer.isCycleBoundary(0L, 0, 3_750)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(3_750L, 0, 3_750)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(7_500L, 0, 3_750)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(11_250L, 0, 3_750)).isTrue();
+        // Mid-slot and just-outside-the-window instants do not fire.
+        assertThat(UtcTimer.isCycleBoundary(1_875L, 0, 3_750)).isFalse();
+        assertThat(UtcTimer.isCycleBoundary(3_700L, 0, 3_750)).isFalse();
+        assertThat(UtcTimer.isCycleBoundary(3_850L, 0, 3_750)).isFalse();
     }
 
     @Test
     public void isCycleBoundary_ft2EveryFireOpensASlotSoLateStartNeverClips() {
         // The transmit late-start math clips leading audio by (systemTime % slotMillis)
-        // beyond the slack. The FT2 regression was that the timer fired when
-        // systemTime % 3800 was large (up to ~3.0s), clipping the leading Costas sync.
-        // With the epoch-anchored predicate, every fire lands within one 100ms tick of a
-        // real 3800ms slot boundary, so msIntoCycle is always < 100 and nothing is clipped.
-        int slotMillis = 3_800;
+        // beyond the slack. Every fire must land within the 100ms slot-open window so
+        // msIntoCycle stays < 100 and the leading Costas sync is never clipped.
+        int slotMillis = 3_750;
         int fires = 0;
         for (long ms = 0; ms < 600_000; ms += 100) { // 10 minutes of ticks
-            if (UtcTimer.isCycleBoundary(ms, 0, 38)) {
+            if (UtcTimer.isCycleBoundary(ms, 0, slotMillis)) {
                 fires++;
                 long msIntoCycle = ms % slotMillis;
                 assertThat(msIntoCycle).isLessThan(100L);
             }
         }
-        // Sanity: ~ one fire per 3.8s over 10 minutes.
-        assertThat(fires).isEqualTo(600_000 / slotMillis + 1);
-    }
-
-    @Test
-    public void isCycleBoundary_legacyFormulaWouldHaveClippedFt2() {
-        // Guard the regression: the OLD predicate fired off the absolute slot grid for
-        // FT2, landing where systemTime % 3800 was large — that is the clip that broke TX.
-        boolean sawLargeOffset = false;
-        for (long ms = 0; ms < 600_000; ms += 100) {
-            if (legacyBoundary(ms, 0, 38) && (ms % 3_800) >= 1_280) {
-                sawLargeOffset = true; // >= FT2 audio slack -> leading audio clipped
-                break;
-            }
-        }
-        assertThat(sawLargeOffset).isTrue();
+        // Exactly one fire per slot over 10 minutes. When slotMillis divides 600000 the
+        // boundary at 600000 itself is excluded (loop is ms < 600000).
+        int expected = (600_000 % slotMillis == 0)
+                ? 600_000 / slotMillis
+                : 600_000 / slotMillis + 1;
+        assertThat(fires).isEqualTo(expected);
     }
 
     @Test

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
@@ -38,8 +38,8 @@ class SlotTimerStateTest {
     }
 
     @Test
-    fun `ft2 slot — 3point8s peaks at 4 seconds`() {
-        val s = slotTimerState(nowMs = 0L, slotMillis = 3_800L)
+    fun `ft2 slot — 3point75s peaks at 4 seconds`() {
+        val s = slotTimerState(nowMs = 0L, slotMillis = 3_750L)
         assertThat(s.secondsRemaining).isEqualTo(4)
     }
 


### PR DESCRIPTION
## What

FT2 is FT4''s channel layout (105 symbols, 4-Costas, 0.024s symbol period) run on a half-length T/R cycle, so its slot should be exactly **half FT4''s 7.5s = 3.75s**. It was running on a **3.8s** grid, opening every slot ~50ms late relative to the intended grid — the drift reported in use.

## Why it was 3.8s

The cycle-boundary detector worked in *tenths of a second* (`UtcTimer.isCycleBoundary`: `(utc/100) % slotTenths == 0`). `3.75s = 37.5 tenths` isn''t an integer, so FT2 had been rounded to 3.8s / 38 tenths, and the millisecond-based timing (`sequential()`, the transmit late-start clip math, the slot-timer UI) was set to a matching 3800ms so the app stayed internally consistent — just at the wrong period.

## The fix

Move boundary detection onto the **millisecond** grid everything else already uses:

- `isCycleBoundary(utc, offsetMs, slotMillis)` now fires in the 100ms window opening each epoch-anchored multiple of `slotMillis`. For FT8 (15000) and FT4 (7500) the firing instants are **byte-for-byte identical** to the old tenths predicate (preserving the epoch-anchoring invariant from #174); only FT2 changes.
- `ModeProfile.FT2.slotMillis` 3800 → **3750** (derived `audioSlackMillis` 1280 → 1230).
- `slotTenths` removed entirely — a 3750ms slot has no honest tenths form, and the timer constructor now takes `slotMillis`.
- Native `FT2_SLOT_TIME` 3.8f → **3.75f** (sizes the from-source decoder''s waterfall buffer; rebuilt by the normal build).
- Comments and the unused legacy `FT8Common.FT2_SLOT_TIME*` constants updated for consistency.

Side note: 3750 × 16 = 60000, so FT2 now also divides the minute evenly (3.8s never did).

## Tests

- `UtcTimerTest`: new cases prove the ms predicate matches the previous tenths predicate for FT8/FT4 across a full minute, and fires on the 3.75s grid (every fire within the 100ms slot-open window, so the leading Costas sync is never clipped).
- `ModeProfileTest`, `Ft8MessageTest`, `SlotTimerStateTest`: FT2 expectations moved to 3750.
- Full `testDebugUnitTest` suite passes; `installDebug` compiles + packages cleanly (native included).

## Not yet verified

On-device FT2 TX (no device was attached) — confirm `msLate ≈ 0` in `debug.log` and a clean decode on another receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)