### PR TITLE
Fix dev-625 regressions: FT8 SNR ~26 dB high + blank waterfall

### DIFF
--- a/ft8af/app/src/main/cpp/CMakeLists.txt
+++ b/ft8af/app/src/main/cpp/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(ft8af SHARED
         ft8af_glue/ft8_hash_jni.cpp
         # JNI wrappers — FFT display
         ft8af_glue/ft8_fft_jni.cpp
+        ft8af_glue/fft_display.c
         # JNI wrappers — audio resampler
         ft8af_glue/ft8_resample_jni.cpp
         # JNI wrappers — FT8 decoder (replaces prebuilt)

--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/decode.c
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/decode.c
@@ -14,6 +14,13 @@
 // FT8's reported range. Empirical; see the note in ft8_snr(). Tune here if FT4 reads high/low.
 #define FT4_SNR_CAL_DB 20
 
+// Bandwidth calibration for FT8. ft8_snr() measures the signal-to-noise ratio in a single
+// FFT bin, but WSJT-X reports SNR referenced to a 2500 Hz noise bandwidth. FT8 tones are
+// spaced 6.25 Hz apart, so the correction is 10*log10(2500/6.25) = 26 dB. Without this the
+// per-bin ratio reads ~26 dB hot (a station WSJT-X calls -10 was reported here as +16).
+// Empirical/standard; re-tune against on-air reciprocity if FT8 reads consistently high/low.
+#define FT8_SNR_CAL_DB 26
+
 /// Compute log likelihood log(p(1) / p(0)) of 174 message bits for later use in soft-decision LDPC decoding
 /// @param[in] wf Waterfall data collected during message slot
 /// @param[in] cand Candidate to extract the message from
@@ -127,9 +134,10 @@ int ft8_snr(const waterfall_t* wf, const candidate_t* candidate)
     }
     if (num_average == 0)
         return -24;
-    // Waterfall magnitudes are in 0.5 dB steps (see monitor_process); halve the
-    // per-symbol difference to return real dB.
-    return (sum_signal - sum_noise) / (2 * num_average);
+    // Waterfall magnitudes are in 0.5 dB steps (see monitor_process); halve the per-symbol
+    // difference to return real per-bin dB, then subtract FT8_SNR_CAL_DB to reference the
+    // result to WSJT-X's 2500 Hz noise bandwidth.
+    return (sum_signal - sum_noise) / (2 * num_average) - FT8_SNR_CAL_DB;
 }
 
 static int ft8_sync_score(const waterfall_t* wf, const candidate_t* candidate)

