### PR TITLE
Desktop: refresh serial ports on backend switch + Refresh button (#7)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -552,6 +552,21 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
     });
   }, []);
 
+  const refreshPorts = () => api.listSerialPorts().then(setPorts);
+
+  // Re-enumerate serial ports whenever a port-list backend becomes visible.
+  // Ports were previously read only once at mount, so a rig attached after
+  // launch — or Hamlib selected first, before its serial port was chosen —
+  // showed an empty/stale list. Switching to Hamlib (serial) or Direct serial
+  // now re-scans, so /dev/ttyACM0 (a QMX/QDX) appears without the
+  // select-Direct-then-Hamlib workaround.
+  const showsPortList =
+    rigCfg.backend === "serial" ||
+    (rigCfg.backend === "hamlib" && !rigCfg.hamlib_network);
+  useEffect(() => {
+    if (showsPortList) refreshPorts();
+  }, [showsPortList]);
+
   function saveStation() {
     api.setStation(call, grid);
     onStatus(`Station set: ${call} ${grid}`);
@@ -760,14 +775,19 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
                 <div className="row">
                   <div className="field">
                     <label>Serial port</label>
-                    <select value={rigCfg.port} onChange={(e) => setRigCfg({ ...rigCfg, port: e.target.value })}>
-                      <option value="">(none — e.g. Dummy)</option>
-                      {ports.map((p) => (
-                        <option key={p.name} value={p.name}>
-                          {p.name} ({p.kind})
-                        </option>
-                      ))}
-                    </select>
+                    <div className="row">
+                      <select value={rigCfg.port} onChange={(e) => setRigCfg({ ...rigCfg, port: e.target.value })}>
+                        <option value="">(none — e.g. Dummy)</option>
+                        {ports.map((p) => (
+                          <option key={p.name} value={p.name}>
+                            {p.name} ({p.kind})
+                          </option>
+                        ))}
+                      </select>
+                      <button type="button" title="Re-scan serial ports" onClick={refreshPorts}>
+                        ↻
+                      </button>
+                    </div>
                   </div>
                   <div className="field">
                     <label>Baud</label>
@@ -830,14 +850,19 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
               </div>
               <div className="field">
                 <label>Serial port</label>
-                <select value={rigCfg.port} onChange={(e) => setRigCfg({ ...rigCfg, port: e.target.value })}>
-                  <option value="">— select —</option>
-                  {ports.map((p) => (
-                    <option key={p.name} value={p.name}>
-                      {p.name} ({p.kind})
-                    </option>
-                  ))}
-                </select>
+                <div className="row">
+                  <select value={rigCfg.port} onChange={(e) => setRigCfg({ ...rigCfg, port: e.target.value })}>
+                    <option value="">— select —</option>
+                    {ports.map((p) => (
+                      <option key={p.name} value={p.name}>
+                        {p.name} ({p.kind})
+                      </option>
+                    ))}
+                  </select>
+                  <button type="button" title="Re-scan serial ports" onClick={refreshPorts}>
+                    ↻
+                  </button>
+                </div>
               </div>
               <div className="row">
                 <div className="field">


### PR DESCRIPTION
## Problem
The reporter found that `/dev/ttyACM0` (a QMX) didn't appear in the port list under **Hamlib**, but did under **Direct serial** — and that selecting Direct serial first, picking the port, then switching back to Hamlib made CAT work.

## Root cause
Serial ports were enumerated **only once, at Settings mount**, into shared `ports` state. A rig attached after launch never showed up. The "Direct-serial-then-Hamlib" dance worked only because `rigCfg.port` persisted across the backend switch — not because Hamlib re-scanned. (The original total absence of `ttyACM0` was the separate, now-resolved libhamlib4/utils conflict.)

## Fix
- **Re-enumerate ports whenever a port-list backend becomes visible** (Direct serial, or Hamlib with a serial connection) via a small effect keyed on backend/connection. Selecting Hamlib now scans exactly like Direct serial, so `ttyACM0` appears without the workaround.
- **A "↻" Refresh button** next to both serial-port dropdowns to re-scan on demand (e.g. after hot-plugging the radio).

## Notes
Frontend-only; the desktop project has no JS test harness (no `test` script), and this is presentational React mirroring the existing dropdowns. The user's underlying environment fix (removing the conflicting system Hamlib) is unrelated to this UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)