### PR TITLE
Add +/- buttons to SWR, ALC target, and TX volume sliders

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/FT8USIcons.kt
@@ -305,6 +305,20 @@ object FT8USIcons {
     }
 
     @Composable
+    fun Minus(
+        modifier: Modifier = Modifier,
+        color: Color = Color.Unspecified,
+        size: Dp = 22.dp,
+        strokeWidth: Float = 1.6f,
+    ) {
+        val tint = if (color == Color.Unspecified) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else color
+        Canvas(modifier = modifier.then(Modifier.sizeOf(size))) {
+            val s = this.size.width / 24f
+            drawLine(tint, Offset(5f * s, 12f * s), Offset(19f * s, 12f * s), strokeWidth * s, StrokeCap.Round)
+        }
+    }
+
+    @Composable
     fun Info(
         modifier: Modifier = Modifier,
         color: Color = Color.Unspecified,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
@@ -809,7 +809,7 @@ private fun TxVolumeSliderDialog(
                             onChange(clamped)
                         }
                     },
-                    size = 32.dp,
+                    size = 36.dp,
                 ) {
                     FT8USIcons.Minus(color = Accent, size = 16.dp)
                 }
@@ -837,7 +837,7 @@ private fun TxVolumeSliderDialog(
                             onChange(clamped)
                         }
                     },
-                    size = 32.dp,
+                    size = 36.dp,
                 ) {
                     FT8USIcons.Plus(color = Accent, size = 16.dp)
                 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
@@ -47,6 +47,8 @@ import com.bg7yoz.ft8cn.rigs.BaseRigOperation
 import com.bg7yoz.ft8cn.rigs.InstructionSet
 import com.bg7yoz.ft8cn.ui.AudioDeviceSpinnerAdapter
 import radio.ks3ckc.ft8us.theme.*
+import radio.ks3ckc.ft8us.ui.components.FT8USIconButton
+import radio.ks3ckc.ft8us.ui.components.FT8USIcons
 import radio.ks3ckc.ft8us.ui.components.GlassCard
 import radio.ks3ckc.ft8us.ui.components.SettingsRow
 import radio.ks3ckc.ft8us.ui.components.Toggle
@@ -795,21 +797,51 @@ private fun TxVolumeSliderDialog(
                 fontSize = 48.sp,
             )
 
-            Slider(
-                value = current.toFloat(),
-                onValueChange = { v ->
-                    val clamped = v.toInt().coerceIn(0, 100)
-                    if (clamped != current) {
-                        current = clamped
-                        onChange(clamped)
-                    }
-                },
-                valueRange = 0f..100f,
-                colors = SliderDefaults.colors(
-                    thumbColor = Accent,
-                    activeTrackColor = Accent,
-                ),
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FT8USIconButton(
+                    onClick = {
+                        val clamped = (current - 5).coerceIn(0, 100)
+                        if (clamped != current) {
+                            current = clamped
+                            onChange(clamped)
+                        }
+                    },
+                    size = 32.dp,
+                ) {
+                    FT8USIcons.Minus(color = Accent, size = 16.dp)
+                }
+                Slider(
+                    value = current.toFloat(),
+                    onValueChange = { v ->
+                        val clamped = v.toInt().coerceIn(0, 100)
+                        if (clamped != current) {
+                            current = clamped
+                            onChange(clamped)
+                        }
+                    },
+                    valueRange = 0f..100f,
+                    modifier = Modifier.weight(1f),
+                    colors = SliderDefaults.colors(
+                        thumbColor = Accent,
+                        activeTrackColor = Accent,
+                    ),
+                )
+                FT8USIconButton(
+                    onClick = {
+                        val clamped = (current + 5).coerceIn(0, 100)
+                        if (clamped != current) {
+                            current = clamped
+                            onChange(clamped)
+                        }
+                    },
+                    size = 32.dp,
+                ) {
+                    FT8USIcons.Plus(color = Accent, size = 16.dp)
+                }
+            }
 
             Text(
                 text = stringResource(R.string.settings_tx_volume_advice),

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
@@ -202,21 +202,21 @@ fun TransmissionSettings(
                             )
                             FT8USIconButton(
                                 onClick = {
-                                    val clamped = (alcTargetLow - 5).coerceIn(10, alcTargetHigh - 10)
+                                    val clamped = (alcTargetLow - 5).coerceIn(10, minOf(200, alcTargetHigh - 10))
                                     alcTargetLow = clamped
                                     GeneralVariables.alcTargetLow = clamped
                                     mainViewModel.databaseOpr.writeConfig(
                                         "alcTargetLow", clamped.toString(), null,
                                     )
                                 },
-                                size = 32.dp,
+                                size = 36.dp,
                             ) {
                                 FT8USIcons.Minus(color = Accent, size = 16.dp)
                             }
                             Slider(
                                 value = alcTargetLow.toFloat(),
                                 onValueChange = { v ->
-                                    val clamped = v.toInt().coerceIn(10, alcTargetHigh - 10)
+                                    val clamped = v.toInt().coerceIn(10, minOf(200, alcTargetHigh - 10))
                                     alcTargetLow = clamped
                                     GeneralVariables.alcTargetLow = clamped
                                 },
@@ -234,14 +234,14 @@ fun TransmissionSettings(
                             )
                             FT8USIconButton(
                                 onClick = {
-                                    val clamped = (alcTargetLow + 5).coerceIn(10, alcTargetHigh - 10)
+                                    val clamped = (alcTargetLow + 5).coerceIn(10, minOf(200, alcTargetHigh - 10))
                                     alcTargetLow = clamped
                                     GeneralVariables.alcTargetLow = clamped
                                     mainViewModel.databaseOpr.writeConfig(
                                         "alcTargetLow", clamped.toString(), null,
                                     )
                                 },
-                                size = 32.dp,
+                                size = 36.dp,
                             ) {
                                 FT8USIcons.Plus(color = Accent, size = 16.dp)
                             }
@@ -268,7 +268,7 @@ fun TransmissionSettings(
                                         "alcTargetHigh", clamped.toString(), null,
                                     )
                                 },
-                                size = 32.dp,
+                                size = 36.dp,
                             ) {
                                 FT8USIcons.Minus(color = Accent, size = 16.dp)
                             }
@@ -300,7 +300,7 @@ fun TransmissionSettings(
                                         "alcTargetHigh", clamped.toString(), null,
                                     )
                                 },
