### PR TITLE
Add a Light theme option in Settings (Appearance > Theme)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -20,7 +20,6 @@ import android.view.WindowManager
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.activity.compose.setContent
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
@@ -55,6 +54,8 @@ import com.k1af.ft8af.maidenhead.MaidenheadGrid
 import com.k1af.ft8af.ui.ToastMessage
 import radio.ks3ckc.ft8af.pota.PotaSessionManager
 import radio.ks3ckc.ft8af.theme.FT8AFTheme
+import radio.ks3ckc.ft8af.theme.applyTheme
+import radio.ks3ckc.ft8af.theme.loadTheme
 import radio.ks3ckc.ft8af.ui.components.ExitConfirmDialog
 import java.io.File
 import java.io.IOException
@@ -75,9 +76,11 @@ class ComposeMainActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Force night mode so the DayNight theme resolves to dark immediately,
-        // preventing any light-mode surface colors from flashing before Compose loads.
-        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+        // Apply the saved theme synchronously before setContent: swap the live
+        // Compose palette and set the matching night mode so neither the
+        // pre-Compose native window background nor the first Compose frame
+        // flashes the wrong shade. Defaults to dark when nothing is saved.
+        applyTheme(loadTheme(this))
 
         // Build permissions list
         val permissions = buildPermissionsList()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
@@ -1,33 +1,147 @@
 package radio.ks3ckc.ft8af.theme
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 
+// ---------------------------------------------------------------------------
+// Theme palette
+// ---------------------------------------------------------------------------
+//
+// The app's structural colors (surfaces, text, borders, accent/signal tints)
+// are theme-switchable. Rather than migrate the ~700 call sites that reference
+// the color names below, we back those names with a single snapshot-state
+// palette: the names stay identical and every read — in composables AND in
+// DrawScope draw lambdas — becomes reactive, because Compose tracks State reads
+// in both the composition and the draw phase. Flipping [activePalette] repaints
+// the whole UI in place with no activity recreate.
+//
+// The saturated semantic hues (Status*, Band*, Target*, PskSpot) are NOT part
+// of the palette: they're small markers/dots tuned to read on either
+// background, and keeping them as plain constants avoids stale static captures
+// (e.g. the band-color map in LogbookScreen).
+
+/** The switchable color set for one theme. */
+data class FT8AFPalette(
+    // Surfaces
+    val bgApp: Color,
+    val bgSurface: Color,
+    val bgSurface2: Color,
+    val bgSurface3: Color,
+    val bgElev: Color,
+    // Borders
+    val border: Color,
+    val borderStrong: Color,
+    val borderAmber: Color,
+    // Text
+    val textPrimary: Color,
+    val textMuted: Color,
+    val textFaint: Color,
+    val textDim: Color,
+    // Accent
+    val accent: Color,
+    val accentSoft: Color,
+    val accentGlow: Color,
+    // Signal
+    val signal: Color,
+    val signalSoft: Color,
+)
+
+/** The original dark theme — the app default. */
+val DarkPalette = FT8AFPalette(
+    bgApp = Color(0xFF07090F),
+    bgSurface = Color(0xFF0E131E),
+    bgSurface2 = Color(0xFF161C2B),
+    bgSurface3 = Color(0xFF1D2538),
+    bgElev = Color(0xFF232C43),
+
+    border = Color(0x1494A3B8),       // rgba(148,163,184, 0.08)
+    borderStrong = Color(0x2994A3B8), // rgba(148,163,184, 0.16)
+    borderAmber = Color(0x38FFAF5E),  // rgba(255,175,94, 0.22)
+
+    textPrimary = Color(0xFFE7ECF3),
+    textMuted = Color(0xFF8A96B1),
+    textFaint = Color(0xFF5A647E),
+    textDim = Color(0xFF3E4862),
+
+    accent = Color(0xFFFFAF5E),
+    accentSoft = Color(0x24FFAF5E),   // rgba(255,175,94, 0.14)
+    accentGlow = Color(0xFFFFD7A0),
+
+    signal = Color(0xFF5CD6E8),
+    signalSoft = Color(0x245CD6E8),   // rgba(92,214,232, 0.14)
+)
+
+/** Light theme — dark text on near-white surfaces; accent/signal darkened for
+ *  legibility against light backgrounds. */
+val LightPalette = FT8AFPalette(
+    bgApp = Color(0xFFF2F4F8),
+    bgSurface = Color(0xFFFFFFFF),
+    bgSurface2 = Color(0xFFEDF1F6),
+    bgSurface3 = Color(0xFFE2E8F0),
+    bgElev = Color(0xFFFFFFFF),
+
+    border = Color(0x1A0F172A),       // rgba(15,23,42, 0.10)
+    borderStrong = Color(0x330F172A), // rgba(15,23,42, 0.20)
+    borderAmber = Color(0x4DD97706),  // rgba(217,119,6, 0.30)
+
+    textPrimary = Color(0xFF0F172A),
+    textMuted = Color(0xFF475569),
+    textFaint = Color(0xFF94A3B8),
+    textDim = Color(0xFFCBD5E1),
+
+    accent = Color(0xFFD97706),       // amber-600 — readable as text on white
+    accentSoft = Color(0x24D97706),   // rgba(217,119,6, 0.14)
+    accentGlow = Color(0xFF9A5B0A),
+
+    signal = Color(0xFF0E7490),       // cyan-700
+    signalSoft = Color(0x240E7490),   // rgba(14,116,144, 0.14)
+)
+
+/**
+ * The currently-applied palette. Snapshot-backed so every color getter below is
+ * reactive in both the composition and draw phases — assigning a new palette
+ * repaints the UI instantly. Set at startup (before setContent) and on theme
+ * change; see [ThemePreference].
+ */
+var activePalette: FT8AFPalette by mutableStateOf(DarkPalette)
+
+// ---------------------------------------------------------------------------
+// Switchable colors — reactive getters over [activePalette].
+// Names are unchanged so existing call sites compile as-is.
+// ---------------------------------------------------------------------------
+
 // Surfaces
