### PR TITLE
iOS Phases 3-6: QSO engine, TX audio, logbook, ADIF, persistence

### DIFF
--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -15,8 +15,11 @@
 		3BA2BC0EFAF62534D39C3A4A /* DecodeFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88688AC6AFBEDC8AC3EF844 /* DecodeFilterSettings.swift */; };
 		49DFEC8ED0237764EA3EE3BF /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF21F5D95598018B8A46ED8D /* AppState.swift */; };
 		4C0C9DCC39ED6528F0D4CDFF /* RadioAudioSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */; };
+		4D87F21162B4DCEC806D8785 /* QsoCelebration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8DAEDCAE1AD9DE02EB1480 /* QsoCelebration.swift */; };
+		51B44F6A9F0A05A7B3CB71FC /* FrequencyPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C698656C5709343F4AEEF0 /* FrequencyPickerSheet.swift */; };
 		595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */; };
 		5C76E98A4BD4854709C3D0E9 /* AppTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53063BBF11F97C62BC0AFC9 /* AppTabView.swift */; };
+		5E2B3105FFFE6C84D86ACD85 /* TransmitGlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF04207CDB5BE8A1CCDD5F5B /* TransmitGlow.swift */; };
 		608EF9D6EAE6CDA82E9E86C4 /* QsoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290AFE608DC2FC9E1A83E16 /* QsoSheet.swift */; };
 		637BC14B19B728028FD01F07 /* FrequencyRuler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */; };
 		65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */; };
@@ -26,6 +29,7 @@
 		7F9F3D670DE6755252D023A3 /* TransmissionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */; };
 		7FC3449767DCA16F70133366 /* DecodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C0E0096ADDC018120C361 /* DecodeScreen.swift */; };
 		80F7FFDDEE3AEE3E706C4A2B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 076A186C88F9B5A2FFAAB073 /* Assets.xcassets */; };
+		8DA0D562E25925F56B638B00 /* GridDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = E429D8A3556534F05374F12A /* GridDistance.swift */; };
 		8EA75A450404FB948C0A6CDC /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */; };
 		A5C16922F13DEDBDF69DFCF6 /* FT8AFTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41EFDE500F865A3B393171D /* FT8AFTab.swift */; };
 		AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306EE5215AE14F95F3329F8 /* FilterChip.swift */; };
@@ -36,6 +40,7 @@
 		CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800081E79EC795EBDE2E077E /* SlotTimerBar.swift */; };
 		D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */; };
 		DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */; };
+		DFA95C747B2F0763C677F2EC /* ActiveQsoPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0244EBDFC2ADDAE77418FF53 /* ActiveQsoPanel.swift */; };
 		E375A4D50C25F5437C2C9F7F /* QsoLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9E40312EA203F05764FA56 /* QsoLogStore.swift */; };
 		EA1C91B3E65DB77ED5703FD9 /* AudioCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42FB097015693FF14B27553 /* AudioCaptureService.swift */; };
 		EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1E760AEB31EF3855951728 /* FT8AFApp.swift */; };
@@ -45,6 +50,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0244EBDFC2ADDAE77418FF53 /* ActiveQsoPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveQsoPanel.swift; sourceTree = "<group>"; };
 		0290AFE608DC2FC9E1A83E16 /* QsoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoSheet.swift; sourceTree = "<group>"; };
 		076A186C88F9B5A2FFAAB073 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0FD3B4836E62F9DC32FAB0DE /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
@@ -70,6 +76,7 @@
 		A41EFDE500F865A3B393171D /* FT8AFTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FT8AFTab.swift; sourceTree = "<group>"; };
 		A53063BBF11F97C62BC0AFC9 /* AppTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTabView.swift; sourceTree = "<group>"; };
 		A88688AC6AFBEDC8AC3EF844 /* DecodeFilterSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeFilterSettings.swift; sourceTree = "<group>"; };
+		AC8DAEDCAE1AD9DE02EB1480 /* QsoCelebration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoCelebration.swift; sourceTree = "<group>"; };
 		B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaScreen.swift; sourceTree = "<group>"; };
 		B681B14FC4FED15C628471DF /* WaterfallCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallCanvas.swift; sourceTree = "<group>"; };
 		BF21F5D95598018B8A46ED8D /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -77,7 +84,10 @@
 		C79C0E0096ADDC018120C361 /* DecodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeScreen.swift; sourceTree = "<group>"; };
 		C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyRuler.swift; sourceTree = "<group>"; };
 		C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumStrip.swift; sourceTree = "<group>"; };
+		DF04207CDB5BE8A1CCDD5F5B /* TransmitGlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmitGlow.swift; sourceTree = "<group>"; };
+		E429D8A3556534F05374F12A /* GridDistance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridDistance.swift; sourceTree = "<group>"; };
 		F287F167508A8E4114F44116 /* FFTProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFTProcessor.swift; sourceTree = "<group>"; };
+		F3C698656C5709343F4AEEF0 /* FrequencyPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyPickerSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +113,14 @@
 				8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */,
 			);
 			path = Map;
+			sourceTree = "<group>";
+		};
+		15375E21B18F3DEE1FACE292 /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				E429D8A3556534F05374F12A /* GridDistance.swift */,
+			);
+			path = Util;
 			sourceTree = "<group>";
 		};
 		1F327B9757517C23BFA52C86 /* Navigation */ = {
@@ -175,8 +193,12 @@
 		7DCF29540DF6FBE5F4ECD5FC /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				0244EBDFC2ADDAE77418FF53 /* ActiveQsoPanel.swift */,
 				5306EE5215AE14F95F3329F8 /* FilterChip.swift */,
+				F3C698656C5709343F4AEEF0 /* FrequencyPickerSheet.swift */,
+				AC8DAEDCAE1AD9DE02EB1480 /* QsoCelebration.swift */,
 				800081E79EC795EBDE2E077E /* SlotTimerBar.swift */,
+				DF04207CDB5BE8A1CCDD5F5B /* TransmitGlow.swift */,
 				64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */,
 			);
 			path = Components;
@@ -214,6 +236,7 @@
 				1F327B9757517C23BFA52C86 /* Navigation */,
 				7F57A25B1504D3F64E790FAC /* Screens */,
 				C97F65A2DD30ABA1707C85D3 /* Theme */,
+				15375E21B18F3DEE1FACE292 /* Util */,
 			);
 			path = FT8AF;
 			sourceTree = "<group>";
@@ -330,6 +353,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DFA95C747B2F0763C677F2EC /* ActiveQsoPanel.swift in Sources */,
 				49DFEC8ED0237764EA3EE3BF /* AppState.swift in Sources */,
 				5C76E98A4BD4854709C3D0E9 /* AppTabView.swift in Sources */,
 				EA1C91B3E65DB77ED5703FD9 /* AudioCaptureService.swift in Sources */,
@@ -341,12 +365,15 @@
 				EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */,
 				A5C16922F13DEDBDF69DFCF6 /* FT8AFTab.swift in Sources */,
 				AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */,
+				51B44F6A9F0A05A7B3CB71FC /* FrequencyPickerSheet.swift in Sources */,
 				637BC14B19B728028FD01F07 /* FrequencyRuler.swift in Sources */,
+				8DA0D562E25925F56B638B00 /* GridDistance.swift in Sources */,
 				AB5310FE1F9048626DC6406B /* LiveEngine.swift in Sources */,
 				33736A682F52CCBB13E8168A /* LogbookScreen.swift in Sources */,
 				65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */,
 				72300AB5D2B37428777C824D /* MapScreen.swift in Sources */,
 				595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */,
+				4D87F21162B4DCEC806D8785 /* QsoCelebration.swift in Sources */,
 				E375A4D50C25F5437C2C9F7F /* QsoLogStore.swift in Sources */,
 				608EF9D6EAE6CDA82E9E86C4 /* QsoSheet.swift in Sources */,
 				4C0C9DCC39ED6528F0D4CDFF /* RadioAudioSettings.swift in Sources */,
@@ -354,6 +381,7 @@
 				CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */,
 				D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */,
 				7F9F3D670DE6755252D023A3 /* TransmissionSettings.swift in Sources */,
+				5E2B3105FFFE6C84D86ACD85 /* TransmitGlow.swift in Sources */,
 				AC1D4BEDBCC1DBA945DB04D5 /* TxPlayerService.swift in Sources */,
 				DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */,
 				FEB99CFFD070BA6B893ADC83 /* WaterfallCanvas.swift in Sources */,

--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		035DDD710715AAC0100E0871 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3B4836E62F9DC32FAB0DE /* Colors.swift */; };
+		0FD449B6C15FD3407D8E3BC0 /* LogbookCharts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DFF1DC42A9F8F8066F97F7 /* LogbookCharts.swift */; };
 		208767EE6D89D470D7C88E77 /* WaterfallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */; };
 		26F661F120C34995BFF73F2D /* FT8DSP in Frameworks */ = {isa = PBXBuildFile; productRef = 93510ED81B9D113E387D0D45 /* FT8DSP */; };
 		303BF422AF4C5F94DF696E5D /* FT8Rig in Frameworks */ = {isa = PBXBuildFile; productRef = 4E7B6368450390C0D64A5715 /* FT8Rig */; };
@@ -37,6 +38,7 @@
 		AB5310FE1F9048626DC6406B /* LiveEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E09812700CD93E6187CC4BC /* LiveEngine.swift */; };
 		AC1D4BEDBCC1DBA945DB04D5 /* TxPlayerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */; };
 		B8FD5A2DF3B2A89740B3CB73 /* WorldMapCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */; };
+		BCEB9305C3EA84C758FAFBA7 /* AzimuthalMapCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB943F6B81F9D36BA85504A3 /* AzimuthalMapCanvas.swift */; };
 		CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800081E79EC795EBDE2E077E /* SlotTimerBar.swift */; };
 		D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */; };
 		DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */; };
@@ -72,6 +74,7 @@
 		89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioAudioSettings.swift; sourceTree = "<group>"; };
 		8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldMapCanvas.swift; sourceTree = "<group>"; };
 		91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookStats.swift; sourceTree = "<group>"; };
+		93DFF1DC42A9F8F8066F97F7 /* LogbookCharts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookCharts.swift; sourceTree = "<group>"; };
 		9BCE0C13DF4842EC394EFADF /* MapScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapScreen.swift; sourceTree = "<group>"; };
 		A41EFDE500F865A3B393171D /* FT8AFTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FT8AFTab.swift; sourceTree = "<group>"; };
 		A53063BBF11F97C62BC0AFC9 /* AppTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTabView.swift; sourceTree = "<group>"; };
@@ -84,6 +87,7 @@
 		C79C0E0096ADDC018120C361 /* DecodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeScreen.swift; sourceTree = "<group>"; };
 		C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyRuler.swift; sourceTree = "<group>"; };
 		C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumStrip.swift; sourceTree = "<group>"; };
+		CB943F6B81F9D36BA85504A3 /* AzimuthalMapCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AzimuthalMapCanvas.swift; sourceTree = "<group>"; };
 		DF04207CDB5BE8A1CCDD5F5B /* TransmitGlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmitGlow.swift; sourceTree = "<group>"; };
 		E429D8A3556534F05374F12A /* GridDistance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridDistance.swift; sourceTree = "<group>"; };
 		F287F167508A8E4114F44116 /* FFTProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFTProcessor.swift; sourceTree = "<group>"; };
@@ -109,6 +113,7 @@
 		14E1746CE387ABA11CDC3F5E /* Map */ = {
 			isa = PBXGroup;
 			children = (
+				CB943F6B81F9D36BA85504A3 /* AzimuthalMapCanvas.swift */,
 				9BCE0C13DF4842EC394EFADF /* MapScreen.swift */,
 				8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */,
 			);
@@ -244,6 +249,7 @@
 		9B85E3FDCB60E378E9DF2E12 /* Logbook */ = {
 			isa = PBXGroup;
 			children = (
+				93DFF1DC42A9F8F8066F97F7 /* LogbookCharts.swift */,
 				76108617D9AEDEE84BAD1054 /* LogbookScreen.swift */,
 				91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */,
 			);
@@ -357,6 +363,7 @@
 				49DFEC8ED0237764EA3EE3BF /* AppState.swift in Sources */,
 				5C76E98A4BD4854709C3D0E9 /* AppTabView.swift in Sources */,
 				EA1C91B3E65DB77ED5703FD9 /* AudioCaptureService.swift in Sources */,
+				BCEB9305C3EA84C758FAFBA7 /* AzimuthalMapCanvas.swift in Sources */,
 				035DDD710715AAC0100E0871 /* Colors.swift in Sources */,
 				3BA2BC0EFAF62534D39C3A4A /* DecodeFilterSettings.swift in Sources */,
 				F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */,
@@ -369,6 +376,7 @@
 				637BC14B19B728028FD01F07 /* FrequencyRuler.swift in Sources */,
 				8DA0D562E25925F56B638B00 /* GridDistance.swift in Sources */,
 				AB5310FE1F9048626DC6406B /* LiveEngine.swift in Sources */,
+				0FD449B6C15FD3407D8E3BC0 /* LogbookCharts.swift in Sources */,
 				33736A682F52CCBB13E8168A /* LogbookScreen.swift in Sources */,
 				65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */,
 				72300AB5D2B37428777C824D /* MapScreen.swift in Sources */,

--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -31,10 +31,12 @@
 		AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306EE5215AE14F95F3329F8 /* FilterChip.swift */; };
 		AAA8FD89DE336CC404CC41E4 /* FT8Engine in Frameworks */ = {isa = PBXBuildFile; productRef = A5E95C3FF3D4A30E2177E137 /* FT8Engine */; };
 		AB5310FE1F9048626DC6406B /* LiveEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E09812700CD93E6187CC4BC /* LiveEngine.swift */; };
+		AC1D4BEDBCC1DBA945DB04D5 /* TxPlayerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */; };
 		B8FD5A2DF3B2A89740B3CB73 /* WorldMapCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */; };
 		CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800081E79EC795EBDE2E077E /* SlotTimerBar.swift */; };
 		D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */; };
 		DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */; };
+		E375A4D50C25F5437C2C9F7F /* QsoLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9E40312EA203F05764FA56 /* QsoLogStore.swift */; };
 		EA1C91B3E65DB77ED5703FD9 /* AudioCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42FB097015693FF14B27553 /* AudioCaptureService.swift */; };
 		EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1E760AEB31EF3855951728 /* FT8AFApp.swift */; };
 		F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DF7123A737FE9F5236677F /* DecodeRow.swift */; };
@@ -49,12 +51,14 @@
 		11DF7123A737FE9F5236677F /* DecodeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeRow.swift; sourceTree = "<group>"; };
 		1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallScreen.swift; sourceTree = "<group>"; };
 		1E706B1D26B550FE4D798B68 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxPlayerService.swift; sourceTree = "<group>"; };
 		4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSettings.swift; sourceTree = "<group>"; };
 		4E09812700CD93E6187CC4BC /* LiveEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveEngine.swift; sourceTree = "<group>"; };
 		504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		5306EE5215AE14F95F3329F8 /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
 		64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxStrip.swift; sourceTree = "<group>"; };
 		654EF0B6A0E279E65F355821 /* FT8AF.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FT8AF.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B9E40312EA203F05764FA56 /* QsoLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoLogStore.swift; sourceTree = "<group>"; };
 		6F1E760AEB31EF3855951728 /* FT8AFApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FT8AFApp.swift; sourceTree = "<group>"; };
 		76108617D9AEDEE84BAD1054 /* LogbookScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookScreen.swift; sourceTree = "<group>"; };
 		800081E79EC795EBDE2E077E /* SlotTimerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotTimerBar.swift; sourceTree = "<group>"; };
@@ -229,6 +233,8 @@
 				C42FB097015693FF14B27553 /* AudioCaptureService.swift */,
 				F287F167508A8E4114F44116 /* FFTProcessor.swift */,
 				4E09812700CD93E6187CC4BC /* LiveEngine.swift */,
+				6B9E40312EA203F05764FA56 /* QsoLogStore.swift */,
+				29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */,
 			);
 			path = Engine;
 			sourceTree = "<group>";
@@ -341,12 +347,14 @@
 				65A688B883398E75D00BCD7E /* LogbookStats.swift in Sources */,
 				72300AB5D2B37428777C824D /* MapScreen.swift in Sources */,
 				595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */,
+				E375A4D50C25F5437C2C9F7F /* QsoLogStore.swift in Sources */,
 				608EF9D6EAE6CDA82E9E86C4 /* QsoSheet.swift in Sources */,
 				4C0C9DCC39ED6528F0D4CDFF /* RadioAudioSettings.swift in Sources */,
 				8EA75A450404FB948C0A6CDC /* SettingsScreen.swift in Sources */,
 				CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */,
 				D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */,
 				7F9F3D670DE6755252D023A3 /* TransmissionSettings.swift in Sources */,
+				AC1D4BEDBCC1DBA945DB04D5 /* TxPlayerService.swift in Sources */,
 				DA94D12D7FDE6D10D116E770 /* TxStrip.swift in Sources */,
 				FEB99CFFD070BA6B893ADC83 /* WaterfallCanvas.swift in Sources */,
 				208767EE6D89D470D7C88E77 /* WaterfallScreen.swift in Sources */,

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -12,6 +12,11 @@ final class AppState {
     let settings = SettingsState()
     let rig = RigState()
     let tx = TxState()
+
+    /// The live engine is set once by `FT8AFApp` at startup. Views access it
+    /// through `appState.engine` instead of a separate `@Environment` entry,
+    /// which avoids fatal crashes when the Observable-environment lookup fails.
+    var engine: LiveEngine?
 }
 
 // MARK: - Decode

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -35,6 +35,8 @@ final class DecodeState {
     var messages: [DecodeMessage] = []
     var activeFilter: DecodeFilter = .all
     var selectedMessage: DecodeMessage?
+    var compactMode: Bool = false
+    var autoClear: Bool = false
 }
 
 /// UI-level decoded message with display-oriented fields. Phase 2+ will map
