### PR TITLE
Fix QRZ logbook upload: expose the API key field in Compose settings

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -257,14 +257,7 @@ public class ThirdPartyService {
                 Log.d(TAG, "QRZ connection failed: no response");
                 return false;
             }
-            String qrzResult = null;
-            for (String s : result.split("&")) {
-                String[] split = s.split("=", 2);
-                if (split.length > 1 && "RESULT".equals(split[0])) {
-                    qrzResult = split[1];
-                    break;
-                }
-            }
+            String qrzResult = parseQrzResult(result);
             Log.d(TAG, "QRZ status RESULT=" + qrzResult);
             return "OK".equals(qrzResult);
         }catch (Exception e){
@@ -296,19 +289,29 @@ public class ThirdPartyService {
             Log.d(TAG, "QRZ upload " + (result != null ? "succeeded" : "failed"));
             if (result == null) return false;
             // QRZ encodes status as RESULT=OK|FAIL|REPLACE within an &-separated body
-            String qrzResult = null;
-            for (String s : result.split("&")) {
-                String[] split = s.split("=", 2);
-                if (split.length > 1 && "RESULT".equals(split[0])) {
-                    qrzResult = split[1];
-                    break;
-                }
-            }
+            String qrzResult = parseQrzResult(result);
             return "OK".equals(qrzResult) || "REPLACE".equals(qrzResult);
         }catch (Exception k){
             Log.d(TAG, "QRZ upload error: " + k.getClass().getSimpleName());
             return false;
         }
+    }
+
+    /**
+     * Extracts the {@code RESULT} value from a QRZ logbook API response. QRZ
+     * replies with an {@code &}-separated body of {@code KEY=VALUE} pairs (e.g.
+     * {@code RESULT=OK&COUNT=1...}); this returns the value of the {@code RESULT}
+     * field, or {@code null} if the response is null/empty or has no such field.
+     */
+    static String parseQrzResult(String response) {
+        if (response == null || response.isEmpty()) return null;
+        for (String s : response.split("&")) {
+            String[] split = s.split("=", 2);
+            if (split.length > 1 && "RESULT".equals(split[0])) {
+                return split[1];
+            }
+        }
+        return null;
     }
 
     /**

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
@@ -63,10 +63,26 @@ fun LoggingSettings(
     var enableCloudlog by remember { mutableStateOf(GeneralVariables.enableCloudlog) }
     var qrzXmlUser by remember { mutableStateOf(GeneralVariables.qrzXmlUsername.orEmpty()) }
     var qrzXmlPass by remember { mutableStateOf(GeneralVariables.qrzXmlPassword.orEmpty()) }
+    var qrzApiKey by remember { mutableStateOf(GeneralVariables.qrzApiKey.orEmpty()) }
     var cloudlogAddress by remember { mutableStateOf(GeneralVariables.cloudlogServerAddress.orEmpty()) }
 
+    var showQrzLogbook by remember { mutableStateOf(false) }
     var showQrzCreds by remember { mutableStateOf(false) }
     var showCloudlog by remember { mutableStateOf(false) }
+
+    // -- QRZ Logbook API Key Dialog (upload credential) --
+    if (showQrzLogbook) {
+        QrzLogbookDialog(
+            initialApiKey = qrzApiKey,
+            onDismiss = { showQrzLogbook = false },
+            onSave = { key ->
+                qrzApiKey = key
+                GeneralVariables.qrzApiKey = key
+                mainViewModel.databaseOpr.writeConfig("qrzApiKey", key, null)
+                showQrzLogbook = false
+            },
+        )
+    }
 
     // -- QRZ Credentials Dialog --
     if (showQrzCreds) {
@@ -159,6 +175,11 @@ fun LoggingSettings(
                     SettingsRow(
                         label = stringResource(R.string.settings_qrz_com),
                         description = stringResource(R.string.settings_qrz_com_desc),
+                        value = if (qrzApiKey.isNotEmpty()) {
+                            stringResource(R.string.common_configured)
+                        } else {
+                            stringResource(R.string.common_not_configured)
+                        },
                         toggle = enableQRZ,
                         onToggleChange = { checked ->
                             enableQRZ = checked
@@ -167,6 +188,8 @@ fun LoggingSettings(
                                 "enableQRZ", if (checked) "1" else "0", null,
                             )
                         },
+                        showChevron = true,
+                        onClick = { showQrzLogbook = true },
                     )
                     SectionDivider()
                     SettingsRow(
@@ -479,6 +502,130 @@ private fun CloudlogSettingsDialog(
                 showStationPicker = false
             },
         )
+    }
+}
+
+/**
+ * Dialog for configuring the QRZ Logbook API key — the credential QRZ QSO uploads
+ * require (distinct from the XML username/password used for avatar lookups). Includes
+ * a Test Connection button that calls [ThirdPartyService.CheckQRZConnection].
+ */
+@Composable
+private fun QrzLogbookDialog(
+    initialApiKey: String,
+    onDismiss: () -> Unit,
+    onSave: (apiKey: String) -> Unit,
+) {
+    var apiKeyInput by remember { mutableStateOf(TextFieldValue(initialApiKey)) }
+    var testResult by remember { mutableStateOf<Boolean?>(null) }
+    var isTesting by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = TextPrimary,
+        unfocusedTextColor = TextPrimary,
+        cursorColor = Accent,
+        focusedBorderColor = Accent,
+        unfocusedBorderColor = BorderStrong,
+        focusedLabelColor = Accent,
+        unfocusedLabelColor = TextMuted,
+    )
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_qrz_logbook),
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+            )
+            Text(
+                text = stringResource(R.string.settings_qrz_logbook_desc),
+                color = TextMuted,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+            )
+
+            OutlinedTextField(
+                value = apiKeyInput,
+                onValueChange = { apiKeyInput = it; testResult = null },
+                label = { Text(stringResource(R.string.settings_api_key)) },
+                placeholder = { Text(stringResource(R.string.settings_qrz_api_key_hint), color = TextFaint) },
+                singleLine = true,
+                colors = fieldColors,
+                textStyle = TextStyle(fontSize = 14.sp),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // Test Connection
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                TextButton(
+                    onClick = {
+                        // Write the typed key so the STATUS test uses the current input.
+                        GeneralVariables.qrzApiKey = apiKeyInput.text.trim()
+                        isTesting = true
+                        testResult = null
+                        scope.launch {
+                            val result = withContext(Dispatchers.IO) {
+                                ThirdPartyService.CheckQRZConnection()
+                            }
+                            testResult = result
+                            isTesting = false
+                        }
+                    },
+                    enabled = !isTesting,
+                ) {
+                    Text(
+                        text = stringResource(R.string.common_test_connection),
+                        color = if (isTesting) TextFaint else Accent,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                if (isTesting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .width(16.dp)
+                            .height(16.dp),
+                        strokeWidth = 2.dp,
+                        color = Accent,
+                    )
+                }
+                if (testResult != null) {
+                    Text(
+                        text = if (testResult == true) stringResource(R.string.common_pass)
+                        else stringResource(R.string.common_fail),
+                        color = if (testResult == true) StatusConfirmed else StatusBad,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 14.sp,
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.action_cancel), color = TextMuted)
+                }
+                TextButton(
+                    onClick = { onSave(apiKeyInput.text.trim()) },
+                ) {
+                    Text(stringResource(R.string.action_save), color = Accent, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
     }
 }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
@@ -521,6 +521,15 @@ private fun QrzLogbookDialog(
     var isTesting by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
+    // Test Connection writes the typed key into GeneralVariables.qrzApiKey so the
+    // STATUS call uses it. If the user dismisses without saving, that in-memory key
+    // would otherwise persist and could drive real uploads even though it was never
+    // committed. Restore the persisted value on every dismiss path (back/outside/Cancel).
+    val handleDismiss = {
+        GeneralVariables.qrzApiKey = initialApiKey
+        onDismiss()
+    }
+
     val fieldColors = OutlinedTextFieldDefaults.colors(
         focusedTextColor = TextPrimary,
         unfocusedTextColor = TextPrimary,
@@ -531,7 +540,7 @@ private fun QrzLogbookDialog(
         unfocusedLabelColor = TextMuted,
     )
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = handleDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -616,7 +625,7 @@ private fun QrzLogbookDialog(
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(onClick = onDismiss) {
+                TextButton(onClick = handleDismiss) {
                     Text(stringResource(R.string.action_cancel), color = TextMuted)
                 }
                 TextButton(

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -21,6 +21,7 @@
     <string name="common_none">None</string>
     <string name="common_off">Off</string>
     <string name="common_not_configured">Not configured</string>
+    <string name="common_configured">Configured</string>
     <string name="common_not_connected">Not connected</string>
     <string name="common_pass">Pass</string>
     <string name="common_fail">Fail</string>
@@ -500,7 +501,10 @@
     <string name="settings_pskreporter">PSKReporter</string>
     <string name="settings_pskreporter_desc">Upload decoded spots to pskreporter.info</string>
     <string name="settings_qrz_com">QRZ.com</string>
-    <string name="settings_qrz_com_desc">Auto-upload QSOs to QRZ Logbook</string>
+    <string name="settings_qrz_com_desc">Auto-upload QSOs to QRZ Logbook (requires a Logbook API key)</string>
+    <string name="settings_qrz_logbook">QRZ Logbook</string>
+    <string name="settings_qrz_logbook_desc">Logbook API key from QRZ Logbook → Settings (not your account password).</string>
+    <string name="settings_qrz_api_key_hint">Your QRZ Logbook API key</string>
     <string name="settings_qrz_profile_lookup">QRZ Profile Lookup</string>
     <string name="settings_qrz_profile_lookup_desc">Username + password for QRZ XML API (avatars)</string>
     <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceQrzTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceQrzTest.java
@@ -1,0 +1,56 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ThirdPartyService#parseQrzResult(String)}: the QRZ logbook
+ * API replies with an {@code &}-separated body of {@code KEY=VALUE} pairs, and the
+ * upload/connection-test paths key off the {@code RESULT} field. Pure JUnit — no
+ * network, no Android types.
+ */
+public class ThirdPartyServiceQrzTest {
+
+    @Test
+    public void parses_resultOk() {
+        assertThat(ThirdPartyService.parseQrzResult("RESULT=OK&COUNT=1&LOGID=12345"))
+                .isEqualTo("OK");
+    }
+
+    @Test
+    public void parses_resultFail() {
+        assertThat(ThirdPartyService.parseQrzResult("RESULT=FAIL&REASON=invalid+api+key"))
+                .isEqualTo("FAIL");
+    }
+
+    @Test
+    public void parses_resultReplace() {
+        assertThat(ThirdPartyService.parseQrzResult("RESULT=REPLACE&COUNT=1"))
+                .isEqualTo("REPLACE");
+    }
+
+    @Test
+    public void parses_resultNotFirstField() {
+        // RESULT can appear after other fields in the body.
+        assertThat(ThirdPartyService.parseQrzResult("STATUS=AUTH&RESULT=OK&COUNT=1"))
+                .isEqualTo("OK");
+    }
+
+    @Test
+    public void returnsNull_whenResultFieldMissing() {
+        assertThat(ThirdPartyService.parseQrzResult("STATUS=AUTH&COUNT=0")).isNull();
+    }
+
+    @Test
+    public void returnsNull_forNullAndEmpty() {
+        assertThat(ThirdPartyService.parseQrzResult(null)).isNull();
+        assertThat(ThirdPartyService.parseQrzResult("")).isNull();
+    }
+
+    @Test
+    public void handles_emptyResultValue() {
+        // RESULT= with no value: split("=", 2) yields ["RESULT", ""], a present-but-empty value.
+        assertThat(ThirdPartyService.parseQrzResult("RESULT=&COUNT=0")).isEqualTo("");
+    }
+}


### PR DESCRIPTION
## Problem

Multiple users reported QRZ logging not working. Root cause: QRZ QSO auto-upload has been **silently broken for everyone on a Compose build**.

- `ThirdPartyService.uploadAdifToQrz()` requires `GeneralVariables.qrzApiKey` and returns `false` immediately when it's empty — failing on a background thread with only a `Log.d` line.
- That key was **only ever written by the legacy `ConfigFragment`**, which is dead code now that `ComposeMainActivity` is the launcher (old `MainActivity`/`main_navigation.xml`/`ConfigFragment` are unreachable).
- The Compose settings exposed the QRZ **enable toggle** and the **XML username/password** (used only for avatar lookups), but **no field for the Logbook API key** — the credential uploads actually need. So `qrzApiKey` stayed `""` and nothing was ever sent.

(Users who set the key in a much older fragment-based build still work, since the value persists in the DB.)

## Fix

- Add a **QRZ Logbook** dialog opened from the QRZ.com settings row, mirroring the working Cloudlog dialog: an API-key field plus a **Test Connection** button backed by the existing `ThirdPartyService.CheckQRZConnection()`. The key is persisted via `writeConfig("qrzApiKey", ...)`, and the row now shows a configured / not-configured status.
- Keep the separate "QRZ Profile Lookup" (XML/avatars) dialog untouched.
- Extract the duplicated QRZ `RESULT=` parsing loop from `CheckQRZConnection` and `uploadAdifToQrz` into a testable `parseQrzResult()` helper.

## Tests

- New `ThirdPartyServiceQrzTest` (pure JUnit + Truth) covering OK / FAIL / REPLACE, RESULT not first, missing RESULT, empty value, and null/empty input.
- `testDebugUnitTest --tests ...ThirdPartyServiceQrzTest` passes; `installDebug` builds and installs on the Pixel 8.

## Manual verification (needs a real QRZ Logbook API key)

Settings → Logging → tap **QRZ.com** → enter API key → **Test Connection** shows PASS → Save → row shows "Configured" → enable toggle → complete a QSO and confirm it lands in the QRZ logbook (`debug.log`/logcat tag `ThirdPartyService` shows `QRZ upload succeeded`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #335.