### PR TITLE
iOS port Phase 4 core: QsoEngine auto-sequencer state machine

### DIFF
--- a/ios/FT8AFKit/Package.swift
+++ b/ios/FT8AFKit/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
     products: [
         .library(name: "FT8DSP", targets: ["FT8DSP"]),
         .library(name: "FT8Audio", targets: ["FT8Audio"]),
+        .library(name: "FT8Engine", targets: ["FT8Engine"]),
     ],
     targets: [
         // C bridge to ft8_lib. Header-search path points at the ft8_lib root so
@@ -57,6 +58,18 @@ let package = Package(
         .testTarget(
             name: "FT8AudioTests",
             dependencies: ["FT8Audio", "FT8DSP"] // tests import FT8DSP for FT8.* constants
+        ),
+        // QSO auto-sequencer state machine + the QsoRecord it emits (port of
+        // desktop qso.rs). Pure logic over DecodedMessage (FT8DSP); no I/O, so the
+        // whole thing is host-testable. The live FT8Engine actor (audio + rig +
+        // cycle loop) is added here later as device code.
+        .target(
+            name: "FT8Engine",
+            dependencies: ["FT8DSP"]
+        ),
+        .testTarget(
+            name: "FT8EngineTests",
+            dependencies: ["FT8Engine", "FT8DSP"] // tests build DecodedMessage fixtures
         ),
     ]
 )

