### PR TITLE
FT8 OSD: order-2 pair-flip search with stricter pair gate (94.5% -> 94.9% recall vs WSJT-X)

### DIFF
--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/osd.c
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/osd.c
@@ -29,6 +29,16 @@
 #define OSD_NHARD_MAX 38
 #endif
 
+// Stricter acceptance for order-2 (pair-flip) solutions. Pair flips run
+// C(depth,2) trials per candidate instead of `depth`, so junk gets many more
+// draws against the CRC+nhard lottery. Benchmark-swept: at the order-1 gate
+// (38) the pairs admit fabricated decodes ("CQ VTIN 0J1NTF R 579 2608"-class
+// junk); 30..34 all keep the genuine pair recoveries and reject every junk
+// decode on the corpus; 28 starts losing genuine ones. 30 chosen for margin.
+#ifndef OSD_NHARD_MAX_ORDER2
+#define OSD_NHARD_MAX_ORDER2 30
+#endif
+
 // ---------------------------------------------------------------------------
 // 91-bit vectors as two 64-bit words.
 // ---------------------------------------------------------------------------
@@ -143,10 +153,10 @@ static bool crc_ok(const bits91_t* plain)
 }
 
 // Evaluate a candidate message: valid codeword bits are re-encoded and
-// compared to the received hard decisions (nhard) and soft values (dist,
-// the summed |LLR| of disagreeing bits — lower is better).
+// compared to the received hard decisions (nhard, capped at nhard_max) and
+// soft values (dist, the summed |LLR| of disagreeing bits — lower is better).
 static bool evaluate(const bits91_t* plain, const float log174[FTX_LDPC_N],
-                     int* nhard_out, float* dist_out)
+                     int nhard_max, int* nhard_out, float* dist_out)
 {
     if (bits91_zero(plain))
         return false;
@@ -166,7 +176,7 @@ static bool evaluate(const bits91_t* plain, const float log174[FTX_LDPC_N],
             dist += fabsf(log174[i]);
         }
     }
-    if (nhard > OSD_NHARD_MAX)
+    if (nhard > nhard_max)
         return false;
     *nhard_out = nhard;
     *dist_out = dist;
@@ -270,7 +280,7 @@ bool osd_decode(const float log174[FTX_LDPC_N], int depth,
 
         int nhard;
         float dist;
-        if (!evaluate(&plain, log174, &nhard, &dist))
+        if (!evaluate(&plain, log174, OSD_NHARD_MAX, &nhard, &dist))
             continue;
         if (best_depth == -2 || dist < best_dist)
         {
@@ -279,6 +289,45 @@ bool osd_decode(const float log174[FTX_LDPC_N], int depth,
             best_depth = flip;
             if (flip == -1)
                 break; // base decode passed all gates: accept immediately
+        }
+    }
+
+    // Order-2: toggle every PAIR of the `depth` least reliable accepted bits
+    // (C(depth,2) trials; 66 at depth 12). Reaches decodes where TWO
+    // moderately unreliable bits are wrong at once — measured on the bench
+    // corpus this converts co-channel near-misses (BP a few parity checks
+    // short) that no single flip can fix, e.g. two overlapping strong
+    // signals that block each other's first decode and therefore the whole
+    // subtract-and-redecode chain. Skipped when the base decode already
+    // passed (early break above leaves best_depth == -1). The same CRC +
+    // nhard gates in evaluate() bound the false-decode risk; cost is a few
+    // microseconds per trial.
+    if (best_depth != -1)
+    {
+        for (int f1 = 0; f1 < depth - 1 && f1 < FTX_LDPC_K - 1; ++f1)
+        {
+            for (int f2 = f1 + 1; f2 < depth && f2 < FTX_LDPC_K; ++f2)
+            {
+                bits91_t ytry = y;
+                bits91_flip(&ytry, FTX_LDPC_K - 1 - f1);
+                bits91_flip(&ytry, FTX_LDPC_K - 1 - f2);
+
+                bits91_t plain = { { 0, 0 } };
+                for (int j = 0; j < FTX_LDPC_K; ++j)
+                    if (bits91_parity_and(&rhs[j], &ytry))
+                        bits91_flip(&plain, pivot_col[j]);
+
+                int nhard;
+                float dist;
+                if (!evaluate(&plain, log174, OSD_NHARD_MAX_ORDER2, &nhard, &dist))
+                    continue;
+                if (best_depth == -2 || dist < best_dist)
+                {
+                    best_plain = plain;
+                    best_dist = dist;
+                    best_depth = f2; // deepest single index touched
+                }
+            }
         }
     }
 

--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/osd.c
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/osd.c
@@ -153,8 +153,9 @@ static bool crc_ok(const bits91_t* plain)
 }
 
 // Evaluate a candidate message: valid codeword bits are re-encoded and
