### PR TITLE
iOS: Add full app shell (Phase 1) — 6-tab UI with mock data

### DIFF
--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -1,0 +1,541 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		035DDD710715AAC0100E0871 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3B4836E62F9DC32FAB0DE /* Colors.swift */; };
+		208767EE6D89D470D7C88E77 /* WaterfallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */; };
+		26F661F120C34995BFF73F2D /* FT8DSP in Frameworks */ = {isa = PBXBuildFile; productRef = 93510ED81B9D113E387D0D45 /* FT8DSP */; };
+		303BF422AF4C5F94DF696E5D /* FT8Rig in Frameworks */ = {isa = PBXBuildFile; productRef = 4E7B6368450390C0D64A5715 /* FT8Rig */; };
+		33736A682F52CCBB13E8168A /* LogbookScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76108617D9AEDEE84BAD1054 /* LogbookScreen.swift */; };
+		3BA2BC0EFAF62534D39C3A4A /* DecodeFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88688AC6AFBEDC8AC3EF844 /* DecodeFilterSettings.swift */; };
+		49DFEC8ED0237764EA3EE3BF /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF21F5D95598018B8A46ED8D /* AppState.swift */; };
+		4C0C9DCC39ED6528F0D4CDFF /* RadioAudioSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */; };
+		595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */; };
+		5C76E98A4BD4854709C3D0E9 /* AppTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53063BBF11F97C62BC0AFC9 /* AppTabView.swift */; };
+		608EF9D6EAE6CDA82E9E86C4 /* QsoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290AFE608DC2FC9E1A83E16 /* QsoSheet.swift */; };
+		637BC14B19B728028FD01F07 /* FrequencyRuler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */; };
+		65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */; };
+		666D9271E9FE64C20C29CF47 /* FT8Audio in Frameworks */ = {isa = PBXBuildFile; productRef = 8A825C5161C267D978D895B8 /* FT8Audio */; };
+		72300AB5D2B37428777C824D /* MapScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCE0C13DF4842EC394EFADF /* MapScreen.swift */; };
+		7F9F3D670DE6755252D023A3 /* TransmissionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */; };
+		7FC3449767DCA16F70133366 /* DecodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C0E0096ADDC018120C361 /* DecodeScreen.swift */; };
+		80F7FFDDEE3AEE3E706C4A2B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 076A186C88F9B5A2FFAAB073 /* Assets.xcassets */; };
+		8EA75A450404FB948C0A6CDC /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */; };
+		A5C16922F13DEDBDF69DFCF6 /* FT8AFTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41EFDE500F865A3B393171D /* FT8AFTab.swift */; };
+		AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306EE5215AE14F95F3329F8 /* FilterChip.swift */; };
+		AAA8FD89DE336CC404CC41E4 /* FT8Engine in Frameworks */ = {isa = PBXBuildFile; productRef = A5E95C3FF3D4A30E2177E137 /* FT8Engine */; };
+		B8FD5A2DF3B2A89740B3CB73 /* WorldMapCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */; };
+		CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800081E79EC795EBDE2E077E /* SlotTimerBar.swift */; };
+		D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */; };
+		DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */; };
+		EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1E760AEB31EF3855951728 /* FT8AFApp.swift */; };
+		F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DF7123A737FE9F5236677F /* DecodeRow.swift */; };
+		FEB99CFFD070BA6B893ADC83 /* WaterfallCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = B681B14FC4FED15C628471DF /* WaterfallCanvas.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0290AFE608DC2FC9E1A83E16 /* QsoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoSheet.swift; sourceTree = "<group>"; };
+		076A186C88F9B5A2FFAAB073 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		0FD3B4836E62F9DC32FAB0DE /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		11DF7123A737FE9F5236677F /* DecodeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeRow.swift; sourceTree = "<group>"; };
+		1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallScreen.swift; sourceTree = "<group>"; };
+		4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSettings.swift; sourceTree = "<group>"; };
+		504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
+		5306EE5215AE14F95F3329F8 /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
+		64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxStrip.swift; sourceTree = "<group>"; };
+		654EF0B6A0E279E65F355821 /* FT8AF.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FT8AF.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F1E760AEB31EF3855951728 /* FT8AFApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FT8AFApp.swift; sourceTree = "<group>"; };
+		76108617D9AEDEE84BAD1054 /* LogbookScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookScreen.swift; sourceTree = "<group>"; };
+		800081E79EC795EBDE2E077E /* SlotTimerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotTimerBar.swift; sourceTree = "<group>"; };
+		82A0D66684F5C2F323454D9B /* FT8AFKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FT8AFKit; path = ../FT8AFKit; sourceTree = SOURCE_ROOT; };
+		89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioAudioSettings.swift; sourceTree = "<group>"; };
+		8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldMapCanvas.swift; sourceTree = "<group>"; };
+		91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookStats.swift; sourceTree = "<group>"; };
+		9BCE0C13DF4842EC394EFADF /* MapScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapScreen.swift; sourceTree = "<group>"; };
+		A41EFDE500F865A3B393171D /* FT8AFTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FT8AFTab.swift; sourceTree = "<group>"; };
+		A53063BBF11F97C62BC0AFC9 /* AppTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTabView.swift; sourceTree = "<group>"; };
+		A88688AC6AFBEDC8AC3EF844 /* DecodeFilterSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeFilterSettings.swift; sourceTree = "<group>"; };
+		B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaScreen.swift; sourceTree = "<group>"; };
+		B681B14FC4FED15C628471DF /* WaterfallCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallCanvas.swift; sourceTree = "<group>"; };
+		BF21F5D95598018B8A46ED8D /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		C79C0E0096ADDC018120C361 /* DecodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeScreen.swift; sourceTree = "<group>"; };
+		C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyRuler.swift; sourceTree = "<group>"; };
+		C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumStrip.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3371CB108C645120B1311F94 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				26F661F120C34995BFF73F2D /* FT8DSP in Frameworks */,
+				666D9271E9FE64C20C29CF47 /* FT8Audio in Frameworks */,
+				AAA8FD89DE336CC404CC41E4 /* FT8Engine in Frameworks */,
+				303BF422AF4C5F94DF696E5D /* FT8Rig in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		14E1746CE387ABA11CDC3F5E /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				9BCE0C13DF4842EC394EFADF /* MapScreen.swift */,
+				8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */,
+			);
+			path = Map;
+			sourceTree = "<group>";
+		};
+		1F327B9757517C23BFA52C86 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				A53063BBF11F97C62BC0AFC9 /* AppTabView.swift */,
+				A41EFDE500F865A3B393171D /* FT8AFTab.swift */,
+			);
+			path = Navigation;
+			sourceTree = "<group>";
+		};
+		233187321B70BBF49A9D862B /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				82A0D66684F5C2F323454D9B /* FT8AFKit */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		3BF125CF2819463DD0E2F81B /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				A88688AC6AFBEDC8AC3EF844 /* DecodeFilterSettings.swift */,
+				89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */,
+				504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */,
+				4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		48CD82AC79D5ACE80B4E114C /* Decode */ = {
+			isa = PBXGroup;
+			children = (
+				11DF7123A737FE9F5236677F /* DecodeRow.swift */,
+				C79C0E0096ADDC018120C361 /* DecodeScreen.swift */,
+				0290AFE608DC2FC9E1A83E16 /* QsoSheet.swift */,
+			);
+			path = Decode;
+			sourceTree = "<group>";
+		};
+		6A561A5BA077FBCEC8F291AB /* Waterfall */ = {
+			isa = PBXGroup;
+			children = (
+				C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */,
+				C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */,
+				B681B14FC4FED15C628471DF /* WaterfallCanvas.swift */,
+				1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */,
+			);
+			path = Waterfall;
+			sourceTree = "<group>";
+		};
+		7ADDAD46CE02777DA8CFC26A = {
+			isa = PBXGroup;
+			children = (
+				975A228795DCD722F01F06F6 /* FT8AF */,
+				233187321B70BBF49A9D862B /* Packages */,
+				D3689D7765BE6F880B857542 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7DCF29540DF6FBE5F4ECD5FC /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				5306EE5215AE14F95F3329F8 /* FilterChip.swift */,
+				800081E79EC795EBDE2E077E /* SlotTimerBar.swift */,
+				64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		7F57A25B1504D3F64E790FAC /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				48CD82AC79D5ACE80B4E114C /* Decode */,
+				9B85E3FDCB60E378E9DF2E12 /* Logbook */,
+				14E1746CE387ABA11CDC3F5E /* Map */,
+				948E7F983E403C535796BAB0 /* POTA */,
+				3BF125CF2819463DD0E2F81B /* Settings */,
+				6A561A5BA077FBCEC8F291AB /* Waterfall */,
+			);
+			path = Screens;
+			sourceTree = "<group>";
+		};
+		948E7F983E403C535796BAB0 /* POTA */ = {
+			isa = PBXGroup;
+			children = (
+				B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */,
+			);
+			path = POTA;
+			sourceTree = "<group>";
+		};
+		975A228795DCD722F01F06F6 /* FT8AF */ = {
+			isa = PBXGroup;
+			children = (
+				BF21F5D95598018B8A46ED8D /* AppState.swift */,
+				076A186C88F9B5A2FFAAB073 /* Assets.xcassets */,
+				6F1E760AEB31EF3855951728 /* FT8AFApp.swift */,
+				7DCF29540DF6FBE5F4ECD5FC /* Components */,
+				1F327B9757517C23BFA52C86 /* Navigation */,
+				7F57A25B1504D3F64E790FAC /* Screens */,
+				C97F65A2DD30ABA1707C85D3 /* Theme */,
+			);
+			path = FT8AF;
+			sourceTree = "<group>";
+		};
+		9B85E3FDCB60E378E9DF2E12 /* Logbook */ = {
+			isa = PBXGroup;
+			children = (
+				76108617D9AEDEE84BAD1054 /* LogbookScreen.swift */,
+				91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */,
+			);
+			path = Logbook;
+			sourceTree = "<group>";
+		};
+		C97F65A2DD30ABA1707C85D3 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				0FD3B4836E62F9DC32FAB0DE /* Colors.swift */,
+			);
+			path = Theme;
+			sourceTree = "<group>";
+		};
+		D3689D7765BE6F880B857542 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				654EF0B6A0E279E65F355821 /* FT8AF.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B9605E495383A032BC1DF832 /* FT8AF */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5650222F2CAD932AA253AC9A /* Build configuration list for PBXNativeTarget "FT8AF" */;
+			buildPhases = (
+				59FFA201BB7BA779F5173CD5 /* Sources */,
+				CCBC8812B22B4288549A4D42 /* Resources */,
+				3371CB108C645120B1311F94 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FT8AF;
+			packageProductDependencies = (
+				93510ED81B9D113E387D0D45 /* FT8DSP */,
+				8A825C5161C267D978D895B8 /* FT8Audio */,
+				A5E95C3FF3D4A30E2177E137 /* FT8Engine */,
+				4E7B6368450390C0D64A5715 /* FT8Rig */,
+			);
+			productName = FT8AF;
+			productReference = 654EF0B6A0E279E65F355821 /* FT8AF.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		765E5D7980EA2125D03F7F74 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = C554E2B15926C57C42EF3BD2 /* Build configuration list for PBXProject "FT8AF" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 7ADDAD46CE02777DA8CFC26A;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				6EBAF921ECA57CA851F92F26 /* XCLocalSwiftPackageReference "../FT8AFKit" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = D3689D7765BE6F880B857542 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B9605E495383A032BC1DF832 /* FT8AF */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CCBC8812B22B4288549A4D42 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				80F7FFDDEE3AEE3E706C4A2B /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		59FFA201BB7BA779F5173CD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49DFEC8ED0237764EA3EE3BF /* AppState.swift in Sources */,
+				5C76E98A4BD4854709C3D0E9 /* AppTabView.swift in Sources */,
+				035DDD710715AAC0100E0871 /* Colors.swift in Sources */,
+				3BA2BC0EFAF62534D39C3A4A /* DecodeFilterSettings.swift in Sources */,
+				F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */,
+				7FC3449767DCA16F70133366 /* DecodeScreen.swift in Sources */,
+				EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */,
+				A5C16922F13DEDBDF69DFCF6 /* FT8AFTab.swift in Sources */,
+				AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */,
+				637BC14B19B728028FD01F07 /* FrequencyRuler.swift in Sources */,
+				33736A682F52CCBB13E8168A /* LogbookScreen.swift in Sources */,
+				65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */,
+				72300AB5D2B37428777C824D /* MapScreen.swift in Sources */,
+				595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */,
+				608EF9D6EAE6CDA82E9E86C4 /* QsoSheet.swift in Sources */,
+				4C0C9DCC39ED6528F0D4CDFF /* RadioAudioSettings.swift in Sources */,
+				8EA75A450404FB948C0A6CDC /* SettingsScreen.swift in Sources */,
+				CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */,
+				D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */,
+				7F9F3D670DE6755252D023A3 /* TransmissionSettings.swift in Sources */,
+				DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */,
+				FEB99CFFD070BA6B893ADC83 /* WaterfallCanvas.swift in Sources */,
+				208767EE6D89D470D7C88E77 /* WaterfallScreen.swift in Sources */,
+				B8FD5A2DF3B2A89740B3CB73 /* WorldMapCanvas.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		114B2295BA5908B5A5B022F2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = radio.ks3ckc.ft8af;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1C711ADDAFD3114BA9D7391A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		B8017F482621D5FE508648E3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = radio.ks3ckc.ft8af;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C9A16BFA5CB997D011C9145F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5650222F2CAD932AA253AC9A /* Build configuration list for PBXNativeTarget "FT8AF" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				114B2295BA5908B5A5B022F2 /* Debug */,
+				B8017F482621D5FE508648E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C554E2B15926C57C42EF3BD2 /* Build configuration list for PBXProject "FT8AF" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C9A16BFA5CB997D011C9145F /* Debug */,
+				1C711ADDAFD3114BA9D7391A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		6EBAF921ECA57CA851F92F26 /* XCLocalSwiftPackageReference "../FT8AFKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../FT8AFKit;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4E7B6368450390C0D64A5715 /* FT8Rig */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FT8Rig;
+		};
+		8A825C5161C267D978D895B8 /* FT8Audio */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FT8Audio;
+		};
+		93510ED81B9D113E387D0D45 /* FT8DSP */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FT8DSP;
+		};
+		A5E95C3FF3D4A30E2177E137 /* FT8Engine */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FT8Engine;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 765E5D7980EA2125D03F7F74 /* Project object */;
+}