-                                size = 32.dp,
+                                size = 36.dp,
                             ) {
                                 FT8USIcons.Plus(color = Accent, size = 16.dp)
                             }
@@ -347,7 +347,7 @@ fun TransmissionSettings(
                                         "swrHaltThreshold", newVal.toString(), null,
                                     )
                                 },
-                                size = 32.dp,
+                                size = 36.dp,
                             ) {
                                 FT8USIcons.Minus(color = Accent, size = 16.dp)
                             }
@@ -378,7 +378,7 @@ fun TransmissionSettings(
                                         "swrHaltThreshold", newVal.toString(), null,
                                     )
                                 },
-                                size = 32.dp,
+                                size = 36.dp,
                             ) {
                                 FT8USIcons.Plus(color = Accent, size = 16.dp)
                             }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
@@ -26,6 +26,8 @@ import com.bg7yoz.ft8cn.MainViewModel
 import com.bg7yoz.ft8cn.R
 import com.bg7yoz.ft8cn.ft8transmit.MeterProtectionController
 import radio.ks3ckc.ft8us.theme.*
+import radio.ks3ckc.ft8us.ui.components.FT8USIconButton
+import radio.ks3ckc.ft8us.ui.components.FT8USIcons
 import radio.ks3ckc.ft8us.ui.components.GlassCard
 import radio.ks3ckc.ft8us.ui.components.SettingsRow
 
@@ -198,6 +200,19 @@ fun TransmissionSettings(
                                 style = TextStyle(fontSize = 12.sp, color = TextMuted),
                                 modifier = Modifier.width(32.dp),
                             )
