### PR TITLE
Fix Hunt mode ignoring the "CQ POTA" filter (#333)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -427,7 +427,9 @@ public class GeneralVariables {
 
     public static boolean autoFollowCQ = false;//Auto-follow CQ
     public static boolean huntCallsCQ = false;//Hunt+CQ hybrid: call CQ when idle, answer CQs when heard
-    public static boolean huntPotaOnly = false;//Mirror of the "CQ POTA" decode filter: Hunt only calls POTA CQs (issue #333)
+    // volatile: written from the Compose UI thread (DecodeScreen) and read from the
+    // transmit/decode processing thread (FT8TransmitSignal), like zoneMapReady above.
+    public static volatile boolean huntPotaOnly = false;//Mirror of the "CQ POTA" decode filter: Hunt only calls POTA CQs (issue #333)
     public static boolean autoCallFollow = true;//Auto-call followed callsigns
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static ArrayList<String> QSL_Callsign_list = new ArrayList<>();//Successfully QSL'd callsigns

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -427,6 +427,7 @@ public class GeneralVariables {
 
     public static boolean autoFollowCQ = false;//Auto-follow CQ
     public static boolean huntCallsCQ = false;//Hunt+CQ hybrid: call CQ when idle, answer CQs when heard
+    public static boolean huntPotaOnly = false;//Mirror of the "CQ POTA" decode filter: Hunt only calls POTA CQs (issue #333)
     public static boolean autoCallFollow = true;//Auto-call followed callsigns
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static ArrayList<String> QSL_Callsign_list = new ArrayList<>();//Successfully QSL'd callsigns

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -1199,6 +1199,9 @@ public class FT8TransmitSignal {
         for (int i = messages.size() - 1; i >= 0; i--) {
             Ft8Message msg = messages.get(i);
             if (isExcludeMessage(msg)) continue;// check if this is an excluded message
+            // POTA-only Hunt ("CQ POTA" filter): never auto-call a non-POTA CQ (issue #333)
+            if (huntFilterExcludes(GeneralVariables.huntPotaOnly,
+                    radio.ks3ckc.ft8af.pota.PotaCqClassifier.isPotaCq(msg))) continue;
 
             // is CQing, not already worked, not myself, and either Hunt mode is on
             // (auto-answer any CQ) or this is a followed callsign we auto-call
@@ -1619,6 +1622,16 @@ public class FT8TransmitSignal {
     }
 
     /**
+     * Whether the POTA-only Hunt filter excludes this CQ. When the operator has the
+     * "CQ POTA" decode filter active ({@code huntPotaOnly} mirrors it), Hunt must skip
+     * any CQ that isn't a POTA CQ so it never auto-calls a general (non-POTA) station.
+     * Shared by both auto-call scans so they agree on who's eligible. Issue #333.
+     */
+    static boolean huntFilterExcludes(boolean huntPotaOnly, boolean isPotaCq) {
+        return huntPotaOnly && !isPotaCq;
+    }
+
+    /**
      * Check watch list for active CQ messages that are not my current target callsign.
      *
      * @param messages watched message list
@@ -1641,6 +1654,12 @@ public class FT8TransmitSignal {
             }
             // not CQ, ignore
             if (!ft8Message.checkIsCQ()) {
+                continue;
+            }
+            // POTA-only Hunt ("CQ POTA" filter): the give-up fallback must also skip
+            // non-POTA CQs so it never re-targets a general station (issue #333).
+            if (huntFilterExcludes(GeneralVariables.huntPotaOnly,
+                    radio.ks3ckc.ft8af.pota.PotaCqClassifier.isPotaCq(ft8Message))) {
                 continue;
             }
             // With Hunt off but auto-call-follow on, only auto-call *followed* callsigns —

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -1199,8 +1199,11 @@ public class FT8TransmitSignal {
         for (int i = messages.size() - 1; i >= 0; i--) {
             Ft8Message msg = messages.get(i);
             if (isExcludeMessage(msg)) continue;// check if this is an excluded message
-            // POTA-only Hunt ("CQ POTA" filter): never auto-call a non-POTA CQ (issue #333)
-            if (huntFilterExcludes(GeneralVariables.huntPotaOnly,
+            // POTA-only Hunt ("CQ POTA" filter): never auto-call a non-POTA CQ (issue #333).
+            // Guard on the flag first so the spot/map lookup in isPotaCq() only runs when
+            // the filter is active (this scan runs every decode cycle).
+            if (GeneralVariables.huntPotaOnly
+                    && huntFilterExcludes(GeneralVariables.huntPotaOnly,
                     radio.ks3ckc.ft8af.pota.PotaCqClassifier.isPotaCq(msg))) continue;
 
             // is CQing, not already worked, not myself, and either Hunt mode is on
@@ -1658,7 +1661,9 @@ public class FT8TransmitSignal {
             }
             // POTA-only Hunt ("CQ POTA" filter): the give-up fallback must also skip
             // non-POTA CQs so it never re-targets a general station (issue #333).
-            if (huntFilterExcludes(GeneralVariables.huntPotaOnly,
+            // Guard on the flag first so isPotaCq()'s spot/map lookup only runs when active.
+            if (GeneralVariables.huntPotaOnly
+                    && huntFilterExcludes(GeneralVariables.huntPotaOnly,
                     radio.ks3ckc.ft8af.pota.PotaCqClassifier.isPotaCq(ft8Message))) {
                 continue;
             }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaCqClassifier.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pota/PotaCqClassifier.kt
@@ -1,0 +1,44 @@
+package radio.ks3ckc.ft8af.pota
+
+import com.k1af.ft8af.Ft8Message
+
+/**
+ * Single source of truth for "is this decode a POTA CQ".
+ *
+ * Shared by the decode-list "CQ POTA" display filter ([radio.ks3ckc.ft8af.ui.decode.filterMessages])
+ * and the Hunt auto-call path ([com.k1af.ft8af.ft8transmit.FT8TransmitSignal]) so the two agree on
+ * who counts as a POTA station — otherwise Hunt would call general CQs even with the POTA filter
+ * selected (issue #333).
+ */
+object PotaCqClassifier {
+    /**
+     * Pure predicate over already-resolved signals — testable without Android/network.
+     *
+     * Matches the same three signals the display filter uses:
+     *  1. an explicit `POTA` [modifier] on a CQ (`CQ POTA …`),
+     *  2. a CQ from a station currently spotted on pota.app ([isSpottedPota]) — activators often
+     *     drop the suffix to save characters,
+     *  3. a garbled free-text fragment where [callsignTo] starts with `CQ POT` (decoders mangle
+     *     long activator calls).
+     */
+    @JvmStatic
+    fun isPotaCq(
+        isCq: Boolean,
+        modifier: String?,
+        callsignTo: String?,
+        isSpottedPota: Boolean,
+    ): Boolean = isCq && (
+        modifier == "POTA" ||
+            isSpottedPota ||
+            (callsignTo?.startsWith("CQ POT", ignoreCase = true) == true)
+    )
+
+    /** Convenience over an [Ft8Message], resolving the spot via [PotaSpotsRepository]. */
+    @JvmStatic
+    fun isPotaCq(msg: Ft8Message): Boolean = isPotaCq(
+        isCq = msg.checkIsCQ(),
+        modifier = msg.modifier,
+        callsignTo = msg.callsignTo,
+        isSpottedPota = PotaSpotsRepository.parkRefFor(msg.callsignFrom) != null,
+    )
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -66,6 +66,14 @@ fun DecodeScreen(
     val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "Needed", "For Me")
     val selectedFilter by mainViewModel.decodeFilter.observeAsState("All")
 
+    // Couple the "CQ POTA" display filter to Hunt: while it's selected, the auto-call
+    // path (FT8TransmitSignal) restricts itself to POTA CQs and won't call general
+    // stations. decodeFilter is only ever mutated from this screen, so syncing here on
+    // every change — including the reset to "All" — keeps the flag accurate (issue #333).
+    LaunchedEffect(selectedFilter) {
+        GeneralVariables.huntPotaOnly = selectedFilter == "CQ POTA"
+    }
+
     // Keep the POTA spots cache warm while the user is browsing decodes so the
     // CQ POTA filter and the green POTA pill on spotted activators work even
     // without visiting the POTA tab. Ref-counted with the POTA screen.
@@ -452,17 +460,9 @@ internal fun filterMessages(
 
     return when (filter) {
         "CQ Calls" -> base.filter { it.checkIsCQ() }
-        "CQ POTA" -> base.filter {
-            // Match three signals: (1) explicit "POTA" suffix on a CQ, (2) any CQ from a
-            // station currently spotted on pota.app (activators often drop the suffix to
-            // save chars), (3) free-text fragments like "CQ POT" that decoders garble
-            // when the activator's call is long.
-            it.checkIsCQ() && (
-                it.modifier == "POTA" ||
-                    radio.ks3ckc.ft8af.pota.PotaSpotsRepository.parkRefFor(it.callsignFrom) != null ||
-                    (it.callsignTo?.startsWith("CQ POT", ignoreCase = true) == true)
-                )
-        }
+        // Same predicate the Hunt auto-call path uses (PotaCqClassifier), so selecting
+        // this filter and hunting agree on who counts as a POTA station — see issue #333.
+        "CQ POTA" -> base.filter { radio.ks3ckc.ft8af.pota.PotaCqClassifier.isPotaCq(it) }
         "New DXCC" -> base.filter { it.checkIsCQ() && it.fromDxcc }
         "Needed" -> base.filter {
             !it.isQSL_Callsign &&

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -316,4 +316,28 @@ public class FT8TransmitSignalTest {
         assertThat(FT8TransmitSignal.shouldResetTargetOnSlotToggle("")).isFalse();
         assertThat(FT8TransmitSignal.shouldResetTargetOnSlotToggle("  ")).isFalse();
     }
+
+    // ---- huntFilterExcludes -------------------------------------------------
+    // Couples the "CQ POTA" decode filter to Hunt: with the filter active
+    // (huntPotaOnly), the auto-call scans must skip any CQ that isn't a POTA CQ
+    // so Hunt never calls a general station. Issue #333.
+
+    @Test
+    public void huntFilter_potaOnlyOff_excludesNothing() {
+        // No POTA filter: every CQ is eligible regardless of whether it's POTA.
+        assertThat(FT8TransmitSignal.huntFilterExcludes(false, false)).isFalse();
+        assertThat(FT8TransmitSignal.huntFilterExcludes(false, true)).isFalse();
+    }
+
+    @Test
+    public void huntFilter_potaOnlyOn_excludesNonPota() {
+        // The bug fix: with "CQ POTA" selected, a non-POTA CQ must be skipped.
+        assertThat(FT8TransmitSignal.huntFilterExcludes(true, false)).isTrue();
+    }
+
+    @Test
+    public void huntFilter_potaOnlyOn_keepsPota() {
+        // A genuine POTA CQ stays eligible when the filter is active.
+        assertThat(FT8TransmitSignal.huntFilterExcludes(true, true)).isFalse();
+    }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaCqClassifierTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pota/PotaCqClassifierTest.kt
@@ -1,0 +1,96 @@
+package radio.ks3ckc.ft8af.pota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [PotaCqClassifier.isPotaCq] — the single predicate shared by the
+ * "CQ POTA" decode filter and the Hunt auto-call path (issue #333). Pure: the
+ * primitive overload takes already-resolved signals, so no Robolectric/network.
+ */
+class PotaCqClassifierTest {
+
+    @Test
+    fun `not a CQ is never a POTA CQ`() {
+        // Even with every POTA signal present, a non-CQ message must not match.
+        assertThat(
+            PotaCqClassifier.isPotaCq(
+                isCq = false,
+                modifier = "POTA",
+                callsignTo = "CQ POTA",
+                isSpottedPota = true,
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `explicit POTA modifier on a CQ matches`() {
+        assertThat(
+            PotaCqClassifier.isPotaCq(
+                isCq = true,
+                modifier = "POTA",
+                callsignTo = "CQ POTA",
+                isSpottedPota = false,
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `CQ from a spotted activator matches even without the suffix`() {
+        // Activators often drop the "POTA" suffix; the spot lookup carries them.
+        assertThat(
+            PotaCqClassifier.isPotaCq(
+                isCq = true,
+                modifier = null,
+                callsignTo = "CQ",
+                isSpottedPota = true,
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `garbled CQ POT prefix matches and is case insensitive`() {
+        assertThat(
+            PotaCqClassifier.isPotaCq(
+                isCq = true,
+                modifier = null,
+                callsignTo = "CQ POT",
+                isSpottedPota = false,
+            ),
+        ).isTrue()
+        assertThat(
+            PotaCqClassifier.isPotaCq(
+                isCq = true,
+                modifier = null,
+                callsignTo = "cq pota",
+                isSpottedPota = false,
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `plain CQ with no POTA signal does not match`() {
+        // The regression we're guarding: a general CQ must NOT be treated as POTA,
+        // so Hunt won't auto-call it while the CQ POTA filter is active.
+        assertThat(
+            PotaCqClassifier.isPotaCq(
+                isCq = true,
+                modifier = null,
+                callsignTo = "CQ",
+                isSpottedPota = false,
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `null callsignTo with no other signal does not match`() {
+        assertThat(
+            PotaCqClassifier.isPotaCq(
+                isCq = true,
+                modifier = null,
+                callsignTo = null,
+                isSpottedPota = false,
+            ),
+        ).isFalse()
+    }
+}


### PR DESCRIPTION
## Problem

Verified bug from issue #333. With Hunt mode on, "Auto answer CQ" enabled, and the **CQ POTA** filter pill selected, the app still auto-called general (non-POTA) CQ stations. Root cause: the decode-list filter (`MainViewModel.decodeFilter`) is **display-only** — it's referenced in `DecodeScreen.kt` and nowhere in the TX/Hunt path. `FT8TransmitSignal`'s auto-call scans (`checkCQMeOrFollowCQMessage` and the `getNewTargetCallsign` give-up fallback) iterate the **raw** decode list with no POTA/filter awareness, so the filter never constrained who Hunt called. This contradicts the intended behavior (Hunt + CQ POTA filter should only call POTAs).

## Fix

- **`PotaCqClassifier`** (new): single source of truth for "is this a POTA CQ", with a pure primitive overload (testable, no Android/network) and an `Ft8Message` convenience that resolves the spot via `PotaSpotsRepository`. The `"CQ POTA"` branch of `filterMessages` now delegates to it, so the display filter and Hunt share one predicate.
- **`GeneralVariables.huntPotaOnly`** (new flag): mirrors the active filter. `DecodeScreen` syncs it on every `selectedFilter` change (including the reset to "All"); `decodeFilter` is only ever mutated from that screen, so the flag stays accurate.
- **`huntFilterExcludes(huntPotaOnly, isPotaCq)`** (new testable helper): both auto-call scans now `continue` past non-POTA CQs when the filter is active, so neither the live auto-answer nor the give-up fallback calls a general station.

Couples to the existing display filter (no new UI), matching the documented intent.

## Scope note

Only the **auto-call/Hunt target selection** is gated. Replying to a station that calls **us** directly is untouched — those loops run before this scan and must always respond regardless of the POTA filter.

The other reported symptom (empty CQ POTA list early in a session) is expected POTA-spots cache lag (first poll up to ~60 s), not a logic defect — see the issue thread. Not addressed here.

## Tests

- `PotaCqClassifierTest` — pure predicate across all signals (modifier, spot, garbled `CQ POT` prefix, case-insensitivity, plain CQ negative, not-a-CQ negative, null `callsignTo`).
- `huntFilterExcludes` cases added to `FT8TransmitSignalTest` (mirrors `mayAutoCall`).
- `testDebugUnitTest` green; `installDebug` builds (NDK native included) and installs on the Pixel 8.

## Manual verification suggested

On a band with POTA activity: enable Hunt + Auto answer CQ, select the **CQ POTA** filter, confirm Hunt only calls CQ POTA stations and ignores general CQs; deselect the filter and confirm Hunt calls any CQ again.

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)