### PR TITLE
Release: Bluetooth CAT auto-connect, 9 new languages, FT2 3.75s slot, rotation-survival

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -160,7 +160,19 @@ jobs:
           working-directory: ft8cn
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedDebugAndroidTest --stacktrace
+          # Stream test progress into the job log. By default
+          # connectedDebugAndroidTest sits silently on a single "> Task" line
+          # for minutes; backgrounding logcat's TestRunner tag (plus any
+          # error-level lines) surfaces each test's started:/finished: events —
+          # and any crash — live instead of leaving the step a black box.
+          script: |
+            adb logcat -c || true
+            adb logcat -s TestRunner:I '*:E' &
+            logcat_pid=$!
+            ./gradlew connectedDebugAndroidTest --stacktrace
+            status=$?
+            kill "$logcat_pid" 2>/dev/null || true
+            exit $status
 
       - name: Upload instrumented test reports on failure
         if: failure()

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -167,7 +167,12 @@ jobs:
           # and any crash — live instead of leaving the step a black box.
           script: |
             adb logcat -c || true
-            adb logcat -s TestRunner:I '*:E' &
+            # TestRunner:I → each test's started:/finished:; AndroidRuntime:E and
+            # *:F → real app crashes/uncaught exceptions. Deliberately NOT '*:E':
+            # a fresh google_apis image floods error-level logs with unrelated
+            # Play-services noise (Firebase, ConnectivityService) that buries the
+            # test signal.
+            adb logcat -s TestRunner:I AndroidRuntime:E '*:F' &
             logcat_pid=$!
             ./gradlew connectedDebugAndroidTest --stacktrace
             status=$?

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -26,6 +26,12 @@ android {
         applicationId "radio.ks3ckc.ft8af"
         minSdk 23
         targetSdk 35
+        // Required for the androidTest suite to actually run: our instrumented
+        // tests use @RunWith(AndroidJUnit4::class). Without this, AGP falls back
+        // to the legacy android.test.InstrumentationTestRunner, which discovers
+        // none of them — connectedDebugAndroidTest then reports "Starting 0
+        // tests" and passes vacuously (a false green).
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         // CI builds derive versionCode from GITHUB_RUN_NUMBER + offset, so each
         // run gets a unique, monotonically increasing value Play Console will
         // accept. Offset clears the manual-upload history (current max in

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -226,6 +226,9 @@ dependencies {
     // the instrumented build needs its own copy or compileDebugAndroidTestKotlin
     // fails with "Unresolved reference: truth".
     androidTestImplementation 'com.google.truth:truth:1.4.2'
+    // GrantPermissionRule (AppSmokeTest) lives in androidx.test:rules. 1.6.1
+    // aligns with the androidx.test:monitor:1.6.1 already on the classpath.
+    androidTestImplementation 'androidx.test:rules:1.6.1'
 }
 
 jacoco {

--- a/ft8cn/app/src/androidTest/kotlin/com/bg7yoz/ft8cn/AppSmokeTest.kt
+++ b/ft8cn/app/src/androidTest/kotlin/com/bg7yoz/ft8cn/AppSmokeTest.kt
@@ -1,9 +1,12 @@
 package com.bg7yoz.ft8cn
 
+import android.Manifest
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
 import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import radio.ks3ckc.ft8us.ComposeMainActivity
@@ -12,12 +15,28 @@ import radio.ks3ckc.ft8us.ComposeMainActivity
  * Instrumented smoke test. Launches the real ComposeMainActivity on a device
  * (or emulator) and asserts it reaches RESUMED without throwing.
  *
- * Not run in CI yet — the GitHub Actions workflow has no emulator wired up.
- * Local invocation:
+ * Runs in CI on an emulator via the `instrumented` job in
+ * .github/workflows/build-release.yml. Local invocation:
  *   cd ft8cn && cmd.exe /c "gradlew.bat connectedDebugAndroidTest"
  */
 @RunWith(AndroidJUnit4::class)
 class AppSmokeTest {
+
+    /**
+     * ComposeMainActivity.onCreate requests these dangerous permissions. On a
+     * fresh install the system permission dialog sits on top of the activity,
+     * which then never leaves PAUSED and the RESUMED assertion below times out.
+     * Pre-granting them lets the activity reach RESUMED so the test exercises
+     * the real launch path rather than the one-time permission prompt. (On the
+     * API-30 CI image BLUETOOTH_CONNECT/POST_NOTIFICATIONS aren't requested, so
+     * these three cover every dialog-triggering permission.)
+     */
+    @get:Rule
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.RECORD_AUDIO,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+    )
 
     @Test
     fun composeMainActivity_launchesAndReachesResumed() {

--- a/ft8cn/app/src/main/AndroidManifest.xml
+++ b/ft8cn/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         <activity
             android:name="radio.ks3ckc.ft8us.ComposeMainActivity"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:configChanges="orientation|screenSize|smallestScreenSize|keyboardHidden|screenLayout|uiMode">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/ft8cn/app/src/main/cpp/ft8_lib/ft8/constants.h
+++ b/ft8cn/app/src/main/cpp/ft8_lib/ft8/constants.h
@@ -16,9 +16,10 @@ extern "C"
 
 // FT2: same channel structure as FT4 (4-GFSK, 4 Costas blocks, 105 symbols, same LDPC),
 // but double the baud — half the FT4 symbol period. ~41.67 Hz tone spacing, ~167 Hz BW,
-// 3.8s T/R cycle. Reuses every FT4_* symbol constant below; only the period/slot differ.
+// 3.75s T/R cycle (exactly half FT4's 7.5s). Reuses every FT4_* symbol constant below;
+// only the period/slot differ.
 #define FT2_SYMBOL_PERIOD (0.024f) ///< FT2 symbol duration (NSPS 288 @ 12kHz)
-#define FT2_SLOT_TIME     (3.8f)   ///< FT2 slot period
+#define FT2_SLOT_TIME     (3.75f)  ///< FT2 slot period
 
 // Define FT8 symbol counts
 // FT8 message structure:

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/FT8Common.java
@@ -9,7 +9,7 @@ public final class FT8Common {
     public static final int FT8_MODE=0;
     public static final int FT4_MODE=1;
     //FT2: same 4-GFSK/Costas/LDPC structure as FT4 but double the baud (0.024s symbol
-    //period, 167Hz BW, 3.8s T/R cycle). Receive uses the from-source FT2 decoder; the
+    //period, 167Hz BW, 3.75s T/R cycle). Receive uses the from-source FT2 decoder; the
     //closed prebuilt libft8cn.so only knows FT8/FT4.
     public static final int FT2_MODE=2;
     public static final int SAMPLE_RATE=12000;
@@ -20,16 +20,17 @@ public final class FT8Common {
     //finish ~1s before the cycle boundary, so a CQ can be answered on the next slot.
     public static final int FT8_EARLY_DECODE_MILLISECOND=13500;
     public static final int FT4_SLOT_TIME_MILLISECOND=7500;
-    public static final int FT2_SLOT_TIME_MILLISECOND=3800;
+    public static final int FT2_SLOT_TIME_MILLISECOND=3750;
     public static final int FT8_5_SYMBOLS_MILLISECOND=800;//time needed for 5 symbols
 
 
     public static final float FT4_SLOT_TIME=7.5f;
-    public static final float FT2_SLOT_TIME=3.8f;
+    public static final float FT2_SLOT_TIME=3.75f;
     public static final int FT8_SLOT_TIME_M=150;//15 seconds
     public static final int FT8_5_SYMBOLS_TIME_M =8;//duration of 5 symbols: 0.8 seconds
     public static final int FT4_SLOT_TIME_M=75;//7.5 seconds
-    public static final int FT2_SLOT_TIME_M=38;//3.8 seconds
+    // FT2's 3.75s slot is 37.5 tenths — not a whole number, so it has no tenths-of-a-second
+    // form. Timing uses FT2_SLOT_TIME_MILLISECOND (3750) directly; see ModeProfile.slotMillis.
     public static final int FT8_TRANSMIT_DELAY=500;//default transmit delay duration in milliseconds
     public static final long DEEP_DECODE_TIMEOUT=7*1000;//maximum time range for deep decode
     public static final int DECODE_MAX_ITERATIONS=1;//number of iterations

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/Ft8Message.java
@@ -330,9 +330,9 @@ public class Ft8Message {
     /**
      * The slot (cycle) index since the epoch for this message's mode.
      *
-     * <p>FT8 keeps its legacy 15s math and FT4 its 7.5s; FT2 uses its own 3.8s
+     * <p>FT8 keeps its legacy 15s math and FT4 its 7.5s; FT2 uses its own 3.75s
      * slot from {@link ModeProfile}, <em>not</em> FT4's 7.5s. Reusing FT4's
-     * period for FT2 collapsed two adjacent 3.8s slots into a single parity, so
+     * period for FT2 collapsed two adjacent 3.75s slots into a single parity, so
      * the QSO auto-sequencer ({@link com.bg7yoz.ft8cn.ft8transmit.FT8TransmitSignal})
      * saw the other station's reply as being in our own slot and skipped it —
      * stalling after a report instead of advancing to RR73 (issue #205). The
@@ -345,7 +345,7 @@ public class Ft8Message {
         if (signalFormat == FT8Common.FT8_MODE) {
             return (utcTime + 750) / 1000 / 15;
         } else if (signalFormat == FT8Common.FT2_MODE) {
-            int slot = ModeProfile.FT2.slotMillis; // 3800ms
+            int slot = ModeProfile.FT2.slotMillis; // 3750ms
             return (utcTime + slot / 20) / slot;
         } else {
             return (utcTime + 370) / 100 / 75;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -319,7 +319,7 @@ public class GeneralVariables {
 
     public static int connectMode = ConnectMode.USB_CABLE;//Connection mode: USB==0, BLUE_TOOTH==1
 
-    //public static String bluetoothDeviceAddress=null;//Bluetooth device address available for connection
+    public static String bluetoothDeviceAddress = null;//last-selected Bluetooth (SPP/CAT) device address, persisted for auto-reconnect
 
 
     //Records callsign-to-grid mapping. todo---should also add this list to background tracking info

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -1165,6 +1165,12 @@ public class MainViewModel extends ViewModel {
         baseRig.setOnRigStateChanged(onRigStateChanged);
         baseRig.setConnector(connector);
 
+        // Route HFP audio over SCO as soon as the CAT rig is wired. Without this, SCO is
+        // only (re)started as a side effect of the TX/RX cycle (needControlSco()/startSco()),
+        // which never fires until a rig is connected -- so on relaunch audio was dead in both
+        // directions until the user manually reconfigured Bluetooth (issue #223).
+        new Handler(Looper.getMainLooper()).post(this::setBlueToothOn);
+
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {//connection takes time, wait before setting frequency
             @Override
             public void run() {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -448,8 +448,8 @@ public class MainViewModel extends ViewModel {
         mutableIsFlexRadio.setValue(false);
         mutableIsXieguRadio.setValue(false);
 
-        //create timer for displaying time
-        utcTimer = new UtcTimer(10, false, new OnUtcTimer() {
+        //create timer for displaying time — a 1-second (1000ms) tick, just to refresh the clock.
+        utcTimer = new UtcTimer(1000, false, new OnUtcTimer() {
             @Override
             public void doHeartBeatTimer(long utc) {//clock info when not triggered
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -1153,6 +1153,14 @@ public class MainViewModel extends ViewModel {
     }
 
     public void connectBluetoothRig(Context context, BluetoothDevice device) {
+        // Remember this device so the SPP/CAT link can auto-reconnect on the next app launch
+        // (issue #223). Centralized here so every entry point -- the Compose picker, the legacy
+        // SelectBluetoothDialog, and the startup auto-connect path -- persists consistently.
+        if (!device.getAddress().equals(GeneralVariables.bluetoothDeviceAddress)) {
+            GeneralVariables.bluetoothDeviceAddress = device.getAddress();
+            databaseOpr.writeConfig("bluetoothDeviceAddress", device.getAddress(), null);
+        }
+
         GeneralVariables.controlMode = ControlMode.CAT;//Bluetooth control mode, only CAT control is supported
         GeneralVariables.mutableControlMode.postValue(GeneralVariables.controlMode);
         connectRig();
@@ -1165,11 +1173,19 @@ public class MainViewModel extends ViewModel {
         baseRig.setOnRigStateChanged(onRigStateChanged);
         baseRig.setConnector(connector);
 
-        // Route HFP audio over SCO as soon as the CAT rig is wired. Without this, SCO is
-        // only (re)started as a side effect of the TX/RX cycle (needControlSco()/startSco()),
-        // which never fires until a rig is connected -- so on relaunch audio was dead in both
-        // directions until the user manually reconfigured Bluetooth (issue #223).
-        new Handler(Looper.getMainLooper()).post(this::setBlueToothOn);
+        // Route HFP audio over SCO as soon as the CAT rig is wired -- but only when a Bluetooth
+        // audio profile (headset/A2DP) is actually connected. SPP-only CAT adapters have no audio
+        // path, so forcing SCO + headset mode on them would be wrong and disruptive (PR #227
+        // review). Without this, SCO is only (re)started as a side effect of the TX/RX cycle
+        // (needControlSco()/startSco()), which never fires until a rig is connected -- so on
+        // relaunch audio was dead in both directions until the user manually reconfigured
+        // Bluetooth (issue #223). The BluetoothStateBroadcastReceive path remains the fallback
+        // for devices whose audio profile connects after this point.
+        new Handler(Looper.getMainLooper()).post(() -> {
+            if (isBTConnected()) {
+                setBlueToothOn();
+            }
+        });
 
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {//connection takes time, wait before setting frequency
             @Override

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ModeProfile.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ModeProfile.java
@@ -15,23 +15,22 @@ import com.bg7yoz.ft8cn.ft8transmit.GenerateFT8;
  * @see FT8Common#FT4_MODE
  */
 public enum ModeProfile {
-    // id, name, slotMs, slotTenths, earlyDecodeMs, symPeriod, symBt, numTones, isFt8
-    FT8(FT8Common.FT8_MODE, "FT8", 15000, 150, 13500, 0.160f, 2.0f, 79, true),
-    FT4(FT8Common.FT4_MODE, "FT4", 7500, 75, 6500, 0.048f, 1.0f, 105, false),
+    // id, name, slotMs, earlyDecodeMs, symPeriod, symBt, numTones, isFt8
+    FT8(FT8Common.FT8_MODE, "FT8", 15000, 13500, 0.160f, 2.0f, 79, true),
+    FT4(FT8Common.FT4_MODE, "FT4", 7500, 6500, 0.048f, 1.0f, 105, false),
     // FT2 reuses FT4's tone layout (4-GFSK, 4 Costas, 105 symbols, same LDPC/encoder) at
-    // double the baud: 0.024s symbol period -> ~2.52s audio, 3.8s slot. isFt8=false so
-    // encode() dispatches to the shared ft4Encode; decode routes to the from-source
-    // decoder (see usesFromSourceDecoder) since the prebuilt has no FT2 protocol.
-    FT2(FT8Common.FT2_MODE, "FT2", 3800, 38, 3000, 0.024f, 1.0f, 105, false);
+    // double the baud: 0.024s symbol period -> ~2.52s audio, 3.75s slot (exactly half FT4's
+    // 7.5s). isFt8=false so encode() dispatches to the shared ft4Encode; decode routes to the
+    // from-source decoder (see usesFromSourceDecoder) since the prebuilt has no FT2 protocol.
+    FT2(FT8Common.FT2_MODE, "FT2", 3750, 3000, 0.024f, 1.0f, 105, false);
 
     /** Mode id, matching the {@code FT8Common.*_MODE} ints (also stored in config + Ft8Message). */
     public final int id;
     /** Human/protocol-facing name ("FT8"/"FT4"), used for logs, PSKReporter, POTA, ADIF. */
     public final String displayName;
-    /** TX/RX cycle length in milliseconds (15000 FT8, 7500 FT4). */
+    /** TX/RX cycle length in milliseconds (15000 FT8, 7500 FT4, 3750 FT2); the
+     * {@link com.bg7yoz.ft8cn.timer.UtcTimer} fires a slot boundary on this grid. */
     public final int slotMillis;
-    /** Cycle length in tenths of a second, as the {@link com.bg7yoz.ft8cn.timer.UtcTimer} expects. */
-    public final int slotTenths;
     /** Shorter RX capture window used when fast/early decode is on. */
     public final int earlyDecodeMillis;
     /** GFSK symbol period in seconds (0.160 FT8, 0.048 FT4). */
@@ -51,13 +50,12 @@ public enum ModeProfile {
      */
     public final int audioSlackMillis;
 
-    ModeProfile(int id, String displayName, int slotMillis, int slotTenths,
+    ModeProfile(int id, String displayName, int slotMillis,
                 int earlyDecodeMillis, float symbolPeriod, float symbolBt,
                 int numTones, boolean isFt8) {
         this.id = id;
         this.displayName = displayName;
         this.slotMillis = slotMillis;
-        this.slotTenths = slotTenths;
         this.earlyDecodeMillis = earlyDecodeMillis;
         this.symbolPeriod = symbolPeriod;
         this.symbolBt = symbolBt;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2372,6 +2372,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("connectMode")) {
                     GeneralVariables.connectMode = result.equals("") ? ConnectMode.USB_CABLE : Integer.parseInt(result);
                 }
+                if (name.equalsIgnoreCase("bluetoothDeviceAddress")) {//last-selected BT (SPP/CAT) device, for auto-reconnect
+                    GeneralVariables.bluetoothDeviceAddress = result;
+                }
                 if (name.equalsIgnoreCase("model")) {//Radio model
                     GeneralVariables.modelNo = result.equals("") ? 0 : Integer.parseInt(result);
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8listener/FT8SignalListener.java
@@ -69,8 +69,8 @@ public class FT8SignalListener {
         this.db = db;
 
         // Create action trigger, synchronized with UTC time, on the current mode's cycle
-        // (FT8 = 15s/150, FT4 = 7.5s/75). DoOnSecTimer fires at the start of each cycle.
-        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotTenths, false, makeTimerCallback());
+        // (FT8 = 15000ms, FT4 = 7500ms, FT2 = 3750ms). DoOnSecTimer fires at the start of each cycle.
+        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotMillis, false, makeTimerCallback());
     }
 
     /** The cycle-trigger callback, shared between the constructor and {@link #rebuildTimer}. */
@@ -96,7 +96,7 @@ public class FT8SignalListener {
     public void rebuildTimer(ModeProfile mode) {
         boolean wasListening = utcTimer.isRunning();
         utcTimer.delete();
-        utcTimer = new UtcTimer(mode.slotTenths, false, makeTimerCallback());
+        utcTimer = new UtcTimer(mode.slotMillis, false, makeTimerCallback());
         if (wasListening) {
             utcTimer.start();
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -170,8 +170,8 @@ public class FT8TransmitSignal {
         // change therefore takes effect within the current cycle, so no per-cycle setVolume()
         // observer is needed here.
 
-        // Cycle timer on the current mode's period (FT8 = 15s/150, FT4 = 7.5s/75).
-        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotTenths, false, makeTimerCallback());
+        // Cycle timer on the current mode's period (FT8 = 15000ms, FT4 = 7500ms, FT2 = 3750ms).
+        utcTimer = new UtcTimer(GeneralVariables.currentMode().slotMillis, false, makeTimerCallback());
 
         utcTimer.start();
 
@@ -227,7 +227,7 @@ public class FT8TransmitSignal {
      */
     public void rebuildTimer(ModeProfile mode) {
         utcTimer.delete();
-        utcTimer = new UtcTimer(mode.slotTenths, false, makeTimerCallback());
+        utcTimer = new UtcTimer(mode.slotMillis, false, makeTimerCallback());
         utcTimer.start();
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
@@ -32,7 +32,8 @@ import java.util.concurrent.Executors;
 
 
 public class UtcTimer {
-    private final int sec;
+    /** Slot (cycle) length in milliseconds: 15000 FT8, 7500 FT4, 3750 FT2. */
+    private final int slotMillis;
     private final boolean doOnce;
     private final OnUtcTimer onUtcTimer;
 
@@ -112,18 +113,18 @@ public class UtcTimer {
 
     /**
      * Constructor for the clock trigger. Requires specifying the clock cycle period, typically 15 seconds or 7.5 seconds.
-     * Since the cycle parameter is an int, the unit is tenths of a second.
+     * The cycle parameter is an int in milliseconds.
      * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
      * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
      * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
      * This trigger requires calling the delete function to fully stop (heartbeat actions also stop).
      *
-     * @param sec        clock cycle period in tenths of a second, e.g.: 15 seconds = 150, 7.5 seconds = 75
+     * @param slotMillis clock cycle period in milliseconds, e.g.: 15 seconds = 15000, 7.5 seconds = 7500, FT2 = 3750
      * @param doOnce     whether to trigger only once
      * @param onUtcTimer callback functions, including heartbeat callback and cycle start action callback
      */
-    public UtcTimer(int sec, boolean doOnce, OnUtcTimer onUtcTimer) {
-        this.sec = sec;
+    public UtcTimer(int slotMillis, boolean doOnce, OnUtcTimer onUtcTimer) {
+        this.slotMillis = slotMillis;
         this.doOnce = doOnce;
         this.onUtcTimer = onUtcTimer;
 
@@ -137,7 +138,7 @@ public class UtcTimer {
 
     /**
      * Define the clock-triggered action.
-     * The clock cycle is typically 15 seconds or 7.5 seconds; since the cycle parameter is an int, the unit is tenths of a second.
+     * The clock cycle is typically 15 seconds or 7.5 seconds; the cycle parameter is an int in milliseconds.
      * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
      * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
      * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
@@ -156,29 +157,37 @@ public class UtcTimer {
         };
     }
 
+    /** Detection window (ms) for opening a slot — see {@link #isCycleBoundary}. */
+    private static final int SLOT_OPEN_WINDOW_MS = 100;
+
     /**
-     * Whether {@code utc} lands on a cycle (slot) boundary for a slot of {@code sec} tenths
-     * of a second, anchored to the Unix epoch.
+     * Whether {@code utc} lands on a cycle (slot) boundary for a slot of {@code slotMillis}
+     * milliseconds, anchored to the Unix epoch.
      *
-     * <p>The original test was {@code (((utc - offsetMs) / 100) % 600) % sec == 0}, which
-     * anchored the slot grid to each UTC minute (600 tenths of a second). That is identical
-     * to this epoch-anchored form only when {@code sec} evenly divides 600 — true for FT8
-     * (150) and FT4 (75), but NOT FT2 (38, since 600 / 38 is not whole). For FT2 the
-     * minute-anchored grid drifted off the absolute 3.8 s slot grid that
-     * {@link #sequential(long, int)} and the transmit late-start clip math both use, so a
-     * normal FT2 transmit fired part-way into its slot and had its leading Costas sync
-     * array clipped — audible on the air but undecodable. Anchoring to the epoch keeps the
-     * FT8/FT4 firing instants byte-for-byte identical while making every slot length
-     * internally consistent.
+     * <p>A slot opens in the {@link #SLOT_OPEN_WINDOW_MS}-millisecond window that starts at
+     * each epoch-anchored multiple of {@code slotMillis}. The 100 ms window is wide enough
+     * that the 10 ms heartbeat reliably lands at least one tick inside it, and the 1 s
+     * post-fire pause in {@link #secTask()} prevents a second fire within the same slot.
      *
-     * @param utc      system time in ms (epoch + {@link #delay})
-     * @param offsetMs manual time offset in ms (see {@link #setTime_sec(int)})
-     * @param sec      slot period in tenths of a second (see ModeProfile.slotTenths)
-     * @return true exactly on the 100 ms tick that opens a slot
+     * <p>This works in milliseconds rather than tenths of a second so a slot length that
+     * isn't a whole number of tenths — FT2's 3750 ms — sits on a clean grid. For FT8
+     * (15000) and FT4 (7500) the firing instants are byte-for-byte identical to the old
+     * tenths predicate {@code (utc/100) % (slotMillis/100) == 0}: both fire exactly in
+     * {@code [k*slotMillis, k*slotMillis + 99]}. The earlier tenths form rounded FT2 to a
+     * 3.8 s grid (37.5 tenths isn't an integer), which drifted off the absolute 3.75 s slot
+     * grid that {@link #sequential(long, int)} and the transmit late-start clip math use, so
+     * a normal FT2 transmit fired part-way into its slot and had its leading Costas sync
+     * array clipped — audible on the air but undecodable.
+     *
+     * @param utc        system time in ms (epoch + {@link #delay})
+     * @param offsetMs   manual time offset in ms (see {@link #setTime_sec(int)})
+     * @param slotMillis slot period in milliseconds (see ModeProfile.slotMillis)
+     * @return true on the heartbeat ticks that open a slot
      */
-    public static boolean isCycleBoundary(long utc, int offsetMs, int sec) {
-        if (sec <= 0) return false;
-        return (((utc - offsetMs) / 100) % sec) == 0;
+    public static boolean isCycleBoundary(long utc, int offsetMs, int slotMillis) {
+        if (slotMillis <= 0) return false;
+        long intoSlot = ((utc - offsetMs) % slotMillis + slotMillis) % slotMillis;
+        return intoSlot < SLOT_OPEN_WINDOW_MS;
     }
 
     private TimerTask secTask() {
@@ -192,7 +201,7 @@ public class UtcTimer {
                     utc = getSystemTime();//get current UTC time
                     //running determines whether to trigger cycle actions
                     //time_sec is the time offset
-                    if (running && isCycleBoundary(utc, time_sec, sec)) {
+                    if (running && isCycleBoundary(utc, time_sec, slotMillis)) {
                         //cycle action
                         //IMPORTANT! doHeartBeatTimer must not perform time-consuming operations and must complete within the heartbeat interval, otherwise thread backlog may occur and affect performance.
                         cachedThreadPool.execute(doSomething);//use thread pool for invocation to reduce system overhead

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
@@ -114,9 +114,10 @@ public class UtcTimer {
     /**
      * Constructor for the clock trigger. Requires specifying the clock cycle period, typically 15 seconds or 7.5 seconds.
      * The cycle parameter is an int in milliseconds.
-     * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
-     * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
-     * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
+     * The cycle-boundary check runs on a fast 10ms task, so cycle (doOnSecTimer) callbacks should be as concise as
+     * possible and must complete before the next tick, to prevent thread stacking and performance impact.
+     * The heartbeat callback (doHeartBeatTimer) runs on a separate 1000ms task and is independent of whether cycle
+     * actions are triggering (running==false); as long as the UtcTimer instance exists it runs (convenient for displaying clock data).
      * This trigger requires calling the delete function to fully stop (heartbeat actions also stop).
      *
      * @param slotMillis clock cycle period in milliseconds, e.g.: 15 seconds = 15000, 7.5 seconds = 7500, FT2 = 3750
@@ -129,8 +130,7 @@ public class UtcTimer {
         this.onUtcTimer = onUtcTimer;
 
         //initialize Timer tasks
-        //TimerTask timerTask = initTask();
-        //execute timer, 0 delay, 100ms period
+        //secTask checks the cycle boundary every 10ms; heartBeatTask fires the display callback every 1000ms.
 
         secTimer.schedule(secTask(), 0, 10);
         heartBeatTimer.schedule(heartBeatTask(), 0, 1000);
@@ -139,9 +139,10 @@ public class UtcTimer {
     /**
      * Define the clock-triggered action.
      * The clock cycle is typically 15 seconds or 7.5 seconds; the cycle parameter is an int in milliseconds.
-     * Because the heartbeat frequency is fast (currently set to 100ms), heartbeat actions should be as concise as possible
-     * and must complete before the next heartbeat starts, to prevent thread stacking and performance impact.
-     * Heartbeat actions are not affected by cycle actions not triggering (running==false); as long as the UtcTimer instance exists, heartbeat actions run (convenient for displaying clock data).
+     * The cycle-boundary check runs on a fast 10ms task, so callbacks should be as concise as possible
+     * and must complete before the next tick, to prevent thread stacking and performance impact.
+     * The heartbeat callback runs on a separate 1000ms task and is independent of whether cycle actions are
+     * triggering (running==false); as long as the UtcTimer instance exists it runs (convenient for displaying clock data).
      *
      * @return TimerTask the action instance
      */

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
@@ -204,7 +204,7 @@ public class UtcTimer {
                     //time_sec is the time offset
                     if (running && isCycleBoundary(utc, time_sec, slotMillis)) {
                         //cycle action
-                        //IMPORTANT! doHeartBeatTimer must not perform time-consuming operations and must complete within the heartbeat interval, otherwise thread backlog may occur and affect performance.
+                        //IMPORTANT! the cycle callback (doSomething -> doOnSecTimer) must not perform time-consuming operations and must complete within the cycle interval, otherwise thread backlog may occur and affect performance.
                         cachedThreadPool.execute(doSomething);//use thread pool for invocation to reduce system overhead
                         //thread.run();
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelGate.java
@@ -9,7 +9,7 @@ package com.bg7yoz.ft8cn.ui;
  * times, at different scroll offsets, and appear to repeat down the waterfall — including
  * over the next slot's blank rows where the signal is already gone. Keyed on a per-slot
  * index (the caller derives it from the current mode's slot length, e.g.
- * {@code utcMs / slotMillis} — 15s FT8, 7.5s FT4, 3.8s FT2), this returns true for only the
+ * {@code utcMs / slotMillis} — 15s FT8, 7.5s FT4, 3.75s FT2), this returns true for only the
  * first stamp of each slot.
  *
  * <p>The slot length is part of the key as well as the slot index, because a single

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelMessages.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallLabelMessages.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
  * the overlay on a non-empty decode, so a silent slot left the previous slot's
  * messages in place and they were re-stamped onto the waterfall each cycle,
  * appearing to repeat and never disappear. The effect is worst on FT4 (7.5s) and
- * especially FT2 (3.8s), whose short, often-empty slots re-stamp far more often
+ * especially FT2 (3.75s), whose short, often-empty slots re-stamp far more often
  * than FT8's 15s slots.
  */
 public final class WaterfallLabelMessages {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/WaterfallView.java
@@ -334,7 +334,7 @@ public class WaterfallView extends View {
             // different scroll offsets, so they appear to repeat down the waterfall —
             // including over the next cycle's not-yet-populated rows where the signal is
             // gone. Stamp at most once per decode slot. Key the gate on the current mode's
-            // slot length (NOT a fixed 15s) so FT4 (7.5s) and FT2 (3.8s) each get one stamp
+            // slot length (NOT a fixed 15s) so FT4 (7.5s) and FT2 (3.75s) each get one stamp
             // per slot instead of one stamp per two-or-more slots. Pass slotMillis as part
             // of the key too: this view (and its gate) is reused across mode changes, and a
             // new mode's slotPeriod can collide with one already stamped under the old mode,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
@@ -1,0 +1,49 @@
+package radio.ks3ckc.ft8us
+
+import com.bg7yoz.ft8cn.connector.ConnectMode
+
+/**
+ * Outcome of evaluating whether to auto-reconnect the Bluetooth (SPP/CAT) rig at startup.
+ * Only [CONNECT] triggers a connection; every other value documents why we held off
+ * (logged to debug.log for field diagnosis since the hardware path can't be unit-tested).
+ */
+internal enum class BtAutoConnectDecision {
+    CONNECT,
+    ALREADY_CONNECTED,
+    NOT_BT_MODE,
+    NO_SAVED_ADDRESS,
+    ADAPTER_OFF,
+    NO_PERMISSION,
+    NOT_BONDED,
+}
+
+/**
+ * Pure decision logic for Bluetooth CAT auto-reconnect (issue #223). Kept free of Android
+ * types so it can be unit-tested directly; the Activity gathers the real adapter/permission/
+ * bond state and feeds it in.
+ *
+ * Precedence (first match wins):
+ *  1. not in Bluetooth connect mode      -> NOT_BT_MODE
+ *  2. no remembered device address       -> NO_SAVED_ADDRESS
+ *  3. a rig is already connected         -> ALREADY_CONNECTED  (double-connect guard, mirrors USB)
+ *  4. the Bluetooth adapter is off       -> ADAPTER_OFF
+ *  5. BLUETOOTH_CONNECT not yet granted  -> NO_PERMISSION      (caller retries after grant)
+ *  6. the saved device isn't bonded      -> NOT_BONDED
+ *  7. otherwise                          -> CONNECT
+ */
+internal fun decideBluetoothAutoConnect(
+    connectMode: Int,
+    savedAddress: String?,
+    rigConnected: Boolean,
+    adapterOn: Boolean,
+    hasConnectPermission: Boolean,
+    isBonded: Boolean,
+): BtAutoConnectDecision {
+    if (connectMode != ConnectMode.BLUE_TOOTH) return BtAutoConnectDecision.NOT_BT_MODE
+    if (savedAddress.isNullOrBlank()) return BtAutoConnectDecision.NO_SAVED_ADDRESS
+    if (rigConnected) return BtAutoConnectDecision.ALREADY_CONNECTED
+    if (!adapterOn) return BtAutoConnectDecision.ADAPTER_OFF
+    if (!hasConnectPermission) return BtAutoConnectDecision.NO_PERMISSION
+    if (!isBonded) return BtAutoConnectDecision.NOT_BONDED
+    return BtAutoConnectDecision.CONNECT
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
@@ -47,3 +47,16 @@ internal fun decideBluetoothAutoConnect(
     if (!isBonded) return BtAutoConnectDecision.NOT_BONDED
     return BtAutoConnectDecision.CONNECT
 }
+
+/**
+ * Redact a Bluetooth MAC for debug.log, which users attach to bug reports. A MAC is a stable
+ * device identifier, so we keep only the first and last octet (enough to correlate log lines)
+ * and hide the middle four (PR #228 review). A null/blank value becomes `<none>`; a corrupted
+ * non-MAC value reveals only its length so the raw identifier never lands in a shareable log.
+ */
+internal fun maskBluetoothAddress(addr: String?): String {
+    if (addr.isNullOrBlank()) return "<none>"
+    val parts = addr.split(":")
+    if (parts.size == 6) return "${parts.first()}:**:**:**:**:${parts.last()}"
+    return "<malformed:${addr.length}>"
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -569,18 +569,24 @@ class ComposeMainActivity : AppCompatActivity() {
     private fun autoConnectBluetoothIfNeeded() {
         val adapter = BluetoothAdapter.getDefaultAdapter()
         val addr = GeneralVariables.bluetoothDeviceAddress
+        // A corrupted/legacy persisted value would make getRemoteDevice() throw
+        // IllegalArgumentException and crash startup, so validate the MAC up front (PR #227 review).
+        val validAddr = !addr.isNullOrBlank() && BluetoothAdapter.checkBluetoothAddress(addr)
+        if (!addr.isNullOrBlank() && !validAddr) {
+            fileLog("autoConnectBT: ignoring invalid saved address=$addr")
+        }
         val hasPerm = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
             ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) ==
             PackageManager.PERMISSION_GRANTED
         val bonded = try {
-            hasPerm && adapter != null && !addr.isNullOrBlank() &&
+            hasPerm && adapter != null && validAddr &&
                 adapter.bondedDevices.any { it.address == addr }
         } catch (_: SecurityException) {
             false
         }
         val decision = decideBluetoothAutoConnect(
             connectMode = GeneralVariables.connectMode,
-            savedAddress = addr,
+            savedAddress = if (validAddr) addr else null,
             rigConnected = mainViewModel.isRigConnected(),
             adapterOn = adapter?.isEnabled == true,
             hasConnectPermission = hasPerm,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -573,7 +573,7 @@ class ComposeMainActivity : AppCompatActivity() {
         // IllegalArgumentException and crash startup, so validate the MAC up front (PR #227 review).
         val validAddr = !addr.isNullOrBlank() && BluetoothAdapter.checkBluetoothAddress(addr)
         if (!addr.isNullOrBlank() && !validAddr) {
-            fileLog("autoConnectBT: ignoring invalid saved address=$addr")
+            fileLog("autoConnectBT: ignoring invalid saved address=${maskBluetoothAddress(addr)}")
         }
         val hasPerm = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
             ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) ==
@@ -592,7 +592,7 @@ class ComposeMainActivity : AppCompatActivity() {
             hasConnectPermission = hasPerm,
             isBonded = bonded,
         )
-        fileLog("autoConnectBT: decision=$decision addr=$addr connectMode=${GeneralVariables.connectMode}")
+        fileLog("autoConnectBT: decision=$decision addr=${maskBluetoothAddress(addr)} connectMode=${GeneralVariables.connectMode}")
         if (decision == BtAutoConnectDecision.CONNECT) {
             mainViewModel.connectBluetoothRig(applicationContext, adapter!!.getRemoteDevice(addr))
         }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -277,6 +277,18 @@ class ComposeMainActivity : AppCompatActivity() {
             }
             GridLocationUpdater.refresh(applicationContext, mainViewModel)
         }
+
+        // On Android 12+ the BT auto-connect at config-load time may have bailed with
+        // NO_PERMISSION because BLUETOOTH_CONNECT was still pending. Once the user grants it,
+        // retry the SPP/CAT auto-reconnect in the same session (issue #223). The rigConnected
+        // guard inside makes this idempotent with the config-callback attempt.
+        val btIdx = permissions.indexOf(Manifest.permission.BLUETOOTH_CONNECT)
+        if (btIdx >= 0 && grantResults.getOrNull(btIdx) == PackageManager.PERMISSION_GRANTED
+            && mainViewModel.configIsLoaded
+        ) {
+            fileLog("onRequestPermissionsResult: BLUETOOTH_CONNECT granted, retrying BT auto-connect")
+            autoConnectBluetoothIfNeeded()
+        }
     }
 
     private fun initData() {
@@ -320,6 +332,11 @@ class ComposeMainActivity : AppCompatActivity() {
                 val ports = mainViewModel.mutableSerialPorts.value
                 fileLog("initData: found ${ports?.size ?: 0} serial port(s)")
                 mainViewModel.reinitializeAudioInput()
+
+                // USB auto-connect is driven by the mutableSerialPorts observer; Bluetooth has
+                // no such device-arrival event, so re-open the remembered SPP/CAT link here now
+                // that connectMode + the saved address are loaded (issue #223).
+                autoConnectBluetoothIfNeeded()
 
                 // Delayed re-scan for slow USB enumeration
                 Handler(Looper.getMainLooper()).postDelayed({
@@ -541,6 +558,38 @@ class ComposeMainActivity : AppCompatActivity() {
             "baudRate=${GeneralVariables.baudRate}, " +
             "controlMode=${GeneralVariables.controlMode})")
         mainViewModel.connectCableRig(applicationContext, ports[0])
+    }
+
+    /**
+     * Re-open the remembered Bluetooth (SPP/CAT) rig on startup when the user is in Bluetooth
+     * connect mode. Without this the CAT link never re-opened on relaunch, which also left
+     * HFP audio unrouted (issue #223). All branch logic lives in [decideBluetoothAutoConnect]
+     * so it is unit-testable; this method only collects Android state and acts on CONNECT.
+     */
+    private fun autoConnectBluetoothIfNeeded() {
+        val adapter = BluetoothAdapter.getDefaultAdapter()
+        val addr = GeneralVariables.bluetoothDeviceAddress
+        val hasPerm = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) ==
+            PackageManager.PERMISSION_GRANTED
+        val bonded = try {
+            hasPerm && adapter != null && !addr.isNullOrBlank() &&
+                adapter.bondedDevices.any { it.address == addr }
+        } catch (_: SecurityException) {
+            false
+        }
+        val decision = decideBluetoothAutoConnect(
+            connectMode = GeneralVariables.connectMode,
+            savedAddress = addr,
+            rigConnected = mainViewModel.isRigConnected(),
+            adapterOn = adapter?.isEnabled == true,
+            hasConnectPermission = hasPerm,
+            isBonded = bonded,
+        )
+        fileLog("autoConnectBT: decision=$decision addr=$addr connectMode=${GeneralVariables.connectMode}")
+        if (decision == BtAutoConnectDecision.CONNECT) {
+            mainViewModel.connectBluetoothRig(applicationContext, adapter!!.getRemoteDevice(addr))
+        }
     }
 
     /** Write a line to /sdcard/Android/data/com.bg7yoz.ft8cn/files/debug.log */

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/AdvancedSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/AdvancedSettings.kt
@@ -1,5 +1,6 @@
 package radio.ks3ckc.ft8us.ui.settings
 
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,11 +20,54 @@ import radio.ks3ckc.ft8us.ui.components.GlassCard
 import radio.ks3ckc.ft8us.ui.components.SettingsRow
 
 /**
- * BCP-47 language tags for the in-app Language picker, parallel to the label list
- * built in the picker dialog. Index 0 ("") means "System default" (empty locale
- * list). Keep in sync with res/xml/locales_config.xml and the values-<locale>/ dirs.
+ * One selectable app language: its BCP-47 tag (as handed to
+ * [AppCompatDelegate.setApplicationLocales]) and the display-name resource shown
+ * in its own script.
  */
-private val LANGUAGE_TAGS = listOf("", "en", "zh-CN", "zh-TW", "ru", "es", "fr", "ja")
+internal data class AppLanguage(val tag: String, @StringRes val nameRes: Int)
+
+/**
+ * Single source of truth for the in-app Language picker, in display order. Adding
+ * a language is one entry here — the tag list, picker labels, and current-language
+ * label all derive from it. Keep in sync with res/xml/locales_config.xml and the
+ * values-<locale>/ translation dirs (English lives in the default values/ dir, so
+ * "en" has no dedicated folder; Indonesian "id" compiles to the legacy values-in).
+ */
+internal val SUPPORTED_LANGUAGES: List<AppLanguage> = listOf(
+    AppLanguage("en", R.string.language_name_en),
+    AppLanguage("zh-CN", R.string.language_name_zh_cn),
+    AppLanguage("zh-TW", R.string.language_name_zh_tw),
+    AppLanguage("ru", R.string.language_name_ru),
+    AppLanguage("es", R.string.language_name_es),
+    AppLanguage("fr", R.string.language_name_fr),
+    AppLanguage("ja", R.string.language_name_ja),
+    AppLanguage("it", R.string.language_name_it),
+    AppLanguage("pl", R.string.language_name_pl),
+    AppLanguage("ko", R.string.language_name_ko),
+    AppLanguage("nl", R.string.language_name_nl),
+    AppLanguage("cs", R.string.language_name_cs),
+    AppLanguage("tr", R.string.language_name_tr),
+    AppLanguage("id", R.string.language_name_id),
+    AppLanguage("uk", R.string.language_name_uk),
+    AppLanguage("ar", R.string.language_name_ar),
+)
+
+/**
+ * BCP-47 language tags for the picker, parallel to the label list built in the
+ * dialog. Index 0 ("") means "System default" (empty locale list).
+ */
+internal val LANGUAGE_TAGS: List<String> = listOf("") + SUPPORTED_LANGUAGES.map { it.tag }
+
+/**
+ * The display-name resource for the currently-applied app locale tags (as returned
+ * by `getApplicationLocales().toLanguageTags()`), or the "system default" label
+ * when nothing matches. The first supported language whose tag prefixes the current
+ * tags wins (e.g. "en-US" → English). Pure logic, unit-tested.
+ */
+@StringRes
+internal fun currentLanguageNameRes(currentTags: String): Int =
+    SUPPORTED_LANGUAGES.firstOrNull { currentTags.startsWith(it.tag) }?.nameRes
+        ?: R.string.settings_language_system
 
 /**
  * Advanced settings: PTT/TX timing delays, late-start tolerance, and the
@@ -113,16 +157,13 @@ fun AdvancedSettings(
     // older) and recreates the activity so the new locale takes effect immediately.
     if (showLanguagePicker) {
         val languageTags = LANGUAGE_TAGS
-        val languageLabels = listOf(
-            stringResource(R.string.settings_language_system),
-            stringResource(R.string.language_name_en),
-            stringResource(R.string.language_name_zh_cn),
-            stringResource(R.string.language_name_zh_tw),
-            stringResource(R.string.language_name_ru),
-            stringResource(R.string.language_name_es),
-            stringResource(R.string.language_name_fr),
-            stringResource(R.string.language_name_ja),
-        )
+        // Built with a for-loop (not map/forEach) so the @Composable stringResource
+        // calls run in a permitted context; mirrors LANGUAGE_TAGS index-for-index.
+        val languageLabels = ArrayList<String>(LANGUAGE_TAGS.size)
+        languageLabels.add(stringResource(R.string.settings_language_system))
+        for (lang in SUPPORTED_LANGUAGES) {
+            languageLabels.add(stringResource(lang.nameRes))
+        }
         val currentTags = AppCompatDelegate.getApplicationLocales().toLanguageTags()
         val currentIndex = languageTags.indexOfFirst { it.isNotEmpty() && currentTags.startsWith(it) }
             .let { if (it >= 0) it else 0 }
@@ -187,18 +228,7 @@ fun AdvancedSettings(
         SettingsSection(title = stringResource(R.string.settings_section_language)) {
             GlassCard(modifier = Modifier.fillMaxWidth()) {
                 val currentTags = AppCompatDelegate.getApplicationLocales().toLanguageTags()
-                val currentLangIndex = LANGUAGE_TAGS
-                    .indexOfFirst { it.isNotEmpty() && currentTags.startsWith(it) }
-                val currentLangRes = when (LANGUAGE_TAGS.getOrElse(currentLangIndex) { "" }) {
-                    "en" -> R.string.language_name_en
-                    "zh-CN" -> R.string.language_name_zh_cn
-                    "zh-TW" -> R.string.language_name_zh_tw
-                    "ru" -> R.string.language_name_ru
-                    "es" -> R.string.language_name_es
-                    "fr" -> R.string.language_name_fr
-                    "ja" -> R.string.language_name_ja
-                    else -> R.string.settings_language_system
-                }
+                val currentLangRes = currentLanguageNameRes(currentTags)
                 SettingsRow(
                     label = stringResource(R.string.settings_language),
                     description = stringResource(R.string.settings_language_desc),

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
@@ -179,14 +179,8 @@ fun BluetoothPickerDialog(
                                             info.device.name,
                                         ),
                                     )
-                                    // Remember this device so we can auto-reconnect the
-                                    // SPP/CAT link on the next app launch (issue #223).
-                                    GeneralVariables.bluetoothDeviceAddress = info.device.address
-                                    mainViewModel.databaseOpr.writeConfig(
-                                        "bluetoothDeviceAddress",
-                                        info.device.address,
-                                        null,
-                                    )
+                                    // connectBluetoothRig() persists the device address centrally
+                                    // so the SPP/CAT link auto-reconnects on the next launch (#223).
                                     mainViewModel.connectBluetoothRig(
                                         GeneralVariables.getMainContext(),
                                         info.device,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/ConnectionDialogs.kt
@@ -179,6 +179,14 @@ fun BluetoothPickerDialog(
                                             info.device.name,
                                         ),
                                     )
+                                    // Remember this device so we can auto-reconnect the
+                                    // SPP/CAT link on the next app launch (issue #223).
+                                    GeneralVariables.bluetoothDeviceAddress = info.device.address
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "bluetoothDeviceAddress",
+                                        info.device.address,
+                                        null,
+                                    )
                                     mainViewModel.connectBluetoothRig(
                                         GeneralVariables.getMainContext(),
                                         info.device,

--- a/ft8cn/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ar/strings_compose.xml
@@ -1,0 +1,543 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Compose UI strings (FT8AF). The live app is the Jetpack Compose UI under
+  ~ radio.ks3ckc.ft8us; these are its user-facing strings, externalized for
+  ~ localization. The legacy strings.xml entries belong to the unreachable old
+  ~ XML/Fragment UI and are NOT used by the running app.
+  ~
+  ~ Translations live in values-<locale>/strings_compose.xml. English here is the
+  ~ source of truth — keep it byte-identical to the original UI text so the English
+  ~ layout never changes. Ham-radio abbreviations (CQ, QSO, DXCC, POTA, SOTA, RST)
+  ~ are intentionally left untranslated across all locales.
+-->
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">إلغاء</string>
+    <string name="action_save">حفظ</string>
+    <string name="action_done">تم</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">خروج</string>
+    <string name="common_none">لا شيء</string>
+    <string name="common_off">إيقاف</string>
+    <string name="common_not_configured">غير مهيأ</string>
+    <string name="common_not_connected">غير متصل</string>
+    <string name="common_pass">نجاح</string>
+    <string name="common_fail">فشل</string>
+    <string name="common_test_connection">اختبار الاتصال</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">أمريكا الشمالية</string>
+    <string name="continent_sa">أمريكا الجنوبية</string>
+    <string name="continent_eu">أوروبا</string>
+    <string name="continent_af">أفريقيا</string>
+    <string name="continent_as">آسيا</string>
+    <string name="continent_oc">أوقيانوسيا</string>
+    <string name="continent_an">القارة القطبية الجنوبية</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">فك التشفير</string>
+    <string name="tab_map">الخريطة</string>
+    <string name="tab_waterfall">الشلال</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">السجل</string>
+    <string name="tab_settings">الإعدادات</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">DXCC جديد</string>
+    <string name="status_new_grid">مربع جديد</string>
+    <string name="status_new_band">نطاق جديد</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">POTA جديد</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">مطلوب</string>
+    <string name="status_worked">تم الاتصال</string>
+    <string name="status_confirmed">مؤكَّد</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">قيد الانتظار</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · الرفيق المحمول</string>
+    <string name="splash_initializing">جارٍ تهيئة الراديو</string>
+    <string name="splash_version">v%1$s · بناء %2$s</string>
+    <string name="app_set_callsign_first">اضبط نداءك في الإعدادات قبل النداء بـ CQ</string>
+    <string name="app_hunt_on">الصيد مفعَّل — رد تلقائي على نداءات CQ</string>
+    <string name="app_hunt_off">الصيد متوقف — نداء CQ والرد على المستجيبين فقط</string>
+    <string name="app_mode_switched">الوضع: %1$s</string>
+    <string name="app_mode_switch_busy">لا يمكن تبديل الوضع أثناء الإرسال</string>
+    <string name="main_tx_volume">مستوى صوت TX: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">الخروج من FT8AF؟</string>
+    <string name="exit_message">هل أنت متأكد أنك تريد إغلاق التطبيق؟ سيُلغى أي QSO نشط.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">اختر التردد</string>
+    <string name="freq_show_alternates">إظهار البدائل</string>
+    <string name="freq_hide_alternates">إخفاء البدائل</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">لا نداء</string>
+    <string name="op_no_grid">لم يُضبط مربع</string>
+    <string name="op_tap_to_edit">انقر للتحرير</string>
+    <string name="op_stat_rig">الجهاز</string>
+    <string name="op_stat_antenna">الهوائي</string>
+    <string name="op_stat_power">القدرة</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">تصدير QSOs</string>
+    <string name="export_date_range">النطاق الزمني</string>
+    <string name="export_date_from_placeholder">"من  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"إلى  YYYYMMDD"</string>
+    <string name="export_share">مشاركة</string>
+    <string name="export_filter_confirmed">المؤكَّدة فقط</string>
+    <string name="export_filter_unconfirmed">غير المؤكَّدة فقط</string>
+    <string name="export_record_singular">سجل</string>
+    <string name="export_record_plural">سجلات</string>
+    <string name="export_summary_all">الكل</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s مطابق %3$s%4$s</string>
+    <string name="export_preparing">جارٍ التحضير…</string>
+    <string name="export_share_chooser_title">مشاركة سجلات QSO</string>
+    <string name="export_saved_to">حُفظ في %1$s</string>
+    <string name="export_save_failed">فشل الحفظ في التنزيلات</string>
+    <string name="export_temp_file_failed">تعذّر إنشاء ملف مؤقت</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">جارٍ الإرسال</string>
+    <string name="tx_listening">جارٍ الاستماع</string>
+    <string name="tx_hunt">صيد</string>
+    <string name="tx_call_cq">نداء CQ</string>
+    <string name="tx_stop">إيقاف</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">العمل مع بعثة DX (Hound)</string>
+    <string name="hound_help">اضبط الجهاز على تردد القرص المعلن للـ Fox أولاً. تنادي أنت في الأعلى (1000–4000 Hz)؛ يقوم التطبيق تلقائياً بنقل ترددك (QSY) إلى حيث يرد الـ Fox ويرد بتقريرك.</string>
+    <string name="hound_fox_callsign">نداء الـ Fox</string>
+    <string name="hound_call_frequency">تردد النداء (Hz، 1000–4000)</string>
+    <string name="hound_start">بدء</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT متصل — انقر لإعادة الاتصال</string>
+    <string name="cat_status_connecting">جارٍ اتصال CAT…</string>
+    <string name="cat_status_disconnected">CAT غير متصل — انقر للاتصال</string>
+    <string name="cat_status_error">خطأ في اتصال CAT — انقر لإعادة المحاولة</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">توقف TX — تم رصد SWR مرتفع (%1$s)</string>
+    <string name="swr_lockout_body">تحقق من الهوائي / خط التغذية قبل الإرسال.</string>
+    <string name="swr_lockout_dismiss">تجاهل</string>
+    <string name="swr_lockout_toast">TX محظور — قفل SWR نشط. تجاهل لافتة القفل أولاً.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">نداء CQ</string>
+    <string name="qsopanel_searching">جارٍ البحث...</string>
+    <string name="qsopanel_qsoing_with">إجراء QSO مع %1$s</string>
+    <string name="qsopanel_waiting_for">في انتظار %1$s</string>
+    <string name="qsopanel_tap_to_view">انقر للعرض ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">في انتظار الرسائل...</string>
+    <string name="qsopanel_log_action">تسجيل</string>
+    <string name="qsopanel_queue">قائمة الانتظار</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">فك التشفير</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d مفكوك هذه الدورة"</string>
+    <string name="decode_clear_list">مسح قائمة فك التشفير</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">الكل</string>
+    <string name="decode_filter_cq_calls">نداءات CQ</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">DXCC جديد</string>
+    <string name="decode_filter_needed">مطلوب</string>
+    <string name="decode_filter_for_me">لي</string>
+    <string name="decode_empty_cq_title">لا نداءات CQ</string>
+    <string name="decode_empty_cq_body">لا توجد محطات تنادي CQ على هذا النطاق الآن.</string>
+    <string name="decode_empty_pota_title">لا رصدات POTA</string>
+    <string name="decode_empty_pota_body">لم تُفك أي تفعيلات حدائق على هذا النطاق بعد — افتح POTA → الصيد لقائمة الرصد.</string>
+    <string name="decode_empty_dxcc_title">لا DXCC جديد</string>
+    <string name="decode_empty_dxcc_body">لم تُفك أي كيانات DXCC لم يُتصل بها بعد.</string>
+    <string name="decode_empty_needed_title">لا شيء مطلوب</string>
+    <string name="decode_empty_needed_body">لم يُعثر على محطات بحاجة إلى تأكيد.</string>
+    <string name="decode_empty_forme_title">لا نداءات لك</string>
+    <string name="decode_empty_forme_body">لا توجد محطات تنادي نداءك الآن.</string>
+    <string name="decode_empty_default_title">لا إشارات مفكوكة</string>
+    <string name="decode_empty_default_body">في انتظار ظهور إشارات FT8...</string>
+    <string name="decode_label_calling">→ ينادي</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ إليك</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">اكتمل QSO</string>
+    <string name="qso_call_action">نداء %1$s</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">الإشارة</string>
+    <string name="qso_stat_distance">المسافة</string>
+    <string name="qso_stat_azimuth">السمت</string>
+    <string name="qso_stat_band">النطاق</string>
+    <string name="qso_sequence_header">تسلسل QSO</string>
+    <string name="qso_step_send_call">إرسال النداء</string>
+    <string name="qso_step_report_sent">أُرسل التقرير</string>
+    <string name="qso_step_roger">استلام</string>
+    <string name="qso_step_confirm">تأكيد</string>
+    <string name="qso_step_logged">مُسجَّل</string>
+    <string name="qso_live_sending">إجراء QSO مع %1$s — إرسال %2$s</string>
+    <string name="qso_live_waiting">في انتظار رد %1$s…</string>
+    <string name="qso_live_transmitting">جارٍ الإرسال…</string>
+    <string name="qso_live_step_fallback">رسالة</string>
+    <string name="qso_tx_now">TX الآن</string>
+    <string name="qso_tx_next">TX التالي</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">الإحصاءات</string>
+    <string name="log_tab_recent">الأخيرة</string>
+    <string name="log_tab_awards">الجوائز</string>
+    <string name="log_title">السجل</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSOs · كل النطاقات</string>
+    <string name="log_cd_sync_to_logging_services">مزامنة مع خدمات التسجيل</string>
+    <string name="log_cd_export_qsos">تصدير QSOs</string>
+    <string name="log_stat_total_qsos">إجمالي QSOs</string>
+    <string name="log_stat_dxcc_entities">كيانات DXCC</string>
+    <string name="log_stat_cq_zones">مناطق CQ</string>
+    <string name="log_stat_itu_zones">مناطق ITU</string>
+    <string name="log_section_band_distribution">توزيع النطاقات</string>
+    <string name="log_section_award_progress">تقدم الجوائز</string>
+    <string name="log_award_dxcc_mixed">DXCC مختلط</string>
+    <string name="log_award_vucc_grid_squares">مربعات VUCC</string>
+    <string name="log_award_dxcc_challenge">تحدي DXCC</string>
+    <string name="log_section_grid_coverage">تغطية المربعات</string>
+    <string name="log_section_signal_trend">اتجاه الإشارة</string>
+    <string name="log_no_qsos_yet">لا QSOs بعد</string>
+    <string name="log_no_qsos_recorded_yet">لم تُسجَّل QSOs بعد</string>
+    <string name="log_state_usa">%1$s، الولايات المتحدة</string>
+    <string name="log_cd_qso_actions">إجراءات QSO</string>
+    <string name="log_action_edit">تحرير</string>
+    <string name="log_action_delete">حذف</string>
+    <string name="log_award_dxcc_mixed_desc">اتصل وأكِّد 100 كيان DXCC على أي نطاق/وضع</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">اتصل بكل الولايات الأمريكية الخمسين مؤكَّدة</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">اتصل بكل مناطق CQ الأربعين مؤكَّدة</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">نادي القرن VHF/UHF -- 100 مربع على نطاق واحد</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">الجزر على الهواء -- اتصل بمحطات على جزر محددة</string>
+    <string name="log_edit_qso">تحرير QSO</string>
+    <string name="log_field_callsign">النداء</string>
+    <string name="log_field_grid_locator">محدد المربع</string>
+    <string name="log_field_mode">الوضع</string>
+    <string name="log_delete_qso_title">حذف QSO؟</string>
+    <string name="log_delete_qso_body_callsign">إزالة QSO مع %1$s من السجل؟ لا يمكن التراجع عن هذا.</string>
+    <string name="log_delete_qso_body">إزالة هذا QSO من السجل؟ لا يمكن التراجع عن هذا.</string>
+    <string name="log_sync_title_no_services">لا خدمات مفعَّلة</string>
+    <string name="log_sync_title_syncing">جارٍ المزامنة…</string>
+    <string name="log_sync_title_complete">اكتملت المزامنة</string>
+    <string name="log_sync_enable_services">فعِّل Cloudlog/Wavelog/Nextlog أو QRZ في الإعدادات، ثم أعد المحاولة.</string>
+    <string name="log_sync_progress_count">%1$d من %2$d QSOs</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d مقبول</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d مقبول</string>
+    <string name="log_sync_nothing_to_upload">لا QSOs في السجل للرفع بعد.</string>
+    <string name="log_sync_working">جارٍ العمل…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">تفعيل</string>
+    <string name="pota_tab_hunt">صيد</string>
+    <string name="pota_tab_history">السجل</string>
+    <string name="pota_start_activation">بدء التفعيل</string>
+    <string name="pota_park_reference_label">مرجع الحديقة (مثل K-1234)</string>
+    <string name="pota_notes_optional_label">ملاحظات (اختياري)</string>
+    <string name="pota_enter_park_reference_first">أدخل مرجع الحديقة أولاً</string>
+    <string name="pota_activating">جارٍ تفعيل %1$s</string>
+    <string name="pota_activation_ended">انتهى التفعيل</string>
+    <string name="pota_set_callsign_first">اضبط نداءك في الإعدادات أولاً</string>
+    <string name="pota_self_spot_posted">تم نشر الرصد الذاتي</string>
+    <string name="pota_self_spot_failed">فشل الرصد الذاتي — راجع السجل</string>
+    <string name="pota_active_park">نشط — %1$s</string>
+    <string name="pota_qsos">QSOs</string>
+    <string name="pota_contacts_map">خريطة الاتصالات</string>
+    <string name="pota_back">رجوع</string>
+    <string name="pota_valid_activation">تفعيل صالح</string>
+    <string name="pota_to_valid">%1$d حتى الصلاحية</string>
+    <string name="pota_elapsed">المنقضي</string>
+    <string name="pota_since_start">منذ البدء</string>
+    <string name="pota_self_spot">رصد ذاتي</string>
+    <string name="pota_end_activation">إنهاء التفعيل</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">سيخرج TX CQ كـ “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">لا رصدات FT8 POTA الآن.</string>
+    <string name="pota_active_spots">%1$d رصد FT8 نشط</string>
+    <string name="pota_targeting">استهداف %1$s @ %2$s kHz (%3$s) — بدّل إلى فك التشفير للنداء</string>
+    <string name="pota_no_past_activations">لا تفعيلات سابقة بعد.</string>
+    <string name="pota_no_browser_available">لا متصفح متاح</string>
+    <string name="pota_export_failed">فشل التصدير — راجع السجل</string>
+    <string name="pota_status_active">نشط</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">مشاركة ADIF</string>
+    <string name="pota_open_pota_app">فتح pota.app</string>
+    <string name="pota_upload_to_pota">الرفع إلى POTA</string>
+    <string name="pota_upload_success">تم رفع %1$d سجل حديقة إلى POTA</string>
+    <string name="pota_upload_failed">فشل الرفع: %1$s</string>
+    <string name="pota_upload_server_error">تعذّر على POTA معالجة الرفع. تحقق من صلاحية مرجع الحديقة وأن نداءك مسجَّل لدى POTA، ثم أعد المحاولة.</string>
+    <string name="pota_upload_network_error">تعذّر الوصول إلى POTA. تحقق من اتصالك بالإنترنت وأعد المحاولة.</string>
+    <string name="pota_login_title">تسجيل الدخول إلى POTA</string>
+    <string name="pota_login_desc">استخدم بريد وكلمة مرور حساب pota.app الخاص بك.</string>
+    <string name="pota_login_email">البريد الإلكتروني</string>
+    <string name="pota_login_password">كلمة المرور</string>
+    <string name="pota_login_button">تسجيل الدخول</string>
+    <string name="pota_login_cancel">إلغاء</string>
+    <string name="pota_login_failed">فشل تسجيل الدخول: %1$s</string>
+    <string name="pota_login_or">أو</string>
+    <string name="pota_login_social">تسجيل الدخول عبر Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">تسجيل الدخول إلى POTA</string>
+    <string name="pota_add_park">إضافة حديقة</string>
+    <string name="pota_remove_park">إزالة</string>
+    <string name="pota_max_parks_reached">تم بلوغ الحد الأقصى وهو 10 حدائق</string>
+    <string name="pota_spotted_n_parks">مرصود في %1$d حدائق</string>
+    <string name="pota_parks_more">+%1$d أخرى</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">تصحيح</string>
+    <string name="debug_line_count">%1$d سطر</string>
+    <string name="debug_logcat_on_suffix">" · logcat ON"</string>
+    <string name="debug_close">إغلاق</string>
+    <string name="debug_share">مشاركة</string>
+    <string name="debug_clear">مسح</string>
+    <string name="debug_logcat_on">Logcat: مفعَّل</string>
+    <string name="debug_logcat_off">Logcat: متوقف</string>
+    <string name="debug_no_log_file">لا ملف سجل</string>
+    <string name="debug_log_cleared">مُسح السجل</string>
+    <string name="debug_share_chooser_title">مشاركة debug.log</string>
+    <string name="map_title">الخريطة</string>
+    <string name="map_no_grid_set">لم يُضبط مربع</string>
+    <string name="map_station_count">%1$d محطة</string>
+    <string name="map_station_count_with_heard">%1$d محطة · %2$d مسموعة</string>
+    <string name="map_psk_error">PSK Reporter غير متاح: %1$s</string>
+    <string name="map_projection_equirectangular">مستطيلي متساوٍ</string>
+    <string name="map_projection_azimuthal">سمتي متساوي البعد</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">المسافة</string>
+    <string name="map_info_bearing">الاتجاه</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">الشلال</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">مباشر</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d محاولة</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d من %2$d مفعَّل</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">بناء %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">الإعدادات</string>
+    <string name="settings_section_operator_identity">هوية المشغِّل</string>
+    <string name="settings_section_radio">الراديو</string>
+    <string name="settings_section_audio">الصوت</string>
+    <string name="settings_section_transmission">الإرسال</string>
+    <string name="settings_section_auto_sequence">التسلسل التلقائي</string>
+    <string name="settings_section_decode_highlights">إبرازات فك التشفير</string>
+    <string name="settings_section_callsign_blocklist">قائمة حظر النداءات</string>
+    <string name="settings_section_decode_filters">مرشحات فك التشفير</string>
+    <string name="settings_section_needed_dx_alerts">تنبيهات DX المطلوبة</string>
+    <string name="settings_section_logging_awards">التسجيل &amp; الجوائز</string>
+    <string name="settings_section_advanced">متقدم</string>
+    <string name="settings_section_about">حول</string>
+    <string name="settings_section_language">اللغة</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">الراديو &amp; الصوت</string>
+    <string name="settings_cat_transmission">الإرسال</string>
+    <string name="settings_cat_decode_filters">فك التشفير &amp; المرشحات</string>
+    <string name="settings_cat_logging">التسجيل &amp; الجوائز</string>
+    <string name="settings_cat_advanced">متقدم</string>
+    <string name="settings_cat_about">حول</string>
+    <string name="settings_cat_time_sync">مزامنة الوقت</string>
+    <string name="settings_cat_time_sync_desc">تصحيح يدوي للساعة للتشغيل دون اتصال</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">تصحيح يدوي</string>
+    <string name="settings_time_current_label">التصحيح الحالي</string>
+    <string name="settings_time_correction_reset">إعادة إلى 0</string>
+    <string name="settings_time_correction_desc">عدِّل ساعة التطبيق عندما لا يتوفر إنترنت للمزامنة. يحتاج FT8 إلى UTC ضمن حوالي ثانية واحدة. اضبط حتى يتمركز عمود DT للمحطات المفكوكة قرب 0.</string>
+    <string name="settings_time_suggest_section">مقترح من فك التشفير</string>
+    <string name="settings_time_suggest_none">لا فك تشفير بعد — ابدأ الاستقبال للحصول على اقتراح.</string>
+    <string name="settings_time_suggest_label">متوسط DT الأخير: %1$s</string>
+    <string name="settings_time_suggest_apply">تطبيق التصحيح المقترح</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">تحديث المربع تلقائياً (GPS)</string>
+    <string name="settings_auto_update_grid_desc">استخدم GPS الجهاز لإبقاء مربع Maidenhead محدثاً</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">طراز الجهاز</string>
+    <string name="settings_control_mode">وضع التحكم</string>
+    <string name="settings_connection_mode">وضع الاتصال</string>
+    <string name="settings_baud_rate">معدل البود</string>
+    <string name="settings_band_frequency">النطاق &amp; التردد</string>
+    <string name="settings_enabled_bands">النطاقات المفعَّلة</string>
+    <string name="settings_audio_frequency">تردد الصوت</string>
+    <string name="settings_spectrum_width">عرض الطيف</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">دخل الصوت</string>
+    <string name="settings_audio_output">خرج الصوت</string>
+    <string name="settings_tx_volume">مستوى صوت TX</string>
+    <string name="settings_tx_volume_desc" formatted="false">مستوى صوت الإرسال (أزرار العتاد ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">تقسيم TX/RX</string>
+    <string name="settings_tx_rx_split_desc">الإرسال على تردد مختلف عن الاستقبال</string>
+    <string name="settings_tx_watchdog">مراقب TX</string>
+    <string name="settings_tx_watchdog_desc">إيقاف الإرسال تلقائياً بعد المهلة</string>
+    <string name="settings_stop_after">التوقف بعد</string>
+    <string name="settings_stop_after_desc">التوقف عن النداء بعد N محاولات بلا رد</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">الصيد (رد تلقائي على CQ)</string>
+    <string name="settings_hunt_desc">نادِ المحطات التي تنادي CQ بشكل استباقي. مثل زر HUNT على شريط TX. الإيقاف = نداء CQ والاتصال فقط بالمحطات التي تجيبك.</string>
+    <string name="settings_auto_call_followed">نداء المتابَعين تلقائياً</string>
+    <string name="settings_auto_call_followed_desc">متابعة نداء النداءات المتابَعة تلقائياً</string>
+    <string name="settings_fast_turnaround">استجابة سريعة</string>
+    <string name="settings_fast_turnaround_desc">فك التشفير قبل ~1 ثانية حتى تتمكن من الرد على CQ في الفتحة التالية بدلاً من الانتظار. قد يفوّت محطات ذات إزاحة ساعة كبيرة.</string>
+    <string name="settings_auto_cq_after_qso">CQ تلقائي بعد QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">واصل نداء CQ تلقائياً بعد كل اتصال مكتمل — دون نقر جديد. يبقى على ترددك (يتجاهل الصيد). يستمر حتى تتوقف أو تنتهي مهلة مراقب TX بلا ردود.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">DXCC جديد</string>
+    <string name="settings_highlight_new_dxcc_desc">إبراز المحطات من كيان DXCC لم يُتصل به</string>
+    <string name="settings_highlight_new_grid">مربع جديد</string>
+    <string name="settings_highlight_new_grid_desc">إبراز مربعات Maidenhead التي لم يُتصل بها بعد</string>
+    <string name="settings_highlight_new_band">نطاق جديد</string>
+    <string name="settings_highlight_new_band_desc">إبراز المحطات التي اتُّصل بها على نطاقات أخرى فقط</string>
+    <string name="settings_highlight_pota">مفعِّلو POTA</string>
+    <string name="settings_highlight_pota_desc">إبراز مفعِّلي POTA المرصودين؛ تبرز الحدائق الجديدة</string>
+    <string name="settings_highlight_worked">اتُّصل به سابقاً</string>
+    <string name="settings_highlight_worked_desc">وسم المحطات الموجودة في سجلك بالفعل</string>
+    <string name="settings_distance_unit">المسافة بالأميال</string>
+    <string name="settings_distance_unit_desc">إظهار المسافات بالأميال بدلاً من الكيلومترات</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">نداءات دقيقة</string>
+    <string name="settings_exact_callsigns_desc">حظر مطابقات النداء الكامل</string>
+    <string name="settings_prefixes">البادئات</string>
+    <string name="settings_prefixes_desc">الحظر حسب بادئة النداء (مثل RA)</string>
+    <string name="settings_keywords">كلمات مفتاحية</string>
+    <string name="settings_keywords_desc">الحظر حسب سلسلة فرعية في النداء أو الرسالة (مثل POTA، /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">إظهار CQ فقط</string>
+    <string name="settings_show_only_cq_desc">إخفاء كل شيء عدا رسائل نوع CQ</string>
+    <string name="settings_dx_only">DX فقط</string>
+    <string name="settings_dx_only_desc">إظهار المحطات خارج قارتك فقط</string>
+    <string name="settings_needed_only">المطلوب فقط</string>
+    <string name="settings_needed_only_desc">إظهار المحطات غير المؤكَّدة بعد فقط (QSL)</string>
+    <string name="settings_filter_by_continent">التصفية حسب القارة</string>
+    <string name="settings_filter_by_continent_desc">إظهار المحطات من قارة مختارة فقط</string>
+    <string name="settings_continent">القارة</string>
+    <string name="settings_skip_directional_cq">تخطي CQ الموجَّهة (رد تلقائي)</string>
+    <string name="settings_skip_directional_cq_desc">لا ترد تلقائياً على CQ DX/EU/JA… الموجَّهة إلى DXCC مختلف</string>
+    <string name="settings_hide_directional_cq">إخفاء CQ الموجَّهة ليست لي</string>
+    <string name="settings_hide_directional_cq_desc">إخفاء CQ الموجَّهة لمنطقة لا تستهدف DXCC الخاص بك</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">DXCC جديد</string>
+    <string name="settings_alert_new_dxcc_desc">صوت + اهتزاز + إشعار عند نداء كيان DXCC لم يُتصل به بـ CQ</string>
+    <string name="settings_alert_new_state">ولاية أمريكية جديدة</string>
+    <string name="settings_alert_new_state_desc">صوت + اهتزاز + إشعار عند نداء محطة من ولاية أمريكية لم يُتصل بها بـ CQ (الولاية من المربع)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">حفظ فك تشفير SWL</string>
+    <string name="settings_save_swl_decodes_desc">تسجيل كل الرسائل المفكوكة في قاعدة البيانات</string>
+    <string name="settings_save_swl_qsos">حفظ QSOs الخاصة بـ SWL</string>
+    <string name="settings_save_swl_qsos_desc">تسجيل QSOs المرصودة بين محطات أخرى</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">رفع الرصدات المفكوكة إلى pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">رفع QSOs تلقائياً إلى سجل QRZ</string>
+    <string name="settings_qrz_profile_lookup">بحث ملف QRZ الشخصي</string>
+    <string name="settings_qrz_profile_lookup_desc">اسم المستخدم + كلمة المرور لواجهة QRZ XML API (الصور الرمزية)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">رفع QSOs تلقائياً إلى نسخة Cloudlog أو Wavelog أو Nextlog</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">تأخير PTT</string>
+    <string name="settings_ptt_delay_desc">التأخير بعد PTT قبل بدء صوت الإرسال</string>
+    <string name="settings_tx_delay">تأخير TX</string>
+    <string name="settings_tx_delay_desc">تأخير قبل الإرسال للسماح بفك تشفير الدورة السابقة</string>
+    <string name="settings_late_start_tolerance">تحمل البدء المتأخر</string>
+    <string name="settings_late_start_tolerance_desc">السماح ببدء TX حتى N ms داخل الدورة؛ يُقتطع الصوت الأمامي لينتهي TX عند حدود الدورة</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">الأسئلة الشائعة &amp; الدعم</string>
+    <string name="settings_report_bug">الإبلاغ عن خطأ</string>
+    <string name="bug_report_description_hint">صف ما حدث من خطأ…</string>
+    <string name="bug_report_send_email">إرسال بريد إلكتروني</string>
+    <string name="bug_report_no_email_app">لم يُعثر على تطبيق بريد لإرسال التقرير</string>
+    <string name="bug_report_open_github">فتح مشكلة GitHub</string>
+    <string name="settings_debug">تصحيح</string>
+    <string name="settings_debug_desc">عرض / مشاركة debug.log</string>
+    <string name="settings_about_body">الإصدار %1$s (بناء %2$s)\nتاريخ البناء %3$s\n\nFT8، بكل سهولة.\n\nتطبيق جهاز إرسال واستقبال FT8 مستقل لنظام Android. تحكم في الجهاز عبر USB وBluetooth والشبكة مع التسلسل والتسجيل التلقائيين.</string>
+    <string name="settings_website">الموقع الإلكتروني</string>
+    <string name="settings_community">المجتمع</string>
+    <string name="settings_built_by">بُني بواسطة</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">حظر نداءات دقيقة</string>
+    <string name="settings_block_exact_desc">مطابقة النداء الكامل. مفصولة بفاصلة أو مسافة، مثل W1AW، K1ABC.</string>
+    <string name="settings_block_prefix_title">حظر بادئات النداءات</string>
+    <string name="settings_block_prefix_desc">مطابقة البادئة، مثل RA تحظر RA0AA..RA9ZZ. مفصولة بفاصلة أو مسافة.</string>
+    <string name="settings_block_keyword_title">حظر الكلمات المفتاحية</string>
+    <string name="settings_block_keyword_desc">مطابقة السلسلة الفرعية مع النداء ونص الرسالة، مثل POTA، /P، QRP.</string>
+    <string name="settings_blocklist_hint">مثل W1AW، RA، /P</string>
+    <string name="settings_filter_continent_title">تصفية القارة</string>
+    <string name="settings_conn_usb_cable">كابل USB</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">الشبكة</string>
+    <string name="settings_no_usb_serial">لم تُرصد أجهزة USB تسلسلية. يرجى توصيل كابل USB براديوك وإعادة المحاولة.</string>
+    <string name="settings_no_bluetooth_devices">لم يُعثر على أجهزة Bluetooth مقترنة. اقترن بجهاز في إعدادات Bluetooth بنظام Android أولاً.</string>
+    <string name="settings_debug_mode_enabled">وضع التصحيح مفعَّل</string>
+    <string name="settings_debug_mode_disabled">وضع التصحيح متوقف</string>
+    <string name="settings_edit_operator_identity">تحرير هوية المشغِّل</string>
+    <string name="settings_callsign">النداء</string>
+    <string name="settings_callsign_hint">مثل W1AW</string>
+    <string name="settings_grid_locator">محدد المربع</string>
+    <string name="settings_grid_locator_hint">مثل FN31pr</string>
+    <string name="settings_logging_server">خادم التسجيل</string>
+    <string name="settings_logging_server_desc">يقبل Cloudlog وWavelog وNextlog جميعها نفس عمليات الرفع.</string>
+    <string name="settings_server_address">عنوان الخادم</string>
+    <string name="settings_api_key">مفتاح API</string>
+    <string name="settings_api_key_hint">مفتاح Cloudlog API الخاص بك</string>
+    <string name="settings_loading_stations">جارٍ تحميل المحطات...</string>
+    <string name="settings_station_id">معرّف المحطة</string>
+    <string name="settings_station_id_hint">مثل 1</string>
+    <string name="settings_select_a_station">اختر محطة</string>
+    <string name="settings_enter_manually">إدخال يدوي</string>
+    <string name="settings_choose_from_server">الاختيار من الخادم</string>
+    <string name="settings_station_profile">ملف المحطة الشخصي</string>
+    <string name="settings_qrz_creds_desc">يُستخدم لجلب صور الملف الشخصي للنداءات المفكوكة عبر واجهة QRZ XML API. يتطلب اشتراك QRZ XML.</string>
+    <string name="settings_username">اسم المستخدم</string>
+    <string name="settings_username_hint">اسم مستخدم QRZ.com الخاص بك</string>
+    <string name="settings_password">كلمة المرور</string>
+    <string name="settings_enabled_bands_dialog_desc">لن تظهر النطاقات المخفية في منتقيات التردد.</string>
+    <string name="settings_select_serial_port">اختر المنفذ التسلسلي</string>
+    <string name="settings_tx_volume_advice">عدِّل مباشرة — يستخدم TX التالي هذا المستوى. راقب ALC في راديوك وخفِّضه حتى يلامس الخط بالكاد.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">اللغة</string>
+    <string name="settings_language_desc">لغة عرض التطبيق</string>
+    <string name="settings_language_system">افتراضي النظام</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-cs/strings_compose.xml
@@ -1,0 +1,543 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Compose UI strings (FT8AF). The live app is the Jetpack Compose UI under
+  ~ radio.ks3ckc.ft8us; these are its user-facing strings, externalized for
+  ~ localization. The legacy strings.xml entries belong to the unreachable old
+  ~ XML/Fragment UI and are NOT used by the running app.
+  ~
+  ~ Translations live in values-<locale>/strings_compose.xml. English here is the
+  ~ source of truth — keep it byte-identical to the original UI text so the English
+  ~ layout never changes. Ham-radio abbreviations (CQ, QSO, DXCC, POTA, SOTA, RST)
+  ~ are intentionally left untranslated across all locales.
+-->
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">Zrušit</string>
+    <string name="action_save">Uložit</string>
+    <string name="action_done">Hotovo</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Ukončit</string>
+    <string name="common_none">Žádné</string>
+    <string name="common_off">Vypnuto</string>
+    <string name="common_not_configured">Nenakonfigurováno</string>
+    <string name="common_not_connected">Nepřipojeno</string>
+    <string name="common_pass">Prošlo</string>
+    <string name="common_fail">Selhalo</string>
+    <string name="common_test_connection">Otestovat připojení</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">Severní Amerika</string>
+    <string name="continent_sa">Jižní Amerika</string>
+    <string name="continent_eu">Evropa</string>
+    <string name="continent_af">Afrika</string>
+    <string name="continent_as">Asie</string>
+    <string name="continent_oc">Oceánie</string>
+    <string name="continent_an">Antarktida</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">Dekódování</string>
+    <string name="tab_map">Mapa</string>
+    <string name="tab_waterfall">Vodopád</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Deník</string>
+    <string name="tab_settings">Nastavení</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">NOVÉ DXCC</string>
+    <string name="status_new_grid">NOVÝ LOKÁTOR</string>
+    <string name="status_new_band">NOVÉ PÁSMO</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">NOVÉ POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">POTŘEBA</string>
+    <string name="status_worked">SPOJENO</string>
+    <string name="status_confirmed">POTVRZENO</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">ČEKÁ</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · MOBILNÍ SPOLEČNÍK</string>
+    <string name="splash_initializing">INICIALIZACE RÁDIA</string>
+    <string name="splash_version">v%1$s · build %2$s</string>
+    <string name="app_set_callsign_first">Před voláním CQ nastavte svou volací značku v Nastavení</string>
+    <string name="app_hunt_on">Lov zapnut — automatická odpověď na CQ</string>
+    <string name="app_hunt_off">Lov vypnut — volání CQ, pracujete jen s odpověďmi</string>
+    <string name="app_mode_switched">Režim: %1$s</string>
+    <string name="app_mode_switch_busy">Během vysílání nelze přepnout režim</string>
+    <string name="main_tx_volume">Hlasitost TX: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">UKONČIT FT8AF?</string>
+    <string name="exit_message">Opravdu chcete aplikaci zavřít? Každé aktivní QSO bude zrušeno.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">VYBRAT FREKVENCI</string>
+    <string name="freq_show_alternates">ZOBRAZIT ALTERNATIVY</string>
+    <string name="freq_hide_alternates">SKRÝT ALTERNATIVY</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">BEZ ZNAČKY</string>
+    <string name="op_no_grid">Lokátor nenastaven</string>
+    <string name="op_tap_to_edit">Klepnutím upravit</string>
+    <string name="op_stat_rig">TRX</string>
+    <string name="op_stat_antenna">ANTÉNA</string>
+    <string name="op_stat_power">VÝKON</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">EXPORTOVAT QSOs</string>
+    <string name="export_date_range">ROZSAH DAT</string>
+    <string name="export_date_from_placeholder">"Od  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"Do  YYYYMMDD"</string>
+    <string name="export_share">Sdílet</string>
+    <string name="export_filter_confirmed">jen potvrzené</string>
+    <string name="export_filter_unconfirmed">jen nepotvrzené</string>
+    <string name="export_record_singular">záznam</string>
+    <string name="export_record_plural">záznamů</string>
+    <string name="export_summary_all">vše</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s odpovídá %3$s%4$s</string>
+    <string name="export_preparing">Příprava…</string>
+    <string name="export_share_chooser_title">Sdílet deníky QSO</string>
+    <string name="export_saved_to">Uloženo do %1$s</string>
+    <string name="export_save_failed">Uložení do Stažených selhalo</string>
+    <string name="export_temp_file_failed">Nepodařilo se vytvořit dočasný soubor</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">VYSÍLÁNÍ</string>
+    <string name="tx_listening">POSLECH</string>
+    <string name="tx_hunt">Lov</string>
+    <string name="tx_call_cq">Volat CQ</string>
+    <string name="tx_stop">Stop</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Pracovat s DXpedicí (Hound)</string>
+    <string name="hound_help">Nejprve nalaďte TRX na zveřejněnou frekvenci Foxe. Voláte nahoře (1000–4000 Hz); aplikace vás automaticky QSY přesune dolů tam, kde Fox odpovídá, a odešle váš report.</string>
+    <string name="hound_fox_callsign">Volací značka Foxe</string>
+    <string name="hound_call_frequency">Frekvence volání (Hz, 1000–4000)</string>
+    <string name="hound_start">Start</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT připojen — klepnutím znovu připojit</string>
+    <string name="cat_status_connecting">CAT se připojuje…</string>
+    <string name="cat_status_disconnected">CAT odpojen — klepnutím připojit</string>
+    <string name="cat_status_error">Chyba připojení CAT — klepnutím opakovat</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX ZASTAVENO — Zjištěn vysoký SWR (%1$s)</string>
+    <string name="swr_lockout_body">Před vysíláním zkontrolujte anténu / napáječ.</string>
+    <string name="swr_lockout_dismiss">ZAVŘÍT</string>
+    <string name="swr_lockout_toast">TX zablokováno — aktivní blokace SWR. Nejprve zavřete banner blokace.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">Volání CQ</string>
+    <string name="qsopanel_searching">Hledání...</string>
+    <string name="qsopanel_qsoing_with">QSO s %1$s</string>
+    <string name="qsopanel_waiting_for">Čekání na %1$s</string>
+    <string name="qsopanel_tap_to_view">klepnutím zobrazit ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">Čekání na zprávy...</string>
+    <string name="qsopanel_log_action">ZAPSAT</string>
+    <string name="qsopanel_queue">FRONTA</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Dekódování</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d dekódováno v tomto cyklu"</string>
+    <string name="decode_clear_list">Vymazat seznam dekódů</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Vše</string>
+    <string name="decode_filter_cq_calls">Volání CQ</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">Nové DXCC</string>
+    <string name="decode_filter_needed">Potřeba</string>
+    <string name="decode_filter_for_me">Pro mě</string>
+    <string name="decode_empty_cq_title">Žádná volání CQ</string>
+    <string name="decode_empty_cq_body">Na tomto pásmu právě nikdo nevolá CQ.</string>
+    <string name="decode_empty_pota_title">Žádné spoty POTA</string>
+    <string name="decode_empty_pota_body">Na tomto pásmu zatím nebyly dekódovány žádné aktivace parků — otevřete POTA → Lov pro seznam spotů.</string>
+    <string name="decode_empty_dxcc_title">Žádné nové DXCC</string>
+    <string name="decode_empty_dxcc_body">Zatím nebyly dekódovány žádné nespojené entity DXCC.</string>
+    <string name="decode_empty_needed_title">Nic není potřeba</string>
+    <string name="decode_empty_needed_body">Nebyly nalezeny žádné stanice vyžadující potvrzení.</string>
+    <string name="decode_empty_forme_title">Žádná volání pro vás</string>
+    <string name="decode_empty_forme_body">Právě nikdo nevolá vaši volací značku.</string>
+    <string name="decode_empty_default_title">Žádné dekódované signály</string>
+    <string name="decode_empty_default_body">Čekání na signály FT8...</string>
+    <string name="decode_label_calling">→ VOLÁ</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ PRO VÁS</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO dokončeno</string>
+    <string name="qso_call_action">Volat %1$s</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Signál</string>
+    <string name="qso_stat_distance">Vzdálenost</string>
+    <string name="qso_stat_azimuth">Azimut</string>
+    <string name="qso_stat_band">Pásmo</string>
+    <string name="qso_sequence_header">SEKVENCE QSO</string>
+    <string name="qso_step_send_call">Odeslat značku</string>
+    <string name="qso_step_report_sent">Report odeslán</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Potvrdit</string>
+    <string name="qso_step_logged">Zapsáno</string>
+    <string name="qso_live_sending">QSO s %1$s — Odesílání %2$s</string>
+    <string name="qso_live_waiting">Čekání na odpověď od %1$s…</string>
+    <string name="qso_live_transmitting">Vysílání…</string>
+    <string name="qso_live_step_fallback">zpráva</string>
+    <string name="qso_tx_now">TX NYNÍ</string>
+    <string name="qso_tx_next">TX DALŠÍ</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">Statistiky</string>
+    <string name="log_tab_recent">Nedávné</string>
+    <string name="log_tab_awards">Diplomy</string>
+    <string name="log_title">Deník</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSOs · Všechna pásma</string>
+    <string name="log_cd_sync_to_logging_services">Synchronizovat s logovacími službami</string>
+    <string name="log_cd_export_qsos">Exportovat QSOs</string>
+    <string name="log_stat_total_qsos">Celkem QSOs</string>
+    <string name="log_stat_dxcc_entities">Entity DXCC</string>
+    <string name="log_stat_cq_zones">Zóny CQ</string>
+    <string name="log_stat_itu_zones">Zóny ITU</string>
+    <string name="log_section_band_distribution">Rozdělení podle pásem</string>
+    <string name="log_section_award_progress">Pokrok diplomů</string>
+    <string name="log_award_dxcc_mixed">DXCC smíšené</string>
+    <string name="log_award_vucc_grid_squares">Lokátory VUCC</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Pokrytí lokátorů</string>
+    <string name="log_section_signal_trend">Trend signálu</string>
+    <string name="log_no_qsos_yet">Zatím žádná QSOs</string>
+    <string name="log_no_qsos_recorded_yet">Zatím nezaznamenána žádná QSOs</string>
+    <string name="log_state_usa">%1$s, USA</string>
+    <string name="log_cd_qso_actions">Akce QSO</string>
+    <string name="log_action_edit">Upravit</string>
+    <string name="log_action_delete">Smazat</string>
+    <string name="log_award_dxcc_mixed_desc">Spojte a potvrďte 100 entit DXCC na libovolném pásmu/módu</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">Spojte všech 50 států USA s potvrzením</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">Spojte všech 40 zón CQ s potvrzením</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 lokátorů na jednom pásmu</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- spojení se stanicemi na vyhrazených ostrovech</string>
+    <string name="log_edit_qso">Upravit QSO</string>
+    <string name="log_field_callsign">Volací značka</string>
+    <string name="log_field_grid_locator">Lokátor</string>
+    <string name="log_field_mode">Mód</string>
+    <string name="log_delete_qso_title">SMAZAT QSO?</string>
+    <string name="log_delete_qso_body_callsign">Odstranit QSO s %1$s z deníku? Tuto akci nelze vrátit.</string>
+    <string name="log_delete_qso_body">Odstranit toto QSO z deníku? Tuto akci nelze vrátit.</string>
+    <string name="log_sync_title_no_services">ŽÁDNÉ POVOLENÉ SLUŽBY</string>
+    <string name="log_sync_title_syncing">SYNCHRONIZACE…</string>
+    <string name="log_sync_title_complete">SYNCHRONIZACE DOKONČENA</string>
+    <string name="log_sync_enable_services">Povolte Cloudlog/Wavelog/Nextlog nebo QRZ v Nastavení a zkuste to znovu.</string>
+    <string name="log_sync_progress_count">%1$d z %2$d QSOs</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d přijato</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d přijato</string>
+    <string name="log_sync_nothing_to_upload">V deníku zatím nejsou žádná QSOs k nahrání.</string>
+    <string name="log_sync_working">Pracuji…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Aktivovat</string>
+    <string name="pota_tab_hunt">Lov</string>
+    <string name="pota_tab_history">Historie</string>
+    <string name="pota_start_activation">Zahájit aktivaci</string>
+    <string name="pota_park_reference_label">Reference parku (např. K-1234)</string>
+    <string name="pota_notes_optional_label">Poznámky (volitelné)</string>
+    <string name="pota_enter_park_reference_first">Nejprve zadejte referenci parku</string>
+    <string name="pota_activating">Aktivace %1$s</string>
+    <string name="pota_activation_ended">Aktivace ukončena</string>
+    <string name="pota_set_callsign_first">Nejprve nastavte svou volací značku v Nastavení</string>
+    <string name="pota_self_spot_posted">Vlastní spot odeslán</string>
+    <string name="pota_self_spot_failed">Vlastní spot selhal — zkontrolujte log</string>
+    <string name="pota_active_park">AKTIVNÍ — %1$s</string>
+    <string name="pota_qsos">QSOs</string>
+    <string name="pota_contacts_map">Mapa spojení</string>
+    <string name="pota_back">Zpět</string>
+    <string name="pota_valid_activation">platná aktivace</string>
+    <string name="pota_to_valid">%1$d do platnosti</string>
+    <string name="pota_elapsed">Uplynulo</string>
+    <string name="pota_since_start">od začátku</string>
+    <string name="pota_self_spot">Vlastní spot</string>
+    <string name="pota_end_activation">Ukončit aktivaci</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">TX CQ vyjde jako “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Právě žádné spoty FT8 POTA.</string>
+    <string name="pota_active_spots">%1$d aktivních spotů FT8</string>
+    <string name="pota_targeting">Cíl %1$s @ %2$s kHz (%3$s) — přepněte na Dekódování pro volání</string>
+    <string name="pota_no_past_activations">Zatím žádné minulé aktivace.</string>
+    <string name="pota_no_browser_available">Není dostupný žádný prohlížeč</string>
+    <string name="pota_export_failed">Export selhal — zkontrolujte log</string>
+    <string name="pota_status_active">aktivní</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">Sdílet ADIF</string>
+    <string name="pota_open_pota_app">Otevřít pota.app</string>
+    <string name="pota_upload_to_pota">Nahrát do POTA</string>
+    <string name="pota_upload_success">Nahráno %1$d deníků parků do POTA</string>
+    <string name="pota_upload_failed">Nahrání selhalo: %1$s</string>
+    <string name="pota_upload_server_error">POTA nemohlo zpracovat nahrání. Zkontrolujte, že reference parku je platná a vaše volací značka je registrována v POTA, a zkuste to znovu.</string>
+    <string name="pota_upload_network_error">Nepodařilo se spojit s POTA. Zkontrolujte připojení k internetu a zkuste to znovu.</string>
+    <string name="pota_login_title">Přihlásit se do POTA</string>
+    <string name="pota_login_desc">Použijte e-mail a heslo svého účtu pota.app.</string>
+    <string name="pota_login_email">E-mail</string>
+    <string name="pota_login_password">Heslo</string>
+    <string name="pota_login_button">Přihlásit se</string>
+    <string name="pota_login_cancel">Zrušit</string>
+    <string name="pota_login_failed">Přihlášení selhalo: %1$s</string>
+    <string name="pota_login_or">nebo</string>
+    <string name="pota_login_social">Přihlásit se přes Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">Přihlásit se do POTA</string>
+    <string name="pota_add_park">Přidat park</string>
+    <string name="pota_remove_park">Odstranit</string>
+    <string name="pota_max_parks_reached">Dosažen maximální počet 10 parků</string>
+    <string name="pota_spotted_n_parks">Spotováno v %1$d parcích</string>
+    <string name="pota_parks_more">+%1$d dalších</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Ladění</string>
+    <string name="debug_line_count">%1$d řádků</string>
+    <string name="debug_logcat_on_suffix">" · logcat ON"</string>
+    <string name="debug_close">Zavřít</string>
+    <string name="debug_share">Sdílet</string>
+    <string name="debug_clear">Vymazat</string>
+    <string name="debug_logcat_on">Logcat: ON</string>
+    <string name="debug_logcat_off">Logcat: OFF</string>
+    <string name="debug_no_log_file">žádný soubor logu</string>
+    <string name="debug_log_cleared">log vymazán</string>
+    <string name="debug_share_chooser_title">Sdílet debug.log</string>
+    <string name="map_title">Mapa</string>
+    <string name="map_no_grid_set">Lokátor nenastaven</string>
+    <string name="map_station_count">%1$d stanic</string>
+    <string name="map_station_count_with_heard">%1$d stanic · %2$d slyšeno</string>
+    <string name="map_psk_error">PSK Reporter nedostupný: %1$s</string>
+    <string name="map_projection_equirectangular">Ekvirektangulární</string>
+    <string name="map_projection_azimuthal">Azimutální ekvidistantní</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">Vzdálenost</string>
+    <string name="map_info_bearing">Azimut</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Vodopád</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">ŽIVĚ</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d pokusů</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d z %2$d povoleno</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Build %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Nastavení</string>
+    <string name="settings_section_operator_identity">IDENTITA OPERÁTORA</string>
+    <string name="settings_section_radio">RÁDIO</string>
+    <string name="settings_section_audio">AUDIO</string>
+    <string name="settings_section_transmission">VYSÍLÁNÍ</string>
+    <string name="settings_section_auto_sequence">AUTO-SEKVENCE</string>
+    <string name="settings_section_decode_highlights">ZVÝRAZNĚNÍ DEKÓDŮ</string>
+    <string name="settings_section_callsign_blocklist">SEZNAM BLOKOVANÝCH ZNAČEK</string>
+    <string name="settings_section_decode_filters">FILTRY DEKÓDŮ</string>
+    <string name="settings_section_needed_dx_alerts">UPOZORNĚNÍ POTŘEBNÉ DX</string>
+    <string name="settings_section_logging_awards">LOGOVÁNÍ &amp; DIPLOMY</string>
+    <string name="settings_section_advanced">POKROČILÉ</string>
+    <string name="settings_section_about">O APLIKACI</string>
+    <string name="settings_section_language">JAZYK</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Rádio &amp; Audio</string>
+    <string name="settings_cat_transmission">Vysílání</string>
+    <string name="settings_cat_decode_filters">Dekódování &amp; Filtry</string>
+    <string name="settings_cat_logging">Logování &amp; Diplomy</string>
+    <string name="settings_cat_advanced">Pokročilé</string>
+    <string name="settings_cat_about">O aplikaci</string>
+    <string name="settings_cat_time_sync">Synchronizace času</string>
+    <string name="settings_cat_time_sync_desc">Ruční korekce hodin pro provoz bez připojení</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Ruční korekce</string>
+    <string name="settings_time_current_label">Aktuální korekce</string>
+    <string name="settings_time_correction_reset">Vynulovat</string>
+    <string name="settings_time_correction_desc">Posuňte hodiny aplikace, když nemáte internet pro synchronizaci. FT8 potřebuje UTC s přesností asi 1 sekunda. Upravujte, dokud se sloupec DT u dekódovaných stanic nevycentruje blízko 0.</string>
+    <string name="settings_time_suggest_section">Návrh z dekódů</string>
+    <string name="settings_time_suggest_none">Zatím žádné dekódy — začněte přijímat pro získání návrhu.</string>
+    <string name="settings_time_suggest_label">Nedávný průměrný DT: %1$s</string>
+    <string name="settings_time_suggest_apply">Použít navrženou korekci</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Auto-aktualizace lokátoru (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Použít GPS zařízení pro udržení aktuálního lokátoru Maidenhead</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Model TRX</string>
+    <string name="settings_control_mode">Režim řízení</string>
+    <string name="settings_connection_mode">Režim připojení</string>
+    <string name="settings_baud_rate">Přenosová rychlost</string>
+    <string name="settings_band_frequency">Pásmo &amp; Frekvence</string>
+    <string name="settings_enabled_bands">Povolená pásma</string>
+    <string name="settings_audio_frequency">Audio frekvence</string>
+    <string name="settings_spectrum_width">Šířka spektra</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Audio vstup</string>
+    <string name="settings_audio_output">Audio výstup</string>
+    <string name="settings_tx_volume">Hlasitost TX</string>
+    <string name="settings_tx_volume_desc" formatted="false">Úroveň vysílaného audia (hardwarová tlačítka ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">Split TX/RX</string>
+    <string name="settings_tx_rx_split_desc">Vysílat na jiné frekvenci než přijímat</string>
+    <string name="settings_tx_watchdog">TX Watchdog</string>
+    <string name="settings_tx_watchdog_desc">Automaticky zastavit vysílání po vypršení limitu</string>
+    <string name="settings_stop_after">Zastavit po</string>
+    <string name="settings_stop_after_desc">Zastavit volání po N neúspěšných pokusech</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Lov (auto-odpověď na CQ)</string>
+    <string name="settings_hunt_desc">Aktivně volat stanice volající CQ. Stejné jako tlačítko HUNT na liště TX. Vypnuto = volat CQ a pracovat jen se stanicemi, které vám odpoví.</string>
+    <string name="settings_auto_call_followed">Auto-volat sledované</string>
+    <string name="settings_auto_call_followed_desc">Automaticky pokračovat ve volání sledovaných volacích značek</string>
+    <string name="settings_fast_turnaround">Rychlý obrat</string>
+    <string name="settings_fast_turnaround_desc">Dekódovat ~1 s dříve, abyste mohli odpovědět na CQ v dalším slotu místo čekání. Může vynechat stanice s velkým posunem hodin.</string>
+    <string name="settings_auto_cq_after_qso">Auto-CQ po QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">Automaticky pokračovat ve volání CQ po každém dokončeném spojení — bez opětovného klepnutí. Zůstává na vaší frekvenci (ignoruje Lov). Běží, dokud nezastavíte nebo dokud TX Watchdog nevyprší bez odpovědí.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">Nové DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">Zvýraznit stanice z nespojené entity DXCC</string>
+    <string name="settings_highlight_new_grid">Nový lokátor</string>
+    <string name="settings_highlight_new_grid_desc">Zvýraznit dosud nespojené lokátory Maidenhead</string>
+    <string name="settings_highlight_new_band">Nové pásmo</string>
+    <string name="settings_highlight_new_band_desc">Zvýraznit stanice spojené jen na jiných pásmech</string>
+    <string name="settings_highlight_pota">Aktivátoři POTA</string>
+    <string name="settings_highlight_pota_desc">Zvýraznit spotované aktivátory POTA; nové parky vyniknou</string>
+    <string name="settings_highlight_worked">Dříve spojeno</string>
+    <string name="settings_highlight_worked_desc">Označit stanice již ve vašem deníku</string>
+    <string name="settings_distance_unit">Vzdálenost v mílích</string>
+    <string name="settings_distance_unit_desc">Zobrazovat vzdálenosti v mílích místo kilometrů</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Přesné volací značky</string>
+    <string name="settings_exact_callsigns_desc">Blokovat shodu celé značky</string>
+    <string name="settings_prefixes">Předpony</string>
+    <string name="settings_prefixes_desc">Blokovat podle předpony volací značky (např. RA)</string>
+    <string name="settings_keywords">Klíčová slova</string>
+    <string name="settings_keywords_desc">Blokovat podle podřetězce ve značce nebo zprávě (např. POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Zobrazit jen CQ</string>
+    <string name="settings_show_only_cq_desc">Skrýt vše kromě zpráv typu CQ</string>
+    <string name="settings_dx_only">Jen DX</string>
+    <string name="settings_dx_only_desc">Zobrazit jen stanice mimo váš vlastní kontinent</string>
+    <string name="settings_needed_only">Jen potřebné</string>
+    <string name="settings_needed_only_desc">Zobrazit jen dosud nepotvrzené stanice (QSL)</string>
+    <string name="settings_filter_by_continent">Filtrovat podle kontinentu</string>
+    <string name="settings_filter_by_continent_desc">Zobrazit jen stanice z vybraného kontinentu</string>
+    <string name="settings_continent">Kontinent</string>
+    <string name="settings_skip_directional_cq">Přeskočit směrová CQ (auto-odpověď)</string>
+    <string name="settings_skip_directional_cq_desc">Neodpovídat automaticky na CQ DX/EU/JA… mířená na jiné DXCC</string>
+    <string name="settings_hide_directional_cq">Skrýt směrová CQ ne pro mě</string>
+    <string name="settings_hide_directional_cq_desc">Skrýt regionálně mířená CQ, která necílí na vaše DXCC</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">Nové DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">Zvuk + vibrace + upozornění, když nespojená entita DXCC volá CQ</string>
+    <string name="settings_alert_new_state">Nový stát USA</string>
+    <string name="settings_alert_new_state_desc">Zvuk + vibrace + upozornění, když stanice z nespojeného státu USA volá CQ (stát z lokátoru)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">Ukládat SWL dekódy</string>
+    <string name="settings_save_swl_decodes_desc">Zaznamenávat všechny dekódované zprávy do databáze</string>
+    <string name="settings_save_swl_qsos">Ukládat SWL QSOs</string>
+    <string name="settings_save_swl_qsos_desc">Zaznamenávat QSOs zjištěná mezi jinými stanicemi</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Nahrávat dekódované spoty na pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">Automaticky nahrávat QSOs do QRZ Logbook</string>
+    <string name="settings_qrz_profile_lookup">Vyhledávání profilů QRZ</string>
+    <string name="settings_qrz_profile_lookup_desc">Uživatelské jméno + heslo pro QRZ XML API (avatary)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">Automaticky nahrávat QSOs do instance Cloudlog, Wavelog nebo Nextlog</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">Zpoždění PTT</string>
+    <string name="settings_ptt_delay_desc">Zpoždění po PTT před zahájením vysílaného audia</string>
+    <string name="settings_tx_delay">Zpoždění TX</string>
+    <string name="settings_tx_delay_desc">Zpoždění před vysíláním pro dekódování předchozího cyklu</string>
+    <string name="settings_late_start_tolerance">Tolerance pozdního startu</string>
+    <string name="settings_late_start_tolerance_desc">Povolit zahájení TX až N ms do cyklu; úvodní audio se ořízne, aby TX skončilo na hranici cyklu</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">FAQ &amp; Podpora</string>
+    <string name="settings_report_bug">Nahlásit chybu</string>
+    <string name="bug_report_description_hint">Popište, co se pokazilo…</string>
+    <string name="bug_report_send_email">Odeslat e-mail</string>
+    <string name="bug_report_no_email_app">Nebyla nalezena žádná e-mailová aplikace pro odeslání hlášení</string>
+    <string name="bug_report_open_github">Otevřít issue na GitHubu</string>
+    <string name="settings_debug">Ladění</string>
+    <string name="settings_debug_desc">Zobrazit / sdílet debug.log</string>
+    <string name="settings_about_body">Verze %1$s (build %2$s)\nDatum buildu %3$s\n\nFT8, jednoduše.\n\nSamostatná aplikace FT8 transceiveru pro Android. Řízení TRX přes USB, Bluetooth a síť s automatickým sekvencováním a logováním.</string>
+    <string name="settings_website">Web</string>
+    <string name="settings_community">Komunita</string>
+    <string name="settings_built_by">Vytvořili</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Blokovat přesné volací značky</string>
+    <string name="settings_block_exact_desc">Shoda celé značky. Oddělené čárkou nebo mezerou, např. W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Blokovat předpony volacích značek</string>
+    <string name="settings_block_prefix_desc">Shoda předpony, např. RA blokuje RA0AA..RA9ZZ. Oddělené čárkou nebo mezerou.</string>
+    <string name="settings_block_keyword_title">Blokovat klíčová slova</string>
+    <string name="settings_block_keyword_desc">Shoda podřetězce proti značce a textu zprávy, např. POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">např. W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Filtrovat kontinent</string>
+    <string name="settings_conn_usb_cable">USB kabel</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Síť</string>
+    <string name="settings_no_usb_serial">Nebyla zjištěna žádná sériová zařízení USB. Připojte USB kabel k rádiu a zkuste to znovu.</string>
+    <string name="settings_no_bluetooth_devices">Nebyla nalezena žádná spárovaná zařízení Bluetooth. Nejprve spárujte zařízení v nastavení Bluetooth systému Android.</string>
+    <string name="settings_debug_mode_enabled">Režim ladění povolen</string>
+    <string name="settings_debug_mode_disabled">Režim ladění zakázán</string>
+    <string name="settings_edit_operator_identity">Upravit identitu operátora</string>
+    <string name="settings_callsign">Volací značka</string>
+    <string name="settings_callsign_hint">např. W1AW</string>
+    <string name="settings_grid_locator">Lokátor</string>
+    <string name="settings_grid_locator_hint">např. FN31pr</string>
+    <string name="settings_logging_server">Logovací server</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog a Nextlog přijímají stejná nahrání.</string>
+    <string name="settings_server_address">Adresa serveru</string>
+    <string name="settings_api_key">API klíč</string>
+    <string name="settings_api_key_hint">Váš API klíč Cloudlog</string>
+    <string name="settings_loading_stations">Načítání stanic...</string>
+    <string name="settings_station_id">ID stanice</string>
+    <string name="settings_station_id_hint">např. 1</string>
+    <string name="settings_select_a_station">Vyberte stanici</string>
+    <string name="settings_enter_manually">Zadat ručně</string>
+    <string name="settings_choose_from_server">Vybrat ze serveru</string>
+    <string name="settings_station_profile">Profil stanice</string>
+    <string name="settings_qrz_creds_desc">Slouží k načtení profilových fotek pro dekódované volací značky přes QRZ XML API. Vyžaduje předplatné QRZ XML.</string>
+    <string name="settings_username">Uživatelské jméno</string>
+    <string name="settings_username_hint">Vaše uživatelské jméno QRZ.com</string>
+    <string name="settings_password">Heslo</string>
+    <string name="settings_enabled_bands_dialog_desc">Skrytá pásma se neobjeví ve výběru frekvencí.</string>
+    <string name="settings_select_serial_port">Vyberte sériový port</string>
+    <string name="settings_tx_volume_advice">Upravujte naživo — vaše příští TX použije tuto úroveň. Sledujte ALC svého rádia a stahujte, dokud se právě nedotýká čáry.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Jazyk</string>
+    <string name="settings_language_desc">Jazyk zobrazení aplikace</string>
+    <string name="settings_language_system">Výchozí systému</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-in/strings_compose.xml
@@ -411,7 +411,7 @@
     <string name="settings_auto_call_followed">Panggil Otomatis yang Diikuti</string>
     <string name="settings_auto_call_followed_desc">Terus memanggil tanda panggil yang diikuti secara otomatis</string>
     <string name="settings_fast_turnaround">Turnaround cepat</string>
-    <string name="settings_fast_turnaround_desc">Dekode ~1d lebih awal sehingga Anda bisa menjawab CQ pada slot berikutnya tanpa menunggu. Mungkin melewatkan stasiun dengan offset jam besar.</string>
+    <string name="settings_fast_turnaround_desc">Dekode ~1s lebih awal sehingga Anda bisa menjawab CQ pada slot berikutnya tanpa menunggu. Mungkin melewatkan stasiun dengan offset jam besar.</string>
     <string name="settings_auto_cq_after_qso">Auto-CQ setelah QSO</string>
     <string name="settings_auto_cq_after_qso_desc">Terus memanggil CQ otomatis setelah setiap kontak selesai — tanpa ketuk ulang. Tetap di frekuensi Anda (abaikan Hunt). Berjalan sampai Anda berhenti atau TX Watchdog habis tanpa jawaban.</string>
 

--- a/ft8cn/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-in/strings_compose.xml
@@ -1,0 +1,543 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Compose UI strings (FT8AF). The live app is the Jetpack Compose UI under
+  ~ radio.ks3ckc.ft8us; these are its user-facing strings, externalized for
+  ~ localization. The legacy strings.xml entries belong to the unreachable old
+  ~ XML/Fragment UI and are NOT used by the running app.
+  ~
+  ~ Translations live in values-<locale>/strings_compose.xml. English here is the
+  ~ source of truth — keep it byte-identical to the original UI text so the English
+  ~ layout never changes. Ham-radio abbreviations (CQ, QSO, DXCC, POTA, SOTA, RST)
+  ~ are intentionally left untranslated across all locales.
+-->
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">Batal</string>
+    <string name="action_save">Simpan</string>
+    <string name="action_done">Selesai</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Keluar</string>
+    <string name="common_none">Tidak ada</string>
+    <string name="common_off">Mati</string>
+    <string name="common_not_configured">Belum dikonfigurasi</string>
+    <string name="common_not_connected">Tidak terhubung</string>
+    <string name="common_pass">Lulus</string>
+    <string name="common_fail">Gagal</string>
+    <string name="common_test_connection">Uji Koneksi</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">Amerika Utara</string>
+    <string name="continent_sa">Amerika Selatan</string>
+    <string name="continent_eu">Eropa</string>
+    <string name="continent_af">Afrika</string>
+    <string name="continent_as">Asia</string>
+    <string name="continent_oc">Oseania</string>
+    <string name="continent_an">Antarktika</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">Dekode</string>
+    <string name="tab_map">Peta</string>
+    <string name="tab_waterfall">Waterfall</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Buku Log</string>
+    <string name="tab_settings">Setelan</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">DXCC BARU</string>
+    <string name="status_new_grid">GRID BARU</string>
+    <string name="status_new_band">BAND BARU</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">POTA BARU</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">DIBUTUHKAN</string>
+    <string name="status_worked">DIKERJAKAN</string>
+    <string name="status_confirmed">DIKONFIRMASI</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">TERTUNDA</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · PENDAMPING SELULER</string>
+    <string name="splash_initializing">MENGINISIALISASI RADIO</string>
+    <string name="splash_version">v%1$s · build %2$s</string>
+    <string name="app_set_callsign_first">Atur tanda panggil Anda di Setelan sebelum memanggil CQ</string>
+    <string name="app_hunt_on">Hunt aktif — menjawab CQ otomatis</string>
+    <string name="app_hunt_off">Hunt mati — memanggil CQ, hanya menjawab balasan</string>
+    <string name="app_mode_switched">Mode: %1$s</string>
+    <string name="app_mode_switch_busy">Tidak bisa ganti mode saat transmisi</string>
+    <string name="main_tx_volume">Volume TX: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">KELUAR DARI FT8AF?</string>
+    <string name="exit_message">Yakin ingin menutup aplikasi? QSO yang aktif akan dibatalkan.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">PILIH FREKUENSI</string>
+    <string name="freq_show_alternates">TAMPILKAN ALTERNATIF</string>
+    <string name="freq_hide_alternates">SEMBUNYIKAN ALTERNATIF</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">TANPA PANGGIL</string>
+    <string name="op_no_grid">Grid belum diatur</string>
+    <string name="op_tap_to_edit">Ketuk untuk ubah</string>
+    <string name="op_stat_rig">RIG</string>
+    <string name="op_stat_antenna">ANTENA</string>
+    <string name="op_stat_power">DAYA</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">EKSPOR QSO</string>
+    <string name="export_date_range">RENTANG TANGGAL</string>
+    <string name="export_date_from_placeholder">"Dari  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"Sampai  YYYYMMDD"</string>
+    <string name="export_share">Bagikan</string>
+    <string name="export_filter_confirmed">hanya yang dikonfirmasi</string>
+    <string name="export_filter_unconfirmed">hanya yang belum dikonfirmasi</string>
+    <string name="export_record_singular">rekaman</string>
+    <string name="export_record_plural">rekaman</string>
+    <string name="export_summary_all">semua</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s cocok dengan %3$s%4$s</string>
+    <string name="export_preparing">Menyiapkan…</string>
+    <string name="export_share_chooser_title">Bagikan log QSO</string>
+    <string name="export_saved_to">Disimpan ke %1$s</string>
+    <string name="export_save_failed">Gagal menyimpan ke Unduhan</string>
+    <string name="export_temp_file_failed">Tidak dapat membuat berkas sementara</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">TRANSMISI</string>
+    <string name="tx_listening">MENDENGARKAN</string>
+    <string name="tx_hunt">Hunt</string>
+    <string name="tx_call_cq">Panggil CQ</string>
+    <string name="tx_stop">Hentikan</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Kerjakan DXpedition (Hound)</string>
+    <string name="hound_help">Tune rig ke frekuensi dial yang dipublikasikan Fox terlebih dahulu. Anda memanggil di frekuensi tinggi (1000–4000 Hz); aplikasi otomatis QSY menurunkan Anda ke tempat Fox menjawab dan membalas dengan laporan Anda.</string>
+    <string name="hound_fox_callsign">Tanda panggil Fox</string>
+    <string name="hound_call_frequency">Frekuensi panggil (Hz, 1000–4000)</string>
+    <string name="hound_start">Mulai</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT terhubung — ketuk untuk sambung ulang</string>
+    <string name="cat_status_connecting">CAT menyambung…</string>
+    <string name="cat_status_disconnected">CAT terputus — ketuk untuk menyambung</string>
+    <string name="cat_status_error">Galat koneksi CAT — ketuk untuk coba lagi</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX DIHENTIKAN — SWR tinggi terdeteksi (%1$s)</string>
+    <string name="swr_lockout_body">Periksa antena / saluran umpan sebelum transmisi.</string>
+    <string name="swr_lockout_dismiss">TUTUP</string>
+    <string name="swr_lockout_toast">TX diblokir — penguncian SWR aktif. Tutup banner penguncian terlebih dahulu.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">Memanggil CQ</string>
+    <string name="qsopanel_searching">Mencari...</string>
+    <string name="qsopanel_qsoing_with">QSO dengan %1$s</string>
+    <string name="qsopanel_waiting_for">Menunggu %1$s</string>
+    <string name="qsopanel_tap_to_view">ketuk untuk lihat ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">Menunggu pesan...</string>
+    <string name="qsopanel_log_action">LOG</string>
+    <string name="qsopanel_queue">ANTRE</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Dekode</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d didekode siklus ini"</string>
+    <string name="decode_clear_list">Bersihkan daftar dekode</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Semua</string>
+    <string name="decode_filter_cq_calls">Panggilan CQ</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">DXCC Baru</string>
+    <string name="decode_filter_needed">Dibutuhkan</string>
+    <string name="decode_filter_for_me">Untuk Saya</string>
+    <string name="decode_empty_cq_title">Tidak ada panggilan CQ</string>
+    <string name="decode_empty_cq_body">Tidak ada stasiun yang memanggil CQ di band ini saat ini.</string>
+    <string name="decode_empty_pota_title">Tidak ada spot POTA</string>
+    <string name="decode_empty_pota_body">Belum ada aktivasi taman yang didekode di band ini — buka POTA → Hunt untuk daftar spot.</string>
+    <string name="decode_empty_dxcc_title">Tidak ada DXCC baru</string>
+    <string name="decode_empty_dxcc_body">Belum ada entitas DXCC yang belum dikerjakan yang didekode.</string>
+    <string name="decode_empty_needed_title">Tidak ada yang dibutuhkan</string>
+    <string name="decode_empty_needed_body">Tidak ditemukan stasiun yang perlu konfirmasi.</string>
+    <string name="decode_empty_forme_title">Tidak ada panggilan untuk Anda</string>
+    <string name="decode_empty_forme_body">Tidak ada stasiun yang memanggil tanda panggil Anda saat ini.</string>
+    <string name="decode_empty_default_title">Tidak ada sinyal didekode</string>
+    <string name="decode_empty_default_body">Menunggu sinyal FT8 muncul...</string>
+    <string name="decode_label_calling">→ MEMANGGIL</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ UNTUK ANDA</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO Selesai</string>
+    <string name="qso_call_action">Panggil %1$s</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Sinyal</string>
+    <string name="qso_stat_distance">Jarak</string>
+    <string name="qso_stat_azimuth">Azimut</string>
+    <string name="qso_stat_band">Band</string>
+    <string name="qso_sequence_header">URUTAN QSO</string>
+    <string name="qso_step_send_call">Kirim panggilan</string>
+    <string name="qso_step_report_sent">Laporan terkirim</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Konfirmasi</string>
+    <string name="qso_step_logged">Tercatat</string>
+    <string name="qso_live_sending">QSO dengan %1$s — Mengirim %2$s</string>
+    <string name="qso_live_waiting">Menunggu %1$s membalas…</string>
+    <string name="qso_live_transmitting">Transmisi…</string>
+    <string name="qso_live_step_fallback">pesan</string>
+    <string name="qso_tx_now">TX SEKARANG</string>
+    <string name="qso_tx_next">TX BERIKUTNYA</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">Statistik</string>
+    <string name="log_tab_recent">Terbaru</string>
+    <string name="log_tab_awards">Penghargaan</string>
+    <string name="log_title">Buku Log</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSO · Semua band</string>
+    <string name="log_cd_sync_to_logging_services">Sinkronkan ke layanan logging</string>
+    <string name="log_cd_export_qsos">Ekspor QSO</string>
+    <string name="log_stat_total_qsos">Total QSO</string>
+    <string name="log_stat_dxcc_entities">Entitas DXCC</string>
+    <string name="log_stat_cq_zones">Zona CQ</string>
+    <string name="log_stat_itu_zones">Zona ITU</string>
+    <string name="log_section_band_distribution">Distribusi Band</string>
+    <string name="log_section_award_progress">Progres Penghargaan</string>
+    <string name="log_award_dxcc_mixed">DXCC Mixed</string>
+    <string name="log_award_vucc_grid_squares">Grid Square VUCC</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Cakupan Grid</string>
+    <string name="log_section_signal_trend">Tren Sinyal</string>
+    <string name="log_no_qsos_yet">Belum ada QSO</string>
+    <string name="log_no_qsos_recorded_yet">Belum ada QSO yang tercatat</string>
+    <string name="log_state_usa">%1$s, USA</string>
+    <string name="log_cd_qso_actions">Tindakan QSO</string>
+    <string name="log_action_edit">Ubah</string>
+    <string name="log_action_delete">Hapus</string>
+    <string name="log_award_dxcc_mixed_desc">Kerjakan dan konfirmasi 100 entitas DXCC di band/mode apa pun</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">Kerjakan semua 50 negara bagian AS terkonfirmasi</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">Kerjakan semua 40 zona CQ terkonfirmasi</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 grid square di satu band</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- kerjakan stasiun di pulau yang ditentukan</string>
+    <string name="log_edit_qso">Ubah QSO</string>
+    <string name="log_field_callsign">Tanda Panggil</string>
+    <string name="log_field_grid_locator">Lokator Grid</string>
+    <string name="log_field_mode">Mode</string>
+    <string name="log_delete_qso_title">HAPUS QSO?</string>
+    <string name="log_delete_qso_body_callsign">Hapus QSO dengan %1$s dari buku log? Ini tidak bisa dibatalkan.</string>
+    <string name="log_delete_qso_body">Hapus QSO ini dari buku log? Ini tidak bisa dibatalkan.</string>
+    <string name="log_sync_title_no_services">TIDAK ADA LAYANAN AKTIF</string>
+    <string name="log_sync_title_syncing">MENYINKRONKAN…</string>
+    <string name="log_sync_title_complete">SINKRONISASI SELESAI</string>
+    <string name="log_sync_enable_services">Aktifkan Cloudlog/Wavelog/Nextlog atau QRZ di Setelan, lalu coba lagi.</string>
+    <string name="log_sync_progress_count">%1$d dari %2$d QSO</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d diterima</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d diterima</string>
+    <string name="log_sync_nothing_to_upload">Belum ada QSO di buku log untuk diunggah.</string>
+    <string name="log_sync_working">Memproses…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Aktivasi</string>
+    <string name="pota_tab_hunt">Hunt</string>
+    <string name="pota_tab_history">Riwayat</string>
+    <string name="pota_start_activation">Mulai aktivasi</string>
+    <string name="pota_park_reference_label">Referensi taman (mis. K-1234)</string>
+    <string name="pota_notes_optional_label">Catatan (opsional)</string>
+    <string name="pota_enter_park_reference_first">Masukkan referensi taman terlebih dahulu</string>
+    <string name="pota_activating">Mengaktivasi %1$s</string>
+    <string name="pota_activation_ended">Aktivasi berakhir</string>
+    <string name="pota_set_callsign_first">Atur tanda panggil Anda di Setelan terlebih dahulu</string>
+    <string name="pota_self_spot_posted">Self-spot diposting</string>
+    <string name="pota_self_spot_failed">Self-spot gagal — periksa log</string>
+    <string name="pota_active_park">AKTIF — %1$s</string>
+    <string name="pota_qsos">QSO</string>
+    <string name="pota_contacts_map">Peta kontak</string>
+    <string name="pota_back">Kembali</string>
+    <string name="pota_valid_activation">aktivasi valid</string>
+    <string name="pota_to_valid">%1$d lagi untuk valid</string>
+    <string name="pota_elapsed">Berlalu</string>
+    <string name="pota_since_start">sejak mulai</string>
+    <string name="pota_self_spot">Self-spot</string>
+    <string name="pota_end_activation">Akhiri aktivasi</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">TX CQ akan dikirim sebagai “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Tidak ada spot FT8 POTA saat ini.</string>
+    <string name="pota_active_spots">%1$d spot FT8 aktif</string>
+    <string name="pota_targeting">Menargetkan %1$s @ %2$s kHz (%3$s) — beralih ke Dekode untuk memanggil</string>
+    <string name="pota_no_past_activations">Belum ada aktivasi sebelumnya.</string>
+    <string name="pota_no_browser_available">Tidak ada browser tersedia</string>
+    <string name="pota_export_failed">Ekspor gagal — periksa log</string>
+    <string name="pota_status_active">aktif</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">Bagikan ADIF</string>
+    <string name="pota_open_pota_app">Buka pota.app</string>
+    <string name="pota_upload_to_pota">Unggah ke POTA</string>
+    <string name="pota_upload_success">Mengunggah %1$d log taman ke POTA</string>
+    <string name="pota_upload_failed">Unggah gagal: %1$s</string>
+    <string name="pota_upload_server_error">POTA tidak dapat memproses unggahan. Pastikan referensi taman valid dan tanda panggil Anda terdaftar di POTA, lalu coba lagi.</string>
+    <string name="pota_upload_network_error">Tidak dapat menjangkau POTA. Periksa koneksi internet Anda dan coba lagi.</string>
+    <string name="pota_login_title">Masuk ke POTA</string>
+    <string name="pota_login_desc">Gunakan email dan kata sandi akun pota.app Anda.</string>
+    <string name="pota_login_email">Email</string>
+    <string name="pota_login_password">Kata Sandi</string>
+    <string name="pota_login_button">Masuk</string>
+    <string name="pota_login_cancel">Batal</string>
+    <string name="pota_login_failed">Gagal masuk: %1$s</string>
+    <string name="pota_login_or">atau</string>
+    <string name="pota_login_social">Masuk dengan Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">Masuk ke POTA</string>
+    <string name="pota_add_park">Tambah taman</string>
+    <string name="pota_remove_park">Hapus</string>
+    <string name="pota_max_parks_reached">Maksimum 10 taman tercapai</string>
+    <string name="pota_spotted_n_parks">Di-spot di %1$d taman</string>
+    <string name="pota_parks_more">+%1$d lagi</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Debug</string>
+    <string name="debug_line_count">%1$d baris</string>
+    <string name="debug_logcat_on_suffix">" · logcat ON"</string>
+    <string name="debug_close">Tutup</string>
+    <string name="debug_share">Bagikan</string>
+    <string name="debug_clear">Bersihkan</string>
+    <string name="debug_logcat_on">Logcat: ON</string>
+    <string name="debug_logcat_off">Logcat: OFF</string>
+    <string name="debug_no_log_file">tidak ada berkas log</string>
+    <string name="debug_log_cleared">log dibersihkan</string>
+    <string name="debug_share_chooser_title">Bagikan debug.log</string>
+    <string name="map_title">Peta</string>
+    <string name="map_no_grid_set">Grid belum diatur</string>
+    <string name="map_station_count">%1$d stasiun</string>
+    <string name="map_station_count_with_heard">%1$d stasiun · %2$d terdengar</string>
+    <string name="map_psk_error">PSK Reporter tidak tersedia: %1$s</string>
+    <string name="map_projection_equirectangular">Equirectangular</string>
+    <string name="map_projection_azimuthal">Azimuthal Equidistant</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">Jarak</string>
+    <string name="map_info_bearing">Arah</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Waterfall</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">LIVE</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d percobaan</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d dari %2$d aktif</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Build %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Setelan</string>
+    <string name="settings_section_operator_identity">IDENTITAS OPERATOR</string>
+    <string name="settings_section_radio">RADIO</string>
+    <string name="settings_section_audio">AUDIO</string>
+    <string name="settings_section_transmission">TRANSMISI</string>
+    <string name="settings_section_auto_sequence">AUTO-SEQUENCE</string>
+    <string name="settings_section_decode_highlights">SOROTAN DEKODE</string>
+    <string name="settings_section_callsign_blocklist">DAFTAR BLOKIR TANDA PANGGIL</string>
+    <string name="settings_section_decode_filters">FILTER DEKODE</string>
+    <string name="settings_section_needed_dx_alerts">PERINGATAN DX DIBUTUHKAN</string>
+    <string name="settings_section_logging_awards">LOGGING &amp; PENGHARGAAN</string>
+    <string name="settings_section_advanced">LANJUTAN</string>
+    <string name="settings_section_about">TENTANG</string>
+    <string name="settings_section_language">BAHASA</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Radio &amp; Audio</string>
+    <string name="settings_cat_transmission">Transmisi</string>
+    <string name="settings_cat_decode_filters">Dekode &amp; Filter</string>
+    <string name="settings_cat_logging">Logging &amp; Penghargaan</string>
+    <string name="settings_cat_advanced">Lanjutan</string>
+    <string name="settings_cat_about">Tentang</string>
+    <string name="settings_cat_time_sync">Sinkronisasi Waktu</string>
+    <string name="settings_cat_time_sync_desc">Koreksi jam manual untuk operasi offline</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Koreksi Manual</string>
+    <string name="settings_time_current_label">Koreksi saat ini</string>
+    <string name="settings_time_correction_reset">Setel ulang ke 0</string>
+    <string name="settings_time_correction_desc">Sesuaikan jam aplikasi saat Anda tidak punya internet untuk sinkronisasi. FT8 perlu UTC dalam sekitar 1 detik. Sesuaikan hingga kolom DT pada stasiun yang didekode berpusat di sekitar 0.</string>
+    <string name="settings_time_suggest_section">Saran dari dekode</string>
+    <string name="settings_time_suggest_none">Belum ada dekode — mulai menerima untuk mendapat saran.</string>
+    <string name="settings_time_suggest_label">Rata-rata DT terbaru: %1$s</string>
+    <string name="settings_time_suggest_apply">Terapkan koreksi yang disarankan</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Perbarui Grid Otomatis (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Gunakan GPS perangkat untuk menjaga grid Maidenhead tetap terkini</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Model Rig</string>
+    <string name="settings_control_mode">Mode Kontrol</string>
+    <string name="settings_connection_mode">Mode Koneksi</string>
+    <string name="settings_baud_rate">Baud Rate</string>
+    <string name="settings_band_frequency">Band &amp; Frekuensi</string>
+    <string name="settings_enabled_bands">Band Aktif</string>
+    <string name="settings_audio_frequency">Frekuensi Audio</string>
+    <string name="settings_spectrum_width">Lebar Spektrum</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Input Audio</string>
+    <string name="settings_audio_output">Output Audio</string>
+    <string name="settings_tx_volume">Volume TX</string>
+    <string name="settings_tx_volume_desc" formatted="false">Tingkat audio transmisi (tombol perangkat keras ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">Split TX/RX</string>
+    <string name="settings_tx_rx_split_desc">Transmisi pada frekuensi berbeda dari penerimaan</string>
+    <string name="settings_tx_watchdog">TX Watchdog</string>
+    <string name="settings_tx_watchdog_desc">Hentikan transmisi otomatis setelah waktu habis</string>
+    <string name="settings_stop_after">Hentikan Setelah</string>
+    <string name="settings_stop_after_desc">Berhenti memanggil setelah N percobaan tak terjawab</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Hunt (jawab CQ otomatis)</string>
+    <string name="settings_hunt_desc">Secara proaktif memanggil stasiun yang memanggil CQ. Sama dengan tombol HUNT di bilah TX. Mati = memanggil CQ dan hanya mengerjakan stasiun yang menjawab Anda.</string>
+    <string name="settings_auto_call_followed">Panggil Otomatis yang Diikuti</string>
+    <string name="settings_auto_call_followed_desc">Terus memanggil tanda panggil yang diikuti secara otomatis</string>
+    <string name="settings_fast_turnaround">Turnaround cepat</string>
+    <string name="settings_fast_turnaround_desc">Dekode ~1d lebih awal sehingga Anda bisa menjawab CQ pada slot berikutnya tanpa menunggu. Mungkin melewatkan stasiun dengan offset jam besar.</string>
+    <string name="settings_auto_cq_after_qso">Auto-CQ setelah QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">Terus memanggil CQ otomatis setelah setiap kontak selesai — tanpa ketuk ulang. Tetap di frekuensi Anda (abaikan Hunt). Berjalan sampai Anda berhenti atau TX Watchdog habis tanpa jawaban.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">DXCC Baru</string>
+    <string name="settings_highlight_new_dxcc_desc">Sorot stasiun dari entitas DXCC yang belum dikerjakan</string>
+    <string name="settings_highlight_new_grid">Grid Baru</string>
+    <string name="settings_highlight_new_grid_desc">Sorot grid Maidenhead yang belum dikerjakan</string>
+    <string name="settings_highlight_new_band">Band Baru</string>
+    <string name="settings_highlight_new_band_desc">Sorot stasiun yang hanya dikerjakan di band lain</string>
+    <string name="settings_highlight_pota">Aktivator POTA</string>
+    <string name="settings_highlight_pota_desc">Sorot aktivator POTA yang di-spot; taman baru menonjol</string>
+    <string name="settings_highlight_worked">Pernah Dikerjakan</string>
+    <string name="settings_highlight_worked_desc">Tandai stasiun yang sudah ada di log Anda</string>
+    <string name="settings_distance_unit">Jarak dalam Mil</string>
+    <string name="settings_distance_unit_desc">Tampilkan jarak dalam mil bukan kilometer</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Tanda Panggil Persis</string>
+    <string name="settings_exact_callsigns_desc">Blokir kecocokan panggilan penuh</string>
+    <string name="settings_prefixes">Prefiks</string>
+    <string name="settings_prefixes_desc">Blokir berdasarkan prefiks tanda panggil (mis. RA)</string>
+    <string name="settings_keywords">Kata Kunci</string>
+    <string name="settings_keywords_desc">Blokir berdasarkan substring di panggilan atau pesan (mis. POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Tampilkan Hanya CQ</string>
+    <string name="settings_show_only_cq_desc">Sembunyikan semua kecuali pesan tipe CQ</string>
+    <string name="settings_dx_only">Hanya DX</string>
+    <string name="settings_dx_only_desc">Tampilkan hanya stasiun di luar benua Anda sendiri</string>
+    <string name="settings_needed_only">Hanya yang Dibutuhkan</string>
+    <string name="settings_needed_only_desc">Tampilkan hanya stasiun yang belum dikonfirmasi (QSL)</string>
+    <string name="settings_filter_by_continent">Filter Berdasarkan Benua</string>
+    <string name="settings_filter_by_continent_desc">Tampilkan hanya stasiun dari benua yang dipilih</string>
+    <string name="settings_continent">Benua</string>
+    <string name="settings_skip_directional_cq">Lewati CQ Terarah (balas otomatis)</string>
+    <string name="settings_skip_directional_cq_desc">Jangan menjawab otomatis CQ DX/EU/JA… yang ditujukan ke DXCC berbeda</string>
+    <string name="settings_hide_directional_cq">Sembunyikan CQ Terarah Bukan Untuk Saya</string>
+    <string name="settings_hide_directional_cq_desc">Sembunyikan CQ terarah wilayah yang tidak menargetkan DXCC Anda</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">DXCC Baru</string>
+    <string name="settings_alert_new_dxcc_desc">Suara + getar + notifikasi saat entitas DXCC yang belum dikerjakan memanggil CQ</string>
+    <string name="settings_alert_new_state">Negara Bagian AS Baru</string>
+    <string name="settings_alert_new_state_desc">Suara + getar + notifikasi saat stasiun dari negara bagian AS yang belum dikerjakan memanggil CQ (negara bagian dari grid)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">Simpan Dekode SWL</string>
+    <string name="settings_save_swl_decodes_desc">Catat semua pesan yang didekode ke basis data</string>
+    <string name="settings_save_swl_qsos">Simpan QSO SWL</string>
+    <string name="settings_save_swl_qsos_desc">Catat QSO yang terdeteksi antara stasiun lain</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Unggah spot yang didekode ke pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">Unggah QSO otomatis ke QRZ Logbook</string>
+    <string name="settings_qrz_profile_lookup">Pencarian Profil QRZ</string>
+    <string name="settings_qrz_profile_lookup_desc">Nama pengguna + kata sandi untuk QRZ XML API (avatar)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">Unggah QSO otomatis ke instans Cloudlog, Wavelog, atau Nextlog</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">Penundaan PTT</string>
+    <string name="settings_ptt_delay_desc">Penundaan setelah PTT sebelum audio transmisi dimulai</string>
+    <string name="settings_tx_delay">Penundaan TX</string>
+    <string name="settings_tx_delay_desc">Penundaan sebelum transmisi untuk memungkinkan dekode siklus sebelumnya</string>
+    <string name="settings_late_start_tolerance">Toleransi Mulai Terlambat</string>
+    <string name="settings_late_start_tolerance_desc">Izinkan memulai TX hingga N ms ke dalam siklus; audio awal dipotong sehingga TX berakhir pada batas siklus</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">FAQ &amp; Dukungan</string>
+    <string name="settings_report_bug">Laporkan Bug</string>
+    <string name="bug_report_description_hint">Jelaskan apa yang salah…</string>
+    <string name="bug_report_send_email">Kirim email</string>
+    <string name="bug_report_no_email_app">Tidak ditemukan aplikasi email untuk mengirim laporan</string>
+    <string name="bug_report_open_github">Buka isu GitHub</string>
+    <string name="settings_debug">Debug</string>
+    <string name="settings_debug_desc">Lihat / bagikan debug.log</string>
+    <string name="settings_about_body">Versi %1$s (build %2$s)\nTanggal build %3$s\n\nFT8, dipermudah.\n\nAplikasi transceiver FT8 mandiri untuk Android. Kontrol rig via USB, Bluetooth, dan jaringan dengan sequencing dan logging otomatis.</string>
+    <string name="settings_website">Situs Web</string>
+    <string name="settings_community">Komunitas</string>
+    <string name="settings_built_by">Dibuat oleh</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Blokir Tanda Panggil Persis</string>
+    <string name="settings_block_exact_desc">Kecocokan panggilan penuh. Dipisah koma atau spasi, mis. W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Blokir Prefiks Tanda Panggil</string>
+    <string name="settings_block_prefix_desc">Kecocokan prefiks, mis. RA memblokir RA0AA..RA9ZZ. Dipisah koma atau spasi.</string>
+    <string name="settings_block_keyword_title">Blokir Kata Kunci</string>
+    <string name="settings_block_keyword_desc">Kecocokan substring terhadap panggilan dan teks pesan, mis. POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">mis. W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Filter Benua</string>
+    <string name="settings_conn_usb_cable">Kabel USB</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Jaringan</string>
+    <string name="settings_no_usb_serial">Tidak ada perangkat serial USB terdeteksi. Hubungkan kabel USB ke radio Anda dan coba lagi.</string>
+    <string name="settings_no_bluetooth_devices">Tidak ditemukan perangkat Bluetooth terpasang. Pasangkan perangkat di setelan Bluetooth Android terlebih dahulu.</string>
+    <string name="settings_debug_mode_enabled">Mode debug diaktifkan</string>
+    <string name="settings_debug_mode_disabled">Mode debug dinonaktifkan</string>
+    <string name="settings_edit_operator_identity">Ubah Identitas Operator</string>
+    <string name="settings_callsign">Tanda Panggil</string>
+    <string name="settings_callsign_hint">mis. W1AW</string>
+    <string name="settings_grid_locator">Lokator Grid</string>
+    <string name="settings_grid_locator_hint">mis. FN31pr</string>
+    <string name="settings_logging_server">Server Logging</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog, dan Nextlog semua menerima unggahan yang sama.</string>
+    <string name="settings_server_address">Alamat Server</string>
+    <string name="settings_api_key">Kunci API</string>
+    <string name="settings_api_key_hint">Kunci API Cloudlog Anda</string>
+    <string name="settings_loading_stations">Memuat stasiun...</string>
+    <string name="settings_station_id">ID Stasiun</string>
+    <string name="settings_station_id_hint">mis. 1</string>
+    <string name="settings_select_a_station">Pilih stasiun</string>
+    <string name="settings_enter_manually">Masukkan manual</string>
+    <string name="settings_choose_from_server">Pilih dari server</string>
+    <string name="settings_station_profile">Profil Stasiun</string>
+    <string name="settings_qrz_creds_desc">Digunakan untuk mengambil foto profil tanda panggil yang didekode via QRZ XML API. Memerlukan langganan QRZ XML.</string>
+    <string name="settings_username">Nama Pengguna</string>
+    <string name="settings_username_hint">Nama pengguna QRZ.com Anda</string>
+    <string name="settings_password">Kata Sandi</string>
+    <string name="settings_enabled_bands_dialog_desc">Band yang disembunyikan tidak akan muncul di pemilih frekuensi.</string>
+    <string name="settings_select_serial_port">Pilih Port Serial</string>
+    <string name="settings_tx_volume_advice">Sesuaikan langsung — TX berikutnya menggunakan tingkat ini. Perhatikan ALC radio Anda dan turunkan sampai hanya menyentuh garis.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Bahasa</string>
+    <string name="settings_language_desc">Bahasa tampilan aplikasi</string>
+    <string name="settings_language_system">Default sistem</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-it/strings_compose.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">Annulla</string>
+    <string name="action_save">Salva</string>
+    <string name="action_done">Fatto</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Esci</string>
+    <string name="common_none">Nessuno</string>
+    <string name="common_off">Off</string>
+    <string name="common_not_configured">Non configurato</string>
+    <string name="common_not_connected">Non connesso</string>
+    <string name="common_pass">Superato</string>
+    <string name="common_fail">Fallito</string>
+    <string name="common_test_connection">Prova connessione</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">America del Nord</string>
+    <string name="continent_sa">America del Sud</string>
+    <string name="continent_eu">Europa</string>
+    <string name="continent_af">Africa</string>
+    <string name="continent_as">Asia</string>
+    <string name="continent_oc">Oceania</string>
+    <string name="continent_an">Antartide</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">Decodifica</string>
+    <string name="tab_map">Mappa</string>
+    <string name="tab_waterfall">Waterfall</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Log</string>
+    <string name="tab_settings">Impostazioni</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">NUOVO DXCC</string>
+    <string name="status_new_grid">NUOVO GRID</string>
+    <string name="status_new_band">NUOVA BANDA</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">NUOVO POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">NECESSARIO</string>
+    <string name="status_worked">LAVORATO</string>
+    <string name="status_confirmed">CONFERMATO</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">IN ATTESA</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · COMPAGNO MOBILE</string>
+    <string name="splash_initializing">INIZIALIZZAZIONE RADIO</string>
+    <string name="splash_version">v%1$s · build %2$s</string>
+    <string name="app_set_callsign_first">Imposta il tuo nominativo nelle Impostazioni prima di chiamare CQ</string>
+    <string name="app_hunt_on">Hunt attivo — risposta automatica ai CQ</string>
+    <string name="app_hunt_off">Hunt disattivo — chiamata CQ, solo risposte</string>
+    <string name="app_mode_switched">Modo: %1$s</string>
+    <string name="app_mode_switch_busy">Impossibile cambiare modo durante la trasmissione</string>
+    <string name="main_tx_volume">Volume TX: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">USCIRE DA FT8AF?</string>
+    <string name="exit_message">Vuoi davvero chiudere l\'app? Qualsiasi QSO attivo verrà annullato.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">SELEZIONA FREQUENZA</string>
+    <string name="freq_show_alternates">MOSTRA ALTERNATIVE</string>
+    <string name="freq_hide_alternates">NASCONDI ALTERNATIVE</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">NESSUN NOMINATIVO</string>
+    <string name="op_no_grid">Nessun grid impostato</string>
+    <string name="op_tap_to_edit">Tocca per modificare</string>
+    <string name="op_stat_rig">RADIO</string>
+    <string name="op_stat_antenna">ANTENNA</string>
+    <string name="op_stat_power">POTENZA</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">ESPORTA QSO</string>
+    <string name="export_date_range">INTERVALLO DATE</string>
+    <string name="export_date_from_placeholder">"Da  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"A  YYYYMMDD"</string>
+    <string name="export_share">Condividi</string>
+    <string name="export_filter_confirmed">solo confermati</string>
+    <string name="export_filter_unconfirmed">solo non confermati</string>
+    <string name="export_record_singular">record</string>
+    <string name="export_record_plural">record</string>
+    <string name="export_summary_all">tutti</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s corrispondenti a %3$s%4$s</string>
+    <string name="export_preparing">Preparazione…</string>
+    <string name="export_share_chooser_title">Condividi log QSO</string>
+    <string name="export_saved_to">Salvato in %1$s</string>
+    <string name="export_save_failed">Salvataggio in Download fallito</string>
+    <string name="export_temp_file_failed">Impossibile creare file temporaneo</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">TRASMISSIONE</string>
+    <string name="tx_listening">IN ASCOLTO</string>
+    <string name="tx_hunt">Hunt</string>
+    <string name="tx_call_cq">Chiama CQ</string>
+    <string name="tx_stop">Stop</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Lavora una DXpedition (Hound)</string>
+    <string name="hound_help">Sintonizza prima la radio sulla frequenza pubblicata della Fox. Chiami in alto (1000–4000 Hz); l\'app ti fa auto-QSY verso il punto dove la Fox risponde e replica con il tuo rapporto.</string>
+    <string name="hound_fox_callsign">Nominativo Fox</string>
+    <string name="hound_call_frequency">Frequenza di chiamata (Hz, 1000–4000)</string>
+    <string name="hound_start">Avvia</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT connesso — tocca per riconnettere</string>
+    <string name="cat_status_connecting">Connessione CAT…</string>
+    <string name="cat_status_disconnected">CAT disconnesso — tocca per connettere</string>
+    <string name="cat_status_error">Errore connessione CAT — tocca per riprovare</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX BLOCCATA — SWR alto rilevato (%1$s)</string>
+    <string name="swr_lockout_body">Controlla antenna / linea di alimentazione prima di trasmettere.</string>
+    <string name="swr_lockout_dismiss">IGNORA</string>
+    <string name="swr_lockout_toast">TX bloccata — blocco SWR attivo. Ignora prima il banner di blocco.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">Chiamata CQ</string>
+    <string name="qsopanel_searching">Ricerca...</string>
+    <string name="qsopanel_qsoing_with">QSO con %1$s</string>
+    <string name="qsopanel_waiting_for">In attesa di %1$s</string>
+    <string name="qsopanel_tap_to_view">tocca per vedere ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">In attesa di messaggi...</string>
+    <string name="qsopanel_log_action">LOG</string>
+    <string name="qsopanel_queue">CODA</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Decodifica</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d decodificati in questo ciclo"</string>
+    <string name="decode_clear_list">Svuota lista decodifiche</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Tutti</string>
+    <string name="decode_filter_cq_calls">Chiamate CQ</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">Nuovo DXCC</string>
+    <string name="decode_filter_needed">Necessari</string>
+    <string name="decode_filter_for_me">Per Me</string>
+    <string name="decode_empty_cq_title">Nessuna chiamata CQ</string>
+    <string name="decode_empty_cq_body">Nessuna stazione sta chiamando CQ su questa banda al momento.</string>
+    <string name="decode_empty_pota_title">Nessuno spot POTA</string>
+    <string name="decode_empty_pota_body">Nessuna attivazione di parco decodificata su questa banda — apri POTA → Hunt per la lista degli spot.</string>
+    <string name="decode_empty_dxcc_title">Nessun nuovo DXCC</string>
+    <string name="decode_empty_dxcc_body">Nessuna entità DXCC non lavorata è stata decodificata finora.</string>
+    <string name="decode_empty_needed_title">Niente di necessario</string>
+    <string name="decode_empty_needed_body">Nessuna stazione che necessita conferma trovata.</string>
+    <string name="decode_empty_forme_title">Nessuna chiamata per te</string>
+    <string name="decode_empty_forme_body">Nessuna stazione sta chiamando il tuo nominativo al momento.</string>
+    <string name="decode_empty_default_title">Nessun segnale decodificato</string>
+    <string name="decode_empty_default_body">In attesa di segnali FT8...</string>
+    <string name="decode_label_calling">→ CHIAMA</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ PER TE</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO Completato</string>
+    <string name="qso_call_action">Chiama %1$s</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Segnale</string>
+    <string name="qso_stat_distance">Distanza</string>
+    <string name="qso_stat_azimuth">Azimut</string>
+    <string name="qso_stat_band">Banda</string>
+    <string name="qso_sequence_header">SEQUENZA QSO</string>
+    <string name="qso_step_send_call">Invia nominativo</string>
+    <string name="qso_step_report_sent">Rapporto inviato</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Conferma</string>
+    <string name="qso_step_logged">Registrato</string>
+    <string name="qso_live_sending">QSO con %1$s — Invio %2$s</string>
+    <string name="qso_live_waiting">In attesa che %1$s risponda…</string>
+    <string name="qso_live_transmitting">Trasmissione…</string>
+    <string name="qso_live_step_fallback">messaggio</string>
+    <string name="qso_tx_now">TX ORA</string>
+    <string name="qso_tx_next">TX DOPO</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">Statistiche</string>
+    <string name="log_tab_recent">Recenti</string>
+    <string name="log_tab_awards">Diplomi</string>
+    <string name="log_title">Log</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSO · Tutte le bande</string>
+    <string name="log_cd_sync_to_logging_services">Sincronizza con i servizi di logging</string>
+    <string name="log_cd_export_qsos">Esporta QSO</string>
+    <string name="log_stat_total_qsos">QSO totali</string>
+    <string name="log_stat_dxcc_entities">Entità DXCC</string>
+    <string name="log_stat_cq_zones">Zone CQ</string>
+    <string name="log_stat_itu_zones">Zone ITU</string>
+    <string name="log_section_band_distribution">Distribuzione per banda</string>
+    <string name="log_section_award_progress">Progresso diplomi</string>
+    <string name="log_award_dxcc_mixed">DXCC Mixed</string>
+    <string name="log_award_vucc_grid_squares">Grid VUCC</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Copertura grid</string>
+    <string name="log_section_signal_trend">Andamento segnale</string>
+    <string name="log_no_qsos_yet">Ancora nessun QSO</string>
+    <string name="log_no_qsos_recorded_yet">Ancora nessun QSO registrato</string>
+    <string name="log_state_usa">%1$s, USA</string>
+    <string name="log_cd_qso_actions">Azioni QSO</string>
+    <string name="log_action_edit">Modifica</string>
+    <string name="log_action_delete">Elimina</string>
+    <string name="log_award_dxcc_mixed_desc">Lavora e conferma 100 entità DXCC su qualsiasi banda/modo</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">Lavora tutti i 50 stati USA confermati</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">Lavora tutte le 40 zone CQ confermate</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 grid su una singola banda</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- lavora stazioni su isole designate</string>
+    <string name="log_edit_qso">Modifica QSO</string>
+    <string name="log_field_callsign">Nominativo</string>
+    <string name="log_field_grid_locator">Locatore grid</string>
+    <string name="log_field_mode">Modo</string>
+    <string name="log_delete_qso_title">ELIMINARE QSO?</string>
+    <string name="log_delete_qso_body_callsign">Rimuovere il QSO con %1$s dal log? L\'operazione non può essere annullata.</string>
+    <string name="log_delete_qso_body">Rimuovere questo QSO dal log? L\'operazione non può essere annullata.</string>
+    <string name="log_sync_title_no_services">NESSUN SERVIZIO ABILITATO</string>
+    <string name="log_sync_title_syncing">SINCRONIZZAZIONE…</string>
+    <string name="log_sync_title_complete">SINCRONIZZAZIONE COMPLETATA</string>
+    <string name="log_sync_enable_services">Abilita Cloudlog/Wavelog/Nextlog o QRZ nelle Impostazioni, poi riprova.</string>
+    <string name="log_sync_progress_count">%1$d di %2$d QSO</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d accettati</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d accettati</string>
+    <string name="log_sync_nothing_to_upload">Nessun QSO nel log da caricare al momento.</string>
+    <string name="log_sync_working">Elaborazione…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Attiva</string>
+    <string name="pota_tab_hunt">Hunt</string>
+    <string name="pota_tab_history">Cronologia</string>
+    <string name="pota_start_activation">Avvia attivazione</string>
+    <string name="pota_park_reference_label">Riferimento parco (es. K-1234)</string>
+    <string name="pota_notes_optional_label">Note (opzionale)</string>
+    <string name="pota_enter_park_reference_first">Inserisci prima un riferimento parco</string>
+    <string name="pota_activating">Attivazione %1$s</string>
+    <string name="pota_activation_ended">Attivazione terminata</string>
+    <string name="pota_set_callsign_first">Imposta prima il tuo nominativo nelle Impostazioni</string>
+    <string name="pota_self_spot_posted">Self-spot pubblicato</string>
+    <string name="pota_self_spot_failed">Self-spot fallito — controlla il log</string>
+    <string name="pota_active_park">ATTIVO — %1$s</string>
+    <string name="pota_qsos">QSO</string>
+    <string name="pota_contacts_map">Mappa contatti</string>
+    <string name="pota_back">Indietro</string>
+    <string name="pota_valid_activation">attivazione valida</string>
+    <string name="pota_to_valid">%1$d alla validità</string>
+    <string name="pota_elapsed">Trascorso</string>
+    <string name="pota_since_start">dall\'inizio</string>
+    <string name="pota_self_spot">Self-spot</string>
+    <string name="pota_end_activation">Termina attivazione</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">Il TX CQ verrà inviato come “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Nessuno spot FT8 POTA al momento.</string>
+    <string name="pota_active_spots">%1$d spot FT8 attivi</string>
+    <string name="pota_targeting">Puntamento %1$s @ %2$s kHz (%3$s) — passa a Decodifica per chiamare</string>
+    <string name="pota_no_past_activations">Ancora nessuna attivazione passata.</string>
+    <string name="pota_no_browser_available">Nessun browser disponibile</string>
+    <string name="pota_export_failed">Esportazione fallita — controlla il log</string>
+    <string name="pota_status_active">attivo</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">Condividi ADIF</string>
+    <string name="pota_open_pota_app">Apri pota.app</string>
+    <string name="pota_upload_to_pota">Carica su POTA</string>
+    <string name="pota_upload_success">Caricati %1$d log di parco su POTA</string>
+    <string name="pota_upload_failed">Caricamento fallito: %1$s</string>
+    <string name="pota_upload_server_error">POTA non è riuscito a elaborare il caricamento. Verifica che il riferimento parco sia valido e che il tuo nominativo sia registrato su POTA, poi riprova.</string>
+    <string name="pota_upload_network_error">Impossibile raggiungere POTA. Controlla la connessione internet e riprova.</string>
+    <string name="pota_login_title">Accedi a POTA</string>
+    <string name="pota_login_desc">Usa email e password del tuo account pota.app.</string>
+    <string name="pota_login_email">Email</string>
+    <string name="pota_login_password">Password</string>
+    <string name="pota_login_button">Accedi</string>
+    <string name="pota_login_cancel">Annulla</string>
+    <string name="pota_login_failed">Accesso fallito: %1$s</string>
+    <string name="pota_login_or">oppure</string>
+    <string name="pota_login_social">Accedi con Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">Accedi a POTA</string>
+    <string name="pota_add_park">Aggiungi parco</string>
+    <string name="pota_remove_park">Rimuovi</string>
+    <string name="pota_max_parks_reached">Raggiunto il massimo di 10 parchi</string>
+    <string name="pota_spotted_n_parks">Spottato in %1$d parchi</string>
+    <string name="pota_parks_more">+%1$d altri</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Debug</string>
+    <string name="debug_line_count">%1$d righe</string>
+    <string name="debug_logcat_on_suffix">" · logcat ON"</string>
+    <string name="debug_close">Chiudi</string>
+    <string name="debug_share">Condividi</string>
+    <string name="debug_clear">Svuota</string>
+    <string name="debug_logcat_on">Logcat: ON</string>
+    <string name="debug_logcat_off">Logcat: OFF</string>
+    <string name="debug_no_log_file">nessun file di log</string>
+    <string name="debug_log_cleared">log svuotato</string>
+    <string name="debug_share_chooser_title">Condividi debug.log</string>
+    <string name="map_title">Mappa</string>
+    <string name="map_no_grid_set">Nessun grid impostato</string>
+    <string name="map_station_count">%1$d stazioni</string>
+    <string name="map_station_count_with_heard">%1$d stazioni · %2$d ascoltate</string>
+    <string name="map_psk_error">PSK Reporter non disponibile: %1$s</string>
+    <string name="map_projection_equirectangular">Equirettangolare</string>
+    <string name="map_projection_azimuthal">Azimutale equidistante</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">Distanza</string>
+    <string name="map_info_bearing">Direzione</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Waterfall</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">LIVE</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d tentativi</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d di %2$d abilitate</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Build %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Impostazioni</string>
+    <string name="settings_section_operator_identity">IDENTITÀ OPERATORE</string>
+    <string name="settings_section_radio">RADIO</string>
+    <string name="settings_section_audio">AUDIO</string>
+    <string name="settings_section_transmission">TRASMISSIONE</string>
+    <string name="settings_section_auto_sequence">AUTO-SEQUENZA</string>
+    <string name="settings_section_decode_highlights">EVIDENZIAZIONI DECODIFICA</string>
+    <string name="settings_section_callsign_blocklist">BLOCCO NOMINATIVI</string>
+    <string name="settings_section_decode_filters">FILTRI DECODIFICA</string>
+    <string name="settings_section_needed_dx_alerts">AVVISI DX NECESSARI</string>
+    <string name="settings_section_logging_awards">LOGGING &amp; DIPLOMI</string>
+    <string name="settings_section_advanced">AVANZATE</string>
+    <string name="settings_section_about">INFO</string>
+    <string name="settings_section_language">LINGUA</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Radio &amp; Audio</string>
+    <string name="settings_cat_transmission">Trasmissione</string>
+    <string name="settings_cat_decode_filters">Decodifica &amp; Filtri</string>
+    <string name="settings_cat_logging">Logging &amp; Diplomi</string>
+    <string name="settings_cat_advanced">Avanzate</string>
+    <string name="settings_cat_about">Info</string>
+    <string name="settings_cat_time_sync">Sincronizzazione ora</string>
+    <string name="settings_cat_time_sync_desc">Correzione manuale dell\'orologio per l\'uso offline</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Correzione manuale</string>
+    <string name="settings_time_current_label">Correzione attuale</string>
+    <string name="settings_time_correction_reset">Azzera</string>
+    <string name="settings_time_correction_desc">Regola l\'orologio dell\'app quando non hai internet per sincronizzare. FT8 richiede UTC entro circa 1 secondo. Regola finché la colonna DT delle stazioni decodificate si centra vicino a 0.</string>
+    <string name="settings_time_suggest_section">Suggerito dalle decodifiche</string>
+    <string name="settings_time_suggest_none">Ancora nessuna decodifica — inizia a ricevere per ottenere un suggerimento.</string>
+    <string name="settings_time_suggest_label">DT medio recente: %1$s</string>
+    <string name="settings_time_suggest_apply">Applica correzione suggerita</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Aggiorna grid automaticamente (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Usa il GPS del dispositivo per mantenere aggiornato il grid Maidenhead</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Modello radio</string>
+    <string name="settings_control_mode">Modo di controllo</string>
+    <string name="settings_connection_mode">Modo di connessione</string>
+    <string name="settings_baud_rate">Baud Rate</string>
+    <string name="settings_band_frequency">Banda &amp; Frequenza</string>
+    <string name="settings_enabled_bands">Bande abilitate</string>
+    <string name="settings_audio_frequency">Frequenza audio</string>
+    <string name="settings_spectrum_width">Larghezza spettro</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Ingresso audio</string>
+    <string name="settings_audio_output">Uscita audio</string>
+    <string name="settings_tx_volume">Volume TX</string>
+    <string name="settings_tx_volume_desc" formatted="false">Livello audio di trasmissione (tasti hardware ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">Split TX/RX</string>
+    <string name="settings_tx_rx_split_desc">Trasmetti su una frequenza diversa da quella di ricezione</string>
+    <string name="settings_tx_watchdog">Watchdog TX</string>
+    <string name="settings_tx_watchdog_desc">Interrompe automaticamente la trasmissione dopo il timeout</string>
+    <string name="settings_stop_after">Stop dopo</string>
+    <string name="settings_stop_after_desc">Interrompi la chiamata dopo N tentativi senza risposta</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Hunt (risposta automatica al CQ)</string>
+    <string name="settings_hunt_desc">Chiama proattivamente le stazioni che chiamano CQ. Come il pulsante HUNT sulla barra TX. Off = chiama CQ e lavora solo le stazioni che ti rispondono.</string>
+    <string name="settings_auto_call_followed">Auto-chiamata seguiti</string>
+    <string name="settings_auto_call_followed_desc">Continua a chiamare automaticamente i nominativi seguiti</string>
+    <string name="settings_fast_turnaround">Turnaround rapido</string>
+    <string name="settings_fast_turnaround_desc">Decodifica ~1s prima così puoi rispondere a un CQ nello slot successivo invece di aspettare. Potrebbe perdere stazioni con un grande scarto di orologio.</string>
+    <string name="settings_auto_cq_after_qso">Auto-CQ dopo QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">Continua a chiamare CQ automaticamente dopo ogni contatto completato — senza ri-toccare. Resta sulla tua frequenza (ignora Hunt). Continua finché non interrompi o il Watchdog TX scade senza risposte.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">Nuovo DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">Evidenzia le stazioni di un\'entità DXCC non lavorata</string>
+    <string name="settings_highlight_new_grid">Nuovo grid</string>
+    <string name="settings_highlight_new_grid_desc">Evidenzia i grid Maidenhead non ancora lavorati</string>
+    <string name="settings_highlight_new_band">Nuova banda</string>
+    <string name="settings_highlight_new_band_desc">Evidenzia le stazioni lavorate solo su altre bande</string>
+    <string name="settings_highlight_pota">Attivatori POTA</string>
+    <string name="settings_highlight_pota_desc">Evidenzia gli attivatori POTA spottati; i nuovi parchi risaltano</string>
+    <string name="settings_highlight_worked">Già lavorati</string>
+    <string name="settings_highlight_worked_desc">Contrassegna le stazioni già nel tuo log</string>
+    <string name="settings_distance_unit">Distanza in miglia</string>
+    <string name="settings_distance_unit_desc">Mostra le distanze in miglia invece che in chilometri</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Nominativi esatti</string>
+    <string name="settings_exact_callsigns_desc">Blocca le corrispondenze di nominativo intero</string>
+    <string name="settings_prefixes">Prefissi</string>
+    <string name="settings_prefixes_desc">Blocca per prefisso di nominativo (es. RA)</string>
+    <string name="settings_keywords">Parole chiave</string>
+    <string name="settings_keywords_desc">Blocca per sottostringa nel nominativo o nel messaggio (es. POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Mostra solo CQ</string>
+    <string name="settings_show_only_cq_desc">Nascondi tutto tranne i messaggi di tipo CQ</string>
+    <string name="settings_dx_only">Solo DX</string>
+    <string name="settings_dx_only_desc">Mostra solo le stazioni fuori dal tuo continente</string>
+    <string name="settings_needed_only">Solo necessari</string>
+    <string name="settings_needed_only_desc">Mostra solo le stazioni non ancora confermate (QSL)</string>
+    <string name="settings_filter_by_continent">Filtra per continente</string>
+    <string name="settings_filter_by_continent_desc">Mostra solo le stazioni di un continente scelto</string>
+    <string name="settings_continent">Continente</string>
+    <string name="settings_skip_directional_cq">Salta CQ direzionali (risposta automatica)</string>
+    <string name="settings_skip_directional_cq_desc">Non rispondere automaticamente a CQ DX/EU/JA… rivolti a un DXCC diverso</string>
+    <string name="settings_hide_directional_cq">Nascondi CQ direzionali non per me</string>
+    <string name="settings_hide_directional_cq_desc">Nascondi i CQ rivolti a regioni che non puntano al tuo DXCC</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">Nuovo DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">Suono + vibrazione + notifica quando un\'entità DXCC non lavorata chiama CQ</string>
+    <string name="settings_alert_new_state">Nuovo stato USA</string>
+    <string name="settings_alert_new_state_desc">Suono + vibrazione + notifica quando una stazione di uno stato USA non lavorato chiama CQ (stato dal grid)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">Salva decodifiche SWL</string>
+    <string name="settings_save_swl_decodes_desc">Registra tutti i messaggi decodificati nel database</string>
+    <string name="settings_save_swl_qsos">Salva QSO SWL</string>
+    <string name="settings_save_swl_qsos_desc">Registra i QSO rilevati tra altre stazioni</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Carica gli spot decodificati su pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">Carica automaticamente i QSO su QRZ Logbook</string>
+    <string name="settings_qrz_profile_lookup">Ricerca profilo QRZ</string>
+    <string name="settings_qrz_profile_lookup_desc">Username + password per QRZ XML API (avatar)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">Carica automaticamente i QSO su un\'istanza Cloudlog, Wavelog o Nextlog</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">Ritardo PTT</string>
+    <string name="settings_ptt_delay_desc">Ritardo dopo il PTT prima dell\'inizio dell\'audio di trasmissione</string>
+    <string name="settings_tx_delay">Ritardo TX</string>
+    <string name="settings_tx_delay_desc">Ritardo prima della trasmissione per consentire la decodifica del ciclo precedente</string>
+    <string name="settings_late_start_tolerance">Tolleranza avvio tardivo</string>
+    <string name="settings_late_start_tolerance_desc">Consenti di avviare il TX fino a N ms dentro un ciclo; l\'audio iniziale viene tagliato così il TX termina sul confine del ciclo</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">FAQ &amp; Supporto</string>
+    <string name="settings_report_bug">Segnala un bug</string>
+    <string name="bug_report_description_hint">Descrivi cosa è andato storto…</string>
+    <string name="bug_report_send_email">Invia email</string>
+    <string name="bug_report_no_email_app">Nessuna app email trovata per inviare la segnalazione</string>
+    <string name="bug_report_open_github">Apri issue su GitHub</string>
+    <string name="settings_debug">Debug</string>
+    <string name="settings_debug_desc">Visualizza / condividi debug.log</string>
+    <string name="settings_about_body">Versione %1$s (build %2$s)\nData build %3$s\n\nFT8, reso facile.\n\nUn\'app transceiver FT8 autonoma per Android. Controllo radio via USB, Bluetooth e rete con sequenziamento e logging automatici.</string>
+    <string name="settings_website">Sito web</string>
+    <string name="settings_community">Community</string>
+    <string name="settings_built_by">Creato da</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Blocca nominativi esatti</string>
+    <string name="settings_block_exact_desc">Corrispondenza di nominativo intero. Separati da virgola o spazio, es. W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Blocca prefissi di nominativo</string>
+    <string name="settings_block_prefix_desc">Corrispondenza per prefisso, es. RA blocca RA0AA..RA9ZZ. Separati da virgola o spazio.</string>
+    <string name="settings_block_keyword_title">Blocca parole chiave</string>
+    <string name="settings_block_keyword_desc">Corrispondenza per sottostringa nel nominativo e nel testo del messaggio, es. POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">es. W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Filtra continente</string>
+    <string name="settings_conn_usb_cable">Cavo USB</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Rete</string>
+    <string name="settings_no_usb_serial">Nessun dispositivo seriale USB rilevato. Collega un cavo USB alla tua radio e riprova.</string>
+    <string name="settings_no_bluetooth_devices">Nessun dispositivo Bluetooth associato trovato. Associa prima un dispositivo nelle impostazioni Bluetooth di Android.</string>
+    <string name="settings_debug_mode_enabled">Modalità debug abilitata</string>
+    <string name="settings_debug_mode_disabled">Modalità debug disabilitata</string>
+    <string name="settings_edit_operator_identity">Modifica identità operatore</string>
+    <string name="settings_callsign">Nominativo</string>
+    <string name="settings_callsign_hint">es. W1AW</string>
+    <string name="settings_grid_locator">Locatore grid</string>
+    <string name="settings_grid_locator_hint">es. FN31pr</string>
+    <string name="settings_logging_server">Server di logging</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog e Nextlog accettano tutti gli stessi caricamenti.</string>
+    <string name="settings_server_address">Indirizzo server</string>
+    <string name="settings_api_key">Chiave API</string>
+    <string name="settings_api_key_hint">La tua chiave API Cloudlog</string>
+    <string name="settings_loading_stations">Caricamento stazioni...</string>
+    <string name="settings_station_id">ID stazione</string>
+    <string name="settings_station_id_hint">es. 1</string>
+    <string name="settings_select_a_station">Seleziona una stazione</string>
+    <string name="settings_enter_manually">Inserisci manualmente</string>
+    <string name="settings_choose_from_server">Scegli dal server</string>
+    <string name="settings_station_profile">Profilo stazione</string>
+    <string name="settings_qrz_creds_desc">Usato per recuperare le foto profilo dei nominativi decodificati tramite QRZ XML API. Richiede un abbonamento QRZ XML.</string>
+    <string name="settings_username">Username</string>
+    <string name="settings_username_hint">Il tuo username QRZ.com</string>
+    <string name="settings_password">Password</string>
+    <string name="settings_enabled_bands_dialog_desc">Le bande nascoste non appariranno nei selettori di frequenza.</string>
+    <string name="settings_select_serial_port">Seleziona porta seriale</string>
+    <string name="settings_tx_volume_advice">Regola in tempo reale — il tuo prossimo TX usa questo livello. Osserva l\'ALC della radio e abbassa finché tocca appena la linea.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Lingua</string>
+    <string name="settings_language_desc">Lingua di visualizzazione dell\'app</string>
+    <string name="settings_language_system">Predefinita di sistema</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ko/strings_compose.xml
@@ -1,0 +1,543 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Compose UI strings (FT8AF). The live app is the Jetpack Compose UI under
+  ~ radio.ks3ckc.ft8us; these are its user-facing strings, externalized for
+  ~ localization. The legacy strings.xml entries belong to the unreachable old
+  ~ XML/Fragment UI and are NOT used by the running app.
+  ~
+  ~ Translations live in values-<locale>/strings_compose.xml. English here is the
+  ~ source of truth — keep it byte-identical to the original UI text so the English
+  ~ layout never changes. Ham-radio abbreviations (CQ, QSO, DXCC, POTA, SOTA, RST)
+  ~ are intentionally left untranslated across all locales.
+-->
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">취소</string>
+    <string name="action_save">저장</string>
+    <string name="action_done">완료</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">종료</string>
+    <string name="common_none">없음</string>
+    <string name="common_off">끔</string>
+    <string name="common_not_configured">설정 안 됨</string>
+    <string name="common_not_connected">연결 안 됨</string>
+    <string name="common_pass">통과</string>
+    <string name="common_fail">실패</string>
+    <string name="common_test_connection">연결 테스트</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">북아메리카</string>
+    <string name="continent_sa">남아메리카</string>
+    <string name="continent_eu">유럽</string>
+    <string name="continent_af">아프리카</string>
+    <string name="continent_as">아시아</string>
+    <string name="continent_oc">오세아니아</string>
+    <string name="continent_an">남극</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">디코드</string>
+    <string name="tab_map">지도</string>
+    <string name="tab_waterfall">워터폴</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">로그북</string>
+    <string name="tab_settings">설정</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">신규 DXCC</string>
+    <string name="status_new_grid">신규 GRID</string>
+    <string name="status_new_band">신규 BAND</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">신규 POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">필요</string>
+    <string name="status_worked">교신함</string>
+    <string name="status_confirmed">확인됨</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">대기 중</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · 모바일 동반자</string>
+    <string name="splash_initializing">무전기 초기화 중</string>
+    <string name="splash_version">v%1$s · 빌드 %2$s</string>
+    <string name="app_set_callsign_first">CQ를 호출하기 전에 설정에서 콜사인을 입력하세요</string>
+    <string name="app_hunt_on">Hunt 켜짐 — CQ 자동 응답</string>
+    <string name="app_hunt_off">Hunt 꺼짐 — CQ 운용, 응답만 처리</string>
+    <string name="app_mode_switched">모드: %1$s</string>
+    <string name="app_mode_switch_busy">송신 중에는 모드를 전환할 수 없습니다</string>
+    <string name="main_tx_volume">TX 볼륨: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">FT8AF를 종료할까요?</string>
+    <string name="exit_message">앱을 닫으시겠습니까? 진행 중인 QSO는 취소됩니다.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">주파수 선택</string>
+    <string name="freq_show_alternates">대체 주파수 표시</string>
+    <string name="freq_hide_alternates">대체 주파수 숨기기</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">콜사인 없음</string>
+    <string name="op_no_grid">그리드 미설정</string>
+    <string name="op_tap_to_edit">탭하여 편집</string>
+    <string name="op_stat_rig">무전기</string>
+    <string name="op_stat_antenna">안테나</string>
+    <string name="op_stat_power">출력</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">QSO 내보내기</string>
+    <string name="export_date_range">날짜 범위</string>
+    <string name="export_date_from_placeholder">"From  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"To  YYYYMMDD"</string>
+    <string name="export_share">공유</string>
+    <string name="export_filter_confirmed">확인된 것만</string>
+    <string name="export_filter_unconfirmed">미확인만</string>
+    <string name="export_record_singular">건</string>
+    <string name="export_record_plural">건</string>
+    <string name="export_summary_all">전체</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%3$s%4$s에 일치하는 %1$d%2$s</string>
+    <string name="export_preparing">준비 중…</string>
+    <string name="export_share_chooser_title">QSO 로그 공유</string>
+    <string name="export_saved_to">%1$s에 저장됨</string>
+    <string name="export_save_failed">다운로드로 저장 실패</string>
+    <string name="export_temp_file_failed">임시 파일을 만들 수 없습니다</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">송신 중</string>
+    <string name="tx_listening">수신 중</string>
+    <string name="tx_hunt">Hunt</string>
+    <string name="tx_call_cq">CQ 호출</string>
+    <string name="tx_stop">정지</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">DX 페디션 교신 (Hound)</string>
+    <string name="hound_help">먼저 무전기를 Fox가 공지한 다이얼 주파수로 맞추세요. 높은 쪽(1000–4000 Hz)으로 호출하면, 앱이 Fox가 응답하는 주파수로 자동 QSY하여 리포트로 응답합니다.</string>
+    <string name="hound_fox_callsign">Fox 콜사인</string>
+    <string name="hound_call_frequency">호출 주파수 (Hz, 1000–4000)</string>
+    <string name="hound_start">시작</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT 연결됨 — 탭하여 재연결</string>
+    <string name="cat_status_connecting">CAT 연결 중…</string>
+    <string name="cat_status_disconnected">CAT 연결 끊김 — 탭하여 연결</string>
+    <string name="cat_status_error">CAT 연결 오류 — 탭하여 재시도</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX 중단 — 높은 SWR 감지 (%1$s)</string>
+    <string name="swr_lockout_body">송신 전에 안테나 / 급전선을 확인하세요.</string>
+    <string name="swr_lockout_dismiss">닫기</string>
+    <string name="swr_lockout_toast">TX 차단됨 — SWR 잠금 활성. 먼저 잠금 배너를 닫으세요.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">CQ 호출 중</string>
+    <string name="qsopanel_searching">검색 중...</string>
+    <string name="qsopanel_qsoing_with">%1$s와 QSO 중</string>
+    <string name="qsopanel_waiting_for">%1$s 대기 중</string>
+    <string name="qsopanel_tap_to_view">탭하여 보기 ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">메시지 대기 중...</string>
+    <string name="qsopanel_log_action">기록</string>
+    <string name="qsopanel_queue">대기열</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">디코드</string>
+    <string name="decode_subtitle">"%1$s  •  이번 주기에 %2$d개 디코드"</string>
+    <string name="decode_clear_list">디코드 목록 지우기</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">전체</string>
+    <string name="decode_filter_cq_calls">CQ 호출</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">신규 DXCC</string>
+    <string name="decode_filter_needed">필요</string>
+    <string name="decode_filter_for_me">나에게</string>
+    <string name="decode_empty_cq_title">CQ 호출 없음</string>
+    <string name="decode_empty_cq_body">지금 이 밴드에서 CQ를 호출하는 국이 없습니다.</string>
+    <string name="decode_empty_pota_title">POTA 스폿 없음</string>
+    <string name="decode_empty_pota_body">아직 이 밴드에서 디코드된 공원 운용이 없습니다 — 스폿 목록은 POTA → Hunt에서 확인하세요.</string>
+    <string name="decode_empty_dxcc_title">신규 DXCC 없음</string>
+    <string name="decode_empty_dxcc_body">아직 미교신 DXCC 엔티티가 디코드되지 않았습니다.</string>
+    <string name="decode_empty_needed_title">필요한 항목 없음</string>
+    <string name="decode_empty_needed_body">확인이 필요한 국을 찾지 못했습니다.</string>
+    <string name="decode_empty_forme_title">나를 호출하는 국 없음</string>
+    <string name="decode_empty_forme_body">지금 당신의 콜사인을 호출하는 국이 없습니다.</string>
+    <string name="decode_empty_default_title">디코드된 신호 없음</string>
+    <string name="decode_empty_default_body">FT8 신호가 나타나기를 기다리는 중...</string>
+    <string name="decode_label_calling">→ 호출 중</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ 나에게</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO 완료</string>
+    <string name="qso_call_action">%1$s 호출</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">신호</string>
+    <string name="qso_stat_distance">거리</string>
+    <string name="qso_stat_azimuth">방위각</string>
+    <string name="qso_stat_band">밴드</string>
+    <string name="qso_sequence_header">QSO 시퀀스</string>
+    <string name="qso_step_send_call">호출 전송</string>
+    <string name="qso_step_report_sent">리포트 전송됨</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">확인</string>
+    <string name="qso_step_logged">기록됨</string>
+    <string name="qso_live_sending">%1$s와 QSO 중 — %2$s 전송 중</string>
+    <string name="qso_live_waiting">%1$s의 응답 대기 중…</string>
+    <string name="qso_live_transmitting">송신 중…</string>
+    <string name="qso_live_step_fallback">메시지</string>
+    <string name="qso_tx_now">지금 TX</string>
+    <string name="qso_tx_next">다음 TX</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">통계</string>
+    <string name="log_tab_recent">최근</string>
+    <string name="log_tab_awards">어워드</string>
+    <string name="log_title">로그북</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSO · 전 밴드</string>
+    <string name="log_cd_sync_to_logging_services">로깅 서비스에 동기화</string>
+    <string name="log_cd_export_qsos">QSO 내보내기</string>
+    <string name="log_stat_total_qsos">총 QSO</string>
+    <string name="log_stat_dxcc_entities">DXCC 엔티티</string>
+    <string name="log_stat_cq_zones">CQ 존</string>
+    <string name="log_stat_itu_zones">ITU 존</string>
+    <string name="log_section_band_distribution">밴드 분포</string>
+    <string name="log_section_award_progress">어워드 진행도</string>
+    <string name="log_award_dxcc_mixed">DXCC Mixed</string>
+    <string name="log_award_vucc_grid_squares">VUCC 그리드</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">그리드 커버리지</string>
+    <string name="log_section_signal_trend">신호 추이</string>
+    <string name="log_no_qsos_yet">아직 QSO 없음</string>
+    <string name="log_no_qsos_recorded_yet">아직 기록된 QSO 없음</string>
+    <string name="log_state_usa">%1$s, USA</string>
+    <string name="log_cd_qso_actions">QSO 작업</string>
+    <string name="log_action_edit">편집</string>
+    <string name="log_action_delete">삭제</string>
+    <string name="log_award_dxcc_mixed_desc">임의의 밴드/모드에서 100개 DXCC 엔티티 교신 및 확인</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">미국 50개 주 모두 교신 및 확인</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">CQ 존 40개 모두 교신 및 확인</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 단일 밴드에서 그리드 100개</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- 지정된 섬의 국과 교신</string>
+    <string name="log_edit_qso">QSO 편집</string>
+    <string name="log_field_callsign">콜사인</string>
+    <string name="log_field_grid_locator">그리드 로케이터</string>
+    <string name="log_field_mode">모드</string>
+    <string name="log_delete_qso_title">QSO를 삭제할까요?</string>
+    <string name="log_delete_qso_body_callsign">%1$s와의 QSO를 로그북에서 삭제할까요? 되돌릴 수 없습니다.</string>
+    <string name="log_delete_qso_body">이 QSO를 로그북에서 삭제할까요? 되돌릴 수 없습니다.</string>
+    <string name="log_sync_title_no_services">활성화된 서비스 없음</string>
+    <string name="log_sync_title_syncing">동기화 중…</string>
+    <string name="log_sync_title_complete">동기화 완료</string>
+    <string name="log_sync_enable_services">설정에서 Cloudlog/Wavelog/Nextlog 또는 QRZ를 활성화한 후 다시 시도하세요.</string>
+    <string name="log_sync_progress_count">%2$d개 중 %1$d개 QSO</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d개 수락됨</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d개 수락됨</string>
+    <string name="log_sync_nothing_to_upload">아직 업로드할 QSO가 로그북에 없습니다.</string>
+    <string name="log_sync_working">처리 중…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">운용</string>
+    <string name="pota_tab_hunt">Hunt</string>
+    <string name="pota_tab_history">기록</string>
+    <string name="pota_start_activation">운용 시작</string>
+    <string name="pota_park_reference_label">공원 참조 (예: K-1234)</string>
+    <string name="pota_notes_optional_label">메모 (선택)</string>
+    <string name="pota_enter_park_reference_first">먼저 공원 참조를 입력하세요</string>
+    <string name="pota_activating">%1$s 운용 중</string>
+    <string name="pota_activation_ended">운용 종료됨</string>
+    <string name="pota_set_callsign_first">먼저 설정에서 콜사인을 입력하세요</string>
+    <string name="pota_self_spot_posted">셀프 스폿 게시됨</string>
+    <string name="pota_self_spot_failed">셀프 스폿 실패 — 로그 확인</string>
+    <string name="pota_active_park">운용 중 — %1$s</string>
+    <string name="pota_qsos">QSO</string>
+    <string name="pota_contacts_map">교신 지도</string>
+    <string name="pota_back">뒤로</string>
+    <string name="pota_valid_activation">유효한 운용</string>
+    <string name="pota_to_valid">유효까지 %1$d</string>
+    <string name="pota_elapsed">경과</string>
+    <string name="pota_since_start">시작 이후</string>
+    <string name="pota_self_spot">셀프 스폿</string>
+    <string name="pota_end_activation">운용 종료</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">TX CQ는 “CQ POTA %1$s %2$s”로 송신됩니다.</string>
+    <string name="pota_no_spots">지금 FT8 POTA 스폿이 없습니다.</string>
+    <string name="pota_active_spots">활성 FT8 스폿 %1$d개</string>
+    <string name="pota_targeting">%1$s @ %2$s kHz (%3$s) 타겟 — 호출하려면 디코드로 전환</string>
+    <string name="pota_no_past_activations">아직 지난 운용이 없습니다.</string>
+    <string name="pota_no_browser_available">사용 가능한 브라우저 없음</string>
+    <string name="pota_export_failed">내보내기 실패 — 로그 확인</string>
+    <string name="pota_status_active">활성</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">ADIF 공유</string>
+    <string name="pota_open_pota_app">pota.app 열기</string>
+    <string name="pota_upload_to_pota">POTA에 업로드</string>
+    <string name="pota_upload_success">공원 로그 %1$d개를 POTA에 업로드함</string>
+    <string name="pota_upload_failed">업로드 실패: %1$s</string>
+    <string name="pota_upload_server_error">POTA가 업로드를 처리하지 못했습니다. 공원 참조가 유효하고 콜사인이 POTA에 등록되어 있는지 확인한 후 다시 시도하세요.</string>
+    <string name="pota_upload_network_error">POTA에 연결할 수 없습니다. 인터넷 연결을 확인하고 다시 시도하세요.</string>
+    <string name="pota_login_title">POTA에 로그인</string>
+    <string name="pota_login_desc">pota.app 계정 이메일과 비밀번호를 사용하세요.</string>
+    <string name="pota_login_email">이메일</string>
+    <string name="pota_login_password">비밀번호</string>
+    <string name="pota_login_button">로그인</string>
+    <string name="pota_login_cancel">취소</string>
+    <string name="pota_login_failed">로그인 실패: %1$s</string>
+    <string name="pota_login_or">또는</string>
+    <string name="pota_login_social">Google / Facebook / Amazon으로 로그인</string>
+    <string name="pota_oauth_title">POTA에 로그인</string>
+    <string name="pota_add_park">공원 추가</string>
+    <string name="pota_remove_park">제거</string>
+    <string name="pota_max_parks_reached">최대 10개 공원에 도달함</string>
+    <string name="pota_spotted_n_parks">%1$d개 공원에서 스폿됨</string>
+    <string name="pota_parks_more">+%1$d개 더</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">디버그</string>
+    <string name="debug_line_count">%1$d줄</string>
+    <string name="debug_logcat_on_suffix">" · logcat ON"</string>
+    <string name="debug_close">닫기</string>
+    <string name="debug_share">공유</string>
+    <string name="debug_clear">지우기</string>
+    <string name="debug_logcat_on">Logcat: 켜짐</string>
+    <string name="debug_logcat_off">Logcat: 꺼짐</string>
+    <string name="debug_no_log_file">로그 파일 없음</string>
+    <string name="debug_log_cleared">로그 지워짐</string>
+    <string name="debug_share_chooser_title">debug.log 공유</string>
+    <string name="map_title">지도</string>
+    <string name="map_no_grid_set">그리드 미설정</string>
+    <string name="map_station_count">%1$d개 국</string>
+    <string name="map_station_count_with_heard">%1$d개 국 · %2$d개 수신</string>
+    <string name="map_psk_error">PSK Reporter 사용 불가: %1$s</string>
+    <string name="map_projection_equirectangular">등장방형 도법</string>
+    <string name="map_projection_azimuthal">방위 등거리 도법</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">거리</string>
+    <string name="map_info_bearing">방위</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">워터폴</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">LIVE</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d회</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%2$d개 중 %1$d개 활성화</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">빌드 %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">설정</string>
+    <string name="settings_section_operator_identity">운용자 정보</string>
+    <string name="settings_section_radio">무전기</string>
+    <string name="settings_section_audio">오디오</string>
+    <string name="settings_section_transmission">송신</string>
+    <string name="settings_section_auto_sequence">자동 시퀀스</string>
+    <string name="settings_section_decode_highlights">디코드 강조</string>
+    <string name="settings_section_callsign_blocklist">콜사인 차단 목록</string>
+    <string name="settings_section_decode_filters">디코드 필터</string>
+    <string name="settings_section_needed_dx_alerts">필요 DX 알림</string>
+    <string name="settings_section_logging_awards">로깅 &amp; 어워드</string>
+    <string name="settings_section_advanced">고급</string>
+    <string name="settings_section_about">정보</string>
+    <string name="settings_section_language">언어</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">무전기 &amp; 오디오</string>
+    <string name="settings_cat_transmission">송신</string>
+    <string name="settings_cat_decode_filters">디코드 &amp; 필터</string>
+    <string name="settings_cat_logging">로깅 &amp; 어워드</string>
+    <string name="settings_cat_advanced">고급</string>
+    <string name="settings_cat_about">정보</string>
+    <string name="settings_cat_time_sync">시간 동기화</string>
+    <string name="settings_cat_time_sync_desc">오프라인 운용을 위한 수동 시계 보정</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">수동 보정</string>
+    <string name="settings_time_current_label">현재 보정값</string>
+    <string name="settings_time_correction_reset">0으로 초기화</string>
+    <string name="settings_time_correction_desc">인터넷으로 동기화할 수 없을 때 앱 시계를 미세 조정합니다. FT8은 UTC를 약 1초 이내로 맞춰야 합니다. 디코드된 국의 DT 열이 0 근처에 모일 때까지 조정하세요.</string>
+    <string name="settings_time_suggest_section">디코드 기반 제안</string>
+    <string name="settings_time_suggest_none">아직 디코드 없음 — 수신을 시작하면 제안을 받을 수 있습니다.</string>
+    <string name="settings_time_suggest_label">최근 평균 DT: %1$s</string>
+    <string name="settings_time_suggest_apply">제안된 보정 적용</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">그리드 자동 업데이트 (GPS)</string>
+    <string name="settings_auto_update_grid_desc">기기 GPS로 Maidenhead 그리드를 최신으로 유지</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">무전기 모델</string>
+    <string name="settings_control_mode">제어 모드</string>
+    <string name="settings_connection_mode">연결 모드</string>
+    <string name="settings_baud_rate">보드 레이트</string>
+    <string name="settings_band_frequency">밴드 &amp; 주파수</string>
+    <string name="settings_enabled_bands">활성화된 밴드</string>
+    <string name="settings_audio_frequency">오디오 주파수</string>
+    <string name="settings_spectrum_width">스펙트럼 폭</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">오디오 입력</string>
+    <string name="settings_audio_output">오디오 출력</string>
+    <string name="settings_tx_volume">TX 볼륨</string>
+    <string name="settings_tx_volume_desc" formatted="false">송신 오디오 레벨 (하드웨어 버튼 ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">TX/RX 분리</string>
+    <string name="settings_tx_rx_split_desc">수신과 다른 주파수로 송신</string>
+    <string name="settings_tx_watchdog">TX 워치독</string>
+    <string name="settings_tx_watchdog_desc">시간 초과 후 송신 자동 중지</string>
+    <string name="settings_stop_after">중지 기준</string>
+    <string name="settings_stop_after_desc">N회 응답 없는 호출 후 중지</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Hunt (CQ 자동 응답)</string>
+    <string name="settings_hunt_desc">CQ를 호출하는 국을 능동적으로 호출합니다. TX 바의 HUNT 버튼과 동일합니다. 끔 = CQ 운용 및 응답하는 국만 처리.</string>
+    <string name="settings_auto_call_followed">팔로우 자동 호출</string>
+    <string name="settings_auto_call_followed_desc">팔로우한 콜사인을 자동으로 계속 호출</string>
+    <string name="settings_fast_turnaround">빠른 전환</string>
+    <string name="settings_fast_turnaround_desc">약 1초 일찍 디코드하여 기다리지 않고 다음 슬롯에 CQ에 응답할 수 있습니다. 시계 오차가 큰 국은 놓칠 수 있습니다.</string>
+    <string name="settings_auto_cq_after_qso">QSO 후 자동 CQ</string>
+    <string name="settings_auto_cq_after_qso_desc">각 교신 완료 후 자동으로 CQ를 계속 호출 — 다시 탭할 필요 없음. 당신의 주파수를 유지합니다(Hunt 무시). 중지하거나 응답 없이 TX 워치독이 시간 초과될 때까지 실행됩니다.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">신규 DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">미교신 DXCC 엔티티의 국 강조</string>
+    <string name="settings_highlight_new_grid">신규 그리드</string>
+    <string name="settings_highlight_new_grid_desc">아직 교신하지 않은 Maidenhead 그리드 강조</string>
+    <string name="settings_highlight_new_band">신규 밴드</string>
+    <string name="settings_highlight_new_band_desc">다른 밴드에서만 교신한 국 강조</string>
+    <string name="settings_highlight_pota">POTA 운용자</string>
+    <string name="settings_highlight_pota_desc">스폿된 POTA 운용자 강조; 신규 공원이 두드러짐</string>
+    <string name="settings_highlight_worked">이전 교신</string>
+    <string name="settings_highlight_worked_desc">이미 로그에 있는 국 표시</string>
+    <string name="settings_distance_unit">거리를 마일로</string>
+    <string name="settings_distance_unit_desc">거리를 킬로미터 대신 마일로 표시</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">정확한 콜사인</string>
+    <string name="settings_exact_callsigns_desc">전체 콜 일치 차단</string>
+    <string name="settings_prefixes">접두사</string>
+    <string name="settings_prefixes_desc">콜사인 접두사로 차단 (예: RA)</string>
+    <string name="settings_keywords">키워드</string>
+    <string name="settings_keywords_desc">콜이나 메시지의 부분 문자열로 차단 (예: POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">CQ만 표시</string>
+    <string name="settings_show_only_cq_desc">CQ 유형 메시지를 제외한 모든 것 숨기기</string>
+    <string name="settings_dx_only">DX만</string>
+    <string name="settings_dx_only_desc">자신의 대륙 밖의 국만 표시</string>
+    <string name="settings_needed_only">필요한 것만</string>
+    <string name="settings_needed_only_desc">아직 확인되지 않은(QSL) 국만 표시</string>
+    <string name="settings_filter_by_continent">대륙별 필터</string>
+    <string name="settings_filter_by_continent_desc">선택한 대륙의 국만 표시</string>
+    <string name="settings_continent">대륙</string>
+    <string name="settings_skip_directional_cq">방향성 CQ 건너뛰기 (자동 응답)</string>
+    <string name="settings_skip_directional_cq_desc">다른 DXCC를 향한 CQ DX/EU/JA…에 자동 응답하지 않음</string>
+    <string name="settings_hide_directional_cq">나를 향하지 않은 방향성 CQ 숨기기</string>
+    <string name="settings_hide_directional_cq_desc">당신의 DXCC를 향하지 않는 지역 지정 CQ 숨기기</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">신규 DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">미교신 DXCC 엔티티가 CQ를 호출하면 소리 + 진동 + 알림</string>
+    <string name="settings_alert_new_state">신규 미국 주</string>
+    <string name="settings_alert_new_state_desc">미교신 미국 주의 국이 CQ를 호출하면 소리 + 진동 + 알림 (그리드로 주 판별)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">SWL 디코드 저장</string>
+    <string name="settings_save_swl_decodes_desc">디코드된 모든 메시지를 데이터베이스에 기록</string>
+    <string name="settings_save_swl_qsos">SWL QSO 저장</string>
+    <string name="settings_save_swl_qsos_desc">다른 국 간에 감지된 QSO 기록</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">디코드된 스폿을 pskreporter.info에 업로드</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">QSO를 QRZ 로그북에 자동 업로드</string>
+    <string name="settings_qrz_profile_lookup">QRZ 프로필 조회</string>
+    <string name="settings_qrz_profile_lookup_desc">QRZ XML API용 사용자 이름 + 비밀번호 (아바타)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">QSO를 Cloudlog, Wavelog 또는 Nextlog 인스턴스에 자동 업로드</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">PTT 지연</string>
+    <string name="settings_ptt_delay_desc">PTT 후 송신 오디오 시작 전 지연</string>
+    <string name="settings_tx_delay">TX 지연</string>
+    <string name="settings_tx_delay_desc">이전 주기 디코드를 위해 송신 전 지연</string>
+    <string name="settings_late_start_tolerance">늦은 시작 허용치</string>
+    <string name="settings_late_start_tolerance_desc">주기 시작 후 최대 N ms까지 TX 시작 허용; TX가 주기 경계에서 끝나도록 앞부분 오디오를 잘라냄</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">FAQ &amp; 지원</string>
+    <string name="settings_report_bug">버그 신고</string>
+    <string name="bug_report_description_hint">무엇이 잘못되었는지 설명하세요…</string>
+    <string name="bug_report_send_email">이메일 보내기</string>
+    <string name="bug_report_no_email_app">신고를 보낼 이메일 앱을 찾을 수 없습니다</string>
+    <string name="bug_report_open_github">GitHub 이슈 열기</string>
+    <string name="settings_debug">디버그</string>
+    <string name="settings_debug_desc">debug.log 보기 / 공유</string>
+    <string name="settings_about_body">버전 %1$s (빌드 %2$s)\n빌드 날짜 %3$s\n\nFT8, 쉽게.\n\nAndroid용 독립형 FT8 트랜시버 앱. USB, Bluetooth, 네트워크 무전기 제어와 자동 시퀀싱 및 로깅 지원.</string>
+    <string name="settings_website">웹사이트</string>
+    <string name="settings_community">커뮤니티</string>
+    <string name="settings_built_by">제작</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">정확한 콜사인 차단</string>
+    <string name="settings_block_exact_desc">전체 콜 일치. 쉼표 또는 공백으로 구분, 예: W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">콜사인 접두사 차단</string>
+    <string name="settings_block_prefix_desc">접두사 일치, 예: RA는 RA0AA..RA9ZZ를 차단. 쉼표 또는 공백으로 구분.</string>
+    <string name="settings_block_keyword_title">키워드 차단</string>
+    <string name="settings_block_keyword_desc">콜과 메시지 텍스트의 부분 문자열 일치, 예: POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">예: W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">대륙 필터</string>
+    <string name="settings_conn_usb_cable">USB 케이블</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">네트워크</string>
+    <string name="settings_no_usb_serial">USB 시리얼 장치가 감지되지 않았습니다. 무전기에 USB 케이블을 연결하고 다시 시도하세요.</string>
+    <string name="settings_no_bluetooth_devices">연결된 Bluetooth 장치를 찾을 수 없습니다. 먼저 Android Bluetooth 설정에서 장치를 페어링하세요.</string>
+    <string name="settings_debug_mode_enabled">디버그 모드 활성화됨</string>
+    <string name="settings_debug_mode_disabled">디버그 모드 비활성화됨</string>
+    <string name="settings_edit_operator_identity">운용자 정보 편집</string>
+    <string name="settings_callsign">콜사인</string>
+    <string name="settings_callsign_hint">예: W1AW</string>
+    <string name="settings_grid_locator">그리드 로케이터</string>
+    <string name="settings_grid_locator_hint">예: FN31pr</string>
+    <string name="settings_logging_server">로깅 서버</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog, Nextlog는 모두 동일한 업로드를 받습니다.</string>
+    <string name="settings_server_address">서버 주소</string>
+    <string name="settings_api_key">API 키</string>
+    <string name="settings_api_key_hint">당신의 Cloudlog API 키</string>
+    <string name="settings_loading_stations">스테이션 로드 중...</string>
+    <string name="settings_station_id">스테이션 ID</string>
+    <string name="settings_station_id_hint">예: 1</string>
+    <string name="settings_select_a_station">스테이션 선택</string>
+    <string name="settings_enter_manually">직접 입력</string>
+    <string name="settings_choose_from_server">서버에서 선택</string>
+    <string name="settings_station_profile">스테이션 프로필</string>
+    <string name="settings_qrz_creds_desc">QRZ XML API를 통해 디코드된 콜사인의 프로필 사진을 가져오는 데 사용됩니다. QRZ XML 구독이 필요합니다.</string>
+    <string name="settings_username">사용자 이름</string>
+    <string name="settings_username_hint">당신의 QRZ.com 사용자 이름</string>
+    <string name="settings_password">비밀번호</string>
+    <string name="settings_enabled_bands_dialog_desc">숨겨진 밴드는 주파수 선택기에 나타나지 않습니다.</string>
+    <string name="settings_select_serial_port">시리얼 포트 선택</string>
+    <string name="settings_tx_volume_advice">실시간으로 조정하세요 — 다음 TX가 이 레벨을 사용합니다. 무전기의 ALC를 지켜보며 선에 살짝 닿을 때까지 낮추세요.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">언어</string>
+    <string name="settings_language_desc">앱 표시 언어</string>
+    <string name="settings_language_system">시스템 기본값</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ko/strings_compose.xml
@@ -88,8 +88,8 @@
     <!-- ===== Export log sheet ===== -->
     <string name="export_title">QSO 내보내기</string>
     <string name="export_date_range">날짜 범위</string>
-    <string name="export_date_from_placeholder">"From  YYYYMMDD"</string>
-    <string name="export_date_to_placeholder">"To  YYYYMMDD"</string>
+    <string name="export_date_from_placeholder">"시작  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"종료  YYYYMMDD"</string>
     <string name="export_share">공유</string>
     <string name="export_filter_confirmed">확인된 것만</string>
     <string name="export_filter_unconfirmed">미확인만</string>

--- a/ft8cn/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-nl/strings_compose.xml
@@ -1,0 +1,543 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Compose UI strings (FT8AF). The live app is the Jetpack Compose UI under
+  ~ radio.ks3ckc.ft8us; these are its user-facing strings, externalized for
+  ~ localization. The legacy strings.xml entries belong to the unreachable old
+  ~ XML/Fragment UI and are NOT used by the running app.
+  ~
+  ~ Translations live in values-<locale>/strings_compose.xml. English here is the
+  ~ source of truth — keep it byte-identical to the original UI text so the English
+  ~ layout never changes. Ham-radio abbreviations (CQ, QSO, DXCC, POTA, SOTA, RST)
+  ~ are intentionally left untranslated across all locales.
+-->
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">Annuleren</string>
+    <string name="action_save">Opslaan</string>
+    <string name="action_done">Klaar</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Afsluiten</string>
+    <string name="common_none">Geen</string>
+    <string name="common_off">Uit</string>
+    <string name="common_not_configured">Niet geconfigureerd</string>
+    <string name="common_not_connected">Niet verbonden</string>
+    <string name="common_pass">Geslaagd</string>
+    <string name="common_fail">Mislukt</string>
+    <string name="common_test_connection">Verbinding testen</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">Noord-Amerika</string>
+    <string name="continent_sa">Zuid-Amerika</string>
+    <string name="continent_eu">Europa</string>
+    <string name="continent_af">Afrika</string>
+    <string name="continent_as">Azië</string>
+    <string name="continent_oc">Oceanië</string>
+    <string name="continent_an">Antarctica</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">Decoderen</string>
+    <string name="tab_map">Kaart</string>
+    <string name="tab_waterfall">Waterval</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Logboek</string>
+    <string name="tab_settings">Instellingen</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">NIEUW DXCC</string>
+    <string name="status_new_grid">NIEUW GRID</string>
+    <string name="status_new_band">NIEUWE BAND</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">NIEUW POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">NODIG</string>
+    <string name="status_worked">GEWERKT</string>
+    <string name="status_confirmed">BEVESTIGD</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">IN AFWACHTING</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · MOBIELE METGEZEL</string>
+    <string name="splash_initializing">RADIO INITIALISEREN</string>
+    <string name="splash_version">v%1$s · build %2$s</string>
+    <string name="app_set_callsign_first">Stel je roepnaam in bij Instellingen voordat je CQ roept</string>
+    <string name="app_hunt_on">Hunt aan — CQ\'s automatisch beantwoorden</string>
+    <string name="app_hunt_off">Hunt uit — CQ roepen, alleen antwoorden werken</string>
+    <string name="app_mode_switched">Modus: %1$s</string>
+    <string name="app_mode_switch_busy">Kan modus niet wijzigen tijdens uitzenden</string>
+    <string name="main_tx_volume">TX-volume: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">FT8AF AFSLUITEN?</string>
+    <string name="exit_message">Weet je zeker dat je de app wilt sluiten? Een actieve QSO wordt geannuleerd.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">FREQUENTIE KIEZEN</string>
+    <string name="freq_show_alternates">ALTERNATIEVEN TONEN</string>
+    <string name="freq_hide_alternates">ALTERNATIEVEN VERBERGEN</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">GEEN ROEPNAAM</string>
+    <string name="op_no_grid">Geen grid ingesteld</string>
+    <string name="op_tap_to_edit">Tik om te bewerken</string>
+    <string name="op_stat_rig">RIG</string>
+    <string name="op_stat_antenna">ANTENNE</string>
+    <string name="op_stat_power">VERMOGEN</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">QSO\'S EXPORTEREN</string>
+    <string name="export_date_range">DATUMBEREIK</string>
+    <string name="export_date_from_placeholder">"Van  JJJJMMDD"</string>
+    <string name="export_date_to_placeholder">"Tot  JJJJMMDD"</string>
+    <string name="export_share">Delen</string>
+    <string name="export_filter_confirmed">alleen bevestigd</string>
+    <string name="export_filter_unconfirmed">alleen onbevestigd</string>
+    <string name="export_record_singular">record</string>
+    <string name="export_record_plural">records</string>
+    <string name="export_summary_all">alle</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s komt overeen met %3$s%4$s</string>
+    <string name="export_preparing">Voorbereiden…</string>
+    <string name="export_share_chooser_title">QSO-logs delen</string>
+    <string name="export_saved_to">Opgeslagen in %1$s</string>
+    <string name="export_save_failed">Opslaan in Downloads mislukt</string>
+    <string name="export_temp_file_failed">Kan tijdelijk bestand niet aanmaken</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">UITZENDEN</string>
+    <string name="tx_listening">LUISTEREN</string>
+    <string name="tx_hunt">Hunt</string>
+    <string name="tx_call_cq">CQ roepen</string>
+    <string name="tx_stop">Stoppen</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Een DXpeditie werken (Hound)</string>
+    <string name="hound_help">Stem de rig eerst af op de gepubliceerde dialfrequentie van de Fox. Jij roept hoog (1000–4000 Hz); de app QSY\'t je automatisch omlaag naar waar de Fox antwoordt en stuurt je rapport mee.</string>
+    <string name="hound_fox_callsign">Roepnaam Fox</string>
+    <string name="hound_call_frequency">Roepfrequentie (Hz, 1000–4000)</string>
+    <string name="hound_start">Starten</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT verbonden — tik om opnieuw te verbinden</string>
+    <string name="cat_status_connecting">CAT verbinden…</string>
+    <string name="cat_status_disconnected">CAT verbroken — tik om te verbinden</string>
+    <string name="cat_status_error">CAT-verbindingsfout — tik om opnieuw te proberen</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX GESTOPT — Hoge SWR gedetecteerd (%1$s)</string>
+    <string name="swr_lockout_body">Controleer antenne / voedingslijn voordat je uitzendt.</string>
+    <string name="swr_lockout_dismiss">SLUITEN</string>
+    <string name="swr_lockout_toast">TX geblokkeerd — SWR-vergrendeling actief. Sluit eerst de vergrendelingsbanner.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">CQ roepen</string>
+    <string name="qsopanel_searching">Zoeken...</string>
+    <string name="qsopanel_qsoing_with">QSO met %1$s</string>
+    <string name="qsopanel_waiting_for">Wachten op %1$s</string>
+    <string name="qsopanel_tap_to_view">tik om te bekijken ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">Wachten op berichten...</string>
+    <string name="qsopanel_log_action">LOGGEN</string>
+    <string name="qsopanel_queue">WACHTRIJ</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Decoderen</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d gedecodeerd deze cyclus"</string>
+    <string name="decode_clear_list">Decodelijst wissen</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Alle</string>
+    <string name="decode_filter_cq_calls">CQ-roepen</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">Nieuw DXCC</string>
+    <string name="decode_filter_needed">Nodig</string>
+    <string name="decode_filter_for_me">Voor mij</string>
+    <string name="decode_empty_cq_title">Geen CQ-roepen</string>
+    <string name="decode_empty_cq_body">Op deze band roept op dit moment geen station CQ.</string>
+    <string name="decode_empty_pota_title">Geen POTA-spots</string>
+    <string name="decode_empty_pota_body">Nog geen parkactivaties gedecodeerd op deze band — open POTA → Hunt voor de spotlijst.</string>
+    <string name="decode_empty_dxcc_title">Geen nieuw DXCC</string>
+    <string name="decode_empty_dxcc_body">Er zijn nog geen ongewerkte DXCC-entiteiten gedecodeerd.</string>
+    <string name="decode_empty_needed_title">Niets nodig</string>
+    <string name="decode_empty_needed_body">Geen stations gevonden die bevestiging nodig hebben.</string>
+    <string name="decode_empty_forme_title">Geen roepen voor jou</string>
+    <string name="decode_empty_forme_body">Geen station roept op dit moment jouw roepnaam.</string>
+    <string name="decode_empty_default_title">Geen signalen gedecodeerd</string>
+    <string name="decode_empty_default_body">Wachten tot FT8-signalen verschijnen...</string>
+    <string name="decode_label_calling">→ ROEPT</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ VOOR JOU</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO voltooid</string>
+    <string name="qso_call_action">%1$s roepen</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Signaal</string>
+    <string name="qso_stat_distance">Afstand</string>
+    <string name="qso_stat_azimuth">Azimut</string>
+    <string name="qso_stat_band">Band</string>
+    <string name="qso_sequence_header">QSO-SEQUENTIE</string>
+    <string name="qso_step_send_call">Roep verzenden</string>
+    <string name="qso_step_report_sent">Rapport verzonden</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Bevestigen</string>
+    <string name="qso_step_logged">Gelogd</string>
+    <string name="qso_live_sending">QSO met %1$s — %2$s verzenden</string>
+    <string name="qso_live_waiting">Wachten tot %1$s antwoordt…</string>
+    <string name="qso_live_transmitting">Uitzenden…</string>
+    <string name="qso_live_step_fallback">bericht</string>
+    <string name="qso_tx_now">TX NU</string>
+    <string name="qso_tx_next">TX VOLGENDE</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">Statistieken</string>
+    <string name="log_tab_recent">Recent</string>
+    <string name="log_tab_awards">Onderscheidingen</string>
+    <string name="log_title">Logboek</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSOs · Alle banden</string>
+    <string name="log_cd_sync_to_logging_services">Synchroniseren met logdiensten</string>
+    <string name="log_cd_export_qsos">QSO\'s exporteren</string>
+    <string name="log_stat_total_qsos">Totaal QSOs</string>
+    <string name="log_stat_dxcc_entities">DXCC-entiteiten</string>
+    <string name="log_stat_cq_zones">CQ-zones</string>
+    <string name="log_stat_itu_zones">ITU-zones</string>
+    <string name="log_section_band_distribution">Bandverdeling</string>
+    <string name="log_section_award_progress">Voortgang onderscheidingen</string>
+    <string name="log_award_dxcc_mixed">DXCC Mixed</string>
+    <string name="log_award_vucc_grid_squares">VUCC-gridvakken</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Griddekking</string>
+    <string name="log_section_signal_trend">Signaaltrend</string>
+    <string name="log_no_qsos_yet">Nog geen QSOs</string>
+    <string name="log_no_qsos_recorded_yet">Nog geen QSOs vastgelegd</string>
+    <string name="log_state_usa">%1$s, USA</string>
+    <string name="log_cd_qso_actions">QSO-acties</string>
+    <string name="log_action_edit">Bewerken</string>
+    <string name="log_action_delete">Verwijderen</string>
+    <string name="log_award_dxcc_mixed_desc">Werk en bevestig 100 DXCC-entiteiten op elke band/modus</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">Werk alle 50 Amerikaanse staten bevestigd</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">Werk alle 40 CQ-zones bevestigd</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 gridvakken op één band</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- werk stations op aangewezen eilanden</string>
+    <string name="log_edit_qso">QSO bewerken</string>
+    <string name="log_field_callsign">Roepnaam</string>
+    <string name="log_field_grid_locator">Gridlocator</string>
+    <string name="log_field_mode">Modus</string>
+    <string name="log_delete_qso_title">QSO VERWIJDEREN?</string>
+    <string name="log_delete_qso_body_callsign">De QSO met %1$s uit het logboek verwijderen? Dit kan niet ongedaan worden gemaakt.</string>
+    <string name="log_delete_qso_body">Deze QSO uit het logboek verwijderen? Dit kan niet ongedaan worden gemaakt.</string>
+    <string name="log_sync_title_no_services">GEEN DIENSTEN INGESCHAKELD</string>
+    <string name="log_sync_title_syncing">SYNCHRONISEREN…</string>
+    <string name="log_sync_title_complete">SYNCHRONISATIE VOLTOOID</string>
+    <string name="log_sync_enable_services">Schakel Cloudlog/Wavelog/Nextlog of QRZ in bij Instellingen en probeer het opnieuw.</string>
+    <string name="log_sync_progress_count">%1$d van %2$d QSOs</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d geaccepteerd</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d geaccepteerd</string>
+    <string name="log_sync_nothing_to_upload">Nog geen QSOs in het logboek om te uploaden.</string>
+    <string name="log_sync_working">Bezig…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Activeren</string>
+    <string name="pota_tab_hunt">Hunt</string>
+    <string name="pota_tab_history">Geschiedenis</string>
+    <string name="pota_start_activation">Activatie starten</string>
+    <string name="pota_park_reference_label">Parkreferentie (bijv. K-1234)</string>
+    <string name="pota_notes_optional_label">Notities (optioneel)</string>
+    <string name="pota_enter_park_reference_first">Voer eerst een parkreferentie in</string>
+    <string name="pota_activating">%1$s activeren</string>
+    <string name="pota_activation_ended">Activatie beëindigd</string>
+    <string name="pota_set_callsign_first">Stel eerst je roepnaam in bij Instellingen</string>
+    <string name="pota_self_spot_posted">Self-spot geplaatst</string>
+    <string name="pota_self_spot_failed">Self-spot mislukt — controleer log</string>
+    <string name="pota_active_park">ACTIEF — %1$s</string>
+    <string name="pota_qsos">QSOs</string>
+    <string name="pota_contacts_map">Contactenkaart</string>
+    <string name="pota_back">Terug</string>
+    <string name="pota_valid_activation">geldige activatie</string>
+    <string name="pota_to_valid">%1$d tot geldig</string>
+    <string name="pota_elapsed">Verstreken</string>
+    <string name="pota_since_start">sinds start</string>
+    <string name="pota_self_spot">Self-spot</string>
+    <string name="pota_end_activation">Activatie beëindigen</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">TX CQ wordt verzonden als “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Op dit moment geen FT8 POTA-spots.</string>
+    <string name="pota_active_spots">%1$d actieve FT8-spots</string>
+    <string name="pota_targeting">Gericht op %1$s @ %2$s kHz (%3$s) — ga naar Decoderen om te roepen</string>
+    <string name="pota_no_past_activations">Nog geen eerdere activaties.</string>
+    <string name="pota_no_browser_available">Geen browser beschikbaar</string>
+    <string name="pota_export_failed">Export mislukt — controleer log</string>
+    <string name="pota_status_active">actief</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">ADIF delen</string>
+    <string name="pota_open_pota_app">pota.app openen</string>
+    <string name="pota_upload_to_pota">Uploaden naar POTA</string>
+    <string name="pota_upload_success">%1$d parklog(s) geüpload naar POTA</string>
+    <string name="pota_upload_failed">Upload mislukt: %1$s</string>
+    <string name="pota_upload_server_error">POTA kon de upload niet verwerken. Controleer of de parkreferentie geldig is en je roepnaam bij POTA is geregistreerd, en probeer het opnieuw.</string>
+    <string name="pota_upload_network_error">Kan POTA niet bereiken. Controleer je internetverbinding en probeer het opnieuw.</string>
+    <string name="pota_login_title">Inloggen bij POTA</string>
+    <string name="pota_login_desc">Gebruik het e-mailadres en wachtwoord van je pota.app-account.</string>
+    <string name="pota_login_email">E-mail</string>
+    <string name="pota_login_password">Wachtwoord</string>
+    <string name="pota_login_button">Inloggen</string>
+    <string name="pota_login_cancel">Annuleren</string>
+    <string name="pota_login_failed">Inloggen mislukt: %1$s</string>
+    <string name="pota_login_or">of</string>
+    <string name="pota_login_social">Inloggen met Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">Inloggen bij POTA</string>
+    <string name="pota_add_park">Park toevoegen</string>
+    <string name="pota_remove_park">Verwijderen</string>
+    <string name="pota_max_parks_reached">Maximum van 10 parken bereikt</string>
+    <string name="pota_spotted_n_parks">Gespot bij %1$d parken</string>
+    <string name="pota_parks_more">+%1$d meer</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Debug</string>
+    <string name="debug_line_count">%1$d regels</string>
+    <string name="debug_logcat_on_suffix">" · logcat AAN"</string>
+    <string name="debug_close">Sluiten</string>
+    <string name="debug_share">Delen</string>
+    <string name="debug_clear">Wissen</string>
+    <string name="debug_logcat_on">Logcat: AAN</string>
+    <string name="debug_logcat_off">Logcat: UIT</string>
+    <string name="debug_no_log_file">geen logbestand</string>
+    <string name="debug_log_cleared">log gewist</string>
+    <string name="debug_share_chooser_title">debug.log delen</string>
+    <string name="map_title">Kaart</string>
+    <string name="map_no_grid_set">Geen grid ingesteld</string>
+    <string name="map_station_count">%1$d stations</string>
+    <string name="map_station_count_with_heard">%1$d stations · %2$d gehoord</string>
+    <string name="map_psk_error">PSK Reporter niet beschikbaar: %1$s</string>
+    <string name="map_projection_equirectangular">Equirectangulair</string>
+    <string name="map_projection_azimuthal">Azimutaal equidistant</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">Afstand</string>
+    <string name="map_info_bearing">Peiling</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Waterval</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">LIVE</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d pogingen</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d van %2$d ingeschakeld</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Build %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Instellingen</string>
+    <string name="settings_section_operator_identity">OPERATORIDENTITEIT</string>
+    <string name="settings_section_radio">RADIO</string>
+    <string name="settings_section_audio">AUDIO</string>
+    <string name="settings_section_transmission">UITZENDING</string>
+    <string name="settings_section_auto_sequence">AUTO-SEQUENTIE</string>
+    <string name="settings_section_decode_highlights">DECODE-HIGHLIGHTS</string>
+    <string name="settings_section_callsign_blocklist">ROEPNAAM-BLOKKEERLIJST</string>
+    <string name="settings_section_decode_filters">DECODE-FILTERS</string>
+    <string name="settings_section_needed_dx_alerts">NODIG-DX-WAARSCHUWINGEN</string>
+    <string name="settings_section_logging_awards">LOGGEN &amp; ONDERSCHEIDINGEN</string>
+    <string name="settings_section_advanced">GEAVANCEERD</string>
+    <string name="settings_section_about">OVER</string>
+    <string name="settings_section_language">TAAL</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Radio &amp; Audio</string>
+    <string name="settings_cat_transmission">Uitzending</string>
+    <string name="settings_cat_decode_filters">Decoderen &amp; Filters</string>
+    <string name="settings_cat_logging">Loggen &amp; Onderscheidingen</string>
+    <string name="settings_cat_advanced">Geavanceerd</string>
+    <string name="settings_cat_about">Over</string>
+    <string name="settings_cat_time_sync">Tijdsynchronisatie</string>
+    <string name="settings_cat_time_sync_desc">Handmatige klokcorrectie voor offline gebruik</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Handmatige correctie</string>
+    <string name="settings_time_current_label">Huidige correctie</string>
+    <string name="settings_time_correction_reset">Terugzetten naar 0</string>
+    <string name="settings_time_correction_desc">Stel de app-klok bij wanneer je geen internet hebt om te synchroniseren. FT8 heeft UTC binnen ongeveer 1 seconde nodig. Pas aan tot de DT-kolom bij gedecodeerde stations rond 0 centreert.</string>
+    <string name="settings_time_suggest_section">Voorgesteld op basis van decodes</string>
+    <string name="settings_time_suggest_none">Nog geen decodes — begin met ontvangen om een suggestie te krijgen.</string>
+    <string name="settings_time_suggest_label">Recent gemiddelde DT: %1$s</string>
+    <string name="settings_time_suggest_apply">Voorgestelde correctie toepassen</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Grid automatisch bijwerken (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Gebruik GPS van het apparaat om je Maidenhead-grid actueel te houden</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Rig-model</string>
+    <string name="settings_control_mode">Besturingsmodus</string>
+    <string name="settings_connection_mode">Verbindingsmodus</string>
+    <string name="settings_baud_rate">Baudrate</string>
+    <string name="settings_band_frequency">Band &amp; Frequentie</string>
+    <string name="settings_enabled_bands">Ingeschakelde banden</string>
+    <string name="settings_audio_frequency">Audiofrequentie</string>
+    <string name="settings_spectrum_width">Spectrumbreedte</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Audio-ingang</string>
+    <string name="settings_audio_output">Audio-uitgang</string>
+    <string name="settings_tx_volume">TX-volume</string>
+    <string name="settings_tx_volume_desc" formatted="false">Uitzendaudio-niveau (hardwareknoppen ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">TX/RX-split</string>
+    <string name="settings_tx_rx_split_desc">Uitzenden op een andere frequentie dan ontvangen</string>
+    <string name="settings_tx_watchdog">TX-watchdog</string>
+    <string name="settings_tx_watchdog_desc">Uitzending automatisch stoppen na time-out</string>
+    <string name="settings_stop_after">Stoppen na</string>
+    <string name="settings_stop_after_desc">Stop met roepen na N onbeantwoorde pogingen</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Hunt (CQ automatisch beantwoorden)</string>
+    <string name="settings_hunt_desc">Roep proactief stations die CQ roepen. Hetzelfde als de HUNT-knop op de TX-balk. Uit = CQ roepen en alleen stations werken die jou antwoorden.</string>
+    <string name="settings_auto_call_followed">Gevolgde automatisch roepen</string>
+    <string name="settings_auto_call_followed_desc">Gevolgde roepnamen automatisch blijven roepen</string>
+    <string name="settings_fast_turnaround">Snelle ommekeer</string>
+    <string name="settings_fast_turnaround_desc">Decodeer ~1 s eerder zodat je een CQ in het volgende slot kunt beantwoorden in plaats van te wachten. Kan stations met een grote klokafwijking missen.</string>
+    <string name="settings_auto_cq_after_qso">Auto-CQ na QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">Blijf automatisch CQ roepen na elk voltooid contact — geen opnieuw tikken. Blijft op je frequentie (negeert Hunt). Loopt door tot je stopt of de TX-watchdog zonder antwoorden verloopt.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">Nieuw DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">Markeer stations van een ongewerkte DXCC-entiteit</string>
+    <string name="settings_highlight_new_grid">Nieuw grid</string>
+    <string name="settings_highlight_new_grid_desc">Markeer nog niet gewerkte Maidenhead-grids</string>
+    <string name="settings_highlight_new_band">Nieuwe band</string>
+    <string name="settings_highlight_new_band_desc">Markeer stations die alleen op andere banden zijn gewerkt</string>
+    <string name="settings_highlight_pota">POTA-activatoren</string>
+    <string name="settings_highlight_pota_desc">Markeer gespotte POTA-activatoren; nieuwe parken vallen op</string>
+    <string name="settings_highlight_worked">Eerder gewerkt</string>
+    <string name="settings_highlight_worked_desc">Markeer stations die al in je log staan</string>
+    <string name="settings_distance_unit">Afstand in mijlen</string>
+    <string name="settings_distance_unit_desc">Toon afstanden in mijlen in plaats van kilometers</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Exacte roepnamen</string>
+    <string name="settings_exact_callsigns_desc">Blokkeer volledige-roep-overeenkomsten</string>
+    <string name="settings_prefixes">Voorvoegsels</string>
+    <string name="settings_prefixes_desc">Blokkeer op roepnaamvoorvoegsel (bijv. RA)</string>
+    <string name="settings_keywords">Trefwoorden</string>
+    <string name="settings_keywords_desc">Blokkeer op deeltekst in roep of bericht (bijv. POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Alleen CQ tonen</string>
+    <string name="settings_show_only_cq_desc">Verberg alles behalve CQ-berichten</string>
+    <string name="settings_dx_only">Alleen DX</string>
+    <string name="settings_dx_only_desc">Toon alleen stations buiten je eigen continent</string>
+    <string name="settings_needed_only">Alleen nodig</string>
+    <string name="settings_needed_only_desc">Toon alleen stations die nog niet bevestigd zijn (QSL)</string>
+    <string name="settings_filter_by_continent">Filteren op continent</string>
+    <string name="settings_filter_by_continent_desc">Toon alleen stations van een gekozen continent</string>
+    <string name="settings_continent">Continent</string>
+    <string name="settings_skip_directional_cq">Gerichte CQ\'s overslaan (auto-antwoord)</string>
+    <string name="settings_skip_directional_cq_desc">Beantwoord geen CQ DX/EU/JA… die op een ander DXCC is gericht</string>
+    <string name="settings_hide_directional_cq">Gerichte CQ\'s niet voor mij verbergen</string>
+    <string name="settings_hide_directional_cq_desc">Verberg regiogerichte CQ\'s die niet op jouw DXCC zijn gericht</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">Nieuw DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">Geluid + trilling + melding wanneer een ongewerkte DXCC-entiteit CQ roept</string>
+    <string name="settings_alert_new_state">Nieuwe Amerikaanse staat</string>
+    <string name="settings_alert_new_state_desc">Geluid + trilling + melding wanneer een station uit een ongewerkte Amerikaanse staat CQ roept (staat uit grid)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">SWL-decodes opslaan</string>
+    <string name="settings_save_swl_decodes_desc">Log alle gedecodeerde berichten in de database</string>
+    <string name="settings_save_swl_qsos">SWL-QSO\'s opslaan</string>
+    <string name="settings_save_swl_qsos_desc">Log QSO\'s die tussen andere stations worden gedetecteerd</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Upload gedecodeerde spots naar pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">QSO\'s automatisch uploaden naar QRZ Logbook</string>
+    <string name="settings_qrz_profile_lookup">QRZ-profiel opzoeken</string>
+    <string name="settings_qrz_profile_lookup_desc">Gebruikersnaam + wachtwoord voor QRZ XML API (avatars)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">QSO\'s automatisch uploaden naar een Cloudlog-, Wavelog- of Nextlog-instantie</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">PTT-vertraging</string>
+    <string name="settings_ptt_delay_desc">Vertraging na PTT voordat uitzendaudio begint</string>
+    <string name="settings_tx_delay">TX-vertraging</string>
+    <string name="settings_tx_delay_desc">Vertraging voor uitzenden om decode van vorige cyclus toe te staan</string>
+    <string name="settings_late_start_tolerance">Tolerantie late start</string>
+    <string name="settings_late_start_tolerance_desc">Sta toe TX tot N ms in een cyclus te starten; leidende audio wordt afgekapt zodat TX op de cyclusgrens eindigt</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">FAQ &amp; Ondersteuning</string>
+    <string name="settings_report_bug">Een bug melden</string>
+    <string name="bug_report_description_hint">Beschrijf wat er misging…</string>
+    <string name="bug_report_send_email">E-mail verzenden</string>
+    <string name="bug_report_no_email_app">Geen e-mailapp gevonden om de melding te verzenden</string>
+    <string name="bug_report_open_github">GitHub-issue openen</string>
+    <string name="settings_debug">Debug</string>
+    <string name="settings_debug_desc">debug.log bekijken / delen</string>
+    <string name="settings_about_body">Versie %1$s (build %2$s)\nBuilddatum %3$s\n\nFT8, eenvoudig gemaakt.\n\nEen zelfstandige FT8-transceiver-app voor Android. USB-, Bluetooth- en netwerk-rigbesturing met automatische sequentie en logboek.</string>
+    <string name="settings_website">Website</string>
+    <string name="settings_community">Community</string>
+    <string name="settings_built_by">Gebouwd door</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Exacte roepnamen blokkeren</string>
+    <string name="settings_block_exact_desc">Volledige-roep-overeenkomst. Gescheiden door komma of spatie, bijv. W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Roepnaamvoorvoegsels blokkeren</string>
+    <string name="settings_block_prefix_desc">Voorvoegsel-overeenkomst, bijv. RA blokkeert RA0AA..RA9ZZ. Gescheiden door komma of spatie.</string>
+    <string name="settings_block_keyword_title">Trefwoorden blokkeren</string>
+    <string name="settings_block_keyword_desc">Deeltekst-overeenkomst tegen de roep en de berichttekst, bijv. POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">bijv. W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Continent filteren</string>
+    <string name="settings_conn_usb_cable">USB-kabel</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Netwerk</string>
+    <string name="settings_no_usb_serial">Geen USB-seriële apparaten gedetecteerd. Sluit een USB-kabel aan op je radio en probeer het opnieuw.</string>
+    <string name="settings_no_bluetooth_devices">Geen gekoppelde Bluetooth-apparaten gevonden. Koppel eerst een apparaat in de Bluetooth-instellingen van Android.</string>
+    <string name="settings_debug_mode_enabled">Debugmodus ingeschakeld</string>
+    <string name="settings_debug_mode_disabled">Debugmodus uitgeschakeld</string>
+    <string name="settings_edit_operator_identity">Operatoridentiteit bewerken</string>
+    <string name="settings_callsign">Roepnaam</string>
+    <string name="settings_callsign_hint">bijv. W1AW</string>
+    <string name="settings_grid_locator">Gridlocator</string>
+    <string name="settings_grid_locator_hint">bijv. FN31pr</string>
+    <string name="settings_logging_server">Logserver</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog en Nextlog accepteren allemaal dezelfde uploads.</string>
+    <string name="settings_server_address">Serveradres</string>
+    <string name="settings_api_key">API-sleutel</string>
+    <string name="settings_api_key_hint">Je Cloudlog API-sleutel</string>
+    <string name="settings_loading_stations">Stations laden...</string>
+    <string name="settings_station_id">Station-ID</string>
+    <string name="settings_station_id_hint">bijv. 1</string>
+    <string name="settings_select_a_station">Selecteer een station</string>
+    <string name="settings_enter_manually">Handmatig invoeren</string>
+    <string name="settings_choose_from_server">Kiezen van server</string>
+    <string name="settings_station_profile">Stationprofiel</string>
+    <string name="settings_qrz_creds_desc">Gebruikt om profielfoto\'s op te halen voor gedecodeerde roepnamen via de QRZ XML API. Vereist een QRZ XML-abonnement.</string>
+    <string name="settings_username">Gebruikersnaam</string>
+    <string name="settings_username_hint">Je QRZ.com-gebruikersnaam</string>
+    <string name="settings_password">Wachtwoord</string>
+    <string name="settings_enabled_bands_dialog_desc">Verborgen banden verschijnen niet in de frequentiekiezers.</string>
+    <string name="settings_select_serial_port">Seriële poort selecteren</string>
+    <string name="settings_tx_volume_advice">Pas live aan — je volgende TX gebruikt dit niveau. Houd de ALC van je radio in de gaten en draai terug tot deze net de lijn raakt.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Taal</string>
+    <string name="settings_language_desc">Weergavetaal van de app</string>
+    <string name="settings_language_system">Systeemstandaard</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-pl/strings_compose.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">Anuluj</string>
+    <string name="action_save">Zapisz</string>
+    <string name="action_done">Gotowe</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Wyjdź</string>
+    <string name="common_none">Brak</string>
+    <string name="common_off">Wył.</string>
+    <string name="common_not_configured">Nie skonfigurowano</string>
+    <string name="common_not_connected">Nie połączono</string>
+    <string name="common_pass">Zaliczone</string>
+    <string name="common_fail">Niezaliczone</string>
+    <string name="common_test_connection">Testuj połączenie</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">Ameryka Północna</string>
+    <string name="continent_sa">Ameryka Południowa</string>
+    <string name="continent_eu">Europa</string>
+    <string name="continent_af">Afryka</string>
+    <string name="continent_as">Azja</string>
+    <string name="continent_oc">Oceania</string>
+    <string name="continent_an">Antarktyda</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">Dekodowanie</string>
+    <string name="tab_map">Mapa</string>
+    <string name="tab_waterfall">Wodospad</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Dziennik</string>
+    <string name="tab_settings">Ustawienia</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">NOWY DXCC</string>
+    <string name="status_new_grid">NOWY LOKATOR</string>
+    <string name="status_new_band">NOWE PASMO</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">NOWY POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">POTRZEBNY</string>
+    <string name="status_worked">PRZEPROWADZONY</string>
+    <string name="status_confirmed">POTWIERDZONY</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">OCZEKUJE</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · MOBILNY TOWARZYSZ</string>
+    <string name="splash_initializing">INICJALIZACJA RADIA</string>
+    <string name="splash_version">v%1$s · kompilacja %2$s</string>
+    <string name="app_set_callsign_first">Ustaw swój znak w Ustawieniach przed wywołaniem CQ</string>
+    <string name="app_hunt_on">Polowanie wł. — auto-odpowiadanie na CQ</string>
+    <string name="app_hunt_off">Polowanie wył. — nadajesz CQ, obsługujesz tylko odpowiedzi</string>
+    <string name="app_mode_switched">Tryb: %1$s</string>
+    <string name="app_mode_switch_busy">Nie można zmienić trybu podczas nadawania</string>
+    <string name="main_tx_volume">Głośność TX: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">ZAMKNĄĆ FT8AF?</string>
+    <string name="exit_message">Na pewno chcesz zamknąć aplikację? Każde aktywne QSO zostanie anulowane.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">WYBIERZ CZĘSTOTLIWOŚĆ</string>
+    <string name="freq_show_alternates">POKAŻ ALTERNATYWNE</string>
+    <string name="freq_hide_alternates">UKRYJ ALTERNATYWNE</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">BRAK ZNAKU</string>
+    <string name="op_no_grid">Brak lokatora</string>
+    <string name="op_tap_to_edit">Dotknij, aby edytować</string>
+    <string name="op_stat_rig">RADIO</string>
+    <string name="op_stat_antenna">ANTENA</string>
+    <string name="op_stat_power">MOC</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">EKSPORTUJ QSO</string>
+    <string name="export_date_range">ZAKRES DAT</string>
+    <string name="export_date_from_placeholder">"Od  RRRRMMDD"</string>
+    <string name="export_date_to_placeholder">"Do  RRRRMMDD"</string>
+    <string name="export_share">Udostępnij</string>
+    <string name="export_filter_confirmed">tylko potwierdzone</string>
+    <string name="export_filter_unconfirmed">tylko niepotwierdzone</string>
+    <string name="export_record_singular">rekord</string>
+    <string name="export_record_plural">rekordów</string>
+    <string name="export_summary_all">wszystkie</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s pasujących do %3$s%4$s</string>
+    <string name="export_preparing">Przygotowywanie…</string>
+    <string name="export_share_chooser_title">Udostępnij dzienniki QSO</string>
+    <string name="export_saved_to">Zapisano w %1$s</string>
+    <string name="export_save_failed">Zapis do Pobranych nie powiódł się</string>
+    <string name="export_temp_file_failed">Nie udało się utworzyć pliku tymczasowego</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">NADAWANIE</string>
+    <string name="tx_listening">NASŁUCH</string>
+    <string name="tx_hunt">Polowanie</string>
+    <string name="tx_call_cq">Wywołaj CQ</string>
+    <string name="tx_stop">Stop</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Pracuj z DXpedycją (Hound)</string>
+    <string name="hound_help">Najpierw nastrój radio na opublikowaną częstotliwość Foxa. Wołasz wysoko (1000–4000 Hz); aplikacja automatycznie przestraja Cię w dół tam, gdzie Fox odpowiada, i wysyła Twój raport.</string>
+    <string name="hound_fox_callsign">Znak Foxa</string>
+    <string name="hound_call_frequency">Częstotliwość wywołania (Hz, 1000–4000)</string>
+    <string name="hound_start">Start</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT połączony — dotknij, aby połączyć ponownie</string>
+    <string name="cat_status_connecting">Łączenie CAT…</string>
+    <string name="cat_status_disconnected">CAT rozłączony — dotknij, aby połączyć</string>
+    <string name="cat_status_error">Błąd połączenia CAT — dotknij, aby spróbować ponownie</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX WSTRZYMANY — Wykryto wysokie SWR (%1$s)</string>
+    <string name="swr_lockout_body">Sprawdź antenę / linię zasilającą przed nadawaniem.</string>
+    <string name="swr_lockout_dismiss">ODRZUĆ</string>
+    <string name="swr_lockout_toast">TX zablokowany — blokada SWR aktywna. Najpierw odrzuć baner blokady.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">Wywoływanie CQ</string>
+    <string name="qsopanel_searching">Szukanie...</string>
+    <string name="qsopanel_qsoing_with">QSO z %1$s</string>
+    <string name="qsopanel_waiting_for">Oczekiwanie na %1$s</string>
+    <string name="qsopanel_tap_to_view">dotknij, aby zobaczyć ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">Oczekiwanie na wiadomości...</string>
+    <string name="qsopanel_log_action">ZAPISZ</string>
+    <string name="qsopanel_queue">KOLEJKA</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Dekodowanie</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d zdekodowanych w tym cyklu"</string>
+    <string name="decode_clear_list">Wyczyść listę dekodowania</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Wszystkie</string>
+    <string name="decode_filter_cq_calls">Wywołania CQ</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">Nowy DXCC</string>
+    <string name="decode_filter_needed">Potrzebne</string>
+    <string name="decode_filter_for_me">Dla mnie</string>
+    <string name="decode_empty_cq_title">Brak wywołań CQ</string>
+    <string name="decode_empty_cq_body">Na tym paśmie nikt teraz nie wywołuje CQ.</string>
+    <string name="decode_empty_pota_title">Brak spotów POTA</string>
+    <string name="decode_empty_pota_body">Na tym paśmie nie zdekodowano jeszcze aktywacji parku — otwórz POTA → Polowanie, aby zobaczyć listę spotów.</string>
+    <string name="decode_empty_dxcc_title">Brak nowych DXCC</string>
+    <string name="decode_empty_dxcc_body">Nie zdekodowano jeszcze żadnych nieprzepracowanych podmiotów DXCC.</string>
+    <string name="decode_empty_needed_title">Nic potrzebnego</string>
+    <string name="decode_empty_needed_body">Nie znaleziono stacji wymagających potwierdzenia.</string>
+    <string name="decode_empty_forme_title">Brak wywołań dla Ciebie</string>
+    <string name="decode_empty_forme_body">Żadna stacja nie wywołuje teraz Twojego znaku.</string>
+    <string name="decode_empty_default_title">Brak zdekodowanych sygnałów</string>
+    <string name="decode_empty_default_body">Oczekiwanie na sygnały FT8...</string>
+    <string name="decode_label_calling">→ WYWOŁUJE</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ DO CIEBIE</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO zakończone</string>
+    <string name="qso_call_action">Wywołaj %1$s</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Sygnał</string>
+    <string name="qso_stat_distance">Odległość</string>
+    <string name="qso_stat_azimuth">Azymut</string>
+    <string name="qso_stat_band">Pasmo</string>
+    <string name="qso_sequence_header">SEKWENCJA QSO</string>
+    <string name="qso_step_send_call">Wyślij znak</string>
+    <string name="qso_step_report_sent">Raport wysłany</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Potwierdź</string>
+    <string name="qso_step_logged">Zapisano</string>
+    <string name="qso_live_sending">QSO z %1$s — Wysyłanie %2$s</string>
+    <string name="qso_live_waiting">Oczekiwanie na odpowiedź %1$s…</string>
+    <string name="qso_live_transmitting">Nadawanie…</string>
+    <string name="qso_live_step_fallback">wiadomość</string>
+    <string name="qso_tx_now">TX TERAZ</string>
+    <string name="qso_tx_next">TX NASTĘPNY</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">Statystyki</string>
+    <string name="log_tab_recent">Ostatnie</string>
+    <string name="log_tab_awards">Dyplomy</string>
+    <string name="log_title">Dziennik</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSO · Wszystkie pasma</string>
+    <string name="log_cd_sync_to_logging_services">Synchronizuj z usługami logowania</string>
+    <string name="log_cd_export_qsos">Eksportuj QSO</string>
+    <string name="log_stat_total_qsos">Łącznie QSO</string>
+    <string name="log_stat_dxcc_entities">Podmioty DXCC</string>
+    <string name="log_stat_cq_zones">Strefy CQ</string>
+    <string name="log_stat_itu_zones">Strefy ITU</string>
+    <string name="log_section_band_distribution">Rozkład pasm</string>
+    <string name="log_section_award_progress">Postęp dyplomów</string>
+    <string name="log_award_dxcc_mixed">DXCC Mixed</string>
+    <string name="log_award_vucc_grid_squares">Pola lokatora VUCC</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Pokrycie lokatorów</string>
+    <string name="log_section_signal_trend">Trend sygnału</string>
+    <string name="log_no_qsos_yet">Brak QSO</string>
+    <string name="log_no_qsos_recorded_yet">Nie zapisano jeszcze żadnych QSO</string>
+    <string name="log_state_usa">%1$s, USA</string>
+    <string name="log_cd_qso_actions">Akcje QSO</string>
+    <string name="log_action_edit">Edytuj</string>
+    <string name="log_action_delete">Usuń</string>
+    <string name="log_award_dxcc_mixed_desc">Przeprowadź i potwierdź 100 podmiotów DXCC na dowolnym paśmie/emisji</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">Przeprowadź i potwierdź wszystkie 50 stanów USA</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">Przeprowadź i potwierdź wszystkie 40 stref CQ</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 pól lokatora na jednym paśmie</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- pracuj ze stacjami na wyznaczonych wyspach</string>
+    <string name="log_edit_qso">Edytuj QSO</string>
+    <string name="log_field_callsign">Znak</string>
+    <string name="log_field_grid_locator">Lokator</string>
+    <string name="log_field_mode">Emisja</string>
+    <string name="log_delete_qso_title">USUNĄĆ QSO?</string>
+    <string name="log_delete_qso_body_callsign">Usunąć QSO z %1$s z dziennika? Tej operacji nie można cofnąć.</string>
+    <string name="log_delete_qso_body">Usunąć to QSO z dziennika? Tej operacji nie można cofnąć.</string>
+    <string name="log_sync_title_no_services">BRAK WŁĄCZONYCH USŁUG</string>
+    <string name="log_sync_title_syncing">SYNCHRONIZACJA…</string>
+    <string name="log_sync_title_complete">SYNCHRONIZACJA ZAKOŃCZONA</string>
+    <string name="log_sync_enable_services">Włącz Cloudlog/Wavelog/Nextlog lub QRZ w Ustawieniach, a następnie spróbuj ponownie.</string>
+    <string name="log_sync_progress_count">%1$d z %2$d QSO</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d zaakceptowano</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d zaakceptowano</string>
+    <string name="log_sync_nothing_to_upload">Brak QSO w dzienniku do wysłania.</string>
+    <string name="log_sync_working">Praca…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Aktywuj</string>
+    <string name="pota_tab_hunt">Polowanie</string>
+    <string name="pota_tab_history">Historia</string>
+    <string name="pota_start_activation">Rozpocznij aktywację</string>
+    <string name="pota_park_reference_label">Identyfikator parku (np. K-1234)</string>
+    <string name="pota_notes_optional_label">Notatki (opcjonalnie)</string>
+    <string name="pota_enter_park_reference_first">Najpierw wpisz identyfikator parku</string>
+    <string name="pota_activating">Aktywacja %1$s</string>
+    <string name="pota_activation_ended">Aktywacja zakończona</string>
+    <string name="pota_set_callsign_first">Najpierw ustaw swój znak w Ustawieniach</string>
+    <string name="pota_self_spot_posted">Spot własny wysłany</string>
+    <string name="pota_self_spot_failed">Spot własny nieudany — sprawdź log</string>
+    <string name="pota_active_park">AKTYWNY — %1$s</string>
+    <string name="pota_qsos">QSO</string>
+    <string name="pota_contacts_map">Mapa łączności</string>
+    <string name="pota_back">Wstecz</string>
+    <string name="pota_valid_activation">ważna aktywacja</string>
+    <string name="pota_to_valid">%1$d do ważności</string>
+    <string name="pota_elapsed">Upłynęło</string>
+    <string name="pota_since_start">od startu</string>
+    <string name="pota_self_spot">Spot własny</string>
+    <string name="pota_end_activation">Zakończ aktywację</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">TX CQ zostanie nadane jako „CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Brak spotów FT8 POTA w tej chwili.</string>
+    <string name="pota_active_spots">%1$d aktywnych spotów FT8</string>
+    <string name="pota_targeting">Cel %1$s @ %2$s kHz (%3$s) — przełącz na Dekodowanie, aby wywołać</string>
+    <string name="pota_no_past_activations">Brak wcześniejszych aktywacji.</string>
+    <string name="pota_no_browser_available">Brak dostępnej przeglądarki</string>
+    <string name="pota_export_failed">Eksport nieudany — sprawdź log</string>
+    <string name="pota_status_active">aktywny</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">Udostępnij ADIF</string>
+    <string name="pota_open_pota_app">Otwórz pota.app</string>
+    <string name="pota_upload_to_pota">Wyślij do POTA</string>
+    <string name="pota_upload_success">Wysłano %1$d dziennik(ów) parków do POTA</string>
+    <string name="pota_upload_failed">Wysyłanie nieudane: %1$s</string>
+    <string name="pota_upload_server_error">POTA nie mogło przetworzyć przesyłki. Sprawdź, czy identyfikator parku jest poprawny i czy Twój znak jest zarejestrowany w POTA, a następnie spróbuj ponownie.</string>
+    <string name="pota_upload_network_error">Nie udało się połączyć z POTA. Sprawdź połączenie z internetem i spróbuj ponownie.</string>
+    <string name="pota_login_title">Zaloguj się do POTA</string>
+    <string name="pota_login_desc">Użyj e-maila i hasła swojego konta pota.app.</string>
+    <string name="pota_login_email">E-mail</string>
+    <string name="pota_login_password">Hasło</string>
+    <string name="pota_login_button">Zaloguj się</string>
+    <string name="pota_login_cancel">Anuluj</string>
+    <string name="pota_login_failed">Logowanie nieudane: %1$s</string>
+    <string name="pota_login_or">lub</string>
+    <string name="pota_login_social">Zaloguj się przez Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">Zaloguj się do POTA</string>
+    <string name="pota_add_park">Dodaj park</string>
+    <string name="pota_remove_park">Usuń</string>
+    <string name="pota_max_parks_reached">Osiągnięto maksimum 10 parków</string>
+    <string name="pota_spotted_n_parks">Wypatrzony w %1$d parkach</string>
+    <string name="pota_parks_more">+%1$d więcej</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Debug</string>
+    <string name="debug_line_count">%1$d wierszy</string>
+    <string name="debug_logcat_on_suffix">" · logcat WŁ."</string>
+    <string name="debug_close">Zamknij</string>
+    <string name="debug_share">Udostępnij</string>
+    <string name="debug_clear">Wyczyść</string>
+    <string name="debug_logcat_on">Logcat: WŁ.</string>
+    <string name="debug_logcat_off">Logcat: WYŁ.</string>
+    <string name="debug_no_log_file">brak pliku logu</string>
+    <string name="debug_log_cleared">log wyczyszczony</string>
+    <string name="debug_share_chooser_title">Udostępnij debug.log</string>
+    <string name="map_title">Mapa</string>
+    <string name="map_no_grid_set">Brak lokatora</string>
+    <string name="map_station_count">%1$d stacji</string>
+    <string name="map_station_count_with_heard">%1$d stacji · %2$d usłyszanych</string>
+    <string name="map_psk_error">PSK Reporter niedostępny: %1$s</string>
+    <string name="map_projection_equirectangular">Walcowa równoodległościowa</string>
+    <string name="map_projection_azimuthal">Azymutalna równoodległościowa</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">Odległość</string>
+    <string name="map_info_bearing">Namiar</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Wodospad</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">NA ŻYWO</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d prób</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d z %2$d włączonych</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Kompilacja %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Ustawienia</string>
+    <string name="settings_section_operator_identity">TOŻSAMOŚĆ OPERATORA</string>
+    <string name="settings_section_radio">RADIO</string>
+    <string name="settings_section_audio">DŹWIĘK</string>
+    <string name="settings_section_transmission">NADAWANIE</string>
+    <string name="settings_section_auto_sequence">AUTO-SEKWENCJA</string>
+    <string name="settings_section_decode_highlights">WYRÓŻNIENIA DEKODOWANIA</string>
+    <string name="settings_section_callsign_blocklist">LISTA BLOKOWANYCH ZNAKÓW</string>
+    <string name="settings_section_decode_filters">FILTRY DEKODOWANIA</string>
+    <string name="settings_section_needed_dx_alerts">ALERTY POTRZEBNEGO DX</string>
+    <string name="settings_section_logging_awards">DZIENNIK I DYPLOMY</string>
+    <string name="settings_section_advanced">ZAAWANSOWANE</string>
+    <string name="settings_section_about">O APLIKACJI</string>
+    <string name="settings_section_language">JĘZYK</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Radio i dźwięk</string>
+    <string name="settings_cat_transmission">Nadawanie</string>
+    <string name="settings_cat_decode_filters">Dekodowanie i filtry</string>
+    <string name="settings_cat_logging">Dziennik i dyplomy</string>
+    <string name="settings_cat_advanced">Zaawansowane</string>
+    <string name="settings_cat_about">O aplikacji</string>
+    <string name="settings_cat_time_sync">Synchronizacja czasu</string>
+    <string name="settings_cat_time_sync_desc">Ręczna korekcja zegara do pracy offline</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Korekcja ręczna</string>
+    <string name="settings_time_current_label">Bieżąca korekcja</string>
+    <string name="settings_time_correction_reset">Zeruj</string>
+    <string name="settings_time_correction_desc">Skoryguj zegar aplikacji, gdy nie masz internetu do synchronizacji. FT8 wymaga UTC z dokładnością do około 1 sekundy. Dostosuj, aż kolumna DT zdekodowanych stacji wycentruje się blisko 0.</string>
+    <string name="settings_time_suggest_section">Sugerowane z dekodów</string>
+    <string name="settings_time_suggest_none">Brak dekodów — rozpocznij odbiór, aby uzyskać sugestię.</string>
+    <string name="settings_time_suggest_label">Ostatnia średnia DT: %1$s</string>
+    <string name="settings_time_suggest_apply">Zastosuj sugerowaną korekcję</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Auto-aktualizacja lokatora (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Użyj GPS urządzenia, aby utrzymywać aktualny lokator Maidenhead</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Model radia</string>
+    <string name="settings_control_mode">Tryb sterowania</string>
+    <string name="settings_connection_mode">Tryb połączenia</string>
+    <string name="settings_baud_rate">Prędkość transmisji</string>
+    <string name="settings_band_frequency">Pasmo i częstotliwość</string>
+    <string name="settings_enabled_bands">Włączone pasma</string>
+    <string name="settings_audio_frequency">Częstotliwość audio</string>
+    <string name="settings_spectrum_width">Szerokość widma</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Wejście audio</string>
+    <string name="settings_audio_output">Wyjście audio</string>
+    <string name="settings_tx_volume">Głośność TX</string>
+    <string name="settings_tx_volume_desc" formatted="false">Poziom audio nadawania (przyciski sprzętowe ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">Split TX/RX</string>
+    <string name="settings_tx_rx_split_desc">Nadawanie na innej częstotliwości niż odbiór</string>
+    <string name="settings_tx_watchdog">Watchdog TX</string>
+    <string name="settings_tx_watchdog_desc">Automatyczne zatrzymanie nadawania po przekroczeniu czasu</string>
+    <string name="settings_stop_after">Zatrzymaj po</string>
+    <string name="settings_stop_after_desc">Przestań wywoływać po N nieodebranych próbach</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Polowanie (auto-odpowiedź na CQ)</string>
+    <string name="settings_hunt_desc">Aktywnie wywołuj stacje nadające CQ. To samo co przycisk POLOWANIE na pasku TX. Wył. = nadawaj CQ i obsługuj tylko stacje, które Ci odpowiedzą.</string>
+    <string name="settings_auto_call_followed">Auto-wywołanie obserwowanych</string>
+    <string name="settings_auto_call_followed_desc">Automatycznie wywołuj obserwowane znaki</string>
+    <string name="settings_fast_turnaround">Szybki obrót</string>
+    <string name="settings_fast_turnaround_desc">Dekoduj ~1s wcześniej, aby odpowiedzieć na CQ w następnym slocie zamiast czekać. Może pomijać stacje z dużym przesunięciem zegara.</string>
+    <string name="settings_auto_cq_after_qso">Auto-CQ po QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">Automatycznie nadawaj CQ po każdej zakończonej łączności — bez ponownego dotknięcia. Pozostaje na Twojej częstotliwości (ignoruje Polowanie). Działa, dopóki nie zatrzymasz lub Watchdog TX nie wygaśnie bez odpowiedzi.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">Nowy DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">Wyróżniaj stacje z nieprzepracowanego podmiotu DXCC</string>
+    <string name="settings_highlight_new_grid">Nowy lokator</string>
+    <string name="settings_highlight_new_grid_desc">Wyróżniaj jeszcze nieprzepracowane lokatory Maidenhead</string>
+    <string name="settings_highlight_new_band">Nowe pasmo</string>
+    <string name="settings_highlight_new_band_desc">Wyróżniaj stacje przepracowane tylko na innych pasmach</string>
+    <string name="settings_highlight_pota">Aktywatorzy POTA</string>
+    <string name="settings_highlight_pota_desc">Wyróżniaj wypatrzonych aktywatorów POTA; nowe parki wyróżniają się</string>
+    <string name="settings_highlight_worked">Wcześniej przepracowane</string>
+    <string name="settings_highlight_worked_desc">Oznaczaj stacje już obecne w dzienniku</string>
+    <string name="settings_distance_unit">Odległość w milach</string>
+    <string name="settings_distance_unit_desc">Pokazuj odległości w milach zamiast kilometrów</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Dokładne znaki</string>
+    <string name="settings_exact_callsigns_desc">Blokuj dopasowania całego znaku</string>
+    <string name="settings_prefixes">Prefiksy</string>
+    <string name="settings_prefixes_desc">Blokuj wg prefiksu znaku (np. RA)</string>
+    <string name="settings_keywords">Słowa kluczowe</string>
+    <string name="settings_keywords_desc">Blokuj wg fragmentu w znaku lub wiadomości (np. POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Pokaż tylko CQ</string>
+    <string name="settings_show_only_cq_desc">Ukryj wszystko oprócz wiadomości typu CQ</string>
+    <string name="settings_dx_only">Tylko DX</string>
+    <string name="settings_dx_only_desc">Pokazuj tylko stacje spoza Twojego kontynentu</string>
+    <string name="settings_needed_only">Tylko potrzebne</string>
+    <string name="settings_needed_only_desc">Pokazuj tylko jeszcze niepotwierdzone stacje (QSL)</string>
+    <string name="settings_filter_by_continent">Filtruj wg kontynentu</string>
+    <string name="settings_filter_by_continent_desc">Pokazuj tylko stacje z wybranego kontynentu</string>
+    <string name="settings_continent">Kontynent</string>
+    <string name="settings_skip_directional_cq">Pomijaj kierunkowe CQ (auto-odpowiedź)</string>
+    <string name="settings_skip_directional_cq_desc">Nie odpowiadaj automatycznie na CQ DX/EU/JA… skierowane do innego DXCC</string>
+    <string name="settings_hide_directional_cq">Ukryj kierunkowe CQ nie dla mnie</string>
+    <string name="settings_hide_directional_cq_desc">Ukrywaj kierunkowe CQ, które nie celują w Twój DXCC</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">Nowy DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">Dźwięk + wibracja + powiadomienie, gdy nieprzepracowany podmiot DXCC wywołuje CQ</string>
+    <string name="settings_alert_new_state">Nowy stan USA</string>
+    <string name="settings_alert_new_state_desc">Dźwięk + wibracja + powiadomienie, gdy stacja z nieprzepracowanego stanu USA wywołuje CQ (stan z lokatora)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">Zapisuj dekody SWL</string>
+    <string name="settings_save_swl_decodes_desc">Zapisuj wszystkie zdekodowane wiadomości do bazy</string>
+    <string name="settings_save_swl_qsos">Zapisuj QSO SWL</string>
+    <string name="settings_save_swl_qsos_desc">Zapisuj QSO wykryte między innymi stacjami</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Wysyłaj zdekodowane spoty do pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">Auto-wysyłka QSO do dziennika QRZ</string>
+    <string name="settings_qrz_profile_lookup">Wyszukiwanie profilu QRZ</string>
+    <string name="settings_qrz_profile_lookup_desc">Nazwa użytkownika + hasło do QRZ XML API (awatary)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">Auto-wysyłka QSO do instancji Cloudlog, Wavelog lub Nextlog</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">Opóźnienie PTT</string>
+    <string name="settings_ptt_delay_desc">Opóźnienie po PTT przed rozpoczęciem audio nadawania</string>
+    <string name="settings_tx_delay">Opóźnienie TX</string>
+    <string name="settings_tx_delay_desc">Opóźnienie przed nadawaniem, aby umożliwić dekodowanie poprzedniego cyklu</string>
+    <string name="settings_late_start_tolerance">Tolerancja spóźnionego startu</string>
+    <string name="settings_late_start_tolerance_desc">Zezwól na start TX do N ms w cyklu; początkowe audio jest przycinane, aby TX zakończył się na granicy cyklu</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">FAQ i wsparcie</string>
+    <string name="settings_report_bug">Zgłoś błąd</string>
+    <string name="bug_report_description_hint">Opisz, co poszło nie tak…</string>
+    <string name="bug_report_send_email">Wyślij e-mail</string>
+    <string name="bug_report_no_email_app">Nie znaleziono aplikacji e-mail do wysłania zgłoszenia</string>
+    <string name="bug_report_open_github">Otwórz zgłoszenie na GitHub</string>
+    <string name="settings_debug">Debug</string>
+    <string name="settings_debug_desc">Wyświetl / udostępnij debug.log</string>
+    <string name="settings_about_body">Wersja %1$s (kompilacja %2$s)\nData kompilacji %3$s\n\nFT8, prosto i łatwo.\n\nSamodzielna aplikacja transceivera FT8 na Androida. Sterowanie radiem przez USB, Bluetooth i sieć z automatyczną sekwencją i logowaniem.</string>
+    <string name="settings_website">Strona internetowa</string>
+    <string name="settings_community">Społeczność</string>
+    <string name="settings_built_by">Stworzone przez</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Blokuj dokładne znaki</string>
+    <string name="settings_block_exact_desc">Dopasowanie całego znaku. Oddzielone przecinkiem lub spacją, np. W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Blokuj prefiksy znaków</string>
+    <string name="settings_block_prefix_desc">Dopasowanie prefiksu, np. RA blokuje RA0AA..RA9ZZ. Oddzielone przecinkiem lub spacją.</string>
+    <string name="settings_block_keyword_title">Blokuj słowa kluczowe</string>
+    <string name="settings_block_keyword_desc">Dopasowanie fragmentu do znaku i tekstu wiadomości, np. POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">np. W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Filtruj kontynent</string>
+    <string name="settings_conn_usb_cable">Kabel USB</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Sieć</string>
+    <string name="settings_no_usb_serial">Nie wykryto urządzeń szeregowych USB. Podłącz kabel USB do radia i spróbuj ponownie.</string>
+    <string name="settings_no_bluetooth_devices">Nie znaleziono sparowanych urządzeń Bluetooth. Najpierw sparuj urządzenie w ustawieniach Bluetooth Androida.</string>
+    <string name="settings_debug_mode_enabled">Tryb debugowania włączony</string>
+    <string name="settings_debug_mode_disabled">Tryb debugowania wyłączony</string>
+    <string name="settings_edit_operator_identity">Edytuj tożsamość operatora</string>
+    <string name="settings_callsign">Znak</string>
+    <string name="settings_callsign_hint">np. W1AW</string>
+    <string name="settings_grid_locator">Lokator</string>
+    <string name="settings_grid_locator_hint">np. FN31pr</string>
+    <string name="settings_logging_server">Serwer dziennika</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog i Nextlog przyjmują te same przesyłki.</string>
+    <string name="settings_server_address">Adres serwera</string>
+    <string name="settings_api_key">Klucz API</string>
+    <string name="settings_api_key_hint">Twój klucz API Cloudlog</string>
+    <string name="settings_loading_stations">Ładowanie stacji...</string>
+    <string name="settings_station_id">ID stacji</string>
+    <string name="settings_station_id_hint">np. 1</string>
+    <string name="settings_select_a_station">Wybierz stację</string>
+    <string name="settings_enter_manually">Wpisz ręcznie</string>
+    <string name="settings_choose_from_server">Wybierz z serwera</string>
+    <string name="settings_station_profile">Profil stacji</string>
+    <string name="settings_qrz_creds_desc">Używane do pobierania zdjęć profilowych dla zdekodowanych znaków przez QRZ XML API. Wymaga subskrypcji QRZ XML.</string>
+    <string name="settings_username">Nazwa użytkownika</string>
+    <string name="settings_username_hint">Twoja nazwa użytkownika QRZ.com</string>
+    <string name="settings_password">Hasło</string>
+    <string name="settings_enabled_bands_dialog_desc">Ukryte pasma nie pojawią się w wyborze częstotliwości.</string>
+    <string name="settings_select_serial_port">Wybierz port szeregowy</string>
+    <string name="settings_tx_volume_advice">Dostosuj na żywo — następne TX użyje tego poziomu. Obserwuj ALC radia i zmniejszaj, aż ledwo dotyka linii.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Język</string>
+    <string name="settings_language_desc">Język wyświetlania aplikacji</string>
+    <string name="settings_language_system">Domyślny systemu</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-tr/strings_compose.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">İptal</string>
+    <string name="action_save">Kaydet</string>
+    <string name="action_done">Tamam</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Çıkış</string>
+    <string name="common_none">Yok</string>
+    <string name="common_off">Kapalı</string>
+    <string name="common_not_configured">Yapılandırılmadı</string>
+    <string name="common_not_connected">Bağlı değil</string>
+    <string name="common_pass">Geçti</string>
+    <string name="common_fail">Başarısız</string>
+    <string name="common_test_connection">Bağlantıyı Test Et</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">Kuzey Amerika</string>
+    <string name="continent_sa">Güney Amerika</string>
+    <string name="continent_eu">Avrupa</string>
+    <string name="continent_af">Afrika</string>
+    <string name="continent_as">Asya</string>
+    <string name="continent_oc">Okyanusya</string>
+    <string name="continent_an">Antarktika</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">Çözümle</string>
+    <string name="tab_map">Harita</string>
+    <string name="tab_waterfall">Şelale</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Günlük</string>
+    <string name="tab_settings">Ayarlar</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">YENİ DXCC</string>
+    <string name="status_new_grid">YENİ GRID</string>
+    <string name="status_new_band">YENİ BANT</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">YENİ POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">GEREKLİ</string>
+    <string name="status_worked">YAPILDI</string>
+    <string name="status_confirmed">ONAYLANDI</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">BEKLİYOR</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · MOBİL YARDIMCI</string>
+    <string name="splash_initializing">RADYO BAŞLATILIYOR</string>
+    <string name="splash_version">v%1$s · derleme %2$s</string>
+    <string name="app_set_callsign_first">CQ çağrısı yapmadan önce Ayarlar\'da çağrı işaretinizi girin</string>
+    <string name="app_hunt_on">Av açık — CQ\'lara otomatik yanıt veriliyor</string>
+    <string name="app_hunt_off">Av kapalı — CQ yapılıyor, yalnızca yanıtlar işleniyor</string>
+    <string name="app_mode_switched">Mod: %1$s</string>
+    <string name="app_mode_switch_busy">Yayın sırasında mod değiştirilemez</string>
+    <string name="main_tx_volume">TX Sesi: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">FT8AF\'TEN ÇIKILSIN MI?</string>
+    <string name="exit_message">Uygulamayı kapatmak istediğinizden emin misiniz? Aktif tüm QSO\'lar iptal edilecek.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">FREKANS SEÇ</string>
+    <string name="freq_show_alternates">ALTERNATİFLERİ GÖSTER</string>
+    <string name="freq_hide_alternates">ALTERNATİFLERİ GİZLE</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">ÇAĞRI YOK</string>
+    <string name="op_no_grid">Grid ayarlanmadı</string>
+    <string name="op_tap_to_edit">Düzenlemek için dokunun</string>
+    <string name="op_stat_rig">CİHAZ</string>
+    <string name="op_stat_antenna">ANTEN</string>
+    <string name="op_stat_power">GÜÇ</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">QSO\'LARI DIŞA AKTAR</string>
+    <string name="export_date_range">TARİH ARALIĞI</string>
+    <string name="export_date_from_placeholder">"Başlangıç  YYYYAAGG"</string>
+    <string name="export_date_to_placeholder">"Bitiş  YYYYAAGG"</string>
+    <string name="export_share">Paylaş</string>
+    <string name="export_filter_confirmed">yalnızca onaylı</string>
+    <string name="export_filter_unconfirmed">yalnızca onaysız</string>
+    <string name="export_record_singular">kayıt</string>
+    <string name="export_record_plural">kayıt</string>
+    <string name="export_summary_all">tümü</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s, %3$s%4$s ile eşleşiyor</string>
+    <string name="export_preparing">Hazırlanıyor…</string>
+    <string name="export_share_chooser_title">QSO günlüklerini paylaş</string>
+    <string name="export_saved_to">%1$s konumuna kaydedildi</string>
+    <string name="export_save_failed">İndirilenler\'e kaydetme başarısız</string>
+    <string name="export_temp_file_failed">Geçici dosya oluşturulamadı</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">YAYINDA</string>
+    <string name="tx_listening">DİNLENİYOR</string>
+    <string name="tx_hunt">Av</string>
+    <string name="tx_call_cq">CQ Çağrısı</string>
+    <string name="tx_stop">Durdur</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">DXpedition ile QSO yap (Hound)</string>
+    <string name="hound_help">Önce cihazı Fox\'un yayımladığı kadran frekansına ayarlayın. Siz yüksekten çağırırsınız (1000–4000 Hz); uygulama sizi Fox\'un yanıtladığı yere otomatik QSY eder ve raporunuzla yanıt verir.</string>
+    <string name="hound_fox_callsign">Fox çağrı işareti</string>
+    <string name="hound_call_frequency">Çağrı frekansı (Hz, 1000–4000)</string>
+    <string name="hound_start">Başlat</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT bağlı — yeniden bağlanmak için dokunun</string>
+    <string name="cat_status_connecting">CAT bağlanıyor…</string>
+    <string name="cat_status_disconnected">CAT bağlı değil — bağlanmak için dokunun</string>
+    <string name="cat_status_error">CAT bağlantı hatası — yeniden denemek için dokunun</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX DURDURULDU — Yüksek SWR algılandı (%1$s)</string>
+    <string name="swr_lockout_body">Yayın yapmadan önce anteni / besleme hattını kontrol edin.</string>
+    <string name="swr_lockout_dismiss">KAPAT</string>
+    <string name="swr_lockout_toast">TX engellendi — SWR kilidi etkin. Önce kilit afişini kapatın.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">CQ çağrılıyor</string>
+    <string name="qsopanel_searching">Aranıyor...</string>
+    <string name="qsopanel_qsoing_with">%1$s ile QSO yapılıyor</string>
+    <string name="qsopanel_waiting_for">%1$s bekleniyor</string>
+    <string name="qsopanel_tap_to_view">görüntülemek için dokunun ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">Mesajlar bekleniyor...</string>
+    <string name="qsopanel_log_action">GÜNLÜK</string>
+    <string name="qsopanel_queue">SIRA</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Çözümle</string>
+    <string name="decode_subtitle">"%1$s  •  bu döngüde %2$d çözümlendi"</string>
+    <string name="decode_clear_list">Çözümleme listesini temizle</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Tümü</string>
+    <string name="decode_filter_cq_calls">CQ Çağrıları</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">Yeni DXCC</string>
+    <string name="decode_filter_needed">Gerekli</string>
+    <string name="decode_filter_for_me">Bana</string>
+    <string name="decode_empty_cq_title">CQ çağrısı yok</string>
+    <string name="decode_empty_cq_body">Şu anda bu bantta CQ çağıran istasyon yok.</string>
+    <string name="decode_empty_pota_title">POTA spotu yok</string>
+    <string name="decode_empty_pota_body">Bu bantta henüz park aktivasyonu çözümlenmedi — spot listesi için POTA → Av\'ı açın.</string>
+    <string name="decode_empty_dxcc_title">Yeni DXCC yok</string>
+    <string name="decode_empty_dxcc_body">Henüz çözümlenmiş, daha önce yapılmamış DXCC bölgesi yok.</string>
+    <string name="decode_empty_needed_title">Gerekli bir şey yok</string>
+    <string name="decode_empty_needed_body">Onay gerektiren istasyon bulunamadı.</string>
+    <string name="decode_empty_forme_title">Size çağrı yok</string>
+    <string name="decode_empty_forme_body">Şu anda çağrı işaretinizi çağıran istasyon yok.</string>
+    <string name="decode_empty_default_title">Çözümlenen sinyal yok</string>
+    <string name="decode_empty_default_body">FT8 sinyallerinin görünmesi bekleniyor...</string>
+    <string name="decode_label_calling">→ ÇAĞIRIYOR</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ SİZE</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO Tamamlandı</string>
+    <string name="qso_call_action">%1$s çağır</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Sinyal</string>
+    <string name="qso_stat_distance">Mesafe</string>
+    <string name="qso_stat_azimuth">Azimut</string>
+    <string name="qso_stat_band">Bant</string>
+    <string name="qso_sequence_header">QSO SIRASI</string>
+    <string name="qso_step_send_call">Çağrı gönder</string>
+    <string name="qso_step_report_sent">Rapor gönderildi</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Onayla</string>
+    <string name="qso_step_logged">Günlüğe işlendi</string>
+    <string name="qso_live_sending">%1$s ile QSO — %2$s gönderiliyor</string>
+    <string name="qso_live_waiting">%1$s\'in yanıtı bekleniyor…</string>
+    <string name="qso_live_transmitting">Yayın yapılıyor…</string>
+    <string name="qso_live_step_fallback">mesaj</string>
+    <string name="qso_tx_now">ŞİMDİ TX</string>
+    <string name="qso_tx_next">SONRAKİ TX</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">İstatistik</string>
+    <string name="log_tab_recent">Son</string>
+    <string name="log_tab_awards">Ödüller</string>
+    <string name="log_title">Günlük</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSO · Tüm bantlar</string>
+    <string name="log_cd_sync_to_logging_services">Günlükleme servisleriyle eşitle</string>
+    <string name="log_cd_export_qsos">QSO\'ları dışa aktar</string>
+    <string name="log_stat_total_qsos">Toplam QSO</string>
+    <string name="log_stat_dxcc_entities">DXCC Bölgeleri</string>
+    <string name="log_stat_cq_zones">CQ Bölgeleri</string>
+    <string name="log_stat_itu_zones">ITU Bölgeleri</string>
+    <string name="log_section_band_distribution">Bant Dağılımı</string>
+    <string name="log_section_award_progress">Ödül İlerlemesi</string>
+    <string name="log_award_dxcc_mixed">DXCC Karışık</string>
+    <string name="log_award_vucc_grid_squares">VUCC Grid Kareleri</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Grid Kapsamı</string>
+    <string name="log_section_signal_trend">Sinyal Eğilimi</string>
+    <string name="log_no_qsos_yet">Henüz QSO yok</string>
+    <string name="log_no_qsos_recorded_yet">Henüz kaydedilmiş QSO yok</string>
+    <string name="log_state_usa">%1$s, ABD</string>
+    <string name="log_cd_qso_actions">QSO işlemleri</string>
+    <string name="log_action_edit">Düzenle</string>
+    <string name="log_action_delete">Sil</string>
+    <string name="log_award_dxcc_mixed_desc">Herhangi bir bant/modda 100 DXCC bölgesi yapın ve onaylayın</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">50 ABD eyaletinin tümünü onaylı olarak yapın</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">40 CQ bölgesinin tümünü onaylı olarak yapın</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- tek bantta 100 grid karesi</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- belirlenen adalardaki istasyonlarla QSO yapın</string>
+    <string name="log_edit_qso">QSO\'yu Düzenle</string>
+    <string name="log_field_callsign">Çağrı İşareti</string>
+    <string name="log_field_grid_locator">Grid Konumu</string>
+    <string name="log_field_mode">Mod</string>
+    <string name="log_delete_qso_title">QSO SİLİNSİN Mİ?</string>
+    <string name="log_delete_qso_body_callsign">%1$s ile yapılan QSO günlükten kaldırılsın mı? Bu işlem geri alınamaz.</string>
+    <string name="log_delete_qso_body">Bu QSO günlükten kaldırılsın mı? Bu işlem geri alınamaz.</string>
+    <string name="log_sync_title_no_services">ETKİN SERVİS YOK</string>
+    <string name="log_sync_title_syncing">EŞİTLENİYOR…</string>
+    <string name="log_sync_title_complete">EŞİTLEME TAMAMLANDI</string>
+    <string name="log_sync_enable_services">Ayarlar\'da Cloudlog/Wavelog/Nextlog veya QRZ\'yi etkinleştirip yeniden deneyin.</string>
+    <string name="log_sync_progress_count">%2$d QSO\'dan %1$d</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d kabul edildi</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d kabul edildi</string>
+    <string name="log_sync_nothing_to_upload">Günlükte henüz yüklenecek QSO yok.</string>
+    <string name="log_sync_working">İşleniyor…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Aktive Et</string>
+    <string name="pota_tab_hunt">Av</string>
+    <string name="pota_tab_history">Geçmiş</string>
+    <string name="pota_start_activation">Aktivasyonu başlat</string>
+    <string name="pota_park_reference_label">Park referansı (ör. K-1234)</string>
+    <string name="pota_notes_optional_label">Notlar (isteğe bağlı)</string>
+    <string name="pota_enter_park_reference_first">Önce bir park referansı girin</string>
+    <string name="pota_activating">%1$s aktive ediliyor</string>
+    <string name="pota_activation_ended">Aktivasyon sona erdi</string>
+    <string name="pota_set_callsign_first">Önce Ayarlar\'da çağrı işaretinizi girin</string>
+    <string name="pota_self_spot_posted">Kendi spotunuz gönderildi</string>
+    <string name="pota_self_spot_failed">Kendi spotu başarısız — günlüğe bakın</string>
+    <string name="pota_active_park">AKTİF — %1$s</string>
+    <string name="pota_qsos">QSO</string>
+    <string name="pota_contacts_map">Bağlantı haritası</string>
+    <string name="pota_back">Geri</string>
+    <string name="pota_valid_activation">geçerli aktivasyon</string>
+    <string name="pota_to_valid">geçerlilik için %1$d</string>
+    <string name="pota_elapsed">Geçen süre</string>
+    <string name="pota_since_start">başlangıçtan beri</string>
+    <string name="pota_self_spot">Kendi spotu</string>
+    <string name="pota_end_activation">Aktivasyonu bitir</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">TX CQ şu şekilde yayımlanacak: “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Şu anda FT8 POTA spotu yok.</string>
+    <string name="pota_active_spots">%1$d aktif FT8 spotu</string>
+    <string name="pota_targeting">%1$s @ %2$s kHz (%3$s) hedefleniyor — çağırmak için Çözümle\'ye geçin</string>
+    <string name="pota_no_past_activations">Henüz geçmiş aktivasyon yok.</string>
+    <string name="pota_no_browser_available">Kullanılabilir tarayıcı yok</string>
+    <string name="pota_export_failed">Dışa aktarma başarısız — günlüğe bakın</string>
+    <string name="pota_status_active">aktif</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">ADIF paylaş</string>
+    <string name="pota_open_pota_app">pota.app\'i aç</string>
+    <string name="pota_upload_to_pota">POTA\'ya yükle</string>
+    <string name="pota_upload_success">%1$d park günlüğü POTA\'ya yüklendi</string>
+    <string name="pota_upload_failed">Yükleme başarısız: %1$s</string>
+    <string name="pota_upload_server_error">POTA yüklemeyi işleyemedi. Park referansının geçerli ve çağrı işaretinizin POTA\'ya kayıtlı olduğundan emin olup yeniden deneyin.</string>
+    <string name="pota_upload_network_error">POTA\'ya ulaşılamadı. İnternet bağlantınızı kontrol edip yeniden deneyin.</string>
+    <string name="pota_login_title">POTA\'ya giriş yap</string>
+    <string name="pota_login_desc">pota.app hesabınızın e-posta ve parolasını kullanın.</string>
+    <string name="pota_login_email">E-posta</string>
+    <string name="pota_login_password">Parola</string>
+    <string name="pota_login_button">Giriş yap</string>
+    <string name="pota_login_cancel">İptal</string>
+    <string name="pota_login_failed">Giriş başarısız: %1$s</string>
+    <string name="pota_login_or">veya</string>
+    <string name="pota_login_social">Google / Facebook / Amazon ile giriş yap</string>
+    <string name="pota_oauth_title">POTA\'ya giriş yap</string>
+    <string name="pota_add_park">Park ekle</string>
+    <string name="pota_remove_park">Kaldır</string>
+    <string name="pota_max_parks_reached">En fazla 10 parka ulaşıldı</string>
+    <string name="pota_spotted_n_parks">%1$d parkta spotlandı</string>
+    <string name="pota_parks_more">+%1$d daha</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Hata Ayıklama</string>
+    <string name="debug_line_count">%1$d satır</string>
+    <string name="debug_logcat_on_suffix">" · logcat AÇIK"</string>
+    <string name="debug_close">Kapat</string>
+    <string name="debug_share">Paylaş</string>
+    <string name="debug_clear">Temizle</string>
+    <string name="debug_logcat_on">Logcat: AÇIK</string>
+    <string name="debug_logcat_off">Logcat: KAPALI</string>
+    <string name="debug_no_log_file">günlük dosyası yok</string>
+    <string name="debug_log_cleared">günlük temizlendi</string>
+    <string name="debug_share_chooser_title">debug.log\'u paylaş</string>
+    <string name="map_title">Harita</string>
+    <string name="map_no_grid_set">Grid ayarlanmadı</string>
+    <string name="map_station_count">%1$d istasyon</string>
+    <string name="map_station_count_with_heard">%1$d istasyon · %2$d duyuldu</string>
+    <string name="map_psk_error">PSK Reporter kullanılamıyor: %1$s</string>
+    <string name="map_projection_equirectangular">Eşdörtgen</string>
+    <string name="map_projection_azimuthal">Azimutal Eşit Uzaklık</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">Mesafe</string>
+    <string name="map_info_bearing">Yön</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Şelale</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">CANLI</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d deneme</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%2$d bandın %1$d\'i etkin</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Derleme %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Ayarlar</string>
+    <string name="settings_section_operator_identity">OPERATÖR KİMLİĞİ</string>
+    <string name="settings_section_radio">RADYO</string>
+    <string name="settings_section_audio">SES</string>
+    <string name="settings_section_transmission">YAYIN</string>
+    <string name="settings_section_auto_sequence">OTOMATİK SIRA</string>
+    <string name="settings_section_decode_highlights">ÇÖZÜMLEME VURGULARI</string>
+    <string name="settings_section_callsign_blocklist">ÇAĞRI İŞARETİ ENGEL LİSTESİ</string>
+    <string name="settings_section_decode_filters">ÇÖZÜMLEME FİLTRELERİ</string>
+    <string name="settings_section_needed_dx_alerts">GEREKLİ-DX UYARILARI</string>
+    <string name="settings_section_logging_awards">GÜNLÜK &amp; ÖDÜLLER</string>
+    <string name="settings_section_advanced">GELİŞMİŞ</string>
+    <string name="settings_section_about">HAKKINDA</string>
+    <string name="settings_section_language">DİL</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Radyo &amp; Ses</string>
+    <string name="settings_cat_transmission">Yayın</string>
+    <string name="settings_cat_decode_filters">Çözümleme &amp; Filtreler</string>
+    <string name="settings_cat_logging">Günlük &amp; Ödüller</string>
+    <string name="settings_cat_advanced">Gelişmiş</string>
+    <string name="settings_cat_about">Hakkında</string>
+    <string name="settings_cat_time_sync">Zaman Eşitleme</string>
+    <string name="settings_cat_time_sync_desc">Çevrimdışı çalışma için manuel saat düzeltmesi</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Manuel Düzeltme</string>
+    <string name="settings_time_current_label">Geçerli düzeltme</string>
+    <string name="settings_time_correction_reset">0\'a sıfırla</string>
+    <string name="settings_time_correction_desc">Eşitlemek için internetiniz olmadığında uygulama saatini ayarlayın. FT8, UTC için yaklaşık 1 saniye hassasiyet gerektirir. Çözümlenen istasyonların DT sütunu 0\'a yakın ortalanana kadar ayarlayın.</string>
+    <string name="settings_time_suggest_section">Çözümlemelerden önerilen</string>
+    <string name="settings_time_suggest_none">Henüz çözümleme yok — öneri almak için alıma başlayın.</string>
+    <string name="settings_time_suggest_label">Son ortalama DT: %1$s</string>
+    <string name="settings_time_suggest_apply">Önerilen düzeltmeyi uygula</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Grid\'i Otomatik Güncelle (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Maidenhead grid\'inizi güncel tutmak için cihaz GPS\'ini kullanın</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Cihaz Modeli</string>
+    <string name="settings_control_mode">Kontrol Modu</string>
+    <string name="settings_connection_mode">Bağlantı Modu</string>
+    <string name="settings_baud_rate">Baud Hızı</string>
+    <string name="settings_band_frequency">Bant &amp; Frekans</string>
+    <string name="settings_enabled_bands">Etkin Bantlar</string>
+    <string name="settings_audio_frequency">Ses Frekansı</string>
+    <string name="settings_spectrum_width">Spektrum Genişliği</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Ses Girişi</string>
+    <string name="settings_audio_output">Ses Çıkışı</string>
+    <string name="settings_tx_volume">TX Sesi</string>
+    <string name="settings_tx_volume_desc" formatted="false">Yayın ses düzeyi (donanım düğmeleri ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">TX/RX Ayrımı</string>
+    <string name="settings_tx_rx_split_desc">Alımdan farklı bir frekansta yayın yapın</string>
+    <string name="settings_tx_watchdog">TX Bekçisi</string>
+    <string name="settings_tx_watchdog_desc">Zaman aşımından sonra yayını otomatik durdur</string>
+    <string name="settings_stop_after">Şundan Sonra Durdur</string>
+    <string name="settings_stop_after_desc">N yanıtsız denemeden sonra çağrıyı durdur</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Av (CQ\'lara otomatik yanıt)</string>
+    <string name="settings_hunt_desc">CQ çağıran istasyonları proaktif olarak çağırın. TX çubuğundaki AV düğmesiyle aynı. Kapalı = CQ yapın ve yalnızca size yanıt veren istasyonlarla QSO yapın.</string>
+    <string name="settings_auto_call_followed">Takip Edileni Otomatik Çağır</string>
+    <string name="settings_auto_call_followed_desc">Takip edilen çağrı işaretlerini otomatik olarak çağırmaya devam et</string>
+    <string name="settings_fast_turnaround">Hızlı dönüş</string>
+    <string name="settings_fast_turnaround_desc">Beklemek yerine bir sonraki yuvada CQ\'ya yanıt verebilmeniz için ~1s daha erken çözümleyin. Büyük saat sapması olan istasyonları kaçırabilir.</string>
+    <string name="settings_auto_cq_after_qso">QSO sonrası Otomatik CQ</string>
+    <string name="settings_auto_cq_after_qso_desc">Tamamlanan her bağlantıdan sonra otomatik olarak CQ çağırmaya devam et — yeniden dokunma yok. Frekansınızda kalır (Av\'ı yok sayar). Siz durdurana veya TX Bekçisi yanıtsız zaman aşımına uğrayana kadar çalışır.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">Yeni DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">Daha önce yapılmamış bir DXCC bölgesinden gelen istasyonları vurgula</string>
+    <string name="settings_highlight_new_grid">Yeni Grid</string>
+    <string name="settings_highlight_new_grid_desc">Henüz yapılmamış Maidenhead grid\'lerini vurgula</string>
+    <string name="settings_highlight_new_band">Yeni Bant</string>
+    <string name="settings_highlight_new_band_desc">Yalnızca diğer bantlarda yapılmış istasyonları vurgula</string>
+    <string name="settings_highlight_pota">POTA Aktivatörleri</string>
+    <string name="settings_highlight_pota_desc">Spotlanan POTA aktivatörlerini vurgula; yeni parklar öne çıkar</string>
+    <string name="settings_highlight_worked">Daha Önce Yapıldı</string>
+    <string name="settings_highlight_worked_desc">Günlüğünüzde zaten olan istasyonları işaretle</string>
+    <string name="settings_distance_unit">Mesafe Mil Olarak</string>
+    <string name="settings_distance_unit_desc">Mesafeleri kilometre yerine mil olarak göster</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Tam Çağrı İşaretleri</string>
+    <string name="settings_exact_callsigns_desc">Tam çağrı eşleşmelerini engelle</string>
+    <string name="settings_prefixes">Ön Ekler</string>
+    <string name="settings_prefixes_desc">Çağrı işareti ön ekine göre engelle (ör. RA)</string>
+    <string name="settings_keywords">Anahtar Sözcükler</string>
+    <string name="settings_keywords_desc">Çağrı veya mesajdaki alt dizeye göre engelle (ör. POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Yalnızca CQ Göster</string>
+    <string name="settings_show_only_cq_desc">CQ türü mesajlar dışındaki her şeyi gizle</string>
+    <string name="settings_dx_only">Yalnızca DX</string>
+    <string name="settings_dx_only_desc">Yalnızca kendi kıtanız dışındaki istasyonları göster</string>
+    <string name="settings_needed_only">Yalnızca Gerekli</string>
+    <string name="settings_needed_only_desc">Yalnızca henüz onaylanmamış (QSL) istasyonları göster</string>
+    <string name="settings_filter_by_continent">Kıtaya Göre Filtrele</string>
+    <string name="settings_filter_by_continent_desc">Yalnızca seçilen bir kıtadan gelen istasyonları göster</string>
+    <string name="settings_continent">Kıta</string>
+    <string name="settings_skip_directional_cq">Yönlü CQ\'ları Atla (otomatik yanıt)</string>
+    <string name="settings_skip_directional_cq_desc">Farklı bir DXCC\'ye yönelik CQ DX/EU/JA… çağrılarına otomatik yanıt verme</string>
+    <string name="settings_hide_directional_cq">Bana Olmayan Yönlü CQ\'ları Gizle</string>
+    <string name="settings_hide_directional_cq_desc">DXCC\'nizi hedeflemeyen bölgesel CQ\'ları gizle</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">Yeni DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">Yapılmamış bir DXCC bölgesi CQ çağırdığında ses + titreşim + bildirim</string>
+    <string name="settings_alert_new_state">Yeni ABD Eyaleti</string>
+    <string name="settings_alert_new_state_desc">Yapılmamış bir ABD eyaletinden istasyon CQ çağırdığında ses + titreşim + bildirim (eyalet grid\'den)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">SWL Çözümlemelerini Kaydet</string>
+    <string name="settings_save_swl_decodes_desc">Çözümlenen tüm mesajları veritabanına kaydet</string>
+    <string name="settings_save_swl_qsos">SWL QSO\'larını Kaydet</string>
+    <string name="settings_save_swl_qsos_desc">Diğer istasyonlar arasında algılanan QSO\'ları kaydet</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Çözümlenen spotları pskreporter.info\'ya yükle</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">QSO\'ları QRZ Günlüğü\'ne otomatik yükle</string>
+    <string name="settings_qrz_profile_lookup">QRZ Profil Sorgulama</string>
+    <string name="settings_qrz_profile_lookup_desc">QRZ XML API için kullanıcı adı + parola (avatarlar)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">QSO\'ları bir Cloudlog, Wavelog veya Nextlog örneğine otomatik yükle</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">PTT Gecikmesi</string>
+    <string name="settings_ptt_delay_desc">PTT\'den sonra yayın sesi başlamadan önceki gecikme</string>
+    <string name="settings_tx_delay">TX Gecikmesi</string>
+    <string name="settings_tx_delay_desc">Önceki döngünün çözümlenmesine izin vermek için yayından önceki gecikme</string>
+    <string name="settings_late_start_tolerance">Geç Başlama Toleransı</string>
+    <string name="settings_late_start_tolerance_desc">TX\'in döngüye N ms\'ye kadar geç başlamasına izin ver; TX döngü sınırında bitsin diye baştaki ses kırpılır</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">SSS &amp; Destek</string>
+    <string name="settings_report_bug">Hata Bildir</string>
+    <string name="bug_report_description_hint">Neyin yanlış gittiğini açıklayın…</string>
+    <string name="bug_report_send_email">E-posta gönder</string>
+    <string name="bug_report_no_email_app">Raporu göndermek için e-posta uygulaması bulunamadı</string>
+    <string name="bug_report_open_github">GitHub sorunu aç</string>
+    <string name="settings_debug">Hata Ayıklama</string>
+    <string name="settings_debug_desc">debug.log\'u görüntüle / paylaş</string>
+    <string name="settings_about_body">Sürüm %1$s (derleme %2$s)\nDerleme tarihi %3$s\n\nFT8, kolaylaştırıldı.\n\nAndroid için bağımsız bir FT8 alıcı-verici uygulaması. Otomatik sıralama ve günlükleme ile USB, Bluetooth ve ağ üzerinden cihaz kontrolü.</string>
+    <string name="settings_website">Web Sitesi</string>
+    <string name="settings_community">Topluluk</string>
+    <string name="settings_built_by">Yapan</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Tam Çağrı İşaretlerini Engelle</string>
+    <string name="settings_block_exact_desc">Tam çağrı eşleşmesi. Virgül veya boşlukla ayrılmış, ör. W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Çağrı İşareti Ön Eklerini Engelle</string>
+    <string name="settings_block_prefix_desc">Ön ek eşleşmesi, ör. RA, RA0AA..RA9ZZ\'yi engeller. Virgül veya boşlukla ayrılmış.</string>
+    <string name="settings_block_keyword_title">Anahtar Sözcükleri Engelle</string>
+    <string name="settings_block_keyword_desc">Çağrı ve mesaj metnine karşı alt dize eşleşmesi, ör. POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">ör. W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Kıta Filtrele</string>
+    <string name="settings_conn_usb_cable">USB Kablo</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Ağ</string>
+    <string name="settings_no_usb_serial">USB seri cihaz algılanmadı. Lütfen radyonuza bir USB kablo bağlayıp yeniden deneyin.</string>
+    <string name="settings_no_bluetooth_devices">Eşleştirilmiş Bluetooth cihazı bulunamadı. Önce Android Bluetooth ayarlarında bir cihaz eşleştirin.</string>
+    <string name="settings_debug_mode_enabled">Hata ayıklama modu etkin</string>
+    <string name="settings_debug_mode_disabled">Hata ayıklama modu devre dışı</string>
+    <string name="settings_edit_operator_identity">Operatör Kimliğini Düzenle</string>
+    <string name="settings_callsign">Çağrı İşareti</string>
+    <string name="settings_callsign_hint">ör. W1AW</string>
+    <string name="settings_grid_locator">Grid Konumu</string>
+    <string name="settings_grid_locator_hint">ör. FN31pr</string>
+    <string name="settings_logging_server">Günlükleme Sunucusu</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog ve Nextlog aynı yüklemeleri kabul eder.</string>
+    <string name="settings_server_address">Sunucu Adresi</string>
+    <string name="settings_api_key">API Anahtarı</string>
+    <string name="settings_api_key_hint">Cloudlog API anahtarınız</string>
+    <string name="settings_loading_stations">İstasyonlar yükleniyor...</string>
+    <string name="settings_station_id">İstasyon Kimliği</string>
+    <string name="settings_station_id_hint">ör. 1</string>
+    <string name="settings_select_a_station">Bir istasyon seçin</string>
+    <string name="settings_enter_manually">Elle gir</string>
+    <string name="settings_choose_from_server">Sunucudan seç</string>
+    <string name="settings_station_profile">İstasyon Profili</string>
+    <string name="settings_qrz_creds_desc">QRZ XML API üzerinden çözümlenen çağrı işaretleri için profil fotoğrafı almakta kullanılır. QRZ XML aboneliği gerektirir.</string>
+    <string name="settings_username">Kullanıcı Adı</string>
+    <string name="settings_username_hint">QRZ.com kullanıcı adınız</string>
+    <string name="settings_password">Parola</string>
+    <string name="settings_enabled_bands_dialog_desc">Gizli bantlar frekans seçicilerde görünmez.</string>
+    <string name="settings_select_serial_port">Seri Port Seç</string>
+    <string name="settings_tx_volume_advice">Canlı ayarlayın — bir sonraki TX\'iniz bu düzeyi kullanır. Radyonuzun ALC\'sini izleyin ve çizgiye değecek kadar düşürün.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Dil</string>
+    <string name="settings_language_desc">Uygulama görüntüleme dili</string>
+    <string name="settings_language_system">Sistem varsayılanı</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-uk/strings_compose.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">Скасувати</string>
+    <string name="action_save">Зберегти</string>
+    <string name="action_done">Готово</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Вийти</string>
+    <string name="common_none">Немає</string>
+    <string name="common_off">Вимк.</string>
+    <string name="common_not_configured">Не налаштовано</string>
+    <string name="common_not_connected">Не під’єднано</string>
+    <string name="common_pass">Пройдено</string>
+    <string name="common_fail">Не пройдено</string>
+    <string name="common_test_connection">Перевірити з’єднання</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">Північна Америка</string>
+    <string name="continent_sa">Південна Америка</string>
+    <string name="continent_eu">Європа</string>
+    <string name="continent_af">Африка</string>
+    <string name="continent_as">Азія</string>
+    <string name="continent_oc">Океанія</string>
+    <string name="continent_an">Антарктида</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">Декод</string>
+    <string name="tab_map">Карта</string>
+    <string name="tab_waterfall">Водоспад</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Журнал</string>
+    <string name="tab_settings">Налаштування</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">НОВИЙ DXCC</string>
+    <string name="status_new_grid">НОВИЙ ЛОКАТОР</string>
+    <string name="status_new_band">НОВИЙ ДІАПАЗОН</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">НОВИЙ POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">ПОТРІБНО</string>
+    <string name="status_worked">ПРОВЕДЕНО</string>
+    <string name="status_confirmed">ПІДТВЕРДЖЕНО</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">В ОЧІКУВАННІ</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · МОБІЛЬНИЙ ПОМІЧНИК</string>
+    <string name="splash_initializing">ІНІЦІАЛІЗАЦІЯ РАДІО</string>
+    <string name="splash_version">v%1$s · збірка %2$s</string>
+    <string name="app_set_callsign_first">Вкажіть свій позивний у Налаштуваннях, перш ніж викликати CQ</string>
+    <string name="app_hunt_on">Полювання увімк. — автовідповідь на CQ</string>
+    <string name="app_hunt_off">Полювання вимк. — виклик CQ, лише робота з відповідями</string>
+    <string name="app_mode_switched">Режим: %1$s</string>
+    <string name="app_mode_switch_busy">Неможливо змінити режим під час передавання</string>
+    <string name="main_tx_volume">Гучність TX: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">ВИЙТИ З FT8AF?</string>
+    <string name="exit_message">Ви впевнені, що хочете закрити застосунок? Будь-який активний QSO буде скасовано.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">ВИБІР ЧАСТОТИ</string>
+    <string name="freq_show_alternates">ПОКАЗАТИ АЛЬТЕРНАТИВНІ</string>
+    <string name="freq_hide_alternates">ПРИХОВАТИ АЛЬТЕРНАТИВНІ</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">НЕМАЄ ПОЗИВНОГО</string>
+    <string name="op_no_grid">Локатор не вказано</string>
+    <string name="op_tap_to_edit">Торкніться, щоб змінити</string>
+    <string name="op_stat_rig">ТРАНСИВЕР</string>
+    <string name="op_stat_antenna">АНТЕНА</string>
+    <string name="op_stat_power">ПОТУЖНІСТЬ</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">ЕКСПОРТ QSOs</string>
+    <string name="export_date_range">ДІАПАЗОН ДАТ</string>
+    <string name="export_date_from_placeholder">"From  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"To  YYYYMMDD"</string>
+    <string name="export_share">Поділитися</string>
+    <string name="export_filter_confirmed">лише підтверджені</string>
+    <string name="export_filter_unconfirmed">лише непідтверджені</string>
+    <string name="export_record_singular">запис</string>
+    <string name="export_record_plural">записів</string>
+    <string name="export_summary_all">усі</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s відповідає %3$s%4$s</string>
+    <string name="export_preparing">Підготовка…</string>
+    <string name="export_share_chooser_title">Поділитися журналами QSO</string>
+    <string name="export_saved_to">Збережено в %1$s</string>
+    <string name="export_save_failed">Не вдалося зберегти в Завантаження</string>
+    <string name="export_temp_file_failed">Не вдалося створити тимчасовий файл</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">ПЕРЕДАВАННЯ</string>
+    <string name="tx_listening">ПРОСЛУХОВУВАННЯ</string>
+    <string name="tx_hunt">Полювання</string>
+    <string name="tx_call_cq">Викликати CQ</string>
+    <string name="tx_stop">Стоп</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Робота з DXpedition (Hound)</string>
+    <string name="hound_help">Спочатку налаштуйте трансивер на оголошену частоту Fox. Ви викликаєте вгорі (1000–4000 Hz); застосунок автоматично переводить вас (QSY) униз туди, де відповідає Fox, і надсилає ваш рапорт.</string>
+    <string name="hound_fox_callsign">Позивний Fox</string>
+    <string name="hound_call_frequency">Частота виклику (Hz, 1000–4000)</string>
+    <string name="hound_start">Старт</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT під’єднано — торкніться, щоб перепід’єднатися</string>
+    <string name="cat_status_connecting">CAT під’єднання…</string>
+    <string name="cat_status_disconnected">CAT від’єднано — торкніться, щоб під’єднатися</string>
+    <string name="cat_status_error">Помилка з’єднання CAT — торкніться, щоб повторити</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX ЗУПИНЕНО — Виявлено високий SWR (%1$s)</string>
+    <string name="swr_lockout_body">Перевірте антену / фідер перед передаванням.</string>
+    <string name="swr_lockout_dismiss">ЗАКРИТИ</string>
+    <string name="swr_lockout_toast">TX заблоковано — активне блокування за SWR. Спочатку закрийте банер блокування.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">Виклик CQ</string>
+    <string name="qsopanel_searching">Пошук...</string>
+    <string name="qsopanel_qsoing_with">QSO з %1$s</string>
+    <string name="qsopanel_waiting_for">Очікування %1$s</string>
+    <string name="qsopanel_tap_to_view">торкніться, щоб переглянути ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">Очікування повідомлень...</string>
+    <string name="qsopanel_log_action">ЖУРНАЛ</string>
+    <string name="qsopanel_queue">ЧЕРГА</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Декод</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d декодовано за цей цикл"</string>
+    <string name="decode_clear_list">Очистити список декодування</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Усі</string>
+    <string name="decode_filter_cq_calls">Виклики CQ</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">Новий DXCC</string>
+    <string name="decode_filter_needed">Потрібні</string>
+    <string name="decode_filter_for_me">Для мене</string>
+    <string name="decode_empty_cq_title">Немає викликів CQ</string>
+    <string name="decode_empty_cq_body">Зараз на цьому діапазоні жодна станція не викликає CQ.</string>
+    <string name="decode_empty_pota_title">Немає спотів POTA</string>
+    <string name="decode_empty_pota_body">На цьому діапазоні ще не декодовано активацій парків — відкрийте POTA → Полювання, щоб переглянути список спотів.</string>
+    <string name="decode_empty_dxcc_title">Немає нових DXCC</string>
+    <string name="decode_empty_dxcc_body">Ще не декодовано непроведених об’єктів DXCC.</string>
+    <string name="decode_empty_needed_title">Нічого не потрібно</string>
+    <string name="decode_empty_needed_body">Станцій, що потребують підтвердження, не знайдено.</string>
+    <string name="decode_empty_forme_title">Немає викликів для вас</string>
+    <string name="decode_empty_forme_body">Зараз жодна станція не викликає ваш позивний.</string>
+    <string name="decode_empty_default_title">Сигналів не декодовано</string>
+    <string name="decode_empty_default_body">Очікування появи сигналів FT8...</string>
+    <string name="decode_label_calling">→ ВИКЛИК</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ ВАМ</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO завершено</string>
+    <string name="qso_call_action">Викликати %1$s</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Сигнал</string>
+    <string name="qso_stat_distance">Відстань</string>
+    <string name="qso_stat_azimuth">Азимут</string>
+    <string name="qso_stat_band">Діапазон</string>
+    <string name="qso_sequence_header">ПОСЛІДОВНІСТЬ QSO</string>
+    <string name="qso_step_send_call">Надіслати позивний</string>
+    <string name="qso_step_report_sent">Рапорт надіслано</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Підтвердити</string>
+    <string name="qso_step_logged">Записано</string>
+    <string name="qso_live_sending">QSO з %1$s — Надсилання %2$s</string>
+    <string name="qso_live_waiting">Очікування відповіді від %1$s…</string>
+    <string name="qso_live_transmitting">Передавання…</string>
+    <string name="qso_live_step_fallback">повідомлення</string>
+    <string name="qso_tx_now">TX ЗАРАЗ</string>
+    <string name="qso_tx_next">TX ДАЛІ</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">Статистика</string>
+    <string name="log_tab_recent">Нещодавні</string>
+    <string name="log_tab_awards">Нагороди</string>
+    <string name="log_title">Журнал</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSOs · Усі діапазони</string>
+    <string name="log_cd_sync_to_logging_services">Синхронізація зі службами журналювання</string>
+    <string name="log_cd_export_qsos">Експорт QSOs</string>
+    <string name="log_stat_total_qsos">Усього QSOs</string>
+    <string name="log_stat_dxcc_entities">Об’єкти DXCC</string>
+    <string name="log_stat_cq_zones">Зони CQ</string>
+    <string name="log_stat_itu_zones">Зони ITU</string>
+    <string name="log_section_band_distribution">Розподіл за діапазонами</string>
+    <string name="log_section_award_progress">Прогрес нагород</string>
+    <string name="log_award_dxcc_mixed">DXCC Mixed</string>
+    <string name="log_award_vucc_grid_squares">Локатори VUCC</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Покриття локаторів</string>
+    <string name="log_section_signal_trend">Тренд сигналу</string>
+    <string name="log_no_qsos_yet">Ще немає QSOs</string>
+    <string name="log_no_qsos_recorded_yet">Ще не записано жодного QSO</string>
+    <string name="log_state_usa">%1$s, США</string>
+    <string name="log_cd_qso_actions">Дії QSO</string>
+    <string name="log_action_edit">Редагувати</string>
+    <string name="log_action_delete">Видалити</string>
+    <string name="log_award_dxcc_mixed_desc">Провести й підтвердити 100 об’єктів DXCC на будь-якому діапазоні/режимі</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">Провести й підтвердити всі 50 штатів США</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">Провести й підтвердити всі 40 зон CQ</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 локаторів на одному діапазоні</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- робота зі станціями на визначених островах</string>
+    <string name="log_edit_qso">Редагувати QSO</string>
+    <string name="log_field_callsign">Позивний</string>
+    <string name="log_field_grid_locator">Локатор</string>
+    <string name="log_field_mode">Режим</string>
+    <string name="log_delete_qso_title">ВИДАЛИТИ QSO?</string>
+    <string name="log_delete_qso_body_callsign">Видалити QSO з %1$s із журналу? Цю дію не можна скасувати.</string>
+    <string name="log_delete_qso_body">Видалити цей QSO із журналу? Цю дію не можна скасувати.</string>
+    <string name="log_sync_title_no_services">ЖОДНУ СЛУЖБУ НЕ УВІМКНЕНО</string>
+    <string name="log_sync_title_syncing">СИНХРОНІЗАЦІЯ…</string>
+    <string name="log_sync_title_complete">СИНХРОНІЗАЦІЮ ЗАВЕРШЕНО</string>
+    <string name="log_sync_enable_services">Увімкніть Cloudlog/Wavelog/Nextlog або QRZ у Налаштуваннях, потім повторіть.</string>
+    <string name="log_sync_progress_count">%1$d з %2$d QSOs</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d прийнято</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d прийнято</string>
+    <string name="log_sync_nothing_to_upload">У журналі ще немає QSOs для вивантаження.</string>
+    <string name="log_sync_working">Робота…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Активація</string>
+    <string name="pota_tab_hunt">Полювання</string>
+    <string name="pota_tab_history">Історія</string>
+    <string name="pota_start_activation">Почати активацію</string>
+    <string name="pota_park_reference_label">Посилання на парк (напр. K-1234)</string>
+    <string name="pota_notes_optional_label">Нотатки (необов’язково)</string>
+    <string name="pota_enter_park_reference_first">Спочатку введіть посилання на парк</string>
+    <string name="pota_activating">Активація %1$s</string>
+    <string name="pota_activation_ended">Активацію завершено</string>
+    <string name="pota_set_callsign_first">Спочатку вкажіть свій позивний у Налаштуваннях</string>
+    <string name="pota_self_spot_posted">Самоспот опубліковано</string>
+    <string name="pota_self_spot_failed">Не вдалося опублікувати самоспот — перевірте журнал</string>
+    <string name="pota_active_park">АКТИВНО — %1$s</string>
+    <string name="pota_qsos">QSOs</string>
+    <string name="pota_contacts_map">Карта зв’язків</string>
+    <string name="pota_back">Назад</string>
+    <string name="pota_valid_activation">дійсна активація</string>
+    <string name="pota_to_valid">%1$d до дійсної</string>
+    <string name="pota_elapsed">Минуло</string>
+    <string name="pota_since_start">від початку</string>
+    <string name="pota_self_spot">Самоспот</string>
+    <string name="pota_end_activation">Завершити активацію</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">TX CQ буде передано як “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Зараз немає спотів FT8 POTA.</string>
+    <string name="pota_active_spots">%1$d активних спотів FT8</string>
+    <string name="pota_targeting">Націлювання на %1$s @ %2$s kHz (%3$s) — перейдіть у Декод, щоб викликати</string>
+    <string name="pota_no_past_activations">Ще немає минулих активацій.</string>
+    <string name="pota_no_browser_available">Браузер недоступний</string>
+    <string name="pota_export_failed">Не вдалося експортувати — перевірте журнал</string>
+    <string name="pota_status_active">активна</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">Поділитися ADIF</string>
+    <string name="pota_open_pota_app">Відкрити pota.app</string>
+    <string name="pota_upload_to_pota">Вивантажити в POTA</string>
+    <string name="pota_upload_success">Вивантажено журналів парків: %1$d у POTA</string>
+    <string name="pota_upload_failed">Не вдалося вивантажити: %1$s</string>
+    <string name="pota_upload_server_error">POTA не зміг обробити вивантаження. Перевірте, що посилання на парк дійсне, а ваш позивний зареєстровано в POTA, потім повторіть.</string>
+    <string name="pota_upload_network_error">Не вдалося зв’язатися з POTA. Перевірте інтернет-з’єднання та повторіть.</string>
+    <string name="pota_login_title">Увійти в POTA</string>
+    <string name="pota_login_desc">Використайте email і пароль вашого облікового запису pota.app.</string>
+    <string name="pota_login_email">Email</string>
+    <string name="pota_login_password">Пароль</string>
+    <string name="pota_login_button">Увійти</string>
+    <string name="pota_login_cancel">Скасувати</string>
+    <string name="pota_login_failed">Не вдалося увійти: %1$s</string>
+    <string name="pota_login_or">або</string>
+    <string name="pota_login_social">Увійти через Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">Увійти в POTA</string>
+    <string name="pota_add_park">Додати парк</string>
+    <string name="pota_remove_park">Видалити</string>
+    <string name="pota_max_parks_reached">Досягнуто максимуму — 10 парків</string>
+    <string name="pota_spotted_n_parks">Споти на %1$d парках</string>
+    <string name="pota_parks_more">+%1$d ще</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Налагодження</string>
+    <string name="debug_line_count">%1$d рядків</string>
+    <string name="debug_logcat_on_suffix">" · logcat ON"</string>
+    <string name="debug_close">Закрити</string>
+    <string name="debug_share">Поділитися</string>
+    <string name="debug_clear">Очистити</string>
+    <string name="debug_logcat_on">Logcat: ON</string>
+    <string name="debug_logcat_off">Logcat: OFF</string>
+    <string name="debug_no_log_file">немає файлу журналу</string>
+    <string name="debug_log_cleared">журнал очищено</string>
+    <string name="debug_share_chooser_title">Поділитися debug.log</string>
+    <string name="map_title">Карта</string>
+    <string name="map_no_grid_set">Локатор не вказано</string>
+    <string name="map_station_count">%1$d станцій</string>
+    <string name="map_station_count_with_heard">%1$d станцій · %2$d почуто</string>
+    <string name="map_psk_error">PSK Reporter недоступний: %1$s</string>
+    <string name="map_projection_equirectangular">Рівнопрямокутна</string>
+    <string name="map_projection_azimuthal">Азимутальна рівновіддалена</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_info_distance">Відстань</string>
+    <string name="map_info_bearing">Пеленг</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Водоспад</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">НАЖИВО</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d спроб</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d з %2$d увімкнено</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Збірка %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Налаштування</string>
+    <string name="settings_section_operator_identity">ДАНІ ОПЕРАТОРА</string>
+    <string name="settings_section_radio">РАДІО</string>
+    <string name="settings_section_audio">АУДІО</string>
+    <string name="settings_section_transmission">ПЕРЕДАВАННЯ</string>
+    <string name="settings_section_auto_sequence">АВТОПОСЛІДОВНІСТЬ</string>
+    <string name="settings_section_decode_highlights">ПІДСВІЧУВАННЯ ДЕКОДУ</string>
+    <string name="settings_section_callsign_blocklist">ЧОРНИЙ СПИСОК ПОЗИВНИХ</string>
+    <string name="settings_section_decode_filters">ФІЛЬТРИ ДЕКОДУ</string>
+    <string name="settings_section_needed_dx_alerts">СПОВІЩЕННЯ ПРО ПОТРІБНІ DX</string>
+    <string name="settings_section_logging_awards">ЖУРНАЛЮВАННЯ &amp; НАГОРОДИ</string>
+    <string name="settings_section_advanced">ДОДАТКОВО</string>
+    <string name="settings_section_about">ПРО ЗАСТОСУНОК</string>
+    <string name="settings_section_language">МОВА</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Радіо &amp; Аудіо</string>
+    <string name="settings_cat_transmission">Передавання</string>
+    <string name="settings_cat_decode_filters">Декод &amp; Фільтри</string>
+    <string name="settings_cat_logging">Журналювання &amp; Нагороди</string>
+    <string name="settings_cat_advanced">Додатково</string>
+    <string name="settings_cat_about">Про застосунок</string>
+    <string name="settings_cat_time_sync">Синхронізація часу</string>
+    <string name="settings_cat_time_sync_desc">Ручне коригування годинника для роботи офлайн</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Ручне коригування</string>
+    <string name="settings_time_current_label">Поточне коригування</string>
+    <string name="settings_time_correction_reset">Скинути на 0</string>
+    <string name="settings_time_correction_desc">Підлаштуйте годинник застосунку, коли немає інтернету для синхронізації. FT8 потребує UTC з точністю близько 1 секунди. Регулюйте, доки стовпець DT декодованих станцій не зосередиться біля 0.</string>
+    <string name="settings_time_suggest_section">Пропозиція з декодувань</string>
+    <string name="settings_time_suggest_none">Ще немає декодувань — почніть приймати, щоб отримати пропозицію.</string>
+    <string name="settings_time_suggest_label">Нещодавнє середнє DT: %1$s</string>
+    <string name="settings_time_suggest_apply">Застосувати запропоноване коригування</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Автооновлення локатора (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Використовувати GPS пристрою для актуалізації вашого локатора Maidenhead</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Модель трансивера</string>
+    <string name="settings_control_mode">Режим керування</string>
+    <string name="settings_connection_mode">Режим з’єднання</string>
+    <string name="settings_baud_rate">Швидкість (бод)</string>
+    <string name="settings_band_frequency">Діапазон &amp; Частота</string>
+    <string name="settings_enabled_bands">Увімкнені діапазони</string>
+    <string name="settings_audio_frequency">Аудіочастота</string>
+    <string name="settings_spectrum_width">Ширина спектра</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Аудіовхід</string>
+    <string name="settings_audio_output">Аудіовихід</string>
+    <string name="settings_tx_volume">Гучність TX</string>
+    <string name="settings_tx_volume_desc" formatted="false">Рівень аудіо передавання (апаратні кнопки ±5%)</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">Рознос TX/RX</string>
+    <string name="settings_tx_rx_split_desc">Передавати на іншій частоті, ніж приймати</string>
+    <string name="settings_tx_watchdog">Сторож TX</string>
+    <string name="settings_tx_watchdog_desc">Автозупинка передавання після тайм-ауту</string>
+    <string name="settings_stop_after">Зупинити після</string>
+    <string name="settings_stop_after_desc">Припинити виклик після N спроб без відповіді</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Полювання (автовідповідь на CQ)</string>
+    <string name="settings_hunt_desc">Активно викликати станції, що дають CQ. Те саме, що кнопка HUNT на панелі TX. Вимк. = давати CQ і працювати лише зі станціями, що вам відповідають.</string>
+    <string name="settings_auto_call_followed">Авто-виклик відстежуваних</string>
+    <string name="settings_auto_call_followed_desc">Автоматично продовжувати виклик відстежуваних позивних</string>
+    <string name="settings_fast_turnaround">Швидкий оборот</string>
+    <string name="settings_fast_turnaround_desc">Декодувати на ~1 с раніше, щоб відповісти на CQ у наступному слоті, а не чекати. Може пропускати станції з великим зсувом годинника.</string>
+    <string name="settings_auto_cq_after_qso">Авто-CQ після QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">Автоматично продовжувати давати CQ після кожного завершеного зв’язку — без повторного дотику. Залишається на вашій частоті (ігнорує Полювання). Працює, доки ви не зупините або Сторож TX не спрацює без відповідей.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">Новий DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">Підсвічувати станції з непроведеного об’єкта DXCC</string>
+    <string name="settings_highlight_new_grid">Новий локатор</string>
+    <string name="settings_highlight_new_grid_desc">Підсвічувати ще не проведені локатори Maidenhead</string>
+    <string name="settings_highlight_new_band">Новий діапазон</string>
+    <string name="settings_highlight_new_band_desc">Підсвічувати станції, проведені лише на інших діапазонах</string>
+    <string name="settings_highlight_pota">Активатори POTA</string>
+    <string name="settings_highlight_pota_desc">Підсвічувати споттені активатори POTA; нові парки виділяються</string>
+    <string name="settings_highlight_worked">Проведені раніше</string>
+    <string name="settings_highlight_worked_desc">Позначати станції, що вже є у вашому журналі</string>
+    <string name="settings_distance_unit">Відстань у милях</string>
+    <string name="settings_distance_unit_desc">Показувати відстані в милях замість кілометрів</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Точні позивні</string>
+    <string name="settings_exact_callsigns_desc">Блокувати збіги цілого позивного</string>
+    <string name="settings_prefixes">Префікси</string>
+    <string name="settings_prefixes_desc">Блокувати за префіксом позивного (напр. RA)</string>
+    <string name="settings_keywords">Ключові слова</string>
+    <string name="settings_keywords_desc">Блокувати за підрядком у позивному чи повідомленні (напр. POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Показувати лише CQ</string>
+    <string name="settings_show_only_cq_desc">Приховати все, крім повідомлень типу CQ</string>
+    <string name="settings_dx_only">Лише DX</string>
+    <string name="settings_dx_only_desc">Показувати лише станції поза вашим власним континентом</string>
+    <string name="settings_needed_only">Лише потрібні</string>
+    <string name="settings_needed_only_desc">Показувати лише ще не підтверджені станції (QSL)</string>
+    <string name="settings_filter_by_continent">Фільтр за континентом</string>
+    <string name="settings_filter_by_continent_desc">Показувати лише станції з обраного континенту</string>
+    <string name="settings_continent">Континент</string>
+    <string name="settings_skip_directional_cq">Пропускати спрямовані CQ (автовідповідь)</string>
+    <string name="settings_skip_directional_cq_desc">Не відповідати автоматично на CQ DX/EU/JA…, спрямовані на інший DXCC</string>
+    <string name="settings_hide_directional_cq">Приховати спрямовані CQ не для мене</string>
+    <string name="settings_hide_directional_cq_desc">Приховати спрямовані на регіон CQ, що не націлені на ваш DXCC</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">Новий DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">Звук + вібрація + сповіщення, коли непроведений об’єкт DXCC дає CQ</string>
+    <string name="settings_alert_new_state">Новий штат США</string>
+    <string name="settings_alert_new_state_desc">Звук + вібрація + сповіщення, коли станція з непроведеного штату США дає CQ (штат за локатором)</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">Зберігати SWL декоди</string>
+    <string name="settings_save_swl_decodes_desc">Записувати всі декодовані повідомлення в базу даних</string>
+    <string name="settings_save_swl_qsos">Зберігати SWL QSOs</string>
+    <string name="settings_save_swl_qsos_desc">Записувати QSOs, виявлені між іншими станціями</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Вивантажувати декодовані споти на pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">Автоматично вивантажувати QSOs до QRZ Logbook</string>
+    <string name="settings_qrz_profile_lookup">Пошук профілю QRZ</string>
+    <string name="settings_qrz_profile_lookup_desc">Ім’я користувача + пароль для QRZ XML API (аватари)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">Автоматично вивантажувати QSOs до екземпляра Cloudlog, Wavelog або Nextlog</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">Затримка PTT</string>
+    <string name="settings_ptt_delay_desc">Затримка після PTT перед початком аудіо передавання</string>
+    <string name="settings_tx_delay">Затримка TX</string>
+    <string name="settings_tx_delay_desc">Затримка перед передаванням для декодування попереднього циклу</string>
+    <string name="settings_late_start_tolerance">Допуск пізнього старту</string>
+    <string name="settings_late_start_tolerance_desc">Дозволити починати TX до N ms у цикл; початкове аудіо обрізається, щоб TX завершувалося на межі циклу</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">Поширені питання &amp; Підтримка</string>
+    <string name="settings_report_bug">Повідомити про помилку</string>
+    <string name="bug_report_description_hint">Опишіть, що пішло не так…</string>
+    <string name="bug_report_send_email">Надіслати email</string>
+    <string name="bug_report_no_email_app">Не знайдено застосунку email для надсилання звіту</string>
+    <string name="bug_report_open_github">Відкрити issue на GitHub</string>
+    <string name="settings_debug">Налагодження</string>
+    <string name="settings_debug_desc">Переглянути / поділитися debug.log</string>
+    <string name="settings_about_body">Версія %1$s (збірка %2$s)\nДата збірки %3$s\n\nFT8, просто.\n\nОкремий застосунок-трансивер FT8 для Android. Керування трансивером через USB, Bluetooth і мережу з автоматичним секвенуванням і журналюванням.</string>
+    <string name="settings_website">Вебсайт</string>
+    <string name="settings_community">Спільнота</string>
+    <string name="settings_built_by">Створено</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Блокувати точні позивні</string>
+    <string name="settings_block_exact_desc">Збіг цілого позивного. Розділяйте комами або пробілами, напр. W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Блокувати префікси позивних</string>
+    <string name="settings_block_prefix_desc">Збіг за префіксом, напр. RA блокує RA0AA..RA9ZZ. Розділяйте комами або пробілами.</string>
+    <string name="settings_block_keyword_title">Блокувати ключові слова</string>
+    <string name="settings_block_keyword_desc">Збіг за підрядком у позивному та тексті повідомлення, напр. POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">напр. W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Фільтр континенту</string>
+    <string name="settings_conn_usb_cable">USB-кабель</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Мережа</string>
+    <string name="settings_no_usb_serial">USB-послідовних пристроїв не виявлено. Під’єднайте USB-кабель до радіо й повторіть.</string>
+    <string name="settings_no_bluetooth_devices">Сполучених пристроїв Bluetooth не знайдено. Спочатку сполучіть пристрій у налаштуваннях Bluetooth Android.</string>
+    <string name="settings_debug_mode_enabled">Режим налагодження увімкнено</string>
+    <string name="settings_debug_mode_disabled">Режим налагодження вимкнено</string>
+    <string name="settings_edit_operator_identity">Редагувати дані оператора</string>
+    <string name="settings_callsign">Позивний</string>
+    <string name="settings_callsign_hint">напр. W1AW</string>
+    <string name="settings_grid_locator">Локатор</string>
+    <string name="settings_grid_locator_hint">напр. FN31pr</string>
+    <string name="settings_logging_server">Сервер журналювання</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog і Nextlog приймають однакові вивантаження.</string>
+    <string name="settings_server_address">Адреса сервера</string>
+    <string name="settings_api_key">Ключ API</string>
+    <string name="settings_api_key_hint">Ваш ключ API Cloudlog</string>
+    <string name="settings_loading_stations">Завантаження станцій...</string>
+    <string name="settings_station_id">ID станції</string>
+    <string name="settings_station_id_hint">напр. 1</string>
+    <string name="settings_select_a_station">Виберіть станцію</string>
+    <string name="settings_enter_manually">Ввести вручну</string>
+    <string name="settings_choose_from_server">Вибрати з сервера</string>
+    <string name="settings_station_profile">Профіль станції</string>
+    <string name="settings_qrz_creds_desc">Використовується для отримання фото профілів декодованих позивних через QRZ XML API. Потрібна підписка QRZ XML.</string>
+    <string name="settings_username">Ім’я користувача</string>
+    <string name="settings_username_hint">Ваше ім’я користувача QRZ.com</string>
+    <string name="settings_password">Пароль</string>
+    <string name="settings_enabled_bands_dialog_desc">Приховані діапазони не з’являтимуться у виборі частоти.</string>
+    <string name="settings_select_serial_port">Виберіть послідовний порт</string>
+    <string name="settings_tx_volume_advice">Регулюйте наживо — ваш наступний TX використає цей рівень. Стежте за ALC радіо й зменшуйте, доки воно лише торкається лінії.</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Мова</string>
+    <string name="settings_language_desc">Мова відображення застосунку</string>
+    <string name="settings_language_system">Системна за замовчуванням</string>
+
+</resources>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -551,5 +551,14 @@
     <string name="language_name_es" translatable="false">Español</string>
     <string name="language_name_fr" translatable="false">Français</string>
     <string name="language_name_ja" translatable="false">日本語</string>
+    <string name="language_name_it" translatable="false">Italiano</string>
+    <string name="language_name_pl" translatable="false">Polski</string>
+    <string name="language_name_ko" translatable="false">한국어</string>
+    <string name="language_name_nl" translatable="false">Nederlands</string>
+    <string name="language_name_cs" translatable="false">Čeština</string>
+    <string name="language_name_tr" translatable="false">Türkçe</string>
+    <string name="language_name_id" translatable="false">Bahasa Indonesia</string>
+    <string name="language_name_uk" translatable="false">Українська</string>
+    <string name="language_name_ar" translatable="false">العربية</string>
 
 </resources>

--- a/ft8cn/app/src/main/res/xml/locales_config.xml
+++ b/ft8cn/app/src/main/res/xml/locales_config.xml
@@ -13,4 +13,13 @@
     <locale android:name="es" />
     <locale android:name="fr" />
     <locale android:name="ja" />
+    <locale android:name="it" />
+    <locale android:name="pl" />
+    <locale android:name="ko" />
+    <locale android:name="nl" />
+    <locale android:name="cs" />
+    <locale android:name="tr" />
+    <locale android:name="id" />
+    <locale android:name="uk" />
+    <locale android:name="ar" />
 </locale-config>

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/Ft8MessageTest.java
@@ -366,28 +366,28 @@ public class Ft8MessageTest {
 
     @Test
     public void getSequence_ft2_alternatesEachShortSlot() {
-        // FT2's 3.8s slot — must alternate twice as fast as FT4's 7.5s.
+        // FT2's 3.75s slot — must alternate twice as fast as FT4's 7.5s.
         Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
         msg.utcTime = 0;
         assertThat(msg.getSequence()).isEqualTo(0);
-        msg.utcTime = 3800;
+        msg.utcTime = 3750;
         assertThat(msg.getSequence()).isEqualTo(1);
-        msg.utcTime = 7600;
+        msg.utcTime = 7500;
         assertThat(msg.getSequence()).isEqualTo(0);
-        msg.utcTime = 11400;
+        msg.utcTime = 11250;
         assertThat(msg.getSequence()).isEqualTo(1);
     }
 
     @Test
     public void getSequence_ft2_adjacentSlotsHaveDistinctParity() {
         // Regression for #205: the old code reused FT4's 7.5s period for FT2, so
-        // two adjacent 3.8s slots (0ms and 3800ms) both mapped to sequence 0.
+        // two adjacent 3.75s slots (0ms and 3750ms) both mapped to sequence 0.
         // The QSO sequencer then saw the other station's reply as being in our
         // own slot and skipped it, stalling on the report instead of sending RR73.
         Ft8Message slotA = new Ft8Message(FT8Common.FT2_MODE);
         slotA.utcTime = 0;
         Ft8Message slotB = new Ft8Message(FT8Common.FT2_MODE);
-        slotB.utcTime = 3800;
+        slotB.utcTime = 3750;
         assertThat(slotA.getSequence()).isNotEqualTo(slotB.getSequence());
     }
 
@@ -396,7 +396,7 @@ public class Ft8MessageTest {
         // utcTime is slot-aligned; the +slot/20 nudge keeps a timestamp a touch
         // early (clock skew) in the correct slot rather than the previous one.
         Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
-        msg.utcTime = 3800 - 50; // 50ms before slot 1's boundary
+        msg.utcTime = 3750 - 50; // 50ms before slot 1's boundary
         assertThat(msg.getSequence()).isEqualTo(1);
     }
 
@@ -405,13 +405,13 @@ public class Ft8MessageTest {
         Ft8Message msg = new Ft8Message(FT8Common.FT2_MODE);
         msg.utcTime = 0;
         assertThat(msg.getSequence4()).isEqualTo(0);
-        msg.utcTime = 3800;
+        msg.utcTime = 3750;
         assertThat(msg.getSequence4()).isEqualTo(1);
-        msg.utcTime = 7600;
+        msg.utcTime = 7500;
         assertThat(msg.getSequence4()).isEqualTo(2);
-        msg.utcTime = 11400;
+        msg.utcTime = 11250;
         assertThat(msg.getSequence4()).isEqualTo(3);
-        msg.utcTime = 15200;
+        msg.utcTime = 15000;
         assertThat(msg.getSequence4()).isEqualTo(0);
     }
 

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ModeProfileTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ModeProfileTest.java
@@ -17,7 +17,6 @@ public class ModeProfileTest {
         assertThat(m.id).isEqualTo(FT8Common.FT8_MODE);
         assertThat(m.displayName).isEqualTo("FT8");
         assertThat(m.slotMillis).isEqualTo(15_000);
-        assertThat(m.slotTenths).isEqualTo(150);
         assertThat(m.numTones).isEqualTo(79);
         assertThat(m.isFt8).isTrue();
         // 79 * 0.160 * 1000 = 12640ms audio; slack = 15000 - 12640.
@@ -31,7 +30,6 @@ public class ModeProfileTest {
         assertThat(m.id).isEqualTo(FT8Common.FT4_MODE);
         assertThat(m.displayName).isEqualTo("FT4");
         assertThat(m.slotMillis).isEqualTo(7_500);
-        assertThat(m.slotTenths).isEqualTo(75);
         assertThat(m.numTones).isEqualTo(105);
         assertThat(m.isFt8).isFalse();
         // 105 * 0.048 * 1000 = 5040ms audio; slack = 7500 - 5040.
@@ -44,17 +42,18 @@ public class ModeProfileTest {
         ModeProfile m = ModeProfile.FT2;
         assertThat(m.id).isEqualTo(FT8Common.FT2_MODE);
         assertThat(m.displayName).isEqualTo("FT2");
-        assertThat(m.slotMillis).isEqualTo(3_800);
-        assertThat(m.slotTenths).isEqualTo(38);
+        // FT2's slot is exactly half FT4's 7.5s, so 3750ms.
+        assertThat(m.slotMillis).isEqualTo(3_750);
+        assertThat(m.slotMillis).isEqualTo(ModeProfile.FT4.slotMillis / 2);
         // FT2 reuses FT4's 105-symbol layout (same encoder/tones).
         assertThat(m.numTones).isEqualTo(105);
         // FT2 decodes as FT4-family (isFt8 false), but receives on the from-source decoder.
         assertThat(m.isFt8).isFalse();
         // Half FT4's symbol period -> double baud.
         assertThat(m.symbolPeriod).isEqualTo(0.024f);
-        // 105 * 0.024 * 1000 = 2520ms audio; slack = 3800 - 2520.
+        // 105 * 0.024 * 1000 = 2520ms audio; slack = 3750 - 2520.
         assertThat(m.audioMillis).isEqualTo(2_520);
-        assertThat(m.audioSlackMillis).isEqualTo(1_280);
+        assertThat(m.audioSlackMillis).isEqualTo(1_230);
     }
 
     @Test

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
@@ -171,6 +171,19 @@ public class UtcTimerTest {
     }
 
     @Test
+    public void isCycleBoundary_oneSecondTickFiresOnSecondGrid() {
+        // MainViewModel's clock-display timer is a 1-second tick. It used to pass the
+        // tenths value 10 (= 1s); under the millisecond API it must pass 1000. Both forms
+        // fire once per second, second-aligned — guard against the unit regression.
+        for (long ms = 0; ms < 10_000; ms += 100) {
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 1_000))
+                    .isEqualTo(tenthsBoundary(ms, 0, 10));
+        }
+        assertThat(UtcTimer.isCycleBoundary(1_000L, 0, 1_000)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(500L, 0, 1_000)).isFalse();
+    }
+
+    @Test
     public void isCycleBoundary_nonPositivePeriodNeverFires() {
         assertThat(UtcTimer.isCycleBoundary(0L, 0, 0)).isFalse();
         assertThat(UtcTimer.isCycleBoundary(15_000L, 0, -5)).isFalse();

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/timer/UtcTimerTest.java
@@ -77,14 +77,14 @@ public class UtcTimerTest {
     }
 
     @Test
-    public void sequential_withSlotMillis_ft2AlternatesEvery3point8s() {
-        // FT2's 3800ms slot isn't a whole number of seconds; sequential() works in ms
-        // directly so the boundary lands exactly on each 3.8s multiple.
-        assertThat(UtcTimer.sequential(0L, 3_800)).isEqualTo(0);
-        assertThat(UtcTimer.sequential(3_799L, 3_800)).isEqualTo(0);
-        assertThat(UtcTimer.sequential(3_800L, 3_800)).isEqualTo(1);
-        assertThat(UtcTimer.sequential(7_600L, 3_800)).isEqualTo(0);
-        assertThat(UtcTimer.sequential(11_400L, 3_800)).isEqualTo(1);
+    public void sequential_withSlotMillis_ft2AlternatesEvery3point75s() {
+        // FT2's 3750ms slot isn't a whole number of seconds; sequential() works in ms
+        // directly so the boundary lands exactly on each 3.75s multiple.
+        assertThat(UtcTimer.sequential(0L, 3_750)).isEqualTo(0);
+        assertThat(UtcTimer.sequential(3_749L, 3_750)).isEqualTo(0);
+        assertThat(UtcTimer.sequential(3_750L, 3_750)).isEqualTo(1);
+        assertThat(UtcTimer.sequential(7_500L, 3_750)).isEqualTo(0);
+        assertThat(UtcTimer.sequential(11_250L, 3_750)).isEqualTo(1);
     }
 
     @Test
@@ -97,83 +97,77 @@ public class UtcTimerTest {
         assertThat(UtcTimer.sequential(29_999L)).isEqualTo(1);
     }
 
-    /** The legacy minute-anchored predicate, kept here to prove equivalence for FT8/FT4. */
-    private static boolean legacyBoundary(long utc, int offsetMs, int sec) {
-        return (((utc - offsetMs) / 100) % 600) % sec == 0;
+    /**
+     * The slot-boundary predicate before this change worked in tenths of a second
+     * ({@code (utc/100) % tenths == 0}). Kept here to prove the new millisecond-window
+     * predicate fires on exactly the same 100ms ticks for FT8 and FT4 — whose slot lengths
+     * are whole tenths (150, 75) — so only FT2 (3.75s, not a whole tenth) changes.
+     */
+    private static boolean tenthsBoundary(long utc, int offsetMs, int tenths) {
+        return (((utc - offsetMs) / 100) % tenths) == 0;
     }
 
     @Test
-    public void isCycleBoundary_ft8MatchesLegacyMinuteAnchoredFormula() {
-        // 150 tenths (15s) divides 600, so the new epoch-anchored test must agree with the
-        // old minute-anchored one at every 100ms tick across a full minute.
+    public void isCycleBoundary_ft8MatchesPreviousTenthsPredicate() {
         for (long ms = 0; ms < 60_000; ms += 100) {
-            assertThat(UtcTimer.isCycleBoundary(ms, 0, 150))
-                    .isEqualTo(legacyBoundary(ms, 0, 150));
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 15_000))
+                    .isEqualTo(tenthsBoundary(ms, 0, 150));
         }
     }
 
     @Test
-    public void isCycleBoundary_ft4MatchesLegacyMinuteAnchoredFormula() {
-        // 75 tenths (7.5s) also divides 600 — behaviour is unchanged for FT4.
+    public void isCycleBoundary_ft4MatchesPreviousTenthsPredicate() {
         for (long ms = 0; ms < 60_000; ms += 100) {
-            assertThat(UtcTimer.isCycleBoundary(ms, 0, 75))
-                    .isEqualTo(legacyBoundary(ms, 0, 75));
+            assertThat(UtcTimer.isCycleBoundary(ms, 0, 7_500))
+                    .isEqualTo(tenthsBoundary(ms, 0, 75));
         }
     }
 
     @Test
     public void isCycleBoundary_ft8FiresOnAbsoluteSlotGrid() {
-        assertThat(UtcTimer.isCycleBoundary(0L, 0, 150)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(15_000L, 0, 150)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(7_500L, 0, 150)).isFalse();
-        // Real-world instant: a boundary iff systemTime % 15000 == 0.
-        assertThat(UtcTimer.isCycleBoundary(T_2023, 0, 150))
-                .isEqualTo(T_2023 % 15_000 == 0);
+        assertThat(UtcTimer.isCycleBoundary(0L, 0, 15_000)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(15_000L, 0, 15_000)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(7_500L, 0, 15_000)).isFalse();
+        // Real-world instant: a boundary iff systemTime % 15000 is inside the open window.
+        assertThat(UtcTimer.isCycleBoundary(T_2023, 0, 15_000))
+                .isEqualTo(T_2023 % 15_000 < 100);
     }
 
     @Test
-    public void isCycleBoundary_ft2FiresOnAbsolute3point8sGrid() {
-        // FT2 (38 tenths) does NOT divide 600, so this is where old and new diverge.
-        // The new predicate fires exactly on multiples of 3.8s from the epoch...
-        assertThat(UtcTimer.isCycleBoundary(0L, 0, 38)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(3_800L, 0, 38)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(7_600L, 0, 38)).isTrue();
-        assertThat(UtcTimer.isCycleBoundary(3_700L, 0, 38)).isFalse();
-        assertThat(UtcTimer.isCycleBoundary(3_900L, 0, 38)).isFalse();
+    public void isCycleBoundary_ft2FiresOnAbsolute3point75sGrid() {
+        // FT2's 3750ms slot has no tenths-of-a-second form (37.5 tenths), so the
+        // millisecond predicate is what puts it on a clean grid. Fires in the 100ms
+        // window opening each slot.
+        assertThat(UtcTimer.isCycleBoundary(0L, 0, 3_750)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(3_750L, 0, 3_750)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(7_500L, 0, 3_750)).isTrue();
+        assertThat(UtcTimer.isCycleBoundary(11_250L, 0, 3_750)).isTrue();
+        // Mid-slot and just-outside-the-window instants do not fire.
+        assertThat(UtcTimer.isCycleBoundary(1_875L, 0, 3_750)).isFalse();
+        assertThat(UtcTimer.isCycleBoundary(3_700L, 0, 3_750)).isFalse();
+        assertThat(UtcTimer.isCycleBoundary(3_850L, 0, 3_750)).isFalse();
     }
 
     @Test
     public void isCycleBoundary_ft2EveryFireOpensASlotSoLateStartNeverClips() {
         // The transmit late-start math clips leading audio by (systemTime % slotMillis)
-        // beyond the slack. The FT2 regression was that the timer fired when
-        // systemTime % 3800 was large (up to ~3.0s), clipping the leading Costas sync.
-        // With the epoch-anchored predicate, every fire lands within one 100ms tick of a
-        // real 3800ms slot boundary, so msIntoCycle is always < 100 and nothing is clipped.
-        int slotMillis = 3_800;
+        // beyond the slack. Every fire must land within the 100ms slot-open window so
+        // msIntoCycle stays < 100 and the leading Costas sync is never clipped.
+        int slotMillis = 3_750;
         int fires = 0;
         for (long ms = 0; ms < 600_000; ms += 100) { // 10 minutes of ticks
-            if (UtcTimer.isCycleBoundary(ms, 0, 38)) {
+            if (UtcTimer.isCycleBoundary(ms, 0, slotMillis)) {
                 fires++;
                 long msIntoCycle = ms % slotMillis;
                 assertThat(msIntoCycle).isLessThan(100L);
             }
         }
-        // Sanity: ~ one fire per 3.8s over 10 minutes.
-        assertThat(fires).isEqualTo(600_000 / slotMillis + 1);
-    }
-
-    @Test
-    public void isCycleBoundary_legacyFormulaWouldHaveClippedFt2() {
-        // Guard the regression: the OLD predicate fired off the absolute slot grid for
-        // FT2, landing where systemTime % 3800 was large — that is the clip that broke TX.
-        boolean sawLargeOffset = false;
-        for (long ms = 0; ms < 600_000; ms += 100) {
-            if (legacyBoundary(ms, 0, 38) && (ms % 3_800) >= 1_280) {
-                sawLargeOffset = true; // >= FT2 audio slack -> leading audio clipped
-                break;
-            }
-        }
-        assertThat(sawLargeOffset).isTrue();
+        // Exactly one fire per slot over 10 minutes. When slotMillis divides 600000 the
+        // boundary at 600000 itself is excluded (loop is ms < 600000).
+        int expected = (600_000 % slotMillis == 0)
+                ? 600_000 / slotMillis
+                : 600_000 / slotMillis + 1;
+        assertThat(fires).isEqualTo(expected);
     }
 
     @Test

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
@@ -180,4 +180,34 @@ class BluetoothAutoConnectTest {
             ),
         ).isEqualTo(BtAutoConnectDecision.ALREADY_CONNECTED)
     }
+
+    // --- maskBluetoothAddress: keep debug.log free of the raw MAC (PR #228 review) ---
+
+    @Test
+    fun maskKeepsOnlyFirstAndLastOctet() {
+        assertThat(maskBluetoothAddress("AA:BB:CC:DD:EE:FF")).isEqualTo("AA:**:**:**:**:FF")
+    }
+
+    @Test
+    fun maskHidesEveryMiddleOctet() {
+        // None of the four middle octets may survive anywhere in the output.
+        val masked = maskBluetoothAddress("11:22:33:44:55:66")
+        for (octet in listOf("22", "33", "44", "55")) {
+            assertThat(masked).doesNotContain(octet)
+        }
+    }
+
+    @Test
+    fun maskNullOrBlankAddressIsNone() {
+        assertThat(maskBluetoothAddress(null)).isEqualTo("<none>")
+        assertThat(maskBluetoothAddress("")).isEqualTo("<none>")
+        assertThat(maskBluetoothAddress("   ")).isEqualTo("<none>")
+    }
+
+    @Test
+    fun maskMalformedAddressLeaksOnlyLengthNotValue() {
+        val masked = maskBluetoothAddress("not-a-mac-address")
+        assertThat(masked).isEqualTo("<malformed:17>")
+        assertThat(masked).doesNotContain("mac")
+    }
 }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
@@ -1,0 +1,183 @@
+package radio.ks3ckc.ft8us
+
+import com.bg7yoz.ft8cn.connector.ConnectMode
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [decideBluetoothAutoConnect] (issue #223). Pure logic, no Android runtime:
+ * [ConnectMode] is a plain class of int constants, so no Robolectric runner is needed.
+ */
+class BluetoothAutoConnectTest {
+
+    /** All preconditions satisfied -> we should open the SPP/CAT link. */
+    @Test
+    fun connectsWhenEverythingReady() {
+        val decision = decideBluetoothAutoConnect(
+            connectMode = ConnectMode.BLUE_TOOTH,
+            savedAddress = "AA:BB:CC:DD:EE:FF",
+            rigConnected = false,
+            adapterOn = true,
+            hasConnectPermission = true,
+            isBonded = true,
+        )
+        assertThat(decision).isEqualTo(BtAutoConnectDecision.CONNECT)
+    }
+
+    @Test
+    fun usbModeIsNotBtMode() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.USB_CABLE,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BT_MODE)
+    }
+
+    @Test
+    fun networkModeIsNotBtMode() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.NETWORK,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BT_MODE)
+    }
+
+    @Test
+    fun nullAddressHasNothingToConnectTo() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = null,
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_SAVED_ADDRESS)
+    }
+
+    @Test
+    fun blankAddressHasNothingToConnectTo() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "   ",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_SAVED_ADDRESS)
+    }
+
+    /** Don't double-connect when a rig is already up (mirrors the USB guard). */
+    @Test
+    fun alreadyConnectedSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = true,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.ALREADY_CONNECTED)
+    }
+
+    @Test
+    fun adapterOffSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = false,
+                hasConnectPermission = true,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.ADAPTER_OFF)
+    }
+
+    @Test
+    fun missingPermissionSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = false,
+                isBonded = true,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_PERMISSION)
+    }
+
+    @Test
+    fun unbondedDeviceSkips() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = false,
+                adapterOn = true,
+                hasConnectPermission = true,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BONDED)
+    }
+
+    // ---- precedence: earlier checks win over later ones ----
+
+    @Test
+    fun notBtModeWinsOverMissingAddress() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.USB_CABLE,
+                savedAddress = null,
+                rigConnected = false,
+                adapterOn = false,
+                hasConnectPermission = false,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NOT_BT_MODE)
+    }
+
+    @Test
+    fun missingAddressWinsOverAlreadyConnected() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "",
+                rigConnected = true,
+                adapterOn = false,
+                hasConnectPermission = false,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.NO_SAVED_ADDRESS)
+    }
+
+    @Test
+    fun alreadyConnectedWinsOverAdapterOff() {
+        assertThat(
+            decideBluetoothAutoConnect(
+                connectMode = ConnectMode.BLUE_TOOTH,
+                savedAddress = "AA:BB:CC:DD:EE:FF",
+                rigConnected = true,
+                adapterOn = false,
+                hasConnectPermission = false,
+                isBonded = false,
+            ),
+        ).isEqualTo(BtAutoConnectDecision.ALREADY_CONNECTED)
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ComposeMainActivityConfigChangesTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ComposeMainActivityConfigChangesTest.kt
@@ -1,0 +1,61 @@
+package radio.ks3ckc.ft8us
+
+import android.content.ComponentName
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Guards the manifest's `android:configChanges` on [ComposeMainActivity].
+ *
+ * Without these flags Android destroys and recreates the launcher activity on
+ * every rotation, which replays the splash and tears down live state (CAT link,
+ * audio loop, decode cycle). Declaring the flags makes Compose simply relay out
+ * in place. This test fails loudly if a future manifest edit drops any of them
+ * and silently reintroduces the rotate-restart bug.
+ *
+ * Robolectric reads the merged manifest, so the assertion reflects what actually
+ * ships. ActivityInfo.configChanges is a bitmask of CONFIG_* flags.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ComposeMainActivityConfigChangesTest {
+
+    private val required = mapOf(
+        "orientation" to ActivityInfo.CONFIG_ORIENTATION,
+        "screenSize" to ActivityInfo.CONFIG_SCREEN_SIZE,
+        "smallestScreenSize" to ActivityInfo.CONFIG_SMALLEST_SCREEN_SIZE,
+        "keyboardHidden" to ActivityInfo.CONFIG_KEYBOARD_HIDDEN,
+        "screenLayout" to ActivityInfo.CONFIG_SCREEN_LAYOUT,
+        "uiMode" to ActivityInfo.CONFIG_UI_MODE,
+    )
+
+    private fun activityInfo(): ActivityInfo {
+        val context = RuntimeEnvironment.getApplication()
+        val component = ComponentName(context, ComposeMainActivity::class.java)
+        return context.packageManager.getActivityInfo(component, PackageManager.GET_META_DATA)
+    }
+
+    @Test
+    fun launcherActivity_handlesRotationWithoutRecreation() {
+        val configChanges = activityInfo().configChanges
+        for ((name, flag) in required) {
+            assertWithMessage("configChanges must declare '$name'")
+                .that(configChanges and flag).isEqualTo(flag)
+        }
+    }
+
+    @Test
+    fun launcherActivity_handlesOrientationAndScreenSizeTogether() {
+        // Rotation changes orientation *and* screen size on modern target SDKs;
+        // both must be claimed or the activity still recreates. This is the
+        // single most important pair for the rotate-restart bug.
+        val configChanges = activityInfo().configChanges
+        val rotationPair = ActivityInfo.CONFIG_ORIENTATION or ActivityInfo.CONFIG_SCREEN_SIZE
+        assertThat(configChanges and rotationPair).isEqualTo(rotationPair)
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/SlotTimerStateTest.kt
@@ -38,8 +38,8 @@ class SlotTimerStateTest {
     }
 
     @Test
-    fun `ft2 slot — 3point8s peaks at 4 seconds`() {
-        val s = slotTimerState(nowMs = 0L, slotMillis = 3_800L)
+    fun `ft2 slot — 3point75s peaks at 4 seconds`() {
+        val s = slotTimerState(nowMs = 0L, slotMillis = 3_750L)
         assertThat(s.secondsRemaining).isEqualTo(4)
     }
 

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
@@ -1,0 +1,116 @@
+package radio.ks3ckc.ft8us.ui.settings
+
+import com.bg7yoz.ft8cn.R
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Test
+
+/**
+ * Guards the in-app Language picker's single source of truth ([SUPPORTED_LANGUAGES])
+ * and the pure [currentLanguageNameRes] mapping, plus parity between that list, the
+ * system per-app locale config (res/xml/locales_config.xml), and the actual
+ * values-<locale>/strings_compose.xml translation folders.
+ *
+ * No Robolectric: R.string.* are plain int constants and the parity checks are file
+ * IO against the module's res/ tree.
+ */
+class LanguagePickerTest {
+
+    @Test
+    fun `tag list is system-default first then the supported tags in order`() {
+        assertThat(LANGUAGE_TAGS.first()).isEmpty()
+        assertThat(LANGUAGE_TAGS.drop(1))
+            .containsExactlyElementsIn(SUPPORTED_LANGUAGES.map { it.tag })
+            .inOrder()
+    }
+
+    @Test
+    fun `supported tags are unique`() {
+        val tags = SUPPORTED_LANGUAGES.map { it.tag }
+        assertThat(tags).containsNoDuplicates()
+    }
+
+    @Test
+    fun `no tag is a prefix of another (prefix matching stays unambiguous)`() {
+        // currentLanguageNameRes() resolves by startsWith; if one tag prefixed
+        // another the earlier list entry could shadow the later one.
+        val tags = SUPPORTED_LANGUAGES.map { it.tag }
+        for (a in tags) {
+            for (b in tags) {
+                if (a !== b && b.startsWith(a)) {
+                    throw AssertionError("Tag '$a' is a prefix of '$b'")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `currentLanguageNameRes resolves each exact tag to its display name`() {
+        for (lang in SUPPORTED_LANGUAGES) {
+            assertThat(currentLanguageNameRes(lang.tag)).isEqualTo(lang.nameRes)
+        }
+    }
+
+    @Test
+    fun `currentLanguageNameRes resolves region-qualified tags by language prefix`() {
+        assertThat(currentLanguageNameRes("en-US")).isEqualTo(R.string.language_name_en)
+        assertThat(currentLanguageNameRes("es-419")).isEqualTo(R.string.language_name_es)
+        // zh-CN must not be shadowed by zh-TW (or vice versa).
+        assertThat(currentLanguageNameRes("zh-CN")).isEqualTo(R.string.language_name_zh_cn)
+        assertThat(currentLanguageNameRes("zh-TW")).isEqualTo(R.string.language_name_zh_tw)
+    }
+
+    @Test
+    fun `currentLanguageNameRes falls back to system default for empty or unknown tags`() {
+        assertThat(currentLanguageNameRes("")).isEqualTo(R.string.settings_language_system)
+        assertThat(currentLanguageNameRes("de")).isEqualTo(R.string.settings_language_system)
+    }
+
+    @Test
+    fun `locales_config lists exactly the supported tags`() {
+        val configTags = Regex("""android:name="([^"]+)"""")
+            .findAll(resFile("xml/locales_config.xml").readText())
+            .map { it.groupValues[1] }
+            .toList()
+        assertThat(configTags)
+            .containsExactlyElementsIn(SUPPORTED_LANGUAGES.map { it.tag })
+    }
+
+    @Test
+    fun `every supported language has a translation folder with strings_compose`() {
+        for (lang in SUPPORTED_LANGUAGES) {
+            // English is the default values/ dir; the others get a values-<qualifier>.
+            val rel = when (lang.tag) {
+                "en" -> "values/strings_compose.xml"
+                else -> "${valuesDir(lang.tag)}/strings_compose.xml"
+            }
+            val f = resFile(rel)
+            assertThat(f.exists()).isTrue()
+            // Non-empty and contains at least one real string entry.
+            assertThat(f.readText()).contains("<string name=")
+        }
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    /** Android resource-qualifier folder for a BCP-47 tag. */
+    private fun valuesDir(tag: String): String = when (tag) {
+        "zh-CN" -> "values-zh-rCN"
+        "zh-TW" -> "values-zh-rTW"
+        "id" -> "values-in" // legacy Indonesian qualifier AAPT2 canonicalizes to
+        else -> "values-$tag"
+    }
+
+    /** Resolve a path under src/main/res regardless of the test working dir. */
+    private fun resFile(rel: String): File {
+        var dir: File? = File("").absoluteFile
+        repeat(8) {
+            val d = dir ?: return@repeat
+            for (base in listOf(File(d, "src/main/res"), File(d, "ft8cn/app/src/main/res"))) {
+                if (base.isDirectory) return File(base, rel)
+            }
+            dir = d.parentFile
+        }
+        throw IllegalStateException("Could not locate src/main/res from ${File("").absolutePath}")
+    }
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
@@ -37,7 +37,7 @@ class LanguagePickerTest {
         val tags = SUPPORTED_LANGUAGES.map { it.tag }
         for (a in tags) {
             for (b in tags) {
-                if (a !== b && b.startsWith(a)) {
+                if (a != b && b.startsWith(a)) {
                     throw AssertionError("Tag '$a' is a prefix of '$b'")
                 }
             }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
@@ -97,7 +97,9 @@ class LanguagePickerTest {
     private fun valuesDir(tag: String): String = when (tag) {
         "zh-CN" -> "values-zh-rCN"
         "zh-TW" -> "values-zh-rTW"
-        "id" -> "values-in" // legacy Indonesian qualifier AAPT2 canonicalizes to
+        // Indonesian: AAPT2 canonicalizes the obsolete "id" code to the legacy
+        // "in", so the resources live in values-in even though the BCP-47 tag is "id".
+        "id" -> "values-in"
         else -> "values-$tag"
     }
 


### PR DESCRIPTION
## Release: `dev` → `main`

Promotes 5 merged feature/fix PRs (#222, #224, #225, #226, #227) plus CI hardening. **15 commits**, net +5,617 / −171 lines (mostly new locale string files).

---

### ✨ Features

**Bluetooth CAT auto-connect (#227)**
- Auto-reconnects the last-paired Bluetooth CAT rig on app startup and routes rig audio over HFP/SCO.
- New `BluetoothAutoConnect.kt` with centralized BT persistence, SCO gating, and MAC-address validation.
- Surfaced in **Advanced Settings**; covered by `BluetoothAutoConnectTest.kt`.

**9 new app languages (#226)**
- Adds Italian, Polish, Korean, Dutch, Czech, Turkish, Indonesian, Ukrainian, and Arabic (`it, pl, ko, nl, cs, tr, id, uk, ar`).
- Full `strings_compose.xml` translations + `locales_config.xml` entries; in-app language picker now lists them (`LanguagePickerTest.kt`).

**Survive screen rotation without restart (#225)**
- App no longer tears down/rebuilds on rotation — handled via `configChanges` in the manifest.
- Keeps RX/TX state and the running cycle alive. Covered by `ComposeMainActivityConfigChangesTest.kt`.

### 🐛 Fixes

**FT2 slot is now a true 3.75 s (#224)**
- Corrected the FT2 timing slot from 3.8 s to 3.75 s across `ModeProfile`, `UtcTimer`, and `FT8Common`.
- Fixed a missed `UtcTimer` call site and corrected stale heartbeat docs. Updated `UtcTimerTest`, `ModeProfileTest`, `Ft8MessageTest`.

### 🔧 CI / Infra (#222)

- Stream instrumented-test progress via logcat during CI runs.
- Set `AndroidJUnitRunner` so instrumented tests actually execute.
- Grant runtime permissions so `AppSmokeTest` reaches `RESUMED`.
- Release workflow + `build.gradle` tweaks.

---

## ✅ Fastest-path test checklist

> Build & install: `cd ft8cn && cmd.exe /c "gradlew.bat installDebug"`

**Smoke (do these first — ~2 min)**
- [ ] App launches and reaches the main screen.
- [ ] **Rotate the phone** (portrait ↔ landscape) — app does **not** restart; decodes/cycle keep running.
- [ ] Decode a live FT8 cycle (waterfall populates, messages appear).

**Bluetooth CAT (#227)**
- [ ] With a previously-paired BT CAT rig powered on, cold-start the app → it auto-connects without manual tap.
- [ ] Rig audio routes over Bluetooth (HFP/SCO) and decodes.
- [ ] Toggle the auto-connect setting in **Advanced Settings**; confirm it persists across restart.

**Languages (#226)**
- [ ] Open the in-app language picker → all 9 new languages appear.
- [ ] Switch to one RTL (Arabic) and one LTR (Korean/Polish) → UI strings localize, layout intact.

**FT2 timing (#224)**
- [ ] Switch to FT2 mode → slot timer reflects 3.75 s; TX fires on-slot and decodes on a second device/PSKReporter.

**Regression guard**
- [ ] FT8 TX still produces decodable spots on PSKReporter (verifies the rotation/manifest changes didn't disturb the TX pipeline).
- [ ] Unit tests green: `cmd.exe /c "gradlew.bat testDebugUnitTest"`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
