### PR TITLE
Auto-reconnect Bluetooth CAT rig on startup and route HFP audio (#223)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -319,7 +319,7 @@ public class GeneralVariables {
 
     public static int connectMode = ConnectMode.USB_CABLE;//Connection mode: USB==0, BLUE_TOOTH==1
 
-    //public static String bluetoothDeviceAddress=null;//Bluetooth device address available for connection
+    public static String bluetoothDeviceAddress = null;//last-selected Bluetooth (SPP/CAT) device address, persisted for auto-reconnect
 
 
     //Records callsign-to-grid mapping. todo---should also add this list to background tracking info

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -1165,6 +1165,12 @@ public class MainViewModel extends ViewModel {
         baseRig.setOnRigStateChanged(onRigStateChanged);
         baseRig.setConnector(connector);
 
+        // Route HFP audio over SCO as soon as the CAT rig is wired. Without this, SCO is
+        // only (re)started as a side effect of the TX/RX cycle (needControlSco()/startSco()),
+        // which never fires until a rig is connected -- so on relaunch audio was dead in both
+        // directions until the user manually reconfigured Bluetooth (issue #223).
+        new Handler(Looper.getMainLooper()).post(this::setBlueToothOn);
+
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {//connection takes time, wait before setting frequency
             @Override
             public void run() {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -1153,6 +1153,14 @@ public class MainViewModel extends ViewModel {
     }
 
     public void connectBluetoothRig(Context context, BluetoothDevice device) {
+        // Remember this device so the SPP/CAT link can auto-reconnect on the next app launch
+        // (issue #223). Centralized here so every entry point -- the Compose picker, the legacy
+        // SelectBluetoothDialog, and the startup auto-connect path -- persists consistently.
+        if (!device.getAddress().equals(GeneralVariables.bluetoothDeviceAddress)) {
+            GeneralVariables.bluetoothDeviceAddress = device.getAddress();
+            databaseOpr.writeConfig("bluetoothDeviceAddress", device.getAddress(), null);
+        }
+
         GeneralVariables.controlMode = ControlMode.CAT;//Bluetooth control mode, only CAT control is supported
         GeneralVariables.mutableControlMode.postValue(GeneralVariables.controlMode);
         connectRig();
@@ -1165,11 +1173,19 @@ public class MainViewModel extends ViewModel {
         baseRig.setOnRigStateChanged(onRigStateChanged);
         baseRig.setConnector(connector);
 
-        // Route HFP audio over SCO as soon as the CAT rig is wired. Without this, SCO is
-        // only (re)started as a side effect of the TX/RX cycle (needControlSco()/startSco()),
-        // which never fires until a rig is connected -- so on relaunch audio was dead in both
-        // directions until the user manually reconfigured Bluetooth (issue #223).
-        new Handler(Looper.getMainLooper()).post(this::setBlueToothOn);
+        // Route HFP audio over SCO as soon as the CAT rig is wired -- but only when a Bluetooth
+        // audio profile (headset/A2DP) is actually connected. SPP-only CAT adapters have no audio
+        // path, so forcing SCO + headset mode on them would be wrong and disruptive (PR #227
+        // review). Without this, SCO is only (re)started as a side effect of the TX/RX cycle
+        // (needControlSco()/startSco()), which never fires until a rig is connected -- so on
+        // relaunch audio was dead in both directions until the user manually reconfigured
+        // Bluetooth (issue #223). The BluetoothStateBroadcastReceive path remains the fallback
+        // for devices whose audio profile connects after this point.
+        new Handler(Looper.getMainLooper()).post(() -> {
+            if (isBTConnected()) {
+                setBlueToothOn();
+            }
+        });
 
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {//connection takes time, wait before setting frequency
             @Override

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2372,6 +2372,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("connectMode")) {
                     GeneralVariables.connectMode = result.equals("") ? ConnectMode.USB_CABLE : Integer.parseInt(result);
                 }
+                if (name.equalsIgnoreCase("bluetoothDeviceAddress")) {//last-selected BT (SPP/CAT) device, for auto-reconnect
+                    GeneralVariables.bluetoothDeviceAddress = result;
+                }
                 if (name.equalsIgnoreCase("model")) {//Radio model
                     GeneralVariables.modelNo = result.equals("") ? 0 : Integer.parseInt(result);
                 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
@@ -1,0 +1,49 @@
+package radio.ks3ckc.ft8us
+
+import com.bg7yoz.ft8cn.connector.ConnectMode
+
+/**
+ * Outcome of evaluating whether to auto-reconnect the Bluetooth (SPP/CAT) rig at startup.
+ * Only [CONNECT] triggers a connection; every other value documents why we held off
+ * (logged to debug.log for field diagnosis since the hardware path can't be unit-tested).
+ */
+internal enum class BtAutoConnectDecision {
+    CONNECT,
+    ALREADY_CONNECTED,
+    NOT_BT_MODE,
+    NO_SAVED_ADDRESS,
+    ADAPTER_OFF,
+    NO_PERMISSION,
+    NOT_BONDED,
+}
+
+/**
+ * Pure decision logic for Bluetooth CAT auto-reconnect (issue #223). Kept free of Android
+ * types so it can be unit-tested directly; the Activity gathers the real adapter/permission/
+ * bond state and feeds it in.
+ *
+ * Precedence (first match wins):
+ *  1. not in Bluetooth connect mode      -> NOT_BT_MODE
+ *  2. no remembered device address       -> NO_SAVED_ADDRESS
+ *  3. a rig is already connected         -> ALREADY_CONNECTED  (double-connect guard, mirrors USB)
+ *  4. the Bluetooth adapter is off       -> ADAPTER_OFF
+ *  5. BLUETOOTH_CONNECT not yet granted  -> NO_PERMISSION      (caller retries after grant)
+ *  6. the saved device isn't bonded      -> NOT_BONDED
+ *  7. otherwise                          -> CONNECT
+ */
+internal fun decideBluetoothAutoConnect(
+    connectMode: Int,
+    savedAddress: String?,
+    rigConnected: Boolean,
+    adapterOn: Boolean,
+    hasConnectPermission: Boolean,
+    isBonded: Boolean,
+): BtAutoConnectDecision {
+    if (connectMode != ConnectMode.BLUE_TOOTH) return BtAutoConnectDecision.NOT_BT_MODE
+    if (savedAddress.isNullOrBlank()) return BtAutoConnectDecision.NO_SAVED_ADDRESS
+    if (rigConnected) return BtAutoConnectDecision.ALREADY_CONNECTED
+    if (!adapterOn) return BtAutoConnectDecision.ADAPTER_OFF
+    if (!hasConnectPermission) return BtAutoConnectDecision.NO_PERMISSION
+    if (!isBonded) return BtAutoConnectDecision.NOT_BONDED
+    return BtAutoConnectDecision.CONNECT
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -569,18 +569,24 @@ class ComposeMainActivity : AppCompatActivity() {
     private fun autoConnectBluetoothIfNeeded() {
         val adapter = BluetoothAdapter.getDefaultAdapter()
         val addr = GeneralVariables.bluetoothDeviceAddress
+        // A corrupted/legacy persisted value would make getRemoteDevice() throw
+        // IllegalArgumentException and crash startup, so validate the MAC up front (PR #227 review).
+        val validAddr = !addr.isNullOrBlank() && BluetoothAdapter.checkBluetoothAddress(addr)
+        if (!addr.isNullOrBlank() && !validAddr) {
+            fileLog("autoConnectBT: ignoring invalid saved address=$addr")
+        }
         val hasPerm = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
             ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) ==
             PackageManager.PERMISSION_GRANTED
         val bonded = try {
-            hasPerm && adapter != null && !addr.isNullOrBlank() &&
+            hasPerm && adapter != null && validAddr &&
                 adapter.bondedDevices.any { it.address == addr }
         } catch (_: SecurityException) {
             false
         }
         val decision = decideBluetoothAutoConnect(
             connectMode = GeneralVariables.connectMode,
-            savedAddress = addr,
+            savedAddress = if (validAddr) addr else null,
             rigConnected = mainViewModel.isRigConnected(),
             adapterOn = adapter?.isEnabled == true,
             hasConnectPermission = hasPerm,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -277,6 +277,18 @@ class ComposeMainActivity : AppCompatActivity() {
             }
             GridLocationUpdater.refresh(applicationContext, mainViewModel)
         }
+
+        // On Android 12+ the BT auto-connect at config-load time may have bailed with
+        // NO_PERMISSION because BLUETOOTH_CONNECT was still pending. Once the user grants it,
+        // retry the SPP/CAT auto-reconnect in the same session (issue #223). The rigConnected
+        // guard inside makes this idempotent with the config-callback attempt.
+        val btIdx = permissions.indexOf(Manifest.permission.BLUETOOTH_CONNECT)
+        if (btIdx >= 0 && grantResults.getOrNull(btIdx) == PackageManager.PERMISSION_GRANTED
+            && mainViewModel.configIsLoaded
+        ) {
+            fileLog("onRequestPermissionsResult: BLUETOOTH_CONNECT granted, retrying BT auto-connect")
+            autoConnectBluetoothIfNeeded()
+        }
     }
 
     private fun initData() {
@@ -320,6 +332,11 @@ class ComposeMainActivity : AppCompatActivity() {
                 val ports = mainViewModel.mutableSerialPorts.value
                 fileLog("initData: found ${ports?.size ?: 0} serial port(s)")
                 mainViewModel.reinitializeAudioInput()
+
+                // USB auto-connect is driven by the mutableSerialPorts observer; Bluetooth has
+                // no such device-arrival event, so re-open the remembered SPP/CAT link here now
+                // that connectMode + the saved address are loaded (issue #223).
+                autoConnectBluetoothIfNeeded()
 
                 // Delayed re-scan for slow USB enumeration
                 Handler(Looper.getMainLooper()).postDelayed({
@@ -541,6 +558,38 @@ class ComposeMainActivity : AppCompatActivity() {
             "baudRate=${GeneralVariables.baudRate}, " +
             "controlMode=${GeneralVariables.controlMode})")
         mainViewModel.connectCableRig(applicationContext, ports[0])
+    }
+
+    /**
+     * Re-open the remembered Bluetooth (SPP/CAT) rig on startup when the user is in Bluetooth
+     * connect mode. Without this the CAT link never re-opened on relaunch, which also left
+     * HFP audio unrouted (issue #223). All branch logic lives in [decideBluetoothAutoConnect]
+     * so it is unit-testable; this method only collects Android state and acts on CONNECT.
+     */
+    private fun autoConnectBluetoothIfNeeded() {
+        val adapter = BluetoothAdapter.getDefaultAdapter()
+        val addr = GeneralVariables.bluetoothDeviceAddress
+        val hasPerm = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) ==
+            PackageManager.PERMISSION_GRANTED
+        val bonded = try {
+            hasPerm && adapter != null && !addr.isNullOrBlank() &&
+                adapter.bondedDevices.any { it.address == addr }
+        } catch (_: SecurityException) {
+            false
+        }
+        val decision = decideBluetoothAutoConnect(
+            connectMode = GeneralVariables.connectMode,
+            savedAddress = addr,
+            rigConnected = mainViewModel.isRigConnected(),
+            adapterOn = adapter?.isEnabled == true,
+            hasConnectPermission = hasPerm,
+            isBonded = bonded,
+        )
+        fileLog("autoConnectBT: decision=$decision addr=$addr connectMode=${GeneralVariables.connectMode}")
+        if (decision == BtAutoConnectDecision.CONNECT) {
+            mainViewModel.connectBluetoothRig(applicationContext, adapter!!.getRemoteDevice(addr))
+        }
     }
 
     /** Write a line to /sdcard/Android/data/com.bg7yoz.ft8cn/files/debug.log */

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
@@ -179,14 +179,8 @@ fun BluetoothPickerDialog(
                                             info.device.name,
                                         ),
                                     )
-                                    // Remember this device so we can auto-reconnect the
-                                    // SPP/CAT link on the next app launch (issue #223).
-                                    GeneralVariables.bluetoothDeviceAddress = info.device.address
-                                    mainViewModel.databaseOpr.writeConfig(
-                                        "bluetoothDeviceAddress",
-                                        info.device.address,
-                                        null,
-                                    )
+                                    // connectBluetoothRig() persists the device address centrally
+                                    // so the SPP/CAT link auto-reconnects on the next launch (#223).
                                     mainViewModel.connectBluetoothRig(
                                         GeneralVariables.getMainContext(),
                                         info.device,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
@@ -179,6 +179,14 @@ fun BluetoothPickerDialog(
                                             info.device.name,
                                         ),
                                     )
+                                    // Remember this device so we can auto-reconnect the
+                                    // SPP/CAT link on the next app launch (issue #223).
+                                    GeneralVariables.bluetoothDeviceAddress = info.device.address
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "bluetoothDeviceAddress",
+                                        info.device.address,
+                                        null,
+                                    )
                                     mainViewModel.connectBluetoothRig(
                                         GeneralVariables.getMainContext(),
                                         info.device,

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
@@ -1,0 +1,183 @@
+package radio.ks3ckc.ft8us
+
+import com.bg7yoz.ft8cn.connector.ConnectMode
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [decideBluetoothAutoConnect] (issue #223). Pure logic, no Android runtime:
+ * [ConnectMode] is a plain class of int constants, so no Robolectric runner is needed.
+ */
+class BluetoothAutoConnectTest {
+
+    /** All preconditions satisfied -> we should open the SPP/CAT link. */
+    @Test
+    fun connectsWhenEverythingReady() {
+        val decision = decideBluetoothAutoConnect(
+            connectMode = ConnectMode.BLUE_TOOTH,
+            savedAddress = "AA:BB:CC:DD:EE:FF",
+            rigConnected = false,
+            adapterOn = true,
+            hasConnectPermission = true,
+            isBonded = true,
+        )
+        assertThat(decision).isEqualTo(BtAutoConnectDecision.CONNECT)
+    }
+
+    @Test
+    fun usbModeIsNotBtMode() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.USB_CABLE,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BT_MODE)
+    }
+
+    @Test
+    fun networkModeIsNotBtMode() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.NETWORK,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BT_MODE)
+    }
+
+    @Test
+    fun nullAddressHasNothingToConnectTo() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = null,
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_SAVED_ADDRESS)
+    }
+
+    @Test
+    fun blankAddressHasNothingToConnectTo() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "   ",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_SAVED_ADDRESS)
+    }
+
+    /** Don't double-connect when a rig is already up (mirrors the USB guard). */
+    @Test
+    fun alreadyConnectedSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = true,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.ALREADY_CONNECTED)
+    }
+
+    @Test
+    fun adapterOffSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = false,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.ADAPTER_OFF)
+    }
+
+    @Test
+    fun missingPermissionSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = false,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_PERMISSION)
+    }
+
+    @Test
+    fun unbondedDeviceSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BONDED)
+    }
+
+    // ---- precedence: earlier checks win over later ones ----
+
+    @Test
+    fun notBtModeWinsOverMissingAddress() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.USB_CABLE,
+                savedAddress = null,
+                rigConnected = false,
+                adapterOn = false,
+                hasConnectPermission = false,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BT_MODE)
+    }
+
+    @Test
+    fun missingAddressWinsOverAlreadyConnected() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "",
+                rigConnected = true,
+                adapterOn = false,
+                hasConnectPermission = false,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_SAVED_ADDRESS)
+    }
+
+    @Test
+    fun alreadyConnectedWinsOverAdapterOff() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = true,
+                adapterOn = false,
+                hasConnectPermission = false,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.ALREADY_CONNECTED)
+    }
+}


