### PR TITLE
iOS port Phase 1: from-source FT8 decode + callsign hash table

### DIFF
--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
@@ -64,6 +64,10 @@ public final class FT8Decoder {
         let block = Int(mon.block_size)
         if block == 0 { return }
         monitor_reset(&mon)
+        // Reset the callsign cache per slot: hashes resolve only against calls
+        // seen "earlier in the same slot", and a never-cleared table would grow
+        // unbounded across slots on a long-lived decoder.
+        hashtable.clear()
         samples.withUnsafeBufferPointer { buf in
             guard let base = buf.baseAddress else { return }
             var pos = 0

--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
@@ -1,0 +1,221 @@
+import CFT8
+import Foundation
+
+/// A single decoded FT8 message with geometry + signal metrics
+/// (mirror desktop dsp/decoder.rs DecodedMessage).
+public struct DecodedMessage: Equatable, Hashable {
+    public var callTo = ""
+    public var callFrom = ""
+    public var extra = ""
+    public var grid = ""
+    public var rawText = ""
+    public var snr = 0
+    public var freqHz: Float = 0
+    public var timeSec: Float = 0
+    public var score = 0
+    public var i3: UInt8 = 0
+    public var n3: UInt8 = 0
+    /// 12-byte a91 (77-bit payload + 14-bit CRC), for deep-decode subtraction.
+    public var a91 = [UInt8](repeating: 0, count: 12)
+
+    public init() {}
+}
+
+/// Safe FT8 decoder wrapper replicating the decoder lifecycle from
+/// ft8af_glue/ft8_decoder.cpp (mirrored in desktop dsp/decoder.rs):
+///   init -> feedSlot -> findSync -> decodeAll -> (deinit frees the monitor).
+///
+/// Owns the C `monitor_t` (freed in deinit), a candidate array (cap 140), and a
+/// per-decoder callsign hash table for resolving hashed compound calls.
+public final class FT8Decoder {
+    private static let maxCandidates = 140
+    private static let minScore: Int32 = 10
+    private static let ldpcItersNormal: Int32 = 20
+    private static let ldpcItersDeep: Int32 = 30
+
+    private var mon = monitor_t()
+    private var candidates = [candidate_t](repeating: candidate_t(), count: FT8Decoder.maxCandidates)
+    private var numCandidates = 0
+    private var ldpcIters = FT8Decoder.ldpcItersNormal
+    private let hashtable = HashTable()
+
+    /// Create a decoder for the given sample rate. `isFT8 = false` selects FT4.
+    public init(sampleRate: Int32 = FT8.sampleRate, isFT8: Bool = true) {
+        var cfg = monitor_config_t()
+        cfg.f_min = 100
+        cfg.f_max = 3500
+        cfg.sample_rate = sampleRate
+        cfg.time_osr = 2
+        cfg.freq_osr = 2
+        cfg.`protocol` = isFT8 ? FTX_PROTOCOL_FT8 : FTX_PROTOCOL_FT4
+        monitor_init(&mon, &cfg)
+    }
+
+    deinit { monitor_free(&mon) }
+
+    /// Set deep-decode mode (more LDPC iterations). Mirrors `setDecodeMode`.
+    public func setDeep(_ deep: Bool) {
+        ldpcIters = deep ? FT8Decoder.ldpcItersDeep : FT8Decoder.ldpcItersNormal
+    }
+
+    /// Feed a full slot of mono Float samples (12 kHz) through the monitor:
+    /// reset then process block by block (mirror feed_slot).
+    public func feedSlot(_ samples: [Float]) {
+        let block = Int(mon.block_size)
+        if block == 0 { return }
+        monitor_reset(&mon)
+        samples.withUnsafeBufferPointer { buf in
+            guard let base = buf.baseAddress else { return }
+            var pos = 0
+            while pos + block <= buf.count {
+                monitor_process(&mon, base + pos)
+                pos += block
+            }
+        }
+    }
+
+    /// Locate sync candidates. Mirrors `DecoderFt8FindSync`.
+    @discardableResult
+    public func findSync() -> Int {
+        let n = candidates.withUnsafeMutableBufferPointer { cbuf in
+            ft8_find_sync(&mon.wf, Int32(FT8Decoder.maxCandidates), cbuf.baseAddress, FT8Decoder.minScore)
+        }
+        numCandidates = max(0, min(Int(n), FT8Decoder.maxCandidates))
+        return numCandidates
+    }
+
+    /// Decode every candidate found by the last `findSync`, returning the
+    /// successfully decoded messages (deduped by text). Mirrors the per-candidate
+    /// `DecoderFt8Analysis` loop.
+    public func decodeAll() -> [DecodedMessage] {
+        var out: [DecodedMessage] = []
+        // The sync search yields several candidates for one signal; collapse
+        // those that decode to identical text so each message appears once.
+        var seen = Set<String>()
+        // Activate this decoder's hash table for the callbacks invoked by
+        // ftx_message_decode*; clear on the way out (RAII via defer).
+        installActiveHashTable(hashtable)
+        defer { clearActiveHashTable() }
+        var iface = makeHashInterface()
+
+        for idx in 0..<numCandidates {
+            var cand = candidates[idx]
+            var message = ftx_message_t()
+            var status = decode_status_t()
+            let ok = ft8_decode(&mon.wf, &cand, ldpcIters, &message, &status)
+            if !ok { continue }
+            if let msg = buildMessage(cand: &cand, message: &message, iface: &iface) {
+                // Keep the first (highest-score) decode of each unique message.
+                if msg.rawText.isEmpty || seen.insert(msg.rawText).inserted {
+                    out.append(msg)
+                }
+            }
+        }
+        return out
+    }
+
+    /// Downsample the monitor's waterfall magnitudes (populated by the last
+    /// `feedSlot`) into a `rows x cols` heatmap of 0...255 values for display.
+    /// Returns (bins, rows, cols, hzPerCol). Mirrors waterfall_heatmap.
+    public func waterfallHeatmap(maxRows: Int, maxCols: Int) -> (bins: [UInt8], rows: Int, cols: Int, hzPerCol: Float) {
+        let wf = mon.wf
+        guard let mag = wf.mag, wf.num_blocks > 0, wf.num_bins > 0 else { return ([], 0, 0, 0) }
+        let numBlocks = Int(wf.num_blocks)
+        let numBins = Int(wf.num_bins)
+        let stride = Int(wf.block_stride)
+        let rows = max(1, min(numBlocks, maxRows))
+        let cols = max(1, min(numBins, maxCols))
+        var bins = [UInt8](repeating: 0, count: rows * cols)
+        for r in 0..<rows {
+            let block = r * numBlocks / rows
+            let base = block * stride // time_sub=0, freq_sub=0 plane
+            for c in 0..<cols {
+                let bin0 = c * numBins / cols
+                let bin1 = min(max((c + 1) * numBins / cols, bin0 + 1), numBins)
+                var mx: UInt8 = 0
+                for bin in bin0..<bin1 {
+                    let v = mag[base + bin]
+                    if v > mx { mx = v }
+                }
+                bins[r * cols + c] = mx
+            }
+        }
+        // Bin spacing in Hz = (1/symbol_period)/freq_osr; columns aggregate bins.
+        let binHz = (1.0 / mon.symbol_period) / Float(wf.freq_osr)
+        let hzPerCol = binHz * (Float(numBins) / Float(cols))
+        return (bins, rows, cols, hzPerCol)
+    }
+
+    private func buildMessage(cand: inout candidate_t, message: inout ftx_message_t,
+                              iface: inout ftx_callsign_hash_interface_t) -> DecodedMessage? {
+        let freqHz = (Float(mon.min_bin) + Float(cand.freq_offset)
+                      + Float(cand.freq_sub) / Float(mon.wf.freq_osr)) / mon.symbol_period
+        let timeSec = (Float(cand.time_offset)
+                       + Float(cand.time_sub) / Float(mon.wf.time_osr)) * mon.symbol_period
+        let snr = ft8_snr(&mon.wf, &cand)
+
+        var a91 = [UInt8](repeating: 0, count: 12)
+        withUnsafeBytes(of: message.payload) { payloadRaw in
+            let payloadPtr = payloadRaw.bindMemory(to: UInt8.self).baseAddress
+            a91.withUnsafeMutableBufferPointer { a in ftx_add_crc(payloadPtr, a.baseAddress) }
+        }
+
+        let i3 = ftx_message_get_i3(&message)
+        let n3 = ftx_message_get_n3(&message)
+        let msgType = ftx_message_get_type(&message)
+
+        // Canonical full text (always available) — mirrors getMessageText.
+        var rawText = ""
+        var textBuf = [CChar](repeating: 0, count: 64)
+        let rcText = textBuf.withUnsafeMutableBufferPointer { ftx_message_decode(&message, &iface, $0.baseAddress) }
+        if rcText == FTX_MESSAGE_RC_OK { rawText = cString(textBuf) }
+
+        var m = DecodedMessage()
+        m.snr = Int(snr)
+        m.freqHz = freqHz
+        m.timeSec = timeSec
+        m.score = Int(cand.score)
+        m.i3 = i3
+        m.n3 = n3
+        m.a91 = a91
+        m.rawText = rawText
+
+        if msgType == FTX_MESSAGE_TYPE_STANDARD || msgType == FTX_MESSAGE_TYPE_NONSTD_CALL {
+            var callTo = [CChar](repeating: 0, count: 24)
+            var callDe = [CChar](repeating: 0, count: 24)
+            var extra = [CChar](repeating: 0, count: 24)
+            let rc = callTo.withUnsafeMutableBufferPointer { ct in
+                callDe.withUnsafeMutableBufferPointer { cd in
+                    extra.withUnsafeMutableBufferPointer { ex in
+                        msgType == FTX_MESSAGE_TYPE_STANDARD
+                            ? ftx_message_decode_std(&message, &iface, ct.baseAddress, cd.baseAddress, ex.baseAddress)
+                            : ftx_message_decode_nonstd(&message, &iface, ct.baseAddress, cd.baseAddress, ex.baseAddress)
+                    }
+                }
+            }
+            if rc != FTX_MESSAGE_RC_OK { return nil }
+            m.callTo = cString(callTo)
+            m.callFrom = cString(callDe)
+            m.extra = cString(extra)
+            if looksLikeGrid(m.extra) { m.grid = m.extra }
+        } else {
+            // Free text + contest sub-types: full text already in rawText.
+            m.extra = m.rawText
+        }
+        return m
+    }
+}
+
+private func cString(_ buf: [CChar]) -> String {
+    buf.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+}
+
+/// A 4-char Maidenhead grid: two A-R letters then two digits.
+func looksLikeGrid(_ s: String) -> Bool {
+    let b = Array(s.utf8)
+    return b.count == 4
+        && (UInt8(ascii: "A")...UInt8(ascii: "R")).contains(b[0])
+        && (UInt8(ascii: "A")...UInt8(ascii: "R")).contains(b[1])
+        && (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(b[2])
+        && (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(b[3])
+}

--- a/ios/FT8AFKit/Sources/FT8DSP/HashTable.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/HashTable.swift
@@ -1,0 +1,95 @@
+import CFT8
+import Foundation
+
+/// Per-decoder callsign hash table, ported from desktop dsp/hashtable.rs (itself
+/// from ft8af_glue/ft8_decoder.cpp). FT8 messages can carry 10/12/22-bit *hashes*
+/// of compound/nonstandard callsigns instead of the full call; ft8_lib resolves
+/// them through the `ftx_callsign_hash_interface_t` save/lookup callbacks, which
+/// need somewhere to stash calls seen earlier in the same slot.
+final class HashTable {
+    static let size = 256
+
+    private struct Entry {
+        var callsign = [UInt8](repeating: 0, count: 12)
+        var hash: UInt32 = 0   // 22-bit
+        var used = false
+    }
+    private var entries = [Entry](repeating: Entry(), count: HashTable.size)
+
+    func clear() {
+        entries = [Entry](repeating: Entry(), count: HashTable.size)
+    }
+
+    /// Mirror of `hash_save` in ft8_decoder.cpp.
+    func save(_ callsign: String, _ n22: UInt32) {
+        let bytes = Array(callsign.utf8)
+        if bytes.isEmpty || bytes[0] == UInt8(ascii: "<") { return }
+        let h10 = (n22 >> 12) & 0x3FF
+        var idx = (Int(h10) * 23) % HashTable.size
+        while entries[idx].used {
+            if entries[idx].hash == n22 { return } // already stored
+            idx = (idx + 1) % HashTable.size
+        }
+        let n = min(bytes.count, 11)
+        var cs = [UInt8](repeating: 0, count: 12)
+        cs.replaceSubrange(0..<n, with: bytes[0..<n])
+        entries[idx].callsign = cs
+        entries[idx].hash = n22
+        entries[idx].used = true
+    }
+
+    /// Mirror of `hash_lookup`. `shift` selects the hash width (0 / 10 / 12).
+    func lookup(shift: UInt8, hash: UInt32) -> String? {
+        for e in entries where e.used {
+            if ((e.hash & 0x3F_FFFF) >> shift) == hash {
+                let len = e.callsign.firstIndex(of: 0) ?? 11
+                return String(decoding: e.callsign[0..<len], as: UTF8.self)
+            }
+        }
+        return nil
+    }
+}
+
+// The C hash interface is plain function pointers with no user-data arg, so the
+// callbacks route through a global pointer to the table active for the current
+// decode pass. Decode passes must not overlap across threads — the engine
+// serializes decode on a single worker (desktop hashtable.rs uses a thread_local
+// for the same role; we don't decode concurrently). `installActiveHashTable` /
+// `clearActiveHashTable` bracket a pass (RAII-style via `defer` in decodeAll).
+private var activeHashTable: HashTable?
+
+func installActiveHashTable(_ table: HashTable) { activeHashTable = table }
+func clearActiveHashTable() { activeHashTable = nil }
+
+/// C callback: store a callsign by its 22-bit hash.
+let saveHashCallback: @convention(c) (UnsafePointer<CChar>?, UInt32) -> Void = { callsign, n22 in
+    guard let table = activeHashTable, let callsign = callsign else { return }
+    table.save(String(cString: callsign), n22)
+}
+
+/// C callback: look up a callsign by its 10/12/22-bit hash, writing it
+/// (NUL-terminated) into `out`. Returns true if found. Shift mapping matches
+/// ft8_decoder.cpp / hashtable.rs.
+let lookupHashCallback: @convention(c) (ftx_callsign_hash_type_e, UInt32, UnsafeMutablePointer<CChar>?) -> Bool = { hashType, hash, out in
+    guard let out = out else { return false }
+    let shift: UInt8
+    switch hashType {
+    case FTX_CALLSIGN_HASH_10_BITS: shift = 12
+    case FTX_CALLSIGN_HASH_12_BITS: shift = 10
+    default: shift = 0
+    }
+    if let table = activeHashTable, let call = table.lookup(shift: shift, hash: hash) {
+        let bytes = Array(call.utf8)
+        let n = min(bytes.count, 11)
+        for i in 0..<n { out[i] = CChar(bitPattern: bytes[i]) }
+        out[n] = 0
+        return true
+    }
+    out[0] = 0
+    return false
+}
+
+/// Build the C hash interface struct wired to our callbacks.
+func makeHashInterface() -> ftx_callsign_hash_interface_t {
+    ftx_callsign_hash_interface_t(lookup_hash: lookupHashCallback, save_hash: saveHashCallback)
+}

--- a/ios/FT8AFKit/Sources/FT8DSP/HashTable.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/HashTable.swift
@@ -26,9 +26,12 @@ final class HashTable {
         if bytes.isEmpty || bytes[0] == UInt8(ascii: "<") { return }
         let h10 = (n22 >> 12) & 0x3FF
         var idx = (Int(h10) * 23) % HashTable.size
+        var probes = 0
         while entries[idx].used {
             if entries[idx].hash == n22 { return } // already stored
             idx = (idx + 1) % HashTable.size
+            probes += 1
+            if probes >= HashTable.size { return } // table full: drop, never spin
         }
         let n = min(bytes.count, 11)
         var cs = [UInt8](repeating: 0, count: 12)
@@ -51,19 +54,28 @@ final class HashTable {
 }
 
 // The C hash interface is plain function pointers with no user-data arg, so the
-// callbacks route through a global pointer to the table active for the current
-// decode pass. Decode passes must not overlap across threads — the engine
-// serializes decode on a single worker (desktop hashtable.rs uses a thread_local
-// for the same role; we don't decode concurrently). `installActiveHashTable` /
-// `clearActiveHashTable` bracket a pass (RAII-style via `defer` in decodeAll).
-private var activeHashTable: HashTable?
+// callbacks route through the table active for the current decode pass. That
+// table is stored **thread-local** (matching desktop hashtable.rs's thread_local)
+// so concurrent decoders on different threads — or a re-entrant decode — never
+// share or clobber each other's active table. The @convention(c) callbacks can't
+// capture context, so they read it back off the current thread.
+// `installActiveHashTable` / `clearActiveHashTable` bracket a pass (RAII-style
+// via `defer` in decodeAll).
+private let activeHashTableThreadKey = "radio.ks3ckc.ft8af.activeHashTable"
 
-func installActiveHashTable(_ table: HashTable) { activeHashTable = table }
-func clearActiveHashTable() { activeHashTable = nil }
+func installActiveHashTable(_ table: HashTable) {
+    Thread.current.threadDictionary[activeHashTableThreadKey] = table
+}
+func clearActiveHashTable() {
+    Thread.current.threadDictionary.removeObject(forKey: activeHashTableThreadKey)
+}
+private func activeHashTable() -> HashTable? {
+    Thread.current.threadDictionary[activeHashTableThreadKey] as? HashTable
+}
 
 /// C callback: store a callsign by its 22-bit hash.
 let saveHashCallback: @convention(c) (UnsafePointer<CChar>?, UInt32) -> Void = { callsign, n22 in
-    guard let table = activeHashTable, let callsign = callsign else { return }
+    guard let table = activeHashTable(), let callsign = callsign else { return }
     table.save(String(cString: callsign), n22)
 }
 
@@ -78,7 +90,7 @@ let lookupHashCallback: @convention(c) (ftx_callsign_hash_type_e, UInt32, Unsafe
     case FTX_CALLSIGN_HASH_12_BITS: shift = 10
     default: shift = 0
     }
-    if let table = activeHashTable, let call = table.lookup(shift: shift, hash: hash) {
+    if let table = activeHashTable(), let call = table.lookup(shift: shift, hash: hash) {
         let bytes = Array(call.utf8)
         let n = min(bytes.count, 11)
         for i in 0..<n { out[i] = CChar(bitPattern: bytes[i]) }

--- a/ios/FT8AFKit/Tests/FT8DSPTests/FT8DecoderTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/FT8DecoderTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import FT8DSP
+
+/// Phase 1 gate: prove the from-source decode path works end to end by encoding
+/// a message to audio, feeding it through the monitor, and decoding it back —
+/// the in-memory round trip (mirror desktop's encode->decode cross-check).
+final class FT8DecoderTests: XCTestCase {
+
+    /// Lay a 12.64 s FT8 waveform at the start of a 15 s slot, scaled by `gain`.
+    private func slot(for text: String, baseFreqHz: Float, gain: Float = 0.5) -> [Float]? {
+        guard let audio = FT8Encoder.generateFT8(text, baseFreqHz: baseFreqHz) else { return nil }
+        var s = [Float](repeating: 0, count: FT8.slotSamples)
+        for i in 0..<min(audio.count, s.count) { s[i] += audio[i] * gain }
+        return s
+    }
+
+    func testEncodeThenDecodeRoundTrip() {
+        let text = "CQ K1ABC FN42"
+        let baseFreq: Float = 1500
+        guard let s = slot(for: text, baseFreqHz: baseFreq) else { return XCTFail("encode failed") }
+
+        let dec = FT8Decoder()
+        dec.feedSlot(s)
+        dec.findSync()
+        let msgs = dec.decodeAll()
+
+        guard let m = msgs.first(where: { $0.rawText == text }) else {
+            return XCTFail("expected \"\(text)\", got \(msgs.map { $0.rawText })")
+        }
+        XCTAssertEqual(m.callTo, "CQ")
+        XCTAssertEqual(m.callFrom, "K1ABC")
+        XCTAssertEqual(m.grid, "FN42")
+        XCTAssertEqual(m.freqHz, baseFreq, accuracy: 6.25, "frequency within one tone bin")
+        XCTAssertEqual(m.timeSec, 0, accuracy: 0.2, "signal placed at slot start -> DT ~ 0")
+        XCTAssertGreaterThan(m.snr, -10, "clean synthetic signal should report decent SNR")
+    }
+
+    /// Two signals at different audio frequencies decode from one slot (exercises
+    /// multi-candidate find_sync + dedup). Doubles as the "known slot" decode.
+    func testDecodesMultipleSignalsInOneSlot() {
+        let specs: [(text: String, freq: Float)] = [
+            ("CQ K1ABC FN42", 800),
+            ("W9XYZ K1ABC RR73", 1600),
+        ]
+        var s = [Float](repeating: 0, count: FT8.slotSamples)
+        for spec in specs {
+            guard let audio = FT8Encoder.generateFT8(spec.text, baseFreqHz: spec.freq) else {
+                return XCTFail("encode failed for \(spec.text)")
+            }
+            for i in 0..<min(audio.count, s.count) { s[i] += audio[i] * 0.4 }
+        }
+
+        let dec = FT8Decoder()
+        dec.feedSlot(s)
+        dec.findSync()
+        let texts = Set(dec.decodeAll().map { $0.rawText })
+        for spec in specs {
+            XCTAssertTrue(texts.contains(spec.text), "missing \"\(spec.text)\" in \(texts)")
+        }
+    }
+
+    /// An empty slot yields no decodes (no false positives from silence).
+    func testSilentSlotDecodesNothing() {
+        let dec = FT8Decoder()
+        dec.feedSlot([Float](repeating: 0, count: FT8.slotSamples))
+        dec.findSync()
+        XCTAssertTrue(dec.decodeAll().isEmpty)
+    }
+
+    /// feedSlot populates the waterfall so a heatmap can be built (Phase 2 UI).
+    func testWaterfallHeatmapPopulatedAfterFeed() {
+        guard let s = slot(for: "CQ K1ABC FN42", baseFreqHz: 1500) else { return XCTFail("encode") }
+        let dec = FT8Decoder()
+        dec.feedSlot(s)
+        let wf = dec.waterfallHeatmap(maxRows: 60, maxCols: 120)
+        XCTAssertGreaterThan(wf.rows, 0)
+        XCTAssertGreaterThan(wf.cols, 0)
+        XCTAssertEqual(wf.bins.count, wf.rows * wf.cols)
+        XCTAssertGreaterThan(wf.hzPerCol, 0)
+        XCTAssertTrue(wf.bins.contains { $0 > 0 }, "signal should light up some bins")
+    }
+}
+
+/// Pure-logic tests for the hash table + helpers (no monitor needed).
+final class HashTableTests: XCTestCase {
+    func testSaveAndLookupAcrossWidths() {
+        let t = HashTable()
+        let n22 = FT8Hash.n22("PJ4/K1ABC") & 0x3F_FFFF
+        t.save("PJ4/K1ABC", n22)
+        XCTAssertEqual(t.lookup(shift: 0, hash: n22), "PJ4/K1ABC")
+        XCTAssertEqual(t.lookup(shift: 10, hash: n22 >> 10), "PJ4/K1ABC")
+        XCTAssertEqual(t.lookup(shift: 12, hash: n22 >> 12), "PJ4/K1ABC")
+        XCTAssertNil(t.lookup(shift: 0, hash: 0x1_2345))
+    }
+
+    func testBracketedCallsignNotStored() {
+        let t = HashTable()
+        t.save("<W9XYZ>", FT8Hash.n22("W9XYZ"))
+        XCTAssertNil(t.lookup(shift: 0, hash: FT8Hash.n22("W9XYZ") & 0x3F_FFFF))
+    }
+
+    func testClearEmptiesTable() {
+        let t = HashTable()
+        let n22 = FT8Hash.n22("K1ABC") & 0x3F_FFFF
+        t.save("K1ABC", n22)
+        t.clear()
+        XCTAssertNil(t.lookup(shift: 0, hash: n22))
+    }
+
+    func testLooksLikeGrid() {
+        XCTAssertTrue(looksLikeGrid("FN42"))
+        XCTAssertTrue(looksLikeGrid("AA00"))
+        XCTAssertTrue(looksLikeGrid("RR99"))
+        XCTAssertFalse(looksLikeGrid("FN4"))   // too short
+        XCTAssertFalse(looksLikeGrid("FN420")) // too long
+        XCTAssertFalse(looksLikeGrid("SN42"))  // S > R
+        XCTAssertFalse(looksLikeGrid("F142"))  // second char not a letter
+        XCTAssertFalse(looksLikeGrid("FNAB"))  // last two not digits
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/FT8DecoderTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/FT8DecoderTests.swift
@@ -67,6 +67,19 @@ final class FT8DecoderTests: XCTestCase {
         XCTAssertTrue(dec.decodeAll().isEmpty)
     }
 
+    /// A long-lived decoder must stay correct across repeated feedSlot calls
+    /// (feedSlot clears the per-slot callsign cache; no stale-state corruption).
+    func testDecoderReusableAcrossSlots() {
+        guard let s = slot(for: "CQ K1ABC FN42", baseFreqHz: 1200) else { return XCTFail("encode") }
+        let dec = FT8Decoder()
+        dec.feedSlot(s); dec.findSync()
+        let first = Set(dec.decodeAll().map { $0.rawText })
+        dec.feedSlot(s); dec.findSync()
+        let second = Set(dec.decodeAll().map { $0.rawText })
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first.contains("CQ K1ABC FN42"))
+    }
+
     /// feedSlot populates the waterfall so a heatmap can be built (Phase 2 UI).
     func testWaterfallHeatmapPopulatedAfterFeed() {
         guard let s = slot(for: "CQ K1ABC FN42", baseFreqHz: 1500) else { return XCTFail("encode") }
@@ -97,6 +110,17 @@ final class HashTableTests: XCTestCase {
         let t = HashTable()
         t.save("<W9XYZ>", FT8Hash.n22("W9XYZ"))
         XCTAssertNil(t.lookup(shift: 0, hash: FT8Hash.n22("W9XYZ") & 0x3F_FFFF))
+    }
+
+    /// Saving past capacity must terminate (bounded linear probe), never hang,
+    /// and the table must still answer a hash stored before it filled.
+    func testSaveIsBoundedWhenTableFull() {
+        let t = HashTable()
+        for i in 0..<(HashTable.size + 10) {
+            t.save("C\(i)", (UInt32(i) << 12) & 0x3F_FFFF)
+        }
+        // Reaching here means every save() returned (no infinite loop).
+        XCTAssertNotNil(t.lookup(shift: 0, hash: 0)) // "C0" (n22 == 0) stored first
     }
 
     func testClearEmptiesTable() {

--- a/ios/README.md
+++ b/ios/README.md
@@ -7,9 +7,8 @@ for the full design and phased roadmap.
 
 ## Status
 
-**Phase 0 — C bridging + encode + golden tests.** This is the make-or-break
-phase: it proves the reused C compiles under Apple clang and produces
-bit-identical FT8 frames. It ships:
+**Phase 0 — C bridging + encode + golden tests** (merged). Proves the reused C
+compiles under Apple clang and produces bit-identical FT8 frames:
 
 - `FT8AFKit/` — a Swift package with:
   - `CFT8` — C module bridging `ft8_lib` + `ft8af_glue/gfsk.c`. The C is **not
@@ -19,13 +18,19 @@ bit-identical FT8 frames. It ships:
   - `FT8DSP` — `FT8Encoder` (pack77 / ft8_encode / GFSK synth / generateFT8) and
     `FT8Hash` (WSJT-X 22-bit callsign hash).
   - Tests: golden-vector encode + Costas, independent LDPC/CRC inverse
-    cross-check, callsign-hash goldens, and C-struct memory-layout guards. The
-    golden tables are copied verbatim from
-    `ft8af/app/src/main/cpp/ft8af_glue/test_golden_encode.c`.
+    cross-check, callsign-hash goldens, and C-struct memory-layout guards.
 
-Later phases (decode, AVAudioEngine capture/TX, QSO sequencing, rig control,
-persistence, SwiftUI) add `FT8Decoder`, `FT8Audio`, `FT8Rig`, `FT8Engine`,
-`FT8Data`, `FT8UI` targets here plus the `FT8AF.xcodeproj` app wrapper.
+**Phase 1 — decode from a fixed buffer** (this branch). Adds the from-source RX
+path: `FT8Decoder` (monitor lifecycle → `feedSlot` → `findSync` → `decodeAll`,
+waterfall heatmap) and the per-decoder callsign `HashTable` + C hash-interface
+callbacks, both ported from desktop `dsp/{decoder,hashtable}.rs`. Gated by an
+in-memory **encode → decode round trip** (`FT8DecoderTests`): generate audio for
+a message, feed it through the monitor, decode it back, and check the call/grid/
+frequency. No audio device involved yet.
+
+Later phases (AVAudioEngine capture/TX, QSO sequencing, rig control,
+persistence, SwiftUI) add `FT8Audio`, `FT8Rig`, `FT8Engine`, `FT8Data`, `FT8UI`
+targets here plus the `FT8AF.xcodeproj` app wrapper.
 
 ## Building / testing — requires macOS
 
@@ -34,7 +39,7 @@ tested on a Mac (where this branch was authored). From `ios/FT8AFKit`:
 
 ```sh
 swift build
-swift test            # runs the Phase 0 golden gate (no simulator needed)
+swift test            # runs the golden gate + encode/decode round trip (no simulator)
 ```
 
 `swift test` compiles `CFT8` (the vendored C) and runs `FT8DSPTests` on the host
@@ -57,6 +62,14 @@ header." If that surfaces, add `-Wno-non-modular-include-in-module` (or
 `-fmodules-allow-nonmodular-includes`) to the C target's flags. Both this and the
 search-path item are pure wiring — they do not touch the DSP, whose correctness
 the golden tests verify once the module compiles.
+
+The C bridging was smoke-compiled with LLVM clang on the Windows dev box: all
+shims and the umbrella compile **except** `message.c`/`unpack.c`, which call
+POSIX `stpcpy`. That is a Windows-libc gap only — Darwin's `<string.h>` (macOS +
+iOS) declares `stpcpy`, so it builds on the real targets (the desktop port hit
+the identical thing and needed a `stpcpy` shim **only** for its Windows host
+build, never macOS). No action needed for iOS; do not "fix" it by editing the
+vendored ft8_lib.
 
 ## Regenerating golden vectors
 


### PR DESCRIPTION
## What

Phase 1 of the native iOS port (follows #282). Adds the **from-source RX path** so the iOS app can decode FT8, over the same `ft8_lib` already bridged in Phase 0.

- **`FT8Decoder`** — wraps the C monitor lifecycle (`monitor_init` → `feedSlot` → `findSync` → `decodeAll` → deinit/`monitor_free`), builds `DecodedMessage` (call/grid/extra, SNR, freq, DT, i3/n3, a91), and exposes a downsampled **waterfall heatmap** for the Phase 2 UI plus `setDeep()` (LDPC 20/30). Faithful port of desktop `dsp/decoder.rs`.
- **`HashTable`** + the `ftx_callsign_hash_interface_t` save/lookup C callbacks for resolving hashed compound calls — port of desktop `dsp/hashtable.rs`. No umbrella/header changes were needed.

## Tests (the gate)

In-memory **encode → decode round trip**: generate audio for a message, feed it through the monitor, decode it back, assert call/grid/frequency/DT. Plus two-signals-in-one-slot (multi-candidate + dedup), silent-slot-decodes-nothing, waterfall-populated, and pure hash-table / grid-helper unit tests.

## Validation done here

Smoke-compiled the C bridging with LLVM clang on the Windows dev box: all shims + the umbrella compile **except** `message.c`/`unpack.c`'s POSIX `stpcpy`, which is a Windows-libc gap only — Darwin's `<string.h>` (macOS + iOS) declares it, so it builds on the real targets (the desktop port needed a `stpcpy` shim **only** for its Windows host build, never macOS). Not an iOS issue.

## Still draft

The Swift layer can't be built on Windows (no Swift toolchain). On a Mac:

```sh
cd ios/FT8AFKit && swift test
```

Marking ready once the round-trip is green there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)