### PR TITLE
FT8 cross-slot decoding: recall WSJT-X structurally cannot reach (97.0% -> 97.7%)

### DIFF
--- a/ft8af/app/src/main/cpp/CMakeLists.txt
+++ b/ft8af/app/src/main/cpp/CMakeLists.txt
@@ -114,6 +114,8 @@ add_library(ft8af SHARED
         ft8af_glue/ft8_subtract.c
         # Fine-sync coherent demod retry (shared with host bench)
         ft8af_glue/ft8_fine.c
+        # Cross-slot decoding: LLR accumulation + message-history retry
+        ft8af_glue/ft8_xslot.c
         # JNI wrappers — FT2/FT4 decoder (from-source, was in ft8af_usb)
         ft8af_glue/ft2_decode_jni.cpp
 )

--- a/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/decode_bench.c
@@ -28,6 +28,9 @@
 //                         caps by wall-clock budget instead)
 //     --wf-subtract       waterfall-domain tone-replacement subtraction (A/B only)
 //     --zero-subtract     use the legacy ±4-bin zeroing subtraction (A/B only)
+//     --no-cross-slot     disable cross-slot decoding (LLR accumulation +
+//                         message-history retry across the corpus files,
+//                         which are treated as consecutive 15 s slots)
 //     --assert-floor F    read "name min_matched" lines from F; exit 1 if any
 //                         listed file matches fewer truth messages than its floor
 //     --self-test         synthesize a clean FT8 signal, decode it, expect 1/1
@@ -56,6 +59,7 @@
 #include "decode_params.h"
 #include "ft8_fine.h"
 #include "ft8_subtract.h"
+#include "ft8_xslot.h"
 
 // From gfsk.c (glue): GFSK synth used by the --self-test signal generator.
 void synth_gfsk_offset(const uint8_t* symbols, int n_sym, float f0,
@@ -88,6 +92,14 @@ enum
     SUBTRACT_ZERO = 2, // legacy ±4-bin zeroing (pre-#360 behavior)
 };
 static int g_subtract_mode = SUBTRACT_TIME;
+
+// Synthetic slot clock for cross-slot decoding: the corpus files are
+// consecutive 15 s slots of one session (message repeats confirm the
+// even/odd parity structure), so file index * 15000 ms reproduces the
+// timing the app passes from real UTC. --no-cross-slot disables the
+// mechanism for A/B runs.
+static int64_t g_utc_ms = 0;
+static bool g_cross_slot = true;
 
 #define BENCH_MAX_CAND_CAP 1024
 #define BENCH_MAX_MSGS 256
@@ -312,26 +324,60 @@ static int run_pass(monitor_t* mon, ft8_fine_ctx_t* fine, int ldpc_iters, int mi
             float llrs[FTX_LDPC_N];
             float f_fine, t_fine, quality;
             if (ft8_fine_demod(fine, mon, cand, llrs, &f_fine, &t_fine, &quality) &&
-                quality >= FT8AF_FINE_SYNC_MIN &&
-                ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, ldpc_iters, osd_depth,
-                                FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
+                quality >= FT8AF_FINE_SYNC_MIN)
             {
-                // Rare message types out of this second-chance path are
-                // junk-prone (see FT8AF_FINE_SYNC_MIN_RARE) — hold them to
-                // the higher sync-quality bar.
-                ftx_message_type_t mtype = ftx_message_get_type(&message);
-                if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
-                    mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
-                    quality >= FT8AF_FINE_SYNC_MIN_RARE)
+                if (ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, ldpc_iters, osd_depth,
+                                    FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
                 {
-                    decoded = true;
+                    // Rare message types out of this second-chance path are
+                    // junk-prone (see FT8AF_FINE_SYNC_MIN_RARE) — hold them
+                    // to the higher sync-quality bar.
+                    ftx_message_type_t mtype = ftx_message_get_type(&message);
+                    if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
+                        mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
+                        quality >= FT8AF_FINE_SYNC_MIN_RARE)
+                        decoded = true;
+                }
+                if (!decoded && g_cross_slot)
+                {
+                    // Cross-slot mechanism B: a recently decoded message at
+                    // this frequency, repeated but now below single-slot
+                    // threshold, matches these LLRs by soft correlation.
+                    memset(&status, 0, sizeof(status));
+                    decoded = ft8_xslot_try_history(f_fine, g_utc_ms, llrs,
+                                                    &message, NULL);
+                }
+                if (!decoded && g_cross_slot &&
+                    ft8_xslot_try_accumulate(f_fine, g_utc_ms, llrs, ldpc_iters,
+                                             osd_depth, FT8AF_OSD_LDPC_ERR_GATE,
+                                             &message, &status))
+                {
+                    // Cross-slot mechanism A: combined with the previous
+                    // same-parity repeat's failed LLRs. Fresh CRC decode —
+                    // same rare-type bar as the fine path.
+                    ftx_message_type_t mtype = ftx_message_get_type(&message);
+                    if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
+                        mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
+                        quality >= FT8AF_FINE_SYNC_MIN_RARE)
+                        decoded = true;
+                }
+                if (decoded)
+                {
                     freq_hz = f_fine;
                     time_sec = t_fine;
+                }
+                else if (g_cross_slot)
+                {
+                    // Keep this repeat's information for the next one.
+                    ft8_xslot_store(f_fine, g_utc_ms, llrs);
                 }
             }
         }
         if (!decoded)
             continue;
+
+        if (g_cross_slot)
+            ft8_xslot_remember(message.payload, freq_hz, g_utc_ms);
 
         // Decode to text the same way DecoderFt8Analysis assembles it.
         char text[64] = { 0 };
@@ -668,6 +714,8 @@ int main(int argc, char** argv)
             g_subtract_mode = SUBTRACT_ZERO;
         else if (strcmp(a, "--wf-subtract") == 0)
             g_subtract_mode = SUBTRACT_WF;
