### PR TITLE
Desktop: top-bar TX-level slider, rig display-name override, and Disconnect button

### DIFF
--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -105,6 +105,9 @@ pub enum EngineCommand {
     SetInputDevice(Option<String>),
     SetOutputDevice(Option<String>),
     SelectRig(RigConfig),
+    /// Drop the live rig connection for this session (CAT/PTT released). Leaves
+    /// the saved rig config intact so Connect — or the next launch — reconnects.
+    DisconnectRig,
     StartCq,
     Answer(AnswerArgs),
     /// Operator manually selects which QSO message to transmit next.
@@ -804,6 +807,14 @@ impl Engine {
                     let _ = self.db.set_config("rig_config", &json);
                 }
                 self.select_rig(cfg);
+            }
+            EngineCommand::DisconnectRig => {
+                // Drop the connection (runs the rig's close/cleanup); keep the
+                // saved config so reconnecting is one click away.
+                self.rig = None;
+                self.ptt = false;
+                self.emit(EngineEvent::Info("rig disconnected".into()));
+                self.publish_rig_status();
             }
             EngineCommand::StartCq => {
                 self.tx_parity = None;

--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -809,7 +809,16 @@ impl Engine {
                 self.select_rig(cfg);
             }
             EngineCommand::DisconnectRig => {
-                // Drop the connection (runs the rig's close/cleanup); keep the
+                // Stop any in-flight TX and drop PTT *before* dropping the rig:
+                // set_ptt() only sends the CAT un-key when the rig is still
+                // connected, so tearing the transport down first could leave the
+                // radio keyed. Also stop CQ/QSO so we don't try to re-key a
+                // disconnected rig on the next slot.
+                self.qso.stop();
+                self.tx_parity = None;
+                self.finalize_tx();
+                self.publish_tx_state();
+                // Now drop the connection (runs the rig's close/cleanup); keep the
                 // saved config so reconnecting is one click away.
                 self.rig = None;
                 self.ptt = false;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -102,6 +102,11 @@ fn select_rig(state: State<AppState>, config: RigConfig) {
 }
 
 #[tauri::command]
+fn disconnect_rig(state: State<AppState>) {
+    state.engine.send(EngineCommand::DisconnectRig);
+}
+
+#[tauri::command]
 fn refresh_status(state: State<AppState>) {
     state.engine.send(EngineCommand::RefreshStatus);
 }
@@ -238,6 +243,7 @@ fn main() {
             set_input_device,
             set_output_device,
             select_rig,
+            disconnect_rig,
             refresh_status,
             resync_time,
             start_cq,

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -73,6 +73,8 @@ export default function App() {
   const [status, setStatus] = useState("");
   const [filter, setFilter] = useState<Filter>("all");
   const [txFreq, setTxFreq] = useState(1500);
+  const [txGain, setTxGain] = useState(90); // TX level as a percentage (0–100)
+  const [rigLabel, setRigLabel] = useState(""); // optional display-name override
   const [bands, setBands] = useState<BandInfo[]>([]);
   const [dialHz, setDialHz] = useState<number>(14074000);
 
@@ -102,6 +104,12 @@ export default function App() {
     });
     api.getConfig("base_freq").then((v) => {
       if (v) setTxFreq(parseInt(v, 10));
+    });
+    api.getConfig("tx_gain").then((v) => {
+      if (v) setTxGain(Math.round(parseFloat(v) * 100));
+    });
+    api.getConfig("rig_label").then((v) => {
+      if (v) setRigLabel(v);
     });
     return () => {
       cancelled = true;
@@ -185,6 +193,12 @@ export default function App() {
         rig={rig}
         clock={clock}
         audio={audio}
+        rigLabel={rigLabel}
+        txGain={txGain}
+        onTxGain={(v) => {
+          setTxGain(v);
+          api.setTxGain(v / 100);
+        }}
       />
       <div className="tabs">
         {(["decode", "log", "settings"] as Tab[]).map((t) => (
@@ -208,7 +222,16 @@ export default function App() {
           />
         )}
         {tab === "log" && <LogScreen />}
-        {tab === "settings" && <SettingsScreen onStatus={setStatus} clock={clock} />}
+        {tab === "settings" && (
+          <SettingsScreen
+            onStatus={setStatus}
+            clock={clock}
+            onRigLabel={(v) => {
+              setRigLabel(v);
+              api.setConfig("rig_label", v);
+            }}
+          />
+        )}
       </div>
       <TxBar
         txState={txState}
@@ -232,8 +255,11 @@ function TopBar(props: {
   rig: RigStatusEvent | null;
   clock: ClockSyncEvent | null;
   audio: { db: number; silent: boolean } | null;
+  rigLabel: string;
+  txGain: number;
+  onTxGain: (v: number) => void;
 }) {
-  const { cycle, decoding, onToggleDecode, bands, dialHz, onBand, rig, clock, audio } = props;
+  const { cycle, decoding, onToggleDecode, bands, dialHz, onBand, rig, clock, audio, rigLabel, txGain, onTxGain } = props;
   const utc = cycle ? new Date(cycle.utc_ms).toISOString().substring(11, 19) : "--:--:--";
   const pct = cycle ? (cycle.ms_into_cycle / 15000) * 100 : 0;
   return (
@@ -246,6 +272,21 @@ function TopBar(props: {
       </div>
       <span className="seq">seq {cycle?.sequential ?? "-"}</span>
       <div className="spacer" />
+      <span className="tx-level" title="TX output level (drive) — lower until ALC stops pinning">
+        <span className="muted">TX</span>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={txGain}
+          onChange={(e) => onTxGain(parseInt(e.target.value, 10))}
+          style={{ width: 90 }}
+        />
+        <span className="muted" style={{ fontVariantNumeric: "tabular-nums", minWidth: 34, textAlign: "right" }}>
+          {txGain}%
+        </span>
+      </span>
       <select value={dialHz} onChange={(e) => onBand(parseInt(e.target.value, 10))}>
         {bands.map((b) => (
           <option key={b.name} value={b.dial_hz}>
@@ -254,7 +295,7 @@ function TopBar(props: {
         ))}
       </select>
       <span className="muted">
-        {rig?.connected ? `rig: ${rig.model}` : "no rig"}
+        {rig?.connected ? `rig: ${rigLabel || rig.model}` : "no rig"}
         {rig?.ptt ? " · PTT" : ""}
       </span>
       <AudioBadge decoding={decoding} audio={audio} />
@@ -551,9 +592,14 @@ function LogScreen() {
   );
 }
 
-function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSyncEvent | null }) {
-  const { onStatus, clock } = props;
+function SettingsScreen(props: {
+  onStatus: (s: string) => void;
+  clock: ClockSyncEvent | null;
+  onRigLabel: (v: string) => void;
+}) {
+  const { onStatus, clock, onRigLabel } = props;
   const [call, setCall] = useState("");
+  const [rigLabel, setRigLabel] = useState("");
   const [grid, setGrid] = useState("");
   const [inputs, setInputs] = useState<AudioDevice[]>([]);
   const [outputs, setOutputs] = useState<AudioDevice[]>([]);
@@ -562,8 +608,6 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
   const [baseFreq, setBaseFreq] = useState(1500);
-  // TX output level as a percentage (0–100); backend gain = pct/100.
-  const [txGain, setTxGain] = useState(90);
   const [rigCfg, setRigCfg] = useState<RigConfig>({
     backend: "hamlib",
     model: "none",
@@ -588,9 +632,6 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
     api.getConfig("input_device").then((v) => v && setInput(v));
     api.getConfig("output_device").then((v) => v && setOutput(v));
     api.getConfig("base_freq").then((v) => v && setBaseFreq(parseInt(v, 10)));
-    api.getConfig("tx_gain").then((v) => {
-      if (v) setTxGain(Math.round(parseFloat(v) * 100));
-    });
     api.getConfig("rig_config").then((v) => {
       if (v) {
         try {
@@ -600,6 +641,7 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
         }
       }
     });
+    api.getConfig("rig_label").then((v) => v && setRigLabel(v));
   }, []);
 
   const refreshPorts = () => api.listSerialPorts().then(setPorts);
@@ -727,32 +769,28 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
               }}
             />
           </div>
-          <div className="field">
-            <label>TX level (drive): {txGain}%</label>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              step={1}
-              value={txGain}
-              onChange={(e) => {
-                const v = parseInt(e.target.value, 10);
-                setTxGain(v);
-                api.setTxGain(v / 100);
-              }}
-            />
-            <span className="muted" style={{ display: "block", marginTop: 4 }}>
-              Output drive into the soundcard/USB audio (e.g. QMX). On desktop
-              there's no OS media-volume tie-in, so set the on-air level here —
-              lower it until ALC stops pinning.
-            </span>
-          </div>
         </div>
       </div>
 
       <div className="panel">
         <h3>Rig control</h3>
         <div className="col">
+          <div className="field">
+            <label>Display name (optional)</label>
+            <input
+              value={rigLabel}
+              onChange={(e) => {
+                setRigLabel(e.target.value);
+                onRigLabel(e.target.value);
+              }}
+              placeholder="e.g. Flex 6400"
+            />
+            <span className="muted" style={{ display: "block", marginTop: 4 }}>
+              Shown in the top bar instead of the CAT model. Useful when connecting
+              a radio through an emulator (e.g. a Flex via SmartSDR CAT reports as
+              Kenwood TS-2000). Leave blank to show the detected model.
+            </span>
+          </div>
           <div className="field">
             <label>Backend</label>
             <select
@@ -972,6 +1010,14 @@ function SettingsScreen(props: { onStatus: (s: string) => void; clock: ClockSync
             }}
           >
             Connect rig
+          </button>
+          <button
+            onClick={() => {
+              api.disconnectRig();
+              onStatus("Rig disconnected");
+            }}
+          >
+            Disconnect
           </button>
         </div>
       </div>

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -106,7 +106,9 @@ export default function App() {
       if (v) setTxFreq(parseInt(v, 10));
     });
     api.getConfig("tx_gain").then((v) => {
-      if (v) setTxGain(Math.round(parseFloat(v) * 100));
+      if (v == null || v === "") return;
+      const pct = Math.round(parseFloat(v) * 100);
+      if (!Number.isNaN(pct)) setTxGain(pct); // keep a persisted 0% (not just falsy-skip)
     });
     api.getConfig("rig_label").then((v) => {
       if (v) setRigLabel(v);
@@ -276,6 +278,7 @@ function TopBar(props: {
         <span className="muted">TX</span>
         <input
           type="range"
+          aria-label="TX output level (drive), percent"
           min={0}
           max={100}
           step={1}

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -152,6 +152,7 @@ export const api = {
   setInputDevice: (name: string | null) => invoke("set_input_device", { name }),
   setOutputDevice: (name: string | null) => invoke("set_output_device", { name }),
   selectRig: (config: RigConfig) => invoke("select_rig", { config }),
+  disconnectRig: () => invoke("disconnect_rig"),
   refreshStatus: () => invoke("refresh_status"),
   resyncTime: () => invoke("resync_time"),
 

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -63,6 +63,8 @@ select, input {
 .cycle-bar { width: 160px; height: 8px; background: var(--panel-2); border-radius: 4px; overflow: hidden; }
 .cycle-bar > div { height: 100%; background: var(--accent); transition: width 0.2s linear; }
 .seq { color: var(--muted); }
+.tx-level { display: inline-flex; align-items: center; gap: 6px; }
+.tx-level input[type="range"] { margin: 0; }
 
 .tabs { display: flex; gap: 4px; padding: 8px 14px 0; background: var(--panel); }
 .tabs button { border-bottom: none; border-radius: 6px 6px 0 0; }


### PR DESCRIPTION
Three small rig-control quality-of-life changes to the desktop app.

## Changes

- **TX level slider moved to the top bar.** Previously buried in Settings; now the on-air drive level is always visible and adjustable. (Persisted as `tx_gain`, same as before.)
- **Optional rig display-name override (`rig_label`).** The top bar shows this instead of the CAT model. Helpful when a radio connects through an emulator that misreports — e.g. a Flex via SmartSDR CAT identifies as a Kenwood TS-2000. Blank falls back to the detected model. Edited in Settings → Rig control.
- **Disconnect button + `DisconnectRig` command.** Drops the live CAT/PTT session (runs the rig's close/cleanup, releasing single-client CAT servers like SmartSDR) while leaving the saved rig config intact so Connect — or the next launch — reconnects in one click.

## Verification

- `tsc --noEmit` passes on the frontend (prop wiring across `TopBar`/`SettingsScreen`).
- `DisconnectRig` is a new `EngineCommand` variant; the exhaustive `match` in `Engine::handle` and the Tauri `invoke_handler` registration are both updated. The handler is a state reset (`rig = None; ptt = false; publish_rig_status()`) mirroring the existing `select_rig` cleanup — no pure-logic seam to unit-test, consistent with the engine's current test surface (only pure helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)