### PR TITLE
Add defensive guards to prevent crashes from malformed data

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -1673,6 +1673,8 @@ public class MainViewModel extends ViewModel {
         // the rig indefinitely. Tear it down here too.
         stopCatLivenessWatchdog();
         PskReporterSender.INSTANCE.stop();
+        getQTHThreadPool.shutdown();
+        sendWaveDataThreadPool.shutdown();
     }
 
     private static final String ACTION_USB_AUDIO_PERMISSION =

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothStateBroadcastReceive.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothStateBroadcastReceive.java
@@ -67,6 +67,7 @@ public class BluetoothStateBroadcastReceive extends BroadcastReceiver {
                 // Permission revoked between the check above and the call — fall through with -1.
             }
         }
+        if (action == null) return;
         switch (action) {
             case BluetoothAdapter.ACTION_CONNECTION_STATE_CHANGED:
             case BluetoothAdapter.EXTRA_CONNECTION_STATE:

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignInfo.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignInfo.java
@@ -58,15 +58,19 @@ public class CallsignInfo {
             Log.e(TAG,"Callsign data format error! "+s);
             return;
         }
-        CountryNameEn = info[0].replace("\n", "").trim();
-        CQZone = Integer.parseInt(info[1].replace("\n", "").replace(" ", ""));
-        ITUZone = Integer.parseInt(info[2].replace("\n", "").replace(" ", ""));
-        Continent = info[3].replace("\n", "").replace(" ", "");
-        Latitude = Float.parseFloat(info[4].replace("\n", "").replace(" ", ""));
-        Longitude = Float.parseFloat(info[5].replace("\n", "").replace(" ", ""));
-        GMT_offset = Float.parseFloat(info[6].replace("\n", "").replace(" ", ""));
-        DXCC = info[7].replace("\n", "").replace(" ", "");
-        CallSign= info[8].replace("\n", "").replace(" ", "");
+        try {
+            CountryNameEn = info[0].replace("\n", "").trim();
+            CQZone = Integer.parseInt(info[1].replace("\n", "").replace(" ", ""));
+            ITUZone = Integer.parseInt(info[2].replace("\n", "").replace(" ", ""));
+            Continent = info[3].replace("\n", "").replace(" ", "");
+            Latitude = Float.parseFloat(info[4].replace("\n", "").replace(" ", ""));
+            Longitude = Float.parseFloat(info[5].replace("\n", "").replace(" ", ""));
+            GMT_offset = Float.parseFloat(info[6].replace("\n", "").replace(" ", ""));
+            DXCC = info[7].replace("\n", "").replace(" ", "");
+            CallSign= info[8].replace("\n", "").replace(" ", "");
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "Error parsing callsign info fields: " + s, e);
+        }
     }
 }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/RigNameList.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/RigNameList.java
@@ -135,9 +135,16 @@ public class RigNameList {
                 return;
             }
             modelName= info[0].trim();
