### PR TITLE
Add "Mute radio speaker" toggle for Flex network connections

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -93,6 +93,9 @@ public class GeneralVariables {
 
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power
+    //Mute the Flex's own speaker/monitor audio on connect; DAX decode is unaffected.
+    //Defaults to muted so users aren't blasted with FT8 tones from the radio.
+    public static boolean flexMuteRadioSpeaker = true;
 
     // Hidden debug mode (unlocked by tapping the version 7 times in About).
     // When true, Settings exposes the Debug screen for log viewing/sharing.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
@@ -108,6 +108,10 @@ public class BaseRigConnector {
         //Used for X6100 FT8CNs mode
     }
 
+    public void setSliceAudioMute(boolean mute){
+        //Mute the radio's own monitor audio (Flex network mode only); no-op otherwise.
+    }
+
     //2023-08-16 Submitted by DS1UFX (based on v0.9) to support (tr)uSDX audio over CAT.
     public void receiveWaveData(byte[] data){
         float[] waveFloat=new float[data.length/2];

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/FlexConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/FlexConnector.java
@@ -180,6 +180,10 @@ public class FlexConnector extends BaseRigConnector {
                 flexRadio.commandSliceSetMode(0, FlexRadio.FlexMode.DIGU);//Set operating mode
                 flexRadio.commandSetFilter(0, 0, 3000);//Set filter to 3000 Hz
 
+                //Mute the radio's own monitor audio so the user isn't blasted with FT8
+                //tones; DAX decode is a separate stream and keeps working. Toggleable.
+                flexRadio.commandSliceSetAudioMute(0, GeneralVariables.flexMuteRadioSpeaker);
+
 
                 flexRadio.commandMeterList();//List the meters
                 //flexRadio.commandSubMeterAll();//Subscription command moved to the response handling section
@@ -249,6 +253,11 @@ public class FlexConnector extends BaseRigConnector {
     @Override
     public void sendData(byte[] data) {
         flexRadio.sendData(data);
+    }
+
+    @Override
+    public void setSliceAudioMute(boolean mute) {
+        flexRadio.commandSliceSetAudioMute(0, mute);
     }
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2515,6 +2515,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.showTxVolumeSlider = !result.equals("0");
                     GeneralVariables.mutableShowTxVolumeSlider.postValue(GeneralVariables.showTxVolumeSlider);
                 }
+                if (name.equalsIgnoreCase("flexMuteSpeaker")) {//Mute Flex radio monitor audio on connect (default on)
+                    GeneralVariables.flexMuteRadioSpeaker = !result.equals("0");
+                }
                 if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexCommand.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexCommand.java
@@ -35,6 +35,7 @@ public enum FlexCommand {
     SLICE_SET_MODE,
     SLICE_SET_NR,
     SLICE_SET_NB,
+    SLICE_SET_AUDIO_MUTE,
     SLICE_REMOVE,
     SLICE_GET_ERROR,
     DAX_AUDIO,

--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
@@ -822,6 +822,23 @@ public class FlexRadio {
         sendCommand(FlexCommand.SLICE_SET_NB, String.format("slice s %d nb=%s", sliceOder, on ? "on" : "off"));
     }
 
+    /**
+     * Build the SmartSDR command that mutes/unmutes a slice's monitor audio
+     * (the radio's speaker/headphone output for that slice). This is the local
+     * RX monitor audio only — the DAX audio stream the app decodes from is a
+     * separate path and is unaffected, so muting here silences the radio
+     * without stopping decoding. Pure so it's unit-testable.
+     */
+    @SuppressLint("DefaultLocale")
+    public static String audioMuteCommand(int sliceOrder, boolean mute) {
+        return String.format("slice s %d audio_mute=%d", sliceOrder, mute ? 1 : 0);
+    }
+
+    @SuppressLint("DefaultLocale")
+    public synchronized void commandSliceSetAudioMute(int sliceOder, boolean mute) {
+        sendCommand(FlexCommand.SLICE_SET_AUDIO_MUTE, audioMuteCommand(sliceOder, mute));
+    }
+
     @SuppressLint("DefaultLocale")
     public synchronized void commandSetDaxAudio(int channel, int sliceOder, boolean txEnable) {
         sendCommand(FlexCommand.DAX_AUDIO, String.format("dax audio set %d slice=%d tx=%s", channel, sliceOder, txEnable ? "1" : "0"));

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -630,6 +630,24 @@ fun RadioAudioSettings(
                             },
                         )
                     }
+                    SectionDivider()
+                    run {
+                        var muteSpeaker by remember { mutableStateOf(GeneralVariables.flexMuteRadioSpeaker) }
+                        SettingsRow(
+                            label = stringResource(R.string.settings_mute_radio_speaker),
+                            description = stringResource(R.string.settings_mute_radio_speaker_desc),
+                            toggle = muteSpeaker,
+                            onToggleChange = { enabled ->
+                                muteSpeaker = enabled
+                                GeneralVariables.flexMuteRadioSpeaker = enabled
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "flexMuteSpeaker", if (enabled) "1" else "0", null,
+                                )
+                                // Apply immediately if a (Flex) rig is connected; no-op otherwise.
+                                mainViewModel.baseRig?.connector?.setSliceAudioMute(enabled)
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -418,6 +418,8 @@
     <string name="settings_tx_volume_desc" formatted="false">Transmit audio level (hardware buttons ±5%)</string>
     <string name="settings_show_volume_slider">Show Volume Slider</string>
     <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_mute_radio_speaker">Mute Radio Speaker</string>
+    <string name="settings_mute_radio_speaker_desc">Silence the radio\'s own speaker on connect (decoding still works)</string>
 
     <!-- ===== Settings: transmission ===== -->
     <string name="settings_tx_rx_split">TX/RX Split</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexAudioMuteCommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexAudioMuteCommandTest.java
@@ -1,0 +1,29 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link FlexRadio#audioMuteCommand(int, boolean)}, the pure
+ * builder for the SmartSDR slice audio-mute command behind the "Mute radio
+ * speaker" setting. The wire format must match the radio's API exactly
+ * ({@code slice s <n> audio_mute=<0|1>}), so the exact strings are asserted.
+ */
+public class FlexAudioMuteCommandTest {
+
+    @Test
+    public void mute_slice0() {
+        assertThat(FlexRadio.audioMuteCommand(0, true)).isEqualTo("slice s 0 audio_mute=1");
+    }
+
+    @Test
+    public void unmute_slice0() {
+        assertThat(FlexRadio.audioMuteCommand(0, false)).isEqualTo("slice s 0 audio_mute=0");
+    }
+
+    @Test
+    public void mute_otherSliceIndex() {
+        assertThat(FlexRadio.audioMuteCommand(2, true)).isEqualTo("slice s 2 audio_mute=1");
+    }
+}


### PR DESCRIPTION
## Problem

When connected to a FlexRadio over the network, users hear the FT8 signals out of the radio's own speaker. The app itself plays no audio in this mode (RX decode has no playback path; `FT8TransmitSignal` skips local playback in network mode) — the sound is the radio playing the active slice's monitor audio. Many users want a silent radio while operating from the app.

The DAX audio stream the app decodes from is a separate path, so the slice's monitor audio can be muted without affecting decoding or the waterfall.

## Fix

Add a per-slice audio mute, defaulted on:

- **`FlexRadio.audioMuteCommand()` / `commandSliceSetAudioMute()`** send the SmartSDR `slice s <n> audio_mute=<0|1>` command (new `FlexCommand.SLICE_SET_AUDIO_MUTE`).
- **`FlexConnector`** mutes slice 0 on connect according to the setting, and overrides `BaseRigConnector.setSliceAudioMute()` so toggling applies live to an active connection.
- **`GeneralVariables.flexMuteRadioSpeaker`** (default `true`), persisted as config key `flexMuteSpeaker`, loaded in `DatabaseOpr`.
- **"Mute Radio Speaker" toggle** in Settings → Radio & Audio (Audio section), defaulted on so users get a quiet radio out of the box; turning it off restores monitor audio immediately.

Only affects slice 0 (which the Flex path already hardcodes) while the app drives the radio. Note: if the slice is later opened in SmartSDR it may appear muted until un-muted there.

## Test

`FlexAudioMuteCommandTest` asserts the exact wire format for mute/unmute and a non-zero slice index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)