### PR TITLE
Fix iOS SPM build: resolve header paths outside package root

### DIFF
--- a/ios/FT8AFKit/.gitignore
+++ b/ios/FT8AFKit/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/ios/FT8AFKit/Package.swift
+++ b/ios/FT8AFKit/Package.swift
@@ -1,5 +1,12 @@
 // swift-tools-version: 5.9
+import Foundation
 import PackageDescription
+
+// Resolve the ft8_lib and ft8af_glue C source directories relative to this
+// Package.swift. SPM rejects .headerSearchPath() outside the package root, so
+// we pass absolute -I flags via .unsafeFlags() instead (see ios/README.md).
+let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+let cppRoot = packageDir + "/../../ft8af/app/src/main/cpp"
 
 // FT8AFKit — the non-UI core of the native iOS port of FT8AF.
 //
@@ -32,10 +39,14 @@ let package = Package(
         .target(
             name: "CFT8",
             cSettings: [
-                .headerSearchPath("../../../../ft8af/app/src/main/cpp/ft8_lib"),
-                .headerSearchPath("../../../../ft8af/app/src/main/cpp/ft8af_glue"),
                 // ft8_lib is third-party C; silence its warnings, keep our own clean.
-                .unsafeFlags(["-w"]),
+                // -I flags replace .headerSearchPath() because SPM rejects search
+                // paths that escape the package root (see ios/README.md).
+                .unsafeFlags([
+                    "-w",
+                    "-I", cppRoot + "/ft8_lib",
+                    "-I", cppRoot + "/ft8af_glue",
+                ]),
             ]
         ),
         // Safe Swift wrappers over CFT8 (mirror desktop dsp/{encode,decoder,hashtable}.rs).

--- a/ios/FT8AFKit/Package.swift
+++ b/ios/FT8AFKit/Package.swift
@@ -5,8 +5,14 @@ import PackageDescription
 // Resolve the ft8_lib and ft8af_glue C source directories relative to this
 // Package.swift. SPM rejects .headerSearchPath() outside the package root, so
 // we pass absolute -I flags via .unsafeFlags() instead (see ios/README.md).
-let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-let cppRoot = packageDir + "/../../ft8af/app/src/main/cpp"
+// Standardize the URL so the `..` segments are collapsed: the compiler then
+// receives a clean, canonical absolute path (stable module-cache keys and
+// diagnostics) instead of one threaded through `../../`.
+let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+let cppRoot = packageDir
+    .appendingPathComponent("../../ft8af/app/src/main/cpp")
+    .standardized
+    .path
 
 // FT8AFKit — the non-UI core of the native iOS port of FT8AF.
 //
@@ -32,10 +38,10 @@ let package = Package(
         .library(name: "FT8Rig", targets: ["FT8Rig"]),
     ],
     targets: [
-        // C bridge to ft8_lib. Header-search path points at the ft8_lib root so
-        // the library's internal `<ft8/...>`, `<fft/...>`, `<common/...>` angle
-        // includes resolve. Path is relative to this target's source dir
-        // (Sources/CFT8): four levels up reaches the repo root.
+        // C bridge to ft8_lib. The library's internal `<ft8/...>`, `<fft/...>`,
+        // `<common/...>` angle includes resolve via absolute -I flags pointing
+        // at the ft8_lib / ft8af_glue roots (cppRoot, computed from #filePath
+        // above) — SPM rejects .headerSearchPath() that escapes the package root.
         .target(
             name: "CFT8",
             cSettings: [

--- a/ios/FT8AFKit/Sources/CFT8/include/common/common.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/common/common.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/common/common.h

--- a/ios/FT8AFKit/Sources/CFT8/include/common/monitor.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/common/monitor.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/common/monitor.h

--- a/ios/FT8AFKit/Sources/CFT8/include/fft/_kiss_fft_guts.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/fft/_kiss_fft_guts.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/fft/_kiss_fft_guts.h

--- a/ios/FT8AFKit/Sources/CFT8/include/fft/kiss_fft.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/fft/kiss_fft.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/fft/kiss_fft.h

--- a/ios/FT8AFKit/Sources/CFT8/include/fft/kiss_fftr.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/fft/kiss_fftr.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/fft/kiss_fftr.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/constants.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/constants.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/constants.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/crc.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/crc.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/crc.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/debug.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/debug.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/debug.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/decode.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/decode.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/decode.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/encode.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/encode.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/encode.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/ldpc.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/ldpc.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/ldpc.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/message.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/message.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/message.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/pack.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/pack.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/pack.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/text.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/text.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/text.h

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8/unpack.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8/unpack.h
@@ -1,0 +1,1 @@
+../../../../../../ft8af/app/src/main/cpp/ft8_lib/ft8/unpack.h


### PR DESCRIPTION
## Summary
- Replace `.headerSearchPath()` with `.unsafeFlags(["-I", ...])` using absolute paths resolved from `#filePath` — SPM rejects search paths that escape the package root
- Add header-only symlinks (`ft8/`, `common/`, `fft/`) under `Sources/CFT8/include/` so the CFT8 module's angle-bracket includes resolve for Swift consumers without double-compiling `.c` sources
- Add `.gitignore` for `.build/` and `.swiftpm/` artifacts

## Test plan
- [x] `swift build` succeeds (clean build)
- [x] `swift test` passes all 85 tests across FT8DSP, FT8Audio, FT8Engine, FT8Rig suites
- [ ] Verify symlinks resolve correctly on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)