### PR TITLE
Decode all remaining FT8 contest/special message types

### DIFF
--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/message.c
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/message.c
@@ -10,6 +10,19 @@
 #define NTOKENS  ((uint32_t)2063592ul)
 #define MAXGRID4 ((uint16_t)32400ul)
 
+// 86 ARRL/RAC section codes, same order as WSJT-X packjt77.f90 csec / Java FT8Package.ARRL_SECTIONS
+static const char* ARRL_SECTIONS[86] = {
+    "AB","AK","AL","AR","AZ","BC","CO","CT","DE","EB",
+    "EMA","ENY","EPA","EWA","GA","GH","IA","ID","IL","IN",
+    "KS","KY","LA","LAX","NS","MB","MDC","ME","MI","MN",
+    "MO","MS","MT","NC","ND","NE","NFL","NH","NL","NLI",
+    "NM","NNJ","NNY","TER","NTX","NV","OH","OK","ONE","ONN",
+    "ONS","OR","ORG","PAC","PR","QC","RI","SB","SC","SCV",
+    "SD","SDG","SF","SFL","SJV","SK","SNJ","STX","SV","TN",
+    "UT","VA","VI","VT","WCF","WI","WMA","WNY","WPA","WTX",
+    "WV","WWA","WY","DX","PE","NB"
+};
+
 ////////////////////////////////////////////////////// Static function prototypes //////////////////////////////////////////////////////////////
 
 static bool trim_brackets(char* result, const char* original, int length);
@@ -91,6 +104,8 @@ ftx_message_type_t ftx_message_get_type(const ftx_message_t* msg)
             return FTX_MESSAGE_TYPE_ARRL_FD;
         case 5:
             return FTX_MESSAGE_TYPE_TELEMETRY;
+        case 6:
+            return FTX_MESSAGE_TYPE_CONTESTING;
         default:
             return FTX_MESSAGE_TYPE_UNKNOWN;
         }
