### PR TITLE
iOS port Phase 2a: audio/engine core (slot buffer + timing + DT calibration)

### DIFF
--- a/ios/FT8AFKit/Package.swift
+++ b/ios/FT8AFKit/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         ),
         .testTarget(
             name: "FT8AudioTests",
-            dependencies: ["FT8Audio"]
+            dependencies: ["FT8Audio", "FT8DSP"] // tests import FT8DSP for FT8.* constants
         ),
     ]
 )

--- a/ios/FT8AFKit/Package.swift
+++ b/ios/FT8AFKit/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
     ],
     products: [
         .library(name: "FT8DSP", targets: ["FT8DSP"]),
+        .library(name: "FT8Audio", targets: ["FT8Audio"]),
     ],
     targets: [
         // C bridge to ft8_lib. Header-search path points at the ft8_lib root so
@@ -43,6 +44,19 @@ let package = Package(
         .testTarget(
             name: "FT8DSPTests",
             dependencies: ["FT8DSP", "CFT8"]
+        ),
+        // Platform-neutral audio/engine core: rolling slot buffer + UTC slot
+        // timing + DT calibration (mirror desktop audio/slot.rs + the slot-timing
+        // and calibrate_dt logic in engine.rs). No AVFoundation here, so it builds
+        // and tests on the macOS host; the AVAudioEngine graph + resampler live in
+        // a later, device-only target.
+        .target(
+            name: "FT8Audio",
+            dependencies: ["FT8DSP"]
+        ),
+        .testTarget(
+            name: "FT8AudioTests",
+            dependencies: ["FT8Audio"]
         ),
     ]
 )

