### PR TITLE
Fix Hunt button inactive on cold start

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -128,6 +128,7 @@ import java.util.concurrent.Executors;
 
 public class MainViewModel extends ViewModel {
     String TAG = "ft8cn MainViewModel";
+    public final MutableLiveData<Boolean> mutableConfigLoaded = new MutableLiveData<>(false);
     public boolean configIsLoaded = false;
 
     /** Write debug line to the app's external files debug.log */

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -305,6 +305,7 @@ class ComposeMainActivity : AppCompatActivity() {
 
             override fun doOnAfterQueryConfig(keyName: String?, value: String?) {
                 mainViewModel.configIsLoaded = true
+                mainViewModel.mutableConfigLoaded.postValue(true)
                 fileLog("configLoaded: instructionSet=${GeneralVariables.instructionSet}, " +
                     "baudRate=${GeneralVariables.baudRate}, " +
                     "controlMode=${GeneralVariables.controlMode}, " +

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -69,6 +69,14 @@ import radio.ks3ckc.ft8us.ui.waterfall.WaterfallScreen
  */
 internal fun qsoPanelOverlaysContent(tab: FT8USTab): Boolean = tab == FT8USTab.WATERFALL
 
+/**
+ * Whether the sequencer should be armed for Hunt on app startup. True when the
+ * persisted Hunt setting is "on" and the operator has set a callsign (Hunt
+ * transmits replies, so a callsign is required).
+ */
+internal fun shouldArmHuntOnStartup(huntEnabled: Boolean, callsign: String?): Boolean =
+    huntEnabled && !callsign.isNullOrEmpty()
+
 @Composable
 fun FT8USApp(mainViewModel: MainViewModel) {
     val context = LocalContext.current
@@ -116,6 +124,18 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     LaunchedEffect(preselectCallsign) {
         if (!preselectCallsign.isNullOrBlank()) {
             activeTab = FT8USTab.DECODE
+        }
+    }
+
+    // If Hunt was persisted as "on", arm the sequencer on first composition so
+    // it actually answers CQs. Without this the button renders as "on" but the
+    // sequencer is never activated — nothing happens until the user toggles Hunt
+    // off and on again. (Issues #1 / #5 / #10)
+    LaunchedEffect(Unit) {
+        if (shouldArmHuntOnStartup(huntEnabled, GeneralVariables.myCallsign)) {
+            mainViewModel.ft8TransmitSignal.armForHunt()
+            mainViewModel.ft8TransmitSignal.setActivated(true)
+            GeneralVariables.resetLaunchSupervision()
         }
     }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -127,12 +127,14 @@ fun FT8USApp(mainViewModel: MainViewModel) {
         }
     }
 
-    // If Hunt was persisted as "on", arm the sequencer on first composition so
-    // it actually answers CQs. Without this the button renders as "on" but the
-    // sequencer is never activated — nothing happens until the user toggles Hunt
-    // off and on again. (Issues #1 / #5 / #10)
-    LaunchedEffect(Unit) {
-        if (shouldArmHuntOnStartup(huntEnabled, GeneralVariables.myCallsign)) {
+    // Wait for config (callsign, autoFollowCQ, etc.) to finish loading from
+    // the database before arming Hunt. LaunchedEffect(Unit) would race with
+    // the async config load and see an empty callsign. (#231)
+    val configLoaded by mainViewModel.mutableConfigLoaded.observeAsState(false)
+    LaunchedEffect(configLoaded) {
+        if (configLoaded && shouldArmHuntOnStartup(
+                GeneralVariables.autoFollowCQ, GeneralVariables.myCallsign)) {
+            huntEnabled = GeneralVariables.autoFollowCQ
             mainViewModel.ft8TransmitSignal.armForHunt()
             mainViewModel.ft8TransmitSignal.setActivated(true)
             GeneralVariables.resetLaunchSupervision()

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/HuntColdStartTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/HuntColdStartTest.kt
@@ -1,0 +1,36 @@
+package radio.ks3ckc.ft8us
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [shouldArmHuntOnStartup] — the predicate that decides whether
+ * Hunt should be armed when the app cold-starts with autoFollowCQ persisted as true.
+ */
+class HuntColdStartTest {
+
+    @Test
+    fun `hunt enabled with valid callsign — should arm`() {
+        assertThat(shouldArmHuntOnStartup(huntEnabled = true, callsign = "W1AW")).isTrue()
+    }
+
+    @Test
+    fun `hunt disabled with valid callsign — should not arm`() {
+        assertThat(shouldArmHuntOnStartup(huntEnabled = false, callsign = "W1AW")).isFalse()
+    }
+
+    @Test
+    fun `hunt enabled with null callsign — should not arm`() {
+        assertThat(shouldArmHuntOnStartup(huntEnabled = true, callsign = null)).isFalse()
+    }
+
+    @Test
+    fun `hunt enabled with empty callsign — should not arm`() {
+        assertThat(shouldArmHuntOnStartup(huntEnabled = true, callsign = "")).isFalse()
+    }
+
+    @Test
+    fun `hunt disabled with null callsign — should not arm`() {
+        assertThat(shouldArmHuntOnStartup(huntEnabled = false, callsign = null)).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
- Arm Hunt sequencer on cold start when `autoFollowCQ` is persisted as true, so the button actually works without toggling off/on
- Extract `shouldArmHuntOnStartup()` predicate for testability
- Closes #231 (also covers reported TX-stuck-red and red-indicator symptoms)

## Test plan
- [ ] Verify `HuntColdStartTest` passes
- [ ] Set Hunt to "on", force-stop app, relaunch — Hunt should immediately answer CQs
- [ ] Cold start with no callsign set — Hunt button should be lit but sequencer should NOT arm (avoids transmitting without a callsign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)