### PR TITLE
TX: add "Hold TX freq" setting (WSJT-X-style)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -379,6 +379,7 @@ public class GeneralVariables {
     public static String qrzXmlPassword = ""; //QRZ XML API password
     public static boolean pskOverlayEnabled = false; //PSK Reporter map overlay (issue #33)
     public static boolean synFrequency = false;//Same-frequency transmit
+    public static boolean holdTxFreq = false;//Hold TX freq: don't move the TX offset to a station you answer (WSJT-X "Hold Tx Freq")
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2379,7 +2379,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.synFrequency = !(result.equals("") || result.equals("0"));
                 }
                 if (name.equalsIgnoreCase("holdTxFreq")) {
-                    GeneralVariables.holdTxFreq = result.equals("1");
+                    // Parse like synFreq above: any non-empty, non-"0" value is true,
+                    // so the two boolean configs handle stored values consistently.
+                    GeneralVariables.holdTxFreq = !(result.equals("") || result.equals("0"));
                 }
                 if (name.equalsIgnoreCase("transDelay")) {
                     if (result.matches("^\\d{1,4}$")) {//Regex: 1-4 digit number

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2378,6 +2378,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("synFreq")) {
                     GeneralVariables.synFrequency = !(result.equals("") || result.equals("0"));
                 }
+                if (name.equalsIgnoreCase("holdTxFreq")) {
+                    GeneralVariables.holdTxFreq = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("transDelay")) {
                     if (result.matches("^\\d{1,4}$")) {//Regex: 1-4 digit number
                         GeneralVariables.transmitDelay = Integer.parseInt(result);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -325,7 +325,10 @@ public class FT8TransmitSignal {
         if (transmitCallsign.frequency == 0) {
             transmitCallsign.frequency = GeneralVariables.getBaseFrequency();
         }
-        if (GeneralVariables.synFrequency) {// if same-frequency mode, match target callsign frequency
+        // Same-frequency mode moves our TX offset onto the station we answer — unless
+        // "Hold TX freq" is on (WSJT-X "Hold Tx Freq"), in which case we keep calling
+        // on our own offset. Tester reported the auto-move felt inverted.
+        if (shouldFollowTargetFreq(GeneralVariables.synFrequency, GeneralVariables.holdTxFreq)) {
             setBaseFrequency(transmitCallsign.frequency);
         }
 
@@ -343,6 +346,16 @@ public class FT8TransmitSignal {
         GeneralVariables.setBaseFrequency(freq);
         // write to database
         databaseOpr.writeConfig("freq", String.format("%.0f", freq), null);
+    }
+
+    /**
+     * Whether to move our TX offset onto the frequency of the station we're about to
+     * answer. True only in same-frequency (TX/RX split) mode AND when "Hold TX freq"
+     * is off — holding TX freq (WSJT-X "Hold Tx Freq") keeps us calling on our own
+     * offset. Pure decision logic so it can be unit-tested without the Android runtime.
+     */
+    static boolean shouldFollowTargetFreq(boolean synFrequency, boolean holdTxFreq) {
+        return synFrequency && !holdTxFreq;
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -350,9 +350,9 @@ public class FT8TransmitSignal {
 
     /**
      * Whether to move our TX offset onto the frequency of the station we're about to
-     * answer. True only in same-frequency (TX/RX split) mode AND when "Hold TX freq"
-     * is off — holding TX freq (WSJT-X "Hold Tx Freq") keeps us calling on our own
-     * offset. Pure decision logic so it can be unit-tested without the Android runtime.
+     * answer. True only in TX=RX (synFrequency) mode AND when "Hold TX freq" is off —
+     * holding TX freq (WSJT-X "Hold Tx Freq") keeps us calling on our own offset.
+     * Pure decision logic so it can be unit-tested without the Android runtime.
      */
     static boolean shouldFollowTargetFreq(boolean synFrequency, boolean holdTxFreq) {
         return synFrequency && !holdTxFreq;

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -40,6 +40,7 @@ fun TransmissionSettings(
     onBack: () -> Unit,
 ) {
     var synFrequency by remember { mutableStateOf(GeneralVariables.synFrequency) }
+    var holdTxFreq by remember { mutableStateOf(GeneralVariables.holdTxFreq) }
     var watchdogMs by remember { mutableIntStateOf(GeneralVariables.launchSupervision) }
     var noReplyLimit by remember { mutableIntStateOf(GeneralVariables.noReplyLimit) }
 
@@ -137,6 +138,19 @@ fun TransmissionSettings(
                             GeneralVariables.synFrequency = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "synFreq", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_hold_tx_freq),
+                        description = stringResource(R.string.settings_hold_tx_freq_desc),
+                        toggle = holdTxFreq,
+                        onToggleChange = { checked ->
+                            holdTxFreq = checked
+                            GeneralVariables.holdTxFreq = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "holdTxFreq", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -423,6 +423,8 @@
     <!-- ===== Settings: transmission ===== -->
     <string name="settings_tx_rx_split">TX/RX Split</string>
     <string name="settings_tx_rx_split_desc">Transmit on a different frequency than receive</string>
+    <string name="settings_hold_tx_freq">Hold TX freq</string>
+    <string name="settings_hold_tx_freq_desc">Keep your TX offset when answering a station instead of moving it to theirs</string>
     <string name="settings_tx_watchdog">TX Watchdog</string>
     <string name="settings_tx_watchdog_desc">Auto-stop transmit after timeout</string>
     <string name="settings_stop_after">Stop After</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -340,4 +340,28 @@ public class FT8TransmitSignalTest {
         // A genuine POTA CQ stays eligible when the filter is active.
         assertThat(FT8TransmitSignal.huntFilterExcludes(true, true)).isFalse();
     }
+
+    // ---- shouldFollowTargetFreq ---------------------------------------------
+    // Same-frequency (TX/RX split) mode moves our TX offset onto the station we
+    // answer. "Hold TX freq" (WSJT-X Hold Tx Freq) must override that and keep us on
+    // our own offset. So we follow the target ONLY when split is on AND hold is off.
+
+    @Test
+    public void followTarget_splitOn_holdOff_follows() {
+        assertThat(FT8TransmitSignal.shouldFollowTargetFreq(
+                /*synFrequency*/ true, /*holdTxFreq*/ false)).isTrue();
+    }
+
+    @Test
+    public void followTarget_splitOn_holdOn_holds() {
+        // The reported request: keep my TX offset even with split on.
+        assertThat(FT8TransmitSignal.shouldFollowTargetFreq(true, true)).isFalse();
+    }
+
+    @Test
+    public void followTarget_splitOff_neverFollows() {
+        // Without split there's nothing to follow, hold flag irrelevant.
+        assertThat(FT8TransmitSignal.shouldFollowTargetFreq(false, false)).isFalse();
+        assertThat(FT8TransmitSignal.shouldFollowTargetFreq(false, true)).isFalse();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -342,9 +342,9 @@ public class FT8TransmitSignalTest {
     }
 
     // ---- shouldFollowTargetFreq ---------------------------------------------
-    // Same-frequency (TX/RX split) mode moves our TX offset onto the station we
-    // answer. "Hold TX freq" (WSJT-X Hold Tx Freq) must override that and keep us on
-    // our own offset. So we follow the target ONLY when split is on AND hold is off.
+    // TX=RX (synFrequency) mode moves our TX offset onto the station we answer.
+    // "Hold TX freq" (WSJT-X Hold Tx Freq) must override that and keep us on our own
+    // offset. So we follow the target ONLY when synFrequency is on AND hold is off.
 
     @Test
     public void followTarget_splitOn_holdOff_follows() {


### PR DESCRIPTION
## Problem

Tester feedback: *"transmission->TX/RX split option feeling invert. when I turn on it, I expect holding my freq and move RX freq only, but it move TX offset to QSO target."*

In same-frequency (TX/RX split, `synFrequency`) mode, `setTransmit()` moves your TX offset onto the frequency of the station you answer (`FT8TransmitSignal.java:328`). There was no way to keep your own TX offset.

## Change

New **`holdTxFreq`** setting (default **off**, persisted as `"holdTxFreq"`, with a toggle in **Transmission settings** right under TX/RX split). When on, your TX offset is held when answering a station instead of moving to theirs — the WSJT-X **"Hold Tx Freq"** behavior.

The follow now goes through **`shouldFollowTargetFreq(synFrequency, holdTxFreq)`** = `synFrequency && !holdTxFreq`, so:
- split off → never follows (unchanged),
- split on, hold off → follows the target (unchanged default),
- split on, hold on → **holds your TX offset** (new).

Default off keeps existing behavior identical until the operator opts in. Hound/DXpedition auto-QSY is untouched.

## Scope note

This is the minimal "add a setting to hold TX" the tester asked for. The broader waterfall-tap semantics rework they also mused about (*"change TX offset only whenever option activated or not"*) is intentionally **not** included here.

## Tests

- New `shouldFollowTargetFreq()` predicate + 3 unit tests in `FT8TransmitSignalTest`.
- `testDebugUnitTest` green; built and installed on the Pixel 8, launches cleanly.

Part of a series addressing tester feedback on the Android UI (the TX/RX split item).