### PR TITLE
Fix CQ marked as BUSY and hashed callsign mismatch in mini log

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -89,9 +89,9 @@ internal fun buildQsoLog(
 
     val entries = mutableListOf<QsoLogEntry>()
     messageList?.forEach { msg ->
-        // Use getCallsignFrom() which strips angle brackets from hashed
-        // callsigns (e.g. "<CALL>" → "CALL") so they match displayCallsign. (#255)
-        val from = msg.callsignFrom?.replace("<", "")?.replace(">", "") ?: ""
+        // getCallsignFrom() handles null and strips angle brackets from
+        // hashed callsigns (e.g. "<CALL>" → "CALL") so they match displayCallsign. (#255)
+        val from = msg.getCallsignFrom()
         // Only the target station's traffic appears in this panel. Own-callsign
         // loopback (from == us) is filtered upstream (OwnTxEchoFilter) and there
         // is deliberately no decoded-list TX branch, so anything not from the
@@ -100,7 +100,8 @@ internal fun buildQsoLog(
 
         // Skip CQ/DE/QRZ messages — the target is calling for contacts, not
         // working someone else, so they are neither RX nor BUSY. (#254)
-        if (msg.checkIsCQ()) return@forEach
+        // Guard: checkIsCQ() calls callsignTo.trim() which NPEs on null.
+        if (msg.callsignTo != null && msg.checkIsCQ()) return@forEach
 
         val to = msg.callsignTo ?: ""
         val toIsMe = to.equals(myCallsign, ignoreCase = true) ||

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -89,12 +89,18 @@ internal fun buildQsoLog(
 
     val entries = mutableListOf<QsoLogEntry>()
     messageList?.forEach { msg ->
-        val from = msg.callsignFrom ?: ""
+        // Use getCallsignFrom() which strips angle brackets from hashed
+        // callsigns (e.g. "<CALL>" → "CALL") so they match displayCallsign. (#255)
+        val from = msg.callsignFrom?.replace("<", "")?.replace(">", "") ?: ""
         // Only the target station's traffic appears in this panel. Own-callsign
         // loopback (from == us) is filtered upstream (OwnTxEchoFilter) and there
         // is deliberately no decoded-list TX branch, so anything not from the
         // target is skipped here — TX rows come solely from synthTx below.
         if (!from.equals(displayCallsign, ignoreCase = true)) return@forEach
+
+        // Skip CQ/DE/QRZ messages — the target is calling for contacts, not
+        // working someone else, so they are neither RX nor BUSY. (#254)
+        if (msg.checkIsCQ()) return@forEach
 
         val to = msg.callsignTo ?: ""
         val toIsMe = to.equals(myCallsign, ignoreCase = true) ||

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
@@ -164,4 +164,29 @@ class ActiveQsoPanelLogicTest {
         assertThat(result).hasSize(1)
         assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.RX)
     }
+
+    @Test
+    fun `target calling CQ is not marked BUSY`() {
+        // A CQ from the target means they are available, not busy. (#254)
+        val list = listOf(msg("CQ", target, 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `target calling CQ DX is not marked BUSY`() {
+        // Directed CQ (DE/QRZ) should also be skipped. (#254)
+        val list = listOf(msg("DE", target, 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `hashed callsign with angle brackets matches display callsign`() {
+        // Hashed calls are stored as "<CALL>" but displayCallsign has no brackets. (#255)
+        val list = listOf(rawMsg(to = myCall, from = "<$target>", utc = 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).hasSize(1)
+        assertThat(result[0].direction).isEqualTo(QsoLogEntry.Direction.RX)
+    }
 }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanelLogicTest.kt
@@ -174,9 +174,15 @@ class ActiveQsoPanelLogicTest {
     }
 
     @Test
-    fun `target calling CQ DX is not marked BUSY`() {
-        // Directed CQ (DE/QRZ) should also be skipped. (#254)
+    fun `target calling DE is not marked BUSY`() {
         val list = listOf(msg("DE", target, 1_000L))
+        val result = buildQsoLog(list, target, myCall, emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `target calling QRZ is not marked BUSY`() {
+        val list = listOf(msg("QRZ", target, 1_000L))
         val result = buildQsoLog(list, target, myCall, emptyList())
         assertThat(result).isEmpty()
     }


### PR DESCRIPTION
## Summary

- **CQ as BUSY (#254):** When the target station calls CQ, `buildQsoLog()` classified it as BUSY because `callsignTo="CQ"` doesn't match our callsign. CQ means available, not busy — skip these messages instead.
- **Hashed callsign mismatch (#255):** Hashed callsigns stored with angle brackets (`<CALL>`) failed to match the bracket-stripped `displayCallsign`, so replies from hashed callsigns never appeared in the mini log. Strip brackets before comparing.

Both bugs are in the same function (`buildQsoLog` in `ActiveQsoPanel.kt`).

Closes #254
Closes #255

## Test plan

- [ ] Three new unit tests added covering CQ skip, DE/QRZ skip, and angle-bracket matching
- [ ] Existing 11 tests still pass (no regressions)
- [ ] On-device: call a station, observe that if they CQ the mini log does not show a BUSY row
- [ ] On-device: call a hashed callsign (`<CALL>`), verify their reply appears in the mini log

🤖 Generated with [Claude Code](https://claude.com/claude-code)