### PR TITLE
Wire up Codecov coverage across all modules (#375)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -154,6 +154,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ft8af/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          # Tag this upload so Codecov reports the Android JVM suite as its own
+          # component instead of merging it into one undifferentiated total.
+          flags: android
 
       - name: Upload test reports on failure
         if: steps.codecov.outcome == 'failure'

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -286,6 +286,22 @@ jobs:
             libudev-dev \
             libasound2-dev
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # cargo llvm-cov runs `cargo test`, which compiles build.rs ->
+      # tauri_build::build(). tauri.conf.json's frontendDist ("../dist") must
+      # exist at compile time, and cargo — unlike `tauri build` — does NOT run the
+      # configured beforeBuildCommand, so build the Vite frontend (outDir: dist)
+      # here first. Without this the crate fails to compile on a missing dist.
+      - name: Build frontend (produces desktop/dist for tauri-build)
+        working-directory: desktop
+        run: |
+          npm ci
+          npm run build
+
       - name: Run tests with coverage
         working-directory: desktop/src-tauri
         run: cargo llvm-cov --lcov --output-path desktop.lcov

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -242,6 +242,62 @@ jobs:
           prerelease: ${{ needs.version.outputs.is_prerelease == 'true' }}
           args: --config '{"bundle":{"active":true}}'
 
+  coverage:
+    name: Rust coverage
+    # Best-effort, NON-GATING desktop coverage: runs the src-tauri crate's unit
+    # tests (src/*.rs #[cfg(test)] modules) under cargo-llvm-cov and uploads to
+    # Codecov under the `desktop` flag. Path-gated via `detect` (skips on unrelated
+    # PRs) and intentionally left OUT of `desktop-gate` — a coverage flake must
+    # never block a merge or a release. Linux-only; reuses the same system deps the
+    # build leg needs to link serialport(libudev) + alsa.
+    needs: detect
+    if: ${{ needs.detect.outputs.run == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Install Linux dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update -o DPkg::Lock::Timeout=600
+          sudo apt-get install -y --no-install-recommends \
+            -o DPkg::Lock::Timeout=600 \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libayatana-appindicator3-dev \
+            libudev-dev \
+            libasound2-dev
+
+      - name: Run tests with coverage
+        working-directory: desktop/src-tauri
+        run: cargo llvm-cov --lcov --output-path desktop.lcov
+
+      - name: Upload desktop coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: desktop/src-tauri/desktop.lcov
+          flags: desktop
+
   desktop-gate:
     name: desktop-gate
     # Always-run aggregator: the single required status check for desktop.

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -100,7 +100,7 @@ jobs:
           objs=()
           while IFS= read -r xctest; do
             objs+=("$xctest/Contents/MacOS/$(basename "${xctest%.xctest}")")
-          done < <(find "$bin" -name '*.xctest' -maxdepth 1)
+          done < <(find "$bin" -maxdepth 1 -name '*.xctest')
           if [[ ${#objs[@]} -eq 0 ]]; then
             echo "::error::No .xctest bundle found under $bin"; exit 1
           fi

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -80,7 +80,40 @@ jobs:
       # header-search-path / non-modular-include caveats if any regress.
       - name: Run FT8AFKit tests
         working-directory: ios/FT8AFKit
-        run: swift test
+        run: swift test --enable-code-coverage
+
+      # Export the SwiftPM coverage run to lcov. swift test writes a merged
+      # default.profdata plus the combined *PackageTests.xctest bundle under the
+      # build bin dir; llvm-cov turns those into lcov for Codecov. .build (vendored
+      # SwiftPM checkouts) is excluded so the ios flag reflects our own sources.
+      - name: Export iOS coverage to lcov
+        working-directory: ios/FT8AFKit
+        run: |
+          set -euo pipefail
+          bin="$(swift build --show-bin-path)"
+          prof="$bin/codecov/default.profdata"
+          # Collect every test bundle's executable (usually one merged bundle).
+          objs=()
+          while IFS= read -r xctest; do
+            objs+=("$xctest/Contents/MacOS/$(basename "${xctest%.xctest}")")
+          done < <(find "$bin" -name '*.xctest' -maxdepth 1)
+          if [[ ${#objs[@]} -eq 0 ]]; then
+            echo "::error::No .xctest bundle found under $bin"; exit 1
+          fi
+          args=("${objs[0]}")
+          for o in "${objs[@]:1}"; do args+=("-object" "$o"); done
+          xcrun llvm-cov export -format=lcov -instr-profile "$prof" \
+            --ignore-filename-regex='\.build/' \
+            "${args[@]}" > ios.lcov
+          echo "Wrote $(wc -l < ios.lcov) lines of lcov."
+
+      - name: Upload iOS coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ios/FT8AFKit/ios.lcov
+          flags: ios
 
       # The app's .xcodeproj is generated from project.yml via XcodeGen and no
       # shared scheme is committed, so regenerate it to get a buildable scheme.

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -87,6 +87,10 @@ jobs:
       # build bin dir; llvm-cov turns those into lcov for Codecov. .build (vendored
       # SwiftPM checkouts) is excluded so the ios flag reflects our own sources.
       - name: Export iOS coverage to lcov
+        # Non-fatal: a coverage-export hiccup must never fail the required
+        # ios-gate (mirrors the native/desktop coverage guards). If this or the
+        # upload below no-ops, the simulator build still gates the PR.
+        continue-on-error: true
         working-directory: ios/FT8AFKit
         run: |
           set -euo pipefail

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -38,9 +38,18 @@ jobs:
       # continue-on-error, so a coverage hiccup (tool mismatch, apt flake) can never
       # fail the required golden-vector check. The source lists mirror the golden
       # and dev625 builds in run_host_tests.sh — keep them in sync when that changes.
+      # DEBIAN_FRONTEND=noninteractive + DPkg::Lock::Timeout guard against the two
+      # ways apt hangs forever on hosted runners (a debconf prompt that -y doesn't
+      # suppress, and the dpkg lock held by a background apt-daily job) — this step
+      # is best-effort, but a hang would still stall the required golden-encode job.
       - name: Install LLVM coverage tools
         continue-on-error: true
-        run: sudo apt-get update && sudo apt-get install -y llvm
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update -o DPkg::Lock::Timeout=600
+          sudo apt-get install -y --no-install-recommends \
+            -o DPkg::Lock::Timeout=600 llvm
 
       - name: Build & run suites with coverage
         continue-on-error: true

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -31,3 +31,48 @@ jobs:
 
       - name: Build & run golden tests
         run: bash ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+
+      # --- Coverage: best-effort, NON-GATING. Rebuilds the golden + dev625 suites
+      # with clang source-based coverage and uploads to Codecov under the `native`
+      # flag. Deliberately separate from the gate above and every step here is
+      # continue-on-error, so a coverage hiccup (tool mismatch, apt flake) can never
+      # fail the required golden-vector check. The source lists mirror the golden
+      # and dev625 builds in run_host_tests.sh — keep them in sync when that changes.
+      - name: Install LLVM coverage tools
+        continue-on-error: true
+        run: sudo apt-get update && sudo apt-get install -y llvm
+
+      - name: Build & run suites with coverage
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          glue=ft8af/app/src/main/cpp/ft8af_glue
+          ft8=ft8af/app/src/main/cpp/ft8_lib
+          core=("$ft8/ft8/pack.c" "$ft8/ft8/encode.c" "$ft8/ft8/crc.c" \
+                "$ft8/ft8/constants.c" "$ft8/ft8/text.c" "$ft8/ft8/message.c")
+          decode=("$ft8/ft8/decode.c" "$ft8/ft8/ldpc.c" "$ft8/ft8/osd.c" "$ft8/ft8/unpack.c")
+          covflags="-fprofile-instr-generate -fcoverage-mapping"
+          mkdir -p cov
+          clang -std=c11 -O1 -D_GNU_SOURCE $covflags \
+            -Wno-deprecated-non-prototype -Wno-unused-function -I "$ft8" \
+            "$glue/test_golden_encode.c" "${core[@]}" -lm -o cov/golden
+          clang -std=c11 -O1 -D_GNU_SOURCE $covflags \
+            -Wno-deprecated-non-prototype -Wno-unused-function -I "$ft8" \
+            "$glue/test_dev625_fixes.c" "${core[@]}" "${decode[@]}" \
+            "$glue/fft_display.c" -lm -o cov/dev625
+          LLVM_PROFILE_FILE=cov/golden.profraw ./cov/golden
+          LLVM_PROFILE_FILE=cov/dev625.profraw ./cov/dev625
+          llvm-profdata merge -sparse cov/*.profraw -o cov/merged.profdata
+          # Exclude the test harnesses themselves so the flag reflects core coverage.
+          llvm-cov export -format=lcov -instr-profile cov/merged.profdata \
+            --ignore-filename-regex='ft8af_glue/(test_|fft_display)' \
+            cov/golden -object cov/dev625 > native.lcov
+          echo "Wrote $(wc -l < native.lcov) lines of lcov."
+
+      - name: Upload native coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: native.lcov
+          flags: native

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,21 @@ coverage:
       default:
         informational: true
 
+# One flag per module/CI lane so the dashboard reports each as its own
+# component instead of one merged total. carryforward keeps a module's last
+# known coverage when its path-filtered workflow doesn't run on a given PR (only
+# the Android lane runs on every PR; ios/native/desktop are path-gated), so an
+# unrelated PR doesn't blank out those components.
+flags:
+  android:
+    carryforward: true
+  ios:
+    carryforward: true
+  native:
+    carryforward: true
+  desktop:
+    carryforward: true
+
 comment:
   layout: "reach, diff, flags, files"
   require_changes: false


### PR DESCRIPTION
Closes #375.

Gives every module its own Codecov flag so coverage is tracked per component instead of one merged (Android-only) total. Coverage stays **informational / non-blocking**; all uploads reuse `CODECOV_TOKEN`.

## What changed

| File | Change | Flag |
|---|---|---|
| `.github/workflows/android.yml` | Add `flags: android` to the existing JaCoCo → Codecov upload | `android` |
| `.github/workflows/ios.yml` | `swift test --enable-code-coverage`, export lcov via `xcrun llvm-cov`, upload | `ios` |
| `.github/workflows/native-tests.yml` | Non-gating steps: rebuild golden + dev625 suites with clang source-based coverage, export lcov, upload | `native` |
| `.github/workflows/desktop.yml` | New non-gating `coverage` job: `cargo llvm-cov` on `src-tauri`, upload | `desktop` |
| `codecov.yml` | Declare the four flags with `carryforward: true` | — |

## Safety of the required gates

- **native-tests** is a required check. The existing `run_host_tests.sh` gate step is **untouched**; all coverage steps are appended *after* it and every one is `continue-on-error: true`. A coverage hiccup (tool version mismatch, apt flake) cannot fail the golden-vector gate.
- **desktop** coverage is a **separate** `coverage` job, path-gated via `detect` and deliberately **not** wired into `desktop-gate`, so it never blocks a merge or release.
- **ios** coverage steps run before the simulator build in the existing `verify` job; the base `swift test` was already there — only `--enable-code-coverage` was added.

## Validation

- ✅ **Native** lcov export run locally end-to-end (via `xcrun` on macOS): produces valid lcov for 11 `ft8_lib` core files, with the test harnesses (`test_*`, `fft_display.c`) correctly excluded.
- ✅ All five files pass YAML parse.
- ⚠️ **iOS** and **desktop** coverage couldn't be fully exercised locally (this box's command-line Swift toolchain lacks `XCTest`; `cargo-llvm-cov` + Linux deps are CI-only). Both use standard `llvm-cov` / `cargo-llvm-cov` flows and the underlying test commands already run in CI, so they'll be confirmed by the workflow runs.

## ⚠️ Manual steps required (human-only — not done here)

1. **`CODECOV_TOKEN` secret is missing on `Reid-n0rc/FT8AF`** (the fork this PR is from). More importantly, GitHub does **not** expose secrets to `pull_request` runs triggered from a fork, so on *this PR's* checks all four Codecov uploads will no-op (harmless — every upload is `continue-on-error`). Real uploads happen once merged, when the workflows run in the `patrickrb/FT8AF` context where `CODECOV_TOKEN` already exists (the Android upload uses it today).
2. **Codecov GitHub App** must be installed on `patrickrb/FT8AF` for the flags/components to appear on the dashboard (OAuth step — can't be automated).

## Notes
- No test suites were refactored; no coverage thresholds were made blocking; release/signing workflows untouched.
- Native source lists in `native-tests.yml` mirror the golden + dev625 builds in `run_host_tests.sh` — a comment flags that they must be kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
