### PR TITLE
Brighten dimmed non-direct decode text (#332)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
@@ -110,7 +110,7 @@ fun DecodeRow(
         modifier = modifier
             .fillMaxWidth()
             .graphicsLayer {
-                alpha = entryAnim.value * (if (isInQsoWithOther) 0.55f else 1f)
+                alpha = entryAnim.value * decodeRowDimAlpha(isInQsoWithOther)
                 translationY = (1f - entryAnim.value) * -12f
             }
             .padding(horizontal = 12.dp, vertical = 3.dp)
@@ -249,12 +249,12 @@ fun DecodeRow(
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         radio.ks3ckc.ft8af.ui.components.FT8AFIcons.Globe(
-                            color = TextDim,
+                            color = TextFaint,
                             size = 12.dp,
                         )
                         Text(
                             text = locationText,
-                            color = TextDim,
+                            color = TextFaint,
                             fontSize = 10.5.sp,
                             fontWeight = FontWeight.Medium,
                         )
@@ -264,6 +264,15 @@ fun DecodeRow(
         }
     }
 }
+
+/**
+ * Alpha applied to a decode row. Rows for stations mid-QSO with a third party
+ * ("noise" when the operator is scanning for someone to call) are de-emphasized
+ * but kept readable; everything else renders at full opacity. See issue #332 —
+ * the old 0.55 floor stacked on already-muted greys was too dark for some users.
+ */
+internal fun decodeRowDimAlpha(isInQsoWithOther: Boolean): Float =
+    if (isInQsoWithOther) 0.8f else 1f
 
 private fun formatTimeAgo(utcMillis: Long, nowMillis: Long): String {
     val diff = ((nowMillis - utcMillis) / 1000L).coerceAtLeast(0)

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRowStyleTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRowStyleTest.kt
@@ -1,0 +1,28 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit-tests [decodeRowDimAlpha], the row-opacity decision extracted from the
+ * DecodeRow graphicsLayer lambda (which can't be unit-tested directly).
+ *
+ * Pure math — no Android types, so no Robolectric runner needed.
+ */
+class DecodeRowStyleTest {
+
+    @Test
+    fun noiseRow_isDimmedButReadable() {
+        val alpha = decodeRowDimAlpha(isInQsoWithOther = true)
+
+        assertThat(alpha).isEqualTo(0.8f)
+        // Must stay brighter than the old 0.55 floor (issue #332) — a regression
+        // back to the unreadable dimming fails here.
+        assertThat(alpha).isGreaterThan(0.55f)
+    }
+
+    @Test
+    fun directRow_isFullOpacity() {
+        assertThat(decodeRowDimAlpha(isInQsoWithOther = false)).isEqualTo(1f)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #332. Non-direct decode rows (stations mid-QSO with a third party) were dimmed to `0.55` alpha, which stacked on already-muted grey text and made the smaller text hard to read — reported by Ron (N7BBQ) for aging eyes.

Per discussion, **no new setting for now** — just better hardcoded defaults.

## Changes
- **Raise the non-direct dim floor `0.55` → `0.8`** in `DecodeRow.kt`. Noise rows stay visibly softer than CQ/TO-YOU rows but are now readable. Because the alpha multiplies the whole row, every element (callsign, message body, metadata, location) brightens proportionally.
- **Extract the alpha decision** into a testable `internal decodeRowDimAlpha(isInQsoWithOther)` (the value lived inside a `graphicsLayer` lambda that can't be unit-tested directly).
- **Brighten the per-row location line** one shade: `TextDim` (0xFF3E4862, darkest grey) → `TextFaint` (0xFF5A647E), the smaller text specifically called out in the report.

## Tests
New `DecodeRowStyleTest` covers `decodeRowDimAlpha`:
- noise row → `0.8f` and asserts `> 0.55f` (regression guard against the old dimming)
- direct row → `1f`

`testDebugUnitTest` passes; built and installed on the Pixel 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)