### PR TITLE
Fix #298: use UNPROCESSED/VOICE_RECOGNITION audio source for FT8 RX

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -14,6 +14,7 @@ import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioRecord;
 import android.media.MediaRecorder;
+import android.os.Build;
 import android.util.Log;
 
 import com.k1af.ft8af.GeneralVariables;
@@ -87,8 +88,10 @@ public class MicRecorder {
         bufferSize = safeBufferSize(
                 AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat));
 
+        int audioSource = chooseAudioSource(Build.VERSION.SDK_INT, isUnprocessedSupported());
+        String srcName = audioSourceName(audioSource);
         try {
-            audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz
+            audioRecord = new AudioRecord(audioSource, sampleRateInHz
                     , channelConfig, audioFormat, bufferSize);//create AudioRecorder object
         } catch (Exception e) {
             GeneralVariables.fileLog(
@@ -104,10 +107,11 @@ public class MicRecorder {
                     GeneralVariables.audioInputDeviceId, AudioManager.GET_DEVICES_INPUTS);
             boolean ok = audioRecord.setPreferredDevice(deviceInfo); // null resets to default
             GeneralVariables.fileLog(String.format(
-                    "MicRecorder: AudioRecord(DEFAULT) preferredDevice id=%d ok=%b deviceFound=%b",
-                    GeneralVariables.audioInputDeviceId, ok, deviceInfo != null));
+                    "MicRecorder: AudioRecord(%s) preferredDevice id=%d ok=%b deviceFound=%b",
+                    srcName, GeneralVariables.audioInputDeviceId, ok, deviceInfo != null));
         } else {
-            GeneralVariables.fileLog("MicRecorder: AudioRecord(DEFAULT) using system default mic");
+            GeneralVariables.fileLog(
+                    "MicRecorder: AudioRecord(" + srcName + ") using system default mic");
         }
     }
 
