### PR TITLE
Fix rig name showing obfuscated single letter on operator card

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsScreen.kt
@@ -74,6 +74,25 @@ private enum class SettingsCategory {
 }
 
 /**
+ * Resolves the rig name shown on the operator card.
+ *
+ * When disconnected, returns [notConnectedLabel]. When connected, returns the
+ * trimmed [modelName] (the user-selected model from RigNameList), falling back
+ * to "--" when it is blank. We deliberately avoid `baseRig.javaClass.simpleName`:
+ * release builds run R8 with the `rigs` package obfuscated, so the class name
+ * collapses to a single letter (e.g. "c") and is useless for display.
+ */
+internal fun resolveRigDisplayName(
+    connected: Boolean,
+    modelName: String,
+    notConnectedLabel: String,
+): String {
+    if (!connected) return notConnectedLabel
+    val trimmed = modelName.trim()
+    return trimmed.ifEmpty { "--" }
+}
+
+/**
  * Settings screen host. Shows a short category list (landing) and drills down
  * into a focused detail screen per category. Drill-down is driven by internal
  * state (no NavHost) since Settings is hosted as a plain tab swap in FT8AFApp.
@@ -155,11 +174,14 @@ private fun SettingsLanding(
     val callsign = callsignState
     val grid = gridLive.orEmpty()
     val rigConnected = mainViewModel.isRigConnected()
-    val rigName = if (rigConnected) {
-        mainViewModel.baseRig?.javaClass?.simpleName ?: "--"
-    } else {
-        stringResource(R.string.common_not_connected)
-    }
+    val rigName = resolveRigDisplayName(
+        connected = rigConnected,
+        // User-selected model name from RigNameList (set in MainViewModel.connectRig).
+        // NOT baseRig.javaClass.simpleName: R8 obfuscates the rigs package in release
+        // builds, so the class name collapses to a single letter like "c".
+        modelName = GeneralVariables.myRigName.orEmpty(),
+        notConnectedLabel = stringResource(R.string.common_not_connected),
+    )
     val antennaDisplay = antennaState.ifEmpty { "--" }
     val powerDisplay = if (powerWattsState > 0) "${powerWattsState}W" else "--"
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/RigDisplayNameTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/RigDisplayNameTest.kt
@@ -1,0 +1,70 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [resolveRigDisplayName], the operator-card rig label logic.
+ *
+ * The bug this guards against: a release build (R8 obfuscation on) rendered the
+ * rig as a single letter like "c" because the old code used
+ * baseRig.javaClass.simpleName, which collapses to an obfuscated name. The fix
+ * uses the user-selected model name instead.
+ */
+class RigDisplayNameTest {
+
+    @Test
+    fun disconnected_returnsNotConnectedLabel() {
+        assertThat(
+            resolveRigDisplayName(
+                connected = false,
+                modelName = "Lab599 TX-500",
+                notConnectedLabel = "Not connected",
+            ),
+        ).isEqualTo("Not connected")
+    }
+
+    @Test
+    fun connected_returnsModelName() {
+        assertThat(
+            resolveRigDisplayName(
+                connected = true,
+                modelName = "Lab599 TX-500",
+                notConnectedLabel = "Not connected",
+            ),
+        ).isEqualTo("Lab599 TX-500")
+    }
+
+    @Test
+    fun connected_trimsModelName() {
+        assertThat(
+            resolveRigDisplayName(
+                connected = true,
+                modelName = "  Kenwood TS-2000  ",
+                notConnectedLabel = "Not connected",
+            ),
+        ).isEqualTo("Kenwood TS-2000")
+    }
+
+    @Test
+    fun connected_blankModelName_fallsBackToDashes() {
+        assertThat(
+            resolveRigDisplayName(
+                connected = true,
+                modelName = "   ",
+                notConnectedLabel = "Not connected",
+            ),
+        ).isEqualTo("--")
+    }
+
+    @Test
+    fun connected_emptyModelName_fallsBackToDashes() {
+        assertThat(
+            resolveRigDisplayName(
+                connected = true,
+                modelName = "",
+                notConnectedLabel = "Not connected",
+            ),
+        ).isEqualTo("--")
+    }
+}


### PR DESCRIPTION
## Problem

A user connected to a Lab599 Discovery TX-500 reported the **RIG** field on the Settings operator card showing just **`c`**. Selecting a different radio and a full reboot didn't change it.

## Root cause

The operator card sourced the rig label from:

```kotlin
mainViewModel.baseRig?.javaClass?.simpleName
```

Release builds run R8 with `minifyEnabled true`, and `proguard-rules.pro` has **no keep rule for `com.k1af.ft8af.rigs.*`**. So `DiscoveryTX500Rig` (and every other rig class) is obfuscated to a single-letter name like `c`, and `simpleName` returns that. Picking another radio doesn't help — those classes are obfuscated the same way — and it survives reboots because it isn't stale state, it's the live (obfuscated) class name.

## Fix

Use `GeneralVariables.myRigName` instead — the user-selected model name from `RigNameList` that `MainViewModel.connectRig()` already computes *for exactly this reason* (its comment notes the Java class name is unreliable; it's also used for the PSKReporter software string).

The resolution logic is extracted into a testable top-level `internal fun resolveRigDisplayName(connected, modelName, notConnectedLabel)` and the card calls that.

## Tests

Added `RigDisplayNameTest` covering connected/disconnected, trimming, and blank/empty fallback to `--`. `testDebugUnitTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
