### PR TITLE
Add 16KB page size support for Android 15+

### DIFF
--- a/ft8cn/app/src/main/cpp/CMakeLists.txt
+++ b/ft8cn/app/src/main/cpp/CMakeLists.txt
@@ -121,6 +121,8 @@ target_include_directories(ft8af_usb PRIVATE ${FT8LIB_ROOT})
 
 find_library(log-lib log)
 
+target_link_options(ft8af_usb PRIVATE "-Wl,-z,max-page-size=16384")
+
 target_link_libraries(ft8af_usb
         usb1.0
         ft8af_dsp


### PR DESCRIPTION
## Summary
- Adds `-Wl,-z,max-page-size=16384` linker flag to `libft8af_usb.so` native build
- Ensures ELF segment alignment is compatible with 16KB memory page kernels on Android 15+ devices
- No runtime behavior change — only affects binary segment padding

## Test plan
- [x] Debug build succeeds for all ABIs (arm64-v8a, armeabi-v7a, x86, x86_64)
- [ ] Verify 16KB page size warning no longer appears on Android 15+ device

🤖 Generated with [Claude Code](https://claude.com/claude-code)