### PR TITLE
iOS port Phase 6 core: rig CAT command-byte framing

### DIFF
--- a/ios/FT8AFKit/Package.swift
+++ b/ios/FT8AFKit/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .library(name: "FT8DSP", targets: ["FT8DSP"]),
         .library(name: "FT8Audio", targets: ["FT8Audio"]),
         .library(name: "FT8Engine", targets: ["FT8Engine"]),
+        .library(name: "FT8Rig", targets: ["FT8Rig"]),
     ],
     targets: [
         // C bridge to ft8_lib. Header-search path points at the ft8_lib root so
@@ -70,6 +71,17 @@ let package = Package(
         .testTarget(
             name: "FT8EngineTests",
             dependencies: ["FT8Engine", "FT8DSP"] // tests build DecodedMessage fixtures
+        ),
+        // CAT command-byte framing for Yaesu/Kenwood/Icom rigs (port of the
+        // per-model Driver impls in desktop rig.rs). Pure bytes -- no transport,
+        // no dependencies -- so it's fully host-testable. The BLE/network
+        // transports that write these bytes are device code added later.
+        .target(
+            name: "FT8Rig"
+        ),
+        .testTarget(
+            name: "FT8RigTests",
+            dependencies: ["FT8Rig"]
         ),
     ]
 )