-val BgApp = Color(0xFF07090F)
-val BgSurface = Color(0xFF0E131E)
-val BgSurface2 = Color(0xFF161C2B)
-val BgSurface3 = Color(0xFF1D2538)
-val BgElev = Color(0xFF232C43)
+val BgApp: Color get() = activePalette.bgApp
+val BgSurface: Color get() = activePalette.bgSurface
+val BgSurface2: Color get() = activePalette.bgSurface2
+val BgSurface3: Color get() = activePalette.bgSurface3
+val BgElev: Color get() = activePalette.bgElev
 
 // Borders
-val Border = Color(0x1494A3B8)       // rgba(148,163,184, 0.08)
-val BorderStrong = Color(0x2994A3B8) // rgba(148,163,184, 0.16)
-val BorderAmber = Color(0x38FFAF5E)  // rgba(255,175,94, 0.22)
+val Border: Color get() = activePalette.border
+val BorderStrong: Color get() = activePalette.borderStrong
+val BorderAmber: Color get() = activePalette.borderAmber
 
 // Text
-val TextPrimary = Color(0xFFE7ECF3)
-val TextMuted = Color(0xFF8A96B1)
-val TextFaint = Color(0xFF5A647E)
-val TextDim = Color(0xFF3E4862)
+val TextPrimary: Color get() = activePalette.textPrimary
+val TextMuted: Color get() = activePalette.textMuted
+val TextFaint: Color get() = activePalette.textFaint
+val TextDim: Color get() = activePalette.textDim
 
 // Accent
-val Accent = Color(0xFFFFAF5E)
-val AccentSoft = Color(0x24FFAF5E)   // rgba(255,175,94, 0.14)
-val AccentGlow = Color(0xFFFFD7A0)
+val Accent: Color get() = activePalette.accent
+val AccentSoft: Color get() = activePalette.accentSoft
+val AccentGlow: Color get() = activePalette.accentGlow
 
 // Signal
