### PR TITLE
Fix empty-state message to show current mode instead of hardcoded FT8

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/decode/DecodeScreen.kt
@@ -490,7 +490,7 @@ internal fun EmptyState(
         "New DXCC" -> stringResource(R.string.decode_empty_dxcc_title) to stringResource(R.string.decode_empty_dxcc_body)
         "Needed" -> stringResource(R.string.decode_empty_needed_title) to stringResource(R.string.decode_empty_needed_body)
         "For Me" -> stringResource(R.string.decode_empty_forme_title) to stringResource(R.string.decode_empty_forme_body)
-        else -> stringResource(R.string.decode_empty_default_title) to stringResource(R.string.decode_empty_default_body)
+        else -> stringResource(R.string.decode_empty_default_title) to stringResource(R.string.decode_empty_default_body, GeneralVariables.currentMode().displayName)
     }
 
     Column(

--- a/ft8cn/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ar/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">لا نداءات لك</string>
     <string name="decode_empty_forme_body">لا توجد محطات تنادي نداءك الآن.</string>
     <string name="decode_empty_default_title">لا إشارات مفكوكة</string>
-    <string name="decode_empty_default_body">في انتظار ظهور إشارات FT8...</string>
+    <string name="decode_empty_default_body">في انتظار ظهور إشارات %s...</string>
     <string name="decode_label_calling">→ ينادي</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ إليك</string>

--- a/ft8cn/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ar/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">لا نداءات لك</string>
     <string name="decode_empty_forme_body">لا توجد محطات تنادي نداءك الآن.</string>
     <string name="decode_empty_default_title">لا إشارات مفكوكة</string>
-    <string name="decode_empty_default_body">في انتظار ظهور إشارات %s...</string>
+    <string name="decode_empty_default_body">في انتظار ظهور إشارات %1$s...</string>
     <string name="decode_label_calling">→ ينادي</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ إليك</string>

--- a/ft8cn/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-cs/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">Žádná volání pro vás</string>
     <string name="decode_empty_forme_body">Právě nikdo nevolá vaši volací značku.</string>
     <string name="decode_empty_default_title">Žádné dekódované signály</string>
-    <string name="decode_empty_default_body">Čekání na signály FT8...</string>
+    <string name="decode_empty_default_body">Čekání na signály %s...</string>
     <string name="decode_label_calling">→ VOLÁ</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ PRO VÁS</string>

--- a/ft8cn/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-cs/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">Žádná volání pro vás</string>
     <string name="decode_empty_forme_body">Právě nikdo nevolá vaši volací značku.</string>
     <string name="decode_empty_default_title">Žádné dekódované signály</string>
-    <string name="decode_empty_default_body">Čekání na signály %s...</string>
+    <string name="decode_empty_default_body">Čekání na signály %1$s...</string>
     <string name="decode_label_calling">→ VOLÁ</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ PRO VÁS</string>

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">Sin llamadas para ti</string>
     <string name="decode_empty_forme_body">Ninguna estación está llamando a tu indicativo ahora mismo.</string>
     <string name="decode_empty_default_title">Sin señales decodificadas</string>
-    <string name="decode_empty_default_body">Esperando que aparezcan señales %s...</string>
+    <string name="decode_empty_default_body">Esperando que aparezcan señales %1$s...</string>
     <string name="decode_label_calling">→ LLAMANDO</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ PARA TI</string>

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">Sin llamadas para ti</string>
     <string name="decode_empty_forme_body">Ninguna estación está llamando a tu indicativo ahora mismo.</string>
     <string name="decode_empty_default_title">Sin señales decodificadas</string>
-    <string name="decode_empty_default_body">Esperando que aparezcan señales FT8...</string>
+    <string name="decode_empty_default_body">Esperando que aparezcan señales %s...</string>
     <string name="decode_label_calling">→ LLAMANDO</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ PARA TI</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">Aucun appel pour vous</string>
     <string name="decode_empty_forme_body">Aucune station n\'appelle votre indicatif pour le moment.</string>
     <string name="decode_empty_default_title">Aucun signal décodé</string>
-    <string name="decode_empty_default_body">En attente de signaux %s...</string>
+    <string name="decode_empty_default_body">En attente de signaux %1$s...</string>
     <string name="decode_label_calling">→ APPEL</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ POUR VOUS</string>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">Aucun appel pour vous</string>
     <string name="decode_empty_forme_body">Aucune station n\'appelle votre indicatif pour le moment.</string>
     <string name="decode_empty_default_title">Aucun signal décodé</string>
-    <string name="decode_empty_default_body">En attente de signaux FT8...</string>
+    <string name="decode_empty_default_body">En attente de signaux %s...</string>
     <string name="decode_label_calling">→ APPEL</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ POUR VOUS</string>

--- a/ft8cn/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-in/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">Tidak ada panggilan untuk Anda</string>
     <string name="decode_empty_forme_body">Tidak ada stasiun yang memanggil tanda panggil Anda saat ini.</string>
     <string name="decode_empty_default_title">Tidak ada sinyal didekode</string>
-    <string name="decode_empty_default_body">Menunggu sinyal %s muncul...</string>
+    <string name="decode_empty_default_body">Menunggu sinyal %1$s muncul...</string>
     <string name="decode_label_calling">→ MEMANGGIL</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ UNTUK ANDA</string>

--- a/ft8cn/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-in/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">Tidak ada panggilan untuk Anda</string>
     <string name="decode_empty_forme_body">Tidak ada stasiun yang memanggil tanda panggil Anda saat ini.</string>
     <string name="decode_empty_default_title">Tidak ada sinyal didekode</string>
-    <string name="decode_empty_default_body">Menunggu sinyal FT8 muncul...</string>
+    <string name="decode_empty_default_body">Menunggu sinyal %s muncul...</string>
     <string name="decode_label_calling">→ MEMANGGIL</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ UNTUK ANDA</string>

--- a/ft8cn/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-it/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Nessuna chiamata per te</string>
     <string name="decode_empty_forme_body">Nessuna stazione sta chiamando il tuo nominativo al momento.</string>
     <string name="decode_empty_default_title">Nessun segnale decodificato</string>
-    <string name="decode_empty_default_body">In attesa di segnali FT8...</string>
+    <string name="decode_empty_default_body">In attesa di segnali %s...</string>
     <string name="decode_label_calling">→ CHIAMA</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ PER TE</string>

--- a/ft8cn/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-it/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Nessuna chiamata per te</string>
     <string name="decode_empty_forme_body">Nessuna stazione sta chiamando il tuo nominativo al momento.</string>
     <string name="decode_empty_default_title">Nessun segnale decodificato</string>
-    <string name="decode_empty_default_body">In attesa di segnali %s...</string>
+    <string name="decode_empty_default_body">In attesa di segnali %1$s...</string>
     <string name="decode_label_calling">→ CHIAMA</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ PER TE</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">自分宛てのコールなし</string>
     <string name="decode_empty_forme_body">現在あなたのコールサインを呼んでいる局はありません。</string>
     <string name="decode_empty_default_title">デコードされた信号なし</string>
-    <string name="decode_empty_default_body">FT8 信号が表示されるのを待機中...</string>
+    <string name="decode_empty_default_body">%s 信号が表示されるのを待機中...</string>
     <string name="decode_label_calling">→ 呼出中</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 自分宛て</string>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">自分宛てのコールなし</string>
     <string name="decode_empty_forme_body">現在あなたのコールサインを呼んでいる局はありません。</string>
     <string name="decode_empty_default_title">デコードされた信号なし</string>
-    <string name="decode_empty_default_body">%s 信号が表示されるのを待機中...</string>
+    <string name="decode_empty_default_body">%1$s 信号が表示されるのを待機中...</string>
     <string name="decode_label_calling">→ 呼出中</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 自分宛て</string>

--- a/ft8cn/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ko/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">나를 호출하는 국 없음</string>
     <string name="decode_empty_forme_body">지금 당신의 콜사인을 호출하는 국이 없습니다.</string>
     <string name="decode_empty_default_title">디코드된 신호 없음</string>
-    <string name="decode_empty_default_body">%s 신호가 나타나기를 기다리는 중...</string>
+    <string name="decode_empty_default_body">%1$s 신호가 나타나기를 기다리는 중...</string>
     <string name="decode_label_calling">→ 호출 중</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 나에게</string>

--- a/ft8cn/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ko/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">나를 호출하는 국 없음</string>
     <string name="decode_empty_forme_body">지금 당신의 콜사인을 호출하는 국이 없습니다.</string>
     <string name="decode_empty_default_title">디코드된 신호 없음</string>
-    <string name="decode_empty_default_body">FT8 신호가 나타나기를 기다리는 중...</string>
+    <string name="decode_empty_default_body">%s 신호가 나타나기를 기다리는 중...</string>
     <string name="decode_label_calling">→ 호출 중</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 나에게</string>

--- a/ft8cn/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-nl/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">Geen roepen voor jou</string>
     <string name="decode_empty_forme_body">Geen station roept op dit moment jouw roepnaam.</string>
     <string name="decode_empty_default_title">Geen signalen gedecodeerd</string>
-    <string name="decode_empty_default_body">Wachten tot %s-signalen verschijnen...</string>
+    <string name="decode_empty_default_body">Wachten tot %1$s-signalen verschijnen...</string>
     <string name="decode_label_calling">→ ROEPT</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ VOOR JOU</string>

--- a/ft8cn/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-nl/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">Geen roepen voor jou</string>
     <string name="decode_empty_forme_body">Geen station roept op dit moment jouw roepnaam.</string>
     <string name="decode_empty_default_title">Geen signalen gedecodeerd</string>
-    <string name="decode_empty_default_body">Wachten tot FT8-signalen verschijnen...</string>
+    <string name="decode_empty_default_body">Wachten tot %s-signalen verschijnen...</string>
     <string name="decode_label_calling">→ ROEPT</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ VOOR JOU</string>

--- a/ft8cn/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-pl/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Brak wywołań dla Ciebie</string>
     <string name="decode_empty_forme_body">Żadna stacja nie wywołuje teraz Twojego znaku.</string>
     <string name="decode_empty_default_title">Brak zdekodowanych sygnałów</string>
-    <string name="decode_empty_default_body">Oczekiwanie na sygnały %s...</string>
+    <string name="decode_empty_default_body">Oczekiwanie na sygnały %1$s...</string>
     <string name="decode_label_calling">→ WYWOŁUJE</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ DO CIEBIE</string>

--- a/ft8cn/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-pl/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Brak wywołań dla Ciebie</string>
     <string name="decode_empty_forme_body">Żadna stacja nie wywołuje teraz Twojego znaku.</string>
     <string name="decode_empty_default_title">Brak zdekodowanych sygnałów</string>
-    <string name="decode_empty_default_body">Oczekiwanie na sygnały FT8...</string>
+    <string name="decode_empty_default_body">Oczekiwanie na sygnały %s...</string>
     <string name="decode_label_calling">→ WYWOŁUJE</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ DO CIEBIE</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">Нет вызовов вам</string>
     <string name="decode_empty_forme_body">Сейчас никто не вызывает ваш позывной.</string>
     <string name="decode_empty_default_title">Нет декодированных сигналов</string>
-    <string name="decode_empty_default_body">Ожидание сигналов %s...</string>
+    <string name="decode_empty_default_body">Ожидание сигналов %1$s...</string>
     <string name="decode_label_calling">→ ВЫЗЫВАЕТ</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ ВАМ</string>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">Нет вызовов вам</string>
     <string name="decode_empty_forme_body">Сейчас никто не вызывает ваш позывной.</string>
     <string name="decode_empty_default_title">Нет декодированных сигналов</string>
-    <string name="decode_empty_default_body">Ожидание сигналов FT8...</string>
+    <string name="decode_empty_default_body">Ожидание сигналов %s...</string>
     <string name="decode_label_calling">→ ВЫЗЫВАЕТ</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ ВАМ</string>

--- a/ft8cn/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-tr/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Size çağrı yok</string>
     <string name="decode_empty_forme_body">Şu anda çağrı işaretinizi çağıran istasyon yok.</string>
     <string name="decode_empty_default_title">Çözümlenen sinyal yok</string>
-    <string name="decode_empty_default_body">FT8 sinyallerinin görünmesi bekleniyor...</string>
+    <string name="decode_empty_default_body">%s sinyallerinin görünmesi bekleniyor...</string>
     <string name="decode_label_calling">→ ÇAĞIRIYOR</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ SİZE</string>

--- a/ft8cn/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-tr/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Size çağrı yok</string>
     <string name="decode_empty_forme_body">Şu anda çağrı işaretinizi çağıran istasyon yok.</string>
     <string name="decode_empty_default_title">Çözümlenen sinyal yok</string>
-    <string name="decode_empty_default_body">%s sinyallerinin görünmesi bekleniyor...</string>
+    <string name="decode_empty_default_body">%1$s sinyallerinin görünmesi bekleniyor...</string>
     <string name="decode_label_calling">→ ÇAĞIRIYOR</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ SİZE</string>

--- a/ft8cn/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-uk/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Немає викликів для вас</string>
     <string name="decode_empty_forme_body">Зараз жодна станція не викликає ваш позивний.</string>
     <string name="decode_empty_default_title">Сигналів не декодовано</string>
-    <string name="decode_empty_default_body">Очікування появи сигналів %s...</string>
+    <string name="decode_empty_default_body">Очікування появи сигналів %1$s...</string>
     <string name="decode_label_calling">→ ВИКЛИК</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ ВАМ</string>

--- a/ft8cn/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-uk/strings_compose.xml
@@ -155,7 +155,7 @@
     <string name="decode_empty_forme_title">Немає викликів для вас</string>
     <string name="decode_empty_forme_body">Зараз жодна станція не викликає ваш позивний.</string>
     <string name="decode_empty_default_title">Сигналів не декодовано</string>
-    <string name="decode_empty_default_body">Очікування появи сигналів FT8...</string>
+    <string name="decode_empty_default_body">Очікування появи сигналів %s...</string>
     <string name="decode_label_calling">→ ВИКЛИК</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ ВАМ</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">没有呼叫您的电台</string>
     <string name="decode_empty_forme_body">当前没有电台在呼叫您的呼号。</string>
     <string name="decode_empty_default_title">未解码到信号</string>
-    <string name="decode_empty_default_body">正在等待 FT8 信号出现...</string>
+    <string name="decode_empty_default_body">正在等待 %s 信号出现...</string>
     <string name="decode_label_calling">→ 正在呼叫</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 呼叫您</string>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">没有呼叫您的电台</string>
     <string name="decode_empty_forme_body">当前没有电台在呼叫您的呼号。</string>
     <string name="decode_empty_default_title">未解码到信号</string>
-    <string name="decode_empty_default_body">正在等待 %s 信号出现...</string>
+    <string name="decode_empty_default_body">正在等待 %1$s 信号出现...</string>
     <string name="decode_label_calling">→ 正在呼叫</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 呼叫您</string>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">沒有呼叫您的電台</string>
     <string name="decode_empty_forme_body">目前沒有電台正在呼叫您的呼號。</string>
     <string name="decode_empty_default_title">未解碼到訊號</string>
-    <string name="decode_empty_default_body">等待 %s 訊號出現中…</string>
+    <string name="decode_empty_default_body">等待 %1$s 訊號出現中…</string>
     <string name="decode_label_calling">→ 呼叫中</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 給您</string>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -124,7 +124,7 @@
     <string name="decode_empty_forme_title">沒有呼叫您的電台</string>
     <string name="decode_empty_forme_body">目前沒有電台正在呼叫您的呼號。</string>
     <string name="decode_empty_default_title">未解碼到訊號</string>
-    <string name="decode_empty_default_body">等待 FT8 訊號出現中…</string>
+    <string name="decode_empty_default_body">等待 %s 訊號出現中…</string>
     <string name="decode_label_calling">→ 呼叫中</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ 給您</string>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">No calls for you</string>
     <string name="decode_empty_forme_body">No stations are calling your callsign right now.</string>
     <string name="decode_empty_default_title">No signals decoded</string>
-    <string name="decode_empty_default_body">Waiting for %s signals to appear...</string>
+    <string name="decode_empty_default_body">Waiting for %1$s signals to appear...</string>
     <string name="decode_label_calling">→ CALLING</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ TO YOU</string>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -166,7 +166,7 @@
     <string name="decode_empty_forme_title">No calls for you</string>
     <string name="decode_empty_forme_body">No stations are calling your callsign right now.</string>
     <string name="decode_empty_default_title">No signals decoded</string>
-    <string name="decode_empty_default_body">Waiting for FT8 signals to appear...</string>
+    <string name="decode_empty_default_body">Waiting for %s signals to appear...</string>
     <string name="decode_label_calling">→ CALLING</string>
     <string name="decode_label_cq">CQ</string>
     <string name="decode_label_to_you">↓ TO YOU</string>


### PR DESCRIPTION
## Summary
- The "no decodes" empty state subtitle always displayed "FT8" (e.g. "Ожидание сигналов FT8...") even when operating in FT4 or FT2 mode
- Replaced the hardcoded "FT8" with a `%s` format placeholder in `decode_empty_default_body` across all 16 locale files
- Pass `GeneralVariables.currentMode().displayName` to the string resource in `EmptyState()` so it dynamically shows the correct mode

## Test plan
- [ ] Switch to FT4 mode, verify the empty state reads "Waiting for FT4 signals..." (or locale equivalent)
- [ ] Switch to FT8 mode, verify it still reads "Waiting for FT8 signals..."
- [ ] Check at least one non-English locale (e.g. Russian) to confirm the placeholder renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)