### PR TITLE
Guard celebration on manual queue switch

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1728,8 +1728,13 @@ public class FT8TransmitSignal {
      *                     instead of the head of the queue.
      */
     public void forceLogAndMoveOn(String nextCallsign) {
-        // Ensure QSO is saved (no-op if already saved at function order 4/5)
-        updateQSlRecordList(4, toCallsign);
+        // Only log and celebrate if the QSO progressed enough (at least one
+        // report exchanged, i.e. order >= 3). Skipping to the next caller at
+        // order 1 or 2 means no real QSO took place — logging it would show a
+        // bogus contact and the celebration animation would be misleading.
+        if (shouldForceLog(functionOrder)) {
+            updateQSlRecordList(4, toCallsign);
+        }
 
         // Mirror the normal QSO-completion path from parseMessageToFunction
         resetToCQ();
@@ -1759,6 +1764,17 @@ public class FT8TransmitSignal {
     /** Convenience overload: log and move on to the head of the queue. */
     public void forceLogAndMoveOn() {
         forceLogAndMoveOn(null);
+    }
+
+    /**
+     * Whether a force-log should actually save the QSO record and trigger the
+     * celebration. A QSO that never progressed past order 2 (no report
+     * exchanged) is not a real contact.
+     *
+     * <p>Package-visible for testing.
+     */
+    static boolean shouldForceLog(int functionOrder) {
+        return functionOrder >= 3;
     }
 
     // ==================== Caller Queue Methods ====================

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1774,7 +1774,9 @@ public class FT8TransmitSignal {
      * <p>Package-visible for testing.
      */
     static boolean shouldForceLog(int functionOrder) {
-        return functionOrder >= 3;
+        // Orders 3-5 indicate a real QSO in progress (report exchanged).
+        // Order 6 is the CQ baseline (idle) — not a real contact.
+        return functionOrder >= 3 && functionOrder != 6;
     }
 
     // ==================== Caller Queue Methods ====================

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/ForceLogGuardTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/ForceLogGuardTest.java
@@ -1,0 +1,47 @@
+package com.bg7yoz.ft8cn.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link FT8TransmitSignal#shouldForceLog} — the guard that
+ * prevents false celebration and bogus log entries when the user skips to the
+ * next caller before any report is exchanged.
+ */
+public class ForceLogGuardTest {
+
+    @Test
+    public void order1_grid_shouldNotLog() {
+        assertThat(FT8TransmitSignal.shouldForceLog(1)).isFalse();
+    }
+
+    @Test
+    public void order2_report_shouldNotLog() {
+        assertThat(FT8TransmitSignal.shouldForceLog(2)).isFalse();
+    }
+
+    @Test
+    public void order3_reportExchanged_shouldLog() {
+        assertThat(FT8TransmitSignal.shouldForceLog(3)).isTrue();
+    }
+
+    @Test
+    public void order4_rr73_shouldLog() {
+        assertThat(FT8TransmitSignal.shouldForceLog(4)).isTrue();
+    }
+
+    @Test
+    public void order5_73_shouldLog() {
+        assertThat(FT8TransmitSignal.shouldForceLog(5)).isTrue();
+    }
+
+    @Test
+    public void order6_cq_shouldNotLog() {
+        // Edge case: if somehow forceLog is called while on CQ baseline,
+        // order 6 >= 3 is true. This is acceptable — forceLogAndMoveOn
+        // exits early for CQ via the toCallsign.callsign == "CQ" check
+        // in updateQSlRecordList.
+        assertThat(FT8TransmitSignal.shouldForceLog(6)).isTrue();
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/ForceLogGuardTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/ForceLogGuardTest.java
@@ -38,10 +38,7 @@ public class ForceLogGuardTest {
 
     @Test
     public void order6_cq_shouldNotLog() {
-        // Edge case: if somehow forceLog is called while on CQ baseline,
-        // order 6 >= 3 is true. This is acceptable — forceLogAndMoveOn
-        // exits early for CQ via the toCallsign.callsign == "CQ" check
-        // in updateQSlRecordList.
-        assertThat(FT8TransmitSignal.shouldForceLog(6)).isTrue();
+        // Order 6 is the CQ baseline (idle state) — not a real contact.
+        assertThat(FT8TransmitSignal.shouldForceLog(6)).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- Only log QSO and trigger celebration when the QSO reached at least order 3 (report exchanged)
- Skipping to next caller at order 1-2 no longer creates bogus log entries or shows false celebration
- Closes #235

## Test plan
- [ ] Verify `ForceLogGuardTest` passes
- [ ] Start calling a station, immediately tap next in queue before any report is exchanged — no celebration should appear
- [ ] Complete a QSO to order 3+, then force-log — celebration should appear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)