-val Signal = Color(0xFF5CD6E8)
-val SignalSoft = Color(0x245CD6E8)   // rgba(92,214,232, 0.14)
+val Signal: Color get() = activePalette.signal
+val SignalSoft: Color get() = activePalette.signalSoft
+
+// ---------------------------------------------------------------------------
+// Theme-independent saturated hues (shared by every theme).
+// ---------------------------------------------------------------------------
 
 // Target — the station the operator is currently calling. Pink/magenta so it's
 // visually distinct from CQ (amber) and TO YOU (cyan); these often stack on a

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -17,7 +18,7 @@ import androidx.core.view.WindowCompat
  * tracks the snapshot read — switching themes rebuilds the scheme live.
  */
 private fun ft8afColorScheme(): ColorScheme {
-    val base = if (activePalette.bgApp.luminanceIsLight()) {
+    val base = if (activePalette.bgApp.isLight()) {
         lightColorScheme()
     } else {
         darkColorScheme()
@@ -61,9 +62,13 @@ private fun ft8afColorScheme(): ColorScheme {
     )
 }
 
-/** True when a color is light enough that dark foreground is appropriate. */
-private fun Color.luminanceIsLight(): Boolean =
-    (0.299f * red + 0.587f * green + 0.114f * blue) > 0.5f
+/**
+ * True when a color is light enough that dark foreground is appropriate. Uses
+ * Compose's [luminance] (WCAG relative luminance, with sRGB gamma decoding)
+ * rather than a raw RGB-weighted average, so near-mid backgrounds classify
+ * correctly.
+ */
+private fun Color.isLight(): Boolean = luminance() > 0.5f
 
 // Additional semantic colors not in Material3 scheme. Getters (not captured
 // vals) so they always reflect the active palette.
@@ -106,7 +111,7 @@ fun FT8AFTheme(content: @Composable () -> Unit) {
     // Dark bar icons (isAppearanceLight* = true) for light themes; light bar
     // icons for dark themes — so the bars stay legible against the app's
     // background when they're transiently revealed under edge-to-edge.
-    val lightBars = activePalette.bgApp.luminanceIsLight()
+    val lightBars = activePalette.bgApp.isLight()
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as? Activity)?.window ?: return@SideEffect

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/FT8AFTheme.kt
@@ -1,100 +1,122 @@
 package radio.ks3ckc.ft8af.theme
 
 import android.app.Activity
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-private val FT8AFDarkColorScheme = darkColorScheme(
-    primary = Accent,
-    onPrimary = BgApp,
-    primaryContainer = AccentSoft,
-    onPrimaryContainer = AccentGlow,
+/**
+ * Build the Material3 [ColorScheme] from the currently-active palette. Called
+ * inside [FT8AFTheme] (not a top-level val) so it re-reads [activePalette] and
+ * tracks the snapshot read — switching themes rebuilds the scheme live.
+ */
+private fun ft8afColorScheme(): ColorScheme {
+    val base = if (activePalette.bgApp.luminanceIsLight()) {
+        lightColorScheme()
+    } else {
+        darkColorScheme()
+    }
+    return base.copy(
+        primary = Accent,
+        onPrimary = BgApp,
+        primaryContainer = AccentSoft,
+        onPrimaryContainer = AccentGlow,
 
-    secondary = Signal,
-    onSecondary = BgApp,
-    secondaryContainer = SignalSoft,
-    onSecondaryContainer = Signal,
+        secondary = Signal,
+        onSecondary = BgApp,
+        secondaryContainer = SignalSoft,
+        onSecondaryContainer = Signal,
 
-    tertiary = StatusNew,
-    onTertiary = BgApp,
+        tertiary = StatusNew,
+        onTertiary = BgApp,
 
-    background = BgApp,
-    onBackground = TextPrimary,
+        background = BgApp,
+        onBackground = TextPrimary,
 
-    surface = BgSurface,
-    onSurface = TextPrimary,
-    surfaceVariant = BgSurface2,
-    onSurfaceVariant = TextMuted,
-    surfaceTint = Accent,
+        surface = BgSurface,
+        onSurface = TextPrimary,
+        surfaceVariant = BgSurface2,
+        onSurfaceVariant = TextMuted,
+        surfaceTint = Accent,
 
-    outline = Border,
-    outlineVariant = BorderStrong,
+        outline = Border,
+        outlineVariant = BorderStrong,
 
-    error = StatusBad,
-    onError = TextPrimary,
-    errorContainer = Color(0x24EF4444),
-    onErrorContainer = StatusBad,
+        error = StatusBad,
+        onError = TextPrimary,
+        errorContainer = Color(0x24EF4444),
+        onErrorContainer = StatusBad,
 
-    inverseSurface = TextPrimary,
-    inverseOnSurface = BgApp,
-    inversePrimary = Accent,
+        inverseSurface = TextPrimary,
+        inverseOnSurface = BgApp,
+        inversePrimary = Accent,
 
-    scrim = Color(0xCC000000),
-)
+        scrim = Color(0xCC000000),
+    )
+}
 
-// Additional semantic colors not in Material3 scheme
+/** True when a color is light enough that dark foreground is appropriate. */
+private fun Color.luminanceIsLight(): Boolean =
+    (0.299f * red + 0.587f * green + 0.114f * blue) > 0.5f
+
+// Additional semantic colors not in Material3 scheme. Getters (not captured
+// vals) so they always reflect the active palette.
 object FT8AFColors {
-    val bgApp = BgApp
-    val bgSurface = BgSurface
-    val bgSurface2 = BgSurface2
-    val bgSurface3 = BgSurface3
-    val bgElev = BgElev
+    val bgApp: Color get() = BgApp
+    val bgSurface: Color get() = BgSurface
+    val bgSurface2: Color get() = BgSurface2
+    val bgSurface3: Color get() = BgSurface3
+    val bgElev: Color get() = BgElev
 
-    val border = Border
-    val borderStrong = BorderStrong
-    val borderAmber = BorderAmber
+    val border: Color get() = Border
+    val borderStrong: Color get() = BorderStrong
+    val borderAmber: Color get() = BorderAmber
 
-    val textPrimary = TextPrimary
-    val textMuted = TextMuted
-    val textFaint = TextFaint
-    val textDim = TextDim
+    val textPrimary: Color get() = TextPrimary
+    val textMuted: Color get() = TextMuted
+    val textFaint: Color get() = TextFaint
+    val textDim: Color get() = TextDim
 
-    val accent = Accent
-    val accentSoft = AccentSoft
-    val accentGlow = AccentGlow
+    val accent: Color get() = Accent
+    val accentSoft: Color get() = AccentSoft
+    val accentGlow: Color get() = AccentGlow
 
-    val signal = Signal
-    val signalSoft = SignalSoft
+    val signal: Color get() = Signal
+    val signalSoft: Color get() = SignalSoft
 
-    val statusNew = StatusNew
-    val statusNeeded = StatusNeeded
-    val statusWorked = StatusWorked
-    val statusConfirmed = StatusConfirmed
-    val statusCq = StatusCq
-    val statusWarn = StatusWarn
-    val statusBad = StatusBad
+    val statusNew: Color get() = StatusNew
+    val statusNeeded: Color get() = StatusNeeded
+    val statusWorked: Color get() = StatusWorked
+    val statusConfirmed: Color get() = StatusConfirmed
+    val statusCq: Color get() = StatusCq
+    val statusWarn: Color get() = StatusWarn
+    val statusBad: Color get() = StatusBad
 }
 
 @Composable
 fun FT8AFTheme(content: @Composable () -> Unit) {
-    val colorScheme = FT8AFDarkColorScheme
+    val colorScheme = ft8afColorScheme()
     val view = LocalView.current
+    // Dark bar icons (isAppearanceLight* = true) for light themes; light bar
+    // icons for dark themes — so the bars stay legible against the app's
+    // background when they're transiently revealed under edge-to-edge.
+    val lightBars = activePalette.bgApp.luminanceIsLight()
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as? Activity)?.window ?: return@SideEffect
             // window.statusBarColor / navigationBarColor are deprecated and no-ops
             // under edge-to-edge on Android 15. The bars are transparent; we only
-            // force light (white) bar icons here (isAppearanceLight* = false) so
-            // they stay legible against the app's dark background when the bars
-            // are transiently revealed.
+            // set the bar-icon appearance here so they stay legible against the
+            // app's background when the bars are transiently revealed.
             WindowCompat.getInsetsController(window, view).apply {
-                isAppearanceLightStatusBars = false
-                isAppearanceLightNavigationBars = false
+                isAppearanceLightStatusBars = lightBars
+                isAppearanceLightNavigationBars = lightBars
             }
         }
     }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/ThemePreference.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/ThemePreference.kt
