### PR TITLE
Add antenna and rig info to PSKReporter uploads

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -329,6 +329,7 @@ public class GeneralVariables {
 
     public static String myCallsign = "";//My callsign
     public static String myAntenna = "";
+    public static String myRigName = "";  // Set by MainViewModel.connectRig(); used in PSKReporter software string
     public static int myPowerWatts = 0;    // 0 = not set, displays as "--"
     public static String toModifier = "";//Call modifier
     private static float baseFrequency = 1000;//Audio frequency

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -1416,6 +1416,11 @@ public class MainViewModel extends ViewModel {
                 break;
         }
 
+        // Store the rig name for PSKReporter software string
+        GeneralVariables.myRigName = (baseRig != null)
+                ? baseRig.getClass().getSimpleName().replace("Rig", "")
+                : "";
+
         if ((GeneralVariables.instructionSet == InstructionSet.FLEX_NETWORK)
                 || ((GeneralVariables.instructionSet == InstructionSet.ICOM
                 || GeneralVariables.instructionSet==InstructionSet.XIEGU_6100

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -63,6 +63,7 @@ import com.bg7yoz.ft8cn.database.ControlMode;
 import com.bg7yoz.ft8cn.database.DatabaseOpr;
 import com.bg7yoz.ft8cn.database.OnAfterQueryFollowCallsigns;
 import com.bg7yoz.ft8cn.database.OperationBand;
+import com.bg7yoz.ft8cn.database.RigNameList;
 import com.bg7yoz.ft8cn.flex.FlexRadio;
 import com.bg7yoz.ft8cn.flex.RadioTcpClient;
 import com.bg7yoz.ft8cn.ft8listener.FT8SignalListener;
@@ -1416,10 +1417,20 @@ public class MainViewModel extends ViewModel {
                 break;
         }
 
-        // Store the rig name for PSKReporter software string
-        GeneralVariables.myRigName = (baseRig != null)
-                ? baseRig.getClass().getSimpleName().replace("Rig", "")
-                : "";
+        // Store the rig name for PSKReporter software string.
+        // Use the user-selected model name from RigNameList (same source as the
+        // Settings rig picker) rather than the Java class name, which can
+        // differ (e.g. YaesuDX10Rig for FT-710).
+        try {
+            android.content.Context ctx = GeneralVariables.getMainContext();
+            if (ctx != null) {
+                RigNameList rigList = RigNameList.getInstance(ctx);
+                GeneralVariables.myRigName =
+                        rigList.getRigNameByIndex(GeneralVariables.modelNo).modelName;
+            }
+        } catch (Exception e) {
+            GeneralVariables.myRigName = "";
+        }
 
         if ((GeneralVariables.instructionSet == InstructionSet.FLEX_NETWORK)
                 || ((GeneralVariables.instructionSet == InstructionSet.ICOM

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
@@ -214,7 +214,7 @@ object PskReporterSender {
         val antenna = GeneralVariables.myAntenna ?: ""
 
         // Build IPFIX packets, respecting MTU limit
-        val packets = buildPackets(myCall, myGrid, software, antenna, spots)
+        val packets = buildPackets(myCall, myGrid, software, spots, antenna)
         for (pkt in packets) {
             try {
                 sendDatagram(pkt)
@@ -234,8 +234,8 @@ object PskReporterSender {
         rxCall: String,
         rxGrid: String,
         software: String,
-        antenna: String = "",
         spots: List<SpotRecord>,
+        antenna: String = "",
     ): List<ByteArray> {
         val packets = mutableListOf<ByteArray>()
         val includeTemplates = needTemplates()

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
@@ -60,6 +60,7 @@ object PskReporterSender {
     private const val FT_RX_CALLSIGN = 2       // receiverCallsign  (0x8002)
     private const val FT_RX_LOCATOR = 4        // receiverLocator   (0x8004)
     private const val FT_DECODING_SW = 8       // decodingSoftware  (0x8008)
+    private const val FT_RX_ANTENNA = 9        // antennaInformation (0x8009)
     // Sender (data) fields — enterprise-specific under 30351, EXCEPT flowStart.
     private const val FT_TX_CALLSIGN = 1       // senderCallsign    (0x8001)
     private const val FT_FREQUENCY = 5         // frequency         (0x8005)
@@ -92,6 +93,16 @@ object PskReporterSender {
 
     @VisibleForTesting
     internal var sequenceNumber = 0
+
+    /**
+     * Build the PSKReporter "decodingSoftware" string, optionally including the
+     * connected rig name. Pure function — testable without Android.
+     */
+    @VisibleForTesting
+    internal fun buildSoftwareString(version: String, rigName: String?): String {
+        val base = "FT8AF $version"
+        return if (!rigName.isNullOrBlank()) "$base ($rigName)" else base
+    }
 
     /** For testing: override the socket send behaviour. */
     @VisibleForTesting
@@ -198,10 +209,12 @@ object PskReporterSender {
         val myCall = GeneralVariables.myCallsign ?: return
         if (myCall.isEmpty()) return
         val myGrid = GeneralVariables.getMyMaidenheadGrid() ?: ""
-        val software = "FT8AF ${GeneralVariables.VERSION}"
+        val software = buildSoftwareString(
+            GeneralVariables.VERSION, GeneralVariables.myRigName)
+        val antenna = GeneralVariables.myAntenna ?: ""
 
         // Build IPFIX packets, respecting MTU limit
-        val packets = buildPackets(myCall, myGrid, software, spots)
+        val packets = buildPackets(myCall, myGrid, software, antenna, spots)
         for (pkt in packets) {
             try {
                 sendDatagram(pkt)
@@ -221,6 +234,7 @@ object PskReporterSender {
         rxCall: String,
         rxGrid: String,
         software: String,
+        antenna: String = "",
         spots: List<SpotRecord>,
     ): List<ByteArray> {
         val packets = mutableListOf<ByteArray>()
@@ -229,7 +243,7 @@ object PskReporterSender {
         var remaining = spots.toMutableList()
         while (remaining.isNotEmpty()) {
             val templateBytes = if (includeTemplates) encodeTemplates() else ByteArray(0)
-            val receiverBytes = encodeReceiverDataSet(rxCall, rxGrid, software)
+            val receiverBytes = encodeReceiverDataSet(rxCall, rxGrid, software, antenna)
 
             // Header is 16 bytes
             val overhead = 16 + templateBytes.size + receiverBytes.size
@@ -312,10 +326,10 @@ object PskReporterSender {
 
     private fun encodeReceiverTemplate(): ByteArray {
         // Options template set (set ID = 0x0003)
-        // Template ID = 0x50E2, field count = 3, scope field count = 0
+        // Template ID = 0x50E2, field count = 4, scope field count = 0
         // Each field: type(2) + length(2) + enterprise(4)
         val fieldSize = 8 // 2+2+4 per field
-        val fieldCount = 3
+        val fieldCount = 4
         val templateRecordLen = 2 + 2 + 2 + (fieldCount * fieldSize) // templateId + fieldCount + scopeFieldCount + fields
         val setLen = 4 + templateRecordLen // setHeader (id+len) + record
         val padding = (4 - (setLen % 4)) % 4
@@ -342,6 +356,11 @@ object PskReporterSender {
 
         // Field 3: decodingSoftware — variable length string
         buf.putShort((FT_DECODING_SW or 0x8000).toShort())
+        buf.putShort(0xFFFF.toShort())
+        buf.putInt(ENTERPRISE_NUMBER)
+
+        // Field 4: antennaInformation — variable length string
+        buf.putShort((FT_RX_ANTENNA or 0x8000).toShort())
         buf.putShort(0xFFFF.toShort())
         buf.putInt(ENTERPRISE_NUMBER)
 
@@ -415,11 +434,14 @@ object PskReporterSender {
      * Set ID = [RECEIVER_DATA_SET_ID].
      */
     @VisibleForTesting
-    internal fun encodeReceiverDataSet(call: String, grid: String, software: String): ByteArray {
+    internal fun encodeReceiverDataSet(
+        call: String, grid: String, software: String, antenna: String,
+    ): ByteArray {
         val callBytes = encodeVarString(call)
         val gridBytes = encodeVarString(grid)
         val swBytes = encodeVarString(software)
-        val bodyLen = callBytes.size + gridBytes.size + swBytes.size
+        val antBytes = encodeVarString(antenna)
+        val bodyLen = callBytes.size + gridBytes.size + swBytes.size + antBytes.size
         val setLen = 4 + bodyLen
         val padding = (4 - (setLen % 4)) % 4
         val totalLen = setLen + padding
@@ -430,6 +452,7 @@ object PskReporterSender {
         buf.put(callBytes)
         buf.put(gridBytes)
         buf.put(swBytes)
+        buf.put(antBytes)
         repeat(padding) { buf.put(0) }
         return buf.array()
     }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
@@ -137,7 +137,7 @@ class PskReporterSenderTest {
     @Test
     fun `encodeReceiverDataSet has correct set ID and alignment`() {
         val data = PskReporterSender.encodeReceiverDataSet(
-            "N0CALL", "EM48", "FT8AF 1.2.3"
+            "N0CALL", "EM48", "FT8AF 1.2.3", "EFHW 40-10m"
         )
         val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
 
@@ -168,6 +168,12 @@ class PskReporterSenderTest {
         val swBytes = ByteArray(11)
         buf.get(swBytes)
         assertThat(String(swBytes)).isEqualTo("FT8AF 1.2.3")
+
+        // Antenna
+        assertThat(buf.get().toInt() and 0xFF).isEqualTo(11)
+        val antBytes = ByteArray(11)
+        buf.get(antBytes)
+        assertThat(String(antBytes)).isEqualTo("EFHW 40-10m")
     }
 
     // ---------------------------------------------------------------
@@ -189,9 +195,9 @@ class PskReporterSenderTest {
         val rxTemplateId = buf.short.toInt() and 0xFFFF
         assertThat(rxTemplateId).isEqualTo(0x50E2)
 
-        // Field count = 3
+        // Field count = 4
         val rxFieldCount = buf.short.toInt() and 0xFFFF
-        assertThat(rxFieldCount).isEqualTo(3)
+        assertThat(rxFieldCount).isEqualTo(4)
 
         // Scope field count = 0
         val scopeFieldCount = buf.short.toInt() and 0xFFFF
@@ -229,10 +235,10 @@ class PskReporterSenderTest {
         val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
 
         val enterpriseValues = mutableListOf<Int>()
-        // Receiver options template: 3 enterprise fields (8 bytes each).
+        // Receiver options template: 4 enterprise fields (8 bytes each).
         // Skip set header(4) + templateId(2) + fieldCount(2) + scopeFieldCount(2) = 10.
         buf.position(10)
-        repeat(3) {
+        repeat(4) {
             buf.short // type
             buf.short // length
             enterpriseValues.add(buf.int)
@@ -267,8 +273,8 @@ class PskReporterSenderTest {
         buf.position(10)
 
         // receiverCallsign 0x8002 / var, receiverLocator 0x8004 / var,
-        // decodingSoftware 0x8008 / var — all enterprise 30351.
-        val expected = listOf(0x8002 to 0xFFFF, 0x8004 to 0xFFFF, 0x8008 to 0xFFFF)
+        // decodingSoftware 0x8008 / var, antennaInformation 0x8009 / var — all enterprise 30351.
+        val expected = listOf(0x8002 to 0xFFFF, 0x8004 to 0xFFFF, 0x8008 to 0xFFFF, 0x8009 to 0xFFFF)
         for ((type, len) in expected) {
             assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(type)
             assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(len)
@@ -318,11 +324,12 @@ class PskReporterSenderTest {
         // IDs as WSJT-X PSKReporter.cpp). Pins the layout so a future field-ID drift
         // fails loudly instead of silently producing discarded packets.
         val expected = hex(
-            // --- Receiver options template (set 0x0003, len 0x0024 = 36) ---
-            "0003 0024 50E2 0003 0000" +
-                "8002 FFFF 0000768F" + // receiverCallsign  (id 2, var)
-                "8004 FFFF 0000768F" + // receiverLocator   (id 4, var)
-                "8008 FFFF 0000768F" + // decodingSoftware  (id 8, var)
+            // --- Receiver options template (set 0x0003, len 0x002C = 44) ---
+            "0003 002C 50E2 0004 0000" +
+                "8002 FFFF 0000768F" + // receiverCallsign    (id 2, var)
+                "8004 FFFF 0000768F" + // receiverLocator     (id 4, var)
+                "8008 FFFF 0000768F" + // decodingSoftware    (id 8, var)
+                "8009 FFFF 0000768F" + // antennaInformation  (id 9, var)
                 "0000" +               // padding to 4-byte boundary
                 // --- Sender data template (set 0x0002, len 0x003C = 60) ---
                 "0002 003C 50E3 0007" +
@@ -457,6 +464,28 @@ class PskReporterSenderTest {
             val seq = buf.int
             assertThat(seq).isEqualTo(i)
         }
+    }
+
+    // ---------------------------------------------------------------
+    // Software string with rig name
+    // ---------------------------------------------------------------
+
+    @Test
+    fun `buildSoftwareString without rig`() {
+        assertThat(PskReporterSender.buildSoftwareString("1.0.2", ""))
+            .isEqualTo("FT8AF 1.0.2")
+    }
+
+    @Test
+    fun `buildSoftwareString with rig`() {
+        assertThat(PskReporterSender.buildSoftwareString("1.0.2", "Icom"))
+            .isEqualTo("FT8AF 1.0.2 (Icom)")
+    }
+
+    @Test
+    fun `buildSoftwareString null rig`() {
+        assertThat(PskReporterSender.buildSoftwareString("1.0.2", null))
+            .isEqualTo("FT8AF 1.0.2")
     }
 
     /** Decode a hex string (all whitespace ignored) into bytes for golden-vector comparison. */


### PR DESCRIPTION
## Summary
- Append rig name to PSKReporter software string: `"FT8AF 1.0.2 (Icom)"`
- Add IPFIX enterprise element 9 (antennaInformation) to receiver template and data set
- Store rig display name in `GeneralVariables.myRigName` when rig connects
- Uses existing `myAntenna` field from Settings operator card
- Closes #243

## Test plan
- [ ] Verify `PskReporterSenderTest` passes (updated golden vector, new software string tests)
- [ ] Check PSKReporter.info after running — antenna and rig should appear on the station page
- [ ] Verify the antenna field from Settings → Operator card is sent
- [ ] Empty antenna/rig should not break PSKReporter (sends empty var string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)