### PR TITLE
Bluetooth SCO: only touch call audio when the rig is in Bluetooth mode

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainActivity.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainActivity.java
@@ -47,6 +47,7 @@ import androidx.navigation.fragment.NavHostFragment;
 import androidx.navigation.ui.NavigationUI;
 
 import com.k1af.ft8af.bluetooth.BluetoothStateBroadcastReceive;
+import com.k1af.ft8af.bluetooth.ScoPolicy;
 import com.k1af.ft8af.callsign.CallsignDatabase;
 import com.k1af.ft8af.connector.CableSerialPort;
 import com.k1af.ft8af.database.DatabaseOpr;
@@ -132,7 +133,10 @@ public class MainActivity extends AppCompatActivity {
 
         ToastMessage.getInstance();
         registerBluetoothReceiver();//register Bluetooth state change broadcast
-        if (mainViewModel.isBTConnected()) {
+        // Only force headset/SCO mode when the rig itself is on Bluetooth --
+        // opening SCO against a car/headphones kicks it out of A2DP music mode.
+        if (ScoPolicy.shouldEnterHeadsetMode(
+                GeneralVariables.connectMode, mainViewModel.isBTConnected())) {
             mainViewModel.setBlueToothOn();
         }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainActivity.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainActivity.java
@@ -133,12 +133,8 @@ public class MainActivity extends AppCompatActivity {
 
         ToastMessage.getInstance();
         registerBluetoothReceiver();//register Bluetooth state change broadcast
-        // Only force headset/SCO mode when the rig itself is on Bluetooth --
-        // opening SCO against a car/headphones kicks it out of A2DP music mode.
-        if (ScoPolicy.shouldEnterHeadsetMode(
-                GeneralVariables.connectMode, mainViewModel.isBTConnected())) {
-            mainViewModel.setBlueToothOn();
-        }
+        // The launch-time headset/SCO decision happens in the config-loaded
+        // callback below -- the persisted connectMode isn't in memory yet here.
 
 
         //observe DEBUG messages
@@ -492,6 +488,19 @@ public class MainActivity extends AppCompatActivity {
                     //write to database
                     mainViewModel.databaseOpr.writeConfig("grid", grid, null);
                 }
+
+                // Bring up headset/SCO for Bluetooth-rig users now that the persisted
+                // connectMode is known; gating on connect mode keeps a car/headphones
+                // paired for music from being yanked out of A2DP (PR #377).
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (ScoPolicy.shouldEnterHeadsetMode(
+                                GeneralVariables.connectMode, mainViewModel.isBTConnected())) {
+                            mainViewModel.setBlueToothOn();
+                        }
+                    }
+                });
 
                 mainViewModel.ft8TransmitSignal.setTimer_sec(GeneralVariables.transmitDelay);
                 //if callsign or grid is empty, navigate to the settings page

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -52,6 +52,7 @@ import androidx.lifecycle.ViewModelStoreOwner;
 import com.k1af.ft8af.callsign.CallsignDatabase;
 import com.k1af.ft8af.callsign.CallsignInfo;
 import com.k1af.ft8af.callsign.OnAfterQueryCallsignLocation;
+import com.k1af.ft8af.bluetooth.ScoPolicy;
 import com.k1af.ft8af.connector.BluetoothRigConnector;
 import com.k1af.ft8af.connector.CableConnector;
 import com.k1af.ft8af.connector.CableSerialPort;
