### PR TITLE
Derive versionName from git tags in CI, bump to v1.1.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -239,6 +239,7 @@ jobs:
           # v*-named candidates we'd actually promote to production.
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             echo "release_tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "version_name=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
@@ -255,6 +256,7 @@ jobs:
             fi
             echo "Latest tag: ${latest:-<none>} -> new tag: $new_tag"
             echo "release_tag=$new_tag" >> "$GITHUB_OUTPUT"
+            echo "version_name=${new_tag#v}" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/dev" ]]; then
@@ -263,12 +265,19 @@ jobs:
             # and so the Play Console releaseName disambiguates them from
             # main-branch release candidates.
             new_tag="dev-${GITHUB_RUN_NUMBER}"
+            # Derive the base semver from the latest v* tag so the APK version
+            # reads e.g. "1.1.0-dev.42" instead of a bare run number.
+            latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+            base_ver="${latest:+${latest#v}}"
+            base_ver="${base_ver:-0.0.0}"
             echo "release_tag=$new_tag" >> "$GITHUB_OUTPUT"
+            echo "version_name=${base_ver}-dev.${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
             # PR or other branch push — build only, no release
             echo "release_tag=" >> "$GITHUB_OUTPUT"
+            echo "version_name=" >> "$GITHUB_OUTPUT"
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
@@ -343,6 +352,12 @@ jobs:
         run: |
           set -euo pipefail
           args=(assembleRelease)
+          # Inject the version derived from the git tag / branch so the APK's
+          # versionName matches the release without manual bumps in build.gradle.
+          version_name="${{ steps.tag.outputs.version_name }}"
+          if [[ -n "$version_name" ]]; then
+            args+=("-PVERSION_NAME_OVERRIDE=$version_name")
+          fi
           # Sign + produce AAB only on release builds — PR builds stay unsigned
           # because the keystore secret isn't available (and shouldn't be) for
           # fork PRs.

--- a/ft8cn/app/build.gradle
+++ b/ft8cn/app/build.gradle
@@ -39,8 +39,11 @@ android {
         // static fallback so debug/release builds run unchanged from a dev
         // machine.
         def ciRunNumber = System.getenv("GITHUB_RUN_NUMBER")
-        versionCode ciRunNumber ? (ciRunNumber.toInteger() + 100) : 4
-        versionName '1.0.2'
+        versionCode ciRunNumber ? (ciRunNumber.toInteger() + 100) : 5
+        // CI passes -PVERSION_NAME_OVERRIDE derived from the git tag (v1.1.0 ->
+        // "1.1.0", dev-42 -> "1.1.0-dev.42"). Local builds use the fallback.
+        def ciVersionName = project.findProperty('VERSION_NAME_OVERRIDE')
+        versionName ciVersionName ?: '1.1.0'
 
 
         dataBinding{
@@ -83,6 +86,7 @@ android {
     buildTypes {
 
         debug{
+            versionNameSuffix '-dev'
             buildConfigField("String", "apkBuildTime", "\"${currentTime}\"")
         }
         release {


### PR DESCRIPTION
## Summary
- APK `versionName` is now driven by git tags via `-PVERSION_NAME_OVERRIDE` Gradle property instead of a hardcoded string in `build.gradle`
- CI computes the version from the release lane: exact tag for `v*` pushes, auto-bumped patch for `main`, `<base>-dev.<run#>` for `dev`
- Local debug builds show `1.1.0-dev` via `versionNameSuffix`; no manual version management needed
- Bumps base version to `1.1.0` and local `versionCode` fallback to `5`

## Version matrix

| Build context | `versionName` | Example display |
|---|---|---|
| Local debug | `1.1.0-dev` | `v1.1.0-dev · build 5` |
| PR build | `1.1.0` (fallback) | unsigned, no release |
| Push to `dev` | `1.1.0-dev.42` | `v1.1.0-dev.42 · build 142` |
| Push to `main` | `1.1.1` (auto-bumped) | `v1.1.1 · build 143` |
| Push `v*` tag | `1.1.0` (exact) | `v1.1.0 · build 144` |

## Test plan
- [ ] Local debug build shows `v1.1.0-dev` in splash and about screens
- [ ] Merge to `dev` produces a `dev-<run#>` release with `1.1.0-dev.<run#>` in the APK
- [ ] Verify `VERSION_NAME_OVERRIDE` property is picked up by Gradle when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)