### PR TITLE
Edge-to-edge migration for Android 15 / SDK 35

### DIFF
--- a/ft8af/app/build.gradle
+++ b/ft8af/app/build.gradle
@@ -154,7 +154,7 @@ android {
 dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-livedata:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.5.1'

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -18,6 +18,7 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.activity.compose.setContent
@@ -30,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.view.WindowCompat
 import android.os.Handler
 import android.os.Looper
 import androidx.lifecycle.Observer
@@ -79,15 +81,17 @@ class ComposeMainActivity : AppCompatActivity() {
         val permissions = buildPermissionsList()
         checkPermission(permissions)
 
-        // Fullscreen and keep screen on
-        @Suppress("DEPRECATION")
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-        )
+        // Edge-to-edge is mandatory on Android 15 (targetSdk 35) and the old
+        // FLAG_FULLSCREEN / window.statusBarColor APIs are deprecated. Opt into
+        // edge-to-edge, then preserve the app's original full-screen look by
+        // hiding the system bars immersively (transient reveal on swipe) instead
+        // of the deprecated fullscreen flag. Keep the screen on as before.
+        enableEdgeToEdge()
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         super.onCreate(savedInstanceState)
+
+        ImmersiveBars.apply(WindowCompat.getInsetsController(window, window.decorView))
 
         GeneralVariables.getInstance().setMainContext(applicationContext)
         mainViewModel = MainViewModel.getInstance(this)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ImmersiveBars.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ImmersiveBars.kt
@@ -19,9 +19,12 @@ internal object ImmersiveBars {
     /** Bars stay hidden; a swipe reveals them transiently, then they re-hide. */
     const val BEHAVIOR = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
 
-    /** Hide the status + navigation bars and arm transient-by-swipe reveal. */
+    /** Arm transient-by-swipe reveal, then hide the status + navigation bars. */
     fun apply(controller: WindowInsetsControllerCompat) {
-        controller.hide(WindowInsetsCompat.Type.systemBars())
+        // Set the behavior before hiding so it's guaranteed to govern this hide
+        // operation — applying it after hide() can be ignored for already-hidden
+        // bars on some implementations.
         controller.systemBarsBehavior = BEHAVIOR
+        controller.hide(WindowInsetsCompat.Type.systemBars())
     }
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ImmersiveBars.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ImmersiveBars.kt
@@ -1,0 +1,27 @@
+package radio.ks3ckc.ft8af
+
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+/**
+ * Immersive system-bar configuration for the edge-to-edge migration.
+ *
+ * Android 15 (targetSdk 35) forces edge-to-edge and deprecates the old
+ * FLAG_FULLSCREEN flag plus window.statusBarColor / navigationBarColor setters.
+ * The app's original look is full-screen with the system bars hidden, so instead
+ * of those deprecated APIs we hide the bars via the insets controller and let
+ * them reappear transiently on a swipe (then auto-hide again).
+ *
+ * Extracted from the Activity so the configuration is unit-testable — the
+ * Activity itself can't be instantiated cheaply in tests.
+ */
+internal object ImmersiveBars {
+    /** Bars stay hidden; a swipe reveals them transiently, then they re-hide. */
+    const val BEHAVIOR = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+
+    /** Hide the status + navigation bars and arm transient-by-swipe reveal. */
+    fun apply(controller: WindowInsetsControllerCompat) {
+        controller.hide(WindowInsetsCompat.Type.systemBars())
+        controller.systemBarsBehavior = BEHAVIOR
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
@@ -89,8 +89,9 @@ fun FT8AFTheme(content: @Composable () -> Unit) {
             val window = (view.context as? Activity)?.window ?: return@SideEffect
             // window.statusBarColor / navigationBarColor are deprecated and no-ops
             // under edge-to-edge on Android 15. The bars are transparent; we only
-            // keep their icon appearance dark (light icons) for when they're
-            // transiently revealed.
+            // force light (white) bar icons here (isAppearanceLight* = false) so
+            // they stay legible against the app's dark background when the bars
+            // are transiently revealed.
             WindowCompat.getInsetsController(window, view).apply {
                 isAppearanceLightStatusBars = false
                 isAppearanceLightNavigationBars = false

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -88,8 +87,10 @@ fun FT8AFTheme(content: @Composable () -> Unit) {
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as? Activity)?.window ?: return@SideEffect
-            window.statusBarColor = BgApp.toArgb()
-            window.navigationBarColor = BgApp.toArgb()
+            // window.statusBarColor / navigationBarColor are deprecated and no-ops
+            // under edge-to-edge on Android 15. The bars are transparent; we only
+            // keep their icon appearance dark (light icons) for when they're
+            // transiently revealed.
             WindowCompat.getInsetsController(window, view).apply {
                 isAppearanceLightStatusBars = false
                 isAppearanceLightNavigationBars = false

--- a/ft8af/app/src/main/res/values-night/themes.xml
+++ b/ft8af/app/src/main/res/values-night/themes.xml
@@ -10,10 +10,10 @@
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">@color/splash_window_bg</item>
-        <!-- Use the same deep navy as the Compose splash backdrop so the system
-             pre-splash blends seamlessly into the animated splash. -->
+        <!-- android:statusBarColor is deprecated and ignored under edge-to-edge
+             on Android 15; the system bars are transparent and hidden immersively
+             (see ImmersiveBars). windowBackground still covers the brief system
+             pre-splash with the same deep navy as the Compose splash backdrop. -->
         <item name="android:windowBackground">@color/splash_window_bg</item>
         <!-- Customize your theme here. -->
     </style>

--- a/ft8af/app/src/main/res/values/themes.xml
+++ b/ft8af/app/src/main/res/values/themes.xml
@@ -10,10 +10,10 @@
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">@color/splash_window_bg</item>
-        <!-- Use the same deep navy as the Compose splash backdrop so the system
-             pre-splash blends seamlessly into the animated splash. -->
+        <!-- android:statusBarColor is deprecated and ignored under edge-to-edge
+             on Android 15; the system bars are transparent and hidden immersively
+             (see ImmersiveBars). windowBackground still covers the brief system
+             pre-splash with the same deep navy as the Compose splash backdrop. -->
         <item name="android:windowBackground">@color/splash_window_bg</item>
         <!-- Customize your theme here. -->
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ImmersiveBarsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ImmersiveBarsTest.kt
@@ -1,0 +1,42 @@
+package radio.ks3ckc.ft8af
+
+import android.app.Activity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the edge-to-edge immersive system-bar configuration.
+ *
+ * The app migrated off the deprecated FLAG_FULLSCREEN / window.statusBarColor
+ * APIs (no-ops on Android 15 / targetSdk 35) to enableEdgeToEdge plus an insets
+ * controller that hides the bars. [ImmersiveBars] must request the
+ * transient-by-swipe behavior so a swipe still reveals the bars and they then
+ * re-hide — losing that constant would either pin the bars open or make them
+ * unrecoverable.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ImmersiveBarsTest {
+
+    @Test
+    fun behavior_isTransientBarsBySwipe() {
+        assertThat(ImmersiveBars.BEHAVIOR)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE)
+    }
+
+    @Test
+    fun apply_setsTransientSwipeBehaviorOnController() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val controller = WindowCompat.getInsetsController(
+            activity.window, activity.window.decorView,
+        )
+
+        ImmersiveBars.apply(controller)
+
+        assertThat(controller.systemBarsBehavior).isEqualTo(ImmersiveBars.BEHAVIOR)
+    }
+}


### PR DESCRIPTION
Addresses the Play Console "3 actions recommended" report.

## What changed
**1. Edge-to-edge (Android 15 forces it on targetSdk 35)**
- `enableEdgeToEdge()` in `ComposeMainActivity.onCreate`, replacing the deprecated `FLAG_FULLSCREEN`.
- The app's full-screen look is preserved by hiding the system bars immersively via `WindowInsetsControllerCompat` with `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` (swipe reveals them transiently, then they auto-hide).
- Config extracted to `ImmersiveBars` so it's unit-testable.

**2. Deprecated edge-to-edge APIs**
- Removed our own `window.statusBarColor` / `navigationBarColor` setters in `FT8AFTheme` (no-ops under edge-to-edge on API 35); kept the non-deprecated dark icon-appearance config.
- Removed the deprecated `android:statusBarColor` theme attribute from `values/` and `values-night/` themes.
- Bumped `com.google.android.material` **1.8.0 → 1.12.0** to clear the library-internal `setStatusBarColor`/`setNavigationBarColor` calls (the `BottomSheetDialog` / `SheetDialog` / `EdgeToEdgeUtils` traces in the Play report).

**3. Picture-in-picture** — generic suggestion for video apps; not applicable to an FT8 app with no video. Skipped intentionally.

## Testing
- New `ImmersiveBarsTest` (Robolectric): verifies the transient-swipe behavior constant and that `ImmersiveBars.apply` sets it on a real insets controller.
- `gradlew testDebugUnitTest` green; `gradlew installDebug` builds (incl. native CMake for all ABIs) and installs on the Pixel 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)