### PR TITLE
Map: per-type marker shapes, SNR tint, decluttered labels (PR2 of map redesign)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -48,9 +47,11 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.k1af.ft8af.Ft8Message
@@ -64,7 +65,6 @@ import kotlinx.coroutines.withContext
 import radio.ks3ckc.ft8af.pskreporter.PskReporterClient
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.GlassCard
-import radio.ks3ckc.ft8af.ui.components.TopBar
 import kotlin.math.PI
 import kotlin.math.acos
 import kotlin.math.atan2
@@ -298,159 +298,161 @@ fun MapScreen(mainViewModel: MainViewModel) {
 
     val selectedStation = stations.find { it.callsign == selectedCallsign }
 
-    Column(
+    // Canvas size for pan clamping — the map now fills this Box edge-to-edge.
+    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+
+    // Clamp a candidate pan so the map can't be dragged into empty space. STANDARD
+    // routes through EquirectViewport (which allows horizontal pan even at zoom 1×,
+    // since the 2:1 world overflows a tall canvas); AZIMUTHAL only pans when zoomed.
+    fun clampPan(px: Float, py: Float, scale: Float): Offset {
+        val w = canvasSize.width.toFloat()
+        val hgt = canvasSize.height.toFloat()
+        if (w <= 0f || hgt <= 0f) return Offset(px, py)
+        return when (viewMode) {
+            MapViewMode.STANDARD -> EquirectViewport(w, hgt, scale).clampPan(px, py)
+            MapViewMode.AZIMUTHAL -> if (scale > 1f) {
+                val mx = w * (scale - 1f) / 2f
+                val my = hgt * (scale - 1f) / 2f
+                Offset(px.coerceIn(-mx, mx), py.coerceIn(-my, my))
+            } else {
+                Offset.Zero
+            }
+        }
+    }
+
+    // Full-bleed map with floating control overlays — pinch to zoom, drag to pan,
+    // double-tap to toggle 2× zoom in/out.
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(BgApp),
-    ) {
-        TopBar(
-            title = stringResource(R.string.map_title),
-            subtitle = {
-                Text(
-                    text = if (myGrid.isNullOrEmpty()) stringResource(R.string.map_no_grid_set) else myGrid,
-                    color = Signal,
-                    fontFamily = GeistMonoFamily,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium,
-                )
-            },
-            actions = {
-                PskOverlayToggle(
-                    enabled = pskOverlayEnabled,
-                    onToggle = { newVal ->
-                        pskOverlayEnabled = newVal
-                        GeneralVariables.pskOverlayEnabled = newVal
-                        mainViewModel.databaseOpr.writeConfig(
-                            "pskOverlayEnabled",
-                            if (newVal) "1" else "0",
-                            null,
-                        )
+            .background(BgApp)
+            .onSizeChanged { canvasSize = it }
+            .pointerInput(viewMode) {
+                detectTransformGestures { _, panDelta, zoom, _ ->
+                    val newScale = (mapScale * zoom).coerceIn(MAP_MIN_ZOOM, MAP_MAX_ZOOM)
+                    val clamped = clampPan(mapPanX + panDelta.x, mapPanY + panDelta.y, newScale)
+                    mapPanX = clamped.x
+                    mapPanY = clamped.y
+                    mapScale = newScale
+                }
+            }
+            .pointerInput(viewMode) {
+                detectTapGestures(
+                    onDoubleTap = { tap ->
+                        // Toggle between 1× and ZOOM_STEP×, zooming around the tap point so
+                        // the tapped feature stays under the finger.
+                        val target = if (mapScale < MAP_ZOOM_STEP * 0.95f) MAP_ZOOM_STEP else 1f
+                        val cx = size.width / 2f
+                        val cy = size.height / 2f
+                        val factor = target / mapScale
+                        val newPanX = (1f - factor) * (tap.x - cx) + factor * mapPanX
+                        val newPanY = (1f - factor) * (tap.y - cy) + factor * mapPanY
+                        val clamped = clampPan(newPanX, newPanY, target)
+                        mapPanX = clamped.x
+                        mapPanY = clamped.y
+                        mapScale = target
                     },
                 )
-                Spacer(modifier = Modifier.width(6.dp))
-                MapViewToggle(
-                    mode = viewMode,
-                    onModeChange = { viewMode = it },
-                )
             },
-        )
-
-        // Map canvas — pinch to zoom, drag to pan, double-tap to toggle 2× zoom in/out.
-        // The STD/AZ mode toggle moved to the TopBar pill since drag now means pan.
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp)
-                .pointerInput(viewMode) {
-                    detectTransformGestures { _, panDelta, zoom, _ ->
-                        val newScale = (mapScale * zoom).coerceIn(MAP_MIN_ZOOM, MAP_MAX_ZOOM)
-                        // Pan only meaningful when zoomed in; clamp so the scaled map can't
-                        // be dragged completely off the canvas.
-                        if (newScale > 1f) {
-                            val maxPanX = size.width.toFloat() * (newScale - 1f) / 2f
-                            val maxPanY = size.height.toFloat() * (newScale - 1f) / 2f
-                            mapPanX = (mapPanX + panDelta.x).coerceIn(-maxPanX, maxPanX)
-                            mapPanY = (mapPanY + panDelta.y).coerceIn(-maxPanY, maxPanY)
-                        } else {
-                            mapPanX = 0f
-                            mapPanY = 0f
-                        }
-                        mapScale = newScale
-                    }
-                }
-                .pointerInput(viewMode) {
-                    detectTapGestures(
-                        onDoubleTap = { tap ->
-                            // Double-tap toggles between 1× and ZOOM_STEP×, zooming around the
-                            // tap point so the tapped feature stays under the finger.
-                            val target = if (mapScale < MAP_ZOOM_STEP * 0.95f) MAP_ZOOM_STEP else 1f
-                            val cx = size.width / 2f
-                            val cy = size.height / 2f
-                            if (target > 1f) {
-                                val factor = target / mapScale
-                                val newPanX = (1f - factor) * (tap.x - cx) + factor * mapPanX
-                                val newPanY = (1f - factor) * (tap.y - cy) + factor * mapPanY
-                                val maxPanX = size.width.toFloat() * (target - 1f) / 2f
-                                val maxPanY = size.height.toFloat() * (target - 1f) / 2f
-                                mapPanX = newPanX.coerceIn(-maxPanX, maxPanX)
-                                mapPanY = newPanY.coerceIn(-maxPanY, maxPanY)
-                            } else {
-                                mapPanX = 0f
-                                mapPanY = 0f
-                            }
-                            mapScale = target
-                        },
-                    )
-                },
-            contentAlignment = Alignment.Center,
-        ) {
-            when (viewMode) {
-                MapViewMode.STANDARD -> StandardMapCanvas(
-                    opLat = opLat,
-                    opLon = opLon,
-                    stations = stations,
-                    pskSpots = pskSpots,
-                    selectedCallsign = selectedCallsign,
-                    onStationSelected = { selectedCallsign = it },
-                    scale = mapScale,
-                    panX = mapPanX,
-                    panY = mapPanY,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(2f),
-                )
-                MapViewMode.AZIMUTHAL -> AzimuthalMapCanvas(
-                    opLat = opLat,
-                    opLon = opLon,
-                    stations = stations,
-                    pskSpots = pskSpots,
-                    selectedCallsign = selectedCallsign,
-                    onStationSelected = { selectedCallsign = it },
-                    scale = mapScale,
-                    panX = mapPanX,
-                    panY = mapPanY,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f),
-                )
-            }
-
-            ZoomControls(
+    ) {
+        when (viewMode) {
+            MapViewMode.STANDARD -> StandardMapCanvas(
+                opLat = opLat,
+                opLon = opLon,
+                stations = stations,
+                pskSpots = pskSpots,
+                selectedCallsign = selectedCallsign,
+                onStationSelected = { selectedCallsign = it },
                 scale = mapScale,
-                onZoomIn = {
-                    val newScale = (mapScale * MAP_ZOOM_STEP).coerceAtMost(MAP_MAX_ZOOM)
-                    if (newScale != mapScale) {
-                        val factor = newScale / mapScale
-                        mapPanX *= factor
-                        mapPanY *= factor
-                        mapScale = newScale
-                    }
-                },
-                onZoomOut = {
-                    val newScale = (mapScale / MAP_ZOOM_STEP).coerceAtLeast(MAP_MIN_ZOOM)
-                    if (newScale <= 1f) {
-                        mapPanX = 0f
-                        mapPanY = 0f
-                    } else {
-                        val factor = newScale / mapScale
-                        mapPanX *= factor
-                        mapPanY *= factor
-                    }
-                    mapScale = newScale
-                },
-                onReset = {
-                    mapScale = 1f
-                    mapPanX = 0f
-                    mapPanY = 0f
-                },
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(8.dp),
+                panX = mapPanX,
+                panY = mapPanY,
+                modifier = Modifier.fillMaxSize(),
+            )
+            MapViewMode.AZIMUTHAL -> AzimuthalMapCanvas(
+                opLat = opLat,
+                opLon = opLon,
+                stations = stations,
+                pskSpots = pskSpots,
+                selectedCallsign = selectedCallsign,
+                onStationSelected = { selectedCallsign = it },
+                scale = mapScale,
+                panX = mapPanX,
+                panY = mapPanY,
+                modifier = Modifier.fillMaxSize(),
             )
         }
 
-        // Selected station info card
+        // Right edge: zoom controls.
+        ZoomControls(
+            scale = mapScale,
+            onZoomIn = {
+                val newScale = (mapScale * MAP_ZOOM_STEP).coerceAtMost(MAP_MAX_ZOOM)
+                if (newScale != mapScale) {
+                    val factor = newScale / mapScale
+                    val clamped = clampPan(mapPanX * factor, mapPanY * factor, newScale)
+                    mapPanX = clamped.x
+                    mapPanY = clamped.y
+                    mapScale = newScale
+                }
+            },
+            onZoomOut = {
+                val newScale = (mapScale / MAP_ZOOM_STEP).coerceAtLeast(MAP_MIN_ZOOM)
+                val factor = newScale / mapScale
+                val clamped = clampPan(mapPanX * factor, mapPanY * factor, newScale)
+                mapPanX = clamped.x
+                mapPanY = clamped.y
+                mapScale = newScale
+            },
+            onReset = {
+                mapScale = 1f
+                mapPanX = 0f
+                mapPanY = 0f
+            },
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(8.dp),
+        )
+
+        // Top-left: grid + station/heard counts + projection (floating chip).
+        MapInfoChip(
+            myGrid = myGrid,
+            stationCount = stations.size,
+            pskOverlayEnabled = pskOverlayEnabled,
+            pskSpotCount = pskSpots.size,
+            pskError = pskError,
+            viewMode = viewMode,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(12.dp),
+        )
+
+        // Top-right: PSK overlay toggle + STD/AZ view toggle (floating).
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            PskOverlayToggle(
+                enabled = pskOverlayEnabled,
+                onToggle = { newVal ->
+                    pskOverlayEnabled = newVal
+                    GeneralVariables.pskOverlayEnabled = newVal
+                    mainViewModel.databaseOpr.writeConfig(
+                        "pskOverlayEnabled",
+                        if (newVal) "1" else "0",
+                        null,
+                    )
+                },
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            MapViewToggle(
+                mode = viewMode,
+                onModeChange = { viewMode = it },
+            )
+        }
+
+        // Bottom: selected station info card (floating sheet).
         if (selectedStation != null) {
             SelectedStationCard(
                 station = selectedStation,
@@ -458,40 +460,59 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 opLon = opLon,
                 onDismiss = { selectedCallsign = null },
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                    .align(Alignment.BottomCenter)
+                    .padding(12.dp)
+                    .fillMaxWidth(),
             )
         }
+    }
+}
 
-        // Station count
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(BgSurface)
-                .padding(horizontal = 12.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+// ---------------------------------------------------------------------------
+// Floating info chip (grid + counts + projection)
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun MapInfoChip(
+    myGrid: String?,
+    stationCount: Int,
+    pskOverlayEnabled: Boolean,
+    pskSpotCount: Int,
+    pskError: String?,
+    viewMode: MapViewMode,
+    modifier: Modifier = Modifier,
+) {
+    GlassCard(modifier = modifier) {
+        Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp)) {
+            Text(
+                text = if (myGrid.isNullOrEmpty()) stringResource(R.string.map_no_grid_set) else myGrid,
+                color = Signal,
+                fontFamily = GeistMonoFamily,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+            )
             Text(
                 text = if (pskOverlayEnabled) {
-                    stringResource(R.string.map_station_count_with_heard, stations.size, pskSpots.size)
+                    stringResource(R.string.map_station_count_with_heard, stationCount, pskSpotCount)
                 } else {
-                    stringResource(R.string.map_station_count, stations.size)
+                    stringResource(R.string.map_station_count, stationCount)
                 },
                 color = TextMuted,
                 fontSize = 10.5.sp,
             )
-            val overlayError = pskError
-            if (pskOverlayEnabled && overlayError != null) {
-                Spacer(modifier = Modifier.width(8.dp))
+            if (pskOverlayEnabled && pskError != null) {
                 Text(
-                    text = stringResource(R.string.map_psk_error, overlayError),
+                    text = stringResource(R.string.map_psk_error, pskError),
                     color = StatusNew,
                     fontSize = 10.5.sp,
                 )
             }
-            Spacer(modifier = Modifier.weight(1f))
             Text(
-                text = if (viewMode == MapViewMode.STANDARD) stringResource(R.string.map_projection_equirectangular) else stringResource(R.string.map_projection_azimuthal),
+                text = if (viewMode == MapViewMode.STANDARD) {
+                    stringResource(R.string.map_projection_equirectangular)
+                } else {
+                    stringResource(R.string.map_projection_azimuthal)
+                },
                 color = TextDim,
                 fontSize = 9.sp,
             )
@@ -850,25 +871,22 @@ private fun StandardMapCanvas(
         value = withContext(Dispatchers.IO) { WorldOutlines.load(context) }
     }
 
-    Canvas(modifier = modifier.clip(RoundedCornerShape(6.dp))) {
-        val w = size.width
-        val h = size.height
-        val halfW = w / 2f
-        val halfH = h / 2f
+    Canvas(modifier = modifier) {
+        val vp = EquirectViewport(size.width, size.height, scale, panX, panY)
 
         // Background panel
         drawRect(color = BgSurface, size = size)
 
         // Land — Natural Earth 110m vector outlines (drawn once polygons are loaded)
-        landRings?.let { rings -> drawWorldLand(rings, w, h, scale, panX, panY) }
+        landRings?.let { rings -> drawWorldLand(rings, vp) }
 
         // Lat/lon grid (over land so it stays visible across continents)
-        drawEquirectGrid(w, h, scale, panX, panY)
+        drawEquirectGrid(vp)
 
         // Operator marker (at projected lat/lon, scaled + panned with map)
-        val opProj = equirectProject(opLat, opLon)
-        val opX = halfW + opProj.x * halfW * scale + panX
-        val opY = halfH + opProj.y * halfH * scale + panY
+        val opPos = vp.projectLatLon(opLat, opLon)
+        val opX = opPos.x
+        val opY = opPos.y
         drawCircle(
             color = Accent.copy(alpha = 0.25f),
             radius = 8f,
@@ -882,9 +900,9 @@ private fun StandardMapCanvas(
 
         // PSK Reporter spots — drawn before stations so decoded markers layer on top.
         for (spot in pskSpots) {
-            val proj = equirectProject(spot.lat, spot.lon)
-            val sx = halfW + proj.x * halfW * scale + panX
-            val sy = halfH + proj.y * halfH * scale + panY
+            val pos = vp.projectLatLon(spot.lat, spot.lon)
+            val sx = pos.x
+            val sy = pos.y
 
             val half = 2.5f
             drawRect(
@@ -917,9 +935,9 @@ private fun StandardMapCanvas(
 
         // Station markers
         for ((index, station) in stations.withIndex()) {
-            val proj = equirectProject(station.lat, station.lon)
-            val sx = halfW + proj.x * halfW * scale + panX
-            val sy = halfH + proj.y * halfH * scale + panY
+            val pos = vp.projectLatLon(station.lat, station.lon)
+            val sx = pos.x
+            val sy = pos.y
 
             val isSelected = station.callsign == selectedCallsign
             val markerR = if (isSelected) 5f else 3.5f
@@ -998,22 +1016,27 @@ private fun StandardMapCanvas(
     }
 }
 
-private fun DrawScope.drawEquirectGrid(w: Float, h: Float, scale: Float, panX: Float, panY: Float) {
+// Inline projection scalars from the viewport. Equivalent to vp.projectLatLon but
+// without allocating an Offset per vertex — these helpers run every animation
+// frame over thousands of land vertices, so the land/grid paths use raw floats.
+private fun DrawScope.drawEquirectGrid(vp: EquirectViewport) {
     val gridColor = Color(0x1894A3B8)
     val axisColor = Color(0x30FFAF5E) // equator + prime meridian — accent tint
     val dashEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 6f))
-    val halfW = w / 2f
-    val halfH = h / 2f
+    val cx = vp.canvasW / 2f
+    val cy = vp.canvasH / 2f
+    val sxUnit = vp.worldPxW / 2f
+    val syUnit = vp.worldPxH / 2f
 
     // Meridians (vertical lines) every 30° lon, from -180 to 180
     var lon = -180
     while (lon <= 180) {
         val isPrime = lon == 0
-        val x = halfW + (lon.toFloat() / 180f) * halfW * scale + panX
+        val x = cx + (lon.toFloat() / 180f) * sxUnit + vp.panX
         drawLine(
             color = if (isPrime) axisColor else gridColor,
             start = Offset(x, 0f),
-            end = Offset(x, h),
+            end = Offset(x, size.height),
             strokeWidth = if (isPrime) 1f else 0.5f,
             pathEffect = dashEffect,
         )
@@ -1024,11 +1047,11 @@ private fun DrawScope.drawEquirectGrid(w: Float, h: Float, scale: Float, panX: F
     var lat = -90
     while (lat <= 90) {
         val isEquator = lat == 0
-        val y = halfH + (-lat.toFloat() / 90f) * halfH * scale + panY
+        val y = cy + (-lat.toFloat() / 90f) * syUnit + vp.panY
         drawLine(
             color = if (isEquator) axisColor else gridColor,
             start = Offset(0f, y),
-            end = Offset(w, y),
+            end = Offset(size.width, y),
             strokeWidth = if (isEquator) 1f else 0.5f,
             pathEffect = dashEffect,
         )
@@ -1036,20 +1059,15 @@ private fun DrawScope.drawEquirectGrid(w: Float, h: Float, scale: Float, panX: F
     }
 }
 
-private fun DrawScope.drawWorldLand(
-    rings: List<FloatArray>,
-    w: Float,
-    h: Float,
-    scale: Float,
-    panX: Float,
-    panY: Float,
-) {
+private fun DrawScope.drawWorldLand(rings: List<FloatArray>, vp: EquirectViewport) {
     // rings are flat float arrays of [lon, lat, lon, lat, ...] in geographic degrees.
     // Project via equirectangular and apply scale + pan around the canvas centre.
-    val halfW = w / 2f
-    val halfH = h / 2f
-    fun px(lon: Float) = halfW + (lon / 180f) * halfW * scale + panX
-    fun py(lat: Float) = halfH + (-lat / 90f) * halfH * scale + panY
+    val cx = vp.canvasW / 2f
+    val cy = vp.canvasH / 2f
+    val sxUnit = vp.worldPxW / 2f
+    val syUnit = vp.worldPxH / 2f
+    fun px(lon: Float) = cx + (lon / 180f) * sxUnit + vp.panX
+    fun py(lat: Float) = cy + (-lat / 90f) * syUnit + vp.panY
 
     val path = Path()
     for (ring in rings) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -1014,9 +1014,11 @@ private fun DrawScope.drawMarkerShape(shape: MarkerShape, cx: Float, cy: Float, 
             drawRect(BgApp, topLeft = Offset(cx - r, cy - r), size = Size(r * 2, r * 2), style = Stroke(width = 0.8f))
         }
         MarkerShape.CHECK_WORKED -> {
-            // Donut: filled disc with the centre punched out — distinct from a plain dot.
+            // Donut: filled disc with the centre punched back to the canvas background
+            // (BgSurface, what both canvases fill) so the hole reads as a cutout, not a
+            // dark dot. The outer ring keeps the standard BgApp marker outline.
             drawCircle(fill, r, Offset(cx, cy))
-            drawCircle(BgApp, r * 0.45f, Offset(cx, cy))
+            drawCircle(BgSurface, r * 0.45f, Offset(cx, cy))
             drawCircle(BgApp, r, Offset(cx, cy), style = Stroke(width = 1.2f))
         }
         MarkerShape.TRIANGLE_CQ -> {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -720,33 +720,26 @@ private fun AzimuthalMapCanvas(
             val ddy = sy - cy
             if (sqrt(ddx * ddx + ddy * ddy) > r) continue
 
-            val half = 2.5f
-            drawRect(
-                color = PskSpot.copy(alpha = 0.7f),
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-            )
-            drawRect(
-                color = BgApp,
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-                style = Stroke(width = 0.8f),
-            )
-            val paint = android.graphics.Paint().apply {
-                color = android.graphics.Color.argb(160, 248, 113, 113)
-                textSize = 14f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            drawMarkerShape(MarkerShape.SQUARE_PSK, sx, sy, 2.5f, PskSpot.copy(alpha = 0.7f))
+
+            // Receiver callsign — only when zoomed in (declutter; PSK spots aren't selectable).
+            if (scale >= LABEL_ZOOM_THRESHOLD) {
+                val paint = android.graphics.Paint().apply {
+                    color = android.graphics.Color.argb(160, 248, 113, 113)
+                    textSize = 14f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    spot.receiverCallsign,
+                    sx + 5f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                spot.receiverCallsign,
-                sx + 5f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
         }
 
         // Station markers
@@ -761,7 +754,14 @@ private fun AzimuthalMapCanvas(
             if (sqrt(ddx * ddx + ddy * ddy) > r) continue
 
             val isSelected = station.callsign == selectedCallsign
-            val markerR = if (isSelected) 5f else 3.5f
+            val style = markerStyleFor(
+                isCQ = station.isCQ,
+                isToMe = station.isToMe,
+                isWorked = station.isWorked,
+                snr = station.snr,
+                isSelected = isSelected,
+                currentZoom = scale,
+            )
             val glowR = if (isSelected) 12f else 8f
 
             // Pulse rings: 2 expanding rings per station, staggered by 0.5 phase. Phase derived from
@@ -774,7 +774,7 @@ private fun AzimuthalMapCanvas(
                 val ringAlpha = (1f - phase) * 0.35f * baseAmp
                 if (ringAlpha > 0f) {
                     drawCircle(
-                        color = station.color.copy(alpha = ringAlpha),
+                        color = style.fill.copy(alpha = ringAlpha),
                         radius = ringR,
                         center = Offset(sx, sy),
                         style = Stroke(width = 1f),
@@ -785,7 +785,7 @@ private fun AzimuthalMapCanvas(
             // Bearing line for selected station (originates at the operator's screen pos)
             if (isSelected) {
                 drawLine(
-                    color = station.color.copy(alpha = 0.4f),
+                    color = style.fill.copy(alpha = 0.4f),
                     start = Offset(opX, opY),
                     end = Offset(sx, sy),
                     strokeWidth = 1.5f,
@@ -795,45 +795,37 @@ private fun AzimuthalMapCanvas(
 
             // Glow
             drawCircle(
-                color = station.color.copy(alpha = if (isSelected) 0.25f else 0.15f),
+                color = style.fill.copy(alpha = if (isSelected) 0.25f else 0.15f),
                 radius = glowR,
                 center = Offset(sx, sy),
             )
 
-            // Marker dot
-            drawCircle(
-                color = station.color,
-                radius = markerR,
-                center = Offset(sx, sy),
-            )
-            drawCircle(
-                color = BgApp,
-                radius = markerR,
-                center = Offset(sx, sy),
-                style = Stroke(width = 1.2f),
-            )
+            // Marker shape (per type: triangle CQ / diamond to-me / donut worked / dot)
+            drawMarkerShape(style.shape, sx, sy, style.radiusPx, style.fill)
 
-            // Callsign label
-            val textColor = if (isSelected) {
-                android.graphics.Color.WHITE
-            } else {
-                android.graphics.Color.argb(180, 138, 150, 177) // TextMuted
-            }
-            val paint = android.graphics.Paint().apply {
-                color = textColor
-                textSize = if (isSelected) 24f else 20f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            // Callsign label — only when zoomed in or selected (declutter)
+            if (style.showLabel) {
+                val textColor = if (isSelected) {
+                    android.graphics.Color.WHITE
+                } else {
+                    android.graphics.Color.argb(180, 138, 150, 177) // TextMuted
+                }
+                val paint = android.graphics.Paint().apply {
+                    color = textColor
+                    textSize = if (isSelected) 24f else 20f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    station.callsign,
+                    sx + glowR + 4f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                station.callsign,
-                sx + glowR + 4f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
         }
     }
 }
@@ -904,33 +896,26 @@ private fun StandardMapCanvas(
             val sx = pos.x
             val sy = pos.y
 
-            val half = 2.5f
-            drawRect(
-                color = PskSpot.copy(alpha = 0.7f),
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-            )
-            drawRect(
-                color = BgApp,
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-                style = Stroke(width = 0.8f),
-            )
-            val paint = android.graphics.Paint().apply {
-                color = android.graphics.Color.argb(160, 248, 113, 113)
-                textSize = 14f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            drawMarkerShape(MarkerShape.SQUARE_PSK, sx, sy, 2.5f, PskSpot.copy(alpha = 0.7f))
+
+            // Receiver callsign — only when zoomed in (declutter; PSK spots aren't selectable).
+            if (scale >= LABEL_ZOOM_THRESHOLD) {
+                val paint = android.graphics.Paint().apply {
+                    color = android.graphics.Color.argb(160, 248, 113, 113)
+                    textSize = 14f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    spot.receiverCallsign,
+                    sx + 5f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                spot.receiverCallsign,
-                sx + 5f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
         }
 
         // Station markers
@@ -940,7 +925,14 @@ private fun StandardMapCanvas(
             val sy = pos.y
 
             val isSelected = station.callsign == selectedCallsign
-            val markerR = if (isSelected) 5f else 3.5f
+            val style = markerStyleFor(
+                isCQ = station.isCQ,
+                isToMe = station.isToMe,
+                isWorked = station.isWorked,
+                snr = station.snr,
+                isSelected = isSelected,
+                currentZoom = scale,
+            )
             val glowR = if (isSelected) 12f else 8f
 
             // Pulse rings (same pattern as azimuthal: shared transition + per-station phase offset)
@@ -952,7 +944,7 @@ private fun StandardMapCanvas(
                 val ringAlpha = (1f - phase) * 0.35f * baseAmp
                 if (ringAlpha > 0f) {
                     drawCircle(
-                        color = station.color.copy(alpha = ringAlpha),
+                        color = style.fill.copy(alpha = ringAlpha),
                         radius = ringR,
                         center = Offset(sx, sy),
                         style = Stroke(width = 1f),
@@ -963,7 +955,7 @@ private fun StandardMapCanvas(
             // Bearing line for selected station (straight rhumb-style on flat map)
             if (isSelected) {
                 drawLine(
-                    color = station.color.copy(alpha = 0.4f),
+                    color = style.fill.copy(alpha = 0.4f),
                     start = Offset(opX, opY),
                     end = Offset(sx, sy),
                     strokeWidth = 1.5f,
@@ -973,45 +965,80 @@ private fun StandardMapCanvas(
 
             // Glow
             drawCircle(
-                color = station.color.copy(alpha = if (isSelected) 0.25f else 0.15f),
+                color = style.fill.copy(alpha = if (isSelected) 0.25f else 0.15f),
                 radius = glowR,
                 center = Offset(sx, sy),
             )
 
-            // Marker dot
-            drawCircle(
-                color = station.color,
-                radius = markerR,
-                center = Offset(sx, sy),
-            )
-            drawCircle(
-                color = BgApp,
-                radius = markerR,
-                center = Offset(sx, sy),
-                style = Stroke(width = 1.2f),
-            )
+            // Marker shape (per type: triangle CQ / diamond to-me / donut worked / dot)
+            drawMarkerShape(style.shape, sx, sy, style.radiusPx, style.fill)
 
-            // Callsign label
-            val textColor = if (isSelected) {
-                android.graphics.Color.WHITE
-            } else {
-                android.graphics.Color.argb(180, 138, 150, 177)
-            }
-            val paint = android.graphics.Paint().apply {
-                color = textColor
-                textSize = if (isSelected) 22f else 18f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            // Callsign label — only when zoomed in or selected (declutter)
+            if (style.showLabel) {
+                val textColor = if (isSelected) {
+                    android.graphics.Color.WHITE
+                } else {
+                    android.graphics.Color.argb(180, 138, 150, 177)
+                }
+                val paint = android.graphics.Paint().apply {
+                    color = textColor
+                    textSize = if (isSelected) 22f else 18f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    station.callsign,
+                    sx + glowR + 4f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                station.callsign,
-                sx + glowR + 4f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
+        }
+    }
+}
+
+// Draw a station/spot marker glyph. The shape encodes the station's state (set by
+// markerStyleFor); colour + size come from the MarkerStyle. Each shape gets a BgApp
+// outline so it reads against land/ocean alike.
+private fun DrawScope.drawMarkerShape(shape: MarkerShape, cx: Float, cy: Float, r: Float, fill: Color) {
+    when (shape) {
+        MarkerShape.DOT_DEFAULT -> {
+            drawCircle(fill, r, Offset(cx, cy))
+            drawCircle(BgApp, r, Offset(cx, cy), style = Stroke(width = 1.2f))
+        }
+        MarkerShape.SQUARE_PSK -> {
+            drawRect(fill, topLeft = Offset(cx - r, cy - r), size = Size(r * 2, r * 2))
+            drawRect(BgApp, topLeft = Offset(cx - r, cy - r), size = Size(r * 2, r * 2), style = Stroke(width = 0.8f))
+        }
+        MarkerShape.CHECK_WORKED -> {
+            // Donut: filled disc with the centre punched out — distinct from a plain dot.
+            drawCircle(fill, r, Offset(cx, cy))
+            drawCircle(BgApp, r * 0.45f, Offset(cx, cy))
+            drawCircle(BgApp, r, Offset(cx, cy), style = Stroke(width = 1.2f))
+        }
+        MarkerShape.TRIANGLE_CQ -> {
+            val p = Path().apply {
+                moveTo(cx, cy - r * 1.3f)
+                lineTo(cx - r * 1.2f, cy + r * 0.9f)
+                lineTo(cx + r * 1.2f, cy + r * 0.9f)
+                close()
+            }
+            drawPath(p, fill)
+            drawPath(p, BgApp, style = Stroke(width = 1.2f))
+        }
+        MarkerShape.DIAMOND_TO_ME -> {
+            val p = Path().apply {
+                moveTo(cx, cy - r * 1.35f)
+                lineTo(cx + r * 1.35f, cy)
+                lineTo(cx, cy + r * 1.35f)
+                lineTo(cx - r * 1.35f, cy)
+                close()
+            }
+            drawPath(p, fill)
+            drawPath(p, BgApp, style = Stroke(width = 1.2f))
         }
     }
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
@@ -1,0 +1,77 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import androidx.compose.ui.geometry.Offset
+
+/**
+ * How the equirectangular world is scaled into the canvas at zoom 1.0.
+ *
+ * COVER fills the whole canvas (the map overflows on whichever axis the canvas
+ * is "too long" in, so there are never dead bands) — used for the full-screen
+ * map. FIT letterboxes the map inside the canvas (kept for completeness/tests).
+ */
+internal enum class FitMode { COVER, FIT }
+
+/**
+ * Maps the pure [equirectProject] output (normalized [-1,1] on each axis) onto a
+ * concrete canvas, edge-to-edge, with a user pinch-zoom and pan offset.
+ *
+ * The world's intrinsic aspect is 2:1 (360° lon by 180° lat), so x gets twice
+ * the pixels-per-normalized-unit that y does. [baseUniform] is the pixels per
+ * normalized **y** half-unit; the world is therefore `4*baseUniform` wide by
+ * `2*baseUniform` tall at zoom 1 (before [userScale]).
+ *
+ * Previously the canvas was locked to a 2:1 box via `.aspectRatio(2f)` and the
+ * projection assumed the unzoomed map exactly filled it (`pan max = size*(scale-1)/2`).
+ * That left dead bands on a tall phone. COVER + [clampPan] (which floors the
+ * allowed pan at 0 when the map is *smaller* than the canvas on an axis) is what
+ * lets the map fill the screen without being draggable into empty space.
+ */
+internal class EquirectViewport(
+    val canvasW: Float,
+    val canvasH: Float,
+    val userScale: Float = 1f,
+    val panX: Float = 0f,
+    val panY: Float = 0f,
+    val fit: FitMode = FitMode.COVER,
+) {
+    // COVER: worldPxW >= canvasW (=> baseUniform >= canvasW/2) AND
+    //        worldPxH >= canvasH (=> baseUniform >= canvasH). Take the max so both hold.
+    // FIT:   the opposite — the smaller scale, so the whole world fits inside.
+    val baseUniform: Float = when (fit) {
+        FitMode.COVER -> maxOf(canvasW / 2f, canvasH)
+        FitMode.FIT -> minOf(canvasW / 2f, canvasH)
+    }.coerceAtLeast(1f)
+
+    val worldPxW: Float = baseUniform * 2f * userScale
+    val worldPxH: Float = baseUniform * 1f * userScale
+
+    /** Project a normalized point (from [equirectProject]) to canvas pixels. */
+    fun project(p: ProjectedPoint): Offset {
+        val cx = canvasW / 2f
+        val cy = canvasH / 2f
+        return Offset(
+            x = cx + p.x * (worldPxW / 2f) + panX,
+            y = cy + p.y * (worldPxH / 2f) + panY,
+        )
+    }
+
+    /** Convenience: project geographic lat/lon straight to canvas pixels. */
+    fun projectLatLon(lat: Double, lon: Double): Offset = project(equirectProject(lat, lon))
+
+    /** Max pan on each axis = half the overflow of the (zoomed) world past the canvas, floored at 0. */
+    fun maxPanX(): Float = ((worldPxW - canvasW) / 2f).coerceAtLeast(0f)
+    fun maxPanY(): Float = ((worldPxH - canvasH) / 2f).coerceAtLeast(0f)
+
+    /**
+     * Clamp a candidate pan so the map can't be dragged off into empty space.
+     * On an axis where the map is smaller than the canvas the allowed pan is 0
+     * (the map stays centered) — this is the load-bearing fix vs. the old
+     * `size*(scale-1)/2` formula, which silently assumed the map always filled
+     * the canvas.
+     */
+    fun clampPan(px: Float, py: Float): Offset {
+        val mx = maxPanX()
+        val my = maxPanY()
+        return Offset(px.coerceIn(-mx, mx), py.coerceIn(-my, my))
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
@@ -15,10 +15,12 @@ internal enum class FitMode { COVER, FIT }
  * Maps the pure [equirectProject] output (normalized [-1,1] on each axis) onto a
  * concrete canvas, edge-to-edge, with a user pinch-zoom and pan offset.
  *
- * The world's intrinsic aspect is 2:1 (360° lon by 180° lat), so x gets twice
- * the pixels-per-normalized-unit that y does. [baseUniform] is the pixels per
- * normalized **y** half-unit; the world is therefore `4*baseUniform` wide by
- * `2*baseUniform` tall at zoom 1 (before [userScale]).
+ * The world's intrinsic aspect is 2:1 (360° lon by 180° lat). [baseUniform] is
+ * the world's full height in pixels at zoom 1, so the world is `2*baseUniform`
+ * wide by `baseUniform` tall (before [userScale]) — i.e. x is scaled to twice as
+ * many pixels per normalized unit as y, which preserves the 2:1 aspect. COVER
+ * picks `max(canvasW/2, canvasH)` so the world is at least as large as the canvas
+ * on both axes (no dead bands).
  *
  * Previously the canvas was locked to a 2:1 box via `.aspectRatio(2f)` and the
  * projection assumed the unzoomed map exactly filled it (`pan max = size*(scale-1)/2`).

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyle.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyle.kt
@@ -1,0 +1,79 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import androidx.compose.ui.graphics.Color
+import radio.ks3ckc.ft8af.theme.Accent
+import radio.ks3ckc.ft8af.theme.Signal
+import radio.ks3ckc.ft8af.theme.StatusNew
+import radio.ks3ckc.ft8af.theme.StatusWorked
+
+/**
+ * Marker appearance, decided once per station from its decode state. Pure (only
+ * touches Compose's [Color], no Android runtime), so it's unit-testable — the
+ * canvas is a thin renderer that switches on [shape] and draws [fill].
+ *
+ * Replaces the old inline `when` that picked a single colour and unconditionally
+ * drew a circle + text label for every station (which overlapped illegibly in a
+ * busy opening). Now each station type gets a distinct shape, the colour is
+ * tinted by SNR, and labels are decluttered to only show when zoomed in or
+ * selected.
+ */
+internal enum class MarkerShape {
+    TRIANGLE_CQ,    // calling CQ — open to be worked
+    DIAMOND_TO_ME,  // directing a message at us
+    CHECK_WORKED,   // already worked / QSL'd
+    DOT_DEFAULT,    // any other decode
+    SQUARE_PSK,     // PSK Reporter receiver that heard us
+}
+
+internal data class MarkerStyle(
+    val shape: MarkerShape,
+    val fill: Color,
+    val radiusPx: Float,
+    val showLabel: Boolean,
+)
+
+/**
+ * Labels only render at/above this zoom, or when the marker is selected. Below
+ * it the callsigns would overlap into an unreadable smear, so we keep just the
+ * shapes until the operator zooms into a region.
+ */
+internal const val LABEL_ZOOM_THRESHOLD = 3.0f
+
+/**
+ * Tint a base type colour by SNR so stronger signals read brighter and weak ones
+ * fade back. FT8 SNRs run roughly -24..+10 dB; map that to an alpha ramp so the
+ * weakest decodes are dim (but still visible) and strong ones are near-opaque.
+ */
+internal fun snrTint(base: Color, snr: Int): Color {
+    val t = ((snr + 24f) / 34f).coerceIn(0f, 1f)
+    val alpha = 0.45f + 0.55f * t
+    return base.copy(alpha = alpha)
+}
+
+internal fun markerStyleFor(
+    isCQ: Boolean,
+    isToMe: Boolean,
+    isWorked: Boolean,
+    snr: Int,
+    isSelected: Boolean,
+    currentZoom: Float,
+): MarkerStyle {
+    // Priority: a station calling us matters most, then worked, then CQ, then plain.
+    val shape = when {
+        isToMe -> MarkerShape.DIAMOND_TO_ME
+        isWorked -> MarkerShape.CHECK_WORKED
+        isCQ -> MarkerShape.TRIANGLE_CQ
+        else -> MarkerShape.DOT_DEFAULT
+    }
+    val base = when {
+        isToMe -> Signal
+        isWorked -> StatusWorked
+        isCQ -> Accent
+        else -> StatusNew
+    }
+    // Selected markers ignore the SNR fade (always full strength) and draw larger.
+    val fill = if (isSelected) base else snrTint(base, snr)
+    val radius = if (isSelected) 5.5f else 3.5f
+    val showLabel = isSelected || currentZoom >= LABEL_ZOOM_THRESHOLD
+    return MarkerStyle(shape, fill, radius, showLabel)
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewportTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewportTest.kt
@@ -1,0 +1,92 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for [EquirectViewport] — the canvas-fit + pan math that makes
+ * the map fill the screen edge-to-edge. No Android/Compose runtime is touched.
+ */
+class MapViewportTest {
+
+    @Test
+    fun cover_portraitCanvas_fillsHeightAndOverflowsWidth() {
+        // Tall canvas: height is the long axis, so COVER scales to fill height and
+        // the 2:1 world overflows horizontally (becomes pannable east-west).
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        assertThat(vp.worldPxH).isWithin(0.01f).of(2000f)   // fills height exactly
+        assertThat(vp.worldPxW).isGreaterThan(1080f)        // wider than the canvas
+        assertThat(vp.worldPxW).isWithin(0.01f).of(4000f)   // 2:1 of the height
+    }
+
+    @Test
+    fun cover_landscapeCanvas_fillsWidth() {
+        // Wide canvas: width is the long axis, so COVER scales to fill width and
+        // the world overflows vertically.
+        val vp = EquirectViewport(canvasW = 2000f, canvasH = 600f)
+        assertThat(vp.worldPxW).isWithin(0.01f).of(2000f)   // fills width exactly
+        assertThat(vp.worldPxH).isGreaterThan(600f)         // taller than the canvas
+        assertThat(vp.worldPxH).isWithin(0.01f).of(1000f)   // half the width
+    }
+
+    @Test
+    fun fit_letterboxesInsteadOfFilling() {
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f, fit = FitMode.FIT)
+        // FIT picks the smaller scale: width-driven here, so the world is no wider
+        // than the canvas and shorter than it (letterboxed top/bottom).
+        assertThat(vp.worldPxW).isWithin(0.01f).of(1080f)
+        assertThat(vp.worldPxH).isLessThan(2000f)
+    }
+
+    @Test
+    fun project_centerOfWorldIsCanvasCenter_atScale1NoPan() {
+        val vp = EquirectViewport(canvasW = 1000f, canvasH = 800f)
+        val p = vp.project(ProjectedPoint(0f, 0f, 0.0))
+        assertThat(p.x).isWithin(1e-3f).of(500f)
+        assertThat(p.y).isWithin(1e-3f).of(400f)
+    }
+
+    @Test
+    fun project_appliesPanOffset() {
+        val vp = EquirectViewport(canvasW = 1000f, canvasH = 800f, panX = 50f, panY = -30f)
+        val p = vp.project(ProjectedPoint(0f, 0f, 0.0))
+        assertThat(p.x).isWithin(1e-3f).of(550f)
+        assertThat(p.y).isWithin(1e-3f).of(370f)
+    }
+
+    @Test
+    fun project_rightEdgeOfWorldIsHalfWorldWidthRight() {
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        val center = vp.project(ProjectedPoint(0f, 0f, 0.0))
+        val east = vp.project(ProjectedPoint(1f, 0f, 0.0)) // lon = +180
+        assertThat(east.x - center.x).isWithin(0.01f).of(vp.worldPxW / 2f)
+    }
+
+    @Test
+    fun clampPan_overflowAxis_clampsToHalfOverflow() {
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        val maxX = (vp.worldPxW - 1080f) / 2f
+        val clamped = vp.clampPan(99999f, 0f)
+        assertThat(clamped.x).isWithin(0.01f).of(maxX)
+    }
+
+    @Test
+    fun clampPan_underflowAxis_locksToZero() {
+        // Portrait COVER fills height exactly => no vertical overflow => pan locks to 0.
+        // This is the load-bearing case: the old formula would have allowed dragging
+        // the map up/down into empty space.
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        assertThat(vp.maxPanY()).isWithin(0.01f).of(0f)
+        val clamped = vp.clampPan(0f, 9999f)
+        assertThat(clamped.y).isWithin(0.01f).of(0f)
+    }
+
+    @Test
+    fun clampPan_scaledUp_allowsMorePan() {
+        val base = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        val zoomed = EquirectViewport(canvasW = 1080f, canvasH = 2000f, userScale = 3f)
+        // Zooming in grows the world, so both axes now overflow and allow (more) pan.
+        assertThat(zoomed.maxPanX()).isGreaterThan(base.maxPanX())
+        assertThat(zoomed.maxPanY()).isGreaterThan(0f)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyleTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyleTest.kt
@@ -1,0 +1,97 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for [markerStyleFor] / [snrTint] — the marker-appearance
+ * decision logic. No Android/Compose runtime is touched (Compose's Color is a
+ * pure-Kotlin value class), so these run as plain JVM tests.
+ */
+class MarkerStyleTest {
+
+    private fun style(
+        isCQ: Boolean = false,
+        isToMe: Boolean = false,
+        isWorked: Boolean = false,
+        snr: Int = 0,
+        isSelected: Boolean = false,
+        zoom: Float = 1f,
+    ) = markerStyleFor(isCQ, isToMe, isWorked, snr, isSelected, zoom)
+
+    @Test
+    fun toMe_isDiamond() {
+        assertThat(style(isToMe = true).shape).isEqualTo(MarkerShape.DIAMOND_TO_ME)
+    }
+
+    @Test
+    fun cq_isTriangle() {
+        assertThat(style(isCQ = true).shape).isEqualTo(MarkerShape.TRIANGLE_CQ)
+    }
+
+    @Test
+    fun worked_isCheck() {
+        assertThat(style(isWorked = true).shape).isEqualTo(MarkerShape.CHECK_WORKED)
+    }
+
+    @Test
+    fun plainDecode_isDot() {
+        assertThat(style().shape).isEqualTo(MarkerShape.DOT_DEFAULT)
+    }
+
+    @Test
+    fun toMeBeatsWorkedAndCq() {
+        // A station both worked and now calling us should read as "calling us".
+        assertThat(style(isToMe = true, isWorked = true, isCQ = true).shape)
+            .isEqualTo(MarkerShape.DIAMOND_TO_ME)
+    }
+
+    @Test
+    fun workedBeatsCq() {
+        assertThat(style(isWorked = true, isCQ = true).shape).isEqualTo(MarkerShape.CHECK_WORKED)
+    }
+
+    @Test
+    fun label_hiddenBelowThresholdWhenNotSelected() {
+        assertThat(style(zoom = LABEL_ZOOM_THRESHOLD - 0.5f, isSelected = false).showLabel).isFalse()
+    }
+
+    @Test
+    fun label_shownWhenSelectedEvenZoomedOut() {
+        assertThat(style(zoom = 1f, isSelected = true).showLabel).isTrue()
+    }
+
+    @Test
+    fun label_shownAtOrAboveThreshold() {
+        assertThat(style(zoom = LABEL_ZOOM_THRESHOLD).showLabel).isTrue()
+        assertThat(style(zoom = LABEL_ZOOM_THRESHOLD + 1f).showLabel).isTrue()
+    }
+
+    @Test
+    fun selected_isLargerRadius() {
+        assertThat(style(isSelected = true).radiusPx).isGreaterThan(style(isSelected = false).radiusPx)
+    }
+
+    @Test
+    fun snrTint_strongerSnrIsMoreOpaque() {
+        val weak = snrTint(radio.ks3ckc.ft8af.theme.Signal, -20)
+        val strong = snrTint(radio.ks3ckc.ft8af.theme.Signal, 10)
+        assertThat(strong.alpha).isGreaterThan(weak.alpha)
+    }
+
+    @Test
+    fun snrTint_clampsExtremes() {
+        // Tolerance covers Compose Color's 8-bit alpha quantization (~1/255 ≈ 0.004).
+        val tooLow = snrTint(radio.ks3ckc.ft8af.theme.Signal, -100)
+        val tooHigh = snrTint(radio.ks3ckc.ft8af.theme.Signal, 100)
+        assertThat(tooLow.alpha).isWithin(0.01f).of(0.45f)
+        assertThat(tooHigh.alpha).isWithin(0.01f).of(1.0f)
+    }
+
+    @Test
+    fun selected_ignoresSnrFade() {
+        // A selected weak-signal marker draws at full strength, not faded.
+        val s = style(snr = -24, isSelected = true)
+        assertThat(s.fill.alpha).isWithin(1e-4f).of(1.0f)
+    }
+}


### PR DESCRIPTION
Second of four map-redesign PRs. **Stacked on #299** (`feat/map-edge-to-edge`) —
its base will retarget to `dev` automatically once #299 merges. Review/merge #299
first.

## Problem
Every decoded station was the same small circle with an always-on callsign label,
so a busy opening turned into an unreadable smear of overlapping text, and the
only state cue was colour (and `Signal`/`StatusWorked` are even the *same* cyan).

## Change
- New pure **`markerStyleFor()`** decides `(shape, fill, radius, showLabel)` from a
  station's state: **triangle** = CQ, **diamond** = calling-me, **donut** = worked,
  **dot** = other; PSK receivers stay **squares**. Priority to-me > worked > CQ > dot.
- **`snrTint()`** fades weak signals back (alpha ramp over ~-24..+10 dB) and leaves
  strong ones near-opaque; selected markers ignore the fade and draw larger.
- **Labels declutter**: a callsign only renders when the marker is selected or
  `zoom >= LABEL_ZOOM_THRESHOLD` (3×). PSK receiver labels gate on zoom too.
- Canvas is now a thin renderer — `drawMarkerShape()` switches on the shape; both
  the standard and azimuthal canvases plus both PSK-spot loops go through it.

## Tests
`MarkerStyleTest` (13 cases, pure JVM): shape per type + priority ordering, the SNR
alpha ramp and clamping, and the label declutter rule (hidden below threshold,
shown when selected or at/above threshold).

## Verification
`./gradlew testDebugUnitTest` green (MarkerStyleTest 13 + existing map tests).
Built + installed on the Pixel 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)