--- a/ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift
@@ -1,0 +1,284 @@
+import FT8DSP
+import Foundation
+
+/// The last message we transmitted — drives what reply we expect next.
+public enum TxStage: String, Codable, Equatable {
+    case idle
+    case cq
+    case grid           // answered a CQ with our grid
+    case report         // sent a signal report
+    case rReport = "r_report" // sent R + report
+    case rr73
+    case bye73
+}
+
+/// Snapshot of QSO/TX state for the UI.
+public struct QsoStatus: Codable, Equatable {
+    public var active: Bool
+    public var stage: TxStage
+    public var target: String?
+    public var txMessage: String?
+    public var reportSent: Int?
+    public var reportRcvd: Int?
+}
+
+/// What the engine wants the scheduler to do after processing a slot.
+public enum QsoOutcome: Equatable {
+    /// A QSO finished and should be logged.
+    case completed(QsoRecord)
+}
+
+/// Classified content of a decoded reply.
+private enum Content {
+    case grid(String)
+    case report(Int)
+    case rReport(Int)
+    case rr73
+    case rrr
+    case bye73
+    case other
+}
+
+/// FT8 QSO auto-sequencer — a pure state machine ported from desktop qso.rs (in
+/// spirit from `FT8TransmitSignal` + `FunctionOfTransmit`). It reacts to each RX
+/// slot's decodes and decides the next TX message, covering both roles: calling
+/// CQ (initiator) and answering a CQ (answerer). On completion it emits a
+/// `QsoRecord` to log. No I/O lives here, so it is fully unit-testable; the
+/// scheduler turns its decisions into encode + PTT + DB + events.
+public final class QsoEngine {
+    public var myCall: String
+    public var myGrid: String       // 4-char
+    public var band: String = ""
+    public var freqMhz: String = ""
+    public var active: Bool = false
+    public var autoReturnToCq: Bool = true
+
+    private var stage: TxStage = .idle
+    private var target: String?
+    private var gridRcvd: String?
+    private var reportSent: Int?
+    private var reportRcvd: Int?
+    private var pendingTx: String?
+    private var startedMs: Int64 = 0
+
+    public init(myCall: String, myGrid: String) {
+        self.myCall = myCall.uppercased()
+        self.myGrid = grid4(myGrid).uppercased()
+    }
+
+    public func status() -> QsoStatus {
+        QsoStatus(active: active, stage: stage, target: target,
+                  txMessage: pendingTx, reportSent: reportSent, reportRcvd: reportRcvd)
+    }
+
+    /// The message queued for the next TX slot (nil when idle).
+    public var txMessage: String? { pendingTx }
+
+    /// Begin calling CQ.
+    public func startCq() {
+        resetQso()
+        active = true
+        stage = .cq
+        pendingTx = "CQ \(myCall) \(myGrid)"
+    }
+
+    /// Begin answering a specific decoded CQ (operator tapped a station).
+    public func answer(_ msg: DecodedMessage) {
+        resetQso()
+        active = true
+        target = msg.callFrom.uppercased()
+        gridRcvd = msg.grid.isEmpty ? nil : msg.grid
+        reportSent = clampReport(msg.snr)
+        stage = .grid
+        startedMs = FT8Time.nowUnixMs()
+        pendingTx = "\(target!) \(myCall) \(myGrid)"
+    }
+
+    /// Operator manually picks which standard message to send next (the WSJT-X
+    /// Tx1–Tx5 buttons). Requires an active target; selecting `.cq`/`.idle` falls
+    /// through to start-CQ / stop so the same control covers the whole strip.
+    public func setStage(_ newStage: TxStage) {
+        switch newStage {
+        case .cq: return startCq()
+        case .idle: return stop()
+        default: break
+        }
+        guard let dx = target else { return } // no station selected yet
+        active = true
+        switch newStage {
+        case .grid:
+            pendingTx = "\(dx) \(myCall) \(myGrid)"
+            stage = .grid
+        case .report: sendReport(dx)
+        case .rReport: sendRReport(dx)
+        case .rr73: sendRr73(dx)
+        case .bye73:
+            pendingTx = "\(dx) \(myCall) 73"
+            stage = .bye73
+        case .cq, .idle: break // handled above
+        }
+    }
+
+    /// Send a free-text / arbitrary message once.
+    public func setFreeText(_ text: String) {
+        active = true
+        pendingTx = text.uppercased()
+    }
+
+    public func stop() {
+        active = false
+        pendingTx = nil
+        stage = .idle
+    }
+
+    private func resetQso() {
+        target = nil
+        gridRcvd = nil
+        reportSent = nil
+        reportRcvd = nil
+        startedMs = FT8Time.nowUnixMs()
+    }
+
+    /// Process the decoded messages of a finished RX slot. Updates the queued TX
+    /// message for the next slot and returns a completion outcome if a QSO ended.
+    public func processRx(_ messages: [DecodedMessage]) -> QsoOutcome? {
+        if !active || stage == .idle { return nil }
+
+        // Find a message addressed to us, from our target if we have one.
+        let mine = messages.first { m in
+            m.callTo.uppercased() == myCall
+                && (target == nil || m.callFrom.uppercased() == target!)
+        }
+        guard let msg = mine else { return nil } // no reply this slot; scheduler retransmits
+
+        if target == nil {
+            target = msg.callFrom.uppercased()
+            startedMs = FT8Time.nowUnixMs()
+        }
+        let dx = target!
+        let content = classify(msg)
+
+        switch stage {
+        case .cq:
+            switch content {
+            case .grid(let g):
+                gridRcvd = g
+                reportSent = clampReport(msg.snr)
+                sendReport(dx)
+            case .report(let n):
+                reportRcvd = n
+                reportSent = clampReport(msg.snr)
+                sendRReport(dx)
+            default: break
+            }
+        case .grid:
+            switch content {
+            case .report(let n):
+                reportRcvd = n
+                // Our report reflects the DX signal from this decode (as WSJT-X recomputes).
+                reportSent = clampReport(msg.snr)
+                sendRReport(dx)
+            case .rReport(let n):
+                reportRcvd = n
+                sendRr73(dx)
+            default: break
+            }
+        case .report:
+            switch content {
+            case .rReport(let n):
+                reportRcvd = n
+                sendRr73(dx)
+            case .rr73, .rrr, .bye73:
+                return complete(dx)
+            default: break
+            }
+        case .rReport:
+            switch content {
+            case .rr73, .rrr, .bye73:
+                // Acknowledge with 73, then log.
+                pendingTx = "\(dx) \(myCall) 73"
+                stage = .bye73
+                return complete(dx)
+            default: break
+            }
+        case .rr73:
+            switch content {
+            case .bye73, .rr73, .rrr:
+                return complete(dx)
+            default: break
+            }
+        case .bye73, .idle:
+            break
+        }
+        return nil
+    }
+
+    private func sendReport(_ dx: String) {
+        let r = reportSent ?? 0
+        pendingTx = "\(dx) \(myCall) \(fmtReport(r))"
+        stage = .report
+    }
+
+    private func sendRReport(_ dx: String) {
+        let r = reportSent ?? 0
+        pendingTx = "\(dx) \(myCall) R\(fmtReport(r))"
+        stage = .rReport
+    }
+
+    private func sendRr73(_ dx: String) {
+        pendingTx = "\(dx) \(myCall) RR73"
+        stage = .rr73
+    }
+
+    private func complete(_ dx: String) -> QsoOutcome {
+        let record = QsoRecord(
+            call: dx,
+            gridsquare: gridRcvd ?? "",
+            mode: "FT8",
+            rstSent: reportSent.map(fmtReport) ?? "",
+            rstRcvd: reportRcvd.map(fmtReport) ?? "",
+            qsoDate: FT8Time.yyyymmdd(fromMs: startedMs),
+            timeOn: FT8Time.hhmmss(fromMs: startedMs),
+            qsoDateOff: FT8Time.utcYyyymmdd(),
+            timeOff: FT8Time.utcHhmmss(),
+            band: band,
+            freq: freqMhz,
+            stationCallsign: myCall,
+            myGridsquare: myGrid,
+            comment: ""
+        )
+
+        // Return to CQ or go idle.
+        if autoReturnToCq {
+            resetQso()
+            stage = .cq
+            pendingTx = "CQ \(myCall) \(myGrid)"
+        } else {
+            stop()
+        }
+        return .completed(record)
+    }
+}
+
+/// FT8 reports are clamped to roughly [-30, +30].
+func clampReport(_ snr: Int) -> Int { min(30, max(-30, snr)) }
+
+/// Format a report as a signed, zero-padded 2+ digit string: -9 -> "-09", 5 -> "+05".
+func fmtReport(_ n: Int) -> String { String(format: "%+03d", Int32(n)) }
+
+private func classify(_ msg: DecodedMessage) -> Content {
+    if !msg.grid.isEmpty { return .grid(msg.grid) }
+    let extra = msg.extra.trimmingCharacters(in: .whitespacesAndNewlines)
+    switch extra {
+    case "RR73": return .rr73
+    case "RRR": return .rrr
+    case "73": return .bye73
+    default: break
+    }
+    if extra.hasPrefix("R") {
+        let rest = String(extra.dropFirst())
+        if let n = Int(rest) { return .rReport(n) }
+    }
+    if let n = Int(extra) { return .report(n) }
+    return .other
+}

