### PR TITLE
Add settings backup export/import to file (#357)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -742,6 +742,41 @@ public class DatabaseOpr extends SQLiteOpenHelper {
     }
 
     /**
+     * Read every config key/value pair synchronously into an insertion-ordered map.
+     * Backs the settings-export feature (issue #357). Must be called off the main
+     * thread (it touches SQLite directly).
+     */
+    @SuppressLint("Range")
+    public java.util.LinkedHashMap<String, String> getAllConfigSync() {
+        java.util.LinkedHashMap<String, String> map = new java.util.LinkedHashMap<>();
+        Cursor cursor = db.rawQuery("select KeyName,Value from config", null);
+        try {
+            while (cursor.moveToNext()) {
+                map.put(cursor.getString(cursor.getColumnIndex("KeyName")),
+                        cursor.getString(cursor.getColumnIndex("Value")));
+            }
+        } finally {
+            cursor.close();
+        }
+        return map;
+    }
+
+    /**
+     * Upsert every entry of {@code config} synchronously (same delete-then-insert as
+     * {@link WriteConfig}). Backs the settings-import feature (issue #357). Must be
+     * called off the main thread. After calling, run {@link #getAllConfigParameter}
+     * to re-hydrate {@link GeneralVariables} from the freshly written values.
+     */
+    public void writeConfigSync(java.util.Map<String, String> config) {
+        for (java.util.Map.Entry<String, String> entry : config.entrySet()) {
+            String value = entry.getValue() == null ? "" : entry.getValue();
+            db.execSQL("DELETE FROM config where KeyName =?", new String[]{entry.getKey()});
+            db.execSQL("INSERT INTO config (KeyName,Value)Values(?,?)",
+                    new String[]{entry.getKey(), value});
+        }
+    }
+
+    /**
      * Query all successfully contacted callsigns, filtered by QSO frequency
      */
     public void getAllQSLCallsigns() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -746,14 +746,16 @@ public class DatabaseOpr extends SQLiteOpenHelper {
      * Backs the settings-export feature (issue #357). Must be called off the main
      * thread (it touches SQLite directly).
      */
-    @SuppressLint("Range")
     public java.util.LinkedHashMap<String, String> getAllConfigSync() {
         java.util.LinkedHashMap<String, String> map = new java.util.LinkedHashMap<>();
-        Cursor cursor = db.rawQuery("select KeyName,Value from config", null);
+        // ORDER BY: SQLite guarantees no row order without it, so the map's insertion
+        // order (which this method promises) would otherwise be nondeterministic.
+        Cursor cursor = db.rawQuery("select KeyName,Value from config order by KeyName", null);
         try {
+            int keyIdx = cursor.getColumnIndexOrThrow("KeyName");
+            int valueIdx = cursor.getColumnIndexOrThrow("Value");
             while (cursor.moveToNext()) {
-                map.put(cursor.getString(cursor.getColumnIndex("KeyName")),
-                        cursor.getString(cursor.getColumnIndex("Value")));
+                map.put(cursor.getString(keyIdx), cursor.getString(valueIdx));
             }
         } finally {
             cursor.close();
@@ -768,11 +770,19 @@ public class DatabaseOpr extends SQLiteOpenHelper {
      * to re-hydrate {@link GeneralVariables} from the freshly written values.
      */
     public void writeConfigSync(java.util.Map<String, String> config) {
-        for (java.util.Map.Entry<String, String> entry : config.entrySet()) {
-            String value = entry.getValue() == null ? "" : entry.getValue();
-            db.execSQL("DELETE FROM config where KeyName =?", new String[]{entry.getKey()});
-            db.execSQL("INSERT INTO config (KeyName,Value)Values(?,?)",
-                    new String[]{entry.getKey(), value});
+        // One transaction: an interrupted import can't leave the table half-updated,
+        // and batching the statements is much faster than autocommitting each one.
+        db.beginTransaction();
+        try {
+            for (java.util.Map.Entry<String, String> entry : config.entrySet()) {
+                String value = entry.getValue() == null ? "" : entry.getValue();
+                db.execSQL("DELETE FROM config where KeyName =?", new String[]{entry.getKey()});
+                db.execSQL("INSERT INTO config (KeyName,Value)Values(?,?)",
+                        new String[]{entry.getKey(), value});
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
         }
     }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
@@ -1,22 +1,49 @@
 package radio.ks3ckc.ft8af.ui.settings
 
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.core.os.LocaleListCompat
 import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
+import com.k1af.ft8af.database.OnAfterQueryConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8af.theme.Accent
+import radio.ks3ckc.ft8af.theme.BgSurface2
+import radio.ks3ckc.ft8af.theme.TextMuted
+import radio.ks3ckc.ft8af.theme.TextPrimary
 import radio.ks3ckc.ft8af.theme.ThemeOption
 import radio.ks3ckc.ft8af.theme.applyTheme
 import radio.ks3ckc.ft8af.theme.currentThemeNameRes
@@ -24,6 +51,9 @@ import radio.ks3ckc.ft8af.theme.loadTheme
 import radio.ks3ckc.ft8af.theme.saveTheme
 import radio.ks3ckc.ft8af.ui.components.GlassCard
 import radio.ks3ckc.ft8af.ui.components.SettingsRow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * One selectable app language: its BCP-47 tag (as handed to
@@ -96,6 +126,136 @@ fun AdvancedSettings(
     var showLateStart by remember { mutableStateOf(false) }
     var showLanguagePicker by remember { mutableStateOf(false) }
     var showThemePicker by remember { mutableStateOf(false) }
+
+    // -- Backup & restore (issue #357) --
+    val scope = rememberCoroutineScope()
+    val databaseOpr = mainViewModel.databaseOpr
+    var showExportDialog by remember { mutableStateOf(false) }
+    // Captured at launch time so the SAF result callback knows whether to include
+    // sensitive keys in the file it writes.
+    var exportIncludeSensitive by remember { mutableStateOf(false) }
+    // Non-null while the import confirmation dialog is showing the parsed backup.
+    var pendingImport by remember { mutableStateOf<SettingsBackup.ParsedBackup?>(null) }
+
+    // Storage Access Framework: user picks where to write the export. On result we
+    // read the whole config table off the main thread, serialize it, and stream it
+    // to the chosen document.
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json"),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        scope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching {
+                    val config = databaseOpr.getAllConfigSync()
+                    val json = SettingsBackup.buildBackupJson(
+                        config = config,
+                        includeSensitive = exportIncludeSensitive,
+                        appVersion = GeneralVariables.VERSION,
+                        createdAt = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date()),
+                    )
+                    context.contentResolver.openOutputStream(uri)?.use {
+                        it.write(json.toByteArray(Charsets.UTF_8))
+                    } ?: error("Could not open the selected file for writing")
+                }
+            }
+            result.fold(
+                onSuccess = {
+                    Toast.makeText(context, R.string.settings_export_success, Toast.LENGTH_LONG).show()
+                },
+                onFailure = {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.settings_export_failed, it.message ?: ""),
+                        Toast.LENGTH_LONG,
+                    ).show()
+                },
+            )
+        }
+    }
+
+    // SAF: user picks a backup file. On result we read + validate it off the main
+    // thread; a valid parse opens the confirmation dialog, a bad file just toasts.
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        scope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching {
+                    val text = context.contentResolver.openInputStream(uri)?.use {
+                        it.readBytes().toString(Charsets.UTF_8)
+                    } ?: error("Could not open the selected file")
+                    SettingsBackup.parseBackupJson(text)
+                }
+            }
+            result.fold(
+                onSuccess = { pendingImport = it },
+                onFailure = {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.settings_import_failed, it.message ?: ""),
+                        Toast.LENGTH_LONG,
+                    ).show()
+                },
+            )
+        }
+    }
+
+    // -- Export options dialog (choose whether to include secrets) --
+    if (showExportDialog) {
+        ExportSettingsDialog(
+            includeSensitive = exportIncludeSensitive,
+            onToggleSensitive = { exportIncludeSensitive = it },
+            onDismiss = { showExportDialog = false },
+            onExport = {
+                showExportDialog = false
+                val fileName = SettingsBackup.defaultFileName(
+                    date = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date()),
+                    appVersion = GeneralVariables.VERSION,
+                )
+                exportLauncher.launch(fileName)
+            },
+        )
+    }
+
+    // -- Import confirmation dialog (preview count, confirm overwrite) --
+    pendingImport?.let { backup ->
+        ConfirmImportDialog(
+            keyCount = backup.config.size,
+            createdAt = backup.createdAt.ifBlank { "?" },
+            onDismiss = { pendingImport = null },
+            onConfirm = {
+                pendingImport = null
+                val toApply = backup.config
+                scope.launch {
+                    val result = withContext(Dispatchers.IO) {
+                        runCatching { databaseOpr.writeConfigSync(toApply) }
+                    }
+                    result.fold(
+                        onSuccess = {
+                            // Re-hydrate GeneralVariables from the freshly written config so
+                            // most settings take effect without waiting for an app restart.
+                            databaseOpr.getAllConfigParameter(object : OnAfterQueryConfig {
+                                override fun doOnBeforeQueryConfig(keyName: String?) {}
+                                override fun doOnAfterQueryConfig(keyName: String?, value: String?) {}
+                            })
+                            Toast.makeText(
+                                context, R.string.settings_import_success, Toast.LENGTH_LONG,
+                            ).show()
+                        },
+                        onFailure = {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.settings_import_failed, it.message ?: ""),
+                                Toast.LENGTH_LONG,
+                            ).show()
+                        },
+                    )
+                }
+            },
+        )
+    }
 
     val txDelayStr = stringResource(R.string.settings_milliseconds_format, txDelay)
     val pttDelayStr = stringResource(R.string.settings_milliseconds_format, pttDelay)
