### PR TITLE
Add 16KB page size support for Android 15+

### DIFF
--- a/ft8cn/app/src/main/cpp/CMakeLists.txt
+++ b/ft8cn/app/src/main/cpp/CMakeLists.txt
@@ -121,6 +121,8 @@ target_include_directories(ft8af_usb PRIVATE ${FT8LIB_ROOT})
 
 find_library(log-lib log)
 
+target_link_options(ft8af_usb PRIVATE "-Wl,-z,max-page-size=16384")
+
 target_link_libraries(ft8af_usb
         usb1.0
         ft8af_dsp


### PR DESCRIPTION
## Summary
- Adds `-Wl,-z,max-page-size=16384` linker flag to `libft8af_usb.so` in CMakeLists.txt
- Fixes Play Store / device warning about the app not supporting 16KB memory page sizes
- Required for Android 15+ (API 35) devices which can run with 16KB page kernels

## Test plan
- [x] Debug build succeeds with the new linker flag (all 4 ABIs)
- [ ] Verify the warning no longer appears on a 16KB-page device (e.g. Pixel 8 with Android 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)