### PR TITLE
Fix Hunt mode enabled by default on first launch

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -411,7 +411,7 @@ public class GeneralVariables {
     public static String icomPassword = "";
 
 
-    public static boolean autoFollowCQ = true;//Auto-follow CQ
+    public static boolean autoFollowCQ = false;//Auto-follow CQ
     public static boolean huntCallsCQ = false;//Hunt+CQ hybrid: call CQ when idle, answer CQs when heard
     public static boolean autoCallFollow = true;//Auto-call followed callsigns
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2393,7 +2393,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.noReplyLimit = result.equals("") ? 0 : Integer.parseInt(result);
                 }
                 if (name.equalsIgnoreCase("autoFollowCQ")) {//Auto-follow CQ
-                    GeneralVariables.autoFollowCQ = (result.equals("") || result.equals("1"));
+                    GeneralVariables.autoFollowCQ = result.equals("1");
                 }
                 if (name.equalsIgnoreCase("huntCallsCQ")) {//Hunt+CQ hybrid
                     GeneralVariables.huntCallsCQ = result.equals("1");


### PR DESCRIPTION
## Summary
- Default `autoFollowCQ` from `true` to `false` so Hunt is off on a fresh install
- Stop the config loader from treating a missing DB entry as Hunt-enabled

On first launch both Hunt and CQ are now disabled — the user starts in a stopped state and explicitly picks a mode.

## Test plan
- [ ] Fresh install: verify neither Hunt nor CQ is highlighted on the TX strip
- [ ] Toggle Hunt on, restart app, verify it persists as on
- [ ] Toggle Hunt off, restart app, verify it persists as off

🤖 Generated with [Claude Code](https://claude.com/claude-code)