### PR TITLE
iOS port skeleton (Phase 0): C bridge + encode + golden gate

### DIFF
--- a/ios/FT8AFKit/Package.swift
+++ b/ios/FT8AFKit/Package.swift
@@ -1,0 +1,48 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// FT8AFKit — the non-UI core of the native iOS port of FT8AF.
+//
+// All FT8 DSP comes from the SAME pure-C `ft8_lib` the Android app and the
+// Tauri desktop port use (kgoba @ 6f528128 + ft8af_glue/gfsk.c). We do NOT
+// duplicate that C: the `CFT8` target's shim .c files `#include` the real
+// sources in place under ../../ft8af/app/src/main/cpp, exactly as the desktop
+// build.rs references them. Single source of truth across all three frontends.
+//
+// Phase 0 ships CFT8 + FT8DSP (encode + hash) and the golden-vector tests that
+// prove the reused C is bit-identical under Apple clang. Later phases add
+// FT8Audio, FT8Rig, FT8Engine, FT8Data, FT8UI as separate targets here.
+let package = Package(
+    name: "FT8AFKit",
+    platforms: [
+        .iOS(.v16),
+        .macOS(.v13), // so the pure-logic suites run via `swift test` on a Mac, no simulator
+    ],
+    products: [
+        .library(name: "FT8DSP", targets: ["FT8DSP"]),
+    ],
+    targets: [
+        // C bridge to ft8_lib. Header-search path points at the ft8_lib root so
+        // the library's internal `<ft8/...>`, `<fft/...>`, `<common/...>` angle
+        // includes resolve. Path is relative to this target's source dir
+        // (Sources/CFT8): four levels up reaches the repo root.
+        .target(
+            name: "CFT8",
+            cSettings: [
+                .headerSearchPath("../../../../ft8af/app/src/main/cpp/ft8_lib"),
+                .headerSearchPath("../../../../ft8af/app/src/main/cpp/ft8af_glue"),
+                // ft8_lib is third-party C; silence its warnings, keep our own clean.
+                .unsafeFlags(["-w"]),
+            ]
+        ),
+        // Safe Swift wrappers over CFT8 (mirror desktop dsp/{encode,decoder,hashtable}.rs).
+        .target(
+            name: "FT8DSP",
+            dependencies: ["CFT8"]
+        ),
+        .testTarget(
+            name: "FT8DSPTests",
+            dependencies: ["FT8DSP", "CFT8"]
+        ),
+    ]
+)

