### PR TITLE
Address remaining PR #252 review comments

### DIFF
--- a/ft8cn/app/src/main/cpp/ft8cn_glue/gfsk.c
+++ b/ft8cn/app/src/main/cpp/ft8cn_glue/gfsk.c
@@ -50,7 +50,14 @@ void synth_gfsk_offset(const uint8_t *symbols, int n_sym, float f0,
                        float symbol_bt, float symbol_period,
                        int signal_rate, float *signal, int offset)
 {
+    // Guard: reject degenerate inputs that would cause division by zero or
+    // zero-length allocations (e.g. signal_rate == 0 producing n_spsym == 0).
+    if (symbols == NULL || signal == NULL || n_sym <= 0 ||
+        signal_rate <= 0 || symbol_period <= 0)
+        return;
+
     int n_spsym = (int)(0.5f + signal_rate * symbol_period); // samples per symbol
+    if (n_spsym <= 0) return; // would cause division by zero in dphi_peak
     int n_wave  = n_sym * n_spsym;                           // total output samples
     float hmod  = 1.0f;
 
@@ -61,6 +68,12 @@ void synth_gfsk_offset(const uint8_t *symbols, int n_sym, float f0,
     int dphi_len = n_wave + 2 * n_spsym;
     float *dphi = (float *)malloc(dphi_len * sizeof(float));
     float *pulse = (float *)malloc(3 * n_spsym * sizeof(float));
+
+    if (dphi == NULL || pulse == NULL) {
+        free(dphi);  // free(NULL) is safe per C standard
+        free(pulse);
+        return;
+    }
 
     // Initialise every sample to the base-frequency phase increment.
     for (int i = 0; i < dphi_len; ++i)

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/ft8transmit/FT8TransmitSignal.java
@@ -1733,7 +1733,11 @@ public class FT8TransmitSignal {
         if (toCallsign == null) {
             //must determine my callsign type to set i3n3 !!!
             int i3 = GenerateFT8.checkI3ByCallsign(GeneralVariables.myCallsign);
-            setTransmit(new TransmitCallsign(i3, 0, "CQ", UtcTimer.getNowSequential())
+            // Use the operator's chosen slot (sequential) instead of
+            // getNowSequential(), which can flip the slot based on the
+            // current time — breaking the method's contract of resetting
+            // to CQ without changing the timing sequence.
+            setTransmit(new TransmitCallsign(i3, 0, "CQ", sequential)
                     , 6, "");
         } else {
             functionOrder = 6;

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/ActiveQsoPanel.kt
@@ -221,16 +221,27 @@ fun ActiveQsoPanel(
     var synthTxTarget by remember { mutableStateOf<String?>(null) }
 
     // Clear TX state when the target genuinely changes to a different station.
-    // Ignore null transitions: when displayCallsign flickers to null during a
-    // tab switch (LiveData observer re-registration), the log must survive.
-    // The panel hides via AnimatedVisibility when hasTarget is false, so stale
-    // entries from the previous QSO are invisible until a new target arrives.
+    // Also handles the same-callsign-new-QSO edge case: when a QSO ends
+    // (displayCallsign → null for > 500ms) and the same station is worked
+    // again, the old TX rows must not carry over. A short delay distinguishes
+    // real QSO ends from tab-switch flickers (LiveData re-subscription emits
+    // null for 1–2 frames). LaunchedEffect cancels the pending delay when the
+    // key changes, so flickers never clear synthTxTarget. (#250 follow-up)
     LaunchedEffect(displayCallsign) {
-        if (displayCallsign != null && displayCallsign != synthTxTarget) {
-            synthTxLog.clear()
-            wasTransmitting = false
-            pendingTxLog = false
+        if (displayCallsign != null) {
+            if (displayCallsign != synthTxTarget) {
+                synthTxLog.clear()
+                wasTransmitting = false
+                pendingTxLog = false
+            }
             synthTxTarget = displayCallsign
+        } else if (synthTxTarget != null) {
+            // Target went null (CQ reset). Wait briefly — tab-switch flickers
+            // resolve within a frame (~16ms). If still null after the delay,
+            // it's a real QSO end; clear synthTxTarget so a subsequent QSO
+            // with the same callsign is treated as fresh.
+            kotlinx.coroutines.delay(500)
+            synthTxTarget = null
         }
     }
 

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -289,6 +289,8 @@ fun TxStrip(
         }
 
         // ---- Inline TX volume slider (togglable from Settings) ----
+        val volumeDecrease = stringResource(R.string.tx_volume_decrease)
+        val volumeIncrease = stringResource(R.string.tx_volume_increase)
         if (showVolumeSlider) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -301,7 +303,7 @@ fun TxStrip(
                         .size(36.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(BgSurface3)
-                        .semantics { role = Role.Button; contentDescription = "Decrease TX volume" }
+                        .semantics { role = Role.Button; contentDescription = volumeDecrease }
                         .clickable {
                             onVolumeChange(clampVolume(txVolume, -5))
                             onVolumeChangeFinished()
@@ -339,7 +341,7 @@ fun TxStrip(
                         .size(36.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(BgSurface3)
-                        .semantics { role = Role.Button; contentDescription = "Increase TX volume" }
+                        .semantics { role = Role.Button; contentDescription = volumeIncrease }
                         .clickable {
                             onVolumeChange(clampVolume(txVolume, 5))
                             onVolumeChangeFinished()

--- a/ft8cn/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ar/strings_compose.xml
@@ -540,4 +540,11 @@
     <string name="settings_language_desc">لغة عرض التطبيق</string>
     <string name="settings_language_system">افتراضي النظام</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-cs/strings_compose.xml
@@ -540,4 +540,11 @@
     <string name="settings_language_desc">Jazyk zobrazení aplikace</string>
     <string name="settings_language_system">Výchozí systému</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-es/strings_compose.xml
@@ -498,4 +498,11 @@
     <string name="settings_time_suggest_label">DT promedio reciente: %1$s</string>
     <string name="settings_time_suggest_none">Aún no hay decodificaciones — empieza a recibir para obtener una sugerencia.</string>
     <string name="settings_time_suggest_apply">Aplicar corrección sugerida</string>
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-fr/strings_compose.xml
@@ -498,4 +498,11 @@
     <string name="settings_time_suggest_label">DT moyen récent : %1$s</string>
     <string name="settings_time_suggest_none">Aucun décodage pour l\'instant — commencez à recevoir pour obtenir une suggestion.</string>
     <string name="settings_time_suggest_apply">Appliquer la correction suggérée</string>
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-in/strings_compose.xml
@@ -540,4 +540,11 @@
     <string name="settings_language_desc">Bahasa tampilan aplikasi</string>
     <string name="settings_language_system">Default sistem</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-it/strings_compose.xml
@@ -529,4 +529,11 @@
     <string name="settings_language_desc">Lingua di visualizzazione dell\'app</string>
     <string name="settings_language_system">Predefinita di sistema</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ja/strings_compose.xml
@@ -498,4 +498,11 @@
     <string name="settings_time_suggest_label">最近の平均 DT: %1$s</string>
     <string name="settings_time_suggest_none">まだデコードがありません — 受信を開始すると提案が表示されます。</string>
     <string name="settings_time_suggest_apply">提案された補正を適用</string>
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ko/strings_compose.xml
@@ -540,4 +540,11 @@
     <string name="settings_language_desc">앱 표시 언어</string>
     <string name="settings_language_system">시스템 기본값</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-nl/strings_compose.xml
@@ -540,4 +540,11 @@
     <string name="settings_language_desc">Weergavetaal van de app</string>
     <string name="settings_language_system">Systeemstandaard</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-pl/strings_compose.xml
@@ -529,4 +529,11 @@
     <string name="settings_language_desc">Język wyświetlania aplikacji</string>
     <string name="settings_language_system">Domyślny systemu</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-ru/strings_compose.xml
@@ -498,4 +498,11 @@
     <string name="settings_time_suggest_label">Средний DT за последнее время: %1$s</string>
     <string name="settings_time_suggest_none">Пока нет декодирований — включите приём, чтобы получить рекомендацию.</string>
     <string name="settings_time_suggest_apply">Применить предложенную коррекцию</string>
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-tr/strings_compose.xml
@@ -529,4 +529,11 @@
     <string name="settings_language_desc">Uygulama görüntüleme dili</string>
     <string name="settings_language_system">Sistem varsayılanı</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-uk/strings_compose.xml
@@ -529,4 +529,11 @@
     <string name="settings_language_desc">Мова відображення застосунку</string>
     <string name="settings_language_system">Системна за замовчуванням</string>
 
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -498,4 +498,11 @@
     <string name="settings_time_suggest_label">近期平均 DT：%1$s</string>
     <string name="settings_time_suggest_none">暂无解码 — 开始接收以获取建议。</string>
     <string name="settings_time_suggest_apply">应用建议的校正</string>
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -498,4 +498,11 @@
     <string name="settings_time_suggest_label">近期平均 DT：%1$s</string>
     <string name="settings_time_suggest_none">尚無解碼 — 開始接收以取得建議。</string>
     <string name="settings_time_suggest_apply">套用建議的校正</string>
+    <!-- Untranslated — added for parity; translate when localization pass runs -->
+    <string name="settings_show_volume_slider">Show Volume Slider</string>
+    <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_hunt_cq">Hunt + CQ</string>
+    <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 </resources>

--- a/ft8cn/app/src/main/res/values/strings_compose.xml
+++ b/ft8cn/app/src/main/res/values/strings_compose.xml
@@ -111,6 +111,8 @@
     <string name="tx_hunt">Hunt</string>
     <string name="tx_call_cq">Call CQ</string>
     <string name="tx_stop">Stop</string>
+    <string name="tx_volume_decrease">Decrease TX volume</string>
+    <string name="tx_volume_increase">Increase TX volume</string>
 
     <!-- ===== Hound (DXpedition) setup ===== -->
     <string name="hound_title">Work a DXpedition (Hound)</string>


### PR DESCRIPTION
## Summary

Addresses the 6 unresolved Copilot review comments on PR #252 (`dev → main`):

- **resetToCQ slot flip** (FT8TransmitSignal.java:1737): Use `sequential` instead of `UtcTimer.getNowSequential()` when `toCallsign` is null, preserving the operator's chosen TX slot per the method's documented contract
- **Synth TX log same-callsign carry-over** (ActiveQsoPanel.kt:235): When a QSO ends (callsign → null) and the same station is worked again, old TX rows no longer carry over. A 500ms debounce distinguishes real QSO ends from tab-switch LiveData flickers
- **Hard-coded a11y strings** (TxStrip.kt:304,342): Volume +/- button `contentDescription` strings now use `stringResource()` so screen readers follow the app locale
- **Missing localized strings** (strings_compose.xml): Added `settings_show_volume_slider*`, `settings_hunt_cq*`, `tx_volume_decrease`, and `tx_volume_increase` to all 15 locale files as English placeholders for translation parity
- **gfsk.c input guards** (gfsk.c:64): Added null-pointer, zero-divisor (`n_spsym == 0`), and malloc-failure guards before any dereference or division
- **QsoSheet.kt isFullyComplete** (QsoSheet.kt:463): No code change needed — Kotlin `&&` already short-circuits, so the QSL lookup is skipped when `isLiveQso` is true. Copilot's analysis was incorrect here.

## Test plan

- [ ] Verify TX slot doesn't flip when resetToCQ is called with null toCallsign (e.g. during Hunt startup)
- [ ] Start a QSO, let it complete (back to CQ), then work the same station again — verify mini-log TX entries are fresh, not carried over from the previous QSO
- [ ] On a non-English locale, verify volume +/- buttons have localized screen-reader labels
- [ ] Build succeeds with no missing resource errors across all locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)