### PR TITLE
POTA: retry transient upload failures and explain them clearly

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaClient.kt
@@ -3,6 +3,7 @@ package radio.ks3ckc.ft8af.pota
 import android.util.Log
 import com.k1af.ft8af.GeneralVariables
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
@@ -20,11 +21,43 @@ import java.util.Locale
 
 /**
  * Thrown by [PotaClient.uploadAdif] when POTA's endpoint returns a non-2xx HTTP
- * status. Carries the status so the UI can tell a server-side rejection (5xx —
- * usually a bad park ref or unregistered callsign) from a client/auth problem.
+ * status. Carries the status so callers can tell a transient gateway outage
+ * (502/503/504 — retryable) from a real log rejection (other 5xx — usually a bad
+ * park ref or unregistered callsign) or a client/auth problem (4xx).
  */
 class PotaUploadException(val httpCode: Int, val body: String) :
     Exception("HTTP $httpCode${if (body.isNotBlank()) ": ${body.take(160)}" else ""}")
+
+/**
+ * HTTP statuses that mean POTA's backend was *transiently* unavailable (a gateway
+ * timed out or the upstream Lambda was cold/overloaded) rather than rejecting the
+ * log itself. These are worth retrying; a 4xx or a plain 500 is not — the request
+ * would fail again identically. POTA returns 502 when its API Gateway can't reach
+ * the upstream, which is exactly the failure observed in the field.
+ */
+private val RETRYABLE_UPLOAD_CODES = setOf(502, 503, 504)
+
+/** Initial attempt plus this many retries before giving up. */
+private const val MAX_UPLOAD_ATTEMPTS = 3
+
+/**
+ * True when [error] is a transient upload failure worth retrying: a gateway status
+ * in [RETRYABLE_UPLOAD_CODES], or a connectivity [java.io.IOException] (timeout,
+ * connection reset, dropped DNS). A non-retryable status (4xx, plain 500) or any
+ * other throwable returns false so the caller surfaces it immediately.
+ */
+internal fun isRetryableUploadFailure(error: Throwable?): Boolean = when (error) {
+    is PotaUploadException -> error.httpCode in RETRYABLE_UPLOAD_CODES
+    is java.io.IOException -> true
+    else -> false
+}
+
+/**
+ * Exponential backoff before retry [attempt] (1-based): 1s, 2s, 4s, … Keeps the
+ * total wait modest (a few seconds) so the upload toast doesn't hang, while still
+ * giving a flapping gateway time to recover between tries.
+ */
+internal fun uploadBackoffMs(attempt: Int): Long = 1000L shl (attempt - 1)
 
 /**
  * Talks to pota.app's read+write endpoints. Mirrors [radio.ks3ckc.ft8af.pskreporter.PskReporterClient]:
@@ -125,48 +158,62 @@ object PotaClient {
      */
     suspend fun uploadAdif(idToken: String, filename: String, adif: String): Result<String> =
         withContext(Dispatchers.IO) {
-            val boundary = "----ft8af${System.nanoTime()}"
-            val preamble = buildString {
-                append("--").append(boundary).append("\r\n")
-                append("Content-Disposition: form-data; name=\"adif\"; filename=\"").append(filename).append("\"\r\n")
-                append("Content-Type: application/octet-stream\r\n\r\n")
-            }.toByteArray(StandardCharsets.UTF_8)
-            val epilogue = "\r\n--$boundary--\r\n".toByteArray(StandardCharsets.UTF_8)
-            val payload = adif.toByteArray(StandardCharsets.UTF_8)
-
-            var conn: HttpURLConnection? = null
-            try {
-                conn = (URL("$BASE_URL/adif").openConnection() as HttpURLConnection).apply {
-                    requestMethod = "POST"
-                    connectTimeout = IO_TIMEOUT_MS
-                    readTimeout = 30_000
-                    doOutput = true
-                    setRequestProperty("User-Agent", USER_AGENT)
-                    setRequestProperty("Authorization", idToken)
-                    setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
-                    setRequestProperty("Accept", "application/json")
+            var last: Result<String> = Result.failure(IllegalStateException("no upload attempt"))
+            for (attempt in 1..MAX_UPLOAD_ATTEMPTS) {
+                if (attempt > 1) {
+                    val backoff = uploadBackoffMs(attempt - 1)
+                    log("uploadAdif $filename retry $attempt/$MAX_UPLOAD_ATTEMPTS after ${backoff}ms")
+                    delay(backoff)
                 }
-                conn.outputStream.use { out ->
-                    out.write(preamble)
-                    out.write(payload)
-                    out.write(epilogue)
-                }
-                val code = conn.responseCode
-                if (code !in 200..299) {
-                    val err = conn.errorStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() } ?: ""
-                    log("uploadAdif $filename -> http $code ${err.take(200)}")
-                    return@withContext Result.failure(PotaUploadException(code, err))
-                }
-                val resp = conn.inputStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() } ?: ""
-                log("uploadAdif ok $filename (${payload.size}B) -> ${resp.take(120)}")
-                Result.success(resp)
-            } catch (e: Exception) {
-                log("uploadAdif $filename failed: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
-                Result.failure(e)
-            } finally {
-                conn?.disconnect()
+                last = uploadAdifOnce(idToken, filename, adif)
+                if (last.isSuccess || !isRetryableUploadFailure(last.exceptionOrNull())) break
             }
+            last
         }
+
+    private fun uploadAdifOnce(idToken: String, filename: String, adif: String): Result<String> {
+        val boundary = "----ft8af${System.nanoTime()}"
+        val preamble = buildString {
+            append("--").append(boundary).append("\r\n")
+            append("Content-Disposition: form-data; name=\"adif\"; filename=\"").append(filename).append("\"\r\n")
+            append("Content-Type: application/octet-stream\r\n\r\n")
+        }.toByteArray(StandardCharsets.UTF_8)
+        val epilogue = "\r\n--$boundary--\r\n".toByteArray(StandardCharsets.UTF_8)
+        val payload = adif.toByteArray(StandardCharsets.UTF_8)
+
+        var conn: HttpURLConnection? = null
+        return try {
+            conn = (URL("$BASE_URL/adif").openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                connectTimeout = IO_TIMEOUT_MS
+                readTimeout = 30_000
+                doOutput = true
+                setRequestProperty("User-Agent", USER_AGENT)
+                setRequestProperty("Authorization", idToken)
+                setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+                setRequestProperty("Accept", "application/json")
+            }
+            conn.outputStream.use { out ->
+                out.write(preamble)
+                out.write(payload)
+                out.write(epilogue)
+            }
+            val code = conn.responseCode
+            if (code !in 200..299) {
+                val err = conn.errorStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() } ?: ""
+                log("uploadAdif $filename -> http $code ${err.take(200)}")
+                return Result.failure(PotaUploadException(code, err))
+            }
+            val resp = conn.inputStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() } ?: ""
+            log("uploadAdif ok $filename (${payload.size}B) -> ${resp.take(120)}")
+            Result.success(resp)
+        } catch (e: Exception) {
+            log("uploadAdif $filename failed: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
+            Result.failure(e)
+        } finally {
+            conn?.disconnect()
+        }
+    }
 
     /** Fetch the user's recent upload/processing jobs (authenticated). Raw JSON. */
     suspend fun getJobs(idToken: String): String? = withContext(Dispatchers.IO) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaClient.kt
