### PR TITLE
TX: free text is a one-shot, sent immediately (WSJT-X Tx5 style)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -46,6 +46,10 @@ public class FT8TransmitSignal {
 
     private boolean transmitFreeText = false;
     private String freeText = "FREE TEXT";
+    // When true, the queued free-text message is a one-shot (WSJT-X Tx5 style): it
+    // transmits once and then the sequencer auto-stops, rather than repeating every
+    // cycle like a CQ. Cleared after the single send completes (see afterPlayAudio).
+    private boolean freeTextOneShot = false;
 
     private final DatabaseOpr databaseOpr;// configuration info and related data database
     private TransmitCallsign toCallsign;// target callsign
@@ -856,6 +860,16 @@ public class FT8TransmitSignal {
         if (audioTrack != null) {
             audioTrack.release();
             audioTrack = null;
+        }
+        // One-shot free text (WSJT-X Tx5 style) just finished sending: stop here
+        // instead of repeating it every cycle, and revert to standard messages so
+        // the next CQ is a normal CQ. Safe to deactivate now — the audio has already
+        // drained (isTransmitting is false above), so setActivated(false)'s
+        // setTransmitting(false) is a no-op for playback and just clears the run.
+        if (shouldStopAfterOneShot(transmitFreeText, freeTextOneShot)) {
+            freeTextOneShot = false;
+            transmitFreeText = false;
+            setActivated(false);
         }
     }
 
@@ -2053,6 +2067,39 @@ public class FT8TransmitSignal {
         } else {
             ToastMessage.show((GeneralVariables.getStringFromResource(R.string.trans_standard_messge_mode)));
         }
+    }
+
+    /**
+     * Send a free-text message ONCE, mirroring WSJT-X's free-text (Tx5) behavior:
+     * free text is an alternative to a 73, not a repeating CQ. The message goes out
+     * this cycle if we're early enough in the slot (immediate TX, like tapping a
+     * decode), otherwise at the next slot boundary, and then the sequencer
+     * auto-stops in {@link #afterPlayAudio()} instead of keying up again each cycle.
+     */
+    public void sendFreeTextOnce(String text) {
+        setFreeText(text);
+        transmitFreeText = true;
+        freeTextOneShot = true;
+        setActivated(true);
+        if (!activated) {
+            // SWR lockout or invalid callsign blocked activation — don't leave the
+            // one-shot armed.
+            freeTextOneShot = false;
+            transmitFreeText = false;
+            return;
+        }
+        GeneralVariables.resetLaunchSupervision();
+        transmitNow();// fire this cycle if within the late-start tolerance window
+    }
+
+    /**
+     * Whether the sequencer should auto-stop after the transmission that just
+     * completed. True only for a one-shot free-text send (WSJT-X Tx5 style), which
+     * goes out once and then stops rather than repeating like a CQ. Extracted as a
+     * pure predicate so it can be unit-tested without the Android runtime.
+     */
+    static boolean shouldStopAfterOneShot(boolean transmitFreeText, boolean freeTextOneShot) {
+        return transmitFreeText && freeTextOneShot;
     }
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -2089,6 +2089,14 @@ public class FT8TransmitSignal {
             return;
         }
         GeneralVariables.resetLaunchSupervision();