@@ -651,13 +652,10 @@ public class MainViewModel extends ViewModel {
         //create transmit object; callbacks: before transmit, after transmit, after QSL success.
         ft8TransmitSignal = new FT8TransmitSignal(databaseOpr, new OnDoTransmitted() {
             private boolean needControlSco() {//determine whether SCO needs to be enabled based on control mode
-                if (GeneralVariables.connectMode == ConnectMode.NETWORK) {
-                    return false;
-                }
-                if (GeneralVariables.controlMode != ControlMode.CAT) {
-                    return true;
-                }
-                return baseRig != null && !baseRig.supportWaveOverCAT();
+                return ScoPolicy.needControlSco(GeneralVariables.connectMode,
+                        GeneralVariables.controlMode,
+                        baseRig != null,
+                        baseRig != null && baseRig.supportWaveOverCAT());
             }
 
             @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
@@ -1,0 +1,43 @@
+package com.k1af.ft8af.bluetooth;
+
+import com.k1af.ft8af.connector.ConnectMode;
+import com.k1af.ft8af.database.ControlMode;
+
+/**
+ * Decides when the app may touch the phone's Bluetooth SCO (hands-free call
+ * audio) link. Opening SCO knocks any connected Bluetooth audio device out of
+ * A2DP music mode — a car head unit pauses whatever is playing — so SCO must
+ * only ever be toggled when the rig's audio actually flows over Bluetooth,
+ * i.e. when the user selected the Bluetooth connect mode (issue: car stereo
+ * pause/unpause loop while the app TXed over a USB-connected rig).
+ */
+public final class ScoPolicy {
+    private ScoPolicy() {
+    }
+
+    /**
+     * Whether the TX/RX cycle needs to toggle SCO around PTT (stop before
+     * transmit, restart after). Only in Bluetooth connect mode; there,
+     * non-CAT control always needs it, and CAT control needs it unless the
+     * rig carries audio over the CAT link itself.
+     */
+    public static boolean needControlSco(int connectMode, int controlMode,
+                                         boolean hasRig, boolean rigSupportsWaveOverCat) {
+        if (connectMode != ConnectMode.BLUE_TOOTH) {
+            return false;
+        }
+        if (controlMode != ControlMode.CAT) {
+            return true;
+        }
+        return hasRig && !rigSupportsWaveOverCat;
+    }
+
+    /**
+     * Whether launch should force Bluetooth headset mode (SCO on). A connected
+     * Bluetooth audio profile alone is not enough — the phone may simply be
+     * paired to a car or headphones for music.
+     */
+    public static boolean shouldEnterHeadsetMode(int connectMode, boolean btAudioProfileConnected) {
+        return connectMode == ConnectMode.BLUE_TOOTH && btAudioProfileConnected;
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -41,6 +41,7 @@ import radio.ks3ckc.ft8af.sync.QsoAutoSync
 import com.k1af.ft8af.service.RxForegroundService
 import com.k1af.ft8af.service.RxServiceController
 import com.k1af.ft8af.bluetooth.BluetoothStateBroadcastReceive
+import com.k1af.ft8af.bluetooth.ScoPolicy
 import com.k1af.ft8af.connector.CableSerialPort
 import com.k1af.ft8af.connector.ConnectMode
 import com.k1af.ft8af.callsign.CallsignDatabase
@@ -150,7 +151,12 @@ class ComposeMainActivity : AppCompatActivity() {
 
         // Register Bluetooth state broadcast receiver
         registerBluetoothReceiver()
-        if (mainViewModel.isBTConnected()) {
+        // Only force headset/SCO mode when the rig itself is on Bluetooth.
+        // Any paired BT audio device (a car, headphones) makes isBTConnected()
+        // true, and opening SCO against it kicks it out of A2DP music mode.
+        if (ScoPolicy.shouldEnterHeadsetMode(
+                GeneralVariables.connectMode, mainViewModel.isBTConnected())
+        ) {
             mainViewModel.setBlueToothOn()
         }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -149,16 +149,10 @@ class ComposeMainActivity : AppCompatActivity() {
             }
         })
 
-        // Register Bluetooth state broadcast receiver
+        // Register Bluetooth state broadcast receiver. The launch-time
+        // headset/SCO decision happens in initData's config-loaded callback:
+        // it needs the persisted connectMode, which isn't in memory yet here.
         registerBluetoothReceiver()
-        // Only force headset/SCO mode when the rig itself is on Bluetooth.
-        // Any paired BT audio device (a car, headphones) makes isBTConnected()
-        // true, and opening SCO against it kicks it out of A2DP music mode.
-        if (ScoPolicy.shouldEnterHeadsetMode(
-                GeneralVariables.connectMode, mainViewModel.isBTConnected())
-        ) {
-            mainViewModel.setBlueToothOn()
-        }
 
         // Register USB detach receiver — without this, a cable yank leaves the
         // recorder waiting on a dead handle and TX still pointing at a closed
@@ -393,6 +387,19 @@ class ComposeMainActivity : AppCompatActivity() {
                 val ports = mainViewModel.mutableSerialPorts.value
                 fileLog("initData: found ${ports?.size ?: 0} serial port(s)")
                 mainViewModel.reinitializeAudioInput()
+
+                // Bring up headset/SCO for Bluetooth-rig users now that the persisted
+                // connectMode is known. Gating this at onCreate time would read the
+                // USB_CABLE default and skip SCO for every Bluetooth rig (PR #377
+                // review); gating on connect mode at all keeps a car/headphones paired
+                // for music from being yanked out of A2DP (the original bug).
+                Handler(Looper.getMainLooper()).post {
+                    if (ScoPolicy.shouldEnterHeadsetMode(
+                            GeneralVariables.connectMode, mainViewModel.isBTConnected())
+                    ) {
+                        mainViewModel.setBlueToothOn()
+                    }
+                }
 
                 // USB auto-connect is driven by the mutableSerialPorts observer; Bluetooth has
                 // no such device-arrival event, so re-open the remembered SPP/CAT link here now

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyTest.java
@@ -1,0 +1,71 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.connector.ConnectMode;
+import com.k1af.ft8af.database.ControlMode;
+
+import org.junit.Test;
+
+public class ScoPolicyTest {
+
+    // The car-stereo bug: USB CAT rig without audio-over-CAT used to toggle
+    // SCO around every TX, pausing/unpausing the car's A2DP music.
+    @Test
+    public void needControlSco_usbCatRig_isFalse() {
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.USB_CABLE, ControlMode.CAT, true, false)).isFalse();
+    }
+
+    @Test
+    public void needControlSco_usbNonCatControl_isFalse() {
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.USB_CABLE, ControlMode.RTS, true, false)).isFalse();
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.USB_CABLE, ControlMode.DTR, true, false)).isFalse();
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.USB_CABLE, ControlMode.VOX, true, false)).isFalse();
+    }
+
+    @Test
+    public void needControlSco_networkMode_isFalse() {
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.NETWORK, ControlMode.CAT, true, false)).isFalse();
+    }
+
+    @Test
+    public void needControlSco_bluetoothNonCatControl_isTrue() {
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.BLUE_TOOTH, ControlMode.VOX, true, false)).isTrue();
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.BLUE_TOOTH, ControlMode.RTS, false, false)).isTrue();
+    }
+
+    @Test
+    public void needControlSco_bluetoothCatRigWithoutWaveOverCat_isTrue() {
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.BLUE_TOOTH, ControlMode.CAT, true, false)).isTrue();
+    }
+
+    @Test
+    public void needControlSco_bluetoothCatRigWithWaveOverCat_isFalse() {
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.BLUE_TOOTH, ControlMode.CAT, true, true)).isFalse();
+    }
+
+    @Test
+    public void needControlSco_bluetoothCatNoRig_isFalse() {
+        assertThat(ScoPolicy.needControlSco(
+                ConnectMode.BLUE_TOOTH, ControlMode.CAT, false, false)).isFalse();
+    }
+
+    @Test
+    public void shouldEnterHeadsetMode_onlyWhenBluetoothModeAndProfileConnected() {
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(ConnectMode.BLUE_TOOTH, true)).isTrue();
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(ConnectMode.BLUE_TOOTH, false)).isFalse();
+        // Phone paired to a car/headphones for music while the rig is on USB
+        // or network must not flip the phone into headset (SCO) mode.
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(ConnectMode.USB_CABLE, true)).isFalse();
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(ConnectMode.NETWORK, true)).isFalse();
+    }
+}


