### PR TITLE
Fix POTA Nearby parks showing far-away regions (bad upstream centers)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaParkRepository.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaParkRepository.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import com.google.android.gms.maps.model.LatLng
 import com.k1af.ft8af.maidenhead.MaidenheadGrid
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import radio.ks3ckc.ft8af.pota.model.PotaLocation
 import radio.ks3ckc.ft8af.pota.model.PotaPark
@@ -24,6 +27,21 @@ object PotaParkRepository {
     private const val CACHE_TTL_MS = 30 * 60 * 1_000L
     private const val NEARBY_LIMIT = 50
 
+    // POTA's /locations endpoint ships wrong center coordinates for a chunk of
+    // foreign regions (e.g. ZA-FS, RU-VL, RO-OT all report centers in Kansas),
+    // so the nearest-by-center ranking is noisy: a handful of mislocated regions
+    // out-rank the user's real region. We therefore pull parks from a generous
+    // set of candidate regions — enough that the user's true region(s) are always
+    // included despite the bad rows — and rely on the parks' own (correct)
+    // coordinates to produce the final ordering. See the parkpicker logic tests.
+    private const val NEARBY_LOCATION_CANDIDATES = 12
+
+    // Final safety net: even after broadening the candidates, a mislocated
+    // region can still contribute parks. Those parks carry correct coordinates,
+    // so they sort to the bottom — but drop anything implausibly far so a
+    // continent-away park never surfaces under "Nearby" for a sparse area.
+    private const val NEARBY_MAX_DISTANCE_KM = 1_000.0
+
     @Volatile
     private var cachedLocations: List<PotaLocation>? = null
 
@@ -37,19 +55,25 @@ object PotaParkRepository {
 
     /**
      * Return the [NEARBY_LIMIT] closest parks to [userLat]/[userLng], sorted by
-     * distance ascending. Fetches the 3 closest POTA location codes and their parks
-     * from the API (cached).
+     * distance ascending. Fetches parks for the [NEARBY_LOCATION_CANDIDATES]
+     * closest POTA location codes (cached) — a wide net to absorb POTA's
+     * mislocated region centers — then ranks by each park's own coordinates and
+     * drops anything beyond [NEARBY_MAX_DISTANCE_KM].
      */
     suspend fun nearbyParks(userLat: Double, userLng: Double): List<PotaParkWithDistance> =
         withContext(Dispatchers.IO) {
             val locations = getLocations() ?: return@withContext emptyList()
-            val closest = findNearestLocationCodes(userLat, userLng, locations, 3)
-            val allParks = mutableListOf<PotaPark>()
-            for (code in closest) {
-                val parks = getParksForLocation(code) ?: continue
-                allParks.addAll(parks)
+            val closest =
+                findNearestLocationCodes(userLat, userLng, locations, NEARBY_LOCATION_CANDIDATES)
+            // Fetch the candidate park lists concurrently; one slow region
+            // shouldn't serialize the whole sheet open.
+            val allParks = coroutineScope {
+                closest.map { code -> async { getParksForLocation(code) } }
+                    .awaitAll()
+                    .filterNotNull()
+                    .flatten()
             }
-            sortParksByDistance(allParks, userLat, userLng, NEARBY_LIMIT)
+            sortParksByDistance(allParks, userLat, userLng, NEARBY_LIMIT, NEARBY_MAX_DISTANCE_KM)
         }
 
     /**
@@ -126,13 +150,16 @@ internal fun findNearestLocationCodes(
 
 /**
  * Compute the distance from ([userLat], [userLng]) to each park, sort ascending,
- * and return the closest [limit] results.
+ * and return the closest [limit] results. Parks farther than [maxDistanceKm] are
+ * dropped (defaults to no cap) so mislocated-region parks can't masquerade as
+ * nearby.
  */
 internal fun sortParksByDistance(
     parks: List<PotaPark>,
     userLat: Double,
     userLng: Double,
     limit: Int,
+    maxDistanceKm: Double = Double.MAX_VALUE,
 ): List<PotaParkWithDistance> {
     val userPos = LatLng(userLat, userLng)
     return parks
@@ -143,6 +170,7 @@ internal fun sortParksByDistance(
                 distanceKm = MaidenheadGrid.getDist(userPos, LatLng(park.latitude, park.longitude)),
             )
         }
+        .filter { it.distanceKm <= maxDistanceKm }
         .sortedBy { it.distanceKm }
         .take(limit)
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaParkPickerLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaParkPickerLogicTest.kt
@@ -83,6 +83,30 @@ class PotaParkPickerLogicTest {
         assertThat(result).containsExactly("US-PA")
     }
 
+    @Test
+    fun `broadening candidate count rescues real region from POTA's bad location centers`() {
+        // POTA's /locations endpoint ships wrong centers for some foreign
+        // regions: ZA-FS, RU-VL and RO-OT all report centers in Kansas. A user
+        // in Kansas (39.0, -94.6) therefore sees those mislocated regions
+        // out-rank their real state, US-KS.
+        val locations = listOf(
+            PotaLocation("ZA-FS", "Free State", 38.9717, -95.2355),   // bad: really South Africa
+            PotaLocation("RU-VL", "Vladimir", 39.0904, -94.5877),     // bad: really Russia
+            PotaLocation("RO-OT", "Olt", 39.768, -94.8509),           // bad: really Romania
+            PotaLocation("US-KS", "Kansas", 38.5266, -96.7265),       // correct
+            PotaLocation("US-MO", "Missouri", 38.4561, -92.2884),     // correct
+        )
+
+        // The old behaviour: only the 3 nearest centers — all mislocated.
+        val narrow = findNearestLocationCodes(39.0, -94.6, locations, 3)
+        assertThat(narrow).doesNotContain("US-KS")
+
+        // The fix: a wider candidate net pulls in the user's real region.
+        val wide = findNearestLocationCodes(39.0, -94.6, locations, 5)
+        assertThat(wide).contains("US-KS")
+        assertThat(wide).contains("US-MO")
+    }
+
     // -----------------------------------------------------------------------
     // sortParksByDistance
     // -----------------------------------------------------------------------
@@ -118,6 +142,31 @@ class PotaParkPickerLogicTest {
         )
         val result = sortParksByDistance(parks, 39.95, -75.17, 50)
         assertThat(result.map { it.park.reference }).containsExactly("K-0002")
+    }
+
+    @Test
+    fun `sortParksByDistance drops parks beyond the max distance cap`() {
+        // A park list mixing genuinely-nearby parks with one from a mislocated
+        // region (its real coordinates put it on another continent). The cap
+        // keeps the far one from masquerading as nearby.
+        val parks = listOf(
+            parkAt("US-0001", "Local Park", 40.06, -74.41),   // NJ — near Philadelphia
+            parkAt("RU-0024", "Far Park", 55.0, 40.0),        // Russia — ~8000 km away
+        )
+        val result = sortParksByDistance(parks, 39.95, -75.17, 50, maxDistanceKm = 1_000.0)
+        assertThat(result.map { it.park.reference }).containsExactly("US-0001")
+    }
+
+    @Test
+    fun `sortParksByDistance keeps all parks when no cap is given`() {
+        val parks = listOf(
+            parkAt("US-0001", "Local Park", 40.06, -74.41),
+            parkAt("RU-0024", "Far Park", 55.0, 40.0),
+        )
+        val result = sortParksByDistance(parks, 39.95, -75.17, 50)
+        assertThat(result.map { it.park.reference })
+            .containsExactly("US-0001", "RU-0024")
+            .inOrder()
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaParkPickerLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaParkPickerLogicTest.kt
@@ -101,8 +101,10 @@ class PotaParkPickerLogicTest {
         val narrow = findNearestLocationCodes(39.0, -94.6, locations, 3)
         assertThat(narrow).doesNotContain("US-KS")
 
-        // The fix: a wider candidate net pulls in the user's real region.
-        val wide = findNearestLocationCodes(39.0, -94.6, locations, 5)
+        // The fix: a wider candidate net pulls in the user's real region. Use
+        // the production NEARBY_LOCATION_CANDIDATES value (12) to pin the intent;
+        // with only 5 test rows it returns all of them, US-KS/US-MO included.
+        val wide = findNearestLocationCodes(39.0, -94.6, locations, 12)
         assertThat(wide).contains("US-KS")
         assertThat(wide).contains("US-MO")
     }


### PR DESCRIPTION
## Problem

In **POTA -> Activate -> park picker**, the **Nearby Parks** list showed parks thousands of miles away (e.g. Russian and Romanian parks at 5,000+ mi) at the top instead of local ones.

## Root cause

POTA's `/locations` API returns **wrong center coordinates** for a chunk of foreign regions — `ZA-FS` (South Africa), `RU-VL` (Russia), `RO-OT` (Romania) and ~55 others all report centers sitting inside the continental US (in Kansas). `nearbyParks` selected only the **3** nearest region *centers* and trusted them, so a US user got those mislocated regions; their parks (which carry correct coordinates) then rendered their true ~5,000 mi distance.

The math (`getDist`) and park coordinates were fine — only the region-center data is corrupt upstream.

## Fix

- Broaden the candidate net from **3 -> 12** nearest region codes so the user's real region(s) are always included despite the bad rows.
- Fetch the candidate park lists **concurrently** (one slow region no longer serializes the sheet open).
- Rank purely by each park's own (correct) coordinates, and add a **`NEARBY_MAX_DISTANCE_KM` (1000 km) cap** so a mislocated region's genuinely-distant parks can never surface as nearby.

## Tests

- Regression test using the real `ZA-FS`/`RU-VL`/`RO-OT`-in-Kansas data: the narrow (3) candidate count excludes the real `US-KS`, while the wider count rescues `US-KS`/`US-MO`.
- `sortParksByDistance` max-distance cap coverage (drops a continent-away park; keeps all when no cap given).

## Verification

Built and installed on the Pixel 8. With the picker open, Nearby Parks now lists local Kansas-area parks (3-16 mi) instead of 5,000-mile foreign ones. (On-device check used a temporary local copy of the #316 picker-open fix to reach the sheet; that change is not part of this branch.)

Note: depends on #316 to actually open the picker; both target `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)