@@ -286,6 +446,149 @@ fun AdvancedSettings(
                     showChevron = true,
                     onClick = { showLanguagePicker = true },
                 )
+            }
+        }
+
+        // =====================================================================
+        // BACKUP & RESTORE (issue #357)
+        // =====================================================================
+        SettingsSection(title = stringResource(R.string.settings_section_backup)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    SettingsRow(
+                        label = stringResource(R.string.settings_export),
+                        description = stringResource(R.string.settings_export_desc),
+                        showChevron = true,
+                        onClick = { showExportDialog = true },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_import),
+                        description = stringResource(R.string.settings_import_desc),
+                        showChevron = true,
+                        onClick = { importLauncher.launch(arrayOf("application/json", "*/*")) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Export options dialog: a single toggle for whether to include sensitive
+ * credentials in the backup, then Export/Cancel. Styled like [EditOperatorDialog]
+ * to match the app's dialog look.
+ */
+@Composable
+private fun ExportSettingsDialog(
+    includeSensitive: Boolean,
+    onToggleSensitive: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
+    onExport: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_export_dialog_title),
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.settings_backup_include_sensitive),
+                        color = TextPrimary,
+                        fontSize = 15.sp,
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_backup_include_sensitive_desc),
+                        color = TextMuted,
+                        fontSize = 12.sp,
+                    )
+                }
+                Switch(
+                    checked = includeSensitive,
+                    onCheckedChange = onToggleSensitive,
+                    colors = SwitchDefaults.colors(checkedTrackColor = Accent),
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.action_cancel), color = TextMuted)
+                }
+                TextButton(onClick = onExport) {
+                    Text(
+                        stringResource(R.string.action_export),
+                        color = Accent,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Import confirmation dialog: previews how many keys will be overwritten and when
+ * the backup was created, then requires an explicit confirm before applying.
+ */
+@Composable
+private fun ConfirmImportDialog(
+    keyCount: Int,
+    createdAt: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(BgSurface2)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_import_confirm_title),
+                color = TextPrimary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+            )
+            Text(
+                text = stringResource(R.string.settings_import_confirm_msg, keyCount, createdAt),
+                color = TextMuted,
+                fontSize = 14.sp,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.action_cancel), color = TextMuted)
+                }
+                TextButton(onClick = onConfirm) {
+                    Text(
+                        stringResource(R.string.action_import),
+                        color = Accent,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
             }
         }
     }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackup.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackup.kt
