### PR TITLE
Fix slider drag support with custom IntSlider

### DIFF
--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/IntSlider.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/IntSlider.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -17,6 +18,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
 
@@ -56,12 +62,12 @@ internal fun pixelToValue(
 internal fun IntSlider(
     value: Int,
     onValueChange: (Int) -> Unit,
+    thumbColor: Color,
+    activeTrackColor: Color,
     modifier: Modifier = Modifier,
     valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
     onValueChangeFinished: (() -> Unit)? = null,
-    thumbColor: Color = Color.Unspecified,
-    activeTrackColor: Color = Color.Unspecified,
-    inactiveTrackColor: Color = Color.Unspecified,
+    inactiveTrackColor: Color = activeTrackColor.copy(alpha = 0.24f),
 ) {
     val rangeStart = valueRange.start
     val rangeEnd = valueRange.endInclusive
@@ -70,8 +76,11 @@ internal fun IntSlider(
     var rawPos by remember { mutableFloatStateOf(value.toFloat()) }
 
     // Sync when value changes externally (e.g. +/- buttons).
-    if (shouldSyncSliderPos(rawPos, value)) {
-        rawPos = value.toFloat()
+    // Done in SideEffect to avoid state writes during composition.
+    SideEffect {
+        if (shouldSyncSliderPos(rawPos, value)) {
+            rawPos = value.toFloat().coerceIn(rangeStart, rangeEnd)
+        }
     }
 
     val fraction = if (rangeEnd > rangeStart) {
@@ -80,16 +89,25 @@ internal fun IntSlider(
 
     val thumbRadius = 10.dp
     val trackHeight = 4.dp
-    val inactiveColor = if (inactiveTrackColor != Color.Unspecified) {
-        inactiveTrackColor
-    } else {
-        thumbColor.copy(alpha = 0.24f)
-    }
 
     Box(
         modifier = modifier
             .height(48.dp) // Minimum touch target
             .fillMaxWidth()
+            .semantics {
+                progressBarRangeInfo = ProgressBarRangeInfo(
+                    current = value.toFloat(),
+                    range = rangeStart..rangeEnd,
+                )
+                stateDescription = "${value.toFloat().roundToInt()}"
+                setProgress { targetValue ->
+                    val clamped = targetValue.roundToInt()
+                        .coerceIn(rangeStart.roundToInt(), rangeEnd.roundToInt())
+                    onValueChange(clamped)
+                    onValueChangeFinished?.invoke()
+                    true
+                }
+            }
             .pointerInput(rangeStart, rangeEnd) {
                 detectTapGestures { offset ->
                     val padding = thumbRadius.toPx()
@@ -135,7 +153,7 @@ internal fun IntSlider(
 
             // Inactive track
             drawLine(
-                color = inactiveColor,
+                color = inactiveTrackColor,
                 start = Offset(activeEndX, centerY),
                 end = Offset(trackEndX, centerY),
                 strokeWidth = trackHeightPx,

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/IntSlider.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/IntSlider.kt
@@ -1,0 +1,162 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+/**
+ * Whether the internal raw slider position should be re-synced to an
+ * externally-provided integer value. Returns `true` when the two differ
+ * (e.g. after a +/- button press) and `false` during a drag where the
+ * rounded raw position still matches the controlled value.
+ */
+internal fun shouldSyncSliderPos(rawPos: Float, externalValue: Int): Boolean =
+    rawPos.roundToInt() != externalValue
+
+/**
+ * Map a pixel x-coordinate on the track to a value in [rangeStart]..[rangeEnd].
+ */
+internal fun pixelToValue(
+    px: Float,
+    trackStartPx: Float,
+    trackEndPx: Float,
+    rangeStart: Float,
+    rangeEnd: Float,
+): Float {
+    if (trackEndPx <= trackStartPx) return rangeStart
+    val fraction = ((px - trackStartPx) / (trackEndPx - trackStartPx)).coerceIn(0f, 1f)
+    return rangeStart + fraction * (rangeEnd - rangeStart)
+}
+
+/**
+ * A custom slider backed by an [Int] value with reliable drag support.
+ *
+ * Material3 [androidx.compose.material3.Slider] on Compose BOM 2024.02.00
+ * prematurely exits its drag state (compose-multiplatform#4366), making
+ * sliders tap-only. This implementation handles horizontal drag and tap
+ * gestures directly via [pointerInput], bypassing the broken drag handling.
+ */
+@Composable
+internal fun IntSlider(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    onValueChangeFinished: (() -> Unit)? = null,
+    thumbColor: Color = Color.Unspecified,
+    activeTrackColor: Color = Color.Unspecified,
+    inactiveTrackColor: Color = Color.Unspecified,
+) {
+    val rangeStart = valueRange.start
+    val rangeEnd = valueRange.endInclusive
+
+    // Raw float position — avoids int snap that kills drag gestures.
+    var rawPos by remember { mutableFloatStateOf(value.toFloat()) }
+
+    // Sync when value changes externally (e.g. +/- buttons).
+    if (shouldSyncSliderPos(rawPos, value)) {
+        rawPos = value.toFloat()
+    }
+
+    val fraction = if (rangeEnd > rangeStart) {
+        ((rawPos - rangeStart) / (rangeEnd - rangeStart)).coerceIn(0f, 1f)
+    } else 0f
+
+    val thumbRadius = 10.dp
+    val trackHeight = 4.dp
+    val inactiveColor = if (inactiveTrackColor != Color.Unspecified) {
+        inactiveTrackColor
+    } else {
+        thumbColor.copy(alpha = 0.24f)
+    }
+
+    Box(
+        modifier = modifier
+            .height(48.dp) // Minimum touch target
+            .fillMaxWidth()
+            .pointerInput(rangeStart, rangeEnd) {
+                detectTapGestures { offset ->
+                    val padding = thumbRadius.toPx()
+                    val newVal = pixelToValue(
+                        offset.x, padding, size.width - padding,
+                        rangeStart, rangeEnd,
+                    )
+                    rawPos = newVal
+                    onValueChange(newVal.roundToInt())
+                    onValueChangeFinished?.invoke()
+                }
+            }
+            .pointerInput(rangeStart, rangeEnd) {
+                val padding = thumbRadius.toPx()
+                detectHorizontalDragGestures(
+                    onDragEnd = {
+                        rawPos = rawPos.roundToInt().toFloat()
+                        onValueChangeFinished?.invoke()
+                    },
+                    onDragCancel = {
+                        rawPos = value.toFloat()
+                    },
+                    onHorizontalDrag = { change, _ ->
+                        change.consume()
+                        val newVal = pixelToValue(
+                            change.position.x, padding, size.width - padding,
+                            rangeStart, rangeEnd,
+                        )
+                        rawPos = newVal
+                        onValueChange(newVal.roundToInt())
+                    },
+                )
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(modifier = Modifier.fillMaxWidth().height(48.dp)) {
+            val padding = thumbRadius.toPx()
+            val trackStartX = padding
+            val trackEndX = size.width - padding
+            val centerY = size.height / 2f
+            val activeEndX = trackStartX + fraction * (trackEndX - trackStartX)
+            val trackHeightPx = trackHeight.toPx()
+
+            // Inactive track
+            drawLine(
+                color = inactiveColor,
+                start = Offset(activeEndX, centerY),
+                end = Offset(trackEndX, centerY),
+                strokeWidth = trackHeightPx,
+                cap = StrokeCap.Round,
+            )
+
+            // Active track
+            drawLine(
+                color = activeTrackColor,
+                start = Offset(trackStartX, centerY),
+                end = Offset(activeEndX, centerY),
+                strokeWidth = trackHeightPx,
+                cap = StrokeCap.Round,
+            )
+
+            // Thumb
+            drawCircle(
+                color = thumbColor,
+                radius = thumbRadius.toPx(),
+                center = Offset(activeEndX, centerY),
+            )
+        }
+    }
+}

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/components/TxStrip.kt
@@ -18,8 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -318,19 +316,16 @@ fun TxStrip(
                 }
 
                 // Slider
-                Slider(
-                    value = txVolume.toFloat(),
+                IntSlider(
+                    value = txVolume,
                     onValueChange = { v ->
-                        val clamped = v.toInt().coerceIn(0, 100)
-                        onVolumeChange(clamped)
+                        onVolumeChange(v.coerceIn(0, 100))
                     },
                     onValueChangeFinished = onVolumeChangeFinished,
                     valueRange = 0f..100f,
                     modifier = Modifier.weight(1f),
-                    colors = SliderDefaults.colors(
-                        thumbColor = Accent,
-                        activeTrackColor = Accent,
-                    ),
+                    thumbColor = Accent,
+                    activeTrackColor = Accent,
                 )
 
                 // Plus button

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/RadioAudioSettings.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -49,6 +47,7 @@ import com.bg7yoz.ft8cn.ui.AudioDeviceSpinnerAdapter
 import radio.ks3ckc.ft8us.theme.*
 import radio.ks3ckc.ft8us.ui.components.FT8USIconButton
 import radio.ks3ckc.ft8us.ui.components.FT8USIcons
+import radio.ks3ckc.ft8us.ui.components.IntSlider
 import radio.ks3ckc.ft8us.ui.components.GlassCard
 import radio.ks3ckc.ft8us.ui.components.SettingsRow
 import radio.ks3ckc.ft8us.ui.components.Toggle
@@ -830,10 +829,10 @@ private fun TxVolumeSliderDialog(
                 ) {
                     FT8USIcons.Minus(color = Accent, size = 16.dp)
                 }
-                Slider(
-                    value = current.toFloat(),
+                IntSlider(
+                    value = current,
                     onValueChange = { v ->
-                        val clamped = v.toInt().coerceIn(0, 100)
+                        val clamped = v.coerceIn(0, 100)
                         if (clamped != current) {
                             current = clamped
                             onChange(clamped)
@@ -841,10 +840,8 @@ private fun TxVolumeSliderDialog(
                     },
                     valueRange = 0f..100f,
                     modifier = Modifier.weight(1f),
-                    colors = SliderDefaults.colors(
-                        thumbColor = Accent,
-                        activeTrackColor = Accent,
-                    ),
+                    thumbColor = Accent,
+                    activeTrackColor = Accent,
                 )
                 FT8USIconButton(
                     onClick = {

--- a/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
+++ b/ft8cn/app/src/main/kotlin/radio/ks3ckc/ft8us/ui/settings/TransmissionSettings.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,6 +26,7 @@ import com.bg7yoz.ft8cn.ft8transmit.MeterProtectionController
 import radio.ks3ckc.ft8us.theme.*
 import radio.ks3ckc.ft8us.ui.components.FT8USIconButton
 import radio.ks3ckc.ft8us.ui.components.FT8USIcons
+import radio.ks3ckc.ft8us.ui.components.IntSlider
 import radio.ks3ckc.ft8us.ui.components.GlassCard
 import radio.ks3ckc.ft8us.ui.components.SettingsRow
 
@@ -213,10 +212,10 @@ fun TransmissionSettings(
                             ) {
                                 FT8USIcons.Minus(color = Accent, size = 16.dp)
                             }
-                            Slider(
-                                value = alcTargetLow.toFloat(),
+                            IntSlider(
+                                value = alcTargetLow,
                                 onValueChange = { v ->
-                                    val clamped = v.toInt().coerceIn(10, minOf(200, alcTargetHigh - 10))
+                                    val clamped = v.coerceIn(10, minOf(200, alcTargetHigh - 10))
                                     alcTargetLow = clamped
                                     GeneralVariables.alcTargetLow = clamped
                                 },
@@ -227,10 +226,8 @@ fun TransmissionSettings(
                                 },
                                 valueRange = 10f..200f,
                                 modifier = Modifier.weight(1f),
-                                colors = SliderDefaults.colors(
-                                    thumbColor = Accent,
-                                    activeTrackColor = Accent,
-                                ),
+                                thumbColor = Accent,
+                                activeTrackColor = Accent,
                             )
                             FT8USIconButton(
                                 onClick = {
@@ -272,10 +269,10 @@ fun TransmissionSettings(
                             ) {
                                 FT8USIcons.Minus(color = Accent, size = 16.dp)
                             }
-                            Slider(
-                                value = alcTargetHigh.toFloat(),
+                            IntSlider(
+                                value = alcTargetHigh,
                                 onValueChange = { v ->
-                                    val clamped = v.toInt().coerceIn(alcTargetLow + 10, 250)
+                                    val clamped = v.coerceIn(alcTargetLow + 10, 250)
                                     alcTargetHigh = clamped
                                     GeneralVariables.alcTargetHigh = clamped
                                 },
@@ -286,10 +283,8 @@ fun TransmissionSettings(
                                 },
                                 valueRange = 20f..250f,
                                 modifier = Modifier.weight(1f),
-                                colors = SliderDefaults.colors(
-                                    thumbColor = Accent,
-                                    activeTrackColor = Accent,
-                                ),
+                                thumbColor = Accent,
+                                activeTrackColor = Accent,
                             )
                             FT8USIconButton(
                                 onClick = {
@@ -351,11 +346,11 @@ fun TransmissionSettings(
                             ) {
                                 FT8USIcons.Minus(color = Accent, size = 16.dp)
                             }
-                            Slider(
-                                value = swrHaltThreshold.toFloat(),
+                            IntSlider(
+                                value = swrHaltThreshold,
                                 onValueChange = { v ->
-                                    swrHaltThreshold = v.toInt()
-                                    GeneralVariables.swrHaltThreshold = v.toInt()
+                                    swrHaltThreshold = v
+                                    GeneralVariables.swrHaltThreshold = v
                                 },
                                 onValueChangeFinished = {
                                     mainViewModel.databaseOpr.writeConfig(
@@ -364,10 +359,8 @@ fun TransmissionSettings(
                                 },
                                 valueRange = 30f..200f, // ~1.3:1 to ~7.0:1
                                 modifier = Modifier.weight(1f),
-                                colors = SliderDefaults.colors(
-                                    thumbColor = Accent,
-                                    activeTrackColor = Accent,
-                                ),
+                                thumbColor = Accent,
+                                activeTrackColor = Accent,
                             )
                             FT8USIconButton(
                                 onClick = {

--- a/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/IntSliderSyncTest.kt
+++ b/ft8cn/app/src/test/kotlin/radio/ks3ckc/ft8us/ui/components/IntSliderSyncTest.kt
@@ -1,0 +1,117 @@
+package radio.ks3ckc.ft8us.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [shouldSyncSliderPos] and [pixelToValue] — the pure helpers
+ * used by [IntSlider].
+ */
+class IntSliderSyncTest {
+
+    // =====================================================================
+    // shouldSyncSliderPos
+    // =====================================================================
+
+    // ---- During drag: raw position rounds to the same int → no sync ----
+
+    @Test
+    fun `mid-range drag position rounds to external value`() {
+        assertThat(shouldSyncSliderPos(45.3f, 45)).isFalse()
+    }
+
+    @Test
+    fun `drag position just below half rounds down`() {
+        assertThat(shouldSyncSliderPos(45.4f, 45)).isFalse()
+    }
+
+    @Test
+    fun `drag position at half rounds up`() {
+        assertThat(shouldSyncSliderPos(45.5f, 46)).isFalse()
+    }
+
+    @Test
+    fun `exact integer position matches`() {
+        assertThat(shouldSyncSliderPos(50.0f, 50)).isFalse()
+    }
+
+    // ---- External change: +/- button moves value away from raw → sync ----
+
+    @Test
+    fun `button increments value past raw position`() {
+        assertThat(shouldSyncSliderPos(45.3f, 50)).isTrue()
+    }
+
+    @Test
+    fun `button decrements value below raw position`() {
+        assertThat(shouldSyncSliderPos(45.3f, 40)).isTrue()
+    }
+
+    @Test
+    fun `value clamped during drag triggers sync`() {
+        assertThat(shouldSyncSliderPos(195.3f, 190)).isTrue()
+    }
+
+    // ---- Boundary values ----
+
+    @Test
+    fun `zero position and value`() {
+        assertThat(shouldSyncSliderPos(0.0f, 0)).isFalse()
+    }
+
+    @Test
+    fun `max position and value`() {
+        assertThat(shouldSyncSliderPos(100.0f, 100)).isFalse()
+    }
+
+    @Test
+    fun `negative raw position rounds to zero`() {
+        assertThat(shouldSyncSliderPos(-0.3f, 0)).isFalse()
+    }
+
+    @Test
+    fun `external value differs by exactly one`() {
+        assertThat(shouldSyncSliderPos(45.3f, 46)).isTrue()
+    }
+
+    // =====================================================================
+    // pixelToValue
+    // =====================================================================
+
+    @Test
+    fun `pixel at track start returns range start`() {
+        assertThat(pixelToValue(20f, 20f, 320f, 0f, 100f)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `pixel at track end returns range end`() {
+        assertThat(pixelToValue(320f, 20f, 320f, 0f, 100f)).isEqualTo(100f)
+    }
+
+    @Test
+    fun `pixel at track midpoint returns range midpoint`() {
+        assertThat(pixelToValue(170f, 20f, 320f, 0f, 100f)).isEqualTo(50f)
+    }
+
+    @Test
+    fun `pixel before track start clamps to range start`() {
+        assertThat(pixelToValue(0f, 20f, 320f, 0f, 100f)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `pixel past track end clamps to range end`() {
+        assertThat(pixelToValue(400f, 20f, 320f, 0f, 100f)).isEqualTo(100f)
+    }
+
+    @Test
+    fun `non-zero range start maps correctly`() {
+        // Track 20..320 (300px), range 10..200 (190 units)
+        // Midpoint pixel = 170, fraction = 0.5, value = 10 + 0.5*190 = 105
+        assertThat(pixelToValue(170f, 20f, 320f, 10f, 200f)).isEqualTo(105f)
+    }
+
+    @Test
+    fun `degenerate track width returns range start`() {
+        assertThat(pixelToValue(50f, 50f, 50f, 0f, 100f)).isEqualTo(0f)
+    }
+}


### PR DESCRIPTION
## Summary
- Material3 `Slider` on Compose BOM 2024.02.00 prematurely exits drag state ([compose-multiplatform#4366](https://github.com/JetBrains/compose-multiplatform/issues/4366)), making all sliders tap-only
- Replaced with custom `IntSlider` that handles horizontal drag and tap gestures directly via `pointerInput` + `Canvas`-drawn track/thumb
- All 5 sliders now support smooth dragging: inline TX volume (TxStrip), ALC target low/high, SWR threshold, TX volume dialog

## Test plan
- [x] Verified drag works on all sliders (Pixel 8)
- [ ] Tap to jump still works on all sliders
- [ ] +/- buttons still update slider position
- [ ] ALC low/high clamping still enforced during drag
- [ ] Value persists to DB on drag end

🤖 Generated with [Claude Code](https://claude.com/claude-code)