### PR TITLE
Fix grid sent instead of RPT when answering a caller

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -934,11 +934,35 @@ public class MainViewModel extends ViewModel {
         // or Auto-CQ after QSO is enabled. (Must come after setActivated(true),
         // which clears the flag on its deactivation path.)
         ft8TransmitSignal.beginSingleQso();
+        // When the tapped message is directed at us (someone answering our CQ),
+        // auto-derive the function order so we reply with RPT (order 2) instead
+        // of grid (order 1). For messages not directed at us (we're initiating),
+        // start at order 1 as before.
+        int order = callStationOrder(message.getCallsignTo(), message.extraInfo);
         ft8TransmitSignal.setTransmit(
                 message.getFromCallTransmitCallsign(),
-                1,
+                order,
                 message.extraInfo);
         ft8TransmitSignal.transmitNow();
+    }
+
+    /**
+     * Determine the starting function order when the user taps a decoded message
+     * to call a station. If the message is directed at us (someone answering our
+     * CQ), auto-derive so we reply with the correct next step (RPT). Otherwise
+     * start at order 1 (grid, initiating a new QSO).
+     *
+     * <p>Package-visible for testing.
+     *
+     * @param callsignTo message's "to" callsign (empty/CQ for broadcast messages)
+     * @param extraInfo  the message's extraInfo field (grid / report / RR73 / 73)
+     * @return function order: -1 for auto-derive, 1 for initiate
+     */
+    static int callStationOrder(String callsignTo, String extraInfo) {
+        if (callsignTo != null && GeneralVariables.checkIsMyCallsign(callsignTo)) {
+            return -1; // auto-derive: setTransmit will compute the correct next step
+        }
+        return 1; // initiating: start with grid
     }
 
     // ===== FT8 DXpedition Hound mode =====

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -938,7 +938,7 @@ public class MainViewModel extends ViewModel {
         // auto-derive the function order so we reply with RPT (order 2) instead
         // of grid (order 1). For messages not directed at us (we're initiating),
         // start at order 1 as before.
-        int order = callStationOrder(message.getCallsignTo(), message.extraInfo);
+        int order = callStationOrder(message.getCallsignTo());
         ft8TransmitSignal.setTransmit(
                 message.getFromCallTransmitCallsign(),
                 order,
@@ -955,10 +955,9 @@ public class MainViewModel extends ViewModel {
      * <p>Package-visible for testing.
      *
      * @param callsignTo message's "to" callsign (empty/CQ for broadcast messages)
-     * @param extraInfo  the message's extraInfo field (grid / report / RR73 / 73)
      * @return function order: -1 for auto-derive, 1 for initiate
      */
-    static int callStationOrder(String callsignTo, String extraInfo) {
+    static int callStationOrder(String callsignTo) {
         if (callsignTo != null && GeneralVariables.checkIsMyCallsign(callsignTo)) {
             return -1; // auto-derive: setTransmit will compute the correct next step
         }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/CallStationOrderTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/CallStationOrderTest.java
@@ -29,27 +29,27 @@ public class CallStationOrderTest {
     @Test
     public void messageDirectedAtMe_autoDerives() {
         // Someone answered our CQ: "THEM W1AW EM73" — callsignTo is our call
-        int order = MainViewModel.callStationOrder("W1AW", "EM73");
+        int order = MainViewModel.callStationOrder("W1AW");
         assertThat(order).isEqualTo(-1);
     }
 
     @Test
     public void messageNotDirectedAtMe_startsAtOrder1() {
         // A CQ or message to someone else — we initiate with grid
-        int order = MainViewModel.callStationOrder("K5ABC", "EM73");
+        int order = MainViewModel.callStationOrder("K5ABC");
         assertThat(order).isEqualTo(1);
     }
 
     @Test
     public void cqMessage_startsAtOrder1() {
         // CQ broadcast — callsignTo is empty after getCallsignTo() strips "CQ"
-        int order = MainViewModel.callStationOrder("", "EM73");
+        int order = MainViewModel.callStationOrder("");
         assertThat(order).isEqualTo(1);
     }
 
     @Test
     public void nullCallsignTo_startsAtOrder1() {
-        int order = MainViewModel.callStationOrder(null, "EM73");
+        int order = MainViewModel.callStationOrder(null);
         assertThat(order).isEqualTo(1);
     }
 
@@ -57,7 +57,7 @@ public class CallStationOrderTest {
     public void compoundCallsign_matchesShortForm() {
         // Our callsign with a portable suffix — checkIsMyCallsign uses contains()
         GeneralVariables.myCallsign = "W1AW/P";
-        int order = MainViewModel.callStationOrder("W1AW", "EM73");
+        int order = MainViewModel.callStationOrder("W1AW");
         assertThat(order).isEqualTo(-1);
     }
 }

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/CallStationOrderTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/CallStationOrderTest.java
@@ -1,0 +1,63 @@
+package com.bg7yoz.ft8cn;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MainViewModel#callStationOrder} — the logic that picks
+ * function order 1 (initiate with grid) vs -1 (auto-derive, reply with RPT)
+ * when the user taps a decoded message.
+ */
+public class CallStationOrderTest {
+
+    private String savedCallsign;
+
+    @Before
+    public void setUp() {
+        savedCallsign = GeneralVariables.myCallsign;
+        GeneralVariables.myCallsign = "W1AW";
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.myCallsign = savedCallsign;
+    }
+
+    @Test
+    public void messageDirectedAtMe_autoDerives() {
+        // Someone answered our CQ: "THEM W1AW EM73" — callsignTo is our call
+        int order = MainViewModel.callStationOrder("W1AW", "EM73");
+        assertThat(order).isEqualTo(-1);
+    }
+
+    @Test
+    public void messageNotDirectedAtMe_startsAtOrder1() {
+        // A CQ or message to someone else — we initiate with grid
+        int order = MainViewModel.callStationOrder("K5ABC", "EM73");
+        assertThat(order).isEqualTo(1);
+    }
+
+    @Test
+    public void cqMessage_startsAtOrder1() {
+        // CQ broadcast — callsignTo is empty after getCallsignTo() strips "CQ"
+        int order = MainViewModel.callStationOrder("", "EM73");
+        assertThat(order).isEqualTo(1);
+    }
+
+    @Test
+    public void nullCallsignTo_startsAtOrder1() {
+        int order = MainViewModel.callStationOrder(null, "EM73");
+        assertThat(order).isEqualTo(1);
+    }
+
+    @Test
+    public void compoundCallsign_matchesShortForm() {
+        // Our callsign with a portable suffix — checkIsMyCallsign uses contains()
+        GeneralVariables.myCallsign = "W1AW/P";
+        int order = MainViewModel.callStationOrder("W1AW", "EM73");
+        assertThat(order).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
## Summary
- Auto-derive function order when tapped message is directed at us (someone answering our CQ), so RPT is sent instead of grid
- Extract `callStationOrder()` static helper for testability
- Closes #233

## Test plan
- [ ] Verify `CallStationOrderTest` passes
- [ ] Call CQ, wait for someone to answer, tap their decode — app should reply with RPT (order 2), not grid (order 1)
- [ ] Tap a CQ from another station — app should initiate with grid (order 1) as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)