### PR TITLE
Upgrade AGP to 8.7.3 / Gradle 8.9 for 16 KB page-size zip-alignment

### DIFF
--- a/ft8af/build.gradle
+++ b/ft8af/build.gradle
@@ -4,7 +4,7 @@ plugins {
     // uncompressed native libraries inside the APK/AAB from 8.5.1 onward
     // (earlier versions zip-align them to 4 KB), which made Google Play flag
     // the bundle even though the .so ELF segments are already 16 KB-aligned
-    // via the linker's -Wl,-z,max-page-size=16384 flag (see app cpp/CMakeLists.txt).
+    // via the linker's -Wl,-z,max-page-size=16384 flag (see app/src/main/cpp/CMakeLists.txt).
     id 'com.android.application' version '8.7.3' apply false
     id 'com.android.library' version '8.7.3' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.22' apply false

--- a/ft8af/build.gradle
+++ b/ft8af/build.gradle
@@ -1,7 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.2.2' apply false
-    id 'com.android.library' version '8.2.2' apply false
+    // AGP 8.7.x: needed for 16 KB page-size support. AGP only 16 KB-aligns
+    // uncompressed native libraries inside the APK/AAB from 8.5.1 onward
+    // (earlier versions zip-align them to 4 KB), which made Google Play flag
+    // the bundle even though the .so ELF segments are already 16 KB-aligned
+    // via the linker's -Wl,-z,max-page-size=16384 flag (see app cpp/CMakeLists.txt).
+    id 'com.android.application' version '8.7.3' apply false
+    id 'com.android.library' version '8.7.3' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
     // Static analysis (issue #63). Applied in app/build.gradle; declared here
     // with apply false so the versions resolve once for the whole build.

--- a/ft8af/gradle/wrapper/gradle-wrapper.properties
+++ b/ft8af/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 14 00:00:00 CST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Problem

The 16 KB page-size error kept showing in production releases even after the
`-Wl,-z,max-page-size=16384` linker flag (#278, 8efe3a24) was added.

## Root cause

16 KB compatibility has **two** requirements:

1. **ELF `LOAD` segments aligned to 16 KB** — handled by the linker flag.
   Verified: `libft8af.so` segments all align to `0x4000`. ✅
2. **Each uncompressed `.so` positioned on a 16 KB boundary inside the
   APK/AAB zip** — the linker can't do this; AGP does it at packaging time. ❌

The project was on **AGP 8.2.2**, which zip-aligns native libs to **4 KB**.
AGP only 16 KB-aligns them from **8.5.1** onward, so Google Play flagged the
bundle even though the ELF itself was already aligned.

## Fix

- AGP `8.2.2` → `8.7.3`
- Gradle `8.4` → `8.9` (required by AGP 8.7.x)

AGP 8.7.x also fully supports the existing `compileSdk 35`.

## Verification

- `:app:bundleRelease` and `:app:assembleRelease` both succeed on the new toolchain.
- `zipalign -c -P 16 -v 4 app-release.apk` → **`Verification succesful`** for all
  four ABIs:
  ```
  lib/arm64-v8a/libft8af.so   (OK)
  lib/armeabi-v7a/libft8af.so (OK)
  lib/x86/libft8af.so         (OK)
  lib/x86_64/libft8af.so      (OK)
  ```

No unit test added — this is a build-tooling version bump with no code path;
the zipalign check is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)