--- a/ios/FT8AFKit/Sources/FT8Rig/RigDriver.swift
+++ b/ios/FT8AFKit/Sources/FT8Rig/RigDriver.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Rig families whose CAT command bytes we know how to build.
 public enum RigModel: String, Codable, Equatable {
     case none
@@ -34,10 +32,13 @@ public func rigDriver(for model: RigModel, civAddress: UInt8 = defaultCivAddress
 }
 
 /// Decimal `hz` as a zero-padded, fixed-width ASCII string (Yaesu/Kenwood CAT).
-/// Avoids printf width/`%llu` pitfalls with UInt64.
+/// Avoids printf width/`%llu` pitfalls with UInt64. Traps if `hz` has more than
+/// `width` digits, so an out-of-range frequency fails fast instead of producing a
+/// malformed (wrong-length) CAT frame.
 func zeroPadded(_ hz: UInt64, width: Int) -> String {
     let s = String(hz)
-    return s.count >= width ? s : String(repeating: "0", count: width - s.count) + s
+    precondition(s.count <= width, "frequency \(hz) exceeds \(width) digits")
+    return s.count == width ? s : String(repeating: "0", count: width - s.count) + s
 }
 
 // MARK: Yaesu (ASCII CAT, e.g. FT-991A/FTDX)
@@ -69,13 +70,16 @@ public struct IcomDriver: RigDriver {
     public init(address: UInt8 = defaultCivAddress) { self.address = address }
 
     /// Wrap a CI-V body: FE FE <radio> E0 <body...> FD.
-    func frame(_ body: [UInt8]) -> [UInt8] {
+    private func frame(_ body: [UInt8]) -> [UInt8] {
         [0xFE, 0xFE, address, 0xE0] + body + [0xFD]
     }
 
     /// 10-digit frequency as 5 little-endian BCD bytes (two digits per byte,
-    /// low nibble first). Port of Icom::freq_bcd.
+    /// low nibble first). Port of Icom::freq_bcd. Traps above 10 decimal digits
+    /// (~9.99 GHz) so a value that can't fit fails fast instead of silently
+    /// emitting truncated CI-V bytes.
     static func frequencyBCD(_ hz: UInt64) -> [UInt8] {
+        precondition(hz < 10_000_000_000, "frequency \(hz) exceeds 10 BCD digits")
         var digits = [UInt8](repeating: 0, count: 10)
         var f = hz
         for i in 0..<10 {

--- a/ios/FT8AFKit/Sources/FT8Rig/RigDriver.swift
+++ b/ios/FT8AFKit/Sources/FT8Rig/RigDriver.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Rig families whose CAT command bytes we know how to build.
+public enum RigModel: String, Codable, Equatable {
+    case none
+    case yaesu
+    case kenwood
+    case icom
+}
+
+/// Builds the raw CAT command bytes for a rig model. The transport that writes
+/// them (BLE CAT adapter, or serial-over-network) is device code; this framing is
+/// pure and host-testable. Port of the per-model `Driver` impls in desktop rig.rs.
+public protocol RigDriver {
+    /// Set the VFO-A dial frequency (Hz).
+    func frequencyCommand(_ hz: UInt64) -> [UInt8]
+    /// Switch to the FT8 data/DIG mode (+ filter where applicable).
+    func dataModeCommand() -> [UInt8]
+    /// Key (`true`) or unkey (`false`) PTT.
+    func pttCommand(_ on: Bool) -> [UInt8]
+}
+
+/// Default CI-V radio address (0x94 = IC-7300).
+public let defaultCivAddress: UInt8 = 0x94
+
+/// The driver for a model, or nil for `.none`. `civAddress` only applies to Icom.
+public func rigDriver(for model: RigModel, civAddress: UInt8 = defaultCivAddress) -> RigDriver? {
+    switch model {
+    case .yaesu: return YaesuDriver()
+    case .kenwood: return KenwoodDriver()
+    case .icom: return IcomDriver(address: civAddress)
+    case .none: return nil
+    }
+}
+
+/// Decimal `hz` as a zero-padded, fixed-width ASCII string (Yaesu/Kenwood CAT).
+/// Avoids printf width/`%llu` pitfalls with UInt64.
+func zeroPadded(_ hz: UInt64, width: Int) -> String {
+    let s = String(hz)
+    return s.count >= width ? s : String(repeating: "0", count: width - s.count) + s
+}
+
+// MARK: Yaesu (ASCII CAT, e.g. FT-991A/FTDX)
+
+public struct YaesuDriver: RigDriver {
+    public init() {}
+    public func frequencyCommand(_ hz: UInt64) -> [UInt8] {
+        Array("FA\(zeroPadded(hz, width: 9));".utf8)
+    }
+    public func dataModeCommand() -> [UInt8] { Array("MD0C;NA00;SH0117;".utf8) }
+    public func pttCommand(_ on: Bool) -> [UInt8] { Array((on ? "TX1;" : "TX0;").utf8) }
+}
+
+// MARK: Kenwood (ASCII CAT, e.g. TS-590/TS-890)
+
+public struct KenwoodDriver: RigDriver {
+    public init() {}
+    public func frequencyCommand(_ hz: UInt64) -> [UInt8] {
+        Array("FA\(zeroPadded(hz, width: 11));".utf8)
+    }
+    public func dataModeCommand() -> [UInt8] { Array("MD2;".utf8) }
+    public func pttCommand(_ on: Bool) -> [UInt8] { Array((on ? "TX;" : "RX;").utf8) }
+}
+
+// MARK: Icom (CI-V)
+
+public struct IcomDriver: RigDriver {
+    public let address: UInt8
+    public init(address: UInt8 = defaultCivAddress) { self.address = address }
+
+    /// Wrap a CI-V body: FE FE <radio> E0 <body...> FD.
+    func frame(_ body: [UInt8]) -> [UInt8] {
+        [0xFE, 0xFE, address, 0xE0] + body + [0xFD]
+    }
+
+    /// 10-digit frequency as 5 little-endian BCD bytes (two digits per byte,
+    /// low nibble first). Port of Icom::freq_bcd.
+    static func frequencyBCD(_ hz: UInt64) -> [UInt8] {
+        var digits = [UInt8](repeating: 0, count: 10)
+        var f = hz
+        for i in 0..<10 {
+            digits[i] = UInt8(f % 10)
+            f /= 10
+        }
+        var out = [UInt8](repeating: 0, count: 5)
+        for i in 0..<5 {
+            out[i] = digits[2 * i] | (digits[2 * i + 1] << 4)
+        }
+        return out
+    }
+
+    public func frequencyCommand(_ hz: UInt64) -> [UInt8] {
+        frame([0x05] + IcomDriver.frequencyBCD(hz))
+    }
+    public func dataModeCommand() -> [UInt8] {
+        // 0x26 set-mode: DATA mode on, FIL1 (USB-D).
+        frame([0x26, 0x00, 0x01, 0x01, 0x01])
+    }
+    public func pttCommand(_ on: Bool) -> [UInt8] {
+        frame([0x1C, 0x00, on ? 0x01 : 0x00])
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8RigTests/RigDriverTests.swift
+++ b/ios/FT8AFKit/Tests/FT8RigTests/RigDriverTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import FT8Rig
+
+final class RigDriverTests: XCTestCase {
+
+    // MARK: Yaesu
+
+    func testYaesuFrequencyCommand() { // port of rig.rs yaesu_freq_command
+        XCTAssertEqual(YaesuDriver().frequencyCommand(14_074_000), Array("FA014074000;".utf8))
+    }
+
+    func testYaesuDataModeAndPtt() {
+        XCTAssertEqual(YaesuDriver().dataModeCommand(), Array("MD0C;NA00;SH0117;".utf8))
+        XCTAssertEqual(YaesuDriver().pttCommand(true), Array("TX1;".utf8))
+        XCTAssertEqual(YaesuDriver().pttCommand(false), Array("TX0;".utf8))
+    }
+
+    // MARK: Kenwood
+
+    func testKenwoodFrequencyCommand() {
+        XCTAssertEqual(KenwoodDriver().frequencyCommand(14_074_000), Array("FA00014074000;".utf8))
+    }
+
+    func testKenwoodDataModeAndPtt() {
+        XCTAssertEqual(KenwoodDriver().dataModeCommand(), Array("MD2;".utf8))
+        XCTAssertEqual(KenwoodDriver().pttCommand(true), Array("TX;".utf8))
+        XCTAssertEqual(KenwoodDriver().pttCommand(false), Array("RX;".utf8))
+    }
+
+    // MARK: Icom CI-V
+
+    func testIcomFrequencyBcdLittleEndian() { // port of rig.rs icom_freq_bcd_little_endian
+        XCTAssertEqual(IcomDriver.frequencyBCD(14_074_000), [0x00, 0x40, 0x07, 0x14, 0x00])
+    }
+
+    func testIcomFrequencyBcdAnotherFreq() {
+        XCTAssertEqual(IcomDriver.frequencyBCD(7_074_000), [0x00, 0x40, 0x07, 0x07, 0x00])
+    }
+
+    func testIcomFrequencyFrame() { // port of rig.rs icom_freq_frame
+        XCTAssertEqual(IcomDriver(address: 0x94).frequencyCommand(14_074_000),
+                       [0xFE, 0xFE, 0x94, 0xE0, 0x05, 0x00, 0x40, 0x07, 0x14, 0x00, 0xFD])
+    }
+
+    func testIcomPttFrame() { // port of rig.rs icom_ptt_frame (+ unkey)
+        XCTAssertEqual(IcomDriver(address: 0x94).pttCommand(true),
+                       [0xFE, 0xFE, 0x94, 0xE0, 0x1C, 0x00, 0x01, 0xFD])
+        XCTAssertEqual(IcomDriver(address: 0x94).pttCommand(false),
+                       [0xFE, 0xFE, 0x94, 0xE0, 0x1C, 0x00, 0x00, 0xFD])
+    }
+
+    func testIcomDataModeFrame() {
+        XCTAssertEqual(IcomDriver(address: 0x94).dataModeCommand(),
+                       [0xFE, 0xFE, 0x94, 0xE0, 0x26, 0x00, 0x01, 0x01, 0x01, 0xFD])
+    }
+
+    func testIcomEmbedsCivAddress() {
+        // A non-default rig address (e.g. IC-705 = 0xA4) is placed in the frame.
+        XCTAssertEqual(IcomDriver(address: 0xA4).pttCommand(true),
+                       [0xFE, 0xFE, 0xA4, 0xE0, 0x1C, 0x00, 0x01, 0xFD])
+    }
+
+    // MARK: factory + model
+
+    func testDriverFactory() {
+        XCTAssertNil(rigDriver(for: .none))
+        XCTAssertTrue(rigDriver(for: .yaesu) is YaesuDriver)
+        XCTAssertTrue(rigDriver(for: .kenwood) is KenwoodDriver)
+        XCTAssertEqual((rigDriver(for: .icom, civAddress: 0xA2) as? IcomDriver)?.address, 0xA2)
+        XCTAssertEqual((rigDriver(for: .icom) as? IcomDriver)?.address, defaultCivAddress)
+        XCTAssertEqual(defaultCivAddress, 0x94)
+    }
+
+    func testRigModelRawValues() {
+        XCTAssertEqual(RigModel.icom.rawValue, "icom")
+        XCTAssertEqual(RigModel(rawValue: "kenwood"), .kenwood)
+    }
+}


### PR DESCRIPTION
## What

Adds a new dependency-free `FT8Rig` target with the CAT command-byte framing, ported from the per-model `Driver` impls in desktop `rig.rs`:

- **`RigDriver`** protocol (`frequencyCommand` / `dataModeCommand` / `pttCommand`) + a `rigDriver(for:civAddress:)` factory and `RigModel` enum.
- **Yaesu** (ASCII CAT): `FA<9-digit>;`, `MD0C;NA00;SH0117;`, `TX1;`/`TX0;`.
- **Kenwood** (ASCII CAT): `FA<11-digit>;`, `MD2;`, `TX;`/`RX;`.
- **Icom** (CI-V): `FE FE <addr> E0 <body> FD` framing; 5-byte little-endian BCD frequency; set-mode (`0x26`) and PTT (`0x1C 00`) bodies; default address `0x94` (IC-7300).

Pure bytes — no transport, no dependencies — so it's fully host-testable. The **BLE / serial-over-network transports** that actually write these bytes (and consume `RigConfig`/CoreBluetooth) are device code added later.

## Tests

`RigDriverTests` ports the four desktop `rig.rs` unit tests (Yaesu freq, Icom BCD little-endian, Icom freq frame, Icom PTT frame) and adds: data-mode frames for all three, PTT unkey, a second BCD frequency, a non-default CI-V address embed (IC-705 `0xA4`), and the driver factory + `RigModel` raw values. Byte arrays are asserted exactly.

## Scope

Decoder-independent, no dependencies, targets `dev` directly. This is the last fully host-verifiable unit — the remaining rig work (BLE/network transports, `RigConfig` persistence) needs a device.

## Still draft

No Swift toolchain on Windows. On a Mac: `cd ios/FT8AFKit && swift test`. Ready once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)