+        // transmitNow() (and the status toast) dereference toCallsign, which stays
+        // null until the first setTransmit/resetToCQ. A free-text one-shot can be the
+        // very first TX action of a session (before any CQ or decode tap), so seed a
+        // CQ baseline here to avoid an NPE. The free-text message itself is built
+        // independently of toCallsign, so this only provides the baseline target.
+        if (toCallsign == null) {
+            resetToCQ();
+        }
         transmitNow();// fire this cycle if within the late-start tolerance window
     }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -375,14 +375,16 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {
                         Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()
+                    } else if (isFreeTextMode && freeTextMessage.isNotBlank()) {
+                        // Free text is a one-shot (WSJT-X Tx5 style): send it once,
+                        // immediately, then the engine auto-stops — it is an alternative
+                        // to a 73, not a repeating CQ. Consume the armed free text so the
+                        // next tap calls a normal CQ instead of re-sending it.
+                        mainViewModel.ft8TransmitSignal.sendFreeTextOnce(freeTextMessage)
+                        isFreeTextMode = false
+                        freeTextMessage = ""
                     } else {
-                        // Apply current CQ mode before activating
-                        if (isFreeTextMode && freeTextMessage.isNotBlank()) {
-                            mainViewModel.ft8TransmitSignal.setFreeText(freeTextMessage)
-                            mainViewModel.ft8TransmitSignal.setTransmitFreeText(true)
-                        } else {
-                            mainViewModel.ft8TransmitSignal.setTransmitFreeText(false)
-                        }
+                        mainViewModel.ft8TransmitSignal.setTransmitFreeText(false)
                         mainViewModel.ft8TransmitSignal.userResetToCQ()
                         mainViewModel.ft8TransmitSignal.setActivated(true)
                         GeneralVariables.resetLaunchSupervision()

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -340,4 +340,35 @@ public class FT8TransmitSignalTest {
         // A genuine POTA CQ stays eligible when the filter is active.
         assertThat(FT8TransmitSignal.huntFilterExcludes(true, true)).isFalse();
     }
+
+    // ---- shouldStopAfterOneShot ---------------------------------------------
+    // Free text is a one-shot (WSJT-X Tx5): it transmits once and then the
+    // sequencer stops, rather than repeating every cycle like a CQ. The auto-stop
+    // must fire ONLY for a free-text one-shot send, never for a normal CQ run or a
+    // persistent free-text mode.
+
+    @Test
+    public void oneShot_freeTextOneShot_stops() {
+        // The reported request: free text sends once, then stop.
+        assertThat(FT8TransmitSignal.shouldStopAfterOneShot(
+                /*transmitFreeText*/ true, /*freeTextOneShot*/ true)).isTrue();
+    }
+
+    @Test
+    public void oneShot_standardCq_neverStops() {
+        // A normal CQ run (no free text) must keep repeating each cycle.
+        assertThat(FT8TransmitSignal.shouldStopAfterOneShot(false, false)).isFalse();
+    }
+
+    @Test
+    public void oneShot_freeTextWithoutOneShotFlag_neverStops() {
+        // Free text armed but not flagged one-shot (defensive): don't auto-stop.
+        assertThat(FT8TransmitSignal.shouldStopAfterOneShot(true, false)).isFalse();
+    }
+
+    @Test
+    public void oneShot_flagSetButNotFreeText_neverStops() {
+        // The one-shot flag without an active free-text message can't trigger a stop.
+        assertThat(FT8TransmitSignal.shouldStopAfterOneShot(false, true)).isFalse();
+    }
 }


### PR DESCRIPTION
## Problem

Tester feedback: *"when I set the free text, it might need to send once. afaik, in wsjtx, free text is alternative option of the 73 not a CQ"* and *"i feel too long waiting time."*

Today, sending free text calls `setTransmitFreeText(true)` and then activates like a CQ, so:
- it **repeats every cycle** until you hit STOP, and
- it only goes out at the **next slot boundary** — up to a full cycle (~15 s on FT8) of dead air after you tap.

## Change

New `sendFreeTextOnce()` on `FT8TransmitSignal`:
- arms the free-text message with a `freeTextOneShot` flag,
- `setActivated(true)` then `transmitNow()` — so it transmits **this cycle** if we're within the late-start tolerance window (the same immediate-TX path tapping a decode already uses), otherwise at the next boundary,
- after the single transmission, `afterPlayAudio()` **auto-stops** the sequencer and reverts `transmitFreeText` to false so the next CQ is a normal CQ.

The app (`onCallCQ`) consumes the armed free text on send (`isFreeTextMode = false`), so the UI reverts to standard CQ after one shot.

Safety: the one-shot stop runs at the end of `afterPlayAudio()`, *after* playback has drained (`isTransmitting` already false), so `setActivated(false)` doesn't abort live audio. Activation blocked by SWR lockout / invalid callsign disarms the one-shot cleanly.

## Tests

- New `shouldStopAfterOneShot()` pure predicate + 4 unit tests (stops only for a free-text one-shot; never for a normal CQ).
- `testDebugUnitTest` green; built and installed on the Pixel 8, launches cleanly.

## Follow-up (not in this PR)

A general "transmit immediately" option for *standard* CQ (the tester mentioned "for free text **and other cases**") could reuse `transmitNow()` on the CQ activate path. Scoped out here to keep the change focused on the free-text behavior.

Part of a series addressing tester feedback on the Android UI (item 2 of 4).