### PR TITLE
Fix Play rollout rejection: bump versionCode offset past pre-split run numbers

### DIFF
--- a/ft8af/app/build.gradle
+++ b/ft8af/app/build.gradle
@@ -34,12 +34,21 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         // CI builds derive versionCode from GITHUB_RUN_NUMBER + offset, so each
         // run gets a unique, monotonically increasing value Play Console will
-        // accept. Offset clears the manual-upload history (current max in
-        // internal track is 4). Local builds without the env var keep the
-        // static fallback so debug/release builds run unchanged from a dev
-        // machine.
+        // accept. Local builds without the env var keep the static fallback so
+        // debug/release builds run unchanged from a dev machine.
+        //
+        // GITHUB_RUN_NUMBER is PER-WORKFLOW-FILE, so it resets when the workflow
+        // is renamed/split. The original build-release.yml reached run ~680
+        // (versionCode ~780 on the Play internal track) before CI was split into
+        // per-project workflows; the replacement android.yml started its own
+        // counter back near 1, so the old +100 offset produced a versionCode
+        // BELOW 780 and Play rejected the rollout ("does not allow any existing
+        // users to upgrade to the newly added APKs"). The +1000 offset clears
+        // that historical max with margin. If the workflow is ever split/renamed
+        // again (resetting the counter), bump this offset past the last
+        // published versionCode once more.
         def ciRunNumber = System.getenv("GITHUB_RUN_NUMBER")
-        versionCode ciRunNumber ? (ciRunNumber.toInteger() + 100) : 5
+        versionCode ciRunNumber ? (ciRunNumber.toInteger() + 1000) : 5
         // CI passes -PVERSION_NAME_OVERRIDE derived from the git tag (v1.1.0 ->
         // "1.1.0", dev-42 -> "1.1.0-dev.42"). Local builds use the fallback.
         def ciVersionName = project.findProperty('VERSION_NAME_OVERRIDE')


### PR DESCRIPTION
## Problem

The `dev → staging` promotion (#321) hit this on the Play publish step:

> You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs.

This is a Play **rollout-validation rejection**, not a build failure — and it's non-blocking (the publish step is `continue-on-error`, so the run stayed green; the signed AAB + GitHub Release succeeded, only the Play upload was skipped).

## Root cause

`versionCode` is `GITHUB_RUN_NUMBER + 100` (`ft8af/app/build.gradle`). `GITHUB_RUN_NUMBER` is **per-workflow-file**:

- Old `build-release.yml` reached run **680** → last versionCode on the internal track = **780** (`dev-680`).
- The per-project CI split introduced a *new* workflow file, `android.yml`, whose counter reset. The staging promotion was Android run **#67** → versionCode `67 + 100` = **167**.
- `167 < 780`, so existing internal testers can't "upgrade" → Play refuses the rollout.

## Fix

Bump the offset `+ 100` → `+ 1000`. The next staging push (run ≈67+) yields `~1067`, clearing the 780 historical max with margin and staying monotonic afterward. Comment updated to explain the per-workflow-counter reset so a future workflow rename is handled correctly.

## Testing

No new test: this is a Gradle `versionCode` constant, not a Kotlin code path (nothing unit-testable). Verification is the next `staging` push producing a versionCode > 780 and the Play upload completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)