### PR TITLE
Enable R8 shrink+obfuscate on release; upload mapping.txt to Play

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -401,6 +401,15 @@ jobs:
           name: ft8af-release-aab
           path: ft8af/app/build/outputs/bundle/release/*.aab
 
+      # R8 mapping for the bundle. Kept as an artifact so a given release's
+      # deobfuscation file is recoverable independently of Play Console.
+      - name: Upload R8 mapping artifact
+        if: steps.tag.outputs.should_release == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ft8af-release-mapping
+          path: ft8af/app/build/outputs/mapping/release/mapping.txt
+
       - name: Create GitHub Release
         if: steps.tag.outputs.should_release == 'true'
         uses: softprops/action-gh-release@v2
@@ -427,6 +436,9 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: radio.ks3ckc.ft8af
           releaseFiles: ft8af/app/build/outputs/bundle/release/app-release.aab
+          # R8 deobfuscation mapping — clears the Play Console "no deobfuscation
+          # file" warning and makes crash/ANR stack traces readable.
+          mappingFile: ft8af/app/build/outputs/mapping/release/mapping.txt
           track: internal
           status: completed
           releaseName: ${{ steps.tag.outputs.release_tag }}

--- a/ft8af/app/build.gradle
+++ b/ft8af/app/build.gradle
@@ -93,10 +93,13 @@ android {
             if (project.hasProperty('RELEASE_STORE_FILE')) {
                 signingConfig signingConfigs.release
             }
-            // TODO: enable R8 once we have a proguard-rules.pro that keeps the JNI entry
-            // points in FT8SignalListener/FT8Package/etc and the reflection-driven
-            // SQLite mappers. Shipping with minify off until that work is done.
-            minifyEnabled false
+            // R8 shrink + obfuscate. proguard-rules.pro keeps the JNI surface the
+            // native libft8af.so reaches by name (Ft8Message fields, the
+            // UsbAudioNative callback) plus the reflection-driven USB serial driver
+            // discovery and the AWS Cognito SDK. minifyEnabled also makes AGP emit
+            // mapping.txt, which CI uploads to Play Console for deobfuscated crashes.
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField("String", "apkBuildTime", "\"${currentTime}\"")
 

--- a/ft8af/app/proguard-rules.pro
+++ b/ft8af/app/proguard-rules.pro
@@ -1,21 +1,64 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# ProGuard / R8 rules for the release build.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Release is built with minifyEnabled true (shrink + obfuscate). The default
+# proguard-android-optimize.txt already covers the common cases we rely on:
+#   * classes that declare `native` methods keep their name + the native method
+#     names (so the libft8af.so JNI symbol names Java_com_k1af_ft8af_* still
+#     resolve) — covers FT8SignalListener, GenerateFT8, FT8Package, FT8Resample,
+#     SpectrumView, SpectrumFragment, UsbAudioNative, ReBuildSignal.
+#   * enum values()/valueOf() and Parcelable CREATOR fields.
+# Everything below is the project-specific surface R8 cannot infer on its own:
+# names the native layer (or reflection) looks up by string.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Keep source/line metadata so the uploaded mapping.txt can deobfuscate crash
+# stack traces back to real file + line numbers in Play Console, then hide the
+# original source file name (it becomes "SourceFile" in the obfuscated build).
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# --- JNI: fields read by name via GetObjectClass(msg)+GetFieldID(...) ---
+# ft8_decode_jni.cpp / ft2_decode_jni.cpp populate an Ft8Message instance field
+# by field by field. The field names are baked into the C++; obfuscating them
+# makes every decode silently write nothing. Keep all fields (methods may still
+# be obfuscated).
+-keepclassmembers class com.k1af.ft8af.Ft8Message {
+    <fields>;
+}
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# --- JNI: callback methods invoked by name via GetMethodID(...) ---
+# usb_audio_capture.cpp calls back into the AudioInputCallback by method name +
+# signature. Keep the interface methods so implementers keep the same names.
+-keepclassmembers interface com.k1af.ft8af.wave.UsbAudioNative$AudioInputCallback {
+    void onAudioData(float[], int);
+    void onCaptureStopped(int);
+}
+
+# --- Reflection: USB serial driver discovery ---
+# UsbSerialProber instantiates each driver via getConstructor(UsbDevice.class)
+# .newInstance(...), and ProbeTable invokes the static getSupportedDevices()
+# via getMethod("getSupportedDevices"). Both are reached only reflectively, so
+# R8 would otherwise drop them as unused.
+-keepclassmembers class * implements com.k1af.ft8af.serialport.UsbSerialDriver {
+    public <init>(android.hardware.usb.UsbDevice);
+    public static java.util.Map getSupportedDevices();
+}
+
+# --- AWS Cognito SDK (POTA login) ---
+# The AWS Android SDK resolves models/marshallers reflectively and does not ship
+# complete consumer keep rules. Keep the whole SDK and silence references to its
+# optional/transitive deps that aren't on our classpath.
+-keep class com.amazonaws.** { *; }
+-keep class com.amazon.** { *; }
+-keepnames class com.amazonaws.** { *; }
+-dontwarn com.amazonaws.**
+-dontwarn org.apache.commons.logging.**
+-dontwarn org.apache.http.**
+-dontwarn javax.naming.**
+
+# --- Plain JARs without consumer rules: silence missing optional references ---
+# nanohttpd / commons-net / MPAndroidChart are used directly (no reflection on
+# our types) but reference optional APIs R8 can't resolve; -dontwarn keeps the
+# build from failing on those phantom references.
+-dontwarn fi.iki.elonen.**
+-dontwarn org.apache.commons.net.**
+-dontwarn com.github.mikephil.charting.**

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/R8KeepRulesTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/R8KeepRulesTest.kt
@@ -21,16 +21,22 @@ import java.io.File
  */
 class R8KeepRulesTest {
 
-    private val proguardRules: String by lazy { File("proguard-rules.pro").readText() }
-    private val buildGradle: String by lazy { File("build.gradle").readText() }
+    // Strip comments at load time so a directive/rule that's been commented out
+    // — whole-line OR trailing-inline — can't satisfy a .contains() assertion.
+    // proguard-rules.pro uses '#' comments; build.gradle uses '//'.
+    private val proguardRules: String by lazy { stripComments("proguard-rules.pro", "#") }
+    private val buildGradle: String by lazy { stripComments("build.gradle", "//") }
+
+    private fun stripComments(fileName: String, marker: String): String =
+        File(fileName).readLines()
+            .joinToString("\n") { line ->
+                val i = line.indexOf(marker)
+                if (i >= 0) line.substring(0, i) else line
+            }
 
     @Test
     fun releaseBuildEnablesR8() {
-        // Strip comments so a commented-out directive can't satisfy the assertion.
-        val active = buildGradle.lineSequence()
-            .filterNot { it.trimStart().startsWith("//") }
-            .joinToString("\n")
-        assertThat(active).contains("minifyEnabled true")
+        assertThat(buildGradle).contains("minifyEnabled true")
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/R8KeepRulesTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/R8KeepRulesTest.kt
@@ -1,0 +1,66 @@
+package radio.ks3ckc.ft8af
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+
+/**
+ * Guard test for the release R8 configuration.
+ *
+ * Enabling minification on the release build is only safe because
+ * proguard-rules.pro keeps the names the native libft8af.so (and a couple of
+ * reflection sites) look up by string. If someone deletes minifyEnabled or one
+ * of those keep rules, the app still *builds* — it just silently breaks decode
+ * (Ft8Message fields obfuscated), USB audio capture (callback methods renamed),
+ * USB serial probing (driver ctor/getSupportedDevices stripped), or POTA login
+ * (AWS Cognito SDK shrunk). None of that is caught by a normal unit test, so
+ * assert the configuration itself stays intact.
+ *
+ * Unit tests run with the working directory at the module root (ft8af/app), so
+ * both files resolve relative to it.
+ */
+class R8KeepRulesTest {
+
+    private val proguardRules: String by lazy { File("proguard-rules.pro").readText() }
+    private val buildGradle: String by lazy { File("build.gradle").readText() }
+
+    @Test
+    fun releaseBuildEnablesR8() {
+        // Strip comments so a commented-out directive can't satisfy the assertion.
+        val active = buildGradle.lineSequence()
+            .filterNot { it.trimStart().startsWith("//") }
+            .joinToString("\n")
+        assertThat(active).contains("minifyEnabled true")
+    }
+
+    @Test
+    fun keepsFt8MessageFieldsForJniFieldAccess() {
+        assertThat(proguardRules).contains("class com.k1af.ft8af.Ft8Message")
+    }
+
+    @Test
+    fun keepsUsbAudioCallbackMethodsForJni() {
+        assertThat(proguardRules)
+            .contains("com.k1af.ft8af.wave.UsbAudioNative\$AudioInputCallback")
+        assertThat(proguardRules).contains("onAudioData(float[], int)")
+        assertThat(proguardRules).contains("onCaptureStopped(int)")
+    }
+
+    @Test
+    fun keepsReflectivelyInstantiatedUsbSerialDrivers() {
+        assertThat(proguardRules)
+            .contains("implements com.k1af.ft8af.serialport.UsbSerialDriver")
+        assertThat(proguardRules).contains("<init>(android.hardware.usb.UsbDevice)")
+        assertThat(proguardRules).contains("getSupportedDevices()")
+    }
+
+    @Test
+    fun keepsAwsCognitoSdk() {
+        assertThat(proguardRules).contains("-keep class com.amazonaws.** { *; }")
+    }
+
+    @Test
+    fun keepsLineNumbersSoMappingDeobfuscatesStackTraces() {
+        assertThat(proguardRules).contains("-keepattributes SourceFile,LineNumberTable")
+    }
+}


### PR DESCRIPTION
## What

Resolves the Play Console warning *"There is no deobfuscation file associated with this App Bundle"* (seen on version code 755 / dev-655) by enabling R8 minification on the release build and uploading the generated `mapping.txt` to Play.

The release `build.gradle` previously had `minifyEnabled false` with a TODO deferring R8 until JNI/reflection keep rules existed. This PR writes those rules and flips it on (`shrink + obfuscate`, per the chosen scope).

## Changes

- **`build.gradle`** — `minifyEnabled true` + `shrinkResources true` on `release`. AGP now emits `mapping.txt`.
- **`proguard-rules.pro`** — keep the surface the native `libft8af.so` and reflection reach *by name* (R8 can't infer these):
  - `Ft8Message` fields — read by `ft8_decode_jni`/`ft2_decode_jni` via `GetFieldID`.
  - `UsbAudioNative$AudioInputCallback` `onAudioData`/`onCaptureStopped` — called via `GetMethodID` in `usb_audio_capture.cpp`.
  - `UsbSerialDriver` implementors' `<init>(UsbDevice)` + static `getSupportedDevices()` — reflective instantiation in `UsbSerialProber`/`ProbeTable`.
  - AWS Cognito SDK (POTA login) — reflective, ships no consumer rules.
  - `-keepattributes SourceFile,LineNumberTable` so the mapping deobfuscates stack traces.
  - Native-method classes (`FT8SignalListener`, `GenerateFT8`, `FT8Package`, `FT8Resample`, `SpectrumView`, `UsbAudioNative`, `ReBuildSignal`) are already covered by the default `proguard-android-optimize.txt` `native <methods>` rule.
- **`build-release.yml`** — pass `mappingFile` to the `upload-google-play` step (clears the warning + deobfuscates crashes/ANRs) and archive `mapping.txt` as a CI artifact.
- **`R8KeepRulesTest`** — guards the config so a later edit can't silently drop `minifyEnabled` or a JNI/reflection keep rule.

## Verification

Local `assembleRelease` succeeds and `minifyReleaseWithR8` runs clean. Cross-checked the R8 outputs:
- `configuration.txt` — all three keep rules parsed/applied.
- `usage.txt` — none of the JNI fields, callback methods, or driver members were removed.
- `mapping.txt` — none were renamed; `Ft8Message` and `AudioInputCallback` keep their original FQNs.

**Not yet smoke-tested on-device in obfuscated form:** the phone's installed build is debug-signed, so installing the release-key-signed APK would need an uninstall (wipes POTA login/logbook). Recommend a manual on-device pass of decode / TX / USB rig / POTA login from a clean install before promoting beyond the internal track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)