-            address=Integer.parseInt(info[1].trim(),16);
-            bauRate=Integer.parseInt(info[2].trim());
-            instructionSet=Integer.parseInt(info[3].trim());
+            try {
+                address=Integer.parseInt(info[1].trim(),16);
+                bauRate=Integer.parseInt(info[2].trim());
+                instructionSet=Integer.parseInt(info[3].trim());
+            } catch (NumberFormatException e) {
+                Log.e(TAG, "Error parsing rig parameters: " + s, e);
+                address=0xA4;
+                bauRate=19200;
+                instructionSet=0;
+            }
         }
 
         public String getName(){

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/FlexMeterInfos.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/FlexMeterInfos.java
@@ -32,7 +32,12 @@ public class FlexMeterInfos extends HashMap<Integer, FlexMeterInfos.FlexMeterInf
             String[] val = temp[i].split("=");
             if (val.length == 2) {
                 if (val[0].contains(".")) {
-                    int index = Integer.parseInt(val[0].substring(0, val[0].indexOf(".")));
+                    int index;
+                    try {
+                        index = Integer.parseInt(val[0].substring(0, val[0].indexOf(".")));
+                    } catch (NumberFormatException e) {
+                        continue;
+                    }
                     FlexMeterInfo meterInfo;
 
                     meterInfo = this.get(index);
@@ -66,10 +71,12 @@ public class FlexMeterInfos extends HashMap<Integer, FlexMeterInfos.FlexMeterInf
 
                     }
                     if (val[0].toLowerCase().contains(".low")) {
-                        meterInfo.low = Float.parseFloat(val[1]);
+                        try { meterInfo.low = Float.parseFloat(val[1]); }
+                        catch (NumberFormatException ignored) {}
                     }
                     if (val[0].toLowerCase().contains(".hi")) {
-                        meterInfo.hi = Float.parseFloat(val[1]);
+                        try { meterInfo.hi = Float.parseFloat(val[1]); }
+                        catch (NumberFormatException ignored) {}
                     }
                     if (val[0].toLowerCase().contains(".desc")) {
                         meterInfo.desc = val[1];

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/FlexRadio.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/flex/FlexRadio.java
@@ -729,8 +729,11 @@ public class FlexRadio {
         //Log.e(TAG, "getCommandStyleFromResponse: "+response.rawData );
 
         try {
-            return FlexCommand.values()[Integer.parseInt(response.head.substring(response.head.length() - 3))];
-        } catch (NumberFormatException e) {
+            int cmdIndex = Integer.parseInt(response.head.substring(response.head.length() - 3));
+            if (cmdIndex >= 0 && cmdIndex < FlexCommand.values().length) {
+                return FlexCommand.values()[cmdIndex];
+            }
+        } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
             e.printStackTrace();
             Log.e(TAG, "getCommandStyleFromResponse exception: " + e.getMessage());
         }
@@ -1074,7 +1077,10 @@ public class FlexRadio {
                     getHeadAndContent(line, "\\|");
                     try {
                         seq_number = Integer.parseInt(head.substring(1));//Parse command sequence number
-                        flexCommand = FlexCommand.values()[seq_number % 1000];
+                        int cmdIndex = seq_number % 1000;
+                        if (cmdIndex >= 0 && cmdIndex < FlexCommand.values().length) {
+                            flexCommand = FlexCommand.values()[cmdIndex];
+                        }
                         switch (flexCommand) {
                             case STREAM_CREATE_DAX_RX:
                                 this.daxStreamId = getStreamId(line);
@@ -1169,11 +1175,11 @@ public class FlexRadio {
          */
         private void getHeadAndContent(String line, String split) {
             String[] temp = line.split(split);
-            if (line.length() > 1) {
+            if (temp.length > 1) {
                 head = temp[0];
                 content = temp[1];
             } else {
-                head = "";
+                head = temp.length > 0 ? temp[0] : "";
                 content = "";
 
             }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8signal/FT8Package.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8signal/FT8Package.java
@@ -235,14 +235,18 @@ public class FT8Package {
         // check if it is a signal report: +dd / -dd / R+dd / R-dd
         // signal report range: -30 to 99 dB
         // signal report regex: [R]?[+-][0-9]{1,2}
-        String s = grid4;
-        if (grid4.charAt(0) == 'R') {
-            s = grid4.substring(1);
-            int irpt = 35 + Integer.parseInt(s);
-            return (MAXGRID4 + irpt) | 0x8000; // R1 = 1
-        } else {
-            int irpt = 35 + Integer.parseInt(grid4);
-            return (MAXGRID4 + irpt); // R1 = 0
+        try {
+            String s = grid4;
+            if (grid4.charAt(0) == 'R') {
+                s = grid4.substring(1);
+                int irpt = 35 + Integer.parseInt(s);
+                return (MAXGRID4 + irpt) | 0x8000; // R1 = 1
+            } else {
+                int irpt = 35 + Integer.parseInt(grid4);
+                return (MAXGRID4 + irpt); // R1 = 0
+            }
+        } catch (NumberFormatException e) {
+            return MAXGRID4 + 1;
         }
 
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/grid_tracker/GridOsmMapView.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/grid_tracker/GridOsmMapView.java
@@ -147,6 +147,7 @@ public class GridOsmMapView {
         line.getOutlinePaint().setStrokeWidth(6);
         //mOutlinePaint = getStrokePaint(0xffFF1E27, 3);
 
+        if (line.getActualPoints().size() < 2) return;
         GeoPoint eastNorthPoint = new GeoPoint(line.getActualPoints().get(0).getLatitude()
                 , line.getActualPoints().get(0).getLongitude());
         GeoPoint westSouthPoint = new GeoPoint(line.getActualPoints().get(1).getLatitude()

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/LogFileImport.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/log/LogFileImport.java
@@ -90,10 +90,12 @@ public class LogFileImport {
                                     int valueLen = Integer.parseInt(ttt[1]);//Field length
                                     if (valueLen > 0) {
                                         if (values[1].length() < valueLen) {
-                                            valueLen = values[1].length() - 1;
+                                            valueLen = values[1].length();
                                         }
-                                        String value = values[1].substring(0, valueLen);//Field value
-                                        record.put(name.toUpperCase(), value);//Save field, key must be uppercase
+                                        if (valueLen > 0) {
+                                            String value = values[1].substring(0, valueLen);//Field value
+                                            record.put(name.toUpperCase(), value);//Save field, key must be uppercase
+                                        }
                                     }
                                 }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/LogFragment.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/LogFragment.java
@@ -600,7 +600,9 @@ public class LogFragment extends Fragment {
     private String getLocalIp() {
         WifiManager wifiManager = (WifiManager) requireContext().getApplicationContext()
                 .getSystemService(Context.WIFI_SERVICE);
+        if (wifiManager == null) return null;
         WifiInfo wifiInfo = wifiManager.getConnectionInfo();
+        if (wifiInfo == null) return null;
         int ipAddress = wifiInfo.getIpAddress();
         if (ipAddress == 0) {
             return null;

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ShareLogsProgressDialog.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ShareLogsProgressDialog.java
@@ -24,6 +24,11 @@ public class ShareLogsProgressDialog extends Dialog {
     private final boolean isImportMode;
     //private final int progressMax;
 
+    private Observer<String> shareInfoObserver;
+    private Observer<Integer> sharePositionObserver;
+    private Observer<Boolean> importShareRunningObserver;
+    private Observer<Boolean> shareRunningObserver;
+    private Observer<Integer> shareCountObserver;
 
     public ShareLogsProgressDialog(@NonNull Context context
             , MainViewModel projectsViewModel, boolean isImportMode) {
@@ -51,44 +56,49 @@ public class ShareLogsProgressDialog extends Dialog {
         Button cancelShareButton = findViewById(R.id.cancelShareButton);
 
 
-        mainViewModel.mutableShareInfo.observeForever(new Observer<String>() {
+        shareInfoObserver = new Observer<String>() {
             @Override
             public void onChanged(String s) {
                 shareDataInfoTextView.setText(s);
             }
-        });
-        mainViewModel.mutableSharePosition.observeForever(new Observer<Integer>() {
+        };
+        mainViewModel.mutableShareInfo.observeForever(shareInfoObserver);
+
+        sharePositionObserver = new Observer<Integer>() {
             @Override
             public void onChanged(Integer integer) {
                 shareFileDataProgressBar.setProgress(integer);
             }
-        });
+        };
+        mainViewModel.mutableSharePosition.observeForever(sharePositionObserver);
 
-        mainViewModel.mutableImportShareRunning.observeForever(new Observer<Boolean>() {
+        importShareRunningObserver = new Observer<Boolean>() {
             @Override
             public void onChanged(Boolean aBoolean) {
                 if (!aBoolean) {
                     dismiss();
                 }
             }
-        });
+        };
+        mainViewModel.mutableImportShareRunning.observeForever(importShareRunningObserver);
 
-        mainViewModel.mutableShareRunning.observeForever(new Observer<Boolean>() {
+        shareRunningObserver = new Observer<Boolean>() {
             @Override
             public void onChanged(Boolean aBoolean) {
                 if (!aBoolean) {
                     dismiss();
                 }
             }
-        });
+        };
+        mainViewModel.mutableShareRunning.observeForever(shareRunningObserver);
 
-
-        mainViewModel.mutableShareCount.observeForever(new Observer<Integer>() {
+        shareCountObserver = new Observer<Integer>() {
             @Override
             public void onChanged(Integer integer) {
                 shareFileDataProgressBar.setMax(integer);
             }
-        });
+        };
+        mainViewModel.mutableShareCount.observeForever(shareCountObserver);
 
         cancelShareButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -101,5 +111,29 @@ public class ShareLogsProgressDialog extends Dialog {
             }
         });
 
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        removeObservers();
+    }
+
+    private void removeObservers() {
+        if (shareInfoObserver != null) {
+            mainViewModel.mutableShareInfo.removeObserver(shareInfoObserver);
+        }
+        if (sharePositionObserver != null) {
+            mainViewModel.mutableSharePosition.removeObserver(sharePositionObserver);
+        }
+        if (importShareRunningObserver != null) {
+            mainViewModel.mutableImportShareRunning.removeObserver(importShareRunningObserver);
+        }
+        if (shareRunningObserver != null) {
+            mainViewModel.mutableShareRunning.removeObserver(shareRunningObserver);
+        }
+        if (shareCountObserver != null) {
+            mainViewModel.mutableShareCount.removeObserver(shareCountObserver);
+        }
     }
 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/x6100/X6100Radio.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/x6100/X6100Radio.java
@@ -647,14 +647,22 @@ public class X6100Radio {
                     for (int i = 0; i < status.length; i++) {//find PTT state and set PTT
                         if (status[i].startsWith("ptt")) {//check PTT
                             String temp[] = status[i].split("=");
-                            isPttOn = temp[1].equalsIgnoreCase("on");
+                            if (temp.length > 1) {
+                                isPttOn = temp[1].equalsIgnoreCase("on");
+                            }
                         }
 
                         if (status[i].startsWith("play_volume")) {//check play volume
                             String temp[] = status[i].split("=");
-                            float vol = Integer.parseInt(temp[1].trim()) * 1.0f / 100f;
-                            GeneralVariables.volumePercent = vol;
-                            GeneralVariables.mutableVolumePercent.postValue(vol);
+                            if (temp.length > 1) {
+                                try {
+                                    float vol = Integer.parseInt(temp[1].trim()) * 1.0f / 100f;
+                                    GeneralVariables.volumePercent = vol;
+                                    GeneralVariables.mutableVolumePercent.postValue(vol);
+                                } catch (NumberFormatException e) {
+                                    Log.e(TAG, "Error parsing play_volume: " + temp[1], e);
+                                }
+                            }
                         }
                     }
                 }
@@ -676,8 +684,13 @@ public class X6100Radio {
         String[] keys = result.split(" ");
         for (int i = 0; i < keys.length; i++) {
             String[] val = keys[i].split("=");
-            if (val[0].equalsIgnoreCase("period")) period = Integer.parseInt(val[1]) / 1000;
-            if (val[0].equalsIgnoreCase("frames")) frames = Integer.parseInt(val[1]);
+            if (val.length < 2) continue;
+            try {
+                if (val[0].equalsIgnoreCase("period")) period = Integer.parseInt(val[1]) / 1000;
+                if (val[0].equalsIgnoreCase("frames")) frames = Integer.parseInt(val[1]);
+            } catch (NumberFormatException e) {
+                Log.e(TAG, "Error parsing audio info: " + keys[i], e);
+            }
         }
         Log.d(TAG, String.format("set audio para:frames=%d,period=%d", frames, period));
     }
@@ -924,7 +937,10 @@ public class X6100Radio {
                     getHeadAndContent(line, "\\|");
                     try {
                         seq_number = Integer.parseInt(head.substring(1));//parse command sequence number
-                        xieguCommand = XieguCommand.values()[seq_number % 1000];
+                        int cmdIndex = seq_number % 1000;
+                        if (cmdIndex >= 0 && cmdIndex < XieguCommand.values().length) {
+                            xieguCommand = XieguCommand.values()[cmdIndex];
+                        }
                     } catch (NumberFormatException e) {
                         e.printStackTrace();
                         Log.e(TAG, "XieguResponse parseInt seq_number exception: " + e.getMessage());
@@ -961,9 +977,11 @@ public class X6100Radio {
             String[] temp = line.split(split);
             if (temp.length > 1) {
                 head = temp[0];
-
-                resultCode = Integer.parseInt(temp[1]);
-
+                try {
+                    resultCode = Integer.parseInt(temp[1]);
+                } catch (NumberFormatException e) {
+                    Log.e(TAG, "Error parsing resultCode: " + temp[1], e);
+                }
             } else {
                 head = "";
             }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/x6100/X6100Radio.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/x6100/X6100Radio.java
@@ -975,15 +975,14 @@ public class X6100Radio {
          */
         private void getHeadAndContent(String line, String split) {
             String[] temp = line.split(split);
+            resultCode = -1;
+            head = temp.length > 0 ? temp[0] : "";
             if (temp.length > 1) {
-                head = temp[0];
                 try {
                     resultCode = Integer.parseInt(temp[1]);
                 } catch (NumberFormatException e) {
                     Log.e(TAG, "Error parsing resultCode: " + temp[1], e);
                 }
-            } else {
-                head = "";
             }
 
             if (temp.length > 2) {


### PR DESCRIPTION
## Summary
- **Null guards** on `intent.getAction()` in Bluetooth receiver and `WifiManager`/`WifiInfo` chain in `LogFragment.getLocalIp()` to prevent NPE
- **Bounds checks** on `getActualPoints()` in `GridOsmMapView.zoomToLineBound()`, `split()` array access in `FlexRadio`/`X6100Radio` protocol parsers, and `EnumType.values()` ordinal lookups in both `FlexCommand` and `XieguCommand`
- **try-catch wrappers** around `parseInt`/`parseFloat` in `CallsignInfo`, `RigNameList`, `FlexMeterInfos`, `FT8Package.pack_R1_g15()`, and `X6100Radio` audio-info/status parsers
- **Fix negative substring index** in `LogFileImport` ADIF parser when declared field length exceeds actual value length (empty value → `length - 1` = -1 → `StringIndexOutOfBoundsException`)
- **Shutdown `ExecutorService` pools** (`getQTHThreadPool`, `sendWaveDataThreadPool`) in `MainViewModel.onCleared()` to prevent leaked threads
- **Remove leaked `observeForever` observers** in `ShareLogsProgressDialog` by storing references and cleaning up in `onStop()`

## Test plan
- [x] All existing unit tests pass (`testDebugUnitTest` BUILD SUCCESSFUL)
- [ ] Verify Bluetooth connect/disconnect still shows toasts in BT mode
- [ ] Verify ADIF log import with various file formats (including truncated/empty fields)
- [ ] Verify Flex Radio and X6100 connection/status updates work normally
- [ ] Verify grid tracker map zoom-to-line still works
- [ ] Verify share logs progress dialog shows/dismisses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)