### PR TITLE
Surface POTA history inline on Activate tab; drop History sub-tab (#334)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
@@ -97,7 +97,6 @@ import radio.ks3ckc.ft8af.theme.TextPrimary
 private enum class PotaSubTab(@StringRes val labelRes: Int) {
     ACTIVATE(R.string.pota_tab_activate),
     HUNT(R.string.pota_tab_hunt),
-    HISTORY(R.string.pota_tab_history),
 }
 
 @Composable
@@ -135,9 +134,8 @@ fun PotaScreen(mainViewModel: MainViewModel) {
         PotaTabHeader(subTab = subTab, onTabSelected = { subTab = it })
         Spacer(Modifier.height(10.dp))
         when (subTab) {
-            PotaSubTab.ACTIVATE -> ActivateTab()
+            PotaSubTab.ACTIVATE -> ActivateTab(onOpenActivation = { selectedActivation = it })
             PotaSubTab.HUNT -> HuntTab(mainViewModel)
-            PotaSubTab.HISTORY -> HistoryTab(onOpenActivation = { selectedActivation = it })
         }
     }
 }
@@ -185,11 +183,21 @@ private fun PotaTabHeader(subTab: PotaSubTab, onTabSelected: (PotaSubTab) -> Uni
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun ActivateTab() {
+private fun ActivateTab(onOpenActivation: (PotaActivation) -> Unit) {
     val activation by PotaSessionManager.currentActivation.collectAsStateWithLifecycle()
     val contacts by PotaSessionManager.activationQsos.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+
+    // Past activations, surfaced inline below the Start Activation form so the
+    // per-park ADIF export (reached by tapping a row) is one tap from this
+    // landing tab instead of buried in a separate History tab. Reload whenever
+    // an activation starts/ends so a just-finished session appears immediately.
+    var history by remember { mutableStateOf<List<PotaActivation>>(emptyList()) }
+    LaunchedEffect(activation?.id, activation?.endedAtMs) {
+        history = withContext(Dispatchers.IO) { PotaSessionManager.history() }
+    }
+    val recent = remember(history) { historyForDisplay(history) }
     val parkRefs = rememberSaveable(
         saver = listSaver(
             save = { it.toList() },
@@ -225,94 +233,118 @@ private fun ActivateTab() {
     // FrequencyPickerSheet is hosted as a sibling overlay in FT8AFApp.
     Box(modifier = Modifier.fillMaxSize()) {
         if (activation == null) {
-            Column(
+            LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Card {
-                    SectionTitle(stringResource(R.string.pota_start_activation))
-                    Spacer(Modifier.height(8.dp))
-                    parkRefs.forEachIndexed { index, ref ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            OutlinedTextField(
-                                value = ref,
-                                onValueChange = { parkRefs[index] = it.uppercase().take(10) },
-                                label = { Text(stringResource(R.string.pota_park_reference_label)) },
-                                singleLine = true,
-                                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
-                                trailingIcon = {
-                                    IconButton(onClick = {
-                                        pickerTargetIndex = index
-                                        showPicker = true
-                                    }) {
+                item(key = "start-card") {
+                    Card {
+                        SectionTitle(stringResource(R.string.pota_start_activation))
+                        Spacer(Modifier.height(8.dp))
+                        parkRefs.forEachIndexed { index, ref ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                OutlinedTextField(
+                                    value = ref,
+                                    onValueChange = { parkRefs[index] = it.uppercase().take(10) },
+                                    label = { Text(stringResource(R.string.pota_park_reference_label)) },
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
+                                    trailingIcon = {
+                                        IconButton(onClick = {
+                                            pickerTargetIndex = index
+                                            showPicker = true
+                                        }) {
+                                            Icon(
+                                                Icons.Filled.Search,
+                                                contentDescription = stringResource(R.string.pota_search_parks),
+                                                tint = TextMuted,
+                                                modifier = Modifier.size(18.dp),
+                                            )
+                                        }
+                                    },
+                                    colors = textFieldColors(),
+                                    modifier = Modifier.weight(1f),
+                                )
+                                if (parkRefs.size > 1) {
+                                    IconButton(onClick = { parkRefs.removeAt(index) }) {
                                         Icon(
-                                            Icons.Filled.Search,
-                                            contentDescription = stringResource(R.string.pota_search_parks),
+                                            Icons.Filled.Close,
+                                            contentDescription = stringResource(R.string.pota_remove_park),
                                             tint = TextMuted,
                                             modifier = Modifier.size(18.dp),
                                         )
                                     }
-                                },
-                                colors = textFieldColors(),
-                                modifier = Modifier.weight(1f),
-                            )
-                            if (parkRefs.size > 1) {
-                                IconButton(onClick = { parkRefs.removeAt(index) }) {
-                                    Icon(
-                                        Icons.Filled.Close,
-                                        contentDescription = stringResource(R.string.pota_remove_park),
-                                        tint = TextMuted,
-                                        modifier = Modifier.size(18.dp),
-                                    )
                                 }
                             }
+                            if (index < parkRefs.lastIndex) Spacer(Modifier.height(4.dp))
                         }
-                        if (index < parkRefs.lastIndex) Spacer(Modifier.height(4.dp))
-                    }
-                    if (parkRefs.size < 10) {
-                        Spacer(Modifier.height(4.dp))
-                        OutlinedButton(
-                            onClick = { parkRefs.add("") },
+                        if (parkRefs.size < 10) {
+                            Spacer(Modifier.height(4.dp))
+                            OutlinedButton(
+                                onClick = { parkRefs.add("") },
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text(stringResource(R.string.pota_add_park), color = TextPrimary, fontSize = 13.sp)
+                            }
+                        } else {
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                stringResource(R.string.pota_max_parks_reached),
+                                color = TextMuted,
+                                fontSize = 11.sp,
+                                modifier = Modifier.padding(start = 4.dp),
+                            )
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        OutlinedTextField(
+                            value = notes,
+                            onValueChange = { notes = it.take(120) },
+                            label = { Text(stringResource(R.string.pota_notes_optional_label)) },
+                            singleLine = true,
+                            colors = textFieldColors(),
                             modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(16.dp))
-                            Spacer(Modifier.width(4.dp))
-                            Text(stringResource(R.string.pota_add_park), color = TextPrimary, fontSize = 13.sp)
-                        }
-                    } else {
-                        Spacer(Modifier.height(4.dp))
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        Button(
+                            onClick = {
+                                val started = PotaSessionManager.start(parkRefs, notes.ifBlank { null })
+                                if (started == null) {
+                                    Toast.makeText(context, context.getString(R.string.pota_enter_park_reference_first), Toast.LENGTH_SHORT).show()
+                                } else {
+                                    Toast.makeText(context, context.getString(R.string.pota_activating, started.parkRefsDisplay), Toast.LENGTH_SHORT).show()
+                                }
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = Accent, contentColor = BgApp),
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { Text(stringResource(R.string.pota_start_activation), fontWeight = FontWeight.SemiBold) }
+                    }
+                }
+                item(key = "recent-header") {
+                    Text(
+                        stringResource(R.string.pota_tab_history),
+                        color = TextMuted,
+                        fontSize = 12.sp,
+                        modifier = Modifier.padding(start = 4.dp),
+                    )
+                }
+                if (recent.isEmpty()) {
+                    item(key = "recent-empty") {
                         Text(
-                            stringResource(R.string.pota_max_parks_reached),
+                            stringResource(R.string.pota_no_past_activations),
                             color = TextMuted,
-                            fontSize = 11.sp,
+                            fontSize = 12.sp,
                             modifier = Modifier.padding(start = 4.dp),
                         )
                     }
-                    Spacer(Modifier.height(8.dp))
-                    OutlinedTextField(
-                        value = notes,
-                        onValueChange = { notes = it.take(120) },
-                        label = { Text(stringResource(R.string.pota_notes_optional_label)) },
-                        singleLine = true,
-                        colors = textFieldColors(),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Spacer(Modifier.height(12.dp))
-                    Button(
-                        onClick = {
-                            val started = PotaSessionManager.start(parkRefs, notes.ifBlank { null })
-                            if (started == null) {
-                                Toast.makeText(context, context.getString(R.string.pota_enter_park_reference_first), Toast.LENGTH_SHORT).show()
-                            } else {
-                                Toast.makeText(context, context.getString(R.string.pota_activating, started.parkRefsDisplay), Toast.LENGTH_SHORT).show()
-                            }
-                        },
-                        colors = ButtonDefaults.buttonColors(containerColor = Accent, contentColor = BgApp),
-                        modifier = Modifier.fillMaxWidth(),
-                    ) { Text(stringResource(R.string.pota_start_activation), fontWeight = FontWeight.SemiBold) }
+                } else {
+                    items(recent, key = { it.id }) { row ->
+                        HistoryRow(row = row, onClick = { onOpenActivation(row) })
+                    }
                 }
             }
         } else {
@@ -635,37 +667,17 @@ private fun SpotRow(spot: PotaSpot, onClick: () -> Unit) {
 }
 
 // ---------------------------------------------------------------------------
-// History tab
+// History
 // ---------------------------------------------------------------------------
 
-@Composable
-private fun HistoryTab(onOpenActivation: (PotaActivation) -> Unit) {
-    var history by remember { mutableStateOf<List<PotaActivation>>(emptyList()) }
-    val activation by PotaSessionManager.currentActivation.collectAsStateWithLifecycle()
-
-    // Reload whenever activation state changes (start/end will appear here).
-    LaunchedEffect(activation?.id, activation?.endedAtMs) {
-        history = PotaSessionManager.history()
-    }
-
-    Column(modifier = Modifier.fillMaxSize()) {
-        if (history.isEmpty()) {
-            Text(
-                stringResource(R.string.pota_no_past_activations),
-                color = TextMuted,
-                fontSize = 12.sp,
-                modifier = Modifier.padding(8.dp),
-            )
-        }
-        LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            items(history, key = { it.id }) { row ->
-                HistoryRow(row = row, onClick = { onOpenActivation(row) })
-            }
-        }
-    }
-}
+/**
+ * Past activations to list (newest first) below the Start Activation form.
+ * Drops any still-active row so the in-progress activation is never shown as
+ * "past", and sorts by start time so the ordering is deterministic regardless
+ * of how the DAO returned the rows.
+ */
+internal fun historyForDisplay(all: List<PotaActivation>): List<PotaActivation> =
+    all.filterNot { it.isActive }.sortedByDescending { it.startedAtMs }
 
 /** No usable ID token (never logged in, or the stored refresh token was revoked). */
 private class NotSignedInException : Exception("not signed in")

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/HistoryForDisplayTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/HistoryForDisplayTest.kt
@@ -1,0 +1,62 @@
+package radio.ks3ckc.ft8af.ui.pota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import radio.ks3ckc.ft8af.pota.model.PotaActivation
+
+/**
+ * Coverage for historyForDisplay — the decision logic behind the recent
+ * activations list inlined on the Activate tab. The composable that renders it
+ * is a thin wrapper; the filter (drop in-progress) and ordering (newest first)
+ * live here. PotaActivation is a plain data class, so no Robolectric is needed.
+ */
+class HistoryForDisplayTest {
+
+    private fun activation(id: Long, startedAtMs: Long, endedAtMs: Long?): PotaActivation =
+        PotaActivation(
+            id = id,
+            parkRef = "K-$id",
+            operator = null,
+            startedAtMs = startedAtMs,
+            endedAtMs = endedAtMs,
+            qsoCount = 0,
+            notes = null,
+        )
+
+    @Test
+    fun excludesActiveEntries() {
+        val finished = activation(1, startedAtMs = 1000, endedAtMs = 2000)
+        val active = activation(2, startedAtMs = 3000, endedAtMs = null)
+
+        val result = historyForDisplay(listOf(finished, active))
+
+        assertThat(result.map { it.id }).containsExactly(1L)
+    }
+
+    @Test
+    fun sortsNewestFirstRegardlessOfInputOrder() {
+        val older = activation(1, startedAtMs = 1000, endedAtMs = 1500)
+        val newer = activation(2, startedAtMs = 5000, endedAtMs = 5500)
+        val middle = activation(3, startedAtMs = 3000, endedAtMs = 3500)
+
+        val result = historyForDisplay(listOf(older, newer, middle))
+
+        assertThat(result.map { it.id }).containsExactly(2L, 3L, 1L).inOrder()
+    }
+
+    @Test
+    fun emptyInputProducesEmptyOutput() {
+        assertThat(historyForDisplay(emptyList())).isEmpty()
+    }
+
+    @Test
+    fun keepsAllFinishedEntries() {
+        val a = activation(1, startedAtMs = 1000, endedAtMs = 2000)
+        val b = activation(2, startedAtMs = 4000, endedAtMs = 5000)
+
+        val result = historyForDisplay(listOf(a, b))
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.id }).containsExactly(2L, 1L).inOrder()
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #334 — makes per-activation / per-park POTA ADIF export discoverable.

The export feature already exists (`PotaAdifExporter.buildActivationAdif` / `shareActivationAdif` produce one ADIF per park, n-fer aware, park ref embedded; the activation **detail screen** has **Share ADIF / Upload to POTA / Open POTA app**). The problem was discoverability: it lived three taps deep behind the **History** tab, so activators (Ron N7BBQ) had to be walked through it.

This PR removes the separate **History** sub-tab and surfaces **recent activations inline on the Activate tab**, below the Start Activation form. Rows stay tappable and open the existing detail screen, bringing export to **one tap** from the default landing tab. No export/upload/ADIF logic changed.

## Changes
- `PotaScreen.kt`:
  - Drop `HISTORY` from the `PotaSubTab` enum and its `when` branch — header now shows **Activate / Hunt** only.
  - Thread `onOpenActivation` into `ActivateTab`; reuse the existing `selectedActivation` detail navigation.
  - Idle Activate view becomes a single `LazyColumn` (start form + recent list scroll together). Empty state reuses `pota_no_past_activations`; section header reuses `pota_tab_history` — no new translations.
  - Move the history reload off the main thread (the old `HistoryTab` read SQLite on the UI thread).
  - Delete the now-unused `HistoryTab` composable; keep `HistoryRow` (reused inline).
  - Extract `internal fun historyForDisplay()` (finished only, newest first) — the decision logic, unit-testable.

## Tests
- New `HistoryForDisplayTest` (JUnit4 + Truth, no Robolectric): excludes in-progress entries, sorts newest-first regardless of input order, empty→empty, keeps all finished entries.
- `gradlew testDebugUnitTest --tests …HistoryForDisplayTest` → **BUILD SUCCESSFUL**.
- ktlint clean on main + test source sets (a pre-existing `AppSmokeTest.kt` androidTest violation is untouched by this PR).

## Verification notes
Full debug compile passed during the test run. **Not yet installed on a device** (no phone attached at build time) — recommend a quick on-device check that the History tab is gone, recent activations appear under the Start form, and tapping a row opens detail → Share ADIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)