### PR TITLE
FT8 fine-sync coherent demod retry (94.9% -> 97.0% recall vs WSJT-X)

### DIFF
--- a/ft8af/app/src/main/cpp/CMakeLists.txt
+++ b/ft8af/app/src/main/cpp/CMakeLists.txt
@@ -112,6 +112,8 @@ add_library(ft8af SHARED
         ft8af_glue/ft8_decode_jni.cpp
         # Deep-decode signal subtraction (shared with host bench + desktop)
         ft8af_glue/ft8_subtract.c
+        # Fine-sync coherent demod retry (shared with host bench)
+        ft8af_glue/ft8_fine.c
         # JNI wrappers — FT2/FT4 decoder (from-source, was in ft8af_usb)
         ft8af_glue/ft2_decode_jni.cpp
 )

--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/decode.c
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/decode.c
@@ -419,19 +419,14 @@ static void ftx_normalize_logl(float* log174)
     }
 }
 
-bool ft8_decode_osd(const waterfall_t* wf, const candidate_t* cand, int max_iterations,
-                    int osd_depth, int osd_err_gate, ftx_message_t* message, decode_status_t* status)
+bool ftx_decode_llrs(ftx_protocol_t protocol, const float* llrs, int max_iterations,
+                     int osd_depth, int osd_err_gate, ftx_message_t* message, decode_status_t* status)
 {
-    float log174[FTX_LDPC_N]; // message bits encoded as likelihood
-    if (wf->protocol != FTX_PROTOCOL_FT8) // FT4 and FT2 share the 2-bit/symbol layout
-    {
-        ft4_extract_likelihood(wf, cand, log174);
-    }
-    else
-    {
-        ft8_extract_likelihood(wf, cand, log174);
-    }
-
+    // Work on a normalized copy: callers hand in raw log-likelihoods on
+    // whatever scale their demodulator produced.
+    float log174[FTX_LDPC_N];
+    for (int i = 0; i < FTX_LDPC_N; ++i)
+        log174[i] = llrs[i];
     ftx_normalize_logl(log174);
 
     uint8_t plain174[FTX_LDPC_N]; // message bits (0/1)
@@ -475,7 +470,7 @@ bool ft8_decode_osd(const waterfall_t* wf, const candidate_t* cand, int max_iter
     // Reuse CRC value as a hash for the message (TODO: 14 bits only, should perhaps use full 16 or 32 bits?)
     message->hash = status->crc_calculated;
 
-    if (wf->protocol != FTX_PROTOCOL_FT8) // FT4 and FT2 both XOR the payload (FT8 does not)
+    if (protocol != FTX_PROTOCOL_FT8) // FT4 and FT2 both XOR the payload (FT8 does not)
     {
         // '[..] for FT4 only, in order to avoid transmitting a long string of zeros when sending CQ messages,
         // the assembled 77-bit message is bitwise exclusive-OR’ed with [a] pseudorandom sequence before computing the CRC and FEC parity bits'
@@ -495,6 +490,22 @@ bool ft8_decode_osd(const waterfall_t* wf, const candidate_t* cand, int max_iter
 
     // LOG(LOG_DEBUG, "Decoded message (CRC %04x), trying to unpack...\n", status->crc_extracted);
     return true;
+}
+
+bool ft8_decode_osd(const waterfall_t* wf, const candidate_t* cand, int max_iterations,
+                    int osd_depth, int osd_err_gate, ftx_message_t* message, decode_status_t* status)
+{
+    float log174[FTX_LDPC_N]; // message bits encoded as likelihood
+    if (wf->protocol != FTX_PROTOCOL_FT8) // FT4 and FT2 share the 2-bit/symbol layout
+    {
+        ft4_extract_likelihood(wf, cand, log174);
+    }
+    else
+    {
+        ft8_extract_likelihood(wf, cand, log174);
+    }
+
+    return ftx_decode_llrs(wf->protocol, log174, max_iterations, osd_depth, osd_err_gate, message, status);
 }
 
 bool ft8_decode(const waterfall_t* wf, const candidate_t* cand, int max_iterations, ftx_message_t* message, decode_status_t* status)

--- a/ft8af/app/src/main/cpp/ft8_lib/ft8/decode.h
+++ b/ft8af/app/src/main/cpp/ft8_lib/ft8/decode.h
@@ -78,6 +78,14 @@ bool ft8_decode(const waterfall_t* power, const candidate_t* cand, int max_itera
 bool ft8_decode_osd(const waterfall_t* power, const candidate_t* cand, int max_iterations,
                     int osd_depth, int osd_err_gate, ftx_message_t* message, decode_status_t* status);
 
+/// The BP (+ optional OSD) + CRC + unpack stage of ft8_decode_osd for
+/// caller-provided log-likelihoods (174 entries, log p(1)/p(0), any scale —
+/// normalized internally). Lets an external demodulator (e.g. the fine-sync
+/// coherent demod in ft8af_glue/ft8_fine.c) reuse the decode chain without a
+/// waterfall. protocol selects the FT4/FT2 payload XOR de-scramble.
+bool ftx_decode_llrs(ftx_protocol_t protocol, const float* llrs, int max_iterations,
+                     int osd_depth, int osd_err_gate, ftx_message_t* message, decode_status_t* status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
@@ -54,6 +54,7 @@
 #include "common/wave.h"
 
 #include "decode_params.h"
+#include "ft8_fine.h"
 #include "ft8_subtract.h"
 
 // From gfsk.c (glue): GFSK synth used by the --self-test signal generator.
@@ -279,8 +280,8 @@ static void subtract_signal_zeroing(monitor_t* mon, const bench_decode_t* dec)
 // (for subtraction); only messages not already in seen are new.
 // Returns the number of NEW messages.
 // ---------------------------------------------------------------------------
-static int run_pass(monitor_t* mon, int ldpc_iters, int min_score, int osd_depth,
-                    bench_msglist_t* seen, bench_declist_t* pass_decs)
+static int run_pass(monitor_t* mon, ft8_fine_ctx_t* fine, int ldpc_iters, int min_score,
+                    int osd_depth, bench_msglist_t* seen, bench_declist_t* pass_decs)
 {
     static candidate_t candidates[BENCH_MAX_CAND_CAP];
     pass_decs->count = 0;
@@ -291,16 +292,46 @@ static int run_pass(monitor_t* mon, int ldpc_iters, int min_score, int osd_depth
     for (int idx = 0; idx < num_candidates; ++idx)
     {
         const candidate_t* cand = &candidates[idx];
-        ftx_message_t message;
-        decode_status_t status;
-        if (!ft8_decode_osd(&mon->wf, cand, ldpc_iters, osd_depth,
-                            FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
-            continue;
 
         float freq_hz = (mon->min_bin + cand->freq_offset +
                          (float)cand->freq_sub / mon->wf.freq_osr) / mon->symbol_period;
         float time_sec = (cand->time_offset +
                           (float)cand->time_sub / mon->wf.time_osr) * mon->symbol_period;
+
+        ftx_message_t message;
+        decode_status_t status;
+        bool decoded = ft8_decode_osd(&mon->wf, cand, ldpc_iters, osd_depth,
+                                      FT8AF_OSD_LDPC_ERR_GATE, &message, &status);
+        if (!decoded && fine && osd_depth > 0)
+        {
+            // Second chance for deep passes: re-demodulate the candidate
+            // from the raw samples with fine dt/df sync (see ft8_fine.h) and
+            // run the same BP+OSD+CRC chain on the float LLRs. On success,
+            // the refined freq/time also make the subsequent subtraction
+            // more accurate than the grid values.
+            float llrs[FTX_LDPC_N];
+            float f_fine, t_fine, quality;
+            if (ft8_fine_demod(fine, mon, cand, llrs, &f_fine, &t_fine, &quality) &&
+                quality >= FT8AF_FINE_SYNC_MIN &&
+                ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, ldpc_iters, osd_depth,
+                                FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
+            {
+                // Rare message types out of this second-chance path are
+                // junk-prone (see FT8AF_FINE_SYNC_MIN_RARE) — hold them to
+                // the higher sync-quality bar.
+                ftx_message_type_t mtype = ftx_message_get_type(&message);
+                if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
+                    mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
+                    quality >= FT8AF_FINE_SYNC_MIN_RARE)
+                {
+                    decoded = true;
+                    freq_hz = f_fine;
+                    time_sec = t_fine;
+                }
+            }
+        }
+        if (!decoded)
+            continue;
 
         // Decode to text the same way DecoderFt8Analysis assembles it.
         char text[64] = { 0 };
@@ -389,12 +420,13 @@ static void decode_buffer(float* signal, int num_samples,
     monitor_t mon;
     monitor_init(&mon, &cfg);
     feed_monitor(&mon, signal, num_samples);
+    ft8_fine_ctx_t* fine = ft8_fine_init(signal, num_samples, BENCH_SAMPLE_RATE);
 
     bench_hash_reset();
     static bench_declist_t pass_decs;
     int passes = 0;
 
-    run_pass(&mon, g_ldpc_fast, g_min_score_fast, 0, seen, &pass_decs);
+    run_pass(&mon, fine, g_ldpc_fast, g_min_score_fast, 0, seen, &pass_decs);
     passes++;
 
     if (g_deep)
@@ -407,7 +439,7 @@ static void decode_buffer(float* signal, int num_samples,
         static uint8_t done[BENCH_MAX_MSGS][FTX_PAYLOAD_LENGTH_BYTES];
         int done_count = 0;
 
-        int new_msgs = run_pass(&mon, g_ldpc_deep, g_min_score_deep, g_osd_depth, seen, &pass_decs);
+        int new_msgs = run_pass(&mon, fine, g_ldpc_deep, g_min_score_deep, g_osd_depth, seen, &pass_decs);
         passes++;
         for (int loop = 0; loop < g_max_loops; ++loop)
         {
@@ -442,14 +474,21 @@ static void decode_buffer(float* signal, int num_samples,
                 }
             }
             if (g_subtract_mode == SUBTRACT_TIME && subtracted)
+            {
                 feed_monitor(&mon, signal, num_samples);
-            new_msgs = run_pass(&mon, g_ldpc_deep, g_min_score_deep, g_osd_depth, seen, &pass_decs);
+                // The samples changed: the fine-demod context must see the
+                // residual, not the original capture.
+                ft8_fine_free(fine);
+                fine = ft8_fine_init(signal, num_samples, BENCH_SAMPLE_RATE);
+            }
+            new_msgs = run_pass(&mon, fine, g_ldpc_deep, g_min_score_deep, g_osd_depth, seen, &pass_decs);
             passes++;
             if (new_msgs == 0)
                 break;
         }
     }
 
+    ft8_fine_free(fine);
     monitor_free(&mon);
     *passes_out = passes;
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
@@ -420,7 +420,12 @@ static void decode_buffer(float* signal, int num_samples,
     monitor_t mon;
     monitor_init(&mon, &cfg);
     feed_monitor(&mon, signal, num_samples);
-    ft8_fine_ctx_t* fine = ft8_fine_init(signal, num_samples, BENCH_SAMPLE_RATE);
+    // The fine-demod retry only runs in deep passes with OSD enabled
+    // (run_pass gates on osd_depth > 0); don't pay its full-buffer FFT
+    // when --fast or --osd-depth 0 makes it unreachable.
+    ft8_fine_ctx_t* fine = (g_deep && g_osd_depth > 0)
+        ? ft8_fine_init(signal, num_samples, BENCH_SAMPLE_RATE)
+        : NULL;
 
     bench_hash_reset();
     static bench_declist_t pass_decs;
@@ -477,9 +482,13 @@ static void decode_buffer(float* signal, int num_samples,
             {
                 feed_monitor(&mon, signal, num_samples);
                 // The samples changed: the fine-demod context must see the
-                // residual, not the original capture.
-                ft8_fine_free(fine);
-                fine = ft8_fine_init(signal, num_samples, BENCH_SAMPLE_RATE);
+                // residual, not the original capture. Rebuild only if the
+                // fine path is enabled at all (same gate as the init).
+                if (fine)
+                {
+                    ft8_fine_free(fine);
+                    fine = ft8_fine_init(signal, num_samples, BENCH_SAMPLE_RATE);
+                }
             }
             new_msgs = run_pass(&mon, fine, g_ldpc_deep, g_min_score_deep, g_osd_depth, seen, &pass_decs);
             passes++;

--- a/ft8af/app/src/main/cpp/ft8af_glue/decode_params.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/decode_params.h
@@ -47,4 +47,24 @@
 #define FT8AF_OSD_DEPTH_DEEP 12
 #define FT8AF_OSD_LDPC_ERR_GATE 24
 
+// Fine-demod retry (ft8af_glue/ft8_fine.c), deep passes only: candidates the
+// waterfall LLRs can't decode are re-demodulated from the raw samples with
+// Costas fine dt/df sync. SYNC_MIN gates the retry on the fine sync quality
+// (aligned Costas power over misaligned trials) so noise candidates don't
+// get a second draw against the CRC+nhard gates. Swept: 1.0 -> 460 matched /
+// 65 extras, 1.2 -> 460/64, 1.4 -> 459/62, 1.7 -> 455/58, 2.0 -> 449/52 —
+// real decodes fall off fast above 1.2.
+// RARE_MIN applies instead when the decoded message is NOT a standard or
+// non-standard-call message: fabricated decodes land disproportionately in
+// the free-text/contest types (random 77-bit payloads), while genuine
+// traffic in those types is rare and strong. Junk observed at the base
+// gate ("1EQ8YXYQDW2 .", "W99WMQ JX3GAH 539 4274") sails through quality
+// ~1.2-2 on a busy band; genuine rare-type decodes clear 2.5 easily.
+#ifndef FT8AF_FINE_SYNC_MIN
+#define FT8AF_FINE_SYNC_MIN 1.2f
+#endif
+#ifndef FT8AF_FINE_SYNC_MIN_RARE
+#define FT8AF_FINE_SYNC_MIN_RARE 2.5f
+#endif
+
 #endif // FT8AF_DECODE_PARAMS_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -27,6 +27,7 @@ int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
 }
 
 #include "decode_params.h"
+#include "ft8_fine.h"
 #include "ft8_subtract.h"
 
 // ---------------------------------------------------------------------------
@@ -73,6 +74,7 @@ struct ft8_decoder_state
     int num_fed;   // samples actually captured into `samples` this slot
     bool wf_dirty; // time-domain subtraction has edited `samples`; the
                    // waterfall must be recomputed before the next find_sync
+    ft8_fine_ctx_t* fine; // fine-demod context over the current `samples`
     int sample_rate;
     long utc;
 
@@ -271,6 +273,7 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DeleteDecoder(
         return;
     if (d->mon_ready)
         monitor_free(&d->mon);
+    ft8_fine_free(d->fine);
     free(d->samples);
     free(d);
 }
@@ -291,6 +294,11 @@ static void ft8_feed(ft8_decoder_state* d, const float* data, int n)
     monitor_reset(&d->mon);
     for (int pos = 0; pos + d->mon.block_size <= n; pos += d->mon.block_size)
         monitor_process(&d->mon, data + pos);
+
+    ft8_fine_free(d->fine);
+    d->fine = (d->num_fed > 0)
+        ? ft8_fine_init(d->samples, d->num_fed, d->sample_rate)
+        : NULL;
 }
 
 // ---------------------------------------------------------------------------
@@ -366,11 +374,13 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8FindSync(
     if (d->wf_dirty && d->samples && d->num_fed > 0)
     {
         // Time-domain subtraction edited the retained samples; recompute the
-        // waterfall from the residual so this pass can uncover what was
-        // underneath the removed signals.
+        // waterfall (and the fine-demod context) from the residual so this
+        // pass can uncover what was underneath the removed signals.
         monitor_reset(&d->mon);
         for (int pos = 0; pos + d->mon.block_size <= d->num_fed; pos += d->mon.block_size)
             monitor_process(&d->mon, d->samples + pos);
+        ft8_fine_free(d->fine);
+        d->fine = ft8_fine_init(d->samples, d->num_fed, d->sample_rate);
         d->wf_dirty = false;
     }
     int min_score = d->deep ? FT8AF_MIN_SCORE_DEEP : FT8AF_MIN_SCORE_FAST;
@@ -393,21 +403,48 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Analysis(
     ft8_cache_fields(env, ft8Message);
     const candidate_t* cand = &d->candidates[idx];
 
-    ftx_message_t message;
-    decode_status_t status;
-    int osd_depth = d->deep ? FT8AF_OSD_DEPTH_DEEP : 0; // OSD only in deep passes
-    if (!ft8_decode_osd(&d->mon.wf, cand, d->ldpc_iterations, osd_depth,
-                        FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
-        return JNI_FALSE;
-
-    d->last_message = message;
-    d->have_last = true;
-
     // Geometry + signal metrics
     float freq_hz = (d->mon.min_bin + cand->freq_offset +
                      (float)cand->freq_sub / d->mon.wf.freq_osr) / d->mon.symbol_period;
     float time_sec = (cand->time_offset +
                       (float)cand->time_sub / d->mon.wf.time_osr) * d->mon.symbol_period;
+
+    ftx_message_t message;
+    decode_status_t status;
+    int osd_depth = d->deep ? FT8AF_OSD_DEPTH_DEEP : 0; // OSD only in deep passes
+    bool decoded = ft8_decode_osd(&d->mon.wf, cand, d->ldpc_iterations, osd_depth,
+                                  FT8AF_OSD_LDPC_ERR_GATE, &message, &status);
+    if (!decoded && d->fine && osd_depth > 0)
+    {
+        // Second chance for deep passes: re-demodulate from the raw samples
+        // with fine dt/df sync (ft8_fine.h) and rerun BP+OSD+CRC on the
+        // float LLRs. Junk guards mirror decode_bench.c: a sync-quality
+        // floor, raised for the junk-prone rare message types. On success
+        // the refined freq/time replace the grid values — they also flow
+        // into a91List and make the subsequent subtraction more accurate.
+        float llrs[FTX_LDPC_N];
+        float f_fine, t_fine, quality;
+        if (ft8_fine_demod(d->fine, &d->mon, cand, llrs, &f_fine, &t_fine, &quality) &&
+            quality >= FT8AF_FINE_SYNC_MIN &&
+            ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, d->ldpc_iterations, osd_depth,
+                            FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
+        {
+            ftx_message_type_t mtype = ftx_message_get_type(&message);
+            if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
+                mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
+                quality >= FT8AF_FINE_SYNC_MIN_RARE)
+            {
+                decoded = true;
+                freq_hz = f_fine;
+                time_sec = t_fine;
+            }
+        }
+    }
+    if (!decoded)
+        return JNI_FALSE;
+
+    d->last_message = message;
+    d->have_last = true;
     g_active = d;
     int snr = ft8_snr(&d->mon.wf, cand);
 

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -74,7 +74,12 @@ struct ft8_decoder_state
     int num_fed;   // samples actually captured into `samples` this slot
     bool wf_dirty; // time-domain subtraction has edited `samples`; the
                    // waterfall must be recomputed before the next find_sync
-    ft8_fine_ctx_t* fine; // fine-demod context over the current `samples`
+    // Fine-demod context over the current `samples`, built LAZILY on the
+    // first deep-pass retry that needs it (deep mode is unknown at feed
+    // time, and non-deep slots must not pay its full-buffer FFT).
+    // fine_tried keeps a failed init from being retried per candidate.
+    ft8_fine_ctx_t* fine;
+    bool fine_tried;
     int sample_rate;
     long utc;
 
@@ -295,10 +300,11 @@ static void ft8_feed(ft8_decoder_state* d, const float* data, int n)
     for (int pos = 0; pos + d->mon.block_size <= n; pos += d->mon.block_size)
         monitor_process(&d->mon, data + pos);
 
+    // Invalidate only: the context is rebuilt lazily when a deep pass
+    // actually needs it (see DecoderFt8Analysis).
     ft8_fine_free(d->fine);
-    d->fine = (d->num_fed > 0)
-        ? ft8_fine_init(d->samples, d->num_fed, d->sample_rate)
-        : NULL;
+    d->fine = NULL;
+    d->fine_tried = false;
 }
 
 // ---------------------------------------------------------------------------
@@ -374,13 +380,16 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8FindSync(
     if (d->wf_dirty && d->samples && d->num_fed > 0)
     {
         // Time-domain subtraction edited the retained samples; recompute the
-        // waterfall (and the fine-demod context) from the residual so this
-        // pass can uncover what was underneath the removed signals.
+        // waterfall from the residual so this pass can uncover what was
+        // underneath the removed signals. The fine-demod context is only
+        // invalidated here — it is rebuilt lazily on first use so modes
+        // that never take the fine path don't pay its full-buffer FFT.
         monitor_reset(&d->mon);
         for (int pos = 0; pos + d->mon.block_size <= d->num_fed; pos += d->mon.block_size)
             monitor_process(&d->mon, d->samples + pos);
         ft8_fine_free(d->fine);
-        d->fine = ft8_fine_init(d->samples, d->num_fed, d->sample_rate);
+        d->fine = NULL;
+        d->fine_tried = false;
         d->wf_dirty = false;
     }
     int min_score = d->deep ? FT8AF_MIN_SCORE_DEEP : FT8AF_MIN_SCORE_FAST;
@@ -414,14 +423,23 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Analysis(
     int osd_depth = d->deep ? FT8AF_OSD_DEPTH_DEEP : 0; // OSD only in deep passes
     bool decoded = ft8_decode_osd(&d->mon.wf, cand, d->ldpc_iterations, osd_depth,
                                   FT8AF_OSD_LDPC_ERR_GATE, &message, &status);
-    if (!decoded && d->fine && osd_depth > 0)
+    if (!decoded && osd_depth > 0 && d->samples && d->num_fed > 0 &&
+        d->mon.wf.protocol == FTX_PROTOCOL_FT8)
     {
         // Second chance for deep passes: re-demodulate from the raw samples
         // with fine dt/df sync (ft8_fine.h) and rerun BP+OSD+CRC on the
-        // float LLRs. Junk guards mirror decode_bench.c: a sync-quality
-        // floor, raised for the junk-prone rare message types. On success
-        // the refined freq/time replace the grid values — they also flow
-        // into a91List and make the subsequent subtraction more accurate.
+        // float LLRs. The context (one full-buffer FFT) is built lazily on
+        // the first candidate that gets here, so fast-only or FT4 slots
+        // never pay for it. Junk guards mirror decode_bench.c: a
+        // sync-quality floor, raised for the junk-prone rare message types.
+        // On success the refined freq/time replace the grid values — they
+        // also flow into a91List and make the subsequent subtraction more
+        // accurate.
+        if (!d->fine && !d->fine_tried)
+        {
+            d->fine = ft8_fine_init(d->samples, d->num_fed, d->sample_rate);
+            d->fine_tried = true;
+        }
         float llrs[FTX_LDPC_N];
         float f_fine, t_fine, quality;
         if (ft8_fine_demod(d->fine, &d->mon, cand, llrs, &f_fine, &t_fine, &quality) &&
@@ -690,6 +708,9 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Reset(
     d->num_fed = 0;
     d->wf_dirty = false;
     d->sub_done_count = 0;
+    ft8_fine_free(d->fine);
+    d->fine = NULL;
+    d->fine_tried = false;
     monitor_reset(&d->mon);
 }
 

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_fine.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_fine.c
@@ -21,6 +21,7 @@
 #include "ft8_fine.h"
 
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -69,6 +70,12 @@ struct ft8_fine_ctx
 ft8_fine_ctx_t* ft8_fine_init(const float* samples, int num_samples, int sample_rate)
 {
     if (!samples || num_samples <= 0 || num_samples > FINE_NFFT1 || sample_rate <= 0)
+        return NULL;
+    // The FINE_* geometry is fixed for the 12 kHz -> 200 Hz mapping
+    // (FINE_NFFT1 / FINE_NFFT2 == sample_rate / FINE_RATE and FINE_SPS
+    // samples per symbol at FINE_RATE). Any other input rate would silently
+    // misplace the baseband and mis-scale dt/df — reject it.
+    if ((int64_t)sample_rate * FINE_NFFT2 != (int64_t)FINE_NFFT1 * FINE_RATE)
         return NULL;
 
     ft8_fine_ctx_t* ctx = (ft8_fine_ctx_t*)calloc(1, sizeof(ft8_fine_ctx_t));

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_fine.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_fine.c
@@ -1,0 +1,299 @@
+// See ft8_fine.h. Structure follows WSJT-X's ft8_downsample + ft8b fine sync
+// (Franke/Taylor), reimplemented against this library's kiss FFT and monitor
+// geometry.
+//
+// Signal path per candidate:
+//   1. From the cached full-buffer spectrum, extract FINE_NFFT2 bins around
+//      the candidate frequency and inverse-FFT them: a complex baseband
+//      cd[] at FINE_RATE Hz where the candidate's tone 0 sits at
+//      FINE_BASE_BIN * 6.25 Hz (32 samples per FT8 symbol, so an unwindowed
+//      32-point DFT has bins exactly at the 8 tone frequencies).
+//   2. Fine dt: the candidate grid is good to ±half a time_osr step; search
+//      the Costas correlation power over ±8 baseband samples (±40 ms in
+//      5 ms steps).
+//   3. Fine df: quadratic-fit the Costas power over a ±2.1 Hz probe around
+//      the grid frequency, then de-rotate cd by the estimate.
+//   4. LLRs: per-symbol 32-point DFT, tone magnitudes to log domain,
+//      max-log bit metrics (same Gray mapping as the waterfall path).
+//      Symbols outside the capture or without signal give near-zero LLRs —
+//      soft erasures the LDPC stage can work around.
+
+#include "ft8_fine.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef FINE_DEBUG
+#include <stdio.h>
+#endif
+
+#include "fft/kiss_fft.h"
+#include "fft/kiss_fftr.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Full-buffer FFT length at 12 kHz: >= 16 s so both the app's 13.5 s early
+// window and a full 15 s slot fit zero-padded, and factors 2^9*3*5^3 keep
+// kiss FFT fast. The downsample ratio maps it to a 3200-point complex
+// baseband at 200 Hz covering the same 16 s.
+#define FINE_NFFT1 192000
+#define FINE_RATE 200
+#define FINE_NFFT2 3200 // FINE_NFFT1 * FINE_RATE / 12000
+#define FINE_SPS 32     // baseband samples per FT8 symbol (200 * 0.16)
+
+// Tone 0 position in the baseband, in units of the 6.25 Hz tone spacing.
+// >0 keeps the whole 8-tone stack away from DC; 2 puts it at 12.5 Hz.
+#define FINE_BASE_BIN 2
+
+// Fine-dt search half-range in baseband samples (5 ms each): ±60 ms covers
+// the candidate grid error (±20 ms) and reaches the true peak even from a
+// candidate one 40 ms grid step off (find_sync regularly emits those for
+// the same signal).
+#define FINE_DT_SPAN 12
+
+// Fine-df probe offsets (Hz). The grid error is bounded by ±1.6 Hz
+// (freq_osr 2); a coarse 3-point parabola over ±2.1 Hz interpolates the
+// peak to well under the ~1 Hz level that matters for a 32-point DFT.
+#define FINE_DF_PROBE 2.1f
+
+struct ft8_fine_ctx
+{
+    kiss_fft_cpx* spectrum; // FINE_NFFT1/2 + 1 bins of the padded input
+    kiss_fft_cfg ifft_cfg;  // FINE_NFFT2-point inverse complex FFT
+    int sample_rate;
+};
+
+ft8_fine_ctx_t* ft8_fine_init(const float* samples, int num_samples, int sample_rate)
+{
+    if (!samples || num_samples <= 0 || num_samples > FINE_NFFT1 || sample_rate <= 0)
+        return NULL;
+
+    ft8_fine_ctx_t* ctx = (ft8_fine_ctx_t*)calloc(1, sizeof(ft8_fine_ctx_t));
+    if (!ctx)
+        return NULL;
+    ctx->sample_rate = sample_rate;
+    ctx->spectrum = (kiss_fft_cpx*)malloc((FINE_NFFT1 / 2 + 1) * sizeof(kiss_fft_cpx));
+    ctx->ifft_cfg = kiss_fft_alloc(FINE_NFFT2, 1 /*inverse*/, NULL, NULL);
+
+    float* padded = (float*)calloc(FINE_NFFT1, sizeof(float));
+    kiss_fftr_cfg fwd = kiss_fftr_alloc(FINE_NFFT1, 0, NULL, NULL);
+    if (!ctx->spectrum || !ctx->ifft_cfg || !padded || !fwd)
+    {
+        free(padded);
+        free(fwd);
+        ft8_fine_free(ctx);
+        return NULL;
+    }
+    memcpy(padded, samples, (size_t)num_samples * sizeof(float));
+    kiss_fftr(fwd, padded, ctx->spectrum);
+    free(padded);
+    free(fwd);
+    return ctx;
+}
+
+void ft8_fine_free(ft8_fine_ctx_t* ctx)
+{
+    if (!ctx)
+        return;
+    free(ctx->spectrum);
+    free(ctx->ifft_cfg);
+    free(ctx);
+}
+
+// 32-point complex DFT of cd[n0..n0+31] at fractional bin b (frequency
+// b * 6.25 Hz + df): returns |X|^2. Samples outside [0, FINE_NFFT2) count
+// as zero (symbol partially or fully outside the capture).
+static float symbol_bin_power(const kiss_fft_cpx* cd, int n0, float freq_hz, float df_hz)
+{
+    double sr = 0.0, si = 0.0;
+    double dph = -2.0 * M_PI * (double)(freq_hz + df_hz) / FINE_RATE;
+    double wr = cos(dph), wi = sin(dph);
+    double cr = 1.0, ci = 0.0;
+    for (int n = 0; n < FINE_SPS; ++n)
+    {
+        int idx = n0 + n;
+        if (idx >= 0 && idx < FINE_NFFT2)
+        {
+            sr += cd[idx].r * cr - cd[idx].i * ci;
+            si += cd[idx].r * ci + cd[idx].i * cr;
+        }
+        double t = cr * wr - ci * wi;
+        ci = cr * wi + ci * wr;
+        cr = t;
+    }
+    return (float)(sr * sr + si * si);
+}
+
+// Costas correlation power at a trial baseband start and frequency offset.
+static float costas_power(const kiss_fft_cpx* cd, int start, float df_hz)
+{
+    float power = 0.0f;
+    for (int m = 0; m < FT8_NUM_SYNC; ++m)
+    {
+        for (int k = 0; k < FT8_LENGTH_SYNC; ++k)
+        {
+            int sym = m * FT8_SYNC_OFFSET + k;
+            float f = (FINE_BASE_BIN + kFT8_Costas_pattern[k]) * 6.25f;
+            power += symbol_bin_power(cd, start + sym * FINE_SPS, f, df_hz);
+        }
+    }
+    return power;
+}
+
+bool ft8_fine_demod(ft8_fine_ctx_t* ctx, const monitor_t* mon,
+                    const candidate_t* cand, float llrs_out[FTX_LDPC_N],
+                    float* freq_hz_out, float* time_sec_out, float* quality_out)
+{
+    if (!ctx || !mon || !cand || !llrs_out || mon->wf.protocol != FTX_PROTOCOL_FT8)
+        return false;
+
+    // Candidate geometry, exactly as the decoder derives it.
+    float freq_hz = (mon->min_bin + cand->freq_offset +
+                     (float)cand->freq_sub / mon->wf.freq_osr) / mon->symbol_period;
+    float time_sec = (cand->time_offset +
+                      (float)cand->time_sub / mon->wf.time_osr) * mon->symbol_period;
+
+    // Candidate time base -> raw-sample signal start (same STFT lag as
+    // ft8_subtract_signal_time; see the derivation there).
+    const int stft_lag = mon->block_size / 2 + mon->nfft / 2 - mon->subblock_size;
+    float start_sec = time_sec - (float)stft_lag / ctx->sample_rate;
+
+    // Baseband extraction: FINE_NFFT2 spectrum bins starting FINE_BASE_BIN
+    // tone-spacings below the candidate, inverse-FFT'd to cd[] at 200 Hz.
+    const double df1 = (double)ctx->sample_rate / FINE_NFFT1; // spectrum bin width
+    int k0 = (int)lrint(((double)freq_hz - FINE_BASE_BIN * 6.25) / df1);
+    if (k0 < 0 || k0 + FINE_NFFT2 > FINE_NFFT1 / 2 + 1)
+        return false; // candidate too close to the band edges
+
+    static _Thread_local kiss_fft_cpx bins[FINE_NFFT2];
+    static _Thread_local kiss_fft_cpx cd[FINE_NFFT2];
+    memcpy(bins, ctx->spectrum + k0, sizeof(bins));
+    // Taper the extraction edges to soften the brick-wall band cut.
+    const int ntaper = 100;
+    for (int i = 0; i < ntaper; ++i)
+    {
+        float w = (float)(0.5 * (1.0 - cos(M_PI * i / ntaper)));
+        bins[i].r *= w;
+        bins[i].i *= w;
+        bins[FINE_NFFT2 - 1 - i].r *= w;
+        bins[FINE_NFFT2 - 1 - i].i *= w;
+    }
+    kiss_fft(ctx->ifft_cfg, bins, cd);
+
+    // Residual of the candidate frequency vs the spectrum grid, folded into
+    // the df estimate below (|k0*df1 - (freq - base)| < df1/2 = 0.03 Hz —
+    // negligible, but free to carry).
+    float grid_df = (float)(((double)freq_hz - FINE_BASE_BIN * 6.25) - k0 * df1);
+
+    // --- Fine dt ---------------------------------------------------------
+    int start0 = (int)lrintf(start_sec * FINE_RATE);
+    float trial_p[2 * FINE_DT_SPAN + 1];
+    int best_s = 0;
+    float best_p = -1.0f;
+    for (int s = -FINE_DT_SPAN; s <= FINE_DT_SPAN; ++s)
+    {
+        float p = costas_power(cd, start0 + s, grid_df);
+        trial_p[s + FINE_DT_SPAN] = p;
+        if (p > best_p)
+        {
+            best_p = p;
+            best_s = s;
+        }
+    }
+    int best_start = start0 + best_s;
+    // Sync quality: peak Costas power over the mean of the trials at least
+    // 3 samples (15 ms) away from it. A real signal's aligned correlation
+    // stands well above its off-peak floor; a junk candidate's trials are
+    // all noise-flat (ratio ~1). Excluding the peak's shoulders keeps the
+    // metric comparable between candidates centered on the signal and
+    // candidates a grid step off (whose in-span trials are mostly floor).
+    float rest_sum = 0.0f;
+    int rest_n = 0;
+    for (int s = -FINE_DT_SPAN; s <= FINE_DT_SPAN; ++s)
+    {
+        if (abs(s - best_s) < 3)
+            continue;
+        rest_sum += trial_p[s + FINE_DT_SPAN];
+        rest_n++;
+    }
+    float rest = (rest_n > 0) ? rest_sum / rest_n : 0.0f;
+    float quality = (rest > 0.0f) ? best_p / rest : 0.0f;
+    // A peak pinned to the search edge is not localized: the candidate sits
+    // too far from the signal (find_sync emits a better-centered duplicate
+    // for it) or there is no peak at all. Zero the quality so gated callers
+    // skip it rather than decode 40+ ms off and mis-report dt.
+    if (best_s == -FINE_DT_SPAN || best_s == FINE_DT_SPAN)
+        quality = 0.0f;
+
+#ifdef FINE_DEBUG
+    printf("FINE f=%.1f t=%.3f start0=%d best_s=%d q=%.2f trials:", freq_hz, time_sec, start0, best_s, quality);
+    for (int s = -FINE_DT_SPAN; s <= FINE_DT_SPAN; ++s)
+        printf(" %.2g", trial_p[s + FINE_DT_SPAN]);
+    printf("\n");
+#endif
+
+    // --- Fine df ---------------------------------------------------------
+    // Three-point parabola over {-probe, 0, +probe} around the grid
+    // frequency; clamp to the probe range (a flat or inverted fit means
+    // there is no usable peak — keep the grid value).
+    float p_m = costas_power(cd, best_start, grid_df - FINE_DF_PROBE);
+    float p_0 = best_p;
+    float p_p = costas_power(cd, best_start, grid_df + FINE_DF_PROBE);
+    float df = 0.0f;
+    float denom = p_m - 2.0f * p_0 + p_p;
+    if (denom < 0.0f)
+    {
+        df = 0.5f * (p_m - p_p) / denom * FINE_DF_PROBE;
+        if (df > FINE_DF_PROBE)
+            df = FINE_DF_PROBE;
+        if (df < -FINE_DF_PROBE)
+            df = -FINE_DF_PROBE;
+    }
+    df += grid_df;
+
+    // --- Per-symbol LLRs ---------------------------------------------------
+    // Log-domain tone magnitudes, max-log bit metrics with the same Gray
+    // mapping as decode.c's ft8_extract_symbol. Dead or out-of-capture
+    // symbols yield near-flat log magnitudes -> near-zero LLRs.
+    for (int k = 0; k < FT8_ND; ++k)
+    {
+        int sym_idx = k + ((k < 29) ? 7 : 14); // skip Costas symbols
+        int n0 = best_start + sym_idx * FINE_SPS;
+
+        float ldb[8];
+        for (int tone = 0; tone < 8; ++tone)
+        {
+            float f = (FINE_BASE_BIN + tone) * 6.25f;
+            float p = symbol_bin_power(cd, n0, f, df);
+            ldb[tone] = 0.5f * logf(p + 1e-30f); // log magnitude
+        }
+
+        float s2[8];
+        for (int j = 0; j < 8; ++j)
+            s2[j] = ldb[kFT8_Gray_map[j]];
+
+        float* logl = llrs_out + 3 * k;
+        float max1_0 = fmaxf(fmaxf(s2[4], s2[5]), fmaxf(s2[6], s2[7]));
+        float max0_0 = fmaxf(fmaxf(s2[0], s2[1]), fmaxf(s2[2], s2[3]));
+        float max1_1 = fmaxf(fmaxf(s2[2], s2[3]), fmaxf(s2[6], s2[7]));
+        float max0_1 = fmaxf(fmaxf(s2[0], s2[1]), fmaxf(s2[4], s2[5]));
+        float max1_2 = fmaxf(fmaxf(s2[1], s2[3]), fmaxf(s2[5], s2[7]));
+        float max0_2 = fmaxf(fmaxf(s2[0], s2[2]), fmaxf(s2[4], s2[6]));
+        logl[0] = max1_0 - max0_0;
+        logl[1] = max1_1 - max0_1;
+        logl[2] = max1_2 - max0_2;
+    }
+
+    // df started at grid_df (== the candidate frequency exactly); the fit
+    // moved it by (df - grid_df) relative to the candidate.
+    if (freq_hz_out)
+        *freq_hz_out = freq_hz + (df - grid_df);
+    if (time_sec_out)
+        *time_sec_out = time_sec + (float)(best_start - start0) / FINE_RATE;
+    if (quality_out)
+        *quality_out = quality;
+    return true;
+}

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_fine.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_fine.h
@@ -1,0 +1,61 @@
+// Fine-sync coherent FT8 demodulator — a second-chance LLR source for
+// candidates the waterfall path can't decode.
+//
+// The standard path derives bit likelihoods from the monitor's 8-bit
+// log-magnitude waterfall at the candidate grid's alignment (±20 ms /
+// ±1.6 Hz at time_osr 4 / freq_osr 2). This module re-demodulates a
+// candidate from the RAW float samples the way WSJT-X's ft8b does: extract
+// a ~200 Hz complex baseband around the candidate (one full-buffer FFT per
+// context, one small inverse FFT per candidate), fine-align dt and df on
+// the Costas sync symbols, then take per-symbol 32-point DFTs to produce
+// float log-domain LLRs. Compared to the waterfall LLRs this restores the
+// alignment loss, adds frequency-error correction the grid can't express,
+// and — because symbols with no signal produce near-flat spectra — hands
+// the LDPC stage soft erasures instead of confidently-wrong bits (the
+// failure mode of partially-transmitted signals, e.g. a station keying up
+// seconds late).
+//
+// Shared by the Android JNI glue (ft8_decode_jni.cpp) and the host decode
+// benchmark (decode_bench.c). FT8-only.
+#ifndef FT8AF_FT8_FINE_H
+#define FT8AF_FT8_FINE_H
+
+#include <stdbool.h>
+
+#include "common/monitor.h"
+#include "ft8/constants.h"
+#include "ft8/decode.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ft8_fine_ctx ft8_fine_ctx_t;
+
+// Build a demod context from one slot of raw audio (mono float, 12 kHz;
+// up to 16 s). Performs the full-buffer forward FFT once. Returns NULL on
+// allocation failure or unsupported input. The samples are not retained.
+ft8_fine_ctx_t* ft8_fine_init(const float* samples, int num_samples, int sample_rate);
+
+void ft8_fine_free(ft8_fine_ctx_t* ctx);
+
+// Re-demodulate `cand` (a candidate of `mon`, FT8 protocol) from the raw
+// samples: baseband extraction, Costas fine dt/df sync, per-symbol DFT ->
+// 174 log-domain LLRs in llrs_out. Optionally reports the refined signal
+// frequency and start time (candidate time base, i.e. directly comparable
+// to the values the decoder derives from the candidate) and the sync
+// quality — the aligned Costas correlation power over the mean of the
+// misaligned trials (~1 for junk candidates, rising with real signal
+// strength; callers gate decode attempts on it to keep noise candidates
+// from re-rolling the CRC lottery). Pass NULL for outputs not needed.
+// Returns false when the candidate geometry cannot be demodulated (out of
+// band / degenerate input).
+bool ft8_fine_demod(ft8_fine_ctx_t* ctx, const monitor_t* mon,
+                    const candidate_t* cand, float llrs_out[FTX_LDPC_N],
+                    float* freq_hz_out, float* time_sec_out, float* quality_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FT8AF_FT8_FINE_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -130,6 +130,7 @@ $benchSrcs = @(
 ) | ForEach-Object { Join-Path $ft8 $_ }
 $benchSrcs += (Join-Path $here "gfsk.c")
 $benchSrcs += (Join-Path $here "ft8_subtract.c")
+$benchSrcs += (Join-Path $here "ft8_fine.c")
 
 $srcBench = Join-Path $here "decode_bench.c"
 $outBench = Join-Path $env:TEMP "ft8_decode_bench.exe"
@@ -187,10 +188,33 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_osd)." }
 & $outOsd
 $osdExit = $LASTEXITCODE
 
+# ---------------------------------------------------------------------------
+# Fine-demod unit tests: the fine-sync coherent retry (partial-transmission
+# recovery, off-grid sync accuracy, pure-noise rejection).
+# ---------------------------------------------------------------------------
+$fineSrcs = @(
+    "ft8\pack.c","ft8\encode.c","ft8\crc.c","ft8\constants.c",
+    "ft8\text.c","ft8\message.c","ft8\decode.c","ft8\ldpc.c","ft8\osd.c","ft8\unpack.c",
+    "common\monitor.c",
+    "fft\kiss_fft.c","fft\kiss_fftr.c"
+) | ForEach-Object { Join-Path $ft8 $_ }
+$fineSrcs += (Join-Path $here "gfsk.c")
+$fineSrcs += (Join-Path $here "ft8_fine.c")
+
+$srcFine = Join-Path $here "test_fine.c"
+$outFine = Join-Path $env:TEMP "ft8_fine_test.exe"
+
+& $Clang @common $srcFine @fineSrcs -o $outFine
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_fine)." }
+
+& $outFine
+$fineExit = $LASTEXITCODE
+
 if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
 if ($firExit -ne 0) { exit $firExit }
 if ($benchSelfExit -ne 0) { exit $benchSelfExit }
 if ($benchExit -ne 0) { exit $benchExit }
 if ($subExit -ne 0) { exit $subExit }
-exit $osdExit
+if ($osdExit -ne 0) { exit $osdExit }
+exit $fineExit

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -97,6 +97,7 @@ bench_srcs=(
     "$here/decode_bench.c"
     "$here/gfsk.c"
     "$here/ft8_subtract.c"
+    "$here/ft8_fine.c"
     "$ft8/ft8/pack.c"
     "$ft8/ft8/encode.c"
     "$ft8/ft8/crc.c"
@@ -166,3 +167,29 @@ osd_out="$tmp/ft8_osd_test"
     -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
     -I "$ft8" "${osd_srcs[@]}" -lm -o "$osd_out"
 "$osd_out"
+
+# Fine-demod unit tests: the fine-sync coherent retry (partial-transmission
+# recovery, off-grid sync accuracy, pure-noise rejection).
+fine_srcs=(
+    "$here/test_fine.c"
+    "$here/gfsk.c"
+    "$here/ft8_fine.c"
+    "$ft8/ft8/pack.c"
+    "$ft8/ft8/encode.c"
+    "$ft8/ft8/crc.c"
+    "$ft8/ft8/constants.c"
+    "$ft8/ft8/text.c"
+    "$ft8/ft8/message.c"
+    "$ft8/ft8/decode.c"
+    "$ft8/ft8/ldpc.c"
+    "$ft8/ft8/osd.c"
+    "$ft8/ft8/unpack.c"
+    "$ft8/common/monitor.c"
+    "$ft8/fft/kiss_fft.c"
+    "$ft8/fft/kiss_fftr.c"
+)
+fine_out="$tmp/ft8_fine_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" "${fine_srcs[@]}" -lm -o "$fine_out"
+"$fine_out"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_fine.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_fine.c
@@ -1,0 +1,268 @@
+// Host unit tests for ft8_fine.c — the fine-sync coherent demod retry.
+// Run by run_host_tests.sh / .ps1.
+//
+// Covered:
+//   1. Partial-transmission recovery (the motivating case, observed on-air:
+//      a station keying up ~4 s late transmits only symbols 27..78, slot-
+//      aligned). The waterfall LLR path fails — the 20 dead data symbols
+//      read random noise magnitudes that swamp BP — while the fine path's
+//      log-domain float LLRs leave them as soft erasures and decode off the
+//      live symbols. Both outcomes are asserted.
+//   2. Fine sync accuracy: an off-grid signal (+1.4 Hz, +15 ms off the
+//      candidate grid) is demodulated and the refined frequency/time are
+//      recovered within tolerance.
+//   3. Junk guard: a fabricated candidate over pure noise reports sync
+//      quality below FT8AF_FINE_SYNC_MIN, so it never reaches the decoder.
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ft8/constants.h>
+#include <ft8/decode.h>
+#include <ft8/encode.h>
+#include <ft8/message.h>
+
+#include "common/monitor.h"
+#include "decode_params.h"
+#include "ft8_fine.h"
+
+void synth_gfsk_offset(const uint8_t* symbols, int n_sym, float f0,
+                       float symbol_bt, float symbol_period,
+                       int signal_rate, float* signal, int offset);
+
+#define RATE 12000
+#define NSAMPLES (13500 * RATE / 1000)
+
+static int g_failures = 0;
+
+static void check(bool ok, const char* what)
+{
+    printf("  %s %s\n", ok ? "ok:  " : "FAIL:", what);
+    if (!ok)
+        g_failures++;
+}
+
+static void add_noise(float* signal, int n, float amp, uint32_t seed)
+{
+    uint32_t s = seed;
+    for (int i = 0; i < n; ++i)
+    {
+        s = s * 1664525u + 1013904223u;
+        signal[i] += amp * (2.0f * ((s >> 8) & 0xFFFF) / 65535.0f - 1.0f);
+    }
+}
+
+static void monitor_setup(monitor_t* mon)
+{
+    monitor_config_t cfg;
+    cfg.f_min = 100;
+    cfg.f_max = 3500;
+    cfg.sample_rate = RATE;
+    cfg.time_osr = FT8AF_TIME_OSR;
+    cfg.freq_osr = FT8AF_FREQ_OSR;
+    cfg.protocol = FTX_PROTOCOL_FT8;
+    monitor_init(mon, &cfg);
+}
+
+static void feed(monitor_t* mon, const float* signal)
+{
+    monitor_reset(mon);
+    for (int pos = 0; pos + mon->block_size <= NSAMPLES; pos += mon->block_size)
+        monitor_process(mon, signal + pos);
+}
+
+// Try to decode `text` near freq_hz: first via the waterfall path, then via
+// the fine retry — mirroring the deep-pass pipeline. Reports which path (if
+// any) succeeded and the refined outputs of the fine path.
+typedef struct
+{
+    bool wf_decoded;
+    bool fine_decoded;
+    float f_fine;
+    float t_fine;
+    float quality;
+} pipeline_result_t;
+
+static pipeline_result_t try_decode(monitor_t* mon, ft8_fine_ctx_t* fine,
+                                    const char* text, float freq_hz)
+{
+    pipeline_result_t r = { false, false, 0, 0, 0 };
+    static candidate_t cands[FT8AF_MAX_CANDIDATES];
+    int n = ft8_find_sync(&mon->wf, FT8AF_MAX_CANDIDATES, cands, FT8AF_MIN_SCORE_DEEP);
+    for (int i = 0; i < n; ++i)
+    {
+        float f = (mon->min_bin + cands[i].freq_offset +
+                   (float)cands[i].freq_sub / mon->wf.freq_osr) / mon->symbol_period;
+        if (fabsf(f - freq_hz) > 10.0f)
+            continue;
+
+        ftx_message_t message;
+        decode_status_t status;
+        char got[64] = { 0 };
+        if (ft8_decode_osd(&mon->wf, &cands[i], FT8AF_LDPC_ITERS_DEEP,
+                           FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                           &message, &status) &&
+            ftx_message_decode(&message, NULL, got) == FTX_MESSAGE_RC_OK &&
+            strcmp(got, text) == 0)
+        {
+            r.wf_decoded = true;
+        }
+
+        float llrs[FTX_LDPC_N];
+        float f_fine, t_fine, quality;
+        if (ft8_fine_demod(fine, mon, &cands[i], llrs, &f_fine, &t_fine, &quality) &&
+            quality >= FT8AF_FINE_SYNC_MIN &&
+            ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, FT8AF_LDPC_ITERS_DEEP,
+                            FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                            &message, &status) &&
+            ftx_message_decode(&message, NULL, got) == FTX_MESSAGE_RC_OK &&
+            strcmp(got, text) == 0)
+        {
+            if (!r.fine_decoded || quality > r.quality)
+            {
+                r.fine_decoded = true;
+                r.f_fine = f_fine;
+                r.t_fine = t_fine;
+                r.quality = quality;
+            }
+        }
+    }
+    return r;
+}
+
+int main(void)
+{
+    static float signal[NSAMPLES];
+    monitor_t mon;
+    monitor_setup(&mon);
+
+    ftx_message_t msg;
+    ftx_message_init(&msg);
+    ftx_message_encode(&msg, NULL, "TA1NGE RA3TPE LO25");
+    uint8_t tones[FT8_NN];
+    ft8_encode(msg.payload, tones);
+    const int n_spsym = RATE * 160 / 1000;
+    const int n_wave = FT8_NN * n_spsym;
+    float* wave = (float*)calloc(n_wave, sizeof(float));
+
+    // ---- 1. partial transmission: only symbols 27..78 on the air -----------
+    // Off-grid frequency and time (like any real station): +1.4 Hz off the
+    // 3.125 Hz grid, 15 ms off the 40 ms grid, on top of the 20 missing data
+    // symbols. The waterfall path gets confidently-wrong LLRs for the dead
+    // symbols AND grid misalignment on the live ones; the fine path corrects
+    // the alignment and soft-erases the dead region.
+    printf("test_fine_partial_transmission:\n");
+    synth_gfsk_offset(tones, FT8_NN, 988.9f, 2.0f, FT8_SYMBOL_PERIOD, RATE, wave, 0);
+// Signal/noise amplitudes for the partial-transmission case, overridable for
+// calibration scans. The outcome depends on the ratio: above ~0.17 the
+// waterfall+OSD path decodes it anyway (OSD's reliability-ordered basis
+// sidesteps the dead symbols once the live bits dominate), below ~0.13 the
+// fine path loses it too. 0.06/0.40 = 0.15 sits between with ~1.5 dB margin
+// each way (scanned; both neighbors at ±1.3x amplitude flip exactly one of
+// the two assertions).
+#ifndef PT_AMP
+#define PT_AMP 0.06f
+#endif
+#ifndef PT_NOISE
+#define PT_NOISE 0.40f
+#endif
+    memset(signal, 0, sizeof(signal));
+    add_noise(signal, NSAMPLES, PT_NOISE, 51);
+    int off = (int)(0.315f * RATE); // nominal signal start
+    for (int i = 27 * n_spsym; i < n_wave; ++i)
+    {
+        int j = off + i;
+        if (j >= 0 && j < NSAMPLES)
+            signal[j] += PT_AMP * wave[i];
+    }
+    feed(&mon, signal);
+    ft8_fine_ctx_t* fine = ft8_fine_init(signal, NSAMPLES, RATE);
+    check(fine != NULL, "fine context initializes");
+    pipeline_result_t r = try_decode(&mon, fine, "TA1NGE RA3TPE LO25", 988.9f);
+    check(!r.wf_decoded, "waterfall path fails on the partial transmission");
+    check(r.fine_decoded, "fine path RECOVERS the partial transmission");
+    check(r.fine_decoded && r.quality >= FT8AF_FINE_SYNC_MIN,
+          "recovery passes the sync-quality gate");
+    ft8_fine_free(fine);
+
+    // ---- 2. fine sync accuracy on an off-grid signal ------------------------
+    printf("test_fine_sync_accuracy:\n");
+    synth_gfsk_offset(tones, FT8_NN, 1501.4f, 2.0f, FT8_SYMBOL_PERIOD, RATE, wave, 0);
+    memset(signal, 0, sizeof(signal));
+    add_noise(signal, NSAMPLES, 0.05f, 52);
+    off = (int)(0.515f * RATE); // 15 ms off the 40 ms candidate grid
+    for (int i = 0; i < n_wave; ++i)
+    {
+        int j = off + i;
+        if (j >= 0 && j < NSAMPLES)
+            signal[j] += 0.5f * wave[i];
+    }
+    feed(&mon, signal);
+    fine = ft8_fine_init(signal, NSAMPLES, RATE);
+    r = try_decode(&mon, fine, "TA1NGE RA3TPE LO25", 1501.4f);
+    check(r.fine_decoded, "off-grid signal decodes via the fine path");
+    if (r.fine_decoded)
+    {
+        float lag = (float)(mon.block_size / 2 + mon.nfft / 2 - mon.subblock_size) / RATE;
+        printf("  (refined f=%.2f Hz t=%.3f s quality=%.2f; true f=1501.40 t=%.3f)\n",
+               r.f_fine, r.t_fine, r.quality, 0.515f + lag);
+        check(fabsf(r.f_fine - 1501.4f) < 0.7f, "refined frequency within 0.7 Hz");
+        // t_fine is in the candidate time base: signal start + STFT lag.
+        // Tolerance: 5 ms search granularity + candidate rounding.
+        check(fabsf(r.t_fine - (0.515f + lag)) < 0.015f, "refined time within 15 ms");
+        check(r.quality >= FT8AF_FINE_SYNC_MIN, "clean signal clears the quality gate");
+    }
+    ft8_fine_free(fine);
+
+    // ---- 3. junk guard: pure noise produces zero fine-path decodes ----------
+    // (The dt-search peak statistic on pure noise sits around 1.3-1.5 — max
+    // of 17 trials — so the base sync gate alone cannot reject noise; the
+    // protection is the full chain: quality gates + BP/OSD + CRC + the
+    // rare-type quality bar. Assert the end result: no decode, and noise
+    // quality stays below the rare-type bar that junk decodes would need.)
+    printf("test_fine_noise_rejection:\n");
+    memset(signal, 0, sizeof(signal));
+    add_noise(signal, NSAMPLES, 0.5f, 53);
+    feed(&mon, signal);
+    fine = ft8_fine_init(signal, NSAMPLES, RATE);
+    static candidate_t cands[FT8AF_MAX_CANDIDATES];
+    int nc = ft8_find_sync(&mon.wf, FT8AF_MAX_CANDIDATES, cands, 1);
+    int accepted = 0;
+    float max_quality = 0.0f;
+    for (int i = 0; i < nc; ++i)
+    {
+        float llrs[FTX_LDPC_N];
+        float f_fine, t_fine, quality;
+        if (!ft8_fine_demod(fine, &mon, &cands[i], llrs, &f_fine, &t_fine, &quality))
+            continue;
+        if (quality > max_quality)
+            max_quality = quality;
+        ftx_message_t message;
+        decode_status_t status;
+        if (quality >= FT8AF_FINE_SYNC_MIN &&
+            ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, FT8AF_LDPC_ITERS_DEEP,
+                            FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                            &message, &status))
+            accepted++;
+    }
+    printf("  (%d noise candidates, max quality %.2f)\n", nc, max_quality);
+    check(accepted == 0, "0 fine-path decodes from pure noise");
+    check(max_quality < FT8AF_FINE_SYNC_MIN_RARE,
+          "noise quality stays below the rare-type bar");
+    ft8_fine_free(fine);
+
+    free(wave);
+    monitor_free(&mon);
+
+    if (g_failures == 0)
+    {
+        printf("all fine-demod tests passed\n");
+        return 0;
+    }
+    printf("%d fine-demod test(s) FAILED\n", g_failures);
+    return 1;
+}

--- a/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
+++ b/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
@@ -13,23 +13,25 @@
 #   STFT-lag correction, NFILT 1440): TOTAL matched=447 recall=94.5%.
 # 2026-07-02 osd-order2 (pair flips, nhard<=30 pair gate): TOTAL matched=449
 #   recall=94.9%; extras 52 -> 51.
+# 2026-07-02 fine-demod (fine-sync coherent retry from raw samples):
+#   TOTAL matched=459 recall=97.0%; 11 of 20 files at 100% of jt9.
 20m_busy_test_01.wav 24
 20m_busy_test_02.wav 21
 20m_busy_test_03.wav 18
-20m_busy_test_04.wav 18
-20m_busy_test_05.wav 30
+20m_busy_test_04.wav 19
+20m_busy_test_05.wav 32
 20m_busy_test_06.wav 26
-20m_busy_test_07.wav 30
+20m_busy_test_07.wav 31
 20m_busy_test_08.wav 18
 20m_busy_test_09.wav 26
 20m_busy_test_10.wav 20
-20m_busy_test_11.wav 29
-20m_busy_test_12.wav 16
+20m_busy_test_11.wav 30
+20m_busy_test_12.wav 18
 websdr_test1.wav 15
 websdr_test2.wav 21
 websdr_test3.wav 11
 websdr_test4.wav 22
 websdr_test5.wav 26
 websdr_test6.wav 28
-websdr_test7.wav 24
+websdr_test7.wav 27
 websdr_test8.wav 26


### PR DESCRIPTION
## Summary

**Stacked on #368** (merge that first; this branch contains its commits). Third step in the decode-gap push: a **fine-sync coherent demodulator** that gives failed candidates a second chance from the raw samples. Bench recall vs `jt9 -d 3`: **94.9% → 97.0%** (449 → 459 of 473), with the observed fabricated decodes eliminated. **Eleven of the twenty corpus files now decode 100% of what jt9 finds.**

## Why

The residual misses profiled as demod-quality losses, not search losses: the waterfall path's LLRs come from 8-bit log magnitudes locked to the candidate grid (±20 ms / ±1.6 Hz). Investigating the most glaring miss (a **+9 dB** signal in `20m_busy_test_05` that jt9 decodes and we didn't) revealed a station that keyed up ~4.3 s late — only symbols 27–78 on the air. The waterfall path reads the dead symbols as confidently-wrong random bits and BP drowns; jt9's demod hands them near-zero LLRs (soft erasures) and decodes off the 114 live bits. That case — and the alignment losses on everything else — is what this PR fixes.

## What

New `ft8af_glue/ft8_fine.c` (+ `test_fine.c`), the same structure as WSJT-X's `ft8_downsample`/`ft8b` demod:
1. One forward FFT of the slot per context; per candidate, extract 3200 spectrum bins around it and inverse-FFT to a ~200 Hz complex baseband (32 samples/symbol — an unwindowed 32-point DFT lands exactly on the 8 tone frequencies).
2. Fine dt: Costas correlation search over ±60 ms (reaches the true peak even from a candidate one grid step off). Fine df: 3-point parabola over the ±1.6 Hz grid error.
3. Per-symbol DFT → float log-domain LLRs → the existing BP+OSD+CRC chain via a new `ftx_decode_llrs()` (refactored out of `ft8_decode_osd`; no interface change for existing callers).

Runs only in deep passes, only for candidates the waterfall path failed. On success the **refined freq/time** replace the grid values and flow into the a91 list — so the time-domain subtraction gets more accurate anchors too. The fine context is rebuilt whenever subtraction edits the samples. JNI-only on the app side (zero Java changes); desktop unaffected.

## Junk control

A retry is a second draw against the CRC+nhard lottery, and the first cut produced junk (`1EQ8YXYQDW2 .`, `W99WMQ JX3GAH 539 4274`). Three gates, all bench-validated:
- **Sync quality** (aligned Costas power / off-peak trial floor) ≥ 1.2 to attempt the decode. Swept: 1.0→460/65, 1.2→460/64, 1.4→459/62, 2.0→449/52 (matched/extras) — real decodes fall off fast above 1.2.
- **Rare-type bar**: decodes that come out as anything other than standard / non-standard-call messages need quality ≥ 2.5 — fabricated decodes concentrate in free-text/contest types; both observed junk decodes die here while every genuine recovery survives (max pure-noise quality measured: 1.67).
- **Edge-pegged peak ⇒ quality 0**: a peak pinned to the search boundary means the candidate is a grid step off (find_sync emits a centered duplicate that handles the signal). This also keeps the refined dt honest — without it, off-center candidates won the quality contest while reporting dt 25–45 ms off.

## Numbers

| | #367 subtract-time | #368 osd-order2 | this PR |
|---|---|---|---|
| matched / truth | 447 / 473 | 449 / 473 | **459 / 473** |
| recall | 94.5% | 94.9% | **97.0%** |
| files at 100% of jt9 | 6 | 6 | **11** |
| fabricated decodes | 0 | 0 | 0 |

Both halves of the file-05 pair now decode: the +9 dB partial transmission via the fine path, then the +2 dB station 32 Hz under it via subtract-and-redecode. Bench runtime ~600 ms/file host (from ~400); on-device the deep loop stays wall-clock-budgeted, the retry costs ~1 ms/candidate plus one 192k FFT per waterfall rebuild.

## Tests

`test_fine.c` (wired into `run_host_tests.sh`/`.ps1` → `native-tests.yml`):
- **Partial-transmission recovery**: symbols 27–78 only, off-grid by +1.4 Hz / +15 ms — asserts the waterfall path *fails* AND the fine path *recovers*. The signal/noise operating point was scanned (the window between "waterfall+OSD decodes it anyway" and "fine loses it too" is documented in the test).
- **Sync accuracy**: off-grid signal refined to within 0.7 Hz / 15 ms of truth.
- **Noise rejection**: 256 candidates over pure noise → zero fine-path decodes; max quality 1.67, below the rare-type bar.

Full host suite green (golden, dev625, FIR, subtract, OSD, fine, bench floor assert at the ratcheted floors); `gradlew assembleDebug testDebugUnitTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