--- a/ios/FT8AF/FT8AF.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -1,4 +1,3 @@
-import FT8DSP
 import FT8Engine
 import Foundation
 import Observation
@@ -33,7 +32,8 @@ final class DecodeState {
     var selectedMessage: DecodeMessage?
 }
 
-/// UI-level decoded message (wraps FT8DSP.DecodedMessage with extra display fields).
+/// UI-level decoded message with display-oriented fields. Phase 2+ will map
+/// `FT8DSP.DecodedMessage` into this shape; for now it carries mock data only.
 struct DecodeMessage: Identifiable, Equatable {
     let id = UUID()
     var utcTime: String
@@ -168,7 +168,10 @@ final class RigState {
 
 // MARK: - TX
 
-enum TxStage: String {
+/// App-local TX progress used by the Phase-1 UI. Named distinctly from
+/// `FT8Engine.TxStage` (imported above) to avoid shadowing the engine type
+/// when QSO wiring lands in a later phase.
+enum TxUIStage: String {
     case idle
     case cqSent
     case reportSent
@@ -178,7 +181,7 @@ enum TxStage: String {
 
 @Observable @MainActor
 final class TxState {
-    var stage: TxStage = .idle
+    var stage: TxUIStage = .idle
     var isActivated: Bool = false
     var huntEnabled: Bool = false
     var slotParity: Int = 0

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -1,0 +1,186 @@
+import FT8DSP
+import FT8Engine
+import Foundation
+import Observation
+
+// MARK: - Root state
+
+@Observable @MainActor
+final class AppState {
+    let decode = DecodeState()
+    let waterfall = WaterfallState()
+    let logbook = LogbookState()
+    let settings = SettingsState()
+    let rig = RigState()
+    let tx = TxState()
+}
+
+// MARK: - Decode
+
+enum DecodeFilter: String, CaseIterable {
+    case all = "All"
+    case cq = "CQ Calls"
+    case cqPota = "CQ POTA"
+    case newDxcc = "New DXCC"
+    case needed = "Needed"
+    case forMe = "For Me"
+}
+
+@Observable @MainActor
+final class DecodeState {
+    var messages: [DecodeMessage] = DecodeMessage.mock
+    var activeFilter: DecodeFilter = .all
+    var selectedMessage: DecodeMessage?
+}
+
+/// UI-level decoded message (wraps FT8DSP.DecodedMessage with extra display fields).
+struct DecodeMessage: Identifiable, Equatable {
+    let id = UUID()
+    var utcTime: String
+    var callFrom: String
+    var callTo: String
+    var snr: Int
+    var freqHz: Float
+    var grid: String
+    var extra: String
+    var slotIndex: Int
+
+    static let mock: [DecodeMessage] = [
+        DecodeMessage(utcTime: "12:30:00", callFrom: "W1AW", callTo: "CQ", snr: -5, freqHz: 1120, grid: "FN31", extra: "FN31", slotIndex: 0),
+        DecodeMessage(utcTime: "12:30:00", callFrom: "KD2OGR", callTo: "CQ POTA", snr: -12, freqHz: 890, grid: "FN20", extra: "K-1234", slotIndex: 0),
+        DecodeMessage(utcTime: "12:30:00", callFrom: "JA1ABC", callTo: "CQ", snr: 3, freqHz: 1450, grid: "PM95", extra: "PM95", slotIndex: 0),
+        DecodeMessage(utcTime: "12:29:45", callFrom: "DL4RCK", callTo: "W1AW", snr: -8, freqHz: 1120, grid: "JO31", extra: "+03", slotIndex: 1),
+        DecodeMessage(utcTime: "12:29:45", callFrom: "VK3BDX", callTo: "CQ", snr: -18, freqHz: 2100, grid: "QF22", extra: "QF22", slotIndex: 1),
+        DecodeMessage(utcTime: "12:29:45", callFrom: "EA4FKR", callTo: "CQ", snr: -2, freqHz: 530, grid: "IN80", extra: "IN80", slotIndex: 1),
+        DecodeMessage(utcTime: "12:29:30", callFrom: "K5ABC", callTo: "JA1ABC", snr: 5, freqHz: 1450, grid: "EM12", extra: "R-08", slotIndex: 2),
+        DecodeMessage(utcTime: "12:29:30", callFrom: "OH2BFO", callTo: "CQ", snr: -15, freqHz: 1780, grid: "KP20", extra: "KP20", slotIndex: 2),
+        DecodeMessage(utcTime: "12:29:30", callFrom: "ZL1BYZ", callTo: "CQ", snr: -22, freqHz: 680, grid: "RF72", extra: "RF72", slotIndex: 2),
+        DecodeMessage(utcTime: "12:29:15", callFrom: "PY2SEX", callTo: "W1AW", snr: -10, freqHz: 1120, grid: "GG87", extra: "RR73", slotIndex: 3),
+        DecodeMessage(utcTime: "12:29:15", callFrom: "UA3ABC", callTo: "CQ", snr: 1, freqHz: 950, grid: "KO85", extra: "KO85", slotIndex: 3),
+        DecodeMessage(utcTime: "12:29:15", callFrom: "VE3XYZ", callTo: "CQ", snr: -7, freqHz: 1300, grid: "FN03", extra: "FN03", slotIndex: 3),
+    ]
+}
+
+// MARK: - Waterfall
+
+@Observable @MainActor
+final class WaterfallState {
+    var rows: [[UInt8]] = []
+    var txFreqHz: Float = 1500
+    var isLive: Bool = false
+}
+
+// MARK: - Logbook
+
+@Observable @MainActor
+final class LogbookState {
+    var records: [QsoRecord] = QsoRecord.mockRecords
+    var totalCount: Int { records.count }
+    var bandStats: [String: Int] {
+        var stats: [String: Int] = [:]
+        for r in records {
+            stats[r.band, default: 0] += 1
+        }
+        return stats
+    }
+}
+
+extension QsoRecord {
+    static let mockRecords: [QsoRecord] = [
+        QsoRecord(id: 1, call: "W1AW", gridsquare: "FN31", mode: "FT8", rstSent: "-05", rstRcvd: "-08",
+                  qsoDate: "20260618", timeOn: "123000", qsoDateOff: "20260618", timeOff: "123115",
+                  band: "20M", freq: "14.074", stationCallsign: "KD2OGR", myGridsquare: "FN20", comment: ""),
+        QsoRecord(id: 2, call: "JA1ABC", gridsquare: "PM95", mode: "FT8", rstSent: "+03", rstRcvd: "-12",
+                  qsoDate: "20260618", timeOn: "122800", qsoDateOff: "20260618", timeOff: "122930",
+                  band: "15M", freq: "21.074", stationCallsign: "KD2OGR", myGridsquare: "FN20", comment: ""),
+        QsoRecord(id: 3, call: "DL4RCK", gridsquare: "JO31", mode: "FT8", rstSent: "-10", rstRcvd: "-03",
+                  qsoDate: "20260617", timeOn: "180000", qsoDateOff: "20260617", timeOff: "180130",
+                  band: "40M", freq: "7.074", stationCallsign: "KD2OGR", myGridsquare: "FN20", comment: ""),
+        QsoRecord(id: 4, call: "VK3BDX", gridsquare: "QF22", mode: "FT8", rstSent: "-18", rstRcvd: "-15",
+                  qsoDate: "20260617", timeOn: "090000", qsoDateOff: "20260617", timeOff: "090130",
+                  band: "20M", freq: "14.074", stationCallsign: "KD2OGR", myGridsquare: "FN20", comment: "Long path"),
+        QsoRecord(id: 5, call: "PY2SEX", gridsquare: "GG87", mode: "FT8", rstSent: "-02", rstRcvd: "+05",
+                  qsoDate: "20260616", timeOn: "220000", qsoDateOff: "20260616", timeOff: "220130",
+                  band: "10M", freq: "28.074", stationCallsign: "KD2OGR", myGridsquare: "FN20", comment: ""),
+        QsoRecord(id: 6, call: "OH2BFO", gridsquare: "KP20", mode: "FT8", rstSent: "-15", rstRcvd: "-10",
+                  qsoDate: "20260615", timeOn: "140000", qsoDateOff: "20260615", timeOff: "140200",
+                  band: "30M", freq: "10.136", stationCallsign: "KD2OGR", myGridsquare: "FN20", comment: ""),
+        QsoRecord(id: 7, call: "EA4FKR", gridsquare: "IN80", mode: "FT8", rstSent: "-05", rstRcvd: "+01",
+                  qsoDate: "20260614", timeOn: "160000", qsoDateOff: "20260614", timeOff: "160200",
+                  band: "17M", freq: "18.100", stationCallsign: "KD2OGR", myGridsquare: "FN20", comment: ""),
+    ]
+}
+
+// MARK: - Settings
+
+enum RigModel: String, CaseIterable, Identifiable {
+    case none = "None"
+    case ic705 = "IC-705"
+    case ic7300 = "IC-7300"
+    case ft991a = "FT-991A"
+    case ft710 = "FT-710"
+    case ft450d = "FT-450D"
+    case ts590s = "TS-590S"
+    case k3 = "K3/K3S"
+    case kx3 = "KX3"
+    case flex6000 = "Flex 6000"
+    case x6100 = "X6100"
+
+    var id: String { rawValue }
+}
+
+enum PttMode: String, CaseIterable, Identifiable {
+    case vox = "VOX"
+    case cat = "CAT"
+    case rts = "RTS"
+    case dtr = "DTR"
+
+    var id: String { rawValue }
+}
+
+@Observable @MainActor
+final class SettingsState {
+    var myCall: String = ""
+    var myGrid: String = ""
+    var band: String = "20M"
+    var rigModel: RigModel = .none
+    var pttMode: PttMode = .vox
+    var txPowerWatts: Int = 5
+    var txVolume: Int = 80
+    var showOnlyCQ: Bool = false
+    var dxOnly: Bool = false
+    var autoLog: Bool = true
+}
+
+// MARK: - Rig
+
+enum ConnectionStatus: String {
+    case disconnected = "Disconnected"
+    case connecting = "Connecting"
+    case connected = "Connected"
+}
+
+@Observable @MainActor
+final class RigState {
+    var connectionStatus: ConnectionStatus = .disconnected
+    var currentFreqHz: UInt64 = 14_074_000
+}
+
+// MARK: - TX
+
+enum TxStage: String {
+    case idle
+    case cqSent
+    case reportSent
+    case rrSent
+    case complete
+}
+
+@Observable @MainActor
+final class TxState {
+    var stage: TxStage = .idle
+    var isActivated: Bool = false
+    var huntEnabled: Bool = false
+    var slotParity: Int = 0
+    var isTransmitting: Bool = false
+}

--- a/ios/FT8AF/FT8AF/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/FT8AF/FT8AF/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5E",
+          "green" : "0xAF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/FT8AF/FT8AF/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/FT8AF/FT8AF/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/FT8AF/FT8AF/Assets.xcassets/Contents.json
+++ b/ios/FT8AF/FT8AF/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/FT8AF/FT8AF/Components/FilterChip.swift
+++ b/ios/FT8AF/FT8AF/Components/FilterChip.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Pill-shaped toggle chip for decode filter bar.
+struct FilterChip: View {
+    let label: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 12, weight: isSelected ? .semibold : .medium, design: .monospaced))
+                .foregroundStyle(isSelected ? bgApp : textMuted)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule()
+                        .fill(isSelected ? accent : bgSurface3)
+                )
+                .overlay(
+                    Capsule()
+                        .strokeBorder(isSelected ? accent : borderSubtle, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ios/FT8AF/FT8AF/Components/SlotTimerBar.swift
+++ b/ios/FT8AF/FT8AF/Components/SlotTimerBar.swift
@@ -1,0 +1,32 @@
+import FT8Audio
+import SwiftUI
+
+/// Thin progress bar showing the current position in the 15 s FT8 cycle.
+/// Blue for RX window, orange for guard time (last ~2.36 s).
+struct SlotTimerBar: View {
+    @State private var progress: Double = 0
+    @State private var isGuard: Bool = false
+
+    private let timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+    private static let guardThresholdMs: Int64 = 12_640 // FT8 message duration
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .fill(bgSurface)
+
+                Rectangle()
+                    .fill(isGuard ? accent : signal)
+                    .frame(width: geo.size.width * progress)
+            }
+        }
+        .frame(height: 3)
+        .onReceive(timer) { _ in
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            let ms = SlotClock.msIntoCycle(atUtcMs: nowMs)
+            progress = Double(ms) / Double(SlotClock.cycleMs)
+            isGuard = ms >= Self.guardThresholdMs
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+/// TX control bar shown at the bottom of Decode/Waterfall screens.
+/// Phase 1: static display with non-functional buttons (wired in Phase 4).
+struct TxStrip: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        let tx = appState.tx
+        let settings = appState.settings
+
+        VStack(spacing: 10) {
+            // Info row: status + frequency/mode chips
+            HStack {
+                // Left: pulse dot + status label
+                HStack(spacing: 6) {
+                    PulseDot(color: tx.isTransmitting ? accent : signal)
+                    Text(tx.isTransmitting ? "TX" : "RX")
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(textPrimary)
+                }
+
+                Spacer()
+
+                // Right: mode + frequency chips
+                HStack(spacing: 6) {
+                    TxChip(label: "FT8", color: accent)
+                    TxChip(label: settings.band, color: textPrimary)
+                }
+            }
+
+            // Action row: HUNT - CQ/STOP - TX slot
+            HStack(spacing: 8) {
+                // HUNT button
+                ActionButton(
+                    label: "HUNT",
+                    icon: "target",
+                    isActive: tx.huntEnabled,
+                    activeColor: signal,
+                    style: .secondary
+                ) { }
+
+                // CQ / STOP button
+                ActionButton(
+                    label: tx.isActivated ? "STOP" : "CALL CQ",
+                    icon: tx.isActivated ? "xmark" : "antenna.radiowaves.left.and.right",
+                    isActive: true,
+                    activeColor: tx.isActivated ? statusBad : accent,
+                    style: .primary
+                ) { }
+
+                // TX slot toggle
+                ActionButton(
+                    label: tx.slotParity == 0 ? "TX1" : "TX2",
+                    icon: "arrow.up",
+                    isActive: false,
+                    activeColor: textMuted,
+                    style: .secondary
+                ) { }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(bgSurface)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(borderSubtle)
+                .frame(height: 1)
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private struct PulseDot: View {
+    let color: Color
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(color.opacity(isPulsing ? 0 : 0.3))
+                .frame(width: isPulsing ? 16 : 6, height: isPulsing ? 16 : 6)
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+        }
+        .frame(width: 22, height: 22)
+        .onAppear {
+            withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
+                isPulsing = true
+            }
+        }
+    }
+}
+
+private struct TxChip: View {
+    let label: String
+    let color: Color
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(bgSurface3)
+            )
+    }
+}
+
+private enum ActionButtonStyle {
+    case primary, secondary
+}
+
+private struct ActionButton: View {
+    let label: String
+    let icon: String
+    let isActive: Bool
+    let activeColor: Color
+    let style: ActionButtonStyle
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Group {
+                switch style {
+                case .primary:
+                    HStack(spacing: 8) {
+                        Image(systemName: icon)
+                            .font(.system(size: 14, weight: .semibold))
+                        Text(label)
+                            .font(.system(size: 15, weight: .bold, design: .monospaced))
+                    }
+                case .secondary:
+                    VStack(spacing: 3) {
+                        Image(systemName: icon)
+                            .font(.system(size: 14, weight: .semibold))
+                        Text(label)
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    }
+                }
+            }
+            .foregroundStyle(isActive ? (style == .primary ? bgApp : activeColor) : textMuted)
+            .frame(maxWidth: .infinity)
+            .frame(height: 54)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isActive ? activeColor.opacity(style == .primary ? 1.0 : 0.18) : bgSurface3)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isActive && style == .secondary ? activeColor.opacity(0.5) : borderSubtle, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ios/FT8AF/FT8AF/FT8AFApp.swift
+++ b/ios/FT8AF/FT8AF/FT8AFApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct FT8AFApp: App {
+    @State private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            AppTabView()
+                .environment(appState)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Navigation/AppTabView.swift
+++ b/ios/FT8AF/FT8AF/Navigation/AppTabView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+struct AppTabView: View {
+    @State private var selectedTab: FT8AFTab = .decode
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            // Screen content
+            Group {
+                switch selectedTab {
+                case .decode:    DecodeScreen()
+                case .waterfall: WaterfallScreen()
+                case .logbook:   LogbookScreen()
+                case .map:       MapScreen()
+                case .pota:      PotaScreen()
+                case .settings:  SettingsScreen()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            // Custom tab bar
+            VStack(spacing: 0) {
+                SlotTimerBar()
+                TabBarView(selectedTab: $selectedTab)
+            }
+        }
+        .background(bgApp)
+        .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - Custom Tab Bar
+
+private struct TabBarView: View {
+    @Binding var selectedTab: FT8AFTab
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(FT8AFTab.allCases) { tab in
+                TabBarButton(
+                    tab: tab,
+                    isSelected: selectedTab == tab
+                ) {
+                    selectedTab = tab
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 8)
+        .padding(.bottom, 30)
+        .background(
+            LinearGradient(
+                colors: [.clear, bgApp.opacity(0.95)],
+                startPoint: .top,
+                endPoint: UnitPoint(x: 0.5, y: 0.3)
+            )
+        )
+    }
+}
+
+private struct TabBarButton: View {
+    let tab: FT8AFTab
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                ZStack {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: 14)
+                            .fill(accent.opacity(0.14))
+                            .frame(width: 40, height: 28)
+                    }
+                    Image(systemName: tab.icon)
+                        .font(.system(size: 16, weight: isSelected ? .semibold : .regular))
+                        .foregroundStyle(isSelected ? accent : textFaint)
+                }
+                .frame(height: 28)
+
+                Text(tab.label)
+                    .font(.system(size: 10.5, weight: isSelected ? .semibold : .medium))
+                    .foregroundStyle(isSelected ? accent : textFaint)
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ios/FT8AF/FT8AF/Navigation/FT8AFTab.swift
+++ b/ios/FT8AF/FT8AF/Navigation/FT8AFTab.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+enum FT8AFTab: String, CaseIterable, Identifiable {
+    case decode
+    case waterfall
+    case logbook
+    case map
+    case pota
+    case settings
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .decode:    return "Decode"
+        case .waterfall: return "Waterfall"
+        case .logbook:   return "Log"
+        case .map:       return "Map"
+        case .pota:      return "POTA"
+        case .settings:  return "Settings"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .decode:    return "waveform"
+        case .waterfall: return "chart.bar.fill"
+        case .logbook:   return "book.closed.fill"
+        case .map:       return "globe"
+        case .pota:      return "tree.fill"
+        case .settings:  return "gearshape.fill"
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeRow.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeRow.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct DecodeRow: View {
+    let message: DecodeMessage
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // UTC time
+            Text(shortTime)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(textFaint)
+                .frame(width: 38, alignment: .leading)
+
+            // SNR badge
+            Text(snrText)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(snrColor)
+                .frame(width: 32, alignment: .trailing)
+                .padding(.trailing, 8)
+
+            // Frequency
+            Text(freqText)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(textFaint)
+                .frame(width: 40, alignment: .trailing)
+                .padding(.trailing, 10)
+
+            // Callsigns + extra
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    // CQ / callTo pill
+                    if message.callTo == "CQ" || message.callTo.hasPrefix("CQ ") {
+                        Text("CQ")
+                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                            .foregroundStyle(bgApp)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(accent)
+                            )
+                    } else {
+                        Text(message.callTo)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .foregroundStyle(signal)
+                    }
+
+                    Image(systemName: "arrow.left")
+                        .font(.system(size: 8))
+                        .foregroundStyle(textDim)
+
+                    Text(message.callFrom)
+                        .font(.system(size: 13, weight: .bold, design: .monospaced))
+                        .foregroundStyle(textPrimary)
+                }
+
+                if !message.grid.isEmpty || !message.extra.isEmpty {
+                    Text(message.grid.isEmpty ? message.extra : message.grid)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textFaint)
+                }
+            }
+
+            Spacer()
+
+            // Chevron
+            Image(systemName: "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(textDim)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(bgApp)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(borderSubtle)
+                .frame(height: 1)
+        }
+    }
+
+    private var shortTime: String {
+        // "12:30:00" -> "12:30"
+        String(message.utcTime.prefix(5))
+    }
+
+    private var snrText: String {
+        message.snr >= 0 ? "+\(message.snr)" : "\(message.snr)"
+    }
+
+    private var snrColor: Color {
+        if message.snr >= 0 { return statusConfirmed }
+        if message.snr >= -10 { return signal }
+        if message.snr >= -18 { return textMuted }
+        return statusBad
+    }
+
+    private var freqText: String {
+        String(format: "%.0f", message.freqHz)
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct DecodeScreen: View {
+    @Environment(AppState.self) private var appState
+    @State private var showQsoSheet = false
+
+    var body: some View {
+        let decode = appState.decode
+
+        VStack(spacing: 0) {
+            // Top bar
+            HStack {
+                Text("Decode")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(textPrimary)
+                Spacer()
+                Text("\(decode.messages.count) msgs")
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textMuted)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            // Filter chips
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(DecodeFilter.allCases, id: \.self) { filter in
+                        FilterChip(
+                            label: filter.rawValue,
+                            isSelected: decode.activeFilter == filter
+                        ) {
+                            appState.decode.activeFilter = filter
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+            .padding(.bottom, 8)
+
+            // Message list
+            if filteredMessages.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(filteredMessages) { message in
+                            DecodeRow(message: message)
+                                .onTapGesture {
+                                    appState.decode.selectedMessage = message
+                                    showQsoSheet = true
+                                }
+                        }
+                    }
+                    .padding(.bottom, 160) // space for TxStrip + TabBar
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            TxStrip()
+        }
+        .background(bgApp)
+        .sheet(isPresented: $showQsoSheet) {
+            if let msg = decode.selectedMessage {
+                QsoSheet(message: msg)
+                    .presentationDetents([.medium])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+    }
+
+    private var filteredMessages: [DecodeMessage] {
+        let msgs = appState.decode.messages
+        switch appState.decode.activeFilter {
+        case .all:     return msgs
+        case .cq:      return msgs.filter { $0.callTo == "CQ" }
+        case .cqPota:  return msgs.filter { $0.extra.contains("K-") || $0.callTo == "CQ POTA" }
+        case .newDxcc: return msgs // Phase 4: filter by DXCC lookup
+        case .needed:  return msgs // Phase 4: filter by needed entities
+        case .forMe:   return msgs.filter { $0.callTo == appState.settings.myCall }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "waveform.slash")
+                .font(.system(size: 40))
+                .foregroundStyle(textFaint)
+            Text("No messages")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(textMuted)
+            Text("Decoded FT8 messages will appear here")
+                .font(.system(size: 13))
+                .foregroundStyle(textFaint)
+            Spacer()
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Bottom sheet showing station detail when a decode row is tapped.
+struct QsoSheet: View {
+    let message: DecodeMessage
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Callsign header
+            VStack(spacing: 4) {
+                Text(message.callFrom)
+                    .font(.system(size: 28, weight: .bold, design: .monospaced))
+                    .foregroundStyle(textPrimary)
+
+                if !message.grid.isEmpty {
+                    Text(message.grid)
+                        .font(.system(size: 14, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textMuted)
+                }
+            }
+            .padding(.top, 20)
+            .padding(.bottom, 16)
+
+            // Stats row
+            HStack(spacing: 24) {
+                StatBadge(label: "SNR", value: message.snr >= 0 ? "+\(message.snr)" : "\(message.snr)")
+                StatBadge(label: "Freq", value: String(format: "%.0f Hz", message.freqHz))
+                StatBadge(label: "UTC", value: message.utcTime)
+            }
+            .padding(.bottom, 20)
+
+            // Extra info
+            if !message.extra.isEmpty && message.extra != message.grid {
+                HStack {
+                    Text("Report")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(textFaint)
+                    Spacer()
+                    Text(message.extra)
+                        .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(textPrimary)
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 16)
+            }
+
+            Spacer()
+
+            // Call button (stub for Phase 4)
+            Button {
+                dismiss()
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .font(.system(size: 14, weight: .semibold))
+                    Text("Call \(message.callFrom)")
+                        .font(.system(size: 16, weight: .bold, design: .monospaced))
+                }
+                .foregroundStyle(bgApp)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(accent)
+                )
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 30)
+        }
+        .frame(maxWidth: .infinity)
+        .background(bgSurface2)
+    }
+}
+
+private struct StatBadge: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(textFaint)
+                .textCase(.uppercase)
+            Text(value)
+                .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                .foregroundStyle(textPrimary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(bgSurface3)
+        )
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Logbook/LogbookScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Logbook/LogbookScreen.swift
@@ -1,0 +1,144 @@
+import FT8Engine
+import SwiftUI
+
+struct LogbookScreen: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        let logbook = appState.logbook
+
+        VStack(spacing: 0) {
+            // Top bar
+            HStack {
+                Text("Logbook")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(textPrimary)
+                Spacer()
+                Text("\(logbook.totalCount) QSOs")
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textMuted)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            ScrollView {
+                VStack(spacing: 12) {
+                    // Stats cards
+                    LogbookStats(totalQsos: logbook.totalCount, bandStats: logbook.bandStats)
+                        .padding(.horizontal, 16)
+
+                    // QSO records list
+                    if logbook.records.isEmpty {
+                        emptyState
+                    } else {
+                        LazyVStack(spacing: 0) {
+                            ForEach(logbook.records, id: \.id) { record in
+                                LogbookRow(record: record)
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 100)
+            }
+        }
+        .background(bgApp)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "book.closed")
+                .font(.system(size: 40))
+                .foregroundStyle(textFaint)
+            Text("No QSOs logged")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(textMuted)
+            Text("Completed contacts will appear here")
+                .font(.system(size: 13))
+                .foregroundStyle(textFaint)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+}
+
+private struct LogbookRow: View {
+    let record: QsoRecord
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Band color indicator
+            RoundedRectangle(cornerRadius: 2)
+                .fill(bandColor(for: record.band))
+                .frame(width: 3, height: 36)
+                .padding(.trailing, 10)
+
+            // Call + grid
+            VStack(alignment: .leading, spacing: 2) {
+                Text(record.call)
+                    .font(.system(size: 14, weight: .bold, design: .monospaced))
+                    .foregroundStyle(textPrimary)
+                if !record.gridsquare.isEmpty {
+                    Text(record.gridsquare)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textFaint)
+                }
+            }
+
+            Spacer()
+
+            // Band pill
+            Text(record.band)
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundStyle(bandColor(for: record.band))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(bandColor(for: record.band).opacity(0.14))
+                )
+                .padding(.trailing, 10)
+
+            // SNR
+            Text(record.rstRcvd)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(textMuted)
+                .frame(width: 30, alignment: .trailing)
+                .padding(.trailing, 10)
+
+            // Date/time
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(formatDate(record.qsoDate))
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textFaint)
+                Text(formatTime(record.timeOn))
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textFaint)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(bgApp)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(borderSubtle)
+                .frame(height: 1)
+        }
+    }
+
+    private func formatDate(_ yyyymmdd: String) -> String {
+        guard yyyymmdd.count == 8,
+              let month = Int(yyyymmdd.dropFirst(4).prefix(2)),
+              let day = Int(yyyymmdd.suffix(2)),
+              (1...12).contains(month), (1...31).contains(day) else { return "" }
+        let months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+        return "\(day) \(months[month - 1])"
+    }
+
+    private func formatTime(_ hhmmss: String) -> String {
+        guard hhmmss.count >= 4 else { return "--:--" }
+        let hh = hhmmss.prefix(2)
+        let mm = hhmmss.dropFirst(2).prefix(2)
+        return "\(hh):\(mm)"
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Logbook/LogbookStats.swift
+++ b/ios/FT8AF/FT8AF/Screens/Logbook/LogbookStats.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// Stats cards shown at the top of the Logbook screen.
+struct LogbookStats: View {
+    let totalQsos: Int
+    let bandStats: [String: Int]
+
+    var body: some View {
+        VStack(spacing: 10) {
+            // Total QSOs card
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Total QSOs")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(textFaint)
+                        .textCase(.uppercase)
+                    Text("\(totalQsos)")
+                        .font(.system(size: 28, weight: .bold, design: .monospaced))
+                        .foregroundStyle(textPrimary)
+                }
+                Spacer()
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(.system(size: 24))
+                    .foregroundStyle(accent.opacity(0.5))
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(bgSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(borderSubtle, lineWidth: 1)
+                    )
+            )
+
+            // Band breakdown
+            if !bandStats.isEmpty {
+                LazyVGrid(columns: [
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                ], spacing: 8) {
+                    ForEach(sortedBands, id: \.0) { band, count in
+                        BandStatCard(band: band, count: count)
+                    }
+                }
+            }
+        }
+    }
+
+    private var sortedBands: [(String, Int)] {
+        let order = ["160M", "80M", "40M", "30M", "20M", "17M", "15M", "12M", "10M", "6M"]
+        return bandStats.sorted { a, b in
+            let ai = order.firstIndex(of: a.key.uppercased()) ?? 99
+            let bi = order.firstIndex(of: b.key.uppercased()) ?? 99
+            return ai < bi
+        }
+    }
+}
+
+private struct BandStatCard: View {
+    let band: String
+    let count: Int
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(band)
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .foregroundStyle(bandColor(for: band))
+            Text("\(count)")
+                .font(.system(size: 16, weight: .semibold, design: .monospaced))
+                .foregroundStyle(textPrimary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(bgSurface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(bandColor(for: band).opacity(0.2), lineWidth: 1)
+                )
+        )
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct MapScreen: View {
+    @Environment(AppState.self) private var appState
+    @State private var scale: CGFloat = 1.0
+    @State private var lastScale: CGFloat = 1.0
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
+    @State private var selectedMarker: MapMarker?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top bar
+            HStack {
+                Text("Map")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(textPrimary)
+                Spacer()
+                Text("\(markers.count) stations")
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textMuted)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            // Map canvas with gestures
+            ZStack {
+                WorldMapCanvas(markers: markers, selectedMarker: $selectedMarker)
+                    .scaleEffect(scale)
+                    .offset(offset)
+                    .gesture(
+                        MagnifyGesture()
+                            .onChanged { value in
+                                scale = lastScale * value.magnification
+                            }
+                            .onEnded { _ in
+                                lastScale = max(1.0, min(scale, 5.0))
+                                scale = lastScale
+                            }
+                    )
+                    .simultaneousGesture(
+                        DragGesture()
+                            .onChanged { value in
+                                offset = CGSize(
+                                    width: lastOffset.width + value.translation.width,
+                                    height: lastOffset.height + value.translation.height
+                                )
+                            }
+                            .onEnded { _ in
+                                lastOffset = offset
+                            }
+                    )
+
+                // Selected marker popup
+                if let marker = selectedMarker {
+                    VStack(spacing: 4) {
+                        Text(marker.callsign)
+                            .font(.system(size: 14, weight: .bold, design: .monospaced))
+                            .foregroundStyle(textPrimary)
+                        Text(marker.grid)
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundStyle(textMuted)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(bgSurface2)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .strokeBorder(borderStrong, lineWidth: 1)
+                            )
+                    )
+                    .position(x: 100, y: 40)
+                    .onTapGesture {
+                        selectedMarker = nil
+                    }
+                }
+            }
+        }
+        .background(bgApp)
+    }
+
+    private var markers: [MapMarker] {
+        appState.decode.messages.compactMap { msg in
+            guard !msg.grid.isEmpty else { return nil }
+            guard let (lat, lon) = gridToLatLon(msg.grid) else { return nil }
+            return MapMarker(callsign: msg.callFrom, grid: msg.grid, lat: lat, lon: lon)
+        }
+    }
+}
+
+struct MapMarker: Identifiable, Equatable {
+    let id = UUID()
+    let callsign: String
+    let grid: String
+    let lat: Double
+    let lon: Double
+}
+
+/// Convert 4-char Maidenhead grid to lat/lon center.
+func gridToLatLon(_ grid: String) -> (Double, Double)? {
+    let chars = Array(grid.uppercased().utf8)
+    guard chars.count >= 4,
+          chars[0] >= 65, chars[0] <= 82, // A-R
+          chars[1] >= 65, chars[1] <= 82,
+          chars[2] >= 48, chars[2] <= 57, // 0-9
+          chars[3] >= 48, chars[3] <= 57 else { return nil }
+    let lon = Double(chars[0] - 65) * 20 + Double(chars[2] - 48) * 2 + 1 - 180
+    let lat = Double(chars[1] - 65) * 10 + Double(chars[3] - 48) * 1 + 0.5 - 90
+    return (lat, lon)
+}

