### PR TITLE
FT8 deep decode: coherent time-domain subtraction (79.1% -> 94.5% recall vs WSJT-X)

### DIFF
--- a/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
@@ -26,6 +26,7 @@
 //     --osd-depth N       OSD flip depth in deep passes, 0 = off (default: app value)
 //     --max-loops N       subtract-and-redecode loop cap (default 16; the app
 //                         caps by wall-clock budget instead)
+//     --wf-subtract       waterfall-domain tone-replacement subtraction (A/B only)
 //     --zero-subtract     use the legacy ±4-bin zeroing subtraction (A/B only)
 //     --assert-floor F    read "name min_matched" lines from F; exit 1 if any
 //                         listed file matches fewer truth messages than its floor
@@ -75,7 +76,17 @@ static int g_window_ms = 13500;
 static int g_max_loops = 16;
 static bool g_deep = true;
 static bool g_verbose = false;
-static bool g_zero_subtract = false; // legacy ±4-bin zeroing, for A/B only
+
+// Subtraction backend for the deep loop (matches the app's default: coherent
+// time-domain subtraction from the float samples, waterfall recomputed per
+// pass). The other two are kept for A/B comparison only.
+enum
+{
+    SUBTRACT_TIME = 0, // ft8_subtract_signal_time + re-feed (app behavior)
+    SUBTRACT_WF = 1,   // waterfall-domain tone replacement (previous behavior)
+    SUBTRACT_ZERO = 2, // legacy ±4-bin zeroing (pre-#360 behavior)
+};
+static int g_subtract_mode = SUBTRACT_TIME;
 
 #define BENCH_MAX_CAND_CAP 1024
 #define BENCH_MAX_MSGS 256