@@ -297,7 +312,7 @@ ftx_message_rc_t ftx_message_decode(const ftx_message_t* msg, ftx_callsign_hash_
 {
     ftx_message_rc_t rc;
 
-    char buf[35]; // 13 + 13 + 6 (std/nonstd) / 14 (free text) / 19 (telemetry)
+    char buf[42]; // 14 (call_to) + 14 (call_de) + 14 (extra: FD exchange up to ~10 chars)
     char* field1 = buf;
     char* field2 = buf + 14;
     char* field3 = buf + 14 + 14;
@@ -325,6 +340,245 @@ ftx_message_rc_t ftx_message_decode(const ftx_message_t* msg, ftx_callsign_hash_
         field3 = NULL;
         rc = FTX_MESSAGE_RC_OK;
         break;
+    case FTX_MESSAGE_TYPE_ARRL_FD: {
+        uint8_t r_flag_val, num_tx_val;
+        char fd_class[2], fd_section[4];
+        rc = ftx_message_decode_fd(msg, hash_if, field1, field2, &r_flag_val, &num_tx_val, fd_class, fd_section);
+        if (rc == FTX_MESSAGE_RC_OK)
+        {
+            // Format field3 as the FD exchange text: "[R ]<numTx><class> <section>"
+            char* dst = field3;
+            if (r_flag_val)
+            {
+                dst = stpcpy(dst, "R ");
+            }
+            // num_tx is 1..16, no leading zeros
+            if (num_tx_val >= 10)
+            {
+                *dst++ = '0' + (num_tx_val / 10);
+            }
+            *dst++ = '0' + (num_tx_val % 10);
+            *dst++ = fd_class[0];
+            *dst++ = ' ';
+            dst = stpcpy(dst, fd_section);
+        }
+        break;
+    }
+    case FTX_MESSAGE_TYPE_DXPEDITION: {
+        uint16_t h10_val;
+        int8_t rpt_val;
+        char fox_call[14];
+        rc = ftx_message_decode_dxped(msg, hash_if, field1, field2, &h10_val, &rpt_val);
+        if (rc == FTX_MESSAGE_RC_OK)
+        {
+            // Format: "call_to RR73; call_de <fox_hash> report"
+            lookup_callsign(hash_if, FTX_CALLSIGN_HASH_10_BITS, h10_val, fox_call);
+            // field1 = acked call, field2 = invited call; format directly into message
+            message = append_string(message, field1);
+            message = append_string(message, " RR73; ");
+            message = append_string(message, field2);
+            message = append_string(message, " ");
+            message = append_string(message, fox_call);
+            message = append_string(message, " ");
+            char rpt_str[8];
+            if (rpt_val >= 0)
+            {
+                rpt_str[0] = '+';
+                int_to_dd(rpt_str + 1, rpt_val, 2, false);
+            }
+            else
+            {
+                int_to_dd(rpt_str, rpt_val, 2, true);
+            }
+            message = append_string(message, rpt_str);
+            return rc; // Already formatted, skip the generic field join below
+        }
+        break;
+    }
+    case FTX_MESSAGE_TYPE_EU_VHF: {
+        // EU VHF contest: i3=0, n3=2
+        // Bit layout (70+1 bits):
+        //   c28 (0-27)  p1 (28)  R1 (29)  r3 (30-32)  s12 (33-44)  g25 (45-69)  n3 (71-73)  i3 (74-76)
+
+        uint32_t c28 = ((uint32_t)msg->payload[0] << 20)
+                     | ((uint32_t)msg->payload[1] << 12)
+                     | ((uint32_t)msg->payload[2] << 4)
+                     | ((uint32_t)msg->payload[3] >> 4);
+
+        uint8_t p1 = (msg->payload[3] >> 3) & 0x01u;
+        uint8_t R1 = (msg->payload[3] >> 2) & 0x01u;
+        uint8_t r3 = ((msg->payload[3] & 0x03u) << 1) | ((msg->payload[4] >> 7) & 0x01u);
+
+        uint16_t s12 = ((uint16_t)(msg->payload[4] & 0x7Fu) << 5)
+                     | ((uint16_t)(msg->payload[5] >> 3) & 0x1Fu);
+
+        uint32_t g25 = ((uint32_t)(msg->payload[5] & 0x07u) << 22)
+                     | ((uint32_t)msg->payload[6] << 14)
+                     | ((uint32_t)msg->payload[7] << 6)
+                     | ((uint32_t)(msg->payload[8] >> 2) & 0x3Fu);
+
+        char eu_call[14];
+        eu_call[0] = '\0';
+        if (unpack28(c28, 0, 0, hash_if, eu_call) < 0)
+        {
+            rc = FTX_MESSAGE_RC_ERROR_CALLSIGN1;
+            break;
+        }
+
+        // Append /P if p1
+        if (p1)
+        {
+            strcat(eu_call, "/P");
+        }
+
+        // Report: 2-digit RST (52-59, from readability=5, strength=r3+2)
+        char rst_2[3];
+        rst_2[0] = '5';
+        rst_2[1] = '0' + (r3 + 2);
+        rst_2[2] = '\0';
+
+        // Grid6 from g25
+        char grid6[7];
+        uint32_t g = g25;
+        grid6[5] = 'A' + (char)(g % 24); g /= 24;
+        grid6[4] = 'A' + (char)(g % 24); g /= 24;
+        grid6[3] = '0' + (char)(g % 10); g /= 10;
+        grid6[2] = '0' + (char)(g % 10); g /= 10;
+        grid6[1] = 'A' + (char)(g % 18); g /= 18;
+        grid6[0] = 'A' + (char)(g);
+        grid6[6] = '\0';
+
+        // Format: "call[/P] [R ]rst serial grid6"
+        message = append_string(message, eu_call);
+        message = append_string(message, " ");
+        if (R1)
+        {
+            message = append_string(message, "R ");
+        }
+        message = append_string(message, rst_2);
+        char ser_str[8];
+        int_to_dd(ser_str, s12, 4, false);
+        message = append_string(message, ser_str);
+        message = append_string(message, " ");
+        message = append_string(message, grid6);
+        rc = FTX_MESSAGE_RC_OK;
+        return rc;
+    }
+    case FTX_MESSAGE_TYPE_CONTESTING: {
+        // Contesting (Fox combo): i3=0, n3=6
+        // Bit layout (71 bits):
+        //   c28a (0-27)  c28b (28-55)  g15 (56-70)  n3 (71-73)  i3 (74-76)
+
+        uint32_t c28a = ((uint32_t)msg->payload[0] << 20)
+                      | ((uint32_t)msg->payload[1] << 12)
+                      | ((uint32_t)msg->payload[2] << 4)
+                      | ((uint32_t)msg->payload[3] >> 4);
+
+        uint32_t c28b = ((uint32_t)(msg->payload[3] & 0x0Fu) << 24)
+                      | ((uint32_t)msg->payload[4] << 16)
+                      | ((uint32_t)msg->payload[5] << 8)
+                      | ((uint32_t)msg->payload[6]);
+
+        uint16_t g15 = ((uint16_t)msg->payload[7] << 7)
+                     | ((uint16_t)(msg->payload[8] >> 1) & 0x7Fu);
+
+        char cont_call_to[14], cont_call_de[14];
+        cont_call_to[0] = cont_call_de[0] = '\0';
+
+        if (unpack28(c28a, 0, 0, hash_if, cont_call_to) < 0)
+        {
+            rc = FTX_MESSAGE_RC_ERROR_CALLSIGN1;
+            break;
+        }
+        if (unpack28(c28b, 0, 0, hash_if, cont_call_de) < 0)
+        {
+            rc = FTX_MESSAGE_RC_ERROR_CALLSIGN2;
+            break;
+        }
+
+        // Unpack g15 as a 4-char grid via existing unpackgrid
+        char grid_extra[14];
+        grid_extra[0] = '\0';
+        unpackgrid(g15, 0, grid_extra);
+
+        // Format: "call_to RR73; CQ call_de grid"
+        message = append_string(message, cont_call_to);
+        message = append_string(message, " RR73; CQ ");
+        message = append_string(message, cont_call_de);
+        message = append_string(message, " ");
+        message = append_string(message, grid_extra);
+        rc = FTX_MESSAGE_RC_OK;
+        return rc;
+    }
+    case FTX_MESSAGE_TYPE_ARRL_RTTY: {
+        uint8_t tu_val = 0, r_flag_val = 0;
+        uint16_t rpt_val = 0;
+        char state_str[8] = {0};
+        bool is_serial_val = false;
+        rc = ftx_message_decode_rtty(msg, hash_if, field1, field2,
+                                     &tu_val, &r_flag_val, &rpt_val, state_str, &is_serial_val);
+        if (rc == FTX_MESSAGE_RC_OK)
+        {
+            // Format: "[TU; ]call_to call_de [R ]report state"
+            if (tu_val)
+            {
+                message = append_string(message, "TU; ");
+            }
+            message = append_string(message, field1);
+            message = append_string(message, " ");
+            message = append_string(message, field2);
+            message = append_string(message, " ");
+            if (r_flag_val)
+            {
+                message = append_string(message, "R ");
+            }
+            char rpt_str[8];
+            int_to_dd(rpt_str, rpt_val, 3, false);
+            message = append_string(message, rpt_str);
+            message = append_string(message, " ");
+            message = append_string(message, state_str);
+            return rc;
+        }
+        break;
+    }
+    case FTX_MESSAGE_TYPE_WWROF: {
+        uint8_t tu_val = 0, r_flag_val = 0;
+        int8_t rpt_val = 0;
+        char grid2[4] = {0};
+        rc = ftx_message_decode_wwrof(msg, hash_if, field1, field2,
+                                      &tu_val, &r_flag_val, &rpt_val, grid2);
+        if (rc == FTX_MESSAGE_RC_OK)
+        {
+            // Format: "[TU; ]call_to call_de [R]report grid2"
+            if (tu_val)
+            {
+                message = append_string(message, "TU; ");
+            }
+            message = append_string(message, field1);
+            message = append_string(message, " ");
+            message = append_string(message, field2);
+            message = append_string(message, " ");
+            if (r_flag_val)
+            {
+                *message++ = 'R';
+            }
+            char rpt_str[8];
+            if (rpt_val >= 0)
+            {
+                rpt_str[0] = '+';
+                int_to_dd(rpt_str + 1, rpt_val, 2, false);
+            }
+            else
+            {
+                int_to_dd(rpt_str, rpt_val, 2, true);
+            }
+            message = append_string(message, rpt_str);
+            message = append_string(message, " ");
+            message = append_string(message, grid2);
+            return rc;
+        }
+        break;
+    }
     default:
         // not handled yet
         field1 = NULL;
@@ -454,6 +708,285 @@ ftx_message_rc_t ftx_message_decode_nonstd(const ftx_message_t* msg, ftx_callsig
     strcpy(call_de, call_2);
 
     LOG(LOG_INFO, "Decoded non-standard (type %d) message [%s] [%s] [%s]\n", i3, call_to, call_de, extra);
+    return FTX_MESSAGE_RC_OK;
+}
+
+ftx_message_rc_t ftx_message_decode_fd(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                       char* call_to, char* call_de,
+                                       uint8_t* r_flag, uint8_t* num_tx,
+                                       char* fd_class, char* section)
+{
+    // ARRL Field Day: i3=0, n3=3 or 4
+    // Bit layout (77 bits):
+    //   n28a (0-27)  n28b (28-55)  R1 (56)  n4 (57-60)  k3 (61-63)  S7 (64-70)  n3 (71-73)  i3 (74-76)
+
+    // Extract n28a (bits 0-27) — same as call_to in standard messages
+    uint32_t n28a = ((uint32_t)msg->payload[0] << 20)
+                  | ((uint32_t)msg->payload[1] << 12)
+                  | ((uint32_t)msg->payload[2] << 4)
+                  | ((uint32_t)msg->payload[3] >> 4);
+
+    // Extract n28b (bits 28-55)
+    uint32_t n28b = ((uint32_t)(msg->payload[3] & 0x0Fu) << 24)
+                  | ((uint32_t)msg->payload[4] << 16)
+                  | ((uint32_t)msg->payload[5] << 8)
+                  | ((uint32_t)msg->payload[6]);
+
+    // R1 (bit 56) = byte 7, bit 7
+    uint8_t R1 = (msg->payload[7] >> 7) & 0x01u;
+
+    // n4 (bits 57-60) = byte 7, bits [6:3]
+    uint8_t n4 = (msg->payload[7] >> 3) & 0x0Fu;
+
+    // k3 (bits 61-63) = byte 7, bits [2:0]
+    uint8_t k3 = msg->payload[7] & 0x07u;
+
+    // S7 (bits 64-70) = byte 8, bits [7:1]
+    uint8_t S7 = (msg->payload[8] >> 1) & 0x7Fu;
+
+    LOG(LOG_DEBUG, "decode_fd() n28a=%u n28b=%u R1=%d n4=%d k3=%d S7=%d\n",
+        n28a, n28b, R1, n4, k3, S7);
+
+    call_to[0] = call_de[0] = '\0';
+
+    // Unpack both callsigns (ip=0, i3=0 — FD callsigns have no /R /P suffix)
+    if (unpack28(n28a, 0, 0, hash_if, call_to) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN1;
+    }
+    if (unpack28(n28b, 0, 0, hash_if, call_de) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN2;
+    }
+
+    *r_flag = R1;
+    *num_tx = n4 + 1; // 0-15 → 1-16
+
+    // k3 → class letter: 0=A, 1=B, ... 5=F
+    if (k3 <= 5)
+    {
+        fd_class[0] = 'A' + k3;
+    }
+    else
+    {
+        fd_class[0] = '?';
+    }
+    fd_class[1] = '\0';
+
+    // S7 → section string (table lookup, bounds-check)
+    if (S7 < 86)
+    {
+        strcpy(section, ARRL_SECTIONS[S7]);
+    }
+    else
+    {
+        strcpy(section, "???");
+    }
+
+    LOG(LOG_INFO, "Decoded Field Day message [%s] [%s] R%d %d%s %s\n",
+        call_to, call_de, R1, *num_tx, fd_class, section);
+    return FTX_MESSAGE_RC_OK;
+}
+
+// 64 RTTY state/province codes, same order as WSJT-X packjt77.f90 cqstate
+static const char* RTTY_STATES[64] = {
+    "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA",
+    "HI","ID","IL","IN","IA","KS","KY","LA","ME","MD",
+    "MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+    "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC",
+    "SD","TN","TX","UT","VT","VA","WA","WV","WI","WY",
+    "DC","AB","BC","MB","NB","NL","NS","NT","NU","ON",
+    "PE","QC","SK","YT"
+};
+
+ftx_message_rc_t ftx_message_decode_dxped(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                          char* call_to, char* call_de,
+                                          uint16_t* h10, int8_t* report)
+{
+    // DXpedition: i3=0, n3=1
+    // Bit layout (71 bits payload):
+    //   c28a (0-27)  c28b (28-55)  h10 (56-65)  r5 (66-70)  n3 (71-73)  i3 (74-76)
+
+    // Extract c28a (bits 0-27)
+    uint32_t c28a = ((uint32_t)msg->payload[0] << 20)
+                  | ((uint32_t)msg->payload[1] << 12)
+                  | ((uint32_t)msg->payload[2] << 4)
+                  | ((uint32_t)msg->payload[3] >> 4);
+
+    // Extract c28b (bits 28-55)
+    uint32_t c28b = ((uint32_t)(msg->payload[3] & 0x0Fu) << 24)
+                  | ((uint32_t)msg->payload[4] << 16)
+                  | ((uint32_t)msg->payload[5] << 8)
+                  | ((uint32_t)msg->payload[6]);
+
+    // h10 (bits 56-65) = byte 7 bits [7:0] (8 bits) + byte 8 bits [7:6] (2 bits)
+    uint16_t h10_val = ((uint16_t)msg->payload[7] << 2)
+                     | ((uint16_t)(msg->payload[8] >> 6) & 0x03u);
+
+    // r5 (bits 66-70) = byte 8 bits [5:1]
+    uint8_t r5 = (msg->payload[8] >> 1) & 0x1Fu;
+
+    LOG(LOG_DEBUG, "decode_dxped() c28a=%u c28b=%u h10=%u r5=%u\n", c28a, c28b, h10_val, r5);
+
+    call_to[0] = call_de[0] = '\0';
+
+    // Unpack both callsigns (ip=0, i3=0 — no /R /P suffix)
+    if (unpack28(c28a, 0, 0, hash_if, call_to) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN1;
+    }
+    if (unpack28(c28b, 0, 0, hash_if, call_de) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN2;
+    }
+
+    *h10 = h10_val;
+    *report = (int8_t)(r5 * 2) - 30;  // even values -30..+30 dB
+
+    LOG(LOG_INFO, "Decoded DXpedition message [%s] [%s] h10=%u report=%d\n",
+        call_to, call_de, h10_val, *report);
+    return FTX_MESSAGE_RC_OK;
+}
+
+ftx_message_rc_t ftx_message_decode_rtty(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                         char* call_to, char* call_de,
+                                         uint8_t* tu_flag, uint8_t* r_flag,
+                                         uint16_t* report, char* state_or_serial, bool* is_serial)
+{
+    // ARRL RTTY Roundup: i3=3
+    // Bit layout (74 bits):
+    //   t1 (0)  c28a (1-28)  c28b (29-56)  R1 (57)  r3 (58-60)  s13 (61-73)  i3 (74-76)
+
+    // t1 (bit 0) = byte 0 bit 7
+    uint8_t t1 = (msg->payload[0] >> 7) & 0x01u;
+
+    // c28a (bits 1-28)
+    uint32_t c28a = ((uint32_t)(msg->payload[0] & 0x7Fu) << 21)
+                  | ((uint32_t)msg->payload[1] << 13)
+                  | ((uint32_t)msg->payload[2] << 5)
+                  | ((uint32_t)msg->payload[3] >> 3);
+
+    // c28b (bits 29-56)
+    uint32_t c28b = ((uint32_t)(msg->payload[3] & 0x07u) << 25)
+                  | ((uint32_t)msg->payload[4] << 17)
+                  | ((uint32_t)msg->payload[5] << 9)
+                  | ((uint32_t)msg->payload[6] << 1)
+                  | ((uint32_t)msg->payload[7] >> 7);
+
+    // R1 (bit 57) = byte 7 bit 6
+    uint8_t R1 = (msg->payload[7] >> 6) & 0x01u;
+
+    // r3 (bits 58-60) = byte 7 bits [5:3]
+    uint8_t r3 = (msg->payload[7] >> 3) & 0x07u;
+
+    // s13 (bits 61-73) = byte 7 bits [2:0] (3 bits) + byte 8 (8 bits) + byte 9 bits [7:6] (2 bits)
+    uint16_t s13 = ((uint16_t)(msg->payload[7] & 0x07u) << 10)
+                 | ((uint16_t)msg->payload[8] << 2)
+                 | ((uint16_t)(msg->payload[9] >> 6) & 0x03u);
+
+    LOG(LOG_DEBUG, "decode_rtty() t1=%u c28a=%u c28b=%u R1=%u r3=%u s13=%u\n",
+        t1, c28a, c28b, R1, r3, s13);
+
+    call_to[0] = call_de[0] = '\0';
+
+    // Unpack both callsigns (ip=0, i3=0 — no /R /P suffix for RTTY)
+    if (unpack28(c28a, 0, 0, hash_if, call_to) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN1;
+    }
+    if (unpack28(c28b, 0, 0, hash_if, call_de) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN2;
+    }
+
+    *tu_flag = t1;
+    *r_flag = R1;
+    *report = r3 * 10 + 529;  // RST 529, 539, ..., 599
+
+    // s13: 1-8000 = serial number, 8001-8064 = state index
+    if (s13 >= 1 && s13 <= 8000)
+    {
+        *is_serial = true;
+        int_to_dd(state_or_serial, s13, 4, false);
+    }
+    else if (s13 >= 8001 && s13 <= 8064)
+    {
+        *is_serial = false;
+        strcpy(state_or_serial, RTTY_STATES[s13 - 8001]);
+    }
+    else
+    {
+        *is_serial = false;
+        state_or_serial[0] = '\0';
+    }
+
+    LOG(LOG_INFO, "Decoded RTTY message [%s] [%s] TU=%u R=%u report=%u %s\n",
+        call_to, call_de, t1, R1, *report, state_or_serial);
+    return FTX_MESSAGE_RC_OK;
+}
+
+ftx_message_rc_t ftx_message_decode_wwrof(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                          char* call_to, char* call_de,
+                                          uint8_t* tu_flag, uint8_t* r_flag,
+                                          int8_t* report, char* grid2)
+{
+    // WWROF contest: i3=5
+    // Bit layout (74 bits):
+    //   t1 (0)  c28a (1-28)  c28b (29-56)  R1 (57)  r7 (58-64)  s9 (65-73)  i3 (74-76)
+
+    // t1 (bit 0) = byte 0 bit 7
+    uint8_t t1 = (msg->payload[0] >> 7) & 0x01u;
+
+    // c28a (bits 1-28)
+    uint32_t c28a = ((uint32_t)(msg->payload[0] & 0x7Fu) << 21)
+                  | ((uint32_t)msg->payload[1] << 13)
+                  | ((uint32_t)msg->payload[2] << 5)
+                  | ((uint32_t)msg->payload[3] >> 3);
+
+    // c28b (bits 29-56)
+    uint32_t c28b = ((uint32_t)(msg->payload[3] & 0x07u) << 25)
+                  | ((uint32_t)msg->payload[4] << 17)
+                  | ((uint32_t)msg->payload[5] << 9)
+                  | ((uint32_t)msg->payload[6] << 1)
+                  | ((uint32_t)msg->payload[7] >> 7);
+
+    // R1 (bit 57) = byte 7 bit 6
+    uint8_t R1 = (msg->payload[7] >> 6) & 0x01u;
+
+    // r7 (bits 58-64) = byte 7 bits [5:0] (6 bits) + byte 8 bit 7 (1 bit)
+    uint8_t r7 = ((msg->payload[7] & 0x3Fu) << 1)
+               | ((msg->payload[8] >> 7) & 0x01u);
+
+    // s9 (bits 65-73) = byte 8 bits [6:0] (7 bits) + byte 9 bits [7:6] (2 bits)
+    uint16_t s9 = ((uint16_t)(msg->payload[8] & 0x7Fu) << 2)
+                | ((uint16_t)(msg->payload[9] >> 6) & 0x03u);
+
+    LOG(LOG_DEBUG, "decode_wwrof() t1=%u c28a=%u c28b=%u R1=%u r7=%u s9=%u\n",
+        t1, c28a, c28b, R1, r7, s9);
+
+    call_to[0] = call_de[0] = '\0';
+
+    // Unpack both callsigns (ip=0, i3=0 — no /R /P suffix)
+    if (unpack28(c28a, 0, 0, hash_if, call_to) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN1;
+    }
+    if (unpack28(c28b, 0, 0, hash_if, call_de) < 0)
+    {
+        return FTX_MESSAGE_RC_ERROR_CALLSIGN2;
+    }
+
+    *tu_flag = t1;
+    *r_flag = R1;
+    *report = (int8_t)r7 - 35;  // signed dB, -35..+35 (typically -30..+30)
+
+    // Grid2 from s9: AA..RR
+    grid2[0] = 'A' + (char)(s9 / 18);
+    grid2[1] = 'A' + (char)(s9 % 18);
+    grid2[2] = '\0';
+
+    LOG(LOG_INFO, "Decoded WWROF message [%s] [%s] TU=%u R=%u report=%d grid=%s\n",
+        call_to, call_de, t1, R1, *report, grid2);
     return FTX_MESSAGE_RC_OK;
 }
 

--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/message.h
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/message.h
@@ -109,6 +109,52 @@ void ftx_message_encode_telemetry(const uint8_t* telemetry);
 ftx_message_rc_t ftx_message_decode(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* message);
 ftx_message_rc_t ftx_message_decode_std(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra);
 ftx_message_rc_t ftx_message_decode_nonstd(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra);
+
+/// Decode an ARRL Field Day message (i3=0, n3=3 or 4).
+/// @param[out] call_to   Destination callsign (at least 14 bytes)
+/// @param[out] call_de   Source callsign (at least 14 bytes)
+/// @param[out] r_flag    Roger flag (0 or 1)
+/// @param[out] num_tx    Number of transmitters (1..16)
+/// @param[out] fd_class  FD class letter as string, e.g. "A" (at least 2 bytes)
+/// @param[out] section   ARRL/RAC section string, e.g. "EMA" (at least 4 bytes)
+ftx_message_rc_t ftx_message_decode_fd(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                       char* call_to, char* call_de,
+                                       uint8_t* r_flag, uint8_t* num_tx,
+                                       char* fd_class, char* section);
+/// Decode a DXpedition message (i3=0, n3=1).
+/// @param[out] call_to   Acked callsign (at least 14 bytes)
+/// @param[out] call_de   Invited callsign (at least 14 bytes)
+/// @param[out] h10       10-bit hash of the fox callsign
+/// @param[out] report    Signal report (even values -30..+30 dB)
+ftx_message_rc_t ftx_message_decode_dxped(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                          char* call_to, char* call_de,
+                                          uint16_t* h10, int8_t* report);
+
+/// Decode an ARRL RTTY Roundup message (i3=3).
+/// @param[out] call_to       Destination callsign (at least 14 bytes)
+/// @param[out] call_de       Source callsign (at least 14 bytes)
+/// @param[out] tu_flag       TU flag (0 or 1)
+/// @param[out] r_flag        Roger flag (0 or 1)
+/// @param[out] report        RST report (529-599)
+/// @param[out] state_or_serial  State/province string or serial number as string (at least 8 bytes)
+/// @param[out] is_serial     True if state_or_serial is a serial number, false if state/province
+ftx_message_rc_t ftx_message_decode_rtty(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                         char* call_to, char* call_de,
+                                         uint8_t* tu_flag, uint8_t* r_flag,
+                                         uint16_t* report, char* state_or_serial, bool* is_serial);
+
+/// Decode a WWROF contest message (i3=5).
+/// @param[out] call_to   Destination callsign (at least 14 bytes)
+/// @param[out] call_de   Source callsign (at least 14 bytes)
+/// @param[out] tu_flag   TU flag (0 or 1)
+/// @param[out] r_flag    Roger flag (0 or 1)
+/// @param[out] report    Signal report (-35..+35 dB, but typically -30..+30)
+/// @param[out] grid2     Two-character grid prefix, e.g. "FN" (at least 3 bytes)
+ftx_message_rc_t ftx_message_decode_wwrof(const ftx_message_t* msg, const ftx_callsign_hash_interface_t* hash_if,
+                                          char* call_to, char* call_de,
+                                          uint8_t* tu_flag, uint8_t* r_flag,
+                                          int8_t* report, char* grid2);
+
 void ftx_message_decode_free(const ftx_message_t* msg, char* text);
 void ftx_message_decode_telemetry_hex(const ftx_message_t* msg, char* telemetry_hex);
 void ftx_message_decode_telemetry(const ftx_message_t* msg, uint8_t* telemetry);

--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/unpack.c
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/unpack.c
@@ -270,6 +270,457 @@ static int unpack_telemetry(const uint8_t* a71, char* telemetry)
     return 0;
 }
 
+// 86 ARRL/RAC section codes, same order as WSJT-X packjt77.f90 csec
+static const char* ARRL_SECTIONS_UNPACK[86] = {
+    "AB","AK","AL","AR","AZ","BC","CO","CT","DE","EB",
+    "EMA","ENY","EPA","EWA","GA","GH","IA","ID","IL","IN",
+    "KS","KY","LA","LAX","NS","MB","MDC","ME","MI","MN",
+    "MO","MS","MT","NC","ND","NE","NFL","NH","NL","NLI",
+    "NM","NNJ","NNY","TER","NTX","NV","OH","OK","ONE","ONN",
+    "ONS","OR","ORG","PAC","PR","QC","RI","SB","SC","SCV",
+    "SD","SDG","SF","SFL","SJV","SK","SNJ","STX","SV","TN",
+    "UT","VA","VI","VT","WCF","WI","WMA","WNY","WPA","WTX",
+    "WV","WWA","WY","DX","PE","NB"
+};
+
+// ARRL Field Day: i3=0, n3=3 or 4
+static int unpack_fd(const uint8_t* a77, char* call_to, char* call_de, char* extra, const unpack_hash_interface_t* hash_if)
+{
+    // Bit layout (77 bits):
+    //   n28a (0-27)  n28b (28-55)  R1 (56)  n4 (57-60)  k3 (61-63)  S7 (64-70)  n3 (71-73)  i3 (74-76)
+
+    // Extract n28a (bits 0-27)
+    uint32_t n28a = ((uint32_t)a77[0] << 20)
+                  | ((uint32_t)a77[1] << 12)
+                  | ((uint32_t)a77[2] << 4)
+                  | ((uint32_t)a77[3] >> 4);
+
+    // Extract n28b (bits 28-55)
+    uint32_t n28b = ((uint32_t)(a77[3] & 0x0F) << 24)
+                  | ((uint32_t)a77[4] << 16)
+                  | ((uint32_t)a77[5] << 8)
+                  | ((uint32_t)a77[6]);
+
+    // R1 (bit 56) = byte 7, bit 7
+    uint8_t R1 = (a77[7] >> 7) & 0x01;
+
+    // n4 (bits 57-60) = byte 7, bits [6:3]
+    uint8_t n4 = (a77[7] >> 3) & 0x0F;
+
+    // k3 (bits 61-63) = byte 7, bits [2:0]
+    uint8_t k3 = a77[7] & 0x07;
+
+    // S7 (bits 64-70) = byte 8, bits [7:1]
+    uint8_t S7 = (a77[8] >> 1) & 0x7F;
+
+    // Unpack both callsigns (ip=0, i3=0 — FD callsigns have no /R /P suffix)
+    if (unpack_callsign(n28a, 0, 0, call_to, hash_if) < 0)
+    {
+        return -1;
+    }
+    if (unpack_callsign(n28b, 0, 0, call_de, hash_if) < 0)
+    {
+        return -2;
+    }
+
+    // Save callsigns to hash table
+    if (hash_if != NULL)
+    {
+        if (call_to[0] != '<' && strlen(call_to) >= 4)
+            hash_if->save_hash(call_to);
+        if (call_de[0] != '<' && strlen(call_de) >= 4)
+            hash_if->save_hash(call_de);
+    }
+
+    // Format extra as the FD exchange: "[R ]<numTx><class> <section>"
+    char* dst = extra;
+    if (R1)
+    {
+        dst = stpcpy(dst, "R ");
+    }
+
+    uint8_t num_tx = n4 + 1; // 0-15 → 1-16
+    if (num_tx >= 10)
+    {
+        *dst++ = '0' + (num_tx / 10);
+    }
+    *dst++ = '0' + (num_tx % 10);
+
+    // k3 → class letter: 0=A, 1=B, ... 5=F
+    *dst++ = (k3 <= 5) ? ('A' + k3) : '?';
+
+    *dst++ = ' ';
+
+    // S7 → section string
+    if (S7 < 86)
+    {
+        dst = stpcpy(dst, ARRL_SECTIONS_UNPACK[S7]);
+    }
+    else
+    {
+        dst = stpcpy(dst, "???");
+    }
+
+    return 0;
+}
+
+// 64 RTTY state/province codes, same order as WSJT-X packjt77.f90 cqstate
+static const char* RTTY_STATES_UNPACK[64] = {
+    "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA",
+    "HI","ID","IL","IN","IA","KS","KY","LA","ME","MD",
+    "MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+    "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC",
+    "SD","TN","TX","UT","VT","VA","WA","WV","WI","WY",
+    "DC","AB","BC","MB","NB","NL","NS","NT","NU","ON",
+    "PE","QC","SK","YT"
+};
+
+// DXpedition: i3=0, n3=1
+static int unpack_dxped(const uint8_t* a77, char* call_to, char* call_de, char* extra, const unpack_hash_interface_t* hash_if)
+{
+    // c28a (0-27)  c28b (28-55)  h10 (56-65)  r5 (66-70)
+    uint32_t c28a = ((uint32_t)a77[0] << 20)
+                  | ((uint32_t)a77[1] << 12)
+                  | ((uint32_t)a77[2] << 4)
+                  | ((uint32_t)a77[3] >> 4);
+
+    uint32_t c28b = ((uint32_t)(a77[3] & 0x0F) << 24)
+                  | ((uint32_t)a77[4] << 16)
+                  | ((uint32_t)a77[5] << 8)
+                  | ((uint32_t)a77[6]);
+
+    uint16_t h10 = ((uint16_t)a77[7] << 2)
+                 | ((uint16_t)(a77[8] >> 6) & 0x03);
+
+    uint8_t r5 = (a77[8] >> 1) & 0x1F;
+
+    if (unpack_callsign(c28a, 0, 0, call_to, hash_if) < 0)
+        return -1;
+    if (unpack_callsign(c28b, 0, 0, call_de, hash_if) < 0)
+        return -2;
+
+    if (hash_if != NULL)
+    {
+        if (call_to[0] != '<' && strlen(call_to) >= 4)
+            hash_if->save_hash(call_to);
+        if (call_de[0] != '<' && strlen(call_de) >= 4)
+            hash_if->save_hash(call_de);
+    }
+
+    // Look up fox call from 10-bit hash
+    char fox_call[14];
+    if (hash_if != NULL && hash_if->hash10 != NULL)
+    {
+        hash_if->hash10(h10, fox_call);
+    }
+    else
+    {
+        strcpy(fox_call, "<...>");
+    }
+
+    int8_t report = (int8_t)(r5 * 2) - 30;
+
+    // Format extra as: "RR73; call_de fox_call report"
+    // But since call_to/call_de are used by the caller, put the combo message in extra
+    // Format: extra = "RR73; <call_de> <fox> <report>" — but the caller joins as "call_to extra"
+    // Actually for DXpedition, the full message is "call_to RR73; call_de fox_hash report"
+    // We put everything after call_to into extra, and leave call_de empty for special handling
+    char* dst = extra;
+    dst = stpcpy(dst, "RR73; ");
+    dst = stpcpy(dst, call_de);
+    *dst++ = ' ';
+    dst = stpcpy(dst, fox_call);
+    *dst++ = ' ';
+    if (report >= 0)
+    {
+        *dst++ = '+';
+        int_to_dd(dst, report, 2, false);
+    }
+    else
+    {
+        int_to_dd(dst, report, 2, true);
+    }
+    // Clear call_de so the caller formats as "call_to extra"
+    call_de[0] = '\0';
+
+    return 0;
+}
+
+// EU VHF contest: i3=0, n3=2
+static int unpack_eu_vhf(const uint8_t* a77, char* call_to, char* call_de, char* extra, const unpack_hash_interface_t* hash_if)
+{
+    // c28 (0-27)  p1 (28)  R1 (29)  r3 (30-32)  s12 (33-44)  g25 (45-69)
+    uint32_t c28 = ((uint32_t)a77[0] << 20)
+                 | ((uint32_t)a77[1] << 12)
+                 | ((uint32_t)a77[2] << 4)
+                 | ((uint32_t)a77[3] >> 4);
+
+    uint8_t p1 = (a77[3] >> 3) & 0x01;
+    uint8_t R1 = (a77[3] >> 2) & 0x01;
+    uint8_t r3 = ((a77[3] & 0x03) << 1) | ((a77[4] >> 7) & 0x01);
+
+    uint16_t s12 = ((uint16_t)(a77[4] & 0x7F) << 5)
+                 | ((uint16_t)(a77[5] >> 3) & 0x1F);
+
+    uint32_t g25 = ((uint32_t)(a77[5] & 0x07) << 22)
+                 | ((uint32_t)a77[6] << 14)
+                 | ((uint32_t)a77[7] << 6)
+                 | ((uint32_t)(a77[8] >> 2) & 0x3F);
+
+    if (unpack_callsign(c28, 0, 0, call_to, hash_if) < 0)
+        return -1;
+
+    if (hash_if != NULL && call_to[0] != '<' && strlen(call_to) >= 4)
+        hash_if->save_hash(call_to);
+
+    if (p1)
+        strcat(call_to, "/P");
+
+    // No second callsign in EU VHF 0.2 format
+    call_de[0] = '\0';
+
+    // Report: 2-digit RST (52-59, from readability=5, strength=r3+2)
+    char rst_2[3];
+    rst_2[0] = '5';
+    rst_2[1] = '0' + (r3 + 2);
+    rst_2[2] = '\0';
+
+    // Grid6 from g25
+    char grid6[7];
+    uint32_t g = g25;
+    grid6[5] = 'A' + (char)(g % 24); g /= 24;
+    grid6[4] = 'A' + (char)(g % 24); g /= 24;
+    grid6[3] = '0' + (char)(g % 10); g /= 10;
+    grid6[2] = '0' + (char)(g % 10); g /= 10;
+    grid6[1] = 'A' + (char)(g % 18); g /= 18;
+    grid6[0] = 'A' + (char)(g);
+    grid6[6] = '\0';
+
+    // Format extra: "[R ]rst_serial grid6"
+    char* dst = extra;
+    if (R1)
+        dst = stpcpy(dst, "R ");
+
+    dst = stpcpy(dst, rst_2);
+    int_to_dd(dst, s12, 4, false);
+    dst += strlen(dst);
+    *dst++ = ' ';
+    dst = stpcpy(dst, grid6);
+
+    return 0;
+}
+
+// Contesting (Fox combo): i3=0, n3=6
+static int unpack_contesting(const uint8_t* a77, char* call_to, char* call_de, char* extra, const unpack_hash_interface_t* hash_if)
+{
+    // c28a (0-27)  c28b (28-55)  g15 (56-70)
+    uint32_t c28a = ((uint32_t)a77[0] << 20)
+                  | ((uint32_t)a77[1] << 12)
+                  | ((uint32_t)a77[2] << 4)
+                  | ((uint32_t)a77[3] >> 4);
+
+    uint32_t c28b = ((uint32_t)(a77[3] & 0x0F) << 24)
+                  | ((uint32_t)a77[4] << 16)
+                  | ((uint32_t)a77[5] << 8)
+                  | ((uint32_t)a77[6]);
+
+    uint16_t g15 = ((uint16_t)a77[7] << 7)
+                 | ((uint16_t)(a77[8] >> 1) & 0x7F);
+
+    char cont_call1[14], cont_call2[14];
+    if (unpack_callsign(c28a, 0, 0, cont_call1, hash_if) < 0)
+        return -1;
+    if (unpack_callsign(c28b, 0, 0, cont_call2, hash_if) < 0)
+        return -2;
+
+    if (hash_if != NULL)
+    {
+        if (cont_call1[0] != '<' && strlen(cont_call1) >= 4)
+            hash_if->save_hash(cont_call1);
+        if (cont_call2[0] != '<' && strlen(cont_call2) >= 4)
+            hash_if->save_hash(cont_call2);
+    }
+
+    // Unpack g15 as grid4
+    char grid4[8];
+    grid4[0] = '\0';
+    if (g15 <= MAXGRID4)
+    {
+        uint16_t n = g15;
+        grid4[3] = '0' + (n % 10); n /= 10;
+        grid4[2] = '0' + (n % 10); n /= 10;
+        grid4[1] = 'A' + (n % 18); n /= 18;
+        grid4[0] = 'A' + (n % 18);
+        grid4[4] = '\0';
+    }
+
+    // Set call_to = cont_call1, clear call_de, format extra
+    strcpy(call_to, cont_call1);
+    call_de[0] = '\0';
+
+    // Format extra: "RR73; CQ call2 grid"
+    char* dst = extra;
+    dst = stpcpy(dst, "RR73; CQ ");
+    dst = stpcpy(dst, cont_call2);
+    if (grid4[0] != '\0')
+    {
+        *dst++ = ' ';
+        dst = stpcpy(dst, grid4);
+    }
+
+    return 0;
+}
+
+// ARRL RTTY Roundup: i3=3
+static int unpack_rtty(const uint8_t* a77, char* call_to, char* call_de, char* extra, const unpack_hash_interface_t* hash_if)
+{
+    // t1 (0)  c28a (1-28)  c28b (29-56)  R1 (57)  r3 (58-60)  s13 (61-73)
+    uint8_t t1 = (a77[0] >> 7) & 0x01;
+
+    uint32_t c28a = ((uint32_t)(a77[0] & 0x7F) << 21)
+                  | ((uint32_t)a77[1] << 13)
+                  | ((uint32_t)a77[2] << 5)
+                  | ((uint32_t)a77[3] >> 3);
+
+    uint32_t c28b = ((uint32_t)(a77[3] & 0x07) << 25)
+                  | ((uint32_t)a77[4] << 17)
+                  | ((uint32_t)a77[5] << 9)
+                  | ((uint32_t)a77[6] << 1)
+                  | ((uint32_t)a77[7] >> 7);
+
+    uint8_t R1 = (a77[7] >> 6) & 0x01;
+    uint8_t r3 = (a77[7] >> 3) & 0x07;
+
+    uint16_t s13 = ((uint16_t)(a77[7] & 0x07) << 10)
+                 | ((uint16_t)a77[8] << 2)
+                 | ((uint16_t)(a77[9] >> 6) & 0x03);
+
+    if (unpack_callsign(c28a, 0, 0, call_to, hash_if) < 0)
+        return -1;
+    if (unpack_callsign(c28b, 0, 0, call_de, hash_if) < 0)
+        return -2;
+
+    if (hash_if != NULL)
+    {
+        if (call_to[0] != '<' && strlen(call_to) >= 4)
+            hash_if->save_hash(call_to);
+        if (call_de[0] != '<' && strlen(call_de) >= 4)
+            hash_if->save_hash(call_de);
+    }
+
+    uint16_t rst = r3 * 10 + 529;
+
+    char state_str[8];
+    if (s13 >= 1 && s13 <= 8000)
+    {
+        int_to_dd(state_str, s13, 4, false);
+    }
+    else if (s13 >= 8001 && s13 <= 8064)
+    {
+        strcpy(state_str, RTTY_STATES_UNPACK[s13 - 8001]);
+    }
+    else
+    {
+        state_str[0] = '\0';
+    }
+
+    // Format extra: "[TU; ]... [R ]report state" — but call_to/call_de are set,
+    // so we put the exchange portion in extra
+    char* dst = extra;
+    if (t1)
+    {
+        // TU prefix — we need to prepend to the whole message, so use call_to trick:
+        // Shift call_to content right and prepend "TU; "
+        char tmp[14];
+        strcpy(tmp, call_to);
+        strcpy(call_to, "TU; ");
+        strcat(call_to, tmp);
+    }
+
+    if (R1)
+        dst = stpcpy(dst, "R ");
+
+    int_to_dd(dst, rst, 3, false);
+    dst += strlen(dst);
+    *dst++ = ' ';
+    dst = stpcpy(dst, state_str);
+
+    return 0;
+}
+
+// WWROF contest: i3=5
+static int unpack_wwrof(const uint8_t* a77, char* call_to, char* call_de, char* extra, const unpack_hash_interface_t* hash_if)
+{
+    // t1 (0)  c28a (1-28)  c28b (29-56)  R1 (57)  r7 (58-64)  s9 (65-73)
+    uint8_t t1 = (a77[0] >> 7) & 0x01;
+
+    uint32_t c28a = ((uint32_t)(a77[0] & 0x7F) << 21)
+                  | ((uint32_t)a77[1] << 13)
+                  | ((uint32_t)a77[2] << 5)
+                  | ((uint32_t)a77[3] >> 3);
+
+    uint32_t c28b = ((uint32_t)(a77[3] & 0x07) << 25)
+                  | ((uint32_t)a77[4] << 17)
+                  | ((uint32_t)a77[5] << 9)
+                  | ((uint32_t)a77[6] << 1)
+                  | ((uint32_t)a77[7] >> 7);
+
+    uint8_t R1 = (a77[7] >> 6) & 0x01;
+
+    uint8_t r7 = ((a77[7] & 0x3F) << 1) | ((a77[8] >> 7) & 0x01);
+
+    uint16_t s9 = ((uint16_t)(a77[8] & 0x7F) << 2)
+                | ((uint16_t)(a77[9] >> 6) & 0x03);
+
+    if (unpack_callsign(c28a, 0, 0, call_to, hash_if) < 0)
+        return -1;
+    if (unpack_callsign(c28b, 0, 0, call_de, hash_if) < 0)
+        return -2;
+
+    if (hash_if != NULL)
+    {
+        if (call_to[0] != '<' && strlen(call_to) >= 4)
+            hash_if->save_hash(call_to);
+        if (call_de[0] != '<' && strlen(call_de) >= 4)
+            hash_if->save_hash(call_de);
+    }
+
+    int8_t report = (int8_t)r7 - 35;
+
+    char grid2[3];
+    grid2[0] = 'A' + (char)(s9 / 18);
+    grid2[1] = 'A' + (char)(s9 % 18);
+    grid2[2] = '\0';
+
+    // Format extra: "[R]report grid2" — with TU prefix via call_to if needed
+    char* dst = extra;
+    if (t1)
+    {
+        char tmp[14];
+        strcpy(tmp, call_to);
+        strcpy(call_to, "TU; ");
+        strcat(call_to, tmp);
+    }
+
+    if (R1)
+        *dst++ = 'R';
+
+    if (report >= 0)
+    {
+        *dst++ = '+';
+        int_to_dd(dst, report, 2, false);
+    }
+    else
+    {
+        int_to_dd(dst, report, 2, true);
+    }
+    dst += strlen(dst);
+    *dst++ = ' ';
+    dst = stpcpy(dst, grid2);
+
+    return 0;
+}
+
 // none standard for wsjt-x 2.0
 // by KD8CEC
 static int unpack_nonstandard(const uint8_t* a77, char* call_to, char* call_de, char* extra, const unpack_hash_interface_t* hash_if)
@@ -362,20 +813,31 @@ int unpack77_fields(const uint8_t* a77, char* call_to, char* call_de, char* extr
             // 0.0  Free text
             return unpack_text(a77, extra);
         }
-        // else if (i3 == 0 && n3 == 1) {
-        //     // 0.1  K1ABC RR73; W9XYZ <KH1/KH7Z> -11   28 28 10 5       71   DXpedition Mode
-        // }
-        // else if (i3 == 0 && n3 == 2) {
-        //     // 0.2  PA3XYZ/P R 590003 IO91NP           28 1 1 3 12 25   70   EU VHF contest
-        // }
-        // else if (i3 == 0 && (n3 == 3 || n3 == 4)) {
-        //     // 0.3   WA9XYZ KA1ABC R 16A EMA            28 28 1 4 3 7    71   ARRL Field Day
-        //     // 0.4   WA9XYZ KA1ABC R 32A EMA            28 28 1 4 3 7    71   ARRL Field Day
-        // }
+        else if (n3 == 1)
+        {
+            // 0.1  K1ABC RR73; W9XYZ <KH1/KH7Z> -11   28 28 10 5       71   DXpedition Mode
+            return unpack_dxped(a77, call_to, call_de, extra, hash_if);
+        }
+        else if (n3 == 2)
+        {
+            // 0.2  PA3XYZ/P R 590003 IO91NP           28 1 1 3 12 25   70   EU VHF contest
+            return unpack_eu_vhf(a77, call_to, call_de, extra, hash_if);
+        }
+        else if (n3 == 3 || n3 == 4)
+        {
+            // 0.3   WA9XYZ KA1ABC R 16A EMA            28 28 1 4 3 7    71   ARRL Field Day
+            // 0.4   WA9XYZ KA1ABC R 32A EMA            28 28 1 4 3 7    71   ARRL Field Day
+            return unpack_fd(a77, call_to, call_de, extra, hash_if);
+        }
         else if (n3 == 5)
         {
             // 0.5   0123456789abcdef01                 71               71   Telemetry (18 hex)
             return unpack_telemetry(a77, extra);
+        }
+        else if (n3 == 6)
+        {
+            // 0.6   K1ABC RR73; CQ W9XYZ EN37          28 28 15         71   Contesting
+            return unpack_contesting(a77, call_to, call_de, extra, hash_if);
         }
     }
     else if (i3 == 1 || i3 == 2)
@@ -383,9 +845,11 @@ int unpack77_fields(const uint8_t* a77, char* call_to, char* call_de, char* extr
         // Type 1 (standard message) or Type 2 ("/P" form for EU VHF contest)
         return unpack_type1(a77, i3, call_to, call_de, extra, hash_if);
     }
-    // else if (i3 == 3) {
-    //     // Type 3: ARRL RTTY Contest
-    // }
+    else if (i3 == 3)
+    {
+        // Type 3: TU; W9XYZ K1ABC R 579 MA           1 28 28 1 3 13   74   ARRL RTTY Roundup
+        return unpack_rtty(a77, call_to, call_de, extra, hash_if);
+    }
     else if (i3 == 4)
     {
         // Type 4: Nonstandard calls, e.g. <WA9XYZ> PJ4/KA1ABC RR73
@@ -393,9 +857,11 @@ int unpack77_fields(const uint8_t* a77, char* call_to, char* call_de, char* extr
         // to 11 characters; and (if not "CQ") an optional RRR, RR73, or 73.
         return unpack_nonstandard(a77, call_to, call_de, extra, hash_if);
     }
-    // else if (i3 == 5) {
-    //     // Type 5: TU; W9XYZ K1ABC R-09 FN             1 28 28 1 7 9       74   WWROF contest
-    // }
+    else if (i3 == 5)
+    {
+        // Type 5: TU; W9XYZ K1ABC R-09 FN             1 28 28 1 7 9       74   WWROF contest
+        return unpack_wwrof(a77, call_to, call_de, extra, hash_if);
+    }
 
     // unknown type, should never get here
     return -1;
@@ -403,9 +869,9 @@ int unpack77_fields(const uint8_t* a77, char* call_to, char* call_de, char* extr
 
 int unpack77(const uint8_t* a77, char* message, const unpack_hash_interface_t* hash_if)
 {
-    char call_to[14];
+    char call_to[14 + 5]; // +5 for "TU; " prefix in RTTY/WWROF
     char call_de[14];
-    char extra[19];
+    char extra[40]; // DXpedition extra can be ~38 chars
 
     int rc = unpack77_fields(a77, call_to, call_de, extra, hash_if);
     if (rc < 0)

--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/unpack.h
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/unpack.h
@@ -13,6 +13,8 @@ typedef struct
     void (*hash22)(uint32_t n22, char* callsign);
     /// Called when a callsign is looked up by its 12 bit hash code
     void (*hash12)(uint32_t n12, char* callsign);
+    /// Called when a callsign is looked up by its 10 bit hash code (DXpedition fox call)
+    void (*hash10)(uint32_t n10, char* callsign);
     /// Called when a callsign should hashed and stored (both by its 22 and 12 bit hash code)
     void (*save_hash)(const char* callsign);
 } unpack_hash_interface_t;

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -423,9 +423,157 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Analysis(
     {
         ok = (ftx_message_decode_nonstd(&message, &hash_if, call_to, call_de, extra) == FTX_MESSAGE_RC_OK);
     }
+    else if (type == FTX_MESSAGE_TYPE_ARRL_FD)
+    {
+        uint8_t r_flag_val = 0, num_tx_val = 0;
+        char fd_class[2] = {0}, fd_section[4] = {0};
+        if (ftx_message_decode_fd(&message, &hash_if, call_to, call_de,
+                                  &r_flag_val, &num_tx_val, fd_class, fd_section) == FTX_MESSAGE_RC_OK)
+        {
+            ft8_set_string(env, ft8Message, FF8.callsignTo, call_to);
+            ft8_set_string(env, ft8Message, FF8.callsignFrom, call_de);
+            ft8_set_call_hashes(env, ft8Message, call_to, FF8.callToHash10, FF8.callToHash12, FF8.callToHash22);
+            ft8_set_call_hashes(env, ft8Message, call_de, FF8.callFromHash10, FF8.callFromHash12, FF8.callFromHash22);
+
+            env->SetIntField(ft8Message, FF8.r_flag, r_flag_val);
+            env->SetIntField(ft8Message, FF8.eu_serial, num_tx_val);
+            ft8_set_string(env, ft8Message, FF8.arrl_class, fd_class);
+            ft8_set_string(env, ft8Message, FF8.arrl_rac, fd_section);
+
+            // Build exchange text for extraInfo display fallback
+            char exchange[20] = {0};
+            char* dst = exchange;
+            if (r_flag_val)
+                dst = stpcpy(dst, "R ");
+            if (num_tx_val >= 10)
+                *dst++ = '0' + (num_tx_val / 10);
+            *dst++ = '0' + (num_tx_val % 10);
+            *dst++ = fd_class[0];
+            *dst++ = ' ';
+            stpcpy(dst, fd_section);
+            ft8_set_string(env, ft8Message, FF8.extraInfo, exchange);
+
+            ok = true;
+        }
+    }
+    else if (type == FTX_MESSAGE_TYPE_DXPEDITION)
+    {
+        uint16_t h10_val = 0;
+        int8_t rpt_val = 0;
+        if (ftx_message_decode_dxped(&message, &hash_if, call_to, call_de,
+                                     &h10_val, &rpt_val) == FTX_MESSAGE_RC_OK)
+        {
+            ft8_set_string(env, ft8Message, FF8.callsignTo, call_to);
+            // call_de is the invited callsign; put it in dx_call_to2
+            ft8_set_string(env, ft8Message, FF8.dx_call_to2, call_de);
+            ft8_set_string(env, ft8Message, FF8.callsignFrom, "");
+            ft8_set_call_hashes(env, ft8Message, call_to, FF8.callToHash10, FF8.callToHash12, FF8.callToHash22);
+            ft8_set_call_hashes(env, ft8Message, call_de, FF8.callFromHash10, FF8.callFromHash12, FF8.callFromHash22);
+            // Store the fox 10-bit hash so Java can look it up
+            env->SetLongField(ft8Message, FF8.callFromHash10, (jlong)h10_val);
+            env->SetIntField(ft8Message, FF8.report, (jint)rpt_val);
+
+            // Build extraInfo for display fallback
+            char fox_call[14] = {0};
+            ft8_hash_lookup(FTX_CALLSIGN_HASH_10_BITS, h10_val, fox_call);
+            char exchange[48] = {0};
+            char* dst = exchange;
+            dst = stpcpy(dst, "RR73; ");
+            dst = stpcpy(dst, call_de);
+            *dst++ = ' ';
+            dst = stpcpy(dst, fox_call);
+            *dst++ = ' ';
+            if (rpt_val >= 0)
+            {
+                *dst++ = '+';
+                int_to_dd(dst, rpt_val, 2, false);
+            }
+            else
+            {
+                int_to_dd(dst, rpt_val, 2, true);
+            }
+            ft8_set_string(env, ft8Message, FF8.extraInfo, exchange);
+            ok = true;
+        }
+    }
+    else if (type == FTX_MESSAGE_TYPE_ARRL_RTTY)
+    {
+        uint8_t tu_val = 0, r_flag_val = 0;
+        uint16_t rpt_val = 0;
+        char state_str[8] = {0};
+        bool is_serial_val = false;
+        if (ftx_message_decode_rtty(&message, &hash_if, call_to, call_de,
+                                    &tu_val, &r_flag_val, &rpt_val,
+                                    state_str, &is_serial_val) == FTX_MESSAGE_RC_OK)
+        {
+            ft8_set_string(env, ft8Message, FF8.callsignTo, call_to);
+            ft8_set_string(env, ft8Message, FF8.callsignFrom, call_de);
+            ft8_set_call_hashes(env, ft8Message, call_to, FF8.callToHash10, FF8.callToHash12, FF8.callToHash22);
+            ft8_set_call_hashes(env, ft8Message, call_de, FF8.callFromHash10, FF8.callFromHash12, FF8.callFromHash22);
+            env->SetIntField(ft8Message, FF8.rtty_tu, (jint)tu_val);
+            env->SetIntField(ft8Message, FF8.r_flag, (jint)r_flag_val);
+            env->SetIntField(ft8Message, FF8.report, (jint)rpt_val);
+            ft8_set_string(env, ft8Message, FF8.rtty_state, state_str);
+
+            // Build extraInfo for display fallback
+            char exchange[40] = {0};
+            char* dst = exchange;
+            if (tu_val)
+                dst = stpcpy(dst, "TU; ");
+            if (r_flag_val)
+                dst = stpcpy(dst, "R ");
+            int_to_dd(dst, rpt_val, 3, false);
+            dst += strlen(dst);
+            *dst++ = ' ';
+            stpcpy(dst, state_str);
+            ft8_set_string(env, ft8Message, FF8.extraInfo, exchange);
+            ok = true;
+        }
+    }
+    else if (type == FTX_MESSAGE_TYPE_WWROF)
+    {
+        uint8_t tu_val = 0, r_flag_val = 0;
+        int8_t rpt_val = 0;
+        char grid2[4] = {0};
+        if (ftx_message_decode_wwrof(&message, &hash_if, call_to, call_de,
+                                     &tu_val, &r_flag_val, &rpt_val, grid2) == FTX_MESSAGE_RC_OK)
+        {
+            ft8_set_string(env, ft8Message, FF8.callsignTo, call_to);
+            ft8_set_string(env, ft8Message, FF8.callsignFrom, call_de);
+            ft8_set_call_hashes(env, ft8Message, call_to, FF8.callToHash10, FF8.callToHash12, FF8.callToHash22);
+            ft8_set_call_hashes(env, ft8Message, call_de, FF8.callFromHash10, FF8.callFromHash12, FF8.callFromHash22);
+            env->SetIntField(ft8Message, FF8.rtty_tu, (jint)tu_val);
+            env->SetIntField(ft8Message, FF8.r_flag, (jint)r_flag_val);
+            env->SetIntField(ft8Message, FF8.report, (jint)rpt_val);
+            ft8_set_string(env, ft8Message, FF8.maidenGrid, grid2);
+            env->SetIntField(ft8Message, FF8.eu_serial, 0);
+
+            // Build extraInfo for display fallback
+            char exchange[32] = {0};
+            char* dst = exchange;
+            if (tu_val)
+                dst = stpcpy(dst, "TU; ");
+            if (r_flag_val)
+                *dst++ = 'R';
+            if (rpt_val >= 0)
+            {
+                *dst++ = '+';
+                int_to_dd(dst, rpt_val, 2, false);
+            }
+            else
+            {
+                int_to_dd(dst, rpt_val, 2, true);
+            }
+            dst += strlen(dst);
+            *dst++ = ' ';
+            stpcpy(dst, grid2);
+            ft8_set_string(env, ft8Message, FF8.extraInfo, exchange);
+            ok = true;
+        }
+    }
     else
     {
-        // Contest sub-types: decode to full text into extraInfo.
+        // Contest sub-types (EU VHF 0.2, Contesting 0.6): decode to full text into extraInfo.
         char text[FTX_MAX_MESSAGE_LENGTH] = {0};
         if (ftx_message_decode(&message, &hash_if, text) == FTX_MESSAGE_RC_OK)
         {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/Ft8Message.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/Ft8Message.java
@@ -54,9 +54,9 @@ public class Ft8Message {
     public String maidenGrid = null;
 
     public String rtty_state =null;//RTTY RU (i3=3 type) state name, two-letter code e.g.: CA, AL
-    public int r_flag=0;//RTTY RU, EU VHF (i3=3, i3=5 type) R flag
-    public int rtty_tu;//RTTY RU (i3=3 type) TU; flag
-    public int eu_serial;//EU VHF i3=5 serial number
+    public int r_flag=0;//RTTY RU, WWROF (i3=3, i3=5 type) R flag
+    public int rtty_tu;//RTTY RU, WWROF (i3=3, i3=5 type) TU; flag
+    public int eu_serial;//Field Day num_tx, or serial number
     public String arrl_rac;//Field day message, ARRL RAC
     public String arrl_class;//Field day transmit class
     public String dx_call_to2;//DXpedition message second receiving callsign
@@ -280,13 +280,14 @@ public class Ft8Message {
                     ,rtty_state);
         }
 
-        if (i3 == 5){//this is EU VHF <G4ABC> <PA9XYZ> R 570007 JO22DB
-            return String.format("%s %s %s%d%04d %s"
+        if (i3 == 5){//this is WWROF contest
+            return String.format("%s%s %s %s%s%d %s"
+                    , rtty_tu == 0 ? "" : "TU; "
                     , callsignTo
                     , callsignFrom
-                    , r_flag == 0?"":"R "
+                    , r_flag == 0 ? "" : "R"
+                    , report >= 0 ? "+" : ""
                     , report
-                    , eu_serial
                     , maidenGrid
                     ).trim();
         }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CqOptionsSheet.kt
@@ -212,153 +212,151 @@ fun CqOptionsSheet(
                 )
             }
 
-            if (fieldDayEnabled) {
-                Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(4.dp))
 
-                // Class chips
-                Text(
-                    text = stringResource(R.string.cq_fd_class),
-                    color = TextMuted,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    fontFamily = GeistMonoFamily,
-                    letterSpacing = 0.04.sp,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    for (cls in listOf("A", "B", "C", "D", "E", "F")) {
-                        val isSelected = fieldDayClass == cls
-                        val bgColor = if (isSelected) AccentSoft else BgSurface2
-                        val borderColor = if (isSelected) BorderAmber else Border
-                        val textColor = if (isSelected) Accent else TextMuted
+            // Class chips
+            Text(
+                text = stringResource(R.string.cq_fd_class),
+                color = TextMuted,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
+                letterSpacing = 0.04.sp,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                for (cls in listOf("A", "B", "C", "D", "E", "F")) {
+                    val isSelected = fieldDayClass == cls
+                    val bgColor = if (isSelected) AccentSoft else BgSurface2
+                    val borderColor = if (isSelected) BorderAmber else Border
+                    val textColor = if (isSelected) Accent else TextMuted
 
-                        Box(
-                            modifier = Modifier
-                                .size(36.dp)
-                                .clip(chipShape)
-                                .background(bgColor, chipShape)
-                                .border(1.dp, borderColor, chipShape)
-                                .clickable { onFieldDayClassChange(cls) },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = cls,
-                                color = textColor,
-                                fontSize = 13.sp,
-                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
-                                fontFamily = GeistMonoFamily,
-                            )
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                // Transmitters stepper
-                Text(
-                    text = stringResource(R.string.cq_fd_transmitters),
-                    color = TextMuted,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    fontFamily = GeistMonoFamily,
-                    letterSpacing = 0.04.sp,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
                     Box(
                         modifier = Modifier
                             .size(36.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(BgSurface3)
-                            .clickable(enabled = fieldDayNumTx > 1) {
-                                onFieldDayNumTxChange((fieldDayNumTx - 1).coerceAtLeast(1))
-                            },
+                            .clip(chipShape)
+                            .background(bgColor, chipShape)
+                            .border(1.dp, borderColor, chipShape)
+                            .clickable { onFieldDayClassChange(cls) },
                         contentAlignment = Alignment.Center,
                     ) {
                         Text(
-                            text = "\u2212",
-                            color = if (fieldDayNumTx > 1) TextMuted else TextFaint,
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold,
+                            text = cls,
+                            color = textColor,
+                            fontSize = 13.sp,
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
                             fontFamily = GeistMonoFamily,
                         )
                     }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Transmitters stepper
+            Text(
+                text = stringResource(R.string.cq_fd_transmitters),
+                color = TextMuted,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
+                letterSpacing = 0.04.sp,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(BgSurface3)
+                        .clickable(enabled = fieldDayNumTx > 1) {
+                            onFieldDayNumTxChange((fieldDayNumTx - 1).coerceAtLeast(1))
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
                     Text(
-                        text = fieldDayNumTx.toString(),
-                        color = TextPrimary,
-                        fontSize = 15.sp,
+                        text = "\u2212",
+                        color = if (fieldDayNumTx > 1) TextMuted else TextFaint,
+                        fontSize = 16.sp,
                         fontWeight = FontWeight.Bold,
                         fontFamily = GeistMonoFamily,
-                        letterSpacing = 0.02.sp,
                     )
-                    Box(
-                        modifier = Modifier
-                            .size(36.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(BgSurface3)
-                            .clickable(enabled = fieldDayNumTx < 16) {
-                                onFieldDayNumTxChange((fieldDayNumTx + 1).coerceAtMost(16))
-                            },
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = "+",
-                            color = if (fieldDayNumTx < 16) TextMuted else TextFaint,
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = GeistMonoFamily,
-                        )
-                    }
                 }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                // Section text field
                 Text(
-                    text = stringResource(R.string.cq_fd_section),
-                    color = TextMuted,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    text = fieldDayNumTx.toString(),
+                    color = TextPrimary,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
                     fontFamily = GeistMonoFamily,
-                    letterSpacing = 0.04.sp,
+                    letterSpacing = 0.02.sp,
                 )
-                Spacer(modifier = Modifier.height(4.dp))
-                OutlinedTextField(
-                    value = fieldDaySection,
-                    onValueChange = {
-                        val cleaned = it.uppercase().filter { c -> c.isLetter() }.take(3)
-                        onFieldDaySectionChange(cleaned)
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    placeholder = {
-                        Text(
-                            text = stringResource(R.string.cq_fd_section_hint),
-                            color = TextFaint,
-                            fontSize = 13.sp,
-                            fontFamily = GeistMonoFamily,
-                        )
-                    },
-                    singleLine = true,
-                    textStyle = androidx.compose.ui.text.TextStyle(
-                        color = TextPrimary,
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(BgSurface3)
+                        .clickable(enabled = fieldDayNumTx < 16) {
+                            onFieldDayNumTxChange((fieldDayNumTx + 1).coerceAtMost(16))
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "+",
+                        color = if (fieldDayNumTx < 16) TextMuted else TextFaint,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = GeistMonoFamily,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Section text field
+            Text(
+                text = stringResource(R.string.cq_fd_section),
+                color = TextMuted,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
+                letterSpacing = 0.04.sp,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            OutlinedTextField(
+                value = fieldDaySection,
+                onValueChange = {
+                    val cleaned = it.uppercase().filter { c -> c.isLetter() }.take(3)
+                    onFieldDaySectionChange(cleaned)
+                },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.cq_fd_section_hint),
+                        color = TextFaint,
                         fontSize = 13.sp,
                         fontFamily = GeistMonoFamily,
-                    ),
-                    keyboardOptions = KeyboardOptions(
-                        capitalization = KeyboardCapitalization.Characters,
-                    ),
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = Accent,
-                        unfocusedBorderColor = Border,
-                        cursorColor = Accent,
-                    ),
-                )
-            }
+                    )
+                },
+                singleLine = true,
+                textStyle = androidx.compose.ui.text.TextStyle(
+                    color = TextPrimary,
+                    fontSize = 13.sp,
+                    fontFamily = GeistMonoFamily,
+                ),
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Characters,
+                ),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = Accent,
+                    unfocusedBorderColor = Border,
+                    cursorColor = Accent,
+                ),
+            )
 
             // ---- Divider: "or" ----
             OrDivider()

--- a/ft8af/app/src/test/java/com/k1af/ft8af/Ft8MessageTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/Ft8MessageTest.java
@@ -172,17 +172,31 @@ public class Ft8MessageTest {
     }
 
     @Test
-    public void getMessageText_euVhf_zeroPadsSerial() {
-        // i3=5 EU VHF: "%s %s %s%d%04d %s" .trim(); report 57 + serial 7 -> "570007".
+    public void getMessageText_wwrof_withTuAndRFlagPositiveReport() {
+        // i3=5 is a WWROF contest message: "[TU; ]<to> <from> [R]<+/-><rpt> <grid4>".
         Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
         msg.i3 = 5;
-        msg.callsignTo = "<G4ABC>";
-        msg.callsignFrom = "<PA9XYZ>";
+        msg.rtty_tu = 1;
+        msg.callsignTo = "K1ABC";
+        msg.callsignFrom = "W9XYZ";
         msg.r_flag = 1;
-        msg.report = 57;
-        msg.eu_serial = 7;
-        msg.maidenGrid = "JO22DB";
-        assertThat(msg.getMessageText()).isEqualTo("<G4ABC> <PA9XYZ> R 570007 JO22DB");
+        msg.report = 12;
+        msg.maidenGrid = "FN20";
+        assertThat(msg.getMessageText()).isEqualTo("TU; K1ABC W9XYZ R+12 FN20");
+    }
+
+    @Test
+    public void getMessageText_wwrof_negativeReportSingleSign() {
+        // No TU/R prefix; a negative report renders a single leading minus (no '+').
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        msg.i3 = 5;
+        msg.rtty_tu = 0;
+        msg.callsignTo = "K1ABC";
+        msg.callsignFrom = "W9XYZ";
+        msg.r_flag = 0;
+        msg.report = -7;
+        msg.maidenGrid = "FN20";
+        assertThat(msg.getMessageText()).isEqualTo("K1ABC W9XYZ -7 FN20");
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageFieldDayTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageFieldDayTest.java
@@ -193,7 +193,186 @@ public class FT8PackageFieldDayTest {
         assertThat(pad).isEqualTo(0);
     }
 
+    // ---- Round-trip encode → decode bit extraction ----------------------------
+
+    /**
+     * Simulate the C-side decode by extracting FD fields from packed bytes.
+     * Verifies the encode/decode bit math matches across Java and C layers.
+     */
+    @Test
+    public void roundTrip_typicalMessage_n3equals3() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 2, "A", "EMA", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+
+        assertThat(d.i3).isEqualTo(0);
+        assertThat(d.n3).isEqualTo(3);
+        assertThat(d.r1).isEqualTo(0);
+        assertThat(d.numTx).isEqualTo(2);
+        assertThat(d.fdClass).isEqualTo("A");
+        assertThat(d.section).isEqualTo("EMA");
+    }
+
+    @Test
+    public void roundTrip_withRoger_n3equals4() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 1, 2, "A", "EMA", 4);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+
+        assertThat(d.i3).isEqualTo(0);
+        assertThat(d.n3).isEqualTo(4);
+        assertThat(d.r1).isEqualTo(1);
+        assertThat(d.numTx).isEqualTo(2);
+        assertThat(d.fdClass).isEqualTo("A");
+        assertThat(d.section).isEqualTo("EMA");
+    }
+
+    @Test
+    public void roundTrip_allSixClasses() {
+        for (int c = 0; c < 6; c++) {
+            String cls = String.valueOf((char) ('A' + c));
+            Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, cls, "CT", 3);
+            byte[] p = FT8Package.generatePack77_fd(msg);
+            FdDecoded d = extractFdFields(p);
+            assertThat(d.fdClass).isEqualTo(cls);
+        }
+    }
+
+    @Test
+    public void roundTrip_numTx_one() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+        assertThat(d.numTx).isEqualTo(1);
+    }
+
+    @Test
+    public void roundTrip_numTx_sixteen() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 16, "A", "CT", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+        assertThat(d.numTx).isEqualTo(16);
+    }
+
+    @Test
+    public void roundTrip_rFlag_zero() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 3, "B", "CT", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+        assertThat(d.r1).isEqualTo(0);
+    }
+
+    @Test
+    public void roundTrip_rFlag_one() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 1, 3, "B", "CT", 4);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+        assertThat(d.r1).isEqualTo(1);
+    }
+
+    @Test
+    public void roundTrip_firstSection_AB() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "AB", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+        assertThat(d.section).isEqualTo("AB");
+    }
+
+    @Test
+    public void roundTrip_lastSection_NB() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "NB", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+        assertThat(d.section).isEqualTo("NB");
+    }
+
+    @Test
+    public void roundTrip_middleSection_STX() {
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "STX", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+        assertThat(d.section).isEqualTo("STX");
+    }
+
+    @Test
+    public void roundTrip_CQ_asCallTo() {
+        Ft8Message msg = buildFdMessage("CQ", "W1AW", 0, 4, "C", "SFL", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+
+        // CQ encodes as n28a=2 (special token)
+        assertThat(d.n28a).isEqualTo(2);
+        assertThat(d.numTx).isEqualTo(4);
+        assertThat(d.fdClass).isEqualTo("C");
+        assertThat(d.section).isEqualTo("SFL");
+    }
+
+    @Test
+    public void roundTrip_callsignBits_preserved() {
+        // Verify the same callsign produces the same n28 whether encoded
+        // via generatePack77_fd or via pack_c28 directly.
+        Ft8Message msg = buildFdMessage("W1AW", "K1ABC", 0, 1, "A", "CT", 3);
+        byte[] p = FT8Package.generatePack77_fd(msg);
+        FdDecoded d = extractFdFields(p);
+
+        long expectedTo = FT8Package.pack_c28("W1AW") & 0x0fffffffL;
+        long expectedDe = FT8Package.pack_c28("K1ABC") & 0x0fffffffL;
+        assertThat(d.n28a).isEqualTo(expectedTo);
+        assertThat(d.n28b).isEqualTo(expectedDe);
+    }
+
     // ---- Helper ---------------------------------------------------------------
+
+    /** Decoded FD fields extracted from packed bytes. */
+    private static class FdDecoded {
+        long n28a, n28b;
+        int r1, numTx;
+        String fdClass, section;
+        int n3, i3;
+    }
+
+    /** Extract FD fields from packed 10-byte payload — mirrors the C decoder bit math. */
+    private static FdDecoded extractFdFields(byte[] p) {
+        FdDecoded d = new FdDecoded();
+
+        // n28a (bits 0-27)
+        d.n28a = ((long)(p[0] & 0xFF) << 20)
+               | ((long)(p[1] & 0xFF) << 12)
+               | ((long)(p[2] & 0xFF) << 4)
+               | ((long)(p[3] & 0xFF) >> 4);
+
+        // n28b (bits 28-55)
+        d.n28b = ((long)(p[3] & 0x0F) << 24)
+               | ((long)(p[4] & 0xFF) << 16)
+               | ((long)(p[5] & 0xFF) << 8)
+               | ((long)(p[6] & 0xFF));
+
+        // R1 (bit 56) = byte 7, bit 7
+        d.r1 = (p[7] >> 7) & 0x01;
+
+        // n4 (bits 57-60) = byte 7, bits [6:3]
+        int n4 = (p[7] >> 3) & 0x0F;
+        d.numTx = n4 + 1;
+
+        // k3 (bits 61-63) = byte 7, bits [2:0]
+        int k3 = p[7] & 0x07;
+        d.fdClass = String.valueOf((char) ('A' + k3));
+
+        // S7 (bits 64-70) = byte 8, bits [7:1]
+        int s7 = (p[8] >> 1) & 0x7F;
+        d.section = (s7 < FT8Package.ARRL_SECTIONS.length)
+                ? FT8Package.ARRL_SECTIONS[s7] : "???";
+
+        // n3 (bits 71-73)
+        int n3_bit0 = p[8] & 0x01;
+        int n3_bits12 = (p[9] >> 6) & 0x03;
+        d.n3 = (n3_bit0 << 2) | n3_bits12;
+
+        // i3 (bits 74-76) = byte 9 bits [5:3]
+        d.i3 = (p[9] >> 3) & 0x07;
+
+        return d;
+    }
 
     private static Ft8Message buildFdMessage(
             String toCall, String fromCall, int rFlag,


### PR DESCRIPTION
## Summary
- Implement decoding for DXpedition (0.1), EU VHF (0.2), Contesting (0.6), ARRL RTTY Roundup (i3=3), and WWROF contest (i3=5) message types
- These were previously silently dropped (`isValid=false`) or mangled into free-text with i3/n3 overwritten to 0/0
- DXpedition, RTTY, and WWROF get dedicated JNI handlers that populate structured Java fields (callsigns, hashes, report, contest flags)
- EU VHF and Contesting decode correctly via the text-based fallback path
- Fix the Java i3=5 formatter which was incorrectly labeled "EU VHF" — it's actually WWROF contest

## Test plan
- [ ] Build passes (verified — native compile clean, APK installed)
- [ ] Tune to busy FT8 frequency during RTTY Roundup — RTTY messages decode with RST + state/serial
- [ ] DXpedition messages appear during DX activity with fox hash, invited call, and report
- [ ] Contesting (0.6) and EU VHF (0.2) messages render as formatted text via fallback
- [ ] WWROF messages show TU flag, R-prefixed report, and 2-char grid
- [ ] Spot check decoded messages match WSJT-X output for same signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)