--- a/ios/FT8AFKit/Sources/FT8Audio/DtCalibrator.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/DtCalibrator.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Capture-latency (DT) calibration — port of `calibrate_dt` in desktop
+/// engine.rs, as a pure function so it is testable off the audio/engine thread.
+///
+/// The FT8 network is NTP-synced, so the *median* DT of a slot's decodes is a
+/// robust estimate of our own systematic timing error (clock residual + audio
+/// buffering latency). We nudge the RX-window offset toward zeroing it with a
+/// slow EMA so it tracks without chasing noise. The engine owns `rxOffsetMs`,
+/// persists it, and re-anchors the boundary; this type only computes the value.
+public enum DtCalibrator {
+    /// Need a few independent decodes for the median to be meaningful.
+    public static let minDecodes = 4
+    /// Correction fraction applied per slot.
+    public static let alpha = 0.6
+    /// Ignore tiny residuals to avoid jitter.
+    public static let deadbandMs: Int64 = 60
+    /// Clamp the accumulated offset to a sane range.
+    public static let maxOffsetMs: Int64 = 4_000
+
+    /// Given the current `rxOffsetMs` and this slot's decoded DTs (seconds),
+    /// return the updated `rxOffsetMs`. Returns the input unchanged when there
+    /// aren't enough decodes, the median residual is within the deadband, or the
+    /// nudge rounds to no change.
+    public static func calibrate(rxOffsetMs: Int64, decodedDtSec: [Float]) -> Int64 {
+        if decodedDtSec.count < minDecodes { return rxOffsetMs }
+
+        let sorted = decodedDtSec.sorted()
+        let medianDtMs = Int64(sorted[sorted.count / 2] * 1000.0) // truncates toward 0, as Rust `as i64`
+        if abs(medianDtMs) <= deadbandMs { return rxOffsetMs }
+
+        let adjusted = rxOffsetMs + Int64((Double(medianDtMs) * alpha).rounded())
+        return min(max(adjusted, -maxOffsetMs), maxOffsetMs)
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Audio/SlotAccumulator.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/SlotAccumulator.swift
@@ -4,26 +4,57 @@ import Foundation
 /// Rolling buffer of 12 kHz mono samples — the iOS equivalent of the Android
 /// `HamRecorder.VoiceDataMonitor` (port of desktop audio/slot.rs). Audio capture
 /// runs continuously and pushes here from the real-time tap; the engine copies
-/// the most recent 15 s slot at each UTC boundary. Thread-safe: the RT tap
-/// `push`es while the engine thread `takeSlot`s / `peekRecent`s.
+/// the most recent 15 s slot at each UTC boundary.
+///
+/// Backed by a fixed-size **circular buffer** so `push` is O(samples pushed) and
+/// never memmoves the whole buffer — important on the RT audio thread (the
+/// desktop uses a VecDeque for the same reason; a plain Array with `removeFirst`
+/// would shift ~16 s of samples on every push once full). Thread-safe: the RT
+/// tap `push`es while the engine thread `takeSlot`s / `peekRecent`s.
 public final class SlotAccumulator {
     private let lock = NSLock()
-    private var buf: [Float]
     private let cap: Int
+    private var storage: [Float] // length == cap
+    private var head = 0         // index of the oldest valid sample
+    private var filled = 0       // number of valid samples (0...cap)
 
     public init() {
         // Hold a little over one slot so a boundary copy always has a full slot.
         cap = FT8.slotSamples + Int(FT8.sampleRate) // ~16 s
-        buf = []
-        buf.reserveCapacity(cap)
+        storage = [Float](repeating: 0, count: cap)
     }
 
     /// Append freshly captured 12 kHz samples, evicting the oldest beyond `cap`.
     public func push(_ samples: [Float]) {
+        let m = samples.count
+        if m == 0 { return }
         lock.lock(); defer { lock.unlock() }
-        buf.append(contentsOf: samples)
-        if buf.count > cap {
-            buf.removeFirst(buf.count - cap)
+
+        if m >= cap {
+            // Only the most recent `cap` samples can be retained.
+            let start = m - cap
+            for i in 0..<cap { storage[i] = samples[start + i] }
+            head = 0
+            filled = cap
+            return
+        }
+
+        // Write `m` samples just past the newest, wrapping at the end (branch, not
+        // modulo, to keep the RT path cheap).
+        var write = head + filled
+        if write >= cap { write -= cap }
+        for i in 0..<m {
+            storage[write] = samples[i]
+            write += 1
+            if write == cap { write = 0 }
+        }
+
+        let newFilled = filled + m
+        if newFilled > cap {
+            head = (head + (newFilled - cap)) % cap // drop the overrun oldest
+            filled = cap
+        } else {
+            filled = newFilled
         }
     }
 
@@ -32,31 +63,45 @@ public final class SlotAccumulator {
     public func takeSlot() -> [Float] {
         lock.lock(); defer { lock.unlock() }
         var out = [Float](repeating: 0, count: FT8.slotSamples)
-        let n = min(buf.count, FT8.slotSamples)
+        let n = min(filled, FT8.slotSamples)
         let startDst = FT8.slotSamples - n // most recent n land at the end
-        let srcStart = buf.count - n
-        for i in 0..<n { out[startDst + i] = buf[srcStart + i] }
+        copyRecent(n, into: &out, dstOffset: startDst)
         return out
     }
 
     /// Copy the most recent `n` samples (for the live waterfall FFT) without
-    /// disturbing the buffer. Returns fewer than `n` only during warm-up.
+    /// disturbing the buffer. Returns fewer than `n` only during warm-up, and an
+    /// empty array for `n <= 0`.
     public func peekRecent(_ n: Int) -> [Float] {
         lock.lock(); defer { lock.unlock() }
-        let take = min(n, buf.count)
+        let take = max(0, min(n, filled))
         if take == 0 { return [] }
-        return Array(buf[(buf.count - take)...])
+        var out = [Float](repeating: 0, count: take)
+        copyRecent(take, into: &out, dstOffset: 0)
+        return out
     }
 
     public var count: Int {
         lock.lock(); defer { lock.unlock() }
-        return buf.count
+        return filled
     }
 
     public var isEmpty: Bool { count == 0 }
 
     public func clear() {
         lock.lock(); defer { lock.unlock() }
-        buf.removeAll(keepingCapacity: true)
+        head = 0
+        filled = 0
+    }
+
+    /// Copy the most recent `n` valid samples (n <= filled) into `out` starting at
+    /// `dstOffset`, in chronological order. Caller holds `lock`.
+    private func copyRecent(_ n: Int, into out: inout [Float], dstOffset: Int) {
+        var src = (head + filled - n) % cap
+        for i in 0..<n {
+            out[dstOffset + i] = storage[src]
+            src += 1
+            if src == cap { src = 0 }
+        }
     }
 }

--- a/ios/FT8AFKit/Sources/FT8Audio/SlotAccumulator.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/SlotAccumulator.swift
@@ -1,0 +1,62 @@
+import FT8DSP
+import Foundation
+
+/// Rolling buffer of 12 kHz mono samples — the iOS equivalent of the Android
+/// `HamRecorder.VoiceDataMonitor` (port of desktop audio/slot.rs). Audio capture
+/// runs continuously and pushes here from the real-time tap; the engine copies
+/// the most recent 15 s slot at each UTC boundary. Thread-safe: the RT tap
+/// `push`es while the engine thread `takeSlot`s / `peekRecent`s.
+public final class SlotAccumulator {
+    private let lock = NSLock()
+    private var buf: [Float]
+    private let cap: Int
+
+    public init() {
+        // Hold a little over one slot so a boundary copy always has a full slot.
+        cap = FT8.slotSamples + Int(FT8.sampleRate) // ~16 s
+        buf = []
+        buf.reserveCapacity(cap)
+    }
+
+    /// Append freshly captured 12 kHz samples, evicting the oldest beyond `cap`.
+    public func push(_ samples: [Float]) {
+        lock.lock(); defer { lock.unlock() }
+        buf.append(contentsOf: samples)
+        if buf.count > cap {
+            buf.removeFirst(buf.count - cap)
+        }
+    }
+
+    /// Copy the most recent full slot (`FT8.slotSamples`), front-padding with
+    /// silence if fewer samples have been captured so far (mirror take_slot).
+    public func takeSlot() -> [Float] {
+        lock.lock(); defer { lock.unlock() }
+        var out = [Float](repeating: 0, count: FT8.slotSamples)
+        let n = min(buf.count, FT8.slotSamples)
+        let startDst = FT8.slotSamples - n // most recent n land at the end
+        let srcStart = buf.count - n
+        for i in 0..<n { out[startDst + i] = buf[srcStart + i] }
+        return out
+    }
+
+    /// Copy the most recent `n` samples (for the live waterfall FFT) without
+    /// disturbing the buffer. Returns fewer than `n` only during warm-up.
+    public func peekRecent(_ n: Int) -> [Float] {
+        lock.lock(); defer { lock.unlock() }
+        let take = min(n, buf.count)
+        if take == 0 { return [] }
+        return Array(buf[(buf.count - take)...])
+    }
+
+    public var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return buf.count
+    }
+
+    public var isEmpty: Bool { count == 0 }
+
+    public func clear() {
+        lock.lock(); defer { lock.unlock() }
+        buf.removeAll(keepingCapacity: true)
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Audio/SlotClock.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/SlotClock.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// UTC 15 s slot timing for the FT8 cycle (the math behind the `FT8Engine` run
+/// loop; port of the slot-id / boundary arithmetic in desktop engine.rs).
+///
+/// All times are Unix-epoch milliseconds, already including any NTP clock offset.
+/// Uses Euclidean division so results stay correct even if a clock correction
+/// pushes the effective time slightly negative (matches Rust `div_euclid` /
+/// `rem_euclid`, which the desktop relies on).
+public enum SlotClock {
+    public static let cycleMs: Int64 = 15_000
+
+    /// The slot index containing `nowMs` (15 s slots since the epoch).
+    public static func slotID(atUtcMs nowMs: Int64) -> Int64 {
+        floorDiv(nowMs, cycleMs)
+    }
+
+    /// Milliseconds elapsed into the current 15 s slot (0..<15000).
+    public static func msIntoCycle(atUtcMs nowMs: Int64) -> Int64 {
+        floorMod(nowMs, cycleMs)
+    }
+
+    /// The RX-window slot index. The RX boundary runs on a clock shifted later by
+    /// the capture-latency compensation (`rxOffsetMs`) so the sliced 15 s slot
+    /// aligns with the audio that has actually arrived in the buffer; UTC display
+    /// and TX still use the unshifted clock.
+    public static func rxSlotID(atUtcMs nowMs: Int64, rxOffsetMs: Int64) -> Int64 {
+        floorDiv(nowMs - rxOffsetMs, cycleMs)
+    }
+
+    /// Even/odd parity of a slot (the FT8 sequential / TX-turn bit).
+    public static func parity(slotID: Int64) -> Int64 {
+        floorMod(slotID, 2)
+    }
+
+    // Euclidean division/modulo: quotient floored toward -inf so the remainder is
+    // always in [0, |b|). For non-negative inputs these equal `/` and `%`.
+    static func floorDiv(_ a: Int64, _ b: Int64) -> Int64 {
+        let q = a / b, r = a % b
+        return (r != 0 && (r < 0) != (b < 0)) ? q - 1 : q
+    }
+    static func floorMod(_ a: Int64, _ b: Int64) -> Int64 {
+        let r = a % b
+        return (r != 0 && (r < 0) != (b < 0)) ? r + b : r
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/DtCalibratorTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/DtCalibratorTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import FT8Audio
+
+final class DtCalibratorTests: XCTestCase {
+
+    func testTooFewDecodesLeavesOffsetUnchanged() {
+        let dts: [Float] = [0.5, 0.5, 0.5] // < minDecodes (4)
+        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 0, decodedDtSec: dts), 0)
+    }
+
+    func testWithinDeadbandLeavesOffsetUnchanged() {
+        // Median DT 40 ms < 60 ms deadband -> no change.
+        let dts: [Float] = [0.04, 0.04, 0.04, 0.04, 0.04]
+        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 123, decodedDtSec: dts), 123)
+    }
+
+    func testNudgesTowardMedianByAlpha() {
+        // Median DT = 0.5 s = 500 ms; nudge = round(500 * 0.6) = 300.
+        let dts: [Float] = [0.5, 0.5, 0.5, 0.5]
+        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 0, decodedDtSec: dts), 300)
+    }
+
+    func testNegativeMedianNudgesNegative() {
+        let dts: [Float] = [-0.2, -0.2, -0.2, -0.2] // -200 ms median
+        // round(-200 * 0.6) = -120, from a starting offset of 100 -> -20.
+        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 100, decodedDtSec: dts), -20)
+    }
+
+    func testMedianIsOrderIndependentAndUsesUpperMiddle() {
+        // 5 values; index 5/2 = 2 of the sorted list is the median (0.5).
+        let unsorted: [Float] = [0.9, 0.1, 0.5, 0.5, 0.5]
+        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 0, decodedDtSec: unsorted), 300)
+    }
+
+    func testClampsToMaxOffset() {
+        // Huge positive median pushes well past the +4000 ms clamp.
+        let dts = [Float](repeating: 9.0, count: 4) // 9000 ms median
+        let out = DtCalibrator.calibrate(rxOffsetMs: 3_900, decodedDtSec: dts)
+        XCTAssertEqual(out, DtCalibrator.maxOffsetMs)
+    }
+
+    func testClampsToMinOffset() {
+        let dts = [Float](repeating: -9.0, count: 4)
+        let out = DtCalibrator.calibrate(rxOffsetMs: -3_900, decodedDtSec: dts)
+        XCTAssertEqual(out, -DtCalibrator.maxOffsetMs)
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SlotAccumulatorTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SlotAccumulatorTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import FT8DSP
+@testable import FT8Audio
+
+final class SlotAccumulatorTests: XCTestCase {
+
+    func testTakeSlotFrontPadsWhenUnderfilled() {
+        let acc = SlotAccumulator()
+        let n = 1000
+        acc.push((0..<n).map { Float($0) }) // 0,1,2,...,999
+        let slot = acc.takeSlot()
+        XCTAssertEqual(slot.count, FT8.slotSamples)
+        // Leading region is silence...
+        XCTAssertTrue(slot[0..<(FT8.slotSamples - n)].allSatisfy { $0 == 0 })
+        // ...and the captured samples land flush at the end, in order.
+        XCTAssertEqual(slot[FT8.slotSamples - n], 0)
+        XCTAssertEqual(slot[FT8.slotSamples - 1], Float(n - 1))
+    }
+
+    func testTakeSlotReturnsMostRecentFullSlotWhenOverfilled() {
+        let acc = SlotAccumulator()
+        let extra = 5000
+        // Push more than a slot; the oldest `extra` samples should be dropped.
+        acc.push((0..<(FT8.slotSamples + extra)).map { Float($0) })
+        let slot = acc.takeSlot()
+        XCTAssertEqual(slot.count, FT8.slotSamples)
+        XCTAssertEqual(slot.first, Float(extra))                    // first kept sample
+        XCTAssertEqual(slot.last, Float(FT8.slotSamples + extra - 1)) // newest sample
+    }
+
+    func testCapEvictsOldestBeyondAboutSixteenSeconds() {
+        let acc = SlotAccumulator()
+        let cap = FT8.slotSamples + Int(FT8.sampleRate)
+        acc.push([Float](repeating: 1, count: cap + 4096))
+        XCTAssertEqual(acc.count, cap, "buffer is capped at ~16 s")
+    }
+
+    func testPeekRecentDuringWarmupAndSteadyState() {
+        let acc = SlotAccumulator()
+        XCTAssertEqual(acc.peekRecent(2048).count, 0, "empty buffer yields nothing")
+        acc.push((0..<500).map { Float($0) })
+        XCTAssertEqual(acc.peekRecent(2048).count, 500, "warm-up: clamped to what's available")
+        let recent = acc.peekRecent(100)
+        XCTAssertEqual(recent.count, 100)
+        XCTAssertEqual(recent.first, 400) // most recent 100 of 0..499
+        XCTAssertEqual(recent.last, 499)
+    }
+
+    func testClear() {
+        let acc = SlotAccumulator()
+        acc.push([Float](repeating: 1, count: 100))
+        XCTAssertFalse(acc.isEmpty)
+        acc.clear()
+        XCTAssertTrue(acc.isEmpty)
+        XCTAssertEqual(acc.count, 0)
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SlotAccumulatorTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SlotAccumulatorTests.swift
@@ -46,6 +46,30 @@ final class SlotAccumulatorTests: XCTestCase {
         XCTAssertEqual(recent.last, 499)
     }
 
+    func testPeekRecentNegativeOrZeroReturnsEmpty() {
+        let acc = SlotAccumulator()
+        acc.push((0..<500).map { Float($0) })
+        XCTAssertEqual(acc.peekRecent(-10).count, 0, "negative n must not crash")
+        XCTAssertEqual(acc.peekRecent(0).count, 0)
+    }
+
+    /// Pushing across the ring boundary keeps samples in chronological order and
+    /// evicts only the overrun (exercises the circular-buffer wrap).
+    func testRingWrapPreservesOrderAndEvictsOldest() {
+        let acc = SlotAccumulator()
+        let cap = FT8.slotSamples + Int(FT8.sampleRate)
+        acc.push([Float](repeating: -1, count: cap - 10)) // nearly full of sentinels
+        acc.push((0..<2000).map { Float($0) })            // forces eviction + wrap
+        XCTAssertEqual(acc.count, cap)
+        let recent = acc.peekRecent(2000)
+        XCTAssertEqual(recent.count, 2000)
+        XCTAssertEqual(recent.first, 0)    // newest run came back in order...
+        XCTAssertEqual(recent.last, 1999)  // ...across the wrap boundary
+        // The full slot's newest tail matches too.
+        let slot = acc.takeSlot()
+        XCTAssertEqual(slot.last, 1999)
+    }
+
     func testClear() {
         let acc = SlotAccumulator()
         acc.push([Float](repeating: 1, count: 100))

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SlotClockTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SlotClockTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import FT8Audio
+
+final class SlotClockTests: XCTestCase {
+
+    func testSlotIDAndMsIntoCycle() {
+        // 3 full cycles + 4.2 s into the 4th.
+        let now: Int64 = 3 * 15_000 + 4_200
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: now), 3)
+        XCTAssertEqual(SlotClock.msIntoCycle(atUtcMs: now), 4_200)
+    }
+
+    func testBoundaryIsExact() {
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: 45_000), 3)
+        XCTAssertEqual(SlotClock.msIntoCycle(atUtcMs: 45_000), 0)
+    }
+
+    func testRxSlotIDShiftsByOffset() {
+        // 200 ms into a new slot, but a 500 ms capture-latency offset means the
+        // RX window is still finishing the previous slot.
+        let now: Int64 = 60_000 + 200
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: now), 4)
+        XCTAssertEqual(SlotClock.rxSlotID(atUtcMs: now, rxOffsetMs: 500), 3)
+        // Zero offset collapses to the plain slot id.
+        XCTAssertEqual(SlotClock.rxSlotID(atUtcMs: now, rxOffsetMs: 0), 4)
+    }
+
+    func testParityAlternates() {
+        XCTAssertEqual(SlotClock.parity(slotID: 0), 0)
+        XCTAssertEqual(SlotClock.parity(slotID: 1), 1)
+        XCTAssertEqual(SlotClock.parity(slotID: 2), 0)
+        XCTAssertEqual(SlotClock.parity(slotID: 3), 1)
+    }
+
+    func testEuclideanWithNegativeTimes() {
+        // A clock correction can push the effective time slightly negative; the
+        // remainder must stay non-negative (Euclidean), not go to -something.
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: -1), -1)
+        XCTAssertEqual(SlotClock.msIntoCycle(atUtcMs: -1), 14_999)
+        XCTAssertEqual(SlotClock.parity(slotID: -1), 1)
+        XCTAssertEqual(SlotClock.parity(slotID: -2), 0)
+    }
+}