--- a/ft8af/app/src/main/cpp/ft8af_glue/fft_display.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/fft_display.c
@@ -1,0 +1,110 @@
+// Waterfall display intensity mapping.
+//
+// WHY THIS EXISTS / WHAT WENT WRONG
+// ---------------------------------
+// The from-source replacement for the prebuilt libft8cn.so (the FFT display path
+// in ft8_fft_jni.cpp) mapped magnitudes to the 0..255 waterfall range with a
+// LINEAR auto-gain: output = mag * (255 / max_mag). That is wrong for a
+// spectrogram. Linear amplitude has no usable dynamic range: the noise floor and
+// every weak signal collapse into the bottom handful of codes while the single
+// loudest bin (often a carrier or birdie) pins the scale to 255 — so the
+// waterfall looked blank ("can't see a thing"). Real waterfalls are logarithmic.
+//
+// This module maps magnitudes on a dB scale referenced to the frame's noise
+// floor, which is exactly what the decoder's own monitor.c does (10*log10 ->
+// 2*db+240). The reference is the MEDIAN bin dB rather than the max, so one
+// strong signal no longer darkens the rest of the row.
+
+#include "fft_display.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+// dB above the noise floor that maps to full (255) brightness.
+#define FT8AF_DISPLAY_DB_RANGE 50.0f
+// Intensity assigned to the noise floor itself. In the raw view we keep the floor
+// faintly visible (a black floor reads as a dead display, which is the symptom
+// users hit); the denoise view pushes the floor to black.
+#define FT8AF_FLOOR_LEVEL_RAW 40
+#define FT8AF_FLOOR_LEVEL_DENOISE 0
+
+static int cmp_float(const void* a, const void* b)
+{
+    float fa = *(const float*)a;
+    float fb = *(const float*)b;
+    return (fa > fb) - (fa < fb);
+}
+
+void ft8af_magnitudes_to_display(const float* mag, int n_bins, int* output, int denoise)
+{
+    if (n_bins <= 0)
+        return;
+
+    // Logarithmic intensity. power = mag^2  =>  dB = 20*log10(mag). The 1e-12
+    // floor keeps log10 finite for silent bins.
+    float* db = (float*)malloc((size_t)n_bins * sizeof(float));
+    if (!db)
+        return;
+    for (int i = 0; i < n_bins; ++i)
+        db[i] = 20.0f * log10f(mag[i] + 1e-12f);
+
+    if (denoise)
+    {
+        // Flatten slowly-varying band tilt: subtract a local sliding-window average
+        // (in dB) so a broadband noise slope doesn't wash out one side of the band.
+        // Window ~5% of bins, min 8; prefix sum gives O(1) per-bin averaging.
+        int win = n_bins / 20;
+        if (win < 8)
+            win = 8;
+        if (win > n_bins)
+            win = n_bins;
+
+        float* prefix = (float*)malloc(((size_t)n_bins + 1) * sizeof(float));
+        if (prefix)
+        {
+            prefix[0] = 0.0f;
+            for (int i = 0; i < n_bins; ++i)
+                prefix[i + 1] = prefix[i] + db[i];
+
+            for (int i = 0; i < n_bins; ++i)
+            {
+                int left = i - win / 2;
+                int right = left + win;
+                if (left < 0) { left = 0; right = win; }
+                if (right > n_bins) { right = n_bins; left = right - win; }
+                if (left < 0) left = 0;
+
+                db[i] -= (prefix[right] - prefix[left]) / (float)(right - left);
+            }
+            free(prefix);
+        }
+    }
+
+    // Noise-floor reference = median bin dB. Robust while signals occupy < 50% of
+    // the bins, which holds for an FT8/FT4 slot. Replaces the old per-frame max
+    // auto-gain, under which one strong bin darkened the whole row.
+    float noise_floor = 0.0f;
+    float* tmp = (float*)malloc((size_t)n_bins * sizeof(float));
+    if (tmp)
+    {
+        memcpy(tmp, db, (size_t)n_bins * sizeof(float));
+        qsort(tmp, (size_t)n_bins, sizeof(float), cmp_float);
+        noise_floor = tmp[n_bins / 2];
+        free(tmp);
+    }
+
+    int floor_level = denoise ? FT8AF_FLOOR_LEVEL_DENOISE : FT8AF_FLOOR_LEVEL_RAW;
+    float gain = (255.0f - (float)floor_level) / FT8AF_DISPLAY_DB_RANGE;
+    for (int i = 0; i < n_bins; ++i)
+    {
+        int val = floor_level + (int)((db[i] - noise_floor) * gain);
+        if (val < 0)
+            val = 0;
+        if (val > 255)
+            val = 255;
+        output[i] = val;
+    }
+
+    free(db);
+}