+                            FT8USIconButton(
+                                onClick = {
+                                    val clamped = (alcTargetLow - 5).coerceIn(10, alcTargetHigh - 10)
+                                    alcTargetLow = clamped
+                                    GeneralVariables.alcTargetLow = clamped
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "alcTargetLow", clamped.toString(), null,
+                                    )
+                                },
+                                size = 32.dp,
+                            ) {
+                                FT8USIcons.Minus(color = Accent, size = 16.dp)
+                            }
                             Slider(
                                 value = alcTargetLow.toFloat(),
                                 onValueChange = { v ->
@@ -217,6 +232,19 @@ fun TransmissionSettings(
                                     activeTrackColor = Accent,
                                 ),
                             )
+                            FT8USIconButton(
+                                onClick = {
+                                    val clamped = (alcTargetLow + 5).coerceIn(10, alcTargetHigh - 10)
+                                    alcTargetLow = clamped
+                                    GeneralVariables.alcTargetLow = clamped
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "alcTargetLow", clamped.toString(), null,
+                                    )
+                                },
+                                size = 32.dp,
+                            ) {
+                                FT8USIcons.Plus(color = Accent, size = 16.dp)
+                            }
                         }
                         // High slider
                         Row(
@@ -231,6 +259,19 @@ fun TransmissionSettings(
                                 style = TextStyle(fontSize = 12.sp, color = TextMuted),
                                 modifier = Modifier.width(32.dp),
                             )
+                            FT8USIconButton(
+                                onClick = {
+                                    val clamped = (alcTargetHigh - 5).coerceIn(alcTargetLow + 10, 250)
+                                    alcTargetHigh = clamped
+                                    GeneralVariables.alcTargetHigh = clamped
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "alcTargetHigh", clamped.toString(), null,
+                                    )
+                                },
+                                size = 32.dp,
+                            ) {
+                                FT8USIcons.Minus(color = Accent, size = 16.dp)
+                            }
                             Slider(
                                 value = alcTargetHigh.toFloat(),
                                 onValueChange = { v ->
@@ -250,6 +291,19 @@ fun TransmissionSettings(
                                     activeTrackColor = Accent,
                                 ),
                             )
+                            FT8USIconButton(
+                                onClick = {
+                                    val clamped = (alcTargetHigh + 5).coerceIn(alcTargetLow + 10, 250)
+                                    alcTargetHigh = clamped
+                                    GeneralVariables.alcTargetHigh = clamped
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "alcTargetHigh", clamped.toString(), null,
+                                    )
+                                },
+                                size = 32.dp,
+                            ) {
+                                FT8USIcons.Plus(color = Accent, size = 16.dp)
+                            }
                         }
                     }
                     SectionDivider()
@@ -284,6 +338,19 @@ fun TransmissionSettings(
                                 "1.5:1",
                                 style = TextStyle(fontSize = 12.sp, color = TextMuted),
                             )
+                            FT8USIconButton(
+                                onClick = {
+                                    val newVal = (swrHaltThreshold - 5).coerceIn(30, 200)
+                                    swrHaltThreshold = newVal
+                                    GeneralVariables.swrHaltThreshold = newVal
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "swrHaltThreshold", newVal.toString(), null,
+                                    )
+                                },
+                                size = 32.dp,
+                            ) {
+                                FT8USIcons.Minus(color = Accent, size = 16.dp)
+                            }
                             Slider(
                                 value = swrHaltThreshold.toFloat(),
                                 onValueChange = { v ->
@@ -302,6 +369,19 @@ fun TransmissionSettings(
                                     activeTrackColor = Accent,
                                 ),
                             )
+                            FT8USIconButton(
+                                onClick = {
+                                    val newVal = (swrHaltThreshold + 5).coerceIn(30, 200)
+                                    swrHaltThreshold = newVal
+                                    GeneralVariables.swrHaltThreshold = newVal
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "swrHaltThreshold", newVal.toString(), null,
+                                    )
+                                },
+                                size = 32.dp,
+                            ) {
+                                FT8USIcons.Plus(color = Accent, size = 16.dp)
+                            }
                             Text(
                                 "7:1",
                                 style = TextStyle(fontSize = 12.sp, color = TextMuted),


### PR DESCRIPTION
## Summary
- Added `Minus` icon to `FT8USIcons` (horizontal line matching `Plus` style)
- Added `-`/`+` `FT8USIconButton`s flanking the **SWR threshold**, **ALC Low**, **ALC High**, and **TX Volume** sliders
- Each button steps by 5 units per tap, with the same clamping logic as the slider callbacks

## Test plan
- [ ] Open Settings > Transmission > enable SWR Protection — verify `-`/`+` buttons adjust the threshold and the ratio label updates
- [ ] Enable Auto Volume (ALC) — verify `-`/`+` on Low and High sliders respect the 10-unit gap constraint
- [ ] Open Settings > Radio & Audio > tap TX Volume — verify `-`/`+` buttons in the dialog update the big percentage readout
- [ ] Confirm sliders still respond to tap/drag alongside the new buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)