### PR TITLE
iOS port Phase 2: WaterfallRowBuilder (spectrum -> brightness)

### DIFF
--- a/ios/FT8AFKit/Sources/FT8Audio/WaterfallRowBuilder.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/WaterfallRowBuilder.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// One row of the scrolling waterfall: per-column brightness (0...255) plus the
+/// Hz width each column spans.
+public struct WaterfallRow: Equatable {
+    public let bins: [UInt8]
+    public let hzPerCol: Float
+    public init(bins: [UInt8], hzPerCol: Float) {
+        self.bins = bins
+        self.hzPerCol = hzPerCol
+    }
+}
+
+/// Turns an averaged power spectrum into a colorized waterfall row — the
+/// platform-neutral, testable core of `WaterfallView` (per the project rule of
+/// extracting `DrawScope`/decision logic into a plain type). Port of the
+/// dB-magnitude → percentile-noise-floor → black-point mapping in desktop
+/// engine.rs `emit_waterfall_row`.
+///
+/// The FFT itself (Welch-averaging `segments` overlapping Hann-windowed FFTs)
+/// stays in the engine / vDSP and is **not** part of this type: callers hand in
+/// `summedPower` (the sum over `segments` of |FFT bin|² for each displayed bin).
+/// This keeps the brightness/geometry logic host-testable with synthetic spectra.
+public struct WaterfallRowBuilder {
+    // Tunables — match the WF_* constants in desktop engine.rs.
+    public static let fftSize = 2048              // ~5.86 Hz/bin at 12 kHz
+    public static let segments = 6                // WF_AVG (Welch segments)
+    public static let step = fftSize / 2          // WF_STEP, 50% overlap
+    public static let maxHz: Float = 3500         // displayed top of the audio band
+    public static let spanDb: Float = 26          // dB above black that maps to full brightness
+    public static let blackOffsetDb: Float = 4    // push black above the noise floor
+    public static let noiseFloorPercentile: Float = 0.30
+    private static let floorEmaUp: Float = 0.9    // previous-floor weight
+    private static let floorEmaNew: Float = 0.1   // new-sample weight
+
+    /// Samples the engine must `peekRecent` to build one row.
+    public static func samplesNeeded() -> Int { fftSize + (segments - 1) * step }
+
+    /// Hz per FFT bin at a given sample rate.
+    public static func binHz(sampleRate: Int) -> Float { Float(sampleRate) / Float(fftSize) }
+
+    /// Number of displayed columns: bins up to `maxHz`, capped at the Nyquist half.
+    public static func columns(sampleRate: Int) -> Int {
+        let bh = binHz(sampleRate: sampleRate)
+        guard bh > 0 else { return 1 }
+        return min(fftSize / 2, max(1, Int(maxHz / bh)))
+    }
+
+    /// EMA state of the noise floor (dB). Seeded at 0 like the engine; it settles
+    /// onto the real floor within a few rows.
+    public private(set) var floorDb: Float
+
+    public init(floorDb: Float = 0) { self.floorDb = floorDb }
+
+    /// Build one brightness row from the summed power spectrum. `summedPower[i]`
+    /// is Σ over `segments` of |FFT bin i|² (length == displayed columns). Updates
+    /// the noise-floor EMA as a side effect.
+    public mutating func buildRow(summedPower: [Float], sampleRate: Int) -> WaterfallRow {
+        let cols = summedPower.count
+        let hzPerCol = Self.binHz(sampleRate: sampleRate)
+        guard cols > 0 else { return WaterfallRow(bins: [], hzPerCol: hzPerCol) }
+
+        // Averaged power -> dB magnitude per bin.
+        var dbs = [Float](repeating: 0, count: cols)
+        for i in 0..<cols {
+            let avg = summedPower[i] / Float(Self.segments)
+            let mag = (avg.squareRoot() * 2.0) / Float(Self.fftSize)
+            dbs[i] = 20.0 * log10(mag + 1e-12)
+        }
+
+        // Noise floor from the 30th-percentile dB (robust on a busy band),
+        // smoothed over time.
+        let sorted = dbs.sorted()
+        let idx = min(Int(Float(cols) * Self.noiseFloorPercentile), cols - 1)
+        floorDb = floorDb * Self.floorEmaUp + sorted[idx] * Self.floorEmaNew
+
+        // Black point a few dB above the floor so noise renders dark; only signals
+        // above it take on color.
+        let blackPoint = floorDb + Self.blackOffsetDb
+        var bins = [UInt8](repeating: 0, count: cols)
+        for i in 0..<cols {
+            let t = min(max((dbs[i] - blackPoint) / Self.spanDb, 0), 1)
+            bins[i] = UInt8(t * 255.0)
+        }
+        return WaterfallRow(bins: bins, hzPerCol: hzPerCol)
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallRowBuilderTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallRowBuilderTests.swift
@@ -48,7 +48,7 @@ final class WaterfallRowBuilderTests: XCTestCase {
         // black point = floor + 4 = -56 dB; span 26 dB -> full bright at -30 dB.
         XCTAssertEqual(row.bins[0], 0, "noise floor renders dark")
         XCTAssertEqual(row.bins[10], 255, "strong signal saturates")
-        XCTAssertEqual(Int(row.bins[20]), 127, accuracy: 4, "-43 dB ~ mid brightness")
+        XCTAssertLessThanOrEqual(abs(Int(row.bins[20]) - 127), 4, "-43 dB ~ mid brightness")
         XCTAssertEqual(row.hzPerCol, 12_000.0 / 2_048.0, accuracy: 1e-4)
     }
 

--- a/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallRowBuilderTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallRowBuilderTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import Foundation
+import FT8Audio
+
+final class WaterfallRowBuilderTests: XCTestCase {
+
+    /// Inverse of the builder's power->dB step: the summed power that yields a
+    /// given per-bin dB magnitude, so tests can specify spectra in dB.
+    private func summedPower(forDb db: Float) -> Float {
+        let mag = Float(pow(10.0, Double(db) / 20.0))
+        let s = mag * Float(WaterfallRowBuilder.fftSize) / 2.0 // == sqrt(avg power)
+        return Float(WaterfallRowBuilder.segments) * s * s
+    }
+
+    func testGeometry() {
+        XCTAssertEqual(WaterfallRowBuilder.binHz(sampleRate: 12_000), 12_000.0 / 2_048.0, accuracy: 1e-4)
+        XCTAssertEqual(WaterfallRowBuilder.columns(sampleRate: 12_000), 597) // 3500 / 5.859 Hz, < Nyquist half
+        XCTAssertEqual(WaterfallRowBuilder.samplesNeeded(), 2_048 + 5 * 1_024)
+    }
+
+    func testEmptySpectrumYieldsEmptyRow() {
+        var b = WaterfallRowBuilder()
+        let row = b.buildRow(summedPower: [], sampleRate: 12_000)
+        XCTAssertTrue(row.bins.isEmpty)
+        XCTAssertEqual(row.hzPerCol, 12_000.0 / 2_048.0, accuracy: 1e-4)
+    }
+
+    func testFloorEmaStepsTowardPercentile() {
+        var b = WaterfallRowBuilder(floorDb: 0)
+        let spec = [Float](repeating: summedPower(forDb: -50), count: 50)
+        _ = b.buildRow(summedPower: spec, sampleRate: 12_000)
+        // One EMA step from 0 toward the -50 dB 30th-percentile floor: 0.9*0 + 0.1*(-50).
+        XCTAssertEqual(b.floorDb, -5, accuracy: 0.3)
+    }
+
+    func testBrightnessMappingOnceFloorSettles() {
+        var b = WaterfallRowBuilder()
+        let cols = 100
+        var spec = [Float](repeating: summedPower(forDb: -60), count: cols) // noise floor
+        spec[10] = summedPower(forDb: -25) // strong signal (above top of span)
+        spec[20] = summedPower(forDb: -43) // mid signal (~half brightness)
+
+        // Let the noise-floor EMA converge onto -60 dB.
+        var row = WaterfallRow(bins: [], hzPerCol: 0)
+        for _ in 0..<200 { row = b.buildRow(summedPower: spec, sampleRate: 12_000) }
+
+        XCTAssertEqual(b.floorDb, -60, accuracy: 0.5)
+        // black point = floor + 4 = -56 dB; span 26 dB -> full bright at -30 dB.
+        XCTAssertEqual(row.bins[0], 0, "noise floor renders dark")
+        XCTAssertEqual(row.bins[10], 255, "strong signal saturates")
+        XCTAssertEqual(Int(row.bins[20]), 127, accuracy: 4, "-43 dB ~ mid brightness")
+        XCTAssertEqual(row.hzPerCol, 12_000.0 / 2_048.0, accuracy: 1e-4)
+    }
+
+    func testColumnsClampToNyquistHalfAtHighRates() {
+        // A very high rate would put maxHz within the first few bins; columns must
+        // still be >= 1 and never exceed fftSize/2.
+        XCTAssertGreaterThanOrEqual(WaterfallRowBuilder.columns(sampleRate: 48_000), 1)
+        XCTAssertLessThanOrEqual(WaterfallRowBuilder.columns(sampleRate: 48_000), WaterfallRowBuilder.fftSize / 2)
+    }
+}


### PR DESCRIPTION
## What

Adds `WaterfallRowBuilder` — the platform-neutral, host-testable core of the waterfall display, extracted from the view per the project's "pull DrawScope/decision logic into a testable type" rule.

Port of the dB-magnitude → 30th-percentile noise-floor (EMA) → black-point brightness mapping in desktop `engine.rs::emit_waterfall_row`, plus geometry (`binHz`, `columns` up to `maxHz` capped at the Nyquist half, `samplesNeeded`). Constants match the desktop `WF_*` (fftSize 2048, 6 Welch segments, 26 dB span, +4 dB black point, 30th-pct floor).

The **FFT itself** (Welch-averaging overlapping Hann-windowed FFTs) stays in the engine / vDSP and is deliberately **not** part of this type — callers pass in `summedPower` (Σ over segments of |FFT bin|²). That keeps the brightness + geometry logic testable with synthetic spectra and free of any FFT/AVFoundation dependency.

## Tests

`WaterfallRowBuilderTests`: geometry; empty-spectrum; floor-EMA single step; the full dB→brightness mapping once the floor settles (noise dark, strong signal saturates to 255, mid signal ~half); and the Nyquist-half column clamp at high sample rates. Spectra are specified in dB via an inverse-of-the-builder helper so the expected brightnesses are exact.

## Notes

Adds to the `FT8Audio` target (introduced in #285, now merged), so this targets `dev` directly. Decoder-independent.

## Still draft

No Swift toolchain on Windows. On a Mac: `cd ios/FT8AFKit && swift test`. Ready once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)