### PR TITLE
Fix CAT over Bluetooth not connecting on Android 13+

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
@@ -13,6 +13,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
+import android.util.Log;
 
 import java.io.IOException;
 import java.security.InvalidParameterException;
@@ -22,6 +24,7 @@ import java.util.concurrent.Executors;
 
 public class BluetoothSerialSocket implements Runnable {
 
+    private static final String TAG = "BluetoothSerialSocket";
     private static final UUID BLUETOOTH_SPP = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
 
     private final BroadcastReceiver disconnectBroadcastReceiver;
@@ -57,7 +60,15 @@ public class BluetoothSerialSocket implements Runnable {
      */
     void connect(BluetoothSerialListener listener) throws IOException {
         this.listener = listener;
-        context.registerReceiver(disconnectBroadcastReceiver, new IntentFilter(BluetoothConstants.INTENT_ACTION_DISCONNECT));
+        // On API 33+ (Android 13) with targetSdk >= 33, registerReceiver() without an
+        // export flag throws SecurityException for non-system broadcasts, silently aborting
+        // the entire SPP/RFCOMM connection (issue #223 – CAT over Bluetooth).
+        IntentFilter filter = new IntentFilter(BluetoothConstants.INTENT_ACTION_DISCONNECT);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(disconnectBroadcastReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(disconnectBroadcastReceiver, filter);
+        }
         Executors.newCachedThreadPool().submit(this);
     }
 
@@ -87,11 +98,14 @@ public class BluetoothSerialSocket implements Runnable {
     @Override
     public void run() { // connect & read
         try {
+            Log.d(TAG, "run: creating RFCOMM socket to " + device.getAddress());
             socket = device.createRfcommSocketToServiceRecord(BLUETOOTH_SPP);
             socket.connect();
+            Log.d(TAG, "run: RFCOMM connected to " + device.getAddress());
             if(listener != null)
                 listener.onSerialConnect();
         } catch (Exception e) {
+            Log.e(TAG, "run: RFCOMM connect failed: " + e.getMessage());
             if(listener != null)
                 listener.onSerialConnectError(e);
             try {

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BluetoothRigConnector.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BluetoothRigConnector.java
@@ -42,13 +42,28 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
             case CREATE_NEW:
                 return new BluetoothRigConnector(context, address, controlMode);
             case RECONNECT_NEW_ADDRESS:
-                if (connector.connected == Connected.True) {
+                // Disconnect any active or in-flight connection to the *old* device
+                // before switching addresses. Leaving a Pending RFCOMM handshake
+                // running would let the old socket succeed after deviceAddress has
+                // already been changed, desynchronizing the connector.
+                if (connector.connected != Connected.False) {
                     connector.socketDisconnect();
+                }
+                // If the service binding is gone (onServiceDisconnected ran), we
+                // can't reuse this connector — create a fresh one.
+                if (connector.service == null) {
+                    return new BluetoothRigConnector(context, address, controlMode);
                 }
                 connector.setDeviceAddress(address);
                 connector.socketConnect();
                 return connector;
             case RETRY:
+                // If the service binding is gone, recreate the connector from
+                // scratch so bindService re-establishes it; calling socketConnect()
+                // with a null service would NPE-chain through socketDisconnect().
+                if (connector.service == null) {
+                    return new BluetoothRigConnector(context, address, controlMode);
+                }
                 connector.socketConnect();
                 return connector;
             case NO_ACTION:
@@ -105,7 +120,7 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
     @Override
     public void onSerialConnect() {
         Log.d(TAG, "onSerialConnect: connected");
-        GeneralVariables.fileLog("BT SPP: connected to " + deviceAddress);
+        GeneralVariables.fileLog("BT SPP: connected to " + BluetoothAutoConnectKt.maskBluetoothAddress(deviceAddress));
         connected = Connected.True;
         getOnConnectorStateChanged().onConnected();
     }
@@ -140,7 +155,9 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
     public void socketDisconnect() {
         connected = Connected.False;
         getOnConnectorStateChanged().onDisconnected();
-        service.disconnect();
+        if (service != null) {
+            service.disconnect();
+        }
     }
 
     /*
@@ -154,7 +171,7 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
             BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
             BluetoothDevice device = bluetoothAdapter.getRemoteDevice(deviceAddress);
             Log.d(TAG, "connecting...");
-            GeneralVariables.fileLog("BT SPP: connecting to " + deviceAddress);
+            GeneralVariables.fileLog("BT SPP: connecting to " + BluetoothAutoConnectKt.maskBluetoothAddress(deviceAddress));
             connected = Connected.Pending;
             getOnConnectorStateChanged().onConnecting();
             BluetoothSerialSocket socket = new BluetoothSerialSocket(context, device);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BluetoothRigConnector.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/BluetoothRigConnector.java
@@ -24,23 +24,36 @@ import com.bg7yoz.ft8cn.ui.ToastMessage;
 
 import java.io.IOException;
 
+import radio.ks3ckc.ft8us.BluetoothAutoConnectKt;
+import radio.ks3ckc.ft8us.BtConnectorAction;
+
 public class BluetoothRigConnector extends BaseRigConnector implements ServiceConnection, BluetoothSerialListener {
     private enum Connected {False, Pending, True}
     private static BluetoothRigConnector connector=null;
 
     public static BluetoothRigConnector getInstance(Context context, String address, int controlMode){
-        if (connector!=null){
-            if (!connector.getDeviceAddress().equals(address)) {
-                if (connector.connected== Connected.True) {
+        BtConnectorAction action = BluetoothAutoConnectKt.decideBtConnectorAction(
+                connector != null,
+                connector != null && connector.getDeviceAddress().equals(address),
+                connector != null && connector.connected == Connected.True,
+                connector != null && connector.connected == Connected.Pending);
+
+        switch (action) {
+            case CREATE_NEW:
+                return new BluetoothRigConnector(context, address, controlMode);
+            case RECONNECT_NEW_ADDRESS:
+                if (connector.connected == Connected.True) {
                     connector.socketDisconnect();
                 }
                 connector.setDeviceAddress(address);
                 connector.socketConnect();
-            }
-
-            return connector;
-        }else {
-            return new BluetoothRigConnector(context,address,controlMode);
+                return connector;
+            case RETRY:
+                connector.socketConnect();
+                return connector;
+            case NO_ACTION:
+            default:
+                return connector;
         }
     }
 
@@ -92,6 +105,7 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
     @Override
     public void onSerialConnect() {
         Log.d(TAG, "onSerialConnect: connected");
+        GeneralVariables.fileLog("BT SPP: connected to " + deviceAddress);
         connected = Connected.True;
         getOnConnectorStateChanged().onConnected();
     }
@@ -99,6 +113,7 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
     @Override
     public void onSerialConnectError(Exception e) {
         Log.e(TAG, "onSerialConnectError: " + e.getMessage());
+        GeneralVariables.fileLog("BT SPP: connect error: " + e.getMessage());
         getOnConnectorStateChanged().onRunError(e.getMessage());
         socketDisconnect();
     }
@@ -117,6 +132,7 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
     @Override
     public void onSerialIoError(Exception e) {
         Log.e(TAG, "onSerialIoError: " + e.getMessage());
+        GeneralVariables.fileLog("BT SPP: I/O error: " + e.getMessage());
         getOnConnectorStateChanged().onRunError(e.getMessage());
         socketDisconnect();
     }
@@ -138,6 +154,7 @@ public class BluetoothRigConnector extends BaseRigConnector implements ServiceCo
             BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
             BluetoothDevice device = bluetoothAdapter.getRemoteDevice(deviceAddress);
             Log.d(TAG, "connecting...");
+            GeneralVariables.fileLog("BT SPP: connecting to " + deviceAddress);
             connected = Connected.Pending;
             getOnConnectorStateChanged().onConnecting();
             BluetoothSerialSocket socket = new BluetoothSerialSocket(context, device);

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnect.kt
@@ -49,6 +49,43 @@ internal fun decideBluetoothAutoConnect(
 }
 
 /**
+ * What the [BluetoothRigConnector.getInstance] singleton should do when called.
+ */
+internal enum class BtConnectorAction {
+    /** No existing connector; create one from scratch (binds the service). */
+    CREATE_NEW,
+    /** A connector exists but for a different address — disconnect and reconnect to the new one. */
+    RECONNECT_NEW_ADDRESS,
+    /** Same address, but the previous attempt failed or was disconnected — retry. */
+    RETRY,
+    /** Same address, already connected or a connection attempt is in progress — do nothing. */
+    NO_ACTION,
+}
+
+/**
+ * Pure decision logic for [BluetoothRigConnector.getInstance] (issue #223 — CAT over Bluetooth).
+ * Before this was extracted, a stale singleton whose previous connect failed would silently
+ * refuse to reconnect when the user re-entered Settings, because `getInstance()` only retried
+ * when the address *changed*.
+ *
+ * @param hasExisting  true when the static singleton is non-null
+ * @param sameAddress  true when the existing singleton's address equals the requested address
+ * @param isConnected  true when the existing singleton has an active RFCOMM link
+ * @param isPending    true when the existing singleton has a connection attempt in flight
+ */
+internal fun decideBtConnectorAction(
+    hasExisting: Boolean,
+    sameAddress: Boolean,
+    isConnected: Boolean,
+    isPending: Boolean,
+): BtConnectorAction {
+    if (!hasExisting) return BtConnectorAction.CREATE_NEW
+    if (!sameAddress) return BtConnectorAction.RECONNECT_NEW_ADDRESS
+    if (isConnected || isPending) return BtConnectorAction.NO_ACTION
+    return BtConnectorAction.RETRY
+}
+
+/**
  * Redact a Bluetooth MAC for debug.log, which users attach to bug reports. A MAC is a stable
  * device identifier, so we keep only the first and last octet (enough to correlate log lines)
  * and hide the middle four (PR #228 review). A null/blank value becomes `<none>`; a corrupted

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/BluetoothAutoConnectTest.kt
@@ -210,4 +210,78 @@ class BluetoothAutoConnectTest {
         assertThat(masked).isEqualTo("<malformed:17>")
         assertThat(masked).doesNotContain("mac")
     }
+
+    // ---- decideBtConnectorAction: singleton reconnect decision (issue #223 part 2) ----
+
+    @Test
+    fun noExistingConnectorCreatesNew() {
+        assertThat(
+            decideBtConnectorAction(
+                hasExisting = false,
+                sameAddress = false,
+                isConnected = false,
+                isPending = false,
+            ),
+        ).isEqualTo(BtConnectorAction.CREATE_NEW)
+    }
+
+    @Test
+    fun differentAddressReconnects() {
+        assertThat(
+            decideBtConnectorAction(
+                hasExisting = true,
+                sameAddress = false,
+                isConnected = false,
+                isPending = false,
+            ),
+        ).isEqualTo(BtConnectorAction.RECONNECT_NEW_ADDRESS)
+    }
+
+    @Test
+    fun differentAddressReconnectsEvenWhenConnected() {
+        assertThat(
+            decideBtConnectorAction(
+                hasExisting = true,
+                sameAddress = false,
+                isConnected = true,
+                isPending = false,
+            ),
+        ).isEqualTo(BtConnectorAction.RECONNECT_NEW_ADDRESS)
+    }
+
+    @Test
+    fun sameAddressDisconnectedRetries() {
+        assertThat(
+            decideBtConnectorAction(
+                hasExisting = true,
+                sameAddress = true,
+                isConnected = false,
+                isPending = false,
+            ),
+        ).isEqualTo(BtConnectorAction.RETRY)
+    }
+
+    @Test
+    fun sameAddressConnectedIsNoAction() {
+        assertThat(
+            decideBtConnectorAction(
+                hasExisting = true,
+                sameAddress = true,
+                isConnected = true,
+                isPending = false,
+            ),
+        ).isEqualTo(BtConnectorAction.NO_ACTION)
+    }
+
+    @Test
+    fun sameAddressPendingIsNoAction() {
+        assertThat(
+            decideBtConnectorAction(
+                hasExisting = true,
+                sameAddress = true,
+                isConnected = false,
+                isPending = true,
+            ),
+        ).isEqualTo(BtConnectorAction.NO_ACTION)
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `BluetoothSerialSocket.connect()` throwing `SecurityException` on Android 13+ (API 33+) by adding the `RECEIVER_NOT_EXPORTED` flag to `registerReceiver()` — the root cause of the SPP/RFCOMM connection never being attempted (issue #223, part 2)
- Fix `BluetoothRigConnector.getInstance()` silently refusing to reconnect when called with the same address after a previous failed attempt
- Add `GeneralVariables.fileLog()` entries for BT SPP connect/disconnect/error events so future Bluetooth issues appear in user-provided debug.log files

## Details

With `targetSdk 35`, calling `context.registerReceiver(receiver, filter)` without `RECEIVER_NOT_EXPORTED` or `RECEIVER_EXPORTED` throws `SecurityException` on Android 13+. This exception was caught by the generic `catch (Exception e)` in `socketConnect()` and routed to `onSerialConnectError()`, but it happened *before* the RFCOMM socket was created — so `socket.connect()` never ran and the BT module's SPP indicator never illuminated.

The same `registerReceiver` pattern was already correctly handled in `ComposeMainActivity.kt` (line 477) and `CableSerialPort.java` (line 312); `BluetoothSerialSocket` was the only callsite that was missed.

Closes #223

## Test plan
- [x] `BluetoothAutoConnectTest` — 6 new tests for `decideBtConnectorAction()` covering all branches (CREATE_NEW, RECONNECT_NEW_ADDRESS, RETRY, NO_ACTION)
- [ ] Manual: Pair a BT SPP module (e.g. DX-BT35), configure CAT over Bluetooth in Settings, verify SPP connects on Android 13+ device
- [ ] Manual: Kill and relaunch app, verify auto-reconnect fires and SPP indicator lights up

🤖 Generated with [Claude Code](https://claude.com/claude-code)