--- a/ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift
@@ -87,7 +87,7 @@ public final class QsoEngine {
         resetQso()
         active = true
         target = msg.callFrom.uppercased()
-        gridRcvd = msg.grid.isEmpty ? nil : msg.grid
+        gridRcvd = msg.grid.isEmpty ? nil : grid4(msg.grid).uppercased()
         reportSent = clampReport(msg.snr)
         stage = .grid
         startedMs = FT8Time.nowUnixMs()
@@ -129,6 +129,9 @@ public final class QsoEngine {
         active = false
         pendingTx = nil
         stage = .idle
+        // Clear the QSO context too, so a later manual setStage() can't re-activate
+        // and transmit to a stale target/report from the QSO we just stopped.
+        resetQso()
     }
 
     private func resetQso() {
@@ -143,6 +146,13 @@ public final class QsoEngine {
     /// message for the next slot and returns a completion outcome if a QSO ended.
     public func processRx(_ messages: [DecodedMessage]) -> QsoOutcome? {
         if !active || stage == .idle { return nil }
+
+        // The courtesy "73" queued on the previous slot has now had its TX slot;
+        // wrap up (return to CQ / stop) regardless of incoming traffic this slot.
+        if stage == .bye73 {
+            finishQso()
+            return nil
+        }
 
         // Find a message addressed to us, from our target if we have one.
         let mine = messages.first { m in
@@ -162,7 +172,7 @@ public final class QsoEngine {
         case .cq:
             switch content {
             case .grid(let g):
-                gridRcvd = g
+                gridRcvd = grid4(g).uppercased()
                 reportSent = clampReport(msg.snr)
                 sendReport(dx)
             case .report(let n):
@@ -248,7 +258,17 @@ public final class QsoEngine {
             comment: ""
         )
 
-        // Return to CQ or go idle.
+        // If a courtesy "73" is queued (the .rReport path set stage = .bye73),
+        // leave pendingTx/stage so the scheduler transmits it; the next slot's
+        // .bye73 handler in processRx then wraps up. Otherwise finish now.
+        if stage != .bye73 {
+            finishQso()
+        }
+        return .completed(record)
+    }
+
+    /// Return to calling CQ, or stop, per `autoReturnToCq`.
+    private func finishQso() {
         if autoReturnToCq {
             resetQso()
             stage = .cq
@@ -256,7 +276,6 @@ public final class QsoEngine {
         } else {
             stop()
         }
-        return .completed(record)
     }
 }
 

--- a/ios/FT8AFKit/Sources/FT8Engine/QsoRecord.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/QsoRecord.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// One logged QSO. Field names follow ADIF (port of desktop db.rs QsoRecord); a
+/// plain value type so both the QSO state machine (which emits it) and the future
+/// FT8Data persistence layer can share it. GRDB conformance, when FT8Data lands,
+/// is added in an extension there.
+public struct QsoRecord: Equatable, Codable {
+    public var id: Int64?
+    public var call: String
+    public var gridsquare: String
+    public var mode: String
+    public var rstSent: String
+    public var rstRcvd: String
+    public var qsoDate: String      // YYYYMMDD (UTC)
+    public var timeOn: String       // HHMMSS (UTC)
+    public var qsoDateOff: String
+    public var timeOff: String
+    public var band: String
+    public var freq: String
+    public var stationCallsign: String
+    public var myGridsquare: String
+    public var comment: String
+
+    public init(
+        id: Int64? = nil,
+        call: String,
+        gridsquare: String,
+        mode: String,
+        rstSent: String,
+        rstRcvd: String,
+        qsoDate: String,
+        timeOn: String,
+        qsoDateOff: String,
+        timeOff: String,
+        band: String,
+        freq: String,
+        stationCallsign: String,
+        myGridsquare: String,
+        comment: String
+    ) {
+        self.id = id
+        self.call = call
+        self.gridsquare = gridsquare
+        self.mode = mode
+        self.rstSent = rstSent
+        self.rstRcvd = rstRcvd
+        self.qsoDate = qsoDate
+        self.timeOn = timeOn
+        self.qsoDateOff = qsoDateOff
+        self.timeOff = timeOff
+        self.band = band
+        self.freq = freq
+        self.stationCallsign = stationCallsign
+        self.myGridsquare = myGridsquare
+        self.comment = comment
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Engine/Util.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/Util.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// UTC date/time helpers for logging (port of the desktop util:: time functions).
+enum FT8Time {
+    private static var utcCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
+    static func nowUnixMs() -> Int64 { Int64(Date().timeIntervalSince1970 * 1000) }
+
+    static func yyyymmdd(fromMs ms: Int64) -> String {
+        let d = Date(timeIntervalSince1970: Double(ms) / 1000.0)
+        let c = utcCalendar.dateComponents([.year, .month, .day], from: d)
+        return String(format: "%04d%02d%02d", c.year!, c.month!, c.day!)
+    }
+
+    static func hhmmss(fromMs ms: Int64) -> String {
+        let d = Date(timeIntervalSince1970: Double(ms) / 1000.0)
+        let c = utcCalendar.dateComponents([.hour, .minute, .second], from: d)
+        return String(format: "%02d%02d%02d", c.hour!, c.minute!, c.second!)
+    }
+
+    static func utcYyyymmdd() -> String { yyyymmdd(fromMs: nowUnixMs()) }
+    static func utcHhmmss() -> String { hhmmss(fromMs: nowUnixMs()) }
+}
+
+/// Truncate a Maidenhead locator to its 4-char field/square (port of util::grid4).
+func grid4(_ s: String) -> String { String(s.prefix(4)) }

--- a/ios/FT8AFKit/Sources/FT8Engine/Util.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/Util.swift
@@ -2,9 +2,11 @@ import Foundation
 
 /// UTC date/time helpers for logging (port of the desktop util:: time functions).
 enum FT8Time {
-    private static var utcCalendar: Calendar = {
+    // `.gmt` is non-optional (iOS 16+/macOS 13+), and `Calendar.component(_:from:)`
+    // returns non-optional Ints — so no force-unwraps anywhere here.
+    private static let utcCalendar: Calendar = {
         var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = TimeZone(identifier: "UTC")!
+        cal.timeZone = .gmt
         return cal
     }()
 
@@ -12,14 +14,18 @@ enum FT8Time {
 
     static func yyyymmdd(fromMs ms: Int64) -> String {
         let d = Date(timeIntervalSince1970: Double(ms) / 1000.0)
-        let c = utcCalendar.dateComponents([.year, .month, .day], from: d)
-        return String(format: "%04d%02d%02d", c.year!, c.month!, c.day!)
+        let y = utcCalendar.component(.year, from: d)
+        let mo = utcCalendar.component(.month, from: d)
+        let da = utcCalendar.component(.day, from: d)
+        return String(format: "%04d%02d%02d", y, mo, da)
     }
 
     static func hhmmss(fromMs ms: Int64) -> String {
         let d = Date(timeIntervalSince1970: Double(ms) / 1000.0)
-        let c = utcCalendar.dateComponents([.hour, .minute, .second], from: d)
-        return String(format: "%02d%02d%02d", c.hour!, c.minute!, c.second!)
+        let h = utcCalendar.component(.hour, from: d)
+        let mi = utcCalendar.component(.minute, from: d)
+        let s = utcCalendar.component(.second, from: d)
+        return String(format: "%02d%02d%02d", h, mi, s)
     }
 
     static func utcYyyymmdd() -> String { yyyymmdd(fromMs: nowUnixMs()) }

--- a/ios/FT8AFKit/Tests/FT8EngineTests/QsoEngineTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/QsoEngineTests.swift
@@ -36,7 +36,7 @@ final class QsoEngineTests: XCTestCase {
         XCTAssertEqual(e.txMessage, "K1ABC K0XYZ R-08")
         XCTAssertEqual(e.status().reportRcvd, -12)
 
-        // DX sends RR73 -> we send 73 and log.
+        // DX sends RR73 -> we log AND queue the courtesy 73 to transmit.
         let out2 = e.processRx([msg("K0XYZ", "K1ABC", "RR73", "", -8)])
         guard case .completed(let rec)? = out2 else { return XCTFail("expected completed QSO") }
         XCTAssertEqual(rec.call, "K1ABC")
@@ -45,6 +45,12 @@ final class QsoEngineTests: XCTestCase {
         XCTAssertEqual(rec.rstRcvd, "-12")
         XCTAssertEqual(rec.mode, "FT8")
         XCTAssertEqual(rec.stationCallsign, "K0XYZ")
+        // The final 73 is queued (not clobbered by the auto-return)...
+        XCTAssertEqual(e.txMessage, "K1ABC K0XYZ 73")
+        XCTAssertEqual(e.status().stage, .bye73)
+        // ...and once its TX slot has passed, the next slot returns to CQ.
+        XCTAssertNil(e.processRx([]))
+        XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
     }
 
     func testInitiatorCqSequenceLogsQso() {
@@ -160,5 +166,42 @@ final class QsoEngineTests: XCTestCase {
         let e = QsoEngine(myCall: "k0xyz", myGrid: "en37mt") // grid truncated to 4 + upper
         e.startCq()
         XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
+    }
+
+    func testStopClearsTargetSoStaleStageIsNoOp() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.answer(msg("CQ", "K1ABC", "FN42", "FN42", -5)) // sets target K1ABC
+        e.stop()
+        e.setStage(.report) // target was cleared by stop -> no-op, no stale TX
+        XCTAssertNil(e.txMessage)
+        XCTAssertFalse(e.status().active)
+        XCTAssertNil(e.status().target)
+    }
+
+    func testAnsweredGridNormalizedToFourCharUpper() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.answer(msg("CQ", "K1ABC", "fn42lk", "fn42lk", -5)) // 6-char lowercase locator
+        _ = e.processRx([msg("K0XYZ", "K1ABC", "-12", "", -8)])
+        let out = e.processRx([msg("K0XYZ", "K1ABC", "RR73", "", -8)])
+        guard case .completed(let rec)? = out else { return XCTFail("expected completed QSO") }
+        XCTAssertEqual(rec.gridsquare, "FN42")
+    }
+
+    func testInitiatorCapturedGridNormalized() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.startCq()
+        _ = e.processRx([msg("K0XYZ", "K1ABC", "fn42", "fn42", -10)]) // lowercase grid
+        _ = e.processRx([msg("K0XYZ", "K1ABC", "R-15", "", -10)])
+        let out = e.processRx([msg("K0XYZ", "K1ABC", "73", "", -10)])
+        guard case .completed(let rec)? = out else { return XCTFail("expected completed QSO") }
+        XCTAssertEqual(rec.gridsquare, "FN42")
+    }
+
+    func testFT8TimeFormatsUtc() {
+        XCTAssertEqual(FT8Time.yyyymmdd(fromMs: 0), "19700101")
+        XCTAssertEqual(FT8Time.hhmmss(fromMs: 0), "000000")
+        // 1_700_000_000 s == 2023-11-14T22:13:20Z
+        XCTAssertEqual(FT8Time.yyyymmdd(fromMs: 1_700_000_000_000), "20231114")
+        XCTAssertEqual(FT8Time.hhmmss(fromMs: 1_700_000_000_000), "221320")
     }
 }

--- a/ios/FT8AFKit/Tests/FT8EngineTests/QsoEngineTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/QsoEngineTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+import FT8DSP
+@testable import FT8Engine
+
+final class QsoEngineTests: XCTestCase {
+
+    /// Build a decoded-message fixture (port of qso.rs tests' `msg` helper).
+    private func msg(_ to: String, _ from: String, _ extra: String, _ grid: String, _ snr: Int) -> DecodedMessage {
+        var m = DecodedMessage()
+        m.callTo = to
+        m.callFrom = from
+        m.extra = extra
+        m.grid = grid
+        m.rawText = "\(to) \(from) \(extra)"
+        m.snr = snr
+        m.freqHz = 1500
+        m.timeSec = 0.5
+        m.score = 30
+        m.i3 = 1
+        m.n3 = 0
+        return m
+    }
+
+    // MARK: ports of the desktop qso.rs unit tests
+
+    func testAnswererFullSequenceLogsQso() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        // Operator answers DX K1ABC who CQ'd from FN42.
+        e.answer(msg("CQ", "K1ABC", "FN42", "FN42", -5))
+        XCTAssertEqual(e.txMessage, "K1ABC K0XYZ EN37")
+        XCTAssertEqual(e.status().stage, .grid)
+
+        // DX reports our signal -12.
+        let out1 = e.processRx([msg("K0XYZ", "K1ABC", "-12", "", -8)])
+        XCTAssertNil(out1)
+        XCTAssertEqual(e.txMessage, "K1ABC K0XYZ R-08")
+        XCTAssertEqual(e.status().reportRcvd, -12)
+
+        // DX sends RR73 -> we send 73 and log.
+        let out2 = e.processRx([msg("K0XYZ", "K1ABC", "RR73", "", -8)])
+        guard case .completed(let rec)? = out2 else { return XCTFail("expected completed QSO") }
+        XCTAssertEqual(rec.call, "K1ABC")
+        XCTAssertEqual(rec.gridsquare, "FN42")
+        XCTAssertEqual(rec.rstSent, "-08")
+        XCTAssertEqual(rec.rstRcvd, "-12")
+        XCTAssertEqual(rec.mode, "FT8")
+        XCTAssertEqual(rec.stationCallsign, "K0XYZ")
+    }
+
+    func testInitiatorCqSequenceLogsQso() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.startCq()
+        XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
+
+        // K1ABC answers our CQ with their grid.
+        _ = e.processRx([msg("K0XYZ", "K1ABC", "FN42", "FN42", -10)])
+        XCTAssertEqual(e.txMessage, "K1ABC K0XYZ -10")
+        XCTAssertEqual(e.status().stage, .report)
+
+        // K1ABC sends R-report.
+        _ = e.processRx([msg("K0XYZ", "K1ABC", "R-15", "", -10)])
+        XCTAssertEqual(e.txMessage, "K1ABC K0XYZ RR73")
+        XCTAssertEqual(e.status().reportRcvd, -15)
+
+        // K1ABC sends 73 -> complete, log, back to CQ.
+        let out = e.processRx([msg("K0XYZ", "K1ABC", "73", "", -10)])
+        guard case .completed(let rec)? = out else { return XCTFail("expected completed QSO") }
+        XCTAssertEqual(rec.call, "K1ABC")
+        XCTAssertEqual(rec.rstSent, "-10")
+        XCTAssertEqual(rec.rstRcvd, "-15")
+        // auto-returned to CQ
+        XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
+    }
+
+    func testIgnoresMessagesForOthers() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.startCq()
+        // traffic between two other stations
+        XCTAssertNil(e.processRx([msg("W1AW", "K1ABC", "FN42", "FN42", -3)]))
+        XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
+    }
+
+    // MARK: additional coverage for new code paths
+
+    func testIdleEngineIgnoresDecodes() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        XCTAssertNil(e.processRx([msg("K0XYZ", "K1ABC", "FN42", "FN42", -3)]))
+        XCTAssertNil(e.txMessage)
+    }
+
+    func testSetStageRequiresTarget() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.setStage(.report) // no station selected yet
+        XCTAssertNil(e.txMessage)
+        XCTAssertFalse(e.status().active)
+    }
+
+    func testSetStageCqAndIdleFallThrough() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.setStage(.cq)
+        XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
+        XCTAssertTrue(e.status().active)
+        e.setStage(.idle)
+        XCTAssertNil(e.txMessage)
+        XCTAssertFalse(e.status().active)
+        XCTAssertEqual(e.status().stage, .idle)
+    }
+
+    func testSetStageManualPickAfterAnswer() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.answer(msg("CQ", "K1ABC", "FN42", "FN42", -7))
+        e.setStage(.rr73)
+        XCTAssertEqual(e.txMessage, "K1ABC K0XYZ RR73")
+        XCTAssertEqual(e.status().stage, .rr73)
+        e.setStage(.bye73)
+        XCTAssertEqual(e.txMessage, "K1ABC K0XYZ 73")
+        XCTAssertEqual(e.status().stage, .bye73)
+    }
+
+    func testSetFreeTextUppercasesAndActivates() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.setFreeText("test msg 123")
+        XCTAssertEqual(e.txMessage, "TEST MSG 123")
+        XCTAssertTrue(e.status().active)
+    }
+
+    func testReportClampedAndFormatted() {
+        // Very weak signal: report clamps to -30 and formats as "-30".
+        let weak = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        weak.startCq()
+        _ = weak.processRx([msg("K0XYZ", "K1ABC", "FN42", "FN42", -99)])
+        XCTAssertEqual(weak.txMessage, "K1ABC K0XYZ -30")
+
+        // Very strong signal: clamps to +30, formats as "+30".
+        let strong = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        strong.startCq()
+        _ = strong.processRx([msg("K0XYZ", "K1ABC", "FN42", "FN42", 99)])
+        XCTAssertEqual(strong.txMessage, "K1ABC K0XYZ +30")
+    }
+
+    func testNoReplyThisSlotKeepsTxMessage() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.startCq()
+        // A reply not addressed to us doesn't advance the sequence.
+        XCTAssertNil(e.processRx([msg("W1AW", "N0CALL", "RR73", "", -3)]))
+        XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
+        XCTAssertEqual(e.status().stage, .cq)
+    }
+
+    func testStopClearsState() {
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.startCq()
+        e.stop()
+        XCTAssertFalse(e.status().active)
+        XCTAssertNil(e.txMessage)
+        XCTAssertEqual(e.status().stage, .idle)
+    }
+
+    func testGridAndCallUppercasedOnInit() {
+        let e = QsoEngine(myCall: "k0xyz", myGrid: "en37mt") // grid truncated to 4 + upper
+        e.startCq()
+        XCTAssertEqual(e.txMessage, "CQ K0XYZ EN37")
+    }
+}


