### PR TITLE
Android: log signal reports with sign + 2 digits (WSJT-X format)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -26,6 +26,7 @@ import com.k1af.ft8af.callsign.CallsignDatabase;
 import com.k1af.ft8af.callsign.CallsignInfo;
 import com.k1af.ft8af.connector.ConnectMode;
 import com.k1af.ft8af.ft8signal.FT8Package;
+import com.k1af.ft8af.log.AdifFormat;
 import com.k1af.ft8af.log.OnQueryQSLCallsign;
 import com.k1af.ft8af.log.OnQueryQSLRecordCallsign;
 import com.k1af.ft8af.log.QSLCallsignRecord;
@@ -1341,8 +1342,8 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     , String.valueOf(record.isLotW_QSL ? 1 : 0)
                     , record.getToMaidenGrid()
                     , record.getMode()
-                    , String.valueOf(record.getSendReport())
-                    , String.valueOf(record.getReceivedReport())
+                    , AdifFormat.formatReport(record.getSendReport())
+                    , AdifFormat.formatReport(record.getReceivedReport())
                     , record.getQso_date()
                     , record.getTime_on()
 
@@ -1411,7 +1412,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             if (record.getSendReport() > -100) {
                 db.execSQL("UPDATE  QSLTable  SET rst_sent=? " +
                                 " WHERE (call=?) and (qso_date=?) and(time_on=?) and(mode=?)"
-                        , new Object[]{record.getSendReport(), record.getToCallsign()
+                        , new Object[]{AdifFormat.formatReport(record.getSendReport()), record.getToCallsign()
                                 , record.getQso_date()
                                 , record.getTime_on()
                                 , record.getMode()});
@@ -1419,7 +1420,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             if (record.getReceivedReport() > -100) {
                 db.execSQL("UPDATE  QSLTable  SET rst_rcvd=? " +
                                 " WHERE (call=?) and (qso_date=?) and(time_on=?) and(mode=?)"
-                        , new Object[]{record.getReceivedReport(), record.getToCallsign()
+                        , new Object[]{AdifFormat.formatReport(record.getReceivedReport()), record.getToCallsign()
                                 , record.getQso_date()
                                 , record.getTime_on()
                                 , record.getMode()});
@@ -1647,8 +1648,8 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             databaseOpr.db.execSQL(querySQL, new String[]{qslRecord.getToCallsign()
                     , qslRecord.getToMaidenGrid()
                     , qslRecord.getMode()
-                    , String.valueOf(qslRecord.getSendReport())
-                    , String.valueOf(qslRecord.getReceivedReport())
+                    , AdifFormat.formatReport(qslRecord.getSendReport())
+                    , AdifFormat.formatReport(qslRecord.getReceivedReport())
                     , qslRecord.getQso_date()
                     , qslRecord.getTime_on()
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -34,4 +34,23 @@ public final class AdifFormat {
         String c = sanitizeCallsign(rawCall);
         return String.format(Locale.US, "<call:%d>%s ", c.length(), c);
     }
+
+    /** "No report" sentinels stored in the SNR int fields; left unformatted so the logbook's
+     * empty-report check still recognises them. */
+    private static final int NO_REPORT = -100;
+    private static final int NO_REPORT_ALT = -120;
+
+    /**
+     * Format an FT8 signal report (SNR in dB) the WSJT-X way: always a sign and at least two
+     * digits, so {@code 5 → "+05"}, {@code -3 → "-03"}, {@code 20 → "+20"}, {@code 0 → "+00"}.
+     *
+     * <p>The "no report" sentinels {@code -100} and {@code -120} are returned unchanged so the
+     * logbook's empty-report check still recognises them.
+     */
+    public static String formatReport(int report) {
+        if (report == NO_REPORT || report == NO_REPORT_ALT) {
+            return String.valueOf(report);
+        }
+        return String.format(Locale.US, "%+03d", report);
+    }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -111,17 +111,11 @@ public class ThirdPartyService {
                     , qslRecord.getMode()));
         }
 
-        if (String.valueOf(qslRecord.getSendReport()) != null) {
-            logStr.append(String.format("<rst_sent:%d>%s "
-                    , String.valueOf(qslRecord.getSendReport()).length()
-                    , String.valueOf(qslRecord.getSendReport())));
-        }
+        String rstSent = AdifFormat.formatReport(qslRecord.getSendReport());
+        logStr.append(String.format("<rst_sent:%d>%s ", rstSent.length(), rstSent));
 
-        if (String.valueOf(qslRecord.getReceivedReport()) != null) {
-            logStr.append(String.format("<rst_rcvd:%d>%s "
-                    , String.valueOf(qslRecord.getReceivedReport()).length()
-                    , String.valueOf(qslRecord.getReceivedReport())));
-        }
+        String rstRcvd = AdifFormat.formatReport(qslRecord.getReceivedReport());
+        logStr.append(String.format("<rst_rcvd:%d>%s ", rstRcvd.length(), rstRcvd));
 
         if (qslRecord.getQso_date() != null) {
             logStr.append(String.format("<qso_date:%d>%s "

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
@@ -48,4 +48,34 @@ public class AdifFormatTest {
             assertThat(value).doesNotContain(">");
         }
     }
+
+    @Test
+    public void formatReport_alwaysSignedAndTwoDigits() {
+        // The bug: bare String.valueOf(int) gave "5"/"-5"/"0" — no sign on positives, no padding.
+        assertThat(AdifFormat.formatReport(5)).isEqualTo("+05");
+        assertThat(AdifFormat.formatReport(-3)).isEqualTo("-03");
+        assertThat(AdifFormat.formatReport(0)).isEqualTo("+00");
+        assertThat(AdifFormat.formatReport(20)).isEqualTo("+20");
+        assertThat(AdifFormat.formatReport(-12)).isEqualTo("-12");
+        assertThat(AdifFormat.formatReport(30)).isEqualTo("+30");
+        assertThat(AdifFormat.formatReport(-30)).isEqualTo("-30");
+    }
+
+    @Test
+    public void formatReport_everyValueHasSignAndAtLeastTwoDigits() {
+        for (int n = -30; n <= 30; n++) {
+            String s = AdifFormat.formatReport(n);
+            assertThat(s.charAt(0)).isAnyOf('+', '-');
+            // At least two digits after the sign.
+            assertThat(s.substring(1).length()).isAtLeast(2);
+            assertThat(Integer.parseInt(s)).isEqualTo(n);
+        }
+    }
+
+    @Test
+    public void formatReport_leavesNoReportSentinelsUnchanged() {
+        // -100/-120 mean "no report" and the logbook compares against those exact strings.
+        assertThat(AdifFormat.formatReport(-100)).isEqualTo("-100");
+        assertThat(AdifFormat.formatReport(-120)).isEqualTo("-120");
+    }
 }


### PR DESCRIPTION
## What

Logged FT8 signal reports should always read the WSJT-X way: a sign and at least two digits — `+05`, `-03`, `+00`, `-12`.

On **Android** they didn't. Reports were written to the QSL/SWL database and the third-party ADIF upload via bare `String.valueOf(int)`, so a +5 dB report logged as `5`, a 0 dB report as `0`, etc. — no sign on positives, no zero-padding.

## Fix

- Add `AdifFormat.formatReport(int)` — `%+03d`, with the `-100`/`-120` "no report" sentinels passed through unchanged so the logbook's empty-report check still recognises them.
- Apply it at every int→string report site:
  - `DatabaseOpr` QSL `INSERT`
  - `DatabaseOpr` QSL `UPDATE` (rst_sent / rst_rcvd)
  - `DatabaseOpr` SWL `INSERT`
  - `ThirdPartyService` (Cloudlog/Wavelog/NextLog ADIF upload)

ADIF exports that read these values back from the DB (`ShareLogs`, `PotaAdifExporter`) get the formatted strings automatically for newly logged QSOs.

## Other platforms

Already correct, no change needed:
- **Desktop** — `qso.rs` `fmt_report` uses `format!("{:+03}", n)`
- **iOS** — `QsoEngine.fmtReport` uses `String(format: "%+03d", ...)`

## Tests

Added `AdifFormatTest` cases: spot values (`+05`, `-03`, `+00`, `+20`, `-12`, `±30`), an exhaustive `-30..30` sweep asserting sign + ≥2 digits + round-trip, and the sentinel pass-through. `gradlew testDebugUnitTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)