### PR TITLE
Desktop: RX input-level meter + "no audio" warning (silent-input diagnosability)

### DIFF
--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -50,6 +50,22 @@ const WF_STEP: usize = WF_FFT_SIZE / 2; // 50% overlap between averaged segments
 const WF_MAX_HZ: f32 = 3_500.0; // displayed top of the audio band (matches decoder f_max)
 const WF_SPAN_DB: f32 = 26.0; // dB above the black point that maps to full brightness
 const WF_BLACK_OFFSET_DB: f32 = 4.0; // push the black point above the noise floor so noise stays dark
+// Input RMS at/below this (dBFS) counts as silence — no audio reaching the app.
+// Real RX audio through a soundcard/DAX sits well above this even on a quiet band;
+// a fully-routed-but-silent virtual device floors near -100 dBFS.
+const SILENCE_DBFS: f32 = -75.0;
+
+/// RMS level of a mono buffer in dBFS (0 dB = full scale). Empty or all-zero
+/// input returns a large negative number rather than -inf, so the meter and the
+/// silence test stay finite.
+fn rms_dbfs(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return -120.0;
+    }
+    let sum_sq: f64 = samples.iter().map(|&s| (s as f64) * (s as f64)).sum();
+    let rms = (sum_sq / samples.len() as f64).sqrt();
+    (20.0 * (rms.max(1e-12)).log10()).max(-120.0) as f32
+}
 
 /// True once per cycle, on the first waterfall row at/after a 15 s boundary on
 /// the rx-corrected clock, advancing `last_slot`. The live waterfall draws audio
@@ -184,8 +200,21 @@ pub enum EngineEvent {
     QsoCompleted(QsoRecord),
     Waterfall(WaterfallFrame),
     WaterfallRow(WaterfallRow),
+    /// Periodic RX input level (~1/s while decoding) so the UI can show a meter
+    /// and warn when the captured audio is silent (e.g. the source/DAX channel
+    /// isn't routed) instead of leaving a mysteriously blank waterfall.
+    InputLevel(InputLevelEvent),
     Info(String),
     Error(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InputLevelEvent {
+    /// RMS level of the recent capture in dBFS (≈ -100 for digital silence).
+    pub db: f32,
+    /// True when the level is at/below the silence floor while decoding — the
+    /// "no audio reaching the app" condition.
+    pub silent: bool,
 }
 
 /// Thread-safe handle for sending commands to the engine. Wraps the `Sender` in
@@ -387,6 +416,17 @@ impl Engine {
                     sequential: slot_id.rem_euclid(2),
                     ms_into_cycle: ms_into,
                 }));
+                // RX input level + silence warning, once we're capturing. Surfaces
+                // a dead source (e.g. DAX channel not routed) that otherwise looks
+                // like a broken waterfall.
+                if self.decoding {
+                    let recent = self.accum.peek_recent(SAMPLE_RATE as usize / 2); // ~0.5 s
+                    let db = rms_dbfs(&recent);
+                    self.emit(EngineEvent::InputLevel(InputLevelEvent {
+                        db,
+                        silent: db <= SILENCE_DBFS,
+                    }));
+                }
             }
 
             // Decode runs on a clock shifted later by the capture-latency
