### PR TITLE
Document tracked native sources in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,10 @@ different task). Instead spin up an isolated worktree per task:
 git worktree add ../NEXT-FT8CN-<short-task-name> -b feat/<task>
 ```
 
-Two gotchas for a fresh worktree:
+Notes for a fresh worktree:
 
-- The `ft8af/app/src/main/cpp/` native sources (`ft8_lib`, `ft8af_glue`,
-  `libsamplerate`) are **untracked** (see `git status` / memory
-  `ft8af-untracked-native-sources.md`), so a new worktree won't have them and the
-  NDK build fails. Copy them over from the primary checkout before building.
+- The `ft8af/app/src/main/cpp/` native sources (`ft8_lib`, `ft8af_glue`) are
+  **tracked** in git, so a fresh worktree builds with no manual copying.
 - Build/install still uses the Windows wrapper from inside the worktree's `ft8af`
   dir (`cmd.exe /c "gradlew.bat installDebug"`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,12 +100,13 @@ audible-but-undecodable signals. Both of these were diagnosed the hard
 way and re-introducing either makes TX silently broken — the rig keys,
 audio is audible, ALC looks right, and zero spots appear on PSKReporter.
 
-**1. `libft8cn.so` generates the entire waveform.** `GenerateFT8.generateFt8(msg,
+**1. The native library generates the entire waveform.** `GenerateFT8.generateFt8(msg,
 freq, 12000)` returns a mono 12.64-second `float[]` at 12 kHz containing the full
 FT8 message. The Costas sync arrays at symbols 0-6, 36-42, 72-78 are
-embedded by `synth_gfsk` in the native lib (the .so is a closed-source JNI
-wrapper around kgoba `ft8_lib @ 6f528128`; see the user's memory entry
-`libft8cn-native-origin.md`). The buffer is correct as generated — everything
+embedded by `synth_gfsk` in the native lib — today that's the from-source
+`libft8af.so` (`System.loadLibrary("ft8af")`, built from the vendored
+`ft8_lib`; historically this was the retired closed prebuilt `libft8cn.so`).
+The buffer is correct as generated — everything
 downstream just has to *not break it*.
 
 **2. `lateStartSkipMs` clips leading audio, but only if we'd overrun the cycle.**

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ cd ft8af
 
 ---
 
+## Native code
+
+The FT8 DSP core is a vendored copy of [kgoba's ft8_lib](https://github.com/kgoba/ft8_lib), pinned to a specific upstream commit — see [`ft8af/app/src/main/cpp/ft8_lib/FT8_LIB_PIN.txt`](ft8af/app/src/main/cpp/ft8_lib/FT8_LIB_PIN.txt) for the exact hash. App-specific JNI glue lives alongside it in `ft8af/app/src/main/cpp/ft8af_glue/`. All of it is built from source by the NDK/CMake toolchain into a single `libft8af.so`, so a fresh clone or worktree builds with no manual copying.
+
+Historical note: the app formerly shipped a closed prebuilt `libft8cn.so` — a JNI wrapper around kgoba ft8_lib @ `6f528128`. It is no longer used and no longer present in the repository; the from-source build replaced it entirely.
+
+---
+
 ## Thanks
 
 Massive thanks to **BG7YOZ**, the original author of FT8CN, and **N0BOY**, who hosts the original repository and did the early translation work. None of this exists without their work — this fork stands entirely on their shoulders.


### PR DESCRIPTION
Fixes #365

Issue #365 asked to either commit the native sources or document that they must be copied into a fresh checkout. The sources were since committed — `ft8af/app/src/main/cpp/ft8_lib` and `ft8af_glue` are tracked in git, and `libsamplerate` was removed entirely — so this PR completes the remaining documentation half:

- **README.md**: new "Native code" section documenting that the DSP core is a vendored copy of kgoba's ft8_lib (pinned; exact commit in `ft8af/app/src/main/cpp/ft8_lib/FT8_LIB_PIN.txt`), glued via `ft8af_glue`, and built from source by the NDK/CMake toolchain into a single `libft8af.so` — a fresh clone or worktree builds with no manual copying. Also records, for the historical record, that the app formerly shipped a closed prebuilt `libft8cn.so` (a JNI wrapper around kgoba ft8_lib @ `6f528128`) which is no longer used or present.
- **CLAUDE.md**: the "Two gotchas for a fresh worktree" section still claimed the native sources were untracked and had to be copied from the primary checkout. Updated to say the sources are tracked and a fresh worktree builds without copying (the Windows gradle wrapper gotcha is kept).

Docs-only change — no code or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)