### PR TITLE
feat: CQ options, Field Day mode, and POTA park picker

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -339,6 +339,12 @@ public class GeneralVariables {
     public static String myRigName = "";  // Set by MainViewModel.connectRig(); used in PSKReporter software string
     public static int myPowerWatts = 0;    // 0 = not set, displays as "--"
     public static String toModifier = "";//Call modifier
+
+    // Field Day mode settings (persisted via writeConfig)
+    public static boolean fieldDayMode = false;
+    public static String fieldDayClass = "A";     // A through F
+    public static int fieldDayNumTx = 1;          // 1-32
+    public static String fieldDaySection = "";    // ARRL/RAC section code
     private static float baseFrequency = 1000;//Audio frequency
 
     public static boolean simpleCallItemMode = false;//Compact message mode

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -343,7 +343,7 @@ public class GeneralVariables {
     // Field Day mode settings (persisted via writeConfig)
     public static boolean fieldDayMode = false;
     public static String fieldDayClass = "A";     // A through F
-    public static int fieldDayNumTx = 1;          // 1-32
+    public static int fieldDayNumTx = 1;          // 1-16
     public static String fieldDaySection = "";    // ARRL/RAC section code
     private static float baseFrequency = 1000;//Audio frequency
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2334,6 +2334,27 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("toModifier")) {
                     GeneralVariables.toModifier = result;
                 }
+                if (name.equalsIgnoreCase("fieldDayMode")) {
+                    GeneralVariables.fieldDayMode = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("fieldDayClass")) {
+                    if (result != null && result.length() > 0) {
+                        GeneralVariables.fieldDayClass = result;
+                    }
+                }
+                if (name.equalsIgnoreCase("fieldDayNumTx")) {
+                    try {
+                        int v = result.equals("") ? 1 : Integer.parseInt(result);
+                        GeneralVariables.fieldDayNumTx = Math.max(1, Math.min(16, v));
+                    } catch (NumberFormatException e) {
+                        GeneralVariables.fieldDayNumTx = 1;
+                    }
+                }
+                if (name.equalsIgnoreCase("fieldDaySection")) {
+                    if (result != null) {
+                        GeneralVariables.fieldDaySection = result;
+                    }
+                }
                 if (name.equalsIgnoreCase("antenna")) {
                     GeneralVariables.myAntenna = result;
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
@@ -424,7 +424,7 @@ public class FT8Package {
      *
      * @param msg the Ft8Message with FD fields populated:
      *            callsignTo, callsignFrom, r_flag (0 or 1),
-     *            eu_serial (transmitter count 1-32), arrl_class ("A"-"F"),
+     *            eu_serial (transmitter count 1-16), arrl_class ("A"-"F"),
      *            arrl_rac (section code), n3 (3 or 4)
      * @return 10-byte packed payload (77 bits, padded to byte boundary)
      */
@@ -436,8 +436,8 @@ public class FT8Package {
             toCall = toCall + " " + msg.modifier;
         }
 
-        long n28a = pack_c28(toCall) & 0x0FFFFFFFFL;
-        long n28b = pack_c28(fromCall) & 0x0FFFFFFFFL;
+        long n28a = pack_c28(toCall) & 0x0fffffffL;
+        long n28b = pack_c28(fromCall) & 0x0fffffffL;
         int R1 = msg.r_flag & 1;
         int n4 = ((msg.eu_serial - 1) & 0x0F);  // 1-16 → 0-15 (clamp to 4 bits)
         int k3 = 0;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
@@ -384,6 +384,114 @@ public class FT8Package {
         return c6;
     }
 
+    /**
+     * Canonical 84-entry ARRL/RAC section table for Field Day messages,
+     * matching the order used by WSJT-X (packjt.f90).
+     */
+    public static final String[] ARRL_SECTIONS = {
+        "CT","EMA","ME","NH","RI","VT","WMA",
+        "ENY","NLI","NNJ","NNY","SNJ","WNY",
+        "DE","EPA","MDC","WPA",
+        "AL","GA","KY","NC","NFL","SC","SFL","WCF","TN","VA","PR","VI",
+        "AR","LA","MS","NM","NTX","OK","STX","WTX",
+        "EB","LAX","ORG","SB","SCV","SDG","SF","SJV","SV",
+        "AZ","EWA","ID","MT","NV","OR","UT","WWA","WY","AK",
+        "MI","OH","WV",
+        "IL","IN","WI",
+        "CO","IA","KS","MN","MO","NE","ND","SD",
+        "HI","PAC",
+        "AB","BC","GH","MAR","MB","NL","NT","ONE","ONN","ONS","PE","QC","SK","TER"
+    };
+
+    /**
+     * Look up the 0-based index of an ARRL/RAC section code.
+     * @return 0-83 on match, -1 if unknown
+     */
+    public static int sectionIndex(String section) {
+        for (int i = 0; i < ARRL_SECTIONS.length; i++) {
+            if (ARRL_SECTIONS[i].equals(section)) return i;
+        }
+        return -1;
+    }
+
+    /**
+     * Generate a 77-bit data packet for Field Day messages (i3=0, n3=3 or n3=4).
+     * Bit layout: c28 c28 R1 n4 k3 S7 n3 i3 = 77 bits packed into 10 bytes.
+     *
+     * Unlike i1 messages, the two c28 fields are directly adjacent (no r1/p1
+     * suffix bit between them). R1 sits at bit 56, followed by the FD-specific
+     * payload fields.
+     *
+     * @param msg the Ft8Message with FD fields populated:
+     *            callsignTo, callsignFrom, r_flag (0 or 1),
+     *            eu_serial (transmitter count 1-32), arrl_class ("A"-"F"),
+     *            arrl_rac (section code), n3 (3 or 4)
+     * @return 10-byte packed payload (77 bits, padded to byte boundary)
+     */
+    public static byte[] generatePack77_fd(Ft8Message msg) {
+        String toCall = msg.callsignTo.replace("<", "").replace(">", "");
+        String fromCall = msg.callsignFrom.replace("<", "").replace(">", "");
+
+        if (msg.checkIsCQ() && msg.modifier != null && msg.modifier.length() > 0) {
+            toCall = toCall + " " + msg.modifier;
+        }
+
+        long n28a = pack_c28(toCall) & 0x0FFFFFFFFL;
+        long n28b = pack_c28(fromCall) & 0x0FFFFFFFFL;
+        int R1 = msg.r_flag & 1;
+        int n4 = ((msg.eu_serial - 1) & 0x0F);  // 1-16 → 0-15 (clamp to 4 bits)
+        int k3 = 0;
+        if (msg.arrl_class != null && msg.arrl_class.length() > 0) {
+            k3 = (msg.arrl_class.charAt(0) - 'A') & 0x07;  // A=0..F=5
+        }
+        int S7 = 0;
+        if (msg.arrl_rac != null) {
+            int idx = sectionIndex(msg.arrl_rac);
+            S7 = (idx >= 0 ? idx : 0) & 0x7F;
+        }
+        int n3 = msg.n3 & 0x07;  // 3 or 4
+        int i3 = 0;              // Field Day is always i3=0
+
+        // Pack 77 bits into 10 bytes:
+        // bits  0-27:  n28a (c28 for callsignTo)
+        // bits 28-55:  n28b (c28 for callsignFrom)
+        // bit  56:     R1
+        // bits 57-60:  n4   (4 bits)
+        // bits 61-63:  k3   (3 bits)
+        // bits 64-70:  S7   (7 bits)
+        // bits 71-73:  n3   (3 bits)
+        // bits 74-76:  i3   (3 bits)
+        // bits 77-79:  padding (zeros)
+
+        // Assemble as a single 80-bit value using longs for the upper and lower halves.
+        // Upper 48 bits = n28a(28) + top 20 of n28b(28)
+        // Lower 32 bits = bottom 8 of n28b + R1(1) + n4(4) + k3(3) + S7(7) + n3(3) + i3(3) + pad(3)
+
+        byte[] data = new byte[10];
+
+        // Byte 0-3: n28a (28 bits) + top 4 bits of n28b
+        data[0] = (byte) ((n28a >> 20) & 0xFF);
+        data[1] = (byte) ((n28a >> 12) & 0xFF);
+        data[2] = (byte) ((n28a >> 4) & 0xFF);
+        data[3] = (byte) (((n28a & 0x0F) << 4) | ((n28b >> 24) & 0x0F));
+
+        // Byte 4-6: middle 24 bits of n28b
+        data[4] = (byte) ((n28b >> 16) & 0xFF);
+        data[5] = (byte) ((n28b >> 8) & 0xFF);
+        data[6] = (byte) (n28b & 0xFF);
+
+        // Byte 7: R1(1) + n4(4) + k3(3) = 8 bits
+        data[7] = (byte) ((R1 << 7) | (n4 << 3) | k3);
+
+        // Byte 8: S7(7) + n3 top bit(1) = 8 bits
+        data[8] = (byte) ((S7 << 1) | ((n3 >> 2) & 0x01));
+
+        // Byte 9: n3 bottom 2 bits(2) + i3(3) + padding(3) = 8 bits
+        data[9] = (byte) (((n3 & 0x03) << 6) | (i3 << 3));
+
+        return data;
+    }
+
     public static native int getHash12(String callsign);
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
@@ -385,27 +385,24 @@ public class FT8Package {
     }
 
     /**
-     * Canonical 84-entry ARRL/RAC section table for Field Day messages,
-     * matching the order used by WSJT-X (packjt.f90).
+     * 86-entry ARRL/RAC section table for Field Day messages,
+     * matching the exact order used by WSJT-X (packjt77.f90 csec array).
      */
     public static final String[] ARRL_SECTIONS = {
-        "CT","EMA","ME","NH","RI","VT","WMA",
-        "ENY","NLI","NNJ","NNY","SNJ","WNY",
-        "DE","EPA","MDC","WPA",
-        "AL","GA","KY","NC","NFL","SC","SFL","WCF","TN","VA","PR","VI",
-        "AR","LA","MS","NM","NTX","OK","STX","WTX",
-        "EB","LAX","ORG","SB","SCV","SDG","SF","SJV","SV",
-        "AZ","EWA","ID","MT","NV","OR","UT","WWA","WY","AK",
-        "MI","OH","WV",
-        "IL","IN","WI",
-        "CO","IA","KS","MN","MO","NE","ND","SD",
-        "HI","PAC",
-        "AB","BC","GH","MAR","MB","NL","NT","ONE","ONN","ONS","PE","QC","SK","TER"
+        "AB","AK","AL","AR","AZ","BC","CO","CT","DE","EB",
+        "EMA","ENY","EPA","EWA","GA","GH","IA","ID","IL","IN",
+        "KS","KY","LA","LAX","NS","MB","MDC","ME","MI","MN",
+        "MO","MS","MT","NC","ND","NE","NFL","NH","NL","NLI",
+        "NM","NNJ","NNY","TER","NTX","NV","OH","OK","ONE","ONN",
+        "ONS","OR","ORG","PAC","PR","QC","RI","SB","SC","SCV",
+        "SD","SDG","SF","SFL","SJV","SK","SNJ","STX","SV","TN",
+        "UT","VA","VI","VT","WCF","WI","WMA","WNY","WPA","WTX",
+        "WV","WWA","WY","DX","PE","NB"
     };
 
     /**
      * Look up the 0-based index of an ARRL/RAC section code.
-     * @return 0-83 on match, -1 if unknown
+     * @return 0-85 on match, -1 if unknown
      */
     public static int sectionIndex(String section) {
         for (int i = 0; i < ARRL_SECTIONS.length; i++) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -346,6 +346,24 @@ public class FT8TransmitSignal {
     }
 
     /**
+     * Build an Ft8Message for a Field Day exchange (i3=0, n3=3 or 4).
+     *
+     * @param toCall  the remote station's callsign
+     * @param rFlag   0 for initial exchange, 1 for R+exchange (acknowledging receipt)
+     * @return fully populated FD message ready for packing
+     */
+    static Ft8Message buildFieldDayMessage(String toCall, int rFlag) {
+        Ft8Message fdMsg = new Ft8Message(0, rFlag == 0 ? 3 : 4,
+                toCall, GeneralVariables.myCallsign, "");
+        fdMsg.r_flag = rFlag;
+        fdMsg.eu_serial = GeneralVariables.fieldDayNumTx;
+        fdMsg.arrl_class = GeneralVariables.fieldDayClass;
+        fdMsg.arrl_rac = GeneralVariables.fieldDaySection;
+        fdMsg.utcTime = UtcTimer.getSystemTime();
+        return fdMsg;
+    }
+
+    /**
      * Generate the corresponding message based on the message number.
      *
      * @param order message number
@@ -353,33 +371,48 @@ public class FT8TransmitSignal {
      */
     public Ft8Message getFunctionCommand(int order) {
         switch (order) {
-            // transmit mode 1: BG7YOY BG7YOZ OL50
+            // transmit mode 1: BG7YOY BG7YOZ OL50  (or FD exchange)
             case 1:
                 resetTargetReport();// reset the signal report record for the other party to -100
+                if (GeneralVariables.fieldDayMode) {
+                    return buildFieldDayMessage(toCallsign.callsign, 0);
+                }
                 return new Ft8Message(1, 0, toCallsign.callsign, GeneralVariables.myCallsign
                         , GeneralVariables.getMyMaidenhead4Grid());
-            // transmit mode 2: BG7YOY BG7YOZ -10
+            // transmit mode 2: BG7YOY BG7YOZ -10  (or FD exchange)
             case 2:
+                if (GeneralVariables.fieldDayMode) {
+                    return buildFieldDayMessage(toCallsign.callsign, 0);
+                }
                 sentTargetReport = toCallsign.snr;
 
                 return new Ft8Message(1, 0, toCallsign.callsign
                         , GeneralVariables.myCallsign, toCallsign.getSnr());
-            // transmit mode 3: BG7YOY BG7YOZ R-10
+            // transmit mode 3: BG7YOY BG7YOZ R-10  (or FD R+exchange)
             case 3:
+                if (GeneralVariables.fieldDayMode) {
+                    return buildFieldDayMessage(toCallsign.callsign, 1);
+                }
                 sentTargetReport = toCallsign.snr;
                 return new Ft8Message(1, 0, toCallsign.callsign
                         , GeneralVariables.myCallsign, "R" + toCallsign.getSnr());
-            // transmit mode 4: BG7YOY BG7YOZ RRR
+            // transmit mode 4: BG7YOY BG7YOZ RRR — unchanged for FD (standard)
             case 4:
                 return new Ft8Message(1, 0, toCallsign.callsign
                         , GeneralVariables.myCallsign, "RR73");
-            // transmit mode 5: BG7YOY BG7YOZ 73
+            // transmit mode 5: BG7YOY BG7YOZ 73 — unchanged for FD (standard)
             case 5:
                 return new Ft8Message(1, 0, toCallsign.callsign
                         , GeneralVariables.myCallsign, "73");
-            // transmit mode 6: CQ BG7YOZ OL50
+            // transmit mode 6: CQ BG7YOZ OL50  (or CQ FD)
             case 6:
                 resetTargetReport();// reset sent and received signal report records to -100
+                if (GeneralVariables.fieldDayMode) {
+                    Ft8Message fdCq = new Ft8Message(1, 0, "CQ", GeneralVariables.myCallsign
+                            , GeneralVariables.getMyMaidenhead4Grid());
+                    fdCq.modifier = "FD";
+                    return fdCq;
+                }
                 Ft8Message msg = new Ft8Message(1, 0, "CQ", GeneralVariables.myCallsign
                         , GeneralVariables.getMyMaidenhead4Grid());
                 msg.modifier = GeneralVariables.toModifier;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
@@ -162,7 +162,7 @@ public class GenerateFT8 {
         // override logic below — they use their own dedicated packer.
         boolean isFieldDay = (msg.i3 == 0 && (msg.n3 == 3 || msg.n3 == 4));
 
-        if (msg.i3 != 0 && !isFieldDay) {// currently only supports i3=1, i3=2, i3=4, i3=0 && n3=0
+        if (msg.i3 != 0 && !isFieldDay) {// supports i3=1, i3=2, i3=4, i3=0&&n3=0, i3=0&&n3=3/4 (FD)
             if (!checkIsStandardCallsign(msg.callsignFrom)
                     && (!checkIsReport(msg.extraInfo) || msg.checkIsCQ())) {
                 msg.i3 = 4;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
@@ -158,7 +158,11 @@ public class GenerateFT8 {
 
 
 
-        if (msg.i3 != 0) {// currently only supports i3=1, i3=2, i3=4, i3=0 && n3=0
+        // Field Day messages (i3=0, n3=3 or n3=4) skip the callsign-format
+        // override logic below — they use their own dedicated packer.
+        boolean isFieldDay = (msg.i3 == 0 && (msg.n3 == 3 || msg.n3 == 4));
+
+        if (msg.i3 != 0 && !isFieldDay) {// currently only supports i3=1, i3=2, i3=4, i3=0 && n3=0
             if (!checkIsStandardCallsign(msg.callsignFrom)
                     && (!checkIsReport(msg.extraInfo) || msg.checkIsCQ())) {
                 msg.i3 = 4;
@@ -175,6 +179,8 @@ public class GenerateFT8 {
             packed = FT8Package.generatePack77_i1(msg);
         } else if (msg.i3 == 4) {// non-standard callsign
             packed = FT8Package.generatePack77_i4(msg);
+        } else if (isFieldDay) {
+            packed = FT8Package.generatePack77_fd(msg);
         } else {
             packFreeTextTo77(msg.getMessageText(), packed);
         }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -43,6 +43,7 @@ import com.k1af.ft8af.rigs.BaseRigOperation
 import radio.ks3ckc.ft8af.theme.BgApp
 import radio.ks3ckc.ft8af.ui.components.ActiveQsoPanel
 import radio.ks3ckc.ft8af.ui.components.shouldShowCatChip
+import radio.ks3ckc.ft8af.ui.components.CqOptionsSheet
 import radio.ks3ckc.ft8af.ui.components.FT8AFTab
 import radio.ks3ckc.ft8af.ui.components.FrequencyPickerSheet
 import radio.ks3ckc.ft8af.ui.components.HoundSetupSheet
@@ -142,6 +143,16 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
     // collects the Fox call + call frequency before starting.
     var dxEnabled by remember { mutableStateOf(GeneralVariables.houndMode) }
     var showHoundSetup by remember { mutableStateOf(false) }
+
+    // CQ Options sheet state — long-press the CQ button to open.
+    var showCqOptions by remember { mutableStateOf(false) }
+    var cqModifier by remember { mutableStateOf(GeneralVariables.toModifier ?: "") }
+    var isFreeTextMode by remember { mutableStateOf(false) }
+    var freeTextMessage by remember { mutableStateOf("") }
+    var fieldDayEnabled by remember { mutableStateOf(GeneralVariables.fieldDayMode) }
+    var fieldDayClass by remember { mutableStateOf(GeneralVariables.fieldDayClass ?: "A") }
+    var fieldDayNumTx by remember { mutableIntStateOf(GeneralVariables.fieldDayNumTx.coerceIn(1, 32)) }
+    var fieldDaySection by remember { mutableStateOf(GeneralVariables.fieldDaySection ?: "") }
 
     // Frequency picker sheet state
     var showFrequencyPicker by rememberSaveable { mutableStateOf(false) }
@@ -347,6 +358,9 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 expanded = qsoPanelExpanded,
                 txVolume = txVolume,
                 showVolumeSlider = showVolumeSlider,
+                cqModifier = cqModifier,
+                isFreeTextMode = isFreeTextMode,
+                fieldDayEnabled = fieldDayEnabled,
                 onVolumeChange = { newVolume ->
                     txVolume = newVolume
                     GeneralVariables.volumePercent = newVolume / 100f
@@ -360,6 +374,13 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {
                         Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()
                     } else {
+                        // Apply current CQ mode before activating
+                        if (isFreeTextMode && freeTextMessage.isNotBlank()) {
+                            mainViewModel.ft8TransmitSignal.setFreeText(freeTextMessage)
+                            mainViewModel.ft8TransmitSignal.setTransmitFreeText(true)
+                        } else {
+                            mainViewModel.ft8TransmitSignal.setTransmitFreeText(false)
+                        }
                         mainViewModel.ft8TransmitSignal.userResetToCQ()
                         mainViewModel.ft8TransmitSignal.setActivated(true)
                         GeneralVariables.resetLaunchSupervision()
@@ -381,7 +402,11 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                             mainViewModel.databaseOpr.writeConfig("autoFollowCQ", "0", null)
                         }
                     }
+                    // Clear free text mode on stop
+                    isFreeTextMode = false
+                    mainViewModel.ft8TransmitSignal.setTransmitFreeText(false)
                 },
+                onLongPressCQ = { showCqOptions = true },
                 onToggleDx = {
                     if (dxEnabled || GeneralVariables.houndMode) {
                         mainViewModel.stopHoundMode()
@@ -497,6 +522,91 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                     dxEnabled = true
                     huntEnabled = false
                     showHoundSetup = false
+                }
+            },
+        )
+
+        // CQ Options — modifier presets, free text, and Field Day configuration.
+        CqOptionsSheet(
+            visible = showCqOptions,
+            currentModifier = cqModifier,
+            isFreeTextMode = isFreeTextMode,
+            freeText = freeTextMessage,
+            fieldDayEnabled = fieldDayEnabled,
+            fieldDayClass = fieldDayClass,
+            fieldDayNumTx = fieldDayNumTx,
+            fieldDaySection = fieldDaySection,
+            onDismiss = { showCqOptions = false },
+            onSelectPreset = { preset ->
+                cqModifier = preset
+                isFreeTextMode = false
+                freeTextMessage = ""
+                fieldDayEnabled = false
+                GeneralVariables.toModifier = preset
+                GeneralVariables.fieldDayMode = false
+                mainViewModel.databaseOpr.writeConfig("toModifier", preset, null)
+                mainViewModel.databaseOpr.writeConfig("fieldDayMode", "0", null)
+            },
+            onCustomModifier = { mod ->
+                cqModifier = mod
+                isFreeTextMode = false
+                freeTextMessage = ""
+                fieldDayEnabled = false
+                GeneralVariables.toModifier = mod
+                GeneralVariables.fieldDayMode = false
+                mainViewModel.databaseOpr.writeConfig("toModifier", mod, null)
+                mainViewModel.databaseOpr.writeConfig("fieldDayMode", "0", null)
+            },
+            onFreeTextChange = { text ->
+                freeTextMessage = text
+                isFreeTextMode = text.isNotBlank()
+                if (text.isNotBlank()) {
+                    fieldDayEnabled = false
+                    cqModifier = ""
+                    GeneralVariables.fieldDayMode = false
+                    GeneralVariables.toModifier = ""
+                }
+            },
+            onFieldDayToggle = { enabled ->
+                fieldDayEnabled = enabled
+                GeneralVariables.fieldDayMode = enabled
+                mainViewModel.databaseOpr.writeConfig("fieldDayMode", if (enabled) "1" else "0", null)
+                if (enabled) {
+                    isFreeTextMode = false
+                    freeTextMessage = ""
+                    cqModifier = "FD"
+                    GeneralVariables.toModifier = "FD"
+                    mainViewModel.databaseOpr.writeConfig("toModifier", "FD", null)
+                }
+            },
+            onFieldDayClassChange = { cls ->
+                fieldDayClass = cls
+                GeneralVariables.fieldDayClass = cls
+                mainViewModel.databaseOpr.writeConfig("fieldDayClass", cls, null)
+            },
+            onFieldDayNumTxChange = { num ->
+                fieldDayNumTx = num
+                GeneralVariables.fieldDayNumTx = num
+                mainViewModel.databaseOpr.writeConfig("fieldDayNumTx", num.toString(), null)
+            },
+            onFieldDaySectionChange = { section ->
+                fieldDaySection = section
+                GeneralVariables.fieldDaySection = section
+                mainViewModel.databaseOpr.writeConfig("fieldDaySection", section, null)
+            },
+            onCallCQ = {
+                if (GeneralVariables.myCallsign.isNullOrEmpty()) {
+                    Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()
+                } else {
+                    if (isFreeTextMode && freeTextMessage.isNotBlank()) {
+                        mainViewModel.ft8TransmitSignal.setFreeText(freeTextMessage)
+                        mainViewModel.ft8TransmitSignal.setTransmitFreeText(true)
+                    } else {
+                        mainViewModel.ft8TransmitSignal.setTransmitFreeText(false)
+                    }
+                    mainViewModel.ft8TransmitSignal.userResetToCQ()
+                    mainViewModel.ft8TransmitSignal.setActivated(true)
+                    GeneralVariables.resetLaunchSupervision()
                 }
             },
         )

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -151,7 +151,7 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
     var freeTextMessage by remember { mutableStateOf("") }
     var fieldDayEnabled by remember { mutableStateOf(GeneralVariables.fieldDayMode) }
     var fieldDayClass by remember { mutableStateOf(GeneralVariables.fieldDayClass ?: "A") }
-    var fieldDayNumTx by remember { mutableIntStateOf(GeneralVariables.fieldDayNumTx.coerceIn(1, 32)) }
+    var fieldDayNumTx by remember { mutableIntStateOf(GeneralVariables.fieldDayNumTx.coerceIn(1, 16)) }
     var fieldDaySection by remember { mutableStateOf(GeneralVariables.fieldDaySection ?: "") }
 
     // Frequency picker sheet state
@@ -402,9 +402,18 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                             mainViewModel.databaseOpr.writeConfig("autoFollowCQ", "0", null)
                         }
                     }
-                    // Clear free text mode on stop
+                    // Clear free text and Field Day mode on stop
                     isFreeTextMode = false
+                    freeTextMessage = ""
                     mainViewModel.ft8TransmitSignal.setTransmitFreeText(false)
+                    if (fieldDayEnabled) {
+                        fieldDayEnabled = false
+                        GeneralVariables.fieldDayMode = false
+                        mainViewModel.databaseOpr.writeConfig("fieldDayMode", "0", null)
+                        cqModifier = ""
+                        GeneralVariables.toModifier = ""
+                        mainViewModel.databaseOpr.writeConfig("toModifier", "", null)
+                    }
                 },
                 onLongPressCQ = { showCqOptions = true },
                 onToggleDx = {
@@ -577,6 +586,10 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                     cqModifier = "FD"
                     GeneralVariables.toModifier = "FD"
                     mainViewModel.databaseOpr.writeConfig("toModifier", "FD", null)
+                } else {
+                    cqModifier = ""
+                    GeneralVariables.toModifier = ""
+                    mainViewModel.databaseOpr.writeConfig("toModifier", "", null)
                 }
             },
             onFieldDayClassChange = { cls ->
@@ -585,9 +598,10 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 mainViewModel.databaseOpr.writeConfig("fieldDayClass", cls, null)
             },
             onFieldDayNumTxChange = { num ->
-                fieldDayNumTx = num
-                GeneralVariables.fieldDayNumTx = num
-                mainViewModel.databaseOpr.writeConfig("fieldDayNumTx", num.toString(), null)
+                val clamped = num.coerceIn(1, 16)
+                fieldDayNumTx = clamped
+                GeneralVariables.fieldDayNumTx = clamped
+                mainViewModel.databaseOpr.writeConfig("fieldDayNumTx", clamped.toString(), null)
             },
             onFieldDaySectionChange = { section ->
                 fieldDaySection = section

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -44,6 +44,8 @@ import radio.ks3ckc.ft8af.theme.BgApp
 import radio.ks3ckc.ft8af.ui.components.ActiveQsoPanel
 import radio.ks3ckc.ft8af.ui.components.shouldShowCatChip
 import radio.ks3ckc.ft8af.ui.components.CqOptionsSheet
+import radio.ks3ckc.ft8af.ui.components.canEnableFieldDay
+import radio.ks3ckc.ft8af.ui.components.shouldPersistSection
 import radio.ks3ckc.ft8af.ui.components.FT8AFTab
 import radio.ks3ckc.ft8af.ui.components.FrequencyPickerSheet
 import radio.ks3ckc.ft8af.ui.components.HoundSetupSheet
@@ -577,19 +579,29 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 }
             },
             onFieldDayToggle = { enabled ->
-                fieldDayEnabled = enabled
-                GeneralVariables.fieldDayMode = enabled
-                mainViewModel.databaseOpr.writeConfig("fieldDayMode", if (enabled) "1" else "0", null)
-                if (enabled) {
-                    isFreeTextMode = false
-                    freeTextMessage = ""
-                    cqModifier = "FD"
-                    GeneralVariables.toModifier = "FD"
-                    mainViewModel.databaseOpr.writeConfig("toModifier", "FD", null)
+                if (enabled && !canEnableFieldDay(fieldDaySection)) {
+                    // Refuse to enable FD without a valid section — otherwise the
+                    // packer would silently transmit "AB" (section index 0).
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.cq_fd_section_required),
+                        Toast.LENGTH_SHORT,
+                    ).show()
                 } else {
-                    cqModifier = ""
-                    GeneralVariables.toModifier = ""
-                    mainViewModel.databaseOpr.writeConfig("toModifier", "", null)
+                    fieldDayEnabled = enabled
+                    GeneralVariables.fieldDayMode = enabled
+                    mainViewModel.databaseOpr.writeConfig("fieldDayMode", if (enabled) "1" else "0", null)
+                    if (enabled) {
+                        isFreeTextMode = false
+                        freeTextMessage = ""
+                        cqModifier = "FD"
+                        GeneralVariables.toModifier = "FD"
+                        mainViewModel.databaseOpr.writeConfig("toModifier", "FD", null)
+                    } else {
+                        cqModifier = ""
+                        GeneralVariables.toModifier = ""
+                        mainViewModel.databaseOpr.writeConfig("toModifier", "", null)
+                    }
                 }
             },
             onFieldDayClassChange = { cls ->
@@ -606,7 +618,11 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
             onFieldDaySectionChange = { section ->
                 fieldDaySection = section
                 GeneralVariables.fieldDaySection = section
-                mainViewModel.databaseOpr.writeConfig("fieldDaySection", section, null)
+                // Only persist a recognized section (or an explicit clear while FD
+                // is off) so a blank/unknown value can't restore as "AB" later.
+                if (shouldPersistSection(section, fieldDayEnabled)) {
+                    mainViewModel.databaseOpr.writeConfig("fieldDaySection", section, null)
+                }
             },
             onCallCQ = {
                 if (GeneralVariables.myCallsign.isNullOrEmpty()) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaActivationDao.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaActivationDao.kt
@@ -75,14 +75,9 @@ internal object PotaActivationDao {
         cursor.use { c ->
             while (c.moveToNext()) rawRefs.add(c.getString(0) ?: "")
         }
-        val seen = LinkedHashSet<String>()
-        for (raw in rawRefs) {
-            for (part in raw.split(",")) {
-                val ref = part.trim()
-                if (ref.isNotEmpty()) seen.add(ref)
-            }
-        }
-        return seen.toList()
+        // Reuse the shared, unit-tested splitter/deduplicator so the parsing
+        // rules stay consistent with the rest of the park-ref handling.
+        return deduplicateRefs(rawRefs)
     }
 
     fun history(limit: Int = 50): List<PotaActivation> {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaActivationDao.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaActivationDao.kt
@@ -61,6 +61,30 @@ internal object PotaActivationDao {
         return cursor.use { c -> if (c.moveToFirst()) c.toActivation() else null }
     }
 
+    /**
+     * Return distinct park references from past activations, most recent first.
+     * Comma-separated refs within a single activation are split and individually
+     * deduplicated while preserving most-recent-first order.
+     */
+    fun recentParkRefs(limit: Int = 20): List<String> {
+        val cursor = db().rawQuery(
+            "SELECT park_ref FROM pota_activation ORDER BY started_at DESC LIMIT ?",
+            arrayOf(limit.toString()),
+        )
+        val rawRefs = mutableListOf<String>()
+        cursor.use { c ->
+            while (c.moveToNext()) rawRefs.add(c.getString(0) ?: "")
+        }
+        val seen = LinkedHashSet<String>()
+        for (raw in rawRefs) {
+            for (part in raw.split(",")) {
+                val ref = part.trim()
+                if (ref.isNotEmpty()) seen.add(ref)
+            }
+        }
+        return seen.toList()
+    }
+
     fun history(limit: Int = 50): List<PotaActivation> {
         val cursor = db().rawQuery(
             "SELECT * FROM pota_activation ORDER BY started_at DESC LIMIT ?",

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaClient.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
+import radio.ks3ckc.ft8af.pota.model.PotaLocation
 import radio.ks3ckc.ft8af.pota.model.PotaPark
 import radio.ks3ckc.ft8af.pota.model.PotaSpot
 import java.io.File
@@ -108,12 +109,78 @@ object PotaClient {
                 reference = ref,
                 name = o.optString("name", ""),
                 locationDesc = o.optString("locationDesc", ""),
+                latitude = o.optDouble("latitude", 0.0),
+                longitude = o.optDouble("longitude", 0.0),
+                grid = o.optString("grid", ""),
+                activations = o.optInt("activations", 0),
+                qsos = o.optInt("qsos", 0),
             )
         } catch (e: Exception) {
             log("park parse error: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
             null
         }
     }
+
+    /** Fetch all POTA location codes (e.g. US-PA, VE-ON) with their center coordinates. */
+    suspend fun getLocations(): List<PotaLocation>? = withContext(Dispatchers.IO) {
+        val body = httpGet("$BASE_URL/locations") ?: return@withContext null
+        try {
+            val arr = JSONArray(body)
+            val out = ArrayList<PotaLocation>(arr.length())
+            for (i in 0 until arr.length()) {
+                val o = arr.getJSONObject(i)
+                val lat = o.optDouble("latitude", Double.NaN)
+                val lng = o.optDouble("longitude", Double.NaN)
+                if (lat.isNaN() || lng.isNaN()) continue
+                out.add(
+                    PotaLocation(
+                        locationDesc = o.optString("locationDesc", ""),
+                        locationName = o.optString("locationName", ""),
+                        latitude = lat,
+                        longitude = lng,
+                    ),
+                )
+            }
+            log("locations ok N=${out.size}")
+            out
+        } catch (e: Exception) {
+            log("locations parse error: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+            null
+        }
+    }
+
+    /** Fetch all parks within a POTA location code (e.g. US-PA). */
+    suspend fun getParksForLocation(locationCode: String): List<PotaPark>? =
+        withContext(Dispatchers.IO) {
+            val code = locationCode.trim().uppercase()
+            if (code.isEmpty()) return@withContext null
+            val body = httpGet("$BASE_URL/location/parks/${urlEncode(code)}")
+                ?: return@withContext null
+            try {
+                val arr = JSONArray(body)
+                val out = ArrayList<PotaPark>(arr.length())
+                for (i in 0 until arr.length()) {
+                    val o = arr.getJSONObject(i)
+                    out.add(
+                        PotaPark(
+                            reference = o.optString("reference", ""),
+                            name = o.optString("name", ""),
+                            locationDesc = o.optString("locationDesc", ""),
+                            latitude = o.optDouble("latitude", 0.0),
+                            longitude = o.optDouble("longitude", 0.0),
+                            grid = o.optString("grid", ""),
+                            activations = o.optInt("activations", 0),
+                            qsos = o.optInt("qsos", 0),
+                        ),
+                    )
+                }
+                log("parks for $code ok N=${out.size}")
+                out
+            } catch (e: Exception) {
+                log("parks parse error ($code): ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+                null
+            }
+        }
 
     /**
      * Upload one ADIF document to the authenticated endpoint. [idToken] is a

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaParkRepository.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaParkRepository.kt
@@ -8,23 +8,32 @@ import kotlinx.coroutines.withContext
 import radio.ks3ckc.ft8af.pota.model.PotaLocation
 import radio.ks3ckc.ft8af.pota.model.PotaPark
 import radio.ks3ckc.ft8af.pota.model.PotaParkWithDistance
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Provides park discovery for the park picker: recent activations and nearby parks.
  * Caches API responses in memory with a 30-minute TTL to avoid hammering pota.app.
+ *
+ * The caches are read and written from `Dispatchers.IO` and can be touched
+ * concurrently by multiple coroutines (e.g. overlapping sheet opens), so they use
+ * thread-safe containers (`ConcurrentHashMap` / `@Volatile`). A benign race may
+ * still trigger a duplicate API fetch, but never a corrupted map or crash.
  */
 object PotaParkRepository {
 
     private const val CACHE_TTL_MS = 30 * 60 * 1_000L
     private const val NEARBY_LIMIT = 50
 
+    @Volatile
     private var cachedLocations: List<PotaLocation>? = null
+
+    @Volatile
     private var locationsTimestamp = 0L
 
-    private val parkCache = HashMap<String, List<PotaPark>>()
-    private val parkCacheTimestamp = HashMap<String, Long>()
+    private val parkCache = ConcurrentHashMap<String, List<PotaPark>>()
+    private val parkCacheTimestamp = ConcurrentHashMap<String, Long>()
 
-    private val lookupCache = HashMap<String, PotaPark>()
+    private val lookupCache = ConcurrentHashMap<String, PotaPark>()
 
     /**
      * Return the [NEARBY_LIMIT] closest parks to [userLat]/[userLng], sorted by

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaParkRepository.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaParkRepository.kt
@@ -1,0 +1,154 @@
+package radio.ks3ckc.ft8af.pota
+
+import android.content.Context
+import com.google.android.gms.maps.model.LatLng
+import com.k1af.ft8af.maidenhead.MaidenheadGrid
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8af.pota.model.PotaLocation
+import radio.ks3ckc.ft8af.pota.model.PotaPark
+import radio.ks3ckc.ft8af.pota.model.PotaParkWithDistance
+
+/**
+ * Provides park discovery for the park picker: recent activations and nearby parks.
+ * Caches API responses in memory with a 30-minute TTL to avoid hammering pota.app.
+ */
+object PotaParkRepository {
+
+    private const val CACHE_TTL_MS = 30 * 60 * 1_000L
+    private const val NEARBY_LIMIT = 50
+
+    private var cachedLocations: List<PotaLocation>? = null
+    private var locationsTimestamp = 0L
+
+    private val parkCache = HashMap<String, List<PotaPark>>()
+    private val parkCacheTimestamp = HashMap<String, Long>()
+
+    private val lookupCache = HashMap<String, PotaPark>()
+
+    /**
+     * Return the [NEARBY_LIMIT] closest parks to [userLat]/[userLng], sorted by
+     * distance ascending. Fetches the 3 closest POTA location codes and their parks
+     * from the API (cached).
+     */
+    suspend fun nearbyParks(userLat: Double, userLng: Double): List<PotaParkWithDistance> =
+        withContext(Dispatchers.IO) {
+            val locations = getLocations() ?: return@withContext emptyList()
+            val closest = findNearestLocationCodes(userLat, userLng, locations, 3)
+            val allParks = mutableListOf<PotaPark>()
+            for (code in closest) {
+                val parks = getParksForLocation(code) ?: continue
+                allParks.addAll(parks)
+            }
+            sortParksByDistance(allParks, userLat, userLng, NEARBY_LIMIT)
+        }
+
+    /**
+     * Return park details for recent park references from activation history.
+     * Names are resolved via the park lookup endpoint (cached).
+     */
+    suspend fun recentParksWithDetails(): List<PotaPark> = withContext(Dispatchers.IO) {
+        val refs = PotaActivationDao.recentParkRefs()
+        refs.mapNotNull { ref -> lookupParkCached(ref) }
+    }
+
+    /** Fetch a park by reference with in-memory caching. */
+    private suspend fun lookupParkCached(reference: String): PotaPark? {
+        lookupCache[reference]?.let { return it }
+        val park = PotaClient.lookupPark(reference) ?: return null
+        lookupCache[reference] = park
+        return park
+    }
+
+    private suspend fun getLocations(): List<PotaLocation>? {
+        val now = System.currentTimeMillis()
+        if (cachedLocations != null && now - locationsTimestamp < CACHE_TTL_MS) {
+            return cachedLocations
+        }
+        val result = PotaClient.getLocations() ?: return cachedLocations
+        cachedLocations = result
+        locationsTimestamp = now
+        return result
+    }
+
+    private suspend fun getParksForLocation(code: String): List<PotaPark>? {
+        val now = System.currentTimeMillis()
+        val cached = parkCache[code]
+        val ts = parkCacheTimestamp[code] ?: 0L
+        if (cached != null && now - ts < CACHE_TTL_MS) return cached
+        val result = PotaClient.getParksForLocation(code) ?: return cached
+        parkCache[code] = result
+        parkCacheTimestamp[code] = now
+        return result
+    }
+
+    /**
+     * Get a [LatLng] from the device GPS, falling back to the user's configured
+     * Maidenhead grid. Returns null only if both are unavailable.
+     */
+    fun getUserLocation(context: Context): LatLng? {
+        return MaidenheadGrid.getLocalLocation(context)
+            ?: com.k1af.ft8af.GeneralVariables.getMyMaidenhead4Grid()
+                ?.let { MaidenheadGrid.gridToLatLng(it) }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper functions — extracted for unit testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the [count] POTA location codes whose center is nearest to ([userLat], [userLng]).
+ * Returns the `locationDesc` field (the location code like "US-PA") for each.
+ */
+internal fun findNearestLocationCodes(
+    userLat: Double,
+    userLng: Double,
+    locations: List<PotaLocation>,
+    count: Int,
+): List<String> {
+    val userPos = LatLng(userLat, userLng)
+    return locations
+        .map { it to MaidenheadGrid.getDist(userPos, LatLng(it.latitude, it.longitude)) }
+        .sortedBy { it.second }
+        .take(count)
+        .map { it.first.locationDesc }
+}
+
+/**
+ * Compute the distance from ([userLat], [userLng]) to each park, sort ascending,
+ * and return the closest [limit] results.
+ */
+internal fun sortParksByDistance(
+    parks: List<PotaPark>,
+    userLat: Double,
+    userLng: Double,
+    limit: Int,
+): List<PotaParkWithDistance> {
+    val userPos = LatLng(userLat, userLng)
+    return parks
+        .filter { it.latitude != 0.0 || it.longitude != 0.0 }
+        .map { park ->
+            PotaParkWithDistance(
+                park = park,
+                distanceKm = MaidenheadGrid.getDist(userPos, LatLng(park.latitude, park.longitude)),
+            )
+        }
+        .sortedBy { it.distanceKm }
+        .take(limit)
+}
+
+/**
+ * Split comma-separated park reference strings and deduplicate, preserving
+ * first-seen (most-recent) order.
+ */
+internal fun deduplicateRefs(rawRefs: List<String>): List<String> {
+    val seen = LinkedHashSet<String>()
+    for (raw in rawRefs) {
+        for (part in raw.split(",")) {
+            val ref = part.trim()
+            if (ref.isNotEmpty()) seen.add(ref)
+        }
+    }
+    return seen.toList()
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/model/PotaModels.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/model/PotaModels.kt
@@ -20,6 +20,25 @@ data class PotaPark(
     val reference: String,
     val name: String,
     val locationDesc: String,
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    val grid: String = "",
+    val activations: Int = 0,
+    val qsos: Int = 0,
+)
+
+/** A POTA location code (e.g. US-PA) with its center coordinates. */
+data class PotaLocation(
+    val locationDesc: String,
+    val locationName: String,
+    val latitude: Double,
+    val longitude: Double,
+)
+
+/** A park paired with its distance from the user's position. */
+data class PotaParkWithDistance(
+    val park: PotaPark,
+    val distanceKm: Double,
 )
 
 /** A single QSO row for the activation contacts list. */

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.k1af.ft8af.R
@@ -52,7 +51,7 @@ internal fun isValidFreeText(text: String): Boolean {
 }
 
 internal fun sanitizeModifier(input: String): String =
-    input.uppercase().filter { it.isLetterOrDigit() }.take(4)
+    input.uppercase().filter { it.isLetter() }.take(4)
 
 internal fun sanitizeFreeText(input: String): String {
     val allowed = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ+-./?".toSet()
@@ -282,14 +281,14 @@ fun CqOptionsSheet(
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(BgSurface3)
-                            .clickable(enabled = fieldDayNumTx < 32) {
-                                onFieldDayNumTxChange((fieldDayNumTx + 1).coerceAtMost(32))
+                            .clickable(enabled = fieldDayNumTx < 16) {
+                                onFieldDayNumTxChange((fieldDayNumTx + 1).coerceAtMost(16))
                             },
                         contentAlignment = Alignment.Center,
                     ) {
                         Text(
                             text = "+",
-                            color = if (fieldDayNumTx < 32) TextMuted else TextFaint,
+                            color = if (fieldDayNumTx < 16) TextMuted else TextFaint,
                             fontSize = 16.sp,
                             fontWeight = FontWeight.Bold,
                             fontFamily = GeistMonoFamily,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.k1af.ft8af.R
+import com.k1af.ft8af.ft8signal.FT8Package
 import radio.ks3ckc.ft8af.theme.*
 
 // ---- Pure logic (extracted for unit testing) ----
@@ -42,8 +43,27 @@ internal val CQ_PRESETS = listOf("", "DX", "NA", "EU", "SA", "AS", "OC", "AF")
 internal fun presetLabel(modifier: String): String =
     if (modifier.isEmpty()) "CQ" else "CQ $modifier"
 
+// Letters-only (1–4) to match the custom-modifier sanitizer, which strips digits.
+// pack_c28 also supports a 3-digit form, but the UI can never produce one, so
+// validating digits here would only accept input the app can't generate.
 internal fun isValidModifier(text: String): Boolean =
-    text.isEmpty() || text.matches(Regex("[A-Z]{1,4}|[0-9]{3}"))
+    text.isEmpty() || text.matches(Regex("[A-Z]{1,4}"))
+
+/**
+ * Field Day must encode a real ARRL/RAC section; an unknown or blank section is
+ * packed as index 0 ("AB") by [FT8Package.generatePack77_fd], silently sending
+ * the wrong exchange. Only allow enabling FD when the section is recognized.
+ */
+internal fun canEnableFieldDay(section: String): Boolean =
+    FT8Package.sectionIndex(section) >= 0
+
+/**
+ * Persist a Field Day section only when the packer recognizes it, or when the
+ * user explicitly clears it while FD is off. This stops a half-typed/unknown
+ * value from being restored as "AB" on the next launch.
+ */
+internal fun shouldPersistSection(section: String, fieldDayEnabled: Boolean): Boolean =
+    FT8Package.sectionIndex(section) >= 0 || (section.isEmpty() && !fieldDayEnabled)
 
 internal fun isValidFreeText(text: String): Boolean {
     val allowed = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ+-./?".toSet()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
@@ -1,0 +1,464 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.R
+import radio.ks3ckc.ft8af.theme.*
+
+// ---- Pure logic (extracted for unit testing) ----
+
+internal val CQ_PRESETS = listOf("", "DX", "NA", "EU", "SA", "AS", "OC", "AF")
+
+internal fun presetLabel(modifier: String): String =
+    if (modifier.isEmpty()) "CQ" else "CQ $modifier"
+
+internal fun isValidModifier(text: String): Boolean =
+    text.isEmpty() || text.matches(Regex("[A-Z]{1,4}|[0-9]{3}"))
+
+internal fun isValidFreeText(text: String): Boolean {
+    val allowed = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ+-./?".toSet()
+    return text.length <= 13 && text.all { it in allowed }
+}
+
+internal fun sanitizeModifier(input: String): String =
+    input.uppercase().filter { it.isLetterOrDigit() }.take(4)
+
+internal fun sanitizeFreeText(input: String): String {
+    val allowed = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ+-./?".toSet()
+    return input.uppercase().filter { it in allowed }.take(13)
+}
+
+// ---- Composable ----
+
+@Composable
+fun CqOptionsSheet(
+    visible: Boolean,
+    currentModifier: String,
+    isFreeTextMode: Boolean,
+    freeText: String,
+    fieldDayEnabled: Boolean,
+    fieldDayClass: String,
+    fieldDayNumTx: Int,
+    fieldDaySection: String,
+    onDismiss: () -> Unit,
+    onSelectPreset: (String) -> Unit,
+    onCustomModifier: (String) -> Unit,
+    onFreeTextChange: (String) -> Unit,
+    onFieldDayToggle: (Boolean) -> Unit,
+    onFieldDayClassChange: (String) -> Unit,
+    onFieldDayNumTxChange: (Int) -> Unit,
+    onFieldDaySectionChange: (String) -> Unit,
+    onCallCQ: () -> Unit,
+) {
+    FT8AFBottomSheet(
+        visible = visible,
+        onDismiss = onDismiss,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+        ) {
+            // ---- Section: CQ MESSAGE ----
+            SectionHeader(stringResource(R.string.cq_message_title))
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Preset chip row
+            val scrollState = rememberScrollState()
+            val chipShape = RoundedCornerShape(999.dp)
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                for (preset in CQ_PRESETS) {
+                    val label = presetLabel(preset)
+                    val isSelected = !isFreeTextMode && !fieldDayEnabled && currentModifier == preset
+                    val bgColor = if (isSelected) AccentSoft else BgSurface2
+                    val borderColor = if (isSelected) BorderAmber else Border
+                    val textColor = if (isSelected) Accent else TextMuted
+
+                    Row(
+                        modifier = Modifier
+                            .height(32.dp)
+                            .clip(chipShape)
+                            .background(bgColor, chipShape)
+                            .border(1.dp, borderColor, chipShape)
+                            .clickable {
+                                onSelectPreset(preset)
+                                onDismiss()
+                            }
+                            .padding(horizontal = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = label,
+                            color = textColor,
+                            fontSize = 12.sp,
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                            fontFamily = GeistMonoFamily,
+                            letterSpacing = 0.02.sp,
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Custom modifier text field
+            OutlinedTextField(
+                value = if (!isFreeTextMode && !fieldDayEnabled) currentModifier else "",
+                onValueChange = { onCustomModifier(sanitizeModifier(it)) },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.cq_custom_modifier_hint),
+                        color = TextFaint,
+                        fontSize = 13.sp,
+                        fontFamily = GeistMonoFamily,
+                    )
+                },
+                singleLine = true,
+                textStyle = androidx.compose.ui.text.TextStyle(
+                    color = TextPrimary,
+                    fontSize = 13.sp,
+                    fontFamily = GeistMonoFamily,
+                ),
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Characters,
+                ),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = Accent,
+                    unfocusedBorderColor = Border,
+                    cursorColor = Accent,
+                ),
+            )
+
+            // ---- Divider: "or" ----
+            OrDivider()
+
+            // ---- Section: FIELD DAY ----
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                SectionHeader(stringResource(R.string.cq_field_day_title))
+                Switch(
+                    checked = fieldDayEnabled,
+                    onCheckedChange = onFieldDayToggle,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Accent,
+                        checkedTrackColor = AccentSoft,
+                        uncheckedThumbColor = TextMuted,
+                        uncheckedTrackColor = BgSurface3,
+                    ),
+                )
+            }
+
+            if (fieldDayEnabled) {
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Class chips
+                Text(
+                    text = stringResource(R.string.cq_fd_class),
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.04.sp,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    for (cls in listOf("A", "B", "C", "D", "E", "F")) {
+                        val isSelected = fieldDayClass == cls
+                        val bgColor = if (isSelected) AccentSoft else BgSurface2
+                        val borderColor = if (isSelected) BorderAmber else Border
+                        val textColor = if (isSelected) Accent else TextMuted
+
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(chipShape)
+                                .background(bgColor, chipShape)
+                                .border(1.dp, borderColor, chipShape)
+                                .clickable { onFieldDayClassChange(cls) },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = cls,
+                                color = textColor,
+                                fontSize = 13.sp,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                                fontFamily = GeistMonoFamily,
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Transmitters stepper
+                Text(
+                    text = stringResource(R.string.cq_fd_transmitters),
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.04.sp,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(BgSurface3)
+                            .clickable(enabled = fieldDayNumTx > 1) {
+                                onFieldDayNumTxChange((fieldDayNumTx - 1).coerceAtLeast(1))
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "\u2212",
+                            color = if (fieldDayNumTx > 1) TextMuted else TextFaint,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = GeistMonoFamily,
+                        )
+                    }
+                    Text(
+                        text = fieldDayNumTx.toString(),
+                        color = TextPrimary,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = GeistMonoFamily,
+                        letterSpacing = 0.02.sp,
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(BgSurface3)
+                            .clickable(enabled = fieldDayNumTx < 32) {
+                                onFieldDayNumTxChange((fieldDayNumTx + 1).coerceAtMost(32))
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "+",
+                            color = if (fieldDayNumTx < 32) TextMuted else TextFaint,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = GeistMonoFamily,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Section text field
+                Text(
+                    text = stringResource(R.string.cq_fd_section),
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.04.sp,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = fieldDaySection,
+                    onValueChange = {
+                        val cleaned = it.uppercase().filter { c -> c.isLetter() }.take(3)
+                        onFieldDaySectionChange(cleaned)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.cq_fd_section_hint),
+                            color = TextFaint,
+                            fontSize = 13.sp,
+                            fontFamily = GeistMonoFamily,
+                        )
+                    },
+                    singleLine = true,
+                    textStyle = androidx.compose.ui.text.TextStyle(
+                        color = TextPrimary,
+                        fontSize = 13.sp,
+                        fontFamily = GeistMonoFamily,
+                    ),
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Characters,
+                    ),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = Accent,
+                        unfocusedBorderColor = Border,
+                        cursorColor = Accent,
+                    ),
+                )
+            }
+
+            // ---- Divider: "or" ----
+            OrDivider()
+
+            // ---- Section: FREE TEXT ----
+            SectionHeader(stringResource(R.string.cq_free_text_title))
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = freeText,
+                onValueChange = { onFreeTextChange(sanitizeFreeText(it)) },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.cq_free_text_hint),
+                        color = TextFaint,
+                        fontSize = 13.sp,
+                        fontFamily = GeistMonoFamily,
+                    )
+                },
+                singleLine = true,
+                textStyle = androidx.compose.ui.text.TextStyle(
+                    color = TextPrimary,
+                    fontSize = 13.sp,
+                    fontFamily = GeistMonoFamily,
+                ),
+                supportingText = {
+                    Text(
+                        text = "${freeText.length}/13",
+                        color = if (freeText.length >= 13) StatusBad else TextMuted,
+                        fontSize = 11.sp,
+                        fontFamily = GeistMonoFamily,
+                    )
+                },
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Characters,
+                ),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = Accent,
+                    unfocusedBorderColor = Border,
+                    cursorColor = Accent,
+                ),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // ---- Action button ----
+            val buttonLabel = when {
+                isFreeTextMode && freeText.isNotBlank() -> stringResource(R.string.cq_send_free_text)
+                fieldDayEnabled -> stringResource(R.string.cq_call_cq) + " FD"
+                currentModifier.isNotEmpty() -> stringResource(R.string.cq_call_cq) + " " + currentModifier
+                else -> stringResource(R.string.cq_call_cq)
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Accent)
+                    .clickable {
+                        onCallCQ()
+                        onDismiss()
+                    }
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FT8AFIcons.Transmit(size = 18.dp, color = BgApp, strokeWidth = 1.8f)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = buttonLabel,
+                    color = BgApp,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.04.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        color = TextMuted,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        fontFamily = GeistMonoFamily,
+        letterSpacing = 0.08.sp,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}
+
+@Composable
+private fun OrDivider() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = Border,
+        )
+        Text(
+            text = stringResource(R.string.cq_or_divider),
+            color = TextFaint,
+            fontSize = 11.sp,
+            fontFamily = GeistMonoFamily,
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = Border,
+        )
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -506,7 +506,6 @@ private fun PrimaryActionButton(
                     softWrap = false,
                 )
             }
-            FT8AFIcons.ChevronDown(size = 10.dp, color = contentColor.copy(alpha = 0.5f), strokeWidth = 2f)
         } else {
             Text(
                 text = label,
@@ -518,6 +517,9 @@ private fun PrimaryActionButton(
                 maxLines = 1,
                 softWrap = false,
             )
+        }
+        if (onLongClick != null) {
+            FT8AFIcons.ChevronDown(size = 10.dp, color = contentColor.copy(alpha = 0.5f), strokeWidth = 2f)
         }
     }
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -5,9 +5,11 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -72,6 +74,7 @@ internal fun txStripActionState(isActivated: Boolean, huntEnabled: Boolean) = Tx
     cqIsStop = isActivated,
 )
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TxStrip(
     isTransmitting: Boolean,
@@ -87,10 +90,14 @@ fun TxStrip(
     expanded: Boolean = false,
     txVolume: Int = 80,
     showVolumeSlider: Boolean = false,
+    cqModifier: String = "",
+    isFreeTextMode: Boolean = false,
+    fieldDayEnabled: Boolean = false,
     onVolumeChange: (Int) -> Unit = {},
     onVolumeChangeFinished: () -> Unit = {},
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
+    onLongPressCQ: () -> Unit = {},
     onToggleSlot: () -> Unit,
     onToggleHunt: () -> Unit,
     onCycleMode: () -> Unit,
@@ -254,10 +261,19 @@ fun TxStrip(
 
             // CQ / STOP — the primary action. Filled amber to call CQ, red to stop.
             // Locked off while HUNT is armed (and no QSO yet).
+            // Long-press opens CQ options (modifier, free text, Field Day).
             val cqIsStop = actions.cqIsStop
+            val cqSubtitle = when {
+                cqIsStop -> null
+                isFreeTextMode -> "FREE"
+                fieldDayEnabled -> "FD"
+                cqModifier.isNotEmpty() -> cqModifier
+                else -> null
+            }
             PrimaryActionButton(
                 modifier = Modifier.weight(1.7f),
                 label = if (cqIsStop) stringResource(R.string.tx_stop) else stringResource(R.string.tx_call_cq),
+                subtitle = cqSubtitle,
                 background = when {
                     cqIsStop -> StatusBad
                     actions.cqDisabled -> Accent.copy(alpha = 0.35f)
@@ -266,6 +282,7 @@ fun TxStrip(
                 contentColor = if (cqIsStop) Color.White else BgApp,
                 enabled = !actions.cqDisabled,
                 onClick = { if (cqIsStop) onStop() else onCallCQ() },
+                onLongClick = if (!cqIsStop) onLongPressCQ else null,
             ) { color ->
                 if (cqIsStop) {
                     FT8AFIcons.Close(size = 18.dp, color = color, strokeWidth = 2f)
@@ -438,6 +455,7 @@ private fun StackedActionButton(
 }
 
 /** The large primary button with the icon beside the label (CQ / STOP). */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PrimaryActionButton(
     label: String,
@@ -446,6 +464,8 @@ private fun PrimaryActionButton(
     enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    onLongClick: (() -> Unit)? = null,
     icon: @Composable (Color) -> Unit,
 ) {
     Row(
@@ -453,22 +473,52 @@ private fun PrimaryActionButton(
             .height(54.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(background)
-            .clickable(enabled = enabled) { onClick() }
+            .combinedClickable(
+                enabled = enabled,
+                onClick = onClick,
+                onLongClick = onLongClick,
+            )
             .padding(horizontal = 12.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         icon(contentColor)
-        Text(
-            text = label,
-            color = contentColor,
-            fontSize = 15.sp,
-            fontWeight = FontWeight.Bold,
-            fontFamily = GeistMonoFamily,
-            letterSpacing = 0.04.sp,
-            maxLines = 1,
-            softWrap = false,
-        )
+        if (subtitle != null) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = label,
+                    color = contentColor,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.04.sp,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+                Text(
+                    text = subtitle,
+                    color = contentColor.copy(alpha = 0.6f),
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            }
+            FT8AFIcons.ChevronDown(size = 10.dp, color = contentColor.copy(alpha = 0.5f), strokeWidth = 2f)
+        } else {
+            Text(
+                text = label,
+                color = contentColor,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = GeistMonoFamily,
+                letterSpacing = 0.04.sp,
+                maxLines = 1,
+                softWrap = false,
+            )
+        }
     }
 }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/ParkPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/ParkPickerSheet.kt
@@ -1,0 +1,318 @@
+package radio.ks3ckc.ft8af.ui.pota
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.R
+import com.k1af.ft8af.maidenhead.MaidenheadGrid
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8af.pota.PotaParkRepository
+import radio.ks3ckc.ft8af.pota.model.PotaPark
+import radio.ks3ckc.ft8af.pota.model.PotaParkWithDistance
+import radio.ks3ckc.ft8af.theme.Accent
+import radio.ks3ckc.ft8af.theme.BgSurface
+import radio.ks3ckc.ft8af.theme.BgSurface2
+import radio.ks3ckc.ft8af.theme.Border
+import radio.ks3ckc.ft8af.theme.StatusConfirmed
+import radio.ks3ckc.ft8af.theme.TextMuted
+import radio.ks3ckc.ft8af.theme.TextPrimary
+import radio.ks3ckc.ft8af.ui.components.FT8AFBottomSheet
+
+/**
+ * Bottom sheet for discovering and selecting POTA park references.
+ * Shows recent activations and nearby parks with a text filter.
+ */
+@Composable
+fun ParkPickerSheet(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    onParkSelected: (String) -> Unit,
+) {
+    FT8AFBottomSheet(visible = visible, onDismiss = onDismiss) {
+        ParkPickerContent(
+            onParkSelected = { ref ->
+                onParkSelected(ref)
+                onDismiss()
+            },
+        )
+    }
+}
+
+@Composable
+private fun ParkPickerContent(
+    onParkSelected: (String) -> Unit,
+) {
+    val context = LocalContext.current
+    var filter by remember { mutableStateOf("") }
+
+    // Recent parks
+    var recentParks by remember { mutableStateOf<List<PotaPark>>(emptyList()) }
+    var recentLoading by remember { mutableStateOf(true) }
+
+    // Nearby parks
+    var nearbyParks by remember { mutableStateOf<List<PotaParkWithDistance>>(emptyList()) }
+    var nearbyLoading by remember { mutableStateOf(true) }
+    var locationAvailable by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        // Load recent parks
+        recentParks = withContext(Dispatchers.IO) {
+            PotaParkRepository.recentParksWithDetails()
+        }
+        recentLoading = false
+
+        // Load nearby parks
+        val location = withContext(Dispatchers.IO) {
+            PotaParkRepository.getUserLocation(context)
+        }
+        if (location != null) {
+            nearbyParks = PotaParkRepository.nearbyParks(location.latitude, location.longitude)
+        } else {
+            locationAvailable = false
+        }
+        nearbyLoading = false
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 14.dp, vertical = 4.dp),
+    ) {
+        // Search field
+        OutlinedTextField(
+            value = filter,
+            onValueChange = { filter = it },
+            placeholder = { Text(stringResource(R.string.pota_search_parks_hint), fontSize = 13.sp) },
+            leadingIcon = {
+                Icon(
+                    Icons.Filled.Search,
+                    contentDescription = stringResource(R.string.pota_search_parks),
+                    tint = TextMuted,
+                    modifier = Modifier.size(18.dp),
+                )
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
+            colors = TextFieldDefaults.colors(
+                focusedTextColor = TextPrimary,
+                unfocusedTextColor = TextPrimary,
+                focusedContainerColor = BgSurface,
+                unfocusedContainerColor = BgSurface,
+                focusedLabelColor = Accent,
+                unfocusedLabelColor = TextMuted,
+                focusedIndicatorColor = Accent,
+                unfocusedIndicatorColor = Border,
+                cursorColor = Accent,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        // Recent parks section
+        SectionHeader(stringResource(R.string.pota_recent_parks))
+        Spacer(Modifier.height(6.dp))
+
+        if (recentLoading) {
+            LoadingRow()
+        } else {
+            val filteredRecent = filterParks(recentParks, filter)
+            if (filteredRecent.isEmpty()) {
+                EmptyRow(stringResource(R.string.pota_no_recent_parks))
+            } else {
+                for (park in filteredRecent) {
+                    ParkRow(
+                        reference = park.reference,
+                        name = park.name,
+                        subtitle = park.locationDesc,
+                        onClick = { onParkSelected(park.reference) },
+                    )
+                    Spacer(Modifier.height(4.dp))
+                }
+            }
+        }
+
+        Spacer(Modifier.height(14.dp))
+
+        // Nearby parks section
+        SectionHeader(stringResource(R.string.pota_nearby_parks))
+        Spacer(Modifier.height(6.dp))
+
+        if (nearbyLoading) {
+            LoadingRow()
+        } else if (!locationAvailable) {
+            EmptyRow(stringResource(R.string.pota_location_unavailable))
+        } else {
+            val filteredNearby = filterNearbyParks(nearbyParks, filter)
+            if (filteredNearby.isEmpty()) {
+                EmptyRow(stringResource(R.string.pota_no_nearby_parks))
+            } else {
+                for (item in filteredNearby) {
+                    ParkRow(
+                        reference = item.park.reference,
+                        name = item.park.name,
+                        subtitle = MaidenheadGrid.formatDist(item.distanceKm),
+                        onClick = { onParkSelected(item.park.reference) },
+                    )
+                    Spacer(Modifier.height(4.dp))
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text,
+        color = TextMuted,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 0.8.sp,
+        modifier = Modifier.padding(start = 4.dp),
+    )
+}
+
+@Composable
+private fun LoadingRow() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(16.dp),
+            color = Accent,
+            strokeWidth = 2.dp,
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            stringResource(R.string.pota_loading_nearby),
+            color = TextMuted,
+            fontSize = 12.sp,
+        )
+    }
+}
+
+@Composable
+private fun EmptyRow(message: String) {
+    Text(
+        message,
+        color = TextMuted,
+        fontSize = 12.sp,
+        modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun ParkRow(
+    reference: String,
+    name: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BgSurface, RoundedCornerShape(10.dp))
+            .border(1.dp, Border, RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Park pill (ref badge)
+        Text(
+            reference,
+            color = StatusConfirmed,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier
+                .background(BgSurface2, RoundedCornerShape(6.dp))
+                .border(1.dp, Border, RoundedCornerShape(6.dp))
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+            fontFamily = FontFamily.Monospace,
+        )
+        Spacer(Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            if (name.isNotBlank()) {
+                Text(
+                    name,
+                    color = TextPrimary,
+                    fontSize = 13.sp,
+                    maxLines = 1,
+                )
+            }
+            if (subtitle.isNotBlank()) {
+                Text(
+                    subtitle,
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filter logic — extracted for testability
+// ---------------------------------------------------------------------------
+
+/** Filter parks by name or reference (case-insensitive substring match). */
+internal fun filterParks(parks: List<PotaPark>, query: String): List<PotaPark> {
+    if (query.isBlank()) return parks
+    val q = query.trim().lowercase()
+    return parks.filter { park ->
+        park.reference.lowercase().contains(q) || park.name.lowercase().contains(q)
+    }
+}
+
+/** Filter nearby parks by name or reference (case-insensitive substring match). */
+internal fun filterNearbyParks(
+    parks: List<PotaParkWithDistance>,
+    query: String,
+): List<PotaParkWithDistance> {
+    if (query.isBlank()) return parks
+    val q = query.trim().lowercase()
+    return parks.filter { item ->
+        item.park.reference.lowercase().contains(q) || item.park.name.lowercase().contains(q)
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/ParkPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/ParkPickerSheet.kt
@@ -148,7 +148,7 @@ private fun ParkPickerContent(
         Spacer(Modifier.height(6.dp))
 
         if (recentLoading) {
-            LoadingRow()
+            LoadingRow(stringResource(R.string.pota_loading_recent))
         } else {
             val filteredRecent = filterParks(recentParks, filter)
             if (filteredRecent.isEmpty()) {
@@ -173,7 +173,7 @@ private fun ParkPickerContent(
         Spacer(Modifier.height(6.dp))
 
         if (nearbyLoading) {
-            LoadingRow()
+            LoadingRow(stringResource(R.string.pota_loading_nearby))
         } else if (!locationAvailable) {
             EmptyRow(stringResource(R.string.pota_location_unavailable))
         } else {
@@ -210,7 +210,7 @@ private fun SectionHeader(text: String) {
 }
 
 @Composable
-private fun LoadingRow() {
+private fun LoadingRow(message: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -225,7 +225,7 @@ private fun LoadingRow() {
         )
         Spacer(Modifier.width(8.dp))
         Text(
-            stringResource(R.string.pota_loading_nearby),
+            message,
             color = TextMuted,
             fontSize = 12.sp,
         )

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -50,6 +51,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -188,9 +190,18 @@ private fun ActivateTab() {
     val contacts by PotaSessionManager.activationQsos.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val parkRefs = remember { mutableStateListOf("") }
+    val parkRefs = rememberSaveable(
+        saver = listSaver(
+            save = { it.toList() },
+            restore = { mutableStateListOf(*it.toTypedArray()) },
+        ),
+    ) { mutableStateListOf("") }
     var notes by rememberSaveable { mutableStateOf("") }
     var refreshKey by remember { mutableIntStateOf(0) }
+
+    // Park picker sheet state
+    var showPicker by remember { mutableStateOf(false) }
+    var pickerTargetIndex by remember { mutableIntStateOf(-1) }
 
     // Refresh the activation's QSO counter periodically while one is running so
     // the on-screen tally reflects QSOs added by the TX/RX path.
@@ -221,6 +232,19 @@ private fun ActivateTab() {
                             label = { Text(stringResource(R.string.pota_park_reference_label)) },
                             singleLine = true,
                             keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
+                            trailingIcon = {
+                                IconButton(onClick = {
+                                    pickerTargetIndex = index
+                                    showPicker = true
+                                }) {
+                                    Icon(
+                                        Icons.Filled.Search,
+                                        contentDescription = stringResource(R.string.pota_search_parks),
+                                        tint = TextMuted,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                }
+                            },
                             colors = textFieldColors(),
                             modifier = Modifier.weight(1f),
                         )
@@ -352,6 +376,16 @@ private fun ActivateTab() {
             }
         }
     }
+
+    ParkPickerSheet(
+        visible = showPicker,
+        onDismiss = { showPicker = false },
+        onParkSelected = { ref ->
+            if (pickerTargetIndex in parkRefs.indices) {
+                parkRefs[pickerTargetIndex] = ref
+            }
+        },
+    )
 }
 
 @OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)

--- a/ft8af/app/src/main/res/values/strings.xml
+++ b/ft8af/app/src/main/res/values/strings.xml
@@ -551,6 +551,20 @@
     <string name="qrz_api_key">API KEY</string>
     <string name="config_enable_qrz">Enable QRZ sync</string>
     <string name="qrz_help">qrz_en.txt</string>
+    <!-- CQ Options Sheet -->
+    <string name="cq_message_title">CQ MESSAGE</string>
+    <string name="cq_custom_modifier_hint">POTA, SOTA, TEST</string>
+    <string name="cq_or_divider">or</string>
+    <string name="cq_free_text_title">FREE TEXT</string>
+    <string name="cq_free_text_hint">13 characters max</string>
+    <string name="cq_call_cq">Call CQ</string>
+    <string name="cq_send_free_text">Send Free Text</string>
+    <string name="cq_field_day_title">FIELD DAY</string>
+    <string name="cq_fd_class">Class</string>
+    <string name="cq_fd_transmitters">Transmitters</string>
+    <string name="cq_fd_section">Section</string>
+    <string name="cq_fd_section_hint">e.g. EMA, WI, SDG</string>
+
     <string name="alram_switch">Alarm switch</string>
     <string name="swr_switch_on" translatable="false">SWR On</string>
     <string name="swr_switch_off" translatable="false">SWR Off</string>

--- a/ft8af/app/src/main/res/values/strings.xml
+++ b/ft8af/app/src/main/res/values/strings.xml
@@ -564,6 +564,7 @@
     <string name="cq_fd_transmitters">Transmitters</string>
     <string name="cq_fd_section">Section</string>
     <string name="cq_fd_section_hint">e.g. EMA, WI, SDG</string>
+    <string name="cq_fd_section_required">Enter a valid ARRL/RAC section before enabling Field Day</string>
 
     <string name="alram_switch">Alarm switch</string>
     <string name="swr_switch_on" translatable="false">SWR On</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -307,6 +307,7 @@
     <string name="pota_no_recent_parks">No recent activations</string>
     <string name="pota_no_nearby_parks">No parks found nearby</string>
     <string name="pota_loading_nearby">Loading nearby parks…</string>
+    <string name="pota_loading_recent">Loading recent parks…</string>
     <string name="pota_location_unavailable">Location unavailable — enable GPS</string>
 
     <!-- ===== Debug log / Map / Waterfall ===== -->

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -300,6 +300,14 @@
     <string name="pota_max_parks_reached">Maximum of 10 parks reached</string>
     <string name="pota_spotted_n_parks">Spotted at %1$d parks</string>
     <string name="pota_parks_more">+%1$d more</string>
+    <string name="pota_search_parks">Search parks</string>
+    <string name="pota_search_parks_hint">Filter by name or reference</string>
+    <string name="pota_recent_parks">RECENT PARKS</string>
+    <string name="pota_nearby_parks">NEARBY PARKS</string>
+    <string name="pota_no_recent_parks">No recent activations</string>
+    <string name="pota_no_nearby_parks">No parks found nearby</string>
+    <string name="pota_loading_nearby">Loading nearby parks…</string>
+    <string name="pota_location_unavailable">Location unavailable — enable GPS</string>
 
     <!-- ===== Debug log / Map / Waterfall ===== -->
     <string name="debug_title">Debug</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageFieldDayTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageFieldDayTest.java
@@ -1,0 +1,208 @@
+package com.k1af.ft8af.ft8signal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+
+import org.junit.Test;
+
+/**
+ * Coverage for Field Day message support in {@link FT8Package}:
+ *   - {@link FT8Package#sectionIndex(String)}
+ *   - {@link FT8Package#generatePack77_fd(Ft8Message)}
+ *
+ * Plain JUnit: FT8Package's static initialiser swallows the
+ * {@code System.loadLibrary("ft8af")} UnsatisfiedLinkError, so the class loads on
+ * the bare JVM. We deliberately use standard callsigns that resolve via the
+ * pure-Java pack_c28 path (no native hash dependency).
+ */
+public class FT8PackageFieldDayTest {
+
+    // ---- sectionIndex -----------------------------------------------------------
+
+    @Test
+    public void sectionIndex_firstSection_returnZero() {
+        assertThat(FT8Package.sectionIndex("CT")).isEqualTo(0);
+    }
+
+    @Test
+    public void sectionIndex_lastSection_returns83() {
+        assertThat(FT8Package.sectionIndex("TER")).isEqualTo(83);
+    }
+
+    @Test
+    public void sectionIndex_middleSection_WI() {
+        assertThat(FT8Package.sectionIndex("WI")).isEqualTo(63);
+    }
+
+    @Test
+    public void sectionIndex_EMA() {
+        assertThat(FT8Package.sectionIndex("EMA")).isEqualTo(1);
+    }
+
+    @Test
+    public void sectionIndex_unknown_returnsNegativeOne() {
+        assertThat(FT8Package.sectionIndex("ZZZ")).isEqualTo(-1);
+    }
+
+    @Test
+    public void sectionIndex_empty_returnsNegativeOne() {
+        assertThat(FT8Package.sectionIndex("")).isEqualTo(-1);
+    }
+
+    @Test
+    public void sectionTable_has84Entries() {
+        assertThat(FT8Package.ARRL_SECTIONS).hasLength(84);
+    }
+
+    @Test
+    public void sectionIndex_allSections_haveUniqueIndices() {
+        // Verify no duplicates by checking every section resolves to a unique index
+        for (int i = 0; i < FT8Package.ARRL_SECTIONS.length; i++) {
+            assertThat(FT8Package.sectionIndex(FT8Package.ARRL_SECTIONS[i])).isEqualTo(i);
+        }
+    }
+
+    // ---- generatePack77_fd ------------------------------------------------------
+
+    @Test
+    public void generatePack77_fd_returnsNonNull() {
+        Ft8Message msg = buildFdMessage("CQ", "W1AW", 0, 6, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        assertThat(packed).isNotNull();
+        assertThat(packed).hasLength(10);
+    }
+
+    @Test
+    public void generatePack77_fd_i3Bits_areZero() {
+        // i3 occupies bits 74-76 which are in byte 9 bits 3-5
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        // i3 should be 0: bits 74-76 = byte 9 bits [5:3]
+        int i3 = (packed[9] >> 3) & 0x07;
+        assertThat(i3).isEqualTo(0);
+    }
+
+    @Test
+    public void generatePack77_fd_n3Bits_three_forInitialExchange() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        // n3 = 3: bits 71-73. Bit 71 is byte 8 bit 0, bits 72-73 are byte 9 bits [7:6]
+        int n3_bit0 = packed[8] & 0x01;
+        int n3_bits12 = (packed[9] >> 6) & 0x03;
+        int n3 = (n3_bit0 << 2) | n3_bits12;
+        assertThat(n3).isEqualTo(3);
+    }
+
+    @Test
+    public void generatePack77_fd_n3Bits_four_forRExchange() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 1, 1, "A", "CT", 4);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int n3_bit0 = packed[8] & 0x01;
+        int n3_bits12 = (packed[9] >> 6) & 0x03;
+        int n3 = (n3_bit0 << 2) | n3_bits12;
+        assertThat(n3).isEqualTo(4);
+    }
+
+    @Test
+    public void generatePack77_fd_rFlag_zeroWhenNoR() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        // R1 is bit 56 = byte 7 bit 7
+        int r1 = (packed[7] >> 7) & 0x01;
+        assertThat(r1).isEqualTo(0);
+    }
+
+    @Test
+    public void generatePack77_fd_rFlag_oneWhenR() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 1, 1, "A", "CT", 4);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int r1 = (packed[7] >> 7) & 0x01;
+        assertThat(r1).isEqualTo(1);
+    }
+
+    @Test
+    public void generatePack77_fd_classEncoding() {
+        // k3 occupies bits 61-63 = byte 7 bits [2:0]
+        for (int c = 0; c < 6; c++) {
+            String cls = String.valueOf((char) ('A' + c));
+            Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, cls, "CT", 3);
+            byte[] packed = FT8Package.generatePack77_fd(msg);
+            int k3 = packed[7] & 0x07;
+            assertThat(k3).isEqualTo(c);
+        }
+    }
+
+    @Test
+    public void generatePack77_fd_numTxEncoding() {
+        // n4 occupies bits 57-60 = byte 7 bits [6:3]
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 6, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int n4 = (packed[7] >> 3) & 0x0F;
+        // numTx=6, stored as 6-1=5
+        assertThat(n4).isEqualTo(5);
+    }
+
+    @Test
+    public void generatePack77_fd_numTx_one_encodesAsZero() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int n4 = (packed[7] >> 3) & 0x0F;
+        assertThat(n4).isEqualTo(0);
+    }
+
+    @Test
+    public void generatePack77_fd_numTx_sixteen_encodesAsFifteen() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 16, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int n4 = (packed[7] >> 3) & 0x0F;
+        assertThat(n4).isEqualTo(15);
+    }
+
+    @Test
+    public void generatePack77_fd_sectionEncoding_CT() {
+        // S7 occupies bits 64-70 = byte 8 bits [7:1]
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int s7 = (packed[8] >> 1) & 0x7F;
+        assertThat(s7).isEqualTo(0); // CT is index 0
+    }
+
+    @Test
+    public void generatePack77_fd_sectionEncoding_TER() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "TER", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int s7 = (packed[8] >> 1) & 0x7F;
+        assertThat(s7).isEqualTo(83); // TER is index 83
+    }
+
+    @Test
+    public void generatePack77_fd_sectionEncoding_WI() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "WI", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int s7 = (packed[8] >> 1) & 0x7F;
+        assertThat(s7).isEqualTo(63); // WI is index 63
+    }
+
+    @Test
+    public void generatePack77_fd_padBits_areZero() {
+        // Bits 77-79 (pad) = byte 9 bits [2:0]
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] packed = FT8Package.generatePack77_fd(msg);
+        int pad = packed[9] & 0x07;
+        assertThat(pad).isEqualTo(0);
+    }
+
+    // ---- Helper ---------------------------------------------------------------
+
+    private static Ft8Message buildFdMessage(
+            String toCall, String fromCall, int rFlag,
+            int numTx, String fdClass, String section, int n3) {
+        Ft8Message msg = new Ft8Message(0, n3, toCall, fromCall, "");
+        msg.r_flag = rFlag;
+        msg.eu_serial = numTx;
+        msg.arrl_class = fdClass;
+        msg.arrl_rac = section;
+        return msg;
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageFieldDayTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageFieldDayTest.java
@@ -22,22 +22,22 @@ public class FT8PackageFieldDayTest {
 
     @Test
     public void sectionIndex_firstSection_returnZero() {
-        assertThat(FT8Package.sectionIndex("CT")).isEqualTo(0);
+        assertThat(FT8Package.sectionIndex("AB")).isEqualTo(0);
     }
 
     @Test
-    public void sectionIndex_lastSection_returns83() {
-        assertThat(FT8Package.sectionIndex("TER")).isEqualTo(83);
+    public void sectionIndex_lastSection_returns85() {
+        assertThat(FT8Package.sectionIndex("NB")).isEqualTo(85);
     }
 
     @Test
     public void sectionIndex_middleSection_WI() {
-        assertThat(FT8Package.sectionIndex("WI")).isEqualTo(63);
+        assertThat(FT8Package.sectionIndex("WI")).isEqualTo(75);
     }
 
     @Test
     public void sectionIndex_EMA() {
-        assertThat(FT8Package.sectionIndex("EMA")).isEqualTo(1);
+        assertThat(FT8Package.sectionIndex("EMA")).isEqualTo(10);
     }
 
     @Test
@@ -51,8 +51,8 @@ public class FT8PackageFieldDayTest {
     }
 
     @Test
-    public void sectionTable_has84Entries() {
-        assertThat(FT8Package.ARRL_SECTIONS).hasLength(84);
+    public void sectionTable_has86Entries() {
+        assertThat(FT8Package.ARRL_SECTIONS).hasLength(86);
     }
 
     @Test
@@ -165,7 +165,7 @@ public class FT8PackageFieldDayTest {
         Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
         byte[] packed = FT8Package.generatePack77_fd(msg);
         int s7 = (packed[8] >> 1) & 0x7F;
-        assertThat(s7).isEqualTo(0); // CT is index 0
+        assertThat(s7).isEqualTo(7); // CT is index 7
     }
 
     @Test
@@ -173,7 +173,7 @@ public class FT8PackageFieldDayTest {
         Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "TER", 3);
         byte[] packed = FT8Package.generatePack77_fd(msg);
         int s7 = (packed[8] >> 1) & 0x7F;
-        assertThat(s7).isEqualTo(83); // TER is index 83
+        assertThat(s7).isEqualTo(43); // TER is index 43
     }
 
     @Test
@@ -181,7 +181,7 @@ public class FT8PackageFieldDayTest {
         Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "WI", 3);
         byte[] packed = FT8Package.generatePack77_fd(msg);
         int s7 = (packed[8] >> 1) & 0x7F;
-        assertThat(s7).isEqualTo(63); // WI is index 63
+        assertThat(s7).isEqualTo(75); // WI is index 75
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FieldDaySequencerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FieldDaySequencerTest.java
@@ -1,0 +1,100 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+import com.k1af.ft8af.GeneralVariables;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Coverage for {@link FT8TransmitSignal#buildFieldDayMessage(String, int)},
+ * the helper that constructs Field Day exchange messages for the auto-sequencer.
+ *
+ * Plain JUnit: touches only static fields on GeneralVariables (no Android
+ * framework dependency) and the pure-Java buildFieldDayMessage helper.
+ */
+public class FieldDaySequencerTest {
+
+    @Before
+    public void setUp() {
+        GeneralVariables.myCallsign = "K1ABC";
+        GeneralVariables.fieldDayClass = "A";
+        GeneralVariables.fieldDayNumTx = 6;
+        GeneralVariables.fieldDaySection = "WI";
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.myCallsign = "";
+        GeneralVariables.fieldDayClass = "A";
+        GeneralVariables.fieldDayNumTx = 1;
+        GeneralVariables.fieldDaySection = "";
+    }
+
+    @Test
+    public void buildFieldDayMessage_noR_setsI3Zero() {
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 0);
+        assertThat(msg.i3).isEqualTo(0);
+    }
+
+    @Test
+    public void buildFieldDayMessage_noR_setsN3Three() {
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 0);
+        assertThat(msg.n3).isEqualTo(3);
+    }
+
+    @Test
+    public void buildFieldDayMessage_withR_setsN3Four() {
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 1);
+        assertThat(msg.n3).isEqualTo(4);
+    }
+
+    @Test
+    public void buildFieldDayMessage_setsRFlag() {
+        Ft8Message noR = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 0);
+        assertThat(noR.r_flag).isEqualTo(0);
+
+        Ft8Message withR = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 1);
+        assertThat(withR.r_flag).isEqualTo(1);
+    }
+
+    @Test
+    public void buildFieldDayMessage_setsCallsigns() {
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 0);
+        assertThat(msg.callsignTo).isEqualTo("W9XYZ");
+        assertThat(msg.callsignFrom).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void buildFieldDayMessage_setsClass() {
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 0);
+        assertThat(msg.arrl_class).isEqualTo("A");
+    }
+
+    @Test
+    public void buildFieldDayMessage_setsNumTx() {
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 0);
+        assertThat(msg.eu_serial).isEqualTo(6);
+    }
+
+    @Test
+    public void buildFieldDayMessage_setsSection() {
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("W9XYZ", 0);
+        assertThat(msg.arrl_rac).isEqualTo("WI");
+    }
+
+    @Test
+    public void buildFieldDayMessage_picksUpChangedSettings() {
+        GeneralVariables.fieldDayClass = "B";
+        GeneralVariables.fieldDayNumTx = 17;
+        GeneralVariables.fieldDaySection = "EMA";
+
+        Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("N0CALL", 0);
+        assertThat(msg.arrl_class).isEqualTo("B");
+        assertThat(msg.eu_serial).isEqualTo(17);
+        assertThat(msg.arrl_rac).isEqualTo("EMA");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FieldDaySequencerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FieldDaySequencerTest.java
@@ -89,12 +89,12 @@ public class FieldDaySequencerTest {
     @Test
     public void buildFieldDayMessage_picksUpChangedSettings() {
         GeneralVariables.fieldDayClass = "B";
-        GeneralVariables.fieldDayNumTx = 17;
+        GeneralVariables.fieldDayNumTx = 16;
         GeneralVariables.fieldDaySection = "EMA";
 
         Ft8Message msg = FT8TransmitSignal.buildFieldDayMessage("N0CALL", 0);
         assertThat(msg.arrl_class).isEqualTo("B");
-        assertThat(msg.eu_serial).isEqualTo(17);
+        assertThat(msg.eu_serial).isEqualTo(16);
         assertThat(msg.arrl_rac).isEqualTo("EMA");
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaParkPickerLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaParkPickerLogicTest.kt
@@ -1,0 +1,212 @@
+package radio.ks3ckc.ft8af.pota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import radio.ks3ckc.ft8af.pota.model.PotaLocation
+import radio.ks3ckc.ft8af.pota.model.PotaPark
+import radio.ks3ckc.ft8af.pota.model.PotaParkWithDistance
+import radio.ks3ckc.ft8af.ui.pota.filterNearbyParks
+import radio.ks3ckc.ft8af.ui.pota.filterParks
+
+/**
+ * Unit tests for the pure helper functions used by the park picker.
+ *
+ * [findNearestLocationCodes] and [sortParksByDistance] reach Play-Services `LatLng`
+ * and `MaidenheadGrid.getDist()`, so Robolectric is required. The deduplication
+ * and filter functions are pure Kotlin but share the test runner for simplicity.
+ */
+@RunWith(RobolectricTestRunner::class)
+class PotaParkPickerLogicTest {
+
+    // -----------------------------------------------------------------------
+    // deduplicateRefs
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `deduplicateRefs splits comma-separated refs`() {
+        val result = deduplicateRefs(listOf("K-1234,K-5678"))
+        assertThat(result).containsExactly("K-1234", "K-5678").inOrder()
+    }
+
+    @Test
+    fun `deduplicateRefs removes duplicates preserving first occurrence`() {
+        val result = deduplicateRefs(listOf("K-1234", "K-5678,K-1234"))
+        assertThat(result).containsExactly("K-1234", "K-5678").inOrder()
+    }
+
+    @Test
+    fun `deduplicateRefs trims whitespace and skips empty`() {
+        val result = deduplicateRefs(listOf(" K-0001 , , K-0002 "))
+        assertThat(result).containsExactly("K-0001", "K-0002").inOrder()
+    }
+
+    @Test
+    fun `deduplicateRefs returns empty list for empty input`() {
+        assertThat(deduplicateRefs(emptyList())).isEmpty()
+    }
+
+    @Test
+    fun `deduplicateRefs preserves most-recent-first order`() {
+        // Simulates 3 activations from newest to oldest
+        val result = deduplicateRefs(listOf("K-0003", "K-0002", "K-0001"))
+        assertThat(result).containsExactly("K-0003", "K-0002", "K-0001").inOrder()
+    }
+
+    // -----------------------------------------------------------------------
+    // findNearestLocationCodes
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `findNearestLocationCodes picks N closest`() {
+        // Philadelphia (39.95, -75.17), locations spread around the US
+        val locations = listOf(
+            PotaLocation("US-PA", "Pennsylvania", 40.27, -76.88),
+            PotaLocation("US-CA", "California", 36.78, -119.42),
+            PotaLocation("US-NJ", "New Jersey", 40.06, -74.41),
+            PotaLocation("US-TX", "Texas", 31.97, -99.90),
+        )
+        val result = findNearestLocationCodes(39.95, -75.17, locations, 2)
+        assertThat(result).hasSize(2)
+        // PA and NJ are closest to Philadelphia
+        assertThat(result).containsExactly("US-NJ", "US-PA").inOrder()
+    }
+
+    @Test
+    fun `findNearestLocationCodes returns fewer than count when input is small`() {
+        val locations = listOf(
+            PotaLocation("US-PA", "Pennsylvania", 40.27, -76.88),
+        )
+        val result = findNearestLocationCodes(39.95, -75.17, locations, 5)
+        assertThat(result).hasSize(1)
+        assertThat(result).containsExactly("US-PA")
+    }
+
+    // -----------------------------------------------------------------------
+    // sortParksByDistance
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `sortParksByDistance orders by distance ascending`() {
+        val parks = listOf(
+            parkAt("K-0001", "Far Park", 34.05, -118.24),       // LA
+            parkAt("K-0002", "Near Park", 40.06, -74.41),       // NJ
+            parkAt("K-0003", "Medium Park", 38.90, -77.03),     // DC
+        )
+        // From Philadelphia
+        val result = sortParksByDistance(parks, 39.95, -75.17, 50)
+        assertThat(result.map { it.park.reference })
+            .containsExactly("K-0002", "K-0003", "K-0001")
+            .inOrder()
+    }
+
+    @Test
+    fun `sortParksByDistance respects limit`() {
+        val parks = (1..100).map { i ->
+            parkAt("K-%04d".format(i), "Park $i", 40.0 + i * 0.01, -75.0)
+        }
+        val result = sortParksByDistance(parks, 40.0, -75.0, 50)
+        assertThat(result).hasSize(50)
+    }
+
+    @Test
+    fun `sortParksByDistance skips parks with zero coordinates`() {
+        val parks = listOf(
+            parkAt("K-0001", "No Coords", 0.0, 0.0),
+            parkAt("K-0002", "Real Park", 40.06, -74.41),
+        )
+        val result = sortParksByDistance(parks, 39.95, -75.17, 50)
+        assertThat(result.map { it.park.reference }).containsExactly("K-0002")
+    }
+
+    @Test
+    fun `sortParksByDistance includes distance in result`() {
+        val parks = listOf(parkAt("K-0001", "Park", 40.06, -74.41))
+        val result = sortParksByDistance(parks, 39.95, -75.17, 50)
+        assertThat(result).hasSize(1)
+        assertThat(result[0].distanceKm).isGreaterThan(0.0)
+    }
+
+    // -----------------------------------------------------------------------
+    // filterParks
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `filterParks returns all when query is blank`() {
+        val parks = listOf(
+            parkAt("K-0001", "Valley Forge"),
+            parkAt("K-0002", "Liberty Bell"),
+        )
+        assertThat(filterParks(parks, "")).hasSize(2)
+        assertThat(filterParks(parks, "  ")).hasSize(2)
+    }
+
+    @Test
+    fun `filterParks matches reference case-insensitively`() {
+        val parks = listOf(
+            parkAt("K-0001", "Valley Forge"),
+            parkAt("K-0002", "Liberty Bell"),
+        )
+        val result = filterParks(parks, "k-0001")
+        assertThat(result).hasSize(1)
+        assertThat(result[0].reference).isEqualTo("K-0001")
+    }
+
+    @Test
+    fun `filterParks matches name substring`() {
+        val parks = listOf(
+            parkAt("K-0001", "Valley Forge National Historical Park"),
+            parkAt("K-0002", "Liberty Bell Trail"),
+        )
+        val result = filterParks(parks, "forge")
+        assertThat(result).hasSize(1)
+        assertThat(result[0].name).contains("Forge")
+    }
+
+    @Test
+    fun `filterParks returns empty when no match`() {
+        val parks = listOf(parkAt("K-0001", "Valley Forge"))
+        assertThat(filterParks(parks, "xyz")).isEmpty()
+    }
+
+    // -----------------------------------------------------------------------
+    // filterNearbyParks
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `filterNearbyParks returns all when query is blank`() {
+        val items = listOf(
+            PotaParkWithDistance(parkAt("K-0001", "Park One"), 10.0),
+            PotaParkWithDistance(parkAt("K-0002", "Park Two"), 20.0),
+        )
+        assertThat(filterNearbyParks(items, "")).hasSize(2)
+    }
+
+    @Test
+    fun `filterNearbyParks matches by reference or name`() {
+        val items = listOf(
+            PotaParkWithDistance(parkAt("K-0001", "Park Alpha"), 10.0),
+            PotaParkWithDistance(parkAt("K-0002", "Park Beta"), 20.0),
+        )
+        assertThat(filterNearbyParks(items, "alpha")).hasSize(1)
+        assertThat(filterNearbyParks(items, "K-0002")).hasSize(1)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private fun parkAt(
+        ref: String,
+        name: String,
+        lat: Double = 0.0,
+        lng: Double = 0.0,
+    ) = PotaPark(
+        reference = ref,
+        name = name,
+        locationDesc = "",
+        latitude = lat,
+        longitude = lng,
+    )
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
@@ -1,0 +1,170 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CqOptionsLogicTest {
+
+    // ---- presetLabel ----
+
+    @Test
+    fun presetLabel_emptyModifier_returnsCQ() {
+        assertThat(presetLabel("")).isEqualTo("CQ")
+    }
+
+    @Test
+    fun presetLabel_dx_returnsCQDX() {
+        assertThat(presetLabel("DX")).isEqualTo("CQ DX")
+    }
+
+    @Test
+    fun presetLabel_pota_returnsCQPOTA() {
+        assertThat(presetLabel("POTA")).isEqualTo("CQ POTA")
+    }
+
+    // ---- isValidModifier ----
+
+    @Test
+    fun isValidModifier_empty_valid() {
+        assertThat(isValidModifier("")).isTrue()
+    }
+
+    @Test
+    fun isValidModifier_dx_valid() {
+        assertThat(isValidModifier("DX")).isTrue()
+    }
+
+    @Test
+    fun isValidModifier_pota_valid() {
+        assertThat(isValidModifier("POTA")).isTrue()
+    }
+
+    @Test
+    fun isValidModifier_threeDigits_valid() {
+        assertThat(isValidModifier("599")).isTrue()
+    }
+
+    @Test
+    fun isValidModifier_fiveLetters_invalid() {
+        assertThat(isValidModifier("ABCDE")).isFalse()
+    }
+
+    @Test
+    fun isValidModifier_lowercase_invalid() {
+        assertThat(isValidModifier("dx")).isFalse()
+    }
+
+    @Test
+    fun isValidModifier_twoDigits_invalid() {
+        assertThat(isValidModifier("12")).isFalse()
+    }
+
+    @Test
+    fun isValidModifier_singleLetter_valid() {
+        assertThat(isValidModifier("A")).isTrue()
+    }
+
+    // ---- isValidFreeText ----
+
+    @Test
+    fun isValidFreeText_allFt8Chars_valid() {
+        assertThat(isValidFreeText("HELLO WORLD")).isTrue()
+    }
+
+    @Test
+    fun isValidFreeText_numbersAndSymbols_valid() {
+        assertThat(isValidFreeText("73 +-./?")).isTrue()
+    }
+
+    @Test
+    fun isValidFreeText_exactlyThirteen_valid() {
+        assertThat(isValidFreeText("1234567890ABC")).isTrue()
+    }
+
+    @Test
+    fun isValidFreeText_overThirteen_invalid() {
+        assertThat(isValidFreeText("12345678901234")).isFalse()
+    }
+
+    @Test
+    fun isValidFreeText_lowercase_invalid() {
+        assertThat(isValidFreeText("hello")).isFalse()
+    }
+
+    @Test
+    fun isValidFreeText_invalidChars_invalid() {
+        assertThat(isValidFreeText("@#\$")).isFalse()
+    }
+
+    @Test
+    fun isValidFreeText_empty_valid() {
+        assertThat(isValidFreeText("")).isTrue()
+    }
+
+    // ---- sanitizeModifier ----
+
+    @Test
+    fun sanitizeModifier_uppercases() {
+        assertThat(sanitizeModifier("dx")).isEqualTo("DX")
+    }
+
+    @Test
+    fun sanitizeModifier_stripsSpecialChars() {
+        assertThat(sanitizeModifier("P@O#T$A")).isEqualTo("POTA")
+    }
+
+    @Test
+    fun sanitizeModifier_truncatesTo4() {
+        assertThat(sanitizeModifier("ABCDEFG")).isEqualTo("ABCD")
+    }
+
+    @Test
+    fun sanitizeModifier_preservesDigits() {
+        assertThat(sanitizeModifier("599")).isEqualTo("599")
+    }
+
+    @Test
+    fun sanitizeModifier_empty_returnsEmpty() {
+        assertThat(sanitizeModifier("")).isEqualTo("")
+    }
+
+    // ---- sanitizeFreeText ----
+
+    @Test
+    fun sanitizeFreeText_uppercases() {
+        assertThat(sanitizeFreeText("hello")).isEqualTo("HELLO")
+    }
+
+    @Test
+    fun sanitizeFreeText_keepsFt8Chars() {
+        assertThat(sanitizeFreeText("73 +-./?")).isEqualTo("73 +-./?")
+    }
+
+    @Test
+    fun sanitizeFreeText_stripsInvalidChars() {
+        assertThat(sanitizeFreeText("HI@THERE#")).isEqualTo("HITHERE")
+    }
+
+    @Test
+    fun sanitizeFreeText_truncatesTo13() {
+        assertThat(sanitizeFreeText("ABCDEFGHIJKLMNOP")).isEqualTo("ABCDEFGHIJKLM")
+    }
+
+    @Test
+    fun sanitizeFreeText_empty_returnsEmpty() {
+        assertThat(sanitizeFreeText("")).isEqualTo("")
+    }
+
+    @Test
+    fun sanitizeFreeText_preservesSpaces() {
+        assertThat(sanitizeFreeText("A B C")).isEqualTo("A B C")
+    }
+
+    // ---- CQ_PRESETS ----
+
+    @Test
+    fun cqPresets_containsExpectedEntries() {
+        assertThat(CQ_PRESETS).containsExactly("", "DX", "NA", "EU", "SA", "AS", "OC", "AF")
+            .inOrder()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
@@ -119,8 +119,8 @@ class CqOptionsLogicTest {
     }
 
     @Test
-    fun sanitizeModifier_preservesDigits() {
-        assertThat(sanitizeModifier("599")).isEqualTo("599")
+    fun sanitizeModifier_stripsDigits() {
+        assertThat(sanitizeModifier("599")).isEqualTo("")
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
@@ -40,8 +40,10 @@ class CqOptionsLogicTest {
     }
 
     @Test
-    fun isValidModifier_threeDigits_valid() {
-        assertThat(isValidModifier("599")).isTrue()
+    fun isValidModifier_threeDigits_invalid() {
+        // The custom-modifier field is letters-only (sanitizeModifier strips
+        // digits), so a 3-digit modifier can never be produced by the UI.
+        assertThat(isValidModifier("599")).isFalse()
     }
 
     @Test
@@ -166,5 +168,44 @@ class CqOptionsLogicTest {
     fun cqPresets_containsExpectedEntries() {
         assertThat(CQ_PRESETS).containsExactly("", "DX", "NA", "EU", "SA", "AS", "OC", "AF")
             .inOrder()
+    }
+
+    // ---- canEnableFieldDay ----
+
+    @Test
+    fun canEnableFieldDay_knownSection_true() {
+        assertThat(canEnableFieldDay("EMA")).isTrue()
+    }
+
+    @Test
+    fun canEnableFieldDay_unknownSection_false() {
+        assertThat(canEnableFieldDay("ZZ")).isFalse()
+    }
+
+    @Test
+    fun canEnableFieldDay_blank_false() {
+        assertThat(canEnableFieldDay("")).isFalse()
+    }
+
+    // ---- shouldPersistSection ----
+
+    @Test
+    fun shouldPersistSection_knownSection_true() {
+        assertThat(shouldPersistSection("WI", fieldDayEnabled = true)).isTrue()
+    }
+
+    @Test
+    fun shouldPersistSection_unknownSection_false() {
+        assertThat(shouldPersistSection("ZZ", fieldDayEnabled = false)).isFalse()
+    }
+
+    @Test
+    fun shouldPersistSection_clearWhileDisabled_true() {
+        assertThat(shouldPersistSection("", fieldDayEnabled = false)).isTrue()
+    }
+
+    @Test
+    fun shouldPersistSection_clearWhileEnabled_false() {
+        assertThat(shouldPersistSection("", fieldDayEnabled = true)).isFalse()
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsLogicTest.kt
@@ -110,7 +110,7 @@ class CqOptionsLogicTest {
 
     @Test
     fun sanitizeModifier_stripsSpecialChars() {
-        assertThat(sanitizeModifier("P@O#T$A")).isEqualTo("POTA")
+        assertThat(sanitizeModifier("P@O#T\$A")).isEqualTo("POTA")
     }
 
     @Test


### PR DESCRIPTION
## Summary

### CQ Options & Field Day
- **CQ Options bottom sheet** (long-press CQ button): preset CQ modifiers (DX/NA/EU/SA/AS/OC/AF), custom modifier entry, free text TX input, and ARRL Field Day configuration
- **Field Day operating mode**: auto-sequencer exchanges class+section instead of signal reports; pure-Java FD message packer (i3=0, n3=3/4) with canonical 86-entry ARRL/RAC section table
- **Free text UI**: exposes the existing free text TX backend through the CQ options sheet with FT8 character validation and 13-char limit
- **CQ button subtitle**: shows active modifier/mode (DX, FD, FREE) beneath the CQ label with a chevron indicator for long-press discoverability

### POTA Park Picker
- **Park picker bottom sheet** — tap the search icon on any park ref field to open a sheet with recent activations and the 50 nearest parks (GPS-sorted), both filterable by name or reference
- **Nearby parks** — fetches location codes and parks from `api.pota.app`, cached 30 min, distances displayed in the user's preferred unit (mi/km)
- **Recent parks** — pulls distinct park refs from `pota_activation` history with park name resolution
- **Tab persistence** — `parkRefs` now uses `rememberSaveable` so switching tabs no longer loses entered park references

## Test plan

### CQ Options / Field Day
- [ ] Long-press CQ → sheet opens with presets, modifier field, FD toggle, free text field
- [ ] Tap preset chip (e.g. CQ DX) → sheet closes, CQ button shows "DX" subtitle, TX sends "CQ DX {CALL} {GRID}"
- [ ] Type custom modifier "POTA" → tap Call CQ → TX sends "CQ POTA {CALL} {GRID}"
- [ ] Type free text "HELLO WORLD" → tap Send Free Text → TX sends free text message
- [ ] Enable Field Day → set class B, 2 TX, section EMA → tap Call CQ FD → TX sends "CQ FD {CALL} {GRID}"; reply triggers "2B EMA" exchange
- [ ] STOP clears free text/FD mode
- [ ] Settings persist across app restart
- [ ] Unit tests pass: `CqOptionsLogicTest`, `FT8PackageFieldDayTest`, `FieldDaySequencerTest`

### POTA Park Picker
- [ ] Enter park refs, switch to Hunt/History tab and back — values preserved
- [ ] Tap search icon on park ref field — picker sheet opens
- [ ] Type partial park name/ref in filter field — lists narrow correctly
- [ ] With GPS enabled, nearby parks section shows sorted by distance
- [ ] After completing an activation, recent section shows it on next open
- [ ] Toggle miles/km in Settings, re-open picker — units match
- [ ] `./gradlew testDebugUnitTest` — 16 new park picker tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)