### PR TITLE
iOS Phase 2: live audio + real-time decode + scrolling waterfall

### DIFF
--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */; };
 		666D9271E9FE64C20C29CF47 /* FT8Audio in Frameworks */ = {isa = PBXBuildFile; productRef = 8A825C5161C267D978D895B8 /* FT8Audio */; };
 		72300AB5D2B37428777C824D /* MapScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCE0C13DF4842EC394EFADF /* MapScreen.swift */; };
+		771EC057824C1F3698C6DC9B /* FFTProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F287F167508A8E4114F44116 /* FFTProcessor.swift */; };
 		7F9F3D670DE6755252D023A3 /* TransmissionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */; };
 		7FC3449767DCA16F70133366 /* DecodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C0E0096ADDC018120C361 /* DecodeScreen.swift */; };
 		80F7FFDDEE3AEE3E706C4A2B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 076A186C88F9B5A2FFAAB073 /* Assets.xcassets */; };
@@ -29,12 +30,15 @@
 		A5C16922F13DEDBDF69DFCF6 /* FT8AFTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41EFDE500F865A3B393171D /* FT8AFTab.swift */; };
 		AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306EE5215AE14F95F3329F8 /* FilterChip.swift */; };
 		AAA8FD89DE336CC404CC41E4 /* FT8Engine in Frameworks */ = {isa = PBXBuildFile; productRef = A5E95C3FF3D4A30E2177E137 /* FT8Engine */; };
+		AB5310FE1F9048626DC6406B /* LiveEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E09812700CD93E6187CC4BC /* LiveEngine.swift */; };
 		B8FD5A2DF3B2A89740B3CB73 /* WorldMapCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */; };
 		CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800081E79EC795EBDE2E077E /* SlotTimerBar.swift */; };
 		D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */; };
 		DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */; };
+		EA1C91B3E65DB77ED5703FD9 /* AudioCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42FB097015693FF14B27553 /* AudioCaptureService.swift */; };
 		EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1E760AEB31EF3855951728 /* FT8AFApp.swift */; };
 		F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DF7123A737FE9F5236677F /* DecodeRow.swift */; };
+		F4E60463DA065CDAE7B84EF3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E706B1D26B550FE4D798B68 /* Accelerate.framework */; };
 		FEB99CFFD070BA6B893ADC83 /* WaterfallCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = B681B14FC4FED15C628471DF /* WaterfallCanvas.swift */; };
 /* End PBXBuildFile section */
 
@@ -44,7 +48,9 @@
 		0FD3B4836E62F9DC32FAB0DE /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		11DF7123A737FE9F5236677F /* DecodeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeRow.swift; sourceTree = "<group>"; };
 		1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallScreen.swift; sourceTree = "<group>"; };
+		1E706B1D26B550FE4D798B68 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSettings.swift; sourceTree = "<group>"; };
+		4E09812700CD93E6187CC4BC /* LiveEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveEngine.swift; sourceTree = "<group>"; };
 		504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		5306EE5215AE14F95F3329F8 /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
 		64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxStrip.swift; sourceTree = "<group>"; };
@@ -63,9 +69,11 @@
 		B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaScreen.swift; sourceTree = "<group>"; };
 		B681B14FC4FED15C628471DF /* WaterfallCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallCanvas.swift; sourceTree = "<group>"; };
 		BF21F5D95598018B8A46ED8D /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		C42FB097015693FF14B27553 /* AudioCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureService.swift; sourceTree = "<group>"; };
 		C79C0E0096ADDC018120C361 /* DecodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeScreen.swift; sourceTree = "<group>"; };
 		C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyRuler.swift; sourceTree = "<group>"; };
 		C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumStrip.swift; sourceTree = "<group>"; };
+		F287F167508A8E4114F44116 /* FFTProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFTProcessor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +85,7 @@
 				666D9271E9FE64C20C29CF47 /* FT8Audio in Frameworks */,
 				AAA8FD89DE336CC404CC41E4 /* FT8Engine in Frameworks */,
 				303BF422AF4C5F94DF696E5D /* FT8Rig in Frameworks */,