--- a/ios/FT8AFKit/Sources/CFT8/include/CFT8.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/CFT8.h
@@ -1,0 +1,47 @@
+// Umbrella header for the CFT8 module — the Swift-visible surface of the pure-C
+// ft8_lib DSP core (kgoba @ 6f528128) plus the ft8af_glue GFSK synth.
+//
+// Swift imports these C declarations directly, so we never re-declare the
+// structs (monitor_t, waterfall_t, candidate_t, ftx_message_t, ...) on the Swift
+// side — Swift sees them natively. We only (1) pull in every public header and
+// (2) add prototypes for the two symbols ft8_lib defines but does not expose in
+// a public header (`ft8_snr`, `synth_gfsk_offset`), mirroring desktop dsp/ffi.rs.
+//
+// The angle includes below resolve via the CFT8 target's header-search path
+// (Package.swift -> ft8_lib root).
+#ifndef FT8AF_CFT8_UMBRELLA_H
+#define FT8AF_CFT8_UMBRELLA_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// --- ft8_lib public surface -------------------------------------------------
+#include <ft8/constants.h> // FTX_LDPC_*, FT8_NN, kFT8_Gray_map, kFT8_Costas_pattern, kFTX_LDPC_Nm, ...
+#include <ft8/message.h>   // ftx_message_t, ftx_message_decode*, hash interface + enums
+#include <ft8/pack.h>      // pack77, packtext77
+#include <ft8/encode.h>    // ft8_encode, ft4_encode
+#include <ft8/crc.h>       // ftx_add_crc, ftx_extract_crc, ftx_compute_crc
+#include <ft8/decode.h>    // waterfall_t, candidate_t, decode_status_t, ft8_find_sync, ft8_decode
+#include <common/monitor.h> // monitor_t, monitor_config_t, monitor_init/reset/process/free
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// --- symbols ft8_lib defines but omits from a public header -----------------
+// `ft8_snr` is non-static in decode.c yet absent from decode.h (desktop
+// ffi.rs:131 declares it the same way). Needs waterfall_t/candidate_t (decode.h).
+int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
+
+// `synth_gfsk_offset` lives in ft8af_glue/gfsk.c; signature mirrors
+// desktop ffi.rs:165-174 and the gfsk.c definition. Writes the GFSK waveform
+// into signal[offset .. offset + n_sym*n_spsym).
+void synth_gfsk_offset(const uint8_t* symbols, int n_sym, float f0,
+                       float symbol_bt, float symbol_period,
+                       int signal_rate, float* signal, int offset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FT8AF_CFT8_UMBRELLA_H

--- a/ios/FT8AFKit/Sources/CFT8/include/module.modulemap
+++ b/ios/FT8AFKit/Sources/CFT8/include/module.modulemap
@@ -1,0 +1,4 @@
+module CFT8 {
+    umbrella header "CFT8.h"
+    export *
+}

--- a/ios/FT8AFKit/Sources/CFT8/shim_constants.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_constants.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/constants.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_crc.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_crc.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/crc.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_decode.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_decode.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/decode.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_encode.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_encode.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/encode.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_gfsk.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_gfsk.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8af_glue/gfsk.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_kiss_fft.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_kiss_fft.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/fft/kiss_fft.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_kiss_fftr.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_kiss_fftr.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/fft/kiss_fftr.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_ldpc.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_ldpc.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/ldpc.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_message.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_message.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/message.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_monitor.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_monitor.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/common/monitor.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_pack.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_pack.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/pack.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_text.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_text.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/text.c"

--- a/ios/FT8AFKit/Sources/CFT8/shim_unpack.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_unpack.c
@@ -1,0 +1,3 @@
+// Shim TU: compiles the real ft8_lib source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+#include "../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/unpack.c"

--- a/ios/FT8AFKit/Sources/FT8DSP/Constants.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/Constants.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Fixed FT8 codec parameters (mirror desktop dsp/mod.rs + dsp/encode.rs).
+public enum FT8 {
+    /// Sample rate the FT8 codec runs at internally (fixed).
+    public static let sampleRate: Int32 = 12_000
+    /// Total channel symbols in an FT8 frame (FT8_NN).
+    public static let nn: Int = 79
+    /// FT8 symbol duration in seconds.
+    public static let symbolPeriod: Float = 0.160
+    /// Gaussian BT product for FT8 GFSK.
+    public static let symbolBT: Float = 2.0
+    /// Samples in one 15 s FT8 slot at `sampleRate`.
+    public static let slotSamples: Int = Int(sampleRate) * 15
+}

--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Encoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Encoder.swift
@@ -1,0 +1,82 @@
+import CFT8
+import Foundation
+
+/// FT8 encode path — safe Swift wrappers over pack77 / ft8_encode /
+/// synth_gfsk_offset, mirroring desktop dsp/encode.rs (and GenerateFT8 on
+/// Android). `generateFT8` is the one call the TX engine uses.
+public enum FT8Encoder {
+
+    /// Pack a structured FT8 message into a 10-byte (77-bit) payload.
+    /// Returns nil if pack77 rejects the message (nonzero status).
+    public static func pack77(_ message: String) -> [UInt8]? {
+        var payload = [UInt8](repeating: 0, count: 10)
+        let rc = message.withCString { cstr in
+            payload.withUnsafeMutableBufferPointer { CFT8.pack77(cstr, $0.baseAddress) }
+        }
+        return rc == 0 ? payload : nil
+    }
+
+    /// Force free-text (i3=0, n3=0) packing regardless of structure.
+    public static func packFreeText(_ text: String) -> [UInt8] {
+        var payload = [UInt8](repeating: 0, count: 10)
+        text.withCString { cstr in
+            _ = payload.withUnsafeMutableBufferPointer { CFT8.packtext77(cstr, $0.baseAddress) }
+        }
+        return payload
+    }
+
+    /// Encode a 10-byte payload into 79 FT8 tones (CRC + LDPC added internally).
+    public static func encodeTones(_ payload: [UInt8]) -> [UInt8] {
+        precondition(payload.count == 10, "FT8 payload must be 10 bytes")
+        var tones = [UInt8](repeating: 0, count: FT8.nn)
+        payload.withUnsafeBufferPointer { p in
+            tones.withUnsafeMutableBufferPointer { t in
+                CFT8.ft8_encode(p.baseAddress, t.baseAddress)
+            }
+        }
+        return tones
+    }
+
+    /// Add the 14-bit CRC, producing the 12-byte a91 (77-bit payload + CRC).
+    public static func addCRC(_ payload: [UInt8]) -> [UInt8] {
+        precondition(payload.count == 10, "FT8 payload must be 10 bytes")
+        var a91 = [UInt8](repeating: 0, count: 12)
+        payload.withUnsafeBufferPointer { p in
+            a91.withUnsafeMutableBufferPointer { a in
+                CFT8.ftx_add_crc(p.baseAddress, a.baseAddress)
+            }
+        }
+        return a91
+    }
+
+    /// Render `tones` as a GFSK waveform into `signal[offset...]`.
+    /// Traps (precondition) if `signal` is too short — mirrors the encode.rs assert.
+    public static func synthGFSK(tones: [UInt8], f0: Float, sampleRate: Int32,
+                                 into signal: inout [Float], offset: Int) {
+        let nSpsym = Int(0.5 + Double(sampleRate) * Double(FT8.symbolPeriod))
+        let nWave = tones.count * nSpsym
+        precondition(offset + nWave <= signal.count,
+                     "synthGFSK: signal buffer too short (need \(nWave) from offset \(offset), have \(signal.count))")
+        tones.withUnsafeBufferPointer { tp in
+            signal.withUnsafeMutableBufferPointer { sp in
+                CFT8.synth_gfsk_offset(tp.baseAddress, Int32(tones.count), f0,
+                                       FT8.symbolBT, FT8.symbolPeriod, sampleRate,
+                                       sp.baseAddress, Int32(offset))
+            }
+        }
+    }
+
+    /// Full encode: structured message text -> 12.64 s of mono Float audio at
+    /// `sampleRate`, centered on `baseFreqHz`. Returns nil if the text can't be
+    /// packed as a structured message. Mirrors desktop generate_ft8 /
+    /// GenerateFT8.generateFt8.
+    public static func generateFT8(_ text: String, baseFreqHz: Float,
+                                   sampleRate: Int32 = FT8.sampleRate) -> [Float]? {
+        guard let payload = pack77(text) else { return nil }
+        let tones = encodeTones(payload)
+        let numSamples = Int(0.5 + Float(FT8.nn) * FT8.symbolPeriod * Float(sampleRate))
+        var signal = [Float](repeating: 0, count: numSamples)
+        synthGFSK(tones: tones, f0: baseFreqHz, sampleRate: sampleRate, into: &signal, offset: 0)
+        return signal
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Encoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Encoder.swift
@@ -55,6 +55,12 @@ public enum FT8Encoder {
                                  into signal: inout [Float], offset: Int) {
         let nSpsym = Int(0.5 + Double(sampleRate) * Double(FT8.symbolPeriod))
         let nWave = tones.count * nSpsym
+        // A negative offset would still satisfy the upper-bound check below yet
+        // make the C write before signal[0] (OOB); and offset is handed to C as
+        // an `int`, so it must fit Int32. The desktop encode.rs sidesteps both by
+        // typing offset as usize — Swift needs the guards explicit.
+        precondition(offset >= 0, "synthGFSK: offset must be non-negative, got \(offset)")
+        precondition(offset <= Int(Int32.max), "synthGFSK: offset \(offset) exceeds C int range")
         precondition(offset + nWave <= signal.count,
                      "synthGFSK: signal buffer too short (need \(nWave) from offset \(offset), have \(signal.count))")
         tones.withUnsafeBufferPointer { tp in

--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Hash.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Hash.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// WSJT-X 22-bit callsign hash (the value behind FT8Package.getHash10/12/22).
+///
+/// Faithful Swift port of `compute_n22` / `save_callsign` (ft8_lib message.c):
+/// base-38 over an 11-char field via " 0123456789A..Z/", times the
+/// 47055833459 magic constant, top 22 bits. h12 = n22>>10, h10 = n22>>12.
+/// The multiply intentionally wraps mod 2^64 (`&*`) — it is a multiplicative hash.
+public enum FT8Hash {
+    private static let table = Array(" 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ/".utf8)
+
+    /// Full 22-bit hash.
+    public static func n22(_ callsign: String) -> UInt32 {
+        var n58: UInt64 = 0
+        let chars = Array(callsign.uppercased().utf8)
+        var i = 0
+        while i < chars.count && i < 11 {
+            let j = table.firstIndex(of: chars[i]) ?? 0
+            n58 = 38 &* n58 &+ UInt64(j)
+            i += 1
+        }
+        while i < 11 {           // pad to 11 chars with the space symbol (index 0)
+            n58 = 38 &* n58
+            i += 1
+        }
+        return UInt32((47055833459 &* n58) >> (64 - 22) & 0x3FFFFF)
+    }
+
+    /// 12-bit hash (n22 >> 10).
+    public static func h12(_ callsign: String) -> UInt32 { n22(callsign) >> 10 }
+    /// 10-bit hash (n22 >> 12).
+    public static func h10(_ callsign: String) -> UInt32 { n22(callsign) >> 12 }
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/FT8EncodeGoldenTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/FT8EncodeGoldenTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import CFT8
+@testable import FT8DSP
+
+/// Layer (A): golden snapshots. pack77(message) and ft8_encode(payload) must
+/// reproduce the frozen vectors bit-for-bit, and the Costas sync arrays must sit
+/// at 0-6 / 36-42 / 72-78. Mirrors test_golden_encode.c layer A.
+final class FT8EncodeGoldenTests: XCTestCase {
+
+    func testPack77MatchesGoldenPayload() {
+        for (k, msg) in Golden.msgs.enumerated() {
+            guard let got = FT8Encoder.pack77(msg) else {
+                XCTFail("[\(msg)] pack77 returned nil (rejected)")
+                continue
+            }
+            XCTAssertTrue(Golden.payload77Eq(got, Golden.payload[k]),
+                          "[\(msg)] payload mismatch vs golden: \(got) != \(Golden.payload[k])")
+        }
+    }
+
+    func testEncodeTonesMatchGoldenAndCostas() {
+        for (k, msg) in Golden.msgs.enumerated() {
+            let tones = FT8Encoder.encodeTones(Golden.payload[k])
+            XCTAssertEqual(tones, Golden.tones[k], "[\(msg)] tone sequence mismatch vs golden")
+
+            // Costas sync arrays must equal kFT8_Costas_pattern at all three groups.
+            withUnsafeBytes(of: kFT8_Costas_pattern) { costas in
+                for s in 0..<7 {
+                    let expect = costas[s]
+                    XCTAssertEqual(tones[s], expect, "[\(msg)] Costas group 0 symbol \(s)")
+                    XCTAssertEqual(tones[36 + s], expect, "[\(msg)] Costas group 1 symbol \(s)")
+                    XCTAssertEqual(tones[72 + s], expect, "[\(msg)] Costas group 2 symbol \(s)")
+                }
+            }
+        }
+    }
+
+    /// The full text -> tones chain (pack then encode) also lands on golden.
+    func testTextToTonesChain() {
+        for (k, msg) in Golden.msgs.enumerated() {
+            guard let payload = FT8Encoder.pack77(msg) else {
+                XCTFail("[\(msg)] pack77 nil"); continue
+            }
+            XCTAssertEqual(FT8Encoder.encodeTones(payload), Golden.tones[k], "[\(msg)] chain")
+        }
+    }
+
+    /// generateFT8 yields the right number of bounded, non-silent samples.
+    func testGenerateFT8ProducesAudio() {
+        guard let sig = FT8Encoder.generateFT8("CQ K1ABC FN42", baseFreqHz: 1000) else {
+            return XCTFail("generateFT8 returned nil")
+        }
+        let expected = Int(0.5 + Float(FT8.nn) * FT8.symbolPeriod * Float(FT8.sampleRate))
+        XCTAssertEqual(sig.count, expected, "sample count (12.64 s @ 12 kHz)")
+        XCTAssertTrue(sig.contains { $0 != 0 }, "waveform must not be silent")
+        XCTAssertTrue(sig.allSatisfy { abs($0) <= 1.0001 }, "amplitude within [-1, 1]")
+    }
+
+    // Note: this ft8_lib's pack77 always returns 0 — it falls back to free-text
+    // packing (packtext77) for anything not a structured message — so
+    // FT8Encoder.pack77 never returns nil here. The Optional is kept for safety
+    // and parity with desktop encode.rs, but there is no reachable nil path to test.
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/FT8EncodeGoldenTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/FT8EncodeGoldenTests.swift
@@ -56,6 +56,24 @@ final class FT8EncodeGoldenTests: XCTestCase {
         XCTAssertTrue(sig.allSatisfy { abs($0) <= 1.0001 }, "amplitude within [-1, 1]")
     }
 
+    /// synthGFSK honors a non-zero offset: it writes the waveform into
+    /// signal[offset...] and leaves the leading region untouched (the offset
+    /// code path the engine uses to place a frame later in a buffer).
+    func testSynthGFSKWritesAtOffsetLeavingPrefixUntouched() {
+        let tones = FT8Encoder.encodeTones(Golden.payload[0])
+        let nSpsym = Int(0.5 + Double(FT8.sampleRate) * Double(FT8.symbolPeriod))
+        let nWave = tones.count * nSpsym
+        let offset = 1000
+        var signal = [Float](repeating: 0, count: offset + nWave)
+        FT8Encoder.synthGFSK(tones: tones, f0: 1000, sampleRate: FT8.sampleRate,
+                             into: &signal, offset: offset)
+        XCTAssertTrue(signal[0..<offset].allSatisfy { $0 == 0 },
+                      "samples before offset must stay silent")
+        XCTAssertTrue(signal[offset..<(offset + nWave)].contains { $0 != 0 },
+                      "waveform region must be non-silent")
+        XCTAssertTrue(signal.allSatisfy { abs($0) <= 1.0001 }, "amplitude within [-1, 1]")
+    }
+
     // Note: this ft8_lib's pack77 always returns 0 — it falls back to free-text
     // packing (packtext77) for anything not a structured message — so
     // FT8Encoder.pack77 never returns nil here. The Optional is kept for safety

--- a/ios/FT8AFKit/Tests/FT8DSPTests/GoldenVectors.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/GoldenVectors.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+// Golden vectors copied VERBATIM from
+//   ft8af/app/src/main/cpp/ft8af_glue/test_golden_encode.c
+// so iOS encode is pinned bit-for-bit to the Android app and desktop port.
+// Never hand-edit a byte: regenerate via that C test's `--emit` mode if the
+// FT8 spec/vectors ever intentionally change.
+enum Golden {
+
+    /// Reference messages spanning the standard FT8 message-type space.
+    static let msgs: [String] = [
+        "CQ K1ABC FN42",    // CQ + grid           (Type 1, standard call)
+        "CQ DX K1ABC FN42", // CQ DX directed
+        "W9XYZ K1ABC FN42", // call-to-call + grid
+        "W9XYZ K1ABC -15",  // signal report
+        "W9XYZ K1ABC R-08", // R + report
+        "W9XYZ K1ABC RRR",  // RRR
+        "W9XYZ K1ABC RR73", // RR73
+        "W9XYZ K1ABC 73",   // 73
+        "CQ G4ABC/P IO91",  // /P suffix           (Type 2)
+        "PJ4/K1ABC RR73",   // nonstandard compound (Type 4)
+    ]
+
+    /// pack77(message) golden: 77-bit payload, 10 bytes MSB-first (low 3 bits of
+    /// byte 9 are unused and masked out of comparisons).
+    static let payload: [[UInt8]] = [
+        [0x00,0x00,0x00,0x20,0x4D,0xEF,0x1A,0x8A,0x19,0x88], // CQ K1ABC FN42
+        [0x2C,0x91,0x27,0x42,0xE2,0x5D,0xA9,0x25,0x68,0x00], // CQ DX K1ABC FN42
+        [0x0C,0x29,0x3B,0x80,0x4D,0xEF,0x1A,0x8A,0x19,0x88], // W9XYZ K1ABC FN42
+        [0x0C,0x29,0x3B,0x80,0x4D,0xEF,0x1A,0x9F,0xA9,0x08], // W9XYZ K1ABC -15
+        [0x0C,0x29,0x3B,0x80,0x4D,0xEF,0x1A,0xBF,0xAA,0xC8], // W9XYZ K1ABC R-08
+        [0x0C,0x29,0x3B,0x80,0x4D,0xEF,0x1A,0x9F,0xA4,0x88], // W9XYZ K1ABC RRR
+        [0x0C,0x29,0x3B,0x80,0x4D,0xEF,0x1A,0x9F,0xA4,0xC8], // W9XYZ K1ABC RR73
+        [0x0C,0x29,0x3B,0x80,0x4D,0xEF,0x1A,0x9F,0xA5,0x08], // W9XYZ K1ABC 73
+        [0x2C,0x91,0x2D,0xF3,0xD6,0x11,0xE7,0x57,0xCE,0x00], // CQ G4ABC/P IO91
+        [0x56,0x7F,0xD3,0xB0,0x0A,0x0C,0x28,0xC7,0x40,0x00], // PJ4/K1ABC RR73
+    ]
+
+    /// ft8_encode(payload) golden: 79 tones (0..7).
+    static let tones: [[UInt8]] = [
+        [3,1,4,0,6,5,2,0,0,0,0,0,0,0,0,1,0,0,5,4,7,6,7,0,4,6,0,6,0,2,1,5,3,3,4,3,3,1,4,0,6,5,2,7,3,6,0,1,1,0,4,7,5,1,7,0,0,7,3,3,4,7,4,5,4,5,5,1,3,3,5,4,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,1,2,1,1,0,5,5,7,3,0,6,4,1,1,2,6,6,3,3,3,3,6,6,0,0,1,1,3,6,3,1,4,0,6,5,2,7,4,3,6,1,1,3,7,2,7,5,4,3,1,6,3,6,1,4,5,7,4,3,0,2,0,6,3,4,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,0,2,0,3,5,5,7,2,5,0,0,5,4,7,6,7,0,4,6,0,6,0,2,1,5,3,5,7,2,3,1,4,0,6,5,2,0,5,3,1,6,5,5,7,4,0,6,1,7,4,0,3,0,0,4,3,4,7,2,2,5,4,1,2,2,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,0,2,0,3,5,5,7,2,5,0,0,5,4,7,6,7,0,4,6,1,7,4,6,1,0,2,1,4,0,3,1,4,0,6,5,2,5,4,5,0,4,2,0,1,1,5,0,1,3,6,5,2,4,7,2,2,5,3,1,4,5,1,5,5,2,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,0,2,0,3,5,5,7,2,5,0,0,5,4,7,6,7,0,4,6,2,7,4,6,3,4,3,5,4,6,3,1,4,0,6,5,2,2,3,1,5,7,4,3,0,3,2,5,5,7,1,1,7,0,0,5,6,2,6,1,4,5,6,0,7,4,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,0,2,0,3,5,5,7,2,5,0,0,5,4,7,6,7,0,4,6,1,7,4,5,5,5,3,0,3,1,3,1,4,0,6,5,2,5,6,4,3,0,5,5,3,5,1,6,1,1,1,7,5,2,4,5,2,3,1,2,7,7,5,3,2,7,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,0,2,0,3,5,5,7,2,5,0,0,5,4,7,6,7,0,4,6,1,7,4,5,5,4,2,4,1,2,3,1,4,0,6,5,2,1,3,4,5,0,4,3,1,0,0,7,5,3,3,2,6,2,0,6,6,1,2,7,6,4,1,2,4,3,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,0,2,0,3,5,5,7,2,5,0,0,5,4,7,6,7,0,4,6,1,7,4,5,6,0,2,7,3,1,3,1,4,0,6,5,2,6,1,4,5,0,7,5,0,5,2,3,3,7,4,6,5,4,5,0,7,0,4,0,3,0,6,5,5,6,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,1,2,1,1,0,5,6,6,7,5,7,6,2,0,3,1,7,1,4,6,2,7,1,4,0,1,3,4,6,3,1,4,0,6,5,2,6,6,1,3,4,1,4,7,5,0,6,2,2,7,4,0,5,2,7,1,7,7,2,5,2,1,2,0,4,3,1,4,0,6,5,2],
+        [3,1,4,0,6,5,2,3,6,5,7,7,7,3,2,6,5,0,0,6,0,1,5,1,3,1,5,2,6,0,0,0,1,5,1,5,3,1,4,0,6,5,2,2,7,3,7,1,7,4,3,4,7,4,6,5,1,2,1,6,1,2,6,4,2,7,1,3,1,4,5,3,3,1,4,0,6,5,2],
+    ]
+
+    /// Callsign-hash golden: { h22, h12, h10 }.
+    static let calls: [String] = ["K1ABC", "W9XYZ", "G4ABC/P", "PJ4/K1ABC", "VK7BO", "EA1ABC"]
+    static let hashes: [(h22: UInt32, h12: UInt32, h10: UInt32)] = [
+        (2920267, 2851, 712), // K1ABC
+        (3982604, 3889, 972), // W9XYZ
+        (3288979, 3211, 802), // G4ABC/P
+        (1420834, 1387, 346), // PJ4/K1ABC
+        (2117032, 2067, 516), // VK7BO
+        ( 527469,  515, 128), // EA1ABC
+    ]
+
+    /// Compare two 77-bit payloads: bytes 0..8 full, byte 9 top 5 bits
+    /// (the low 3 bits are unused payload, masked out — see payload77_eq in C).
+    static func payload77Eq(_ a: [UInt8], _ b: [UInt8]) -> Bool {
+        for i in 0..<9 where a[i] != b[i] { return false }
+        return (a[9] & 0xF8) == (b[9] & 0xF8)
+    }
+
+    /// Costas sync symbols sit at indices 0-6, 36-42, 72-78.
+    static func isCostasPos(_ t: Int) -> Bool {
+        (t >= 0 && t < 7) || (t >= 36 && t < 43) || (t >= 72 && t < 79)
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/HashGoldenTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/HashGoldenTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import FT8DSP
+
+/// Callsign-hash goldens — FT8Hash.n22/h12/h10 must match the frozen WSJT-X
+/// hashes (test_golden_encode.c test_hash_golden).
+final class HashGoldenTests: XCTestCase {
+    func testCallsignHashesMatchGolden() {
+        for (k, call) in Golden.calls.enumerated() {
+            let g = Golden.hashes[k]
+            XCTAssertEqual(FT8Hash.n22(call), g.h22, "[\(call)] h22")
+            XCTAssertEqual(FT8Hash.h12(call), g.h12, "[\(call)] h12")
+            XCTAssertEqual(FT8Hash.h10(call), g.h10, "[\(call)] h10")
+        }
+    }
+
+    /// Lowercase input must hash identically (the algorithm upcases a-z).
+    func testHashIsCaseInsensitive() {
+        XCTAssertEqual(FT8Hash.n22("k1abc"), FT8Hash.n22("K1ABC"))
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/InverseCrossCheckTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/InverseCrossCheckTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import CFT8
+@testable import FT8DSP
+
+/// Layer (B): prove each golden tone set is a GENUINE FT8 frame for its payload,
+/// using the decoder's own LDPC parity + CRC validation — no encoder involved.
+/// Invert the Gray map, drop the Costas symbols, rebuild the 174-bit codeword,
+/// confirm every LDPC parity check is satisfied and the CRC validates, and that
+/// the recovered 77-bit payload equals the golden payload. Verbatim port of
+/// test_golden_encode.c's test_inverse_crosscheck, using the same C tables/CRC
+/// (kFT8_Gray_map, kFTX_LDPC_Nm, kFTX_LDPC_Num_rows, ftx_extract_crc,
+/// ftx_compute_crc) via CFT8 so the check stays independent of FT8DSP's encoder.
+final class InverseCrossCheckTests: XCTestCase {
+
+    private let ldpcN = Int(FTX_LDPC_N) // 174
+    private let ldpcM = Int(FTX_LDPC_M) // 83
+    private let ldpcK = Int(FTX_LDPC_K) // 91
+
+    /// 79 tones -> 174-bit hard codeword via inverse Gray map. nil on a bad tone
+    /// or wrong bit count.
+    private func tonesToCodeword(_ tones: [UInt8]) -> [UInt8]? {
+        var invGray = [UInt8](repeating: 0, count: 8)
+        withUnsafeBytes(of: kFT8_Gray_map) { g in
+            for b in 0..<8 { invGray[Int(g[b])] = UInt8(b) }
+        }
+        var cw = [UInt8]()
+        cw.reserveCapacity(ldpcN)
+        for t in 0..<79 {
+            if Golden.isCostasPos(t) { continue }
+            if tones[t] > 7 { return nil }
+            let b3 = invGray[Int(tones[t])]
+            cw.append((b3 >> 2) & 1)
+            cw.append((b3 >> 1) & 1)
+            cw.append((b3 >> 0) & 1)
+        }
+        return cw.count == ldpcN ? cw : nil
+    }
+
+    /// Count unsatisfied LDPC parity checks; 0 == valid codeword. Port of the
+    /// static ldpc_check() in ft8_lib/ft8/ldpc.c.
+    private func ldpcCheckHard(_ cw: [UInt8]) -> Int {
+        var errors = 0
+        withUnsafeBytes(of: kFTX_LDPC_Num_rows) { numRows in
+            withUnsafeBytes(of: kFTX_LDPC_Nm) { nm in
+                for m in 0..<ldpcM {
+                    var x: UInt8 = 0
+                    let rows = Int(numRows[m])
+                    for i in 0..<rows {
+                        x ^= cw[Int(nm[m * 7 + i]) - 1]
+                    }
+                    if x != 0 { errors += 1 }
+                }
+            }
+        }
+        return errors
+    }
+
+    /// Pack the first FTX_LDPC_K (91) hard bits, MSB-first, into a 12-byte a91.
+    private func packA91(_ cw: [UInt8]) -> [UInt8] {
+        var a91 = [UInt8](repeating: 0, count: 12)
+        for i in 0..<ldpcK where cw[i] != 0 {
+            a91[i / 8] |= UInt8(0x80 >> (i % 8))
+        }
+        return a91
+    }
+
+    func testGoldenTonesAreGenuineFT8Frames() {
+        for (k, msg) in Golden.msgs.enumerated() {
+            guard let cw = tonesToCodeword(Golden.tones[k]) else {
+                XCTFail("[\(msg)] tones->codeword failed (out-of-range tone)")
+                continue
+            }
+            XCTAssertEqual(ldpcCheckHard(cw), 0, "[\(msg)] LDPC parity not satisfied")
+
+            var a91 = packA91(cw)
+            let crcExtracted = a91.withUnsafeBufferPointer { ftx_extract_crc($0.baseAddress) }
+            a91[9] &= 0xF8 // zero the CRC region exactly as decode.c does
+            a91[10] = 0
+            let crcCalculated = a91.withUnsafeBufferPointer { ftx_compute_crc($0.baseAddress, 96 - 14) }
+            XCTAssertEqual(crcExtracted, crcCalculated, "[\(msg)] CRC mismatch")
+
+            XCTAssertTrue(Golden.payload77Eq(a91, Golden.payload[k]),
+                          "[\(msg)] recovered payload != golden payload")
+        }
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/MemoryLayoutTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/MemoryLayoutTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+import CFT8
+
+/// Guard against C-struct layout drift from the pinned ft8_lib (6f528128).
+/// These sizes are what the C side expects on LP64 (arm64 device + simulator);
+/// port of desktop dsp/mod.rs layout_tests. A mismatch means a header changed
+/// under the pin and every FFI call is suspect.
+final class MemoryLayoutTests: XCTestCase {
+    func testStructSizes() {
+        XCTAssertEqual(MemoryLayout<candidate_t>.size, 10, "candidate_t")
+        XCTAssertEqual(MemoryLayout<ftx_message_t>.size, 12, "ftx_message_t")
+        XCTAssertEqual(MemoryLayout<decode_status_t>.size, 8, "decode_status_t")
+        // 5*int(20) + pad(4) + ptr(8) + int(4) + enum(4) = 40 with 8-byte ptr align.
+        XCTAssertEqual(MemoryLayout<waterfall_t>.size, 40, "waterfall_t")
+        XCTAssertEqual(MemoryLayout<monitor_config_t>.size, 24, "monitor_config_t")
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,65 @@
+# FT8AF — iOS port
+
+Native Swift + SwiftUI port of FT8AF. Reuses the **same pure-C `ft8_lib` DSP
+core** the Android app (`ft8af/`) and the Tauri desktop port (`desktop/`) use —
+no DSP is reimplemented. See `.claude/plans/i-want-to-add-expressive-bengio.md`
+for the full design and phased roadmap.
+
+## Status
+
+**Phase 0 — C bridging + encode + golden tests.** This is the make-or-break
+phase: it proves the reused C compiles under Apple clang and produces
+bit-identical FT8 frames. It ships:
+
+- `FT8AFKit/` — a Swift package with:
+  - `CFT8` — C module bridging `ft8_lib` + `ft8af_glue/gfsk.c`. The C is **not
+    copied**; shim `.c` files (`Sources/CFT8/shim_*.c`) `#include` the real
+    sources in place under `../../ft8af/app/src/main/cpp`, the same single
+    source of truth the desktop `build.rs` references.
+  - `FT8DSP` — `FT8Encoder` (pack77 / ft8_encode / GFSK synth / generateFT8) and
+    `FT8Hash` (WSJT-X 22-bit callsign hash).
+  - Tests: golden-vector encode + Costas, independent LDPC/CRC inverse
+    cross-check, callsign-hash goldens, and C-struct memory-layout guards. The
+    golden tables are copied verbatim from
+    `ft8af/app/src/main/cpp/ft8af_glue/test_golden_encode.c`.
+
+Later phases (decode, AVAudioEngine capture/TX, QSO sequencing, rig control,
+persistence, SwiftUI) add `FT8Decoder`, `FT8Audio`, `FT8Rig`, `FT8Engine`,
+`FT8Data`, `FT8UI` targets here plus the `FT8AF.xcodeproj` app wrapper.
+
+## Building / testing — requires macOS
+
+The Swift toolchain does not run on Windows, so the package can only be built and
+tested on a Mac (where this branch was authored). From `ios/FT8AFKit`:
+
+```sh
+swift build
+swift test            # runs the Phase 0 golden gate (no simulator needed)
+```
+
+`swift test` compiles `CFT8` (the vendored C) and runs `FT8DSPTests` on the host
+Mac. Green here == the reused DSP is bit-identical under Apple clang.
+
+### Header-search-path caveat (verify first on Mac)
+
+`CFT8` needs the `ft8_lib` root on its header search path so the library's
+internal `<ft8/...>`, `<fft/...>`, `<common/...>` angle includes resolve.
+`Package.swift` sets this with `.headerSearchPath("../../../../ft8af/app/src/main/cpp/ft8_lib")`
+(relative to `Sources/CFT8`). Some SwiftPM versions warn about a search path
+that escapes the package root. If `swift build` rejects it, the fallback is to
+switch those entries to `.unsafeFlags(["-I", "<path>"])`, or to symlink/copy the
+`cpp` tree under `Sources/CFT8/vendor`. This is the first thing to confirm on the
+Mac since everything downstream depends on the C module compiling.
+
+A second thing to watch: the `CFT8.h` umbrella pulls in `ft8_lib` headers that
+live outside the module, which `-fmodules` can flag as "include of non-modular
+header." If that surfaces, add `-Wno-non-modular-include-in-module` (or
+`-fmodules-allow-nonmodular-includes`) to the C target's flags. Both this and the
+search-path item are pure wiring — they do not touch the DSP, whose correctness
+the golden tests verify once the module compiles.
+
+## Regenerating golden vectors
+
+Never hand-edit the golden tables in `Tests/FT8DSPTests/GoldenVectors.swift`.
+They are copied from the C golden test; regenerate via its `--emit` mode
+(`ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1 -Regen`) and re-copy.


### PR DESCRIPTION
## What

Starts a **native Swift + SwiftUI iOS port** of FT8AF as a third frontend over the same pure-C `ft8_lib` DSP core the Android app (`ft8af/`) and Tauri desktop port (`desktop/`) already share. No DSP is reimplemented.

This PR is **Phase 0** of a 9-phase roadmap (full design: `.claude/plans/i-want-to-add-expressive-bengio.md`) — the make-or-break C-bridge + bit-exact encode gate that proves the reused C compiles under Apple clang and produces FT8 frames bit-identical to the other two frontends.

## Contents — new SwiftPM package `ios/FT8AFKit`

- **`CFT8`** — C module bridging `ft8_lib` + `ft8af_glue/gfsk.c`. Shim `.c` files `#include` the real sources **in place** under `ft8af/app/src/main/cpp` (no copy) — the same single source of truth `desktop/src-tauri/build.rs` references. Umbrella header exposes the FFI surface plus `ft8_snr` and `synth_gfsk_offset` (defined in the C but absent from a public header), mirroring desktop `dsp/ffi.rs`.
- **`FT8DSP`** — `FT8Encoder` (`pack77` / `encodeTones` / `addCRC` / `synthGFSK` / `generateFT8`, mirroring desktop `encode.rs`) and `FT8Hash` (WSJT-X 22-bit callsign hash).
- **Tests** — golden-vector encode + Costas, an independent LDPC/CRC inverse cross-check via the C tables, callsign-hash goldens, and C-struct memory-layout guards. Golden tables copied verbatim from `ft8af_glue/test_golden_encode.c`, so iOS encode is pinned bit-for-bit to Android/desktop.

## Draft, because it can't be built on the dev box

The Swift/Xcode toolchain does not run on Windows (the primary dev machine), so Phase 0 is authored to be drop-in buildable but **the gate has not been run**. On a Mac:

```sh
cd ios/FT8AFKit && swift test
```

Two pure-wiring risks to confirm there first (documented in `ios/README.md`, neither touches the DSP):
1. the `ft8_lib` header-search-path escaping the package root;
2. `-fmodules` non-modular-header strictness on the umbrella header.

Marking ready for review once `swift test` is green on a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)