@@ -400,8 +404,11 @@ public class MicRecorder {
         if (!useUsbAudio) {
             bufferSize = safeBufferSize(
                     AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat));
+            int audioSource = chooseAudioSource(Build.VERSION.SDK_INT, isUnprocessedSupported());
+            GeneralVariables.fileLog(
+                    "MicRecorder: reinit AudioRecord(" + audioSourceName(audioSource) + ")");
             try {
-                audioRecord = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRateInHz,
+                audioRecord = new AudioRecord(audioSource, sampleRateInHz,
                         channelConfig, audioFormat, bufferSize);
             } catch (Exception e) {
                 GeneralVariables.fileLog(
@@ -423,6 +430,51 @@ public class MicRecorder {
         if (wasRunning) {
             start();
         }
+    }
+
+    /**
+     * Choose the least-processed recording source available. FT8 (like all
+     * digital modes) needs raw audio: the OEM voice DSP behind
+     * {@code AudioSource.DEFAULT}/{@code MIC} runs automatic gain control, noise
+     * suppression, and multi-mic noise cancellation. That noise canceller uses
+     * the phone's *second built-in mic* to subtract what it thinks is background
+     * noise, mangling a weak line-in FT8 tone — the parasitic "internal mic"
+     * artifact reported in issue #298.
+     *
+     * <p>{@code UNPROCESSED} (API 24+, only when the device advertises support)
+     * guarantees no processing. {@code VOICE_RECOGNITION} is the floor: it
+     * disables AGC/NS on most devices and is available back to API 3, so it's
+     * safe for our minSdk 23 and for devices lacking UNPROCESSED support.
+     *
+     * <p>Package-visible for testing.
+     */
+    static int chooseAudioSource(int sdkInt, boolean unprocessedSupported) {
+        if (sdkInt >= Build.VERSION_CODES.N && unprocessedSupported) {
+            return MediaRecorder.AudioSource.UNPROCESSED;
+        }
+        return MediaRecorder.AudioSource.VOICE_RECOGNITION;
+    }
+
+    /**
+     * Whether the device advertises support for the UNPROCESSED audio source.
+     * Returns false on any error or when the property is unknown/unsupported.
+     */
+    private static boolean isUnprocessedSupported() {
+        Context context = GeneralVariables.getMainContext();
+        if (context == null) return false;
+        AudioManager audioManager =
+                (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager == null) return false;
+        String supported = audioManager.getProperty(
+                AudioManager.PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED);
+        return "true".equalsIgnoreCase(supported);
+    }
+
+    /** Human-readable name for an AudioSource constant, for debug logging. */
+    private static String audioSourceName(int source) {
+        if (source == MediaRecorder.AudioSource.UNPROCESSED) return "UNPROCESSED";
+        if (source == MediaRecorder.AudioSource.VOICE_RECOGNITION) return "VOICE_RECOGNITION";
+        return String.valueOf(source);
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/MicRecorderAudioSourceTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/MicRecorderAudioSourceTest.java
@@ -1,0 +1,59 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.media.MediaRecorder;
+import android.os.Build;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link MicRecorder#chooseAudioSource} — the recording-source selection
+ * that keeps the OEM voice DSP (AGC / noise-suppression / multi-mic noise
+ * cancellation) out of the FT8 RX path (issue #298). We must prefer UNPROCESSED
+ * when the device supports it (API 24+) and otherwise fall back to
+ * VOICE_RECOGNITION, never to the processed DEFAULT/MIC sources.
+ */
+public class MicRecorderAudioSourceTest {
+
+    @Test
+    public void api24_unprocessedSupported_usesUnprocessed() {
+        assertThat(MicRecorder.chooseAudioSource(Build.VERSION_CODES.N, true))
+                .isEqualTo(MediaRecorder.AudioSource.UNPROCESSED);
+    }
+
+    @Test
+    public void api24_unprocessedUnsupported_fallsBackToVoiceRecognition() {
+        assertThat(MicRecorder.chooseAudioSource(Build.VERSION_CODES.N, false))
+                .isEqualTo(MediaRecorder.AudioSource.VOICE_RECOGNITION);
+    }
+
+    @Test
+    public void belowApi24_usesVoiceRecognition_evenIfFlagTrue() {
+        // UNPROCESSED constant only exists from API 24; on minSdk 23 we must not
+        // request it regardless of the (meaningless) capability flag value.
+        assertThat(MicRecorder.chooseAudioSource(Build.VERSION_CODES.M, true))
+                .isEqualTo(MediaRecorder.AudioSource.VOICE_RECOGNITION);
+    }
+
+    @Test
+    public void modernApi_supported_usesUnprocessed() {
+        assertThat(MicRecorder.chooseAudioSource(Build.VERSION_CODES.TIRAMISU, true))
+                .isEqualTo(MediaRecorder.AudioSource.UNPROCESSED);
+    }
+
+    @Test
+    public void neverReturnsDefaultOrMic() {
+        // Across the support/version matrix, the chosen source must always be one
+        // of the two low-processing sources — never DEFAULT/MIC.
+        int[] sdks = {Build.VERSION_CODES.M, Build.VERSION_CODES.N, Build.VERSION_CODES.TIRAMISU};
+        boolean[] flags = {true, false};
+        for (int sdk : sdks) {
+            for (boolean flag : flags) {
+                int src = MicRecorder.chooseAudioSource(sdk, flag);
+                assertThat(src).isNotEqualTo(MediaRecorder.AudioSource.DEFAULT);
+                assertThat(src).isNotEqualTo(MediaRecorder.AudioSource.MIC);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #298.

## Problem

Reporter (Anton, R2ZJT) sees weak, clearly-audible FT8 stations fail to decode with an external transceiver connected, attributing it to the phone's built-in mic injecting parasitic noise / phase-shifted echo.

His literal model ("two inputs mixed into one stream") isn't how Android `AudioRecord` works (one stream = one device), but the underlying problem is real. The standard `AudioRecord` capture path in `MicRecorder.java` was built with `MediaRecorder.AudioSource.DEFAULT`. `DEFAULT`/`MIC` routes through the OEM voice DSP — automatic gain control, noise suppression, and **multi-mic noise cancellation that uses the second built-in mic to subtract "background noise."** Fed a weak line-in FT8 tone, that noise canceller treats the signal as noise and mangles it — exactly the "internal mic noise injection / phase shift" reported.

This path is used for the audio-cable input, AudioManager-selected USB sound cards, **and as the fallback whenever the USB-direct path fails**, so it affects a large fraction of users.

## Fix

Choose the least-processed source available instead of `DEFAULT`:

- `UNPROCESSED` when the device advertises support (API 24+, gated on `PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED`) — guarantees no DSP.
- else `VOICE_RECOGNITION` — disables AGC/NS on most devices, available back to API 3 (safe for minSdk 23).
- never `DEFAULT`/`MIC`.

Always-on, no new UI. The reporter's suggested `setMicrophoneMute` / `VOICE_UPLINK` are **intentionally not used** — they would mute/redirect the line-in capture too. The **USB-direct (libusb) path was already isolated** from the built-in mic and is unchanged; users on automotive skins where `setPreferredDevice` is overridden should keep using the "(USB direct)" input.

## Tests

Selection logic is extracted into `MicRecorder.chooseAudioSource(sdkInt, unprocessedSupported)` (AudioRecord itself can't be unit-tested) with new `MicRecorderAudioSourceTest` covering the UNPROCESSED/VOICE_RECOGNITION matrix and asserting DEFAULT/MIC are never returned. `testDebugUnitTest` passes.

## On-device verification

Built and installed on a Pixel 8; `debug.log` confirms the chosen source changed from `DEFAULT` to `VOICE_RECOGNITION` (the Pixel 8 doesn't advertise UNPROCESSED support, so it correctly falls back), and the reinit path logs the source too. Live-band weak-signal decode comparison is left to field testing — the reporter offered to beta-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)