### PR TITLE
Desktop: decode at ~13.2 s so CQ replies don't skip a cycle (#4)

### DIFF
--- a/desktop/src-tauri/src/audio/slot.rs
+++ b/desktop/src-tauri/src/audio/slot.rs
@@ -45,6 +45,28 @@ impl SlotAccumulator {
         out
     }
 
+    /// Copy a slot aligned to the slot *start*: the most recent `elapsed_samples`
+    /// captured samples (the audio belonging to the current slot so far) placed at
+    /// the FRONT of a `SLOT_SAMPLES` buffer, zero-padding the tail. The FT8
+    /// waveform begins at the slot boundary, so it lands at sample 0 — the
+    /// alignment the decoder expects (DT measured from the buffer start). This lets
+    /// the decoder run as soon as the 12.64 s waveform is captured (~13 s into the
+    /// cycle) instead of waiting for the full 15 s boundary, pulling decodes — and
+    /// the operator's reply — a slot earlier (matches WSJT-X).
+    ///
+    /// At `elapsed_samples >= SLOT_SAMPLES` (a full slot) this matches `take_slot`:
+    /// the most recent 15 s with the signal at the front.
+    pub fn take_slot_from_start(&self, elapsed_samples: usize) -> Vec<f32> {
+        let buf = self.inner.lock();
+        let mut out = vec![0.0f32; SLOT_SAMPLES];
+        let n = elapsed_samples.min(buf.len()).min(SLOT_SAMPLES);
+        // The oldest of these n samples is the slot-start sample → position 0.
+        for (i, s) in buf.iter().skip(buf.len() - n).enumerate() {
+            out[i] = *s;
+        }
+        out
+    }
+
     /// Copy the most recent `n` samples (for the live waterfall FFT) without
     /// disturbing the buffer. Returns fewer than `n` only during warm-up.
     pub fn peek_recent(&self, n: usize) -> Vec<f32> {
@@ -70,5 +92,41 @@ impl SlotAccumulator {
 impl Default for SlotAccumulator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_slot_from_start_front_aligns_partial_slot() {
+        let acc = SlotAccumulator::new();
+        // Simulate ~13 s of a slot: a 1.0 marker at the slot start, then a ramp.
+        let elapsed = SAMPLE_RATE as usize * 13;
+        let mut audio = vec![0.0f32; elapsed];
+        audio[0] = 1.0; // slot-start sample
+        audio[elapsed - 1] = 0.5; // most-recent sample
+        acc.push(&audio);
+
+        let slot = acc.take_slot_from_start(elapsed);
+        assert_eq!(slot.len(), SLOT_SAMPLES);
+        // Slot-start sample lands at index 0 (DT == 0 for the decoder).
+        assert_eq!(slot[0], 1.0);
+        // Most-recent captured sample lands at index elapsed-1, not at the end.
+        assert_eq!(slot[elapsed - 1], 0.5);
+        // The tail (after captured audio) is zero-padded, never noise.
+        assert!(slot[elapsed..].iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn take_slot_from_start_full_slot_matches_take_slot() {
+        let acc = SlotAccumulator::new();
+        let audio: Vec<f32> = (0..SLOT_SAMPLES).map(|i| (i % 7) as f32).collect();
+        acc.push(&audio);
+        // A full slot's worth of elapsed samples reproduces the boundary copy.
+        assert_eq!(acc.take_slot_from_start(SLOT_SAMPLES), acc.take_slot());
+        // Asking for more than a slot is clamped, not an overrun.
+        assert_eq!(acc.take_slot_from_start(SLOT_SAMPLES * 2), acc.take_slot());
     }
 }

--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -27,6 +27,14 @@ const PTT_DELAY_MS: u64 = 100;
 // waveform (plus the PTT lead) land before the next slot boundary. Start later
 // than this and the leading Costas array gets clipped — audible but undecodable.
 const TX_LATEST_MS: i64 = TX_SLACK_MS - PTT_DELAY_MS as i64;
+// Point in the (rx-corrected) cycle at which we hand the slot to the decoder.
+// The FT8 waveform is complete at 12.64 s, so decoding ~0.6 s later returns
+// results around the 15 s boundary even on a slow CPU — early enough that the
+// operator's reply lands in the very next slot instead of skipping a cycle.
+// The rx-offset calibration aligns this clock to the real signal timing, and
+// any positive capture latency only pushes the real trigger later (safer), so
+// 13.2 s keeps a comfortable margin above the 12.64 s waveform end.
+const DECODE_AT_MS: i64 = 13_200;
 const DEFAULT_TX_AUDIO_HZ: i32 = 1_500;
 const WF_FFT_SIZE: usize = 2048; // ~5.86 Hz/bin at 12 kHz
 const WF_AVG: usize = 6; // averaged FFT segments per row (Welch) to smooth the noise floor
@@ -197,7 +205,9 @@ struct Engine {
     decoding: bool,
     dial_hz: u64,
     tx_audio_hz: i32,
-    last_rx_slot_id: i64,
+    /// Slot id (rx-corrected clock) most recently handed to the decode worker.
+    /// Guards the once-per-slot early decode trigger in the run loop.
+    last_decoded_slot: i64,
     /// Audio-capture latency compensation (ms). The RX decode window is sliced
     /// this much later than the UTC cycle boundary so that buffered/late-arriving
     /// input audio lands aligned — drives decoded DT toward 0. Auto-calibrated
@@ -283,7 +293,7 @@ impl Engine {
             decoding: false,
             dial_hz,
             tx_audio_hz,
-            last_rx_slot_id: -1,
+            last_decoded_slot: -1,
             rx_offset_ms,
             last_tick_ms: 0,
             tx_parity: None,
@@ -335,13 +345,23 @@ impl Engine {
                 }));
             }
 
-            // RX window boundary runs on a clock shifted later by the capture-latency
-            // compensation, so the sliced 15 s slot aligns with the audio that has
+            // Decode runs on a clock shifted later by the capture-latency
+            // compensation, so the sliced slot aligns with the audio that has
             // actually arrived in the buffer (UTC display + TX still use real `now`).
-            let rx_slot_id = (now - self.rx_offset_ms).div_euclid(CYCLE_MS);
-            if rx_slot_id != self.last_rx_slot_id {
-                self.last_rx_slot_id = rx_slot_id;
-                self.on_slot_boundary(rx_slot_id);
+            // We fire once per slot as soon as the 12.64 s waveform is captured
+            // (~13.2 s in) rather than at the 15 s boundary, so decodes land a slot
+            // earlier and the operator can reply on the next cycle (not skip one).
+            let corrected = now - self.rx_offset_ms;
+            let rx_slot_id = corrected.div_euclid(CYCLE_MS);
+            let into_rx_cycle = corrected.rem_euclid(CYCLE_MS);
+            if self.decoding && rx_slot_id != self.last_decoded_slot && into_rx_cycle >= DECODE_AT_MS
+            {
+                self.last_decoded_slot = rx_slot_id;
+                // The slot's audio so far = the most recent `into_rx_cycle` of it,
+                // front-aligned (signal at sample 0) with the tail zero-padded.
+                let elapsed = (into_rx_cycle * SAMPLE_RATE as i64 / 1000) as usize;
+                let slot = self.accum.take_slot_from_start(elapsed);
+                let _ = self.slot_tx.send(slot);
             }
 
             // Act on any decodes the worker has finished (off-loop DSP). This is
@@ -388,21 +408,12 @@ impl Engine {
             return;
         }
         self.rx_offset_ms = new_offset;
-        // Re-anchor so the offset change doesn't re-trigger a boundary for this cycle.
-        self.last_rx_slot_id = (self.now() - self.rx_offset_ms).div_euclid(CYCLE_MS);
+        // No re-anchor needed: the decode trigger requires `into_rx_cycle >=
+        // DECODE_AT_MS`, and offset changes land early in the cycle (right after a
+        // decode is delivered), far below that threshold — so a shifted slot id
+        // can't spuriously re-fire the decode this cycle.
         let _ = self.db.set_config("rx_offset_ms", &new_offset.to_string());
         self.publish_clock_sync();
-    }
-
-    fn on_slot_boundary(&mut self, _entering_slot: i64) {
-        // Hand the slot that just ended to the decode worker; decoding happens
-        // off this loop, so the waterfall + clock keep updating. The worker's
-        // results are consumed in the run loop (see handle_decoded), which then
-        // drives QSO sequencing + TX for the slot we're now in.
-        if self.decoding {
-            let slot = self.accum.take_slot();
-            let _ = self.slot_tx.send(slot);
-        }
     }
 
     /// Handle one slot's decodes (from the worker): publish them, advance the QSO


### PR DESCRIPTION
## Problem

A user testing the desktop app on an Inovato Quadra 4K (low-power ARM SBC) reported that **answering a CQ skips a full 15 s cycle** before the app keys up, and as a result he could never complete a QSO (WSJT-Z on the same rig worked fine).

## Root cause

The engine only kicked off the FT8 decode at the **15 s slot boundary** (`on_slot_boundary` → `take_slot`). On a weak CPU the decode then finished 2–3 s *into the next slot*. Add operator reaction time and the click landed past `TX_LATEST_MS` (2.26 s), so `maybe_transmit` refused to key this slot and deferred to the next **same-parity** slot — two cycles later. That's the "skips a cycle" the reporter saw.

WSJT-X decodes as soon as the 12.64 s waveform is complete, so decodes appear *before* the boundary and the reply lands in the very next slot.

## Fix

- **`SlotAccumulator::take_slot_from_start(elapsed)`** — copies the slot's audio so far, front-aligned (signal at sample 0, the alignment the decoder's DT expects) with the tail zero-padded to a full `SLOT_SAMPLES` buffer. At a full slot it's identical to `take_slot`.
- Engine fires the decode **once per slot at `DECODE_AT_MS` (13.2 s)** on the rx-corrected clock instead of at the 15 s boundary. The rx-offset calibration aligns that clock to real signal timing, and positive capture latency only pushes the real trigger *later*, so the 0.6 s margin above the 12.64 s waveform end is safe.
- Removed the now-spurious `last_rx_slot_id` re-anchor in `calibrate_dt` — the `into_rx_cycle >= DECODE_AT_MS` guard already prevents an offset change (which lands early in the cycle) from re-firing the decode.

## Tests

`take_slot_from_start` front-aligns a partial slot and zero-pads the tail; a full slot reproduces `take_slot`. Full lib suite green (13 tests).

First of a series addressing the desktop timing/usability reports (this is the keystone "can't complete a QSO" bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)