@@ -1,0 +1,83 @@
+package radio.ks3ckc.ft8af.theme
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatDelegate
+import com.k1af.ft8af.R
+
+/**
+ * A selectable app theme: its persisted id, the display-name resource shown in
+ * the picker, the palette it applies, and whether it is a light theme (used to
+ * pick night-mode + system-bar icon appearance).
+ *
+ * Adding a theme later is a single entry here plus its [FT8AFPalette]; the
+ * picker, persistence, and startup application all derive from this enum.
+ */
+enum class ThemeOption(
+    val id: String,
+    @StringRes val nameRes: Int,
+    val palette: FT8AFPalette,
+    val isLight: Boolean,
+) {
+    DARK("dark", R.string.theme_name_dark, DarkPalette, isLight = false),
+    LIGHT("light", R.string.theme_name_light, LightPalette, isLight = true),
+}
+
+/** The app default when nothing is saved yet. */
+val DEFAULT_THEME: ThemeOption = ThemeOption.DARK
+
+/** The [FT8AFPalette] for a theme (convenience over [ThemeOption.palette]). */
+fun paletteFor(option: ThemeOption): FT8AFPalette = option.palette
+
+/** Persisted id for a theme. */
+fun idOf(option: ThemeOption): String = option.id
+
+/**
+ * The theme for a persisted id, falling back to [DEFAULT_THEME] for unknown or
+ * missing values. Pure logic, unit-tested.
+ */
+fun parseThemeId(raw: String?): ThemeOption =
+    ThemeOption.entries.firstOrNull { it.id == raw } ?: DEFAULT_THEME
+
+/** The display-name resource for the given theme. Pure logic, unit-tested. */
+@StringRes
+fun currentThemeNameRes(option: ThemeOption): Int = option.nameRes
+
+// ---------------------------------------------------------------------------
+// Persistence + application
+// ---------------------------------------------------------------------------
+//
+// The theme is stored in a small SharedPreferences so it can be read
+// *synchronously* before setContent — the app's SQLite config (DatabaseOpr)
+// loads asynchronously and would let the wrong shade flash on cold start. This
+// mirrors how the framework stores the locale/night-mode outside the app DB.
+
+private const val PREFS_NAME = "ft8af_theme"
+private const val KEY_THEME = "theme"
+
+/** The saved theme, or [DEFAULT_THEME] if none. Safe to call before UI exists. */
+fun loadTheme(context: Context): ThemeOption {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    return parseThemeId(prefs.getString(KEY_THEME, null))
+}
+
+/** Persist the chosen theme. */
+fun saveTheme(context: Context, option: ThemeOption) {
+    context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        .edit()
+        .putString(KEY_THEME, option.id)
+        .apply()
+}
+
+/**
+ * Apply a theme everywhere it affects: swap the live [activePalette] (instant
+ * repaint of the whole Compose UI) and set the matching night mode so the
+ * pre-Compose native window background and any AppCompat surfaces match.
+ */
+fun applyTheme(option: ThemeOption) {
+    activePalette = option.palette
+    AppCompatDelegate.setDefaultNightMode(
+        if (option.isLight) AppCompatDelegate.MODE_NIGHT_NO
+        else AppCompatDelegate.MODE_NIGHT_YES,
+    )
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
@@ -11,11 +11,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.os.LocaleListCompat
 import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
+import radio.ks3ckc.ft8af.theme.ThemeOption
+import radio.ks3ckc.ft8af.theme.applyTheme
+import radio.ks3ckc.ft8af.theme.currentThemeNameRes
+import radio.ks3ckc.ft8af.theme.loadTheme
+import radio.ks3ckc.ft8af.theme.saveTheme
 import radio.ks3ckc.ft8af.ui.components.GlassCard
 import radio.ks3ckc.ft8af.ui.components.SettingsRow
 
@@ -78,14 +84,18 @@ fun AdvancedSettings(
     mainViewModel: MainViewModel,
     onBack: () -> Unit,
 ) {
+    val context = LocalContext.current
+
     var pttDelay by remember { mutableIntStateOf(GeneralVariables.pttDelay) }
     var txDelay by remember { mutableIntStateOf(GeneralVariables.transmitDelay) }
     var lateStartMs by remember { mutableIntStateOf(GeneralVariables.lateStartTolerance) }
+    var currentTheme by remember { mutableStateOf(loadTheme(context)) }
 
     var showPttDelay by remember { mutableStateOf(false) }
     var showTxDelay by remember { mutableStateOf(false) }
     var showLateStart by remember { mutableStateOf(false) }
     var showLanguagePicker by remember { mutableStateOf(false) }
+    var showThemePicker by remember { mutableStateOf(false) }
 
     val txDelayStr = stringResource(R.string.settings_milliseconds_format, txDelay)
     val pttDelayStr = stringResource(R.string.settings_milliseconds_format, pttDelay)
@@ -185,6 +195,31 @@ fun AdvancedSettings(
         )
     }
 
+    // -- Theme Picker --
+    // Selecting a theme applies it live (swaps the Compose palette + night mode,
+    // no activity recreate) and persists the choice. Built like the language
+    // picker so adding a future theme is one ThemeOption entry.
+    if (showThemePicker) {
+        val themes = ThemeOption.entries
+        val themeLabels = ArrayList<String>(themes.size)
+        for (theme in themes) {
+            themeLabels.add(stringResource(theme.nameRes))
+        }
+        ListPickerDialog(
+            title = stringResource(R.string.settings_theme),
+            items = themeLabels,
+            selectedIndex = themes.indexOf(currentTheme).coerceAtLeast(0),
+            onDismiss = { showThemePicker = false },
+            onSelect = { index ->
+                showThemePicker = false
+                val theme = themes[index]
+                currentTheme = theme
+                applyTheme(theme)
+                saveTheme(context, theme)
+            },
+        )
+    }
+
     SettingsDetailScaffold(
         title = stringResource(R.string.settings_cat_advanced),
         onBack = onBack,
@@ -219,6 +254,21 @@ fun AdvancedSettings(
                         onClick = { showLateStart = true },
                     )
                 }
+            }
+        }
+
+        // =====================================================================
+        // APPEARANCE
+        // =====================================================================
+        SettingsSection(title = stringResource(R.string.settings_section_appearance)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                SettingsRow(
+                    label = stringResource(R.string.settings_theme),
+                    description = stringResource(R.string.settings_theme_desc),
+                    value = stringResource(currentThemeNameRes(currentTheme)),
+                    showChevron = true,
+                    onClick = { showThemePicker = true },
+                )
             }
         }
 

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -377,6 +377,13 @@
     <string name="settings_section_advanced">ADVANCED</string>
     <string name="settings_section_about">ABOUT</string>
     <string name="settings_section_language">LANGUAGE</string>