+				F4E60463DA065CDAE7B84EF3 /* Accelerate.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,6 +139,14 @@
 			path = Decode;
 			sourceTree = "<group>";
 		};
+		619D5D4BD9524DA75C5309CA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1E706B1D26B550FE4D798B68 /* Accelerate.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		6A561A5BA077FBCEC8F291AB /* Waterfall */ = {
 			isa = PBXGroup;
 			children = (
@@ -146,6 +163,7 @@
 			children = (
 				975A228795DCD722F01F06F6 /* FT8AF */,
 				233187321B70BBF49A9D862B /* Packages */,
+				619D5D4BD9524DA75C5309CA /* Frameworks */,
 				D3689D7765BE6F880B857542 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -188,6 +206,7 @@
 				076A186C88F9B5A2FFAAB073 /* Assets.xcassets */,
 				6F1E760AEB31EF3855951728 /* FT8AFApp.swift */,
 				7DCF29540DF6FBE5F4ECD5FC /* Components */,
+				B571E3EEC914286395700259 /* Engine */,
 				1F327B9757517C23BFA52C86 /* Navigation */,
 				7F57A25B1504D3F64E790FAC /* Screens */,
 				C97F65A2DD30ABA1707C85D3 /* Theme */,
@@ -202,6 +221,16 @@
 				91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */,
 			);
 			path = Logbook;
+			sourceTree = "<group>";
+		};
+		B571E3EEC914286395700259 /* Engine */ = {
+			isa = PBXGroup;
+			children = (
+				C42FB097015693FF14B27553 /* AudioCaptureService.swift */,
+				F287F167508A8E4114F44116 /* FFTProcessor.swift */,
+				4E09812700CD93E6187CC4BC /* LiveEngine.swift */,
+			);
+			path = Engine;
 			sourceTree = "<group>";
 		};
 		C97F65A2DD30ABA1707C85D3 /* Theme */ = {
@@ -297,14 +326,17 @@
 			files = (
 				49DFEC8ED0237764EA3EE3BF /* AppState.swift in Sources */,
 				5C76E98A4BD4854709C3D0E9 /* AppTabView.swift in Sources */,
+				EA1C91B3E65DB77ED5703FD9 /* AudioCaptureService.swift in Sources */,
 				035DDD710715AAC0100E0871 /* Colors.swift in Sources */,
 				3BA2BC0EFAF62534D39C3A4A /* DecodeFilterSettings.swift in Sources */,
 				F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */,
 				7FC3449767DCA16F70133366 /* DecodeScreen.swift in Sources */,
+				771EC057824C1F3698C6DC9B /* FFTProcessor.swift in Sources */,
 				EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */,
 				A5C16922F13DEDBDF69DFCF6 /* FT8AFTab.swift in Sources */,
 				AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */,
 				637BC14B19B728028FD01F07 /* FrequencyRuler.swift in Sources */,
+				AB5310FE1F9048626DC6406B /* LiveEngine.swift in Sources */,
 				33736A682F52CCBB13E8168A /* LogbookScreen.swift in Sources */,
 				65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */,
 				72300AB5D2B37428777C824D /* MapScreen.swift in Sources */,
@@ -331,6 +363,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "FT8AF needs microphone access to capture radio audio for FT8 decoding";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -409,6 +442,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "FT8AF needs microphone access to capture radio audio for FT8 decoding";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -27,7 +27,7 @@ enum DecodeFilter: String, CaseIterable {
 
 @Observable @MainActor
 final class DecodeState {
-    var messages: [DecodeMessage] = DecodeMessage.mock
+    var messages: [DecodeMessage] = []
     var activeFilter: DecodeFilter = .all
     var selectedMessage: DecodeMessage?
 }
@@ -66,6 +66,7 @@ struct DecodeMessage: Identifiable, Equatable {
 @Observable @MainActor
 final class WaterfallState {
     var rows: [[UInt8]] = []
+    var spectrum: [Float] = []
     var txFreqHz: Float = 1500
     var isLive: Bool = false
 }

--- a/ios/FT8AF/FT8AF/Engine/AudioCaptureService.swift
+++ b/ios/FT8AF/FT8AF/Engine/AudioCaptureService.swift
@@ -1,0 +1,157 @@
+import AVFoundation
+import FT8Audio
+import FT8DSP
+
+/// Captures microphone audio via AVAudioEngine, downsamples to 12 kHz mono,
+/// and pushes samples into a `SlotAccumulator` for the decode and waterfall
+/// pipelines.
+final class AudioCaptureService: @unchecked Sendable {
+    let accumulator = SlotAccumulator()
+
+    private let engine = AVAudioEngine()
+    private var converter: AVAudioConverter?
+    private var _isRunning = false
+    private let lock = NSLock()
+
+    var isRunning: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isRunning
+    }
+
+    /// Request microphone permission. Returns `true` if granted.
+    func requestPermission() async -> Bool {
+        await withCheckedContinuation { cont in
+            AVAudioApplication.requestRecordPermission { granted in
+                cont.resume(returning: granted)
+            }
+        }
+    }
+
+    /// Configure the audio session, install a tap on the input node, and start
+    /// capturing. Throws if the audio session or engine fails to start.
+    func start() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .allowBluetooth])
+        try session.setActive(true)
+
+        let inputNode = engine.inputNode
+        let hwFormat = inputNode.outputFormat(forBus: 0)
+
+        // Target: 12 kHz, mono, Float32 — the FT8 codec sample rate.
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(FT8.sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw AudioCaptureError.formatCreationFailed
+        }
+
+        guard let conv = AVAudioConverter(from: hwFormat, to: targetFormat) else {
+            throw AudioCaptureError.converterCreationFailed
+        }
+        converter = conv
+
+        // Install tap at the hardware format; we downsample in the callback.
+        let bufferSize = AVAudioFrameCount(hwFormat.sampleRate * 0.1) // ~100 ms chunks
+        inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: hwFormat) {
+            [weak self] buffer, _ in
+            self?.handleAudioBuffer(buffer)
+        }
+
+        try engine.start()
+
+        lock.lock()
+        _isRunning = true
+        lock.unlock()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleInterruption),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+    }
+
+    /// Stop the audio engine and remove the tap.
+    func stop() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        converter = nil
+
+        lock.lock()
+        _isRunning = false
+        lock.unlock()
+
+        NotificationCenter.default.removeObserver(
+            self,
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+    }
+
+    // MARK: - Private
+
+    private func handleAudioBuffer(_ buffer: AVAudioPCMBuffer) {
+        guard let conv = converter else { return }
+
+        // Allocate output buffer for the downsampled result.
+        let ratio = Double(FT8.sampleRate) / buffer.format.sampleRate
+        let outFrames = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
+        guard let outBuffer = AVAudioPCMBuffer(
+            pcmFormat: conv.outputFormat,
+            frameCapacity: outFrames
+        ) else { return }
+
+        var error: NSError?
+        var consumed = false
+        conv.convert(to: outBuffer, error: &error) { _, outStatus in
+            if consumed {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        if error != nil { return }
+        guard let channelData = outBuffer.floatChannelData,
+              outBuffer.frameLength > 0 else { return }
+
+        let samples = Array(UnsafeBufferPointer(
+            start: channelData[0],
+            count: Int(outBuffer.frameLength)
+        ))
+        accumulator.push(samples)
+    }
+
+    @objc private func handleInterruption(_ notification: Notification) {
+        guard let info = notification.userInfo,
+              let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+
+        switch type {
+        case .began:
+            lock.lock()
+            _isRunning = false
+            lock.unlock()
+        case .ended:
+            let options = (info[AVAudioSessionInterruptionOptionKey] as? UInt)
+                .flatMap(AVAudioSession.InterruptionOptions.init) ?? []
+            if options.contains(.shouldResume) {
+                try? engine.start()
+                lock.lock()
+                _isRunning = true
+                lock.unlock()
+            }
+        @unknown default:
+            break
+        }
+    }
+}
+
+enum AudioCaptureError: Error {
+    case formatCreationFailed
+    case converterCreationFailed
+}

--- a/ios/FT8AF/FT8AF/Engine/AudioCaptureService.swift
+++ b/ios/FT8AF/FT8AF/Engine/AudioCaptureService.swift
@@ -13,6 +13,12 @@ final class AudioCaptureService: @unchecked Sendable {
     private var _isRunning = false
     private let lock = NSLock()
 
+    /// Output buffer reused across tap callbacks so the real-time audio thread
+    /// doesn't heap-allocate a fresh `AVAudioPCMBuffer` on every chunk. Touched
+    /// only on the tap thread (the tap is serialized); grown if a larger input
+    /// chunk ever arrives.
+    private var reusableOutBuffer: AVAudioPCMBuffer?
+
     var isRunning: Bool {
         lock.lock(); defer { lock.unlock() }
         return _isRunning
@@ -50,7 +56,9 @@ final class AudioCaptureService: @unchecked Sendable {
         guard let conv = AVAudioConverter(from: hwFormat, to: targetFormat) else {
             throw AudioCaptureError.converterCreationFailed
         }
+        lock.lock()
         converter = conv
+        lock.unlock()
 
         // Install tap at the hardware format; we downsample in the callback.
         let bufferSize = AVAudioFrameCount(hwFormat.sampleRate * 0.1) // ~100 ms chunks
@@ -77,9 +85,9 @@ final class AudioCaptureService: @unchecked Sendable {
     func stop() {
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
-        converter = nil
 
         lock.lock()
+        converter = nil
         _isRunning = false
         lock.unlock()
 
@@ -93,15 +101,26 @@ final class AudioCaptureService: @unchecked Sendable {
     // MARK: - Private
 
     private func handleAudioBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard let conv = converter else { return }
+        // Copy the converter to a local strong reference under the lock — `stop()`
+        // may clear it from the main thread while this runs on the audio thread.
+        lock.lock()
+        let conv = converter
+        lock.unlock()
+        guard let conv else { return }
 
-        // Allocate output buffer for the downsampled result.
+        // Reuse the output buffer across callbacks; only (re)allocate when none
+        // exists yet or the input chunk grew beyond the current capacity.
         let ratio = Double(FT8.sampleRate) / buffer.format.sampleRate
         let outFrames = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
-        guard let outBuffer = AVAudioPCMBuffer(
-            pcmFormat: conv.outputFormat,
-            frameCapacity: outFrames
-        ) else { return }
+        if reusableOutBuffer == nil || reusableOutBuffer!.frameCapacity < outFrames {
+            guard let buf = AVAudioPCMBuffer(
+                pcmFormat: conv.outputFormat,
+                frameCapacity: outFrames
+            ) else { return }
+            reusableOutBuffer = buf
+        }
+        guard let outBuffer = reusableOutBuffer else { return }
+        outBuffer.frameLength = 0
 
         var error: NSError?
         var consumed = false
@@ -119,11 +138,12 @@ final class AudioCaptureService: @unchecked Sendable {
         guard let channelData = outBuffer.floatChannelData,
               outBuffer.frameLength > 0 else { return }
 
-        let samples = Array(UnsafeBufferPointer(
+        // Hand samples straight to the accumulator without an intermediate
+        // `[Float]` allocation on the real-time thread.
+        accumulator.push(UnsafeBufferPointer(
             start: channelData[0],
             count: Int(outBuffer.frameLength)
         ))
-        accumulator.push(samples)
     }
 
     @objc private func handleInterruption(_ notification: Notification) {

--- a/ios/FT8AF/FT8AF/Engine/FFTProcessor.swift
+++ b/ios/FT8AF/FT8AF/Engine/FFTProcessor.swift
@@ -38,21 +38,20 @@ enum FFTProcessor {
         var realp = [Float](repeating: 0, count: halfN)
         var imagp = [Float](repeating: 0, count: halfN)
 
+        samples.withUnsafeBufferPointer { samplesPtr in
         for seg in 0..<segments {
             let offset = seg * step
             guard offset + fftSize <= samples.count else { break }
 
-            // Apply Hann window.
+            // Window this segment in place — offset directly into `samples` via
+            // the base pointer (no per-segment `Array` allocation, no redundant
+            // window pass over the buffer start).
             vDSP_vmul(
-                samples, 1,      // vDSP_vmul takes UnsafePointer but Array bridging handles offset
+                samplesPtr.baseAddress! + offset, 1,
                 window, 1,
                 &windowed, 1,
                 vDSP_Length(fftSize)
             )
-            // Re-apply with correct offset — vDSP_vmul above operates on
-            // the start of `samples`; we actually need to window the segment.
-            let segSlice = Array(samples[offset..<(offset + fftSize)])
-            vDSP_vmul(segSlice, 1, window, 1, &windowed, 1, vDSP_Length(fftSize))
 
             // Pack into split-complex form for the real FFT.
             windowed.withUnsafeBufferPointer { src in
@@ -76,6 +75,7 @@ enum FFTProcessor {
                 }
             }
         }
+        } // samples.withUnsafeBufferPointer
 
         return summedPower
     }

--- a/ios/FT8AF/FT8AF/Engine/FFTProcessor.swift
+++ b/ios/FT8AF/FT8AF/Engine/FFTProcessor.swift
@@ -1,0 +1,82 @@
+import Accelerate
+import FT8Audio
+
+/// Welch-averaged FFT using vDSP, producing the `summedPower` array that
+/// `WaterfallRowBuilder.buildRow` expects. Caches the `vDSP_FFTSetup` for
+/// the session.
+enum FFTProcessor {
+    /// Shared FFT setup for `fftSize = 2048` (log2 = 11). Created once.
+    private static let fftSetup: FFTSetup = {
+        let log2n = vDSP_Length(log2(Float(WaterfallRowBuilder.fftSize)))
+        return vDSP_create_fftsetup(log2n, FFTRadix(kFFTRadix2))!
+    }()
+
+    /// Compute Welch-averaged power spectrum from raw 12 kHz samples.
+    ///
+    /// Returns `summedPower[0..<columns]` where each element is the sum of
+    /// |FFT bin|^2 across `segments` Hann-windowed, 50%-overlapping segments.
+    /// Ready to pass directly to `WaterfallRowBuilder.buildRow()`.
+    static func welchPower(
+        samples: [Float],
+        fftSize: Int = WaterfallRowBuilder.fftSize,
+        segments: Int = WaterfallRowBuilder.segments,
+        step: Int = WaterfallRowBuilder.step,
+        columns: Int
+    ) -> [Float] {
+        let log2n = vDSP_Length(log2(Float(fftSize)))
+        let halfN = fftSize / 2
+
+        // Pre-compute Hann window.
+        var window = [Float](repeating: 0, count: fftSize)
+        vDSP_hann_window(&window, vDSP_Length(fftSize), Int32(vDSP_HANN_NORM))
+
+        // Accumulate |bin|^2 across segments.
+        var summedPower = [Float](repeating: 0, count: columns)
+
+        var windowed = [Float](repeating: 0, count: fftSize)
+        // Split complex storage for the in-place FFT.
+        var realp = [Float](repeating: 0, count: halfN)
+        var imagp = [Float](repeating: 0, count: halfN)
+
+        for seg in 0..<segments {
+            let offset = seg * step
+            guard offset + fftSize <= samples.count else { break }
+
+            // Apply Hann window.
+            vDSP_vmul(
+                samples, 1,      // vDSP_vmul takes UnsafePointer but Array bridging handles offset
+                window, 1,
+                &windowed, 1,
+                vDSP_Length(fftSize)
+            )
+            // Re-apply with correct offset — vDSP_vmul above operates on
+            // the start of `samples`; we actually need to window the segment.
+            let segSlice = Array(samples[offset..<(offset + fftSize)])
+            vDSP_vmul(segSlice, 1, window, 1, &windowed, 1, vDSP_Length(fftSize))
+
+            // Pack into split-complex form for the real FFT.
+            windowed.withUnsafeBufferPointer { src in
+                realp.withUnsafeMutableBufferPointer { rp in
+                    imagp.withUnsafeMutableBufferPointer { ip in
+                        var split = DSPSplitComplex(realp: rp.baseAddress!, imagp: ip.baseAddress!)
+                        src.baseAddress!.withMemoryRebound(to: DSPComplex.self, capacity: halfN) { complexPtr in
+                            vDSP_ctoz(complexPtr, 2, &split, 1, vDSP_Length(halfN))
+                        }
+                        // In-place FFT.
+                        vDSP_fft_zrip(fftSetup, &split, 1, log2n, FFTDirection(kFFTDirection_Forward))
+
+                        // Compute magnitude squared per bin and accumulate.
+                        let cols = min(columns, halfN)
+                        for i in 0..<cols {
+                            let re = rp[i]
+                            let im = ip[i]
+                            summedPower[i] += re * re + im * im
+                        }
+                    }
+                }
+            }
+        }
+
+        return summedPower
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -1,0 +1,191 @@
+import FT8Audio
+import FT8DSP
+import Foundation
+import Observation
+
+/// Top-level coordinator that owns audio capture and runs the decode +
+/// waterfall pipelines as concurrent structured tasks. Lifecycle: create once,
+/// call `start(appState:)`, and later `stop()`.
+@Observable @MainActor
+final class LiveEngine {
+    private(set) var isRunning = false
+
+    private let audio = AudioCaptureService()
+    private var engineTask: Task<Void, Never>?
+    private var rxOffsetMs: Int64 = 0
+
+    /// Start audio capture and kick off decode + waterfall loops.
+    func start(appState: AppState) async {
+        guard !isRunning else { return }
+
+        let granted = await audio.requestPermission()
+        guard granted else { return }
+
+        do {
+            try audio.start()
+        } catch {
+            return
+        }
+
+        isRunning = true
+        appState.waterfall.isLive = true
+
+        let accumulator = audio.accumulator
+        let rxOffset = rxOffsetMs
+
+        engineTask = Task.detached { [weak self] in
+            await withTaskGroup(of: Void.self) { group in
+                // Decode pipeline
+                group.addTask {
+                    await self?.runDecodeLoop(
+                        accumulator: accumulator,
+                        appState: appState,
+                        initialRxOffset: rxOffset
+                    )
+                }
+                // Waterfall pipeline
+                group.addTask {
+                    await self?.runWaterfallLoop(
+                        accumulator: accumulator,
+                        appState: appState
+                    )
+                }
+            }
+        }
+    }
+
+    /// Stop audio capture and cancel background tasks.
+    func stop() {
+        engineTask?.cancel()
+        engineTask = nil
+        audio.stop()
+        isRunning = false
+    }
+
+    // MARK: - Decode loop
+
+    /// Polls for slot boundaries and runs the FT8 decoder at each transition.
+    private nonisolated func runDecodeLoop(
+        accumulator: SlotAccumulator,
+        appState: AppState,
+        initialRxOffset: Int64
+    ) async {
+        var rxOffsetMs = initialRxOffset
+        var lastSlotID: Int64 = SlotClock.rxSlotID(
+            atUtcMs: Int64(Date().timeIntervalSince1970 * 1000),
+            rxOffsetMs: rxOffsetMs
+        )
+
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(200))
+            if Task.isCancelled { break }
+
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            let currentSlot = SlotClock.rxSlotID(atUtcMs: nowMs, rxOffsetMs: rxOffsetMs)
+
+            guard currentSlot != lastSlotID else { continue }
+            lastSlotID = currentSlot
+
+            // Extract the slot's audio and decode.
+            let samples = accumulator.takeSlot()
+            let decoder = FT8Decoder()
+            decoder.feedSlot(samples)
+            decoder.findSync()
+            let decoded = decoder.decodeAll()
+
+            // DT calibration from this slot's decodes.
+            if !decoded.isEmpty {
+                let dtValues = decoded.map(\.timeSec)
+                rxOffsetMs = DtCalibrator.calibrate(
+                    rxOffsetMs: rxOffsetMs,
+                    decodedDtSec: dtValues
+                )
+            }
+
+            // Map to UI messages and update state on MainActor.
+            let utcTime = Self.utcTimeString(from: nowMs)
+            let slotIndex = Int(SlotClock.parity(slotID: currentSlot))
+            let uiMessages = decoded.map { msg in
+                DecodeMessage(
+                    utcTime: utcTime,
+                    callFrom: msg.callFrom,
+                    callTo: msg.callTo,
+                    snr: msg.snr,
+                    freqHz: msg.freqHz,
+                    grid: msg.grid,
+                    extra: msg.extra,
+                    slotIndex: slotIndex
+                )
+            }
+
+            if !uiMessages.isEmpty {
+                await MainActor.run {
+                    appState.decode.messages.insert(contentsOf: uiMessages, at: 0)
+                    // Trim to keep a reasonable history.
+                    if appState.decode.messages.count > 200 {
+                        appState.decode.messages.removeLast(
+                            appState.decode.messages.count - 200
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Waterfall loop
+
+    /// Runs ~4x per second, building FFT rows and updating the waterfall +
+    /// spectrum state.
+    private nonisolated func runWaterfallLoop(
+        accumulator: SlotAccumulator,
+        appState: AppState
+    ) async {
+        let sampleRate = Int(FT8.sampleRate)
+        let needed = WaterfallRowBuilder.samplesNeeded()
+        let columns = WaterfallRowBuilder.columns(sampleRate: sampleRate)
+        var builder = WaterfallRowBuilder()
+
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(250))
+            if Task.isCancelled { break }
+
+            let samples = accumulator.peekRecent(needed)
+            guard samples.count >= needed else { continue }
+
+            // Compute Welch-averaged power spectrum.
+            let power = FFTProcessor.welchPower(
+                samples: samples,
+                columns: columns
+            )
+
+            // Build the brightness row.
+            let row = builder.buildRow(summedPower: power, sampleRate: sampleRate)
+
+            // Normalize power for spectrum strip display (0...1 range).
+            let maxPower = power.max() ?? 1.0
+            let scale = maxPower > 0 ? 1.0 / maxPower : 1.0
+            let spectrum = power.map { min($0 * scale, 1.0) }
+
+            await MainActor.run {
+                appState.waterfall.rows.append(row.bins)
+                // Keep at most 120 rows for the scrolling waterfall.
+                if appState.waterfall.rows.count > 120 {
+                    appState.waterfall.rows.removeFirst(
+                        appState.waterfall.rows.count - 120
+                    )
+                }
+                appState.waterfall.spectrum = spectrum
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private nonisolated static func utcTimeString(from epochMs: Int64) -> String {
+        let date = Date(timeIntervalSince1970: Double(epochMs) / 1000.0)
+        let fmt = DateFormatter()
+        fmt.dateFormat = "HH:mm:ss"
+        fmt.timeZone = TimeZone(identifier: "UTC")
+        return fmt.string(from: date)
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -13,6 +13,8 @@ final class LiveEngine {
     private let audio = AudioCaptureService()
     private var engineTask: Task<Void, Never>?
     private var rxOffsetMs: Int64 = 0
+    /// Weakly held so `stop()` can clear the LIVE indicator it set in `start()`.
+    private weak var appState: AppState?
 
     /// Start audio capture and kick off decode + waterfall loops.
     func start(appState: AppState) async {
@@ -28,10 +30,31 @@ final class LiveEngine {
         }
 
         isRunning = true
+        self.appState = appState
         appState.waterfall.isLive = true
 
         let accumulator = audio.accumulator
         let rxOffset = rxOffsetMs
+
+        // Build the MainActor state-mutation closures here, on the main actor, so
+        // the background loops never reference `AppState` directly. The closures
+        // are `@Sendable @MainActor`: they may be handed to the detached task, but
+        // their captured `AppState` is only ever touched back on the main actor.
+        let applyDecodes: @Sendable @MainActor ([DecodeMessage]) -> Void = { messages in
+            appState.decode.messages.insert(contentsOf: messages, at: 0)
+            // Trim to keep a reasonable history.
+            if appState.decode.messages.count > 200 {
+                appState.decode.messages.removeLast(appState.decode.messages.count - 200)
+            }
+        }
+        let applyWaterfall: @Sendable @MainActor ([UInt8], [Float]) -> Void = { row, spectrum in
+            appState.waterfall.rows.append(row)
+            // Keep at most 120 rows for the scrolling waterfall.
+            if appState.waterfall.rows.count > 120 {
+                appState.waterfall.rows.removeFirst(appState.waterfall.rows.count - 120)
+            }
+            appState.waterfall.spectrum = spectrum
+        }
 
         engineTask = Task.detached { [weak self] in
             await withTaskGroup(of: Void.self) { group in
@@ -39,15 +62,15 @@ final class LiveEngine {
                 group.addTask {
                     await self?.runDecodeLoop(
                         accumulator: accumulator,
-                        appState: appState,
-                        initialRxOffset: rxOffset
+                        initialRxOffset: rxOffset,
+                        applyDecodes: applyDecodes
                     )
                 }
                 // Waterfall pipeline
                 group.addTask {
                     await self?.runWaterfallLoop(
                         accumulator: accumulator,
-                        appState: appState
+                        applyWaterfall: applyWaterfall
                     )
                 }
             }
@@ -60,6 +83,8 @@ final class LiveEngine {
         engineTask = nil
         audio.stop()
         isRunning = false
+        appState?.waterfall.isLive = false
+        appState = nil
     }
 
     // MARK: - Decode loop
@@ -67,8 +92,8 @@ final class LiveEngine {
     /// Polls for slot boundaries and runs the FT8 decoder at each transition.
     private nonisolated func runDecodeLoop(
         accumulator: SlotAccumulator,
-        appState: AppState,
-        initialRxOffset: Int64
+        initialRxOffset: Int64,
+        applyDecodes: @escaping @Sendable @MainActor ([DecodeMessage]) -> Void
     ) async {
         var rxOffsetMs = initialRxOffset
         var lastSlotID: Int64 = SlotClock.rxSlotID(
@@ -119,15 +144,7 @@ final class LiveEngine {
             }
 
             if !uiMessages.isEmpty {
-                await MainActor.run {
-                    appState.decode.messages.insert(contentsOf: uiMessages, at: 0)
-                    // Trim to keep a reasonable history.
-                    if appState.decode.messages.count > 200 {
-                        appState.decode.messages.removeLast(
-                            appState.decode.messages.count - 200
-                        )
-                    }
-                }
+                await MainActor.run { applyDecodes(uiMessages) }
             }
         }
     }
@@ -138,7 +155,7 @@ final class LiveEngine {
     /// spectrum state.
     private nonisolated func runWaterfallLoop(
         accumulator: SlotAccumulator,
-        appState: AppState
+        applyWaterfall: @escaping @Sendable @MainActor ([UInt8], [Float]) -> Void
     ) async {
         let sampleRate = Int(FT8.sampleRate)
         let needed = WaterfallRowBuilder.samplesNeeded()
@@ -166,16 +183,7 @@ final class LiveEngine {
             let scale = maxPower > 0 ? 1.0 / maxPower : 1.0
             let spectrum = power.map { min($0 * scale, 1.0) }
 
-            await MainActor.run {
-                appState.waterfall.rows.append(row.bins)
-                // Keep at most 120 rows for the scrolling waterfall.
-                if appState.waterfall.rows.count > 120 {
-                    appState.waterfall.rows.removeFirst(
-                        appState.waterfall.rows.count - 120
-                    )
-                }
-                appState.waterfall.spectrum = spectrum
-            }
+            await MainActor.run { applyWaterfall(row.bins, spectrum) }
         }
     }
 

--- a/ios/FT8AF/FT8AF/FT8AFApp.swift
+++ b/ios/FT8AF/FT8AF/FT8AFApp.swift
@@ -3,11 +3,15 @@ import SwiftUI
 @main
 struct FT8AFApp: App {
     @State private var appState = AppState()
+    @State private var engine = LiveEngine()
 
     var body: some Scene {
         WindowGroup {
             AppTabView()
                 .environment(appState)
+                .task {
+                    await engine.start(appState: appState)
+                }
         }
     }
 }

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
@@ -1,31 +1,14 @@
 import SwiftUI
 
-/// Vertical bar chart of FFT magnitudes with a TX frequency marker.
+/// Vertical bar chart of live FFT magnitudes with a TX frequency marker.
+/// Reads normalized magnitudes (0...1) from `appState.waterfall.spectrum`.
 struct SpectrumStrip: View {
     @Environment(AppState.self) private var appState
 
-    // Mock spectrum data: 120 bins across 0-3000 Hz
-    private static let mockMagnitudes: [Float] = {
-        var mags = [Float](repeating: 0, count: 120)
-        for i in 0..<120 {
-            // Base noise floor
-            mags[i] = Float.random(in: 0.05...0.15)
-        }
-        // Add signal peaks matching waterfall mock
-        let peaks = [15, 35, 52, 70, 88, 105]
-        for p in peaks {
-            if p < 120 {
-                mags[p] = Float.random(in: 0.5...0.9)
-                if p > 0 { mags[p - 1] = Float.random(in: 0.2...0.4) }
-                if p < 119 { mags[p + 1] = Float.random(in: 0.2...0.4) }
-            }
-        }
-        return mags
-    }()
-
     var body: some View {
         Canvas { context, size in
-            let mags = Self.mockMagnitudes
+            let mags = appState.waterfall.spectrum
+            guard !mags.isEmpty else { return }
             let barW = size.width / CGFloat(mags.count)
 
             for (i, mag) in mags.enumerated() {

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
@@ -1,63 +1,26 @@
 import SwiftUI
 
-/// Static mock waterfall heatmap. Phase 2 replaces this with a live MTKView.
+/// Live scrolling waterfall heatmap, driven by `appState.waterfall.rows`.
+/// Each row is a `[UInt8]` of brightness values (0...255) produced by
+/// `WaterfallRowBuilder`. Renders newest rows at the bottom.
 struct WaterfallCanvas: View {
-    // Deterministic mock data. WaterfallScreen ticks its UTC clock every second,
-    // which re-creates this view; using `UInt8.random`/`Int.random` here would
-    // regenerate different bins each tick and make the "static" mock flicker.
-    // A hash-based pseudo-noise keeps the textured look while staying stable.
-    private let mockData: (bins: [UInt8], rows: Int, cols: Int) = WaterfallCanvas.makeMockData()
-
-    private static func makeMockData() -> (bins: [UInt8], rows: Int, cols: Int) {
-        let rows = 80
-        let cols = 120
-        var bins = [UInt8](repeating: 0, count: rows * cols)
-        // Simulate a few FT8 signals as bright horizontal bands
-        let signals: [(col: Int, width: Int, intensity: UInt8)] = [
-            (15, 3, 200), (35, 2, 150), (52, 3, 220),
-            (70, 2, 130), (88, 4, 180), (105, 2, 160),
-        ]
-        for r in 0..<rows {
-            for c in 0..<cols {
-                // Background noise (deterministic, 5...35)
-                let noise = UInt8(5 + pseudoNoise(r, c) % 31)
-                var value = noise
-                // Add signal traces
-                for sig in signals {
-                    if c >= sig.col && c < sig.col + sig.width {
-                        let variation = Int(pseudoNoise(r, c + 7919) % 41) - 20
-                        let signalVal = Int(sig.intensity) + variation
-                        value = UInt8(max(Int(value), min(255, signalVal)))
-                    }
-                }
-                bins[r * cols + c] = value
-            }
-        }
-        return (bins, rows, cols)
-    }
-
-    /// Stable 0..<2^31 pseudo-random hash of two integer coordinates.
-    private static func pseudoNoise(_ a: Int, _ b: Int) -> Int {
-        var h = UInt32(truncatingIfNeeded: (a &* 73856093) ^ (b &* 19349663))
-        h ^= h >> 13
-        h = h &* 0x5bd1_e995
-        h ^= h >> 15
-        return Int(h & 0x7fff_ffff)
-    }
+    @Environment(AppState.self) private var appState
 
     var body: some View {
         Canvas { context, size in
-            let rows = mockData.rows
-            let cols = mockData.cols
-            let bins = mockData.bins
-            guard rows > 0, cols > 0 else { return }
+            let rows = appState.waterfall.rows
+            guard !rows.isEmpty else { return }
+            let numRows = rows.count
+            let numCols = rows[0].count
+            guard numCols > 0 else { return }
 
-            let cellW = size.width / CGFloat(cols)
-            let cellH = size.height / CGFloat(rows)
+            let cellW = size.width / CGFloat(numCols)
+            let cellH = size.height / CGFloat(numRows)
 
-            for r in 0..<rows {
-                for c in 0..<cols {
-                    let value = bins[r * cols + c]
+            for r in 0..<numRows {
+                let row = rows[r]
+                for c in 0..<min(numCols, row.count) {
+                    let value = row[c]
                     let color = waterfallColor(value)
                     let rect = CGRect(
                         x: CGFloat(c) * cellW,
@@ -69,6 +32,7 @@ struct WaterfallCanvas: View {
                 }
             }
         }
+        .background(bgApp)
         .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 

--- a/ios/FT8AF/project.yml
+++ b/ios/FT8AF/project.yml
@@ -26,6 +26,7 @@ targets:
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         SWIFT_VERSION: "5.9"
         PRODUCT_BUNDLE_IDENTIFIER: radio.ks3ckc.ft8af
+        INFOPLIST_KEY_NSMicrophoneUsageDescription: "FT8AF needs microphone access to capture radio audio for FT8 decoding"
     dependencies:
       - package: FT8AFKit
         product: FT8DSP
@@ -35,3 +36,4 @@ targets:
         product: FT8Engine
       - package: FT8AFKit
         product: FT8Rig
+      - sdk: Accelerate.framework

--- a/ios/FT8AFKit/Sources/FT8Audio/SlotAccumulator.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/SlotAccumulator.swift
@@ -11,7 +11,7 @@ import Foundation
 /// desktop uses a VecDeque for the same reason; a plain Array with `removeFirst`
 /// would shift ~16 s of samples on every push once full). Thread-safe: the RT
 /// tap `push`es while the engine thread `takeSlot`s / `peekRecent`s.
-public final class SlotAccumulator {
+public final class SlotAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private let cap: Int
     private var storage: [Float] // length == cap
@@ -26,14 +26,22 @@ public final class SlotAccumulator {
 
     /// Append freshly captured 12 kHz samples, evicting the oldest beyond `cap`.
     public func push(_ samples: [Float]) {
+        samples.withUnsafeBufferPointer { push($0) }
+    }
+
+    /// Pointer overload of `push` — lets the real-time audio tap hand samples
+    /// over directly from the converter's channel data without first copying
+    /// into a freshly allocated `[Float]` on every callback.
+    public func push(_ samples: UnsafeBufferPointer<Float>) {
         let m = samples.count
         if m == 0 { return }
+        guard let src = samples.baseAddress else { return }
         lock.lock(); defer { lock.unlock() }
 
         if m >= cap {
             // Only the most recent `cap` samples can be retained.
             let start = m - cap
-            for i in 0..<cap { storage[i] = samples[start + i] }
+            for i in 0..<cap { storage[i] = src[start + i] }
             head = 0
             filled = cap
             return
@@ -44,7 +52,7 @@ public final class SlotAccumulator {
         var write = head + filled
         if write >= cap { write -= cap }
         for i in 0..<m {
-            storage[write] = samples[i]
+            storage[write] = src[i]
             write += 1
             if write == cap { write = 0 }
         }

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SlotAccumulatorTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SlotAccumulatorTests.swift
@@ -70,6 +70,28 @@ final class SlotAccumulatorTests: XCTestCase {
         XCTAssertEqual(slot.last, 1999)
     }
 
+    /// The `UnsafeBufferPointer` overload must produce the same buffer state as
+    /// the `[Float]` overload (which now delegates to it).
+    func testPointerPushMatchesArrayPush() {
+        let viaArray = SlotAccumulator()
+        let viaPointer = SlotAccumulator()
+        let data = (0..<1500).map { Float($0) }
+
+        viaArray.push(data)
+        data.withUnsafeBufferPointer { viaPointer.push($0) }
+
+        XCTAssertEqual(viaArray.count, viaPointer.count)
+        XCTAssertEqual(viaArray.peekRecent(1500), viaPointer.peekRecent(1500))
+    }
+
+    /// An empty pointer (and a null base address) must be a no-op, not a crash.
+    func testPointerPushEmptyIsNoOp() {
+        let acc = SlotAccumulator()
+        let empty = [Float]()
+        empty.withUnsafeBufferPointer { acc.push($0) }
+        XCTAssertTrue(acc.isEmpty)
+    }
+
     func testClear() {
         let acc = SlotAccumulator()
         acc.push([Float](repeating: 1, count: 100))


### PR DESCRIPTION
## Summary
- **AudioCaptureService**: AVAudioEngine microphone capture with `AVAudioConverter` downsampling to 12 kHz mono, pushing into `SlotAccumulator` on the real-time audio thread
- **FFTProcessor**: Welch-averaged FFT via Accelerate/vDSP (6 segments, 2048-point, 50% overlap) producing `summedPower` for `WaterfallRowBuilder`
- **LiveEngine**: `@Observable @MainActor` coordinator that runs two concurrent background tasks — decode pipeline (fires at 15s slot boundaries via `SlotClock`) and waterfall pipeline (~4 rows/sec via `peekRecent`)
- **UI wiring**: `WaterfallCanvas` and `SpectrumStrip` now render live data from `appState.waterfall.rows`/`.spectrum`; `DecodeState` starts empty and fills from live decoder output
- **project.yml**: `NSMicrophoneUsageDescription` for mic permission prompt, `Accelerate.framework` for vDSP FFT

## Architecture
```
AVAudioEngine tap (hardware rate)
  → AVAudioConverter → 12 kHz mono
    → SlotAccumulator.push()
      ├─ Decode: takeSlot() → FT8Decoder → AppState.decode.messages
      └─ Waterfall: peekRecent(7168) → vDSP FFT → WaterfallRowBuilder → AppState.waterfall.rows
```

## Test plan
- [ ] `xcodegen generate && xcodebuild build` succeeds with zero errors
- [ ] App launches and requests microphone permission on first run
- [ ] After granting permission, waterfall tab shows live scrolling noise floor
- [ ] LIVE indicator turns green
- [ ] Spectrum strip shows real-time FFT bar chart
- [ ] Decode tab starts empty; decoded FT8 signals appear as messages when present
- [ ] Other tabs (Logbook, Map, POTA, Settings) remain functional
- [ ] Slot timer bar continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)