+        else if (strcmp(a, "--no-cross-slot") == 0)
+            g_cross_slot = false;
         else if (strcmp(a, "--window-ms") == 0 && i + 1 < argc)
             g_window_ms = atoi(argv[++i]);
         else if (strcmp(a, "--candidates") == 0 && i + 1 < argc)
@@ -745,6 +793,7 @@ int main(int argc, char** argv)
 
     for (int w = 0; w < num_wavs; ++w)
     {
+        g_utc_ms = (int64_t)w * 15000; // corpus files are consecutive slots
         int num_samples = BENCH_MAX_SAMPLES; // in: capacity, out: samples read
         int sample_rate = 0;
         if (load_wav(signal, &num_samples, &sample_rate, wavs[w]) != 0)

--- a/ft8af/app/src/main/cpp/ft8af_glue/decode_params.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/decode_params.h
@@ -67,4 +67,36 @@
 #define FT8AF_FINE_SYNC_MIN_RARE 2.5f
 #endif
 
+// Cross-slot decoding (ft8af_glue/ft8_xslot.c): FT8 stations repeat a
+// message for many cycles on the same parity and frequency, so failed
+// fine-demod LLRs are cached and combined with the next same-parity repeat
+// (~3 dB), and recently decoded messages are re-tested against failed
+// candidates by soft correlation. WSJT-X decodes each slot in isolation —
+// this recall exists only across slots.
+// FREQ_TOL: match window in Hz (fine-demod refined frequencies are good to
+// well under 1 Hz; stations sit still between repeats).
+// MAX_AGE: LLR entries live for two same-parity repeats (30 s apart).
+// HIST_*: remembered decodes live longer (CQers run for minutes); HIST_MIN
+// is the normalized soft-correlation acceptance for the history retry —
+// the CRC is vacuous there, so this gate carries the entire false-accept
+// burden. Statistics: noise correlates ~N(0, 1/sqrt(174)) (sigma 0.076), so
+// 0.55 is ~7 sigma. Swept on the bench (matched/extras): 0.35 -> 461/99,
+// 0.45 -> 461/90, 0.55 -> 462/80, 0.65 -> 460/77. Of the decodes the
+// mechanism adds at 0.55, 49 of 57 are corroborated by jt9's truth in
+// OTHER slots of the same session (jt9 misses them in the slot where the
+// retry fires) and the rest are consistent QSO progressions of stations
+// already decoded — this recall exists only across slots.
+#ifndef FT8AF_XSLOT_FREQ_TOL
+#define FT8AF_XSLOT_FREQ_TOL 4.0f
+#endif
+#ifndef FT8AF_XSLOT_MAX_AGE_MS
+#define FT8AF_XSLOT_MAX_AGE_MS 65000
+#endif
+#ifndef FT8AF_XSLOT_HIST_MAX_AGE_MS
+#define FT8AF_XSLOT_HIST_MAX_AGE_MS 120000
+#endif
+#ifndef FT8AF_XSLOT_HIST_MIN
+#define FT8AF_XSLOT_HIST_MIN 0.55f
+#endif
+
 #endif // FT8AF_DECODE_PARAMS_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -29,6 +29,7 @@ int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
 #include "decode_params.h"
 #include "ft8_fine.h"
 #include "ft8_subtract.h"
+#include "ft8_xslot.h"
 
 // ---------------------------------------------------------------------------
 // 22-bit WSJT-X callsign hash (same as ft2_decode_jni.cpp / test_golden_encode.c).
@@ -81,7 +82,8 @@ struct ft8_decoder_state
     ft8_fine_ctx_t* fine;
     bool fine_tried;
     int sample_rate;
-    long utc;
+    int64_t utc; // slot UTC in ms (jlong; drives cross-slot parity/aging —
+                 // `long` would truncate on 32-bit ABIs)
 
     int ldpc_iterations;
     bool deep; // deep passes lower the sync-score threshold (FT8AF_MIN_SCORE_DEEP)
@@ -443,23 +445,56 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Analysis(
         float llrs[FTX_LDPC_N];
         float f_fine, t_fine, quality;
         if (ft8_fine_demod(d->fine, &d->mon, cand, llrs, &f_fine, &t_fine, &quality) &&
-            quality >= FT8AF_FINE_SYNC_MIN &&
-            ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, d->ldpc_iterations, osd_depth,
-                            FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
+            quality >= FT8AF_FINE_SYNC_MIN)
         {
-            ftx_message_type_t mtype = ftx_message_get_type(&message);
-            if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
-                mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
-                quality >= FT8AF_FINE_SYNC_MIN_RARE)
+            if (ftx_decode_llrs(FTX_PROTOCOL_FT8, llrs, d->ldpc_iterations, osd_depth,
+                                FT8AF_OSD_LDPC_ERR_GATE, &message, &status))
             {
-                decoded = true;
+                ftx_message_type_t mtype = ftx_message_get_type(&message);
+                if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
+                    mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
+                    quality >= FT8AF_FINE_SYNC_MIN_RARE)
+                    decoded = true;
+            }
+            if (!decoded)
+            {
+                // Cross-slot mechanism B (ft8_xslot.h): a recently decoded
+                // message at this frequency and slot parity, repeated but
+                // now below single-slot threshold.
+                memset(&status, 0, sizeof(status));
+                decoded = ft8_xslot_try_history(f_fine, d->utc, llrs, &message, NULL);
+            }
+            if (!decoded &&
+                ft8_xslot_try_accumulate(f_fine, d->utc, llrs, d->ldpc_iterations,
+                                         osd_depth, FT8AF_OSD_LDPC_ERR_GATE,
+                                         &message, &status))
+            {
+                // Cross-slot mechanism A: this repeat's LLRs combined with
+                // the previous same-parity repeat's. Fresh CRC decode —
+                // same rare-type bar as the fine path.
+                ftx_message_type_t mtype = ftx_message_get_type(&message);
+                if (mtype == FTX_MESSAGE_TYPE_STANDARD ||
+                    mtype == FTX_MESSAGE_TYPE_NONSTD_CALL ||
+                    quality >= FT8AF_FINE_SYNC_MIN_RARE)
+                    decoded = true;
+            }
+            if (decoded)
+            {
                 freq_hz = f_fine;
                 time_sec = t_fine;
+            }
+            else
+            {
+                // Keep this repeat's information for the next one.
+                ft8_xslot_store(f_fine, d->utc, llrs);
             }
         }
     }
     if (!decoded)
         return JNI_FALSE;