-// compared to the received hard decisions (nhard, capped at nhard_max) and
-// soft values (dist, the summed |LLR| of disagreeing bits — lower is better).
+// compared to the received hard decisions (nhard; the candidate is REJECTED
+// when nhard exceeds nhard_max) and soft values (dist, the summed |LLR| of
+// disagreeing bits — lower is better).
 static bool evaluate(const bits91_t* plain, const float log174[FTX_LDPC_N],
                      int nhard_max, int* nhard_out, float* dist_out)
 {

--- a/ft8af/app/src/main/cpp/ft8af_glue/decode_params.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/decode_params.h
@@ -36,8 +36,12 @@
 #define FT8AF_LDPC_ITERS_DEEP 30
 
 // Ordered-statistics backstop (ft8_lib/ft8/osd.c), deep passes only.
-// DEPTH = single-bit-flip retries over the least reliable basis positions.
-// Swept on the bench: 6 -> 78.6%, 12 -> 79.1%, 24 -> flat with more junk.
+// DEPTH = flip window over the least reliable basis positions: `depth`
+// single-bit retries plus C(depth,2) pair retries (order-2; pairs use a
+// stricter acceptance gate, see OSD_NHARD_MAX_ORDER2 in osd.c). Swept on
+// the bench: order-1 6 -> 78.6%, 12 -> 79.1%, 24 -> flat with more junk;
+// with order-2 pairs (post time-domain subtraction) depth 12 -> 94.9%,
+// 16..32 -> matched flat while false decodes climb. Keep 12.
 // ERR_GATE = max unsatisfied BP parity checks for which OSD is attempted
 // (junk candidates typically fail 40-80 checks and are skipped).
 #define FT8AF_OSD_DEPTH_DEEP 12

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_osd.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_osd.c
@@ -11,6 +11,11 @@
 //      recovers the exact message (the reason the backstop exists).
 //   4. False-decode guard: 1000 seeded pure-noise LLR vectors produce zero
 //      accepted decodes.
+//   5. Order-2 recovery: TWO moderately confident wrong bits land in the
+//      reordered basis tail (forced by a mass of near-erasure correct bits),
+//      so the base decode and every single flip fail and only a pair flip
+//      reaches the codeword. Fails on the order-1-only implementation
+//      (verified against it on 252 of 300 seeds; this seed is one of them).
 
 #include <math.h>
 #include <stdbool.h>
@@ -143,6 +148,34 @@ int main(void)
     check(accepted == 0, "0 of 1000 pure-noise vectors accepted");
     if (accepted > 0)
         printf("  (accepted %d)\n", accepted);
+
+    // ---- 5. order-2 (pair-flip) recovery --------------------------------------
+    // Two moderately confident WRONG bits (|LLR| 0.4) plus 87 near-erasure
+    // CORRECT bits (|LLR| ~0.02-0.04). The erasure mass forces the wrong bits
+    // into the reliability-ordered basis near its tail: the base decode is
+    // wrong in two basis positions (CRC rejects), no single flip can fix
+    // both, and the pair search recovers the exact codeword. bp_decode fails
+    // outright (the erasure mass alone exceeds BP's capacity).
+    printf("test_osd_order2_pair_recovery:\n");
+    g_seed = 1;
+    clean_llrs(cw, 1.0f, llr);
+    corrupted = 0;
+    while (corrupted < 2 + 87)
+    {
+        int i = (int)(prng_uniform() * FTX_LDPC_N);
+        if (fabsf(llr[i]) < 0.9f)
+            continue; // already corrupted
+        if (corrupted < 2)
+            llr[i] = (cw[i] ? -1.0f : 1.0f) * 0.4f; // confident and WRONG
+        else
+            llr[i] = (cw[i] ? 1.0f : -1.0f) * 0.02f * (1.0f + prng_uniform());
+        corrupted++;
+    }
+    bp_decode(llr, 30, plain174, &errors);
+    check(errors > 0, "belief propagation fails (erasure mass over capacity)");
+    ok = osd_decode(llr, 12, plain174, &depth_used);
+    check(ok, "osd_decode recovers via a pair flip");
+    check(ok && memcmp(plain174, cw, FTX_LDPC_N) == 0, "recovered bits equal the codeword");
 
     if (g_failures == 0)
     {

--- a/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
+++ b/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
@@ -11,11 +11,13 @@
 #   across the corpus.
 # 2026-07-02 subtract-time (coherent time-domain subtraction, fine dt/df sync,
 #   STFT-lag correction, NFILT 1440): TOTAL matched=447 recall=94.5%.
+# 2026-07-02 osd-order2 (pair flips, nhard<=30 pair gate): TOTAL matched=449
+#   recall=94.9%; extras 52 -> 51.
 20m_busy_test_01.wav 24
 20m_busy_test_02.wav 21
 20m_busy_test_03.wav 18
 20m_busy_test_04.wav 18
-20m_busy_test_05.wav 29
+20m_busy_test_05.wav 30
 20m_busy_test_06.wav 26
 20m_busy_test_07.wav 30
 20m_busy_test_08.wav 18
@@ -23,7 +25,7 @@
 20m_busy_test_10.wav 20
 20m_busy_test_11.wav 29
 20m_busy_test_12.wav 16
-websdr_test1.wav 14
+websdr_test1.wav 15
 websdr_test2.wav 21
 websdr_test3.wav 11
 websdr_test4.wav 22


### PR DESCRIPTION
## Summary

Follow-up to #367 in the decode-gap effort: extends the OSD backstop from order-1 (single-bit flips) to **order-2 (pair flips)** with a stricter acceptance gate for pair solutions. Bench recall vs `jt9 -d 3`: **94.5% → 94.9%** (447 → 449 of 473), with false-positive extras *down* one (52 → 51).

## Why

Profiling the 26 post-#367 misses turned up strong signals (down to −6/−10 dB, one at +9 dB) that jt9 decodes and we don't. Probing one case (20m_busy_test_05, two strong signals 32 Hz apart in the same slot): both produce good sync candidates, BP stops just 3–5 parity checks short — but single-flip OSD can't bridge a near-miss whose basis tail holds **two** wrong bits, which is exactly what mutually overlapping co-channel signals produce. And because neither decodes, the subtract-and-redecode chain never gets to untangle the pair. WSJT-X's `osd174_91` searches higher orders; this brings us one order closer.

## What

- `ft8_lib/ft8/osd.c`: after the existing `depth` single flips, try every pair among the same `depth` least-reliable basis positions — C(12,2) = 66 extra trials, a few µs each, deep passes only (same call sites, no signature change).
- **Stricter pair gate** `OSD_NHARD_MAX_ORDER2 = 30` (vs 38 for order-1). Pairs get 5.5× more draws against the CRC+nhard lottery; at the order-1 gate they admit fabricated decodes (`CQ VTIN 0J1NTF R 579 2608`-class junk — extras 54 at depth 12, 97 at depth 32). Swept: 30–34 rejects every fabricated decode on the corpus while keeping both genuine recoveries; 28 starts losing them; 30 chosen for margin.
- Depth stays 12 — swept 16/20/24/32: matched flat at 450–451 while extras climb to 97. Not worth it.
- `decode_params.h` OSD notes updated; floors ratcheted (`20m_busy_test_05` 29→30, `websdr_test1` 14→15).

The two new matches are genuine truth messages, both co-channel near-misses: `HB9BIN UR7HN RR73` (−10 dB) and `R2ATW IZ0VLL -16` (−6 dB).

## Tests

New `test_osd.c` case: LLRs constructed so the reliability-ordered basis tail contains exactly two moderately confident wrong bits (forced there by a mass of near-erasure correct bits) — `bp_decode` fails, the base decode and every single flip fail CRC, only a pair flip recovers the exact codeword. Verified against the pre-change order-1 implementation: it fails this model on 252 of 300 seeds, including the committed one — so the test is a true regression guard for the order-2 path. The 1000-trial pure-noise rejection guard still passes with 0 accepted.

Full host suite green (golden, dev625, FIR, subtract, OSD, bench `--assert-floor`); `gradlew assembleDebug testDebugUnitTest` green. Desktop compiles the same `osd.c` via `build.rs`; no interface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