### PR DESCRIPTION
## Problem

With the phone paired to a car stereo (or headphones) for music while the rig runs over **USB or network**, FT8AF repeatedly paused/unpaused the car's audio. Two paths rang up a Bluetooth SCO (hands-free call) link against a device that's only there for music — and opening SCO forces a head unit out of A2DP:

1. **Every TX cycle** — `needControlSco()` only excluded NETWORK mode, so a USB CAT rig without audio-over-CAT called `stopSco()` before PTT and `startSco()` after TX, every 15 seconds. Car music paused/unpaused in a loop while transmitting.
2. **At launch** — `ComposeMainActivity.onCreate` called `setBlueToothOn()` whenever *any* BT audio profile was connected, so opening the app in the car flipped the phone into headset/SCO mode.

`BluetoothStateBroadcastReceive` already had the right gate (`connectMode == BLUE_TOOTH`, from FT8CN PR #168); these two paths never got it.

## Fix

New `ScoPolicy` holds the extracted decisions, gated on Bluetooth connect mode:

- `needControlSco(connectMode, controlMode, hasRig, rigSupportsWaveOverCat)` — false outside `BLUE_TOOTH`; unchanged semantics within it.
- `shouldEnterHeadsetMode(connectMode, btAudioProfileConnected)` — used by the launch paths in `ComposeMainActivity` and legacy `MainActivity`.

Bluetooth-rig users are unaffected: `connectBluetoothRig()` and the broadcast receiver still bring SCO up in Bluetooth mode, and `needControlSco()` still toggles it around PTT there.

## Testing

- New `ScoPolicyTest` covers the car-bug case (USB CAT rig → no SCO), all connect/control-mode combinations, and the launch-time gate.
- `gradlew testDebugUnitTest --tests com.k1af.ft8af.bluetooth.ScoPolicyTest` passes; full debug compile (Kotlin + Java) succeeds.
- Not device-tested locally (a local debug install would wipe the CI-signed app's data); verify via the CI build: with the rig on USB and the phone on car Bluetooth, music should keep playing through app launch and TX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)