--- a/ft8af/app/src/main/cpp/ft8af_glue/fft_display.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/fft_display.h
@@ -1,0 +1,27 @@
+// Waterfall display intensity mapping — extracted from ft8_fft_jni.cpp so it can
+// be unit-tested on the host (it has no JNI / FFT dependency; it is pure data in,
+// data out). See fft_display.c for the rationale.
+
+#ifndef FT8AF_FFT_DISPLAY_H
+#define FT8AF_FFT_DISPLAY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Map linear FFT bin magnitudes to 0..255 display intensities on a LOGARITHMIC
+// (dB) scale referenced to the frame's noise floor (median dB).
+//
+//   mag      [in]  n_bins linear magnitudes (sqrt(re^2+im^2)), >= 0
+//   n_bins   [in]  number of bins (no-op if <= 0)
+//   output   [out] n_bins intensities clamped to 0..255
+//   denoise  [in]  0 = raw view (noise floor kept faintly visible);
+//                  non-0 = also subtract a local band-tilt estimate and push the
+//                          noise floor to black.
+void ft8af_magnitudes_to_display(const float* mag, int n_bins, int* output, int denoise);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FT8AF_FFT_DISPLAY_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
@@ -22,6 +22,7 @@
 
 extern "C" {
 #include "fft/kiss_fftr.h"
+#include "fft_display.h"
 }
 
 // ---------------------------------------------------------------------------