### PR DESCRIPTION
Fixes #223.

## Problem
A **DX-BT35** Bluetooth module (HFP audio + SPP/UART CAT) works in FT8CN/FT8TW but not FT8AF. Two symptoms, **one root cause**:

1. **Audio dies after the first launch** — works on a fresh install's first run, then both directions go silent on relaunch. Reconfiguring Settings → Radio & Audio restores it.
2. **CAT over Bluetooth never connects** — the module's SPP indicator LED never lights (it lights instantly with FT8CN/FT8TW).

## Root cause
Nothing re-opened the Bluetooth CAT link on startup:

- `BluetoothPickerDialog` never **persisted** the selected device address (only `connectMode=1` was saved), and `ComposeMainActivity` only auto-connects **USB** — the `mutableSerialPorts` observer → `autoConnectUsbIfNeeded()` bails when `connectMode != USB_CABLE`, and there was no Bluetooth equivalent. So `connectBluetoothRig()` was never called on relaunch → the RFCOMM/SPP socket never opened (**LED dark**) and `baseRig` stayed `null`.
- **Audio is downstream of the same gap.** SCO is only (re)started inside the TX/RX cycle via `needControlSco()`/`startSco()`, which requires a connected CAT rig (`baseRig != null`). With no auto-reconnect, SCO never started, so HFP audio was never routed — exactly why the manual reconfigure (which reconnects CAT) brought audio back.

## Fix
- **Persist** the chosen device address (`bluetoothDeviceAddress` config key) in the picker; load it back in `DatabaseOpr` config parsing; uncomment the `GeneralVariables` field.
- **Auto-reconnect**: new `autoConnectBluetoothIfNeeded()` in `ComposeMainActivity`, run after config load and retried once `BLUETOOTH_CONNECT` is granted. All branch logic is extracted into a pure, unit-tested helper `decideBluetoothAutoConnect()` (per the repo's extract-decision-logic rule).
- **Audio**: start SCO deterministically in `connectBluetoothRig()` (posted to the main looper) so audio routes the moment the CAT rig is wired — for both the manual and auto-connect paths. Scoped to the BT path; USB/NETWORK and `needControlSco()` TX semantics are untouched.

## Testing
- `BluetoothAutoConnectTest` covers every decision branch and precedence ordering — **passes**.
- Full build + install on a **Pixel 8** succeeds (native NDK build included).
- ⚠️ The hardware path can't be verified locally (no DX-BT35 here). Every decision is logged to `debug.log` (`autoConnectBT: decision=...`) so @temskiy can confirm in the field. A follow-up should also fix the stale `debug.log` path on the wiki bug-reports page (noted in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)