### PR DESCRIPTION
## What

Adds a new `FT8Engine` target with the **QSO auto-sequencer** — a pure port of desktop `qso.rs`. It's a state machine over `DecodedMessage` (FT8DSP) that reacts to each RX slot's decodes and decides the next TX message, covering both roles:

- **Answerer** (operator taps a CQ): grid → R-report → 73, logs on RR73.
- **Initiator** (calling CQ): CQ → report → RR73, logs on 73, auto-returns to CQ.

Plus report clamping/formatting (`-30…+30`, `"-08"`/`"+30"`), manual WSJT-X Tx1–Tx5 stage selection (`setStage`), free text, `stop`, and a `QsoRecord` emitted on completion. No I/O lives here, so it's fully host-testable.

Also adds `QsoRecord` (a plain ADIF-field value type the future `FT8Data` layer will share — GRDB conformance gets added there) and UTC date/`grid4` `Util` helpers.

## Tests

`QsoEngineTests` ports the **three desktop `qso.rs` unit tests verbatim** (answerer full sequence, initiator CQ sequence, ignores-messages-for-others) and adds coverage for every new path: idle-ignores-decodes, `setStage` requires/uses a target, cq/idle fall-through, manual stage pick, free text, report clamp/format at both rails, no-reply retransmit, `stop`, and init upcasing + `grid4` truncation.

## Scope

Decoder-independent (uses only the `DecodedMessage` type) and decision-only, so it builds and runs under `swift test` on the macOS host. The **live `FT8Engine` actor** (audio + rig + UTC cycle-loop wiring that drives this state machine) is device code added to this target later. Targets `dev` directly.

## Still draft

No Swift toolchain on Windows. On a Mac: `cd ios/FT8AFKit && swift test`. Ready once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)