@@ -1,0 +1,134 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import org.json.JSONObject
+
+/**
+ * Pure logic for exporting/importing the app's settings as a JSON backup file
+ * (issue #357). The Compose UI and Storage Access Framework wiring in
+ * [AdvancedSettings] is a thin wrapper over these functions so that the
+ * serialization, filtering, and validation stay unit-testable (Compose/SAF code
+ * cannot be exercised in a plain unit test).
+ *
+ * The backup is the app's `config` key/value table serialized verbatim, wrapped
+ * with metadata (format version, app version, creation time). Restoring writes
+ * each key back through `DatabaseOpr`.
+ */
+object SettingsBackup {
+    /** Bumped when the on-disk backup schema changes incompatibly. */
+    const val FORMAT_VERSION = 1
+
+    /** Marker written to identify our files and reject unrelated JSON on import. */
+    const val APP_NAME = "FT8AF"
+
+    /**
+     * Config keys holding credentials/secrets. These are excluded from an export
+     * unless the user explicitly opts in, so a shared or cloud-stored backup never
+     * leaks API keys or passwords by default.
+     */
+    val SENSITIVE_KEYS: Set<String> = setOf(
+        "cloudlogApiKey",
+        "qrzApiKey",
+        "qrzXmlUsername",
+        "qrzXmlPassword",
+        "icomUserName",
+        "icomPassword",
+    )
+
+    /** Metadata + config restored from a backup file. */
+    data class ParsedBackup(
+        val formatVersion: Int,
+        val appVersion: String,
+        val createdAt: String,
+        val config: Map<String, String>,
+    )
+
+    /**
+     * Drop sensitive keys from [config] unless [includeSensitive]. Preserves order
+     * so exports are stable when the caller passes an ordered map.
+     */
+    internal fun filterConfig(
+        config: Map<String, String>,
+        includeSensitive: Boolean,
+    ): Map<String, String> =
+        config.filterKeys { key -> includeSensitive || key !in SENSITIVE_KEYS }
+
+    /**
+     * Serialize [config] to the backup JSON text. Non-sensitive keys are always
+     * included; sensitive keys only when [includeSensitive]. Keys are sorted so the
+     * output is deterministic and diff-friendly across exports.
+     */
+    fun buildBackupJson(
+        config: Map<String, String>,
+        includeSensitive: Boolean,
+        appVersion: String,
+        createdAt: String,
+    ): String {
+        val filtered = filterConfig(config, includeSensitive)
+        val configJson = JSONObject()
+        for (key in filtered.keys.sorted()) {
+            configJson.put(key, filtered[key])
+        }
+        val root = JSONObject()
+        root.put("appName", APP_NAME)
+        root.put("formatVersion", FORMAT_VERSION)
+        root.put("appVersion", appVersion)
+        root.put("createdAt", createdAt)
+        root.put("includesSensitive", includeSensitive)
+        root.put("config", configJson)
+        return root.toString(2)
+    }
+
+    /**
+     * Parse and validate backup JSON. Throws [IllegalArgumentException] with a
+     * user-facing message when the text is not a recognizable FT8AF backup, or when
+     * its format version is newer than this build understands.
+     */
+    fun parseBackupJson(text: String): ParsedBackup {
+        val root = try {
+            JSONObject(text)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Not a valid backup file (invalid JSON).")
+        }
+        if (!root.has("config") || !root.has("formatVersion")) {
+            throw IllegalArgumentException("Not a valid FT8AF settings backup.")
+        }
+        val formatVersion = root.optInt("formatVersion", -1)
+        if (formatVersion <= 0) {
+            throw IllegalArgumentException("Not a valid FT8AF settings backup.")
+        }
+        if (formatVersion > FORMAT_VERSION) {
+            throw IllegalArgumentException(
+                "This backup was created by a newer version of FT8AF " +
+                    "(format $formatVersion). Please update the app to import it.",
+            )
+        }
+        val configJson = root.optJSONObject("config")
+            ?: throw IllegalArgumentException("Backup contains no settings to restore.")
+        val config = LinkedHashMap<String, String>()
+        val keys = configJson.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            config[key] = configJson.optString(key, "")
+        }
+        if (config.isEmpty()) {
+            throw IllegalArgumentException("Backup contains no settings to restore.")
+        }
+        return ParsedBackup(
+            formatVersion = formatVersion,
+            appVersion = root.optString("appVersion", ""),
+            createdAt = root.optString("createdAt", ""),
+            config = config,
+        )
+    }
+
+    /**
+     * Suggested export file name, e.g. "ft8af-settings-2026-07-03-v1.2.3.json".
+     * [date] is an already-formatted yyyy-MM-dd string; [appVersion] is sanitized to
+     * keep the name filesystem-safe.
+     */
+    fun defaultFileName(date: String, appVersion: String): String {
+        val safeVersion = appVersion.ifBlank { "unknown" }
+            .replace(Regex("[^A-Za-z0-9._-]"), "_")
+        return "ft8af-settings-$date-v$safeVersion.json"
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackup.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackup.kt
@@ -89,6 +89,12 @@ object SettingsBackup {
         } catch (e: Exception) {
             throw IllegalArgumentException("Not a valid backup file (invalid JSON).")
         }
+        // The appName marker is what actually distinguishes our backups from any
+        // other JSON that happens to carry formatVersion+config keys — reject
+        // anything not stamped by us before looking at versions.
+        if (root.optString("appName") != APP_NAME) {
+            throw IllegalArgumentException("Not a valid FT8AF settings backup.")
+        }
         if (!root.has("config") || !root.has("formatVersion")) {
             throw IllegalArgumentException("Not a valid FT8AF settings backup.")
         }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -379,6 +379,24 @@
     <string name="settings_section_about">ABOUT</string>
     <string name="settings_section_language">LANGUAGE</string>
     <string name="settings_section_appearance">APPEARANCE</string>
+    <string name="settings_section_backup">BACKUP &amp; RESTORE</string>
+
+    <!-- ===== Settings: backup / restore (export & import config) ===== -->
+    <string name="settings_export">Export settings</string>
+    <string name="settings_export_desc">Save all settings to a backup file</string>
+    <string name="settings_import">Import settings</string>
+    <string name="settings_import_desc">Restore settings from a backup file</string>
+    <string name="settings_export_dialog_title">Export settings</string>
+    <string name="settings_backup_include_sensitive">Include sensitive data</string>
+    <string name="settings_backup_include_sensitive_desc">API keys and passwords (Cloudlog, QRZ, rig login)</string>
+    <string name="action_export">Export</string>
+    <string name="action_import">Import</string>
+    <string name="settings_import_confirm_title">Import settings?</string>
+    <string name="settings_import_confirm_msg">This will overwrite %1$d setting(s) with values from the backup created %2$s.</string>
+    <string name="settings_export_success">Settings exported</string>
+    <string name="settings_export_failed">Export failed: %1$s</string>
+    <string name="settings_import_success">Settings imported — restart the app to apply all changes</string>
+    <string name="settings_import_failed">Import failed: %1$s</string>
 
     <!-- ===== Settings: appearance / theme ===== -->
     <string name="settings_theme">Theme</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigSyncTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigSyncTest.java
@@ -1,0 +1,88 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Tests for the synchronous config helpers backing settings backup/restore
+ * (issue #357): writeConfigSync's transactional upsert and getAllConfigSync's
+ * deterministic (KeyName-ordered) read-back. Uses a Robolectric in-memory
+ * database (name=null) so no on-disk state is touched.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseOprConfigSyncTest {
+
+    private DatabaseOpr opr;
+
+    @Before
+    public void setUp() {
+        opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 18);
+    }
+
+    @After
+    public void tearDown() {
+        opr.close();
+    }
+
+    @Test
+    public void writeThenRead_roundTripsAllEntries() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("callsign", "K1AF");
+        config.put("grid", "FN42");
+        opr.writeConfigSync(config);
+
+        Map<String, String> read = opr.getAllConfigSync();
+        assertThat(read).containsAtLeastEntriesIn(config);
+    }
+
+    @Test
+    public void read_returnsKeysInKeyNameOrder() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("zulu", "1");
+        config.put("alpha", "2");
+        config.put("mike", "3");
+        opr.writeConfigSync(config);
+
+        Map<String, String> read = opr.getAllConfigSync();
+        // The map promises insertion order == query order; the query orders by KeyName.
+        java.util.List<String> keys = new java.util.ArrayList<>(read.keySet());
+        java.util.List<String> sorted = new java.util.ArrayList<>(keys);
+        java.util.Collections.sort(sorted);
+        assertThat(keys).isEqualTo(sorted);
+    }
+
+    @Test
+    public void write_upsertsExistingKeysInsteadOfDuplicating() {
+        Map<String, String> first = new LinkedHashMap<>();
+        first.put("callsign", "K1AF");
+        opr.writeConfigSync(first);
+
+        Map<String, String> second = new LinkedHashMap<>();
+        second.put("callsign", "KS3CKC");
+        opr.writeConfigSync(second);
+
+        Map<String, String> read = opr.getAllConfigSync();
+        assertThat(read).containsEntry("callsign", "KS3CKC");
+        assertThat(java.util.Collections.frequency(
+                new java.util.ArrayList<>(read.keySet()), "callsign")).isEqualTo(1);
+    }
+
+    @Test
+    public void write_treatsNullValueAsEmptyString() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("cloudlogApiKey", null);
+        opr.writeConfigSync(config);
+
+        assertThat(opr.getAllConfigSync()).containsEntry("cloudlogApiKey", "");
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackupTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackupTest.kt
@@ -108,7 +108,7 @@ class SettingsBackupTest {
 
     @Test
     fun `parse rejects a future format version`() {
-        val future = "{\"formatVersion\":999,\"config\":{\"callsign\":\"K1AF\"}}"
+        val future = "{\"appName\":\"FT8AF\",\"formatVersion\":999,\"config\":{\"callsign\":\"K1AF\"}}"
         val e = runCatching { SettingsBackup.parseBackupJson(future) }.exceptionOrNull()
         assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
         assertThat(e).hasMessageThat().contains("newer")
@@ -116,8 +116,25 @@ class SettingsBackupTest {
 
     @Test
     fun `parse rejects a backup with an empty config`() {
-        val empty = "{\"formatVersion\":1,\"config\":{}}"
+        val empty = "{\"appName\":\"FT8AF\",\"formatVersion\":1,\"config\":{}}"
         val e = runCatching { SettingsBackup.parseBackupJson(empty) }.exceptionOrNull()
+        assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `parse rejects JSON missing the appName marker`() {
+        // formatVersion+config alone must not be treated as one of our backups.
+        val unmarked = "{\"formatVersion\":1,\"config\":{\"callsign\":\"K1AF\"}}"
+        val e = runCatching { SettingsBackup.parseBackupJson(unmarked) }.exceptionOrNull()
+        assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(e).hasMessageThat().contains("FT8AF")
+    }
+
+    @Test
+    fun `parse rejects JSON with a foreign appName`() {
+        val foreign =
+            "{\"appName\":\"OtherApp\",\"formatVersion\":1,\"config\":{\"callsign\":\"K1AF\"}}"
+        val e = runCatching { SettingsBackup.parseBackupJson(foreign) }.exceptionOrNull()
         assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
     }
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackupTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsBackupTest.kt
@@ -1,0 +1,141 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for the settings backup export/import logic (issue #357). These touch
+ * org.json (an Android type), so they run under Robolectric per the project's
+ * testing convention.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SettingsBackupTest {
+
+    private val sampleConfig = linkedMapOf(
+        "callsign" to "K1AF",
+        "grid" to "FN42",
+        "cloudlogApiKey" to "secret-key",
+        "qrzXmlPassword" to "hunter2",
+        "pttDelay" to "50",
+    )
+
+    // -- filterConfig --
+
+    @Test
+    fun `filterConfig drops sensitive keys by default`() {
+        val filtered = SettingsBackup.filterConfig(sampleConfig, includeSensitive = false)
+        assertThat(filtered.keys).containsExactly("callsign", "grid", "pttDelay")
+        assertThat(filtered).doesNotContainKey("cloudlogApiKey")
+        assertThat(filtered).doesNotContainKey("qrzXmlPassword")
+    }
+
+    @Test
+    fun `filterConfig keeps sensitive keys when opted in`() {
+        val filtered = SettingsBackup.filterConfig(sampleConfig, includeSensitive = true)
+        assertThat(filtered).containsKey("cloudlogApiKey")
+        assertThat(filtered).containsKey("qrzXmlPassword")
+        assertThat(filtered).hasSize(sampleConfig.size)
+    }
+
+    // -- buildBackupJson --
+
+    @Test
+    fun `export without sensitive omits secrets but keeps normal keys`() {
+        val json = SettingsBackup.buildBackupJson(
+            sampleConfig, includeSensitive = false, appVersion = "1.2.3", createdAt = "2026-07-03 10:00",
+        )
+        assertThat(json).contains("\"callsign\"")
+        assertThat(json).contains("K1AF")
+        assertThat(json).doesNotContain("secret-key")
+        assertThat(json).doesNotContain("hunter2")
+        assertThat(json).contains("\"formatVersion\": 1")
+        assertThat(json).contains("1.2.3")
+        assertThat(json).contains("2026-07-03 10:00")
+    }
+
+    @Test
+    fun `export with sensitive includes secrets`() {
+        val json = SettingsBackup.buildBackupJson(
+            sampleConfig, includeSensitive = true, appVersion = "1.2.3", createdAt = "now",
+        )
+        assertThat(json).contains("secret-key")
+        assertThat(json).contains("hunter2")
+    }
+
+    // -- round trip --
+
+    @Test
+    fun `export then import round-trips the non-sensitive config`() {
+        val json = SettingsBackup.buildBackupJson(
+            sampleConfig, includeSensitive = false, appVersion = "1.0", createdAt = "2026-07-03",
+        )
+        val parsed = SettingsBackup.parseBackupJson(json)
+        assertThat(parsed.formatVersion).isEqualTo(SettingsBackup.FORMAT_VERSION)
+        assertThat(parsed.appVersion).isEqualTo("1.0")
+        assertThat(parsed.createdAt).isEqualTo("2026-07-03")
+        assertThat(parsed.config).containsExactly(
+            "callsign", "K1AF",
+            "grid", "FN42",
+            "pttDelay", "50",
+        )
+    }
+
+    @Test
+    fun `export with sensitive round-trips every key`() {
+        val json = SettingsBackup.buildBackupJson(
+            sampleConfig, includeSensitive = true, appVersion = "1.0", createdAt = "x",
+        )
+        val parsed = SettingsBackup.parseBackupJson(json)
+        assertThat(parsed.config).containsAtLeastEntriesIn(sampleConfig)
+    }
+
+    // -- parse validation --
+
+    @Test
+    fun `parse rejects non-JSON text`() {
+        val e = runCatching { SettingsBackup.parseBackupJson("not json at all") }.exceptionOrNull()
+        assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `parse rejects JSON that is not a backup`() {
+        val e = runCatching { SettingsBackup.parseBackupJson("{\"hello\":\"world\"}") }.exceptionOrNull()
+        assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(e).hasMessageThat().contains("FT8AF")
+    }
+
+    @Test
+    fun `parse rejects a future format version`() {
+        val future = "{\"formatVersion\":999,\"config\":{\"callsign\":\"K1AF\"}}"
+        val e = runCatching { SettingsBackup.parseBackupJson(future) }.exceptionOrNull()
+        assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(e).hasMessageThat().contains("newer")
+    }
+
+    @Test
+    fun `parse rejects a backup with an empty config`() {
+        val empty = "{\"formatVersion\":1,\"config\":{}}"
+        val e = runCatching { SettingsBackup.parseBackupJson(empty) }.exceptionOrNull()
+        assertThat(e).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    // -- defaultFileName --
+
+    @Test
+    fun `default file name embeds date and sanitized version`() {
+        val name = SettingsBackup.defaultFileName("2026-07-03", "1.2.3 (Beta 4)")
+        assertThat(name).startsWith("ft8af-settings-2026-07-03-v")
+        assertThat(name).endsWith(".json")
+        // Spaces and parens are replaced so the name stays filesystem-safe.
+        assertThat(name).doesNotContain(" ")
+        assertThat(name).doesNotContain("(")
+    }
+
+    @Test
+    fun `default file name falls back when version is blank`() {
+        val name = SettingsBackup.defaultFileName("2026-07-03", "")
+        assertThat(name).contains("unknown")
+    }
+}


### PR DESCRIPTION
Closes #357.

Adds a **Backup & Restore** section to **Settings → Advanced** that exports the app's configuration to a JSON file and imports it back — a simple backup/restore and device-migration workflow.

## What's included
- **Export**: a dialog with an *Include sensitive data* toggle, then a Storage Access Framework "create document" picker. The file is named `ft8af-settings-<date>-v<version>.json` and contains the full `config` table wrapped with metadata (`formatVersion`, `appVersion`, `createdAt`). Credentials (Cloudlog / QRZ / rig login) are **excluded unless the user opts in**.
- **Import**: SAF "open document" picker → parse & validate → a confirmation dialog previewing how many keys will be overwritten and when the backup was made → apply. After writing, `GeneralVariables` is re-hydrated so most settings take effect live (no restart needed for the common ones).
- Graceful failure on invalid JSON, non-FT8AF files, and backups from a newer format version.

## Implementation
- `SettingsBackup.kt` — pure, unit-tested logic (sensitive-key filtering, JSON build/parse/validate, file naming). The Compose + SAF code is a thin wrapper per the project's testability convention.
- `DatabaseOpr` — `getAllConfigSync` / `writeConfigSync` helpers to read and upsert the whole config table off the main thread.
- `SettingsBackupTest.kt` — covers filtering, round-trips, and validation rejections.

## Testing
- Unit tests pass (`testDebugUnitTest`).
- Verified end-to-end on the emulator: exported settings, edited the file, imported it, and confirmed the operator card updated live (callsign/grid changed).
- Verified the Backup & Restore UI and export dialog render on a physical phone (moto g stylus 5G).

## Follow-up (not in this PR)
- Desktop (Tauri) export/import.
- Optional per-category toggles and auto-revert-to-temp on import, as floated in the issue.

cc @patrickrb

🤖 Generated with [Claude Code](https://claude.com/claude-code)