+    <string name="settings_section_appearance">APPEARANCE</string>
+
+    <!-- ===== Settings: appearance / theme ===== -->
+    <string name="settings_theme">Theme</string>
+    <string name="settings_theme_desc">App color theme</string>
+    <string name="theme_name_dark">Dark</string>
+    <string name="theme_name_light">Light</string>
 
     <!-- ===== Settings: drill-down category labels ===== -->
     <string name="settings_cat_radio_audio">Radio &amp; Audio</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/theme/ThemePreferenceTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/theme/ThemePreferenceTest.kt
@@ -1,0 +1,73 @@
+package radio.ks3ckc.ft8af.theme
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import org.junit.Test
+
+/**
+ * Guards the pure logic behind the in-app Theme picker: id parsing/round-trip,
+ * the theme→palette mapping, and the display-name resolver. The Android-touching
+ * bits (SharedPreferences IO, applyTheme's night-mode call) are thin wrappers and
+ * are not covered here.
+ *
+ * No Robolectric: R.string.* are plain int constants and [FT8AFPalette] is a pure
+ * data class of packed Color values.
+ */
+class ThemePreferenceTest {
+
+    @Test
+    fun `default theme is dark`() {
+        assertThat(DEFAULT_THEME).isEqualTo(ThemeOption.DARK)
+    }
+
+    @Test
+    fun `parseThemeId resolves each known id`() {
+        assertThat(parseThemeId("dark")).isEqualTo(ThemeOption.DARK)
+        assertThat(parseThemeId("light")).isEqualTo(ThemeOption.LIGHT)
+    }
+
+    @Test
+    fun `parseThemeId falls back to default for unknown or missing ids`() {
+        assertThat(parseThemeId(null)).isEqualTo(DEFAULT_THEME)
+        assertThat(parseThemeId("")).isEqualTo(DEFAULT_THEME)
+        assertThat(parseThemeId("solarized")).isEqualTo(DEFAULT_THEME)
+    }
+
+    @Test
+    fun `idOf and parseThemeId round-trip for every theme`() {
+        for (option in ThemeOption.entries) {
+            assertThat(parseThemeId(idOf(option))).isEqualTo(option)
+        }
+    }
+
+    @Test
+    fun `theme ids are unique`() {
+        val ids = ThemeOption.entries.map { it.id }
+        assertThat(ids).containsNoDuplicates()
+    }
+
+    @Test
+    fun `paletteFor returns the theme's palette`() {
+        assertThat(paletteFor(ThemeOption.DARK)).isSameInstanceAs(DarkPalette)
+        assertThat(paletteFor(ThemeOption.LIGHT)).isSameInstanceAs(LightPalette)
+    }
+
+    @Test
+    fun `dark and light palettes actually differ`() {
+        assertThat(LightPalette.bgApp).isNotEqualTo(DarkPalette.bgApp)
+        assertThat(LightPalette.textPrimary).isNotEqualTo(DarkPalette.textPrimary)
+        assertThat(LightPalette.bgSurface).isNotEqualTo(DarkPalette.bgSurface)
+    }
+
+    @Test
+    fun `only light theme reports isLight`() {
+        assertThat(ThemeOption.LIGHT.isLight).isTrue()
+        assertThat(ThemeOption.DARK.isLight).isFalse()
+    }
+
+    @Test
+    fun `currentThemeNameRes maps each theme to its display name`() {
+        assertThat(currentThemeNameRes(ThemeOption.DARK)).isEqualTo(R.string.theme_name_dark)
+        assertThat(currentThemeNameRes(ThemeOption.LIGHT)).isEqualTo(R.string.theme_name_light)
+    }
+}