@@ -192,4 +194,56 @@ final class TxState {
     var huntEnabled: Bool = false
     var slotParity: Int = 0
     var isTransmitting: Bool = false
+    var expanded: Bool = false
+    var targetCall: String = ""
+    var txMessage: String = ""
+    var qsoCompletedAt: Date?
+}
+
+// MARK: - Settings Persistence
+
+enum SettingsPersistence {
+    private static let prefix = "ft8af_"
+
+    @MainActor static func save(_ s: SettingsState) {
+        let d = UserDefaults.standard
+        d.set(s.myCall, forKey: key("myCall"))
+        d.set(s.myGrid, forKey: key("myGrid"))
+        d.set(s.band, forKey: key("band"))
+        d.set(s.rigModel.rawValue, forKey: key("rigModel"))
+        d.set(s.pttMode.rawValue, forKey: key("pttMode"))
+        d.set(s.txPowerWatts, forKey: key("txPowerWatts"))
+        d.set(s.txVolume, forKey: key("txVolume"))
+        d.set(s.showOnlyCQ, forKey: key("showOnlyCQ"))
+        d.set(s.dxOnly, forKey: key("dxOnly"))
+        d.set(s.autoLog, forKey: key("autoLog"))
+    }
+
+    @MainActor static func load(into s: SettingsState) {
+        let d = UserDefaults.standard
+        if let v = d.string(forKey: key("myCall")) { s.myCall = v }
+        if let v = d.string(forKey: key("myGrid")) { s.myGrid = v }
+        if let v = d.string(forKey: key("band")) { s.band = v }
+        if let v = d.string(forKey: key("rigModel")),
+           let m = RigModel(rawValue: v) { s.rigModel = m }
+        if let v = d.string(forKey: key("pttMode")),
+           let m = PttMode(rawValue: v) { s.pttMode = m }
+        if d.object(forKey: key("txPowerWatts")) != nil {
+            s.txPowerWatts = d.integer(forKey: key("txPowerWatts"))
+        }
+        if d.object(forKey: key("txVolume")) != nil {
+            s.txVolume = d.integer(forKey: key("txVolume"))
+        }
+        if d.object(forKey: key("showOnlyCQ")) != nil {
+            s.showOnlyCQ = d.bool(forKey: key("showOnlyCQ"))
+        }
+        if d.object(forKey: key("dxOnly")) != nil {
+            s.dxOnly = d.bool(forKey: key("dxOnly"))
+        }
+        if d.object(forKey: key("autoLog")) != nil {
+            s.autoLog = d.bool(forKey: key("autoLog"))
+        }
+    }
+
+    private static func key(_ name: String) -> String { prefix + name }
 }

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -75,7 +75,7 @@ final class WaterfallState {
 
 @Observable @MainActor
 final class LogbookState {
-    var records: [QsoRecord] = QsoRecord.mockRecords
+    var records: [QsoRecord] = []
     var totalCount: Int { records.count }
     var bandStats: [String: Int] {
         var stats: [String: Int] = [:]

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -12,6 +12,7 @@ final class AppState {
     let settings = SettingsState()
     let rig = RigState()
     let tx = TxState()
+    let pota = PotaState()
 
     /// The live engine is set once by `FT8AFApp` at startup. Views access it
     /// through `appState.engine` instead of a separate `@Environment` entry,
@@ -76,6 +77,25 @@ final class WaterfallState {
     var spectrum: [Float] = []
     var txFreqHz: Float = 1500
     var isLive: Bool = false
+    var noiseReduction: Bool = false
+    var messageMarking: Bool = true
+    var updateCount: Int = 0
+}
+
+// MARK: - QSO Conversation Log
+
+enum QsoLogDirection: String {
+    case tx = "TX"
+    case rx = "RX"
+    case busy = "BUSY"
+}
+
+struct QsoLogEntry: Identifiable {
+    let id = UUID()
+    let direction: QsoLogDirection
+    let message: String
+    let snr: Int?
+    let utcTime: String
 }
 
 // MARK: - Logbook
@@ -198,6 +218,21 @@ final class TxState {
     var targetCall: String = ""
     var txMessage: String = ""
     var qsoCompletedAt: Date?
+    var conversationLog: [QsoLogEntry] = []
+    /// Set by the engine when our CQ is answered, to auto-open QsoSheet.
+    var autoOpenMessage: DecodeMessage?
+}
+
+// MARK: - POTA
+
+@Observable @MainActor
+final class PotaState {
+    var parkInput: String = ""
+    var parkRefs: [String] = []
+    var notes: String = ""
+    var isActivating: Bool = false
+    var activationQsoCount: Int = 0
+    var activationStartTime: Date?
 }
 
 // MARK: - Settings Persistence

--- a/ios/FT8AF/FT8AF/Components/ActiveQsoPanel.swift
+++ b/ios/FT8AF/FT8AF/Components/ActiveQsoPanel.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+/// Floating panel showing active QSO progress above the TxStrip.
+struct ActiveQsoPanel: View {
+    @Environment(AppState.self) private var appState
+    @State private var isExpanded = true
+
+    var body: some View {
+        let tx = appState.tx
+
+        if isExpanded {
+            expandedView(tx: tx)
+        } else {
+            collapsedView(tx: tx)
+        }
+    }
+
+    private func expandedView(tx: TxState) -> some View {
+        VStack(spacing: 8) {
+            // Header row with target call and collapse button
+            HStack {
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(accent)
+
+                Text(tx.targetCall.isEmpty ? "CQ" : tx.targetCall)
+                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                    .foregroundStyle(textPrimary)
+
+                Spacer()
+
+                Text(stageLabel(tx.stage))
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(accent)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(accent.opacity(0.14))
+                    )
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded = false
+                    }
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(textMuted)
+                }
+                .buttonStyle(.plain)
+            }
+
+            // TX message
+            if !tx.txMessage.isEmpty {
+                Text(tx.txMessage)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textMuted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(bgSurface3)
+                    )
+            }
+
+            // Stage progress dots
+            QsoStageDots(currentStage: tx.stage)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(bgSurface2)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(accent.opacity(0.3), lineWidth: 1)
+                )
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 4)
+    }
+
+    private func collapsedView(tx: TxState) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded = true
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(accent)
+                    .frame(width: 6, height: 6)
+
+                Text("QSO: \(tx.targetCall.isEmpty ? "CQ" : tx.targetCall)")
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(textPrimary)
+
+                Text("— \(stageLabel(tx.stage))")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textMuted)
+
+                Spacer()
+
+                Image(systemName: "chevron.up")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(textMuted)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(bgSurface2)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(accent.opacity(0.2), lineWidth: 1)
+                    )
+            )
+            .padding(.horizontal, 16)
+            .padding(.bottom, 4)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func stageLabel(_ stage: TxUIStage) -> String {
+        switch stage {
+        case .idle:       return "IDLE"
+        case .cqSent:     return "CQ"
+        case .reportSent: return "REPORT"
+        case .rrSent:     return "RR73"
+        case .complete:   return "DONE"
+        }
+    }
+}
+
+/// Horizontal 5-step progress indicator for QSO stages.
+struct QsoStageDots: View {
+    let currentStage: TxUIStage
+
+    private let stages: [(label: String, stage: TxUIStage)] = [
+        ("CQ", .cqSent),
+        ("GRID", .reportSent),
+        ("RPT", .reportSent),
+        ("RR73", .rrSent),
+        ("73", .complete),
+    ]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(stages.enumerated()), id: \.offset) { idx, item in
+                if idx > 0 {
+                    Rectangle()
+                        .fill(isReached(idx) ? accent : textDim.opacity(0.3))
+                        .frame(height: 2)
+                }
+                VStack(spacing: 3) {
+                    Circle()
+                        .fill(isReached(idx) ? accent : textDim.opacity(0.3))
+                        .frame(width: isCurrent(idx) ? 10 : 7, height: isCurrent(idx) ? 10 : 7)
+                    Text(item.label)
+                        .font(.system(size: 8, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(isReached(idx) ? accent : textFaint)
+                }
+            }
+        }
+    }
+
+    private var stageIndex: Int {
+        switch currentStage {
+        case .idle: return -1
+        case .cqSent: return 0
+        case .reportSent: return 2
+        case .rrSent: return 3
+        case .complete: return 4
+        }
+    }
+
+    private func isReached(_ idx: Int) -> Bool { idx <= stageIndex }
+    private func isCurrent(_ idx: Int) -> Bool { idx == stageIndex }
+}

--- a/ios/FT8AF/FT8AF/Components/ActiveQsoPanel.swift
+++ b/ios/FT8AF/FT8AF/Components/ActiveQsoPanel.swift
@@ -51,8 +51,28 @@ struct ActiveQsoPanel: View {
                 .buttonStyle(.plain)
             }
 
-            // TX message
-            if !tx.txMessage.isEmpty {
+            // Conversation log
+            if !tx.conversationLog.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(spacing: 2) {
+                            ForEach(tx.conversationLog) { entry in
+                                ConversationRow(entry: entry)
+                                    .id(entry.id)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 100)
+                    .onChange(of: tx.conversationLog.count) { _, _ in
+                        if let last = tx.conversationLog.last {
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                proxy.scrollTo(last.id, anchor: .bottom)
+                            }
+                        }
+                    }
+                }
+            } else if !tx.txMessage.isEmpty {
+                // Fallback: show current TX message if no log entries yet
                 Text(tx.txMessage)
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundStyle(textMuted)
@@ -130,6 +150,61 @@ struct ActiveQsoPanel: View {
         case .reportSent: return "REPORT"
         case .rrSent:     return "RR73"
         case .complete:   return "DONE"
+        }
+    }
+}
+
+// MARK: - Conversation Row
+
+private struct ConversationRow: View {
+    let entry: QsoLogEntry
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Direction badge
+            Text(entry.direction.rawValue)
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(directionColor)
+                .frame(width: 28)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(directionColor.opacity(0.14))
+                )
+
+            // Message
+            Text(entry.message)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(textPrimary)
+                .lineLimit(1)
+
+            Spacer()
+
+            // SNR (for RX)
+            if let snr = entry.snr {
+                Text(snr >= 0 ? "+\(snr)" : "\(snr)")
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(textFaint)
+            }
+
+            // Time
+            Text(String(entry.utcTime.prefix(5)))
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundStyle(textDim)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(bgSurface3.opacity(0.5))
+        )
+    }
+
+    private var directionColor: Color {
+        switch entry.direction {
+        case .tx:   return accent
+        case .rx:   return signal
+        case .busy: return textFaint
         }
     }
 }

--- a/ios/FT8AF/FT8AF/Components/FrequencyPickerSheet.swift
+++ b/ios/FT8AF/FT8AF/Components/FrequencyPickerSheet.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// Bottom sheet listing all HF amateur bands with their FT8 dial frequencies.
+struct FrequencyPickerSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    private let bands: [(band: String, freq: String)] = [
+        ("160M", "1.840 MHz"),
+        ("80M", "3.573 MHz"),
+        ("60M", "5.357 MHz"),
+        ("40M", "7.074 MHz"),
+        ("30M", "10.136 MHz"),
+        ("20M", "14.074 MHz"),
+        ("17M", "18.100 MHz"),
+        ("15M", "21.074 MHz"),
+        ("12M", "24.915 MHz"),
+        ("10M", "28.074 MHz"),
+        ("6M", "50.313 MHz"),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(bands, id: \.band) { item in
+                    Button {
+                        appState.settings.band = item.band
+                        SettingsPersistence.save(appState.settings)
+                        dismiss()
+                    } label: {
+                        HStack {
+                            Circle()
+                                .fill(bandColor(for: item.band))
+                                .frame(width: 8, height: 8)
+
+                            Text(item.band)
+                                .font(.system(size: 16, weight: .bold, design: .monospaced))
+                                .foregroundStyle(textPrimary)
+
+                            Text("—")
+                                .foregroundStyle(textDim)
+
+                            Text(item.freq)
+                                .font(.system(size: 14, weight: .medium, design: .monospaced))
+                                .foregroundStyle(textMuted)
+
+                            Spacer()
+
+                            if appState.settings.band == item.band {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(accent)
+                            }
+                        }
+                    }
+                    .listRowBackground(bgSurface)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(bgApp)
+            .navigationTitle("Select Band")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                        .foregroundStyle(accent)
+                }
+            }
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Components/QsoCelebration.swift
+++ b/ios/FT8AF/FT8AF/Components/QsoCelebration.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// Confetti burst animation triggered on QSO completion.
+struct QsoCelebration: View {
+    let onFinished: () -> Void
+
+    @State private var particles: [Particle] = []
+    @State private var opacity: Double = 1.0
+
+    private let colors: [Color] = [accent, signal, target, statusConfirmed, statusNew, statusWarn]
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                ForEach(particles) { p in
+                    Circle()
+                        .fill(p.color)
+                        .frame(width: p.size, height: p.size)
+                        .position(p.position)
+                        .opacity(opacity)
+                }
+            }
+            .onAppear {
+                spawnParticles(in: geo.size)
+                // Fade out after 1.5 seconds
+                withAnimation(.easeOut(duration: 0.5).delay(1.5)) {
+                    opacity = 0
+                }
+                // Remove after animation completes
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                    onFinished()
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .ignoresSafeArea()
+    }
+
+    private func spawnParticles(in size: CGSize) {
+        let centerX = size.width / 2
+        let centerY = size.height * 0.4
+
+        particles = (0..<40).map { _ in
+            let angle = Double.random(in: 0..<2 * .pi)
+            let distance = Double.random(in: 60...200)
+            let targetX = centerX + cos(angle) * distance
+            let targetY = centerY + sin(angle) * distance - Double.random(in: 20...80)
+
+            return Particle(
+                color: colors.randomElement()!,
+                size: CGFloat.random(in: 4...10),
+                position: CGPoint(x: centerX, y: centerY),
+                targetPosition: CGPoint(x: targetX, y: targetY)
+            )
+        }
+
+        // Animate particles outward
+        withAnimation(.easeOut(duration: 1.0)) {
+            for i in particles.indices {
+                particles[i].position = particles[i].targetPosition
+            }
+        }
+    }
+}
+
+private struct Particle: Identifiable {
+    let id = UUID()
+    let color: Color
+    let size: CGFloat
+    var position: CGPoint
+    let targetPosition: CGPoint
+}

--- a/ios/FT8AF/FT8AF/Components/TransmitGlow.swift
+++ b/ios/FT8AF/FT8AF/Components/TransmitGlow.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Full-screen border glow overlay shown during TX. Taps pass through.
+struct TransmitGlow: View {
+    @State private var pulse = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 0)
+            .strokeBorder(
+                LinearGradient(
+                    colors: [
+                        Color(red: 1.0, green: 0.3, blue: 0.1).opacity(pulse ? 0.6 : 0.3),
+                        Color(red: 1.0, green: 0.5, blue: 0.0).opacity(pulse ? 0.4 : 0.15),
+                        Color(red: 1.0, green: 0.3, blue: 0.1).opacity(pulse ? 0.6 : 0.3),
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ),
+                lineWidth: 4
+            )
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                    pulse = true
+                }
+            }
+    }
+}

--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -3,7 +3,11 @@ import SwiftUI
 /// TX control bar shown at the bottom of Decode/Waterfall screens.
 struct TxStrip: View {
     @Environment(AppState.self) private var appState
-    @Environment(LiveEngine.self) private var engine
+
+    var onHunt: () -> Void = {}
+    var onCallCQ: () -> Void = {}
+    var onStop: () -> Void = {}
+    var onToggleSlot: () -> Void = {}
 
     var body: some View {
         let tx = appState.tx
@@ -38,7 +42,7 @@ struct TxStrip: View {
                     isActive: tx.huntEnabled,
                     activeColor: signal,
                     style: .secondary
-                ) { engine.toggleHunt() }
+                ) { onHunt() }
 
                 // CQ / STOP button
                 ActionButton(
@@ -49,9 +53,9 @@ struct TxStrip: View {
                     style: .primary
                 ) {
                     if tx.isActivated {
-                        engine.stopTx()
+                        onStop()
                     } else {
-                        engine.callCQ()
+                        onCallCQ()
                     }
                 }
 
@@ -62,7 +66,7 @@ struct TxStrip: View {
                     isActive: false,
                     activeColor: textMuted,
                     style: .secondary
-                ) { engine.toggleSlotParity() }
+                ) { onToggleSlot() }
             }
         }
         .padding(.horizontal, 16)

