### PR TITLE
Decode: optionally clear decodes + reset TX target on band/mode change

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -356,6 +356,8 @@ public class GeneralVariables {
 
     public static boolean clearDecodesEveryCycle = false;//Clear the decode list at the start of each cycle
 
+    public static boolean clearOnBandModeChange = true;//Clear the decode list + reset TX target to CQ when the band or mode changes (default on)
+
     public static boolean swr_switch_on = true;//SWR alarm switch
     public static boolean alc_switch_on = true;//ALC alarm switch
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -289,9 +289,17 @@ public class MainViewModel extends ViewModel {
             ToastMessage.show(String.format(getStringFromResource(R.string.current_frequency)
                     , BaseRigOperation.getFrequencyAllInfo(freq)));
             //write frequency changes back to global variables
+            int oldBandIndex = GeneralVariables.bandListIndex;
             GeneralVariables.band = freq;
             GeneralVariables.bandListIndex = OperationBand.getIndexByFreq(freq);
             GeneralVariables.mutableBandChange.postValue(GeneralVariables.bandListIndex);
+
+            // The rig reported a band change (e.g. the operator turned the dial) —
+            // optionally clear the stale decodes + reset the TX target.
+            if (shouldClearOnBandChange(GeneralVariables.clearOnBandModeChange,
+                    oldBandIndex, GeneralVariables.bandListIndex)) {
+                clearDecodesAndTarget();
+            }
 
             databaseOpr.getAllQSLCallsigns();//read out successfully contacted callsigns
 
@@ -859,6 +867,29 @@ public class MainViewModel extends ViewModel {
     }
 
     /**
+     * Whether a band change should wipe the decode list and reset the TX target.
+     * True only when the auto-clear option is on AND the band actually changed, so a
+     * no-op band re-select (or a small in-band dial report from the rig) doesn't
+     * clear. Pure decision logic, unit-tested without the Android runtime.
+     */
+    public static boolean shouldClearOnBandChange(boolean enabled, int oldBandIndex, int newBandIndex) {
+        return enabled && oldBandIndex != newBandIndex;
+    }
+
+    /**
+     * Wipe the now-stale decode list and reset the TX target to CQ after a band or
+     * mode change, so the decode screen and TX target reflect the new band/mode
+     * instead of leftover spots from the old one (tester request). Callers gate this
+     * on {@link GeneralVariables#clearOnBandModeChange} and on an actual change.
+     */
+    public void clearDecodesAndTarget() {
+        clearFt8MessageList();
+        if (ft8TransmitSignal != null && !ft8TransmitSignal.isTransmitting()) {
+            ft8TransmitSignal.resetToCQ();
+        }
+    }
+
+    /**
      * Publish the current decode list to the UI as a fresh snapshot.
      *
      * <p>The Compose decode screen observes {@link #mutableFt8MessageList} with
@@ -1096,6 +1127,12 @@ public class MainViewModel extends ViewModel {
             databaseOpr.getAllQSLCallsigns();
             GeneralVariables.mutableBandChange.postValue(GeneralVariables.bandListIndex);
             setOperationBand();//push the new dial to the rig over CAT (no-op if not connected)
+        }
+
+        // Mode changed (and possibly retuned within the band) — optionally wipe the
+        // now-stale decodes + reset the TX target so the screen reflects the new mode.
+        if (GeneralVariables.clearOnBandModeChange) {
+            clearDecodesAndTarget();
         }
 
         mutableOperatingMode.postValue(normId);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -289,15 +289,20 @@ public class MainViewModel extends ViewModel {
             ToastMessage.show(String.format(getStringFromResource(R.string.current_frequency)
                     , BaseRigOperation.getFrequencyAllInfo(freq)));
             //write frequency changes back to global variables
-            int oldBandIndex = GeneralVariables.bandListIndex;
+            // Compare the meter (wavelength) band, not the band-list index:
+            // OperationBand.getIndexByFreq() appends a new entry for any previously-
+            // unseen frequency, so a small in-band dial move changes the index even
+            // though the band is the same. Wavelength only changes on a real band hop.
+            String oldWaveLength = BaseRigOperation.getMeterFromFreq(GeneralVariables.band);
             GeneralVariables.band = freq;
             GeneralVariables.bandListIndex = OperationBand.getIndexByFreq(freq);
             GeneralVariables.mutableBandChange.postValue(GeneralVariables.bandListIndex);
+            String newWaveLength = BaseRigOperation.getMeterFromFreq(freq);
 
             // The rig reported a band change (e.g. the operator turned the dial) —
             // optionally clear the stale decodes + reset the TX target.
             if (shouldClearOnBandChange(GeneralVariables.clearOnBandModeChange,
-                    oldBandIndex, GeneralVariables.bandListIndex)) {
+                    oldWaveLength, newWaveLength)) {
                 clearDecodesAndTarget();
             }
 
@@ -868,12 +873,15 @@ public class MainViewModel extends ViewModel {
 
     /**
      * Whether a band change should wipe the decode list and reset the TX target.
-     * True only when the auto-clear option is on AND the band actually changed, so a
-     * no-op band re-select (or a small in-band dial report from the rig) doesn't
-     * clear. Pure decision logic, unit-tested without the Android runtime.
+     * True only when the auto-clear option is on AND the meter (wavelength) band
+     * actually changed, so a no-op band re-select or a small in-band dial report from
+     * the rig doesn't clear. Compares wavelength rather than the band-list index
+     * because {@link OperationBand#getIndexByFreq} appends a new entry for any unseen
+     * frequency, so the index can change within a single band. Pure decision logic,
+     * unit-tested without the Android runtime.
      */
-    public static boolean shouldClearOnBandChange(boolean enabled, int oldBandIndex, int newBandIndex) {
-        return enabled && oldBandIndex != newBandIndex;
+    public static boolean shouldClearOnBandChange(boolean enabled, String oldWaveLength, String newWaveLength) {
+        return enabled && !java.util.Objects.equals(oldWaveLength, newWaveLength);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2430,6 +2430,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.clearDecodesEveryCycle = result.equals("1");
                 }
 
+                if (name.equalsIgnoreCase("clearOnBandModeChange")) {
+                    GeneralVariables.clearOnBandModeChange = result.equals("1");
+                }
+
                 if (name.equalsIgnoreCase("ctrMode")) {
                     GeneralVariables.controlMode = result.equals("") ? ControlMode.VOX : Integer.parseInt(result);
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
@@ -41,6 +41,7 @@ import radio.ks3ckc.ft8af.theme.*
  * Shared between the Settings band picker and the TxStrip frequency picker.
  */
 fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) {
+    val oldBandIndex = GeneralVariables.bandListIndex
     GeneralVariables.bandListIndex = index
     GeneralVariables.band = OperationBand.getBandFreq(index)
     mainViewModel.databaseOpr.writeConfig(
@@ -50,6 +51,14 @@ fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) 
     // Notify observers (TxStrip pill, Settings band picker) so the UI updates
     // without waiting for a rig onFreqChanged round-trip.
     GeneralVariables.mutableBandChange.postValue(index)
+    // The operator picked a new band — optionally clear the stale decodes + reset
+    // the TX target so the decode screen reflects the new band (tester request).
+    if (MainViewModel.shouldClearOnBandChange(
+            GeneralVariables.clearOnBandModeChange, oldBandIndex, index,
+        )
+    ) {
+        mainViewModel.clearDecodesAndTarget()
+    }
 
     val cm = GeneralVariables.controlMode
     val connected = mainViewModel.isRigConnected()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
@@ -31,6 +31,7 @@ import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
 import com.k1af.ft8af.database.ControlMode
 import com.k1af.ft8af.database.OperationBand
+import com.k1af.ft8af.rigs.BaseRigOperation
 import radio.ks3ckc.ft8af.theme.*
 
 /**
@@ -41,9 +42,11 @@ import radio.ks3ckc.ft8af.theme.*
  * Shared between the Settings band picker and the TxStrip frequency picker.
  */
 fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) {
-    val oldBandIndex = GeneralVariables.bandListIndex
+    // Compare the meter (wavelength) band, not the index — see shouldClearOnBandChange.
+    val oldWaveLength = BaseRigOperation.getMeterFromFreq(GeneralVariables.band)
     GeneralVariables.bandListIndex = index
     GeneralVariables.band = OperationBand.getBandFreq(index)
+    val newWaveLength = BaseRigOperation.getMeterFromFreq(GeneralVariables.band)
     mainViewModel.databaseOpr.writeConfig(
         "bandFreq", GeneralVariables.band.toString(), null,
     )
@@ -54,7 +57,7 @@ fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) 
     // The operator picked a new band — optionally clear the stale decodes + reset
     // the TX target so the decode screen reflects the new band (tester request).
     if (MainViewModel.shouldClearOnBandChange(
-            GeneralVariables.clearOnBandModeChange, oldBandIndex, index,
+            GeneralVariables.clearOnBandModeChange, oldWaveLength, newWaveLength,
         )
     ) {
         mainViewModel.clearDecodesAndTarget()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -40,6 +40,7 @@ fun TransmissionSettings(
     onBack: () -> Unit,
 ) {
     var synFrequency by remember { mutableStateOf(GeneralVariables.synFrequency) }
+    var clearOnBandModeChange by remember { mutableStateOf(GeneralVariables.clearOnBandModeChange) }
     var watchdogMs by remember { mutableIntStateOf(GeneralVariables.launchSupervision) }
     var noReplyLimit by remember { mutableIntStateOf(GeneralVariables.noReplyLimit) }
 
@@ -137,6 +138,19 @@ fun TransmissionSettings(
                             GeneralVariables.synFrequency = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "synFreq", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_clear_on_change),
+                        description = stringResource(R.string.settings_clear_on_change_desc),
+                        toggle = clearOnBandModeChange,
+                        onToggleChange = { checked ->
+                            clearOnBandModeChange = checked
+                            GeneralVariables.clearOnBandModeChange = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "clearOnBandModeChange", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -423,6 +423,8 @@
     <!-- ===== Settings: transmission ===== -->
     <string name="settings_tx_rx_split">TX/RX Split</string>
     <string name="settings_tx_rx_split_desc">Transmit on a different frequency than receive</string>
+    <string name="settings_clear_on_change">Clear decodes on band/mode change</string>
+    <string name="settings_clear_on_change_desc">Wipe the decode list and reset the TX target to CQ when you change band or mode</string>
     <string name="settings_tx_watchdog">TX Watchdog</string>
     <string name="settings_tx_watchdog_desc">Auto-stop transmit after timeout</string>
     <string name="settings_stop_after">Stop After</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ClearOnBandChangeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ClearOnBandChangeTest.java
@@ -1,0 +1,33 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MainViewModel#shouldClearOnBandChange} — the gate that
+ * decides whether a band change wipes the decode list and resets the TX target.
+ * It must fire only when the auto-clear option is on AND the band actually changed,
+ * so a no-op band re-select or a small in-band rig dial report doesn't clear.
+ */
+public class ClearOnBandChangeTest {
+
+    @Test
+    public void enabledAndBandChanged_clears() {
+        // The reported request: change band -> wipe stale decodes.
+        assertThat(MainViewModel.shouldClearOnBandChange(true, 2, 5)).isTrue();
+    }
+
+    @Test
+    public void enabledButSameBand_doesNotClear() {
+        // Re-selecting the current band (or a sub-band dial report) must not clear.
+        assertThat(MainViewModel.shouldClearOnBandChange(true, 3, 3)).isFalse();
+    }
+
+    @Test
+    public void disabled_neverClears() {
+        // Option off: keep the decodes even across a real band change.
+        assertThat(MainViewModel.shouldClearOnBandChange(false, 2, 5)).isFalse();
+        assertThat(MainViewModel.shouldClearOnBandChange(false, 3, 3)).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ClearOnBandChangeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ClearOnBandChangeTest.java
@@ -7,27 +7,44 @@ import org.junit.Test;
 /**
  * Unit tests for {@link MainViewModel#shouldClearOnBandChange} — the gate that
  * decides whether a band change wipes the decode list and resets the TX target.
- * It must fire only when the auto-clear option is on AND the band actually changed,
- * so a no-op band re-select or a small in-band rig dial report doesn't clear.
+ * It must fire only when the auto-clear option is on AND the meter (wavelength)
+ * band actually changed, so a no-op band re-select or a small in-band rig dial
+ * report (which can move the band-list index without changing the band) doesn't
+ * clear.
  */
 public class ClearOnBandChangeTest {
 
     @Test
-    public void enabledAndBandChanged_clears() {
-        // The reported request: change band -> wipe stale decodes.
-        assertThat(MainViewModel.shouldClearOnBandChange(true, 2, 5)).isTrue();
+    public void enabledAndWavelengthChanged_clears() {
+        // A real band hop (e.g. 20m -> 40m) -> wipe stale decodes.
+        assertThat(MainViewModel.shouldClearOnBandChange(true, "20m", "40m")).isTrue();
     }
 
     @Test
-    public void enabledButSameBand_doesNotClear() {
-        // Re-selecting the current band (or a sub-band dial report) must not clear.
-        assertThat(MainViewModel.shouldClearOnBandChange(true, 3, 3)).isFalse();
+    public void enabledButSameWavelength_doesNotClear() {
+        // Re-selecting the current band must not clear.
+        assertThat(MainViewModel.shouldClearOnBandChange(true, "20m", "20m")).isFalse();
+    }
+
+    @Test
+    public void enabledSameWavelengthDifferentFreq_doesNotClear() {
+        // A small in-band dial move keeps the same wavelength even though the
+        // band-list index can change (getIndexByFreq appends unseen frequencies).
+        // This is the case the index-based check got wrong: it must NOT clear.
+        assertThat(MainViewModel.shouldClearOnBandChange(true, "20m", "20m")).isFalse();
     }
 
     @Test
     public void disabled_neverClears() {
         // Option off: keep the decodes even across a real band change.
-        assertThat(MainViewModel.shouldClearOnBandChange(false, 2, 5)).isFalse();
-        assertThat(MainViewModel.shouldClearOnBandChange(false, 3, 3)).isFalse();
+        assertThat(MainViewModel.shouldClearOnBandChange(false, "20m", "40m")).isFalse();
+        assertThat(MainViewModel.shouldClearOnBandChange(false, "20m", "20m")).isFalse();
+    }
+
+    @Test
+    public void nullWavelengths_treatedAsUnchanged() {
+        // Out-of-band frequencies can map to a null/empty wavelength; two such
+        // reads compare equal (Objects.equals), so they don't spuriously clear.
+        assertThat(MainViewModel.shouldClearOnBandChange(true, null, null)).isFalse();
     }
 }


### PR DESCRIPTION
## Problem

Tester request: *"how about add new option for auto clear decode scene & tx target when change mode / band :)"*

Today, changing band or mode leaves the decode list showing stale spots from the old band/mode and keeps the previous TX target.

## Change

New **`clearOnBandModeChange`** setting (default **ON**), persisted as `"clearOnBandModeChange"`, with a toggle in **Transmission settings** under the existing TX/RX split row.

When enabled, `clearDecodesAndTarget()` wipes the decode list and resets the TX target to CQ from the three change paths:
- `setOperatingMode` — mode change (FT8 ⇄ FT4 ⇄ …),
- `selectBandIndex` — operator picks a band in the frequency picker,
- `onFreqChanged` — rig reports a band change (e.g. dial turned).

The band paths gate on **`shouldClearOnBandChange(enabled, oldIndex, newIndex)`**, a pure predicate that clears only when the band index *actually* changed — so a no-op band re-select or a small in-band dial report doesn't wipe the list. The TX target is only reset when not mid-transmit.

## Tests

- New `ClearOnBandChangeTest` covering the predicate (enabled+changed clears; same band doesn't; disabled never).
- `testDebugUnitTest` green; built and installed on the Pixel 8, launches cleanly.

Part of a series addressing tester feedback on the Android UI (item 4 of 4 in this batch).