### PR DESCRIPTION
## What

Adds a selectable **Light theme** (dark stays the default) via a **Theme** list picker in a new **Appearance** section under Settings → Advanced. Built so more themes can be added later with a single enum entry.

## Why

The app was hard-locked to dark — a single `darkColorScheme` plus a forced `MODE_NIGHT_YES`, with ~700 color references pointing directly at hardcoded dark constants. There was no light palette and no way to switch.

## How

The key trick avoids rewriting ~700 call sites: back the existing color names in `theme/Color.kt` with a single `mutableStateOf` palette (`activePalette`). Compose tracks `State` reads in **both** the composition and the **draw** phase, so every existing color read — in composables *and* in `DrawScope` lambdas — becomes reactive automatically. Switching themes swaps the palette and repaints the whole UI **live, in place** (no activity recreate, no flicker).

Saturated semantic hues (`Status*`, `Band*`, `Target*`, `PskSpot`) stay theme-independent constants — they read fine on either background and this avoids stale static captures (e.g. the band-color map).

### Changes
- **`theme/Color.kt`** — `FT8AFPalette` data class, `DarkPalette`/`LightPalette`, `activePalette` snapshot state; switchable colors are now reactive getters (names unchanged).
- **`theme/FT8AFTheme.kt`** — build the Material `ColorScheme` from the active palette; drive system-bar icon appearance off palette luminance; `FT8AFColors` members become getters.
- **`theme/ThemePreference.kt`** *(new)* — `ThemeOption` enum, palette map, id parse/round-trip, **SharedPreferences** persistence (read synchronously before `setContent` to avoid a cold-start flash), and live `applyTheme()`.
- **`ComposeMainActivity`** — apply the saved theme before `setContent` instead of forcing `MODE_NIGHT_YES`.
- **`AdvancedSettings`** — Appearance section + Theme picker (mirrors the Language picker).
- **`strings_compose.xml`** — new appearance/theme strings (locale files fall back to default until translated).

## Tests
New `ThemePreferenceTest` (pure logic, no Robolectric): id parse/round-trip + unknown→default fallback, `paletteFor` mapping, dark≠light palette spot checks, `isLight` flags, and `currentThemeNameRes`. `gradlew testDebugUnitTest` passes; `assembleDebug` packages cleanly.

## Not done here
On-device visual verification: installing a local debug build over the CI-signed app requires an uninstall that **wipes the QSO log/config**, so I left the device check for the maintainer. Proposed Light hex values are a sensible starting point and may want on-device tuning (notably the amber accent / cyan signal contrast on white).

🤖 Generated with [Claude Code](https://claude.com/claude-code)