### PR TITLE
Fix POTA park picker sheet not opening (tap does nothing)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
@@ -218,6 +218,12 @@ private fun ActivateTab() {
         }
     }
 
+    // Box host so ParkPickerSheet (a fillMaxSize scrim + sheet) overlays the tab
+    // content. Without it the sheet is a trailing sibling of the fillMaxSize
+    // Activate content in PotaScreen's Column, so it lays out into 0 leftover
+    // height and the picker is invisible (tap does nothing). Mirrors how
+    // FrequencyPickerSheet is hosted as a sibling overlay in FT8AFApp.
+    Box(modifier = Modifier.fillMaxSize()) {
     if (activation == null) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -391,6 +397,7 @@ private fun ActivateTab() {
             }
         },
     )
+    }
 }
 
 @OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/BottomSheetOverlayHostTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/BottomSheetOverlayHostTest.kt
@@ -1,0 +1,71 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Regression test for the POTA park picker "tap does nothing" bug.
+ *
+ * [FT8AFBottomSheet] renders a fillMaxSize scrim + sheet. When it is emitted as
+ * a trailing sibling of a fillMaxSize content node inside a [Column], the column
+ * gives the greedy first child all the height and the sheet lays out into zero
+ * leftover height — visible = true, but nothing on screen. Hosting both in a
+ * [Box] (as FrequencyPickerSheet does in FT8AFApp, and as ActivateTab now does)
+ * lets the sheet overlay the content. These two cases pin that behaviour.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp-xhdpi")
+class BottomSheetOverlayHostTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val sheetLabel = "PICKER_CONTENT"
+
+    @Composable
+    private fun sheetContent() {
+        FT8AFBottomSheet(visible = true, onDismiss = {}) {
+            Text(sheetLabel)
+        }
+    }
+
+    @Test
+    fun sheetInColumnAfterFillMaxSizeSibling_isNotDisplayed() {
+        // Reproduces the bug: greedy fillMaxSize sibling starves the sheet of
+        // height, so its content composes but is laid out at zero size.
+        composeRule.setContent {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Box(modifier = Modifier.fillMaxSize())
+                sheetContent()
+            }
+        }
+
+        composeRule.onNodeWithText(sheetLabel).assertIsNotDisplayed()
+    }
+
+    @Test
+    fun sheetWrappedInBoxOverlay_isDisplayed() {
+        // The fix: a Box host lets the sheet overlay the fillMaxSize content.
+        composeRule.setContent {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Box(modifier = Modifier.fillMaxSize())
+                sheetContent()
+            }
+        }
+
+        composeRule.onNodeWithText(sheetLabel).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Problem

Tapping the magnifying glass on a park reference field in **POTA → Activate** did nothing — the search/recent/nearby park picker never appeared.

## Root cause

`ParkPickerSheet` was emitted as a trailing sibling of the `fillMaxSize` Activate content, all inside `PotaScreen`'s `Column`. In a `Column`, the greedy `fillMaxSize` child consumes all available height, so the sheet (itself a `fillMaxSize` scrim + sheet) was laid out into **zero leftover height**. `showPicker` flipped to `true` on tap and the sheet composed, but nothing was visible.

The frequency/band picker avoids this by being hosted as a sibling overlay inside a `Box` at the app root (`FT8AFApp.kt`).

## Fix

Wrap `ActivateTab`'s content and the `ParkPickerSheet` call in a `Box(Modifier.fillMaxSize())` so the sheet overlays the content.

## Test

Added `BottomSheetOverlayHostTest` (Compose UI test via Robolectric) pinning the geometry the fix depends on:
- `FT8AFBottomSheet` placed after a `fillMaxSize` sibling in a `Column` → **not displayed** (the bug)
- same wrapped in a `Box` → **displayed** (the fix)

## Verification

Built and installed on the Pixel 8; confirmed on-device that tapping the magnifying glass now opens the picker with the search filter, Recent Parks, and Nearby Parks sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)