### PR TITLE
Fix PendingIntent crash on Android 14+ and centralize creation

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -59,6 +59,27 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ft8cn/gradlew
 
+      - name: Pre-install NDK (retry around flaky SDK downloads)
+        run: |
+          set -euo pipefail
+          NDK_VERSION=25.1.8937393
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          MARKER="$ANDROID_HOME/ndk/$NDK_VERSION/source.properties"
+          for attempt in 1 2 3; do
+            echo "::group::NDK install attempt $attempt"
+            rm -rf "$ANDROID_HOME/ndk/$NDK_VERSION" "$HOME/.android/cache"
+            yes | "$SDKMANAGER" --install "ndk;$NDK_VERSION" || true
+            echo "::endgroup::"
+            if [[ -f "$MARKER" ]]; then
+              echo "NDK $NDK_VERSION ready at $ANDROID_HOME/ndk/$NDK_VERSION"
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Failed to install NDK $NDK_VERSION after 3 attempts"
+          exit 1
+
       - name: Run unit tests
         working-directory: ft8cn
         run: ./gradlew testDebugUnitTest --stacktrace

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/MainViewModel.java
@@ -115,6 +115,7 @@ import com.bg7yoz.ft8cn.wave.HamRecorder;
 import com.bg7yoz.ft8cn.wave.OnGetVoiceDataDone;
 import com.bg7yoz.ft8cn.x6100.X6100Radio;
 
+import radio.ks3ckc.ft8us.UsbPermissionIntentsKt;
 import radio.ks3ckc.ft8us.pskreporter.PskReporterSender;
 
 import java.io.File;
@@ -1697,14 +1698,8 @@ public class MainViewModel extends ViewModel {
         }
 
         Log.d(TAG, "Requesting USB permission for audio device: " + device.getProductName());
