### PR TITLE
Send rig name as dedicated PSKReporter IPFIX field

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSender.kt
@@ -61,6 +61,7 @@ object PskReporterSender {
     private const val FT_RX_LOCATOR = 4        // receiverLocator   (0x8004)
     private const val FT_DECODING_SW = 8       // decodingSoftware  (0x8008)
     private const val FT_RX_ANTENNA = 9        // antennaInformation (0x8009)
+    private const val FT_RX_RIG = 13            // rigInformation     (0x800D)
     // Sender (data) fields — enterprise-specific under 30351, EXCEPT flowStart.
     private const val FT_TX_CALLSIGN = 1       // senderCallsign    (0x8001)
     private const val FT_FREQUENCY = 5         // frequency         (0x8005)
@@ -209,12 +210,13 @@ object PskReporterSender {
         val myCall = GeneralVariables.myCallsign ?: return
         if (myCall.isEmpty()) return
         val myGrid = GeneralVariables.getMyMaidenheadGrid() ?: ""
+        val rigName = GeneralVariables.myRigName ?: ""
         val software = buildSoftwareString(
             GeneralVariables.VERSION, GeneralVariables.myRigName)
         val antenna = GeneralVariables.myAntenna ?: ""
 
         // Build IPFIX packets, respecting MTU limit
-        val packets = buildPackets(myCall, myGrid, software, spots, antenna)
+        val packets = buildPackets(myCall, myGrid, software, spots, antenna, rigName)
         for (pkt in packets) {
             try {
                 sendDatagram(pkt)
@@ -236,6 +238,7 @@ object PskReporterSender {
         software: String,
         spots: List<SpotRecord>,
         antenna: String = "",
+        rig: String = "",
     ): List<ByteArray> {
         val packets = mutableListOf<ByteArray>()
         val includeTemplates = needTemplates()
@@ -243,7 +246,7 @@ object PskReporterSender {
         var remaining = spots.toMutableList()
         while (remaining.isNotEmpty()) {
             val templateBytes = if (includeTemplates) encodeTemplates() else ByteArray(0)
-            val receiverBytes = encodeReceiverDataSet(rxCall, rxGrid, software, antenna)
+            val receiverBytes = encodeReceiverDataSet(rxCall, rxGrid, software, antenna, rig)
 
             // Header is 16 bytes
             val overhead = 16 + templateBytes.size + receiverBytes.size
@@ -326,10 +329,10 @@ object PskReporterSender {
 
     private fun encodeReceiverTemplate(): ByteArray {
         // Options template set (set ID = 0x0003)
-        // Template ID = 0x50E2, field count = 4, scope field count = 0
+        // Template ID = 0x50E2, field count = 5, scope field count = 0
         // Each field: type(2) + length(2) + enterprise(4)
         val fieldSize = 8 // 2+2+4 per field
-        val fieldCount = 4
+        val fieldCount = 5
         val templateRecordLen = 2 + 2 + 2 + (fieldCount * fieldSize) // templateId + fieldCount + scopeFieldCount + fields
         val setLen = 4 + templateRecordLen // setHeader (id+len) + record
         val padding = (4 - (setLen % 4)) % 4
@@ -361,6 +364,11 @@ object PskReporterSender {
 
         // Field 4: antennaInformation — variable length string
         buf.putShort((FT_RX_ANTENNA or 0x8000).toShort())
+        buf.putShort(0xFFFF.toShort())
+        buf.putInt(ENTERPRISE_NUMBER)
+
+        // Field 5: rigInformation — variable length string
+        buf.putShort((FT_RX_RIG or 0x8000).toShort())
         buf.putShort(0xFFFF.toShort())
         buf.putInt(ENTERPRISE_NUMBER)
 
@@ -435,13 +443,14 @@ object PskReporterSender {
      */
     @VisibleForTesting
     internal fun encodeReceiverDataSet(
-        call: String, grid: String, software: String, antenna: String,
+        call: String, grid: String, software: String, antenna: String, rig: String = "",
     ): ByteArray {
         val callBytes = encodeVarString(call)
         val gridBytes = encodeVarString(grid)
         val swBytes = encodeVarString(software)
         val antBytes = encodeVarString(antenna)
-        val bodyLen = callBytes.size + gridBytes.size + swBytes.size + antBytes.size
+        val rigBytes = encodeVarString(rig)
+        val bodyLen = callBytes.size + gridBytes.size + swBytes.size + antBytes.size + rigBytes.size
         val setLen = 4 + bodyLen
         val padding = (4 - (setLen % 4)) % 4
         val totalLen = setLen + padding
@@ -453,6 +462,7 @@ object PskReporterSender {
         buf.put(gridBytes)
         buf.put(swBytes)
         buf.put(antBytes)
+        buf.put(rigBytes)
         repeat(padding) { buf.put(0) }
         return buf.array()
     }

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/pskreporter/PskReporterSenderTest.kt
@@ -137,7 +137,7 @@ class PskReporterSenderTest {
     @Test
     fun `encodeReceiverDataSet has correct set ID and alignment`() {
         val data = PskReporterSender.encodeReceiverDataSet(
-            "N0CALL", "EM48", "FT8AF 1.2.3", "EFHW 40-10m"
+            "N0CALL", "EM48", "FT8AF 1.2.3", "EFHW 40-10m", "IC-7300"
         )
         val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
 
@@ -174,6 +174,12 @@ class PskReporterSenderTest {
         val antBytes = ByteArray(11)
         buf.get(antBytes)
         assertThat(String(antBytes)).isEqualTo("EFHW 40-10m")
+
+        // Rig
+        assertThat(buf.get().toInt() and 0xFF).isEqualTo(7) // "IC-7300"
+        val rigBytes = ByteArray(7)
+        buf.get(rigBytes)
+        assertThat(String(rigBytes)).isEqualTo("IC-7300")
     }
 
     // ---------------------------------------------------------------
@@ -195,9 +201,9 @@ class PskReporterSenderTest {
         val rxTemplateId = buf.short.toInt() and 0xFFFF
         assertThat(rxTemplateId).isEqualTo(0x50E2)
 
-        // Field count = 4
+        // Field count = 5
         val rxFieldCount = buf.short.toInt() and 0xFFFF
-        assertThat(rxFieldCount).isEqualTo(4)
+        assertThat(rxFieldCount).isEqualTo(5)
 
         // Scope field count = 0
         val scopeFieldCount = buf.short.toInt() and 0xFFFF
@@ -235,10 +241,10 @@ class PskReporterSenderTest {
         val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
 
         val enterpriseValues = mutableListOf<Int>()
-        // Receiver options template: 4 enterprise fields (8 bytes each).
+        // Receiver options template: 5 enterprise fields (8 bytes each).
         // Skip set header(4) + templateId(2) + fieldCount(2) + scopeFieldCount(2) = 10.
         buf.position(10)
-        repeat(4) {
+        repeat(5) {
             buf.short // type
             buf.short // length
             enterpriseValues.add(buf.int)
@@ -273,8 +279,9 @@ class PskReporterSenderTest {
         buf.position(10)
 
         // receiverCallsign 0x8002 / var, receiverLocator 0x8004 / var,
-        // decodingSoftware 0x8008 / var, antennaInformation 0x8009 / var — all enterprise 30351.
-        val expected = listOf(0x8002 to 0xFFFF, 0x8004 to 0xFFFF, 0x8008 to 0xFFFF, 0x8009 to 0xFFFF)
+        // decodingSoftware 0x8008 / var, antennaInformation 0x8009 / var,
+        // rigInformation 0x800D / var — all enterprise 30351.
+        val expected = listOf(0x8002 to 0xFFFF, 0x8004 to 0xFFFF, 0x8008 to 0xFFFF, 0x8009 to 0xFFFF, 0x800D to 0xFFFF)
         for ((type, len) in expected) {
             assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(type)
             assertThat(buf.short.toInt() and 0xFFFF).isEqualTo(len)
@@ -324,12 +331,13 @@ class PskReporterSenderTest {
         // IDs as WSJT-X PSKReporter.cpp). Pins the layout so a future field-ID drift
         // fails loudly instead of silently producing discarded packets.
         val expected = hex(
-            // --- Receiver options template (set 0x0003, len 0x002C = 44) ---
-            "0003 002C 50E2 0004 0000" +
+            // --- Receiver options template (set 0x0003, len 0x0034 = 52) ---
+            "0003 0034 50E2 0005 0000" +
                 "8002 FFFF 0000768F" + // receiverCallsign    (id 2, var)
                 "8004 FFFF 0000768F" + // receiverLocator     (id 4, var)
                 "8008 FFFF 0000768F" + // decodingSoftware    (id 8, var)
                 "8009 FFFF 0000768F" + // antennaInformation  (id 9, var)
+                "800D FFFF 0000768F" + // rigInformation      (id 13, var)
                 "0000" +               // padding to 4-byte boundary
                 // --- Sender data template (set 0x0002, len 0x003C = 60) ---
                 "0002 003C 50E3 0007" +


### PR DESCRIPTION
## Summary
- Adds IPFIX enterprise field 30351.13 (`rigInformation`) to the receiver options template and data set
- The connected rig name (e.g. "Discovery TX-500") is now sent as a dedicated field so it appears in the **Rig** column on pskreporter.info, instead of only being embedded in the "Using" (decodingSoftware) string
- Updates all IPFIX binary encoding tests including the golden-vector byte layout

## Test plan
- [ ] Verify unit tests pass (`testDebugUnitTest --tests PskReporterSenderTest`)
- [ ] Connect a rig, decode spots, and confirm the rig name appears in the "Rig" column on pskreporter.info

🤖 Generated with [Claude Code](https://claude.com/claude-code)