### PR TITLE
Add inline TX volume slider to main screen

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/GeneralVariables.java
@@ -83,6 +83,9 @@ public class GeneralVariables {
     public static MutableLiveData<Float> mutableVolumePercent = new MutableLiveData<>();
     public static float volumePercent = 0.8f;//Audio playback volume, as a percentage
 
+    public static boolean showTxVolumeSlider = true;//Show inline TX volume slider on main screen
+    public static MutableLiveData<Boolean> mutableShowTxVolumeSlider = new MutableLiveData<>(true);
+
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2489,6 +2489,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("volumeValue")) {//Output volume level
                     GeneralVariables.volumePercent = result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
                 }
+                if (name.equalsIgnoreCase("showTxVolumeSlider")) {//Inline TX volume slider visibility
+                    GeneralVariables.showTxVolumeSlider = !result.equals("0");
+                    GeneralVariables.mutableShowTxVolumeSlider.postValue(GeneralVariables.showTxVolumeSlider);
+                }
                 if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
                 }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/database/DatabaseOpr.java
@@ -2488,6 +2488,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 if (name.equalsIgnoreCase("volumeValue")) {//Output volume level
                     GeneralVariables.volumePercent = result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
+                    GeneralVariables.mutableVolumePercent.postValue(GeneralVariables.volumePercent);
                 }
                 if (name.equalsIgnoreCase("showTxVolumeSlider")) {//Inline TX volume slider visibility
                     GeneralVariables.showTxVolumeSlider = !result.equals("0");

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -96,6 +97,27 @@ fun FT8USApp(mainViewModel: MainViewModel) {
     // switches VOX <-> CAT/RTS/DTR in Settings (seeds from the current value).
     val controlMode by GeneralVariables.mutableControlMode.observeAsState(GeneralVariables.controlMode)
     val showCatChip = shouldShowCatChip(controlMode, catState)
+
+    // TX Volume state — observe LiveData so hardware buttons, ALC auto-volume,
+    // and the settings slider all update the inline slider bidirectionally.
+    val volumeLive by GeneralVariables.mutableVolumePercent.observeAsState(
+        GeneralVariables.volumePercent,
+    )
+    var txVolume by remember { mutableIntStateOf((GeneralVariables.volumePercent * 100).toInt()) }
+    LaunchedEffect(volumeLive) {
+        txVolume = ((volumeLive ?: GeneralVariables.volumePercent) * 100).toInt()
+    }
+
+    // Inline volume slider visibility — observed so toggling in Settings
+    // immediately shows/hides the slider on the main screen.
+    val showVolumeSliderLive by GeneralVariables.mutableShowTxVolumeSlider.observeAsState(
+        GeneralVariables.showTxVolumeSlider,
+    )
+    var showVolumeSlider by remember { mutableStateOf(GeneralVariables.showTxVolumeSlider) }
+    LaunchedEffect(showVolumeSliderLive) {
+        showVolumeSlider = showVolumeSliderLive ?: GeneralVariables.showTxVolumeSlider
+    }
+
     // Consume the one-shot celebration signal so LiveData doesn't replay it
     // on recomposition / resubscription.
     LaunchedEffect(qsoCompletedAt) {
@@ -308,6 +330,15 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                 catState = catState,
                 showCatChip = showCatChip,
                 expanded = qsoPanelExpanded,
+                txVolume = txVolume,
+                showVolumeSlider = showVolumeSlider,
+                onVolumeChange = { newVolume ->
+                    txVolume = newVolume
+                    GeneralVariables.volumePercent = newVolume / 100f
+                    GeneralVariables.mutableVolumePercent.postValue(newVolume / 100f)
+                    mainViewModel.databaseOpr.writeConfig("volumeValue", newVolume.toString(), null)
+                    mainViewModel.baseRig?.connector?.setRFVolume(newVolume)
+                },
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {
                         Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/FT8USApp.kt
@@ -336,8 +336,10 @@ fun FT8USApp(mainViewModel: MainViewModel) {
                     txVolume = newVolume
                     GeneralVariables.volumePercent = newVolume / 100f
                     GeneralVariables.mutableVolumePercent.postValue(newVolume / 100f)
-                    mainViewModel.databaseOpr.writeConfig("volumeValue", newVolume.toString(), null)
-                    mainViewModel.baseRig?.connector?.setRFVolume(newVolume)
+                },
+                onVolumeChangeFinished = {
+                    mainViewModel.databaseOpr.writeConfig("volumeValue", txVolume.toString(), null)
+                    mainViewModel.baseRig?.connector?.setRFVolume(txVolume)
                 },
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -54,6 +56,13 @@ internal data class TxStripActionState(
     val cqIsStop: Boolean,
 )
 
+/**
+ * Clamp a volume value after a +/- step to the 0–100 range.
+ * Extracted so it can be unit-tested without Compose.
+ */
+internal fun clampVolume(current: Int, delta: Int): Int =
+    (current + delta).coerceIn(0, 100)
+
 internal fun txStripActionState(isActivated: Boolean, huntEnabled: Boolean) = TxStripActionState(
     huntDisabled = isActivated && !huntEnabled,
     huntActive = huntEnabled,
@@ -74,6 +83,9 @@ fun TxStrip(
     catState: CatConnectionState = CatConnectionState.DISCONNECTED,
     showCatChip: Boolean = false,
     expanded: Boolean = false,
+    txVolume: Int = 80,
+    showVolumeSlider: Boolean = false,
+    onVolumeChange: (Int) -> Unit = {},
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
     onToggleSlot: () -> Unit,
@@ -269,6 +281,76 @@ fun TxStrip(
                 enabled = true,
                 onClick = onToggleSlot,
             ) { color -> FT8USIcons.ArrowUp(size = 18.dp, color = color, strokeWidth = 1.8f) }
+        }
+
+        // ---- Inline TX volume slider (togglable from Settings) ----
+        if (showVolumeSlider) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                // Minus button
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(BgSurface3)
+                        .clickable { onVolumeChange(clampVolume(txVolume, -5)) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "\u2212", // minus sign
+                        color = TextMuted,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = GeistMonoFamily,
+                    )
+                }
+
+                // Slider
+                Slider(
+                    value = txVolume.toFloat(),
+                    onValueChange = { v ->
+                        val clamped = v.toInt().coerceIn(0, 100)
+                        onVolumeChange(clamped)
+                    },
+                    valueRange = 0f..100f,
+                    modifier = Modifier.weight(1f),
+                    colors = SliderDefaults.colors(
+                        thumbColor = Accent,
+                        activeTrackColor = Accent,
+                    ),
+                )
+
+                // Plus button
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(BgSurface3)
+                        .clickable { onVolumeChange(clampVolume(txVolume, 5)) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "+",
+                        color = TextMuted,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = GeistMonoFamily,
+                    )
+                }
+
+                // Percentage label
+                Text(
+                    text = "${txVolume}%",
+                    color = TextPrimary,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
+                )
+            }
         }
     }
 }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -27,6 +27,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Brush
