### PR TITLE
Harden OperationBand index bounds and band-line parsing

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/OperationBand.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/OperationBand.java
@@ -52,11 +52,22 @@ public class OperationBand {
      * @return
      */
     public Band getBandByIndex(int index){
-        if (index==-1||index>=bandList.size()){
+        if (!isValidBandIndex(index)){
             return new Band(getDefaultBand(),getDefaultWaveLength());
         }else {
             return bandList.get(index);
         }
+    }
+
+    /**
+     * True when {@code index} is a valid position in {@link #bandList}.
+     * Centralises the bounds check so every accessor rejects both negative
+     * indices and indices at/after the end. {@link #getBandFreq(int)} previously
+     * used an off-by-one {@code index > size} guard that let {@code index == size}
+     * through into {@code bandList.get(index)} and threw IndexOutOfBounds.
+     */
+    static boolean isValidBandIndex(int index){
+        return index>=0 && index<bandList.size();
     }
 
     /**
@@ -87,12 +98,7 @@ public class OperationBand {
             bandList.clear();
             InputStream inputStream= assetManager.open("bands.txt");
             String[] st=getLinesFromInputStream(inputStream,"\n");
-            for (int i = 0; i <st.length ; i++) {
-                if (!isBandLine(st[i])){
-                    continue;
-                }
-               bandList.add(new Band(st[i]));
-            }
+            bandList.addAll(parseBandLines(st));
             inputStream.close();
         } catch (IOException e) {
             e.printStackTrace();
@@ -113,12 +119,37 @@ public class OperationBand {
         if (trimmed.isEmpty() || trimmed.startsWith("#")) return false;
         return trimmed.contains(":");
     }
-    public static String getBandInfo(int index){
-        if (index>=bandList.size()){
-            return bandList.get(0).getBandInfo();
-        }else {
-            return bandList.get(index).getBandInfo();
+
+    /**
+     * Parses bands.txt lines into {@link Band} entries, skipping comment/blank
+     * lines (see {@link #isBandLine}) and any line that fails to parse — e.g. a
+     * truncated {@code "20m:"} with no frequency, which would otherwise throw
+     * out of the {@link Band#Band(String)} constructor. A single malformed line
+     * is logged and skipped rather than aborting the whole band-list load and
+     * leaving the app with no bands.
+     */
+    static ArrayList<Band> parseBandLines(String[] lines){
+        ArrayList<Band> out = new ArrayList<>();
+        if (lines == null) return out;
+        for (String line : lines) {
+            if (!isBandLine(line)) continue;
+            try {
+                out.add(new Band(line));
+            } catch (RuntimeException e) {
+                Log.e(TAG, "Skipping malformed band line \""+line+"\": "+e.getMessage());
+            }
         }
+        return out;
+    }
+
+    public static String getBandInfo(int index){
+        if (bandList.isEmpty()){
+            return new Band(getDefaultBand(),getDefaultWaveLength()).getBandInfo();
+        }
+        if (!isValidBandIndex(index)){
+            return bandList.get(0).getBandInfo();
+        }
+        return bandList.get(index).getBandInfo();
     }
 
     /**
@@ -167,8 +198,8 @@ public class OperationBand {
     }
 
     public static long getBandFreq(int index){
-        if (index>bandList.size()){
-            return 14074000;
+        if (!isValidBandIndex(index)){
+            return getDefaultBand();
         }
         return bandList.get(index).band;
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/OperationBand.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/OperationBand.java
@@ -136,7 +136,7 @@ public class OperationBand {
             try {
                 out.add(new Band(line));
             } catch (RuntimeException e) {
-                Log.e(TAG, "Skipping malformed band line \""+line+"\": "+e.getMessage());
+                Log.e(TAG, "Skipping malformed band line \""+line+"\"", e);
             }
         }
         return out;

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/database/OperationBandTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/database/OperationBandTest.java
@@ -75,7 +75,7 @@ public class OperationBandTest {
 
     @Test
     public void getBandFreq_outOfRangeIndex_returnsDefault() {
-        // index strictly greater than size falls back to the 20m default.
+        // an out-of-range index falls back to the 20m default.
         assertThat(OperationBand.getBandFreq(99)).isEqualTo(14_074_000L);
     }
 
@@ -267,4 +267,88 @@ public class OperationBandTest {
         assertThat(OperationBand.isBandLine(
                 "# QO-100 geostationary satellite (Es'hail-2): 2.4 GHz uplink / 10.489 GHz downlink."))
                 .isFalse();
-    }}
+    }
+
+    // ---- index bounds hardening --------------------------------------------
+    // Index accessors must reject negative indices and indices at/after the end
+    // of bandList. getBandFreq previously used an off-by-one `index > size`
+    // guard, so index == size fell through into bandList.get(index) and threw
+    // IndexOutOfBounds; getBandInfo did bandList.get(0) on an empty list.
+
+    @Test
+    public void isValidBandIndex_acceptsInRangeRejectsNegativeAndEnd() {
+        OperationBand.bandList.add(new OperationBand.Band(14_074_000L, "20m"));
+        OperationBand.bandList.add(new OperationBand.Band(7_074_000L, "40m"));
+        assertThat(OperationBand.isValidBandIndex(0)).isTrue();
+        assertThat(OperationBand.isValidBandIndex(1)).isTrue();
+        assertThat(OperationBand.isValidBandIndex(-1)).isFalse();
+        assertThat(OperationBand.isValidBandIndex(2)).isFalse();   // == size (the off-by-one)
+        assertThat(OperationBand.isValidBandIndex(99)).isFalse();
+    }
+
+    @Test
+    public void getBandFreq_indexEqualToSize_returnsDefault() {
+        // The off-by-one: index == size passed the old `index > size` guard and
+        // dereferenced past the end. It must now fall back to the default band.
+        OperationBand.bandList.add(new OperationBand.Band(7_074_000L, "40m"));
+        assertThat(OperationBand.getBandFreq(1)).isEqualTo(OperationBand.getDefaultBand());
+    }
+
+    @Test
+    public void getBandFreq_negativeIndex_returnsDefault() {
+        OperationBand.bandList.add(new OperationBand.Band(7_074_000L, "40m"));
+        assertThat(OperationBand.getBandFreq(-1)).isEqualTo(OperationBand.getDefaultBand());
+    }
+
+    @Test
+    public void getBandInfo_emptyList_returnsDefaultInsteadOfCrashing() {
+        // bandList empty (bands.txt missing/corrupt): the old code did
+        // bandList.get(0) and threw. Now it formats the default band.
+        assertThat(OperationBand.bandList).isEmpty();
+        assertThat(OperationBand.getBandInfo(0)).isEqualTo("  14.074 MHz (20m)");
+    }
+
+    @Test
+    public void getBandInfo_negativeIndex_fallsBackToFirst() {
+        OperationBand.bandList.add(new OperationBand.Band(14_074_000L, "20m"));
+        assertThat(OperationBand.getBandInfo(-1)).isEqualTo("  14.074 MHz (20m)");
+    }
+
+    // ---- parseBandLines -----------------------------------------------------
+    // A single malformed line must be logged and skipped, not abort the whole
+    // band-list load and leave the app with no bands.
+
+    @Test
+    public void parseBandLines_keepsValidSkipsCommentsAndBlanks() {
+        String[] lines = {"*:14074000:20m", "# a comment", "", " :7074000:40m"};
+        java.util.ArrayList<OperationBand.Band> bands = OperationBand.parseBandLines(lines);
+        assertThat(bands).hasSize(2);
+        assertThat(bands.get(0).band).isEqualTo(14_074_000L);
+        assertThat(bands.get(1).band).isEqualTo(7_074_000L);
+    }
+
+    @Test
+    public void parseBandLines_skipsTruncatedLineButKeepsNeighbours() {
+        // "20m:" has a colon (so isBandLine accepts it) but splits to a single
+        // field, so the Band constructor throws AIOOBE. It must be skipped while
+        // the surrounding valid lines still load.
+        String[] lines = {"*:14074000:20m", "20m:", " :7074000:40m"};
+        java.util.ArrayList<OperationBand.Band> bands = OperationBand.parseBandLines(lines);
+        assertThat(bands).hasSize(2);
+        assertThat(bands.get(0).waveLength).isEqualTo("20m");
+        assertThat(bands.get(1).waveLength).isEqualTo("40m");
+    }
+
+    @Test
+    public void parseBandLines_skipsNonNumericFrequency() {
+        String[] lines = {"*:notanumber:20m", " :7074000:40m"};
+        java.util.ArrayList<OperationBand.Band> bands = OperationBand.parseBandLines(lines);
+        assertThat(bands).hasSize(1);
+        assertThat(bands.get(0).band).isEqualTo(7_074_000L);
+    }
+
+    @Test
+    public void parseBandLines_nullInput_returnsEmpty() {
+        assertThat(OperationBand.parseBandLines(null)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Context

First fix from the pre-app-store **bug bash** triage ledger (PR 2 — the highest-confidence cluster of real defects). Triage-verified by reading source; these are genuine crashers reachable from the band/frequency pickers and the `bands.txt` asset loader.

## Bugs fixed

| Where | Bug | Trigger |
|-------|-----|---------|
| `OperationBand.getBandFreq(int)` | Guard was `index > size` — **off-by-one**. `index == size` slipped through to `bandList.get(index)` → `IndexOutOfBounds`. Negatives unguarded. | Band picker at the list boundary |
| `OperationBand.getBandInfo(int)` | Returned `bandList.get(0)` when `index >= size` → crashes on an **empty list** (missing/corrupt `bands.txt`); negatives unguarded. | First-run / corrupt asset |
| `OperationBand.Band(String)` | A truncated line like `"20m:"` passes `isBandLine()` (it has a colon) but splits to one field → constructor throws and **aborts the entire band-list load**, leaving the app with no bands. | One malformed line in `bands.txt` |

## Approach

- Centralised the bounds check in a single `isValidBandIndex()` helper used by every accessor (rejects both negatives and `index >= size`).
- `getBandInfo` falls back to the default band when the list is empty.
- Extracted the asset parse loop into `parseBandLines()`, which logs and **skips an individual malformed line** instead of aborting the whole load.
- No behaviour change for valid input.

## Tests

`OperationBandTest` (now 34 tests, all green) gains coverage for: the off-by-one (`index == size`), negative indices on both accessors, empty-list `getBandInfo`, and `parseBandLines` skipping truncated / non-numeric / comment / blank lines while keeping valid neighbours.

Run: `cmd.exe /c "gradlew.bat testDebugUnitTest --tests com.bg7yoz.ft8cn.database.OperationBandTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)