+
+    if (d->mon.wf.protocol == FTX_PROTOCOL_FT8)
+        ft8_xslot_remember(message.payload, freq_hz, d->utc);
 
     d->last_message = message;
     d->have_last = true;

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_xslot.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_xslot.c
@@ -35,14 +35,29 @@ typedef struct
     uint8_t payload[10];
     float freq_hz;
     int64_t utc_ms;
+    // Codeword signs (+1 bit 1 / -1 bit 0), precomputed at remember() time:
+    // the history test runs per failed candidate in the decode hot path and
+    // must not regenerate the 83 LDPC parity bits per entry per call.
+    float sign[FTX_LDPC_N];
 } xslot_hist_t;
 
 static xslot_entry_t g_entries[XSLOT_MAX_ENTRIES];
 static xslot_hist_t g_history[XSLOT_MAX_HISTORY];
 
+static void codeword_signs(const uint8_t payload[10], float sign[FTX_LDPC_N]);
+
 static int slot_parity(int64_t utc_ms)
 {
     return (int)((utc_ms / XSLOT_SLOT_MS) & 1);
+}
+
+// Entry lifetime check that also treats timestamps from the "future" as
+// expired: a backwards clock step (NTP correction, user adjustment) must
+// not pin entries in the cache until array churn evicts them.
+static bool expired(int64_t now_ms, int64_t entry_ms, int64_t max_age_ms)
+{
+    int64_t age = now_ms - entry_ms;
+    return age < 0 || age > max_age_ms;
 }
 
 void ft8_xslot_clear(void)
@@ -71,7 +86,7 @@ void ft8_xslot_store(float freq_hz, int64_t utc_ms, const float llrs[FTX_LDPC_N]
                 slot = i;
                 break;
             }
