### PR TITLE
Fix retry limit counter reset and unlimited failsafe

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -120,7 +120,6 @@ public class FT8TransmitSignal {
     // never answers instead of transmitting at it forever. RR73 (order 4): the
     // QSO is already logged, so only repeat RR73 a few times for the partner's
     // benefit, then return to CQ / next caller.
-    private static final int NO_REPLY_GIVEUP_CYCLES = 4;
     private static final int RR73_GIVEUP_CYCLES = 3;
 
     // Caller queue: stations that called us while we're in an active QSO
@@ -1601,6 +1600,10 @@ public class FT8TransmitSignal {
             setTransmitting(false);
             clearCallerQueue();
             singleQsoMode = false;
+            // Reset retry counters so a fresh run to the same callsign
+            // doesn't inherit a stale noReplyCount from the previous session.
+            GeneralVariables.noReplyCount = 0;
+            lastNoReplyTarget = "";
         }
         mutableIsActivated.postValue(activated);
     }
@@ -1784,7 +1787,7 @@ public class FT8TransmitSignal {
      * <p>Package-visible for testing.
      */
     static boolean shouldGiveUpTarget(int noReplyLimit, int noReplyCount) {
-        return noReplyLimit > 0 && noReplyCount > noReplyLimit;
+        return noReplyLimit > 0 && noReplyCount >= noReplyLimit;
     }
 
     // ==================== Caller Queue Methods ====================

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -64,6 +64,10 @@ public class FT8TransmitSignal {
     // operator has Hunt or Auto-CQ-after-QSO enabled. Cleared when a CQ run
     // starts (userResetToCQ) or TX is deactivated.
     private volatile boolean singleQsoMode = false;
+    // Tracks the callsign for which noReplyCount is accumulating. When
+    // generateFun() is called for the same target (e.g. Hunt re-targets the
+    // same CQ station), the counter is preserved instead of being reset to 0.
+    private String lastNoReplyTarget = "";
     private volatile boolean isTransmitting = false;
     public MutableLiveData<Boolean> mutableIsTransmitting = new MutableLiveData<>();// whether currently transmitting
     public MutableLiveData<String> mutableTransmittingMessage = new MutableLiveData<>();// current message content
@@ -388,8 +392,15 @@ public class FT8TransmitSignal {
      * Generate the command sequence.
      */
     public void generateFun() {
-        //ArrayList<FunctionOfTransmit> functions = new ArrayList<>();
-        GeneralVariables.noReplyCount = 0;
+        // Only reset the no-reply counter when the target callsign actually
+        // changes. Previously this was unconditional, so Hunt re-targeting the
+        // SAME station (still calling CQ) would reset the counter every cycle,
+        // preventing the retry limit from ever triggering.
+        String currentTarget = (toCallsign != null) ? toCallsign.callsign : "";
+        if (shouldResetNoReplyCount(currentTarget, lastNoReplyTarget)) {
+            GeneralVariables.noReplyCount = 0;
+            lastNoReplyTarget = currentTarget;
+        }
         functionList.clear();
         for (int i = 1; i <= 6; i++) {
             if (functionOrder == 6) {// if current command is 6 (CQ), generate only one message
@@ -1353,21 +1364,15 @@ public class FT8TransmitSignal {
                 GeneralVariables.noReplyCount, functionOrder,
                 toCallsign != null ? toCallsign.callsign : "?"));
 
-        // Give up the current target and fall back to CQ / next caller when:
-        //  - the user-configured no-reply limit is hit (noReplyLimit > 0), OR
-        //  - the limit is "ignore" (0) but we're calling a station (order 1-3)
-        //    that never answers — a hard failsafe so we don't transmit at a
-        //    no-reply station forever. (Order 4/RR73 has its own cap in the
-        //    completion check above; order 5/73 already completes there.)
-        boolean limitHit = (GeneralVariables.noReplyLimit > 0)
-                && (GeneralVariables.noReplyCount > GeneralVariables.noReplyLimit);
-        boolean failsafeHit = (GeneralVariables.noReplyLimit == 0)
-                && (functionOrder >= 1 && functionOrder <= 3)
-                && (GeneralVariables.noReplyCount > NO_REPLY_GIVEUP_CYCLES);
-        if (limitHit || failsafeHit) {
+        // Give up the current target and fall back to CQ / next caller when
+        // the user-configured no-reply limit is hit (noReplyLimit > 0). When
+        // the limit is "unlimited" (0), honour the user's choice — the TX
+        // supervision timeout (launchSupervision) already acts as the ultimate
+        // safety net. (Order 4/RR73 has its own cap in the completion check
+        // above; order 5/73 already completes there.)
+        if (shouldGiveUpTarget(GeneralVariables.noReplyLimit, GeneralVariables.noReplyCount)) {
             GeneralVariables.fileLog("QSO: give up calling " + toCallsign.callsign
-                    + " (order=" + functionOrder + ", "
-                    + (failsafeHit ? "failsafe" : "limit") + ") -> CQ/next");
+                    + " (order=" + functionOrder + ", limit) -> CQ/next");
             // try queued callers first, then check watched messages, then fall back to CQ
             if (!dequeueNextCaller()) {
                 if (!getNewTargetCallsign(messages)) {//check CQ messages in watch list; returns true if a new target is found
@@ -1759,6 +1764,27 @@ public class FT8TransmitSignal {
     /** Convenience overload: log and move on to the head of the queue. */
     public void forceLogAndMoveOn() {
         forceLogAndMoveOn(null);
+    }
+
+    /**
+     * Whether the no-reply counter should be reset when generating the transmit
+     * command list. Only resets when the target callsign has actually changed.
+     *
+     * <p>Package-visible for testing.
+     */
+    static boolean shouldResetNoReplyCount(String currentTarget, String lastTarget) {
+        return !currentTarget.equals(lastTarget);
+    }
+
+    /**
+     * Whether to give up calling the current target based on the retry limit.
+     * When the user selects "unlimited" (noReplyLimit == 0), we never give up
+     * via this check — the TX supervision timeout is the ultimate safety net.
+     *
+     * <p>Package-visible for testing.
+     */
+    static boolean shouldGiveUpTarget(int noReplyLimit, int noReplyCount) {
+        return noReplyLimit > 0 && noReplyCount > noReplyLimit;
     }
 
     // ==================== Caller Queue Methods ====================

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/RetryLimitTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/RetryLimitTest.java
@@ -1,0 +1,78 @@
+package com.bg7yoz.ft8cn.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for retry-limit logic in {@link FT8TransmitSignal}:
+ * <ul>
+ *   <li>{@link FT8TransmitSignal#shouldResetNoReplyCount} — only resets when the
+ *       target callsign changes (fixes counter being zeroed every cycle when
+ *       Hunt re-targets the same station still calling CQ).</li>
+ *   <li>{@link FT8TransmitSignal#shouldGiveUpTarget} — respects "unlimited"
+ *       (noReplyLimit == 0) by never triggering, relying on the TX supervision
+ *       timeout as the safety net.</li>
+ * </ul>
+ */
+public class RetryLimitTest {
+
+    // ===== shouldResetNoReplyCount =====
+
+    @Test
+    public void sameTarget_doesNotReset() {
+        assertThat(FT8TransmitSignal.shouldResetNoReplyCount("K5ABC", "K5ABC")).isFalse();
+    }
+
+    @Test
+    public void differentTarget_resets() {
+        assertThat(FT8TransmitSignal.shouldResetNoReplyCount("K5ABC", "W1AW")).isTrue();
+    }
+
+    @Test
+    public void emptyToCallsign_resets() {
+        assertThat(FT8TransmitSignal.shouldResetNoReplyCount("", "K5ABC")).isTrue();
+    }
+
+    @Test
+    public void firstCall_emptyLast_resets() {
+        assertThat(FT8TransmitSignal.shouldResetNoReplyCount("K5ABC", "")).isTrue();
+    }
+
+    @Test
+    public void cqToReal_resets() {
+        assertThat(FT8TransmitSignal.shouldResetNoReplyCount("K5ABC", "CQ")).isTrue();
+    }
+
+    // ===== shouldGiveUpTarget =====
+
+    @Test
+    public void unlimitedMode_neverGivesUp() {
+        // noReplyLimit == 0 means "unlimited"; should never trigger give-up
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(0, 0)).isFalse();
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(0, 4)).isFalse();
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(0, 100)).isFalse();
+    }
+
+    @Test
+    public void limitSet_belowLimit_noGiveUp() {
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(3, 2)).isFalse();
+    }
+
+    @Test
+    public void limitSet_atLimit_noGiveUp() {
+        // "noReplyCount > noReplyLimit" so at-limit is not yet give-up
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(3, 3)).isFalse();
+    }
+
+    @Test
+    public void limitSet_exceedsLimit_givesUp() {
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(3, 4)).isTrue();
+    }
+
+    @Test
+    public void limitOf1_exceedsAfterSecondNoReply() {
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(1, 1)).isFalse();
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(1, 2)).isTrue();
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/RetryLimitTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/RetryLimitTest.java
@@ -60,9 +60,9 @@ public class RetryLimitTest {
     }
 
     @Test
-    public void limitSet_atLimit_noGiveUp() {
-        // "noReplyCount > noReplyLimit" so at-limit is not yet give-up
-        assertThat(FT8TransmitSignal.shouldGiveUpTarget(3, 3)).isFalse();
+    public void limitSet_atLimit_givesUp() {
+        // "Stop after N unanswered attempts" — give up at exactly N
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(3, 3)).isTrue();
     }
 
     @Test
@@ -71,8 +71,7 @@ public class RetryLimitTest {
     }
 
     @Test
-    public void limitOf1_exceedsAfterSecondNoReply() {
-        assertThat(FT8TransmitSignal.shouldGiveUpTarget(1, 1)).isFalse();
-        assertThat(FT8TransmitSignal.shouldGiveUpTarget(1, 2)).isTrue();
+    public void limitOf1_givesUpAfterFirstNoReply() {
+        assertThat(FT8TransmitSignal.shouldGiveUpTarget(1, 1)).isTrue();
     }
 }


### PR DESCRIPTION
## Summary
- Only reset `noReplyCount` when the target callsign actually changes (prevents Hunt from resetting the counter every cycle when re-targeting the same station)
- Remove hidden failsafe that contradicted "unlimited" retry setting (TX supervision timeout still acts as safety net)
- Extract `shouldResetNoReplyCount()` and `shouldGiveUpTarget()` predicates for testability
- Closes #239

## Test plan
- [ ] Verify `RetryLimitTest` passes
- [ ] Set retry limit to 3, call a station that doesn't answer — should give up after 3 no-replies
- [ ] Set retry limit to unlimited, call a station — should keep calling until TX supervision timeout
- [ ] Hunt mode: station keeps calling CQ — retry counter should increment, not reset each cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)