### PR TITLE
Add Hunt+CQ hybrid mode (call CQ when idle)

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -407,6 +407,7 @@ public class GeneralVariables {
 
 
     public static boolean autoFollowCQ = true;//Auto-follow CQ
+    public static boolean huntCallsCQ = false;//Hunt+CQ hybrid: call CQ when idle, answer CQs when heard
     public static boolean autoCallFollow = true;//Auto-call followed callsigns
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static ArrayList<String> QSL_Callsign_list = new ArrayList<>();//Successfully QSL'd callsigns

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2391,6 +2391,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("autoFollowCQ")) {//Auto-follow CQ
                     GeneralVariables.autoFollowCQ = (result.equals("") || result.equals("1"));
                 }
+                if (name.equalsIgnoreCase("huntCallsCQ")) {//Hunt+CQ hybrid
+                    GeneralVariables.huntCallsCQ = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("autoCallFollow")) {//Auto-call followed stations
                     GeneralVariables.autoCallFollow = (result.equals("") || result.equals("1"));
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -206,7 +206,10 @@ public class FT8TransmitSignal {
                     // Idle hunt: stay silent this slot and keep listening rather than keying
                     // up a CQ. Once parseMessageToFunction locks a caller (order advances,
                     // target becomes a real callsign) this is false and the reply transmits.
-                    if (isHuntListeningIdle(GeneralVariables.autoFollowCQ, functionOrder, toCallsign)) {
+                    // When huntCallsCQ is true, skip this check — let doTransmit send CQ
+                    // while idle, and checkCQMeOrFollowCQMessage will interrupt to answer.
+                    if (shouldSuppressIdleHunt(GeneralVariables.huntCallsCQ,
+                            GeneralVariables.autoFollowCQ, functionOrder, toCallsign)) {
                         return;
                     }
                     if (GeneralVariables.myCallsign.length() < 3) {
@@ -1023,6 +1026,19 @@ public class FT8TransmitSignal {
         if (functionOrder != 6) return false;
         // "no target" == null or the CQ placeholder (see TransmitCallsign.haveTargetCallsign).
         return toCallsign == null || !toCallsign.haveTargetCallsign();
+    }
+
+    /**
+     * Whether the idle-hunt state should suppress transmission this slot.
+     * When {@code huntCallsCQ} is true (Hunt+CQ mode), we let the idle hunt
+     * fall through to {@code doTransmit()} which sends CQ. The existing
+     * {@code checkCQMeOrFollowCQMessage} path will interrupt CQ to answer
+     * any incoming callers.
+     */
+    static boolean shouldSuppressIdleHunt(boolean huntCallsCQ, boolean autoFollowCQ,
+                                          int functionOrder, TransmitCallsign toCallsign) {
+        if (huntCallsCQ) return false;
+        return isHuntListeningIdle(autoFollowCQ, functionOrder, toCallsign);
     }
 
     private boolean checkCQMeOrFollowCQMessage(ArrayList<Ft8Message> messages, boolean suppressHunt) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
@@ -51,6 +51,7 @@ fun TransmissionSettings(
 
     // Auto-sequence state
     var autoFollowCQ by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
+    var huntCallsCQ by remember { mutableStateOf(GeneralVariables.huntCallsCQ) }
     var autoCallFollow by remember { mutableStateOf(GeneralVariables.autoCallFollow) }
     var earlyDecode by remember { mutableStateOf(GeneralVariables.earlyDecode) }
     var autoCQAfterQSO by remember { mutableStateOf(GeneralVariables.autoCQAfterQSO) }
@@ -326,6 +327,19 @@ fun TransmissionSettings(
                             GeneralVariables.autoFollowCQ = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "autoFollowCQ", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_hunt_cq),
+                        description = stringResource(R.string.settings_hunt_cq_desc),
+                        toggle = huntCallsCQ,
+                        onToggleChange = { checked ->
+                            huntCallsCQ = checked
+                            GeneralVariables.huntCallsCQ = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "huntCallsCQ", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -408,6 +408,8 @@
     <!-- ===== Settings: auto-sequence ===== -->
     <string name="settings_hunt">Hunt (auto-answer CQ)</string>
     <string name="settings_hunt_desc">Proactively call stations calling CQ. Same as the HUNT button on the TX bar. Off = run CQ and work only stations that answer you.</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="settings_auto_call_followed">Auto-call Followed</string>
     <string name="settings_auto_call_followed_desc">Continue calling followed callsigns automatically</string>
     <string name="settings_fast_turnaround">Fast turnaround</string>

--- a/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/HuntCqHybridTest.java
+++ b/ft8cn/app/src/test/java/com/bg7yoz/ft8cn/ft8transmit/HuntCqHybridTest.java
@@ -1,0 +1,80 @@
+package com.bg7yoz.ft8cn.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link FT8TransmitSignal#shouldSuppressIdleHunt} — the gate
+ * that decides whether Hunt should stay silent (normal Hunt) or fall through
+ * to CQ (Hunt+CQ hybrid mode).
+ */
+public class HuntCqHybridTest {
+
+    private static TransmitCallsign noTarget() {
+        // null callsign → haveTargetCallsign() == false
+        return new TransmitCallsign(1, 0, null, 0);
+    }
+
+    private static TransmitCallsign withTarget(String call) {
+        return new TransmitCallsign(1, 0, call, 0);
+    }
+
+    // ---- Normal Hunt (huntCallsCQ = false) ----
+
+    @Test
+    public void normalHunt_idleState_suppressesTransmit() {
+        // Hunt on, order 6 (CQ baseline), no target → should suppress
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                false, true, 6, noTarget())).isTrue();
+    }
+
+    @Test
+    public void normalHunt_idleWithNullCallsign_suppressesTransmit() {
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                false, true, 6, null)).isTrue();
+    }
+
+    @Test
+    public void normalHunt_activeQso_doesNotSuppress() {
+        // Hunt on, order 2 (sending RPT), has target → active QSO, don't suppress
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                false, true, 2, withTarget("W1AW"))).isFalse();
+    }
+
+    @Test
+    public void normalHunt_huntOff_doesNotSuppress() {
+        // Hunt off → not in hunt mode at all
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                false, false, 6, noTarget())).isFalse();
+    }
+
+    // ---- Hunt+CQ mode (huntCallsCQ = true) ----
+
+    @Test
+    public void huntCq_idleState_doesNotSuppress() {
+        // Hunt+CQ on, idle → should NOT suppress, let CQ transmit
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                true, true, 6, noTarget())).isFalse();
+    }
+
+    @Test
+    public void huntCq_idleWithNullCallsign_doesNotSuppress() {
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                true, true, 6, null)).isFalse();
+    }
+
+    @Test
+    public void huntCq_activeQso_doesNotSuppress() {
+        // Active QSO in Hunt+CQ → don't suppress either
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                true, true, 2, withTarget("W1AW"))).isFalse();
+    }
+
+    @Test
+    public void huntCq_huntOff_doesNotSuppress() {
+        // huntCallsCQ true but Hunt itself off → never suppresses
+        assertThat(FT8TransmitSignal.shouldSuppressIdleHunt(
+                true, false, 6, noTarget())).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Add new "Hunt + CQ" setting: when enabled, Hunt calls CQ when idle (no stations heard) instead of staying silent
- When an incoming CQ is detected, CQ is interrupted to answer it (existing Hunt behavior)
- New `shouldSuppressIdleHunt()` predicate in `FT8TransmitSignal` gates the idle-hunt suppression
- Toggle added to Settings > Transmission > Auto-Sequence, off by default
- Persisted in database via `huntCallsCQ` config key

Closes #245

## Test plan

- [x] Unit tests for `shouldSuppressIdleHunt()` — 8 test cases covering normal Hunt and Hunt+CQ modes
- [ ] Manual: enable Hunt+CQ, verify CQ is sent when no stations on band
- [ ] Manual: with Hunt+CQ active, verify incoming CQ is answered (interrupts CQ)
- [ ] Manual: disable Hunt+CQ, verify normal Hunt behavior (stays silent when idle)
- [ ] Manual: verify setting persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)