### PR TITLE
Keep app alive on rotation (no splash/restart)

### DIFF
--- a/ft8cn/app/src/main/AndroidManifest.xml
+++ b/ft8cn/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         <activity
             android:name="radio.ks3ckc.ft8us.ComposeMainActivity"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:configChanges="orientation|screenSize|smallestScreenSize|keyboardHidden|screenLayout|uiMode">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ComposeMainActivityConfigChangesTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ComposeMainActivityConfigChangesTest.kt
@@ -1,0 +1,61 @@
+package radio.ks3ckc.ft8us
+
+import android.content.ComponentName
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Guards the manifest's `android:configChanges` on [ComposeMainActivity].
+ *
+ * Without these flags Android destroys and recreates the launcher activity on
+ * every rotation, which replays the splash and tears down live state (CAT link,
+ * audio loop, decode cycle). Declaring the flags makes Compose simply relay out
+ * in place. This test fails loudly if a future manifest edit drops any of them
+ * and silently reintroduces the rotate-restart bug.
+ *
+ * Robolectric reads the merged manifest, so the assertion reflects what actually
+ * ships. ActivityInfo.configChanges is a bitmask of CONFIG_* flags.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ComposeMainActivityConfigChangesTest {
+
+    private val required = mapOf(
+        "orientation" to ActivityInfo.CONFIG_ORIENTATION,
+        "screenSize" to ActivityInfo.CONFIG_SCREEN_SIZE,
+        "smallestScreenSize" to ActivityInfo.CONFIG_SMALLEST_SCREEN_SIZE,
+        "keyboardHidden" to ActivityInfo.CONFIG_KEYBOARD_HIDDEN,
+        "screenLayout" to ActivityInfo.CONFIG_SCREEN_LAYOUT,
+        "uiMode" to ActivityInfo.CONFIG_UI_MODE,
+    )
+
+    private fun activityInfo(): ActivityInfo {
+        val context = RuntimeEnvironment.getApplication()
+        val component = ComponentName(context, ComposeMainActivity::class.java)
+        return context.packageManager.getActivityInfo(component, PackageManager.GET_META_DATA)
+    }
+
+    @Test
+    fun launcherActivity_handlesRotationWithoutRecreation() {
+        val configChanges = activityInfo().configChanges
+        for ((name, flag) in required) {
+            assertWithMessage("configChanges must declare '$name'")
+                .that(configChanges and flag).isEqualTo(flag)
+        }
+    }
+
+    @Test
+    fun launcherActivity_handlesOrientationAndScreenSizeTogether() {
+        // Rotation changes orientation *and* screen size on modern target SDKs;
+        // both must be claimed or the activity still recreates. This is the
+        // single most important pair for the rotate-restart bug.
+        val configChanges = activityInfo().configChanges
+        val rotationPair = ActivityInfo.CONFIG_ORIENTATION or ActivityInfo.CONFIG_SCREEN_SIZE
+        assertThat(configChanges and rotationPair).isEqualTo(rotationPair)
+    }
+}


### PR DESCRIPTION
## Problem

Rotating the phone flashed the splash screen and looked like the app was restarting. Cause: `ComposeMainActivity` (the launcher activity) declared no `android:configChanges`, so Android destroyed and recreated the activity on every rotation — replaying the splash and tearing down live state (CAT link, audio loop, decode cycle).

## Fix

Declare `orientation|screenSize|smallestScreenSize|keyboardHidden|screenLayout|uiMode` on the activity. The framework now hands the config change to the activity instead of recreating it; Jetpack Compose re-reads the configuration and relays out in place. Rotation just reflows the UI — no splash, no restart, no dropped connection.

`screenSize`/`smallestScreenSize` are required alongside `orientation` because rotation changes those dimensions too on modern target SDKs; without them the activity would still recreate. `uiMode`/`screenLayout` also cover dark-mode and multi-window changes.

## Test

Added `ComposeMainActivityConfigChangesTest` (Robolectric) that reads the **merged** manifest and asserts the launcher activity declares each required flag — so a future manifest edit can't silently drop them and reintroduce the rotate-restart bug. `testDebugUnitTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)