--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -8,13 +8,15 @@ struct TxStrip: View {
     var onCallCQ: () -> Void = {}
     var onStop: () -> Void = {}
     var onToggleSlot: () -> Void = {}
+    var onOpenFrequencyPicker: () -> Void = {}
+    var onVolumeChange: (Int) -> Void = { _ in }
 
     var body: some View {
         let tx = appState.tx
         let settings = appState.settings
 
         VStack(spacing: 10) {
-            // Info row: status + frequency/mode chips
+            // Info row: status + frequency/mode chips + expand chevron
             HStack {
                 // Left: pulse dot + status label
                 HStack(spacing: 6) {
@@ -26,11 +28,89 @@ struct TxStrip: View {
 
                 Spacer()
 
+                // CAT status chip
+                CatChip(status: appState.rig.connectionStatus)
+
                 // Right: mode + frequency chips
                 HStack(spacing: 6) {
                     TxChip(label: "FT8", color: accent)
-                    TxChip(label: settings.band, color: textPrimary)
+
+                    // Tappable frequency/band chip
+                    Button { onOpenFrequencyPicker() } label: {
+                        TxChip(label: settings.band, color: textPrimary)
+                    }
+                    .buttonStyle(.plain)
                 }
+
+                // Expand/collapse chevron
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        appState.tx.expanded.toggle()
+                    }
+                } label: {
+                    Image(systemName: tx.expanded ? "chevron.down" : "chevron.up")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(textMuted)
+                        .frame(width: 28, height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(bgSurface3)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+
+            // Expanded section: volume slider
+            if tx.expanded {
+                VStack(spacing: 8) {
+                    HStack(spacing: 8) {
+                        Text("VOL")
+                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                            .foregroundStyle(textFaint)
+
+                        // Step down
+                        Button {
+                            let newVol = max(0, settings.txVolume - 5)
+                            onVolumeChange(newVol)
+                        } label: {
+                            Image(systemName: "minus")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundStyle(textMuted)
+                                .frame(width: 24, height: 24)
+                                .background(Circle().fill(bgSurface3))
+                        }
+                        .buttonStyle(.plain)
+
+                        Slider(
+                            value: Binding(
+                                get: { Double(settings.txVolume) },
+                                set: { onVolumeChange(Int($0)) }
+                            ),
+                            in: 0...100,
+                            step: 1
+                        )
+                        .tint(accent)
+
+                        // Step up
+                        Button {
+                            let newVol = min(100, settings.txVolume + 5)
+                            onVolumeChange(newVol)
+                        } label: {
+                            Image(systemName: "plus")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundStyle(textMuted)
+                                .frame(width: 24, height: 24)
+                                .background(Circle().fill(bgSurface3))
+                        }
+                        .buttonStyle(.plain)
+
+                        Text("\(settings.txVolume)%")
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(textMuted)
+                            .frame(width: 36, alignment: .trailing)
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
             // Action row: HUNT - CQ/STOP - TX slot
@@ -81,6 +161,36 @@ struct TxStrip: View {
 }
 
 // MARK: - Subviews
+
+private struct CatChip: View {
+    let status: ConnectionStatus
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(dotColor)
+                .frame(width: 6, height: 6)
+            Text("CAT")
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(textMuted)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(bgSurface3)
+        )
+        .padding(.trailing, 6)
+    }
+
+    private var dotColor: Color {
+        switch status {
+        case .disconnected: return statusBad
+        case .connecting:   return statusWarn
+        case .connected:    return statusConfirmed
+        }
+    }
+}
 
 private struct PulseDot: View {
     let color: Color

--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// TX control bar shown at the bottom of Decode/Waterfall screens.
-/// Phase 1: static display with non-functional buttons (wired in Phase 4).
 struct TxStrip: View {
     @Environment(AppState.self) private var appState
+    @Environment(LiveEngine.self) private var engine
 
     var body: some View {
         let tx = appState.tx
@@ -38,7 +38,7 @@ struct TxStrip: View {
                     isActive: tx.huntEnabled,
                     activeColor: signal,
                     style: .secondary
-                ) { }
+                ) { engine.toggleHunt() }
 
                 // CQ / STOP button
                 ActionButton(
@@ -47,7 +47,13 @@ struct TxStrip: View {
                     isActive: true,
                     activeColor: tx.isActivated ? statusBad : accent,
                     style: .primary
-                ) { }
+                ) {
+                    if tx.isActivated {
+                        engine.stopTx()
+                    } else {
+                        engine.callCQ()
+                    }
+                }
 
                 // TX slot toggle
                 ActionButton(
@@ -56,7 +62,7 @@ struct TxStrip: View {
                     isActive: false,
                     activeColor: textMuted,
                     style: .secondary
-                ) { }
+                ) { engine.toggleSlotParity() }
             }
         }
         .padding(.horizontal, 16)

--- a/ios/FT8AF/FT8AF/Engine/AudioCaptureService.swift
+++ b/ios/FT8AF/FT8AF/Engine/AudioCaptureService.swift
@@ -8,7 +8,11 @@ import FT8DSP
 final class AudioCaptureService: @unchecked Sendable {
     let accumulator = SlotAccumulator()
 
-    private let engine = AVAudioEngine()
+    /// The underlying `AVAudioEngine`. Exposed so `TxPlayerService` can attach
+    /// its player node to the same engine for audio output.
+    let audioEngine = AVAudioEngine()
+
+    private var engine: AVAudioEngine { audioEngine }
     private var converter: AVAudioConverter?
     private var _isRunning = false
     private let lock = NSLock()

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -1,20 +1,28 @@
 import FT8Audio
 import FT8DSP
+import FT8Engine
 import Foundation
 import Observation
 
-/// Top-level coordinator that owns audio capture and runs the decode +
-/// waterfall pipelines as concurrent structured tasks. Lifecycle: create once,
-/// call `start(appState:)`, and later `stop()`.
+/// Top-level coordinator that owns audio capture, the QSO auto-sequencer, and
+/// the TX player. Runs the decode + waterfall pipelines as concurrent
+/// structured tasks.  Lifecycle: create once, call `start(appState:)`, and
+/// later `stop()`.
 @Observable @MainActor
 final class LiveEngine {
     private(set) var isRunning = false
 
     private let audio = AudioCaptureService()
+    private let txPlayer = TxPlayerService()
     private var engineTask: Task<Void, Never>?
     private var rxOffsetMs: Int64 = 0
     /// Weakly held so `stop()` can clear the LIVE indicator it set in `start()`.
     private weak var appState: AppState?
+
+    // QSO engine — created once start() has settings available.
+    private var qsoEngine: QsoEngine?
+
+    // MARK: - Public control methods (called from UI)
 
     /// Start audio capture and kick off decode + waterfall loops.
     func start(appState: AppState) async {
@@ -29,9 +37,19 @@ final class LiveEngine {
             return
         }
 
+        // Attach the TX player node to the shared AVAudioEngine.
+        txPlayer.configure(engine: audio.audioEngine)
+
         isRunning = true
         self.appState = appState
         appState.waterfall.isLive = true
+
+        // Initialize the QSO engine from current settings.
+        let settings = appState.settings
+        let qso = QsoEngine(myCall: settings.myCall, myGrid: settings.myGrid)
+        qso.band = settings.band
+        qso.freqMhz = bandToFreqMhz(settings.band)
+        qsoEngine = qso
 
         let accumulator = audio.accumulator
         let rxOffset = rxOffsetMs
@@ -81,15 +99,65 @@ final class LiveEngine {
     func stop() {
         engineTask?.cancel()
         engineTask = nil
+        txPlayer.stop()
         audio.stop()
         isRunning = false
         appState?.waterfall.isLive = false
         appState = nil
+        qsoEngine = nil
+    }
+
+    /// Begin calling CQ.
+    func callCQ() {
+        syncSettingsToQso()
+        qsoEngine?.startCq()
+        syncQsoStatusToUI()
+    }
+
+    /// Stop any active TX/QSO.
+    func stopTx() {
+        qsoEngine?.stop()
+        txPlayer.stop()
+        syncQsoStatusToUI()
+    }
+
+    /// Answer a station from a decoded message (user tapped "Call" in QsoSheet).
+    func answerStation(_ msg: DecodeMessage) {
+        syncSettingsToQso()
+        let decoded = FT8DSP.DecodedMessage(
+            callTo: msg.callTo,
+            callFrom: msg.callFrom,
+            extra: msg.extra,
+            grid: msg.grid,
+            rawText: "",
+            snr: msg.snr,
+            freqHz: msg.freqHz,
+            timeSec: 0,
+            score: 0,
+            i3: 0,
+            n3: 0,
+            a91: [UInt8](repeating: 0, count: 12)
+        )
+        qsoEngine?.answer(decoded)
+        syncQsoStatusToUI()
+    }
+
+    /// Toggle hunt mode (auto-answer incoming CQs).
+    func toggleHunt() {
+        guard let appState else { return }
+        appState.tx.huntEnabled.toggle()
+    }
+
+    /// Switch TX slot parity (TX1 ↔ TX2).
+    func toggleSlotParity() {
+        guard let appState else { return }
+        appState.tx.slotParity = appState.tx.slotParity == 0 ? 1 : 0
     }
 
     // MARK: - Decode loop
 
     /// Polls for slot boundaries and runs the FT8 decoder at each transition.
+    /// After decoding, feeds results to the QSO engine and handles TX scheduling.
     private nonisolated func runDecodeLoop(
         accumulator: SlotAccumulator,
         initialRxOffset: Int64,
@@ -146,6 +214,58 @@ final class LiveEngine {
             if !uiMessages.isEmpty {
                 await MainActor.run { applyDecodes(uiMessages) }
             }
+
+            // Feed decoded messages to QSO engine and handle TX on main actor.
+            await MainActor.run { [decoded] in
+                self.processQsoRx(decoded, slotID: currentSlot)
+            }
+        }
+    }
+
+    // MARK: - QSO processing + TX scheduling (MainActor)
+
+    /// Process decoded messages through the QSO engine and schedule TX if needed.
+    private func processQsoRx(_ decoded: [DecodedMessage], slotID: Int64) {
+        guard let qso = qsoEngine, let appState else { return }
+
+        // Sync latest settings into the engine before processing.
+        syncSettingsToQso()
+
+        // Feed decodes to the QSO sequencer.
+        let outcome = qso.processRx(decoded)
+
+        // Handle QSO completion.
+        if case .completed(var record) = outcome {
+            // Assign a unique ID based on the current record count.
+            let nextId = Int64((appState.logbook.records.map { $0.id ?? 0 }.max() ?? 0) + 1)
+            record.id = nextId
+            appState.logbook.records.insert(record, at: 0)
+            QsoLogStore.save(appState.logbook.records)
+        }
+
+        // Sync QSO status back to UI.
+        syncQsoStatusToUI()
+
+        // TX scheduling: if QSO engine has a message and slot parity matches, transmit.
+        if let txMsg = qso.txMessage {
+            let nextSlotParity = Int(SlotClock.parity(slotID: slotID + 1))
+            let desiredParity = appState.tx.slotParity
+            if nextSlotParity == desiredParity {
+                scheduleTx(message: txMsg, freqHz: appState.waterfall.txFreqHz)
+            }
+        }
+    }
+
+    /// Generate FT8 audio and play it through the speaker.
+    private func scheduleTx(message: String, freqHz: Float) {
+        guard let appState else { return }
+        guard let samples = FT8Encoder.generateFT8(message, baseFreqHz: freqHz) else { return }
+
+        appState.tx.isTransmitting = true
+        txPlayer.play(samples) { [weak self] in
+            Task { @MainActor in
+                self?.appState?.tx.isTransmitting = false
+            }
         }
     }
 
@@ -189,11 +309,80 @@ final class LiveEngine {
 
     // MARK: - Helpers
 
+    /// Push current user settings into the QSO engine.
+    private func syncSettingsToQso() {
+        guard let qso = qsoEngine, let appState else { return }
+        let s = appState.settings
+        qso.myCall = s.myCall.uppercased()
+        qso.myGrid = s.myGrid.uppercased()
+        qso.band = s.band
+        qso.freqMhz = bandToFreqMhz(s.band)
+    }
+
+    /// Reflect QSO engine status into the UI TxState.
+    private func syncQsoStatusToUI() {
+        guard let qso = qsoEngine, let appState else { return }
+        let status = qso.status()
+        appState.tx.isActivated = status.active
+        appState.tx.stage = mapStage(status.stage)
+    }
+
+    private func mapStage(_ stage: TxStage) -> TxUIStage {
+        switch stage {
+        case .idle: return .idle
+        case .cq: return .cqSent
+        case .grid, .report: return .reportSent
+        case .rReport, .rr73: return .rrSent
+        case .bye73: return .complete
+        }
+    }
+
+    /// Map amateur band name to a common FT8 frequency in MHz.
+    private func bandToFreqMhz(_ band: String) -> String {
+        switch band {
+        case "160M": return "1.840"
+        case "80M": return "3.573"
+        case "60M": return "5.357"
+        case "40M": return "7.074"
+        case "30M": return "10.136"
+        case "20M": return "14.074"
+        case "17M": return "18.100"
+        case "15M": return "21.074"
+        case "12M": return "24.915"
+        case "10M": return "28.074"
+        case "6M": return "50.313"
+        case "2M": return "144.174"
+        default: return "14.074"
+        }
+    }
+
     private nonisolated static func utcTimeString(from epochMs: Int64) -> String {
         let date = Date(timeIntervalSince1970: Double(epochMs) / 1000.0)
         let fmt = DateFormatter()
         fmt.dateFormat = "HH:mm:ss"
         fmt.timeZone = TimeZone(identifier: "UTC")
         return fmt.string(from: date)
+    }
+}
+
+/// Initializer extension on DecodedMessage for constructing from individual
+/// fields (used when mapping UI DecodeMessage back to the DSP type).
+extension FT8DSP.DecodedMessage {
+    init(callTo: String, callFrom: String, extra: String, grid: String,
+         rawText: String, snr: Int, freqHz: Float, timeSec: Float,
+         score: Int, i3: UInt8, n3: UInt8, a91: [UInt8]) {
+        self.init()
+        self.callTo = callTo
+        self.callFrom = callFrom
+        self.extra = extra
+        self.grid = grid
+        self.rawText = rawText
+        self.snr = snr
+        self.freqHz = freqHz
+        self.timeSec = timeSec
+        self.score = score
+        self.i3 = i3
+        self.n3 = n3
+        self.a91 = a91
     }
 }

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -241,6 +241,8 @@ final class LiveEngine {
             record.id = nextId
             appState.logbook.records.insert(record, at: 0)
             QsoLogStore.save(appState.logbook.records)
+            // Trigger QSO celebration animation.
+            appState.tx.qsoCompletedAt = Date()
         }
 
         // Sync QSO status back to UI.
@@ -325,6 +327,8 @@ final class LiveEngine {
         let status = qso.status()
         appState.tx.isActivated = status.active
         appState.tx.stage = mapStage(status.stage)
+        appState.tx.targetCall = status.target ?? ""
+        appState.tx.txMessage = status.txMessage ?? ""
     }
 
     private func mapStage(_ stage: TxStage) -> TxUIStage {

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -72,6 +72,7 @@ final class LiveEngine {
                 appState.waterfall.rows.removeFirst(appState.waterfall.rows.count - 120)
             }
             appState.waterfall.spectrum = spectrum
+            appState.waterfall.updateCount += 1
         }
 
         engineTask = Task.detached { [weak self] in
@@ -110,6 +111,7 @@ final class LiveEngine {
     /// Begin calling CQ.
     func callCQ() {
         syncSettingsToQso()
+        appState?.tx.conversationLog.removeAll()
         qsoEngine?.startCq()
         syncQsoStatusToUI()
     }
@@ -124,6 +126,7 @@ final class LiveEngine {
     /// Answer a station from a decoded message (user tapped "Call" in QsoSheet).
     func answerStation(_ msg: DecodeMessage) {
         syncSettingsToQso()
+        appState?.tx.conversationLog.removeAll()
         let decoded = FT8DSP.DecodedMessage(
             callTo: msg.callTo,
             callFrom: msg.callFrom,
@@ -231,8 +234,41 @@ final class LiveEngine {
         // Sync latest settings into the engine before processing.
         syncSettingsToQso()
 
+        // Log incoming RX messages addressed to us for the conversation panel.
+        let myCall = appState.settings.myCall.uppercased()
+        if !myCall.isEmpty {
+            for msg in decoded where msg.callTo.uppercased() == myCall {
+                let utcTime = Self.utcTimeString(from: Int64(Date().timeIntervalSince1970 * 1000))
+                appState.tx.conversationLog.append(
+                    QsoLogEntry(direction: .rx, message: msg.rawText.isEmpty ? "\(msg.callTo) \(msg.callFrom) \(msg.extra)" : msg.rawText,
+                                snr: msg.snr, utcTime: utcTime)
+                )
+            }
+        }
+
+        // Capture pre-RX target to detect new QSO answers.
+        let previousTarget = qso.status().target
+
         // Feed decodes to the QSO sequencer.
         let outcome = qso.processRx(decoded)
+
+        // Auto-open QSO sheet when our CQ gets answered (target goes from nil to non-nil).
+        let newTarget = qso.status().target
+        if previousTarget == nil, let dx = newTarget {
+            // Find the decoded message from this station to use as autoOpenMessage.
+            if let answerMsg = decoded.first(where: { $0.callFrom.uppercased() == dx.uppercased() }) {
+                appState.tx.autoOpenMessage = DecodeMessage(
+                    utcTime: Self.utcTimeString(from: Int64(Date().timeIntervalSince1970 * 1000)),
+                    callFrom: answerMsg.callFrom,
+                    callTo: answerMsg.callTo,
+                    snr: answerMsg.snr,
+                    freqHz: answerMsg.freqHz,
+                    grid: answerMsg.grid,
+                    extra: answerMsg.extra,
+                    slotIndex: Int(SlotClock.parity(slotID: slotID))
+                )
+            }
+        }
 
         // Handle QSO completion.
         if case .completed(var record) = outcome {
@@ -262,6 +298,12 @@ final class LiveEngine {
     private func scheduleTx(message: String, freqHz: Float) {
         guard let appState else { return }
         guard let samples = FT8Encoder.generateFT8(message, baseFreqHz: freqHz) else { return }
+
+        // Log the TX message to conversation panel.
+        let utcTime = Self.utcTimeString(from: Int64(Date().timeIntervalSince1970 * 1000))
+        appState.tx.conversationLog.append(
+            QsoLogEntry(direction: .tx, message: message, snr: nil, utcTime: utcTime)
+        )
 
         appState.tx.isTransmitting = true
         txPlayer.play(samples) { [weak self] in

--- a/ios/FT8AF/FT8AF/Engine/QsoLogStore.swift
+++ b/ios/FT8AF/FT8AF/Engine/QsoLogStore.swift
@@ -36,4 +36,20 @@ enum QsoLogStore {
             // Best-effort: log persistence failure is non-fatal.
         }
     }
+
+    /// Delete a QSO record by ID and persist.
+    @MainActor
+    static func delete(id: Int64, from appState: AppState) {
+        appState.logbook.records.removeAll { $0.id == id }
+        save(appState.logbook.records)
+    }
+
+    /// Update a QSO record in-place and persist.
+    @MainActor
+    static func update(_ record: QsoRecord, in appState: AppState) {
+        if let idx = appState.logbook.records.firstIndex(where: { $0.id == record.id }) {
+            appState.logbook.records[idx] = record
+            save(appState.logbook.records)
+        }
+    }
 }

--- a/ios/FT8AF/FT8AF/Engine/QsoLogStore.swift
+++ b/ios/FT8AF/FT8AF/Engine/QsoLogStore.swift
@@ -1,0 +1,39 @@
+import FT8Engine
+import Foundation
+
+/// Simple file-based persistence for QSO records. Stores the log as a JSON
+/// array in the app's documents directory. Loaded on startup and saved after
+/// each new QSO.
+enum QsoLogStore {
+    private static let fileName = "qso_log.json"
+
+    static func fileURL() -> URL {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return docs.appendingPathComponent(fileName)
+    }
+
+    static func load() -> [QsoRecord] {
+        let url = fileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+        do {
+            let data = try Data(contentsOf: url)
+            var records = try JSONDecoder().decode([QsoRecord].self, from: data)
+            // Ensure every record has a unique ID (fixup for any legacy data).
+            for i in records.indices where records[i].id == nil {
+                records[i].id = Int64(i + 1)
+            }
+            return records
+        } catch {
+            return []
+        }
+    }
+
+    static func save(_ records: [QsoRecord]) {
+        do {
+            let data = try JSONEncoder().encode(records)
+            try data.write(to: fileURL(), options: .atomic)
+        } catch {
+            // Best-effort: log persistence failure is non-fatal.
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/TxPlayerService.swift
+++ b/ios/FT8AF/FT8AF/Engine/TxPlayerService.swift
@@ -1,0 +1,91 @@
+import AVFoundation
+import FT8DSP
+
+/// Plays a mono 12 kHz FT8 waveform through the device speaker using an
+/// `AVAudioPlayerNode` attached to a shared `AVAudioEngine`. The TX scheduler
+/// calls `play(_:)` at the correct slot time; the service handles sample-rate
+/// conversion to the hardware output format internally.
+final class TxPlayerService: @unchecked Sendable {
+    private let playerNode = AVAudioPlayerNode()
+    private var engine: AVAudioEngine?
+    private var outputConverter: AVAudioConverter?
+    private let lock = NSLock()
+    private var _isPlaying = false
+
+    /// The 12 kHz mono format used by FT8Encoder output.
+    private let ft8Format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: Double(FT8.sampleRate),
+        channels: 1,
+        interleaved: false
+    )!
+
+    var isPlaying: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isPlaying
+    }
+
+    /// Attach the player node to the shared `AVAudioEngine` (the same one
+    /// `AudioCaptureService` owns). Call once at setup before any `play()`.
+    func configure(engine: AVAudioEngine) {
+        self.engine = engine
+        engine.attach(playerNode)
+        let outputFormat = engine.outputNode.outputFormat(forBus: 0)
+        engine.connect(playerNode, to: engine.mainMixerNode, format: outputFormat)
+        outputConverter = AVAudioConverter(from: ft8Format, to: outputFormat)
+    }
+
+    /// Schedule and play `samples` (mono Float32 at 12 kHz). Interrupts any
+    /// previously playing buffer so a new TX overrides the old one.
+    func play(_ samples: [Float], completion: (() -> Void)? = nil) {
+        guard let converter = outputConverter else { return }
+
+        // Wrap input samples in a PCM buffer at 12 kHz.
+        let frameCount = AVAudioFrameCount(samples.count)
+        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: ft8Format, frameCapacity: frameCount) else { return }
+        inputBuffer.frameLength = frameCount
+        samples.withUnsafeBufferPointer { src in
+            inputBuffer.floatChannelData![0].update(from: src.baseAddress!, count: samples.count)
+        }
+
+        // Convert to the hardware output format.
+        let outputFormat = converter.outputFormat
+        let ratio = outputFormat.sampleRate / ft8Format.sampleRate
+        let outFrames = AVAudioFrameCount(Double(frameCount) * ratio) + 1
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outFrames) else { return }
+
+        var error: NSError?
+        var consumed = false
+        converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+            if consumed {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            outStatus.pointee = .haveData
+            return inputBuffer
+        }
+        if error != nil { return }
+
+        lock.lock()
+        _isPlaying = true
+        lock.unlock()
+
+        playerNode.stop()
+        playerNode.scheduleBuffer(outputBuffer, at: nil, options: .interrupts) { [weak self] in
+            self?.lock.lock()
+            self?._isPlaying = false
+            self?.lock.unlock()
+            completion?()
+        }
+        playerNode.play()
+    }
+
+    /// Cancel any pending/active playback.
+    func stop() {
+        playerNode.stop()
+        lock.lock()
+        _isPlaying = false
+        lock.unlock()
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/TxPlayerService.swift
+++ b/ios/FT8AF/FT8AF/Engine/TxPlayerService.swift
@@ -5,12 +5,17 @@ import FT8DSP
 /// `AVAudioPlayerNode` attached to a shared `AVAudioEngine`. The TX scheduler
 /// calls `play(_:)` at the correct slot time; the service handles sample-rate
 /// conversion to the hardware output format internally.
+///
+/// Node attachment is deferred to the first `play()` call so that the output
+/// hardware format has stabilized (on Simulator the output node may report
+/// 0 Hz at engine-start time, which crashes `connect()`).
 final class TxPlayerService: @unchecked Sendable {
     private let playerNode = AVAudioPlayerNode()
     private var engine: AVAudioEngine?
     private var outputConverter: AVAudioConverter?
     private let lock = NSLock()
     private var _isPlaying = false
+    private var isAttached = false
 
     /// The 12 kHz mono format used by FT8Encoder output.
     private let ft8Format = AVAudioFormat(
@@ -25,24 +30,48 @@ final class TxPlayerService: @unchecked Sendable {
         return _isPlaying
     }
 
-    /// Attach the player node to the shared `AVAudioEngine` (the same one
-    /// `AudioCaptureService` owns). Call once at setup before any `play()`.
+    /// Store the engine reference for deferred attachment. Does NOT connect
+    /// the player node yet — that happens lazily in `ensureAttached()`.
     func configure(engine: AVAudioEngine) {
         self.engine = engine
+    }
+
+    /// Attach and connect the player node, creating the format converter.
+    /// Returns `false` if the hardware output format is invalid (e.g. 0 Hz
+    /// on Simulator at startup) — the caller should skip playback.
+    private func ensureAttached() -> Bool {
+        if isAttached { return outputConverter != nil }
+        guard let engine else { return false }
+
+        // Use the mixer's output format — on real devices this is the
+        // hardware rate (e.g. 48 kHz stereo); on Simulator it becomes valid
+        // once the engine is running.
+        let mixerFormat = engine.mainMixerNode.outputFormat(forBus: 0)
+        guard mixerFormat.sampleRate > 0, mixerFormat.channelCount > 0 else {
+            return false
+        }
+
         engine.attach(playerNode)
-        let outputFormat = engine.outputNode.outputFormat(forBus: 0)
-        engine.connect(playerNode, to: engine.mainMixerNode, format: outputFormat)
-        outputConverter = AVAudioConverter(from: ft8Format, to: outputFormat)
+        engine.connect(playerNode, to: engine.mainMixerNode, format: mixerFormat)
+        outputConverter = AVAudioConverter(from: ft8Format, to: mixerFormat)
+        isAttached = true
+        return outputConverter != nil
     }
 
     /// Schedule and play `samples` (mono Float32 at 12 kHz). Interrupts any
     /// previously playing buffer so a new TX overrides the old one.
     func play(_ samples: [Float], completion: (() -> Void)? = nil) {
-        guard let converter = outputConverter else { return }
+        guard ensureAttached(), let converter = outputConverter else {
+            completion?()
+            return
+        }
 
         // Wrap input samples in a PCM buffer at 12 kHz.
         let frameCount = AVAudioFrameCount(samples.count)
-        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: ft8Format, frameCapacity: frameCount) else { return }
+        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: ft8Format, frameCapacity: frameCount) else {
+            completion?()
+            return
+        }
         inputBuffer.frameLength = frameCount
         samples.withUnsafeBufferPointer { src in
             inputBuffer.floatChannelData![0].update(from: src.baseAddress!, count: samples.count)
@@ -52,7 +81,10 @@ final class TxPlayerService: @unchecked Sendable {
         let outputFormat = converter.outputFormat
         let ratio = outputFormat.sampleRate / ft8Format.sampleRate
         let outFrames = AVAudioFrameCount(Double(frameCount) * ratio) + 1
-        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outFrames) else { return }
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outFrames) else {
+            completion?()
+            return
+        }
 
         var error: NSError?
         var consumed = false
@@ -65,7 +97,10 @@ final class TxPlayerService: @unchecked Sendable {
             outStatus.pointee = .haveData
             return inputBuffer
         }
-        if error != nil { return }
+        if error != nil {
+            completion?()
+            return
+        }
 
         lock.lock()
         _isPlaying = true

--- a/ios/FT8AF/FT8AF/FT8AFApp.swift
+++ b/ios/FT8AF/FT8AF/FT8AFApp.swift
@@ -9,8 +9,9 @@ struct FT8AFApp: App {
         WindowGroup {
             AppTabView()
                 .environment(appState)
-                .environment(engine)
                 .task {
+                    // Wire engine into AppState so every view can reach it.
+                    appState.engine = engine
                     // Load persisted QSO log before starting the engine.
                     appState.logbook.records = QsoLogStore.load()
                     await engine.start(appState: appState)

--- a/ios/FT8AF/FT8AF/FT8AFApp.swift
+++ b/ios/FT8AF/FT8AF/FT8AFApp.swift
@@ -9,7 +9,10 @@ struct FT8AFApp: App {
         WindowGroup {
             AppTabView()
                 .environment(appState)
+                .environment(engine)
                 .task {
+                    // Load persisted QSO log before starting the engine.
+                    appState.logbook.records = QsoLogStore.load()
                     await engine.start(appState: appState)
                 }
         }

--- a/ios/FT8AF/FT8AF/FT8AFApp.swift
+++ b/ios/FT8AF/FT8AF/FT8AFApp.swift
@@ -12,7 +12,8 @@ struct FT8AFApp: App {
                 .task {
                     // Wire engine into AppState so every view can reach it.
                     appState.engine = engine
-                    // Load persisted QSO log before starting the engine.
+                    // Load persisted settings and QSO log before starting the engine.
+                    SettingsPersistence.load(into: appState.settings)
                     appState.logbook.records = QsoLogStore.load()
                     await engine.start(appState: appState)
                 }

--- a/ios/FT8AF/FT8AF/Navigation/AppTabView.swift
+++ b/ios/FT8AF/FT8AF/Navigation/AppTabView.swift
@@ -4,6 +4,11 @@ struct AppTabView: View {
     @State private var selectedTab: FT8AFTab = .decode
     @Environment(AppState.self) private var appState
 
+    /// Whether the current tab shows the TX control strip.
+    private var showsTxStrip: Bool {
+        selectedTab == .decode || selectedTab == .waterfall
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             // Screen content
@@ -19,8 +24,16 @@ struct AppTabView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            // Custom tab bar
+            // Bottom chrome: TxStrip (on decode/waterfall tabs) + SlotTimer + TabBar
             VStack(spacing: 0) {
+                if showsTxStrip {
+                    TxStrip(
+                        onHunt: { appState.engine?.toggleHunt() },
+                        onCallCQ: { appState.engine?.callCQ() },
+                        onStop: { appState.engine?.stopTx() },
+                        onToggleSlot: { appState.engine?.toggleSlotParity() }
+                    )
+                }
                 SlotTimerBar()
                 TabBarView(selectedTab: $selectedTab)
             }

--- a/ios/FT8AF/FT8AF/Navigation/AppTabView.swift
+++ b/ios/FT8AF/FT8AF/Navigation/AppTabView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct AppTabView: View {
     @State private var selectedTab: FT8AFTab = .decode
+    @State private var showFrequencyPicker = false
+    @State private var showCelebration = false
     @Environment(AppState.self) private var appState
 
     /// Whether the current tab shows the TX control strip.
@@ -24,22 +26,57 @@ struct AppTabView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            // Bottom chrome: TxStrip (on decode/waterfall tabs) + SlotTimer + TabBar
+            // Bottom chrome: ActiveQsoPanel + TxStrip + SlotTimer + TabBar
             VStack(spacing: 0) {
+                if showsTxStrip && appState.tx.isActivated {
+                    ActiveQsoPanel()
+                }
+
                 if showsTxStrip {
                     TxStrip(
                         onHunt: { appState.engine?.toggleHunt() },
                         onCallCQ: { appState.engine?.callCQ() },
                         onStop: { appState.engine?.stopTx() },
-                        onToggleSlot: { appState.engine?.toggleSlotParity() }
+                        onToggleSlot: { appState.engine?.toggleSlotParity() },
+                        onOpenFrequencyPicker: { showFrequencyPicker = true },
+                        onVolumeChange: { newVol in
+                            appState.settings.txVolume = newVol
+                            SettingsPersistence.save(appState.settings)
+                        }
                     )
                 }
                 SlotTimerBar()
                 TabBarView(selectedTab: $selectedTab)
             }
+
+            // TX glow overlay
+            if appState.tx.isTransmitting {
+                TransmitGlow()
+            }
+
+            // QSO celebration overlay
+            if showCelebration {
+                QsoCelebration {
+                    showCelebration = false
+                }
+            }
         }
         .background(bgApp)
         .preferredColorScheme(.dark)
+        .sheet(isPresented: $showFrequencyPicker) {
+            FrequencyPickerSheet()
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .onChange(of: appState.tx.qsoCompletedAt) { _, newVal in
+            if newVal != nil {
+                showCelebration = true
+                // Clear the trigger so it can fire again next QSO.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    appState.tx.qsoCompletedAt = nil
+                }
+            }
+        }
     }
 }
 

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeRow.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeRow.swift
@@ -2,38 +2,41 @@ import SwiftUI
 
 struct DecodeRow: View {
     let message: DecodeMessage
+    var myCall: String = ""
+    var workedCalls: Set<String> = []
+    var compact: Bool = false
 
     var body: some View {
         HStack(spacing: 0) {
             // UTC time
             Text(shortTime)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .font(.system(size: compact ? 10 : 11, weight: .medium, design: .monospaced))
                 .foregroundStyle(textFaint)
-                .frame(width: 38, alignment: .leading)
+                .frame(width: compact ? 34 : 38, alignment: .leading)
 
             // SNR badge
             Text(snrText)
-                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .font(.system(size: compact ? 10 : 11, weight: .semibold, design: .monospaced))
                 .foregroundStyle(snrColor)
-                .frame(width: 32, alignment: .trailing)
-                .padding(.trailing, 8)
+                .frame(width: compact ? 28 : 32, alignment: .trailing)
+                .padding(.trailing, compact ? 6 : 8)
 
             // Frequency
             Text(freqText)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .font(.system(size: compact ? 10 : 11, weight: .medium, design: .monospaced))
                 .foregroundStyle(textFaint)
-                .frame(width: 40, alignment: .trailing)
-                .padding(.trailing, 10)
+                .frame(width: compact ? 36 : 40, alignment: .trailing)
+                .padding(.trailing, compact ? 8 : 10)
 
             // Callsigns + extra
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: compact ? 1 : 2) {
                 HStack(spacing: 4) {
                     // CQ / callTo pill
                     if message.callTo == "CQ" || message.callTo.hasPrefix("CQ ") {
                         Text("CQ")
-                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                            .font(.system(size: compact ? 9 : 10, weight: .bold, design: .monospaced))
                             .foregroundStyle(bgApp)
-                            .padding(.horizontal, 5)
+                            .padding(.horizontal, compact ? 4 : 5)
                             .padding(.vertical, 1)
                             .background(
                                 RoundedRectangle(cornerRadius: 3)
@@ -41,20 +44,20 @@ struct DecodeRow: View {
                             )
                     } else {
                         Text(message.callTo)
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .font(.system(size: compact ? 11 : 12, weight: .medium, design: .monospaced))
                             .foregroundStyle(signal)
                     }
 
                     Image(systemName: "arrow.left")
-                        .font(.system(size: 8))
+                        .font(.system(size: compact ? 7 : 8))
                         .foregroundStyle(textDim)
 
                     Text(message.callFrom)
-                        .font(.system(size: 13, weight: .bold, design: .monospaced))
+                        .font(.system(size: compact ? 12 : 13, weight: .bold, design: .monospaced))
                         .foregroundStyle(textPrimary)
                 }
 
-                if !message.grid.isEmpty || !message.extra.isEmpty {
+                if !compact, !message.grid.isEmpty || !message.extra.isEmpty {
                     Text(message.grid.isEmpty ? message.extra : message.grid)
                         .font(.system(size: 10, weight: .medium, design: .monospaced))
                         .foregroundStyle(textFaint)
@@ -65,12 +68,12 @@ struct DecodeRow: View {
 
             // Chevron
             Image(systemName: "chevron.right")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: compact ? 9 : 10, weight: .semibold))
                 .foregroundStyle(textDim)
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .background(bgApp)
+        .padding(.vertical, compact ? 5 : 8)
+        .background(rowBackground)
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(borderSubtle)
@@ -78,8 +81,26 @@ struct DecodeRow: View {
         }
     }
 
+    private var rowBackground: Color {
+        if isForMe { return target.opacity(0.10) }
+        if isCQ { return accent.opacity(0.06) }
+        if isWorked { return signal.opacity(0.06) }
+        return bgApp
+    }
+
+    private var isCQ: Bool {
+        message.callTo == "CQ" || message.callTo.hasPrefix("CQ ")
+    }
+
+    private var isForMe: Bool {
+        !myCall.isEmpty && message.callTo.uppercased() == myCall.uppercased()
+    }
+
+    private var isWorked: Bool {
+        workedCalls.contains(message.callFrom.uppercased())
+    }
+
     private var shortTime: String {
-        // "12:30:00" -> "12:30"
         String(message.utcTime.prefix(5))
     }
 

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DecodeScreen: View {
     @Environment(AppState.self) private var appState
+    @Environment(LiveEngine.self) private var engine
     @State private var showQsoSheet = false
 
     var body: some View {
@@ -58,14 +59,21 @@ struct DecodeScreen: View {
 
             Spacer(minLength: 0)
 
-            TxStrip()
+            TxStrip(
+                onHunt: { engine.toggleHunt() },
+                onCallCQ: { engine.callCQ() },
+                onStop: { engine.stopTx() },
+                onToggleSlot: { engine.toggleSlotParity() }
+            )
         }
         .background(bgApp)
         .sheet(isPresented: $showQsoSheet) {
             if let msg = decode.selectedMessage {
-                QsoSheet(message: msg)
-                    .presentationDetents([.medium])
-                    .presentationDragIndicator(.visible)
+                QsoSheet(message: msg) { message in
+                    engine.answerStation(message)
+                }
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
             }
         }
     }

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
@@ -114,6 +114,22 @@ struct DecodeScreen: View {
                 .presentationDragIndicator(.visible)
             }
         }
+        // Auto-open QSO sheet when our CQ is answered.
+        .onChange(of: appState.tx.autoOpenMessage?.id) { _, newId in
+            if let msg = appState.tx.autoOpenMessage, newId != nil {
+                appState.decode.selectedMessage = msg
+                showQsoSheet = true
+                appState.tx.autoOpenMessage = nil
+            }
+        }
+        // Auto-close QSO sheet after completion (5 second delay).
+        .onChange(of: appState.tx.qsoCompletedAt) { _, newVal in
+            if newVal != nil && showQsoSheet {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+                    showQsoSheet = false
+                }
+            }
+        }
     }
 
     private var filteredMessages: [DecodeMessage] {

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct DecodeScreen: View {
     @Environment(AppState.self) private var appState
-    @Environment(LiveEngine.self) private var engine
     @State private var showQsoSheet = false
 
     var body: some View {
@@ -60,17 +59,17 @@ struct DecodeScreen: View {
             Spacer(minLength: 0)
 
             TxStrip(
-                onHunt: { engine.toggleHunt() },
-                onCallCQ: { engine.callCQ() },
-                onStop: { engine.stopTx() },
-                onToggleSlot: { engine.toggleSlotParity() }
+                onHunt: { appState.engine?.toggleHunt() },
+                onCallCQ: { appState.engine?.callCQ() },
+                onStop: { appState.engine?.stopTx() },
+                onToggleSlot: { appState.engine?.toggleSlotParity() }
             )
         }
         .background(bgApp)
         .sheet(isPresented: $showQsoSheet) {
             if let msg = decode.selectedMessage {
                 QsoSheet(message: msg) { message in
-                    engine.answerStation(message)
+                    appState.engine?.answerStation(message)
                 }
                 .presentationDetents([.medium])
                 .presentationDragIndicator(.visible)

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
@@ -57,13 +57,6 @@ struct DecodeScreen: View {
             }
 
             Spacer(minLength: 0)
-
-            TxStrip(
-                onHunt: { appState.engine?.toggleHunt() },
-                onCallCQ: { appState.engine?.callCQ() },
-                onStop: { appState.engine?.stopTx() },
-                onToggleSlot: { appState.engine?.toggleSlotParity() }
-            )
         }
         .background(bgApp)
         .sheet(isPresented: $showQsoSheet) {

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
@@ -13,7 +13,31 @@ struct DecodeScreen: View {
                 Text("Decode")
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(textPrimary)
+
                 Spacer()
+
+                // Compact mode toggle
+                Button {
+                    appState.decode.compactMode.toggle()
+                } label: {
+                    Image(systemName: decode.compactMode ? "list.bullet" : "list.bullet.indent")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(decode.compactMode ? accent : textMuted)
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 8)
+
+                // Auto-clear toggle
+                Button {
+                    appState.decode.autoClear.toggle()
+                } label: {
+                    Image(systemName: decode.autoClear ? "arrow.clockwise.circle.fill" : "arrow.clockwise.circle")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(decode.autoClear ? accent : textMuted)
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 8)
+
                 Text("\(decode.messages.count) msgs")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundStyle(textMuted)
@@ -42,17 +66,39 @@ struct DecodeScreen: View {
             if filteredMessages.isEmpty {
                 emptyState
             } else {
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        ForEach(filteredMessages) { message in
-                            DecodeRow(message: message)
-                                .onTapGesture {
-                                    appState.decode.selectedMessage = message
-                                    showQsoSheet = true
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(groupedBySlot.enumerated()), id: \.offset) { groupIdx, group in
+                                // Time divider between slot groups
+                                if groupIdx > 0 {
+                                    SlotDivider(time: group.first?.utcTime ?? "")
                                 }
+
+                                ForEach(group) { message in
+                                    DecodeRow(
+                                        message: message,
+                                        myCall: appState.settings.myCall,
+                                        workedCalls: workedCallSet,
+                                        compact: decode.compactMode
+                                    )
+                                    .id(message.id)
+                                    .onTapGesture {
+                                        appState.decode.selectedMessage = message
+                                        showQsoSheet = true
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.bottom, 160)
+                    }
+                    .onChange(of: decode.messages.first?.id) { _, newId in
+                        if let id = newId {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                proxy.scrollTo(id, anchor: .top)
+                            }
                         }
                     }
-                    .padding(.bottom, 160) // space for TxStrip + TabBar
                 }
             }
 
@@ -64,7 +110,7 @@ struct DecodeScreen: View {
                 QsoSheet(message: msg) { message in
                     appState.engine?.answerStation(message)
                 }
-                .presentationDetents([.medium])
+                .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
             }
         }
@@ -74,12 +120,31 @@ struct DecodeScreen: View {
         let msgs = appState.decode.messages
         switch appState.decode.activeFilter {
         case .all:     return msgs
-        case .cq:      return msgs.filter { $0.callTo == "CQ" }
+        case .cq:      return msgs.filter { $0.callTo == "CQ" || $0.callTo.hasPrefix("CQ ") }
         case .cqPota:  return msgs.filter { $0.extra.contains("K-") || $0.callTo == "CQ POTA" }
-        case .newDxcc: return msgs // Phase 4: filter by DXCC lookup
-        case .needed:  return msgs // Phase 4: filter by needed entities
-        case .forMe:   return msgs.filter { $0.callTo == appState.settings.myCall }
+        case .newDxcc: return msgs
+        case .needed:  return msgs
+        case .forMe:   return msgs.filter { $0.callTo.uppercased() == appState.settings.myCall.uppercased() }
         }
+    }
+
+    /// Group filtered messages by slotIndex for time dividers.
+    private var groupedBySlot: [[DecodeMessage]] {
+        var groups: [[DecodeMessage]] = []
+        var currentSlot: Int?
+        for msg in filteredMessages {
+            if msg.slotIndex != currentSlot {
+                groups.append([msg])
+                currentSlot = msg.slotIndex
+            } else {
+                groups[groups.count - 1].append(msg)
+            }
+        }
+        return groups
+    }
+
+    private var workedCallSet: Set<String> {
+        Set(appState.logbook.records.map { $0.call.uppercased() })
     }
 
     private var emptyState: some View {
@@ -96,5 +161,26 @@ struct DecodeScreen: View {
                 .foregroundStyle(textFaint)
             Spacer()
         }
+    }
+}
+
+/// Thin time divider line between slot groups.
+private struct SlotDivider: View {
+    let time: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(textDim.opacity(0.4))
+                .frame(height: 1)
+            Text(String(time.prefix(5)))
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundStyle(textFaint)
+            Rectangle()
+                .fill(textDim.opacity(0.4))
+                .frame(height: 1)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 4)
     }
 }

--- a/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct QsoSheet: View {
     let message: DecodeMessage
     var onCall: (DecodeMessage) -> Void = { _ in }
+    @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -24,12 +25,31 @@ struct QsoSheet: View {
             .padding(.bottom, 16)
 
             // Stats row
-            HStack(spacing: 24) {
+            HStack(spacing: 12) {
                 StatBadge(label: "SNR", value: message.snr >= 0 ? "+\(message.snr)" : "\(message.snr)")
                 StatBadge(label: "Freq", value: String(format: "%.0f Hz", message.freqHz))
                 StatBadge(label: "UTC", value: message.utcTime)
+
+                // Distance & Azimuth (if grids available)
+                if let dist = distanceInfo {
+                    StatBadge(label: "Dist", value: dist.distance)
+                    StatBadge(label: "Azim", value: dist.bearing)
+                }
             }
-            .padding(.bottom, 20)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+
+            // QSO Sequence Visualizer
+            if appState.tx.isActivated {
+                VStack(spacing: 6) {
+                    Text("QSO PROGRESS")
+                        .font(.system(size: 9, weight: .bold, design: .monospaced))
+                        .foregroundStyle(textFaint)
+                    QsoStageDots(currentStage: appState.tx.stage)
+                        .padding(.horizontal, 24)
+                }
+                .padding(.bottom, 16)
+            }
 
             // Extra info
             if !message.extra.isEmpty && message.extra != message.grid {
@@ -48,7 +68,7 @@ struct QsoSheet: View {
 
             Spacer()
 
-            // Call button — starts answering this station's CQ
+            // Call button
             Button {
                 onCall(message)
                 dismiss()
@@ -74,6 +94,17 @@ struct QsoSheet: View {
         .frame(maxWidth: .infinity)
         .background(bgSurface2)
     }
+
+    private var distanceInfo: (distance: String, bearing: String)? {
+        let myGrid = appState.settings.myGrid
+        guard !myGrid.isEmpty, !message.grid.isEmpty,
+              let myPos = gridToLatLon(myGrid),
+              let theirPos = gridToLatLon(message.grid) else { return nil }
+
+        let dist = haversineDistance(from: myPos, to: theirPos)
+        let brg = bearing(from: myPos, to: theirPos)
+        return (formatDistance(dist), formatBearing(brg))
+    }
 }
 
 private struct StatBadge: View {
@@ -87,10 +118,13 @@ private struct StatBadge: View {
                 .foregroundStyle(textFaint)
                 .textCase(.uppercase)
             Text(value)
-                .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
                 .foregroundStyle(textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
         }
-        .padding(.horizontal, 12)
+        .frame(minWidth: 48)
+        .padding(.horizontal, 8)
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 8)

--- a/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// Bottom sheet showing station detail when a decode row is tapped.
 struct QsoSheet: View {
     let message: DecodeMessage
+    var onCall: (DecodeMessage) -> Void = { _ in }
     @Environment(\.dismiss) private var dismiss
-    @Environment(LiveEngine.self) private var engine
 
     var body: some View {
         VStack(spacing: 0) {
@@ -50,7 +50,7 @@ struct QsoSheet: View {
 
             // Call button — starts answering this station's CQ
             Button {
-                engine.answerStation(message)
+                onCall(message)
                 dismiss()
             } label: {
                 HStack(spacing: 8) {

--- a/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct QsoSheet: View {
     let message: DecodeMessage
     @Environment(\.dismiss) private var dismiss
+    @Environment(LiveEngine.self) private var engine
 
     var body: some View {
         VStack(spacing: 0) {
@@ -47,8 +48,9 @@ struct QsoSheet: View {
 
             Spacer()
 
-            // Call button (stub for Phase 4)
+            // Call button — starts answering this station's CQ
             Button {
+                engine.answerStation(message)
                 dismiss()
             } label: {
                 HStack(spacing: 8) {

--- a/ios/FT8AF/FT8AF/Screens/Logbook/LogbookCharts.swift
+++ b/ios/FT8AF/FT8AF/Screens/Logbook/LogbookCharts.swift
@@ -1,0 +1,414 @@
+import FT8Engine
+import SwiftUI
+
+/// Rich stats view with donut chart, sparkline, grid heatmap, and award progress.
+struct LogbookChartsView: View {
+    let records: [QsoRecord]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Big stat cards row
+            HStack(spacing: 10) {
+                BigStatCard(title: "QSOs", value: records.count, color: accent)
+                BigStatCard(title: "DXCC", value: uniqueDxccCount, color: signal)
+                BigStatCard(title: "Grids", value: uniqueGridCount, color: target)
+            }
+            .padding(.horizontal, 16)
+
+            // Band donut chart
+            if !records.isEmpty {
+                BandDonutChart(bandStats: bandStats)
+                    .padding(.horizontal, 16)
+            }
+
+            // Signal strength sparkline
+            if records.count >= 3 {
+                SnrSparkline(records: records)
+                    .padding(.horizontal, 16)
+            }
+
+            // Grid square heatmap
+            if uniqueGridCount > 0 {
+                GridHeatmap(records: records)
+                    .padding(.horizontal, 16)
+            }
+
+            // Award progress
+            AwardProgressSection(
+                totalQsos: records.count,
+                dxccCount: uniqueDxccCount,
+                gridCount: uniqueGridCount
+            )
+            .padding(.horizontal, 16)
+        }
+    }
+
+    private var bandStats: [(band: String, count: Int)] {
+        var stats: [String: Int] = [:]
+        for r in records { stats[r.band, default: 0] += 1 }
+        let order = ["160M","80M","40M","30M","20M","17M","15M","12M","10M","6M"]
+        return stats.sorted { a, b in
+            let ai = order.firstIndex(of: a.key.uppercased()) ?? 99
+            let bi = order.firstIndex(of: b.key.uppercased()) ?? 99
+            return ai < bi
+        }.map { (band: $0.key, count: $0.value) }
+    }
+
+    private var uniqueDxccCount: Int {
+        // Approximate: unique callsign prefixes (first letter + digit)
+        Set(records.map { dxccPrefix($0.call) }).count
+    }
+
+    private var uniqueGridCount: Int {
+        Set(records.compactMap { $0.gridsquare.isEmpty ? nil : String($0.gridsquare.prefix(4).uppercased()) }).count
+    }
+
+    private func dxccPrefix(_ call: String) -> String {
+        // Simple heuristic: first letter(s) up to first digit
+        var prefix = ""
+        for ch in call {
+            if ch.isNumber { prefix.append(ch); break }
+            prefix.append(ch)
+        }
+        return prefix
+    }
+}
+
+// MARK: - Big Stat Card
+
+private struct BigStatCard: View {
+    let title: String
+    let value: Int
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("\(value)")
+                .font(.system(size: 22, weight: .bold, design: .monospaced))
+                .foregroundStyle(textPrimary)
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(textFaint)
+                .textCase(.uppercase)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(bgSurface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(color.opacity(0.2), lineWidth: 1)
+                )
+        )
+    }
+}
+
+// MARK: - Band Donut Chart
+
+private struct BandDonutChart: View {
+    let bandStats: [(band: String, count: Int)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("BAND DISTRIBUTION")
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundStyle(textFaint)
+
+            HStack(spacing: 16) {
+                // Donut
+                ZStack {
+                    ForEach(Array(segments.enumerated()), id: \.offset) { _, seg in
+                        DonutSegment(
+                            startAngle: seg.start,
+                            endAngle: seg.end,
+                            color: seg.color
+                        )
+                    }
+                    // Center label
+                    VStack(spacing: 1) {
+                        Text("\(total)")
+                            .font(.system(size: 16, weight: .bold, design: .monospaced))
+                            .foregroundStyle(textPrimary)
+                        Text("QSOs")
+                            .font(.system(size: 8, weight: .medium))
+                            .foregroundStyle(textFaint)
+                    }
+                }
+                .frame(width: 90, height: 90)
+
+                // Legend
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(bandStats.prefix(6), id: \.band) { item in
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(bandColor(for: item.band))
+                                .frame(width: 6, height: 6)
+                            Text(item.band)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(textMuted)
+                            Spacer()
+                            Text("\(item.count)")
+                                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                                .foregroundStyle(textPrimary)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(bgSurface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(borderSubtle, lineWidth: 1)
+                )
+        )
+    }
+
+    private var total: Int { bandStats.reduce(0) { $0 + $1.count } }
+
+    private var segments: [(start: Angle, end: Angle, color: Color)] {
+        guard total > 0 else { return [] }
+        var segs: [(start: Angle, end: Angle, color: Color)] = []
+        var current = Angle.degrees(-90)
+        for item in bandStats {
+            let sweep = Angle.degrees(Double(item.count) / Double(total) * 360)
+            segs.append((start: current, end: current + sweep, color: bandColor(for: item.band)))
+            current = current + sweep
+        }
+        return segs
+    }
+}
+
+private struct DonutSegment: Shape {
+    let startAngle: Angle
+    let endAngle: Angle
+    let color: Color
+
+    func path(in rect: CGRect) -> Path {
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let outerRadius = min(rect.width, rect.height) / 2
+        let innerRadius = outerRadius * 0.6
+
+        var path = Path()
+        path.addArc(center: center, radius: outerRadius,
+                    startAngle: startAngle, endAngle: endAngle, clockwise: false)
+        path.addArc(center: center, radius: innerRadius,
+                    startAngle: endAngle, endAngle: startAngle, clockwise: true)
+        path.closeSubpath()
+        return path
+    }
+}
+
+extension DonutSegment: View {
+    var body: some View {
+        self.fill(color)
+    }
+}
+
+// MARK: - SNR Sparkline
+
+private struct SnrSparkline: View {
+    let records: [QsoRecord]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("SIGNAL TREND")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(textFaint)
+                Spacer()
+                Text("Last \(snrValues.count) QSOs")
+                    .font(.system(size: 9, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textDim)
+            }
+
+            Canvas { context, size in
+                let values = snrValues
+                guard values.count >= 2 else { return }
+
+                let minSNR = Double(values.min() ?? -30)
+                let maxSNR = Double(values.max() ?? 10)
+                let range = max(maxSNR - minSNR, 1)
+                let w = size.width
+                let h = size.height
+                let padding: CGFloat = 4
+
+                // Zero line
+                let zeroY = h - padding - ((0 - minSNR) / range) * (h - 2 * padding)
+                let zeroPath = Path { p in
+                    p.move(to: CGPoint(x: 0, y: zeroY))
+                    p.addLine(to: CGPoint(x: w, y: zeroY))
+                }
+                context.stroke(zeroPath, with: .color(textDim.opacity(0.3)),
+                             style: StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+
+                // Sparkline
+                let path = Path { p in
+                    for (i, val) in values.enumerated() {
+                        let x = padding + CGFloat(i) / CGFloat(values.count - 1) * (w - 2 * padding)
+                        let y = h - padding - ((Double(val) - minSNR) / range) * (h - 2 * padding)
+                        if i == 0 { p.move(to: CGPoint(x: x, y: y)) }
+                        else { p.addLine(to: CGPoint(x: x, y: y)) }
+                    }
+                }
+                context.stroke(path, with: .color(signal), lineWidth: 1.5)
+
+                // Fill under
+                var fillPath = path
+                let lastX = padding + CGFloat(values.count - 1) / CGFloat(values.count - 1) * (w - 2 * padding)
+                fillPath.addLine(to: CGPoint(x: lastX, y: h))
+                fillPath.addLine(to: CGPoint(x: padding, y: h))
+                fillPath.closeSubpath()
+                context.fill(fillPath, with: .color(signal.opacity(0.08)))
+            }
+            .frame(height: 60)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(bgSurface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(borderSubtle, lineWidth: 1)
+                )
+        )
+    }
+
+    private var snrValues: [Int] {
+        records.prefix(30).reversed().compactMap { r in
+            Int(r.rstRcvd.trimmingCharacters(in: CharacterSet(charactersIn: "+-").inverted))
+            ?? Int(r.rstRcvd)
+        }
+    }
+}
+
+// MARK: - Grid Heatmap
+
+private struct GridHeatmap: View {
+    let records: [QsoRecord]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("GRID COVERAGE")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(textFaint)
+                Spacer()
+                Text("\(workedFields.count)/324 fields")
+                    .font(.system(size: 9, weight: .medium, design: .monospaced))
+                    .foregroundStyle(textDim)
+            }
+
+            Canvas { context, size in
+                let cols = 18 // A-R
+                let rows = 18 // A-R
+                let cellW = size.width / CGFloat(cols)
+                let cellH = size.height / CGFloat(rows)
+
+                for row in 0..<rows {
+                    for col in 0..<cols {
+                        let field = "\(Character(UnicodeScalar(65 + col)!))\(Character(UnicodeScalar(65 + row)!))"
+                        let rect = CGRect(x: CGFloat(col) * cellW, y: CGFloat(rows - 1 - row) * cellH,
+                                         width: cellW - 0.5, height: cellH - 0.5)
+
+                        let count = workedFields[field] ?? 0
+                        let color: Color = count > 0 ? signal.opacity(min(0.3 + Double(count) * 0.15, 1.0)) : bgSurface3.opacity(0.3)
+                        context.fill(Path(rect), with: .color(color))
+                    }
+                }
+            }
+            .frame(height: 100)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(bgSurface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(borderSubtle, lineWidth: 1)
+                )
+        )
+    }
+
+    private var workedFields: [String: Int] {
+        var fields: [String: Int] = [:]
+        for r in records {
+            let g = r.gridsquare.uppercased()
+            guard g.count >= 2 else { continue }
+            let field = String(g.prefix(2))
+            fields[field, default: 0] += 1
+        }
+        return fields
+    }
+}
+
+// MARK: - Award Progress
+
+private struct AwardProgressSection: View {
+    let totalQsos: Int
+    let dxccCount: Int
+    let gridCount: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("AWARDS PROGRESS")
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundStyle(textFaint)
+
+            AwardBar(name: "DXCC Mixed", current: dxccCount, goal: 100, color: signal)
+            AwardBar(name: "VUCC Grids", current: gridCount, goal: 100, color: target)
+            AwardBar(name: "WAS", current: min(totalQsos, 50), goal: 50, color: accent)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(bgSurface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(borderSubtle, lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct AwardBar: View {
+    let name: String
+    let current: Int
+    let goal: Int
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(name)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(textMuted)
+                Spacer()
+                Text("\(current)/\(goal)")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(textFaint)
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(bgSurface3)
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(
+                            LinearGradient(
+                                colors: [color, color.opacity(0.6)],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: geo.size.width * min(CGFloat(current) / CGFloat(max(goal, 1)), 1.0))
+                }
+            }
+            .frame(height: 6)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Logbook/LogbookScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Logbook/LogbookScreen.swift
@@ -3,6 +3,9 @@ import SwiftUI
 
 struct LogbookScreen: View {
     @Environment(AppState.self) private var appState
+    @State private var searchText = ""
+    @State private var editingRecord: QsoRecord?
+    @State private var showExportSheet = false
 
     var body: some View {
         let logbook = appState.logbook
@@ -14,6 +17,18 @@ struct LogbookScreen: View {
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(textPrimary)
                 Spacer()
+
+                // Export button
+                Button {
+                    showExportSheet = true
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(textMuted)
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 8)
+
                 Text("\(logbook.totalCount) QSOs")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundStyle(textMuted)
@@ -22,19 +37,67 @@ struct LogbookScreen: View {
             .padding(.top, 12)
             .padding(.bottom, 8)
 
+            // Search bar
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 13))
+                    .foregroundStyle(textFaint)
+                TextField("Search callsign, band, date...", text: $searchText)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundStyle(textPrimary)
+                    .textInputAutocapitalization(.characters)
+                    .autocorrectionDisabled()
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 13))
+                            .foregroundStyle(textFaint)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(bgSurface)
+            )
+            .padding(.horizontal, 16)
+            .padding(.bottom, 8)
+
             ScrollView {
                 VStack(spacing: 12) {
-                    // Stats cards
-                    LogbookStats(totalQsos: logbook.totalCount, bandStats: logbook.bandStats)
-                        .padding(.horizontal, 16)
+                    // Stats cards (only when not searching)
+                    if searchText.isEmpty {
+                        LogbookStats(totalQsos: logbook.totalCount, bandStats: logbook.bandStats)
+                            .padding(.horizontal, 16)
+                    }
 
                     // QSO records list
-                    if logbook.records.isEmpty {
-                        emptyState
+                    if filteredRecords.isEmpty {
+                        if searchText.isEmpty {
+                            emptyState
+                        } else {
+                            noResultsState
+                        }
                     } else {
                         LazyVStack(spacing: 0) {
-                            ForEach(logbook.records, id: \.id) { record in
+                            ForEach(filteredRecords, id: \.id) { record in
                                 LogbookRow(record: record)
+                                    .onTapGesture {
+                                        editingRecord = record
+                                    }
+                                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                        Button(role: .destructive) {
+                                            if let id = record.id {
+                                                QsoLogStore.delete(id: id, from: appState)
+                                            }
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                    }
                             }
                         }
                     }
@@ -43,6 +106,36 @@ struct LogbookScreen: View {
             }
         }
         .background(bgApp)
+        .sheet(item: $editingRecord) { record in
+            QsoEditSheet(record: record) { updated in
+                QsoLogStore.update(updated, in: appState)
+            }
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showExportSheet) {
+            if let url = exportAdifFile() {
+                ShareSheet(items: [url])
+            }
+        }
+    }
+
+    private var filteredRecords: [QsoRecord] {
+        guard !searchText.isEmpty else { return appState.logbook.records }
+        let query = searchText.uppercased()
+        return appState.logbook.records.filter { r in
+            r.call.uppercased().contains(query)
+            || r.band.uppercased().contains(query)
+            || r.gridsquare.uppercased().contains(query)
+            || r.qsoDate.contains(query)
+        }
+    }
+
+    private func exportAdifFile() -> URL? {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("ft8af_log.adi")
+        let content = Adif.export(appState.logbook.records)
+        try? content.data(using: .utf8)?.write(to: tmp, options: .atomic)
+        return tmp
     }
 
     private var emptyState: some View {
@@ -60,7 +153,25 @@ struct LogbookScreen: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 60)
     }
+
+    private var noResultsState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 40))
+                .foregroundStyle(textFaint)
+            Text("No matches")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(textMuted)
+            Text("No QSOs match \"\(searchText)\"")
+                .font(.system(size: 13))
+                .foregroundStyle(textFaint)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
 }
+
+// MARK: - LogbookRow
 
 private struct LogbookRow: View {
     let record: QsoRecord
@@ -142,3 +253,107 @@ private struct LogbookRow: View {
         return "\(hh):\(mm)"
     }
 }
+
+// MARK: - QSO Edit Sheet
+
+private struct QsoEditSheet: View {
+    @State var record: QsoRecord
+    let onSave: (QsoRecord) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    init(record: QsoRecord, onSave: @escaping (QsoRecord) -> Void) {
+        _record = State(initialValue: record)
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    editField("Callsign", text: $record.call)
+                    editField("Grid", text: $record.gridsquare)
+                } header: {
+                    Text("Station").foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                Section {
+                    editField("RST Sent", text: $record.rstSent)
+                    editField("RST Rcvd", text: $record.rstRcvd)
+                } header: {
+                    Text("Signal Reports").foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                Section {
+                    HStack {
+                        Text("Band")
+                            .foregroundStyle(textPrimary)
+                        Spacer()
+                        Text(record.band)
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(textMuted)
+                    }
+                } header: {
+                    Text("Frequency").foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+
+                Section {
+                    editField("Comment", text: $record.comment)
+                } header: {
+                    Text("Notes").foregroundStyle(textMuted)
+                }
+                .listRowBackground(bgSurface)
+            }
+            .scrollContentBackground(.hidden)
+            .background(bgApp)
+            .navigationTitle("Edit QSO")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(accent)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        onSave(record)
+                        dismiss()
+                    }
+                    .foregroundStyle(accent)
+                    .fontWeight(.bold)
+                }
+            }
+        }
+    }
+
+    private func editField(_ label: String, text: Binding<String>) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(textPrimary)
+            Spacer()
+            TextField("", text: text)
+                .font(.system(.body, design: .monospaced))
+                .multilineTextAlignment(.trailing)
+                .foregroundStyle(textPrimary)
+                .textInputAutocapitalization(.characters)
+                .autocorrectionDisabled()
+        }
+    }
+}
+
+// MARK: - Share Sheet
+
+private struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+// Conformance for sheet(item:)
+extension QsoRecord: @retroactive Identifiable {}

--- a/ios/FT8AF/FT8AF/Screens/Logbook/LogbookScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Logbook/LogbookScreen.swift
@@ -1,8 +1,14 @@
 import FT8Engine
 import SwiftUI
 
+enum LogbookTab: String, CaseIterable {
+    case recent = "Recent"
+    case stats = "Stats"
+}
+
 struct LogbookScreen: View {
     @Environment(AppState.self) private var appState
+    @State private var selectedTab: LogbookTab = .recent
     @State private var searchText = ""
     @State private var editingRecord: QsoRecord?
     @State private var showExportSheet = false
@@ -37,72 +43,24 @@ struct LogbookScreen: View {
             .padding(.top, 12)
             .padding(.bottom, 8)
 
-            // Search bar
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 13))
-                    .foregroundStyle(textFaint)
-                TextField("Search callsign, band, date...", text: $searchText)
-                    .font(.system(size: 14, design: .monospaced))
-                    .foregroundStyle(textPrimary)
-                    .textInputAutocapitalization(.characters)
-                    .autocorrectionDisabled()
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 13))
-                            .foregroundStyle(textFaint)
-                    }
-                    .buttonStyle(.plain)
+            // Sub-tab picker
+            Picker("", selection: $selectedTab) {
+                ForEach(LogbookTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(bgSurface)
-            )
+            .pickerStyle(.segmented)
             .padding(.horizontal, 16)
             .padding(.bottom, 8)
 
-            ScrollView {
-                VStack(spacing: 12) {
-                    // Stats cards (only when not searching)
-                    if searchText.isEmpty {
-                        LogbookStats(totalQsos: logbook.totalCount, bandStats: logbook.bandStats)
-                            .padding(.horizontal, 16)
-                    }
-
-                    // QSO records list
-                    if filteredRecords.isEmpty {
-                        if searchText.isEmpty {
-                            emptyState
-                        } else {
-                            noResultsState
-                        }
-                    } else {
-                        LazyVStack(spacing: 0) {
-                            ForEach(filteredRecords, id: \.id) { record in
-                                LogbookRow(record: record)
-                                    .onTapGesture {
-                                        editingRecord = record
-                                    }
-                                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                                        Button(role: .destructive) {
-                                            if let id = record.id {
-                                                QsoLogStore.delete(id: id, from: appState)
-                                            }
-                                        } label: {
-                                            Label("Delete", systemImage: "trash")
-                                        }
-                                    }
-                            }
-                        }
-                    }
+            switch selectedTab {
+            case .recent:
+                recentTab(logbook: logbook)
+            case .stats:
+                ScrollView {
+                    LogbookChartsView(records: logbook.records)
+                        .padding(.bottom, 100)
                 }
-                .padding(.bottom, 100)
             }
         }
         .background(bgApp)
@@ -117,6 +75,75 @@ struct LogbookScreen: View {
             if let url = exportAdifFile() {
                 ShareSheet(items: [url])
             }
+        }
+    }
+
+    @ViewBuilder
+    private func recentTab(logbook: LogbookState) -> some View {
+        // Search bar
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13))
+                .foregroundStyle(textFaint)
+            TextField("Search callsign, band, date...", text: $searchText)
+                .font(.system(size: 14, design: .monospaced))
+                .foregroundStyle(textPrimary)
+                .textInputAutocapitalization(.characters)
+                .autocorrectionDisabled()
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(textFaint)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(bgSurface)
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+
+        ScrollView {
+            VStack(spacing: 12) {
+                if searchText.isEmpty {
+                    LogbookStats(totalQsos: logbook.totalCount, bandStats: logbook.bandStats)
+                        .padding(.horizontal, 16)
+                }
+
+                if filteredRecords.isEmpty {
+                    if searchText.isEmpty {
+                        emptyState
+                    } else {
+                        noResultsState
+                    }
+                } else {
+                    LazyVStack(spacing: 0) {
+                        ForEach(filteredRecords, id: \.id) { record in
+                            LogbookRow(record: record)
+                                .onTapGesture {
+                                    editingRecord = record
+                                }
+                                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                    Button(role: .destructive) {
+                                        if let id = record.id {
+                                            QsoLogStore.delete(id: id, from: appState)
+                                        }
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                }
+                        }
+                    }
+                }
+            }
+            .padding(.bottom, 100)
         }
     }
 

--- a/ios/FT8AF/FT8AF/Screens/Map/AzimuthalMapCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/AzimuthalMapCanvas.swift
@@ -1,0 +1,255 @@
+import SwiftUI
+
+/// Canvas-drawn azimuthal equidistant projection centered on the operator's grid.
+/// Shows range rings, compass bearings, and station markers projected radially
+/// from the operator's position.
+struct AzimuthalMapCanvas: View {
+    let markers: [MapMarker]
+    @Binding var selectedMarker: MapMarker?
+    var operatorGrid: String = ""
+
+    /// Range ring distances in km.
+    private let ringDistances: [Double] = [2500, 5000, 10000, 15000, 20000]
+    /// Maximum distance in km (half the Earth's circumference).
+    private let maxDistKm: Double = 20015.0
+    /// Compass labels at 45-degree intervals.
+    private let compassLabels = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
+
+    var body: some View {
+        GeometryReader { geo in
+            let size = geo.size
+            let center = CGPoint(x: size.width / 2, y: size.height / 2)
+            let radius = min(size.width, size.height) / 2 - 20
+
+            Canvas { context, _ in
+                // Background
+                context.fill(Path(CGRect(origin: .zero, size: size)), with: .color(bgSurface))
+
+                // Outer circle (Earth boundary)
+                let outerRect = CGRect(
+                    x: center.x - radius,
+                    y: center.y - radius,
+                    width: radius * 2,
+                    height: radius * 2
+                )
+                context.fill(Path(ellipseIn: outerRect), with: .color(bgSurface2))
+                context.stroke(Path(ellipseIn: outerRect),
+                               with: .color(textDim.opacity(0.4)), lineWidth: 1)
+
+                // Range rings
+                for dist in ringDistances {
+                    let ringRadius = radius * CGFloat(dist / maxDistKm)
+                    let ringRect = CGRect(
+                        x: center.x - ringRadius,
+                        y: center.y - ringRadius,
+                        width: ringRadius * 2,
+                        height: ringRadius * 2
+                    )
+                    context.stroke(Path(ellipseIn: ringRect),
+                                   with: .color(textDim.opacity(0.25)),
+                                   style: StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+
+                    // Distance label on right side of ring
+                    let labelText = dist >= 1000 ? "\(Int(dist / 1000))k" : "\(Int(dist))"
+                    let text = context.resolve(Text(labelText)
+                        .font(.system(size: 8, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textFaint))
+                    let labelX = center.x + ringRadius + 2
+                    let labelY = center.y - 5
+                    if labelX < size.width - 20 {
+                        context.draw(text, at: CGPoint(x: labelX, y: labelY), anchor: .leading)
+                    }
+                }
+
+                // Compass bearing lines (8 directions at 45-degree intervals)
+                for i in 0..<8 {
+                    let angle = Double(i) * 45.0
+                    let rad = angle * .pi / 180
+                    let endX = center.x + radius * CGFloat(sin(rad))
+                    let endY = center.y - radius * CGFloat(cos(rad))
+
+                    let linePath = Path { p in
+                        p.move(to: center)
+                        p.addLine(to: CGPoint(x: endX, y: endY))
+                    }
+                    context.stroke(linePath,
+                                   with: .color(textDim.opacity(i == 0 ? 0.4 : 0.15)),
+                                   lineWidth: i == 0 ? 1 : 0.5)
+
+                    // Compass label beyond the ring
+                    let labelDist = radius + 12
+                    let lx = center.x + labelDist * CGFloat(sin(rad))
+                    let ly = center.y - labelDist * CGFloat(cos(rad))
+                    let compassText = context.resolve(Text(compassLabels[i])
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(i == 0 ? textMuted : textFaint))
+                    context.draw(compassText, at: CGPoint(x: lx, y: ly), anchor: .center)
+                }
+
+                // Simplified continent outlines projected
+                if let opPos = operatorPosition {
+                    drawProjectedContinents(
+                        context: context, center: center, radius: radius, opPos: opPos
+                    )
+                }
+
+                // Draw great circle line to selected marker
+                if let marker = selectedMarker, let opPos = operatorPosition {
+                    let brg = bearing(from: opPos, to: (marker.lat, marker.lon))
+                    let dist = haversineDistance(from: opPos, to: (marker.lat, marker.lon))
+                    let r = radius * CGFloat(min(dist / maxDistKm, 1.0))
+                    let rad = brg * .pi / 180
+                    let endPt = CGPoint(
+                        x: center.x + r * CGFloat(sin(rad)),
+                        y: center.y - r * CGFloat(cos(rad))
+                    )
+                    let gcPath = Path { p in
+                        p.move(to: center)
+                        p.addLine(to: endPt)
+                    }
+                    context.stroke(gcPath, with: .color(accent.opacity(0.5)),
+                                   style: StrokeStyle(lineWidth: 1.5, dash: [4, 4]))
+                }
+
+                // Draw station markers
+                if let opPos = operatorPosition {
+                    for marker in markers {
+                        let brg = bearing(from: opPos, to: (marker.lat, marker.lon))
+                        let dist = haversineDistance(from: opPos, to: (marker.lat, marker.lon))
+                        guard dist <= maxDistKm else { continue }
+
+                        let r = radius * CGFloat(dist / maxDistKm)
+                        let rad = brg * .pi / 180
+                        let mx = center.x + r * CGFloat(sin(rad))
+                        let my = center.y - r * CGFloat(cos(rad))
+
+                        let color = markerColor(marker.status)
+                        let isSelected = selectedMarker?.id == marker.id
+
+                        // Outer glow
+                        let glowSize: CGFloat = isSelected ? 16 : 12
+                        let glowRect = CGRect(
+                            x: mx - CGFloat(glowSize / 2),
+                            y: my - CGFloat(glowSize / 2),
+                            width: CGFloat(glowSize),
+                            height: CGFloat(glowSize)
+                        )
+                        context.fill(Path(ellipseIn: glowRect), with: .color(color.opacity(0.25)))
+
+                        // Inner dot
+                        let dotSize: CGFloat = isSelected ? 8 : 6
+                        let dotRect = CGRect(
+                            x: mx - CGFloat(dotSize / 2),
+                            y: my - CGFloat(dotSize / 2),
+                            width: CGFloat(dotSize),
+                            height: CGFloat(dotSize)
+                        )
+                        context.fill(Path(ellipseIn: dotRect), with: .color(color))
+                    }
+                }
+
+                // Operator position at center (diamond)
+                if operatorPosition != nil {
+                    let dSize: CGFloat = 8
+                    let diamond = Path { p in
+                        p.move(to: CGPoint(x: center.x, y: center.y - dSize))
+                        p.addLine(to: CGPoint(x: center.x + dSize, y: center.y))
+                        p.addLine(to: CGPoint(x: center.x, y: center.y + dSize))
+                        p.addLine(to: CGPoint(x: center.x - dSize, y: center.y))
+                        p.closeSubpath()
+                    }
+                    context.fill(diamond, with: .color(accent))
+                    context.stroke(diamond, with: .color(accentGlow), lineWidth: 1)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .contentShape(Rectangle())
+            .onTapGesture { location in
+                guard let opPos = operatorPosition else { return }
+                let cx = size.width / 2
+                let cy = size.height / 2
+                let r = min(size.width, size.height) / 2 - 20
+
+                selectedMarker = markers.first { marker in
+                    let brg = bearing(from: opPos, to: (marker.lat, marker.lon))
+                    let dist = haversineDistance(from: opPos, to: (marker.lat, marker.lon))
+                    guard dist <= maxDistKm else { return false }
+
+                    let mr = r * CGFloat(dist / maxDistKm)
+                    let rad = brg * .pi / 180
+                    let mx = cx + mr * CGFloat(sin(rad))
+                    let my = cy - mr * CGFloat(cos(rad))
+
+                    let dx = abs(location.x - mx)
+                    let dy = abs(location.y - my)
+                    return dx < 15 && dy < 15
+                }
+            }
+        }
+    }
+
+    private var operatorPosition: (Double, Double)? {
+        operatorGrid.isEmpty ? nil : gridToLatLon(operatorGrid)
+    }
+
+    private func markerColor(_ status: MarkerStatus) -> Color {
+        switch status {
+        case .cq:       return accent
+        case .worked:   return signal
+        case .forMe:    return target
+        case .standard: return textMuted
+        }
+    }
+
+    /// Draw simplified continent outlines projected onto the azimuthal map.
+    private func drawProjectedContinents(
+        context: GraphicsContext, center: CGPoint, radius: CGFloat,
+        opPos: (Double, Double)
+    ) {
+        // Simplified continent polygons as (lon, lat) pairs
+        let continents: [[(Double, Double)]] = [
+            // North America
+            [(-170,72),(-170,55),(-130,50),(-120,35),(-100,25),(-80,25),(-75,30),(-65,45),(-55,50),(-80,60),(-100,65),(-130,70),(-170,72)],
+            // South America
+            [(-80,12),(-80,-5),(-75,-15),(-70,-25),(-65,-35),(-70,-55),(-75,-55),(-60,-35),(-50,-25),(-35,-5),(-50,5),(-60,10),(-80,12)],
+            // Europe
+            [(-10,36),(0,38),(5,44),(10,48),(20,55),(30,60),(40,65),(30,70),(20,70),(10,65),(0,55),(-5,48),(-10,36)],
+            // Africa
+            [(-15,35),(-5,30),(10,35),(35,30),(50,12),(40,0),(30,-15),(25,-35),(20,-35),(15,-25),(10,-5),(0,5),(-10,10),(-15,35)],
+            // Asia / Oceania
+            [(40,30),(50,40),(60,55),(80,60),(100,70),(130,65),(145,60),(150,55),(140,45),(130,35),(120,25),(100,25),(80,30),(60,35),(40,30)],
+            // Australia
+            [(115,-15),(130,-15),(145,-20),(150,-30),(145,-38),(130,-35),(115,-35),(115,-25),(115,-15)],
+        ]
+
+        for continent in continents {
+            let path = Path { p in
+                var first = true
+                for (lon, lat) in continent {
+                    let brg = bearing(from: opPos, to: (lat, lon))
+                    let dist = haversineDistance(from: opPos, to: (lat, lon))
+                    guard dist <= maxDistKm else {
+                        first = true
+                        continue
+                    }
+
+                    let r = radius * CGFloat(dist / maxDistKm)
+                    let rad = brg * .pi / 180
+                    let x = center.x + r * CGFloat(sin(rad))
+                    let y = center.y - r * CGFloat(cos(rad))
+                    let pt = CGPoint(x: x, y: y)
+
+                    if first {
+                        p.move(to: pt)
+                        first = false
+                    } else {
+                        p.addLine(to: pt)
+                    }
+                }
+                p.closeSubpath()
+            }
+            context.fill(path, with: .color(bgElev))
+            context.stroke(path, with: .color(textDim.opacity(0.5)), lineWidth: 0.5)
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+enum MapProjection: String, CaseIterable {
+    case equirectangular = "Standard"
+    case azimuthal = "Azimuthal"
+}
+
 struct MapScreen: View {
     @Environment(AppState.self) private var appState
     @State private var scale: CGFloat = 1.0
@@ -7,6 +12,7 @@ struct MapScreen: View {
     @State private var offset: CGSize = .zero
     @State private var lastOffset: CGSize = .zero
     @State private var selectedMarker: MapMarker?
+    @State private var projection: MapProjection = .equirectangular
 
     var body: some View {
         VStack(spacing: 0) {
@@ -15,7 +21,33 @@ struct MapScreen: View {
                 Text("Map")
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(textPrimary)
+
                 Spacer()
+
+                // Projection toggle
+                Button {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        projection = projection == .equirectangular ? .azimuthal : .equirectangular
+                        resetView()
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: projection == .equirectangular ? "map" : "globe")
+                            .font(.system(size: 11, weight: .medium))
+                        Text(projection.rawValue)
+                            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    }
+                    .foregroundStyle(textMuted)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(bgSurface3)
+                    )
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 8)
+
                 Text("\(markers.count) stations")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundStyle(textMuted)
@@ -24,13 +56,23 @@ struct MapScreen: View {
             .padding(.top, 12)
             .padding(.bottom, 8)
 
-            // Map canvas with gestures
-            ZStack {
-                WorldMapCanvas(
-                    markers: markers,
-                    selectedMarker: $selectedMarker,
-                    operatorGrid: appState.settings.myGrid
-                )
+            // Map canvas with gestures + zoom controls
+            ZStack(alignment: .topTrailing) {
+                Group {
+                    if projection == .equirectangular {
+                        WorldMapCanvas(
+                            markers: markers,
+                            selectedMarker: $selectedMarker,
+                            operatorGrid: appState.settings.myGrid
+                        )
+                    } else {
+                        AzimuthalMapCanvas(
+                            markers: markers,
+                            selectedMarker: $selectedMarker,
+                            operatorGrid: appState.settings.myGrid
+                        )
+                    }
+                }
                 .scaleEffect(scale)
                 .offset(offset)
                 .gesture(
@@ -39,7 +81,7 @@ struct MapScreen: View {
                             scale = lastScale * value.magnification
                         }
                         .onEnded { _ in
-                            lastScale = max(1.0, min(scale, 5.0))
+                            lastScale = max(1.0, min(scale, 8.0))
                             scale = lastScale
                         }
                 )
@@ -56,6 +98,32 @@ struct MapScreen: View {
                         }
                 )
 
+                // Zoom controls
+                VStack(spacing: 4) {
+                    ZoomButton(icon: "plus") {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            lastScale = min(lastScale * 2, 8.0)
+                            scale = lastScale
+                        }
+                    }
+                    .disabled(lastScale >= 8.0)
+
+                    ZoomButton(icon: "minus") {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            lastScale = max(lastScale / 2, 1.0)
+                            scale = lastScale
+                        }
+                    }
+                    .disabled(lastScale <= 1.0)
+
+                    ZoomButton(icon: "1.circle") {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            resetView()
+                        }
+                    }
+                }
+                .padding(8)
+
                 // Selected marker popup
                 if let marker = selectedMarker {
                     markerPopup(marker)
@@ -63,6 +131,13 @@ struct MapScreen: View {
             }
         }
         .background(bgApp)
+    }
+
+    private func resetView() {
+        scale = 1.0
+        lastScale = 1.0
+        offset = .zero
+        lastOffset = .zero
     }
 
     @ViewBuilder
@@ -83,6 +158,11 @@ struct MapScreen: View {
                 }
                 if let dist = markerDistance(marker) {
                     Text(dist)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textFaint)
+                }
+                if let brg = markerBearing(marker) {
+                    Text(brg)
                         .font(.system(size: 10, weight: .medium, design: .monospaced))
                         .foregroundStyle(textFaint)
                 }
@@ -109,6 +189,13 @@ struct MapScreen: View {
         guard !myGrid.isEmpty, let myPos = gridToLatLon(myGrid) else { return nil }
         let dist = haversineDistance(from: myPos, to: (marker.lat, marker.lon))
         return formatDistance(dist)
+    }
+
+    private func markerBearing(_ marker: MapMarker) -> String? {
+        let myGrid = appState.settings.myGrid
+        guard !myGrid.isEmpty, let myPos = gridToLatLon(myGrid) else { return nil }
+        let brg = bearing(from: myPos, to: (marker.lat, marker.lon))
+        return formatBearing(brg)
     }
 
     private var markers: [MapMarker] {
@@ -141,6 +228,33 @@ struct MapScreen: View {
     }
 }
 
+// MARK: - Zoom Button
+
+private struct ZoomButton: View {
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(textPrimary)
+                .frame(width: 32, height: 32)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(bgSurface2.opacity(0.9))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(borderSubtle, lineWidth: 1)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Types
+
 enum MarkerStatus {
     case cq, worked, forMe, standard
 }
@@ -163,9 +277,9 @@ struct MapMarker: Identifiable, Equatable {
 func gridToLatLon(_ grid: String) -> (Double, Double)? {
     let chars = Array(grid.uppercased().utf8)
     guard chars.count >= 4,
-          chars[0] >= 65, chars[0] <= 82, // A-R
+          chars[0] >= 65, chars[0] <= 82,
           chars[1] >= 65, chars[1] <= 82,
-          chars[2] >= 48, chars[2] <= 57, // 0-9
+          chars[2] >= 48, chars[2] <= 57,
           chars[3] >= 48, chars[3] <= 57 else { return nil }
     let lon = Double(chars[0] - 65) * 20 + Double(chars[2] - 48) * 2 + 1 - 180
     let lat = Double(chars[1] - 65) * 10 + Double(chars[3] - 48) * 1 + 0.5 - 90

--- a/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
@@ -26,69 +26,123 @@ struct MapScreen: View {
 
             // Map canvas with gestures
             ZStack {
-                WorldMapCanvas(markers: markers, selectedMarker: $selectedMarker)
-                    .scaleEffect(scale)
-                    .offset(offset)
-                    .gesture(
-                        MagnifyGesture()
-                            .onChanged { value in
-                                scale = lastScale * value.magnification
-                            }
-                            .onEnded { _ in
-                                lastScale = max(1.0, min(scale, 5.0))
-                                scale = lastScale
-                            }
-                    )
-                    .simultaneousGesture(
-                        DragGesture()
-                            .onChanged { value in
-                                offset = CGSize(
-                                    width: lastOffset.width + value.translation.width,
-                                    height: lastOffset.height + value.translation.height
-                                )
-                            }
-                            .onEnded { _ in
-                                lastOffset = offset
-                            }
-                    )
+                WorldMapCanvas(
+                    markers: markers,
+                    selectedMarker: $selectedMarker,
+                    operatorGrid: appState.settings.myGrid
+                )
+                .scaleEffect(scale)
+                .offset(offset)
+                .gesture(
+                    MagnifyGesture()
+                        .onChanged { value in
+                            scale = lastScale * value.magnification
+                        }
+                        .onEnded { _ in
+                            lastScale = max(1.0, min(scale, 5.0))
+                            scale = lastScale
+                        }
+                )
+                .simultaneousGesture(
+                    DragGesture()
+                        .onChanged { value in
+                            offset = CGSize(
+                                width: lastOffset.width + value.translation.width,
+                                height: lastOffset.height + value.translation.height
+                            )
+                        }
+                        .onEnded { _ in
+                            lastOffset = offset
+                        }
+                )
 
                 // Selected marker popup
                 if let marker = selectedMarker {
-                    VStack(spacing: 4) {
-                        Text(marker.callsign)
-                            .font(.system(size: 14, weight: .bold, design: .monospaced))
-                            .foregroundStyle(textPrimary)
-                        Text(marker.grid)
-                            .font(.system(size: 11, weight: .medium, design: .monospaced))
-                            .foregroundStyle(textMuted)
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(bgSurface2)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .strokeBorder(borderStrong, lineWidth: 1)
-                            )
-                    )
-                    .position(x: 100, y: 40)
-                    .onTapGesture {
-                        selectedMarker = nil
-                    }
+                    markerPopup(marker)
                 }
             }
         }
         .background(bgApp)
     }
 
-    private var markers: [MapMarker] {
-        appState.decode.messages.compactMap { msg in
-            guard !msg.grid.isEmpty else { return nil }
-            guard let (lat, lon) = gridToLatLon(msg.grid) else { return nil }
-            return MapMarker(callsign: msg.callFrom, grid: msg.grid, lat: lat, lon: lon)
+    @ViewBuilder
+    private func markerPopup(_ marker: MapMarker) -> some View {
+        VStack(spacing: 4) {
+            Text(marker.callsign)
+                .font(.system(size: 14, weight: .bold, design: .monospaced))
+                .foregroundStyle(textPrimary)
+            Text(marker.grid)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(textMuted)
+
+            HStack(spacing: 8) {
+                if let snr = marker.snr {
+                    Text("SNR: \(snr >= 0 ? "+\(snr)" : "\(snr)")")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textFaint)
+                }
+                if let dist = markerDistance(marker) {
+                    Text(dist)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textFaint)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(bgSurface2)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(borderStrong, lineWidth: 1)
+                )
+        )
+        .position(x: 100, y: 40)
+        .onTapGesture {
+            selectedMarker = nil
         }
     }
+
+    private func markerDistance(_ marker: MapMarker) -> String? {
+        let myGrid = appState.settings.myGrid
+        guard !myGrid.isEmpty, let myPos = gridToLatLon(myGrid) else { return nil }
+        let dist = haversineDistance(from: myPos, to: (marker.lat, marker.lon))
+        return formatDistance(dist)
+    }
+
+    private var markers: [MapMarker] {
+        let workedCalls = Set(appState.logbook.records.map { $0.call.uppercased() })
+        let myCall = appState.settings.myCall.uppercased()
+
+        return appState.decode.messages.compactMap { msg in
+            guard !msg.grid.isEmpty else { return nil }
+            guard let (lat, lon) = gridToLatLon(msg.grid) else { return nil }
+
+            let status: MarkerStatus
+            if !myCall.isEmpty && msg.callTo.uppercased() == myCall {
+                status = .forMe
+            } else if workedCalls.contains(msg.callFrom.uppercased()) {
+                status = .worked
+            } else if msg.callTo == "CQ" || msg.callTo.hasPrefix("CQ ") {
+                status = .cq
+            } else {
+                status = .standard
+            }
+
+            return MapMarker(
+                callsign: msg.callFrom,
+                grid: msg.grid,
+                lat: lat, lon: lon,
+                snr: msg.snr,
+                status: status
+            )
+        }
+    }
+}
+
+enum MarkerStatus {
+    case cq, worked, forMe, standard
 }
 
 struct MapMarker: Identifiable, Equatable {
@@ -97,6 +151,12 @@ struct MapMarker: Identifiable, Equatable {
     let grid: String
     let lat: Double
     let lon: Double
+    var snr: Int?
+    var status: MarkerStatus = .standard
+
+    static func == (lhs: MapMarker, rhs: MapMarker) -> Bool {
+        lhs.id == rhs.id
+    }
 }
 
 /// Convert 4-char Maidenhead grid to lat/lon center.

--- a/ios/FT8AF/FT8AF/Screens/Map/WorldMapCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/WorldMapCanvas.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct WorldMapCanvas: View {
     let markers: [MapMarker]
     @Binding var selectedMarker: MapMarker?
+    var operatorGrid: String = ""
 
     var body: some View {
         Canvas { context, size in
@@ -19,27 +20,127 @@ struct WorldMapCanvas: View {
             // Draw grid lines
             drawGridLines(context: context, width: w, height: h)
 
-            // Draw station markers
+            // Operator position
+            let opPos: (Double, Double)? = operatorGrid.isEmpty ? nil : gridToLatLon(operatorGrid)
+
+            // Draw great circle line to selected marker
+            if let marker = selectedMarker, let op = opPos {
+                drawGreatCircle(
+                    context: context, width: w, height: h,
+                    from: op, to: (marker.lat, marker.lon)
+                )
+            }
+
+            // Draw station markers with status-based colors
             for marker in markers {
                 let x = (marker.lon + 180) / 360 * Double(w)
                 let y = (90 - marker.lat) / 180 * Double(h)
-                let markerRect = CGRect(x: x - 4, y: y - 4, width: 8, height: 8)
-                context.fill(Path(ellipseIn: markerRect), with: .color(signal))
+
+                let color = markerColor(marker.status)
+                let isSelected = selectedMarker?.id == marker.id
+
                 // Outer glow
-                let glowRect = CGRect(x: x - 6, y: y - 6, width: 12, height: 12)
-                context.fill(Path(ellipseIn: glowRect), with: .color(signal.opacity(0.2)))
+                let glowSize: CGFloat = isSelected ? 16 : 12
+                let glowRect = CGRect(x: x - Double(glowSize/2), y: y - Double(glowSize/2),
+                                      width: Double(glowSize), height: Double(glowSize))
+                context.fill(Path(ellipseIn: glowRect), with: .color(color.opacity(0.25)))
+
+                // Inner dot
+                let dotSize: CGFloat = isSelected ? 8 : 6
+                let markerRect = CGRect(x: x - Double(dotSize/2), y: y - Double(dotSize/2),
+                                        width: Double(dotSize), height: Double(dotSize))
+                context.fill(Path(ellipseIn: markerRect), with: .color(color))
+            }
+
+            // Draw operator position marker
+            if let op = opPos {
+                let ox = (op.1 + 180) / 360 * Double(w)
+                let oy = (90 - op.0) / 180 * Double(h)
+
+                // Diamond shape for operator
+                let size: CGFloat = 8
+                let diamond = Path { p in
+                    p.move(to: CGPoint(x: ox, y: oy - Double(size)))
+                    p.addLine(to: CGPoint(x: ox + Double(size), y: oy))
+                    p.addLine(to: CGPoint(x: ox, y: oy + Double(size)))
+                    p.addLine(to: CGPoint(x: ox - Double(size), y: oy))
+                    p.closeSubpath()
+                }
+                context.fill(diamond, with: .color(accent))
+                context.stroke(diamond, with: .color(accentGlow), lineWidth: 1)
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .contentShape(Rectangle())
         .onTapGesture { location in
-            // Simplified marker hit testing
-            selectedMarker = nil
+            // Hit test markers
+            selectedMarker = markers.first { marker in
+                let x = (marker.lon + 180) / 360
+                let y = (90 - marker.lat) / 180
+                // We need the canvas size for accurate hit testing; approximate
+                let dx = abs(location.x - x * 400) // rough approximation
+                let dy = abs(location.y - y * 200)
+                return dx < 15 && dy < 15
+            }
         }
     }
 
+    private func markerColor(_ status: MarkerStatus) -> Color {
+        switch status {
+        case .cq:       return accent      // orange for CQ
+        case .worked:   return signal      // cyan for worked
+        case .forMe:    return target      // pink for messages to me
+        case .standard: return textMuted   // dim gray for others
+        }
+    }
+
+    private func drawGreatCircle(
+        context: GraphicsContext, width: CGFloat, height: CGFloat,
+        from a: (Double, Double), to b: (Double, Double)
+    ) {
+        let segments = 60
+        let path = Path { p in
+            for i in 0...segments {
+                let f = Double(i) / Double(segments)
+                let (lat, lon) = interpolateGreatCircle(from: a, to: b, fraction: f)
+                let x = (lon + 180) / 360 * Double(width)
+                let y = (90 - lat) / 180 * Double(height)
+                if i == 0 { p.move(to: CGPoint(x: x, y: y)) }
+                else { p.addLine(to: CGPoint(x: x, y: y)) }
+            }
+        }
+        context.stroke(path, with: .color(accent.opacity(0.5)),
+                       style: StrokeStyle(lineWidth: 1.5, dash: [4, 4]))
+    }
+
+    /// Spherical linear interpolation between two lat/lon points.
+    private func interpolateGreatCircle(
+        from a: (Double, Double), to b: (Double, Double), fraction f: Double
+    ) -> (Double, Double) {
+        let lat1 = a.0 * .pi / 180, lon1 = a.1 * .pi / 180
+        let lat2 = b.0 * .pi / 180, lon2 = b.1 * .pi / 180
+
+        let dLon = lon2 - lon1
+        let cosLat1 = cos(lat1), sinLat1 = sin(lat1)
+        let cosLat2 = cos(lat2), sinLat2 = sin(lat2)
+
+        let d = acos(sinLat1 * sinLat2 + cosLat1 * cosLat2 * cos(dLon))
+        guard d > 1e-10 else { return a } // same point
+
+        let sinD = sin(d)
+        let A = sin((1 - f) * d) / sinD
+        let B = sin(f * d) / sinD
+
+        let x = A * cosLat1 * cos(lon1) + B * cosLat2 * cos(lon2)
+        let y = A * cosLat1 * sin(lon1) + B * cosLat2 * sin(lon2)
+        let z = A * sinLat1 + B * sinLat2
+
+        let lat = atan2(z, sqrt(x * x + y * y)) * 180 / .pi
+        let lon = atan2(y, x) * 180 / .pi
+        return (lat, lon)
+    }
+
     private func drawGridLines(context: GraphicsContext, width: CGFloat, height: CGFloat) {
-        // Latitude lines every 30 degrees
         for lat in stride(from: -60.0, through: 60.0, by: 30.0) {
             let y = (90 - lat) / 180 * Double(height)
             let path = Path { p in
@@ -48,7 +149,6 @@ struct WorldMapCanvas: View {
             }
             context.stroke(path, with: .color(textDim.opacity(0.3)), lineWidth: 0.5)
         }
-        // Longitude lines every 30 degrees
         for lon in stride(from: -150.0, through: 180.0, by: 30.0) {
             let x = (lon + 180) / 360 * Double(width)
             let path = Path { p in
@@ -60,19 +160,12 @@ struct WorldMapCanvas: View {
     }
 
     private func drawContinents(context: GraphicsContext, width: CGFloat, height: CGFloat) {
-        // Simplified continent shapes as filled polygons
         let continents: [(Color, [(Double, Double)])] = [
-            // North America (simplified outline)
             (bgElev, [(-170,72),(-170,55),(-130,50),(-120,35),(-100,25),(-80,25),(-75,30),(-65,45),(-55,50),(-80,60),(-100,65),(-130,70),(-170,72)]),
-            // South America
             (bgElev, [(-80,12),(-80,-5),(-75,-15),(-70,-25),(-65,-35),(-70,-55),(-75,-55),(-60,-35),(-50,-25),(-35,-5),(-50,5),(-60,10),(-80,12)]),
-            // Europe
             (bgElev, [(-10,36),(0,38),(5,44),(10,48),(20,55),(30,60),(40,65),(30,70),(20,70),(10,65),(0,55),(-5,48),(-10,36)]),
-            // Africa
             (bgElev, [(-15,35),(-5,30),(10,35),(35,30),(50,12),(40,0),(30,-15),(25,-35),(20,-35),(15,-25),(10,-5),(0,5),(-10,10),(-15,35)]),
-            // Asia
             (bgElev, [(40,30),(50,40),(60,55),(80,60),(100,70),(130,65),(145,60),(150,55),(140,45),(130,35),(120,25),(100,25),(80,30),(60,35),(40,30)]),
-            // Australia
             (bgElev, [(115,-15),(130,-15),(145,-20),(150,-30),(145,-38),(130,-35),(115,-35),(115,-25),(115,-15)]),
         ]
 

--- a/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
@@ -9,6 +9,7 @@ enum PotaTab: String, CaseIterable, Identifiable {
 }
 
 struct PotaScreen: View {
+    @Environment(AppState.self) private var appState
     @State private var selectedTab: PotaTab = .hunt
 
     var body: some View {
@@ -18,7 +19,19 @@ struct PotaScreen: View {
                 Text("POTA")
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(textPrimary)
+
                 Spacer()
+
+                if appState.pota.isActivating {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(statusConfirmed)
+                            .frame(width: 6, height: 6)
+                        Text("ACTIVE")
+                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                            .foregroundStyle(statusConfirmed)
+                    }
+                }
             }
             .padding(.horizontal, 16)
             .padding(.top, 12)
@@ -49,7 +62,18 @@ struct PotaScreen: View {
 
     // MARK: - Activate Tab
 
+    @ViewBuilder
     private var activateTab: some View {
+        let pota = appState.pota
+
+        if pota.isActivating {
+            activeSessionView(pota: pota)
+        } else {
+            startActivationView
+        }
+    }
+
+    private var startActivationView: some View {
         VStack(spacing: 16) {
             Spacer()
             Image(systemName: "tree.fill")
@@ -63,37 +87,195 @@ struct PotaScreen: View {
                 .foregroundStyle(textMuted)
                 .multilineTextAlignment(.center)
 
-            // Park reference field (stub)
-            HStack {
-                Text("Park Ref:")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(textMuted)
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(bgSurface3)
-                    .frame(height: 36)
-                    .overlay(
-                        Text("K-0000")
-                            .font(.system(size: 14, design: .monospaced))
-                            .foregroundStyle(textFaint),
-                        alignment: .leading
-                    )
-                    .padding(.leading, 8)
-            }
-            .padding(.horizontal, 40)
+            // Park reference input
+            VStack(spacing: 8) {
+                HStack {
+                    Text("Park Ref:")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(textMuted)
+                    TextField("K-0000", text: Bindable(appState.pota).parkInput)
+                        .font(.system(size: 14, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textPrimary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(bgSurface3)
+                        )
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                }
+                .padding(.horizontal, 40)
 
-            Button { } label: {
+                // Notes field
+                HStack {
+                    Text("Notes:")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(textMuted)
+                    TextField("Optional notes", text: Bindable(appState.pota).notes)
+                        .font(.system(size: 13))
+                        .foregroundStyle(textPrimary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(bgSurface3)
+                        )
+                }
+                .padding(.horizontal, 40)
+            }
+
+            Button {
+                startActivation()
+            } label: {
                 Text("Start Activation")
                     .font(.system(size: 14, weight: .bold))
                     .foregroundStyle(bgApp)
                     .frame(width: 200, height: 44)
                     .background(
                         RoundedRectangle(cornerRadius: 10)
-                            .fill(statusConfirmed)
+                            .fill(appState.pota.parkInput.isEmpty ? textFaint : statusConfirmed)
                     )
             }
             .buttonStyle(.plain)
+            .disabled(appState.pota.parkInput.isEmpty)
+
             Spacer()
         }
+    }
+
+    private func activeSessionView(pota: PotaState) -> some View {
+        VStack(spacing: 16) {
+            // Activation card
+            VStack(spacing: 12) {
+                HStack {
+                    Image(systemName: "tree.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(statusConfirmed)
+                    Text(pota.parkInput)
+                        .font(.system(size: 18, weight: .bold, design: .monospaced))
+                        .foregroundStyle(statusConfirmed)
+                    Spacer()
+                }
+
+                if !pota.notes.isEmpty {
+                    Text(pota.notes)
+                        .font(.system(size: 12))
+                        .foregroundStyle(textMuted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Divider().overlay(borderSubtle)
+
+                // Stats row
+                HStack(spacing: 0) {
+                    activationStat(
+                        label: "QSOs",
+                        value: "\(pota.activationQsoCount)",
+                        color: pota.activationQsoCount >= 10 ? statusConfirmed : accent
+                    )
+                    activationStat(
+                        label: "Needed",
+                        value: "\(max(0, 10 - pota.activationQsoCount))",
+                        color: pota.activationQsoCount >= 10 ? statusConfirmed : statusWarn
+                    )
+                    activationStat(
+                        label: "Elapsed",
+                        value: elapsedString(from: pota.activationStartTime),
+                        color: textMuted
+                    )
+                }
+
+                // Progress bar to 10 QSOs
+                VStack(spacing: 4) {
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(bgSurface3)
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(pota.activationQsoCount >= 10 ? statusConfirmed : accent)
+                                .frame(width: geo.size.width * min(CGFloat(pota.activationQsoCount) / 10.0, 1.0))
+                        }
+                    }
+                    .frame(height: 6)
+
+                    Text(pota.activationQsoCount >= 10 ? "Activation complete!" : "\(pota.activationQsoCount)/10 for valid activation")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(pota.activationQsoCount >= 10 ? statusConfirmed : textFaint)
+                }
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(bgSurface2)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(statusConfirmed.opacity(0.3), lineWidth: 1)
+                    )
+            )
+            .padding(.horizontal, 16)
+
+            // End activation button
+            Button {
+                endActivation()
+            } label: {
+                Text("End Activation")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(statusBad)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(statusBad.opacity(0.14))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .strokeBorder(statusBad.opacity(0.3), lineWidth: 1)
+                            )
+                    )
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 16)
+
+            Spacer()
+        }
+        .padding(.top, 8)
+    }
+
+    private func activationStat(label: String, value: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.system(size: 22, weight: .bold, design: .monospaced))
+                .foregroundStyle(color)
+            Text(label)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(textFaint)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func startActivation() {
+        appState.pota.isActivating = true
+        appState.pota.activationQsoCount = 0
+        appState.pota.activationStartTime = Date()
+        if !appState.pota.parkRefs.contains(appState.pota.parkInput) {
+            appState.pota.parkRefs.append(appState.pota.parkInput)
+        }
+    }
+
+    private func endActivation() {
+        appState.pota.isActivating = false
+        appState.pota.activationStartTime = nil
+    }
+
+    private func elapsedString(from date: Date?) -> String {
+        guard let date else { return "0:00" }
+        let elapsed = Int(Date().timeIntervalSince(date))
+        let hrs = elapsed / 3600
+        let mins = (elapsed % 3600) / 60
+        if hrs > 0 {
+            return "\(hrs):\(String(format: "%02d", mins))"
+        }
+        return "\(mins)m"
     }
 
     // MARK: - Hunt Tab
@@ -112,18 +294,53 @@ struct PotaScreen: View {
     // MARK: - History Tab
 
     private var historyTab: some View {
-        VStack(spacing: 12) {
-            Spacer()
-            Image(systemName: "clock.arrow.circlepath")
-                .font(.system(size: 40))
-                .foregroundStyle(textFaint)
-            Text("No activations yet")
-                .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(textMuted)
-            Text("Past POTA activations will appear here")
-                .font(.system(size: 13))
-                .foregroundStyle(textFaint)
-            Spacer()
+        Group {
+            if appState.pota.parkRefs.isEmpty {
+                VStack(spacing: 12) {
+                    Spacer()
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.system(size: 40))
+                        .foregroundStyle(textFaint)
+                    Text("No activations yet")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(textMuted)
+                    Text("Past POTA activations will appear here")
+                        .font(.system(size: 13))
+                        .foregroundStyle(textFaint)
+                    Spacer()
+                }
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(appState.pota.parkRefs, id: \.self) { ref in
+                            HStack {
+                                Image(systemName: "tree.fill")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(statusConfirmed.opacity(0.6))
+
+                                Text(ref)
+                                    .font(.system(size: 14, weight: .bold, design: .monospaced))
+                                    .foregroundStyle(textPrimary)
+
+                                Spacer()
+
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundStyle(textFaint)
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+                            .background(bgApp)
+                            .overlay(alignment: .bottom) {
+                                Rectangle()
+                                    .fill(borderSubtle)
+                                    .frame(height: 1)
+                            }
+                        }
+                    }
+                    .padding(.bottom, 100)
+                }
+            }
         }
     }
 }

--- a/ios/FT8AF/FT8AF/Screens/Settings/DecodeFilterSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/DecodeFilterSettings.swift
@@ -75,6 +75,8 @@ struct DecodeFilterSettings: View {
         .navigationTitle("Decode Filters")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .onChange(of: settings.showOnlyCQ) { _, _ in SettingsPersistence.save(appState.settings) }
+        .onChange(of: settings.dxOnly) { _, _ in SettingsPersistence.save(appState.settings) }
     }
 
     private func highlightRow(_ title: String, description: String, color: Color) -> some View {

--- a/ios/FT8AF/FT8AF/Screens/Settings/RadioAudioSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/RadioAudioSettings.swift
@@ -34,9 +34,6 @@ struct RadioAudioSettings: View {
             } header: {
                 Text("Audio")
                     .foregroundStyle(textMuted)
-            } footer: {
-                Text("Phase 2 will add audio input device selection with AVAudioEngine")
-                    .foregroundStyle(textFaint)
             }
             .listRowBackground(bgSurface)
 
@@ -61,9 +58,6 @@ struct RadioAudioSettings: View {
             } header: {
                 Text("Bluetooth")
                     .foregroundStyle(textMuted)
-            } footer: {
-                Text("Phase 3 will add CoreBluetooth BLE SPP rig control")
-                    .foregroundStyle(textFaint)
             }
             .listRowBackground(bgSurface)
 

--- a/ios/FT8AF/FT8AF/Screens/Settings/RadioAudioSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/RadioAudioSettings.swift
@@ -95,6 +95,7 @@ struct RadioAudioSettings: View {
         .navigationTitle("Radio & Audio")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .onChange(of: settings.rigModel) { _, _ in SettingsPersistence.save(appState.settings) }
     }
 
     private var statusColor: Color {

--- a/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
@@ -1,7 +1,10 @@
+import FT8Engine
 import SwiftUI
 
 struct SettingsScreen: View {
     @Environment(AppState.self) private var appState
+    @State private var showShareSheet = false
+    @State private var adifString = ""
 
     var body: some View {
         @Bindable var settings = appState.settings
@@ -100,7 +103,10 @@ struct SettingsScreen: View {
                     }
                     .tint(accent)
 
-                    Button { } label: {
+                    Button {
+                        adifString = Adif.export(appState.logbook.records)
+                        showShareSheet = true
+                    } label: {
                         HStack {
                             Text("Export ADIF")
                                 .foregroundStyle(textPrimary)
@@ -131,7 +137,7 @@ struct SettingsScreen: View {
                         Text("Version")
                             .foregroundStyle(textPrimary)
                         Spacer()
-                        Text("1.0.0 (Phase 1)")
+                        Text("1.0.0")
                             .font(.system(size: 14, design: .monospaced))
                             .foregroundStyle(textFaint)
                     }
@@ -146,6 +152,20 @@ struct SettingsScreen: View {
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.large)
             .toolbarColorScheme(.dark, for: .navigationBar)
+            .sheet(isPresented: $showShareSheet) {
+                ShareSheet(items: [adifString])
+            }
         }
     }
+}
+
+/// Minimal UIKit share sheet wrapper for ADIF export.
+private struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }

--- a/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
@@ -153,9 +153,21 @@ struct SettingsScreen: View {
             .navigationBarTitleDisplayMode(.large)
             .toolbarColorScheme(.dark, for: .navigationBar)
             .sheet(isPresented: $showShareSheet) {
-                ShareSheet(items: [adifString])
+                if let url = adifFileURL {
+                    ShareSheet(items: [url])
+                }
             }
+            .onChange(of: appState.settings.myCall) { _, _ in SettingsPersistence.save(appState.settings) }
+            .onChange(of: appState.settings.myGrid) { _, _ in SettingsPersistence.save(appState.settings) }
+            .onChange(of: appState.settings.autoLog) { _, _ in SettingsPersistence.save(appState.settings) }
         }
+    }
+
+    private var adifFileURL: URL? {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("ft8af_log.adi")
+        let content = Adif.export(appState.logbook.records)
+        try? content.data(using: .utf8)?.write(to: tmp, options: .atomic)
+        return tmp
     }
 }
 

--- a/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
@@ -91,5 +91,9 @@ struct TransmissionSettings: View {
         .navigationTitle("Transmission")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .onChange(of: settings.txPowerWatts) { _, _ in SettingsPersistence.save(appState.settings) }
+        .onChange(of: settings.pttMode) { _, _ in SettingsPersistence.save(appState.settings) }
+        .onChange(of: settings.txVolume) { _, _ in SettingsPersistence.save(appState.settings) }
+        .onChange(of: settings.band) { _, _ in SettingsPersistence.save(appState.settings) }
     }
 }

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct WaterfallScreen: View {
     @Environment(AppState.self) private var appState
-    @Environment(LiveEngine.self) private var engine
     @State private var utcString = ""
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
@@ -40,10 +39,10 @@ struct WaterfallScreen: View {
             .background(bgSurface)
 
             TxStrip(
-                onHunt: { engine.toggleHunt() },
-                onCallCQ: { engine.callCQ() },
-                onStop: { engine.stopTx() },
-                onToggleSlot: { engine.toggleSlotParity() }
+                onHunt: { appState.engine?.toggleHunt() },
+                onCallCQ: { appState.engine?.callCQ() },
+                onStop: { appState.engine?.stopTx() },
+                onToggleSlot: { appState.engine?.toggleSlotParity() }
             )
         }
         .background(bgApp)

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
@@ -38,12 +38,6 @@ struct WaterfallScreen: View {
             .frame(height: 34)
             .background(bgSurface)
 
-            TxStrip(
-                onHunt: { appState.engine?.toggleHunt() },
-                onCallCQ: { appState.engine?.callCQ() },
-                onStop: { appState.engine?.stopTx() },
-                onToggleSlot: { appState.engine?.toggleSlotParity() }
-            )
         }
         .background(bgApp)
         .onReceive(timer) { _ in

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
@@ -29,8 +29,24 @@ struct WaterfallScreen: View {
                 Spacer()
 
                 HStack(spacing: 12) {
-                    InfoChip(label: "NR", isOn: false)
-                    InfoChip(label: "MSG", isOn: true)
+                    Button {
+                        appState.waterfall.noiseReduction.toggle()
+                    } label: {
+                        InfoChip(label: "NR", isOn: appState.waterfall.noiseReduction)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        appState.waterfall.messageMarking.toggle()
+                    } label: {
+                        InfoChip(label: "MSG", isOn: appState.waterfall.messageMarking)
+                    }
+                    .buttonStyle(.plain)
+
+                    Text("\(appState.waterfall.updateCount)")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(textDim)
+
                     LiveIndicator(isLive: appState.waterfall.isLive)
                 }
             }

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct WaterfallScreen: View {
     @Environment(AppState.self) private var appState
+    @Environment(LiveEngine.self) private var engine
     @State private var utcString = ""
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
@@ -38,7 +39,12 @@ struct WaterfallScreen: View {
             .frame(height: 34)
             .background(bgSurface)
 
-            TxStrip()
+            TxStrip(
+                onHunt: { engine.toggleHunt() },
+                onCallCQ: { engine.callCQ() },
+                onStop: { engine.stopTx() },
+                onToggleSlot: { engine.toggleSlotParity() }
+            )
         }
         .background(bgApp)
         .onReceive(timer) { _ in

--- a/ios/FT8AF/FT8AF/Util/GridDistance.swift
+++ b/ios/FT8AF/FT8AF/Util/GridDistance.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Haversine distance between two (lat, lon) points in kilometers.
+func haversineDistance(from a: (Double, Double), to b: (Double, Double)) -> Double {
+    let R = 6371.0 // Earth radius in km
+    let dLat = (b.0 - a.0) * .pi / 180
+    let dLon = (b.1 - a.1) * .pi / 180
+    let lat1 = a.0 * .pi / 180
+    let lat2 = b.0 * .pi / 180
+
+    let sinDLat = sin(dLat / 2)
+    let sinDLon = sin(dLon / 2)
+    let h = sinDLat * sinDLat + cos(lat1) * cos(lat2) * sinDLon * sinDLon
+    return 2 * R * asin(min(1, sqrt(h)))
+}
+
+/// Initial bearing from point A to point B in degrees (0-360).
+func bearing(from a: (Double, Double), to b: (Double, Double)) -> Double {
+    let lat1 = a.0 * .pi / 180
+    let lat2 = b.0 * .pi / 180
+    let dLon = (b.1 - a.1) * .pi / 180
+
+    let y = sin(dLon) * cos(lat2)
+    let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
+    let theta = atan2(y, x)
+    return (theta * 180 / .pi + 360).truncatingRemainder(dividingBy: 360)
+}
+
+/// Format distance for display: km if >=1, else meters.
+func formatDistance(_ km: Double) -> String {
+    if km >= 1000 {
+        return String(format: "%.0f km", km)
+    } else if km >= 1 {
+        return String(format: "%.1f km", km)
+    } else {
+        return String(format: "%.0f m", km * 1000)
+    }
+}
+
+/// Format bearing for display with cardinal direction.
+func formatBearing(_ degrees: Double) -> String {
+    let cardinals = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
+    let idx = Int((degrees + 22.5) / 45) % 8
+    return String(format: "%.0f\u{00B0} %@", degrees, cardinals[idx])
+}
+
+/// Convert distance in km to miles.
+func kmToMiles(_ km: Double) -> Double { km * 0.621371 }


### PR DESCRIPTION
## Summary

Wires the remaining engine capabilities into the iOS FT8AF UI, completing phases 3–6:

- **QSO auto-sequencer**: `LiveEngine` now owns a `QsoEngine` instance, feeding decoded messages to the state machine and generating TX messages automatically through a full QSO sequence (CQ → grid → report → RR73 → 73)
- **TX audio playback**: New `TxPlayerService` generates FT8 waveforms via `FT8Encoder.generateFT8()` and plays them through `AVAudioPlayerNode` attached to the shared `AVAudioEngine`, with 12 kHz → hardware rate conversion
- **TxStrip wiring**: HUNT, CALL CQ/STOP, TX1/TX2 buttons now control the QSO engine via `LiveEngine` methods
- **QsoSheet "Call" button**: Tapping "Call" on a decoded station starts answering that CQ
- **Live logbook**: Completed QSOs from `QsoEngine` append to the logbook in real-time (replacing mock data)
- **ADIF export**: Settings → Export ADIF generates valid ADIF via `Adif.export()` and presents a share sheet
- **File persistence**: New `QsoLogStore` saves/loads QSO records as JSON to the app documents directory, loaded on startup
- **Settings cleanup**: Removed phase footer notes, updated version string to "1.0.0"

### Files changed

| Action | File | Purpose |
|--------|------|---------|
| **New** | `Engine/TxPlayerService.swift` | AVAudioPlayerNode TX playback with format conversion |
| **New** | `Engine/QsoLogStore.swift` | JSON persistence for QSO records |
| **Modified** | `Engine/LiveEngine.swift` | QsoEngine integration, TX scheduling, UI control methods |
| **Modified** | `Engine/AudioCaptureService.swift` | Expose `audioEngine` for shared use |
| **Modified** | `AppState.swift` | Empty logbook init (loaded from disk) |
| **Modified** | `FT8AFApp.swift` | Load saved QSOs, pass engine to environment |
| **Modified** | `Components/TxStrip.swift` | Wire HUNT/CQ/TX buttons to engine |
| **Modified** | `Screens/Decode/QsoSheet.swift` | Wire "Call" button to engine |
| **Modified** | `Screens/Settings/SettingsScreen.swift` | Wire ADIF export + share sheet, update version |
| **Modified** | `Screens/Settings/RadioAudioSettings.swift` | Remove phase footer notes |

## Test plan

- [ ] `xcodegen generate && xcodebuild build` succeeds with zero errors
- [ ] Set callsign + grid in Settings → tap CALL CQ → TxStrip shows TX status → audio plays through speaker
- [ ] Tap a CQ message in Decode tab → QsoSheet opens → tap "Call" → engine starts answering
- [ ] Completed QSOs appear in Logbook tab → persist across app restart
- [ ] Settings → Export ADIF → share sheet with valid ADIF content
- [ ] HUNT button toggles hunt mode (visual feedback)
- [ ] TX1/TX2 toggles slot parity
- [ ] STOP cancels active CQ/QSO
- [ ] Waterfall + decode continue working during TX
- [ ] Other tabs remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)