### PR TITLE
Address Copilot review on PR #228 (mask BT MAC, doc/test fixes, Korean strings)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/timer/UtcTimer.java
@@ -204,7 +204,7 @@ public class UtcTimer {
                     //time_sec is the time offset
                     if (running && isCycleBoundary(utc, time_sec, slotMillis)) {
                         //cycle action
-                        //IMPORTANT! doHeartBeatTimer must not perform time-consuming operations and must complete within the heartbeat interval, otherwise thread backlog may occur and affect performance.
+                        //IMPORTANT! the cycle callback (doSomething -> doOnSecTimer) must not perform time-consuming operations and must complete within the cycle interval, otherwise thread backlog may occur and affect performance.
                         cachedThreadPool.execute(doSomething);//use thread pool for invocation to reduce system overhead
                         //thread.run();
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
@@ -47,3 +47,16 @@ internal fun decideBluetoothAutoConnect(
     if (!isBonded) return BtAutoConnectDecision.NOT_BONDED
     return BtAutoConnectDecision.CONNECT
 }
+
+/**
+ * Redact a Bluetooth MAC for debug.log, which users attach to bug reports. A MAC is a stable
+ * device identifier, so we keep only the first and last octet (enough to correlate log lines)
+ * and hide the middle four (PR #228 review). A null/blank value becomes `<none>`; a corrupted
+ * non-MAC value reveals only its length so the raw identifier never lands in a shareable log.
+ */
+internal fun maskBluetoothAddress(addr: String?): String {
+    if (addr.isNullOrBlank()) return "<none>"
+    val parts = addr.split(":")
+    if (parts.size == 6) return "${parts.first()}:**:**:**:**:${parts.last()}"
+    return "<malformed:${addr.length}>"
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -573,7 +573,7 @@ class ComposeMainActivity : AppCompatActivity() {
         // IllegalArgumentException and crash startup, so validate the MAC up front (PR #227 review).
         val validAddr = !addr.isNullOrBlank() && BluetoothAdapter.checkBluetoothAddress(addr)
         if (!addr.isNullOrBlank() && !validAddr) {
-            fileLog("autoConnectBT: ignoring invalid saved address=$addr")
+            fileLog("autoConnectBT: ignoring invalid saved address=${maskBluetoothAddress(addr)}")
         }
         val hasPerm = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
             ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) ==
@@ -592,7 +592,7 @@ class ComposeMainActivity : AppCompatActivity() {
             hasConnectPermission = hasPerm,
             isBonded = bonded,
         )
-        fileLog("autoConnectBT: decision=$decision addr=$addr connectMode=${GeneralVariables.connectMode}")
+        fileLog("autoConnectBT: decision=$decision addr=${maskBluetoothAddress(addr)} connectMode=${GeneralVariables.connectMode}")
         if (decision == BtAutoConnectDecision.CONNECT) {
             mainViewModel.connectBluetoothRig(applicationContext, adapter!!.getRemoteDevice(addr))
         }

--- a/ft8cn/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ko/strings_compose.xml
@@ -88,8 +88,8 @@
     <!-- ===== Export log sheet ===== -->
     <string name="export_title">QSO 내보내기</string>
     <string name="export_date_range">날짜 범위</string>
-    <string name="export_date_from_placeholder">"From  YYYYMMDD"</string>
-    <string name="export_date_to_placeholder">"To  YYYYMMDD"</string>
+    <string name="export_date_from_placeholder">"시작  YYYYMMDD"</string>
+    <string name="export_date_to_placeholder">"종료  YYYYMMDD"</string>
     <string name="export_share">공유</string>
     <string name="export_filter_confirmed">확인된 것만</string>
     <string name="export_filter_unconfirmed">미확인만</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
@@ -180,4 +180,34 @@ class BluetoothAutoConnectTest {
             ),
         ).isEqualTo(BtAutoConnectDecision.ALREADY_CONNECTED)
     }
+
+    // --- maskBluetoothAddress: keep debug.log free of the raw MAC (PR #228 review) ---
+
+    @Test
+    fun maskKeepsOnlyFirstAndLastOctet() {
+        assertThat(maskBluetoothAddress("AA:BB:CC:DD:EE:FF")).isEqualTo("AA:**:**:**:**:FF")
+    }
+
+    @Test
+    fun maskHidesEveryMiddleOctet() {
+        // None of the four middle octets may survive anywhere in the output.
+        val masked = maskBluetoothAddress("11:22:33:44:55:66")
+        for (octet in listOf("22", "33", "44", "55")) {
+            assertThat(masked).doesNotContain(octet)
+        }
+    }
+
+    @Test
+    fun maskNullOrBlankAddressIsNone() {
+        assertThat(maskBluetoothAddress(null)).isEqualTo("<none>")
+        assertThat(maskBluetoothAddress("")).isEqualTo("<none>")
+        assertThat(maskBluetoothAddress("   ")).isEqualTo("<none>")
+    }
+
+    @Test
+    fun maskMalformedAddressLeaksOnlyLengthNotValue() {
+        val masked = maskBluetoothAddress("not-a-mac-address")
+        assertThat(masked).isEqualTo("<malformed:17>")
+        assertThat(masked).doesNotContain("mac")
+    }
 }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/settings/LanguagePickerTest.kt
@@ -37,7 +37,7 @@ class LanguagePickerTest {
         val tags = SUPPORTED_LANGUAGES.map { it.tag }
         for (a in tags) {
             for (b in tags) {
-                if (a !== b && b.startsWith(a)) {
+                if (a != b && b.startsWith(a)) {
                     throw AssertionError("Tag '$a' is a prefix of '$b'")
                 }
             }


### PR DESCRIPTION
Addresses the 5 Copilot review comments on #228.

| # | File | Fix |
|---|------|-----|
| 1,2 | `ComposeMainActivity.kt` / `BluetoothAutoConnect.kt` | **Mask the Bluetooth MAC in `debug.log`.** New pure `maskBluetoothAddress()` keeps only the first/last octet (`AA:**:**:**:**:FF`); both the invalid-address and decision log lines now redact. Malformed values leak only their length. |
| 3 | `UtcTimer.java` | Comment named `doHeartBeatTimer` but the code runs the cycle callback (`doSomething` → `doOnSecTimer`) — corrected. |
| 4 | `LanguagePickerTest.kt` | Prefix-ambiguity guard used identity (`!==`); switched to value comparison (`!=`). |
| 5 | `values-ko/strings_compose.xml` | Korean export date placeholders were still English ("From"/"To") → 시작/종료. |

**Tests:** `maskBluetoothAddress()` is a new code path, so it's covered by 4 new unit tests in `BluetoothAutoConnectTest` (valid mask, every middle octet hidden, null/blank → `<none>`, malformed leaks only length). `testDebugUnitTest` green for `BluetoothAutoConnectTest` + `LanguagePickerTest`.

Once merged to `dev`, these flow into release PR #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