### PR DESCRIPTION
## What

First slice of Phase 2 (audio). Adds the **platform-neutral, host-testable core** of the iOS audio/engine layer as a new `FT8Audio` target — independent of the decoder (#284) and of any iOS framework, so it builds and runs under `swift test` on the macOS host with no simulator.

- **`SlotAccumulator`** — rolling ~16 s ring of 12 kHz mono samples. `push` from the RT tap; `takeSlot` copies the most recent 15 s slot (front-padded with silence during warm-up); `peekRecent` feeds the live waterfall FFT. Port of desktop `audio/slot.rs` (NSLock in place of parking_lot).
- **`SlotClock`** — UTC 15 s slot-id / ms-into-cycle / rx-window (rxOffset-shifted) / parity math, using **Euclidean** div/mod so a negative clock correction stays correct. Port of the slot-timing arithmetic in `engine.rs`.
- **`DtCalibrator`** — the `calibrate_dt` EMA (median decoded DT → rxOffset nudge, with minDecodes / alpha / deadband / clamp) as a pure function. Port of `engine.rs`.

## Tests

`FT8AudioTests` covers front-padding, overfill windowing, cap eviction, peek warm-up; slot/rx/parity timing including negative times (Euclidean); and every `calibrate` branch (too-few, deadband, nudge, negative, clamp both ways, order-independence).

## Scope / why this split

These three are faithful 1:1 ports of well-understood Rust with deterministic tests — exactly the part of Phase 2 that can be authored and verified without a device. The **device-only** remainder of Phase 2 (AVAudioEngine graph, `AudioInputSource` + `MicAudioSource`, the `AVAudioConverter` resampler, and the `FT8Engine` that wires decoder + audio + timing into live decode) lands in follow-up PRs once #284 is merged. `SlotClock`/`DtCalibrator` live in `FT8Audio` for now to stay decoder-independent; the real `FT8Engine` target will consume them.

## Still draft

No Swift toolchain on Windows (the dev box). On a Mac:

```sh
cd ios/FT8AFKit && swift test
```

Marking ready once green there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)