### PR TITLE
fix: POTA QSO counter not updating after force-log

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaActivationDao.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaActivationDao.kt
@@ -8,6 +8,7 @@ import radio.ks3ckc.ft8af.pota.model.PotaQso
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 /**
  * Thin DAO over the pota_activation SQLite table. Single-threaded callers from the
@@ -98,7 +99,9 @@ internal object PotaActivationDao {
      * activations at the same park don't bleed into each other.
      */
     fun getActivationQsos(activation: PotaActivation): List<PotaQso> {
-        val fmt = SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
+        val fmt = SimpleDateFormat("yyyyMMddHHmmss", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }
         val startStamp = fmt.format(Date(activation.startedAtMs))
         val endStamp = activation.endedAtMs?.let { fmt.format(Date(it)) } ?: "99991231235959"
         val cursor = db().rawQuery(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
@@ -210,7 +210,10 @@ private fun ActivateTab() {
     LaunchedEffect(activation?.id, refreshKey) {
         if (activation != null) {
             if (refreshKey > 0) kotlinx.coroutines.delay(3000)
-            PotaSessionManager.refreshCounter()
+            // refreshCounter() does blocking SQLite (reload + QSO list); keep it
+            // off the main dispatcher so the immediate first poll (and every 3s
+            // poll after) can't jank the UI / trigger an ANR.
+            withContext(Dispatchers.IO) { PotaSessionManager.refreshCounter() }
             refreshKey++
         }
     }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
@@ -204,10 +204,12 @@ private fun ActivateTab() {
     var pickerTargetIndex by remember { mutableIntStateOf(-1) }
 
     // Refresh the activation's QSO counter periodically while one is running so
-    // the on-screen tally reflects QSOs added by the TX/RX path.
+    // the on-screen tally reflects QSOs added by the TX/RX path. The first
+    // refresh is immediate (no delay) so QSOs logged while on another tab are
+    // visible as soon as the user switches back to the POTA tab.
     LaunchedEffect(activation?.id, refreshKey) {
         if (activation != null) {
-            kotlinx.coroutines.delay(3000)
+            if (refreshKey > 0) kotlinx.coroutines.delay(3000)
             PotaSessionManager.refreshCounter()
             refreshKey++
         }


### PR DESCRIPTION
## Summary

- **Immediate counter refresh** — skip the 3-second delay on the first `refreshCounter()` poll when the POTA tab enters composition, so QSOs logged while on the Decode tab are visible as soon as the user switches back
- **Timezone fix in activation QSO query** — `getActivationQsos` was formatting start/end bounds in local time while QSO timestamps in the database are UTC, causing QSOs near activation boundaries to be excluded from the contacts list

## Test plan

- [ ] Start a POTA activation, switch to Decode tab, complete a QSO (auto-sequence or LOG), switch back to POTA tab — counter reflects the new QSO immediately
- [ ] End the activation, check History — all QSOs appear in the contacts list (no missing QSOs near end of activation)
- [ ] `./gradlew testDebugUnitTest` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)