### PR TITLE
Fix stale QSL callsign display on decode list

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -345,7 +345,7 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
     // decode time, so a QSO completed after the message was decoded would leave
     // the stale field as false. The live check catches newly-worked callsigns.
     val isWorked = message.isQSL_Callsign ||
-        GeneralVariables.checkQSLCallsign(message.callsignFrom ?: "")
+        GeneralVariables.checkQSLCallsign(message.getCallsignFrom())
     val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
     val modifier = message.modifier
     val grid = message.maidenGrid

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeRow.kt
@@ -341,7 +341,11 @@ private fun MetaText(text: String) {
  */
 internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
     val isCQ = message.checkIsCQ()
-    val isWorked = message.isQSL_Callsign
+    // Use live lookup instead of the cached field: isQSL_Callsign is set at
+    // decode time, so a QSO completed after the message was decoded would leave
+    // the stale field as false. The live check catches newly-worked callsigns.
+    val isWorked = message.isQSL_Callsign ||
+        GeneralVariables.checkQSLCallsign(message.callsignFrom ?: "")
     val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
     val modifier = message.modifier
     val grid = message.maidenGrid

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -460,7 +460,7 @@ private fun computeCurrentStepIndex(
     liveFunctionOrder: Int,
 ): Int {
     val isFullyComplete = (message.isQSL_Callsign ||
-        GeneralVariables.checkQSLCallsign(message.callsignFrom ?: "")) && !isLiveQso
+        GeneralVariables.checkQSLCallsign(message.getCallsignFrom())) && !isLiveQso
     return when {
         isFullyComplete -> 5
         isLiveQso -> when (liveFunctionOrder) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/QsoSheet.kt
@@ -459,7 +459,8 @@ private fun computeCurrentStepIndex(
     isLiveQso: Boolean,
     liveFunctionOrder: Int,
 ): Int {
-    val isFullyComplete = message.isQSL_Callsign && !isLiveQso
+    val isFullyComplete = (message.isQSL_Callsign ||
+        GeneralVariables.checkQSLCallsign(message.callsignFrom ?: "")) && !isLiveQso
     return when {
         isFullyComplete -> 5
         isLiveQso -> when (liveFunctionOrder) {

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/QslDisplayFreshnessTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/QslDisplayFreshnessTest.kt
@@ -6,6 +6,9 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import radio.ks3ckc.ft8us.ui.components.QsoStatus
 
 /**
  * Tests that [resolveQsoStatus] uses the live QSL callsign list, not just the
@@ -15,12 +18,27 @@ import org.junit.Test
  * "worked" marker on the decode list even though the waterfall (which uses a
  * live check) showed it correctly.
  */
+@RunWith(RobolectricTestRunner::class)
 class QslDisplayFreshnessTest {
 
-    private val savedCallsign = GeneralVariables.myCallsign
+    private var savedCallsign: String? = null
+    private var savedHighlightPota = false
+    private var savedHighlightNewDxcc = false
+    private var savedHighlightNewGrid = false
+    private var savedHighlightNewBand = false
+    private var savedHighlightWorked = false
+    private lateinit var savedQslList: ArrayList<String>
 
     @Before
     fun setUp() {
+        savedCallsign = GeneralVariables.myCallsign
+        savedHighlightPota = GeneralVariables.highlightPota
+        savedHighlightNewDxcc = GeneralVariables.highlightNewDxcc
+        savedHighlightNewGrid = GeneralVariables.highlightNewGrid
+        savedHighlightNewBand = GeneralVariables.highlightNewBand
+        savedHighlightWorked = GeneralVariables.highlightWorked
+        savedQslList = ArrayList(GeneralVariables.QSL_Callsign_list)
+
         GeneralVariables.myCallsign = "W1AW"
         GeneralVariables.QSL_Callsign_list.clear()
         // Disable all highlight toggles except "worked" so the when-chain
@@ -35,7 +53,13 @@ class QslDisplayFreshnessTest {
     @After
     fun tearDown() {
         GeneralVariables.myCallsign = savedCallsign
+        GeneralVariables.highlightPota = savedHighlightPota
+        GeneralVariables.highlightNewDxcc = savedHighlightNewDxcc
+        GeneralVariables.highlightNewGrid = savedHighlightNewGrid
+        GeneralVariables.highlightNewBand = savedHighlightNewBand
+        GeneralVariables.highlightWorked = savedHighlightWorked
         GeneralVariables.QSL_Callsign_list.clear()
+        GeneralVariables.QSL_Callsign_list.addAll(savedQslList)
     }
 
     private fun makeCqMessage(from: String, cachedQsl: Boolean): Ft8Message {

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/QslDisplayFreshnessTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/decode/QslDisplayFreshnessTest.kt
@@ -1,0 +1,67 @@
+package radio.ks3ckc.ft8us.ui.decode
+
+import com.bg7yoz.ft8cn.Ft8Message
+import com.bg7yoz.ft8cn.GeneralVariables
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests that [resolveQsoStatus] uses the live QSL callsign list, not just the
+ * cached [Ft8Message.isQSL_Callsign] field which is set at decode time.
+ *
+ * The user reported that a station completed mid-session would not show the
+ * "worked" marker on the decode list even though the waterfall (which uses a
+ * live check) showed it correctly.
+ */
+class QslDisplayFreshnessTest {
+
+    private val savedCallsign = GeneralVariables.myCallsign
+
+    @Before
+    fun setUp() {
+        GeneralVariables.myCallsign = "W1AW"
+        GeneralVariables.QSL_Callsign_list.clear()
+        // Disable all highlight toggles except "worked" so the when-chain
+        // falls through to the WORKED branch we're testing.
+        GeneralVariables.highlightPota = false
+        GeneralVariables.highlightNewDxcc = false
+        GeneralVariables.highlightNewGrid = false
+        GeneralVariables.highlightNewBand = false
+        GeneralVariables.highlightWorked = true
+    }
+
+    @After
+    fun tearDown() {
+        GeneralVariables.myCallsign = savedCallsign
+        GeneralVariables.QSL_Callsign_list.clear()
+    }
+
+    private fun makeCqMessage(from: String, cachedQsl: Boolean): Ft8Message {
+        val msg = Ft8Message("CQ", from, "EM73")
+        msg.isQSL_Callsign = cachedQsl
+        return msg
+    }
+
+    @Test
+    fun `cached field true — shows WORKED`() {
+        val msg = makeCqMessage("K5ABC", cachedQsl = true)
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.WORKED)
+    }
+
+    @Test
+    fun `cached field false but live list has callsign — shows WORKED`() {
+        // Simulates a QSO that completed after the message was decoded:
+        // the cached field is false, but the live list now includes the call.
+        GeneralVariables.QSL_Callsign_list.add("K5ABC")
+        val msg = makeCqMessage("K5ABC", cachedQsl = false)
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.WORKED)
+    }
+
+    @Test
+    fun `both false — shows CQ`() {
+        val msg = makeCqMessage("K5ABC", cachedQsl = false)
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.CQ)
+    }
+}


### PR DESCRIPTION
## Summary
- Add live `checkQSLCallsign()` lookup in `resolveQsoStatus()` and `computeCurrentStepIndex()` alongside the cached `isQSL_Callsign` field
- Stations completed mid-session now immediately show "worked" marker on decode list
- Closes #237

## Test plan
- [ ] Verify `QslDisplayFreshnessTest` passes
- [ ] Complete a QSO, observe the decode list — the station should immediately show as "worked" without needing a new decode cycle
- [ ] Stations that were worked before app start should still show as "worked" (cached field still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)