### PR TITLE
Add CQ-reply and QSO-complete notifications

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -464,6 +464,13 @@ public class GeneralVariables {
     public static boolean alertNewDxcc = false;
     public static boolean alertNewState = false;
 
+    // QSO & CQ alerts (Settings → Needed-DX Alerts). Opt-in, default off.
+    //   - alertOnCqReply:     notify when any decoded message is addressed to my callsign
+    //                         (someone calling me). Own-TX echoes are already filtered out.
+    //   - alertOnQsoComplete: notify when a QSO is logged (DxAlertNotifier.notifyQsoComplete).
+    public static boolean alertOnCqReply = false;
+    public static boolean alertOnQsoComplete = false;
+
     // Geographic continent-directed CQ tokens — matched against myContinent.
     private static final java.util.Set<String> CONTINENT_CODES =
             new java.util.HashSet<>(java.util.Arrays.asList("NA", "SA", "EU", "AF", "AS", "OC", "AN"));

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -722,6 +722,9 @@ public class MainViewModel extends ViewModel {
             public void doAfterTransmit(QSLRecord qslRecord) {
                 databaseOpr.addQSL_Callsign(qslRecord);//two operations: record callsign and QSL
 
+                // QSO-complete alert (opt-in). Fires once per logged contact.
+                dxAlertNotifier.notifyQsoComplete(qslRecord);
+
                 // record to third-party service; may take some time
                 new Thread(new Runnable() {
                     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/alert/AlertDecisions.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/alert/AlertDecisions.java
@@ -1,0 +1,48 @@
+package com.k1af.ft8af.alert;
+
+/**
+ * Pure, Android-free decision + dedup logic for {@link DxAlertNotifier}, extracted so the
+ * branching can be unit-tested without a device (the notifier itself touches
+ * NotificationManager and can't be).
+ *
+ * <p>Two alert kinds are gated here:
+ * <ul>
+ *   <li><b>CQ reply</b> — fire when a decoded message is addressed to the user's callsign
+ *       (someone calling them). Own-TX echoes are filtered upstream before the notifier
+ *       sees them, so an in-list message to my call is always another station.</li>
+ *   <li><b>QSO complete</b> — fire once when a contact is logged.</li>
+ * </ul>
+ *
+ * <p>Dedup keys are namespaced strings collected in a per-session set; {@code DxAlertNotifier}
+ * only posts a notification the first time it sees a given key.
+ */
+public final class AlertDecisions {
+    private AlertDecisions() {}
+
+    /**
+     * @param enabled       the {@code alertOnCqReply} user setting
+     * @param addressedToMe whether the decoded message's target callsign is mine
+     *                      (resolved by the caller via {@code checkIsMyCallsign})
+     * @param blocked       whether the message is filtered by the user's block list
+     */
+    public static boolean shouldAlertCqReply(boolean enabled, boolean addressedToMe, boolean blocked) {
+        return enabled && addressedToMe && !blocked;
+    }
+
+    /** Dedup key for a CQ-reply alert: distinct sender + message text alert once per session. */
+    public static String cqReplyDedupKey(String fromCallsign, String messageText) {
+        return "CQREPLY:" + norm(fromCallsign) + "|" + norm(messageText);
+    }
+
+    /**
+     * Dedup key for a QSO-complete alert: one per worked station + completion time.
+     * {@code endTime} is the log record's end-time token (date-time string).
+     */
+    public static String qsoCompleteDedupKey(String toCallsign, String endTime) {
+        return "QSO:" + norm(toCallsign) + "|" + norm(endTime);
+    }
+
+    private static String norm(String s) {
+        return s == null ? "" : s.trim().toUpperCase();
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
@@ -17,6 +17,7 @@ import androidx.core.content.ContextCompat;
 import com.k1af.ft8af.Ft8Message;
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
+import com.k1af.ft8af.log.QSLRecord;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,45 +25,56 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Needed-DX alerts: plays a sound + vibrates and posts a notification when a station
- * calling CQ is a NEW (unworked) one in a user-enabled category — a new DXCC entity
- * ({@link GeneralVariables#alertNewDxcc}) or a new US state
- * ({@link GeneralVariables#alertNewState}).
+ * Sound + vibrate + notification alerts. Two independent channels:
  *
- * <p>Driven from {@code MainViewModel.GetQTHRunnable.run()} after
- * {@code CallsignDatabase.getMessagesLocation} has populated the {@code from*} flags,
- * so this just reads {@link Ft8Message#fromDxcc} / {@link Ft8Message#fromNewState}.
+ * <ul>
+ *   <li>{@code dx_alerts} — a station calling CQ that is a NEW (unworked) entity in a
+ *       user-enabled category: a new DXCC ({@link GeneralVariables#alertNewDxcc}) or US
+ *       state ({@link GeneralVariables#alertNewState}). Driven from
+ *       {@code MainViewModel.GetQTHRunnable.run()} once the {@code from*} flags are set.</li>
+ *   <li>{@code qso_alerts} — someone calling YOU
+ *       ({@link GeneralVariables#alertOnCqReply}, also driven from {@code processDecodes})
+ *       and a completed QSO ({@link GeneralVariables#alertOnQsoComplete}, fired from
+ *       {@code MainViewModel.doAfterTransmit} via {@link #notifyQsoComplete}).</li>
+ * </ul>
  *
- * <p>Sound + vibration are handled by a high-importance notification channel, so they
- * respect Do-Not-Disturb and the user's per-channel system settings. Alerts are
- * de-duplicated per (category + identifier) for the lifetime of the process, so a
- * station calling CQ every cycle — or several stations from the same needed entity —
- * only alert once.
+ * <p>Each channel is high-importance so sound + vibration respect Do-Not-Disturb and the
+ * user's per-channel system settings. Alerts are de-duplicated per key (see
+ * {@link AlertDecisions}) for the lifetime of the process so a station calling every cycle
+ * only alerts once.
  */
 public class DxAlertNotifier {
     private static final String CHANNEL_ID = "dx_alerts";
+    private static final String QSO_CHANNEL_ID = "qso_alerts";
     public static final String EXTRA_CALLSIGN = "alert_callsign";
     public static final String EXTRA_BAND = "alert_band";
 
     private final Context appContext;
-    // Already-alerted keys this session: "DXCC:<country>" / "STATE:<code>".
+    // Already-alerted keys this session (namespaced: "DXCC:"/"STATE:"/"CQREPLY:"/"QSO:").
     private final Set<String> alerted = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public DxAlertNotifier(Context context) {
         this.appContext = context != null ? context.getApplicationContext() : null;
-        createChannel();
+        createChannels();
     }
 
-    private void createChannel() {
+    private void createChannels() {
         if (appContext == null) return;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
         NotificationManager nm = (NotificationManager)
                 appContext.getSystemService(Context.NOTIFICATION_SERVICE);
         if (nm == null) return;
-        if (nm.getNotificationChannel(CHANNEL_ID) != null) return;
+        createHighChannel(nm, CHANNEL_ID, "Needed-DX alerts",
+                "New DXCC / US state stations calling CQ");
+        createHighChannel(nm, QSO_CHANNEL_ID, "QSO & CQ alerts",
+                "Someone calling you, and completed-QSO alerts");
+    }
+
+    private void createHighChannel(NotificationManager nm, String id, String name, String desc) {
+        if (nm.getNotificationChannel(id) != null) return;
         NotificationChannel channel = new NotificationChannel(
-                CHANNEL_ID, "Needed-DX alerts", NotificationManager.IMPORTANCE_HIGH);
-        channel.setDescription("New DXCC / US state stations calling CQ");
+                id, name, NotificationManager.IMPORTANCE_HIGH);
+        channel.setDescription(desc);
         channel.enableVibration(true);
         channel.setVibrationPattern(new long[]{0, 250, 150, 250});
         Uri sound = android.media.RingtoneManager
@@ -77,38 +89,96 @@ public class DxAlertNotifier {
     }
 
     /**
-     * Inspect a freshly-decoded batch and fire alerts for newly-needed CQ stations.
+     * Inspect a freshly-decoded batch and fire alerts: newly-needed CQ stations
+     * (DXCC/state) and — when enabled — any message addressed to the user's callsign.
      */
     public void processDecodes(List<Ft8Message> messages) {
         if (appContext == null || messages == null) return;
-        if (!GeneralVariables.alertNewDxcc && !GeneralVariables.alertNewState) return;
+        if (!GeneralVariables.alertNewDxcc && !GeneralVariables.alertNewState
+                && !GeneralVariables.alertOnCqReply) {
+            return;
+        }
 
         for (Ft8Message msg : messages) {
-            if (msg == null || !msg.checkIsCQ()) continue;          // workable stations only
+            if (msg == null) continue;
             if (GeneralVariables.checkIsBlockedMessage(msg)) continue;
+
+            // CQ reply: any decoded message addressed to my callsign. The batch is already
+            // own-TX-echo filtered upstream, so a message to my call is another station
+            // calling me. Checked before the CQ-only gate below since a reply isn't a CQ.
+            boolean addressedToMe = GeneralVariables.checkIsMyCallsign(msg.getCallsignTo());
+            if (AlertDecisions.shouldAlertCqReply(
+                    GeneralVariables.alertOnCqReply, addressedToMe, false)) {
+                fire(AlertDecisions.cqReplyDedupKey(msg.getCallsignFrom(), msg.getMessageText()),
+                        QSO_CHANNEL_ID,
+                        appContext.getString(R.string.alert_cq_reply_title, msg.getCallsignFrom()),
+                        cqReplyBody(msg), msg.getCallsignFrom(), msg.band);
+            }
+
+            // Needed-DX alerts apply to CQ broadcasts only.
+            if (!msg.checkIsCQ()) continue;
 
             if (GeneralVariables.alertNewDxcc && msg.fromDxcc) {
                 String country = (msg.fromWhere == null || msg.fromWhere.isEmpty())
                         ? msg.getCallsignFrom() : msg.fromWhere;
-                fireOnce("DXCC:" + country, "New DXCC: " + country, msg);
+                fire("DXCC:" + country, CHANNEL_ID, "New DXCC: " + country,
+                        defaultBody(msg), msg.getCallsignFrom(), msg.band);
             }
             if (GeneralVariables.alertNewState && msg.fromNewState && msg.fromState != null) {
-                fireOnce("STATE:" + msg.fromState, "New state: " + msg.fromState, msg);
+                fire("STATE:" + msg.fromState, CHANNEL_ID, "New state: " + msg.fromState,
+                        defaultBody(msg), msg.getCallsignFrom(), msg.band);
             }
         }
     }
 
-    private void fireOnce(String dedupKey, String title, Ft8Message msg) {
-        if (!alerted.add(dedupKey)) return;                         // already alerted this session
+    /** Fire a notification when a QSO has just been logged, if the user enabled it. */
+    public void notifyQsoComplete(QSLRecord qslRecord) {
+        if (appContext == null || qslRecord == null) return;
+        if (!GeneralVariables.alertOnQsoComplete) return;
 
+        String call = qslRecord.getToCallsign();
+        StringBuilder body = new StringBuilder(call == null ? "" : call);
+        if (qslRecord.getToMaidenGrid() != null && !qslRecord.getToMaidenGrid().isEmpty()) {
+            body.append("  ").append(qslRecord.getToMaidenGrid());
+        }
+        if (qslRecord.getMode() != null && !qslRecord.getMode().isEmpty()) {
+            body.append("  ").append(qslRecord.getMode());
+        }
+        body.append("  R↑").append(qslRecord.getSendReport())
+            .append(" R↓").append(qslRecord.getReceivedReport());
+
+        fire(AlertDecisions.qsoCompleteDedupKey(call, qslRecord.getEndTime()),
+                QSO_CHANNEL_ID,
+                appContext.getString(R.string.alert_qso_complete_title),
+                body.toString(), call, qslRecord.getBandFreq());
+    }
+
+    private static String defaultBody(Ft8Message msg) {
         StringBuilder body = new StringBuilder(msg.getCallsignFrom());
         if (msg.maidenGrid != null && !msg.maidenGrid.isEmpty()) {
             body.append("  ").append(msg.maidenGrid);
         }
         body.append("  ").append(msg.snr).append(" dB");
+        return body.toString();
+    }
 
-        GeneralVariables.fileLog("DX_ALERT fire key=[" + dedupKey + "] "
-                + title + " call=" + msg.getCallsignFrom());
+    private static String cqReplyBody(Ft8Message msg) {
+        StringBuilder body = new StringBuilder(msg.getMessageText());
+        if (msg.snr != Ft8Message.SNR_UNKNOWN) {
+            body.append("  ").append(msg.snr).append(" dB");
+        }
+        return body.toString();
+    }
+
+    /**
+     * Post a notification once per dedup key. {@code callsignExtra}/{@code bandExtra} ride on
+     * the tap intent so the Decode screen can pre-select that station.
+     */
+    private void fire(String dedupKey, String channelId, String title, String body,
+                      String callsignExtra, long bandExtra) {
+        if (!alerted.add(dedupKey)) return;                         // already alerted this session
+
+        GeneralVariables.fileLog("ALERT fire key=[" + dedupKey + "] " + title);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
                 && ContextCompat.checkSelfPermission(appContext,
@@ -122,8 +192,8 @@ public class DxAlertNotifier {
                 radio.ks3ckc.ft8af.ComposeMainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP
                 | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        intent.putExtra(EXTRA_CALLSIGN, msg.getCallsignFrom());
-        intent.putExtra(EXTRA_BAND, msg.band);
+        if (callsignExtra != null) intent.putExtra(EXTRA_CALLSIGN, callsignExtra);
+        intent.putExtra(EXTRA_BAND, bandExtra);
 
         int piFlags = PendingIntent.FLAG_UPDATE_CURRENT;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -131,10 +201,10 @@ public class DxAlertNotifier {
         }
         PendingIntent pi = PendingIntent.getActivity(appContext, id, intent, piFlags);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(appContext, CHANNEL_ID)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(appContext, channelId)
                 .setSmallIcon(R.mipmap.ic_launcher)
                 .setContentTitle(title)
-                .setContentText(body.toString())
+                .setContentText(body)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setCategory(NotificationCompat.CATEGORY_EVENT)
                 .setAutoCancel(true)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2532,6 +2532,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("alertNewState")) {//Needed-DX alert: new US state
                     GeneralVariables.alertNewState = result.equals("1");
                 }
+                if (name.equalsIgnoreCase("alertOnCqReply")) {//Alert when someone replies to my CQ
+                    GeneralVariables.alertOnCqReply = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("alertOnQsoComplete")) {//Alert when a QSO completes
+                    GeneralVariables.alertOnQsoComplete = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
                     GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
@@ -45,6 +45,8 @@ fun DecodeFilterSettings(
     var filterDirectionalCQ by remember { mutableStateOf(GeneralVariables.filterDirectionalCQ) }
     var alertNewDxcc by remember { mutableStateOf(GeneralVariables.alertNewDxcc) }
     var alertNewState by remember { mutableStateOf(GeneralVariables.alertNewState) }
+    var alertOnCqReply by remember { mutableStateOf(GeneralVariables.alertOnCqReply) }
+    var alertOnQsoComplete by remember { mutableStateOf(GeneralVariables.alertOnQsoComplete) }
 
     // Continent codes (stored on the message) and their display names, parallel lists.
     val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
@@ -379,6 +381,32 @@ fun DecodeFilterSettings(
                             GeneralVariables.alertNewState = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "alertNewState", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_alert_cq_reply),
+                        description = stringResource(R.string.settings_alert_cq_reply_desc),
+                        toggle = alertOnCqReply,
+                        onToggleChange = { checked ->
+                            alertOnCqReply = checked
+                            GeneralVariables.alertOnCqReply = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "alertOnCqReply", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_alert_qso_complete),
+                        description = stringResource(R.string.settings_alert_qso_complete_desc),
+                        toggle = alertOnQsoComplete,
+                        onToggleChange = { checked ->
+                            alertOnQsoComplete = checked
+                            GeneralVariables.alertOnQsoComplete = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "alertOnQsoComplete", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -471,6 +471,12 @@
     <string name="settings_alert_new_dxcc_desc">Sound + vibrate + notify when an unworked DXCC entity calls CQ</string>
     <string name="settings_alert_new_state">New US State</string>
     <string name="settings_alert_new_state_desc">Sound + vibrate + notify when a station from an unworked US state calls CQ (state from grid)</string>
+    <string name="settings_alert_cq_reply">CQ reply</string>
+    <string name="settings_alert_cq_reply_desc">Sound + vibrate + notify when a station calls you (any message addressed to your callsign)</string>
+    <string name="settings_alert_qso_complete">QSO complete</string>
+    <string name="settings_alert_qso_complete_desc">Sound + vibrate + notify when a QSO is logged</string>
+    <string name="alert_cq_reply_title">Calling you: %1$s</string>
+    <string name="alert_qso_complete_title">QSO complete</string>
 
     <!-- ===== Settings: logging &amp; awards ===== -->
     <string name="settings_save_swl_decodes">Save SWL Decodes</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/alert/AlertDecisionsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/alert/AlertDecisionsTest.java
@@ -1,0 +1,56 @@
+package com.k1af.ft8af.alert;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/** Pure-JVM tests for {@link AlertDecisions} (no Android runtime needed). */
+public class AlertDecisionsTest {
+
+    @Test
+    public void cqReply_firesOnlyWhenEnabledAddressedAndNotBlocked() {
+        assertThat(AlertDecisions.shouldAlertCqReply(true, true, false)).isTrue();
+    }
+
+    @Test
+    public void cqReply_suppressedWhenDisabled() {
+        assertThat(AlertDecisions.shouldAlertCqReply(false, true, false)).isFalse();
+    }
+
+    @Test
+    public void cqReply_suppressedWhenNotAddressedToMe() {
+        assertThat(AlertDecisions.shouldAlertCqReply(true, false, false)).isFalse();
+    }
+
+    @Test
+    public void cqReply_suppressedWhenBlocked() {
+        assertThat(AlertDecisions.shouldAlertCqReply(true, true, true)).isFalse();
+    }
+
+    @Test
+    public void cqReplyDedupKey_isStableAndCaseInsensitive() {
+        String a = AlertDecisions.cqReplyDedupKey("k1af", " K1AF W5XYZ -12 ");
+        String b = AlertDecisions.cqReplyDedupKey("K1AF", "k1af w5xyz -12");
+        assertThat(a).isEqualTo(b);
+        assertThat(a).startsWith("CQREPLY:");
+    }
+
+    @Test
+    public void cqReplyDedupKey_differsByContent() {
+        String first = AlertDecisions.cqReplyDedupKey("K1AF", "W5XYZ K1AF -12");
+        String second = AlertDecisions.cqReplyDedupKey("K1AF", "W5XYZ K1AF R-09");
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    public void cqReplyDedupKey_handlesNulls() {
+        assertThat(AlertDecisions.cqReplyDedupKey(null, null)).isEqualTo("CQREPLY:|");
+    }
+
+    @Test
+    public void qsoCompleteDedupKey_uniquePerCallAndTime() {
+        String k = AlertDecisions.qsoCompleteDedupKey("w5xyz", "20231114-123456");
+        assertThat(k).isEqualTo("QSO:W5XYZ|20231114-123456");
+        assertThat(k).isNotEqualTo(AlertDecisions.qsoCompleteDedupKey("W5XYZ", "20231114-123457"));
+    }
+}


### PR DESCRIPTION
## Summary

Two opt-in notifications, requested by the user, built on the app's existing alert stack (`DxAlertNotifier`) and settings pattern:

1. **CQ reply** — notify when **any** decoded message is addressed to your callsign (someone calling you).
2. **QSO complete** — notify once when a contact is logged.

## How it works

- **CQ reply** hooks the existing `DxAlertNotifier.processDecodes()` batch already run from `MainViewModel.GetQTHRunnable`. The batch is own-TX-echo filtered upstream, so a message whose `callsignTo` is mine (`GeneralVariables.checkIsMyCallsign`) is another station calling me. Fires regardless of QSO state ("any message to my call", per request).
- **QSO complete** fires from `MainViewModel.doAfterTransmit(QSLRecord)` (once per logged contact) via new `notifyQsoComplete()`.
- Both ride a new high-importance channel **`qso_alerts` ("QSO & CQ alerts")**, separate from the existing `dx_alerts` channel so users control sound/DND independently.
- Settings: two toggles beside the Needed-DX alert rows in `DecodeFilterSettings.kt`, persisted via `DatabaseOpr.writeConfig` like the existing `alertNewDxcc`/`alertNewState` flags (`GeneralVariables.alertOnCqReply` / `alertOnQsoComplete`).

## Tests

- New `AlertDecisionsTest` (pure JVM) covers the extracted gating + dedup-key logic: enabled/addressed/blocked truth table, case-insensitive + null-safe dedup keys, content-distinct keys. The notifier itself touches `NotificationManager` and isn't unit-testable.
- Full `testDebugUnitTest` suite green locally.

## Notes / follow-ups

- English strings added to the default `strings_compose.xml`; the 5 other locales fall back to English (can be translated later).
- These alerts fire while the app is running. A **foreground RX service** (so they keep firing with the screen off / app backgrounded) is the next PR in this series; **Android Auto** support follows after that.
- No connected device was available for an on-device smoke test; CI Build APK covers full packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)