### PR TITLE
Map: PSK Reporter filters — time / band / mode / direction (PR4 of map redesign)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterClient.kt
@@ -32,12 +32,16 @@ import java.util.Locale
  * Returns null on transport/parse failure or while in cooldown — caller keeps
  * any stale list; empty list means a successful fetch returned zero spots.
  */
+/**
+ * One reception report, reduced to the station we plot. [callsign]/[grid]/[lat]/[lon]
+ * describe the *other* station: the receiver that heard us (when querying by
+ * senderCallsign) or the sender we heard (when querying by receiverCallsign).
+ */
 data class PskReporterSpot(
-    val senderCallsign: String,
-    val receiverCallsign: String,
-    val receiverGrid: String,
-    val receiverLat: Double,
-    val receiverLon: Double,
+    val callsign: String,
+    val grid: String,
+    val lat: Double,
+    val lon: Double,
     val frequencyHz: Long,
     val snr: Int,
     val mode: String,
@@ -79,8 +83,18 @@ object PskReporterClient {
      * an empty overlay just because a prior visit's fetch was recent. The 429/503
      * rate-limit back-off is always honoured, so a forced call never hammers a
      * server that has asked us to wait.
+     *
+     * [mode] overrides the queried mode (null = the rig's current mode). [byReceiver]
+     * flips the query from "who heard me" (senderCallsign=[call], plot the receiver)
+     * to "who I heard" (receiverCallsign=[call], plot the sender).
      */
-    suspend fun fetchSpotsForMe(call: String, secondsBack: Int, force: Boolean = false): List<PskReporterSpot>? = withContext(Dispatchers.IO) {
+    suspend fun fetchSpotsForMe(
+        call: String,
+        secondsBack: Int,
+        force: Boolean = false,
+        mode: String? = null,
+        byReceiver: Boolean = false,
+    ): List<PskReporterSpot>? = withContext(Dispatchers.IO) {
         val now = clock()
         if (now < rateLimitedUntilEpochMs) {
             log("skipped (rate-limit back-off ${(rateLimitedUntilEpochMs - now) / 1000}s remaining)")
@@ -98,15 +112,19 @@ object PskReporterClient {
         lastFetchEpochMs = now
 
         val callUpper = call.uppercase()
-        val url = "$baseUrl?senderCallsign=${urlEncode(callUpper)}" +
+        // byReceiver=false: reports where we transmitted (who heard us) -> plot the receiver.
+        // byReceiver=true:  reports where we received (who we heard)     -> plot the sender.
+        val callParam = if (byReceiver) "receiverCallsign" else "senderCallsign"
+        val modeName = mode ?: GeneralVariables.currentMode().displayName
+        val url = "$baseUrl?$callParam=${urlEncode(callUpper)}" +
             "&flowStartSeconds=-$secondsBack" +
             "&rronly=1" +
-            "&mode=${GeneralVariables.currentMode().displayName}" +
+            "&mode=${urlEncode(modeName)}" +
             "&appcontact=${urlEncode(APP_CONTACT)}"
-        log("fetch start call=$callUpper secondsBack=$secondsBack")
+        log("fetch start call=$callUpper secondsBack=$secondsBack mode=$modeName byReceiver=$byReceiver")
 
         val body = fetch(url) ?: return@withContext null
-        val spots = parseSpots(body)
+        val spots = parseSpots(body, plotSender = byReceiver)
         lastError = null
         log("fetch ok N=${spots.size}")
         spots
@@ -143,7 +161,7 @@ object PskReporterClient {
         }
     }
 
-    private fun parseSpots(xml: String): List<PskReporterSpot> {
+    private fun parseSpots(xml: String, plotSender: Boolean): List<PskReporterSpot> {
         val out = mutableListOf<PskReporterSpot>()
         var skippedNoGrid = 0
         var skippedBadGrid = 0
@@ -157,7 +175,11 @@ object PskReporterClient {
                 if (event == XmlPullParser.START_TAG && parser.name == "receptionReport") {
                     val sender = parser.getAttributeValue(null, "senderCallsign") ?: ""
                     val receiver = parser.getAttributeValue(null, "receiverCallsign") ?: ""
-                    val grid = parser.getAttributeValue(null, "receiverLocator") ?: ""
+                    // The station we plot + its locator: the sender when we queried as the
+                    // receiver (who we heard), otherwise the receiver (who heard us).
+                    val otherCall = if (plotSender) sender else receiver
+                    val grid = (if (plotSender) parser.getAttributeValue(null, "senderLocator")
+                                else parser.getAttributeValue(null, "receiverLocator")) ?: ""
                     val freqStr = parser.getAttributeValue(null, "frequency")
                     val snrStr = parser.getAttributeValue(null, "sNR")
                     val flowStr = parser.getAttributeValue(null, "flowStartSeconds")
@@ -179,11 +201,10 @@ object PskReporterClient {
                         } else {
                             out.add(
                                 PskReporterSpot(
-                                    senderCallsign = sender,
-                                    receiverCallsign = receiver,
-                                    receiverGrid = grid,
-                                    receiverLat = latLng.latitude,
-                                    receiverLon = latLng.longitude,
+                                    callsign = otherCall,
+                                    grid = grid,
+                                    lat = latLng.latitude,
+                                    lon = latLng.longitude,
                                     frequencyHz = freq,
                                     snr = snr,
                                     mode = mode,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/ConnectionLines.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/ConnectionLines.kt
@@ -1,0 +1,65 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import androidx.compose.ui.graphics.Color
+import radio.ks3ckc.ft8af.theme.Accent
+import radio.ks3ckc.ft8af.theme.Signal
+
+/**
+ * A line drawn from the operator to a station. The "from" end is always the
+ * operator (same for every line, and the canvas already knows its screen pos),
+ * so only the far endpoint + style are carried here.
+ *
+ * Replaces the old behaviour where a line was only ever drawn to the *selected*
+ * marker. GridTracker-style, we now persistently draw a solid line to the station
+ * we're actively calling and dashed lines from anyone calling us.
+ */
+internal enum class LineStyle { SOLID_TX, DASHED_CALLING_ME }
+
+internal data class ConnectionLine(
+    val toLat: Double,
+    val toLon: Double,
+    val style: LineStyle,
+    val color: Color,
+    val callsign: String,
+)
+
+/** Minimal view of a station the line builder needs — [StationMarker] implements it. */
+internal interface StationLine {
+    val callsign: String
+    val lat: Double
+    val lon: Double
+    val isToMe: Boolean
+}
+
+/**
+ * Build the connection lines to draw:
+ *  - a SOLID line to the station we're actively calling ([txTargetCallsign]), but
+ *    only if it's among the decoded [stations] — we can only place a callsign we
+ *    have a grid for. An unmatched target draws nothing.
+ *  - a DASHED line from every station whose decode is directed at us, skipping the
+ *    TX target so it isn't drawn twice.
+ *
+ * The caller resolves [txTargetCallsign] from the sequencer (null when calling CQ
+ * or idle), so this stays pure and unit-testable.
+ */
+internal fun buildConnectionLines(
+    stations: List<StationLine>,
+    txTargetCallsign: String?,
+): List<ConnectionLine> {
+    val target = txTargetCallsign?.takeIf { it.isNotBlank() }
+    val out = ArrayList<ConnectionLine>()
+
+    if (target != null) {
+        stations.firstOrNull { it.callsign.equals(target, ignoreCase = true) }?.let {
+            out.add(ConnectionLine(it.lat, it.lon, LineStyle.SOLID_TX, Accent, it.callsign))
+        }
+    }
+
+    for (s in stations) {
+        if (s.isToMe && (target == null || !s.callsign.equals(target, ignoreCase = true))) {
+            out.add(ConnectionLine(s.lat, s.lon, LineStyle.DASHED_CALLING_ME, Signal, s.callsign))
+        }
+    }
+
+    return out
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -48,9 +47,11 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.k1af.ft8af.Ft8Message
@@ -64,7 +65,6 @@ import kotlinx.coroutines.withContext
 import radio.ks3ckc.ft8af.pskreporter.PskReporterClient
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.GlassCard
-import radio.ks3ckc.ft8af.ui.components.TopBar
 import kotlin.math.PI
 import kotlin.math.acos
 import kotlin.math.atan2
@@ -298,159 +298,161 @@ fun MapScreen(mainViewModel: MainViewModel) {
 
     val selectedStation = stations.find { it.callsign == selectedCallsign }
 
-    Column(
+    // Canvas size for pan clamping — the map now fills this Box edge-to-edge.
+    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+
+    // Clamp a candidate pan so the map can't be dragged into empty space. STANDARD
+    // routes through EquirectViewport (which allows horizontal pan even at zoom 1×,
+    // since the 2:1 world overflows a tall canvas); AZIMUTHAL only pans when zoomed.
+    fun clampPan(px: Float, py: Float, scale: Float): Offset {
+        val w = canvasSize.width.toFloat()
+        val hgt = canvasSize.height.toFloat()
+        if (w <= 0f || hgt <= 0f) return Offset(px, py)
+        return when (viewMode) {
+            MapViewMode.STANDARD -> EquirectViewport(w, hgt, scale).clampPan(px, py)
+            MapViewMode.AZIMUTHAL -> if (scale > 1f) {
+                val mx = w * (scale - 1f) / 2f
+                val my = hgt * (scale - 1f) / 2f
+                Offset(px.coerceIn(-mx, mx), py.coerceIn(-my, my))
+            } else {
+                Offset.Zero
+            }
+        }
+    }
+
+    // Full-bleed map with floating control overlays — pinch to zoom, drag to pan,
+    // double-tap to toggle 2× zoom in/out.
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(BgApp),
-    ) {
-        TopBar(
-            title = stringResource(R.string.map_title),
-            subtitle = {
-                Text(
-                    text = if (myGrid.isNullOrEmpty()) stringResource(R.string.map_no_grid_set) else myGrid,
-                    color = Signal,
-                    fontFamily = GeistMonoFamily,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium,
-                )
-            },
-            actions = {
-                PskOverlayToggle(
-                    enabled = pskOverlayEnabled,
-                    onToggle = { newVal ->
-                        pskOverlayEnabled = newVal
-                        GeneralVariables.pskOverlayEnabled = newVal
-                        mainViewModel.databaseOpr.writeConfig(
-                            "pskOverlayEnabled",
-                            if (newVal) "1" else "0",
-                            null,
-                        )
+            .background(BgApp)
+            .onSizeChanged { canvasSize = it }
+            .pointerInput(viewMode) {
+                detectTransformGestures { _, panDelta, zoom, _ ->
+                    val newScale = (mapScale * zoom).coerceIn(MAP_MIN_ZOOM, MAP_MAX_ZOOM)
+                    val clamped = clampPan(mapPanX + panDelta.x, mapPanY + panDelta.y, newScale)
+                    mapPanX = clamped.x
+                    mapPanY = clamped.y
+                    mapScale = newScale
+                }
+            }
+            .pointerInput(viewMode) {
+                detectTapGestures(
+                    onDoubleTap = { tap ->
+                        // Toggle between 1× and ZOOM_STEP×, zooming around the tap point so
+                        // the tapped feature stays under the finger.
+                        val target = if (mapScale < MAP_ZOOM_STEP * 0.95f) MAP_ZOOM_STEP else 1f
+                        val cx = size.width / 2f
+                        val cy = size.height / 2f
+                        val factor = target / mapScale
+                        val newPanX = (1f - factor) * (tap.x - cx) + factor * mapPanX
+                        val newPanY = (1f - factor) * (tap.y - cy) + factor * mapPanY
+                        val clamped = clampPan(newPanX, newPanY, target)
+                        mapPanX = clamped.x
+                        mapPanY = clamped.y
+                        mapScale = target
                     },
                 )
-                Spacer(modifier = Modifier.width(6.dp))
-                MapViewToggle(
-                    mode = viewMode,
-                    onModeChange = { viewMode = it },
-                )
             },
-        )
-
-        // Map canvas — pinch to zoom, drag to pan, double-tap to toggle 2× zoom in/out.
-        // The STD/AZ mode toggle moved to the TopBar pill since drag now means pan.
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp)
-                .pointerInput(viewMode) {
-                    detectTransformGestures { _, panDelta, zoom, _ ->
-                        val newScale = (mapScale * zoom).coerceIn(MAP_MIN_ZOOM, MAP_MAX_ZOOM)
-                        // Pan only meaningful when zoomed in; clamp so the scaled map can't
-                        // be dragged completely off the canvas.
-                        if (newScale > 1f) {
-                            val maxPanX = size.width.toFloat() * (newScale - 1f) / 2f
-                            val maxPanY = size.height.toFloat() * (newScale - 1f) / 2f
-                            mapPanX = (mapPanX + panDelta.x).coerceIn(-maxPanX, maxPanX)
-                            mapPanY = (mapPanY + panDelta.y).coerceIn(-maxPanY, maxPanY)
-                        } else {
-                            mapPanX = 0f
-                            mapPanY = 0f
-                        }
-                        mapScale = newScale
-                    }
-                }
-                .pointerInput(viewMode) {
-                    detectTapGestures(
-                        onDoubleTap = { tap ->
-                            // Double-tap toggles between 1× and ZOOM_STEP×, zooming around the
-                            // tap point so the tapped feature stays under the finger.
-                            val target = if (mapScale < MAP_ZOOM_STEP * 0.95f) MAP_ZOOM_STEP else 1f
-                            val cx = size.width / 2f
-                            val cy = size.height / 2f
-                            if (target > 1f) {
-                                val factor = target / mapScale
-                                val newPanX = (1f - factor) * (tap.x - cx) + factor * mapPanX
-                                val newPanY = (1f - factor) * (tap.y - cy) + factor * mapPanY
-                                val maxPanX = size.width.toFloat() * (target - 1f) / 2f
-                                val maxPanY = size.height.toFloat() * (target - 1f) / 2f
-                                mapPanX = newPanX.coerceIn(-maxPanX, maxPanX)
-                                mapPanY = newPanY.coerceIn(-maxPanY, maxPanY)
-                            } else {
-                                mapPanX = 0f
-                                mapPanY = 0f
-                            }
-                            mapScale = target
-                        },
-                    )
-                },
-            contentAlignment = Alignment.Center,
-        ) {
-            when (viewMode) {
-                MapViewMode.STANDARD -> StandardMapCanvas(
-                    opLat = opLat,
-                    opLon = opLon,
-                    stations = stations,
-                    pskSpots = pskSpots,
-                    selectedCallsign = selectedCallsign,
-                    onStationSelected = { selectedCallsign = it },
-                    scale = mapScale,
-                    panX = mapPanX,
-                    panY = mapPanY,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(2f),
-                )
-                MapViewMode.AZIMUTHAL -> AzimuthalMapCanvas(
-                    opLat = opLat,
-                    opLon = opLon,
-                    stations = stations,
-                    pskSpots = pskSpots,
-                    selectedCallsign = selectedCallsign,
-                    onStationSelected = { selectedCallsign = it },
-                    scale = mapScale,
-                    panX = mapPanX,
-                    panY = mapPanY,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f),
-                )
-            }
-
-            ZoomControls(
+    ) {
+        when (viewMode) {
+            MapViewMode.STANDARD -> StandardMapCanvas(
+                opLat = opLat,
+                opLon = opLon,
+                stations = stations,
+                pskSpots = pskSpots,
+                selectedCallsign = selectedCallsign,
+                onStationSelected = { selectedCallsign = it },
                 scale = mapScale,
-                onZoomIn = {
-                    val newScale = (mapScale * MAP_ZOOM_STEP).coerceAtMost(MAP_MAX_ZOOM)
-                    if (newScale != mapScale) {
-                        val factor = newScale / mapScale
-                        mapPanX *= factor
-                        mapPanY *= factor
-                        mapScale = newScale
-                    }
-                },
-                onZoomOut = {
-                    val newScale = (mapScale / MAP_ZOOM_STEP).coerceAtLeast(MAP_MIN_ZOOM)
-                    if (newScale <= 1f) {
-                        mapPanX = 0f
-                        mapPanY = 0f
-                    } else {
-                        val factor = newScale / mapScale
-                        mapPanX *= factor
-                        mapPanY *= factor
-                    }
-                    mapScale = newScale
-                },
-                onReset = {
-                    mapScale = 1f
-                    mapPanX = 0f
-                    mapPanY = 0f
-                },
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(8.dp),
+                panX = mapPanX,
+                panY = mapPanY,
+                modifier = Modifier.fillMaxSize(),
+            )
+            MapViewMode.AZIMUTHAL -> AzimuthalMapCanvas(
+                opLat = opLat,
+                opLon = opLon,
+                stations = stations,
+                pskSpots = pskSpots,
+                selectedCallsign = selectedCallsign,
+                onStationSelected = { selectedCallsign = it },
+                scale = mapScale,
+                panX = mapPanX,
+                panY = mapPanY,
+                modifier = Modifier.fillMaxSize(),
             )
         }
 
-        // Selected station info card
+        // Right edge: zoom controls.
+        ZoomControls(
+            scale = mapScale,
+            onZoomIn = {
+                val newScale = (mapScale * MAP_ZOOM_STEP).coerceAtMost(MAP_MAX_ZOOM)
+                if (newScale != mapScale) {
+                    val factor = newScale / mapScale
+                    val clamped = clampPan(mapPanX * factor, mapPanY * factor, newScale)
+                    mapPanX = clamped.x
+                    mapPanY = clamped.y
+                    mapScale = newScale
+                }
+            },
+            onZoomOut = {
+                val newScale = (mapScale / MAP_ZOOM_STEP).coerceAtLeast(MAP_MIN_ZOOM)
+                val factor = newScale / mapScale
+                val clamped = clampPan(mapPanX * factor, mapPanY * factor, newScale)
+                mapPanX = clamped.x
+                mapPanY = clamped.y
+                mapScale = newScale
+            },
+            onReset = {
+                mapScale = 1f
+                mapPanX = 0f
+                mapPanY = 0f
+            },
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(8.dp),
+        )
+
+        // Top-left: grid + station/heard counts + projection (floating chip).
+        MapInfoChip(
+            myGrid = myGrid,
+            stationCount = stations.size,
+            pskOverlayEnabled = pskOverlayEnabled,
+            pskSpotCount = pskSpots.size,
+            pskError = pskError,
+            viewMode = viewMode,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(12.dp),
+        )
+
+        // Top-right: PSK overlay toggle + STD/AZ view toggle (floating).
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            PskOverlayToggle(
+                enabled = pskOverlayEnabled,
+                onToggle = { newVal ->
+                    pskOverlayEnabled = newVal
+                    GeneralVariables.pskOverlayEnabled = newVal
+                    mainViewModel.databaseOpr.writeConfig(
+                        "pskOverlayEnabled",
+                        if (newVal) "1" else "0",
+                        null,
+                    )
+                },
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            MapViewToggle(
+                mode = viewMode,
+                onModeChange = { viewMode = it },
+            )
+        }
+
+        // Bottom: selected station info card (floating sheet).
         if (selectedStation != null) {
             SelectedStationCard(
                 station = selectedStation,
@@ -458,40 +460,59 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 opLon = opLon,
                 onDismiss = { selectedCallsign = null },
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                    .align(Alignment.BottomCenter)
+                    .padding(12.dp)
+                    .fillMaxWidth(),
             )
         }
+    }
+}
 
-        // Station count
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(BgSurface)
-                .padding(horizontal = 12.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+// ---------------------------------------------------------------------------
+// Floating info chip (grid + counts + projection)
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun MapInfoChip(
+    myGrid: String?,
+    stationCount: Int,
+    pskOverlayEnabled: Boolean,
+    pskSpotCount: Int,
+    pskError: String?,
+    viewMode: MapViewMode,
+    modifier: Modifier = Modifier,
+) {
+    GlassCard(modifier = modifier) {
+        Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp)) {
+            Text(
+                text = if (myGrid.isNullOrEmpty()) stringResource(R.string.map_no_grid_set) else myGrid,
+                color = Signal,
+                fontFamily = GeistMonoFamily,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+            )
             Text(
                 text = if (pskOverlayEnabled) {
-                    stringResource(R.string.map_station_count_with_heard, stations.size, pskSpots.size)
+                    stringResource(R.string.map_station_count_with_heard, stationCount, pskSpotCount)
                 } else {
-                    stringResource(R.string.map_station_count, stations.size)
+                    stringResource(R.string.map_station_count, stationCount)
                 },
                 color = TextMuted,
                 fontSize = 10.5.sp,
             )
-            val overlayError = pskError
-            if (pskOverlayEnabled && overlayError != null) {
-                Spacer(modifier = Modifier.width(8.dp))
+            if (pskOverlayEnabled && pskError != null) {
                 Text(
-                    text = stringResource(R.string.map_psk_error, overlayError),
+                    text = stringResource(R.string.map_psk_error, pskError),
                     color = StatusNew,
                     fontSize = 10.5.sp,
                 )
             }
-            Spacer(modifier = Modifier.weight(1f))
             Text(
-                text = if (viewMode == MapViewMode.STANDARD) stringResource(R.string.map_projection_equirectangular) else stringResource(R.string.map_projection_azimuthal),
+                text = if (viewMode == MapViewMode.STANDARD) {
+                    stringResource(R.string.map_projection_equirectangular)
+                } else {
+                    stringResource(R.string.map_projection_azimuthal)
+                },
                 color = TextDim,
                 fontSize = 9.sp,
             )
@@ -850,25 +871,22 @@ private fun StandardMapCanvas(
         value = withContext(Dispatchers.IO) { WorldOutlines.load(context) }
     }
 
-    Canvas(modifier = modifier.clip(RoundedCornerShape(6.dp))) {
-        val w = size.width
-        val h = size.height
-        val halfW = w / 2f
-        val halfH = h / 2f
+    Canvas(modifier = modifier) {
+        val vp = EquirectViewport(size.width, size.height, scale, panX, panY)
 
         // Background panel
         drawRect(color = BgSurface, size = size)
 
         // Land — Natural Earth 110m vector outlines (drawn once polygons are loaded)
-        landRings?.let { rings -> drawWorldLand(rings, w, h, scale, panX, panY) }
+        landRings?.let { rings -> drawWorldLand(rings, vp) }
 
         // Lat/lon grid (over land so it stays visible across continents)
-        drawEquirectGrid(w, h, scale, panX, panY)
+        drawEquirectGrid(vp)
 
         // Operator marker (at projected lat/lon, scaled + panned with map)
-        val opProj = equirectProject(opLat, opLon)
-        val opX = halfW + opProj.x * halfW * scale + panX
-        val opY = halfH + opProj.y * halfH * scale + panY
+        val opPos = vp.projectLatLon(opLat, opLon)
+        val opX = opPos.x
+        val opY = opPos.y
         drawCircle(
             color = Accent.copy(alpha = 0.25f),
             radius = 8f,
@@ -882,9 +900,9 @@ private fun StandardMapCanvas(
 
         // PSK Reporter spots — drawn before stations so decoded markers layer on top.
         for (spot in pskSpots) {
-            val proj = equirectProject(spot.lat, spot.lon)
-            val sx = halfW + proj.x * halfW * scale + panX
-            val sy = halfH + proj.y * halfH * scale + panY
+            val pos = vp.projectLatLon(spot.lat, spot.lon)
+            val sx = pos.x
+            val sy = pos.y
 
             val half = 2.5f
             drawRect(
@@ -917,9 +935,9 @@ private fun StandardMapCanvas(
 
         // Station markers
         for ((index, station) in stations.withIndex()) {
-            val proj = equirectProject(station.lat, station.lon)
-            val sx = halfW + proj.x * halfW * scale + panX
-            val sy = halfH + proj.y * halfH * scale + panY
+            val pos = vp.projectLatLon(station.lat, station.lon)
+            val sx = pos.x
+            val sy = pos.y
 
             val isSelected = station.callsign == selectedCallsign
             val markerR = if (isSelected) 5f else 3.5f
@@ -998,22 +1016,27 @@ private fun StandardMapCanvas(
     }
 }
 
-private fun DrawScope.drawEquirectGrid(w: Float, h: Float, scale: Float, panX: Float, panY: Float) {
+// Inline projection scalars from the viewport. Equivalent to vp.projectLatLon but
+// without allocating an Offset per vertex — these helpers run every animation
+// frame over thousands of land vertices, so the land/grid paths use raw floats.
+private fun DrawScope.drawEquirectGrid(vp: EquirectViewport) {
     val gridColor = Color(0x1894A3B8)
     val axisColor = Color(0x30FFAF5E) // equator + prime meridian — accent tint
     val dashEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 6f))
-    val halfW = w / 2f
-    val halfH = h / 2f
+    val cx = vp.canvasW / 2f
+    val cy = vp.canvasH / 2f
+    val sxUnit = vp.worldPxW / 2f
+    val syUnit = vp.worldPxH / 2f
 
     // Meridians (vertical lines) every 30° lon, from -180 to 180
     var lon = -180
     while (lon <= 180) {
         val isPrime = lon == 0
-        val x = halfW + (lon.toFloat() / 180f) * halfW * scale + panX
+        val x = cx + (lon.toFloat() / 180f) * sxUnit + vp.panX
         drawLine(
             color = if (isPrime) axisColor else gridColor,
             start = Offset(x, 0f),
-            end = Offset(x, h),
+            end = Offset(x, size.height),
             strokeWidth = if (isPrime) 1f else 0.5f,
             pathEffect = dashEffect,
         )
@@ -1024,11 +1047,11 @@ private fun DrawScope.drawEquirectGrid(w: Float, h: Float, scale: Float, panX: F
     var lat = -90
     while (lat <= 90) {
         val isEquator = lat == 0
-        val y = halfH + (-lat.toFloat() / 90f) * halfH * scale + panY
+        val y = cy + (-lat.toFloat() / 90f) * syUnit + vp.panY
         drawLine(
             color = if (isEquator) axisColor else gridColor,
             start = Offset(0f, y),
-            end = Offset(w, y),
+            end = Offset(size.width, y),
             strokeWidth = if (isEquator) 1f else 0.5f,
             pathEffect = dashEffect,
         )
@@ -1036,20 +1059,15 @@ private fun DrawScope.drawEquirectGrid(w: Float, h: Float, scale: Float, panX: F
     }
 }
 
-private fun DrawScope.drawWorldLand(
-    rings: List<FloatArray>,
-    w: Float,
-    h: Float,
-    scale: Float,
-    panX: Float,
-    panY: Float,
-) {
+private fun DrawScope.drawWorldLand(rings: List<FloatArray>, vp: EquirectViewport) {
     // rings are flat float arrays of [lon, lat, lon, lat, ...] in geographic degrees.
     // Project via equirectangular and apply scale + pan around the canvas centre.
-    val halfW = w / 2f
-    val halfH = h / 2f
-    fun px(lon: Float) = halfW + (lon / 180f) * halfW * scale + panX
-    fun py(lat: Float) = halfH + (-lat / 90f) * halfH * scale + panY
+    val cx = vp.canvasW / 2f
+    val cy = vp.canvasH / 2f
+    val sxUnit = vp.worldPxW / 2f
+    val syUnit = vp.worldPxH / 2f
+    fun px(lon: Float) = cx + (lon / 180f) * sxUnit + vp.panX
+    fun py(lat: Float) = cy + (-lat / 90f) * syUnit + vp.panY
 
     val path = Path()
     for (ring in rings) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -77,17 +77,17 @@ import kotlin.math.sqrt
 // ---------------------------------------------------------------------------
 
 private data class StationMarker(
-    val callsign: String,
+    override val callsign: String,
     val grid: String,
-    val lat: Double,
-    val lon: Double,
+    override val lat: Double,
+    override val lon: Double,
     val snr: Int,
     val isCQ: Boolean,
     val isWorked: Boolean,
-    val isToMe: Boolean,
+    override val isToMe: Boolean,
     val color: Color,
     val message: Ft8Message,
-)
+) : StationLine
 
 // PSK Reporter overlay (issue #33) — a receiver that has decoded the operator's signal.
 private data class PskSpotMarker(
@@ -177,6 +177,10 @@ fun MapScreen(mainViewModel: MainViewModel) {
     val myGrid by GeneralVariables.mutableMyMaidenheadGrid.observeAsState(
         GeneralVariables.getMyMaidenheadGrid() ?: ""
     )
+    // Active TX target — the station we're calling — drives the solid connection
+    // line. "CQ"/blank/null means we're calling CQ or idle (no target line).
+    val txTarget by mainViewModel.ft8TransmitSignal.mutableToCallsign.observeAsState()
+    val txTargetCall = txTarget?.callsign?.takeIf { it.isNotBlank() && it != "CQ" }
 
     var selectedCallsign by remember { mutableStateOf<String?>(null) }
     var viewMode by rememberSaveable { mutableStateOf(MapViewMode.STANDARD) }
@@ -298,6 +302,11 @@ fun MapScreen(mainViewModel: MainViewModel) {
 
     val selectedStation = stations.find { it.callsign == selectedCallsign }
 
+    // Connection lines: solid to the TX target, dashed from anyone calling us.
+    val connectionLines = remember(stations, txTargetCall) {
+        buildConnectionLines(stations, txTargetCall)
+    }
+
     // Canvas size for pan clamping — the map now fills this Box edge-to-edge.
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
 
@@ -361,6 +370,7 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 opLon = opLon,
                 stations = stations,
                 pskSpots = pskSpots,
+                connectionLines = connectionLines,
                 selectedCallsign = selectedCallsign,
                 onStationSelected = { selectedCallsign = it },
                 scale = mapScale,
@@ -373,6 +383,7 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 opLon = opLon,
                 stations = stations,
                 pskSpots = pskSpots,
+                connectionLines = connectionLines,
                 selectedCallsign = selectedCallsign,
                 onStationSelected = { selectedCallsign = it },
                 scale = mapScale,
@@ -651,6 +662,7 @@ private fun AzimuthalMapCanvas(
     opLon: Double,
     stations: List<StationMarker>,
     pskSpots: List<PskSpotMarker>,
+    connectionLines: List<ConnectionLine>,
     selectedCallsign: String?,
     onStationSelected: (String?) -> Unit,
     scale: Float,
@@ -701,6 +713,18 @@ private fun AzimuthalMapCanvas(
         // Compass bearings stay anchored to the disc — they're a fixed UI reference,
         // not a map feature, so they don't pan or scale.
         drawCompassBearings(cx, cy, r)
+
+        // Connection lines (operator -> TX target / stations calling us). Drawn under
+        // the operator marker + station markers. Skip any whose endpoint is off-disc.
+        for (line in connectionLines) {
+            val proj = azProject(opLat, opLon, line.toLat, line.toLon)
+            val ex = cx + proj.x * r * scale + panX
+            val ey = cy + proj.y * r * scale + panY
+            val ddx = ex - cx
+            val ddy = ey - cy
+            if (sqrt(ddx * ddx + ddy * ddy) > r) continue
+            drawConnectionLine(opX, opY, ex, ey, line.style, line.color)
+        }
 
         // Operator center marker
         drawCircle(
@@ -840,6 +864,7 @@ private fun StandardMapCanvas(
     opLon: Double,
     stations: List<StationMarker>,
     pskSpots: List<PskSpotMarker>,
+    connectionLines: List<ConnectionLine>,
     selectedCallsign: String?,
     onStationSelected: (String?) -> Unit,
     scale: Float,
@@ -889,6 +914,14 @@ private fun StandardMapCanvas(
             radius = 4f,
             center = Offset(opX, opY),
         )
+
+        // Connection lines (operator -> TX target / stations calling us). Drawn under
+        // the station markers; both endpoints project through the viewport so they
+        // pan/zoom with the map.
+        for (line in connectionLines) {
+            val end = vp.projectLatLon(line.toLat, line.toLon)
+            drawConnectionLine(opX, opY, end.x, end.y, line.style, line.color)
+        }
 
         // PSK Reporter spots — drawn before stations so decoded markers layer on top.
         for (spot in pskSpots) {
@@ -997,6 +1030,33 @@ private fun StandardMapCanvas(
                 )
             }
         }
+    }
+}
+
+// Draw an operator -> station connection line. Solid + thicker for the active TX
+// target; dashed + thinner for stations calling us.
+private fun DrawScope.drawConnectionLine(
+    x0: Float,
+    y0: Float,
+    x1: Float,
+    y1: Float,
+    style: LineStyle,
+    color: Color,
+) {
+    when (style) {
+        LineStyle.SOLID_TX -> drawLine(
+            color = color.copy(alpha = 0.85f),
+            start = Offset(x0, y0),
+            end = Offset(x1, y1),
+            strokeWidth = 2.2f,
+        )
+        LineStyle.DASHED_CALLING_ME -> drawLine(
+            color = color.copy(alpha = 0.7f),
+            start = Offset(x0, y0),
+            end = Offset(x1, y1),
+            strokeWidth = 1.6f,
+            pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)),
+        )
     }
 }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -11,10 +11,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,6 +34,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -89,17 +92,17 @@ private data class StationMarker(
     val message: Ft8Message,
 ) : StationLine
 
-// PSK Reporter overlay (issue #33) — a receiver that has decoded the operator's signal.
+// PSK Reporter overlay (issue #33) — the other station in a reception report
+// (a receiver that heard us, or a sender we heard, per the direction filter).
 private data class PskSpotMarker(
-    val receiverCallsign: String,
+    val callsign: String,
     val grid: String,
     val lat: Double,
     val lon: Double,
     val snr: Int,
-    val frequencyHz: Long,
-)
+    override val frequencyHz: Long,
+) : HasFrequencyHz
 
-private const val PSK_OVERLAY_SECONDS_BACK = 3600
 private const val PSK_POLL_INTERVAL_MS = 5L * 60L * 1000L
 
 internal data class ProjectedPoint(
@@ -113,6 +116,19 @@ internal enum class MapViewMode { STANDARD, AZIMUTHAL }
 private const val MAP_MIN_ZOOM = 1f
 private const val MAP_MAX_ZOOM = 8f
 private const val MAP_ZOOM_STEP = 2f
+
+// Persists the PSK filter across config changes / process death. band == "" means all.
+private val PskFilterSaver = listSaver<PskFilter, Any>(
+    save = { listOf(it.timeWindowSec, it.band?.name ?: "", it.mode.name, it.direction.name) },
+    restore = {
+        PskFilter(
+            timeWindowSec = it[0] as Int,
+            band = (it[1] as String).takeIf { s -> s.isNotEmpty() }?.let { s -> Band.valueOf(s) },
+            mode = PskMode.valueOf(it[2] as String),
+            direction = PskDirection.valueOf(it[3] as String),
+        )
+    },
+)
 
 // ---------------------------------------------------------------------------
 // Great-circle distance (km) — used by both projections
@@ -190,6 +206,10 @@ fun MapScreen(mainViewModel: MainViewModel) {
     // succeeded or was a benign cooldown skip. Surfaced in the status row so an empty
     // overlay caused by a failure is distinguishable from "genuinely no spots".
     var pskError by remember { mutableStateOf<String?>(null) }
+    // PSK overlay filters (band / mode / time window / direction); survives config
+    // changes via PskFilterSaver. Changing it re-runs the fetch (force-once below).
+    var pskFilter by rememberSaveable(stateSaver = PskFilterSaver) { mutableStateOf(PskFilter()) }
+    var filterSheetOpen by rememberSaveable { mutableStateOf(false) }
 
     // Zoom + pan (issue #51). Scale is clamped to [1, MAX_ZOOM]; pan is clamped so the
     // scaled map can't be dragged entirely off-screen. Both reset whenever the projection
@@ -207,7 +227,7 @@ fun MapScreen(mainViewModel: MainViewModel) {
     // PSK Reporter polling — fires immediately on enter and every 5 min while enabled.
     // Re-reads myCallsign each cycle so a mid-session change is picked up on the next tick.
     // Structured concurrency cancels the loop when MapScreen leaves composition.
-    LaunchedEffect(pskOverlayEnabled) {
+    LaunchedEffect(pskOverlayEnabled, pskFilter) {
         if (!pskOverlayEnabled) {
             pskSpots = emptyList()
             pskError = null
@@ -220,22 +240,31 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 pskSpots = emptyList()
                 pskError = null
             } else {
-                // force=true only on the first fetch after the overlay is (re)entered so a
-                // recent prior-visit fetch within the 5-min cooldown doesn't leave the
-                // overlay blank; the 429/503 back-off is still honoured.
-                val spots = PskReporterClient.fetchSpotsForMe(call, PSK_OVERLAY_SECONDS_BACK, force = firstFetch)
+                // force=true on the first fetch after the overlay is (re)entered OR the
+                // filter changes (this effect re-keys on pskFilter), so a deliberate filter
+                // change isn't swallowed by the 5-min cooldown; the 429/503 back-off still holds.
+                val modeOverride = if (pskFilter.mode == PskMode.CURRENT) null else pskFilter.mode.label
+                val spots = PskReporterClient.fetchSpotsForMe(
+                    call,
+                    pskFilter.timeWindowSec,
+                    force = firstFetch,
+                    mode = modeOverride,
+                    byReceiver = pskFilter.direction == PskDirection.WHO_I_HEARD,
+                )
                 firstFetch = false
                 if (spots != null) {
-                    pskSpots = spots.map {
+                    val markers = spots.map {
                         PskSpotMarker(
-                            receiverCallsign = it.receiverCallsign,
-                            grid = it.receiverGrid,
-                            lat = it.receiverLat,
-                            lon = it.receiverLon,
+                            callsign = it.callsign,
+                            grid = it.grid,
+                            lat = it.lat,
+                            lon = it.lon,
                             snr = it.snr,
                             frequencyHz = it.frequencyHz,
                         )
                     }
+                    // Band is filtered client-side (the API returns all bands).
+                    pskSpots = applyPskBandFilter(markers, pskFilter.band)
                     pskError = null
                 } else {
                     // null = transport/HTTP error, rate-limit back-off, or cooldown skip.
@@ -437,17 +466,22 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 .padding(12.dp),
         )
 
-        // Top-right: PSK overlay toggle + STD/AZ view toggle (floating).
+        // Top-right: filter button (when overlay on) + PSK overlay toggle + STD/AZ toggle.
         Row(
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            if (pskOverlayEnabled) {
+                FilterPill(active = filterSheetOpen, onClick = { filterSheetOpen = !filterSheetOpen })
+                Spacer(modifier = Modifier.width(6.dp))
+            }
             PskOverlayToggle(
                 enabled = pskOverlayEnabled,
                 onToggle = { newVal ->
                     pskOverlayEnabled = newVal
+                    if (!newVal) filterSheetOpen = false
                     GeneralVariables.pskOverlayEnabled = newVal
                     mainViewModel.databaseOpr.writeConfig(
                         "pskOverlayEnabled",
@@ -463,8 +497,19 @@ fun MapScreen(mainViewModel: MainViewModel) {
             )
         }
 
-        // Bottom: selected station info card (floating sheet).
-        if (selectedStation != null) {
+        // Bottom: the PSK filter sheet takes the bottom slot when open; otherwise the
+        // selected-station card. (Mutually exclusive so they don't stack.)
+        if (pskOverlayEnabled && filterSheetOpen) {
+            PskFilterSheet(
+                filter = pskFilter,
+                onFilterChange = { pskFilter = it },
+                onClose = { filterSheetOpen = false },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(12.dp)
+                    .fillMaxWidth(),
+            )
+        } else if (selectedStation != null) {
             SelectedStationCard(
                 station = selectedStation,
                 opLat = opLat,
@@ -476,6 +521,142 @@ fun MapScreen(mainViewModel: MainViewModel) {
                     .fillMaxWidth(),
             )
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PSK filter button + sheet
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun FilterPill(active: Boolean, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (active) Accent else BgSurface3)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.map_filter),
+            color = if (active) BgApp else TextMuted,
+            fontFamily = GeistMonoFamily,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun PskFilterSheet(
+    filter: PskFilter,
+    onFilterChange: (PskFilter) -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    GlassCard(modifier = modifier) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.map_filter_title),
+                    color = TextPrimary,
+                    fontFamily = GeistMonoFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 13.sp,
+                )
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .clickable(onClick = onClose)
+                        .padding(horizontal = 8.dp, vertical = 2.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.map_filter_done),
+                        color = Accent,
+                        fontFamily = GeistMonoFamily,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+
+            FilterRow(stringResource(R.string.map_filter_time)) {
+                for (sec in PSK_TIME_PRESETS) {
+                    FilterChip(pskTimeLabel(sec), filter.timeWindowSec == sec) {
+                        onFilterChange(filter.copy(timeWindowSec = sec))
+                    }
+                }
+            }
+            FilterRow(stringResource(R.string.map_filter_band)) {
+                FilterChip(stringResource(R.string.map_filter_all), filter.band == null) {
+                    onFilterChange(filter.copy(band = null))
+                }
+                for (b in Band.entries) {
+                    FilterChip(b.label, filter.band == b) { onFilterChange(filter.copy(band = b)) }
+                }
+            }
+            FilterRow(stringResource(R.string.map_filter_mode)) {
+                for (m in PskMode.entries) {
+                    FilterChip(m.label, filter.mode == m) { onFilterChange(filter.copy(mode = m)) }
+                }
+            }
+            FilterRow(stringResource(R.string.map_filter_direction)) {
+                for (d in PskDirection.entries) {
+                    FilterChip(d.label, filter.direction == d) { onFilterChange(filter.copy(direction = d)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterRow(label: String, content: @Composable RowScope.() -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            color = TextDim,
+            fontFamily = GeistMonoFamily,
+            fontSize = 10.sp,
+            modifier = Modifier.width(64.dp),
+        )
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun FilterChip(label: String, active: Boolean, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(if (active) Accent else BgSurface3)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 9.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            color = if (active) BgApp else TextMuted,
+            fontFamily = GeistMonoFamily,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
     }
 }
 
@@ -758,7 +939,7 @@ private fun AzimuthalMapCanvas(
                     )
                 }
                 drawContext.canvas.nativeCanvas.drawText(
-                    spot.receiverCallsign,
+                    spot.callsign,
                     sx + 5f,
                     sy + paint.textSize / 3f,
                     paint,
@@ -943,7 +1124,7 @@ private fun StandardMapCanvas(
                     )
                 }
                 drawContext.canvas.nativeCanvas.drawText(
-                    spot.receiverCallsign,
+                    spot.callsign,
                     sx + 5f,
                     sy + paint.textSize / 3f,
                     paint,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -720,33 +720,26 @@ private fun AzimuthalMapCanvas(
             val ddy = sy - cy
             if (sqrt(ddx * ddx + ddy * ddy) > r) continue
 
-            val half = 2.5f
-            drawRect(
-                color = PskSpot.copy(alpha = 0.7f),
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-            )
-            drawRect(
-                color = BgApp,
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-                style = Stroke(width = 0.8f),
-            )
-            val paint = android.graphics.Paint().apply {
-                color = android.graphics.Color.argb(160, 248, 113, 113)
-                textSize = 14f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            drawMarkerShape(MarkerShape.SQUARE_PSK, sx, sy, 2.5f, PskSpot.copy(alpha = 0.7f))
+
+            // Receiver callsign — only when zoomed in (declutter; PSK spots aren't selectable).
+            if (scale >= LABEL_ZOOM_THRESHOLD) {
+                val paint = android.graphics.Paint().apply {
+                    color = android.graphics.Color.argb(160, 248, 113, 113)
+                    textSize = 14f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    spot.receiverCallsign,
+                    sx + 5f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                spot.receiverCallsign,
-                sx + 5f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
         }
 
         // Station markers
@@ -761,7 +754,14 @@ private fun AzimuthalMapCanvas(
             if (sqrt(ddx * ddx + ddy * ddy) > r) continue
 
             val isSelected = station.callsign == selectedCallsign
-            val markerR = if (isSelected) 5f else 3.5f
+            val style = markerStyleFor(
+                isCQ = station.isCQ,
+                isToMe = station.isToMe,
+                isWorked = station.isWorked,
+                snr = station.snr,
+                isSelected = isSelected,
+                currentZoom = scale,
+            )
             val glowR = if (isSelected) 12f else 8f
 
             // Pulse rings: 2 expanding rings per station, staggered by 0.5 phase. Phase derived from
@@ -774,7 +774,7 @@ private fun AzimuthalMapCanvas(
                 val ringAlpha = (1f - phase) * 0.35f * baseAmp
                 if (ringAlpha > 0f) {
                     drawCircle(
-                        color = station.color.copy(alpha = ringAlpha),
+                        color = style.fill.copy(alpha = ringAlpha),
                         radius = ringR,
                         center = Offset(sx, sy),
                         style = Stroke(width = 1f),
@@ -785,7 +785,7 @@ private fun AzimuthalMapCanvas(
             // Bearing line for selected station (originates at the operator's screen pos)
             if (isSelected) {
                 drawLine(
-                    color = station.color.copy(alpha = 0.4f),
+                    color = style.fill.copy(alpha = 0.4f),
                     start = Offset(opX, opY),
                     end = Offset(sx, sy),
                     strokeWidth = 1.5f,
@@ -795,45 +795,37 @@ private fun AzimuthalMapCanvas(
 
             // Glow
             drawCircle(
-                color = station.color.copy(alpha = if (isSelected) 0.25f else 0.15f),
+                color = style.fill.copy(alpha = if (isSelected) 0.25f else 0.15f),
                 radius = glowR,
                 center = Offset(sx, sy),
             )
 
-            // Marker dot
-            drawCircle(
-                color = station.color,
-                radius = markerR,
-                center = Offset(sx, sy),
-            )
-            drawCircle(
-                color = BgApp,
-                radius = markerR,
-                center = Offset(sx, sy),
-                style = Stroke(width = 1.2f),
-            )
+            // Marker shape (per type: triangle CQ / diamond to-me / donut worked / dot)
+            drawMarkerShape(style.shape, sx, sy, style.radiusPx, style.fill)
 
-            // Callsign label
-            val textColor = if (isSelected) {
-                android.graphics.Color.WHITE
-            } else {
-                android.graphics.Color.argb(180, 138, 150, 177) // TextMuted
-            }
-            val paint = android.graphics.Paint().apply {
-                color = textColor
-                textSize = if (isSelected) 24f else 20f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            // Callsign label — only when zoomed in or selected (declutter)
+            if (style.showLabel) {
+                val textColor = if (isSelected) {
+                    android.graphics.Color.WHITE
+                } else {
+                    android.graphics.Color.argb(180, 138, 150, 177) // TextMuted
+                }
+                val paint = android.graphics.Paint().apply {
+                    color = textColor
+                    textSize = if (isSelected) 24f else 20f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    station.callsign,
+                    sx + glowR + 4f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                station.callsign,
-                sx + glowR + 4f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
         }
     }
 }
@@ -904,33 +896,26 @@ private fun StandardMapCanvas(
             val sx = pos.x
             val sy = pos.y
 
-            val half = 2.5f
-            drawRect(
-                color = PskSpot.copy(alpha = 0.7f),
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-            )
-            drawRect(
-                color = BgApp,
-                topLeft = Offset(sx - half, sy - half),
-                size = Size(half * 2, half * 2),
-                style = Stroke(width = 0.8f),
-            )
-            val paint = android.graphics.Paint().apply {
-                color = android.graphics.Color.argb(160, 248, 113, 113)
-                textSize = 14f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            drawMarkerShape(MarkerShape.SQUARE_PSK, sx, sy, 2.5f, PskSpot.copy(alpha = 0.7f))
+
+            // Receiver callsign — only when zoomed in (declutter; PSK spots aren't selectable).
+            if (scale >= LABEL_ZOOM_THRESHOLD) {
+                val paint = android.graphics.Paint().apply {
+                    color = android.graphics.Color.argb(160, 248, 113, 113)
+                    textSize = 14f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    spot.receiverCallsign,
+                    sx + 5f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                spot.receiverCallsign,
-                sx + 5f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
         }
 
         // Station markers
@@ -940,7 +925,14 @@ private fun StandardMapCanvas(
             val sy = pos.y
 
             val isSelected = station.callsign == selectedCallsign
-            val markerR = if (isSelected) 5f else 3.5f
+            val style = markerStyleFor(
+                isCQ = station.isCQ,
+                isToMe = station.isToMe,
+                isWorked = station.isWorked,
+                snr = station.snr,
+                isSelected = isSelected,
+                currentZoom = scale,
+            )
             val glowR = if (isSelected) 12f else 8f
 
             // Pulse rings (same pattern as azimuthal: shared transition + per-station phase offset)
@@ -952,7 +944,7 @@ private fun StandardMapCanvas(
                 val ringAlpha = (1f - phase) * 0.35f * baseAmp
                 if (ringAlpha > 0f) {
                     drawCircle(
-                        color = station.color.copy(alpha = ringAlpha),
+                        color = style.fill.copy(alpha = ringAlpha),
                         radius = ringR,
                         center = Offset(sx, sy),
                         style = Stroke(width = 1f),
@@ -963,7 +955,7 @@ private fun StandardMapCanvas(
             // Bearing line for selected station (straight rhumb-style on flat map)
             if (isSelected) {
                 drawLine(
-                    color = station.color.copy(alpha = 0.4f),
+                    color = style.fill.copy(alpha = 0.4f),
                     start = Offset(opX, opY),
                     end = Offset(sx, sy),
                     strokeWidth = 1.5f,
@@ -973,45 +965,80 @@ private fun StandardMapCanvas(
 
             // Glow
             drawCircle(
-                color = station.color.copy(alpha = if (isSelected) 0.25f else 0.15f),
+                color = style.fill.copy(alpha = if (isSelected) 0.25f else 0.15f),
                 radius = glowR,
                 center = Offset(sx, sy),
             )
 
-            // Marker dot
-            drawCircle(
-                color = station.color,
-                radius = markerR,
-                center = Offset(sx, sy),
-            )
-            drawCircle(
-                color = BgApp,
-                radius = markerR,
-                center = Offset(sx, sy),
-                style = Stroke(width = 1.2f),
-            )
+            // Marker shape (per type: triangle CQ / diamond to-me / donut worked / dot)
+            drawMarkerShape(style.shape, sx, sy, style.radiusPx, style.fill)
 
-            // Callsign label
-            val textColor = if (isSelected) {
-                android.graphics.Color.WHITE
-            } else {
-                android.graphics.Color.argb(180, 138, 150, 177)
-            }
-            val paint = android.graphics.Paint().apply {
-                color = textColor
-                textSize = if (isSelected) 22f else 18f
-                isAntiAlias = true
-                typeface = android.graphics.Typeface.create(
-                    android.graphics.Typeface.MONOSPACE,
-                    android.graphics.Typeface.NORMAL,
+            // Callsign label — only when zoomed in or selected (declutter)
+            if (style.showLabel) {
+                val textColor = if (isSelected) {
+                    android.graphics.Color.WHITE
+                } else {
+                    android.graphics.Color.argb(180, 138, 150, 177)
+                }
+                val paint = android.graphics.Paint().apply {
+                    color = textColor
+                    textSize = if (isSelected) 22f else 18f
+                    isAntiAlias = true
+                    typeface = android.graphics.Typeface.create(
+                        android.graphics.Typeface.MONOSPACE,
+                        android.graphics.Typeface.NORMAL,
+                    )
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    station.callsign,
+                    sx + glowR + 4f,
+                    sy + paint.textSize / 3f,
+                    paint,
                 )
             }
-            drawContext.canvas.nativeCanvas.drawText(
-                station.callsign,
-                sx + glowR + 4f,
-                sy + paint.textSize / 3f,
-                paint,
-            )
+        }
+    }
+}
+
+// Draw a station/spot marker glyph. The shape encodes the station's state (set by
+// markerStyleFor); colour + size come from the MarkerStyle. Each shape gets a BgApp
+// outline so it reads against land/ocean alike.
+private fun DrawScope.drawMarkerShape(shape: MarkerShape, cx: Float, cy: Float, r: Float, fill: Color) {
+    when (shape) {
+        MarkerShape.DOT_DEFAULT -> {
+            drawCircle(fill, r, Offset(cx, cy))
+            drawCircle(BgApp, r, Offset(cx, cy), style = Stroke(width = 1.2f))
+        }
+        MarkerShape.SQUARE_PSK -> {
+            drawRect(fill, topLeft = Offset(cx - r, cy - r), size = Size(r * 2, r * 2))
+            drawRect(BgApp, topLeft = Offset(cx - r, cy - r), size = Size(r * 2, r * 2), style = Stroke(width = 0.8f))
+        }
+        MarkerShape.CHECK_WORKED -> {
+            // Donut: filled disc with the centre punched out — distinct from a plain dot.
+            drawCircle(fill, r, Offset(cx, cy))
+            drawCircle(BgApp, r * 0.45f, Offset(cx, cy))
+            drawCircle(BgApp, r, Offset(cx, cy), style = Stroke(width = 1.2f))
+        }
+        MarkerShape.TRIANGLE_CQ -> {
+            val p = Path().apply {
+                moveTo(cx, cy - r * 1.3f)
+                lineTo(cx - r * 1.2f, cy + r * 0.9f)
+                lineTo(cx + r * 1.2f, cy + r * 0.9f)
+                close()
+            }
+            drawPath(p, fill)
+            drawPath(p, BgApp, style = Stroke(width = 1.2f))
+        }
+        MarkerShape.DIAMOND_TO_ME -> {
+            val p = Path().apply {
+                moveTo(cx, cy - r * 1.35f)
+                lineTo(cx + r * 1.35f, cy)
+                lineTo(cx, cy + r * 1.35f)
+                lineTo(cx - r * 1.35f, cy)
+                close()
+            }
+            drawPath(p, fill)
+            drawPath(p, BgApp, style = Stroke(width = 1.2f))
         }
     }
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -927,7 +927,8 @@ private fun AzimuthalMapCanvas(
 
             drawMarkerShape(MarkerShape.SQUARE_PSK, sx, sy, 2.5f, PskSpot.copy(alpha = 0.7f))
 
-            // Receiver callsign — only when zoomed in (declutter; PSK spots aren't selectable).
+            // Spot callsign (receiver or sender, per the direction filter) — only when
+            // zoomed in (declutter; PSK spots aren't selectable).
             if (scale >= LABEL_ZOOM_THRESHOLD) {
                 val paint = android.graphics.Paint().apply {
                     color = android.graphics.Color.argb(160, 248, 113, 113)
@@ -1112,7 +1113,8 @@ private fun StandardMapCanvas(
 
             drawMarkerShape(MarkerShape.SQUARE_PSK, sx, sy, 2.5f, PskSpot.copy(alpha = 0.7f))
 
-            // Receiver callsign — only when zoomed in (declutter; PSK spots aren't selectable).
+            // Spot callsign (receiver or sender, per the direction filter) — only when
+            // zoomed in (declutter; PSK spots aren't selectable).
             if (scale >= LABEL_ZOOM_THRESHOLD) {
                 val paint = android.graphics.Paint().apply {
                     color = android.graphics.Color.argb(160, 248, 113, 113)
@@ -1214,6 +1216,10 @@ private fun StandardMapCanvas(
     }
 }
 
+// Cached so the dashed connection line doesn't allocate a PathEffect (and its
+// backing float array) every frame it's drawn.
+private val ConnectionDashEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f))
+
 // Draw an operator -> station connection line. Solid + thicker for the active TX
 // target; dashed + thinner for stations calling us.
 private fun DrawScope.drawConnectionLine(
@@ -1236,7 +1242,7 @@ private fun DrawScope.drawConnectionLine(
             start = Offset(x0, y0),
             end = Offset(x1, y1),
             strokeWidth = 1.6f,
-            pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)),
+            pathEffect = ConnectionDashEffect,
         )
     }
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
@@ -1,0 +1,77 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import androidx.compose.ui.geometry.Offset
+
+/**
+ * How the equirectangular world is scaled into the canvas at zoom 1.0.
+ *
+ * COVER fills the whole canvas (the map overflows on whichever axis the canvas
+ * is "too long" in, so there are never dead bands) — used for the full-screen
+ * map. FIT letterboxes the map inside the canvas (kept for completeness/tests).
+ */
+internal enum class FitMode { COVER, FIT }
+
+/**
+ * Maps the pure [equirectProject] output (normalized [-1,1] on each axis) onto a
+ * concrete canvas, edge-to-edge, with a user pinch-zoom and pan offset.
+ *
+ * The world's intrinsic aspect is 2:1 (360° lon by 180° lat), so x gets twice
+ * the pixels-per-normalized-unit that y does. [baseUniform] is the pixels per
+ * normalized **y** half-unit; the world is therefore `4*baseUniform` wide by
+ * `2*baseUniform` tall at zoom 1 (before [userScale]).
+ *
+ * Previously the canvas was locked to a 2:1 box via `.aspectRatio(2f)` and the
+ * projection assumed the unzoomed map exactly filled it (`pan max = size*(scale-1)/2`).
+ * That left dead bands on a tall phone. COVER + [clampPan] (which floors the
+ * allowed pan at 0 when the map is *smaller* than the canvas on an axis) is what
+ * lets the map fill the screen without being draggable into empty space.
+ */
+internal class EquirectViewport(
+    val canvasW: Float,
+    val canvasH: Float,
+    val userScale: Float = 1f,
+    val panX: Float = 0f,
+    val panY: Float = 0f,
+    val fit: FitMode = FitMode.COVER,
+) {
+    // COVER: worldPxW >= canvasW (=> baseUniform >= canvasW/2) AND
+    //        worldPxH >= canvasH (=> baseUniform >= canvasH). Take the max so both hold.
+    // FIT:   the opposite — the smaller scale, so the whole world fits inside.
+    val baseUniform: Float = when (fit) {
+        FitMode.COVER -> maxOf(canvasW / 2f, canvasH)
+        FitMode.FIT -> minOf(canvasW / 2f, canvasH)
+    }.coerceAtLeast(1f)
+
+    val worldPxW: Float = baseUniform * 2f * userScale
+    val worldPxH: Float = baseUniform * 1f * userScale
+
+    /** Project a normalized point (from [equirectProject]) to canvas pixels. */
+    fun project(p: ProjectedPoint): Offset {
+        val cx = canvasW / 2f
+        val cy = canvasH / 2f
+        return Offset(
+            x = cx + p.x * (worldPxW / 2f) + panX,
+            y = cy + p.y * (worldPxH / 2f) + panY,
+        )
+    }
+
+    /** Convenience: project geographic lat/lon straight to canvas pixels. */
+    fun projectLatLon(lat: Double, lon: Double): Offset = project(equirectProject(lat, lon))
+
+    /** Max pan on each axis = half the overflow of the (zoomed) world past the canvas, floored at 0. */
+    fun maxPanX(): Float = ((worldPxW - canvasW) / 2f).coerceAtLeast(0f)
+    fun maxPanY(): Float = ((worldPxH - canvasH) / 2f).coerceAtLeast(0f)
+
+    /**
+     * Clamp a candidate pan so the map can't be dragged off into empty space.
+     * On an axis where the map is smaller than the canvas the allowed pan is 0
+     * (the map stays centered) — this is the load-bearing fix vs. the old
+     * `size*(scale-1)/2` formula, which silently assumed the map always filled
+     * the canvas.
+     */
+    fun clampPan(px: Float, py: Float): Offset {
+        val mx = maxPanX()
+        val my = maxPanY()
+        return Offset(px.coerceIn(-mx, mx), py.coerceIn(-my, my))
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewport.kt
@@ -15,10 +15,12 @@ internal enum class FitMode { COVER, FIT }
  * Maps the pure [equirectProject] output (normalized [-1,1] on each axis) onto a
  * concrete canvas, edge-to-edge, with a user pinch-zoom and pan offset.
  *
- * The world's intrinsic aspect is 2:1 (360° lon by 180° lat), so x gets twice
- * the pixels-per-normalized-unit that y does. [baseUniform] is the pixels per
- * normalized **y** half-unit; the world is therefore `4*baseUniform` wide by
- * `2*baseUniform` tall at zoom 1 (before [userScale]).
+ * The world's intrinsic aspect is 2:1 (360° lon by 180° lat). [baseUniform] is
+ * the world's full height in pixels at zoom 1, so the world is `2*baseUniform`
+ * wide by `baseUniform` tall (before [userScale]) — i.e. x is scaled to twice as
+ * many pixels per normalized unit as y, which preserves the 2:1 aspect. COVER
+ * picks `max(canvasW/2, canvasH)` so the world is at least as large as the canvas
+ * on both axes (no dead bands).
  *
  * Previously the canvas was locked to a 2:1 box via `.aspectRatio(2f)` and the
  * projection assumed the unzoomed map exactly filled it (`pan max = size*(scale-1)/2`).

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyle.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyle.kt
@@ -1,0 +1,79 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import androidx.compose.ui.graphics.Color
+import radio.ks3ckc.ft8af.theme.Accent
+import radio.ks3ckc.ft8af.theme.Signal
+import radio.ks3ckc.ft8af.theme.StatusNew
+import radio.ks3ckc.ft8af.theme.StatusWorked
+
+/**
+ * Marker appearance, decided once per station from its decode state. Pure (only
+ * touches Compose's [Color], no Android runtime), so it's unit-testable — the
+ * canvas is a thin renderer that switches on [shape] and draws [fill].
+ *
+ * Replaces the old inline `when` that picked a single colour and unconditionally
+ * drew a circle + text label for every station (which overlapped illegibly in a
+ * busy opening). Now each station type gets a distinct shape, the colour is
+ * tinted by SNR, and labels are decluttered to only show when zoomed in or
+ * selected.
+ */
+internal enum class MarkerShape {
+    TRIANGLE_CQ,    // calling CQ — open to be worked
+    DIAMOND_TO_ME,  // directing a message at us
+    CHECK_WORKED,   // already worked / QSL'd
+    DOT_DEFAULT,    // any other decode
+    SQUARE_PSK,     // PSK Reporter receiver that heard us
+}
+
+internal data class MarkerStyle(
+    val shape: MarkerShape,
+    val fill: Color,
+    val radiusPx: Float,
+    val showLabel: Boolean,
+)
+
+/**
+ * Labels only render at/above this zoom, or when the marker is selected. Below
+ * it the callsigns would overlap into an unreadable smear, so we keep just the
+ * shapes until the operator zooms into a region.
+ */
+internal const val LABEL_ZOOM_THRESHOLD = 3.0f
+
+/**
+ * Tint a base type colour by SNR so stronger signals read brighter and weak ones
+ * fade back. FT8 SNRs run roughly -24..+10 dB; map that to an alpha ramp so the
+ * weakest decodes are dim (but still visible) and strong ones are near-opaque.
+ */
+internal fun snrTint(base: Color, snr: Int): Color {
+    val t = ((snr + 24f) / 34f).coerceIn(0f, 1f)
+    val alpha = 0.45f + 0.55f * t
+    return base.copy(alpha = alpha)
+}
+
+internal fun markerStyleFor(
+    isCQ: Boolean,
+    isToMe: Boolean,
+    isWorked: Boolean,
+    snr: Int,
+    isSelected: Boolean,
+    currentZoom: Float,
+): MarkerStyle {
+    // Priority: a station calling us matters most, then worked, then CQ, then plain.
+    val shape = when {
+        isToMe -> MarkerShape.DIAMOND_TO_ME
+        isWorked -> MarkerShape.CHECK_WORKED
+        isCQ -> MarkerShape.TRIANGLE_CQ
+        else -> MarkerShape.DOT_DEFAULT
+    }
+    val base = when {
+        isToMe -> Signal
+        isWorked -> StatusWorked
+        isCQ -> Accent
+        else -> StatusNew
+    }
+    // Selected markers ignore the SNR fade (always full strength) and draw larger.
+    val fill = if (isSelected) base else snrTint(base, snr)
+    val radius = if (isSelected) 5.5f else 3.5f
+    val showLabel = isSelected || currentZoom >= LABEL_ZOOM_THRESHOLD
+    return MarkerStyle(shape, fill, radius, showLabel)
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/PskFilter.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/PskFilter.kt
@@ -1,0 +1,65 @@
+package radio.ks3ckc.ft8af.ui.map
+
+/**
+ * PSK Reporter overlay filters (band / mode / time window / direction). The map
+ * holds one [PskFilter] as state; changing it re-runs the fetch (band is applied
+ * client-side, the rest go into the query). Pure + unit-testable.
+ */
+
+internal enum class Band(val label: String, val lowHz: Long, val highHz: Long) {
+    M160("160m", 1_800_000, 2_000_000),
+    M80("80m", 3_500_000, 4_000_000),
+    M60("60m", 5_250_000, 5_450_000),
+    M40("40m", 7_000_000, 7_300_000),
+    M30("30m", 10_100_000, 10_150_000),
+    M20("20m", 14_000_000, 14_350_000),
+    M17("17m", 18_068_000, 18_168_000),
+    M15("15m", 21_000_000, 21_450_000),
+    M12("12m", 24_890_000, 24_990_000),
+    M10("10m", 28_000_000, 29_700_000),
+    M6("6m", 50_000_000, 54_000_000),
+}
+
+/** Map a spot frequency (absolute Hz) to its amateur band, or null if out of band. */
+internal fun freqHzToBand(freqHz: Long): Band? =
+    Band.entries.firstOrNull { freqHz in it.lowHz..it.highHz }
+
+internal enum class PskMode(val label: String) {
+    CURRENT("Current"),  // follow the rig's current mode at fetch time
+    FT8("FT8"),
+    FT4("FT4"),
+    FT2("FT2"),
+}
+
+internal enum class PskDirection(val label: String) {
+    WHO_HEARD_ME("Heard me"),  // receivers that decoded us (senderCallsign=me)
+    WHO_I_HEARD("I heard"),    // stations we decoded (receiverCallsign=me)
+}
+
+/** Time-window presets in seconds, shown as 15m / 1h / 3h / 6h / 24h. */
+internal val PSK_TIME_PRESETS = listOf(900, 3600, 10800, 21600, 86400)
+
+internal fun pskTimeLabel(sec: Int): String = when (sec) {
+    900 -> "15m"
+    3600 -> "1h"
+    10800 -> "3h"
+    21600 -> "6h"
+    86400 -> "24h"
+    else -> "${sec / 60}m"
+}
+
+internal data class PskFilter(
+    val timeWindowSec: Int = 3600,
+    val band: Band? = null,                              // null = all bands
+    val mode: PskMode = PskMode.CURRENT,
+    val direction: PskDirection = PskDirection.WHO_HEARD_ME,
+)
+
+/** Anything carrying an absolute frequency the band filter can read. */
+internal interface HasFrequencyHz {
+    val frequencyHz: Long
+}
+
+/** Client-side band filter — the retrieve API returns all bands, so we cull here. */
+internal fun <T : HasFrequencyHz> applyPskBandFilter(spots: List<T>, band: Band?): List<T> =
+    if (band == null) spots else spots.filter { freqHzToBand(it.frequencyHz) == band }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -323,6 +323,14 @@
     <string name="map_mode_standard">STD</string>
     <string name="map_mode_azimuthal">AZ</string>
     <string name="map_overlay_psk">PSK</string>
+    <string name="map_filter">Filter</string>
+    <string name="map_filter_title">PSK filters</string>
+    <string name="map_filter_done">Done</string>
+    <string name="map_filter_time">Time</string>
+    <string name="map_filter_band">Band</string>
+    <string name="map_filter_mode">Mode</string>
+    <string name="map_filter_direction">Direction</string>
+    <string name="map_filter_all">All</string>
     <string name="map_info_distance">Distance</string>
     <string name="map_info_bearing">Bearing</string>
     <string name="map_info_snr">SNR</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterClientTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterClientTest.kt
@@ -47,7 +47,7 @@ class PskReporterClientTest {
         // empty receiverLocator (skippedNoGrid path), and VK2YY has a
         // non-numeric frequency (skippedBadGrid path).
         assertThat(spots!!).hasSize(2)
-        assertThat(spots.map { it.receiverCallsign })
+        assertThat(spots.map { it.callsign })
             .containsExactly("VE3XY", "DL1AA")
     }
 
@@ -56,11 +56,11 @@ class PskReporterClientTest {
         server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
 
         val spots = PskReporterClient.fetchSpotsForMe("W1AW", secondsBack = 900)!!
-        val ve3xy = spots.first { it.receiverCallsign == "VE3XY" }
+        val ve3xy = spots.first { it.callsign == "VE3XY" }
 
         // FN03ab decodes to roughly 43.08N / -79.94W (Niagara peninsula).
-        assertThat(ve3xy.receiverLat).isWithin(0.5).of(43.08)
-        assertThat(ve3xy.receiverLon).isWithin(0.5).of(-79.94)
+        assertThat(ve3xy.lat).isWithin(0.5).of(43.08)
+        assertThat(ve3xy.lon).isWithin(0.5).of(-79.94)
         // Plus the metadata we passed through verbatim.
         assertThat(ve3xy.frequencyHz).isEqualTo(14076234L)
         assertThat(ve3xy.snr).isEqualTo(-8)
@@ -194,6 +194,31 @@ class PskReporterClientTest {
 
         val req = server.takeRequest()
         assertThat(req.path).contains("senderCallsign=W1AW")
+    }
+
+    @Test
+    fun fetchSpots_modeParamOverridesQueriedMode() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        PskReporterClient.fetchSpotsForMe("W1AW", 900, mode = "FT4")
+
+        val req = server.takeRequest()
+        assertThat(req.path).contains("mode=FT4")
+    }
+
+    @Test
+    fun fetchSpots_byReceiverQueriesReceiverCallsignAndPlotsSender() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setBody(fixture("pskreporter/reception-report.xml")))
+
+        val spots = PskReporterClient.fetchSpotsForMe("W1AW", 900, byReceiver = true)!!
+
+        val req = server.takeRequest()
+        assertThat(req.path).contains("receiverCallsign=W1AW")
+        // Every report's sender is W1AW @ FN31; with byReceiver we plot the sender, so the
+        // only dropped report is VK2YY (non-numeric frequency).
+        assertThat(spots).hasSize(3)
+        assertThat(spots.map { it.callsign }.toSet()).containsExactly("W1AW")
+        assertThat(spots.map { it.grid }.toSet()).containsExactly("FN31")
     }
 
     private fun fixture(path: String): String =

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/ConnectionLinesTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/ConnectionLinesTest.kt
@@ -1,0 +1,83 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for [buildConnectionLines] — which operator→station lines to
+ * draw given the decoded stations and the active TX target. No Android runtime.
+ */
+class ConnectionLinesTest {
+
+    private data class TestStation(
+        override val callsign: String,
+        override val lat: Double = 10.0,
+        override val lon: Double = 20.0,
+        override val isToMe: Boolean = false,
+    ) : StationLine
+
+    @Test
+    fun txTargetMatched_solidLine() {
+        val lines = buildConnectionLines(listOf(TestStation("K1ABC")), "K1ABC")
+        assertThat(lines).hasSize(1)
+        assertThat(lines[0].style).isEqualTo(LineStyle.SOLID_TX)
+        assertThat(lines[0].callsign).isEqualTo("K1ABC")
+    }
+
+    @Test
+    fun txTargetMatched_caseInsensitive() {
+        val lines = buildConnectionLines(listOf(TestStation("K1ABC")), "k1abc")
+        assertThat(lines).hasSize(1)
+        assertThat(lines[0].style).isEqualTo(LineStyle.SOLID_TX)
+    }
+
+    @Test
+    fun txTargetUnmatched_noLine() {
+        // Target isn't among decoded stations (no grid known) → nothing to draw.
+        val lines = buildConnectionLines(listOf(TestStation("K1ABC")), "W9XYZ")
+        assertThat(lines).isEmpty()
+    }
+
+    @Test
+    fun toMeStations_dashedLines() {
+        val lines = buildConnectionLines(
+            listOf(TestStation("A", isToMe = true), TestStation("B", isToMe = true), TestStation("C")),
+            null,
+        )
+        assertThat(lines).hasSize(2)
+        assertThat(lines.map { it.style }.toSet()).containsExactly(LineStyle.DASHED_CALLING_ME)
+        assertThat(lines.map { it.callsign }.toSet()).containsExactly("A", "B")
+    }
+
+    @Test
+    fun txTargetAlsoToMe_noDuplicate() {
+        // A station that is both the TX target and calling us draws only the solid line.
+        val lines = buildConnectionLines(listOf(TestStation("K1ABC", isToMe = true)), "K1ABC")
+        assertThat(lines).hasSize(1)
+        assertThat(lines[0].style).isEqualTo(LineStyle.SOLID_TX)
+    }
+
+    @Test
+    fun cqOrNullTarget_onlyDashedToMe() {
+        val lines = buildConnectionLines(
+            listOf(TestStation("A", isToMe = true), TestStation("B")),
+            null,
+        )
+        assertThat(lines).hasSize(1)
+        assertThat(lines[0].style).isEqualTo(LineStyle.DASHED_CALLING_ME)
+        assertThat(lines[0].callsign).isEqualTo("A")
+    }
+
+    @Test
+    fun blankTarget_treatedAsNoTarget() {
+        val lines = buildConnectionLines(listOf(TestStation("A", isToMe = true)), "   ")
+        assertThat(lines).hasSize(1)
+        assertThat(lines[0].style).isEqualTo(LineStyle.DASHED_CALLING_ME)
+    }
+
+    @Test
+    fun empty_whenNoTargetNoToMe() {
+        val lines = buildConnectionLines(listOf(TestStation("A"), TestStation("B")), null)
+        assertThat(lines).isEmpty()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewportTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapViewportTest.kt
@@ -1,0 +1,92 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for [EquirectViewport] — the canvas-fit + pan math that makes
+ * the map fill the screen edge-to-edge. No Android/Compose runtime is touched.
+ */
+class MapViewportTest {
+
+    @Test
+    fun cover_portraitCanvas_fillsHeightAndOverflowsWidth() {
+        // Tall canvas: height is the long axis, so COVER scales to fill height and
+        // the 2:1 world overflows horizontally (becomes pannable east-west).
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        assertThat(vp.worldPxH).isWithin(0.01f).of(2000f)   // fills height exactly
+        assertThat(vp.worldPxW).isGreaterThan(1080f)        // wider than the canvas
+        assertThat(vp.worldPxW).isWithin(0.01f).of(4000f)   // 2:1 of the height
+    }
+
+    @Test
+    fun cover_landscapeCanvas_fillsWidth() {
+        // Wide canvas: width is the long axis, so COVER scales to fill width and
+        // the world overflows vertically.
+        val vp = EquirectViewport(canvasW = 2000f, canvasH = 600f)
+        assertThat(vp.worldPxW).isWithin(0.01f).of(2000f)   // fills width exactly
+        assertThat(vp.worldPxH).isGreaterThan(600f)         // taller than the canvas
+        assertThat(vp.worldPxH).isWithin(0.01f).of(1000f)   // half the width
+    }
+
+    @Test
+    fun fit_letterboxesInsteadOfFilling() {
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f, fit = FitMode.FIT)
+        // FIT picks the smaller scale: width-driven here, so the world is no wider
+        // than the canvas and shorter than it (letterboxed top/bottom).
+        assertThat(vp.worldPxW).isWithin(0.01f).of(1080f)
+        assertThat(vp.worldPxH).isLessThan(2000f)
+    }
+
+    @Test
+    fun project_centerOfWorldIsCanvasCenter_atScale1NoPan() {
+        val vp = EquirectViewport(canvasW = 1000f, canvasH = 800f)
+        val p = vp.project(ProjectedPoint(0f, 0f, 0.0))
+        assertThat(p.x).isWithin(1e-3f).of(500f)
+        assertThat(p.y).isWithin(1e-3f).of(400f)
+    }
+
+    @Test
+    fun project_appliesPanOffset() {
+        val vp = EquirectViewport(canvasW = 1000f, canvasH = 800f, panX = 50f, panY = -30f)
+        val p = vp.project(ProjectedPoint(0f, 0f, 0.0))
+        assertThat(p.x).isWithin(1e-3f).of(550f)
+        assertThat(p.y).isWithin(1e-3f).of(370f)
+    }
+
+    @Test
+    fun project_rightEdgeOfWorldIsHalfWorldWidthRight() {
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        val center = vp.project(ProjectedPoint(0f, 0f, 0.0))
+        val east = vp.project(ProjectedPoint(1f, 0f, 0.0)) // lon = +180
+        assertThat(east.x - center.x).isWithin(0.01f).of(vp.worldPxW / 2f)
+    }
+
+    @Test
+    fun clampPan_overflowAxis_clampsToHalfOverflow() {
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        val maxX = (vp.worldPxW - 1080f) / 2f
+        val clamped = vp.clampPan(99999f, 0f)
+        assertThat(clamped.x).isWithin(0.01f).of(maxX)
+    }
+
+    @Test
+    fun clampPan_underflowAxis_locksToZero() {
+        // Portrait COVER fills height exactly => no vertical overflow => pan locks to 0.
+        // This is the load-bearing case: the old formula would have allowed dragging
+        // the map up/down into empty space.
+        val vp = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        assertThat(vp.maxPanY()).isWithin(0.01f).of(0f)
+        val clamped = vp.clampPan(0f, 9999f)
+        assertThat(clamped.y).isWithin(0.01f).of(0f)
+    }
+
+    @Test
+    fun clampPan_scaledUp_allowsMorePan() {
+        val base = EquirectViewport(canvasW = 1080f, canvasH = 2000f)
+        val zoomed = EquirectViewport(canvasW = 1080f, canvasH = 2000f, userScale = 3f)
+        // Zooming in grows the world, so both axes now overflow and allow (more) pan.
+        assertThat(zoomed.maxPanX()).isGreaterThan(base.maxPanX())
+        assertThat(zoomed.maxPanY()).isGreaterThan(0f)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyleTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MarkerStyleTest.kt
@@ -1,0 +1,97 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for [markerStyleFor] / [snrTint] — the marker-appearance
+ * decision logic. No Android/Compose runtime is touched (Compose's Color is a
+ * pure-Kotlin value class), so these run as plain JVM tests.
+ */
+class MarkerStyleTest {
+
+    private fun style(
+        isCQ: Boolean = false,
+        isToMe: Boolean = false,
+        isWorked: Boolean = false,
+        snr: Int = 0,
+        isSelected: Boolean = false,
+        zoom: Float = 1f,
+    ) = markerStyleFor(isCQ, isToMe, isWorked, snr, isSelected, zoom)
+
+    @Test
+    fun toMe_isDiamond() {
+        assertThat(style(isToMe = true).shape).isEqualTo(MarkerShape.DIAMOND_TO_ME)
+    }
+
+    @Test
+    fun cq_isTriangle() {
+        assertThat(style(isCQ = true).shape).isEqualTo(MarkerShape.TRIANGLE_CQ)
+    }
+
+    @Test
+    fun worked_isCheck() {
+        assertThat(style(isWorked = true).shape).isEqualTo(MarkerShape.CHECK_WORKED)
+    }
+
+    @Test
+    fun plainDecode_isDot() {
+        assertThat(style().shape).isEqualTo(MarkerShape.DOT_DEFAULT)
+    }
+
+    @Test
+    fun toMeBeatsWorkedAndCq() {
+        // A station both worked and now calling us should read as "calling us".
+        assertThat(style(isToMe = true, isWorked = true, isCQ = true).shape)
+            .isEqualTo(MarkerShape.DIAMOND_TO_ME)
+    }
+
+    @Test
+    fun workedBeatsCq() {
+        assertThat(style(isWorked = true, isCQ = true).shape).isEqualTo(MarkerShape.CHECK_WORKED)
+    }
+
+    @Test
+    fun label_hiddenBelowThresholdWhenNotSelected() {
+        assertThat(style(zoom = LABEL_ZOOM_THRESHOLD - 0.5f, isSelected = false).showLabel).isFalse()
+    }
+
+    @Test
+    fun label_shownWhenSelectedEvenZoomedOut() {
+        assertThat(style(zoom = 1f, isSelected = true).showLabel).isTrue()
+    }
+
+    @Test
+    fun label_shownAtOrAboveThreshold() {
+        assertThat(style(zoom = LABEL_ZOOM_THRESHOLD).showLabel).isTrue()
+        assertThat(style(zoom = LABEL_ZOOM_THRESHOLD + 1f).showLabel).isTrue()
+    }
+
+    @Test
+    fun selected_isLargerRadius() {
+        assertThat(style(isSelected = true).radiusPx).isGreaterThan(style(isSelected = false).radiusPx)
+    }
+
+    @Test
+    fun snrTint_strongerSnrIsMoreOpaque() {
+        val weak = snrTint(radio.ks3ckc.ft8af.theme.Signal, -20)
+        val strong = snrTint(radio.ks3ckc.ft8af.theme.Signal, 10)
+        assertThat(strong.alpha).isGreaterThan(weak.alpha)
+    }
+
+    @Test
+    fun snrTint_clampsExtremes() {
+        // Tolerance covers Compose Color's 8-bit alpha quantization (~1/255 ≈ 0.004).
+        val tooLow = snrTint(radio.ks3ckc.ft8af.theme.Signal, -100)
+        val tooHigh = snrTint(radio.ks3ckc.ft8af.theme.Signal, 100)
+        assertThat(tooLow.alpha).isWithin(0.01f).of(0.45f)
+        assertThat(tooHigh.alpha).isWithin(0.01f).of(1.0f)
+    }
+
+    @Test
+    fun selected_ignoresSnrFade() {
+        // A selected weak-signal marker draws at full strength, not faded.
+        val s = style(snr = -24, isSelected = true)
+        assertThat(s.fill.alpha).isWithin(1e-4f).of(1.0f)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/PskFilterTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/PskFilterTest.kt
@@ -1,0 +1,60 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for the PSK filter helpers — band classification and the
+ * client-side band cull. No Android runtime.
+ */
+class PskFilterTest {
+
+    private data class Spot(override val frequencyHz: Long) : HasFrequencyHz
+
+    @Test
+    fun freqHzToBand_classifiesCommonBands() {
+        assertThat(freqHzToBand(14_076_000)).isEqualTo(Band.M20)
+        assertThat(freqHzToBand(7_074_000)).isEqualTo(Band.M40)
+        assertThat(freqHzToBand(50_313_000)).isEqualTo(Band.M6)
+        assertThat(freqHzToBand(1_840_000)).isEqualTo(Band.M160)
+    }
+
+    @Test
+    fun freqHzToBand_outOfBandIsNull() {
+        assertThat(freqHzToBand(100_000_000)).isNull()
+        assertThat(freqHzToBand(9_000_000)).isNull()  // between 30m and 40m
+    }
+
+    @Test
+    fun freqHzToBand_boundariesInclusive() {
+        assertThat(freqHzToBand(14_000_000)).isEqualTo(Band.M20)  // low edge
+        assertThat(freqHzToBand(14_350_000)).isEqualTo(Band.M20)  // high edge
+    }
+
+    @Test
+    fun applyPskBandFilter_nullBandPassesAll() {
+        val spots = listOf(Spot(14_076_000), Spot(7_074_000))
+        assertThat(applyPskBandFilter(spots, null)).hasSize(2)
+    }
+
+    @Test
+    fun applyPskBandFilter_keepsOnlyMatchingBand() {
+        val spots = listOf(Spot(14_076_000), Spot(7_074_000), Spot(14_080_000))
+        val filtered = applyPskBandFilter(spots, Band.M20)
+        assertThat(filtered).hasSize(2)
+        assertThat(filtered.map { it.frequencyHz }).containsExactly(14_076_000L, 14_080_000L)
+    }
+
+    @Test
+    fun applyPskBandFilter_dropsOutOfBandSpots() {
+        val spots = listOf(Spot(14_076_000), Spot(9_000_000))
+        assertThat(applyPskBandFilter(spots, Band.M20)).hasSize(1)
+    }
+
+    @Test
+    fun pskTimeLabel_mapsPresets() {
+        assertThat(pskTimeLabel(900)).isEqualTo("15m")
+        assertThat(pskTimeLabel(3600)).isEqualTo("1h")
+        assertThat(pskTimeLabel(86400)).isEqualTo("24h")
+    }
+}


### PR DESCRIPTION
Last of four map-redesign PRs. **Stacked on #301** (`feat/map-connection-lines`) —
base retargets to `dev` as the stack merges. Merge order: #299 → #300 → #301 → this.

## Problem
The PSK overlay was hardwired to a fixed 1-hour window, the rig's current mode, all
bands, and "who heard me" — no way to narrow it down.

## Change
- New pure **`PskFilter`** model: `Band` enum + `freqHzToBand` (client-side band
  cull via `applyPskBandFilter`), `PskMode` (incl. `CURRENT` = follow the rig),
  `PskDirection`, and time-window presets (15m/1h/3h/6h/24h).
- **`PskReporterClient.fetchSpotsForMe`** gains `mode` + `byReceiver` params. `mode`
  overrides the queried mode (null = current). `byReceiver` flips the query from
  `senderCallsign=me` (plot the receiver that heard us) to `receiverCallsign=me`
  (plot the sender we heard, via `senderLocator`). **Cooldown / 429-503 back-off
  unchanged.** `PskReporterSpot` is now neutral (`callsign/grid/lat/lon`) since the
  plotted station depends on direction.
- **`MapScreen`** holds the filter as saveable state, shows a floating filter sheet
  (scrollable chip rows per axis), and re-runs the fetch when it changes —
  **force-once** so a deliberate change isn't swallowed by the 5-min cooldown; band
  applied client-side.

## Scope note
Direction is two single-callsign queries (heard-me / I-heard). The unbounded "all
stations in area" query is **deliberately deferred** — it trips PSK Reporter's
rate-limit on a 5-min poll and overflows the 500-spot cap. "I heard" depends on
`senderLocator` being present in the report.

## Tests
`PskFilterTest` (7): band classification, inclusive boundaries, client-side cull,
time labels. `PskReporterClientTest` extended: `mode` param in the query, and the
`byReceiver` query + plot-sender path; existing cooldown/back-off cases still green.

## Verification
`./gradlew testDebugUnitTest` green; built + installed on the Pixel 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)