@@ -865,7 +905,25 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-    use super::{clamp_tx_gain, wf_boundary_row, CYCLE_MS};
+    use super::{clamp_tx_gain, rms_dbfs, wf_boundary_row, CYCLE_MS, SILENCE_DBFS};
+
+    #[test]
+    fn rms_dbfs_flags_silence_and_signal() {
+        // Digital silence floors well below the silence threshold (not -inf).
+        let silence = vec![0.0f32; 6000];
+        let db_silent = rms_dbfs(&silence);
+        assert!(db_silent.is_finite());
+        assert!(db_silent <= SILENCE_DBFS, "silence {db_silent} should be ≤ {SILENCE_DBFS}");
+
+        // Empty buffer is treated as silence, never a panic or -inf.
+        assert!(rms_dbfs(&[]) <= SILENCE_DBFS);
+
+        // A half-scale full-amplitude square wave is ~ -6 dBFS — clearly "audio".
+        let signal = vec![0.5f32; 6000];
+        let db_signal = rms_dbfs(&signal);
+        assert!((db_signal - -6.02).abs() < 0.1, "0.5 RMS should be ~-6 dBFS, got {db_signal}");
+        assert!(db_signal > SILENCE_DBFS);
+    }
 
     #[test]
     fn tx_gain_clamps_to_unit_range() {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -209,6 +209,15 @@ fn main() {
                 .name("ft8af-event-forwarder".into())
                 .spawn(move || {
                     while let Ok(ev) = evt_rx.recv() {
+                        // Mirror status messages to the terminal. The app has no
+                        // logger, so audio/rig/decode problems (e.g. "audio start
+                        // failed") were previously invisible outside the in-app
+                        // status line — making remote diagnosis impossible.
+                        match &ev {
+                            engine::EngineEvent::Error(m) => eprintln!("[ft8af] ERROR: {m}"),
+                            engine::EngineEvent::Info(m) => eprintln!("[ft8af] {m}"),
+                            _ => {}
+                        }
                         let _ = handle.emit("engine-event", ev);
                     }
                 })?;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -69,6 +69,7 @@ export default function App() {
   const [rig, setRig] = useState<RigStatusEvent | null>(null);
   const [clock, setClock] = useState<ClockSyncEvent | null>(null);
   const [decoding, setDecoding] = useState(false);
+  const [audio, setAudio] = useState<{ db: number; silent: boolean } | null>(null);
   const [status, setStatus] = useState("");
   const [filter, setFilter] = useState<Filter>("all");
   const [txFreq, setTxFreq] = useState(1500);
@@ -137,6 +138,9 @@ export default function App() {
       case "waterfall_row":
         drawWaterfallRow(e.data.bins, e.data.boundary);
         break;
+      case "input_level":
+        setAudio(e.data);
+        break;
       case "qso_completed":
         setStatus(`QSO logged: ${e.data.call} ${e.data.rst_sent}/${e.data.rst_rcvd}`);
         break;
@@ -153,6 +157,7 @@ export default function App() {
     if (decodingRef.current) {
       api.stopDecode();
       setDecoding(false);
+      setAudio(null); // no input meter while stopped
     } else {
       api.startDecode();
       setDecoding(true);
@@ -179,6 +184,7 @@ export default function App() {
         onBand={onBand}
         rig={rig}
         clock={clock}
+        audio={audio}
       />
       <div className="tabs">
         {(["decode", "log", "settings"] as Tab[]).map((t) => (
@@ -225,8 +231,9 @@ function TopBar(props: {
   onBand: (hz: number) => void;
   rig: RigStatusEvent | null;
   clock: ClockSyncEvent | null;
+  audio: { db: number; silent: boolean } | null;
 }) {
-  const { cycle, decoding, onToggleDecode, bands, dialHz, onBand, rig, clock } = props;
+  const { cycle, decoding, onToggleDecode, bands, dialHz, onBand, rig, clock, audio } = props;
   const utc = cycle ? new Date(cycle.utc_ms).toISOString().substring(11, 19) : "--:--:--";
   const pct = cycle ? (cycle.ms_into_cycle / 15000) * 100 : 0;
   return (
@@ -250,10 +257,46 @@ function TopBar(props: {
         {rig?.connected ? `rig: ${rig.model}` : "no rig"}
         {rig?.ptt ? " · PTT" : ""}
       </span>
+      <AudioBadge decoding={decoding} audio={audio} />
       <button className={decoding ? "danger" : "primary"} onClick={onToggleDecode}>
         {decoding ? "Stop" : "Start"} decode
       </button>
     </div>
+  );
+}
+
+// RX input-level indicator. Shows the captured level in dBFS while decoding, and
+// a clear "no audio" warning when the input is silent — the case where the source
+// (e.g. a DAX/soundcard channel) isn't actually routed and the waterfall is blank.
+function AudioBadge({
+  decoding,
+  audio,
+}: {
+  decoding: boolean;
+  audio: { db: number; silent: boolean } | null;
+}) {
+  if (!decoding) return null;
+  if (!audio) {
+    return <span className="muted" title="Waiting for the first input-level reading">audio …</span>;
+  }
+  if (audio.silent) {
+    return (
+      <span
+        style={{ color: "var(--tx)", fontVariantNumeric: "tabular-nums" }}
+        title="No audio is reaching the app. Check that the selected input device is the right one and that its source is routed (e.g. SmartSDR slice → DAX RX channel, soundcard input not muted)."
+      >
+        ⚠ no audio
+      </span>
+    );
+  }
+  return (
+    <span
+      className="muted"
+      style={{ fontVariantNumeric: "tabular-nums" }}
+      title="RX input level (dBFS) of the captured audio"
+    >
+      audio {audio.db.toFixed(0)} dB
+    </span>
   );
 }
 

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -126,6 +126,7 @@ export type EngineEvent =
   | { type: "qso_completed"; data: QsoRecord }
   | { type: "waterfall"; data: { bins: number[]; rows: number; cols: number; hz_per_col: number } }
   | { type: "waterfall_row"; data: { bins: number[]; hz_per_col: number; boundary: boolean } }
+  | { type: "input_level"; data: { db: number; silent: boolean } }
   | { type: "info"; data: string }
   | { type: "error"; data: string };
 


### PR DESCRIPTION
## Why
Diagnosing the blank waterfall on a live Flex station required an **out-of-app ffmpeg probe** to discover the captured input was *digital silence* (the SmartSDR slice wasn't routed to its DAX RX channel — the device opened fine but carried -91 dBFS). The app gave no signal at all: the waterfall just sat empty, and there's no logger so nothing reached the terminal either.

## What
Make audio state visible, in the app and the log:

- **engine** — once a second while decoding, compute the RX RMS level (dBFS) from the recent capture and emit `InputLevel { db, silent }`. `silent` trips at/below `SILENCE_DBFS` (-75), the "no audio reaching the app" floor. Pure `rms_dbfs` helper floors empty/zero input at a finite -120 (never -inf).
- **UI** — an `AudioBadge` next to the decode button shows the live level (`audio -42 dB`) while decoding, and a clear **`⚠ no audio`** (tooltip pointing at input selection / DAX routing) when the source is silent. Clears when decode stops.
- **main.rs** — mirror engine `Info`/`Error` events to **stderr**. The app inits no logger, so `audio start failed`, rig errors, etc. were invisible outside the in-app status line. Now they also print to the terminal, so this class of problem is diagnosable remotely.

## Test
`rms_dbfs` flags digital silence and an empty buffer as ≤ the silence floor, and reports ~-6 dBFS for a 0.5-amplitude buffer (clearly above it). Full lib suite green (19 tests).

## Note
This came directly out of a live debugging session: the user's Flex connected over CAT fine, but the waterfall was blank because DAX RX 1 wasn't routed. With this, the app would have said "⚠ no audio" immediately instead of looking broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)