### PR TITLE
Desktop: abortable + low-latency TX — Stop TX works mid-cycle, less PTT dead air (#1, #3)

### DIFF
--- a/desktop/src-tauri/src/audio/output.rs
+++ b/desktop/src-tauri/src/audio/output.rs
@@ -1,8 +1,22 @@
 //! TX audio playback: render a 12 kHz mono FT8 waveform to an output device,
 //! resampling to the device rate and fanning the mono sample across channels.
+//!
+//! Playback is split into two phases so the engine can key the rig with minimal
+//! dead air and stop a transmission mid-stream:
+//!   * [`prepare`] does the heavy lifting — open the device, resample the whole
+//!     waveform, build the (paused) output stream. The caller runs this *before*
+//!     raising PTT so the rig isn't keyed during the resample (which is slow on
+//!     weak CPUs).
+//!   * [`PreparedTx::start`] is cheap: seek past any leading clip and unpause the
+//!     stream. The caller runs it right after PTT settles.
+//! The returned handle is polled (`is_done`/`timed_out`) and can be `abort`ed or
+//! simply dropped to stop audio immediately (dropping the stream halts the cpal
+//! callback). The `cpal::Stream` is `!Send` on Windows, so the handle must live
+//! on the thread that created it (the engine thread).
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, StreamTrait};
 use cpal::{FromSample, SampleFormat, SizedSample};
@@ -11,13 +25,79 @@ use super::devices::find_output_device;
 use super::resample::resample_buffer;
 use crate::dsp::SAMPLE_RATE;
 