@@ -86,6 +90,7 @@ fun TxStrip(
     txVolume: Int = 80,
     showVolumeSlider: Boolean = false,
     onVolumeChange: (Int) -> Unit = {},
+    onVolumeChangeFinished: () -> Unit = {},
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
     onToggleSlot: () -> Unit,
@@ -293,10 +298,14 @@ fun TxStrip(
                 // Minus button
                 Box(
                     modifier = Modifier
-                        .size(32.dp)
+                        .size(36.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(BgSurface3)
-                        .clickable { onVolumeChange(clampVolume(txVolume, -5)) },
+                        .semantics { role = Role.Button; contentDescription = "Decrease TX volume" }
+                        .clickable {
+                            onVolumeChange(clampVolume(txVolume, -5))
+                            onVolumeChangeFinished()
+                        },
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
@@ -315,6 +324,7 @@ fun TxStrip(
                         val clamped = v.toInt().coerceIn(0, 100)
                         onVolumeChange(clamped)
                     },
+                    onValueChangeFinished = onVolumeChangeFinished,
                     valueRange = 0f..100f,
                     modifier = Modifier.weight(1f),
                     colors = SliderDefaults.colors(
@@ -326,10 +336,14 @@ fun TxStrip(
                 // Plus button
                 Box(
                     modifier = Modifier
-                        .size(32.dp)
+                        .size(36.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(BgSurface3)
-                        .clickable { onVolumeChange(clampVolume(txVolume, 5)) },
+                        .semantics { role = Role.Button; contentDescription = "Increase TX volume" }
+                        .clickable {
+                            onVolumeChange(clampVolume(txVolume, 5))
+                            onVolumeChangeFinished()
+                        },
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
@@ -618,19 +618,16 @@ fun RadioAudioSettings(
                         SettingsRow(
                             label = stringResource(R.string.settings_show_volume_slider),
                             description = stringResource(R.string.settings_show_volume_slider_desc),
-                        ) {
-                            Toggle(
-                                checked = showSlider,
-                                onCheckedChange = { enabled ->
-                                    showSlider = enabled
-                                    GeneralVariables.showTxVolumeSlider = enabled
-                                    GeneralVariables.mutableShowTxVolumeSlider.postValue(enabled)
-                                    mainViewModel.databaseOpr.writeConfig(
-                                        "showTxVolumeSlider", if (enabled) "1" else "0", null,
-                                    )
-                                },
-                            )
-                        }
+                            toggle = showSlider,
+                            onToggleChange = { enabled ->
+                                showSlider = enabled
+                                GeneralVariables.showTxVolumeSlider = enabled
+                                GeneralVariables.mutableShowTxVolumeSlider.postValue(enabled)
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "showTxVolumeSlider", if (enabled) "1" else "0", null,
+                                )
+                            },
+                        )
                     }
                 }
             }

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
@@ -612,6 +612,26 @@ fun RadioAudioSettings(
                         showChevron = true,
                         onClick = { showTxVolume = true },
                     )
+                    SectionDivider()
+                    run {
+                        var showSlider by remember { mutableStateOf(GeneralVariables.showTxVolumeSlider) }
+                        SettingsRow(
+                            label = stringResource(R.string.settings_show_volume_slider),
+                            description = stringResource(R.string.settings_show_volume_slider_desc),
+                        ) {
+                            Toggle(
+                                checked = showSlider,
+                                onCheckedChange = { enabled ->
+                                    showSlider = enabled
+                                    GeneralVariables.showTxVolumeSlider = enabled
+                                    GeneralVariables.mutableShowTxVolumeSlider.postValue(enabled)
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "showTxVolumeSlider", if (enabled) "1" else "0", null,
+                                    )
+                                },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -396,6 +396,8 @@
     <string name="settings_audio_output">Audio Output</string>
     <string name="settings_tx_volume">TX Volume</string>
     <string name="settings_tx_volume_desc" formatted="false">Transmit audio level (hardware buttons ±5%)</string>
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
 
     <!-- ===== Settings: transmission ===== -->
     <string name="settings_tx_rx_split">TX/RX Split</string>

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxStripVolumeTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/TxStripVolumeTest.kt
@@ -1,0 +1,76 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [clampVolume] — the pure volume-stepping helper used by the
+ * inline TX volume slider's +/- buttons. No Android runtime needed.
+ */
+class TxStripVolumeTest {
+
+    @Test
+    fun `step up by 5 from mid-range`() {
+        assertThat(clampVolume(50, 5)).isEqualTo(55)
+    }
+
+    @Test
+    fun `step down by 5 from mid-range`() {
+        assertThat(clampVolume(50, -5)).isEqualTo(45)
+    }
+
+    @Test
+    fun `step up clamps at 100`() {
+        assertThat(clampVolume(98, 5)).isEqualTo(100)
+    }
+
+    @Test
+    fun `step down clamps at 0`() {
+        assertThat(clampVolume(2, -5)).isEqualTo(0)
+    }
+
+    @Test
+    fun `step up from 100 stays at 100`() {
+        assertThat(clampVolume(100, 5)).isEqualTo(100)
+    }
+
+    @Test
+    fun `step down from 0 stays at 0`() {
+        assertThat(clampVolume(0, -5)).isEqualTo(0)
+    }
+
+    @Test
+    fun `step up from 0`() {
+        assertThat(clampVolume(0, 5)).isEqualTo(5)
+    }
+
+    @Test
+    fun `step down from 100`() {
+        assertThat(clampVolume(100, -5)).isEqualTo(95)
+    }
+
+    @Test
+    fun `large positive delta clamps at 100`() {
+        assertThat(clampVolume(50, 200)).isEqualTo(100)
+    }
+
+    @Test
+    fun `large negative delta clamps at 0`() {
+        assertThat(clampVolume(50, -200)).isEqualTo(0)
+    }
+
+    @Test
+    fun `zero delta returns same value`() {
+        assertThat(clampVolume(42, 0)).isEqualTo(42)
+    }
+
+    @Test
+    fun `boundary value 100 with zero delta`() {
+        assertThat(clampVolume(100, 0)).isEqualTo(100)
+    }
+
+    @Test
+    fun `boundary value 0 with zero delta`() {
+        assertThat(clampVolume(0, 0)).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a full-width TX volume slider with +/− buttons below the CQ/Hunt action buttons in TxStrip, so operators can adjust TX output level without navigating to Settings
- Bidirectionally synced with the settings slider, hardware volume buttons, and ALC auto-volume via the existing `mutableVolumePercent` LiveData
- Slider visibility defaults to on and is togglable from Settings > Radio & Audio > Show Volume Slider, persisted across restarts
- Includes unit tests for volume clamping/stepping logic (`TxStripVolumeTest`)

## Test plan
- [ ] Volume slider visible below CQ/Hunt buttons by default
- [ ] Drag slider — volume changes immediately (verify via next TX or ALC meter)
- [ ] Tap +/− buttons — volume steps by 5%
- [ ] Change volume in Settings > Radio & Audio > TX Volume — inline slider updates
- [ ] Change inline slider — Settings slider reflects the new value
- [ ] Press hardware volume buttons — inline slider updates
- [ ] Toggle "Show Volume Slider" off in settings — slider disappears from main screen
- [ ] Restart app — visibility preference persists
- [ ] Run unit tests: `TxStripVolumeTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)