--- a/ios/FT8AF/FT8AF/Screens/Map/WorldMapCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/WorldMapCanvas.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Canvas-drawn equirectangular world map with station markers.
+struct WorldMapCanvas: View {
+    let markers: [MapMarker]
+    @Binding var selectedMarker: MapMarker?
+
+    var body: some View {
+        Canvas { context, size in
+            let w = size.width
+            let h = size.height
+
+            // Background ocean
+            context.fill(Path(CGRect(origin: .zero, size: size)), with: .color(bgSurface))
+
+            // Draw simplified continent outlines
+            drawContinents(context: context, width: w, height: h)
+
+            // Draw grid lines
+            drawGridLines(context: context, width: w, height: h)
+
+            // Draw station markers
+            for marker in markers {
+                let x = (marker.lon + 180) / 360 * Double(w)
+                let y = (90 - marker.lat) / 180 * Double(h)
+                let markerRect = CGRect(x: x - 4, y: y - 4, width: 8, height: 8)
+                context.fill(Path(ellipseIn: markerRect), with: .color(signal))
+                // Outer glow
+                let glowRect = CGRect(x: x - 6, y: y - 6, width: 12, height: 12)
+                context.fill(Path(ellipseIn: glowRect), with: .color(signal.opacity(0.2)))
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .contentShape(Rectangle())
+        .onTapGesture { location in
+            // Simplified marker hit testing
+            selectedMarker = nil
+        }
+    }
+
+    private func drawGridLines(context: GraphicsContext, width: CGFloat, height: CGFloat) {
+        // Latitude lines every 30 degrees
+        for lat in stride(from: -60.0, through: 60.0, by: 30.0) {
+            let y = (90 - lat) / 180 * Double(height)
+            let path = Path { p in
+                p.move(to: CGPoint(x: 0, y: y))
+                p.addLine(to: CGPoint(x: Double(width), y: y))
+            }
+            context.stroke(path, with: .color(textDim.opacity(0.3)), lineWidth: 0.5)
+        }
+        // Longitude lines every 30 degrees
+        for lon in stride(from: -150.0, through: 180.0, by: 30.0) {
+            let x = (lon + 180) / 360 * Double(width)
+            let path = Path { p in
+                p.move(to: CGPoint(x: x, y: 0))
+                p.addLine(to: CGPoint(x: x, y: Double(height)))
+            }
+            context.stroke(path, with: .color(textDim.opacity(0.3)), lineWidth: 0.5)
+        }
+    }
+
+    private func drawContinents(context: GraphicsContext, width: CGFloat, height: CGFloat) {
+        // Simplified continent shapes as filled polygons
+        let continents: [(Color, [(Double, Double)])] = [
+            // North America (simplified outline)
+            (bgElev, [(-170,72),(-170,55),(-130,50),(-120,35),(-100,25),(-80,25),(-75,30),(-65,45),(-55,50),(-80,60),(-100,65),(-130,70),(-170,72)]),
+            // South America
+            (bgElev, [(-80,12),(-80,-5),(-75,-15),(-70,-25),(-65,-35),(-70,-55),(-75,-55),(-60,-35),(-50,-25),(-35,-5),(-50,5),(-60,10),(-80,12)]),
+            // Europe
+            (bgElev, [(-10,36),(0,38),(5,44),(10,48),(20,55),(30,60),(40,65),(30,70),(20,70),(10,65),(0,55),(-5,48),(-10,36)]),
+            // Africa
+            (bgElev, [(-15,35),(-5,30),(10,35),(35,30),(50,12),(40,0),(30,-15),(25,-35),(20,-35),(15,-25),(10,-5),(0,5),(-10,10),(-15,35)]),
+            // Asia
+            (bgElev, [(40,30),(50,40),(60,55),(80,60),(100,70),(130,65),(145,60),(150,55),(140,45),(130,35),(120,25),(100,25),(80,30),(60,35),(40,30)]),
+            // Australia
+            (bgElev, [(115,-15),(130,-15),(145,-20),(150,-30),(145,-38),(130,-35),(115,-35),(115,-25),(115,-15)]),
+        ]
+
+        for (color, points) in continents {
+            let path = Path { p in
+                for (i, point) in points.enumerated() {
+                    let x = (point.0 + 180) / 360 * Double(width)
+                    let y = (90 - point.1) / 180 * Double(height)
+                    if i == 0 { p.move(to: CGPoint(x: x, y: y)) }
+                    else { p.addLine(to: CGPoint(x: x, y: y)) }
+                }
+                p.closeSubpath()
+            }
+            context.fill(path, with: .color(color))
+            context.stroke(path, with: .color(textDim.opacity(0.5)), lineWidth: 0.5)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+enum PotaTab: String, CaseIterable, Identifiable {
+    case activate = "Activate"
+    case hunt = "Hunt"
+    case history = "History"
+
+    var id: String { rawValue }
+}
+
+struct PotaScreen: View {
+    @State private var selectedTab: PotaTab = .hunt
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top bar
+            HStack {
+                Text("POTA")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(textPrimary)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            // Sub-tab picker
+            Picker("", selection: $selectedTab) {
+                ForEach(PotaTab.allCases) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+
+            // Tab content
+            Group {
+                switch selectedTab {
+                case .activate: activateTab
+                case .hunt:     huntTab
+                case .history:  historyTab
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(bgApp)
+    }
+
+    // MARK: - Activate Tab
+
+    private var activateTab: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "tree.fill")
+                .font(.system(size: 40))
+                .foregroundStyle(statusConfirmed.opacity(0.5))
+            Text("Park Activation")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(textPrimary)
+            Text("Enter a POTA park reference (e.g. K-1234)\nto start an activation session")
+                .font(.system(size: 13))
+                .foregroundStyle(textMuted)
+                .multilineTextAlignment(.center)
+
+            // Park reference field (stub)
+            HStack {
+                Text("Park Ref:")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(textMuted)
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(bgSurface3)
+                    .frame(height: 36)
+                    .overlay(
+                        Text("K-0000")
+                            .font(.system(size: 14, design: .monospaced))
+                            .foregroundStyle(textFaint),
+                        alignment: .leading
+                    )
+                    .padding(.leading, 8)
+            }
+            .padding(.horizontal, 40)
+
+            Button { } label: {
+                Text("Start Activation")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(bgApp)
+                    .frame(width: 200, height: 44)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(statusConfirmed)
+                    )
+            }
+            .buttonStyle(.plain)
+            Spacer()
+        }
+    }
+
+    // MARK: - Hunt Tab
+
+    private var huntTab: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(PotaSpotMock.spots) { spot in
+                    PotaSpotRow(spot: spot)
+                }
+            }
+            .padding(.bottom, 100)
+        }
+    }
+
+    // MARK: - History Tab
+
+    private var historyTab: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 40))
+                .foregroundStyle(textFaint)
+            Text("No activations yet")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(textMuted)
+            Text("Past POTA activations will appear here")
+                .font(.system(size: 13))
+                .foregroundStyle(textFaint)
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Mock data
+
+struct PotaSpotMock: Identifiable {
+    let id = UUID()
+    let activator: String
+    let reference: String
+    let parkName: String
+    let freqKhz: Int
+    let mode: String
+    let spotTime: String
+
+    static let spots: [PotaSpotMock] = [
+        PotaSpotMock(activator: "W1AW", reference: "K-0001", parkName: "Acadia NP", freqKhz: 14074, mode: "FT8", spotTime: "12:28"),
+        PotaSpotMock(activator: "KD2OGR", reference: "K-1234", parkName: "Harriman SP", freqKhz: 7074, mode: "FT8", spotTime: "12:25"),
+        PotaSpotMock(activator: "N5TIM", reference: "K-0042", parkName: "Big Bend NP", freqKhz: 14074, mode: "FT8", spotTime: "12:22"),
+        PotaSpotMock(activator: "VE3XYZ", reference: "VE-0456", parkName: "Algonquin PP", freqKhz: 21074, mode: "FT8", spotTime: "12:18"),
+        PotaSpotMock(activator: "DL4RCK", reference: "DL-0123", parkName: "Black Forest NP", freqKhz: 14074, mode: "FT8", spotTime: "12:15"),
+    ]
+}
+
+private struct PotaSpotRow: View {
+    let spot: PotaSpotMock
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Activator + park
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(spot.activator)
+                        .font(.system(size: 13, weight: .bold, design: .monospaced))
+                        .foregroundStyle(textPrimary)
+                    Text(spot.reference)
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(statusConfirmed)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(statusConfirmed.opacity(0.14))
+                        )
+                }
+                Text(spot.parkName)
+                    .font(.system(size: 11))
+                    .foregroundStyle(textMuted)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            // Frequency + time
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(spot.freqKhz) kHz")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textMuted)
+                Text(spot.spotTime)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textFaint)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(bgApp)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(borderSubtle)
+                .frame(height: 1)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Settings/DecodeFilterSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/DecodeFilterSettings.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct DecodeFilterSettings: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        @Bindable var settings = appState.settings
+
+        List {
+            Section {
+                Toggle(isOn: $settings.showOnlyCQ) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show Only CQ")
+                            .foregroundStyle(textPrimary)
+                        Text("Hide QSO traffic, show only CQ calls")
+                            .font(.system(size: 12))
+                            .foregroundStyle(textFaint)
+                    }
+                }
+                .tint(accent)
+
+                Toggle(isOn: $settings.dxOnly) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("DX Only")
+                            .foregroundStyle(textPrimary)
+                        Text("Hide domestic stations, show only DX")
+                            .font(.system(size: 12))
+                            .foregroundStyle(textFaint)
+                    }
+                }
+                .tint(accent)
+            } header: {
+                Text("Filters")
+                    .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+
+            Section {
+                highlightRow("New DXCC", description: "Purple highlight for unworked DXCC entities", color: statusNew)
+                highlightRow("New Grid", description: "Highlight for unworked grid squares", color: signal)
+                highlightRow("POTA Activators", description: "Green pill for spotted park activators", color: statusConfirmed)
+                highlightRow("Worked Stations", description: "Cyan indicator for previously worked calls", color: statusWorked)
+            } header: {
+                Text("Highlights")
+                    .foregroundStyle(textMuted)
+            } footer: {
+                Text("Highlight rules take effect in Phase 4 when the logbook database is integrated")
+                    .foregroundStyle(textFaint)
+            }
+            .listRowBackground(bgSurface)
+
+            Section {
+                HStack {
+                    Text("Continent Filter")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    Text("All")
+                        .foregroundStyle(textMuted)
+                }
+                HStack {
+                    Text("Blocked Callsigns")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    Text("0")
+                        .foregroundStyle(textMuted)
+                }
+            } header: {
+                Text("Advanced")
+                    .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+        }
+        .scrollContentBackground(.hidden)
+        .background(bgApp)
+        .navigationTitle("Decode Filters")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    private func highlightRow(_ title: String, description: String, color: Color) -> some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(color)
+                .frame(width: 10, height: 10)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .foregroundStyle(textPrimary)
+                Text(description)
+                    .font(.system(size: 12))
+                    .foregroundStyle(textFaint)
+            }
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Settings/RadioAudioSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/RadioAudioSettings.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct RadioAudioSettings: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        @Bindable var settings = appState.settings
+
+        List {
+            // Rig model
+            Section {
+                Picker("Rig Model", selection: $settings.rigModel) {
+                    ForEach(RigModel.allCases) { model in
+                        Text(model.rawValue).tag(model)
+                    }
+                }
+                .foregroundStyle(textPrimary)
+            } header: {
+                Text("Rig")
+                    .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+
+            // Audio input
+            Section {
+                HStack {
+                    Text("Input Device")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    Text("Built-in Microphone")
+                        .font(.system(size: 14))
+                        .foregroundStyle(textMuted)
+                }
+            } header: {
+                Text("Audio")
+                    .foregroundStyle(textMuted)
+            } footer: {
+                Text("Phase 2 will add audio input device selection with AVAudioEngine")
+                    .foregroundStyle(textFaint)
+            }
+            .listRowBackground(bgSurface)
+
+            // BLE device
+            Section {
+                HStack {
+                    Text("BLE Device")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    Text("Not connected")
+                        .font(.system(size: 14))
+                        .foregroundStyle(textFaint)
+                }
+                Button { } label: {
+                    HStack {
+                        Image(systemName: "antenna.radiowaves.left.and.right")
+                            .foregroundStyle(signal)
+                        Text("Scan for BLE Devices")
+                            .foregroundStyle(signal)
+                    }
+                }
+            } header: {
+                Text("Bluetooth")
+                    .foregroundStyle(textMuted)
+            } footer: {
+                Text("Phase 3 will add CoreBluetooth BLE SPP rig control")
+                    .foregroundStyle(textFaint)
+            }
+            .listRowBackground(bgSurface)
+
+            // Connection status
+            Section {
+                HStack {
+                    Text("Status")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(statusColor)
+                            .frame(width: 8, height: 8)
+                        Text(appState.rig.connectionStatus.rawValue)
+                            .font(.system(size: 14, design: .monospaced))
+                            .foregroundStyle(textMuted)
+                    }
+                }
+                HStack {
+                    Text("Frequency")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    Text(formatFreq(appState.rig.currentFreqHz))
+                        .font(.system(size: 14, design: .monospaced))
+                        .foregroundStyle(textMuted)
+                }
+            } header: {
+                Text("Connection")
+                    .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+        }
+        .scrollContentBackground(.hidden)
+        .background(bgApp)
+        .navigationTitle("Radio & Audio")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    private var statusColor: Color {
+        switch appState.rig.connectionStatus {
+        case .disconnected: return statusBad
+        case .connecting:   return statusWarn
+        case .connected:    return statusConfirmed
+        }
+    }
+
+    private func formatFreq(_ hz: UInt64) -> String {
+        let mhz = Double(hz) / 1_000_000
+        return String(format: "%.3f MHz", mhz)
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+
+struct SettingsScreen: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        @Bindable var settings = appState.settings
+
+        NavigationStack {
+            List {
+                // Operator section
+                Section {
+                    HStack {
+                        Text("Callsign")
+                            .foregroundStyle(textPrimary)
+                        Spacer()
+                        TextField("e.g. KD2OGR", text: $settings.myCall)
+                            .font(.system(.body, design: .monospaced))
+                            .multilineTextAlignment(.trailing)
+                            .foregroundStyle(textPrimary)
+                            .textInputAutocapitalization(.characters)
+                            .autocorrectionDisabled()
+                    }
+                    HStack {
+                        Text("Grid Square")
+                            .foregroundStyle(textPrimary)
+                        Spacer()
+                        TextField("e.g. FN20", text: $settings.myGrid)
+                            .font(.system(.body, design: .monospaced))
+                            .multilineTextAlignment(.trailing)
+                            .foregroundStyle(textPrimary)
+                            .textInputAutocapitalization(.characters)
+                            .autocorrectionDisabled()
+                    }
+                } header: {
+                    Text("Operator")
+                        .foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                // Radio & Audio section
+                Section {
+                    NavigationLink {
+                        RadioAudioSettings()
+                    } label: {
+                        HStack {
+                            Text("Radio & Audio")
+                                .foregroundStyle(textPrimary)
+                            Spacer()
+                            Text(settings.rigModel.rawValue)
+                                .font(.system(size: 14, design: .monospaced))
+                                .foregroundStyle(textMuted)
+                        }
+                    }
+                } header: {
+                    Text("Radio")
+                        .foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                // Transmission section
+                Section {
+                    NavigationLink {
+                        TransmissionSettings()
+                    } label: {
+                        HStack {
+                            Text("Transmission")
+                                .foregroundStyle(textPrimary)
+                            Spacer()
+                            Text("\(settings.txPowerWatts)W / \(settings.pttMode.rawValue)")
+                                .font(.system(size: 14, design: .monospaced))
+                                .foregroundStyle(textMuted)
+                        }
+                    }
+                } header: {
+                    Text("Transmit")
+                        .foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                // Decode Filters section
+                Section {
+                    NavigationLink {
+                        DecodeFilterSettings()
+                    } label: {
+                        Text("Decode Filters")
+                            .foregroundStyle(textPrimary)
+                    }
+                } header: {
+                    Text("Decode")
+                        .foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                // Logging section
+                Section {
+                    Toggle(isOn: $settings.autoLog) {
+                        Text("Auto-log QSOs")
+                            .foregroundStyle(textPrimary)
+                    }
+                    .tint(accent)
+
+                    Button { } label: {
+                        HStack {
+                            Text("Export ADIF")
+                                .foregroundStyle(textPrimary)
+                            Spacer()
+                            Image(systemName: "square.and.arrow.up")
+                                .foregroundStyle(textMuted)
+                        }
+                    }
+                } header: {
+                    Text("Logging")
+                        .foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                // Advanced section
+                Section {
+                    Button { } label: {
+                        HStack {
+                            Text("Debug Log")
+                                .foregroundStyle(textPrimary)
+                            Spacer()
+                            Image(systemName: "doc.text")
+                                .foregroundStyle(textMuted)
+                        }
+                    }
+
+                    HStack {
+                        Text("Version")
+                            .foregroundStyle(textPrimary)
+                        Spacer()
+                        Text("1.0.0 (Phase 1)")
+                            .font(.system(size: 14, design: .monospaced))
+                            .foregroundStyle(textFaint)
+                    }
+                } header: {
+                    Text("Advanced")
+                        .foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+            }
+            .scrollContentBackground(.hidden)
+            .background(bgApp)
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct TransmissionSettings: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        @Bindable var settings = appState.settings
+
+        List {
+            // TX Power
+            Section {
+                HStack {
+                    Text("TX Power")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    TextField("Watts", value: $settings.txPowerWatts, format: .number)
+                        .font(.system(.body, design: .monospaced))
+                        .multilineTextAlignment(.trailing)
+                        .foregroundStyle(textPrimary)
+                        .keyboardType(.numberPad)
+                        .frame(width: 60)
+                    Text("W")
+                        .foregroundStyle(textMuted)
+                }
+            } header: {
+                Text("Power")
+                    .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+
+            // PTT Mode
+            Section {
+                Picker("PTT Mode", selection: $settings.pttMode) {
+                    ForEach(PttMode.allCases) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .foregroundStyle(textPrimary)
+            } header: {
+                Text("PTT Control")
+                    .foregroundStyle(textMuted)
+            } footer: {
+                Text("VOX: use audio-triggered PTT. CAT/RTS/DTR: hardware control via rig connection")
+                    .foregroundStyle(textFaint)
+            }
+            .listRowBackground(bgSurface)
+
+            // Volume
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("TX Volume")
+                            .foregroundStyle(textPrimary)
+                        Spacer()
+                        Text("\(settings.txVolume)%")
+                            .font(.system(size: 14, design: .monospaced))
+                            .foregroundStyle(textMuted)
+                    }
+                    Slider(
+                        value: Binding(
+                            get: { Double(settings.txVolume) },
+                            set: { settings.txVolume = Int($0) }
+                        ),
+                        in: 0...100,
+                        step: 5
+                    )
+                    .tint(accent)
+                }
+            } header: {
+                Text("Audio")
+                    .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+
+            // Band selection
+            Section {
+                Picker("Band", selection: $settings.band) {
+                    ForEach(["160M","80M","40M","30M","20M","17M","15M","12M","10M","6M"], id: \.self) { band in
+                        Text(band).tag(band)
+                    }
+                }
+                .foregroundStyle(textPrimary)
+            } header: {
+                Text("Frequency")
+                    .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+        }
+        .scrollContentBackground(.hidden)
+        .background(bgApp)
+        .navigationTitle("Transmission")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/FrequencyRuler.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/FrequencyRuler.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Horizontal ruler showing Hz tick marks from 0 to 3000.
+struct FrequencyRuler: View {
+    private let ticks = stride(from: 0, through: 3000, by: 500).map { $0 }
+
+    var body: some View {
+        Canvas { context, size in
+            let hzRange: CGFloat = 3000
+            for hz in ticks {
+                let x = CGFloat(hz) / hzRange * size.width
+                // Tick mark
+                let tickPath = Path { p in
+                    p.move(to: CGPoint(x: x, y: 0))
+                    p.addLine(to: CGPoint(x: x, y: 6))
+                }
+                context.stroke(tickPath, with: .color(textFaint), lineWidth: 0.5)
+                // Label
+                let label = "\(hz)"
+                context.draw(
+                    Text(label)
+                        .font(.system(size: 8, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textFaint),
+                    at: CGPoint(x: x, y: 14),
+                    anchor: .center
+                )
+            }
+        }
+        .background(bgSurface)
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Vertical bar chart of FFT magnitudes with a TX frequency marker.
+struct SpectrumStrip: View {
+    @Environment(AppState.self) private var appState
+
+    // Mock spectrum data: 120 bins across 0-3000 Hz
+    private static let mockMagnitudes: [Float] = {
+        var mags = [Float](repeating: 0, count: 120)
+        for i in 0..<120 {
+            // Base noise floor
+            mags[i] = Float.random(in: 0.05...0.15)
+        }
+        // Add signal peaks matching waterfall mock
+        let peaks = [15, 35, 52, 70, 88, 105]
+        for p in peaks {
+            if p < 120 {
+                mags[p] = Float.random(in: 0.5...0.9)
+                if p > 0 { mags[p - 1] = Float.random(in: 0.2...0.4) }
+                if p < 119 { mags[p + 1] = Float.random(in: 0.2...0.4) }
+            }
+        }
+        return mags
+    }()
+
+    var body: some View {
+        Canvas { context, size in
+            let mags = Self.mockMagnitudes
+            let barW = size.width / CGFloat(mags.count)
+
+            for (i, mag) in mags.enumerated() {
+                let barH = CGFloat(mag) * size.height
+                let rect = CGRect(
+                    x: CGFloat(i) * barW,
+                    y: size.height - barH,
+                    width: barW + 0.5,
+                    height: barH
+                )
+                let color: Color = mag > 0.3 ? signal : signal.opacity(0.4)
+                context.fill(Path(rect), with: .color(color))
+            }
+
+            // TX frequency marker line
+            let txBin = CGFloat(appState.waterfall.txFreqHz / 3000.0) * CGFloat(mags.count)
+            let markerX = txBin * barW
+            let markerRect = CGRect(x: markerX - 0.5, y: 0, width: 1, height: size.height)
+            context.fill(Path(markerRect), with: .color(accent))
+        }
+        .background(bgSurface)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(borderSubtle)
+                .frame(height: 1)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
@@ -2,8 +2,13 @@ import SwiftUI
 
 /// Static mock waterfall heatmap. Phase 2 replaces this with a live MTKView.
 struct WaterfallCanvas: View {
-    // Generate static mock data once
-    private let mockData: (bins: [UInt8], rows: Int, cols: Int) = {
+    // Deterministic mock data. WaterfallScreen ticks its UTC clock every second,
+    // which re-creates this view; using `UInt8.random`/`Int.random` here would
+    // regenerate different bins each tick and make the "static" mock flicker.
+    // A hash-based pseudo-noise keeps the textured look while staying stable.
+    private let mockData: (bins: [UInt8], rows: Int, cols: Int) = WaterfallCanvas.makeMockData()
+
+    private static func makeMockData() -> (bins: [UInt8], rows: Int, cols: Int) {
         let rows = 80
         let cols = 120
         var bins = [UInt8](repeating: 0, count: rows * cols)
@@ -14,13 +19,13 @@ struct WaterfallCanvas: View {
         ]
         for r in 0..<rows {
             for c in 0..<cols {
-                // Background noise
-                let noise = UInt8.random(in: 5...35)
+                // Background noise (deterministic, 5...35)
+                let noise = UInt8(5 + pseudoNoise(r, c) % 31)
                 var value = noise
                 // Add signal traces
                 for sig in signals {
                     if c >= sig.col && c < sig.col + sig.width {
-                        let variation = Int.random(in: -20...20)
+                        let variation = Int(pseudoNoise(r, c + 7919) % 41) - 20
                         let signalVal = Int(sig.intensity) + variation
                         value = UInt8(max(Int(value), min(255, signalVal)))
                     }
@@ -29,7 +34,16 @@ struct WaterfallCanvas: View {
             }
         }
         return (bins, rows, cols)
-    }()
+    }
+
+    /// Stable 0..<2^31 pseudo-random hash of two integer coordinates.
+    private static func pseudoNoise(_ a: Int, _ b: Int) -> Int {
+        var h = UInt32(truncatingIfNeeded: (a &* 73856093) ^ (b &* 19349663))
+        h ^= h >> 13
+        h = h &* 0x5bd1_e995
+        h ^= h >> 15
+        return Int(h & 0x7fff_ffff)
+    }
 
     var body: some View {
         Canvas { context, size in

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Static mock waterfall heatmap. Phase 2 replaces this with a live MTKView.
+struct WaterfallCanvas: View {
+    // Generate static mock data once
+    private let mockData: (bins: [UInt8], rows: Int, cols: Int) = {
+        let rows = 80
+        let cols = 120
+        var bins = [UInt8](repeating: 0, count: rows * cols)
+        // Simulate a few FT8 signals as bright horizontal bands
+        let signals: [(col: Int, width: Int, intensity: UInt8)] = [
+            (15, 3, 200), (35, 2, 150), (52, 3, 220),
+            (70, 2, 130), (88, 4, 180), (105, 2, 160),
+        ]
+        for r in 0..<rows {
+            for c in 0..<cols {
+                // Background noise
+                let noise = UInt8.random(in: 5...35)
+                var value = noise
+                // Add signal traces
+                for sig in signals {
+                    if c >= sig.col && c < sig.col + sig.width {
+                        let variation = Int.random(in: -20...20)
+                        let signalVal = Int(sig.intensity) + variation
+                        value = UInt8(max(Int(value), min(255, signalVal)))
+                    }
+                }
+                bins[r * cols + c] = value
+            }
+        }
+        return (bins, rows, cols)
+    }()
+
+    var body: some View {
+        Canvas { context, size in
+            let rows = mockData.rows
+            let cols = mockData.cols
+            let bins = mockData.bins
+            guard rows > 0, cols > 0 else { return }
+
+            let cellW = size.width / CGFloat(cols)
+            let cellH = size.height / CGFloat(rows)
+
+            for r in 0..<rows {
+                for c in 0..<cols {
+                    let value = bins[r * cols + c]
+                    let color = waterfallColor(value)
+                    let rect = CGRect(
+                        x: CGFloat(c) * cellW,
+                        y: CGFloat(r) * cellH,
+                        width: cellW + 1,
+                        height: cellH + 1
+                    )
+                    context.fill(Path(rect), with: .color(color))
+                }
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+
+    private func waterfallColor(_ value: UInt8) -> Color {
+        let v = Double(value) / 255.0
+        if v < 0.25 {
+            let t = v / 0.25
+            return Color(red: 0, green: 0, blue: 0.2 + 0.8 * t)
+        } else if v < 0.5 {
+            let t = (v - 0.25) / 0.25
+            return Color(red: 0, green: t, blue: 1.0 - t)
+        } else if v < 0.75 {
+            let t = (v - 0.5) / 0.25
+            return Color(red: t, green: 1.0, blue: 0)
+        } else {
+            let t = (v - 0.75) / 0.25
+            return Color(red: 1.0, green: 1.0 - t, blue: 0)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
@@ -1,0 +1,84 @@
+import FT8Audio
+import SwiftUI
+
+struct WaterfallScreen: View {
+    @Environment(AppState.self) private var appState
+    @State private var utcString = ""
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Spectrum strip (top)
+            SpectrumStrip()
+                .frame(height: 96)
+
+            // Frequency ruler
+            FrequencyRuler()
+                .frame(height: 20)
+
+            // Waterfall canvas (fills remaining space)
+            WaterfallCanvas()
+                .padding(.horizontal, 2)
+
+            // Info bar (bottom)
+            HStack {
+                Text(utcString)
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(textPrimary)
+
+                Spacer()
+
+                HStack(spacing: 12) {
+                    InfoChip(label: "NR", isOn: false)
+                    InfoChip(label: "MSG", isOn: true)
+                    LiveIndicator(isLive: appState.waterfall.isLive)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 34)
+            .background(bgSurface)
+
+            TxStrip()
+        }
+        .background(bgApp)
+        .onReceive(timer) { _ in
+            let fmt = DateFormatter()
+            fmt.dateFormat = "HH:mm:ss"
+            fmt.timeZone = TimeZone(identifier: "UTC")
+            utcString = fmt.string(from: Date()) + " UTC"
+        }
+    }
+}
+
+private struct InfoChip: View {
+    let label: String
+    let isOn: Bool
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+            .foregroundStyle(isOn ? accent : textFaint)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isOn ? accentSoft : bgSurface3)
+            )
+    }
+}
+
+private struct LiveIndicator: View {
+    let isLive: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(isLive ? statusConfirmed : statusBad)
+                .frame(width: 6, height: 6)
+            Text(isLive ? "LIVE" : "OFF")
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundStyle(isLive ? statusConfirmed : textFaint)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
@@ -1,4 +1,3 @@
-import FT8Audio
 import SwiftUI
 
 struct WaterfallScreen: View {

--- a/ios/FT8AF/FT8AF/Theme/Colors.swift
+++ b/ios/FT8AF/FT8AF/Theme/Colors.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+// MARK: - Surfaces
+
+let bgApp      = Color(red: 0x07/255, green: 0x09/255, blue: 0x0F/255)
+let bgSurface  = Color(red: 0x0E/255, green: 0x13/255, blue: 0x1E/255)
+let bgSurface2 = Color(red: 0x16/255, green: 0x1C/255, blue: 0x2B/255)
+let bgSurface3 = Color(red: 0x1D/255, green: 0x25/255, blue: 0x38/255)
+let bgElev     = Color(red: 0x23/255, green: 0x2C/255, blue: 0x43/255)
+
+// MARK: - Borders
+
+let borderSubtle = Color(red: 148/255, green: 163/255, blue: 184/255).opacity(0.08)
+let borderStrong = Color(red: 148/255, green: 163/255, blue: 184/255).opacity(0.16)
+let borderAmber  = Color(red: 255/255, green: 175/255, blue: 94/255).opacity(0.22)
+
+// MARK: - Text
+
+let textPrimary = Color(red: 0xE7/255, green: 0xEC/255, blue: 0xF3/255)
+let textMuted   = Color(red: 0x8A/255, green: 0x96/255, blue: 0xB1/255)
+let textFaint   = Color(red: 0x5A/255, green: 0x64/255, blue: 0x7E/255)
+let textDim     = Color(red: 0x3E/255, green: 0x48/255, blue: 0x62/255)
+
+// MARK: - Accent
+
+let accent     = Color(red: 0xFF/255, green: 0xAF/255, blue: 0x5E/255)
+let accentSoft = Color(red: 0xFF/255, green: 0xAF/255, blue: 0x5E/255).opacity(0.14)
+let accentGlow = Color(red: 0xFF/255, green: 0xD7/255, blue: 0xA0/255)
+
+// MARK: - Signal
+
+let signal     = Color(red: 0x5C/255, green: 0xD6/255, blue: 0xE8/255)
+let signalSoft = Color(red: 0x5C/255, green: 0xD6/255, blue: 0xE8/255).opacity(0.14)
+
+// MARK: - Target
+
+let target       = Color(red: 0xF4/255, green: 0x72/255, blue: 0xB6/255)
+let targetSoft   = Color(red: 0xF4/255, green: 0x72/255, blue: 0xB6/255).opacity(0.14)
+let targetBorder = Color(red: 0xF4/255, green: 0x72/255, blue: 0xB6/255).opacity(0.28)
+
+// MARK: - Status
+
+let statusNew       = Color(red: 0xC0/255, green: 0x84/255, blue: 0xFC/255)
+let statusNeeded    = Color(red: 0xFF/255, green: 0xAF/255, blue: 0x5E/255)
+let statusWorked    = Color(red: 0x5C/255, green: 0xD6/255, blue: 0xE8/255)
+let statusConfirmed = Color(red: 0x4A/255, green: 0xDE/255, blue: 0x80/255)
+let statusCq        = Color(red: 0xFF/255, green: 0xAF/255, blue: 0x5E/255)
+let statusWarn      = Color(red: 0xFA/255, green: 0xCC/255, blue: 0x15/255)
+let statusBad       = Color(red: 0xEF/255, green: 0x44/255, blue: 0x44/255)
+
+// MARK: - Band colors
+
+let band20m = Color(red: 0x5C/255, green: 0xD6/255, blue: 0xE8/255)
+let band15m = Color(red: 0x4A/255, green: 0xDE/255, blue: 0x80/255)
+let band40m = Color(red: 0xFF/255, green: 0xAF/255, blue: 0x5E/255)
+let band10m = Color(red: 0xC0/255, green: 0x84/255, blue: 0xFC/255)
+let band30m = Color(red: 0xF4/255, green: 0x72/255, blue: 0xB6/255)
+let band17m = Color(red: 0xFA/255, green: 0xCC/255, blue: 0x15/255)
+let band12m = Color(red: 0xFB/255, green: 0x71/255, blue: 0x85/255)
+let band80m = Color(red: 0x60/255, green: 0xA5/255, blue: 0xFA/255)
+let band160m = Color(red: 0x94/255, green: 0xA3/255, blue: 0xB8/255)
+let band6m  = Color(red: 0xA7/255, green: 0x8B/255, blue: 0xFA/255)
+
+// PSK Reporter overlay
+let pskSpot = Color(red: 0xF8/255, green: 0x71/255, blue: 0x71/255)
+
+/// Return the band color for a given band label (e.g. "20M", "40m").
+func bandColor(for band: String) -> Color {
+    switch band.uppercased() {
+    case "160M": return band160m
+    case "80M":  return band80m
+    case "40M":  return band40m
+    case "30M":  return band30m
+    case "20M":  return band20m
+    case "17M":  return band17m
+    case "15M":  return band15m
+    case "12M":  return band12m
+    case "10M":  return band10m
+    case "6M":   return band6m
+    default:     return textMuted
+    }
+}

--- a/ios/FT8AF/project.yml
+++ b/ios/FT8AF/project.yml
@@ -1,0 +1,37 @@
+name: FT8AF
+options:
+  bundleIdPrefix: radio.ks3ckc
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "15.0"
+  generateEmptyDirectories: true
+
+packages:
+  FT8AFKit:
+    path: ../FT8AFKit
+
+targets:
+  FT8AF:
+    type: application
+    platform: iOS
+    sources:
+      - FT8AF
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        SWIFT_VERSION: "5.9"
+        PRODUCT_BUNDLE_IDENTIFIER: radio.ks3ckc.ft8af
+    dependencies:
+      - package: FT8AFKit
+        product: FT8DSP
+      - package: FT8AFKit
+        product: FT8Audio
+      - package: FT8AFKit
+        product: FT8Engine
+      - package: FT8AFKit
+        product: FT8Rig

--- a/ios/FT8AFDemo/FT8AFDemo.xcodeproj/project.pbxproj
+++ b/ios/FT8AFDemo/FT8AFDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,386 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1B2C2A4371EC9AD357C5E63D /* RoundTripViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA2D506472095697CDABFB6 /* RoundTripViewModel.swift */; };
+		22E1DC74A7166C03C58E2546 /* WaterfallCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DAD7E4842BE1DCF4E9D424 /* WaterfallCanvas.swift */; };
+		2861E869AA9465EF9705C612 /* QsoSimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326BE233AA2DE5A105268C51 /* QsoSimView.swift */; };
+		35B91E4DE19345D0D147E61D /* FT8Engine in Frameworks */ = {isa = PBXBuildFile; productRef = 787E0CA07F88E40CF1BE8F79 /* FT8Engine */; };
+		53E77E768808C436674E4DEE /* FT8AFDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C88A4F74CDF3D3F76C86F29 /* FT8AFDemoApp.swift */; };
+		7857D5600A191D96D303F9E8 /* FT8DSP in Frameworks */ = {isa = PBXBuildFile; productRef = 253195C0BE6076BD2155E786 /* FT8DSP */; };
+		8D44232B4FAD69B6FD21538C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1BD31E6CF949EDFB1A6EA3D5 /* Assets.xcassets */; };
+		C8847799F27A3BCA8451E183 /* RoundTripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEF4630DA972AE6A6832084 /* RoundTripView.swift */; };
+		DA95A9D063D202F95B9C4C50 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90CEDB9DACC96961313CCAA /* ContentView.swift */; };
+		E7547973A44191E9C8234A9A /* FT8Audio in Frameworks */ = {isa = PBXBuildFile; productRef = 2D3A28346FD46F855149D570 /* FT8Audio */; };
+		E8D78CCC4C8AD2B29FF85180 /* SlotClockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAE4708FB5DF128DEB01129 /* SlotClockView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1BD31E6CF949EDFB1A6EA3D5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		326BE233AA2DE5A105268C51 /* QsoSimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoSimView.swift; sourceTree = "<group>"; };
+		3AEF4630DA972AE6A6832084 /* RoundTripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundTripView.swift; sourceTree = "<group>"; };
+		8C88A4F74CDF3D3F76C86F29 /* FT8AFDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FT8AFDemoApp.swift; sourceTree = "<group>"; };
+		A7DAD7E4842BE1DCF4E9D424 /* WaterfallCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallCanvas.swift; sourceTree = "<group>"; };
+		A90CEDB9DACC96961313CCAA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		AFAE4708FB5DF128DEB01129 /* SlotClockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotClockView.swift; sourceTree = "<group>"; };
+		C522161F14B2298B8BBD6C9E /* FT8AFDemo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FT8AFDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DEF33EB79A2DE07EDE7DCC4B /* FT8AFKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FT8AFKit; path = ../FT8AFKit; sourceTree = SOURCE_ROOT; };
+		FCA2D506472095697CDABFB6 /* RoundTripViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundTripViewModel.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2D1CFCAE0BA23DC21DE8C9E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7857D5600A191D96D303F9E8 /* FT8DSP in Frameworks */,
+				E7547973A44191E9C8234A9A /* FT8Audio in Frameworks */,
+				35B91E4DE19345D0D147E61D /* FT8Engine in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6F477863D2AE9D79738158FA /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				DEF33EB79A2DE07EDE7DCC4B /* FT8AFKit */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		DED10D440AA2C064D01DD500 = {
+			isa = PBXGroup;
+			children = (
+				E717ED7E73A2591E1C323460 /* FT8AFDemo */,
+				6F477863D2AE9D79738158FA /* Packages */,
+				F8B1671597E1CD460E614A83 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E717ED7E73A2591E1C323460 /* FT8AFDemo */ = {
+			isa = PBXGroup;
+			children = (
+				1BD31E6CF949EDFB1A6EA3D5 /* Assets.xcassets */,
+				A90CEDB9DACC96961313CCAA /* ContentView.swift */,
+				8C88A4F74CDF3D3F76C86F29 /* FT8AFDemoApp.swift */,
+				326BE233AA2DE5A105268C51 /* QsoSimView.swift */,
+				3AEF4630DA972AE6A6832084 /* RoundTripView.swift */,
+				FCA2D506472095697CDABFB6 /* RoundTripViewModel.swift */,
+				AFAE4708FB5DF128DEB01129 /* SlotClockView.swift */,
+				A7DAD7E4842BE1DCF4E9D424 /* WaterfallCanvas.swift */,
+			);
+			path = FT8AFDemo;
+			sourceTree = "<group>";
+		};
+		F8B1671597E1CD460E614A83 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C522161F14B2298B8BBD6C9E /* FT8AFDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6F193F8FCAEDFC739E303AAA /* FT8AFDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F0D7EB4D8E80DA1C784EF507 /* Build configuration list for PBXNativeTarget "FT8AFDemo" */;
+			buildPhases = (
+				E9C4F7C54536D70BB9097228 /* Sources */,
+				3872217FC07CE343DB29E478 /* Resources */,
+				2D1CFCAE0BA23DC21DE8C9E2 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FT8AFDemo;
+			packageProductDependencies = (
+				253195C0BE6076BD2155E786 /* FT8DSP */,
+				2D3A28346FD46F855149D570 /* FT8Audio */,
+				787E0CA07F88E40CF1BE8F79 /* FT8Engine */,
+			);
+			productName = FT8AFDemo;
+			productReference = C522161F14B2298B8BBD6C9E /* FT8AFDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		36E0211EB41F2062AFB3708B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 4BEC2539EE3937718E668123 /* Build configuration list for PBXProject "FT8AFDemo" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = DED10D440AA2C064D01DD500;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				CD53659727434A0CB9C508B3 /* XCLocalSwiftPackageReference "../FT8AFKit" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = F8B1671597E1CD460E614A83 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6F193F8FCAEDFC739E303AAA /* FT8AFDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3872217FC07CE343DB29E478 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8D44232B4FAD69B6FD21538C /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E9C4F7C54536D70BB9097228 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA95A9D063D202F95B9C4C50 /* ContentView.swift in Sources */,
+				53E77E768808C436674E4DEE /* FT8AFDemoApp.swift in Sources */,
+				2861E869AA9465EF9705C612 /* QsoSimView.swift in Sources */,
+				C8847799F27A3BCA8451E183 /* RoundTripView.swift in Sources */,
+				1B2C2A4371EC9AD357C5E63D /* RoundTripViewModel.swift in Sources */,
+				E8D78CCC4C8AD2B29FF85180 /* SlotClockView.swift in Sources */,
+				22E1DC74A7166C03C58E2546 /* WaterfallCanvas.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0E110F6CAC76379945212F90 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = radio.ks3ckc.ft8afdemo;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		5CBFEA95E6626CA964E79A17 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = radio.ks3ckc.ft8afdemo;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8F256DB00D185ED1DA3ACC9D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		B84787B8ECC5F0F1C62EF888 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4BEC2539EE3937718E668123 /* Build configuration list for PBXProject "FT8AFDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B84787B8ECC5F0F1C62EF888 /* Debug */,
+				8F256DB00D185ED1DA3ACC9D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F0D7EB4D8E80DA1C784EF507 /* Build configuration list for PBXNativeTarget "FT8AFDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CBFEA95E6626CA964E79A17 /* Debug */,
+				0E110F6CAC76379945212F90 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		CD53659727434A0CB9C508B3 /* XCLocalSwiftPackageReference "../FT8AFKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../FT8AFKit;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		253195C0BE6076BD2155E786 /* FT8DSP */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FT8DSP;
+		};
+		2D3A28346FD46F855149D570 /* FT8Audio */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FT8Audio;
+		};
+		787E0CA07F88E40CF1BE8F79 /* FT8Engine */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FT8Engine;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 36E0211EB41F2062AFB3708B /* Project object */;
+}

--- a/ios/FT8AFDemo/FT8AFDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/FT8AFDemo/FT8AFDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/FT8AFDemo/FT8AFDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/FT8AFDemo/FT8AFDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/FT8AFDemo/FT8AFDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/Assets.xcassets/Contents.json
+++ b/ios/FT8AFDemo/FT8AFDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/ContentView.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/ContentView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            RoundTripView()
+                .tabItem {
+                    Label("Round Trip", systemImage: "waveform")
+                }
+
+            SlotClockView()
+                .tabItem {
+                    Label("Slot Clock", systemImage: "clock")
+                }
+
+            QsoSimView()
+                .tabItem {
+                    Label("QSO Sim", systemImage: "antenna.radiowaves.left.and.right")
+                }
+        }
+    }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/FT8AFDemoApp.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/FT8AFDemoApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct FT8AFDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/QsoSimView.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/QsoSimView.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+import FT8DSP
+import FT8Engine
+
+struct QsoSimView: View {
+    @State private var myCall = "K1ABC"
+    @State private var myGrid = "FN42"
+    @State private var dxCall = "W9XYZ"
+    @State private var dxGrid = "EM48"
+    @State private var engine: QsoEngine?
+    @State private var log: [String] = []
+    @State private var statusText = "Idle"
+    @State private var stepCount = 0
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("My Station") {
+                    TextField("My Call", text: $myCall)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                    TextField("My Grid", text: $myGrid)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                }
+
+                Section("DX Station (simulated)") {
+                    TextField("DX Call", text: $dxCall)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                    TextField("DX Grid", text: $dxGrid)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                }
+
+                Section("Engine Status") {
+                    Text(statusText)
+                        .font(.system(.body, design: .monospaced))
+                }
+
+                Section("Controls") {
+                    Button("Call CQ") {
+                        startCq()
+                    }
+
+                    Button("Answer CQ") {
+                        answerCq()
+                    }
+
+                    Button("Step RX") {
+                        stepRx()
+                    }
+                    .disabled(engine == nil)
+
+                    Button("Stop", role: .destructive) {
+                        stop()
+                    }
+                    .disabled(engine == nil)
+                }
+
+                if !log.isEmpty {
+                    Section("Log") {
+                        ForEach(Array(log.enumerated()), id: \.offset) { _, entry in
+                            Text(entry)
+                                .font(.system(.caption, design: .monospaced))
+                        }
+                    }
+                }
+            }
+            .navigationTitle("QSO Sim")
+        }
+    }
+
+    private func ensureEngine() -> QsoEngine {
+        if let e = engine { return e }
+        let e = QsoEngine(myCall: myCall, myGrid: myGrid)
+        engine = e
+        return e
+    }
+
+    private func startCq() {
+        let e = ensureEngine()
+        e.myCall = myCall
+        e.myGrid = myGrid
+        e.startCq()
+        stepCount = 0
+        appendLog(">>> Started CQ")
+        refreshStatus()
+    }
+
+    private func answerCq() {
+        let e = ensureEngine()
+        e.myCall = myCall
+        e.myGrid = myGrid
+
+        // Simulate receiving a CQ from DX
+        var cqMsg = DecodedMessage()
+        cqMsg.callTo = "CQ"
+        cqMsg.callFrom = dxCall
+        cqMsg.extra = ""
+        cqMsg.grid = dxGrid
+        cqMsg.rawText = "CQ \(dxCall) \(dxGrid)"
+        cqMsg.snr = -10
+        cqMsg.freqHz = 1000
+        cqMsg.timeSec = 0
+        cqMsg.score = 100
+        cqMsg.i3 = 0
+        cqMsg.n3 = 0
+        cqMsg.a91 = []
+
+        e.answer(cqMsg)
+        stepCount = 0
+        appendLog(">>> Answered CQ from \(dxCall)")
+        refreshStatus()
+    }
+
+    private func stepRx() {
+        guard let e = engine else { return }
+        stepCount += 1
+
+        // Build a synthetic RX message based on current engine stage
+        let status = e.status()
+        let rxMessages = buildSimulatedRx(for: status.stage, step: stepCount)
+
+        appendLog("RX step \(stepCount): feeding \(rxMessages.count) message(s)")
+        for m in rxMessages {
+            appendLog("  < \(m.rawText)")
+        }
+
+        if let outcome = e.processRx(rxMessages) {
+            if case .completed(let record) = outcome {
+                appendLog("*** QSO COMPLETE with \(record.call) ***")
+            }
+        }
+
+        refreshStatus()
+    }
+
+    private func stop() {
+        engine?.stop()
+        refreshStatus()
+        appendLog(">>> Stopped")
+    }
+
+    private func refreshStatus() {
+        guard let e = engine else {
+            statusText = "Idle"
+            return
+        }
+        let s = e.status()
+        var parts = ["Stage: \(s.stage.rawValue)", "Active: \(s.active)"]
+        if let t = s.target { parts.append("Target: \(t)") }
+        if let tx = s.txMessage { parts.append("TX: \(tx)") }
+        if let rs = s.reportSent { parts.append("Sent: \(rs)") }
+        if let rr = s.reportRcvd { parts.append("Rcvd: \(rr)") }
+        statusText = parts.joined(separator: "\n")
+    }
+
+    private func buildSimulatedRx(for stage: TxStage, step: Int) -> [DecodedMessage] {
+        // Simulate the DX station's responses based on our current TX stage
+        var msg = DecodedMessage()
+        msg.snr = -12
+        msg.freqHz = 1000
+        msg.timeSec = 0
+        msg.score = 100
+        msg.i3 = 0
+        msg.n3 = 0
+        msg.a91 = []
+
+        switch stage {
+        case .cq:
+            // DX answers our CQ
+            msg.callTo = myCall
+            msg.callFrom = dxCall
+            msg.grid = dxGrid
+            msg.extra = dxGrid
+            msg.rawText = "\(myCall) \(dxCall) \(dxGrid)"
+
+        case .grid:
+            // DX sends signal report
+            msg.callTo = myCall
+            msg.callFrom = dxCall
+            msg.extra = "-12"
+            msg.grid = ""
+            msg.rawText = "\(myCall) \(dxCall) -12"
+
+        case .report:
+            // DX sends R+report
+            msg.callTo = myCall
+            msg.callFrom = dxCall
+            msg.extra = "R-10"
+            msg.grid = ""
+            msg.rawText = "\(myCall) \(dxCall) R-10"
+
+        case .rReport:
+            // DX sends RR73
+            msg.callTo = myCall
+            msg.callFrom = dxCall
+            msg.extra = "RR73"
+            msg.grid = ""
+            msg.rawText = "\(myCall) \(dxCall) RR73"
+
+        case .rr73, .bye73:
+            // DX sends 73
+            msg.callTo = myCall
+            msg.callFrom = dxCall
+            msg.extra = "73"
+            msg.grid = ""
+            msg.rawText = "\(myCall) \(dxCall) 73"
+
+        case .idle:
+            return []
+        }
+
+        return [msg]
+    }
+
+    private func appendLog(_ text: String) {
+        log.append(text)
+        // Keep log manageable
+        if log.count > 50 {
+            log.removeFirst(log.count - 50)
+        }
+    }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/RoundTripView.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/RoundTripView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import FT8DSP
+
+struct RoundTripView: View {
+    @State private var vm = RoundTripViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Input") {
+                    TextField("FT8 Message", text: $vm.message)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+
+                    HStack {
+                        Text("Base Freq: \(Int(vm.baseFreqHz)) Hz")
+                        Spacer()
+                        Slider(value: $vm.baseFreqHz, in: 200...3000, step: 50)
+                            .frame(width: 180)
+                    }
+
+                    Button {
+                        vm.encodeAndDecode()
+                    } label: {
+                        HStack {
+                            if vm.isRunning {
+                                ProgressView()
+                                    .padding(.trailing, 4)
+                            }
+                            Text("Encode + Decode")
+                        }
+                    }
+                    .disabled(vm.isRunning || vm.message.isEmpty)
+                }
+
+                if let err = vm.errorText {
+                    Section {
+                        Text(err)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                if !vm.decodedMessages.isEmpty {
+                    Section("Decoded Messages") {
+                        ForEach(vm.decodedMessages, id: \.self) { msg in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(msg.rawText)
+                                    .font(.system(.body, design: .monospaced))
+                                Text("SNR: \(msg.snr) dB  |  \(String(format: "%.0f", msg.freqHz)) Hz  |  Score: \(msg.score)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+
+                if !vm.waterfallBins.isEmpty {
+                    Section("Waterfall") {
+                        WaterfallCanvas(
+                            bins: vm.waterfallBins,
+                            rows: vm.waterfallRows,
+                            cols: vm.waterfallCols
+                        )
+                        .frame(height: 200)
+                    }
+                }
+            }
+            .navigationTitle("Round Trip")
+        }
+    }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/RoundTripViewModel.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/RoundTripViewModel.swift
@@ -1,0 +1,52 @@
+import Foundation
+import FT8DSP
+
+@MainActor
+@Observable
+final class RoundTripViewModel {
+    var message: String = "CQ K1ABC FN42"
+    var baseFreqHz: Float = 1000
+    var decodedMessages: [DecodedMessage] = []
+    var waterfallBins: [UInt8] = []
+    var waterfallRows: Int = 0
+    var waterfallCols: Int = 0
+    var hzPerCol: Float = 0
+    var isRunning: Bool = false
+    var errorText: String?
+
+    func encodeAndDecode() {
+        guard !isRunning else { return }
+        isRunning = true
+        errorText = nil
+        decodedMessages = []
+        waterfallBins = []
+
+        let msg = message
+        let freq = baseFreqHz
+
+        Task.detached {
+            guard let samples = FT8Encoder.generateFT8(msg, baseFreqHz: freq) else {
+                await MainActor.run { [weak self] in
+                    self?.errorText = "Encoding failed — check message format"
+                    self?.isRunning = false
+                }
+                return
+            }
+
+            let decoder = FT8Decoder()
+            decoder.feedSlot(samples)
+            decoder.findSync()
+            let decoded = decoder.decodeAll()
+            let heatmap = decoder.waterfallHeatmap(maxRows: 100, maxCols: 200)
+
+            await MainActor.run { [weak self] in
+                self?.decodedMessages = decoded
+                self?.waterfallBins = heatmap.bins
+                self?.waterfallRows = heatmap.rows
+                self?.waterfallCols = heatmap.cols
+                self?.hzPerCol = heatmap.hzPerCol
+                self?.isRunning = false
+            }
+        }
+    }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/RoundTripViewModel.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/RoundTripViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import FT8DSP
 
 @MainActor

--- a/ios/FT8AFDemo/FT8AFDemo/SlotClockView.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/SlotClockView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import FT8Audio
 
 struct SlotClockView: View {
-    @State private var nowMs: Int64 = currentUtcMs()
+    @State private var nowMs: Int64 = Self.currentUtcMs()
     private let timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
 
     var body: some View {

--- a/ios/FT8AFDemo/FT8AFDemo/SlotClockView.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/SlotClockView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import FT8Audio
+
+struct SlotClockView: View {
+    @State private var nowMs: Int64 = currentUtcMs()
+    private let timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 32) {
+                Spacer()
+
+                // UTC time display
+                Text(utcTimeString(nowMs))
+                    .font(.system(size: 48, weight: .light, design: .monospaced))
+
+                // Slot info
+                let slotID = SlotClock.slotID(atUtcMs: nowMs)
+                let parity = SlotClock.parity(slotID: slotID)
+                let msInto = SlotClock.msIntoCycle(atUtcMs: nowMs)
+                let progress = Double(msInto) / Double(SlotClock.cycleMs)
+
+                VStack(spacing: 12) {
+                    HStack(spacing: 24) {
+                        LabeledValue(label: "Slot ID", value: "\(slotID)")
+                        LabeledValue(label: "Parity", value: parity == 0 ? "Even" : "Odd")
+                        LabeledValue(label: "Into Cycle", value: "\(msInto) ms")
+                    }
+
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .tint(progress < 0.84 ? .blue : .orange)
+                        .padding(.horizontal, 32)
+
+                    Text(progress < 0.84 ? "RX Window" : "Guard")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Text("Cycle: \(SlotClock.cycleMs) ms")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+
+                Spacer()
+            }
+            .navigationTitle("Slot Clock")
+            .onReceive(timer) { _ in
+                nowMs = Self.currentUtcMs()
+            }
+        }
+    }
+
+    private static func currentUtcMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private func utcTimeString(_ ms: Int64) -> String {
+        let total = ms / 1000
+        let h = (total % 86400) / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        let frac = (ms % 1000) / 100
+        return String(format: "%02d:%02d:%02d.%d", h, m, s, frac)
+    }
+}
+
+private struct LabeledValue: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(.title3, design: .monospaced))
+        }
+    }
+}

--- a/ios/FT8AFDemo/FT8AFDemo/WaterfallCanvas.swift
+++ b/ios/FT8AFDemo/FT8AFDemo/WaterfallCanvas.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct WaterfallCanvas: View {
+    let bins: [UInt8]
+    let rows: Int
+    let cols: Int
+
+    var body: some View {
+        Canvas { context, size in
+            guard rows > 0, cols > 0, bins.count == rows * cols else { return }
+
+            let cellW = size.width / CGFloat(cols)
+            let cellH = size.height / CGFloat(rows)
+
+            for r in 0..<rows {
+                for c in 0..<cols {
+                    let value = bins[r * cols + c]
+                    let color = waterfallColor(value)
+                    let rect = CGRect(
+                        x: CGFloat(c) * cellW,
+                        y: CGFloat(r) * cellH,
+                        width: cellW + 1,      // +1 to avoid sub-pixel gaps
+                        height: cellH + 1
+                    )
+                    context.fill(Path(rect), with: .color(color))
+                }
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// Map 0-255 intensity to a blue-green-yellow-red gradient.
+    private func waterfallColor(_ value: UInt8) -> Color {
+        let v = Double(value) / 255.0
+        if v < 0.25 {
+            let t = v / 0.25
+            return Color(red: 0, green: 0, blue: 0.2 + 0.8 * t)
+        } else if v < 0.5 {
+            let t = (v - 0.25) / 0.25
+            return Color(red: 0, green: t, blue: 1.0 - t)
+        } else if v < 0.75 {
+            let t = (v - 0.5) / 0.25
+            return Color(red: t, green: 1.0, blue: 0)
+        } else {
+            let t = (v - 0.75) / 0.25
+            return Color(red: 1.0, green: 1.0 - t, blue: 0)
+        }
+    }
+}

--- a/ios/FT8AFDemo/project.yml
+++ b/ios/FT8AFDemo/project.yml
@@ -1,0 +1,35 @@
+name: FT8AFDemo
+options:
+  bundleIdPrefix: radio.ks3ckc
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "15.0"
+  generateEmptyDirectories: true
+
+packages:
+  FT8AFKit:
+    path: ../FT8AFKit
+
+targets:
+  FT8AFDemo:
+    type: application
+    platform: iOS
+    sources:
+      - FT8AFDemo
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        SWIFT_VERSION: "5.9"
+        PRODUCT_BUNDLE_IDENTIFIER: radio.ks3ckc.ft8afdemo
+    dependencies:
+      - package: FT8AFKit
+        product: FT8DSP
+      - package: FT8AFKit
+        product: FT8Audio
+      - package: FT8AFKit
+        product: FT8Engine


### PR DESCRIPTION
## Summary

- **Phase 1 of the iOS FT8AF port**: full 6-tab app shell with static/mock data, establishing architecture, theme, and state management that mirrors the Android app
- **25 Swift source files** in `ios/FT8AF/` — Theme, Navigation, Components, and 6 screen tabs
- **Also commits `ios/FT8AFDemo/`** (3-tab demo app, previously untracked) that exercises FT8AFKit encode/decode/slot-clock

### Screens
| Tab | Contents |
|-----|----------|
| **Decode** | Filter chips (All/CQ/POTA/New DXCC/Needed/For Me), scrollable message list with CQ badges, SNR, frequencies, callsigns; tap → QSO bottom sheet |
| **Waterfall** | SpectrumStrip (FFT bars + TX marker), FrequencyRuler (0–3000 Hz), static mock heatmap, UTC clock + LIVE indicator |
| **Logbook** | Total QSO card, per-band stat grid with band colors, QSO record list with formatted dates |
| **Map** | Canvas-drawn equirectangular world map with continent outlines, grid lines, station markers (grid → lat/lon) |
| **POTA** | 3 segmented sub-tabs (Activate/Hunt/History) with mock spots |
| **Settings** | NavigationStack: Operator, Radio & Audio, Transmission, Decode Filters, Logging, Advanced |

### Architecture
- Distributed `@Observable` state: `AppState` → `DecodeState`, `WaterfallState`, `LogbookState`, `SettingsState`, `RigState`, `TxState`
- Dark-mode color tokens ported 1:1 from Android `Color.kt`
- Custom bottom tab bar with accent pill indicator
- `TxStrip` control bar (HUNT/CQ-STOP/TX slot)
- Real-time `SlotTimerBar` (15s FT8 cycle, 100ms refresh)
- xcodegen `project.yml` targeting iOS 17+, depends on FT8AFKit (FT8DSP, FT8Audio, FT8Engine, FT8Rig)

### Build
- `xcodebuild build` succeeds with **zero errors, zero warnings**
- App installs and launches on iPhone 16 Pro simulator

## Test plan
- [x] `xcodebuild -scheme FT8AF -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build` succeeds
- [x] App launches, shows Decode tab with mock messages
- [x] All 6 tabs render correctly (verified via simulator screenshots)
- [x] Slot timer bar updates in real-time
- [x] Settings fields are editable, navigation links drill down
- [ ] Manual: tap decode row → QSO sheet appears
- [ ] Manual: pinch-to-zoom on Map tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)