@@ -352,9 +363,19 @@ static int run_pass(monitor_t* mon, int ldpc_iters, int min_score, int osd_depth
 // ---------------------------------------------------------------------------
 // Full pipeline over one audio buffer, mirroring decodeFt8():
 // fast pass -> deep pass -> (subtract, deep pass) until no new messages.
+// In the default time-domain mode the subtraction edits `signal` in place and
+// the waterfall is recomputed from the residual before each redecode pass —
+// exactly what the app does (doSubtractSignal + DecoderFt8FindSync rebuild).
 // Returns total pass count via *passes_out.
 // ---------------------------------------------------------------------------
-static void decode_buffer(const float* signal, int num_samples,
+static void feed_monitor(monitor_t* mon, const float* signal, int num_samples)
+{
+    monitor_reset(mon);
+    for (int pos = 0; pos + mon->block_size <= num_samples; pos += mon->block_size)
+        monitor_process(mon, signal + pos);
+}
+
+static void decode_buffer(float* signal, int num_samples,
                           bench_msglist_t* seen, int* passes_out)
 {
     monitor_config_t cfg;
@@ -367,9 +388,7 @@ static void decode_buffer(const float* signal, int num_samples,
 
     monitor_t mon;
     monitor_init(&mon, &cfg);
-    monitor_reset(&mon);
-    for (int pos = 0; pos + mon.block_size <= num_samples; pos += mon.block_size)
-        monitor_process(&mon, signal + pos);
+    feed_monitor(&mon, signal, num_samples);
 
     bench_hash_reset();
     static bench_declist_t pass_decs;
@@ -380,19 +399,50 @@ static void decode_buffer(const float* signal, int num_samples,
 
     if (g_deep)
     {
+        // Payloads already subtracted from the sample buffer this slot. The
+        // same transmission decodes from several neighboring candidates (and
+        // again from its residual in later loops); subtracting it more than
+        // once fits the fine sync to junk and pollutes the residual with the
+        // bogus estimate. Mirrors the dedup in ft8_decode_jni.cpp.
+        static uint8_t done[BENCH_MAX_MSGS][FTX_PAYLOAD_LENGTH_BYTES];
+        int done_count = 0;
+
         int new_msgs = run_pass(&mon, g_ldpc_deep, g_min_score_deep, g_osd_depth, seen, &pass_decs);
         passes++;
         for (int loop = 0; loop < g_max_loops; ++loop)
         {
+            bool subtracted = false;
             for (int i = 0; i < pass_decs.count; ++i)
             {
-                if (g_zero_subtract)
+                if (g_subtract_mode == SUBTRACT_ZERO)
                     subtract_signal_zeroing(&mon, &pass_decs.items[i]);
-                else
+                else if (g_subtract_mode == SUBTRACT_WF)
                     ft8_subtract_signal(&mon, pass_decs.items[i].payload,
                                         pass_decs.items[i].freq_hz,
                                         pass_decs.items[i].time_sec);
+                else
+                {
+                    bool dup = false;
+                    for (int j = 0; j < done_count && !dup; ++j)
+                        dup = (memcmp(done[j], pass_decs.items[i].payload,
+                                      FTX_PAYLOAD_LENGTH_BYTES) == 0);
+                    if (dup)
+                        continue;
+                    if (ft8_subtract_signal_time(&mon, signal, num_samples,
+                                                 BENCH_SAMPLE_RATE,
+                                                 pass_decs.items[i].payload,
+                                                 pass_decs.items[i].freq_hz,
+                                                 pass_decs.items[i].time_sec))
+                    {
+                        subtracted = true;
+                        if (done_count < BENCH_MAX_MSGS)
+                            memcpy(done[done_count++], pass_decs.items[i].payload,
+                                   FTX_PAYLOAD_LENGTH_BYTES);
+                    }
+                }
             }
+            if (g_subtract_mode == SUBTRACT_TIME && subtracted)
+                feed_monitor(&mon, signal, num_samples);
             new_msgs = run_pass(&mon, g_ldpc_deep, g_min_score_deep, g_osd_depth, seen, &pass_decs);
             passes++;
             if (new_msgs == 0)
@@ -567,7 +617,9 @@ int main(int argc, char** argv)
         else if (strcmp(a, "--self-test") == 0)
             do_self_test = true;
         else if (strcmp(a, "--zero-subtract") == 0)
-            g_zero_subtract = true;
+            g_subtract_mode = SUBTRACT_ZERO;
+        else if (strcmp(a, "--wf-subtract") == 0)
+            g_subtract_mode = SUBTRACT_WF;
         else if (strcmp(a, "--window-ms") == 0 && i + 1 < argc)
             g_window_ms = atoi(argv[++i]);
         else if (strcmp(a, "--candidates") == 0 && i + 1 < argc)

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -70,6 +70,9 @@ struct ft8_decoder_state
 
     float* samples;
     int num_samples;
+    int num_fed;   // samples actually captured into `samples` this slot
+    bool wf_dirty; // time-domain subtraction has edited `samples`; the
+                   // waterfall must be recomputed before the next find_sync
     int sample_rate;
     long utc;
 
@@ -81,6 +84,13 @@ struct ft8_decoder_state
 
     ftx_message_t last_message;
     bool have_last;
+
+    // Payloads already time-subtracted this slot: the same transmission
+    // decodes from several neighboring candidates and again from its own
+    // residual in later passes; a second subtraction would fit the fine sync
+    // to junk and pollute the residual samples.
+    uint8_t sub_done[kMaxCandidates][10];
+    int sub_done_count;
 
     ft8_hash_entry_t hashtable[FT8_HASHTABLE_SIZE];
     int hashtable_count;
@@ -270,8 +280,14 @@ static void ft8_feed(ft8_decoder_state* d, const float* data, int n)
 {
     if (!d || !d->mon_ready)
         return;
+    d->num_fed = 0;
+    d->wf_dirty = false;
+    d->sub_done_count = 0;
     if (d->samples && n <= d->num_samples)
+    {
         memcpy(d->samples, data, sizeof(float) * n);
+        d->num_fed = n;
+    }
     monitor_reset(&d->mon);
     for (int pos = 0; pos + d->mon.block_size <= n; pos += d->mon.block_size)
         monitor_process(&d->mon, data + pos);
@@ -347,6 +363,16 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8FindSync(
     ft8_decoder_state* d = (ft8_decoder_state*)(intptr_t)handle;
     if (!d || !d->mon_ready)
         return 0;
+    if (d->wf_dirty && d->samples && d->num_fed > 0)
+    {
+        // Time-domain subtraction edited the retained samples; recompute the
+        // waterfall from the residual so this pass can uncover what was
+        // underneath the removed signals.
+        monitor_reset(&d->mon);
+        for (int pos = 0; pos + d->mon.block_size <= d->num_fed; pos += d->mon.block_size)
+            monitor_process(&d->mon, d->samples + pos);
+        d->wf_dirty = false;
+    }
     int min_score = d->deep ? FT8AF_MIN_SCORE_DEEP : FT8AF_MIN_SCORE_FAST;
     d->num_candidates = ft8_find_sync(&d->mon.wf, kMaxCandidates, d->candidates, min_score);
     return d->num_candidates;
@@ -624,6 +650,9 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Reset(
         return;
     d->utc = utcTime;
     d->num_samples = num_samples;
+    d->num_fed = 0;
+    d->wf_dirty = false;
+    d->sub_done_count = 0;
     monitor_reset(&d->mon);
 }
 
@@ -646,11 +675,14 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderGetA91(
 }
 
 // ---------------------------------------------------------------------------
-// doSubtractSignal — deep-decode subtraction for FT8: tone-accurate,
-// noise-floor-referenced removal of the decoded signal (ft8_subtract.c) so
-// the next find_sync pass can't re-detect it, while co-channel weaker
-// signals survive. Replaces the earlier ±4-bin waterfall zeroing, which
-// erased a ~56 Hz x 12.6 s swath including anything underneath.
+// doSubtractSignal — deep-decode subtraction for FT8. Preferred path:
+// coherent time-domain subtraction from the retained float samples
+// (ft8_subtract.c, WSJT-X subtractft8 approach) — removes the decoded
+// signal's full spectral footprint so even a co-channel signal a few Hz away
+// becomes decodable once DecoderFt8FindSync recomputes the waterfall from
+// the residual. Falls back to the waterfall-domain tone replacement when no
+// sample copy is available. Each payload is subtracted at most once per
+// slot: re-subtracting a residual fits junk and pollutes the samples.
 // ---------------------------------------------------------------------------
 extern "C" JNIEXPORT void JNICALL
 Java_com_k1af_ft8af_ft8listener_ReBuildSignal_doSubtractSignal(
@@ -668,6 +700,23 @@ Java_com_k1af_ft8af_ft8listener_ReBuildSignal_doSubtractSignal(
     if (n > FTX_LDPC_K_BYTES)
         n = FTX_LDPC_K_BYTES;
     env->GetByteArrayRegion(payload, 0, n, a91);
+
+    if (d->samples && d->num_fed > 0)
+    {
+        for (int i = 0; i < d->sub_done_count; ++i)
+            if (memcmp(d->sub_done[i], a91, sizeof(d->sub_done[0])) == 0)
+                return; // already subtracted this transmission this slot
+
+        if (ft8_subtract_signal_time(&d->mon, d->samples, d->num_fed,
+                                     d->sample_rate, (const uint8_t*)a91,
+                                     frequency, time_sec))
+        {
+            d->wf_dirty = true;
+            if (d->sub_done_count < kMaxCandidates)
+                memcpy(d->sub_done[d->sub_done_count++], a91, sizeof(d->sub_done[0]));
+            return;
+        }
+    }
 
     ft8_subtract_signal(&d->mon, (const uint8_t*)a91, frequency, time_sec);
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.c
@@ -32,11 +32,15 @@ float* synth_gfsk_dphi_alloc(const uint8_t* symbols, int n_sym, float f0,
 // above the local noise estimate by at least this much (units of 0.5 dB).
 #define SUBTRACT_MIN_EXCESS 2
 
-// Moving-average window (samples at 12 kHz) for the complex-gain estimate in
-// ft8_subtract_signal_time. Trade-off: wider tracks the gain with less noise
-// but attenuates the estimate when the candidate grid's residual frequency
-// error (up to ~±1.6 Hz at freq_osr=2) rotates the phase within the window;
-// narrower follows that rotation but estimates the gain from fewer samples.
+// Nominal moving-average window (samples at 12 kHz) for the complex-gain
+// estimate in ft8_subtract_signal_time. The average is centered and
+// symmetric, so the EFFECTIVE window is the odd 2*(SUBTRACT_TD_NFILT/2) + 1
+// samples (1441 at the default) — keep that in mind when comparing sweep
+// values; the half-width SUBTRACT_TD_NFILT/2 is what the code uses.
+// Trade-off: wider tracks the gain with less noise but attenuates the
+// estimate when the candidate grid's residual frequency error (up to
+// ~±1.6 Hz at freq_osr=2) rotates the phase within the window; narrower
+// follows that rotation but estimates the gain from fewer samples.
 // Swept on the decode benchmark (corpus recall): 960 -> 92.2, 1200 -> 93.7,
 // 1440 -> 94.5, 1680 -> 94.1, 1920 -> 94.3, 2880 -> 92.8, 3840 -> 91.5.
 // WSJT-X's subtractft8 uses a comparable ~1500-sample window at 12 kHz.

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.c
@@ -8,14 +8,42 @@
 #include "ft8_subtract.h"
 
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
+
+#ifdef SUBTRACT_TD_DEBUG
+#include <stdio.h>
+#endif
 
 #include "ft8/constants.h"
 #include "ft8/encode.h"
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// From gfsk.c: per-sample GFSK phase increments for a tone sequence
+// (malloc'd, caller frees) — the basis of the complex reference waveform.
+float* synth_gfsk_dphi_alloc(const uint8_t* symbols, int n_sym, float f0,
+                             float symbol_bt, float symbol_period,
+                             int signal_rate, int* n_wave_out);
+
 // Don't punch holes on marginal fits: only replace a bin that actually sits
 // above the local noise estimate by at least this much (units of 0.5 dB).
 #define SUBTRACT_MIN_EXCESS 2
+
+// Moving-average window (samples at 12 kHz) for the complex-gain estimate in
+// ft8_subtract_signal_time. Trade-off: wider tracks the gain with less noise
+// but attenuates the estimate when the candidate grid's residual frequency
+// error (up to ~±1.6 Hz at freq_osr=2) rotates the phase within the window;
+// narrower follows that rotation but estimates the gain from fewer samples.
+// Swept on the decode benchmark (corpus recall): 960 -> 92.2, 1200 -> 93.7,
+// 1440 -> 94.5, 1680 -> 94.1, 1920 -> 94.3, 2880 -> 92.8, 3840 -> 91.5.
+// WSJT-X's subtractft8 uses a comparable ~1500-sample window at 12 kHz.
+// (Overridable from the compile line for sweeps.)
+#ifndef SUBTRACT_TD_NFILT
+#define SUBTRACT_TD_NFILT 1440
+#endif
 
 // Floor division for possibly-negative sub-unit indices (DT can be < 0).
 static int floor_div(int a, int b)
@@ -94,4 +122,229 @@ void ft8_subtract_signal(monitor_t* mon, const uint8_t* a91,
             }
         }
     }
+}
+
+// Fine time sync for the subtraction: sum of per-symbol tone-correlation
+// energies |sum_n x[n] e^{-i 2 pi f_k n}|^2 with the correlation windows
+// starting at `start`, restricted to symbols k in [k_min, k_max]. Phase-
+// insensitive per symbol, so it peaks at the true signal start regardless of
+// the (unknown) carrier phase and of small frequency error, and falls off as
+// the windows straddle tone transitions. The caller must pass a symbol range
+// that stays in-buffer for EVERY trial offset it compares: windows of pure
+// noise add a positive floor, so trials that pull more windows into the
+// buffer would otherwise always win (measured: dt pegs at the search edge
+// for any signal extending past the capture window).
+static double tone_coherence(const float* samples, int sample_rate,
+                             const uint8_t* tones, float f0, int start,
+                             int n_spsym, int k_min, int k_max)
+{
+    double metric = 0.0;
+    for (int k = k_min; k <= k_max; ++k)
+    {
+        // FT8 tone spacing == symbol rate == sample_rate / n_spsym.
+        double f = (double)f0 + tones[k] * ((double)sample_rate / n_spsym);
+        double dph = -2.0 * M_PI * f / sample_rate;
+        double wr = cos(dph), wi = sin(dph);
+        double cr = 1.0, ci = 0.0;
+        double sr = 0.0, si = 0.0;
+        const float* base = samples + start + k * n_spsym;
+        for (int n = 0; n < n_spsym; ++n)
+        {
+            double x = base[n];
+            sr += x * cr;
+            si += x * ci;
+            double t = cr * wr - ci * wi;
+            ci = cr * wi + ci * wr;
+            cr = t;
+        }
+        metric += sr * sr + si * si;
+    }
+    return metric;
+}
+
+// One pass of reference synthesis + prefix sums of w(t) = samples * conj(ref).
+// ref = e^{i phi(t)} is the unit-amplitude complex GFSK reference; the
+// low-pass of w is the complex gain track camp(t) ~ (A/2) e^{i dtheta(t)}
+// (the double-frequency image of the real input averages out over a window
+// of >= 1 symbol). df_hz is added to the base frequency of the dphi track.
+static void build_ref_prefix(const float* samples, int num_samples, int start,
+                             const float* dphi, int n_wave, float df_rad,
+                             float* ref_re, float* ref_im,
+                             double* pre_re, double* pre_im)
+{
+    float phi = 0.0f;
+    pre_re[0] = 0.0;
+    pre_im[0] = 0.0;
+    for (int k = 0; k < n_wave; ++k)
+    {
+        ref_re[k] = cosf(phi);
+        ref_im[k] = sinf(phi);
+        int idx = start + k;
+        float x = (idx >= 0 && idx < num_samples) ? samples[idx] : 0.0f;
+        pre_re[k + 1] = pre_re[k] + (double)(x * ref_re[k]);
+        pre_im[k + 1] = pre_im[k] - (double)(x * ref_im[k]);
+        phi = fmodf(phi + dphi[k] + df_rad, 2.0f * (float)M_PI);
+    }
+}
+
+bool ft8_subtract_signal_time(const monitor_t* mon, float* samples,
+                              int num_samples, int sample_rate,
+                              const uint8_t* a91, float freq_hz, float time_sec)
+{
+    if (!mon || !samples || num_samples <= 0 || sample_rate <= 0 || !a91)
+        return false;
+
+    // Re-encode the 77-bit payload to the 79-tone sequence (same contract as
+    // ft8_subtract_signal: clear the CRC bits sharing byte 9).
+    uint8_t payload[10];
+    memcpy(payload, a91, sizeof(payload));
+    payload[9] &= 0xF8;
+    uint8_t tones[FT8_NN];
+    ft8_encode(payload, tones);
+
+    int n_wave = 0;
+    float* dphi = synth_gfsk_dphi_alloc(tones, FT8_NN, freq_hz, 2.0f,
+                                        FT8_SYMBOL_PERIOD, sample_rate, &n_wave);
+    if (!dphi)
+        return false;
+    const int n_spsym = n_wave / FT8_NN;
+
+    // Candidate time -> signal start sample. The waterfall's time base lags
+    // the raw stream: the STFT frame for block b / sub-block t is a Hann
+    // window over the trailing nfft samples ending at b*block_size +
+    // (t+1)*subblock_size, so a symbol starting at sample s0 peaks at
+    // (b + t/time_osr)*block_size = s0 + block_size/2 + nfft/2 -
+    // subblock_size (measured: exactly +0.2 s at 12 kHz / time_osr 4 /
+    // freq_osr 2 — ten times the fine-sync search radius below).
+    const int stft_lag = mon->block_size / 2 + mon->nfft / 2 - mon->subblock_size;
+
+    // --- Fine time sync ------------------------------------------------------
+    // The candidate grid is only good to ±half a time_osr step (±20 ms at
+    // time_osr=4); a 20 ms reference misalignment randomizes the per-symbol
+    // phase at every tone transition and caps suppression near -8 dB
+    // (measured), leaving a residual that still masks co-channel signals.
+    // Search ±24 ms in 4 ms steps for the tone-coherence peak, scored over
+    // the symbols that stay in-buffer at every trial offset (see the note on
+    // tone_coherence for why the range must be common across trials).
+    const int start0 = (int)lrintf(time_sec * (float)sample_rate) - stft_lag;
+    const int dt_step = sample_rate * 4 / 1000;
+    const int dt_span = 6 * dt_step;
+    int k_min = 0;
+    while (k_min < FT8_NN && start0 - dt_span + k_min * n_spsym < 0)
+        ++k_min;
+    int k_max = FT8_NN - 1;
+    while (k_max >= 0 && start0 + dt_span + (k_max + 1) * n_spsym > num_samples)
+        --k_max;
+    int start = start0;
+    if (k_max - k_min >= FT8_NN / 4) // enough in-buffer symbols to sync on
+    {
+        double best_m = -1.0;
+        for (int s = -6; s <= 6; ++s)
+        {
+            int st = start0 + s * dt_step;
+            double m = tone_coherence(samples, sample_rate, tones,
+                                      freq_hz, st, n_spsym, k_min, k_max);
+            if (m > best_m)
+            {
+                best_m = m;
+                start = st;
+            }
+        }
+    }
+
+    float* ref_re = (float*)malloc((size_t)n_wave * sizeof(float));
+    float* ref_im = (float*)malloc((size_t)n_wave * sizeof(float));
+    double* pre_re = (double*)malloc(((size_t)n_wave + 1) * sizeof(double));
+    double* pre_im = (double*)malloc(((size_t)n_wave + 1) * sizeof(double));
+    if (!ref_re || !ref_im || !pre_re || !pre_im)
+    {
+        free(dphi);
+        free(ref_re);
+        free(ref_im);
+        free(pre_re);
+        free(pre_im);
+        return false;
+    }
+
+    build_ref_prefix(samples, num_samples, start, dphi, n_wave, 0.0f,
+                     ref_re, ref_im, pre_re, pre_im);
+
+    // --- Fine frequency sync -------------------------------------------------
+    // Residual frequency error (up to ~±1.6 Hz off the freq_osr=2 grid)
+    // shows up as a steady rotation of the gain track. Standard phase
+    // discriminator: per-symbol phasors p_k from the prefix sums, then
+    // df = arg(sum_k p_{k+1} conj(p_k)) / (2 pi T). Unambiguous to ±1/(2T)
+    // = ±3.125 Hz, well beyond the grid error.
+    double acc_re = 0.0, acc_im = 0.0;
+    double prev_re = 0.0, prev_im = 0.0;
+    bool have_prev = false;
+    for (int k = 0; k < FT8_NN; ++k)
+    {
+        double p_re = pre_re[(k + 1) * n_spsym] - pre_re[k * n_spsym];
+        double p_im = pre_im[(k + 1) * n_spsym] - pre_im[k * n_spsym];
+        if (have_prev)
+        {
+            acc_re += p_re * prev_re + p_im * prev_im;
+            acc_im += p_im * prev_re - p_re * prev_im;
+        }
+        prev_re = p_re;
+        prev_im = p_im;
+        have_prev = true;
+    }
+    float df_hz = 0.0f;
+    if (acc_re != 0.0 || acc_im != 0.0)
+        df_hz = (float)(atan2(acc_im, acc_re) / (2.0 * M_PI * FT8_SYMBOL_PERIOD));
+    // A real decode's frequency error is bounded by the candidate grid
+    // (±1.6 Hz) plus a little drift; a larger estimate means the
+    // discriminator locked onto noise or a neighbor — distrust it.
+    if (fabsf(df_hz) > 2.0f)
+        df_hz = 0.0f;
+    float df_rad = 2.0f * (float)M_PI * df_hz / (float)sample_rate;
+
+    // Rebuild the reference at the refined frequency (skippable when the
+    // discriminator found nothing meaningful).
+    if (fabsf(df_hz) > 0.02f)
+        build_ref_prefix(samples, num_samples, start, dphi, n_wave, df_rad,
+                         ref_re, ref_im, pre_re, pre_im);
+    free(dphi);
+
+    // In-range portion of the reference: only samples the buffer actually
+    // holds contribute to the gain average (out-of-range ones added zero
+    // above and must not dilute the normalization at the buffer edges).
+    const int lo = (start < 0) ? -start : 0;
+    const int hi_excl = (start + n_wave > num_samples) ? num_samples - start : n_wave;
+    const int half = SUBTRACT_TD_NFILT / 2;
+
+    for (int k = lo; k < hi_excl; ++k)
+    {
+        int w_lo = k - half;
+        int w_hi = k + half; // inclusive
+        if (w_lo < lo)
+            w_lo = lo;
+        if (w_hi >= hi_excl)
+            w_hi = hi_excl - 1;
+        int cnt = w_hi - w_lo + 1;
+        if (cnt <= 0)
+            continue;
+        float camp_re = (float)((pre_re[w_hi + 1] - pre_re[w_lo]) / cnt);
+        float camp_im = (float)((pre_im[w_hi + 1] - pre_im[w_lo]) / cnt);
+        // s_est(t) = 2*Re(camp * ref) reconstructs A cos(phi + dtheta).
+        samples[start + k] -= 2.0f * (camp_re * ref_re[k] - camp_im * ref_im[k]);
+    }
+
+    free(ref_re);
+    free(ref_im);
+    free(pre_re);
+    free(pre_im);
+
+#ifdef SUBTRACT_TD_DEBUG
+    if (k_max >= k_min)
+    {
+        double pre = tone_coherence(samples, sample_rate, tones,
+                                    freq_hz + df_hz, start, n_spsym, k_min, k_max);
+        printf("TD-SUB f=%7.1f t=%5.2f dt_fix=%+3d ms df=%+5.2f Hz post-coh %10.3g\n",
+               freq_hz, time_sec, (start - start0) * 1000 / sample_rate, df_hz, pre);
+    }
+#endif
+    return true;
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.h
@@ -9,6 +9,7 @@
 #ifndef FT8AF_FT8_SUBTRACT_H
 #define FT8AF_FT8_SUBTRACT_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "common/monitor.h"
@@ -29,6 +30,30 @@ extern "C" {
 // Bins that are not on the signal's tone track are never touched.
 void ft8_subtract_signal(monitor_t* mon, const uint8_t* a91,
                          float freq_hz, float time_sec);
+
+// Coherent time-domain subtraction of the decoded signal from the raw float
+// sample buffer (WSJT-X subtractft8 approach): synthesize the exact GFSK
+// waveform as a complex reference, estimate the received signal's complex
+// gain over time with a moving-average low-pass of samples * conj(reference)
+// — which absorbs the unknown amplitude, phase, and the residual frequency
+// error of the coarse candidate grid — and subtract 2*Re(gain * reference)
+// in place. Unlike the waterfall-domain ft8_subtract_signal above, this
+// removes the signal's full spectral footprint (Hann spill, sidelobes, tone
+// transients), so a weaker co-channel signal only a few Hz away becomes
+// decodable after the waterfall is recomputed from the residual samples.
+//
+// samples is modified in place; the caller must re-run the monitor STFT over
+// it before the next decode pass. mon is the monitor the candidate came from
+// — only its STFT geometry is read, to convert time_sec (which is in the
+// waterfall's time base, lagging the raw sample stream by a constant
+// block_size/2 + nfft/2 - subblock_size samples) into the signal's start
+// sample. a91 follows the same 77-bit-payload contract as
+// ft8_subtract_signal. Returns true if a subtraction was applied, false on
+// degenerate input or allocation failure (samples then unchanged — callers
+// can fall back to the waterfall-domain subtraction).
+bool ft8_subtract_signal_time(const monitor_t* mon, float* samples,
+                              int num_samples, int sample_rate,
+                              const uint8_t* a91, float freq_hz, float time_sec);
 
 #ifdef __cplusplus
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/gfsk.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/gfsk.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -34,32 +35,26 @@ static void gfsk_pulse(int n_spsym, float symbol_bt, float *pulse)
     }
 }
 
-// Synthesise a GFSK waveform from a tone sequence, writing into
-// signal[offset .. offset + n_sym*n_spsym).
-//
-// Parameters match the JNI signature of GenerateFT8.synth_gfsk:
-//   symbols      — tone values (0..7 for FT8, 0..3 for FT4)
-//   n_sym        — number of symbols (79 for FT8, 105 for FT4)
-//   f0           — base audio frequency in Hz
-//   symbol_bt    — Gaussian BT product (2.0 for FT8, 1.0 for FT4)
-//   symbol_period— symbol duration in seconds (0.160 for FT8)
-//   signal_rate  — output sample rate in Hz (e.g. 12000)
-//   signal       — output buffer (caller-allocated)
-//   offset       — sample index at which to start writing
-void synth_gfsk_offset(const uint8_t *symbols, int n_sym, float f0,
-                       float symbol_bt, float symbol_period,
-                       int signal_rate, float *signal, int offset)
+// Build the per-sample GFSK phase increments for a tone sequence: exactly the
+// n_sym * n_spsym increments the waveform loop integrates (the guard-symbol
+// extension of the first/last tones is applied internally). Returns a
+// malloc'd array the caller frees, or NULL on degenerate input / allocation
+// failure. Shared by synth_gfsk_offset below and the time-domain subtraction
+// reference synthesis in ft8_subtract.c, which needs the phase track (for a
+// complex reference) rather than the real waveform.
+float *synth_gfsk_dphi_alloc(const uint8_t *symbols, int n_sym, float f0,
+                             float symbol_bt, float symbol_period,
+                             int signal_rate, int *n_wave_out)
 {
-    // Guard: reject degenerate inputs that would cause division by zero or
-    // zero-length allocations (e.g. signal_rate == 0 producing n_spsym == 0).
-    if (symbols == NULL || signal == NULL || n_sym <= 0 ||
+    if (symbols == NULL || n_wave_out == NULL || n_sym <= 0 ||
         signal_rate <= 0 || symbol_period <= 0)
-        return;
+        return NULL;
 
     int n_spsym = (int)(0.5f + signal_rate * symbol_period); // samples per symbol
-    if (n_spsym <= 0) return; // would cause division by zero in dphi_peak
-    int n_wave  = n_sym * n_spsym;                           // total output samples
-    float hmod  = 1.0f;
+    if (n_spsym <= 0)
+        return NULL; // would cause division by zero in dphi_peak
+    int n_wave = n_sym * n_spsym; // total output samples
+    float hmod = 1.0f;
 
     float dphi_peak = 2 * (float)M_PI * hmod / n_spsym;
 
@@ -72,7 +67,7 @@ void synth_gfsk_offset(const uint8_t *symbols, int n_sym, float f0,
     if (dphi == NULL || pulse == NULL) {
         free(dphi);  // free(NULL) is safe per C standard
         free(pulse);
-        return;
+        return NULL;
     }
 
     // Initialise every sample to the base-frequency phase increment.
@@ -98,12 +93,46 @@ void synth_gfsk_offset(const uint8_t *symbols, int n_sym, float f0,
         dphi[j + n_sym * n_spsym] += dphi_peak * pulse[j]            * symbols[n_sym - 1];
     }
 
+    free(pulse);
+
+    // Drop the leading guard symbol so dphi[k] is the increment applied after
+    // emitting sample k (the loop below used dphi[k + n_spsym]).
+    memmove(dphi, dphi + n_spsym, (size_t)n_wave * sizeof(float));
+    *n_wave_out = n_wave;
+    return dphi;
+}
+
+// Synthesise a GFSK waveform from a tone sequence, writing into
+// signal[offset .. offset + n_sym*n_spsym).
+//
+// Parameters match the JNI signature of GenerateFT8.synth_gfsk:
+//   symbols      — tone values (0..7 for FT8, 0..3 for FT4)
+//   n_sym        — number of symbols (79 for FT8, 105 for FT4)
+//   f0           — base audio frequency in Hz
+//   symbol_bt    — Gaussian BT product (2.0 for FT8, 1.0 for FT4)
+//   symbol_period— symbol duration in seconds (0.160 for FT8)
+//   signal_rate  — output sample rate in Hz (e.g. 12000)
+//   signal       — output buffer (caller-allocated)
+//   offset       — sample index at which to start writing
+void synth_gfsk_offset(const uint8_t *symbols, int n_sym, float f0,
+                       float symbol_bt, float symbol_period,
+                       int signal_rate, float *signal, int offset)
+{
+    if (signal == NULL)
+        return;
+    int n_wave = 0;
+    float *dphi = synth_gfsk_dphi_alloc(symbols, n_sym, f0, symbol_bt,
+                                        symbol_period, signal_rate, &n_wave);
+    if (dphi == NULL)
+        return;
+    int n_spsym = n_wave / n_sym;
+
     // Integrate phase and generate the sinusoidal waveform.
     float phi = 0;
     for (int k = 0; k < n_wave; ++k)
     {
         signal[offset + k] = sinf(phi);
-        phi = fmodf(phi + dphi[k + n_spsym], 2 * (float)M_PI);
+        phi = fmodf(phi + dphi[k], 2 * (float)M_PI);
     }
 
     // Raised-cosine envelope ramp on the first and last 1/8 symbol.
@@ -116,5 +145,4 @@ void synth_gfsk_offset(const uint8_t *symbols, int n_sym, float f0,
     }
 
     free(dphi);
-    free(pulse);
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -147,8 +147,9 @@ $wavs = Get-ChildItem (Join-Path $corpus "*.wav") | ForEach-Object { $_.FullName
 $benchExit = $LASTEXITCODE
 
 # ---------------------------------------------------------------------------
-# Subtraction unit tests: tone-accurate deep-decode subtraction properties
-# (removal, neighbor preservation, masked co-channel recovery, bounded damage).
+# Subtraction unit tests: waterfall-domain (tone replacement) and coherent
+# time-domain deep-decode subtraction properties (removal, neighbor
+# preservation, masked/same-frequency co-channel recovery, bounded damage).
 # ---------------------------------------------------------------------------
 $subSrcs = @(
     "ft8\pack.c","ft8\encode.c","ft8\crc.c","ft8\constants.c",

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -120,8 +120,9 @@ bench_out="$tmp/ft8_decode_bench"
 "$bench_out" --self-test
 "$bench_out" --assert-floor "$here/testdata/ft8/floors.txt" "$here"/testdata/ft8/*.wav
 
-# Subtraction unit tests: tone-accurate deep-decode subtraction properties
-# (removal, neighbor preservation, masked co-channel recovery, bounded damage).
+# Subtraction unit tests: waterfall-domain (tone replacement) and coherent
+# time-domain deep-decode subtraction properties (removal, neighbor
+# preservation, masked/same-frequency co-channel recovery, bounded damage).
 subtract_srcs=(
     "$here/test_subtract.c"
     "$here/gfsk.c"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_subtract.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_subtract.c
@@ -1,7 +1,9 @@
-// Host unit tests for ft8_subtract.c — the tone-accurate, noise-floor-
-// referenced deep-decode subtraction. Run by run_host_tests.sh / .ps1.
+// Host unit tests for ft8_subtract.c — the waterfall-domain tone-accurate
+// subtraction AND the coherent time-domain subtraction. Run by
+// run_host_tests.sh / .ps1.
 //
-// Properties verified (each was violated by the old ±4-bin zeroing, except 1):
+// Waterfall-domain properties (each was violated by the old ±4-bin zeroing,
+// except 1):
 //   1. Subtracting a decoded signal prevents its re-decode on the next pass.
 //   2. A neighbor signal outside the subtracted signal's tone track survives.
 //   3. Co-channel recovery: a weak signal masked by a strong one 25 Hz away
@@ -9,6 +11,18 @@
 //      legacy zeroing (the regression the rewrite exists to fix).
 //   4. Subtracting with a wrong payload leaves an actual signal decodable
 //      (damage is bounded to the wrong tone track).
+//
+// Time-domain properties (ft8_subtract_signal_time + waterfall refeed):
+//   5. Subtraction removes nearly all of the signal's power from the raw
+//      samples (candidate-time convention included — a regression here means
+//      the STFT-lag correction broke) and prevents its re-decode.
+//   6. Same-frequency co-channel recovery: a weak signal UNDER a strong one
+//      (2 Hz apart, overlapping in time) decodes after the strong one is
+//      subtracted — structurally impossible for the waterfall-domain method,
+//      and the reason the time-domain path exists.
+//   7. A neighbor signal 100 Hz away is not damaged.
+//   8. A phantom subtraction elsewhere in the band leaves a real signal
+//      decodable (an uncorrelated reference estimates ~zero gain).
 
 #include <math.h>
 #include <stdbool.h>
@@ -275,6 +289,101 @@ int main(void)
         ftx_message_encode(&wrong, NULL, MSG_B);
         // Phantom subtraction 300 Hz above the real signal.
         ft8_subtract_signal(&mon, wrong.payload, a->freq_hz + 300.0f, a->time_sec);
+        n = decode_all(&mon, out);
+        check(find_text(out, n, MSG_A) != NULL, "signal survives a phantom subtraction 300 Hz away");
+    }
+
+    // ---- 5. time-domain subtraction removes the signal ----------------------
+    printf("test_td_removes_signal:\n");
+    memset(signal, 0, sizeof(signal));
+    add_noise(signal, NSAMPLES, 0.02f, 46);
+    add_message(signal, MSG_A, 1500.0f, 0.5f, 1.0f, pay_a);
+    feed(&mon, signal);
+    n = decode_all(&mon, out);
+    a = find_text(out, n, MSG_A);
+    check(a != NULL, "signal decodes before time-domain subtraction");
+    if (a)
+    {
+        double power_before = 0, power_after = 0;
+        for (int i = 0; i < NSAMPLES; ++i)
+            power_before += (double)signal[i] * signal[i];
+        bool applied = ft8_subtract_signal_time(&mon, signal, NSAMPLES, RATE,
+                                                a->payload, a->freq_hz, a->time_sec);
+        for (int i = 0; i < NSAMPLES; ++i)
+            power_after += (double)signal[i] * signal[i];
+        check(applied, "subtraction reports success");
+        // amp 1.0 signal over noise amp 0.02: virtually all buffer power is
+        // the signal; >=90% must be gone (a broken STFT-lag correction leaves
+        // most of it: a 20 ms miss caps removal near -8 dB / 84%,
+        // 200 ms leaves nearly everything).
+        check(power_after < 0.1 * power_before, "at least 90% of signal power removed");
+        feed(&mon, signal);
+        n = decode_all(&mon, out);
+        check(find_text(out, n, MSG_A) == NULL, "signal gone after refeed");
+    }
+
+    // ---- 6. same-frequency co-channel recovery (time-domain money test) -----
+    // B sits 2 Hz above A — deep inside every tone bin A occupies — 10 dB
+    // weaker and shifted 0.7 s. No waterfall-domain trick can remove A
+    // without erasing B; coherent sample-domain subtraction can.
+    printf("test_td_same_freq_recovery:\n");
+    memset(signal, 0, sizeof(signal));
+    add_noise(signal, NSAMPLES, 0.02f, 47);
+    add_message(signal, MSG_A, 1500.0f, 0.2f, 1.0f, pay_a);
+    add_message(signal, MSG_B, 1502.0f, 0.9f, 0.3f, pay_b);
+    feed(&mon, signal);
+    n = decode_all(&mon, out);
+    a = find_text(out, n, MSG_A);
+    check(a != NULL, "strong signal decodes in pass 1");
+    check(find_text(out, n, MSG_B) == NULL, "weak same-frequency signal is masked in pass 1");
+    if (a)
+    {
+        check(ft8_subtract_signal_time(&mon, signal, NSAMPLES, RATE,
+                                       a->payload, a->freq_hz, a->time_sec),
+              "subtraction reports success");
+        feed(&mon, signal);
+        n = decode_all(&mon, out);
+        check(find_text(out, n, MSG_B) != NULL, "masked same-frequency signal RECOVERED");
+        check(find_text(out, n, MSG_A) == NULL, "strong signal itself is gone");
+    }
+
+    // ---- 7. time-domain: neighbor 100 Hz away survives -----------------------
+    printf("test_td_neighbor_survives:\n");
+    memset(signal, 0, sizeof(signal));
+    add_noise(signal, NSAMPLES, 0.02f, 48);
+    add_message(signal, MSG_A, 1500.0f, 0.5f, 1.0f, pay_a);
+    add_message(signal, MSG_B, 1600.0f, 0.5f, 0.5f, pay_b);
+    feed(&mon, signal);
+    n = decode_all(&mon, out);
+    a = find_text(out, n, MSG_A);
+    check(a != NULL && find_text(out, n, MSG_B) != NULL, "both decode initially");
+    if (a)
+    {
+        ft8_subtract_signal_time(&mon, signal, NSAMPLES, RATE,
+                                 a->payload, a->freq_hz, a->time_sec);
+        feed(&mon, signal);
+        n = decode_all(&mon, out);
+        check(find_text(out, n, MSG_B) != NULL, "neighbor still decodes after subtracting A");
+        check(find_text(out, n, MSG_A) == NULL, "A itself is gone");
+    }
+
+    // ---- 8. time-domain: phantom subtraction leaves a real signal intact ----
+    printf("test_td_phantom_bounded:\n");
+    memset(signal, 0, sizeof(signal));
+    add_noise(signal, NSAMPLES, 0.02f, 49);
+    add_message(signal, MSG_A, 1500.0f, 0.5f, 0.5f, pay_a);
+    feed(&mon, signal);
+    n = decode_all(&mon, out);
+    a = find_text(out, n, MSG_A);
+    check(a != NULL, "signal decodes before phantom subtraction");
+    if (a)
+    {
+        ftx_message_t wrong;
+        ftx_message_init(&wrong);
+        ftx_message_encode(&wrong, NULL, MSG_B);
+        ft8_subtract_signal_time(&mon, signal, NSAMPLES, RATE, wrong.payload,
+                                 a->freq_hz + 300.0f, a->time_sec);
+        feed(&mon, signal);
         n = decode_all(&mon, out);
         check(find_text(out, n, MSG_A) != NULL, "signal survives a phantom subtraction 300 Hz away");
     }

--- a/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
+++ b/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
@@ -9,23 +9,25 @@
 #   Documented trade: 20m_busy_test_05 floor lowered 22 -> 21 (one decode lost
 #   to subtract-loop interplay with an OSD-recovered neighbor) for +8 matched
 #   across the corpus.
-20m_busy_test_01.wav 20
-20m_busy_test_02.wav 19
-20m_busy_test_03.wav 12
-20m_busy_test_04.wav 17
-20m_busy_test_05.wav 21
-20m_busy_test_06.wav 22
-20m_busy_test_07.wav 24
-20m_busy_test_08.wav 16
-20m_busy_test_09.wav 21
-20m_busy_test_10.wav 18
-20m_busy_test_11.wav 24
-20m_busy_test_12.wav 15
+# 2026-07-02 subtract-time (coherent time-domain subtraction, fine dt/df sync,
+#   STFT-lag correction, NFILT 1440): TOTAL matched=447 recall=94.5%.
+20m_busy_test_01.wav 24
+20m_busy_test_02.wav 21
+20m_busy_test_03.wav 18
+20m_busy_test_04.wav 18
+20m_busy_test_05.wav 29
+20m_busy_test_06.wav 26
+20m_busy_test_07.wav 30
+20m_busy_test_08.wav 18
+20m_busy_test_09.wav 26
+20m_busy_test_10.wav 20
+20m_busy_test_11.wav 29
+20m_busy_test_12.wav 16
 websdr_test1.wav 14
-websdr_test2.wav 19
-websdr_test3.wav 9
-websdr_test4.wav 21
-websdr_test5.wav 20
-websdr_test6.wav 21
-websdr_test7.wav 20
-websdr_test8.wav 21
+websdr_test2.wav 21
+websdr_test3.wav 11
+websdr_test4.wav 22
+websdr_test5.wav 26
+websdr_test6.wav 28
+websdr_test7.wav 24
+websdr_test8.wav 26


### PR DESCRIPTION
## Summary

Continues the decode-gap work (#358–#361, 71.5% → 79.1%). This PR replaces the waterfall-domain tone replacement as the primary deep-decode subtraction with **WSJT-X-style coherent time-domain waveform subtraction**, taking bench recall vs `jt9 -d 3` from **79.1% → 94.5%** (374 → 447 of 473) — past the project's ≥90% target. Six of the twenty corpus files now decode 100% of what jt9 finds.

The miss analysis showed nearly every remaining miss sat within 60 Hz of a decoded stronger signal — including strong (SNR ≥ −10) signals 5–33 Hz from a decode. The waterfall method replaces only the transmitted-tone bin with a noise estimate, so anything sharing those bins stayed buried. The time-domain method synthesizes the decoded signal's complex GFSK reference, estimates its complex gain over time (moving-average low-pass of `samples · conj(ref)`, which absorbs amplitude, phase, and residual frequency error), subtracts `2·Re(gain·ref)` from the retained float samples, and recomputes the waterfall from the residual before the next pass.

## What it took to make it work in situ

A textbook implementation measured **worse** than the waterfall method (76.1%). Three fixes, each diagnosed on the bench corpus:

1. **STFT-lag correction.** A candidate's `time_sec` lags the raw sample stream by a constant `block_size/2 + nfft/2 − subblock_size` samples (**+0.200 s** at 12 kHz / time_osr 4 / freq_osr 2) because the waterfall's Hann analysis frame trails the samples it summarizes. Every subtraction previously landed 200 ms off target and removed almost nothing. The waterfall-domain subtraction never noticed — it operates in the same shifted time base.
2. **Fine dt/df sync.** The candidate grid is only good to ±20 ms / ±1.6 Hz, and a 20 ms reference misalignment caps suppression near −8 dB (each tone transition at the wrong instant randomizes the per-symbol phase). A ±24 ms tone-coherence search — scored only over symbols that stay in-buffer at *every* trial offset, otherwise pure-noise windows bias the peak toward the search edge for any signal extending past the capture window — plus a per-symbol phase discriminator for df restores ~−30 dB suppression.
3. **One subtraction per transmission per slot.** The same signal decodes from several neighboring candidates (and again from its own residual in later loops); each extra subtraction fits the fine sync to junk and *injects* the bogus estimate into the residual. Payloads are deduped in the JNI decoder state and the bench loop.

## Numbers

| File | before | after | | File | before | after |
|---|---|---|---|---|---|---|
| 20m_busy_01 | 83.3 | **100.0** | | websdr_1 | 77.8 | 77.8 |
| 20m_busy_02 | 79.2 | 87.5 | | websdr_2 | 90.5 | **100.0** |
| 20m_busy_03 | 63.2 | 94.7 | | websdr_3 | 81.8 | **100.0** |
| 20m_busy_04 | 85.0 | 90.0 | | websdr_4 | 95.5 | **100.0** |
| 20m_busy_05 | 65.6 | 90.6 | | websdr_5 | 74.1 | 96.3 |
| 20m_busy_06 | 81.5 | 96.3 | | websdr_6 | 72.4 | 96.6 |
| 20m_busy_07 | 77.4 | 96.8 | | websdr_7 | 74.1 | 88.9 |
| 20m_busy_08 | 84.2 | 94.7 | | websdr_8 | 80.8 | **100.0** |
| 20m_busy_09 | 77.8 | 96.3 | | **TOTAL** | **79.1** | **94.5** |
| 20m_busy_10 | 90.0 | **100.0** | | | | |
| 20m_busy_11 | 77.4 | 93.5 | | | | |
| 20m_busy_12 | 83.3 | 88.9 | | | | |

- Gain-track window `SUBTRACT_TD_NFILT` swept: 960 → 92.2, 1200 → 93.7, **1440 → 94.5 (chosen)**, 1680 → 94.1, 1920 → 94.3, 2880 → 92.8, 3840 → 91.5. (WSJT-X's `subtractft8` uses a comparable ~1500-sample window.)
- Extras (decodes not in jt9 truth) rose 31 → 52, but inspection shows they are dominated by **real signals jt9 misses**: `CQ ON3JJT JO20` appears in six files at the same frequency with DT +2.8 s (beyond jt9's search window), and most others appear in the truth sidecars of neighboring slots of the same recording (`CQ RX3ASQ KO95`, `JO1COV PA0CAH JO21`, `CQ IU8DMZ JN70`, the `R7FE IK4ISR −12`/`RRR` QSO progression, …).
- Bench runtime ~110 → ~400 ms/file on the host; on-device the deep loop is already wall-clock-budgeted (11.25 s), and each subtraction is a few ms + one STFT rebuild per pass.

## Wiring

- **App: JNI-only, zero Java changes.** `doSubtractSignal` now subtracts from the float samples retained by `ft8_feed` and marks the waterfall dirty; `DecoderFt8FindSync` rebuilds it from the residual. The waterfall-domain `ft8_subtract_signal` remains the fallback when no sample copy exists.
- **Bench**: time-domain is the default (matching the app); `--wf-subtract` and `--zero-subtract` kept for A/B.
- `gfsk.c` gains `synth_gfsk_dphi_alloc` (phase-increment track shared by TX synthesis and the subtraction reference); `synth_gfsk_offset` behavior is unchanged (bench `--self-test` still decodes its own synth).
- Desktop unaffected: `build.rs` doesn't compile `ft8_subtract.c`, and no `decode_params.h` constants changed.

## Tests

- Four new host cases in `test_subtract.c` (run by `run_host_tests.sh`/`.ps1` and `native-tests.yml`):
  - ≥90% of signal power removed when subtracting at the candidate-time convention — a direct regression guard for the STFT-lag correction (a 20 ms miss caps removal at ~84%, a 200 ms miss removes almost nothing);
  - **same-frequency co-channel recovery** (weak signal 2 Hz under a 10 dB stronger one — structurally impossible for the waterfall method);
  - 100 Hz neighbor survival;
  - phantom-subtraction damage bounding (uncorrelated reference estimates ~zero gain).
- `floors.txt` ratcheted to the new per-file matched counts (TOTAL 374 → 447).
- Full host suite green (golden encode, dev625, FIR, subtract ×27, OSD, bench floor assert); `gradlew assembleDebug testDebugUnitTest` green.

On-device verification: no Java changes and the pipeline is exercised end-to-end by the bench (same monitor config, passes, and subtraction as `FT8SignalListener` + `ft8_decode_jni.cpp`); a live side-by-side vs WSJT-X on a busy band is worth doing from the next CI/staging build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