@@ -53,68 +54,19 @@ static void compute_fft_magnitudes(const float* input, int n, int* output, bool 
 
     kiss_fftr(cfg, input, freq);
 
-    // Compute magnitude for each bin and find the maximum for normalization.
+    // Compute the linear magnitude for each bin.
     float* mag = (float*)malloc(n_bins * sizeof(float));
     if (!mag) {
         free(freq);
         kiss_fftr_free(cfg);
         return;
     }
-
-    float max_mag = 1e-10f;
-    for (int i = 0; i < n_bins; ++i) {
+    for (int i = 0; i < n_bins; ++i)
         mag[i] = sqrtf(freq[i].r * freq[i].r + freq[i].i * freq[i].i);
-        if (mag[i] > max_mag) max_mag = mag[i];
-    }
 
-    if (denoise) {
-        // Simple denoising: compute a local average noise floor using a sliding
-        // window, then subtract it. Window size is ~5% of the bin count, minimum 8.
-        // Uses a prefix-sum for O(1) per-bin window average instead of O(win).
-        int win = n_bins / 20;
-        if (win < 8) win = 8;
-        if (win > n_bins) win = n_bins;
-
-        // Prefix sum: prefix[i] = sum of mag[0..i-1], prefix[0] = 0
-        float* prefix = (float*)malloc((n_bins + 1) * sizeof(float));
-        if (prefix) {
-            prefix[0] = 0;
-            for (int i = 0; i < n_bins; ++i)
-                prefix[i + 1] = prefix[i] + mag[i];
-
-            // Subtract noise floor in-place using prefix sums
-            // We need the original mag values for the prefix sum, so compute
-            // denoised values into a separate pass.
-            for (int i = 0; i < n_bins; ++i) {
-                int left = i - win / 2;
-                int right = left + win;
-                if (left < 0) { left = 0; right = win; }
-                if (right > n_bins) { right = n_bins; left = right - win; }
-                if (left < 0) left = 0;
-
-                float avg = (prefix[right] - prefix[left]) / (right - left);
-                mag[i] -= avg;
-                if (mag[i] < 0) mag[i] = 0;
-            }
-
-            // Recompute max after denoising
-            max_mag = 1e-10f;
-            for (int i = 0; i < n_bins; ++i) {
-                if (mag[i] > max_mag) max_mag = mag[i];
-            }
-
-            free(prefix);
-        }
-    }
-
-    // Scale magnitudes to 0..255 for display
-    float scale = 255.0f / max_mag;
-    for (int i = 0; i < n_bins; ++i) {
-        int val = (int)(mag[i] * scale);
-        if (val > 255) val = 255;
-        if (val < 0) val = 0;
-        output[i] = val;
-    }
+    // Map to 0..255 on a logarithmic (dB), noise-floor-referenced scale. Linear
+    // scaling here made the waterfall blank; see fft_display.c.
+    ft8af_magnitudes_to_display(mag, n_bins, output, denoise ? 1 : 0);
 
     free(mag);
     free(freq);

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
@@ -22,8 +22,10 @@
 
 extern "C" {
 #include "fft/kiss_fftr.h"
-#include "fft_display.h"
 }
+// fft_display.h guards its own C linkage (extern "C"), so include it outside the
+// kissfft block rather than nesting it under this one.
+#include "fft_display.h"
 
 // ---------------------------------------------------------------------------
 // Core FFT computation: time-domain samples → magnitude array.

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -77,4 +77,27 @@ if ($Regen) {
 }
 
 & $out
-exit $LASTEXITCODE
+$goldenExit = $LASTEXITCODE
+
+# ---------------------------------------------------------------------------
+# dev-625 regression tests: ft8_snr() FT8 calibration + the waterfall display
+# magnitude mapping (fft_display.c). Links the decoder + the extracted display
+# helper; separate executable (own main()).
+# ---------------------------------------------------------------------------
+$dev625Srcs = @(
+    "ft8\pack.c","ft8\encode.c","ft8\crc.c","ft8\constants.c",
+    "ft8\text.c","ft8\message.c","ft8\decode.c","ft8\ldpc.c","ft8\unpack.c"
+) | ForEach-Object { Join-Path $ft8 $_ }
+$dev625Srcs += (Join-Path $here "fft_display.c")
+
+$src625 = Join-Path $here "test_dev625_fixes.c"
+$out625 = Join-Path $env:TEMP "ft8_dev625_test.exe"
+
+& $Clang @common $src625 @dev625Srcs -o $out625
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (dev625)." }
+
+& $out625
+$dev625Exit = $LASTEXITCODE
+
+if ($goldenExit -ne 0) { exit $goldenExit }
+exit $dev625Exit

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -34,6 +34,10 @@ srcs=(
 )
 
 tmp="$(mktemp -d)"
+# Clean up the temp build dir on exit. We deliberately do NOT exec the test
+# binaries below (which would replace the shell and skip this trap); set -e
+# still propagates a failing test's exit status as the script's exit status.
+trap 'rm -rf "$tmp"' EXIT
 out="$tmp/ft8_golden_test"
 
 # -D_GNU_SOURCE: expose POSIX stpcpy + M_PI from glibc (harmless on macOS).
@@ -45,7 +49,8 @@ out="$tmp/ft8_golden_test"
 
 # --emit (golden re-gen) only applies to the golden-vector binary.
 if [ "${1:-}" = "--emit" ]; then
-    exec "$out" "$@"
+    "$out" "$@"
+    exit "$?"
 fi
 
 "$out"
@@ -70,4 +75,5 @@ out625="$tmp/ft8_dev625_test"
     -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
     -I "$ft8" "${dev625_srcs[@]}" -lm -o "$out625"
 
-exec "$out625"
+# Not exec'd, so the EXIT trap cleans up $tmp. set -e propagates a failure.
+"$out625"

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -33,7 +33,8 @@ srcs=(
     "$ft8/ft8/message.c"
 )
 
-out="$(mktemp -d)/ft8_golden_test"
+tmp="$(mktemp -d)"
+out="$tmp/ft8_golden_test"
 
 # -D_GNU_SOURCE: expose POSIX stpcpy + M_PI from glibc (harmless on macOS).
 # Warnings from the vendored ft8_lib are non-fatal; the test's own exit code is
@@ -42,4 +43,31 @@ out="$(mktemp -d)/ft8_golden_test"
     -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
     -I "$ft8" "${srcs[@]}" -lm -o "$out"
 
-exec "$out" "$@"
+# --emit (golden re-gen) only applies to the golden-vector binary.
+if [ "${1:-}" = "--emit" ]; then
+    exec "$out" "$@"
+fi
+
+"$out"
+
+# dev-625 regression tests: ft8_snr() FT8 calibration + the waterfall display
+# magnitude mapping (fft_display.c). Separate executable (own main()).
+dev625_srcs=(
+    "$here/test_dev625_fixes.c"
+    "$ft8/ft8/pack.c"
+    "$ft8/ft8/encode.c"
+    "$ft8/ft8/crc.c"
+    "$ft8/ft8/constants.c"
+    "$ft8/ft8/text.c"
+    "$ft8/ft8/message.c"
+    "$ft8/ft8/decode.c"
+    "$ft8/ft8/ldpc.c"
+    "$ft8/ft8/unpack.c"
+    "$here/fft_display.c"
+)
+out625="$tmp/ft8_dev625_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" "${dev625_srcs[@]}" -lm -o "$out625"
+
+exec "$out625"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_dev625_fixes.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_dev625_fixes.c
@@ -1,0 +1,188 @@
+// Regression tests for the dev-625 fixes:
+//
+//   (1) ft8_snr() FT8 bandwidth calibration. A tester reported on-air FT8 SNRs
+//       reading ~+16 where WSJT-X says ~-10: the FT8 path returned a per-FFT-bin
+//       ratio with no 2500 Hz reference, unlike the FT4 path (FT4_SNR_CAL_DB).
+//       We pin the calibrated arithmetic on a synthetic waterfall with known
+//       Costas-tone magnitudes.
+//
+//   (2) ft8af_magnitudes_to_display(). The from-source waterfall mapped
+//       magnitudes LINEARLY with per-frame max auto-gain, collapsing the noise
+//       floor and weak signals to black ("can't see a thing"). We verify the new
+//       log / noise-floor-referenced mapping keeps the floor visible, saturates a
+//       strong signal, and that one loud bin no longer darkens the rest.
+//
+// HOST BUILD (no device): run_host_tests.ps1 / run_host_tests.sh build and run
+// this alongside test_golden_encode.c. Exit code 0 == all pass.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ft8/decode.h"
+#include "ft8/constants.h"
+
+#include "fft_display.h"
+
+// ft8_snr is defined (non-static) in decode.c but not declared in decode.h.
+int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
+
+static int g_failures = 0;
+
+#define CHECK_EQ(actual, expected, label)                                       \
+    do {                                                                        \
+        int a_ = (actual), e_ = (expected);                                     \
+        if (a_ != e_) {                                                         \
+            printf("  FAIL: %s: got %d, expected %d\n", (label), a_, e_);       \
+            ++g_failures;                                                       \
+        } else {                                                                \
+            printf("  ok:   %s == %d\n", (label), e_);                          \
+        }                                                                       \
+    } while (0)
+
+#define CHECK_TRUE(cond, label)                                                 \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            printf("  FAIL: %s\n", (label));                                    \
+            ++g_failures;                                                       \
+        } else {                                                                \
+            printf("  ok:   %s\n", (label));                                    \
+        }                                                                       \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// (1) ft8_snr FT8 calibration
+//
+// Build a waterfall whose three Costas sync groups (symbols 0-6, 36-42, 72-78)
+// each have the expected tone at magnitude S and the other seven tones at N.
+// Per sync symbol the noise estimate is (3 + 8N's minus the signal)/7 == N, so
+//   raw per-bin dB = (S - N) / 2   (magnitudes are 0.5 dB units)
+//   reported       = (S - N) / 2 - FT8_SNR_CAL_DB(26)
+// ---------------------------------------------------------------------------
+static void fill_sync(uint8_t* mag, int block_stride, int S, int N)
+{
+    for (int block = 0; block < FT8_NN; ++block)
+    {
+        int k = block % FT8_SYNC_OFFSET;
+        if (k >= FT8_LENGTH_SYNC)
+            continue; // data symbol — value irrelevant
+        uint8_t* p8 = mag + (block * block_stride);
+        for (int m = 0; m < 8; ++m)
+            p8[m] = (uint8_t)N;
+        p8[kFT8_Costas_pattern[k]] = (uint8_t)S;
+    }
+}
+
+static int run_snr(int S, int N)
+{
+    const int num_bins = 64;
+    const int time_osr = 2, freq_osr = 2;
+    waterfall_t wf;
+    memset(&wf, 0, sizeof(wf));
+    wf.num_bins = num_bins;
+    wf.time_osr = time_osr;
+    wf.freq_osr = freq_osr;
+    wf.block_stride = time_osr * freq_osr * num_bins;
+    wf.max_blocks = 100;
+    wf.num_blocks = 100;
+    wf.protocol = FTX_PROTOCOL_FT8;
+    wf.mag = (uint8_t*)calloc((size_t)wf.max_blocks * wf.block_stride, 1);
+
+    fill_sync(wf.mag, wf.block_stride, S, N);
+
+    candidate_t cand;
+    memset(&cand, 0, sizeof(cand));
+    // time_sub=freq_sub=freq_offset=time_offset=0 -> mag base is wf.mag[0].
+
+    int snr = ft8_snr(&wf, &cand);
+    free(wf.mag);
+    return snr;
+}
+
+static void test_ft8_snr_calibration(void)
+{
+    printf("test_ft8_snr_calibration:\n");
+
+    // S-N = 40 -> 40/2 - 26 = -6 (a normal, slightly-strong report).
+    CHECK_EQ(run_snr(160, 120), -6, "S-N=40 -> -6 dB");
+
+    // S-N = 120 -> 120/2 - 26 = 60 - 26 = +34 (a very strong local).
+    CHECK_EQ(run_snr(220, 100), 34, "S-N=120 -> +34 dB");
+
+    // S == N (noise only): 0 - 26 = -26 (deep, near the decode floor).
+    CHECK_EQ(run_snr(100, 100), -26, "S==N -> -26 dB (floor)");
+
+    // Sanity: without the 26 dB calibration this last case would read 0 dB, the
+    // exact "+16 where it should be negative" class of bug we are fixing.
+    CHECK_TRUE(run_snr(100, 100) < 0, "noise-only report is negative");
+}
+
+// ---------------------------------------------------------------------------
+// (2) ft8af_magnitudes_to_display
+// ---------------------------------------------------------------------------
+static void test_display_mapping(void)
+{
+    printf("test_display_mapping:\n");
+
+    const int n = 200;
+    float* mag = (float*)malloc(n * sizeof(float));
+    int* out_raw = (int*)malloc(n * sizeof(int));
+    int* out_dn = (int*)malloc(n * sizeof(int));
+
+    // Flat noise field (mag 1.0 -> 0 dB) with one strong spike 60 dB above it.
+    for (int i = 0; i < n; ++i)
+        mag[i] = 1.0f;
+    mag[100] = 1000.0f; // 20*log10(1000) = 60 dB
+
+    ft8af_magnitudes_to_display(mag, n, out_raw, 0);
+    ft8af_magnitudes_to_display(mag, n, out_dn, 1);
+
+    // Raw view: the noise floor (median dB == 0) maps to the visible floor level
+    // (40), NOT to black. This is the core regression: under the old linear
+    // auto-gain the floor collapsed to ~0 and the waterfall looked empty.
+    CHECK_EQ(out_raw[0], 40, "raw: noise floor -> 40 (visible)");
+    CHECK_TRUE(out_raw[0] > 0, "raw: noise floor is not black");
+
+    // The 60 dB spike saturates.
+    CHECK_EQ(out_raw[100], 255, "raw: strong spike -> 255");
+
+    // The single loud bin must not darken the rest of the row (old max auto-gain
+    // bug): every noise bin stays at the floor level regardless of the spike.
+    int all_floor = 1;
+    for (int i = 0; i < n; ++i)
+        if (i != 100 && out_raw[i] != 40) all_floor = 0;
+    CHECK_TRUE(all_floor, "raw: noise unaffected by a strong neighbor");
+
+    // Denoise view pushes the noise floor to black while the signal stays bright.
+    CHECK_EQ(out_dn[0], 0, "denoise: noise floor -> 0 (black)");
+    CHECK_TRUE(out_dn[100] > 200, "denoise: spike still bright");
+
+    // Monotonicity: a louder bin never maps darker than a quieter one.
+    float twin[3] = { 1.0f, 10.0f, 100.0f }; // 0, 20, 40 dB
+    int twout[3];
+    ft8af_magnitudes_to_display(twin, 3, twout, 0);
+    CHECK_TRUE(twout[0] <= twout[1] && twout[1] <= twout[2], "monotonic in dB");
+
+    // Degenerate sizes don't crash / write.
+    int dummy = 123;
+    ft8af_magnitudes_to_display(mag, 0, &dummy, 0);
+    CHECK_EQ(dummy, 123, "n_bins=0 writes nothing");
+
+    free(mag);
+    free(out_raw);
+    free(out_dn);
+}
+
+int main(void)
+{
+    test_ft8_snr_calibration();
+    test_display_mapping();
+
+    if (g_failures == 0)
+    {
+        printf("\nALL DEV-625 TESTS PASSED\n");
+        return 0;
+    }
+    printf("\n%d DEV-625 TEST(S) FAILED\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## What the tester reported (dev-625)

> what happend to waterfall? noise reduction is disabled … i cant see a thing on this waterfall
>
> signal report is probably wrong too, +16 is looking way off, usual its negative numbers, -4 probably the biggest one that i gave someone ever

Two independent regressions, both introduced by **#275** (replacing the prebuilt `libft8cn.so` with the from-source `libft8af.so`). The closed-source `.so` applied two corrections the from-source reimplementations dropped.

## 1. FT8 SNR reads ~26 dB too high

`ft8_snr()` returned a **per-FFT-bin** signal/noise ratio with no reference to WSJT-X's 2500 Hz noise bandwidth, so every report read ~26 dB hot — the tester's **+16 ≈ WSJT-X −10**. The FT4 path already subtracts `FT4_SNR_CAL_DB` for exactly this reason; FT8 subtracted nothing.

Fix: add `FT8_SNR_CAL_DB = 26` (`10·log10(2500/6.25)`, FT8's 6.25 Hz tone spacing) to the already-halved per-bin dB. (The prior commit `6f67cc8a` added the `/2` for the 0.5 dB-per-unit magnitude scale but not the bandwidth offset.)

## 2. Waterfall blank / "can't see a thing"

The display FFT (`ft8_fft_jni.cpp`) scaled magnitudes **linearly** with per-frame max auto-gain (`255/max_mag`). Linear amplitude has no dynamic range for a spectrogram: the noise floor and weak signals collapse to black while one loud bin/birdie pins the scale.

Fix: map on a **logarithmic (dB) scale referenced to the median bin dB** (the noise floor) — the same log scaling the decoder's own `monitor.c` uses. Raw view keeps the floor faintly visible (intensity 40); denoise flattens band tilt and pushes the floor to black. The mapping is extracted to `fft_display.c/.h` (no JNI/FFT deps) so it's host-testable.

## Tests

New `test_dev625_fixes.c` (host build, CI-gated via `run_host_tests.sh`):
- pins calibrated `ft8_snr` output on a synthetic waterfall (`S−N=40 → −6 dB`, noise-only `→ −26`, asserts noise-only is negative — the exact bug class);
- verifies the display mapping keeps the floor visible, saturates a strong signal, leaves noise unaffected by a loud neighbor (the old auto-gain bug), and is monotonic in dB.

Golden encode test still passes; `assembleDebug` builds the native lib + APK clean.

## Tuning notes
- `FT8_SNR_CAL_DB = 26` is the standard 2500/6.25 Hz reference; documented as re-tunable against on-air reciprocity like the FT4 constant.
- Waterfall floor level (40) / dB range (50) are display constants in `fft_display.c` if the look needs tweaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
