### PR TITLE
Fix zoneMapReady gate closed by startup ordering race

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainActivity.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainActivity.java
@@ -466,7 +466,7 @@ public class MainActivity extends AppCompatActivity {
         // runs first, the null-check early-return leaves zoneMapReady false
         // permanently and DXCC/zone "new" flags never compute. (#251 review)
         if (GeneralVariables.callsignDatabase == null) {
-            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(getBaseContext(), null, 1);
+            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(getApplicationContext(), null, 1);
         }
 
         mainViewModel.databaseOpr.getQslDxccToMap();

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainActivity.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainActivity.java
@@ -461,6 +461,14 @@ public class MainActivity extends AppCompatActivity {
             mainViewModel.operationBand = OperationBand.getInstance(getBaseContext());
         }
 
+        // Callsign database must be ready before getQslDxccToMap() — that
+        // method's background thread needs it to resolve DXCC prefixes. If it
+        // runs first, the null-check early-return leaves zoneMapReady false
+        // permanently and DXCC/zone "new" flags never compute. (#251 review)
+        if (GeneralVariables.callsignDatabase == null) {
+            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(getBaseContext(), null, 1);
+        }
+
         mainViewModel.databaseOpr.getQslDxccToMap();
 
         //get all configuration parameters
@@ -499,10 +507,6 @@ public class MainActivity extends AppCompatActivity {
         new DatabaseOpr.GetCallsignMapGrid(mainViewModel.databaseOpr.getDb()).execute();
 
         mainViewModel.getFollowCallsignsFromDataBase();
-        //open the callsign location database; currently using in-memory database.
-        if (GeneralVariables.callsignDatabase == null) {
-            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(getBaseContext(), null, 1);
-        }
     }
 
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/callsign/CallsignDatabase.java
@@ -22,6 +22,8 @@ import com.google.android.gms.maps.model.LatLng;
 
 import java.util.ArrayList;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class CallsignDatabase extends SQLiteOpenHelper {
     private static final String TAG = "CallsignDatabase";
@@ -29,6 +31,10 @@ public class CallsignDatabase extends SQLiteOpenHelper {
     private static CallsignDatabase instance;
     private final Context context;
     private SQLiteDatabase db;
+
+    // Signals when the async CTY.DAT import (InitDatabase) completes.
+    // getQslDxccToMap() waits on this so it doesn't query empty tables.
+    private static final CountDownLatch importLatch = new CountDownLatch(1);
 
     public static CallsignDatabase getInstance(@Nullable Context context, @Nullable String databaseName, int version) {
         if (instance == null) {
@@ -49,6 +55,19 @@ public class CallsignDatabase extends SQLiteOpenHelper {
 
     public SQLiteDatabase getDb() {
         return db;
+    }
+
+    /**
+     * Block until the async CTY.DAT import finishes, or until the timeout
+     * elapses. Safe to call from a background thread; must NOT be called
+     * from the main thread.
+     */
+    public static void awaitImport(long timeoutMs) {
+        try {
+            importLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     /**
@@ -257,43 +276,47 @@ public class CallsignDatabase extends SQLiteOpenHelper {
 
         @Override
         protected Void doInBackground(Void... voids) {
-            Log.d(TAG, "Starting callsign location data import...");
-            String insertCountriesSQL = "INSERT INTO countries (id,CountryNameEn,CountryNameCN,CQZone" +
-                    ",ITUZone,Continent,Latitude,Longitude,GMT_offset,DXCC)\n" +
-                    "VALUES(?,?,?,?,?,?,?,?,?,?)";
+            try {
+                Log.d(TAG, "Starting callsign location data import...");
+                String insertCountriesSQL = "INSERT INTO countries (id,CountryNameEn,CountryNameCN,CQZone" +
+                        ",ITUZone,Continent,Latitude,Longitude,GMT_offset,DXCC)\n" +
+                        "VALUES(?,?,?,?,?,?,?,?,?,?)";
 
-            ArrayList<CallsignInfo> callsignInfos =
-                    CallsignFileOperation.getCallSingInfoFromFile(context);
-            ContentValues values = new ContentValues();
-            for (int i = 0; i < callsignInfos.size(); i++) {
-                try {
-                    // Write country and region data into the table; id is used to associate with callsigns
-                    db.execSQL(insertCountriesSQL, new Object[]{
-                            i, // ID number
-                            callsignInfos.get(i).CountryNameEn,
-                            callsignInfos.get(i).CountryNameCN,
-                            callsignInfos.get(i).CQZone,
-                            callsignInfos.get(i).ITUZone,
-                            callsignInfos.get(i).Continent,
-                            callsignInfos.get(i).Latitude,
-                            callsignInfos.get(i).Longitude,
-                            callsignInfos.get(i).GMT_offset,
-                            callsignInfos.get(i).DXCC});
-                    Set<String> calls = CallsignFileOperation.getCallsigns(callsignInfos.get(i).CallSign);
+                ArrayList<CallsignInfo> callsignInfos =
+                        CallsignFileOperation.getCallSingInfoFromFile(context);
+                ContentValues values = new ContentValues();
+                for (int i = 0; i < callsignInfos.size(); i++) {
+                    try {
+                        // Write country and region data into the table; id is used to associate with callsigns
+                        db.execSQL(insertCountriesSQL, new Object[]{
+                                i, // ID number
+                                callsignInfos.get(i).CountryNameEn,
+                                callsignInfos.get(i).CountryNameCN,
+                                callsignInfos.get(i).CQZone,
+                                callsignInfos.get(i).ITUZone,
+                                callsignInfos.get(i).Continent,
+                                callsignInfos.get(i).Latitude,
+                                callsignInfos.get(i).Longitude,
+                                callsignInfos.get(i).GMT_offset,
+                                callsignInfos.get(i).DXCC});
+                        Set<String> calls = CallsignFileOperation.getCallsigns(callsignInfos.get(i).CallSign);
 
-                    for (String s : calls
-                    ) {
-                        values.put("countryId", i);
-                        values.put("callsign", s);
-                        db.insert("callsigns", null, values);
-                        values.clear();
+                        for (String s : calls
+                        ) {
+                            values.put("countryId", i);
+                            values.put("callsign", s);
+                            db.insert("callsigns", null, values);
+                            values.clear();
+                        }
+
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error: " + e.getMessage());
                     }
-
-                } catch (Exception e) {
-                    Log.e(TAG, "Error: " + e.getMessage());
                 }
+                Log.d(TAG, "Callsign location data import complete!");
+            } finally {
+                importLatch.countDown();
             }
-            Log.d(TAG, "Callsign location data import complete!");
             return null;
         }
     }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -1154,6 +1154,11 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     return;
                 }
 
+                // The in-memory callsign database imports CTY.DAT asynchronously.
+                // Wait for that import to finish so the tables are populated before
+                // we try to resolve DXCC prefixes from logged QSOs.
+                CallsignDatabase.awaitImport(30_000);
+
                 Cursor cursor = db.rawQuery(
                         "SELECT DISTINCT \"call\" FROM QSLTable WHERE \"call\" IS NOT NULL AND \"call\" <> ''",
                         null);

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -298,6 +298,14 @@ class ComposeMainActivity : AppCompatActivity() {
             mainViewModel.operationBand = OperationBand.getInstance(baseContext)
         }
 
+        // Callsign database must be ready before getQslDxccToMap() — that
+        // method's background thread needs it to resolve DXCC prefixes. If it
+        // runs first, the null-check early-return leaves zoneMapReady false
+        // permanently and DXCC/zone "new" flags never compute. (#251 review)
+        if (GeneralVariables.callsignDatabase == null) {
+            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(baseContext, null, 1)
+        }
+
         mainViewModel.databaseOpr.getQslDxccToMap()
 
         mainViewModel.databaseOpr.getAllConfigParameter(object : OnAfterQueryConfig {
@@ -355,10 +363,6 @@ class ComposeMainActivity : AppCompatActivity() {
 
         DatabaseOpr.GetCallsignMapGrid(mainViewModel.databaseOpr.db).execute()
         mainViewModel.getFollowCallsignsFromDataBase()
-
-        if (GeneralVariables.callsignDatabase == null) {
-            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(baseContext, null, 1)
-        }
     }
 
     private fun doReceiveShareFile(intent: Intent) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ComposeMainActivity.kt
@@ -303,7 +303,7 @@ class ComposeMainActivity : AppCompatActivity() {
         // runs first, the null-check early-return leaves zoneMapReady false
         // permanently and DXCC/zone "new" flags never compute. (#251 review)
         if (GeneralVariables.callsignDatabase == null) {
-            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(baseContext, null, 1)
+            GeneralVariables.callsignDatabase = CallsignDatabase.getInstance(applicationContext, null, 1)
         }
 
         mainViewModel.databaseOpr.getQslDxccToMap()


### PR DESCRIPTION
## Summary
- `getQslDxccToMap()` was called before `callsignDatabase` was initialized in both `MainActivity` and `ComposeMainActivity`, so the background thread could early-return and leave `zoneMapReady` permanently false
- Moved `callsignDatabase` initialization before the `getQslDxccToMap()` call in both activities, removing the duplicate init that was at the end of each `initData()` method
- Addresses the unresolved Copilot review comment on PR #251

## Test plan
- [x] Existing `ZoneMapReadinessTest` passes (gate behavior unchanged)
- [x] Compilation verified for both activities
- [ ] Manual: cold start the app, verify DXCC "new" badges appear after a few seconds (not permanently suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)