@@ -2,6 +2,7 @@ package radio.ks3ckc.ft8af.pota
 
 import android.util.Log
 import com.k1af.ft8af.GeneralVariables
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -37,7 +38,7 @@ class PotaUploadException(val httpCode: Int, val body: String) :
  */
 private val RETRYABLE_UPLOAD_CODES = setOf(502, 503, 504)
 
-/** Initial attempt plus this many retries before giving up. */
+/** Total upload attempts (the initial try plus retries) before giving up. */
 private const val MAX_UPLOAD_ATTEMPTS = 3
 
 /**
@@ -207,6 +208,10 @@ object PotaClient {
             val resp = conn.inputStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() } ?: ""
             log("uploadAdif ok $filename (${payload.size}B) -> ${resp.take(120)}")
             Result.success(resp)
+        } catch (e: CancellationException) {
+            // Don't let coroutine cancellation (e.g. the user navigated away) be
+            // swallowed into a failed Result and surfaced as an upload-error toast.
+            throw e
         } catch (e: Exception) {
             log("uploadAdif $filename failed: ${e.javaClass.simpleName}: ${e.message ?: "?"}")
             Result.failure(e)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
@@ -657,15 +657,22 @@ private suspend fun uploadActivation(
 }
 
 /** How an upload failed, mapped to a user-facing message in [startUpload]. */
