### PR TITLE
TX strip: make the CQ options sheet discoverable

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -74,6 +74,24 @@ internal fun txStripActionState(isActivated: Boolean, huntEnabled: Boolean) = Tx
     cqIsStop = isActivated,
 )
 
+/**
+ * The small subtitle shown under "Call CQ" that reflects which CQ variant is queued.
+ * Precedence: free-text > Field Day > custom modifier > none. Null while the button is
+ * in its STOP state. Extracted so the precedence can be unit-tested without Compose.
+ */
+internal fun cqStripSubtitle(
+    cqIsStop: Boolean,
+    isFreeTextMode: Boolean,
+    fieldDayEnabled: Boolean,
+    cqModifier: String,
+): String? = when {
+    cqIsStop -> null
+    isFreeTextMode -> "FREE"
+    fieldDayEnabled -> "FD"
+    cqModifier.isNotEmpty() -> cqModifier
+    else -> null
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TxStrip(
@@ -263,13 +281,7 @@ fun TxStrip(
             // Locked off while HUNT is armed (and no QSO yet).
             // Long-press opens CQ options (modifier, free text, Field Day).
             val cqIsStop = actions.cqIsStop
-            val cqSubtitle = when {
-                cqIsStop -> null
-                isFreeTextMode -> "FREE"
-                fieldDayEnabled -> "FD"
-                cqModifier.isNotEmpty() -> cqModifier
-                else -> null
-            }
+            val cqSubtitle = cqStripSubtitle(cqIsStop, isFreeTextMode, fieldDayEnabled, cqModifier)
             PrimaryActionButton(
                 modifier = Modifier.weight(1.7f),
                 label = if (cqIsStop) stringResource(R.string.tx_stop) else stringResource(R.string.tx_call_cq),
@@ -283,6 +295,7 @@ fun TxStrip(
                 enabled = !actions.cqDisabled,
                 onClick = { if (cqIsStop) onStop() else onCallCQ() },
                 onLongClick = if (!cqIsStop) onLongPressCQ else null,
+                optionsContentDescription = stringResource(R.string.tx_cq_options),
             ) { color ->
                 if (cqIsStop) {
                     FT8AFIcons.Close(size = 18.dp, color = color, strokeWidth = 2f)
@@ -466,6 +479,7 @@ private fun PrimaryActionButton(
     modifier: Modifier = Modifier,
     subtitle: String? = null,
     onLongClick: (() -> Unit)? = null,
+    optionsContentDescription: String = "",
     icon: @Composable (Color) -> Unit,
 ) {
     Row(
@@ -519,7 +533,24 @@ private fun PrimaryActionButton(
             )
         }
         if (onLongClick != null) {
-            FT8AFIcons.ChevronDown(size = 10.dp, color = contentColor.copy(alpha = 0.5f), strokeWidth = 2f)
+            // A visible, separately-tappable "more options" affordance. A plain tap opens the
+            // CQ options sheet (discoverable), and the whole button still long-presses to the
+            // same sheet as a shortcut. Without this the sheet was effectively hidden — a tester
+            // reported they'd never have found the long-press.
+            Box(
+                modifier = Modifier
+                    .size(width = 30.dp, height = 38.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(contentColor.copy(alpha = 0.16f))
+                    .clickable(enabled = enabled, onClick = onLongClick)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = optionsContentDescription
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                FT8AFIcons.ChevronDown(size = 16.dp, color = contentColor, strokeWidth = 2.2f)
+            }
         }
     }
 }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -114,6 +114,7 @@
     <string name="tx_stop">Stop</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_cq_options">CQ message options (modifier, free text, Field Day)</string>
 
     <!-- ===== Hound (DXpedition) setup ===== -->
     <string name="hound_title">Work a DXpedition (Hound)</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqStripSubtitleTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CqStripSubtitleTest.kt
@@ -1,0 +1,41 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [cqStripSubtitle] — the precedence that decides the small label under the
+ * "Call CQ" button (free-text > Field Day > custom modifier > none, and nothing while in STOP).
+ */
+class CqStripSubtitleTest {
+
+    @Test
+    fun `stop state shows no subtitle`() {
+        assertThat(cqStripSubtitle(cqIsStop = true, isFreeTextMode = true, fieldDayEnabled = true, cqModifier = "DX"))
+            .isNull()
+    }
+
+    @Test
+    fun `free text wins over field day and modifier`() {
+        assertThat(cqStripSubtitle(cqIsStop = false, isFreeTextMode = true, fieldDayEnabled = true, cqModifier = "DX"))
+            .isEqualTo("FREE")
+    }
+
+    @Test
+    fun `field day wins over modifier`() {
+        assertThat(cqStripSubtitle(cqIsStop = false, isFreeTextMode = false, fieldDayEnabled = true, cqModifier = "DX"))
+            .isEqualTo("FD")
+    }
+
+    @Test
+    fun `modifier shown when set and no higher-priority mode`() {
+        assertThat(cqStripSubtitle(cqIsStop = false, isFreeTextMode = false, fieldDayEnabled = false, cqModifier = "DX"))
+            .isEqualTo("DX")
+    }
+
+    @Test
+    fun `blank modifier and no modes yields no subtitle`() {
+        assertThat(cqStripSubtitle(cqIsStop = false, isFreeTextMode = false, fieldDayEnabled = false, cqModifier = ""))
+            .isNull()
+    }
+}


### PR DESCRIPTION
## Problem

Holding the **CQ** button opens an options sheet (CQ modifier, free text, Field Day), but the only hint it existed was a 10dp, 50%-alpha chevron tucked after the label plus the whole-button long-press gesture. A tester reported: *"it's too hard to understand that holding CQ button shown popup. I wouldn't know if I dont report this issue."*

## Change

- Replace the faint glyph with a **visible, separately-tappable chevron button** at the trailing edge of the CQ button. A plain tap opens the options sheet — no need to discover the long-press.
- Add a `tx_cq_options` content description ("CQ message options …") for accessibility / TalkBack.
- Whole-button **long-press still opens the same sheet** (shortcut kept); short-tap still calls CQ.
- Extract the subtitle precedence (free text > Field Day > modifier > none) into a testable `cqStripSubtitle()` helper.

## Tests

- New `CqStripSubtitleTest` covering the precedence + STOP-state cases.
- `testDebugUnitTest` green; built and installed on the Pixel 8, launches cleanly.

Part of a series addressing tester feedback on the Android UI (item 1 of 4).