### PR TITLE
CI: tag Android releases at the built commit, not main's HEAD

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -567,6 +567,12 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.release_tag }}
           name: ${{ steps.tag.outputs.release_tag }}
+          # Without this, a not-yet-existing tag (the android-dev.* / auto-bumped
+          # android-v* lanes) is created by the release API from the repo's
+          # DEFAULT branch (main), not the commit that was built — so staging
+          # releases got tagged on main's HEAD and sorted under its old date on
+          # the Releases page.
+          target_commitish: ${{ github.sha }}
           files: ft8af/app/build/outputs/apk/release/FT8AF-*.apk
           generate_release_notes: true
           # android-dev.* releases are flagged as prerelease so they sort under


### PR DESCRIPTION
## Problem

Staging builds were "missing" from the Releases page. They were actually published, but every `android-dev.*` tag pointed at `main`'s HEAD (`ee764862`, June 19) instead of the staging commit that was built — verified for `android-dev.53/.67/.74/.172`. GitHub orders the Releases page by the tagged commit's date, so each new staging release sorted back at June 19 and was buried.

## Cause

The "Create GitHub Release" step uses `softprops/action-gh-release` without `target_commitish`. When the tag doesn't exist yet (always, for the `android-dev.*` and auto-bumped `android-v*` lanes), the release API creates it from the repo's **default branch**, not the built commit.

## Fix

Pass `target_commitish: ${{ github.sha }}` so the tag lands on the commit the workflow built. This matches what `tauri-action` already does for the desktop lane, whose `desktop-dev.*` tags were correct.

No test: CI-workflow-only change with no app code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)