### PR TITLE
Fix crash: guard executor submits against teardown race

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ExecutorUtils.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ExecutorUtils.java
@@ -1,0 +1,45 @@
+package com.k1af.ft8af;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Helpers for submitting work to executors that may be torn down concurrently.
+ *
+ * <p>The decode pipeline runs on its own thread and calls back into
+ * {@code MainViewModel} after each pass to kick off background work (QTH/grid
+ * lookups, network TX audio). Those pools are shut down in
+ * {@code MainViewModel.onCleared()} when the ViewModel is destroyed (app close,
+ * connection reset/reconnect). A decode result that lands in the same instant
+ * the pool is shut down would otherwise reach {@link ExecutorService#execute}
+ * on a terminated pool and throw {@link RejectedExecutionException} on the
+ * decode thread, crashing the app. See the {@code afterDecode} race fixed
+ * alongside this helper.
+ */
+public final class ExecutorUtils {
+
+    private ExecutorUtils() {
+    }
+
+    /**
+     * Submit {@code task} to {@code pool}, tolerating a pool that is shutting
+     * down. The {@link ExecutorService#isShutdown()} check avoids the common
+     * case; the catch covers the narrow race where the pool is shut down
+     * between the check and {@link ExecutorService#execute}.
+     *
+     * @return {@code true} if the task was accepted, {@code false} if it was
+     *     dropped because the pool (or task) was unavailable.
+     */
+    public static boolean safeExecute(ExecutorService pool, Runnable task) {
+        if (pool == null || task == null || pool.isShutdown()) {
+            return false;
+        }
+        try {
+            pool.execute(task);
+            return true;
+        } catch (RejectedExecutionException e) {
+            // Pool was shut down concurrently (ViewModel teardown). Drop the task.
+            return false;
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -591,7 +591,10 @@ public class MainViewModel extends ViewModel {
 
 
                 getQTHRunnable.messages = messages;
-                getQTHThreadPool.execute(getQTHRunnable);//query location via thread pool
+                //query location via thread pool; guarded so a decode landing during
+                //ViewModel teardown (pool shut down in onCleared()) drops the lookup
+                //instead of crashing with RejectedExecutionException.
+                ExecutorUtils.safeExecute(getQTHThreadPool, getQTHRunnable);
 
                 //this variable also notifies message list changes
                 mutable_Decoded_Counter.postValue(
@@ -685,8 +688,8 @@ public class MainViewModel extends ViewModel {
                         if (baseRig.isConnected()) {
                             sendWaveDataRunnable.baseRig = baseRig;
                             sendWaveDataRunnable.message = msg;
-                            //send network data packets via thread pool
-                            sendWaveDataThreadPool.execute(sendWaveDataRunnable);
+                            //send network data packets via thread pool (guarded against teardown race)
+                            ExecutorUtils.safeExecute(sendWaveDataThreadPool, sendWaveDataRunnable);
                         }
                     }
                 }
@@ -714,7 +717,7 @@ public class MainViewModel extends ViewModel {
                 }
                 sendWaveDataRunnable.baseRig = baseRig;
                 sendWaveDataRunnable.message = msg;
-                sendWaveDataThreadPool.execute(sendWaveDataRunnable);
+                ExecutorUtils.safeExecute(sendWaveDataThreadPool, sendWaveDataRunnable);
             }
 
         }, new OnTransmitSuccess() {//when QSO is successful

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ExecutorUtilsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ExecutorUtilsTest.java
@@ -1,0 +1,61 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for {@link ExecutorUtils#safeExecute(ExecutorService, Runnable)}.
+ *
+ * <p>Locks the invariant behind the {@code afterDecode} crash fix: submitting a
+ * decode-followup task to a pool that has been shut down (ViewModel teardown)
+ * must drop the task quietly instead of throwing
+ * {@link java.util.concurrent.RejectedExecutionException}.
+ */
+public class ExecutorUtilsTest {
+
+    @Test
+    public void activePool_runsTaskAndReturnsTrue() throws InterruptedException {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            CountDownLatch ran = new CountDownLatch(1);
+            boolean accepted = ExecutorUtils.safeExecute(pool, ran::countDown);
+            assertThat(accepted).isTrue();
+            assertThat(ran.await(2, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    public void shutdownPool_dropsTaskAndReturnsFalse() {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        pool.shutdown();
+        // The pre-fix code path: execute() on a terminated pool threw and crashed
+        // the decode thread. safeExecute must swallow it and report the drop.
+        boolean accepted = ExecutorUtils.safeExecute(pool, () -> {
+            throw new AssertionError("task must not run on a shut-down pool");
+        });
+        assertThat(accepted).isFalse();
+    }
+
+    @Test
+    public void nullPool_returnsFalse() {
+        assertThat(ExecutorUtils.safeExecute(null, () -> { })).isFalse();
+    }
+
+    @Test
+    public void nullTask_returnsFalse() {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            assertThat(ExecutorUtils.safeExecute(pool, null)).isFalse();
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The app crashes with `RejectedExecutionException` after a decode when the connection is reset/reconnected or the app is closing. Observed live on a FlexRadio network reconnect:

```
FATAL EXCEPTION: Thread-101
java.util.concurrent.RejectedExecutionException: Task ...GetQTHRunnable rejected from
   ThreadPoolExecutor[Terminated, pool size = 0 ...]
   at MainViewModel$4.afterDecode(MainViewModel.java:594)
   at FT8SignalListener$3.run(FT8SignalListener.java:189)
```

`afterDecode()` runs on the FT8 decode thread and submits a QTH/grid-lookup task to `getQTHThreadPool` after every pass. That pool — and `sendWaveDataThreadPool` — is shut down in `MainViewModel.onCleared()` when the ViewModel is destroyed (app close, connection reset/reconnect). A decode result that lands in the same instant the pool is shut down reaches `ExecutorService.execute()` on a terminated pool and throws on the decode thread, crashing the app.

## Fix

Add `ExecutorUtils.safeExecute(pool, task)`, which:
- skips submission when `pool.isShutdown()`, and
- catches the residual `RejectedExecutionException` for the narrow check-then-execute race,

dropping the follow-up task instead of crashing. The dropped work is non-essential (a grid lookup, or a TX-audio send during teardown).

Routed all three submit sites through it: the QTH lookup (line 594) and the two network/CAT TX-audio sends (lines 689, 717).

## Test

`ExecutorUtilsTest` (pure JUnit4 + Truth, no runner needed): active pool runs the task and returns true; shut-down pool drops the task and returns false without throwing; null pool/task return false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)