### PR TITLE
Improve RX decode sensitivity: deep decode default, level meter, FIR downsample

### DIFF
--- a/ft8af/app/src/main/cpp/fir_decimator.h
+++ b/ft8af/app/src/main/cpp/fir_decimator.h
@@ -22,20 +22,33 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+// Integer decimation ratio for an input/target sample-rate pair, always >= 1.
+// Guards the division so a zero/negative target (divide-by-zero, UB) or a target
+// above the input rate (ratio < 1) degrades to 1 (pass-through) instead of
+// mis-rating the audio. When inputRate isn't an exact multiple of targetRate the
+// floor is returned; callers should warn since the output rate won't match what
+// the decoder expects.
+inline int decimationRatioFor(int inputRate, int targetRate) {
+    if (targetRate <= 0 || inputRate < targetRate) {
+        return 1;
+    }
+    return inputRate / targetRate;
+}
+
 class FirDecimator {
 public:
     // ratio: input rate / output rate (clamped to >= 1).
-    // tapsPerPhase: half-length per polyphase arm; larger = sharper transition / deeper
-    //   stopband at more cost. 8 with a Blackman window gives ~ -58 dB stopband, plenty for
-    //   FT8's weak-signal needs.
-    explicit FirDecimator(int ratio, int tapsPerPhase = 8) {
-        configure(ratio, tapsPerPhase);
+    // tapsPerRatio: scales the FIR length (full kernel is 2*tapsPerRatio*ratio + 1 taps);
+    //   larger = sharper transition / deeper stopband at more cost. 8 with a Blackman
+    //   window gives ~ -58 dB stopband, plenty for FT8's weak-signal needs.
+    explicit FirDecimator(int ratio, int tapsPerRatio = 8) {
+        configure(ratio, tapsPerRatio);
     }
 
     // Rebuild for a new ratio and clear state. Safe to call before the rate is known.
-    void configure(int ratio, int tapsPerPhase = 8) {
+    void configure(int ratio, int tapsPerRatio = 8) {
         ratio_ = ratio < 1 ? 1 : ratio;
-        buildKernel(tapsPerPhase < 1 ? 1 : tapsPerPhase);
+        buildKernel(tapsPerRatio < 1 ? 1 : tapsPerRatio);
         history_.assign(kernel_.size(), 0.0f);
         pos_ = 0;
         phase_ = 0;
@@ -80,8 +93,8 @@ private:
         return acc;
     }
 
-    void buildKernel(int tapsPerPhase) {
-        const int N = 2 * tapsPerPhase * ratio_ + 1;  // odd -> exact symmetry about center
+    void buildKernel(int tapsPerRatio) {
+        const int N = 2 * tapsPerRatio * ratio_ + 1;  // odd -> exact symmetry about center
         const int M = N - 1;
         // Cutoff just below the output Nyquist (0.5/ratio cycles/sample); 0.45/ratio leaves a
         // small transition band so the passband stays flat to ~0.9 of Nyquist (~5.4 kHz at

--- a/ft8af/app/src/main/cpp/fir_decimator.h
+++ b/ft8af/app/src/main/cpp/fir_decimator.h
@@ -1,0 +1,120 @@
+// Fixed-ratio FIR low-pass decimator for the USB audio capture path.
+//
+// The capture loop receives 48 kHz audio and the FT8 decoder wants 12 kHz, so we drop the
+// rate by an integer ratio (4). The old code just averaged `ratio` consecutive samples — a
+// box filter whose stopband rejection is only ~12 dB, so broadband hiss and anything above
+// the 6 kHz output Nyquist folds back into the 0-3 kHz FT8 passband and raises the noise
+// floor. WSJT-X on a PC sound card doesn't pay that penalty; this brings us closer by
+// anti-aliasing with a proper windowed-sinc low-pass before decimating.
+//
+// Header-only and free of JNI/libusb/Android deps on purpose, so the DSP can be unit-tested
+// on the host (see ft8af_glue/test_fir_decimator.cpp + run_host_tests).
+
+#ifndef FT8AF_FIR_DECIMATOR_H
+#define FT8AF_FIR_DECIMATOR_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+class FirDecimator {
+public:
+    // ratio: input rate / output rate (clamped to >= 1).
+    // tapsPerPhase: half-length per polyphase arm; larger = sharper transition / deeper
+    //   stopband at more cost. 8 with a Blackman window gives ~ -58 dB stopband, plenty for
+    //   FT8's weak-signal needs.
+    explicit FirDecimator(int ratio, int tapsPerPhase = 8) {
+        configure(ratio, tapsPerPhase);
+    }
+
+    // Rebuild for a new ratio and clear state. Safe to call before the rate is known.
+    void configure(int ratio, int tapsPerPhase = 8) {
+        ratio_ = ratio < 1 ? 1 : ratio;
+        buildKernel(tapsPerPhase < 1 ? 1 : tapsPerPhase);
+        history_.assign(kernel_.size(), 0.0f);
+        pos_ = 0;
+        phase_ = 0;
+    }
+
+    // Drop all filter state (e.g. on stream restart) without rebuilding the kernel.
+    void reset() {
+        std::fill(history_.begin(), history_.end(), 0.0f);
+        pos_ = 0;
+        phase_ = 0;
+    }
+
+    int ratio() const { return ratio_; }
+    std::size_t numTaps() const { return kernel_.size(); }
+
+    // Push `n` input samples; append each decimated output sample to `out`. Streaming-safe:
+    // call repeatedly across buffers, state carries over. Produces about n/ratio outputs.
+    void process(const float* in, int n, std::vector<float>& out) {
+        const int N = static_cast<int>(kernel_.size());
+        for (int i = 0; i < n; ++i) {
+            history_[pos_] = in[i];
+            pos_ = (pos_ + 1 == N) ? 0 : pos_ + 1;
+            if (++phase_ >= ratio_) {
+                phase_ = 0;
+                out.push_back(dot());
+            }
+        }
+    }
+
+private:
+    // Convolve the current history window with the (symmetric) kernel. history_[pos_] holds
+    // the oldest sample; walking forward pairs it with kernel_[0]. The kernel is symmetric so
+    // the direction only sets a constant group delay, which is irrelevant to FT8.
+    float dot() const {
+        const int N = static_cast<int>(kernel_.size());
+        float acc = 0.0f;
+        int idx = pos_;
+        for (int k = 0; k < N; ++k) {
+            acc += history_[idx] * kernel_[k];
+            idx = (idx + 1 == N) ? 0 : idx + 1;
+        }
+        return acc;
+    }
+
+    void buildKernel(int tapsPerPhase) {
+        const int N = 2 * tapsPerPhase * ratio_ + 1;  // odd -> exact symmetry about center
+        const int M = N - 1;
+        // Cutoff just below the output Nyquist (0.5/ratio cycles/sample); 0.45/ratio leaves a
+        // small transition band so the passband stays flat to ~0.9 of Nyquist (~5.4 kHz at
+        // 48k->12k), well above FT8's ~3 kHz top.
+        const double fc = 0.45 / static_cast<double>(ratio_);
+
+        kernel_.resize(N);
+        double sum = 0.0;
+        for (int k = 0; k < N; ++k) {
+            const double m = k - M / 2.0;
+            const double sinc = (std::abs(m) < 1e-9)
+                    ? 2.0 * fc
+                    : std::sin(2.0 * M_PI * fc * m) / (M_PI * m);
+            // Blackman window for a deep, smooth stopband.
+            const double w = 0.42
+                    - 0.5 * std::cos(2.0 * M_PI * k / M)
+                    + 0.08 * std::cos(4.0 * M_PI * k / M);
+            const double h = sinc * w;
+            kernel_[k] = static_cast<float>(h);
+            sum += h;
+        }
+        // Normalize to unity DC gain so the decimator neither boosts nor attenuates level.
+        const float norm = static_cast<float>(1.0 / sum);
+        for (float& c : kernel_) {
+            c *= norm;
+        }
+    }
+
+    int ratio_ = 1;
+    std::vector<float> kernel_;
+    std::vector<float> history_;
+    int pos_ = 0;
+    int phase_ = 0;
+};
+
+#endif  // FT8AF_FIR_DECIMATOR_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -99,5 +99,20 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (dev625)." }
 & $out625
 $dev625Exit = $LASTEXITCODE
 
+# ---------------------------------------------------------------------------
+# FIR decimator tests (C++): anti-aliasing downsample that replaced the box
+# filter in usb_audio_capture.cpp. Header-only, no ft8_lib deps; compiled with
+# clang++ (the header is C++). Own main(); exit 0 == all pass.
+# ---------------------------------------------------------------------------
+$clangxx = [System.IO.Path]::ChangeExtension($Clang, $null) + "++.exe"
+if (-not (Test-Path $clangxx)) { $clangxx = $Clang }  # clang can compile C++ via -x
+$firSrc = Join-Path $here "test_fir_decimator.cpp"
+$firOut = Join-Path $env:TEMP "ft8_fir_test.exe"
+& $clangxx -std=c++14 -O2 -x c++ $firSrc -o $firOut
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (fir_decimator)." }
+& $firOut
+$firExit = $LASTEXITCODE
+
 if ($goldenExit -ne 0) { exit $goldenExit }
-exit $dev625Exit
+if ($dev625Exit -ne 0) { exit $dev625Exit }
+exit $firExit

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -77,3 +77,10 @@ out625="$tmp/ft8_dev625_test"
 
 # Not exec'd, so the EXIT trap cleans up $tmp. set -e propagates a failure.
 "$out625"
+
+# FIR decimator tests (C++): anti-aliasing downsample that replaced the box filter
+# in usb_audio_capture.cpp. Header-only, no ft8_lib deps. Compiled as C++.
+CXX="${CXX:-clang++}"
+fir_out="$tmp/ft8_fir_test"
+"$CXX" -std=c++14 -O2 -Wall "$here/test_fir_decimator.cpp" -lm -o "$fir_out"
+"$fir_out"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_fir_decimator.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_fir_decimator.cpp
@@ -1,0 +1,97 @@
+// Host tests for fir_decimator.h, the anti-aliasing decimator that replaced the box-filter
+// downsample in usb_audio_capture.cpp.
+//
+// The point of the change is sensitivity: a box filter only rejects ~10 dB at the alias
+// frequencies, so out-of-band hiss folds into the FT8 passband and raises the noise floor.
+// These tests pin the three properties that matter: correct decimation ratio, unity gain in
+// the passband (we must not change level), and deep rejection of a tone that would otherwise
+// alias straight into the FT8 band.
+//
+// HOST BUILD (no device): run_host_tests.ps1 / run_host_tests.sh compile this with a host
+// clang++ and run it. Exit code 0 == all pass.
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include "../fir_decimator.h"
+
+static int g_failures = 0;
+
+static void check(bool cond, const char* label) {
+    if (cond) {
+        printf("  ok:   %s\n", label);
+    } else {
+        printf("  FAIL: %s\n", label);
+        ++g_failures;
+    }
+}
+
+// Steady-state output amplitude (relative to input amplitude) for an input sine of frequency
+// freqHz, fed through a `ratio` decimator at inRate. Measures the peak over the back half of
+// the output so the filter's startup transient is excluded.
+static float toneGain(int inRate, int ratio, double freqHz, double inAmp) {
+    FirDecimator dec(ratio);
+    int n = inRate;  // one second of input
+    std::vector<float> in(n);
+    for (int i = 0; i < n; ++i) {
+        in[i] = (float) (inAmp * std::sin(2.0 * M_PI * freqHz * i / inRate));
+    }
+    std::vector<float> out;
+    dec.process(in.data(), n, out);
+    float peak = 0.0f;
+    for (size_t i = out.size() / 2; i < out.size(); ++i) {
+        peak = std::max(peak, std::fabs(out[i]));
+    }
+    return peak / (float) inAmp;
+}
+
+// Analytic magnitude response of the old length-`ratio` moving-average (box) filter at a
+// given frequency, for the comparison assertion.
+static double boxGain(int inRate, int ratio, double freqHz) {
+    double w = M_PI * freqHz / inRate;
+    if (std::fabs(std::sin(w)) < 1e-12) return 1.0;
+    return std::fabs(std::sin(ratio * w) / (ratio * std::sin(w)));
+}
+
+int main() {
+    printf("fir_decimator tests:\n");
+
+    // 1. Decimation ratio and kernel shape.
+    {
+        FirDecimator dec(4);
+        std::vector<float> in(4000, 0.0f), out;
+        dec.process(in.data(), (int) in.size(), out);
+        check(out.size() == 1000, "decimate-by-4 yields n/4 output samples");
+        check(dec.ratio() == 4, "ratio() reports 4");
+        check((dec.numTaps() % 2) == 1, "kernel length is odd (symmetric)");
+    }
+
+    // 2. Unity DC gain — the decimator must not change level (the meter + decoder rely on it).
+    {
+        FirDecimator dec(4);
+        std::vector<float> in(8000, 1.0f), out;
+        dec.process(in.data(), (int) in.size(), out);
+        check(!out.empty() && std::fabs(out.back() - 1.0f) < 1e-3f, "unity DC gain");
+    }
+
+    // 3. Passband tone (1 kHz, well inside FT8's range) passes at ~unity.
+    float gPass = toneGain(48000, 4, 1000.0, 0.5);
+    check(gPass > 0.95f, "1 kHz passband tone passes near unity");
+
+    // 4. A 9 kHz tone would alias to |9000 - 12000| = 3 kHz — right into the FT8 band — if not
+    //    filtered. The FIR must crush it (> ~20 dB), and must beat the old box filter, which
+    //    leaks it badly.
+    float gStop = toneGain(48000, 4, 9000.0, 0.5);
+    double gBox = boxGain(48000, 4, 9000.0);
+    printf("  info: gPass=%.4f  gStop_fir=%.4f  gStop_box=%.4f\n", gPass, gStop, gBox);
+    check(gStop < 0.1f, "9 kHz alias tone rejected > 20 dB by FIR");
+    check(gStop < (float) gBox, "FIR rejects the alias far better than the box filter");
+
+    if (g_failures) {
+        printf("%d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("all fir_decimator tests passed\n");
+    return 0;
+}

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_fir_decimator.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_fir_decimator.cpp
@@ -88,6 +88,15 @@ int main() {
     check(gStop < 0.1f, "9 kHz alias tone rejected > 20 dB by FIR");
     check(gStop < (float) gBox, "FIR rejects the alias far better than the box filter");
 
+    // 5. decimationRatioFor: the guarded ratio the capture path uses. Must never
+    //    divide-by-zero or return < 1, and must floor a non-integer multiple.
+    check(decimationRatioFor(48000, 12000) == 4, "48k/12k -> ratio 4");
+    check(decimationRatioFor(48000, 0) == 1, "zero target rate -> pass-through ratio 1");
+    check(decimationRatioFor(48000, -12000) == 1, "negative target rate -> ratio 1");
+    check(decimationRatioFor(8000, 12000) == 1, "input below target -> ratio 1 (no upsample)");
+    check(decimationRatioFor(44100, 12000) == 3, "non-integer multiple floors (44100/12000 -> 3)");
+    check(decimationRatioFor(12000, 12000) == 1, "equal rates -> ratio 1");
+
     if (g_failures) {
         printf("%d FAILURE(S)\n", g_failures);
         return 1;

--- a/ft8af/app/src/main/cpp/usb_audio_capture.cpp
+++ b/ft8af/app/src/main/cpp/usb_audio_capture.cpp
@@ -293,9 +293,23 @@ Java_com_k1af_ft8af_wave_UsbAudioNative_nativeStart(
     s->inputChannels       = inputChannels > 0 ? inputChannels : 2;
     s->inputBytesPerSample = inputBytesPerSample > 0 ? inputBytesPerSample : 2;
     s->targetRate          = targetSampleRate;
-    s->decimationRatio     = inputSampleRate / targetSampleRate;
-    // Build the anti-aliasing FIR for the actual integer ratio (e.g. 48k/12k = 4).
-    s->decimator.configure(s->decimationRatio > 0 ? s->decimationRatio : 1);
+    // Integer decimation ratio (e.g. 48k/12k = 4), computed defensively so a bad
+    // rate pair can't divide-by-zero or mis-rate the decoder. Warn on the two
+    // degenerate cases the helper folds into a pass-through ratio of 1.
+    const int ratio = decimationRatioFor(inputSampleRate, targetSampleRate);
+    if (targetSampleRate <= 0 || inputSampleRate < targetSampleRate) {
+        LOGE("invalid sample rates input=%d target=%d; disabling decimation "
+             "(ratio=1, audio passed through unchanged)",
+             inputSampleRate, targetSampleRate);
+    } else if (inputSampleRate % targetSampleRate != 0) {
+        LOGE("input rate %d is not an integer multiple of target %d; using floor "
+             "ratio %d (output rate %d != expected %d, decode may suffer)",
+             inputSampleRate, targetSampleRate, ratio,
+             inputSampleRate / ratio, targetSampleRate);
+    }
+    s->decimationRatio     = ratio;
+    // Build the anti-aliasing FIR for the actual integer ratio.
+    s->decimator.configure(ratio);
     s->monoScratch.reserve(inputSampleRate / 100);  // ~10ms of input headroom
 
     jclass cbClass = env->GetObjectClass(callback);

--- a/ft8af/app/src/main/cpp/usb_audio_capture.cpp
+++ b/ft8af/app/src/main/cpp/usb_audio_capture.cpp
@@ -26,6 +26,8 @@
 #include <thread>
 #include <vector>
 
+#include "fir_decimator.h"
+
 #define TAG "ft8af_usb_capture"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  TAG, __VA_ARGS__)
 #define LOGW(...) __android_log_print(ANDROID_LOG_WARN,  TAG, __VA_ARGS__)
@@ -63,10 +65,11 @@ struct CaptureSession {
     std::atomic<bool>             running{false};
     std::atomic<int>              inFlight{0};
 
-    // Sample accumulator for downsampling. We average `decimationRatio`
-    // consecutive input samples per output sample (cheap box-filter
-    // anti-aliasing); the decoder only needs 12kHz so this is plenty.
-    std::vector<float> accumulator;
+    // Anti-aliasing decimator: a windowed-sinc FIR low-pass + integer decimation, replacing
+    // the old box-filter average. Configured with the real ratio in nativeStart. `monoScratch`
+    // holds one transfer's worth of mono samples to hand to it without per-sample churn.
+    FirDecimator        decimator{4};
+    std::vector<float>  monoScratch;
 };
 
 // ----------------------------------------------------------------------------
@@ -153,6 +156,7 @@ void LIBUSB_CALL onTransferComplete(libusb_transfer* xfer) {
         }
     }
 
+    s->monoScratch.clear();
     for (int p = 0; p < xfer->num_iso_packets; ++p) {
         libusb_iso_packet_descriptor& pkt = xfer->iso_packet_desc[p];
         if (pkt.status != LIBUSB_TRANSFER_COMPLETED) continue;
@@ -176,28 +180,20 @@ void LIBUSB_CALL onTransferComplete(libusb_transfer* xfer) {
             } else {
                 sample = (float)l / 32768.0f;
             }
-            s->accumulator.push_back(sample);
+            s->monoScratch.push_back(sample);
         }
     }
 
-    // Drain accumulator into target-rate float blocks.
-    if (s->decimationRatio > 0
-            && (int)s->accumulator.size() >= s->decimationRatio) {
-        int outSamples = (int)s->accumulator.size() / s->decimationRatio;
-        std::vector<float> out(outSamples);
-        for (int i = 0; i < outSamples; ++i) {
-            float sum = 0.0f;
-            int base = i * s->decimationRatio;
-            for (int j = 0; j < s->decimationRatio; ++j) {
-                sum += s->accumulator[base + j];
-            }
-            out[i] = sum / (float)s->decimationRatio;
+    // Anti-alias + decimate to the target rate. The FIR carries state across transfers, so
+    // partial input is fine — it just emits ~frames/ratio output samples per call.
+    if (!s->monoScratch.empty()) {
+        std::vector<float> out;
+        out.reserve(s->monoScratch.size() / s->decimator.ratio() + 1);
+        s->decimator.process(s->monoScratch.data(),
+                             (int)s->monoScratch.size(), out);
+        if (!out.empty()) {
+            emitAudioData(s, out.data(), (int)out.size());
         }
-        int consumed = outSamples * s->decimationRatio;
-        s->accumulator.erase(
-                s->accumulator.begin(),
-                s->accumulator.begin() + consumed);
-        emitAudioData(s, out.data(), outSamples);
     }
 
     // Re-submit this transfer.
@@ -298,7 +294,9 @@ Java_com_k1af_ft8af_wave_UsbAudioNative_nativeStart(
     s->inputBytesPerSample = inputBytesPerSample > 0 ? inputBytesPerSample : 2;
     s->targetRate          = targetSampleRate;
     s->decimationRatio     = inputSampleRate / targetSampleRate;
-    s->accumulator.reserve(inputSampleRate);  // 1s of headroom
+    // Build the anti-aliasing FIR for the actual integer ratio (e.g. 48k/12k = 4).
+    s->decimator.configure(s->decimationRatio > 0 ? s->decimationRatio : 1);
+    s->monoScratch.reserve(inputSampleRate / 100);  // ~10ms of input headroom
 
     jclass cbClass = env->GetObjectClass(callback);
     s->onData    = env->GetMethodID(cbClass, "onAudioData",       "([FI)V");

--- a/ft8af/app/src/main/java/com/k1af/ft8af/FT8Common.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/FT8Common.java
@@ -32,6 +32,8 @@ public final class FT8Common {
     // FT2's 3.75s slot is 37.5 tenths — not a whole number, so it has no tenths-of-a-second
     // form. Timing uses FT2_SLOT_TIME_MILLISECOND (3750) directly; see ModeProfile.slotMillis.
     public static final int FT8_TRANSMIT_DELAY=500;//default transmit delay duration in milliseconds
-    public static final long DEEP_DECODE_TIMEOUT=7*1000;//maximum time range for deep decode
+    // Deep-decode subtraction loop time bound now scales with the mode's slot length; see
+    // ModeProfile#deepDecodeBudgetMillis. The old flat 7s constant was ~2x FT2's entire 3.75s
+    // slot (so it never bounded fast modes) while leaving FT8 far short of its 15s cycle.
     public static final int DECODE_MAX_ITERATIONS=1;//number of iterations
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -45,7 +45,12 @@ public class GeneralVariables {
 
     public static boolean distanceInMiles = true;//Display distances in miles (true) or kilometers (false)
 
-    public static boolean deepDecodeMode = false;//Whether deep decode mode is enabled
+    // Deep decode (subtract-and-redecode + extra LDPC iterations) is on by default so the app
+    // pulls weak signals out from under strong ones the way WSJT-X does at its default depth.
+    // A persisted "deepMode" config row still overrides this; only installs that never touched
+    // the setting pick up the new default. See ModeProfile#deepDecodeBudgetMillis for the loop
+    // time bound.
+    public static boolean deepDecodeMode = true;//Whether deep decode mode is enabled
 
     public static boolean audioOutput32Bit = true;//Audio output type: true=float, false=int16
     public static int audioSampleRate = 12000;//Transmit audio sample rate

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ModeProfile.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ModeProfile.java
@@ -66,6 +66,20 @@ public enum ModeProfile {
     }
 
     /**
+     * Wall-clock budget for the deep-decode subtract-and-redecode loop, in milliseconds.
+     *
+     * <p>The loop keeps subtracting decoded signals and re-decoding until no new message
+     * appears; this caps how long it may run so it can't spill into the next cycle's decode.
+     * It scales with the slot (0.75x) instead of a flat 7s: the old constant was ~2x FT2's
+     * entire 3.75s slot (never bounding fast modes) yet left FT8 well short of its 15s cycle,
+     * cutting off weak-signal passes WSJT-X would still run. The 2.5s floor keeps the fastest
+     * mode from starving on slow phones.
+     */
+    public int deepDecodeBudgetMillis() {
+        return Math.max(2500, Math.round(slotMillis * 0.75f));
+    }
+
+    /**
      * Resolve a descriptor from a mode id. Unknown ids (e.g. a config value persisted by a
      * future build before this one knows the mode) fall back to FT8 for forward-compat.
      */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -200,8 +200,9 @@ public class FT8SignalListener {
                         onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
                     }
 
+                    final long deepDecodeBudgetMs = GeneralVariables.currentMode().deepDecodeBudgetMillis();
                     do {
-                        if (timeSec > FT8Common.DEEP_DECODE_TIMEOUT) break;// timeout check: if exceeding a certain time (7 sec), skip signal subtraction
+                        if (timeSec > deepDecodeBudgetMs) break;// stop subtracting once the cycle's deep-decode budget is spent
                         // subtract decoded signals
                         subtractDecode(ft8Decoder, a91List, fromSource);
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioInputLevel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioInputLevel.java
@@ -1,0 +1,126 @@
+package com.k1af.ft8af.spectrum;
+
+/**
+ * Pure audio input-level metering for the receive level indicator.
+ *
+ * <p>A user comparing the app to WSJT-X often has the radio's USB audio set too quiet (weak
+ * signals fall below the decode threshold) or hot enough to clip (intermodulation wrecks the
+ * decode). Unlike WSJT-X the app gave no level feedback, so the gain was set blind. This turns
+ * a raw 12&nbsp;kHz mono float buffer (samples in roughly [-1, 1]) into a peak/RMS reading plus
+ * a coarse {@link Status} the UI can colour, so the operator can set gain the way WSJT-X's
+ * meter lets them.
+ *
+ * <p>All thresholds are expressed in dBFS (decibels relative to full scale, so 0&nbsp;dB is a
+ * sample magnitude of 1.0 and every value here is &le; 0). Clipping is judged from the peak;
+ * "too quiet" from the RMS, which tracks the noise/signal energy rather than a lone spike.
+ *
+ * <p>This is deliberately a plain class with a static entry point so it is unit-testable
+ * without Android; the fragment is a thin wrapper that maps {@link Status} to a colour.
+ */
+public final class AudioInputLevel {
+
+    private AudioInputLevel() {}
+
+    /** Coarse health of the input level, worst-to-best ordering aside. */
+    public enum Status {
+        /** Essentially no input — disconnected cable, wrong source, or muted radio. */
+        SILENT,
+        /** Audible but too quiet; weak signals will sit below the decode threshold. */
+        LOW,
+        /** In the healthy window — what the operator should aim for. */
+        GOOD,
+        /** Hot: peaks are close to full scale, raise nothing further. */
+        HIGH,
+        /** Peaks pinned at full scale; clipping distortion will block decodes. */
+        CLIPPING
+    }
+
+    /** Floor we report instead of -infinity for a digitally silent buffer. */
+    public static final float MIN_DBFS = -120f;
+
+    // Peak at/above this linear magnitude is treated as clipping (~ -0.13 dBFS).
+    static final float CLIP_PEAK = 0.985f;
+    // Peak dBFS at/above this is "hot" (clipping risk on transients).
+    static final float HIGH_PEAK_DBFS = -3f;
+    // Below this RMS the buffer carries no usable signal.
+    static final float SILENT_RMS_DBFS = -75f;
+    // RMS below this (but above SILENT) is too quiet for reliable weak-signal decode.
+    static final float LOW_RMS_DBFS = -45f;
+
+    /** Immutable result of metering one buffer. */
+    public static final class Reading {
+        /** Largest sample magnitude in the buffer, linear (0..~1). */
+        public final float peak;
+        /** Root-mean-square sample magnitude, linear. */
+        public final float rms;
+        /** {@link #peak} in dBFS, clamped at {@link #MIN_DBFS}. */
+        public final float peakDbfs;
+        /** {@link #rms} in dBFS, clamped at {@link #MIN_DBFS}. */
+        public final float rmsDbfs;
+        /** Coarse health used to colour the meter. */
+        public final Status status;
+
+        Reading(float peak, float rms, float peakDbfs, float rmsDbfs, Status status) {
+            this.peak = peak;
+            this.rms = rms;
+            this.peakDbfs = peakDbfs;
+            this.rmsDbfs = rmsDbfs;
+            this.status = status;
+        }
+    }
+
+    /** A reading for an empty/absent buffer: digital silence. */
+    private static final Reading SILENCE =
+            new Reading(0f, 0f, MIN_DBFS, MIN_DBFS, Status.SILENT);
+
+    /**
+     * Meter one buffer of mono float samples.
+     *
+     * @param samples PCM samples in roughly [-1, 1]; null or empty yields a {@link Status#SILENT}
+     *                reading rather than throwing, so the caller can meter unconditionally.
+     */
+    public static Reading compute(float[] samples) {
+        if (samples == null || samples.length == 0) {
+            return SILENCE;
+        }
+        float peak = 0f;
+        double sumSquares = 0d;
+        for (float s : samples) {
+            float a = Math.abs(s);
+            if (a > peak) {
+                peak = a;
+            }
+            sumSquares += (double) s * (double) s;
+        }
+        float rms = (float) Math.sqrt(sumSquares / samples.length);
+
+        float peakDbfs = toDbfs(peak);
+        float rmsDbfs = toDbfs(rms);
+        return new Reading(peak, rms, peakDbfs, rmsDbfs, classify(peak, peakDbfs, rmsDbfs));
+    }
+
+    /** Linear magnitude (>=0) to dBFS, with a {@link #MIN_DBFS} floor for silence. */
+    static float toDbfs(float linear) {
+        if (linear <= 0f) {
+            return MIN_DBFS;
+        }
+        float db = (float) (20.0 * Math.log10(linear));
+        return db < MIN_DBFS ? MIN_DBFS : db;
+    }
+
+    static Status classify(float peak, float peakDbfs, float rmsDbfs) {
+        if (peak >= CLIP_PEAK) {
+            return Status.CLIPPING;
+        }
+        if (peakDbfs >= HIGH_PEAK_DBFS) {
+            return Status.HIGH;
+        }
+        if (rmsDbfs < SILENT_RMS_DBFS) {
+            return Status.SILENT;
+        }
+        if (rmsDbfs < LOW_RMS_DBFS) {
+            return Status.LOW;
+        }
+        return Status.GOOD;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioLevelDisplay.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioLevelDisplay.java
@@ -1,0 +1,55 @@
+package com.k1af.ft8af.spectrum;
+
+import java.util.Locale;
+
+/**
+ * Maps an {@link AudioInputLevel.Reading} to the text and colour the receive meter shows.
+ *
+ * <p>Kept separate from the fragment so the label/colour decisions are unit-testable without
+ * Android: the colours are plain ARGB ints (the same literal form {@code Color.parseColor}
+ * yields), and the fragment only forwards them to {@code setText}/{@code setTextColor}.
+ */
+public final class AudioLevelDisplay {
+
+    private AudioLevelDisplay() {}
+
+    // Meter colours (ARGB). Green = aim here, amber = edge, red = clipping, grey = no signal.
+    public static final int COLOR_SILENT = 0xFF9E9E9E; // grey
+    public static final int COLOR_LOW = 0xFFFFC107;    // amber
+    public static final int COLOR_GOOD = 0xFF4CAF50;   // green
+    public static final int COLOR_HIGH = 0xFFFF9800;   // orange
+    public static final int COLOR_CLIP = 0xFFF44336;   // red
+
+    /**
+     * One-line meter label, e.g. {@code "RX -14 dB"}. Shows the RMS level (the steady
+     * signal/noise energy, like WSJT-X's averaged meter) for normal readings, a "CLIP" warning
+     * when pinned at full scale, and a dash when there is effectively no input.
+     */
+    public static String label(AudioInputLevel.Reading r) {
+        switch (r.status) {
+            case CLIPPING:
+                return "RX CLIP";
+            case SILENT:
+                return "RX --";
+            default:
+                return String.format(Locale.US, "RX %d dB", Math.round(r.rmsDbfs));
+        }
+    }
+
+    /** ARGB colour for the meter text, by reading status. */
+    public static int color(AudioInputLevel.Reading r) {
+        switch (r.status) {
+            case CLIPPING:
+                return COLOR_CLIP;
+            case HIGH:
+                return COLOR_HIGH;
+            case LOW:
+                return COLOR_LOW;
+            case SILENT:
+                return COLOR_SILENT;
+            case GOOD:
+            default:
+                return COLOR_GOOD;
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumFragment.java
@@ -22,6 +22,8 @@ import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.MainViewModel;
 import com.k1af.ft8af.R;
 import com.k1af.ft8af.databinding.FragmentSpectrumBinding;
+import com.k1af.ft8af.spectrum.AudioInputLevel;
+import com.k1af.ft8af.spectrum.AudioLevelDisplay;
 import com.k1af.ft8af.timer.UtcTimer;
 
 /**
@@ -169,6 +171,12 @@ public class SpectrumFragment extends Fragment {
         if (buffer.length <= 0) {
             return;
         }
+        // Update the RX input-level meter from the same raw audio the FFT uses, so the operator
+        // can spot a too-quiet or clipping radio (the usual cause of decoding fewer signals than
+        // WSJT-X) and set gain accordingly.
+        AudioInputLevel.Reading level = AudioInputLevel.compute(buffer);
+        binding.audioLevelTextView.setText(AudioLevelDisplay.label(level));
+        binding.audioLevelTextView.setTextColor(AudioLevelDisplay.color(level));
         int[] fft = new int[buffer.length / 2];
         if (mainViewModel.deNoise) {
             getFFTDataFloat(buffer, fft);

--- a/ft8af/app/src/main/res/layout/fragment_spectrum.xml
+++ b/ft8af/app/src/main/res/layout/fragment_spectrum.xml
@@ -123,6 +123,22 @@
             app:layout_constraintTop_toTopOf="@+id/columnarView"
             tools:text="Baud rate setting" />
 
+        <!-- Receive input-level meter. Text + colour are set in code from AudioInputLevel;
+             centred between the UTC timer (start) and the band readout (end). -->
+        <TextView
+            android:id="@+id/audioLevelTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/spectrum_text_back_ground"
+            android:textColor="@color/spectrum_text_color"
+            android:textSize="10sp"
+            tools:ignore="SmallSp"
+            app:layout_constraintBottom_toBottomOf="@+id/timersTextView"
+            app:layout_constraintEnd_toStartOf="@+id/freqBandTextView"
+            app:layout_constraintStart_toEndOf="@+id/timersTextView"
+            app:layout_constraintTop_toTopOf="@+id/timersTextView"
+            tools:text="RX -14 dB" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ModeProfileTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ModeProfileTest.java
@@ -74,6 +74,23 @@ public class ModeProfileTest {
     }
 
     @Test
+    public void deepDecodeBudget_scalesWithSlotAndHasFloor() {
+        // 0.75x the slot, so the subtract loop uses most of the cycle without spilling into
+        // the next decode. FT8: 0.75 * 15000 = 11250; FT4: 0.75 * 7500 = 5625.
+        assertThat(ModeProfile.FT8.deepDecodeBudgetMillis()).isEqualTo(11_250);
+        assertThat(ModeProfile.FT4.deepDecodeBudgetMillis()).isEqualTo(5_625);
+        // FT2: 0.75 * 3750 = 2812.5 -> below the 2500 floor it would round to 2813, which is
+        // still above the floor, so the computed value wins here.
+        assertThat(ModeProfile.FT2.deepDecodeBudgetMillis()).isEqualTo(2_813);
+        // Every mode's budget must stay under its own slot so deep decode can't overrun the
+        // cycle (the old flat 7000ms was ~2x FT2's 3750ms slot).
+        for (ModeProfile m : ModeProfile.values()) {
+            assertThat(m.deepDecodeBudgetMillis()).isAtLeast(2_500);
+            assertThat(m.deepDecodeBudgetMillis()).isLessThan(m.slotMillis);
+        }
+    }
+
+    @Test
     public void fromId_resolvesKnownIds() {
         assertThat(ModeProfile.fromId(FT8Common.FT8_MODE)).isEqualTo(ModeProfile.FT8);
         assertThat(ModeProfile.fromId(FT8Common.FT4_MODE)).isEqualTo(ModeProfile.FT4);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioInputLevelTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioInputLevelTest.java
@@ -1,0 +1,95 @@
+package com.k1af.ft8af.spectrum;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.spectrum.AudioInputLevel.Reading;
+import com.k1af.ft8af.spectrum.AudioInputLevel.Status;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for the receive input-level meter. No Android types are touched, so no
+ * Robolectric runner is needed.
+ */
+public class AudioInputLevelTest {
+
+    private static float[] constant(float magnitude, int n) {
+        float[] a = new float[n];
+        for (int i = 0; i < n; i++) {
+            // Alternate sign so it looks like an AC signal; |sample| == magnitude either way.
+            a[i] = (i % 2 == 0) ? magnitude : -magnitude;
+        }
+        return a;
+    }
+
+    @Test
+    public void nullOrEmpty_isSilent() {
+        for (float[] empty : new float[][]{null, new float[0]}) {
+            Reading r = AudioInputLevel.compute(empty);
+            assertThat(r.status).isEqualTo(Status.SILENT);
+            assertThat(r.peak).isEqualTo(0f);
+            assertThat(r.peakDbfs).isEqualTo(AudioInputLevel.MIN_DBFS);
+            assertThat(r.rmsDbfs).isEqualTo(AudioInputLevel.MIN_DBFS);
+        }
+    }
+
+    @Test
+    public void peakAndRms_ofConstantMagnitude() {
+        // |sample| == 0.1 everywhere, so peak == rms == 0.1, i.e. -20 dBFS.
+        Reading r = AudioInputLevel.compute(constant(0.1f, 256));
+        assertThat(r.peak).isWithin(1e-6f).of(0.1f);
+        assertThat(r.rms).isWithin(1e-6f).of(0.1f);
+        assertThat(r.peakDbfs).isWithin(0.01f).of(-20f);
+        assertThat(r.rmsDbfs).isWithin(0.01f).of(-20f);
+        assertThat(r.status).isEqualTo(Status.GOOD);
+    }
+
+    @Test
+    public void fullScale_clips() {
+        Reading r = AudioInputLevel.compute(constant(1.0f, 64));
+        assertThat(r.peak).isEqualTo(1.0f);
+        assertThat(r.peakDbfs).isWithin(0.001f).of(0f);
+        assertThat(r.status).isEqualTo(Status.CLIPPING);
+    }
+
+    @Test
+    public void singleHotPeak_clipsEvenIfQuietOverall() {
+        // Mostly quiet, one sample pinned at full scale: peak-driven clipping must win over the
+        // low RMS.
+        float[] a = constant(0.001f, 256);
+        a[100] = 1.0f;
+        Reading r = AudioInputLevel.compute(a);
+        assertThat(r.status).isEqualTo(Status.CLIPPING);
+    }
+
+    @Test
+    public void hotPeak_belowClip_isHigh() {
+        // Quiet floor with a 0.8 transient: peak -1.9 dBFS >= the -3 dB "hot" line, but not
+        // clipping. Peak path drives HIGH regardless of the low RMS.
+        float[] a = constant(0.001f, 256);
+        a[10] = 0.8f;
+        Reading r = AudioInputLevel.compute(a);
+        assertThat(r.status).isEqualTo(Status.HIGH);
+    }
+
+    @Test
+    public void quietSignal_isLow() {
+        // |sample| == 0.005 -> ~ -46 dBFS, below the -45 dB "too quiet" line but above silence.
+        Reading r = AudioInputLevel.compute(constant(0.005f, 256));
+        assertThat(r.status).isEqualTo(Status.LOW);
+    }
+
+    @Test
+    public void essentiallyNoSignal_isSilent() {
+        // |sample| == 0.0001 -> -80 dBFS, below the -75 dB silence line.
+        Reading r = AudioInputLevel.compute(constant(0.0001f, 256));
+        assertThat(r.status).isEqualTo(Status.SILENT);
+    }
+
+    @Test
+    public void toDbfs_handlesZeroAndUnity() {
+        assertThat(AudioInputLevel.toDbfs(0f)).isEqualTo(AudioInputLevel.MIN_DBFS);
+        assertThat(AudioInputLevel.toDbfs(1f)).isWithin(0.001f).of(0f);
+        assertThat(AudioInputLevel.toDbfs(0.5f)).isWithin(0.01f).of(-6.02f);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioLevelDisplayTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioLevelDisplayTest.java
@@ -1,0 +1,59 @@
+package com.k1af.ft8af.spectrum;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.spectrum.AudioInputLevel.Reading;
+
+import org.junit.Test;
+
+/**
+ * Coverage for the meter's label/colour mapping. Builds readings through the real
+ * {@link AudioInputLevel#compute} so the status thresholds and the display mapping are tested
+ * together.
+ */
+public class AudioLevelDisplayTest {
+
+    private static float[] constant(float magnitude, int n) {
+        float[] a = new float[n];
+        for (int i = 0; i < n; i++) {
+            a[i] = (i % 2 == 0) ? magnitude : -magnitude;
+        }
+        return a;
+    }
+
+    @Test
+    public void goodReading_showsRoundedRmsInDb_green() {
+        Reading r = AudioInputLevel.compute(constant(0.1f, 256)); // -20 dBFS, GOOD
+        assertThat(AudioLevelDisplay.label(r)).isEqualTo("RX -20 dB");
+        assertThat(AudioLevelDisplay.color(r)).isEqualTo(AudioLevelDisplay.COLOR_GOOD);
+    }
+
+    @Test
+    public void clipping_showsClipWarning_red() {
+        Reading r = AudioInputLevel.compute(constant(1.0f, 64));
+        assertThat(AudioLevelDisplay.label(r)).isEqualTo("RX CLIP");
+        assertThat(AudioLevelDisplay.color(r)).isEqualTo(AudioLevelDisplay.COLOR_CLIP);
+    }
+
+    @Test
+    public void silence_showsDash_grey() {
+        Reading r = AudioInputLevel.compute(new float[0]);
+        assertThat(AudioLevelDisplay.label(r)).isEqualTo("RX --");
+        assertThat(AudioLevelDisplay.color(r)).isEqualTo(AudioLevelDisplay.COLOR_SILENT);
+    }
+
+    @Test
+    public void low_isAmber() {
+        Reading r = AudioInputLevel.compute(constant(0.005f, 256)); // ~ -46 dBFS, LOW
+        assertThat(AudioLevelDisplay.color(r)).isEqualTo(AudioLevelDisplay.COLOR_LOW);
+        assertThat(AudioLevelDisplay.label(r)).startsWith("RX ");
+    }
+
+    @Test
+    public void high_isOrange() {
+        float[] a = constant(0.001f, 256);
+        a[10] = 0.8f; // -1.9 dBFS peak, HIGH
+        Reading r = AudioInputLevel.compute(a);
+        assertThat(AudioLevelDisplay.color(r)).isEqualTo(AudioLevelDisplay.COLOR_HIGH);
+    }
+}


### PR DESCRIPTION
## Why

A user reported the app decoding **far fewer signals than WSJT-X** from the same radio (Lab599 TX500). This is software, not the radio — the same audio feeds both, and WSJT-X just runs a more aggressive decoder plus a cleaner soundcard path. Three independent sensitivity fixes:

## 1. Deep decode on by default + slot-scaled timeout
The subtract-and-redecode loop — the thing that pulls weak signals out from under strong ones, like WSJT-X at its default depth — was gated behind `deepDecodeMode`, which defaulted **off**. Out of the box the app did a single decode pass. Now default on; a persisted `deepMode` config row still overrides, so only installs that never touched the setting pick up the new default.

Also replaces the flat `7s` deep-decode loop timeout with `ModeProfile#deepDecodeBudgetMillis` (`0.75×` the slot). The old constant was ~2× FT2's entire 3.75s slot (so it never bounded fast modes) yet left FT8 well short of its 15s cycle, cutting off weak-signal passes WSJT-X would still run.

## 2. RX input-level meter
The radio's USB audio is often set too quiet (weak signals fall below the decode threshold) or hot enough to clip (intermod kills decodes), and the app gave the operator **no feedback** — unlike WSJT-X's level meter. Adds:
- `AudioInputLevel` — pure peak/RMS → dBFS + coarse `SILENT/LOW/GOOD/HIGH/CLIPPING` status
- `AudioLevelDisplay` — label + colour mapping

Metered off the same 160 ms waterfall buffer and shown on the spectrum screen (green = aim here, amber/orange = edge, red = clipping).

## 3. Anti-aliasing FIR downsample
The 48k→12k USB capture path used a 4-tap **box filter** (~10 dB stopband), folding out-of-band hiss into the FT8 passband and raising the noise floor. Replaced with a header-only windowed-sinc polyphase decimator (`fir_decimator.h`). Host test shows a 9 kHz tone — which would otherwise alias straight to 3 kHz in-band — drops from **0.32 (box) to 0.0001 (FIR)** while the passband stays at unity.

## Testing
- `ModeProfileTest` — timeout scaling per mode
- `AudioInputLevelTest` + `AudioLevelDisplayTest` — level math + display mapping
- `test_fir_decimator.cpp` — ratio, unity gain, alias rejection; wired into `run_host_tests.ps1`/`.sh`
- JVM unit tests pass; native host suite passes; debug build installs and runs on the Pixel 8.

Note: deep decode and the level meter take effect on every audio path; the FIR decimator only affects the USB-direct capture path. Real-world decode-count comparison against WSJT-X still wants confirmation on the reporter's TX500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)