-internal enum class UploadFailureKind { SERVER, NETWORK, OTHER }
+internal enum class UploadFailureKind { BUSY, SERVER, NETWORK, OTHER }
 
 /**
- * Classify an upload failure so the UI can explain it. A 5xx is POTA's backend
- * rejecting the log (almost always a bad park ref or a callsign not registered to
- * the account); an [java.io.IOException] is a connectivity problem; anything else
- * falls back to the raw message.
+ * Classify an upload failure so the UI can explain it.
+ *
+ *  - [BUSY]: a gateway status (502/503/504) — POTA's backend was transiently down.
+ *    [PotaClient.uploadAdif] already retried with backoff, so by the time this
+ *    surfaces it's still flapping; tell the user to try again shortly, *not* to
+ *    go check their park ref.
+ *  - [SERVER]: any other 5xx — POTA accepted the request but rejected the log,
+ *    almost always a bad park ref or a callsign not registered to the account.
+ *  - [NETWORK]: an [java.io.IOException] — a connectivity problem on our side.
+ *  - [OTHER]: anything else, surfaced with its raw message.
  */
 internal fun classifyUploadFailure(error: Throwable?): UploadFailureKind = when {
+    error is PotaUploadException && error.httpCode in setOf(502, 503, 504) -> UploadFailureKind.BUSY
     error is PotaUploadException && error.httpCode in 500..599 -> UploadFailureKind.SERVER
     error is java.io.IOException -> UploadFailureKind.NETWORK
     else -> UploadFailureKind.OTHER
@@ -873,6 +880,7 @@ private fun ActivationDetailScreen(
                     loginPending = true
                 } else {
                     val msg = when (classifyUploadFailure(e)) {
+                        UploadFailureKind.BUSY -> context.getString(R.string.pota_upload_busy)
                         UploadFailureKind.SERVER -> context.getString(R.string.pota_upload_server_error)
                         UploadFailureKind.NETWORK -> context.getString(R.string.pota_upload_network_error)
                         UploadFailureKind.OTHER -> context.getString(R.string.pota_upload_failed, e.message ?: "?")

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -282,6 +282,7 @@
     <string name="pota_upload_success">تم رفع %1$d سجل حديقة إلى POTA</string>
     <string name="pota_upload_failed">فشل الرفع: %1$s</string>
     <string name="pota_upload_server_error">تعذّر على POTA معالجة الرفع. تحقق من صلاحية مرجع الحديقة وأن نداءك مسجَّل لدى POTA، ثم أعد المحاولة.</string>
+    <string name="pota_upload_busy">خوادم POTA غير متاحة مؤقتًا. حاولنا عدة مرات دون جدوى — يرجى المحاولة مرة أخرى بعد بضع دقائق.</string>
     <string name="pota_upload_network_error">تعذّر الوصول إلى POTA. تحقق من اتصالك بالإنترنت وأعد المحاولة.</string>
     <string name="pota_login_title">تسجيل الدخول إلى POTA</string>
     <string name="pota_login_desc">استخدم بريد وكلمة مرور حساب pota.app الخاص بك.</string>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -282,6 +282,7 @@
     <string name="pota_upload_success">Nahráno %1$d deníků parků do POTA</string>
     <string name="pota_upload_failed">Nahrání selhalo: %1$s</string>
     <string name="pota_upload_server_error">POTA nemohlo zpracovat nahrání. Zkontrolujte, že reference parku je platná a vaše volací značka je registrována v POTA, a zkuste to znovu.</string>
+    <string name="pota_upload_busy">Servery POTA jsou dočasně nedostupné. Několikrát jsme to zkusili bez úspěchu — zkuste to prosím znovu za pár minut.</string>
     <string name="pota_upload_network_error">Nepodařilo se spojit s POTA. Zkontrolujte připojení k internetu a zkuste to znovu.</string>
     <string name="pota_login_title">Přihlásit se do POTA</string>
     <string name="pota_login_desc">Použijte e-mail a heslo svého účtu pota.app.</string>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -282,6 +282,7 @@
     <string name="pota_upload_success">Mengunggah %1$d log taman ke POTA</string>
     <string name="pota_upload_failed">Unggah gagal: %1$s</string>
     <string name="pota_upload_server_error">POTA tidak dapat memproses unggahan. Pastikan referensi taman valid dan tanda panggil Anda terdaftar di POTA, lalu coba lagi.</string>
+    <string name="pota_upload_busy">Server POTA sedang tidak tersedia sementara. Kami sudah mencoba beberapa kali tanpa hasil — silakan coba lagi dalam beberapa menit.</string>
     <string name="pota_upload_network_error">Tidak dapat menjangkau POTA. Periksa koneksi internet Anda dan coba lagi.</string>
     <string name="pota_login_title">Masuk ke POTA</string>
     <string name="pota_login_desc">Gunakan email dan kata sandi akun pota.app Anda.</string>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -271,6 +271,7 @@
     <string name="pota_upload_success">Caricati %1$d log di parco su POTA</string>
     <string name="pota_upload_failed">Caricamento fallito: %1$s</string>
     <string name="pota_upload_server_error">POTA non è riuscito a elaborare il caricamento. Verifica che il riferimento parco sia valido e che il tuo nominativo sia registrato su POTA, poi riprova.</string>
+    <string name="pota_upload_busy">I server di POTA non sono temporaneamente disponibili. Abbiamo riprovato alcune volte senza successo — riprova tra qualche minuto.</string>
     <string name="pota_upload_network_error">Impossibile raggiungere POTA. Controlla la connessione internet e riprova.</string>
     <string name="pota_login_title">Accedi a POTA</string>
     <string name="pota_login_desc">Usa email e password del tuo account pota.app.</string>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -282,6 +282,7 @@
     <string name="pota_upload_success">공원 로그 %1$d개를 POTA에 업로드함</string>
     <string name="pota_upload_failed">업로드 실패: %1$s</string>
     <string name="pota_upload_server_error">POTA가 업로드를 처리하지 못했습니다. 공원 참조가 유효하고 콜사인이 POTA에 등록되어 있는지 확인한 후 다시 시도하세요.</string>
+    <string name="pota_upload_busy">POTA 서버를 일시적으로 사용할 수 없습니다. 여러 번 다시 시도했지만 실패했습니다 — 몇 분 후에 다시 시도하세요.</string>
     <string name="pota_upload_network_error">POTA에 연결할 수 없습니다. 인터넷 연결을 확인하고 다시 시도하세요.</string>
     <string name="pota_login_title">POTA에 로그인</string>
     <string name="pota_login_desc">pota.app 계정 이메일과 비밀번호를 사용하세요.</string>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -282,6 +282,7 @@
     <string name="pota_upload_success">%1$d parklog(s) geüpload naar POTA</string>
     <string name="pota_upload_failed">Upload mislukt: %1$s</string>
     <string name="pota_upload_server_error">POTA kon de upload niet verwerken. Controleer of de parkreferentie geldig is en je roepnaam bij POTA is geregistreerd, en probeer het opnieuw.</string>
+    <string name="pota_upload_busy">De servers van POTA zijn tijdelijk niet beschikbaar. We hebben het een paar keer opnieuw geprobeerd zonder succes — probeer het over een paar minuten opnieuw.</string>
     <string name="pota_upload_network_error">Kan POTA niet bereiken. Controleer je internetverbinding en probeer het opnieuw.</string>
     <string name="pota_login_title">Inloggen bij POTA</string>
     <string name="pota_login_desc">Gebruik het e-mailadres en wachtwoord van je pota.app-account.</string>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -271,6 +271,7 @@
     <string name="pota_upload_success">Wysłano %1$d dziennik(ów) parków do POTA</string>
     <string name="pota_upload_failed">Wysyłanie nieudane: %1$s</string>
     <string name="pota_upload_server_error">POTA nie mogło przetworzyć przesyłki. Sprawdź, czy identyfikator parku jest poprawny i czy Twój znak jest zarejestrowany w POTA, a następnie spróbuj ponownie.</string>
+    <string name="pota_upload_busy">Serwery POTA są tymczasowo niedostępne. Spróbowaliśmy kilka razy bez powodzenia — spróbuj ponownie za kilka minut.</string>
     <string name="pota_upload_network_error">Nie udało się połączyć z POTA. Sprawdź połączenie z internetem i spróbuj ponownie.</string>
     <string name="pota_login_title">Zaloguj się do POTA</string>
     <string name="pota_login_desc">Użyj e-maila i hasła swojego konta pota.app.</string>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -271,6 +271,7 @@
     <string name="pota_upload_success">%1$d park günlüğü POTA\'ya yüklendi</string>
     <string name="pota_upload_failed">Yükleme başarısız: %1$s</string>
     <string name="pota_upload_server_error">POTA yüklemeyi işleyemedi. Park referansının geçerli ve çağrı işaretinizin POTA\'ya kayıtlı olduğundan emin olup yeniden deneyin.</string>
+    <string name="pota_upload_busy">POTA sunucuları geçici olarak kullanılamıyor. Birkaç kez denedik ama başaramadık — lütfen birkaç dakika sonra tekrar deneyin.</string>
     <string name="pota_upload_network_error">POTA\'ya ulaşılamadı. İnternet bağlantınızı kontrol edip yeniden deneyin.</string>
     <string name="pota_login_title">POTA\'ya giriş yap</string>
     <string name="pota_login_desc">pota.app hesabınızın e-posta ve parolasını kullanın.</string>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -271,6 +271,7 @@
     <string name="pota_upload_success">Вивантажено журналів парків: %1$d у POTA</string>
     <string name="pota_upload_failed">Не вдалося вивантажити: %1$s</string>
     <string name="pota_upload_server_error">POTA не зміг обробити вивантаження. Перевірте, що посилання на парк дійсне, а ваш позивний зареєстровано в POTA, потім повторіть.</string>
+    <string name="pota_upload_busy">Сервери POTA тимчасово недоступні. Ми кілька разів повторили спробу безуспішно — повторіть, будь ласка, за кілька хвилин.</string>
     <string name="pota_upload_network_error">Не вдалося зв’язатися з POTA. Перевірте інтернет-з’єднання та повторіть.</string>
     <string name="pota_login_title">Увійти в POTA</string>
     <string name="pota_login_desc">Використайте email і пароль вашого облікового запису pota.app.</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -284,6 +284,7 @@
     <string name="pota_upload_success">Uploaded %1$d park log(s) to POTA</string>
     <string name="pota_upload_failed">Upload failed: %1$s</string>
     <string name="pota_upload_server_error">POTA couldn\'t process the upload. Check that the park reference is valid and your callsign is registered with POTA, then try again.</string>
+    <string name="pota_upload_busy">POTA\'s servers are temporarily unavailable. We retried a few times without luck — please try again in a few minutes.</string>
     <string name="pota_upload_network_error">Couldn\'t reach POTA. Check your internet connection and try again.</string>
     <string name="pota_login_title">Sign in to POTA</string>
     <string name="pota_login_desc">Use your pota.app account email and password.</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/UploadRetryTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/UploadRetryTest.kt
@@ -1,6 +1,7 @@
 package radio.ks3ckc.ft8af.pota
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CancellationException
 import org.junit.Test
 import java.io.IOException
 import java.net.SocketTimeoutException
@@ -41,6 +42,14 @@ class UploadRetryTest {
     fun `non-network non-http failures are not retryable`() {
         assertThat(isRetryableUploadFailure(null)).isFalse()
         assertThat(isRetryableUploadFailure(IllegalStateException("no database"))).isFalse()
+    }
+
+    @Test
+    fun `coroutine cancellation is not retryable`() {
+        // uploadAdifOnce re-throws CancellationException rather than returning it
+        // as a failure, but guard the policy too: a cancelled upload must never be
+        // retried even if a cancellation ever reached the loop.
+        assertThat(isRetryableUploadFailure(CancellationException("navigated away"))).isFalse()
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/UploadRetryTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/UploadRetryTest.kt
@@ -1,0 +1,52 @@
+package radio.ks3ckc.ft8af.pota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+/**
+ * Coverage for the upload retry policy in [PotaClient]: which failures are worth
+ * retrying ([isRetryableUploadFailure]) and how long to wait between tries
+ * ([uploadBackoffMs]). Pure JVM logic — no Android types, so no Robolectric.
+ */
+class UploadRetryTest {
+
+    @Test
+    fun `gateway statuses are retryable`() {
+        // The 502 seen in the field, plus the sibling gateway statuses.
+        assertThat(isRetryableUploadFailure(PotaUploadException(502, "Internal server error"))).isTrue()
+        assertThat(isRetryableUploadFailure(PotaUploadException(503, ""))).isTrue()
+        assertThat(isRetryableUploadFailure(PotaUploadException(504, ""))).isTrue()
+    }
+
+    @Test
+    fun `plain 500 and 4xx are not retryable`() {
+        // A non-gateway 5xx means the log itself was rejected; a 4xx is an
+        // auth/request problem. Retrying either just fails again identically.
+        assertThat(isRetryableUploadFailure(PotaUploadException(500, ""))).isFalse()
+        assertThat(isRetryableUploadFailure(PotaUploadException(400, "bad request"))).isFalse()
+        assertThat(isRetryableUploadFailure(PotaUploadException(403, "forbidden"))).isFalse()
+    }
+
+    @Test
+    fun `connectivity exceptions are retryable`() {
+        assertThat(isRetryableUploadFailure(SocketTimeoutException("timeout"))).isTrue()
+        assertThat(isRetryableUploadFailure(UnknownHostException("api.pota.app"))).isTrue()
+        assertThat(isRetryableUploadFailure(IOException("connection reset"))).isTrue()
+    }
+
+    @Test
+    fun `non-network non-http failures are not retryable`() {
+        assertThat(isRetryableUploadFailure(null)).isFalse()
+        assertThat(isRetryableUploadFailure(IllegalStateException("no database"))).isFalse()
+    }
+
+    @Test
+    fun `backoff grows exponentially from one second`() {
+        assertThat(uploadBackoffMs(1)).isEqualTo(1000L)
+        assertThat(uploadBackoffMs(2)).isEqualTo(2000L)
+        assertThat(uploadBackoffMs(3)).isEqualTo(4000L)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/ClassifyUploadFailureTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/ClassifyUploadFailureTest.kt
@@ -15,9 +15,21 @@ import java.net.UnknownHostException
 class ClassifyUploadFailureTest {
 
     @Test
-    fun `5xx from POTA is a server rejection`() {
+    fun `gateway statuses are transient busy errors`() {
+        // 502/503/504 = POTA's gateway couldn't reach the upstream — retried then
+        // surfaced as BUSY ("try again shortly"), not a log rejection.
         assertThat(classifyUploadFailure(PotaUploadException(502, "Internal server error")))
-            .isEqualTo(UploadFailureKind.SERVER)
+            .isEqualTo(UploadFailureKind.BUSY)
+        assertThat(classifyUploadFailure(PotaUploadException(503, "")))
+            .isEqualTo(UploadFailureKind.BUSY)
+        assertThat(classifyUploadFailure(PotaUploadException(504, "")))
+            .isEqualTo(UploadFailureKind.BUSY)
+    }
+
+    @Test
+    fun `other 5xx is a server rejection`() {
+        // A plain 500 (or other non-gateway 5xx) means POTA processed the request
+        // and rejected the log — point the user at their park ref / callsign.
         assertThat(classifyUploadFailure(PotaUploadException(500, "")))
             .isEqualTo(UploadFailureKind.SERVER)
         assertThat(classifyUploadFailure(PotaUploadException(599, "")))


### PR DESCRIPTION
## What

Today a 3-park POTA activation upload failed for all three parks with `HTTP 502 {"message": "Internal server error"}` from pota.app's API Gateway (found in `debug.log`):

```
10:51:55.828  Pota: uploadAdif pota-US-4579-20260621-0747.adi -> http 502 {"message": "Internal server error"}
10:51:56.184  Pota: uploadAdif pota-US-4576-20260621-0747.adi -> http 502 {"message": "Internal server error"}
10:51:56.511  Pota: uploadAdif pota-US-4566-20260621-0747.adi -> http 502 {"message": "Internal server error"}
```

A 502 is a **transient gateway outage** on POTA's side, not a problem with the log. But the app (a) made no attempt to retry, and (b) surfaced the generic 5xx message telling the user to check their park reference and callsign registration — actively misleading for a server outage.

## Changes

- **Retry with backoff** — `PotaClient.uploadAdif` now retries transient failures (gateway `502`/`503`/`504` and connectivity `IOException`s) up to 3 attempts with exponential backoff (1s, 2s). Non-retryable failures (4xx, plain 500) still fail fast. The single-attempt request is extracted into `uploadAdifOnce`.
- **Clearer message** — `classifyUploadFailure` gains a `BUSY` bucket for `502`/`503`/`504` mapped to a new "POTA's servers are temporarily unavailable, try again in a few minutes" string. Other 5xx keep the existing "check your park ref / callsign" rejection message. New string translated into the 9 locales that already carry the sibling upload strings.

## Tests

- New `UploadRetryTest` covers `isRetryableUploadFailure` (gateway vs plain-500 vs 4xx vs IOException vs other) and `uploadBackoffMs` (exponential growth).
- `ClassifyUploadFailureTest` updated for the BUSY/SERVER split.
- `gradlew testDebugUnitTest` for both classes: BUILD SUCCESSFUL.

Not installed on device — the retry path can only be exercised when POTA's gateway actually 502s; logic is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)