### PR TITLE
Add Android Auto templated Car App (decode list, DHU/dev only)

### DIFF
--- a/ft8af/app/build.gradle
+++ b/ft8af/app/build.gradle
@@ -166,6 +166,9 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.5.3'
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
+    // Android Auto templated Car App (DHU/dev only — see Ft8CarAppService).
+    implementation 'androidx.car.app:app:1.4.0'
+
     implementation 'com.google.guava:guava:31.1-android'//Used for HashTable (multi-key HashMap)
 
     implementation files('src/libs/MPAndroidChartv_3.1.0.jar')

--- a/ft8af/app/src/main/AndroidManifest.xml
+++ b/ft8af/app/src/main/AndroidManifest.xml
@@ -24,6 +24,11 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <!-- Android Auto templated Car App is optional hardware. -->
+    <uses-feature
+        android:name="android.hardware.type.automotive"
+        android:required="false" />
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -80,6 +85,25 @@
         <service
             android:name=".bluetooth.BluetoothSerialService"
             android:exported="false" />
+
+        <!-- Android Auto (Car App Library). DHU/dev only: an FT8 decoder fits no
+             Play-distributable Car App category, so this is declared IOT and won't pass
+             production review. Surfaces the live decode list on a connected head unit. -->
+        <service
+            android:name="com.k1af.ft8af.car.Ft8CarAppService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.car.app.CarAppService" />
+                <category android:name="androidx.car.app.category.IOT" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="androidx.car.app.minCarApiLevel"
+            android:value="1" />
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
 
         <!-- Persists the user's per-app language choice (AppCompatDelegate
              .setApplicationLocales) on Android 12 and below. On Android 13+

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -411,6 +411,16 @@ public class MainViewModel extends ViewModel {
     }
 
     /**
+     * Owner-less accessor to the already-created singleton, for components that have no
+     * {@link ViewModelStoreOwner} (e.g. the Android Auto {@code CarAppService}, which runs in
+     * its own service lifecycle). Returns null if the Activity hasn't created the instance
+     * yet; never creates one. Read-only consumers must null-check.
+     */
+    public static MainViewModel peekInstance() {
+        return viewModel;
+    }
+
+    /**
      * The value afterDecode() must post to mutableIsDecoding (the spectrum-display
      * "decoding" marker) once a decode pass finishes. beforeListen() turns the marker
      * on at the start of every cycle, so every pass must turn it back off when done —

--- a/ft8af/app/src/main/java/com/k1af/ft8af/car/CarRowProjector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/car/CarRowProjector.java
@@ -1,0 +1,76 @@
+package com.k1af.ft8af.car;
+
+import com.k1af.ft8af.Ft8Message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pure projection of decoded {@link Ft8Message}s into the rows the Android Auto decode
+ * screen renders. Extracted from {@code DecodeListScreen} so the formatting + the
+ * host-imposed row cap can be unit-tested without a car host (the Screen/template code
+ * can't be).
+ */
+public final class CarRowProjector {
+    /** Android Auto list templates only surface a handful of rows while driving. */
+    public static final int MAX_ROWS = 6;
+
+    private CarRowProjector() {}
+
+    /** A single rendered row: a non-empty title plus a subtitle line. */
+    public static final class CarRow {
+        public final String title;
+        public final String subtitle;
+
+        public CarRow(String title, String subtitle) {
+            this.title = title;
+            this.subtitle = subtitle;
+        }
+    }
+
+    /**
+     * Project the most recent {@code maxRows} messages, newest first. Null / empty input and
+     * null elements are tolerated.
+     */
+    public static List<CarRow> project(List<Ft8Message> messages, int maxRows) {
+        List<CarRow> rows = new ArrayList<>();
+        if (messages == null || maxRows <= 0) return rows;
+        for (int i = messages.size() - 1; i >= 0 && rows.size() < maxRows; i--) {
+            Ft8Message m = messages.get(i);
+            if (m == null) continue;
+            rows.add(new CarRow(rowTitle(m), rowSubtitle(m)));
+        }
+        return rows;
+    }
+
+    static String rowTitle(Ft8Message m) {
+        String from = m.getCallsignFrom();
+        if (m.callsignTo != null && m.checkIsCQ()) {
+            return ("CQ " + from).trim();
+        }
+        String to = m.getCallsignTo();
+        String title = to.isEmpty() ? from : (from + " → " + to);
+        return title.isEmpty() ? "—" : title; // never empty: car rows reject blank titles
+    }
+
+    static String rowSubtitle(Ft8Message m) {
+        StringBuilder sb = new StringBuilder("SNR ").append(snrText(m));
+        if (m.maidenGrid != null && !m.maidenGrid.isEmpty()) {
+            sb.append("  ").append(m.maidenGrid);
+        }
+        return sb.toString();
+    }
+
+    static String snrText(Ft8Message m) {
+        return m.snr == Ft8Message.SNR_UNKNOWN ? "—" : String.valueOf(m.snr);
+    }
+
+    /** Template header: reflects whether we're transmitting and to whom. */
+    public static String headerTitle(boolean isTransmitting, String targetCallsign) {
+        if (isTransmitting) {
+            String t = targetCallsign == null ? "" : targetCallsign.trim();
+            return t.isEmpty() ? "TX" : ("TX → " + t);
+        }
+        return "Receiving";
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/car/DecodeListScreen.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/car/DecodeListScreen.java
@@ -1,0 +1,69 @@
+package com.k1af.ft8af.car;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.Screen;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.ListTemplate;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+
+import com.k1af.ft8af.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Android Auto decode list. A {@link Screen} is a {@code LifecycleOwner}, so it observes the
+ * existing decode / QSO LiveData (via {@link Ft8DataHolder}) on its own lifecycle —
+ * observers are auto-removed when the screen is popped, so the Activity is never leaked.
+ * Each update rebuilds the rows ({@link CarRowProjector}) and calls {@link #invalidate()} to
+ * re-render the template.
+ */
+public class DecodeListScreen extends Screen implements DefaultLifecycleObserver {
+    private List<CarRowProjector.CarRow> rows = new ArrayList<>();
+    private boolean transmitting = false;
+    private String targetCall = "";
+
+    public DecodeListScreen(@NonNull CarContext carContext) {
+        super(carContext);
+        getLifecycle().addObserver(this);
+    }
+
+    @Override
+    public void onCreate(@NonNull LifecycleOwner owner) {
+        Ft8DataHolder.decodes().observe(this, messages -> {
+            rows = CarRowProjector.project(messages, CarRowProjector.MAX_ROWS);
+            invalidate();
+        });
+        Ft8DataHolder.isTransmitting().observe(this, tx -> {
+            transmitting = tx != null && tx;
+            invalidate();
+        });
+        Ft8DataHolder.currentTarget().observe(this, target -> {
+            targetCall = target == null ? "" : target.callsign;
+            invalidate();
+        });
+    }
+
+    @NonNull
+    @Override
+    public Template onGetTemplate() {
+        ItemList.Builder list = new ItemList.Builder()
+                .setNoItemsMessage(getCarContext().getString(R.string.car_empty_decodes));
+        for (CarRowProjector.CarRow r : rows) {
+            list.addItem(new Row.Builder()
+                    .setTitle(r.title)
+                    .addText(r.subtitle)
+                    .build());
+        }
+        return new ListTemplate.Builder()
+                .setHeaderAction(Action.APP_ICON)
+                .setTitle(CarRowProjector.headerTitle(transmitting, targetCall))
+                .setSingleList(list.build())
+                .build();
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/car/Ft8CarAppService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/car/Ft8CarAppService.java
@@ -1,0 +1,32 @@
+package com.k1af.ft8af.car;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarAppService;
+import androidx.car.app.Session;
+import androidx.car.app.validation.HostValidator;
+
+/**
+ * Android Auto entry point. Templated Car App (androidx.car.app) that surfaces the live FT8
+ * decode list / QSO status on a connected head unit.
+ *
+ * <p>NOTE: an FT8 decoder fits none of Google's distributable Car App categories
+ * (navigation / parking / charging / POI), so this is <b>developer / Desktop-Head-Unit (DHU)
+ * only</b> — it is declared with the IOT category and uses
+ * {@link HostValidator#ALLOW_ALL_HOSTS_VALIDATOR}, which must be tightened before any
+ * production distribution.
+ */
+public class Ft8CarAppService extends CarAppService {
+
+    @NonNull
+    @Override
+    public HostValidator createHostValidator() {
+        // Dev/DHU only — accept any host. Replace with an allow-list before shipping.
+        return HostValidator.ALLOW_ALL_HOSTS_VALIDATOR;
+    }
+
+    @NonNull
+    @Override
+    public Session onCreateSession() {
+        return new Ft8Session();
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/car/Ft8DataHolder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/car/Ft8DataHolder.java
@@ -1,0 +1,43 @@
+package com.k1af.ft8af.car;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.k1af.ft8af.Ft8Message;
+import com.k1af.ft8af.MainViewModel;
+import com.k1af.ft8af.ft8transmit.TransmitCallsign;
+
+import java.util.ArrayList;
+
+/**
+ * Read-only bridge between the Android Auto car screens and the live decode / QSO state held
+ * in the {@link MainViewModel} singleton. The {@code CarAppService} has no
+ * {@code ViewModelStoreOwner}, so it can't call {@code getInstance(owner)}; this hands back
+ * the existing LiveData via {@link MainViewModel#peekInstance()} and falls back to empty
+ * streams when the Activity hasn't created the ViewModel yet. It never mutates RX state.
+ */
+public final class Ft8DataHolder {
+    private static final MutableLiveData<ArrayList<Ft8Message>> EMPTY_DECODES =
+            new MutableLiveData<>(new ArrayList<>());
+    private static final MutableLiveData<Boolean> EMPTY_TX = new MutableLiveData<>(false);
+    private static final MutableLiveData<TransmitCallsign> EMPTY_TARGET = new MutableLiveData<>(null);
+
+    private Ft8DataHolder() {}
+
+    public static LiveData<ArrayList<Ft8Message>> decodes() {
+        MainViewModel vm = MainViewModel.peekInstance();
+        return vm != null ? vm.mutableFt8MessageList : EMPTY_DECODES;
+    }
+
+    public static LiveData<Boolean> isTransmitting() {
+        MainViewModel vm = MainViewModel.peekInstance();
+        return (vm != null && vm.ft8TransmitSignal != null)
+                ? vm.ft8TransmitSignal.mutableIsTransmitting : EMPTY_TX;
+    }
+
+    public static LiveData<TransmitCallsign> currentTarget() {
+        MainViewModel vm = MainViewModel.peekInstance();
+        return (vm != null && vm.ft8TransmitSignal != null)
+                ? vm.ft8TransmitSignal.mutableToCallsign : EMPTY_TARGET;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/car/Ft8Session.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/car/Ft8Session.java
@@ -1,0 +1,16 @@
+package com.k1af.ft8af.car;
+
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.Screen;
+import androidx.car.app.Session;
+
+/** Android Auto session: opens the live decode list screen. */
+public class Ft8Session extends Session {
+    @NonNull
+    @Override
+    public Screen onCreateScreen(@NonNull Intent intent) {
+        return new DecodeListScreen(getCarContext());
+    }
+}

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -471,6 +471,7 @@
     <string name="settings_alert_new_dxcc_desc">Sound + vibrate + notify when an unworked DXCC entity calls CQ</string>
     <string name="settings_alert_new_state">New US State</string>
     <string name="settings_alert_new_state_desc">Sound + vibrate + notify when a station from an unworked US state calls CQ (state from grid)</string>
+    <string name="car_empty_decodes">Listening… no decodes yet</string>
 
     <!-- ===== Settings: logging &amp; awards ===== -->
     <string name="settings_save_swl_decodes">Save SWL Decodes</string>

--- a/ft8af/app/src/main/res/xml/automotive_app_desc.xml
+++ b/ft8af/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Declares this app to Android Auto as a templated (Car App Library) app. -->
+<automotiveApp>
+    <uses name="template" />
+</automotiveApp>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/car/CarRowProjectorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/car/CarRowProjectorTest.java
@@ -1,0 +1,93 @@
+package com.k1af.ft8af.car;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for {@link CarRowProjector}. Robolectric because constructing {@link Ft8Message}
+ * loads a class that references Play-Services types (LatLng fields), per the repo's testing
+ * convention.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CarRowProjectorTest {
+
+    private static Ft8Message msg(String from, String to, int snr, String grid) {
+        Ft8Message m = new Ft8Message(0);
+        m.callsignFrom = from;
+        m.callsignTo = to;
+        m.snr = snr;
+        m.maidenGrid = grid;
+        return m;
+    }
+
+    @Test
+    public void project_nullOrEmpty_returnsEmpty() {
+        assertThat(CarRowProjector.project(null, 6)).isEmpty();
+        assertThat(CarRowProjector.project(new ArrayList<>(), 6)).isEmpty();
+    }
+
+    @Test
+    public void project_capsToMaxRows_newestFirst() {
+        List<Ft8Message> msgs = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            msgs.add(msg("CALL" + i, "CQ", -10, null));
+        }
+        List<CarRowProjector.CarRow> rows = CarRowProjector.project(msgs, CarRowProjector.MAX_ROWS);
+        assertThat(rows).hasSize(6);
+        // newest (last appended, CALL7) first
+        assertThat(rows.get(0).title).isEqualTo("CQ CALL7");
+        assertThat(rows.get(5).title).isEqualTo("CQ CALL2");
+    }
+
+    @Test
+    public void project_skipsNullElements() {
+        List<Ft8Message> msgs = new ArrayList<>();
+        msgs.add(msg("K1AF", "CQ", -5, null));
+        msgs.add(null);
+        assertThat(CarRowProjector.project(msgs, 6)).hasSize(1);
+    }
+
+    @Test
+    public void rowTitle_cqBroadcast() {
+        assertThat(CarRowProjector.rowTitle(msg("W5XYZ", "CQ", -3, "EM10"))).isEqualTo("CQ W5XYZ");
+    }
+
+    @Test
+    public void rowTitle_directedExchange() {
+        assertThat(CarRowProjector.rowTitle(msg("W5XYZ", "K1AF", -3, null)))
+                .isEqualTo("W5XYZ → K1AF");
+    }
+
+    @Test
+    public void rowTitle_neverEmpty() {
+        assertThat(CarRowProjector.rowTitle(msg(null, null, -3, null))).isEqualTo("—");
+    }
+
+    @Test
+    public void snrText_unknownRendersDash() {
+        assertThat(CarRowProjector.snrText(msg("A", "CQ", Ft8Message.SNR_UNKNOWN, null)))
+                .isEqualTo("—");
+        assertThat(CarRowProjector.snrText(msg("A", "CQ", -12, null))).isEqualTo("-12");
+    }
+
+    @Test
+    public void rowSubtitle_includesGridWhenPresent() {
+        assertThat(CarRowProjector.rowSubtitle(msg("A", "CQ", -7, "FN20"))).isEqualTo("SNR -7  FN20");
+        assertThat(CarRowProjector.rowSubtitle(msg("A", "CQ", -7, null))).isEqualTo("SNR -7");
+    }
+
+    @Test
+    public void headerTitle_reflectsTxRxState() {
+        assertThat(CarRowProjector.headerTitle(false, "K1AF")).isEqualTo("Receiving");
+        assertThat(CarRowProjector.headerTitle(true, "K1AF")).isEqualTo("TX → K1AF");
+        assertThat(CarRowProjector.headerTitle(true, null)).isEqualTo("TX");
+    }
+}


### PR DESCRIPTION
## Summary

Android Auto support via a **Car App Library** (`androidx.car.app`) surface that shows the **live FT8 decode list + QSO status** on a connected head unit.

### Scope caveat (as discussed)
An FT8 decoder fits **none** of Google's Play-distributable Car App categories (navigation / parking / charging / POI). So this is declared with the **IOT** category and uses `ALLOW_ALL_HOSTS_VALIDATOR` — it runs in the **Desktop Head Unit (DHU)** for development but **won't pass production review as-is**. This was the agreed trade-off for "full templated car app."

## Design — reads only, zero RX-path risk

- `Ft8CarAppService` → `Ft8Session` → `DecodeListScreen` render a `ListTemplate`.
- A `Screen` is a `LifecycleOwner`, so it observes the **existing** decode/QSO `LiveData` on its own lifecycle (observers auto-removed when the screen is popped — no Activity leak).
- The `CarAppService` has no `ViewModelStoreOwner`, so it reads via a new **`MainViewModel.peekInstance()`** (owner-less, nullable, never creates an instance) wrapped in **`Ft8DataHolder`**, which falls back to empty streams when the Activity hasn't created the ViewModel yet. The car screen **never mutates** RX state.
- The decode→row projection (newest-first, capped to 6, SNR/grid formatting, CQ vs directed title, TX/RX header) is extracted into the pure **`CarRowProjector`**.

## Manifest / deps

- `CarAppService` with the `androidx.car.app.CarAppService` action + `category.IOT`, `minCarApiLevel` + `com.google.android.gms.car.application` meta-data, `automotive_app_desc.xml` (`<uses name="template"/>`), optional automotive `uses-feature`.
- Adds `androidx.car.app:app:1.4.0`.

## Tests

- `CarRowProjectorTest` (Robolectric — constructing `Ft8Message` loads a Play-Services-referencing class) covers: null/empty input, cap-to-6 + newest-first, null-element skip, CQ vs directed title, never-empty title, SNR_UNKNOWN → "—", grid formatting, TX/RX header.
- Full `testDebugUnitTest` + `assembleDebug` (manifest merge + packaging) green locally.

## Verify

Connect the **Desktop Head Unit (DHU)** against a debug build; the decode list should populate and the header should reflect TX/RX. (Most useful with #309's foreground service so data stays alive when the phone screen is off.)

Branches off `dev`; independent at the code level from #308 / #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)