### PR TITLE
Fix crash during audio subsystem init with USB detach

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -47,6 +47,7 @@ public class MicRecorder {
     private volatile boolean usbAudioSawData = false;
     private static final long MIN_REINIT_INTERVAL_MS = 2000;
     private static final int MAX_CONSECUTIVE_USB_FAILURES = 3;
+    static final int FALLBACK_BUFFER_SIZE = 4096;
 
     public interface OnDataListener{
         void onDataReceived(float[] data,int len);
@@ -83,13 +84,8 @@ public class MicRecorder {
         }
 
         //calculate minimum buffer size
-        bufferSize = AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat);
-        if (bufferSize <= 0) {
-            GeneralVariables.fileLog(String.format(
-                    "MicRecorder: getMinBufferSize returned %d, using fallback 4096", bufferSize));
-            Log.e(TAG, "getMinBufferSize returned " + bufferSize);
-            bufferSize = 4096;
-        }
+        bufferSize = safeBufferSize(
+                AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat));
 
         try {
             audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz
@@ -382,7 +378,15 @@ public class MicRecorder {
         // Re-check for USB audio input
         if (GeneralVariables.audioInputDeviceId == -1
                 && GeneralVariables.usbAudioInputVendorId != 0) {
-            usbAudioDevice = openUsbAudioInput();
+            try {
+                usbAudioDevice = openUsbAudioInput();
+            } catch (Exception e) {
+                GeneralVariables.fileLog(
+                        "MicRecorder: reinit USB audio CRASHED: " + e.getClass().getSimpleName()
+                                + ": " + e.getMessage());
+                Log.e(TAG, "reinitialize: USB audio open failed", e);
+                usbAudioDevice = null;
+            }
             if (usbAudioDevice != null) {
                 useUsbAudio = true;
                 UsbAudioDevice.setActiveInputDevice(usbAudioDevice);
@@ -394,11 +398,20 @@ public class MicRecorder {
 
         // Set up standard AudioRecord if not using USB audio
         if (!useUsbAudio) {
-            bufferSize = AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat);
-            audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz,
-                    channelConfig, audioFormat, bufferSize);
+            bufferSize = safeBufferSize(
+                    AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat));
+            try {
+                audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz,
+                        channelConfig, audioFormat, bufferSize);
+            } catch (Exception e) {
+                GeneralVariables.fileLog(
+                        "MicRecorder: reinit AudioRecord CRASHED: " + e.getClass().getSimpleName()
+                                + ": " + e.getMessage());
+                Log.e(TAG, "reinitialize: AudioRecord init failed", e);
+                // audioRecord stays null — start() will be a no-op
+            }
 
-            if (GeneralVariables.audioInputDeviceId > 0) {
+            if (audioRecord != null && GeneralVariables.audioInputDeviceId > 0) {
                 AudioDeviceInfo deviceInfo = findAudioDeviceById(
                         GeneralVariables.audioInputDeviceId, AudioManager.GET_DEVICES_INPUTS);
                 audioRecord.setPreferredDevice(deviceInfo);
@@ -410,5 +423,19 @@ public class MicRecorder {
         if (wasRunning) {
             start();
         }
+    }
+
+    /**
+     * Returns a safe buffer size for AudioRecord. If {@code rawSize} is an
+     * error value ({@code <= 0}), returns {@link #FALLBACK_BUFFER_SIZE}.
+     *
+     * <p>Package-visible for testing.
+     */
+    static int safeBufferSize(int rawSize) {
+        if (rawSize <= 0) {
+            Log.e(TAG, "getMinBufferSize returned " + rawSize + ", using fallback");
+            return FALLBACK_BUFFER_SIZE;
+        }
+        return rawSize;
     }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/wave/MicRecorder.java
@@ -63,7 +63,15 @@ public class MicRecorder {
         // Check if USB audio input is selected
         if (GeneralVariables.audioInputDeviceId == -1
                 && GeneralVariables.usbAudioInputVendorId != 0) {
-            usbAudioDevice = openUsbAudioInput();
+            try {
+                usbAudioDevice = openUsbAudioInput();
+            } catch (Exception e) {
+                GeneralVariables.fileLog(
+                        "MicRecorder: USB audio open CRASHED: " + e.getClass().getSimpleName()
+                                + ": " + e.getMessage());
+                Log.e(TAG, "USB audio open failed", e);
+                usbAudioDevice = null;
+            }
             if (usbAudioDevice != null) {
                 useUsbAudio = true;
                 UsbAudioDevice.setActiveInputDevice(usbAudioDevice);
@@ -76,9 +84,23 @@ public class MicRecorder {
 
         //calculate minimum buffer size
         bufferSize = AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat);
-//        audioRecord = new AudioRecord(MediaRecorder.AudioSource.MIC, sampleRateInHz
-        audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz
-                , channelConfig, audioFormat, bufferSize);//create AudioRecorder object
+        if (bufferSize <= 0) {
+            GeneralVariables.fileLog(String.format(
+                    "MicRecorder: getMinBufferSize returned %d, using fallback 4096", bufferSize));
+            Log.e(TAG, "getMinBufferSize returned " + bufferSize);
+            bufferSize = 4096;
+        }
+
+        try {
+            audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz
+                    , channelConfig, audioFormat, bufferSize);//create AudioRecorder object
+        } catch (Exception e) {
+            GeneralVariables.fileLog(
+                    "MicRecorder: AudioRecord init CRASHED: " + e.getClass().getSimpleName()
+                            + ": " + e.getMessage());
+            Log.e(TAG, "AudioRecord init failed", e);
+            return; // audioRecord stays null — start() will be a no-op
+        }
 
         //set preferred input device
         if (GeneralVariables.audioInputDeviceId > 0) {
@@ -176,12 +198,15 @@ public class MicRecorder {
 
     public void start(){
         if (isRunning) return;
-        isRunning = true;
 
         if (useUsbAudio && usbAudioDevice != null) {
+            isRunning = true;
             startUsbCapture();
-        } else {
+        } else if (audioRecord != null) {
+            isRunning = true;
             startAudioRecordCapture();
+        } else {
+            GeneralVariables.fileLog("MicRecorder: start() skipped — no audio source available");
         }
     }
 

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/wave/MicRecorderBufferSizeTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/wave/MicRecorderBufferSizeTest.java
@@ -1,0 +1,44 @@
+package com.bg7yoz.ft8cn.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests the buffer size validation added to MicRecorder init.
+ * {@code AudioRecord.getMinBufferSize()} can return ERROR (-1) or
+ * ERROR_BAD_VALUE (-2) when the audio subsystem is unavailable.
+ * The recorder must use a safe fallback instead of crashing.
+ */
+public class MicRecorderBufferSizeTest {
+
+    /** Replicates the validation logic from the MicRecorder constructor. */
+    static int safeBufferSize(int rawBufferSize) {
+        if (rawBufferSize <= 0) {
+            return 4096;
+        }
+        return rawBufferSize;
+    }
+
+    @Test
+    public void validBufferSize_passedThrough() {
+        assertThat(safeBufferSize(1920)).isEqualTo(1920);
+    }
+
+    @Test
+    public void errorMinusOne_fallsBack() {
+        // AudioRecord.ERROR == -1
+        assertThat(safeBufferSize(-1)).isEqualTo(4096);
+    }
+
+    @Test
+    public void errorBadValue_fallsBack() {
+        // AudioRecord.ERROR_BAD_VALUE == -2
+        assertThat(safeBufferSize(-2)).isEqualTo(4096);
+    }
+
+    @Test
+    public void zero_fallsBack() {
+        assertThat(safeBufferSize(0)).isEqualTo(4096);
+    }
+}

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/wave/MicRecorderBufferSizeTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/wave/MicRecorderBufferSizeTest.java
@@ -5,40 +5,33 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.Test;
 
 /**
- * Tests the buffer size validation added to MicRecorder init.
- * {@code AudioRecord.getMinBufferSize()} can return ERROR (-1) or
- * ERROR_BAD_VALUE (-2) when the audio subsystem is unavailable.
- * The recorder must use a safe fallback instead of crashing.
+ * Tests {@link MicRecorder#safeBufferSize} — the validation applied to
+ * {@code AudioRecord.getMinBufferSize()} results before constructing an
+ * AudioRecord. The system call can return ERROR (-1) or ERROR_BAD_VALUE (-2)
+ * when the audio subsystem is unavailable; the helper must return a safe
+ * fallback instead of passing the error through (which would crash).
  */
 public class MicRecorderBufferSizeTest {
 
-    /** Replicates the validation logic from the MicRecorder constructor. */
-    static int safeBufferSize(int rawBufferSize) {
-        if (rawBufferSize <= 0) {
-            return 4096;
-        }
-        return rawBufferSize;
-    }
-
     @Test
     public void validBufferSize_passedThrough() {
-        assertThat(safeBufferSize(1920)).isEqualTo(1920);
+        assertThat(MicRecorder.safeBufferSize(1920)).isEqualTo(1920);
     }
 
     @Test
     public void errorMinusOne_fallsBack() {
         // AudioRecord.ERROR == -1
-        assertThat(safeBufferSize(-1)).isEqualTo(4096);
+        assertThat(MicRecorder.safeBufferSize(-1)).isEqualTo(MicRecorder.FALLBACK_BUFFER_SIZE);
     }
 
     @Test
     public void errorBadValue_fallsBack() {
         // AudioRecord.ERROR_BAD_VALUE == -2
-        assertThat(safeBufferSize(-2)).isEqualTo(4096);
+        assertThat(MicRecorder.safeBufferSize(-2)).isEqualTo(MicRecorder.FALLBACK_BUFFER_SIZE);
     }
 
     @Test
     public void zero_fallsBack() {
-        assertThat(safeBufferSize(0)).isEqualTo(4096);
+        assertThat(MicRecorder.safeBufferSize(0)).isEqualTo(MicRecorder.FALLBACK_BUFFER_SIZE);
     }
 }


### PR DESCRIPTION
## Summary
- Wrap USB audio open and AudioRecord constructor in try-catch with graceful fallback
- Validate `getMinBufferSize()` return value (can be ERROR/-1 or ERROR_BAD_VALUE/-2)
- Guard `start()` against null audioRecord after failed init
- Closes #241

## Test plan
- [ ] Verify `MicRecorderBufferSizeTest` passes
- [ ] Connect USB audio device, start app, unplug during startup — app should fall back to built-in mic instead of crashing
- [ ] Normal startup without USB audio should be unaffected
- [ ] Ask UB8CSJ for `adb logcat` crash trace to confirm the specific exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)