### PR TITLE
Auto-upload offline-logged QSOs when connectivity returns

### DIFF
--- a/ft8af/app/src/main/AndroidManifest.xml
+++ b/ft8af/app/src/main/AndroidManifest.xml
@@ -20,6 +20,8 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Observe connectivity so offline-logged QSOs auto-upload when the network returns. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- Needed-DX alerts: post notifications (Android 13+) and vibrate. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -339,6 +339,48 @@ public class ThirdPartyService {
     }
 
     /**
+     * The {@code WHERE} clause (with a leading space) selecting QSLTable rows that
+     * still need an upload to at least one enabled service. Returns an empty string
+     * when neither service is enabled (caller should not query in that case). Single
+     * source of truth shared by {@link #syncAllQSOs} and {@link #countUnsyncedQSOs}.
+     */
+    private static String unsyncedFilter(boolean cloudlog, boolean qrz) {
+        if (cloudlog && qrz) {
+            return " where synced_cloudlog = 0 or synced_qrz = 0";
+        } else if (cloudlog) {
+            return " where synced_cloudlog = 0";
+        } else if (qrz) {
+            return " where synced_qrz = 0";
+        }
+        return "";
+    }
+
+    /**
+     * Number of QSLTable rows still awaiting upload to an enabled service. Returns 0
+     * when neither Cloudlog nor QRZ is enabled (nothing to do). Lets the auto-sync
+     * skip spawning upload work when there's nothing pending. Uses the same filter as
+     * {@link #syncAllQSOs} so the count and the actual sync always agree.
+     */
+    public static int countUnsyncedQSOs(SQLiteDatabase db) {
+        boolean cl = GeneralVariables.enableCloudlog;
+        boolean qrz = GeneralVariables.enableQRZ;
+        if (db == null || (!cl && !qrz)) return 0;
+        Cursor cursor = null;
+        try {
+            cursor = db.rawQuery(
+                    "select count(*) from QSLTable" + unsyncedFilter(cl, qrz), null);
+            if (cursor.moveToFirst()) {
+                return cursor.getInt(0);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "countUnsyncedQSOs error: " + e.getClass().getSimpleName());
+        } finally {
+            if (cursor != null) cursor.close();
+        }
+        return 0;
+    }
+
+    /**
      * Re-upload every QSO in QSLTable to whichever third-party services the user has
      * enabled. Services dedupe by callsign+date+time+mode so repeated calls are safe.
      *
@@ -358,15 +400,8 @@ public class ThirdPartyService {
             // Skip rows already accepted by every enabled service. The user can still
             // tell something happened via the dialog's row counts, and a re-press isn't
             // wasted on already-confirmed records.
-            String filter;
-            if (cl && qrz) {
-                filter = " where synced_cloudlog = 0 or synced_qrz = 0";
-            } else if (cl) {
-                filter = " where synced_cloudlog = 0";
-            } else {
-                filter = " where synced_qrz = 0";
-            }
-            cursor = db.rawQuery("select * from QSLTable" + filter + " order by id asc", null);
+            cursor = db.rawQuery(
+                    "select * from QSLTable" + unsyncedFilter(cl, qrz) + " order by id asc", null);
             total = cursor.getCount();
             if (progress != null) progress.onProgress(0, total, 0, 0);
             int idCol = cursor.getColumnIndex("id");

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.Observer
 import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
+import radio.ks3ckc.ft8af.sync.QsoAutoSync
 import com.k1af.ft8af.service.RxForegroundService
 import com.k1af.ft8af.service.RxServiceController
 import com.k1af.ft8af.bluetooth.BluetoothStateBroadcastReceive
@@ -66,6 +67,7 @@ class ComposeMainActivity : AppCompatActivity() {
 
     private var bluetoothReceiver: BluetoothStateBroadcastReceive? = null
     private var usbDetachReceiver: BroadcastReceiver? = null
+    private var qsoAutoSync: QsoAutoSync? = null
     private lateinit var mainViewModel: MainViewModel
     private val showExitConfirm: MutableState<Boolean> = mutableStateOf(false)
 
@@ -154,6 +156,15 @@ class ComposeMainActivity : AppCompatActivity() {
         // UsbDeviceConnection. We tear down those handles here so the next
         // ATTACH event can rebind cleanly.
         registerUsbDetachReceiver()
+
+        // Auto-upload QSOs that failed to reach QRZ/Cloudlog while offline: listen for
+        // connectivity returning and flush the unsynced rows, and flush once on start
+        // (covers a QSO logged offline before the app was last closed). No-op unless a
+        // service is enabled and rows are actually pending.
+        qsoAutoSync = QsoAutoSync(applicationContext).apply {
+            register()
+            syncNow("app-start")
+        }
 
         // Set Compose UI — splash plays once per cold start, then crossfades into the app.
         setContent {
@@ -564,6 +575,7 @@ class ComposeMainActivity : AppCompatActivity() {
     override fun onDestroy() {
         unregisterBluetoothReceiver()
         unregisterUsbDetachReceiver()
+        qsoAutoSync?.unregister()
         super.onDestroy()
     }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
@@ -1,0 +1,157 @@
+package radio.ks3ckc.ft8af.sync
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.database.DatabaseOpr
+import com.k1af.ft8af.log.ThirdPartyService
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Decides whether an auto-sync run may start. Pure logic (no Android types) so it is
+ * unit-testable in isolation — the [QsoAutoSync] wrapper holds the Android wiring.
+ *
+ * Two guards:
+ *  - single-flight: while a run is in flight, no second run may start (avoids two
+ *    concurrent [ThirdPartyService.syncAllQSOs] passes hammering the same rows).
+ *  - debounce: a run may not start within [minIntervalMs] of the last *started* run,
+ *    so a flapping connection (rapid onAvailable/onLost) can't spam the services.
+ *
+ * Callers pass `now` explicitly (tests inject a fake clock). Methods are synchronized
+ * because triggers arrive from both the ConnectivityManager callback thread and the
+ * app-start caller.
+ */
+internal class QsoSyncGate(private val minIntervalMs: Long = 15_000L) {
+    private var inFlight = false
+    private var lastStartedMs = Long.MIN_VALUE
+
+    /** True when a run is allowed to start right now. Does not mutate state. */
+    @Synchronized
+    fun shouldRun(now: Long, anyServiceEnabled: Boolean): Boolean {
+        if (!anyServiceEnabled) return false
+        if (inFlight) return false
+        // Long.MIN_VALUE first-run sentinel: `now - MIN_VALUE` overflows, so special-case it.
+        if (lastStartedMs != Long.MIN_VALUE && now - lastStartedMs < minIntervalMs) return false
+        return true
+    }
+
+    /** Mark a run as begun; subsequent [shouldRun] calls are gated until [markFinished]. */
+    @Synchronized
+    fun markStarted(now: Long) {
+        inFlight = true
+        lastStartedMs = now
+    }
+
+    /** Mark the in-flight run complete, re-opening the single-flight guard. */
+    @Synchronized
+    fun markFinished() {
+        inFlight = false
+    }
+}
+
+/**
+ * Auto-uploads QSOs that failed to upload while offline. When a QSO is logged with no
+ * internet, the immediate post-QSO upload fails and the row's `synced_*` flags stay 0;
+ * this re-runs the existing catch-up uploader ([ThirdPartyService.syncAllQSOs]) the
+ * moment connectivity returns, plus once on app start — so the user never has to press
+ * the manual Sync button.
+ *
+ * Thin Android wrapper: all the start/skip decisions live in the testable [QsoSyncGate].
+ * Scoped to QRZ + Cloudlog (the services with per-QSO sync flags). POTA is excluded.
+ */
+class QsoAutoSync(private val appContext: Context) {
+
+    private val gate = QsoSyncGate()
+    private val cm =
+        appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            requestSync("network-available")
+        }
+    }
+
+    private var registered = false
+
+    /** Begin listening for connectivity so a returning network triggers a flush. */
+    fun register() {
+        val manager = cm ?: return
+        if (registered) return
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        try {
+            manager.registerNetworkCallback(request, callback)
+            registered = true
+        } catch (e: Exception) {
+            log("register failed: ${e.javaClass.simpleName}")
+        }
+    }
+
+    /** Stop listening. Safe to call when not registered. */
+    fun unregister() {
+        val manager = cm ?: return
+        if (!registered) return
+        try {
+            manager.unregisterNetworkCallback(callback)
+        } catch (_: Exception) {
+            // Already unregistered / never succeeded — ignore.
+        }
+        registered = false
+    }
+
+    /** Public entry for the app-start flush (and any other explicit trigger). */
+    fun syncNow(reason: String) = requestSync(reason)
+
+    /**
+     * Run a catch-up upload if the gate allows it and there is actually something
+     * pending. Off-loads the blocking upload to a background thread (mirrors the plain
+     * Thread used by the immediate post-QSO path in MainViewModel).
+     */
+    private fun requestSync(reason: String) {
+        val now = System.currentTimeMillis()
+        val anyEnabled = GeneralVariables.enableCloudlog || GeneralVariables.enableQRZ
+        if (!gate.shouldRun(now, anyEnabled)) {
+            log("skip ($reason): enabled=$anyEnabled")
+            return
+        }
+        gate.markStarted(now)
+        Thread {
+            try {
+                val db = DatabaseOpr.getInstance(null, null)?.db
+                if (db == null) {
+                    log("skip ($reason): no db")
+                    return@Thread
+                }
+                val pending = ThirdPartyService.countUnsyncedQSOs(db)
+                if (pending <= 0) {
+                    log("nothing pending ($reason)")
+                    return@Thread
+                }
+                log("start ($reason): $pending pending")
+                val result = ThirdPartyService.syncAllQSOs(db, null)
+                log("done ($reason): cloudlog=${result.cloudlogOk} qrz=${result.qrzOk} of ${result.total}")
+            } catch (e: Exception) {
+                log("error ($reason): ${e.javaClass.simpleName} ${e.message}")
+            } finally {
+                gate.markFinished()
+            }
+        }.start()
+    }
+
+    /** Append a line to the shared debug.log (same file ComposeMainActivity writes). */
+    private fun log(msg: String) {
+        try {
+            val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            val dir = appContext.getExternalFilesDir(null) ?: return
+            File(dir, "debug.log").appendText("$ts QsoAutoSync: $msg\n")
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.SystemClock
 import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.database.DatabaseOpr
 import com.k1af.ft8af.log.ThirdPartyService
@@ -83,8 +84,13 @@ class QsoAutoSync(private val appContext: Context) {
     fun register() {
         val manager = cm ?: return
         if (registered) return
+        // Require VALIDATED, not just INTERNET: NET_CAPABILITY_INTERNET fires for
+        // networks that aren't actually usable yet (captive portal, still
+        // validating), which would trigger a sync pass that just fails and churns.
+        // VALIDATED means the system has confirmed real connectivity.
         val request = NetworkRequest.Builder()
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
             .build()
         try {
             manager.registerNetworkCallback(request, callback)
@@ -115,7 +121,11 @@ class QsoAutoSync(private val appContext: Context) {
      * Thread used by the immediate post-QSO path in MainViewModel).
      */
     private fun requestSync(reason: String) {
-        val now = System.currentTimeMillis()
+        // Monotonic clock for the debounce interval: elapsedRealtime() can't jump
+        // backwards/forwards on NTP sync, manual time changes, or timezone shifts,
+        // which would otherwise wedge the gate open or shut. (Only used for the
+        // interval; the gate compares deltas, never wall-clock dates.)
+        val now = SystemClock.elapsedRealtime()
         val anyEnabled = GeneralVariables.enableCloudlog || GeneralVariables.enableQRZ
         if (!gate.shouldRun(now, anyEnabled)) {
             log("skip ($reason): enabled=$anyEnabled")
@@ -124,7 +134,11 @@ class QsoAutoSync(private val appContext: Context) {
         gate.markStarted(now)
         Thread {
             try {
-                val db = DatabaseOpr.getInstance(null, null)?.db
+                // Pass our application Context (and the same db name MainViewModel
+                // uses) so a cold-start trigger that beats MainViewModel's init can't
+                // construct the singleton with a null Context — getWritableDatabase()
+                // would NPE, or a null name would open a throwaway in-memory db.
+                val db = DatabaseOpr.getInstance(appContext, "data.db")?.db
                 if (db == null) {
                     log("skip ($reason): no db")
                     return@Thread

--- a/ft8af/app/src/test/kotlin/com/k1af/ft8af/log/ThirdPartyServiceUnsyncedCountTest.kt
+++ b/ft8af/app/src/test/kotlin/com/k1af/ft8af/log/ThirdPartyServiceUnsyncedCountTest.kt
@@ -1,0 +1,98 @@
+package com.k1af.ft8af.log
+
+import android.database.sqlite.SQLiteDatabase
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.GeneralVariables
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Coverage for [ThirdPartyService.countUnsyncedQSOs] — the gate the auto-sync uses to
+ * decide whether anything is actually pending before spawning an upload pass. It must
+ * agree with the WHERE clause [ThirdPartyService.syncAllQSOs] uses, keyed off the
+ * per-service enable flags. Drives a real (Robolectric) in-memory SQLite database.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ThirdPartyServiceUnsyncedCountTest {
+
+    private lateinit var db: SQLiteDatabase
+    private var savedCloudlog = false
+    private var savedQrz = false
+
+    @Before
+    fun setUp() {
+        savedCloudlog = GeneralVariables.enableCloudlog
+        savedQrz = GeneralVariables.enableQRZ
+        db = SQLiteDatabase.create(null)
+        db.execSQL(
+            """
+            CREATE TABLE QSLTable (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                synced_cloudlog INTEGER DEFAULT 0,
+                synced_qrz INTEGER DEFAULT 0
+            )
+            """.trimIndent(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        GeneralVariables.enableCloudlog = savedCloudlog
+        GeneralVariables.enableQRZ = savedQrz
+    }
+
+    private fun insert(cloudlog: Int, qrz: Int) {
+        db.execSQL(
+            "INSERT INTO QSLTable (synced_cloudlog, synced_qrz) VALUES (?, ?)",
+            arrayOf<Any>(cloudlog, qrz),
+        )
+    }
+
+    @Test
+    fun zero_whenNoServiceEnabled() {
+        GeneralVariables.enableCloudlog = false
+        GeneralVariables.enableQRZ = false
+        insert(cloudlog = 0, qrz = 0) // pending for both, but nothing is enabled
+        assertThat(ThirdPartyService.countUnsyncedQSOs(db)).isEqualTo(0)
+    }
+
+    @Test
+    fun zero_whenDbNull() {
+        GeneralVariables.enableCloudlog = true
+        assertThat(ThirdPartyService.countUnsyncedQSOs(null)).isEqualTo(0)
+    }
+
+    @Test
+    fun countsCloudlogPending_whenOnlyCloudlogEnabled() {
+        GeneralVariables.enableCloudlog = true
+        GeneralVariables.enableQRZ = false
+        insert(cloudlog = 0, qrz = 0) // needs cloudlog
+        insert(cloudlog = 1, qrz = 0) // cloudlog done -> not counted (qrz disabled)
+        insert(cloudlog = 0, qrz = 1) // needs cloudlog
+        assertThat(ThirdPartyService.countUnsyncedQSOs(db)).isEqualTo(2)
+    }
+
+    @Test
+    fun countsQrzPending_whenOnlyQrzEnabled() {
+        GeneralVariables.enableCloudlog = false
+        GeneralVariables.enableQRZ = true
+        insert(cloudlog = 0, qrz = 0) // needs qrz
+        insert(cloudlog = 0, qrz = 1) // qrz done -> not counted
+        assertThat(ThirdPartyService.countUnsyncedQSOs(db)).isEqualTo(1)
+    }
+
+    @Test
+    fun countsEitherPending_whenBothEnabled() {
+        GeneralVariables.enableCloudlog = true
+        GeneralVariables.enableQRZ = true
+        insert(cloudlog = 1, qrz = 1) // fully synced -> not counted
+        insert(cloudlog = 0, qrz = 1) // needs cloudlog -> counted
+        insert(cloudlog = 1, qrz = 0) // needs qrz -> counted
+        insert(cloudlog = 0, qrz = 0) // needs both -> counted once
+        assertThat(ThirdPartyService.countUnsyncedQSOs(db)).isEqualTo(3)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoSyncGateTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoSyncGateTest.kt
@@ -1,0 +1,65 @@
+package radio.ks3ckc.ft8af.sync
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [QsoSyncGate] — the single-flight + debounce decision behind the
+ * connectivity-triggered auto-sync. Pure logic: no Android types, an injected clock,
+ * so no Robolectric runner is needed.
+ */
+class QsoSyncGateTest {
+
+    @Test
+    fun blocked_whenNoServiceEnabled() {
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = false)).isFalse()
+    }
+
+    @Test
+    fun allowed_onFirstRun_whenEnabled() {
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = true)).isTrue()
+    }
+
+    @Test
+    fun singleFlight_blocksSecondRun_untilFinished() {
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = true)).isTrue()
+        gate.markStarted(now = 0)
+
+        // A trigger arriving while the first run is in flight is rejected even though
+        // the debounce window would otherwise allow it.
+        assertThat(gate.shouldRun(now = 5000, anyServiceEnabled = true)).isFalse()
+
+        gate.markFinished()
+        // markFinished re-opens the gate (5000 is past the 1000ms window from start@0).
+        assertThat(gate.shouldRun(now = 5000, anyServiceEnabled = true)).isTrue()
+    }
+
+    @Test
+    fun debounce_blocksWithinWindow_allowsAfter() {
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = true)).isTrue()
+        gate.markStarted(now = 0)
+        gate.markFinished()
+
+        // Within the 1000ms window from the last *started* run: blocked.
+        assertThat(gate.shouldRun(now = 999, anyServiceEnabled = true)).isFalse()
+        // Exactly at the window boundary: allowed.
+        assertThat(gate.shouldRun(now = 1000, anyServiceEnabled = true)).isTrue()
+    }
+
+    @Test
+    fun debounce_measuredFromStart_notFinish() {
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        gate.markStarted(now = 0)
+        gate.markFinished()
+        gate.markStarted(now = 1000)
+        gate.markFinished()
+
+        // Window is measured from the most recent start (1000), not the first.
+        assertThat(gate.shouldRun(now = 1500, anyServiceEnabled = true)).isFalse()
+        assertThat(gate.shouldRun(now = 2000, anyServiceEnabled = true)).isTrue()
+    }
+}


### PR DESCRIPTION
## Problem

If a user logs a QSO with no internet, the contact saves locally fine but the immediate QRZ/Cloudlog upload silently fails — the row's `synced_cloudlog`/`synced_qrz` flags stay `0`. The only recovery today is remembering to open the logbook and press the manual **Sync** button.

## Fix

The QRZ/Cloudlog path already has the full persistence foundation (per-QSO sync flags + a working catch-up uploader `ThirdPartyService.syncAllQSOs`). The only missing piece was an automatic trigger.

This adds a lightweight `ConnectivityManager.NetworkCallback` (`QsoAutoSync`) that re-runs the catch-up uploader the moment a network with internet becomes available, plus once on app start (covers a QSO logged offline before the app was last closed).

- **`QsoSyncGate`** (pure, unit-tested): single-flight so two triggers can't launch concurrent upload passes, and a 15 s debounce so a flapping connection can't spam the services.
- **`ThirdPartyService.countUnsyncedQSOs`**: shares one `unsyncedFilter()` with `syncAllQSOs`, so the auto-sync skips spawning work when nothing is pending.
- Wired into `ComposeMainActivity` alongside the existing USB/Bluetooth receivers (register + `syncNow("app-start")` in `onCreate`, `unregister` in `onDestroy`).

**Scope:** QRZ + Cloudlog only (the services with per-QSO sync flags). POTA stays manual. No new dependency — fits the existing no-WorkManager codebase. The immediate post-QSO upload path is unchanged; offline failures correctly leave the flags at `0` for the auto-sync to pick up.

**Trade-off:** does not cover the app being killed *and* staying killed until internet returns — the next launch catches that up via the app-start flush.

## Tests

- `QsoSyncGateTest` (pure JUnit): single-flight, debounce window, debounce-measured-from-start, service-disabled gating.
- `ThirdPartyServiceUnsyncedCountTest` (Robolectric + in-memory SQLite): count matches the `syncAllQSOs` filter across each enable-flag combination; 0 when both disabled or db null.

Both pass: `gradlew.bat testDebugUnitTest --tests *QsoSyncGateTest --tests *ThirdPartyServiceUnsyncedCountTest` → BUILD SUCCESSFUL. Full `installDebug` APK builds clean (native libs + packaging + signing).

## Not yet verified on-device

No phone/emulator was connected at commit time, so the manual end-to-end (airplane mode → log QSO → re-enable network → confirm `synced_*` flip to 1 and `debug.log` shows the `QsoAutoSync` lines) still needs a device run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)