-/// Play a 12 kHz mono buffer to completion (blocking). `gain` scales amplitude.
-/// Returns when the whole buffer has been clocked out (plus a short tail).
-pub fn play_blocking(
+/// Slack added to the expected playback duration before the stuck-device
+/// deadline trips and PTT is force-released.
+const DEADLINE_MARGIN_SECS: f32 = 2.0;
+
+/// Cursor (in device-rate mono samples) to start playback from, given a leading
+/// clip of `skip_ms` of the original 12 kHz waveform. Clamped to `total` so an
+/// over-long clip simply starts at the end (plays nothing) rather than panicking.
+fn skip_cursor(skip_ms: i64, device_rate: u32, total: usize) -> usize {
+    let skip = (skip_ms.max(0) * device_rate as i64 / 1000) as usize;
+    skip.min(total)
+}
+
+/// Seconds of audio left to play from `cursor` to the end of a `total`-sample
+/// device-rate buffer. Drives the stuck-device deadline.
+fn remaining_secs(total: usize, cursor: usize, device_rate: u32) -> f32 {
+    total.saturating_sub(cursor) as f32 / device_rate.max(1) as f32
+}
+
+/// A built-but-not-yet-playing TX waveform plus the shared state its cpal
+/// callback drives. Hold it on the engine thread; poll [`is_done`]/[`timed_out`]
+/// each loop tick and call [`finalize`-by-drop] (drop) when finished or stopping.
+pub struct PreparedTx {
+    // Kept alive for the life of the transmission; dropping it stops the audio.
+    _stream: cpal::Stream,
+    cursor: Arc<AtomicUsize>,
+    done: Arc<AtomicBool>,
+    abort: Arc<AtomicBool>,
+    total: usize,
+    device_rate: u32,
+    /// Set when playback starts; bounds how long we'll hold PTT if the device
+    /// callback never reaches the end (so a stalled stream can't key forever).
+    deadline: Option<Instant>,
+}
+
+impl PreparedTx {
+    /// Begin playback, skipping the first `skip_ms` of the (12 kHz) waveform.
+    /// Cheap — meant to run immediately after PTT settles. Idempotent-safe.
+    pub fn start(&mut self, skip_ms: i64) -> anyhow::Result<()> {
+        let skip = skip_cursor(skip_ms, self.device_rate, self.total);
+        self.cursor.store(skip, Ordering::Relaxed);
+        self._stream.play()?;
+        let remaining = remaining_secs(self.total, skip, self.device_rate);
+        self.deadline = Some(Instant::now() + Duration::from_secs_f32(remaining + DEADLINE_MARGIN_SECS));
+        Ok(())
+    }
+
+    /// True once the whole buffer has been clocked out (or playback was aborted).
+    pub fn is_done(&self) -> bool {
+        self.done.load(Ordering::Relaxed)
+    }
+
+    /// True if playback has been running longer than its expected duration plus a
+    /// safety margin — a stuck-device backstop so PTT is never held indefinitely.
+    pub fn timed_out(&self) -> bool {
+        matches!(self.deadline, Some(d) if Instant::now() > d)
+    }
+
+    /// Signal the callback to stop emitting samples (fills silence, marks done).
+    /// Dropping the handle also stops audio; this just makes the intent explicit.
+    pub fn abort(&self) {
+        self.abort.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Render a 12 kHz mono buffer for `device_name`, applying `gain`, and build the
+/// (paused) output stream. Does NOT key audio — call [`PreparedTx::start`] to
+/// begin. This is the slow phase (device open + full-buffer resample); run it
+/// before raising PTT.
+pub fn prepare(
     device_name: Option<&str>,
     samples_12k: &[f32],
     gain: f32,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PreparedTx> {
     let device = find_output_device(device_name)
         .ok_or_else(|| anyhow::anyhow!("no output audio device available"))?;
     let supported = device.default_output_config()?;
@@ -36,30 +116,26 @@ pub fn play_blocking(
     let buffer = Arc::new(data);
     let cursor = Arc::new(AtomicUsize::new(0));
     let done = Arc::new(AtomicBool::new(false));
+    let abort = Arc::new(AtomicBool::new(false));
 
     let err_fn = |e| log::error!("audio output stream error: {e}");
 
     let stream = match sample_format {
-        SampleFormat::F32 => build_output::<f32>(&device, &config, channels, &buffer, &cursor, &done, err_fn)?,
-        SampleFormat::I16 => build_output::<i16>(&device, &config, channels, &buffer, &cursor, &done, err_fn)?,
-        SampleFormat::U16 => build_output::<u16>(&device, &config, channels, &buffer, &cursor, &done, err_fn)?,
+        SampleFormat::F32 => build_output::<f32>(&device, &config, channels, &buffer, &cursor, &done, &abort, err_fn)?,
+        SampleFormat::I16 => build_output::<i16>(&device, &config, channels, &buffer, &cursor, &done, &abort, err_fn)?,
+        SampleFormat::U16 => build_output::<u16>(&device, &config, channels, &buffer, &cursor, &done, &abort, err_fn)?,
         other => anyhow::bail!("unsupported output sample format: {other:?}"),
     };
-    stream.play()?;
 
-    // Wait for the callback to clock out the whole buffer.
-    let timeout = std::time::Duration::from_secs_f32(total as f32 / device_rate as f32 + 2.0);
-    let start = std::time::Instant::now();
-    while !done.load(Ordering::Relaxed) {
-        if start.elapsed() > timeout {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-    // brief tail so the device flushes its final buffer
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    drop(stream);
-    Ok(())
+    Ok(PreparedTx {
+        _stream: stream,
+        cursor,
+        done,
+        abort,
+        total,
+        device_rate,
+        deadline: None,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -70,6 +146,7 @@ fn build_output<T>(
     buffer: &Arc<Vec<f32>>,
     cursor: &Arc<AtomicUsize>,
     done: &Arc<AtomicBool>,
+    abort: &Arc<AtomicBool>,
     err_fn: impl FnMut(cpal::StreamError) + Send + 'static,
 ) -> anyhow::Result<cpal::Stream>
 where
@@ -78,9 +155,16 @@ where
     let buffer = buffer.clone();
     let cursor = cursor.clone();
     let done = done.clone();
+    let abort = abort.clone();
     let stream = device.build_output_stream(
         config,
         move |out: &mut [T], _| {
+            // Stop TX: emit silence and report done so the engine drops PTT.
+            if abort.load(Ordering::Relaxed) {
+                done.store(true, Ordering::Relaxed);
+                out.fill(T::from_sample(0.0f32));
+                return;
+            }
             for frame in out.chunks_mut(channels) {
                 let idx = cursor.load(Ordering::Relaxed);
                 let sample = if idx < buffer.len() {
@@ -100,4 +184,36 @@ where
         None,
     )?;
     Ok(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skip_cursor_converts_ms_to_device_samples() {
+        // 100 ms at 48 kHz = 4800 samples.
+        assert_eq!(skip_cursor(100, 48_000, 1_000_000), 4_800);
+        // The normal case: no leading clip → start at sample 0.
+        assert_eq!(skip_cursor(0, 48_000, 1_000_000), 0);
+        // Negative is treated as zero, never a huge usize.
+        assert_eq!(skip_cursor(-500, 48_000, 1_000_000), 0);
+    }
+
+    #[test]
+    fn skip_cursor_clamps_to_total() {
+        // A clip longer than the buffer starts at the end (plays silence), never
+        // overruns the buffer.
+        assert_eq!(skip_cursor(60_000, 48_000, 1_000), 1_000);
+    }
+
+    #[test]
+    fn remaining_secs_measures_unplayed_audio() {
+        // 48000 samples left at 48 kHz = 1.0 s.
+        assert_eq!(remaining_secs(96_000, 48_000, 48_000), 1.0);
+        // Past the end clamps to zero rather than going negative.
+        assert_eq!(remaining_secs(48_000, 96_000, 48_000), 0.0);
+        // Zero device rate can't divide-by-zero.
+        assert!(remaining_secs(48_000, 0, 0).is_finite());
+    }
 }

--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -211,6 +211,10 @@ struct Engine {
     /// results back into this loop.
     cmd_tx: Sender<EngineCommand>,
     ptt: bool,
+    /// In-flight TX playback, if any. Held on this thread (the cpal stream is
+    /// `!Send`); polled each loop tick so completion drops PTT, and dropped to
+    /// stop audio immediately on Stop TX.
+    tx_playback: Option<output::PreparedTx>,
     // live waterfall FFT
     fft: Arc<dyn Fft<f32>>,
     hann: Vec<f32>,
@@ -291,6 +295,7 @@ impl Engine {
             time_synced: saved_offset.is_some(),
             cmd_tx,
             ptt: false,
+            tx_playback: None,
             fft,
             hann,
             wf_floor_db: -60.0,
@@ -350,6 +355,16 @@ impl Engine {
             // on an operator tap is handled separately, in the command handlers.
             while let Ok(msgs) = self.dec_rx.try_recv() {
                 self.handle_decoded(msgs, slot_id);
+            }
+
+            // Drop PTT as soon as the TX waveform finishes clocking out (or a
+            // stalled device trips the deadline). Polling here — rather than
+            // blocking inside `transmit` — is what lets Stop TX take effect
+            // mid-transmission instead of at the end of the cycle.
+            if let Some(pb) = self.tx_playback.as_ref() {
+                if pb.is_done() || pb.timed_out() {
+                    self.finalize_tx();
+                }
             }
 
             // Live scrolling waterfall: one spectrum row per ~100 ms tick.
@@ -420,7 +435,7 @@ impl Engine {
             }
         }
         self.maybe_transmit(slot_id);
-        self.publish_tx_state(false);
+        self.publish_tx_state();
     }
 
     /// Key up this slot's QSO message if we're armed, it's our turn, and the
@@ -450,7 +465,7 @@ impl Engine {
         self.tx_parity = Some(parity);
         self.txed_slot = slot_id;
         if let Some(msg) = self.qso.tx_message().map(|s| s.to_string()) {
-            self.transmit(&msg);
+            self.start_transmit(&msg);
         }
     }
 
@@ -464,7 +479,15 @@ impl Engine {
         self.cur_slot().rem_euclid(2)
     }
 
-    fn transmit(&mut self, message: &str) {
+    /// Begin transmitting `message`, returning immediately. Playback runs off the
+    /// loop (in `tx_playback`) so the engine keeps draining commands — that's what
+    /// makes Stop TX able to interrupt mid-transmission. PTT is dropped later, when
+    /// the run loop sees the playback finish (or on Stop TX).
+    fn start_transmit(&mut self, message: &str) {
+        // Never key a second transmission over a live one.
+        if self.tx_playback.is_some() {
+            return;
+        }
         let signal = match crate::dsp::encode::generate_ft8(message, self.tx_audio_hz as f32, SAMPLE_RATE) {
             Some(s) => s,
             None => {
@@ -473,22 +496,45 @@ impl Engine {
             }
         };
 
+        // Do the slow work — device open + full-buffer resample — BEFORE keying
+        // the rig, so PTT isn't held through it. On a weak CPU this resample is
+        // hundreds of ms; running it after PTT is what produced the long
+        // keyed-but-silent gap reported on the Inovato Quadra.
+        let mut prepared = match output::prepare(self.output_device.as_deref(), &signal, 0.9) {
+            Ok(p) => p,
+            Err(e) => {
+                self.emit(EngineEvent::Error(format!("playback failed: {e}")));
+                return;
+            }
+        };
+
+        // Key up, let the rig's T/R relay settle, then start clocking samples.
         self.set_ptt(true);
-        self.publish_tx_state(true);
         std::thread::sleep(Duration::from_millis(PTT_DELAY_MS));
 
         // Clip leading audio only if we'd overrun the cycle (CLAUDE.md gotcha:
-        // ms_late = max(0, into_cycle - 2360), NOT into_cycle % 15000).
+        // ms_late = max(0, into_cycle - 2360), NOT into_cycle % 15000). Computed
+        // here, right before audio starts, so it reflects the real lateness after
+        // the PTT settle — `maybe_transmit`'s window check keeps this at 0 in
+        // normal operation.
         let into_cycle = self.now().rem_euclid(CYCLE_MS);
         let ms_late = (into_cycle - TX_SLACK_MS).max(0);
-        let skip = (ms_late * SAMPLE_RATE as i64 / 1000) as usize;
-        let clipped = if skip < signal.len() { &signal[skip..] } else { &[] };
-
-        if let Err(e) = output::play_blocking(self.output_device.as_deref(), clipped, 0.9) {
+        if let Err(e) = prepared.start(ms_late) {
             self.emit(EngineEvent::Error(format!("playback failed: {e}")));
+            self.set_ptt(false);
+            return;
         }
+        self.tx_playback = Some(prepared);
+        self.publish_tx_state();
+    }
 
-        self.set_ptt(false);
+    /// Stop the in-flight transmission (if any): dropping the handle halts the
+    /// cpal stream immediately, then PTT goes down. Safe to call when not TXing.
+    fn finalize_tx(&mut self) {
+        if self.tx_playback.take().is_some() {
+            self.set_ptt(false);
+            self.publish_tx_state();
+        }
     }
 
     fn set_ptt(&mut self, on: bool) {
@@ -582,9 +628,11 @@ impl Engine {
         self.emit(EngineEvent::Decoded(ui));
     }
 
-    fn publish_tx_state(&self, transmitting: bool) {
+    fn publish_tx_state(&self) {
         self.emit(EngineEvent::TxState(TxStateEvent {
-            transmitting,
+            // Derived from the live playback handle so the badge can't get stuck:
+            // it's TX exactly while a transmission is clocking out.
+            transmitting: self.tx_playback.is_some(),
             message: self.qso.tx_message().map(|s| s.to_string()),
             status: self.qso.status(),
         }));
@@ -666,7 +714,7 @@ impl Engine {
                 // Start CQ this very slot if we're still inside the window;
                 // otherwise the first transmission lands at the next free slot.
                 self.maybe_transmit(self.cur_slot());
-                self.publish_tx_state(false);
+                self.publish_tx_state();
             }
             EngineCommand::Answer(args) => {
                 let msg = DecodedMessage {
@@ -681,28 +729,30 @@ impl Engine {
                 self.tx_parity = Some(self.cur_parity());
                 self.qso.answer(&msg);
                 self.maybe_transmit(self.cur_slot());
-                self.publish_tx_state(false);
+                self.publish_tx_state();
             }
             EngineCommand::SetStage(stage) => {
                 self.tx_parity = None;
                 self.qso.set_stage(stage);
                 self.maybe_transmit(self.cur_slot());
-                self.publish_tx_state(false);
+                self.publish_tx_state();
             }
             EngineCommand::StopTx => {
                 self.qso.stop();
                 self.tx_parity = None;
-                self.publish_tx_state(false);
+                // Halt audio + drop PTT now, not at the end of the cycle.
+                self.finalize_tx();
+                self.publish_tx_state();
             }
             EngineCommand::FreeText(text) => {
                 self.tx_parity = None;
                 self.qso.set_free_text(&text);
                 self.maybe_transmit(self.cur_slot());
-                self.publish_tx_state(false);
+                self.publish_tx_state();
             }
             EngineCommand::RefreshStatus => {
                 self.publish_rig_status();
-                self.publish_tx_state(self.ptt);
+                self.publish_tx_state();
                 self.publish_clock_sync();
             }
             EngineCommand::SetClockOffset(offset_ms) => {


### PR DESCRIPTION
Addresses two TX-path issues from the Inovato Quadra 4K field report.

## #1 — Stop TX did nothing until the cycle ended
`Engine::transmit()` called the **blocking** `play_blocking()`, parking the engine thread for the full ~12.64 s. While parked, the command loop couldn't run, so `StopTx` sat unread — and nothing dropped PTT or stopped audio until playback finished on its own.

## #3 — Lag between CAT keying the rig and audio
The device open + full-buffer resample ran **after** PTT was raised, so on a weak CPU the rig was keyed but silent for hundreds of ms.

## Fix — prepare/start split

`audio/output.rs`:
- **`prepare()`** does the slow work (open device, resample whole buffer, build a *paused* cpal stream) and runs **before** PTT.
- **`PreparedTx::start(skip_ms)`** is cheap (seek past any leading clip, unpause) and runs right after the PTT settle — dead air ≈ the T/R relay time only.
- Handle lives in `Engine.tx_playback` (the cpal `Stream` is `!Send`, stays on the engine thread, same pattern as `AudioInput`). The run loop polls `is_done()`/`timed_out()` each tick and drops PTT when the waveform finishes or a stalled device trips the deadline — so the loop **keeps draining commands throughout TX**.
- **StopTx** → `finalize_tx()`: dropping the handle halts the stream instantly and PTT goes down immediately; an abort flag in the callback is the belt-and-suspenders path.
- `publish_tx_state()` now derives `transmitting` from the live handle, so the TX/RX badge can't get stuck.

## Tests
Pure helpers `skip_cursor` (ms→device-sample clip, clamped & non-negative) and `remaining_secs` (deadline math, divide-by-zero-safe) extracted from the cpal-bound start path and unit-tested. Full lib suite green (14 tests).

Part of the desktop timing/usability series; sits on top of #340 (decode timing) conceptually but is independent in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)