### PR TITLE
ci: add staging stage to the release lifecycle

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,39 +4,49 @@ name: Android CI & Release
 # emulator tests, static analysis (lint/detekt/ktlint), and the signed
 # APK/AAB build + GitHub Release + Play internal publish.
 #
+# Release lifecycle (see docs/release-pipeline.md):
+#   PR to dev/staging/main -> build-only (unsigned), tests
+#   push to dev            -> build-only sanity, NO release (dev builds never
+#                             reach the Releases page)
+#   push to staging        -> android-dev.<run#> PRERELEASE + Play internal
+#   push to main           -> android-v<auto-bump> release + Play production
+#   android-v* tag push    -> release + Play production
+# Feature work lands on dev; the dev build is cut only when dev -> staging
+# merges, and production only when staging -> main merges.
+#
 # PATH-FILTERED: on pull requests and dev pushes this whole pipeline only runs
 # when Android-relevant files change (ft8af/** — which includes the shared
 # native C core at ft8af/app/src/main/cpp/ — or this workflow file). Pushes to
-# main and v* tags always build (a full per-version release snapshot,
+# staging/main and android-v* tags always build (a full release snapshot,
 # regardless of what changed). The always-run `android-gate` job is the single
 # required status check so branch protection never gets stuck "pending" when the
 # build jobs are path-skipped.
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, staging, dev]
     tags:
-      - 'v*'
+      - 'android-v*'
   pull_request:
-    branches: [main, dev]
+    branches: [main, staging, dev]
 
 permissions:
   contents: write
 
 # Google Play allows only one active "edit" per app, so two release builds
 # publishing at once make the second fail with "This edit has expired, please
-# create a new Edit." Serialize the release-publishing runs (pushes to dev/main
-# and v* tags) into a single queue so they never overlap on the Play API.
-# cancel-in-progress is false so an in-flight publish finishes rather than being
-# killed mid-upload. Pull request runs get a unique group keyed to run id, so
-# they never queue and CI stays fast.
+# create a new Edit." Serialize the release-publishing runs (pushes to
+# staging/main and android-v* tags) into a single queue so they never overlap on
+# the Play API. cancel-in-progress is false so an in-flight publish finishes
+# rather than being killed mid-upload. Other runs (PRs, dev pushes) get a unique
+# group keyed to run id, so they never queue and CI stays fast.
 concurrency:
   group: >-
     ${{
       (github.event_name == 'push'
         && (github.ref == 'refs/heads/main'
-          || github.ref == 'refs/heads/dev'
-          || startsWith(github.ref, 'refs/tags/v')))
+          || github.ref == 'refs/heads/staging'
+          || startsWith(github.ref, 'refs/tags/android-v')))
       && 'play-publish'
       || format('build-{0}', github.run_id)
     }}
@@ -67,9 +77,10 @@ jobs:
           CHANGED: ${{ steps.filter.outputs.android }}
         run: |
           set -euo pipefail