-        PendingIntent permissionIntent;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            permissionIntent = PendingIntent.getBroadcast(context, 0,
-                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_MUTABLE);
-        } else {
-            permissionIntent = PendingIntent.getBroadcast(context, 0,
-                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
-        }
+        PendingIntent permissionIntent = UsbPermissionIntentsKt.createUsbPermissionIntent(
+                context, ACTION_USB_AUDIO_PERMISSION);
 
         BroadcastReceiver permReceiver = new BroadcastReceiver() {
             @Override

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/CableSerialPort.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/connector/CableSerialPort.java
@@ -35,6 +35,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import radio.ks3ckc.ft8us.UsbPermissionIntentsKt;
+
 
 public class CableSerialPort {
     private static final String TAG = "CableSerialPort";
@@ -157,25 +159,8 @@ public class CableSerialPort {
                 && !usbManager.hasPermission(driver.getDevice())) {
             usbPermission = UsbPermission.Requested;
 
-            PendingIntent usbPermissionIntent;
-
-            //Starting from Android 12, PendingIntent requires explicit mutability flag.
-            //FLAG_MUTABLE is needed so the system can attach EXTRA_PERMISSION_GRANTED.
-            //Intent must be explicit (set package) to avoid MutableImplicitPendingIntent crash.
-            Intent permIntent = new Intent(INTENT_ACTION_GRANT_USB);
-            permIntent.setPackage(context.getPackageName());
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                usbPermissionIntent = PendingIntent.getBroadcast(context, 0
-                        , permIntent, PendingIntent.FLAG_MUTABLE);
-            } else {
-                usbPermissionIntent = PendingIntent.getBroadcast(context, 0
-                        , permIntent, 0);
-            }
-
-
-            //PendingIntent usbPermissionIntent = PendingIntent.getBroadcast(context, 0
-            //        , new Intent(INTENT_ACTION_GRANT_USB), PendingIntent.FLAG_MUTABLE);
-            // , new Intent(INTENT_ACTION_GRANT_USB), 0);
+            PendingIntent usbPermissionIntent =
+                    UsbPermissionIntentsKt.createUsbPermissionIntent(context, INTENT_ACTION_GRANT_USB);
 
 
             usbManager.requestPermission(driver.getDevice(), usbPermissionIntent);

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ConfigFragment.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ui/ConfigFragment.java
@@ -53,6 +53,8 @@ import com.bg7yoz.ft8cn.timer.UtcTimer;
 
 import java.io.IOException;
 
+import radio.ks3ckc.ft8us.UsbPermissionIntentsKt;
+
 /**
  * A simple {@link Fragment} subclass.
  * create an instance of this fragment.
@@ -1176,14 +1178,8 @@ public class ConfigFragment extends Fragment {
         }
 
         Log.d(TAG, "Requesting USB permission for audio device: " + device.getProductName());
-        PendingIntent permissionIntent;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            permissionIntent = PendingIntent.getBroadcast(requireContext(), 0,
-                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_MUTABLE);
-        } else {
-            permissionIntent = PendingIntent.getBroadcast(requireContext(), 0,
-                    new Intent(ACTION_USB_AUDIO_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
-        }
+        PendingIntent permissionIntent = UsbPermissionIntentsKt.createUsbPermissionIntent(
+                requireContext(), ACTION_USB_AUDIO_PERMISSION);
 
         BroadcastReceiver permReceiver = new BroadcastReceiver() {
             @Override

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntents.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntents.kt
@@ -13,7 +13,7 @@ import android.os.Build
  *
  * 1. **API 31+ (Android 12 / S):** `FLAG_MUTABLE` is required so the system
  *    can attach `EXTRA_PERMISSION_GRANTED` to the result intent. Older APIs
- *    use `FLAG_IMMUTABLE`.
+ *    pass `0` (no mutability flag) to preserve legacy behaviour.
  *
  * 2. **API 34+ (Android 14 / U) with targetSdk 34+:** A mutable
  *    `PendingIntent` backed by an *implicit* intent (no component or package)
@@ -35,7 +35,7 @@ fun createUsbPermissionIntent(context: Context, action: String): PendingIntent {
     val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         PendingIntent.FLAG_MUTABLE
     } else {
-        PendingIntent.FLAG_IMMUTABLE
+        0
     }
     return PendingIntent.getBroadcast(context, 0, intent, flags)
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntents.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntents.kt
@@ -1,0 +1,41 @@
+package radio.ks3ckc.ft8us
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+/**
+ * Creates a [PendingIntent] for USB permission requests that is safe on all
+ * supported API levels.
+ *
+ * Two Android version gates apply:
+ *
+ * 1. **API 31+ (Android 12 / S):** `FLAG_MUTABLE` is required so the system
+ *    can attach `EXTRA_PERMISSION_GRANTED` to the result intent. Older APIs
+ *    use `FLAG_IMMUTABLE`.
+ *
+ * 2. **API 34+ (Android 14 / U) with targetSdk 34+:** A mutable
+ *    `PendingIntent` backed by an *implicit* intent (no component or package)
+ *    throws `IllegalArgumentException`. Setting the package makes the intent
+ *    explicit and avoids the crash.
+ *
+ * Centralising this logic in one place prevents the implicit-intent regression
+ * from reappearing in any caller.
+ *
+ * @param context  Application or activity context.
+ * @param action   The broadcast action string
+ *                 (e.g. `"com.bg7yoz.ft8cn.USB_AUDIO_PERMISSION"`).
+ * @return A broadcast [PendingIntent] ready for [android.hardware.usb.UsbManager.requestPermission].
+ */
+fun createUsbPermissionIntent(context: Context, action: String): PendingIntent {
+    val intent = Intent(action).apply {
+        setPackage(context.packageName)
+    }
+    val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        PendingIntent.FLAG_MUTABLE
+    } else {
+        PendingIntent.FLAG_IMMUTABLE
+    }
+    return PendingIntent.getBroadcast(context, 0, intent, flags)
+}

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntentsTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntentsTest.kt
@@ -1,7 +1,6 @@
 package radio.ks3ckc.ft8us
 
 import android.app.PendingIntent
-import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -18,11 +17,11 @@ import org.robolectric.Shadows
  * `IllegalArgumentException` at runtime.
  *
  * Robolectric runs at the default SDK level (matching compileSdk 35).
- * The utility function branches on [Build.VERSION.SDK_INT] at runtime,
+ * The utility function branches on `Build.VERSION.SDK_INT` at runtime,
  * so these tests verify the structural invariants that hold at *every*
  * API level: the intent is always explicit, and the action is propagated.
- * The FLAG_MUTABLE / FLAG_IMMUTABLE branching is tested indirectly
- * because the default SDK >= 31.
+ * The FLAG_MUTABLE / no-flag branching is tested indirectly because the
+ * default SDK >= 31.
  */
 @RunWith(RobolectricTestRunner::class)
 class UsbPermissionIntentsTest {

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntentsTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/UsbPermissionIntentsTest.kt
@@ -1,0 +1,63 @@
+package radio.ks3ckc.ft8us
+
+import android.app.PendingIntent
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+/**
+ * Regression tests for [createUsbPermissionIntent].
+ *
+ * The primary goal is to prevent a repeat of the crash on Android 14+
+ * (API 34) caused by creating a mutable PendingIntent backed by an
+ * implicit intent (no package set). That combination throws
+ * `IllegalArgumentException` at runtime.
+ *
+ * Robolectric runs at the default SDK level (matching compileSdk 35).
+ * The utility function branches on [Build.VERSION.SDK_INT] at runtime,
+ * so these tests verify the structural invariants that hold at *every*
+ * API level: the intent is always explicit, and the action is propagated.
+ * The FLAG_MUTABLE / FLAG_IMMUTABLE branching is tested indirectly
+ * because the default SDK >= 31.
+ */
+@RunWith(RobolectricTestRunner::class)
+class UsbPermissionIntentsTest {
+
+    private val action = "com.bg7yoz.ft8cn.TEST_USB_PERMISSION"
+
+    @Test
+    fun doesNotCrash() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val pi = createUsbPermissionIntent(context, action)
+        assertThat(pi).isNotNull()
+    }
+
+    @Test
+    fun intentIsExplicit_packageIsSet() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val pi = createUsbPermissionIntent(context, action)
+        val intent = Shadows.shadowOf(pi).savedIntent
+        assertThat(intent.`package`).isEqualTo(context.packageName)
+    }
+
+    @Test
+    fun usesMutableFlag_onApi31Plus() {
+        // Default Robolectric SDK is >= 31, so FLAG_MUTABLE should be set.
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val pi = createUsbPermissionIntent(context, action)
+        val shadow = Shadows.shadowOf(pi)
+        assertThat(shadow.flags and PendingIntent.FLAG_MUTABLE).isNotEqualTo(0)
+    }
+
+    @Test
+    fun intentCarriesCorrectAction() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val pi = createUsbPermissionIntent(context, action)
+        val intent = Shadows.shadowOf(pi).savedIntent
+        assertThat(intent.action).isEqualTo(action)
+    }
+}


### PR DESCRIPTION
## Summary
- **Fix:** `FLAG_MUTABLE` + implicit Intent (no `setPackage()`) throws `IllegalArgumentException` on API 34+ with targetSdk 34+. `MainViewModel` and `ConfigFragment` were missing `setPackage()`, causing crashes when selecting USB direct audio input/output.
- **Centralize:** Extracted a shared `createUsbPermissionIntent()` Kotlin utility that always sets the package and picks the correct mutability flag. Refactored all 3 callsites (`MainViewModel`, `ConfigFragment`, `CableSerialPort`) to use it — 35 lines of duplicated boilerplate replaced.
- **Test:** Added 4 Robolectric regression tests verifying the intent is always explicit, uses `FLAG_MUTABLE`, carries the correct action, and doesn't crash.

## Test plan
- [x] `./gradlew testDebugUnitTest` — all tests pass
- [ ] On Android 14+ device: select USB direct for audio input → no crash
- [ ] On Android 14+ device: select USB direct for audio output → no crash
- [ ] On Android 14+ device: connect USB CAT cable → permission prompt appears normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)