-            if (utc_ms - g_entries[i].utc_ms > FT8AF_XSLOT_MAX_AGE_MS)
+            if (expired(utc_ms, g_entries[i].utc_ms, FT8AF_XSLOT_MAX_AGE_MS))
             {
                 g_entries[i].used = false;
                 if (slot < 0)
@@ -150,7 +165,7 @@ void ft8_xslot_remember(const uint8_t payload[10], float freq_hz, int64_t utc_ms
                 slot = i; // refresh
                 break;
             }
-            if (utc_ms - g_history[i].utc_ms > FT8AF_XSLOT_HIST_MAX_AGE_MS)
+            if (expired(utc_ms, g_history[i].utc_ms, FT8AF_XSLOT_HIST_MAX_AGE_MS))
             {
                 g_history[i].used = false;
                 if (slot < 0)
@@ -174,6 +189,7 @@ void ft8_xslot_remember(const uint8_t payload[10], float freq_hz, int64_t utc_ms
     memcpy(g_history[slot].payload, payload, 10);
     g_history[slot].freq_hz = freq_hz;
     g_history[slot].utc_ms = utc_ms;
+    codeword_signs(payload, g_history[slot].sign);
 }
 
 // Build the 174-bit codeword signs (+1 for bit 1, -1 for bit 0) for a
@@ -224,13 +240,12 @@ bool ft8_xslot_try_history(float freq_hz, int64_t utc_ms, const float llrs[FTX_L
         // Normalized soft correlation: 1.0 = every bit agrees weighted by
         // confidence, ~N(0, 1/sqrt(174)) for an unrelated signal or noise.
         // The CRC proves nothing here (the payload is known), so this IS
-        // the acceptance evidence — threshold swept on the bench.
-        float sign[FTX_LDPC_N];
-        codeword_signs(h->payload, sign);
+        // the acceptance evidence — threshold swept on the bench. The sign
+        // vector was precomputed when the message was remembered.
         float num = 0.0f, den = 0.0f;
         for (int k = 0; k < FTX_LDPC_N; ++k)
         {
-            num += llrs[k] * sign[k];
+            num += llrs[k] * h->sign[k];
             den += fabsf(llrs[k]);
         }
         float c = (den > 0.0f) ? num / den : 0.0f;

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_xslot.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_xslot.c
@@ -1,0 +1,258 @@
+// See ft8_xslot.h.
+
+#include "ft8_xslot.h"
+
+#include <math.h>
+#include <string.h>
+
+#include "ft8/crc.h"
+
+#include "decode_params.h"
+
+#define XSLOT_SLOT_MS 15000
+
+// Mechanism A entries: one candidate's failed LLRs. ~64 is far beyond the
+// number of undecoded-but-real candidates in one slot; a busy band's junk
+// candidates never get stored (the caller gates on fine sync quality).
+#define XSLOT_MAX_ENTRIES 64
+
+// Mechanism B entries: recently decoded messages. A busy slot decodes ~30
+// messages and CQers repeat for minutes; 96 covers two full slots of
+// distinct traffic.
+#define XSLOT_MAX_HISTORY 96
+
+typedef struct
+{
+    bool used;
+    float freq_hz;
+    int64_t utc_ms;
+    float llrs[FTX_LDPC_N];
+} xslot_entry_t;
+
+typedef struct
+{
+    bool used;
+    uint8_t payload[10];
+    float freq_hz;
+    int64_t utc_ms;
+} xslot_hist_t;
+
+static xslot_entry_t g_entries[XSLOT_MAX_ENTRIES];
+static xslot_hist_t g_history[XSLOT_MAX_HISTORY];
+
+static int slot_parity(int64_t utc_ms)
+{
+    return (int)((utc_ms / XSLOT_SLOT_MS) & 1);
+}
+
+void ft8_xslot_clear(void)
+{
+    memset(g_entries, 0, sizeof(g_entries));
+    memset(g_history, 0, sizeof(g_history));
+}
+
+void ft8_xslot_store(float freq_hz, int64_t utc_ms, const float llrs[FTX_LDPC_N])
+{
+    if (!llrs)
+        return;
+    int parity = slot_parity(utc_ms);
+    int slot = -1;
+    // Reuse a matching same-parity entry (newest attempt wins), else an
+    // expired/free one, else the oldest.
+    int64_t oldest = INT64_MAX;
+    int oldest_i = 0;
+    for (int i = 0; i < XSLOT_MAX_ENTRIES; ++i)
+    {
+        if (g_entries[i].used)
+        {
+            if (slot_parity(g_entries[i].utc_ms) == parity &&
+                fabsf(g_entries[i].freq_hz - freq_hz) <= FT8AF_XSLOT_FREQ_TOL)
+            {
+                slot = i;
+                break;
+            }
+            if (utc_ms - g_entries[i].utc_ms > FT8AF_XSLOT_MAX_AGE_MS)
+            {
+                g_entries[i].used = false;
+                if (slot < 0)
+                    slot = i;
+            }
+            else if (g_entries[i].utc_ms < oldest)
+            {
+                oldest = g_entries[i].utc_ms;
+                oldest_i = i;
+            }
+        }
+        else if (slot < 0)
+        {
+            slot = i;
+        }
+    }
+    if (slot < 0)
+        slot = oldest_i;
+
+    g_entries[slot].used = true;
+    g_entries[slot].freq_hz = freq_hz;
+    g_entries[slot].utc_ms = utc_ms;
+    memcpy(g_entries[slot].llrs, llrs, sizeof(g_entries[slot].llrs));
+}
+
+bool ft8_xslot_try_accumulate(float freq_hz, int64_t utc_ms, const float llrs[FTX_LDPC_N],
+                              int max_iterations, int osd_depth, int osd_err_gate,
+                              ftx_message_t* message, decode_status_t* status)
+{
+    if (!llrs || !message || !status)
+        return false;
+    int parity = slot_parity(utc_ms);
+    for (int i = 0; i < XSLOT_MAX_ENTRIES; ++i)
+    {
+        xslot_entry_t* e = &g_entries[i];
+        if (!e->used)
+            continue;
+        int64_t age = utc_ms - e->utc_ms;
+        if (age <= 0 || age > FT8AF_XSLOT_MAX_AGE_MS)
+            continue; // same slot, from the future, or stale
+        if (slot_parity(e->utc_ms) != parity)
+            continue;
+        if (fabsf(e->freq_hz - freq_hz) > FT8AF_XSLOT_FREQ_TOL)
+            continue;
+
+        // Sum of independent LLRs for the same repeated message is the
+        // optimal non-coherent combine (~3 dB for two repeats). A different
+        // message underneath just fails the CRC.
+        float combined[FTX_LDPC_N];
+        for (int k = 0; k < FTX_LDPC_N; ++k)
+            combined[k] = e->llrs[k] + llrs[k];
+
+        if (ftx_decode_llrs(FTX_PROTOCOL_FT8, combined, max_iterations,
+                            osd_depth, osd_err_gate, message, status))
+        {
+            e->used = false; // consumed — don't decode it twice
+            return true;
+        }
+    }
+    return false;
+}
+
+void ft8_xslot_remember(const uint8_t payload[10], float freq_hz, int64_t utc_ms)
+{
+    if (!payload)
+        return;
+    int slot = -1;
+    int64_t oldest = INT64_MAX;
+    int oldest_i = 0;
+    for (int i = 0; i < XSLOT_MAX_HISTORY; ++i)
+    {
+        if (g_history[i].used)
+        {
+            if (memcmp(g_history[i].payload, payload, 10) == 0)
+            {
+                slot = i; // refresh
+                break;
+            }
+            if (utc_ms - g_history[i].utc_ms > FT8AF_XSLOT_HIST_MAX_AGE_MS)
+            {
+                g_history[i].used = false;
+                if (slot < 0)
+                    slot = i;
+            }
+            else if (g_history[i].utc_ms < oldest)
+            {
+                oldest = g_history[i].utc_ms;
+                oldest_i = i;
+            }
+        }
+        else if (slot < 0)
+        {
+            slot = i;
+        }
+    }
+    if (slot < 0)
+        slot = oldest_i;
+
+    g_history[slot].used = true;
+    memcpy(g_history[slot].payload, payload, 10);
+    g_history[slot].freq_hz = freq_hz;
+    g_history[slot].utc_ms = utc_ms;
+}
+
+// Build the 174-bit codeword signs (+1 for bit 1, -1 for bit 0) for a
+// payload: a91 = payload+CRC (91 systematic bits), then 83 parity bits from
+// kFTX_LDPC_generator — the same construction as osd.c / test_osd.c.
+static void codeword_signs(const uint8_t payload[10], float sign[FTX_LDPC_N])
+{
+    uint8_t a91[FTX_LDPC_K_BYTES];
+    ftx_add_crc(payload, a91);
+
+    uint8_t bits[FTX_LDPC_N];
+    for (int i = 0; i < FTX_LDPC_K; ++i)
+        bits[i] = (a91[i / 8] >> (7 - (i % 8))) & 1u;
+    for (int p = 0; p < FTX_LDPC_M; ++p)
+    {
+        int sum = 0;
+        for (int j = 0; j < FTX_LDPC_K; ++j)
+            if ((kFTX_LDPC_generator[p][j / 8] >> (7 - (j % 8))) & 1u)
+                sum ^= bits[j];
+        bits[FTX_LDPC_K + p] = (uint8_t)sum;
+    }
+    for (int i = 0; i < FTX_LDPC_N; ++i)
+        sign[i] = bits[i] ? 1.0f : -1.0f;
+}
+
+bool ft8_xslot_try_history(float freq_hz, int64_t utc_ms, const float llrs[FTX_LDPC_N],
+                           ftx_message_t* message, float* correlation_out)
+{
+    if (!llrs || !message)
+        return false;
+
+    float best_c = 0.0f;
+    const xslot_hist_t* best = NULL;
+    int parity = slot_parity(utc_ms);
+    for (int i = 0; i < XSLOT_MAX_HISTORY; ++i)
+    {
+        const xslot_hist_t* h = &g_history[i];
+        if (!h->used)
+            continue;
+        int64_t age = utc_ms - h->utc_ms;
+        if (age <= 0 || age > FT8AF_XSLOT_HIST_MAX_AGE_MS)
+            continue;
+        if (slot_parity(h->utc_ms) != parity)
+            continue; // stations repeat on their own slot parity
+        if (fabsf(h->freq_hz - freq_hz) > FT8AF_XSLOT_FREQ_TOL)
+            continue;
+
+        // Normalized soft correlation: 1.0 = every bit agrees weighted by
+        // confidence, ~N(0, 1/sqrt(174)) for an unrelated signal or noise.
+        // The CRC proves nothing here (the payload is known), so this IS
+        // the acceptance evidence — threshold swept on the bench.
+        float sign[FTX_LDPC_N];
+        codeword_signs(h->payload, sign);
+        float num = 0.0f, den = 0.0f;
+        for (int k = 0; k < FTX_LDPC_N; ++k)
+        {
+            num += llrs[k] * sign[k];
+            den += fabsf(llrs[k]);
+        }
+        float c = (den > 0.0f) ? num / den : 0.0f;
+        if (c > best_c)
+        {
+            best_c = c;
+            best = h;
+        }
+    }
+
+    if (correlation_out)
+        *correlation_out = best_c;
+    if (!best || best_c < FT8AF_XSLOT_HIST_MIN)
+        return false;
+
+    ftx_message_init(message);
+    memcpy(message->payload, best->payload, 10);
+    // Same hash convention as ftx_decode_llrs: the message CRC.
+    uint8_t a91[FTX_LDPC_K_BYTES];
+    ftx_add_crc(best->payload, a91);
+    a91[9] &= 0xF8;
+    a91[10] = 0;
+    message->hash = ftx_compute_crc(a91, 96 - 14);
+    return true;
+}

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_xslot.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_xslot.h
@@ -1,0 +1,76 @@
+// Cross-slot FT8 decoding — recall below the single-slot threshold by using
+// the repetition structure of FT8 traffic. WSJT-X decodes every 15 s slot in
+// isolation; stations, however, repeat the same message for many cycles
+// (CQs and 73s especially), always on the same slot parity and frequency.
+// This module keeps a small process-global cache across slots with two
+// mechanisms, both operating on the fine-demod float LLRs (ft8_fine.h):
+//
+//  A. LLR accumulation. A candidate that fails to decode (but has genuine
+//     sync quality) stores its 174 LLRs keyed by frequency and slot parity.
+//     When the next same-parity slot produces a failed candidate at the
+//     same frequency, the two LLR sets are summed — a coherent-information
+//     combine worth ~3 dB — and the BP+OSD+CRC chain reruns on the sum.
+//     This decodes stations that are below threshold in EVERY single slot.
+//
+//  B. Message-history retry. Every successful decode is remembered
+//     (payload + frequency). A failed candidate at a remembered frequency
+//     is tested against the remembered codeword by normalized soft
+//     correlation of the LLRs; a strong match means the station repeated
+//     its transmission but faded below decode threshold this cycle. The
+//     CRC is vacuous here (the payload is known), so acceptance rests on
+//     the correlation gate — see FT8AF_XSLOT_HIST_MIN in decode_params.h,
+//     benchmark-swept against false accepts.
+//
+// Entries expire on their own (an accumulated LLR after ~2 same-parity
+// slots, a history entry after ~2 minutes), so band changes self-heal;
+// ft8_xslot_clear() empties everything immediately.
+//
+// State is process-global and NOT thread-safe by design: the app decodes
+// one slot at a time on a single worker thread, and the bench is
+// single-threaded. utc_ms timestamps drive slot parity ((utc/15000) % 2)
+// and expiry; callers must pass consistent values within a session.
+#ifndef FT8AF_FT8_XSLOT_H
+#define FT8AF_FT8_XSLOT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "ft8/constants.h"
+#include "ft8/decode.h"
+#include "ft8/message.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Record the fine-demod LLRs of a candidate that failed every decode
+// attempt this slot. Replaces an existing same-parity entry within the
+// frequency tolerance (the newest attempt supersedes older ones).
+void ft8_xslot_store(float freq_hz, int64_t utc_ms, const float llrs[FTX_LDPC_N]);
+
+// Mechanism A: combine `llrs` with a stored same-parity, same-frequency
+// entry from an earlier slot and rerun BP+OSD+CRC on the sum. On success
+// fills message/status (like ftx_decode_llrs) and consumes the entry.
+bool ft8_xslot_try_accumulate(float freq_hz, int64_t utc_ms, const float llrs[FTX_LDPC_N],
+                              int max_iterations, int osd_depth, int osd_err_gate,
+                              ftx_message_t* message, decode_status_t* status);
+
+// Remember a successful decode (payload + where it was heard) for
+// mechanism B. Payloads follow ftx_message_t: 77 bits in 10 bytes.
+void ft8_xslot_remember(const uint8_t payload[10], float freq_hz, int64_t utc_ms);
+
+// Mechanism B: test `llrs` against remembered messages near freq_hz by
+// normalized soft correlation. On a match above FT8AF_XSLOT_HIST_MIN,
+// fills `message` with the remembered payload and returns true.
+// correlation_out (optional) reports the winning score.
+bool ft8_xslot_try_history(float freq_hz, int64_t utc_ms, const float llrs[FTX_LDPC_N],
+                           ftx_message_t* message, float* correlation_out);
+
+// Drop all cross-slot state (e.g. on band change).
+void ft8_xslot_clear(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FT8AF_FT8_XSLOT_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -131,6 +131,7 @@ $benchSrcs = @(
 $benchSrcs += (Join-Path $here "gfsk.c")
 $benchSrcs += (Join-Path $here "ft8_subtract.c")
 $benchSrcs += (Join-Path $here "ft8_fine.c")
+$benchSrcs += (Join-Path $here "ft8_xslot.c")
 
 $srcBench = Join-Path $here "decode_bench.c"
 $outBench = Join-Path $env:TEMP "ft8_decode_bench.exe"
@@ -210,6 +211,25 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_fine)." }
 & $outFine
 $fineExit = $LASTEXITCODE
 
+# ---------------------------------------------------------------------------
+# Cross-slot unit tests: LLR accumulation across same-parity slots and the
+# message-history retry (acceptance, parity/frequency/noise rejection).
+# ---------------------------------------------------------------------------
+$xslotSrcs = @(
+    "ft8\pack.c","ft8\encode.c","ft8\crc.c","ft8\constants.c",
+    "ft8\text.c","ft8\message.c","ft8\decode.c","ft8\ldpc.c","ft8\osd.c","ft8\unpack.c"
+) | ForEach-Object { Join-Path $ft8 $_ }
+$xslotSrcs += (Join-Path $here "ft8_xslot.c")
+
+$srcXslot = Join-Path $here "test_xslot.c"
+$outXslot = Join-Path $env:TEMP "ft8_xslot_test.exe"
+
+& $Clang @common $srcXslot @xslotSrcs -o $outXslot
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_xslot)." }
+
+& $outXslot
+$xslotExit = $LASTEXITCODE
+
 if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
 if ($firExit -ne 0) { exit $firExit }
@@ -217,4 +237,5 @@ if ($benchSelfExit -ne 0) { exit $benchSelfExit }
 if ($benchExit -ne 0) { exit $benchExit }
 if ($subExit -ne 0) { exit $subExit }
 if ($osdExit -ne 0) { exit $osdExit }
-exit $fineExit
+if ($fineExit -ne 0) { exit $fineExit }
+exit $xslotExit

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -98,6 +98,7 @@ bench_srcs=(
     "$here/gfsk.c"
     "$here/ft8_subtract.c"
     "$here/ft8_fine.c"
+    "$here/ft8_xslot.c"
     "$ft8/ft8/pack.c"
     "$ft8/ft8/encode.c"
     "$ft8/ft8/crc.c"
@@ -193,3 +194,25 @@ fine_out="$tmp/ft8_fine_test"
     -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
     -I "$ft8" "${fine_srcs[@]}" -lm -o "$fine_out"
 "$fine_out"
+
+# Cross-slot unit tests: LLR accumulation across same-parity slots and the
+# message-history retry (acceptance, parity/frequency/noise rejection).
+xslot_srcs=(
+    "$here/test_xslot.c"
+    "$here/ft8_xslot.c"
+    "$ft8/ft8/pack.c"
+    "$ft8/ft8/encode.c"
+    "$ft8/ft8/crc.c"
+    "$ft8/ft8/constants.c"
+    "$ft8/ft8/text.c"
+    "$ft8/ft8/message.c"
+    "$ft8/ft8/decode.c"
+    "$ft8/ft8/ldpc.c"
+    "$ft8/ft8/osd.c"
+    "$ft8/ft8/unpack.c"
+)
+xslot_out="$tmp/ft8_xslot_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" "${xslot_srcs[@]}" -lm -o "$xslot_out"
+"$xslot_out"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_xslot.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_xslot.c
@@ -1,0 +1,190 @@
+// Host unit tests for ft8_xslot.c — cross-slot decoding. Run by
+// run_host_tests.sh / .ps1.
+//
+// Covered:
+//   1. LLR accumulation: two repeats of one message, each with too many
+//      erased bits to decode alone, decode from the summed LLRs — and only
+//      across slots of the SAME parity, only once (the entry is consumed).
+//   2. Message-history retry: a remembered decode is re-accepted from weak
+//      LLRs at the same frequency and parity; rejected for pure noise, for
+//      the wrong slot parity, and for a different frequency.
+//   3. ft8_xslot_clear drops all state.
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ft8/constants.h>
+#include <ft8/crc.h>
+#include <ft8/decode.h>
+#include <ft8/message.h>
+
+#include "decode_params.h"
+#include "ft8_xslot.h"
+
+static int g_failures = 0;
+
+static void check(bool ok, const char* what)
+{
+    printf("  %s %s\n", ok ? "ok:  " : "FAIL:", what);
+    if (!ok)
+        g_failures++;
+}
+
+static uint32_t g_seed = 1;
+static uint32_t prng(void)
+{
+    g_seed = g_seed * 1664525u + 1013904223u;
+    return g_seed;
+}
+static float prng_uniform(void)
+{
+    return (float)(prng() >> 8) / 16777216.0f;
+}
+
+// 174-bit codeword for a message text (same construction as test_osd.c).
+static bool make_codeword(const char* text, uint8_t cw[FTX_LDPC_N], uint8_t payload_out[10])
+{
+    ftx_message_t msg;
+    ftx_message_init(&msg);
+    if (ftx_message_encode(&msg, NULL, text) != FTX_MESSAGE_RC_OK)
+        return false;
+    memcpy(payload_out, msg.payload, 10);
+    uint8_t a91[FTX_LDPC_K_BYTES];
+    ftx_add_crc(msg.payload, a91);
+    for (int i = 0; i < FTX_LDPC_K; ++i)
+        cw[i] = (a91[i / 8] >> (7 - (i % 8))) & 1u;
+    for (int p = 0; p < FTX_LDPC_M; ++p)
+    {
+        int sum = 0;
+        for (int j = 0; j < FTX_LDPC_K; ++j)
+            if ((kFTX_LDPC_generator[p][j / 8] >> (7 - (j % 8))) & 1u)
+                sum ^= cw[j];
+        cw[FTX_LDPC_K + p] = (uint8_t)sum;
+    }
+    return true;
+}
+
+// A "repeat" of the codeword: clean moderate LLRs with n_erase seeded
+// positions zeroed (deep-faded symbols) — enough that a single repeat's
+// basis must include erased bits and the decode fails.
+static void make_repeat(const uint8_t cw[FTX_LDPC_N], int n_erase, uint32_t seed,
+                        float llrs[FTX_LDPC_N])
+{
+    g_seed = seed;
+    for (int i = 0; i < FTX_LDPC_N; ++i)
+        llrs[i] = cw[i] ? 0.5f : -0.5f;
+    int erased = 0;
+    while (erased < n_erase)
+    {
+        int i = (int)(prng_uniform() * FTX_LDPC_N);
+        if (llrs[i] == 0.0f)
+            continue;
+        llrs[i] = 0.0f;
+        erased++;
+    }
+}
+
+static const char* TEXT = "OK2BJ JG1SRO -15";
+
+int main(void)
+{
+    uint8_t cw[FTX_LDPC_N], payload[10];
+    check(make_codeword(TEXT, cw, payload), "message encodes");
+
+    ftx_message_t message;
+    decode_status_t status;
+    float rep_a[FTX_LDPC_N], rep_b[FTX_LDPC_N];
+    // 100 erasures per repeat: 74 clean bits < 91, so the decoder cannot
+    // build a basis from clean bits alone and fails (asserted below). The
+    // two repeats erase different positions (independent fading), so the
+    // sum has ~57 joint erasures — well within reach.
+    make_repeat(cw, 100, 11, rep_a);
+    make_repeat(cw, 100, 22, rep_b);
+
+    // ---- 1. accumulation across same-parity slots ---------------------------
+    printf("test_xslot_accumulate:\n");
+    ft8_xslot_clear();
+    check(!ftx_decode_llrs(FTX_PROTOCOL_FT8, rep_a, FT8AF_LDPC_ITERS_DEEP,
+                           FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                           &message, &status),
+          "first repeat fails alone");
+    check(!ftx_decode_llrs(FTX_PROTOCOL_FT8, rep_b, FT8AF_LDPC_ITERS_DEEP,
+                           FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                           &message, &status),
+          "second repeat fails alone");
+
+    ft8_xslot_store(1453.0f, 0, rep_a);
+    check(!ft8_xslot_try_accumulate(1453.5f, 15000, rep_b, FT8AF_LDPC_ITERS_DEEP,
+                                    FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                                    &message, &status),
+          "wrong slot parity does not combine");
+    check(ft8_xslot_try_accumulate(1453.5f, 30000, rep_b, FT8AF_LDPC_ITERS_DEEP,
+                                   FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                                   &message, &status),
+          "same parity, next repeat: combined LLRs DECODE");
+    check(memcmp(message.payload, payload, 10) == 0, "decoded payload is the message");
+    check(!ft8_xslot_try_accumulate(1453.5f, 30000, rep_b, FT8AF_LDPC_ITERS_DEEP,
+                                    FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                                    &message, &status),
+          "entry is consumed after a successful combine");
+
+    ft8_xslot_store(1453.0f, 0, rep_a);
+    check(!ft8_xslot_try_accumulate(1500.0f, 30000, rep_b, FT8AF_LDPC_ITERS_DEEP,
+                                    FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                                    &message, &status),
+          "frequency outside the tolerance does not combine");
+
+    // ---- 2. message-history retry --------------------------------------------
+    printf("test_xslot_history:\n");
+    ft8_xslot_clear();
+    ft8_xslot_remember(payload, 1453.0f, 0);
+
+    // Weak but genuine repeat: correct-signed LLRs at low confidence.
+    float weak[FTX_LDPC_N];
+    g_seed = 33;
+    for (int i = 0; i < FTX_LDPC_N; ++i)
+        weak[i] = (cw[i] ? 1.0f : -1.0f) * 0.1f + 0.05f * (2.0f * prng_uniform() - 1.0f);
+    float corr = 0.0f;
+    check(ft8_xslot_try_history(1453.5f, 30000, weak, &message, &corr),
+          "weak genuine repeat is accepted");
+    printf("  (correlation %.2f)\n", corr);
+    check(corr >= FT8AF_XSLOT_HIST_MIN, "correlation clears the gate");
+    check(memcmp(message.payload, payload, 10) == 0, "accepted payload is the remembered message");
+
+    check(!ft8_xslot_try_history(1453.5f, 15000, weak, &message, NULL),
+          "wrong slot parity is rejected");
+    check(!ft8_xslot_try_history(1470.0f, 30000, weak, &message, NULL),
+          "different frequency is rejected");
+
+    float noise[FTX_LDPC_N];
+    g_seed = 44;
+    for (int i = 0; i < FTX_LDPC_N; ++i)
+        noise[i] = 2.0f * prng_uniform() - 1.0f;
+    check(!ft8_xslot_try_history(1453.5f, 30000, noise, &message, &corr),
+          "pure noise at the same frequency is rejected");
+    printf("  (noise correlation %.2f)\n", corr);
+
+    // ---- 3. clear -------------------------------------------------------------
+    printf("test_xslot_clear:\n");
+    ft8_xslot_store(1453.0f, 0, rep_a);
+    ft8_xslot_remember(payload, 1453.0f, 0);
+    ft8_xslot_clear();
+    check(!ft8_xslot_try_accumulate(1453.0f, 30000, rep_b, FT8AF_LDPC_ITERS_DEEP,
+                                    FT8AF_OSD_DEPTH_DEEP, FT8AF_OSD_LDPC_ERR_GATE,
+                                    &message, &status),
+          "no accumulation after clear");
+    check(!ft8_xslot_try_history(1453.0f, 30000, weak, &message, NULL),
+          "no history after clear");
+
+    if (g_failures == 0)
+    {
+        printf("all cross-slot tests passed\n");
+        return 0;
+    }
+    printf("%d cross-slot test(s) FAILED\n", g_failures);
+    return 1;
+}

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_xslot.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_xslot.c
@@ -80,7 +80,11 @@ static void make_repeat(const uint8_t cw[FTX_LDPC_N], int n_erase, uint32_t seed
     int erased = 0;
     while (erased < n_erase)
     {
+        // Clamp: prng_uniform() approaches 1.0 closely enough that float
+        // rounding of the product must not be trusted to stay below N.
         int i = (int)(prng_uniform() * FTX_LDPC_N);
+        if (i >= FTX_LDPC_N)
+            i = FTX_LDPC_N - 1;
         if (llrs[i] == 0.0f)
             continue;
         llrs[i] = 0.0f;

--- a/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
+++ b/ft8af/app/src/main/cpp/ft8af_glue/testdata/ft8/floors.txt
@@ -15,6 +15,8 @@
 #   recall=94.9%; extras 52 -> 51.
 # 2026-07-02 fine-demod (fine-sync coherent retry from raw samples):
 #   TOTAL matched=459 recall=97.0%; 11 of 20 files at 100% of jt9.
+# 2026-07-02 cross-slot (LLR accumulation + message-history retry):
+#   TOTAL matched=462 recall=97.7%; 14 of 20 files at 100% of jt9.
 20m_busy_test_01.wav 24
 20m_busy_test_02.wav 21
 20m_busy_test_03.wav 18
@@ -22,10 +24,10 @@
 20m_busy_test_05.wav 32
 20m_busy_test_06.wav 26
 20m_busy_test_07.wav 31
-20m_busy_test_08.wav 18
-20m_busy_test_09.wav 26
+20m_busy_test_08.wav 19
+20m_busy_test_09.wav 27
 20m_busy_test_10.wav 20
-20m_busy_test_11.wav 30
+20m_busy_test_11.wav 31
 20m_busy_test_12.wav 18
 websdr_test1.wav 15
 websdr_test2.wav 21


### PR DESCRIPTION
## Summary

The first capability in this stack that **WSJT-X structurally does not have**: cross-slot decoding. WSJT-X decodes every 15 s slot in isolation; FT8 stations repeat the same message for many cycles on the same slot parity and frequency. This PR exploits that: bench recall vs `jt9 -d 3` goes **97.0% → 97.7%** (459 → 462 of 473, **14 of 20 files at 100% of jt9**), and beyond the truth set it produces 57 additional decodes of which **49 are corroborated by jt9's own truth in other slots of the same session** — real repeats jt9 misses in the slot where we catch them.

## What

New `ft8af_glue/ft8_xslot.c` — a small process-global cache across slots, driven by the fine-demod float LLRs (#369):

**A. LLR accumulation.** A candidate that fails every decode attempt (but has genuine fine sync quality) stores its 174 LLRs keyed by frequency + slot parity. The next same-parity repeat's failed candidate at that frequency gets the two LLR sets *summed* (~3 dB non-coherent combine) and the BP+OSD+CRC chain reruns on the sum — decoding stations that are below threshold in **every single slot**. Entries expire after ~2 repeats and are consumed on use.

**B. Message-history retry.** Every successful decode is remembered (payload + frequency). A failed candidate at a remembered frequency/parity is tested against the remembered codeword by **normalized soft LLR correlation**. The CRC proves nothing here (the payload is known), so the correlation gate carries the entire false-accept burden:
- noise correlates ~N(0, 1/√174), σ = 0.076 → the 0.55 gate is ~7σ (p ≈ 10⁻¹³ per test);
- swept: 0.35 → 461 matched / 99 extras, 0.45 → 461/90, **0.55 → 462/80**, 0.65 → 460/77;
- the **slot-parity check is load-bearing** — without it the mechanism fires in slots where the station cannot be transmitting (first cut: extras 101).

The three new truth matches are exactly the repeat-miss cases the miss profile predicted (`CQ 7Z1AL` −22 dB, `JO1COV PA0CAH` −22 dB, `CQ RX3ASQ` −24 dB — each decoded in an earlier slot, faded below single-slot threshold in the missed one).

## On the "extras" number

Extras rise 62 → 80 by construction: the mechanism decodes repeats in slots where jt9's truth doesn't have them. Corroboration analysis of all 57 added decodes: 49 appear verbatim in *other* files' jt9 truth (same station, same frequency, the session's even/odd repeat cadence); the remaining 8 are consistent QSO progressions of stations already decoded (e.g. the `RA1CP`/`OM7JG` exchange pair, `F6DEO/QRP` who is in truth as `<9A9A> F6DEO/QRP`). This is the feature working, not junk — a 7σ correlation cannot come from noise.

## Wiring

- **Bench**: corpus files are consecutive 15 s slots of one session (the truth sidecars' repeat structure confirms it), so a synthetic slot clock (file index × 15 s) drives parity/aging. `--no-cross-slot` for A/B.
- **App**: JNI-only, zero Java changes, FT8 only. Real slot UTC flows through the existing `InitDecoder` plumbing (`d->utc` widened to `int64_t` — `long` truncates on 32-bit ABIs). State is process-global by design (the app creates a new decoder per slot) and single-threaded like the decode loop; band changes self-heal through entry expiry (~30 s / 2 min).
- Desktop unaffected.

## Tests

`test_xslot.c` (wired into `run_host_tests.sh`/`.ps1` → CI):
- accumulation decodes two individually-undecodable repeats (100 erased bits each — asserted to fail alone), only across same-parity slots, within the frequency tolerance, and consumes the entry;
- history retry accepts a weak genuine repeat (correlation ~1.0) and rejects pure noise (measured 0.05), wrong parity, and wrong frequency;
- `ft8_xslot_clear()` drops all state.

Full host suite green (golden, dev625, FIR, subtract, OSD, fine, cross-slot, bench floor assert at the ratcheted floors — `08` 18→19, `09` 26→27, `11` 30→31); `gradlew assembleDebug testDebugUnitTest` green.

## Stack progression

| | recall | files at 100% |
|---|---|---|
| #367 time-domain subtraction | 94.5% | 6/20 |
| #368 order-2 OSD | 94.9% | 6/20 |
| #369 fine-sync demod | 97.0% | 11/20 |
| **this PR: cross-slot** | **97.7%** | **14/20** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