-          # main pushes and v* tags always build the full release; otherwise
-          # build only when Android-relevant files changed.
-          if [[ "$GITHUB_EVENT_NAME" == "push" && ( "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == refs/tags/v* ) ]]; then
+          # staging/main pushes and android-v* tags always build the full
+          # release snapshot; otherwise (dev push, PRs) build only when
+          # Android-relevant files changed.
+          if [[ "$GITHUB_EVENT_NAME" == "push" && ( "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/staging" || "$GITHUB_REF" == refs/tags/android-v* ) ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           elif [[ "$CHANGED" == "true" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
@@ -80,7 +91,7 @@ jobs:
   test:
     name: Unit tests & coverage
     needs: detect
-    if: ${{ needs.detect.outputs.run == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    if: ${{ needs.detect.outputs.run == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'))) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -162,7 +173,7 @@ jobs:
     # checks while it stabilises (issue #60) — a flaky emulator must never block
     # a release.
     needs: detect
-    if: ${{ needs.detect.outputs.run == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    if: ${{ needs.detect.outputs.run == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'))) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -334,8 +345,9 @@ jobs:
   build:
     name: Build APK
     needs: [detect, test]
-    # Run when Android is in scope (detect.run) AND tests passed (PR/main push) or
-    # were skipped (push to dev/tags). Block only on actual test failure/cancel.
+    # Run when Android is in scope (detect.run) AND tests passed (PR / staging /
+    # main push) or were skipped (dev push, tags). Block only on actual test
+    # failure/cancel.
     if: ${{ always() && needs.detect.outputs.run == 'true' && needs.test.result != 'failure' && needs.test.result != 'cancelled' }}
     runs-on: ubuntu-latest
 
@@ -352,56 +364,72 @@ jobs:
         id: tag
         run: |
           set -euo pipefail
-          # Three release lanes (everything else is build-only):
-          #   v* tag push  -> production-named release, NOT prerelease
-          #   push to main -> auto-bumped v* tag, NOT prerelease
-          #   push to dev  -> dev-<run_number> tag, PRERELEASE
-          # Prereleases are still uploaded to Play internal but with a
-          # distinct releaseName so they're easy to tell apart from the
-          # v*-named candidates we'd actually promote to production.
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+          # Release lanes (everything else — dev push, PRs — is build-only):
+          #   android-v* tag push -> production release, Play production
+          #   push to main        -> auto-bumped android-v* tag, Play production
+          #   push to staging     -> android-dev.<run#> tag, PRERELEASE, Play internal
+          # The dev build is cut on staging, NOT on dev: dev pushes never reach
+          # this release path. The android- prefix keeps these tags separate from
+          # the desktop-v* lane on the Releases page (issue: per-platform tags).
+          # Bumps seed from a legacy bare v* tag when no android-v* exists yet so
+          # the version sequence stays continuous with pre-split releases.
+          if [[ "${GITHUB_REF}" == refs/tags/android-v* ]]; then
             echo "release_tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-            echo "version_name=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "version_name=${GITHUB_REF_NAME#android-v}" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "play_track=production" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            # Auto-bump patch from latest v* tag.
-            latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-            if [[ -z "$latest" ]]; then
-              new_tag="v0.1"
+            # Auto-bump the last component from the latest android-v* tag (or a
+            # legacy v* tag for continuity), e.g. android-v1.2 -> android-v1.3.
+            latest=$(git tag --list 'android-v*' --sort=-v:refname | head -n1)
+            base="${latest#android-v}"
+            if [[ -z "$base" ]]; then
+              legacy=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+              base="${legacy#v}"
+            fi
+            if [[ -z "$base" ]]; then
+              new_ver="0.1"
             else
-              version="${latest#v}"
-              IFS='.' read -ra parts <<< "$version"
+              IFS='.' read -ra parts <<< "$base"
               last_idx=$((${#parts[@]} - 1))
               parts[$last_idx]=$((parts[$last_idx] + 1))
-              new_tag="v$(IFS=.; echo "${parts[*]}")"
+              new_ver="$(IFS=.; echo "${parts[*]}")"
             fi
-            echo "Latest tag: ${latest:-<none>} -> new tag: $new_tag"
+            new_tag="android-v$new_ver"
+            echo "Latest android tag: ${latest:-<none>} -> new tag: $new_tag"
             echo "release_tag=$new_tag" >> "$GITHUB_OUTPUT"
-            echo "version_name=${new_tag#v}" >> "$GITHUB_OUTPUT"
+            echo "version_name=$new_ver" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/dev" ]]; then
-            # dev pushes get a run-numbered tag and are flagged as prereleases.
-            # Distinct prefix so they sort separately from v* in GitHub releases
-            # and so the Play Console releaseName disambiguates them from
-            # main-branch release candidates.
-            new_tag="dev-${GITHUB_RUN_NUMBER}"
-            # Derive the base semver from the latest v* tag so the APK version
-            # reads e.g. "1.1.0-dev.42" instead of a bare run number.
-            latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-            base_ver="${latest:+${latest#v}}"
+            echo "play_track=production" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/staging" ]]; then
+            # staging pushes (a dev -> staging merge) cut a run-numbered
+            # PRERELEASE, published to the Play internal track. Distinct prefix so
+            # it sorts separately from android-v* and so the Play releaseName
+            # disambiguates it from production candidates.
+            new_tag="android-dev.${GITHUB_RUN_NUMBER}"
+            # Derive the base semver from the latest android-v* (or legacy v*) so
+            # the APK reads e.g. "1.1.0-dev.42" instead of a bare run number.
+            latest=$(git tag --list 'android-v*' --sort=-v:refname | head -n1)
+            base_ver="${latest#android-v}"
+            if [[ -z "$base_ver" ]]; then
+              legacy=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+              base_ver="${legacy#v}"
+            fi
             base_ver="${base_ver:-0.0.0}"
             echo "release_tag=$new_tag" >> "$GITHUB_OUTPUT"
             echo "version_name=${base_ver}-dev.${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "play_track=internal" >> "$GITHUB_OUTPUT"
           else
-            # PR or other branch push — build only, no release
+            # dev push, PR, or other branch — build only, no release
             echo "release_tag=" >> "$GITHUB_OUTPUT"
             echo "version_name=" >> "$GITHUB_OUTPUT"
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "play_track=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up JDK 17
@@ -537,11 +565,12 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.release_tag }}
+          name: ${{ steps.tag.outputs.release_tag }}
           files: ft8af/app/build/outputs/apk/release/FT8AF-*.apk
           generate_release_notes: true
-          # dev-* releases are flagged as prerelease so they sort under the
-          # latest v* and don't get picked up by downstream tooling that
-          # looks for "latest release".
+          # android-dev.* releases are flagged as prerelease so they sort under
+          # the latest android-v* and don't get picked up by downstream tooling
+          # that looks for "latest release".
           prerelease: ${{ steps.tag.outputs.is_prerelease == 'true' }}
           append_body: true
           body: |
@@ -561,7 +590,7 @@ jobs:
       # the dev→main PR. So continue-on-error here (mirroring the Codecov upload
       # above) and surface a warning in the next step instead. A genuinely
       # broken build fails earlier, in "Build APK & AAB".
-      - name: Publish AAB to Play Internal track
+      - name: Publish AAB to Play
         id: play_publish
         if: steps.tag.outputs.should_release == 'true'
         continue-on-error: true
@@ -573,7 +602,8 @@ jobs:
           # R8 deobfuscation mapping — clears the Play Console "no deobfuscation
           # file" warning and makes crash/ANR stack traces readable.
           mappingFile: ft8af/app/build/outputs/mapping/release/mapping.txt
-          track: internal
+          # staging -> internal track; main / android-v* tag -> production track.
+          track: ${{ steps.tag.outputs.play_track }}
           status: completed
           releaseName: ${{ steps.tag.outputs.release_tag }}
 
@@ -582,7 +612,7 @@ jobs:
       - name: Warn if Play publish failed
         if: steps.tag.outputs.should_release == 'true' && steps.play_publish.outcome == 'failure'
         run: |
-          echo "::warning::Play Internal publish failed for ${{ steps.tag.outputs.release_tag }} (non-blocking). The signed AAB built and the GitHub Release was created; only the Play upload did not complete. Check the 'Publish AAB to Play Internal track' step log — common causes are an upgrade-path rejection or an expired Play edit."
+          echo "::warning::Play publish (track=${{ steps.tag.outputs.play_track }}) failed for ${{ steps.tag.outputs.release_tag }} (non-blocking). The signed AAB built and the GitHub Release was created; only the Play upload did not complete. Check the 'Publish AAB to Play' step log — common causes are an upgrade-path rejection or an expired Play edit."
 
   android-gate:
     name: android-gate

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,8 @@ name: Android CI & Release
 
 # Android pipeline for the ft8af/ app: unit tests + coverage, instrumented
 # emulator tests, static analysis (lint/detekt/ktlint), and the signed
-# APK/AAB build + GitHub Release + Play internal publish.
+# APK/AAB build + GitHub Release + Play publish (internal track on staging,
+# production track on main / android-v* tags — see the Release lifecycle below).
 #
 # Release lifecycle (see docs/release-pipeline.md):
 #   PR to dev/staging/main -> build-only (unsigned), tests

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -5,24 +5,26 @@ name: Desktop CI & Release
 # Windows + macOS + Linux. On main pushes and desktop-v* tags it builds native
 # bundles on all three OSes and publishes them to a per-platform GitHub Release.
 #
-# Release scheme is namespaced so it sits separately from the Android v* / dev-N
-# releases on the Releases page:
+# Release scheme is namespaced so it sits separately from the Android
+# android-v* / android-dev.N releases on the Releases page:
 #   desktop-v* tag  -> production desktop release
 #   push to main    -> auto-bumped desktop-v* release
-#   push to dev     -> desktop-dev-<run_number> PRERELEASE
+#   push to staging -> desktop-dev.<run_number> PRERELEASE
+#   push to dev     -> compile-check only, NO release
+# The dev build is cut on staging (a dev -> staging merge), never on dev itself.
 #
 # PATH-FILTERED: PRs and dev pushes only build when desktop/** or the shared
 # native C core (ft8af/app/src/main/cpp/**) changes, or this workflow file.
-# main pushes and desktop-v* tags always build. The always-run `desktop-gate`
-# job is the required status check.
+# staging/main pushes and desktop-v* tags always build. The always-run
+# `desktop-gate` job is the required status check.
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, staging, dev]
     tags:
       - 'desktop-v*'
   pull_request:
-    branches: [main, dev]
+    branches: [main, staging, dev]
 
 permissions:
   contents: write
@@ -32,7 +34,7 @@ concurrency:
     ${{
       (github.event_name == 'push'
         && (github.ref == 'refs/heads/main'
-          || github.ref == 'refs/heads/dev'
+          || github.ref == 'refs/heads/staging'
           || startsWith(github.ref, 'refs/tags/desktop-v')))
       && 'desktop-release'
       || format('desktop-{0}', github.run_id)
@@ -65,9 +67,10 @@ jobs:
           CHANGED: ${{ steps.filter.outputs.desktop }}
         run: |
           set -euo pipefail
-          # main pushes and desktop-v* tags always build the full release;
-          # otherwise build only when desktop-relevant files changed.
-          if [[ "$GITHUB_EVENT_NAME" == "push" && ( "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == refs/tags/desktop-v* ) ]]; then
+          # staging/main pushes and desktop-v* tags always build the full
+          # release; otherwise (dev push, PRs) build only when desktop-relevant
+          # files changed.
+          if [[ "$GITHUB_EVENT_NAME" == "push" && ( "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/staging" || "$GITHUB_REF" == refs/tags/desktop-v* ) ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           elif [[ "$CHANGED" == "true" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
@@ -122,8 +125,9 @@ jobs:
             echo "version_name=${new_tag#desktop-v}" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/dev" ]]; then
-            new_tag="desktop-dev-${GITHUB_RUN_NUMBER}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/staging" ]]; then
+            # staging push (a dev -> staging merge) cuts the desktop dev build.
+            new_tag="desktop-dev.${GITHUB_RUN_NUMBER}"
             latest=$(git tag --list 'desktop-v*' --sort=-v:refname | head -n1)
             base_ver="${latest:+${latest#desktop-v}}"
             base_ver="${base_ver:-0.1.0}"
@@ -132,7 +136,7 @@ jobs:
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            # PR or other branch push — compile-check only, no release.
+            # dev push, PR, or other branch — compile-check only, no release.
             echo "release_tag=" >> "$GITHUB_OUTPUT"
             echo "version_name=" >> "$GITHUB_OUTPUT"
             echo "should_release=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/discord-merge-notify.yml
+++ b/.github/workflows/discord-merge-notify.yml
@@ -2,7 +2,7 @@ name: Discord — merge notify
 
 on:
   push:
-    branches: [dev, main]
+    branches: [dev, staging, main]
 
 jobs:
   notify:
@@ -27,10 +27,13 @@ jobs:
             exit 1
           fi
           if [[ "$BRANCH" == "main" ]]; then
-            color=3066993   # green
+            color=3066993   # green — production release
             emoji="🚀"
+          elif [[ "$BRANCH" == "staging" ]]; then
+            color=3447003   # blue — dev (prerelease) build cut
+            emoji="📦"
           else
-            color=15105570  # orange
+            color=15105570  # orange — landed on dev
             emoji="🔧"
           fi
           sha_short="${SHA:0:7}"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -7,14 +7,16 @@ name: iOS CI
 # Developer cert + provisioning profile, which aren't wired up yet.
 #
 # PATH-FILTERED: only runs when ios/** or the shared native C core
-# (ft8af/app/src/main/cpp/**) changes, or this workflow file. Pushes to main
-# always verify. The always-run `ios-gate` job is the required status check.
+# (ft8af/app/src/main/cpp/**) changes, or this workflow file. Pushes to
+# staging/main always verify. The always-run `ios-gate` job is the required
+# status check. iOS has no release artifact yet (CI build/test only), so the
+# staging/main split only affects when the verify runs.
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, staging, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [main, staging, dev]
 
 concurrency:
   group: ios-${{ github.event.pull_request.number || github.ref }}
@@ -46,9 +48,9 @@ jobs:
           CHANGED: ${{ steps.filter.outputs.ios }}
         run: |
           set -euo pipefail
-          # main pushes always verify; otherwise only when iOS-relevant files
-          # (or the shared C core) changed.
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          # staging/main pushes always verify; otherwise only when iOS-relevant
+          # files (or the shared C core) changed.
+          if [[ "$GITHUB_EVENT_NAME" == "push" && ( "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/staging" ) ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           elif [[ "$CHANGED" == "true" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -1,21 +1,22 @@
 name: Main branch source gate
 
-# Enforces release discipline: PRs targeting main must come from `dev`.
-# Feature branches are expected to land on dev first; only dev → main is
-# allowed as the "promote to production" step, gated by branch protection
+# Enforces release discipline: PRs targeting main must come from `staging`.
+# The promotion path is feature -> dev -> staging -> main; only staging -> main
+# is allowed as the "promote to production" step, gated by branch protection
 # requiring this status check.
 #
 # To enforce it: GitHub → Settings → Branches → Branch protection rule for
 # `main` → Require status checks to pass → add "Main branch source gate /
-# enforce-source-is-dev" to the required list.
+# enforce-source-is-staging" to the required list. (If you previously required
+# the old "enforce-source-is-dev" check, swap it for this one.)
 
 on:
   pull_request:
     branches: [main]
 
 jobs:
-  enforce-source-is-dev:
-    name: enforce-source-is-dev
+  enforce-source-is-staging:
+    name: enforce-source-is-staging
     runs-on: ubuntu-latest
     steps:
       - name: Check PR head branch
@@ -23,9 +24,9 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
-          if [[ "${HEAD_REF}" != "dev" ]]; then
-            echo "::error title=PR source must be dev::PRs to main are only allowed from the dev branch. Source branch: ${HEAD_REF}"
-            echo "Land your changes on dev first (PR from your feature branch into dev), then open dev → main."
+          if [[ "${HEAD_REF}" != "staging" ]]; then
+            echo "::error title=PR source must be staging::PRs to main are only allowed from the staging branch. Source branch: ${HEAD_REF}"
+            echo "Promote through staging first (feature → dev → staging), then open staging → main."
             exit 1
           fi
-          echo "OK — PR source is dev."
+          echo "OK — PR source is staging."

--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -22,11 +22,21 @@ jobs:
       - name: Check PR head branch
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Require the promotion PR to come from the staging branch IN THIS
+          # repo. Checking the branch name alone is insufficient: a fork could
+          # open a PR from its own branch literally named "staging" and pass, so
+          # also pin the head repo to the base repo.
+          if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+            echo "::error title=PR source must be this repo::PRs to main must originate from staging in ${BASE_REPO}, not a fork (${HEAD_REPO})."
+            exit 1
+          fi
           if [[ "${HEAD_REF}" != "staging" ]]; then
             echo "::error title=PR source must be staging::PRs to main are only allowed from the staging branch. Source branch: ${HEAD_REF}"
             echo "Promote through staging first (feature → dev → staging), then open staging → main."
             exit 1
           fi
-          echo "OK — PR source is staging."
+          echo "OK — PR source is staging in ${BASE_REPO}."

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -3,15 +3,15 @@ name: Native FT8 tests
 # Gate on the native FT8 encode/hash golden vectors (issue #61). These guard the
 # from-source reconstruction of libft8cn.so: a regression in pack77 / ft8_encode
 # / the callsign hash would otherwise ship silently. The build is host-only C
-# (seconds), so it runs on every PR to dev/main without a path filter — keeping
-# it a reliable required status check (a path-filtered check that doesn't run
-# would leave branch protection stuck "pending").
+# (seconds), so it runs on every PR to dev/staging/main without a path filter —
+# keeping it a reliable required status check (a path-filtered check that doesn't
+# run would leave branch protection stuck "pending").
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, staging, dev]
   push:
-    branches: [main, dev]
+    branches: [main, staging, dev]
 
 # A new push to the same PR/branch cancels the prior in-flight run.
 concurrency:

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -1,0 +1,32 @@
+name: Staging branch source gate
+
+# Enforces release discipline: PRs targeting staging must come from `dev`.
+# The promotion path is feature -> dev -> staging -> main; bundling many dev PRs
+# into a single dev -> staging promotion is what cuts a dev (prerelease) build.
+# Only dev -> staging is allowed here, gated by branch protection requiring this
+# status check.
+#
+# To enforce it: GitHub → Settings → Branches → Branch protection rule for
+# `staging` → Require status checks to pass → add "Staging branch source gate /
+# enforce-source-is-dev" to the required list.
+
+on:
+  pull_request:
+    branches: [staging]
+
+jobs:
+  enforce-source-is-dev:
+    name: enforce-source-is-dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR head branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${HEAD_REF}" != "dev" ]]; then
+            echo "::error title=PR source must be dev::PRs to staging are only allowed from the dev branch. Source branch: ${HEAD_REF}"
+            echo "Land your changes on dev first (PR from your feature branch into dev), then open dev → staging to cut a dev build."
+            exit 1
+          fi
+          echo "OK — PR source is dev."

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -22,11 +22,21 @@ jobs:
       - name: Check PR head branch
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Require the promotion PR to come from the dev branch IN THIS repo.
+          # Checking the branch name alone is insufficient: a fork could open a
+          # PR from its own branch literally named "dev" and pass, so also pin
+          # the head repo to the base repo.
+          if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+            echo "::error title=PR source must be this repo::PRs to staging must originate from dev in ${BASE_REPO}, not a fork (${HEAD_REPO})."
+            exit 1
+          fi
           if [[ "${HEAD_REF}" != "dev" ]]; then
             echo "::error title=PR source must be dev::PRs to staging are only allowed from the dev branch. Source branch: ${HEAD_REF}"
             echo "Land your changes on dev first (PR from your feature branch into dev), then open dev → staging to cut a dev build."
             exit 1
           fi
-          echo "OK — PR source is dev."
+          echo "OK — PR source is dev in ${BASE_REPO}."

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -1,0 +1,65 @@
+# Release pipeline
+
+Three platforms (Android, desktop, iOS) build and release **independently** —
+each has its own workflow, its own path filter, its own tag namespace, and its
+own required status-check gate. A change to one platform never rebuilds the
+others (except a change to the shared native C core under
+`ft8af/app/src/main/cpp/**`, which all three depend on).
+
+## Branch lifecycle
+
+```
+feature/* ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
+                  │            │               │
+                  │            │               └─ PRODUCTION build → Releases + Play production
+                  │            └───────────────── DEV (prerelease) build → Releases + Play internal
+                  └────────────────────────────── CI only, NO release
+```
+
+- **feature → dev** — every work item. CI runs (tests, build check) but nothing
+  is published. Dev builds **never** reach the Releases page.
+- **dev → staging** — bundle up many dev PRs and promote them together. Merging
+  this PR (a push to `staging`) cuts a **dev / prerelease** build of every
+  platform: prerelease GitHub Releases + Play **internal** track for Android.
+- **staging → main** — promote the validated staging build. Merging this PR (a
+  push to `main`) cuts the **production** build: full GitHub Releases + Play
+  **production** track for Android.
+
+Source gates (enforced as required status checks):
+
+- PRs to `staging` must come from `dev` (`Staging branch source gate`).
+- PRs to `main` must come from `staging` (`Main branch source gate`).
+
+## Tag / release namespaces
+
+Per-platform prefixes keep the Releases page unambiguous:
+
+| Platform | Production tag        | Dev (prerelease) tag      | Trigger of dev build |
+|----------|-----------------------|---------------------------|----------------------|
+| Android  | `android-v<x.y>`      | `android-dev.<run#>`      | push to `staging`    |
+| Desktop  | `desktop-v<x.y.z>`    | `desktop-dev.<run#>`      | push to `staging`    |
+| iOS      | _(no release yet)_    | _(no release yet)_        | —                    |
+
+- Production tags are auto-bumped on a push to `main` from the latest matching
+  tag. Android seeds from a legacy bare `v*` tag if no `android-v*` exists yet,
+  so numbering stays continuous with pre-split releases.
+- iOS is CI-only: it builds the FT8AFKit test suite and an unsigned simulator
+  build to prove it compiles. A distributable `.ipa` needs an Apple Developer
+  cert + provisioning profile / TestFlight, which are not wired up yet.
+
+## One-time setup on GitHub (manual)
+
+These cannot be done from a workflow file — do them in the repo settings:
+
+1. **Create the `staging` branch** from `dev`:
+   `git checkout dev && git pull && git checkout -b staging && git push -u origin staging`.
+2. **Branch protection for `staging`** → Require status checks →
+   add `Staging branch source gate / enforce-source-is-dev` (plus the platform
+   gates `android-gate`, `desktop-gate`, `ios-gate` as desired).
+3. **Branch protection for `main`** → Require status checks →
+   add `Main branch source gate / enforce-source-is-staging`. If the old
+   `enforce-source-is-dev` check was required on `main`, remove it — that gate
+   now lives on `staging`.
+4. **Play Console** → confirm the `PLAY_SERVICE_ACCOUNT_JSON` service account has
+   release permission on the **production** track (it previously only needed
+   internal). `main` merges now publish there.


### PR DESCRIPTION
## What

Inserts a **`staging`** branch between `dev` and `main` so many dev PRs can be bundled and promoted together, and moves the release triggers accordingly. The per-platform separation (`android.yml` / `desktop.yml` / `ios.yml`) already on `dev` is preserved — this only changes *when* each lane releases.

### New lifecycle
```
feature ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
                │           │               │
   CI only,     │           │               └ PRODUCTION build → Releases + Play production
   NO release ──┘           └ DEV (prerelease) build → Releases + Play internal
```

- **Dev pushes no longer publish anything to the Releases page.** The dev build is cut on a `dev → staging` merge; production on a `staging → main` merge.
- Android tags moved to the `android-v*` / `android-dev.<run#>` namespace (seeded from legacy `v*` for continuous numbering) so they sit cleanly alongside `desktop-v*`.
- Android Play track is now parametrized: **staging → internal, main → production** (was internal for both).
- Desktop dev-build cut moved `dev → staging` (`desktop-dev.<run#>`); dev pushes are compile-check only.
- iOS verifies on staging too (still CI-only, no release artifact — signing/TestFlight is future work).
- `native-tests.yml` golden gate now runs on dev/staging/main PRs + pushes.

### Gates
- `main-gate.yml` → PRs to `main` must come from `staging` (check renamed `enforce-source-is-staging`).
- `staging-gate.yml` (new) → PRs to `staging` must come from `dev`.

## ⚠️ Required manual setup after merge (see `docs/release-pipeline.md`)
1. Create the `staging` branch from `dev`.
2. Branch protection on `staging`: require `Staging branch source gate / enforce-source-is-dev` (+ platform gates).
3. Branch protection on `main`: swap the old `enforce-source-is-dev` required check for `Main branch source gate / enforce-source-is-staging`.
4. Confirm `PLAY_SERVICE_ACCOUNT_JSON` has **production** track permission (main merges now publish there).

## Testing
Workflow YAML only (no app code path) — validated all workflow files parse and checked the release-branch/Play-track invariants. There is no Kotlin code path to unit-test here.