### PR TITLE
Refactor: extract shared LocationSubscriber base for GridLocationUpdater and GpsClockUpdater

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
@@ -7,8 +7,6 @@ import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
-import android.os.Bundle;
-import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.util.Log;
@@ -38,9 +36,12 @@ import com.k1af.ft8af.timer.UtcTimer;
  * satisfaction, no root required.
  *
  * <p>Singleton — call {@link #refresh(Context)} whenever the toggle/interval changes or
- * the activity starts. Mirrors {@link GridLocationUpdater}.
+ * the activity starts. The subscription lifecycle is shared with
+ * {@link GridLocationUpdater} via {@link LocationSubscriber} (issue #380); this class
+ * supplies the clock-specific pieces: GPS-only provider at a configurable, re-tunable
+ * cadence, offset computation on each fix, and capture/restore of the pre-GPS baseline.
  */
-public class GpsClockUpdater {
+public class GpsClockUpdater extends LocationSubscriber {
     private static final String TAG = "GpsClockUpdater";
 
     /**
@@ -64,13 +65,10 @@ public class GpsClockUpdater {
 
     private static GpsClockUpdater instance;
 
-    private final Context appContext;
-    private LocationManager locationManager;
-    // running is read from applyFix (main looper) without holding the monitor, so it must be
-    // volatile for the disable/stop() write to be visible and abort a late in-flight fix.
-    private volatile boolean running = false;
     private long subscribedIntervalMs = -1;
-    private LocationListener listener;
+    // The interval chosen by prepareStart() for the in-flight start(); consumed by
+    // subscribeProviders() and onSubscribed(). Only touched under the monitor.
+    private long pendingIntervalMs = -1;
     // The offset UtcTimer.delay held *before* GPS discipline took it over (NTP's %-15000
     // sync, a manual correction, or 0). Captured on the first start() and restored by stop()
     // so disabling GPS returns the clock to its pre-GPS state instead of clobbering it with
@@ -78,7 +76,7 @@ public class GpsClockUpdater {
     private int savedDelayBeforeGps = NO_SAVED_DELAY;
 
     private GpsClockUpdater(Context context) {
-        this.appContext = context.getApplicationContext();
+        super(context);
     }
 
     public static synchronized GpsClockUpdater getInstance(Context context) {
@@ -93,118 +91,104 @@ public class GpsClockUpdater {
      * Safe to call repeatedly.
      */
     public static synchronized void refresh(Context context) {
-        GpsClockUpdater u = getInstance(context);
-        if (GeneralVariables.disciplineClockFromGPS) {
-            u.start();
-        } else {
-            u.stop();
-        }
+        getInstance(context).refreshSubscription();
     }
 
-    @SuppressLint("MissingPermission")
-    private synchronized void start() {
+    @Override
+    protected String tag() {
+        return TAG;
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return GeneralVariables.disciplineClockFromGPS;
+    }
+
+    // GPS_PROVIDER requires ACCESS_FINE_LOCATION; a coarse-only grant (Android 12+
+    // "approximate location") can't subscribe to it, so treating coarse as sufficient
+    // here would just trade this guard for a SecurityException on subscribe.
+    @Override
+    protected boolean hasRequiredPermission() {
+        if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
+            Log.d(TAG, "ACCESS_FINE_LOCATION not granted; skipping start");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected synchronized boolean prepareStart() {
         long intervalMs = clampIntervalMinutes(GeneralVariables.gpsClockIntervalMinutes) * 60_000L;
 
         // Already running at the requested cadence — nothing to do.
-        if (!shouldResubscribe(running, subscribedIntervalMs, intervalMs)) return;
+        if (!shouldResubscribe(isRunning(), subscribedIntervalMs, intervalMs)) return false;
 
         // Running at a different cadence: drop the old subscription and re-subscribe. Use
         // unsubscribe(), NOT stop(): a re-tune must not disturb UtcTimer.delay (the GPS
         // offset is still valid) or the captured pre-GPS baseline.
-        if (running) unsubscribe();
+        if (isRunning()) unsubscribe();
 
-        // GPS_PROVIDER requires ACCESS_FINE_LOCATION; a coarse-only grant (Android 12+
-        // "approximate location") can't subscribe to it, so treating coarse as sufficient
-        // here would just trade this guard for a SecurityException below.
-        if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION)
-                != PackageManager.PERMISSION_GRANTED) {
-            Log.d(TAG, "ACCESS_FINE_LOCATION not granted; skipping start");
-            return;
-        }
-        if (locationManager == null) {
-            locationManager = (LocationManager) appContext.getSystemService(Context.LOCATION_SERVICE);
-        }
-        if (locationManager == null) {
-            Log.e(TAG, "No LocationManager available");
-            return;
-        }
+        pendingIntervalMs = intervalMs;
+        return true;
+    }
 
-        listener = new LocationListener() {
-            @Override
-            public void onLocationChanged(Location location) {
-                applyFix(location);
-            }
-
-            @Override
-            public void onStatusChanged(String provider, int status, Bundle extras) {}
-
-            @Override
-            public void onProviderEnabled(String provider) {}
-
-            @Override
-            public void onProviderDisabled(String provider) {}
-        };
-
+    @SuppressLint("MissingPermission")
+    @Override
+    protected boolean subscribeProviders(LocationManager manager, LocationListener listener) {
         try {
-            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, intervalMs, 0f,
+            manager.requestLocationUpdates(LocationManager.GPS_PROVIDER, pendingIntervalMs, 0f,
                     listener, Looper.getMainLooper());
+            return true;
         } catch (SecurityException se) {
             Log.e(TAG, "SecurityException subscribing to GPS: " + se.getMessage());
-            listener = null;
-            return;
+            return false;
         } catch (IllegalArgumentException iae) {
             // No GPS provider on this device — gracefully no-op (issue #373 acceptance).
             Log.d(TAG, "GPS provider unavailable on this device");
-            listener = null;
-            return;
+            return false;
         }
+    }
 
+    @Override
+    protected synchronized void onSubscribed() {
         // Capture the pre-GPS offset once, before any fix overwrites UtcTimer.delay, so stop()
         // can hand the clock back exactly as it was. Only on the first start() — a re-tune
         // reaches here with delay already holding a GPS offset, which must not be captured.
         if (savedDelayBeforeGps == NO_SAVED_DELAY) {
             savedDelayBeforeGps = UtcTimer.delay;
         }
-
-        running = true;
-        subscribedIntervalMs = intervalMs;
-        Log.d(TAG, "Started GPS clock discipline, interval " + intervalMs + "ms");
-
-        // Discipline immediately from the last known GPS fix so the clock snaps into
-        // alignment without waiting a full interval for the next fix.
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Location last = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
-                    if (last != null) applyFix(last);
-                } catch (SecurityException se) {
-                    Log.e(TAG, "getLastKnownLocation denied: " + se.getMessage());
-                }
-            }
-        });
+        subscribedIntervalMs = pendingIntervalMs;
+        Log.d(TAG, "Started GPS clock discipline, interval " + pendingIntervalMs + "ms");
     }
 
-    /**
-     * Drop the location subscription without touching the clock. Used both by the public
-     * {@link #stop()} and by a re-tune in {@link #start()} (which must keep the GPS offset).
-     */
-    private synchronized void unsubscribe() {
-        if (locationManager != null && listener != null) {
-            try {
-                locationManager.removeUpdates(listener);
-            } catch (Exception e) {
-                Log.e(TAG, "removeUpdates failed: " + e.getMessage());
-            }
-        }
-        listener = null;
-        running = false;
+    @Override
+    protected synchronized void onUnsubscribed() {
         subscribedIntervalMs = -1;
     }
 
+    @Override
+    protected void onFix(Location location) {
+        applyFix(location);
+    }
+
+    // Discipline immediately from the last known GPS fix so the clock snaps into
+    // alignment without waiting a full interval for the next fix.
+    @SuppressLint("MissingPermission")
+    @Override
+    protected void applyLastKnown() {
+        try {
+            Location last = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+            if (last != null) applyFix(last);
+        } catch (SecurityException se) {
+            Log.e(TAG, "getLastKnownLocation denied: " + se.getMessage());
+        }
+    }
+
     /** Disable discipline: unsubscribe and restore the clock to its pre-GPS offset. */
-    private synchronized void stop() {
-        if (!running && savedDelayBeforeGps == NO_SAVED_DELAY) return;
+    @Override
+    protected synchronized void stop() {
+        if (!isRunning() && savedDelayBeforeGps == NO_SAVED_DELAY) return;
         unsubscribe();
 
         // Return UtcTimer.delay to whatever it was before GPS took over (an NTP sync, a manual
@@ -226,7 +210,7 @@ public class GpsClockUpdater {
         // main looper when the user disabled discipline (stop() flipped running=false) is
         // dropped instead of re-writing the clock after we've handed it back.
         Integer offsetMs = computeAppliedOffset(
-                running,
+                isRunning(),
                 fixUtcMs,
                 location.getElapsedRealtimeNanos(),
                 SystemClock.elapsedRealtimeNanos(),
@@ -315,7 +299,7 @@ public class GpsClockUpdater {
     }
 
     /**
-     * Whether {@link #start()} needs to (re)subscribe: yes when not currently running, or when
+     * Whether {@code start()} needs to (re)subscribe: yes when not currently running, or when
      * running at a cadence different from the one requested. A no-op when already subscribed at
      * the requested interval, so repeated refreshes don't churn the location subscription.
      */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/location/GridLocationUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/location/GridLocationUpdater.java
@@ -7,8 +7,6 @@ import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
-import android.os.Bundle;
-import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
@@ -24,9 +22,12 @@ import com.google.android.gms.maps.model.LatLng;
  * is enabled, and writes the resulting Maidenhead grid back to GeneralVariables + config.
  *
  * Singleton — call {@link #refresh(Context, MainViewModel)} whenever the toggle changes
- * or when the activity starts.
+ * or when the activity starts. The subscription lifecycle lives in
+ * {@link LocationSubscriber} (issue #380); this class supplies the grid-specific pieces:
+ * all enabled providers at a fixed 5-minute cadence, and lat/lon → Maidenhead grid on
+ * each fix.
  */
-public class GridLocationUpdater {
+public class GridLocationUpdater extends LocationSubscriber {
     private static final String TAG = "GridLocationUpdater";
 
     // 5-minute update interval, 1km min distance — keeps battery use light.
@@ -35,13 +36,16 @@ public class GridLocationUpdater {
 
     private static GridLocationUpdater instance;
 
-    private final Context appContext;
-    private LocationManager locationManager;
-    private boolean running = false;
-    private LocationListener listener;
+    // The view model whose databaseOpr receives grid writes. refresh() records the caller's
+    // view model in requestedViewModel; prepareStart() latches it into mainViewModel only
+    // when a start actually proceeds. This mirrors the pre-refactor behavior, where the
+    // anonymous listener captured the view model at subscribe time — a refresh() while
+    // already running kept writing through the originally captured view model.
+    private MainViewModel requestedViewModel;
+    private MainViewModel mainViewModel;
 
     private GridLocationUpdater(Context context) {
-        this.appContext = context.getApplicationContext();
+        super(context);
     }
 
     public static synchronized GridLocationUpdater getInstance(Context context) {
@@ -57,52 +61,51 @@ public class GridLocationUpdater {
      */
     public static synchronized void refresh(Context context, MainViewModel mainViewModel) {
         GridLocationUpdater u = getInstance(context);
-        if (GeneralVariables.autoUpdateGridFromGPS) {
-            u.start(mainViewModel);
-        } else {
-            u.stop();
-        }
+        u.setRequestedViewModel(mainViewModel);
+        u.refreshSubscription();
     }
 
-    @SuppressLint("MissingPermission")
-    private synchronized void start(final MainViewModel mainViewModel) {
-        if (running) return;
+    private synchronized void setRequestedViewModel(MainViewModel viewModel) {
+        this.requestedViewModel = viewModel;
+    }
+
+    @Override
+    protected String tag() {
+        return TAG;
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return GeneralVariables.autoUpdateGridFromGPS;
+    }
+
+    @Override
+    protected boolean hasRequiredPermission() {
         if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED
                 && ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_COARSE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
             Log.d(TAG, "Location permission not granted; skipping start");
-            return;
+            return false;
         }
-        if (locationManager == null) {
-            locationManager = (LocationManager) appContext.getSystemService(Context.LOCATION_SERVICE);
-        }
-        if (locationManager == null) {
-            Log.e(TAG, "No LocationManager available");
-            return;
-        }
+        return true;
+    }
 
-        listener = new LocationListener() {
-            @Override
-            public void onLocationChanged(Location location) {
-                applyGridFromLatLng(location.getLatitude(), location.getLongitude(), mainViewModel);
-            }
+    @Override
+    protected synchronized boolean prepareStart() {
+        if (isRunning()) return false;
+        mainViewModel = requestedViewModel;
+        return true;
+    }
 
-            @Override
-            public void onStatusChanged(String provider, int status, Bundle extras) {}
-
-            @Override
-            public void onProviderEnabled(String provider) {}
-
-            @Override
-            public void onProviderDisabled(String provider) {}
-        };
-
-        // Use the best available provider; subscribe to both for robustness.
+    // Use the best available provider; subscribe to all enabled ones for robustness.
+    @SuppressLint("MissingPermission")
+    @Override
+    protected boolean subscribeProviders(LocationManager manager, LocationListener listener) {
         boolean subscribed = false;
-        for (String provider : locationManager.getProviders(true)) {
+        for (String provider : manager.getProviders(true)) {
             try {
-                locationManager.requestLocationUpdates(provider, MIN_TIME_MS, MIN_DISTANCE_M,
+                manager.requestLocationUpdates(provider, MIN_TIME_MS, MIN_DISTANCE_M,
                         listener, Looper.getMainLooper());
                 subscribed = true;
             } catch (SecurityException se) {
@@ -113,35 +116,22 @@ public class GridLocationUpdater {
         }
         if (!subscribed) {
             Log.d(TAG, "No providers subscribed");
-            listener = null;
-            return;
         }
-
-        running = true;
-
-        // Also fire an immediate update from last known location so the grid refreshes promptly.
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                LatLng latLng = MaidenheadGrid.getLocalLocation(appContext);
-                if (latLng != null) {
-                    applyGridFromLatLng(latLng.latitude, latLng.longitude, mainViewModel);
-                }
-            }
-        });
+        return subscribed;
     }
 
-    private synchronized void stop() {
-        if (!running) return;
-        if (locationManager != null && listener != null) {
-            try {
-                locationManager.removeUpdates(listener);
-            } catch (Exception e) {
-                Log.e(TAG, "removeUpdates failed: " + e.getMessage());
-            }
+    @Override
+    protected void onFix(Location location) {
+        applyGridFromLatLng(location.getLatitude(), location.getLongitude(), mainViewModel);
+    }
+
+    // Immediate update from the last known location so the grid refreshes promptly.
+    @Override
+    protected void applyLastKnown() {
+        LatLng latLng = MaidenheadGrid.getLocalLocation(appContext);
+        if (latLng != null) {
+            applyGridFromLatLng(latLng.latitude, latLng.longitude, mainViewModel);
         }
-        listener = null;
-        running = false;
     }
 
     private void applyGridFromLatLng(double lat, double lon, MainViewModel mainViewModel) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/location/LocationSubscriber.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/location/LocationSubscriber.java
@@ -1,0 +1,197 @@
+package com.k1af.ft8af.location;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+/**
+ * Shared location-subscription lifecycle for {@link GridLocationUpdater} and
+ * {@link GpsClockUpdater} (issue #380).
+ *
+ * <p>Owns the half that the two updaters used to duplicate: the toggle-driven
+ * start/stop dispatch, the permission gate, the lazy {@link LocationManager}
+ * lookup with null-guard, the four-method {@link LocationListener} where only
+ * {@code onLocationChanged} matters, the subscribe/teardown bookkeeping, and the
+ * "apply immediately from the last-known location via {@code Handler.post}"
+ * bootstrap. Subclasses fill in template hooks for what genuinely differs:
+ * provider selection and cadence ({@link #subscribeProviders}), the
+ * enabled-toggle predicate ({@link #isEnabled}), the permission requirement
+ * ({@link #hasRequiredPermission}), what to do with a fix ({@link #onFix}), and
+ * the last-known-fix bootstrap ({@link #applyLastKnown}).
+ *
+ * <p>All lifecycle transitions are serialized on {@code this}; hooks are invoked
+ * with the monitor held unless noted otherwise. {@code running} is volatile so a
+ * subclass may consult {@link #isRunning()} from a main-looper fix callback
+ * without the monitor and still observe a concurrent {@link #stop()} (see
+ * {@code GpsClockUpdater#applyFix}).
+ */
+abstract class LocationSubscriber {
+
+    protected final Context appContext;
+    /** Lazily looked up on first successful start; kept for teardown and last-known reads. */
+    protected LocationManager locationManager;
+    // Volatile: written under the monitor, but read without it from main-looper fix
+    // callbacks (GpsClockUpdater drops a fix that raced past a disable).
+    private volatile boolean running = false;
+    private LocationListener listener;
+
+    protected LocationSubscriber(Context context) {
+        this.appContext = context.getApplicationContext();
+    }
+
+    // =====================================================================
+    // Template hooks — the parts that differ between the two updaters.
+    // =====================================================================
+
+    /** Log tag for the shared lifecycle messages. */
+    protected abstract String tag();
+
+    /** The {@code GeneralVariables} toggle gating this subscriber. */
+    protected abstract boolean isEnabled();
+
+    /**
+     * Whether the granted location permissions are sufficient to subscribe.
+     * Implementations log their own reason and return {@code false} on denial.
+     */
+    protected abstract boolean hasRequiredPermission();
+
+    /**
+     * Decide whether this {@link #start()} call should proceed toward a (re)subscribe.
+     * Runs first, before the permission and manager checks, with the monitor held.
+     * Return {@code false} to make the start a no-op (e.g. already running at the
+     * requested cadence). Implementations that support re-tuning drop the stale
+     * subscription here (via {@link #unsubscribe()}) before returning {@code true}.
+     */
+    protected abstract boolean prepareStart();
+
+    /**
+     * Subscribe {@code listener} to this subscriber's provider(s) at its cadence.
+     * Implementations own their {@code SecurityException} / {@code IllegalArgumentException}
+     * handling and logging. Return {@code true} if at least one provider subscribed;
+     * on {@code false} the base clears the listener and abandons the start.
+     */
+    protected abstract boolean subscribeProviders(LocationManager manager, LocationListener listener);
+
+    /**
+     * Called once after a successful subscribe, with the monitor held, before the
+     * last-known bootstrap is posted. Default no-op.
+     */
+    protected void onSubscribed() {
+    }
+
+    /**
+     * Called at the end of every {@link #unsubscribe()}, with the monitor held,
+     * after the listener is removed and {@code running} cleared. Default no-op.
+     */
+    protected void onUnsubscribed() {
+    }
+
+    /** Handle a live location fix (invoked on the main looper, without the monitor). */
+    protected abstract void onFix(Location location);
+
+    /**
+     * Apply an immediate update from the last-known location so the subscriber takes
+     * effect promptly instead of waiting a full update interval. Posted to the main
+     * looper right after a successful subscribe; runs without the monitor.
+     */
+    protected abstract void applyLastKnown();
+
+    // =====================================================================
+    // Shared lifecycle.
+    // =====================================================================
+
+    protected final boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Start or stop this subscriber based on the current toggle state.
+     * Safe to call repeatedly.
+     */
+    final synchronized void refreshSubscription() {
+        if (isEnabled()) {
+            start();
+        } else {
+            stop();
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private synchronized void start() {
+        if (!prepareStart()) return;
+        if (!hasRequiredPermission()) return;
+        if (locationManager == null) {
+            locationManager = (LocationManager) appContext.getSystemService(Context.LOCATION_SERVICE);
+        }
+        if (locationManager == null) {
+            Log.e(tag(), "No LocationManager available");
+            return;
+        }
+
+        listener = new LocationListener() {
+            @Override
+            public void onLocationChanged(Location location) {
+                onFix(location);
+            }
+
+            @Override
+            public void onStatusChanged(String provider, int status, Bundle extras) {}
+
+            @Override
+            public void onProviderEnabled(String provider) {}
+
+            @Override
+            public void onProviderDisabled(String provider) {}
+        };
+
+        if (!subscribeProviders(locationManager, listener)) {
+            listener = null;
+            return;
+        }
+
+        onSubscribed();
+        running = true;
+
+        // Fire an immediate update from the last-known location so the effect (grid
+        // refresh / clock snap) doesn't have to wait for the first live fix.
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                applyLastKnown();
+            }
+        });
+    }
+
+    /**
+     * Stop this subscriber. The base drops the subscription only if running; a subclass
+     * may override to add teardown side effects (and must still call {@link #unsubscribe()}).
+     */
+    protected synchronized void stop() {
+        if (!running) return;
+        unsubscribe();
+    }
+
+    /**
+     * Drop the location subscription and clear {@code running}, without any
+     * subclass-specific teardown side effects. Used by {@link #stop()} and by
+     * re-tunes in {@link #prepareStart()} implementations.
+     */
+    protected final synchronized void unsubscribe() {
+        if (locationManager != null && listener != null) {
+            try {
+                locationManager.removeUpdates(listener);
+            } catch (Exception e) {
+                Log.e(tag(), "removeUpdates failed: " + e.getMessage());
+            }
+        }
+        listener = null;
+        running = false;
+        onUnsubscribed();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/location/GpsClockUpdaterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/location/GpsClockUpdaterTest.java
@@ -2,15 +2,23 @@ package com.k1af.ft8af.location;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.timer.UtcTimer;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 /**
  * Covers the pure offset/should-apply/interval logic extracted from
- * {@link GpsClockUpdater} for GPS clock discipline (issue #373). Robolectric is
- * used only so the Android-typed class links cleanly; the methods under test are
- * plain arithmetic and never touch a {@code LocationManager}.
+ * {@link GpsClockUpdater} for GPS clock discipline (issue #373), plus the
+ * toggle/permission gating the class wires into {@link LocationSubscriber}
+ * (issue #380). Robolectric is used so the Android-typed class links cleanly;
+ * the arithmetic under test never touches a {@code LocationManager}.
  */
 @RunWith(RobolectricTestRunner.class)
 public class GpsClockUpdaterTest {
@@ -177,5 +185,32 @@ public class GpsClockUpdaterTest {
     @Test
     public void disciplinedUtc_shiftsFastClockBack() {
         assertThat(GpsClockUpdater.disciplinedUtcMs(10_000L, -1_500)).isEqualTo(8_500L);
+    }
+
+    // ---- LocationSubscriber wiring (issue #380): toggle + permission gates ----
+
+    @Test
+    public void refresh_toggleOff_leavesDisciplineStopped() {
+        Context ctx = ApplicationProvider.getApplicationContext();
+        GeneralVariables.disciplineClockFromGPS = false;
+        GpsClockUpdater.refresh(ctx);
+        assertThat(GpsClockUpdater.getInstance(ctx).isRunning()).isFalse();
+    }
+
+    @Test
+    public void refresh_toggleOn_withoutFinePermission_doesNotStartOrTouchClock() {
+        // Robolectric grants no runtime permissions by default, so the FINE-only
+        // check must veto the start — and a vetoed start must not capture/alter
+        // the pre-GPS clock offset.
+        Context ctx = ApplicationProvider.getApplicationContext();
+        int delayBefore = UtcTimer.delay;
+        GeneralVariables.disciplineClockFromGPS = true;
+        try {
+            GpsClockUpdater.refresh(ctx);
+            assertThat(GpsClockUpdater.getInstance(ctx).isRunning()).isFalse();
+            assertThat(UtcTimer.delay).isEqualTo(delayBefore);
+        } finally {
+            GeneralVariables.disciplineClockFromGPS = false;
+        }
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/location/GridLocationUpdaterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/location/GridLocationUpdaterTest.java
@@ -2,6 +2,11 @@ package com.k1af.ft8af.location;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.maidenhead.MaidenheadGrid;
 import com.google.android.gms.maps.model.LatLng;
 
@@ -11,9 +16,10 @@ import org.robolectric.RobolectricTestRunner;
 
 /**
  * Covers {@link GridLocationUpdater#gridUpdateFor} — the GPS-grid update
- * decision extracted from {@code applyGridFromLatLng} (issue #59). Robolectric
- * is required because the method reaches Play-Services {@link LatLng} via
- * {@link MaidenheadGrid#getGridSquare}.
+ * decision extracted from {@code applyGridFromLatLng} (issue #59) — plus the
+ * toggle/permission gating the class wires into {@link LocationSubscriber}
+ * (issue #380). Robolectric is required because the method reaches
+ * Play-Services {@link LatLng} via {@link MaidenheadGrid#getGridSquare}.
  */
 @RunWith(RobolectricTestRunner.class)
 public class GridLocationUpdaterTest {
@@ -60,5 +66,29 @@ public class GridLocationUpdaterTest {
         assertThat(GridLocationUpdater.gridUpdateFor(BOSTON_LAT, BOSTON_LON, startGrid)).isNull();
         // After the boundary crossing => update to the new square.
         assertThat(GridLocationUpdater.gridUpdateFor(euLat, euLon, startGrid)).isEqualTo(endGrid);
+    }
+
+    // ---- LocationSubscriber wiring (issue #380): toggle + permission gates ----
+
+    @Test
+    public void refresh_toggleOff_leavesUpdaterStopped() {
+        Context ctx = ApplicationProvider.getApplicationContext();
+        GeneralVariables.autoUpdateGridFromGPS = false;
+        GridLocationUpdater.refresh(ctx, null);
+        assertThat(GridLocationUpdater.getInstance(ctx).isRunning()).isFalse();
+    }
+
+    @Test
+    public void refresh_toggleOn_withoutLocationPermission_doesNotStart() {
+        // Robolectric grants no runtime permissions by default, so the dual
+        // FINE/COARSE check must veto the start.
+        Context ctx = ApplicationProvider.getApplicationContext();
+        GeneralVariables.autoUpdateGridFromGPS = true;
+        try {
+            GridLocationUpdater.refresh(ctx, null);
+            assertThat(GridLocationUpdater.getInstance(ctx).isRunning()).isFalse();
+        } finally {
+            GeneralVariables.autoUpdateGridFromGPS = false;
+        }
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/location/LocationSubscriberTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/location/LocationSubscriberTest.java
@@ -1,0 +1,247 @@
+package com.k1af.ft8af.location;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Looper;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Covers the shared location-subscription lifecycle extracted into
+ * {@link LocationSubscriber} (issue #380) through a fake subclass, so every
+ * template decision — toggle dispatch, prepare-gate, permission gate, subscribe
+ * failure, fix dispatch, last-known bootstrap, re-tune, teardown — is exercised
+ * without a real provider. Robolectric supplies the Context/LocationManager and
+ * the paused main looper used for the bootstrap post.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LocationSubscriberTest {
+
+    /** Minimal concrete subscriber with every hook controllable/observable. */
+    private static class FakeSubscriber extends LocationSubscriber {
+        boolean enabled = false;
+        boolean permissionGranted = true;
+        boolean prepareResult = true;
+        boolean subscribeResult = true;
+        boolean unsubscribeOnPrepare = false; // models GpsClockUpdater's re-tune
+
+        int prepareCalls = 0;
+        int permissionChecks = 0;
+        int subscribeCalls = 0;
+        int onSubscribedCalls = 0;
+        int onUnsubscribedCalls = 0;
+        int lastKnownCalls = 0;
+        final List<Location> fixes = new ArrayList<>();
+        LocationListener capturedListener;
+
+        FakeSubscriber(Context context) {
+            super(context);
+        }
+
+        @Override
+        protected String tag() {
+            return "FakeSubscriber";
+        }
+
+        @Override
+        protected boolean isEnabled() {
+            return enabled;
+        }
+
+        @Override
+        protected boolean hasRequiredPermission() {
+            permissionChecks++;
+            return permissionGranted;
+        }
+
+        @Override
+        protected synchronized boolean prepareStart() {
+            prepareCalls++;
+            if (unsubscribeOnPrepare && isRunning()) unsubscribe();
+            return prepareResult;
+        }
+
+        @Override
+        protected boolean subscribeProviders(LocationManager manager, LocationListener listener) {
+            subscribeCalls++;
+            capturedListener = listener;
+            return subscribeResult;
+        }
+
+        @Override
+        protected void onSubscribed() {
+            onSubscribedCalls++;
+        }
+
+        @Override
+        protected void onUnsubscribed() {
+            onUnsubscribedCalls++;
+        }
+
+        @Override
+        protected void onFix(Location location) {
+            fixes.add(location);
+        }
+
+        @Override
+        protected void applyLastKnown() {
+            lastKnownCalls++;
+        }
+    }
+
+    private FakeSubscriber subscriber;
+
+    @Before
+    public void setUp() {
+        subscriber = new FakeSubscriber(ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    public void refresh_enabledToggle_subscribesAndRuns() {
+        subscriber.enabled = true;
+        subscriber.refreshSubscription();
+
+        assertThat(subscriber.isRunning()).isTrue();
+        assertThat(subscriber.subscribeCalls).isEqualTo(1);
+        assertThat(subscriber.onSubscribedCalls).isEqualTo(1);
+    }
+
+    @Test
+    public void refresh_disabledToggle_neverStarted_isNoOp() {
+        subscriber.enabled = false;
+        subscriber.refreshSubscription();
+
+        // stop() on a never-started subscriber must not tear anything down.
+        assertThat(subscriber.isRunning()).isFalse();
+        assertThat(subscriber.prepareCalls).isEqualTo(0);
+        assertThat(subscriber.onUnsubscribedCalls).isEqualTo(0);
+    }
+
+    @Test
+    public void refresh_toggleFlippedOff_stopsAndUnsubscribes() {
+        subscriber.enabled = true;
+        subscriber.refreshSubscription();
+        subscriber.enabled = false;
+        subscriber.refreshSubscription();
+
+        assertThat(subscriber.isRunning()).isFalse();
+        assertThat(subscriber.onUnsubscribedCalls).isEqualTo(1);
+    }
+
+    @Test
+    public void start_prepareStartFalse_skipsPermissionAndSubscribe() {
+        // e.g. already running at the requested cadence: the whole start is a no-op.
+        subscriber.enabled = true;
+        subscriber.prepareResult = false;
+        subscriber.refreshSubscription();
+
+        assertThat(subscriber.isRunning()).isFalse();
+        assertThat(subscriber.permissionChecks).isEqualTo(0);
+        assertThat(subscriber.subscribeCalls).isEqualTo(0);
+    }
+
+    @Test
+    public void start_permissionDenied_doesNotSubscribe() {
+        subscriber.enabled = true;
+        subscriber.permissionGranted = false;
+        subscriber.refreshSubscription();
+
+        assertThat(subscriber.isRunning()).isFalse();
+        assertThat(subscriber.subscribeCalls).isEqualTo(0);
+        assertThat(subscriber.onSubscribedCalls).isEqualTo(0);
+    }
+
+    @Test
+    public void start_subscribeFails_staysStopped_andSkipsBootstrap() {
+        subscriber.enabled = true;
+        subscriber.subscribeResult = false;
+        subscriber.refreshSubscription();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertThat(subscriber.isRunning()).isFalse();
+        assertThat(subscriber.onSubscribedCalls).isEqualTo(0);
+        // The last-known bootstrap must only be posted after a successful subscribe.
+        assertThat(subscriber.lastKnownCalls).isEqualTo(0);
+    }
+
+    @Test
+    public void start_postsLastKnownBootstrap_toMainLooper() {
+        subscriber.enabled = true;
+        subscriber.refreshSubscription();
+
+        // Posted, not run inline: nothing until the main looper drains.
+        assertThat(subscriber.lastKnownCalls).isEqualTo(0);
+        shadowOf(Looper.getMainLooper()).idle();
+        assertThat(subscriber.lastKnownCalls).isEqualTo(1);
+    }
+
+    @Test
+    public void liveFix_isDispatchedToOnFix() {
+        subscriber.enabled = true;
+        subscriber.refreshSubscription();
+
+        Location fix = new Location(LocationManager.GPS_PROVIDER);
+        subscriber.capturedListener.onLocationChanged(fix);
+
+        assertThat(subscriber.fixes).containsExactly(fix);
+    }
+
+    @Test
+    public void refresh_whileRunning_prepareFalse_doesNotResubscribe() {
+        // Models GridLocationUpdater / an at-cadence GpsClockUpdater: repeated refreshes
+        // while running must not churn the subscription.
+        subscriber.enabled = true;
+        subscriber.refreshSubscription();
+        subscriber.prepareResult = false;
+        subscriber.refreshSubscription();
+
+        assertThat(subscriber.isRunning()).isTrue();
+        assertThat(subscriber.subscribeCalls).isEqualTo(1);
+    }
+
+    @Test
+    public void refresh_whileRunning_retuneViaPrepare_resubscribes() {
+        // Models GpsClockUpdater's interval change: prepareStart() unsubscribes the stale
+        // cadence and lets the start proceed to a fresh subscribe.
+        subscriber.enabled = true;
+        subscriber.refreshSubscription();
+        subscriber.unsubscribeOnPrepare = true;
+        subscriber.refreshSubscription();
+
+        assertThat(subscriber.isRunning()).isTrue();
+        assertThat(subscriber.subscribeCalls).isEqualTo(2);
+        assertThat(subscriber.onUnsubscribedCalls).isEqualTo(1);
+        assertThat(subscriber.onSubscribedCalls).isEqualTo(2);
+    }
+
+    @Test
+    public void stop_dropsListenerBeforeOnUnsubscribed_soLateFixesStillDispatchButGuarded() {
+        // After a stop, the base has cleared running; a fix that raced past the disable is
+        // still delivered to onFix (the base doesn't filter), so subclasses must gate on
+        // isRunning() — exactly what GpsClockUpdater.computeAppliedOffset does.
+        subscriber.enabled = true;
+        subscriber.refreshSubscription();
+        LocationListener listener = subscriber.capturedListener;
+
+        subscriber.enabled = false;
+        subscriber.refreshSubscription();
+        assertThat(subscriber.isRunning()).isFalse();
+
+        listener.onLocationChanged(new Location(LocationManager.GPS_PROVIDER));
+        assertThat(subscriber.fixes).hasSize(1);
+        assertThat(subscriber.isRunning()).isFalse();
+    }
+}


### PR DESCRIPTION
Fixes #380 (refs #373 / #379 — `GpsClockUpdater` was deliberately modeled on `GridLocationUpdater` in #379, and the shared-base extraction was deferred from that review to keep it focused).

## What

Extracts an abstract `LocationSubscriber` (package-private, same `com.k1af.ft8af.location` package) that owns the location-subscription lifecycle the two updaters previously duplicated:

- toggle-driven start/stop dispatch (`refreshSubscription()` on an `isEnabled()` hook)
- permission gate before subscribing
- lazy `LocationManager` lookup with null-guard
- the four-method anonymous `LocationListener` where only `onLocationChanged` matters
- subscribe bookkeeping (listener cleared on failure) and `removeUpdates` teardown
- the "apply immediately from last-known location via `Handler.post`" bootstrap

Template hooks cover exactly what differs, per the issue's proposal:

- **provider selection**: `subscribeProviders(...)` — Grid subscribes all enabled providers (per-provider try/catch, fixed 5-min/1-km cadence); GPS clock subscribes `GPS_PROVIDER` only at its configurable interval
- **cadence / re-tune**: `prepareStart()` — Grid no-ops when already running; GpsClockUpdater keeps its `shouldResubscribe` + `unsubscribe()`-without-restore re-tune on interval change
- **fix handling**: `onFix(Location)` / `applyLastKnown()` — grid write vs clock-offset write
- **enabled-toggle predicate**: `GeneralVariables.autoUpdateGridFromGPS` vs `disciplineClockFromGPS`
- **permission requirement**: dual FINE/COARSE (grid) vs FINE-only (GPS clock, unchanged rationale comment)

Both classes are now thin subclasses. `GpsClockUpdater` keeps its pre-GPS baseline capture (`onSubscribed`) and restore-on-disable (`stop()` override) exactly as before.

## What stayed put

- All pure, unit-tested static helpers stay on their original classes: `gridUpdateFor`, `gpsUtcNow`, `gpsClockOffsetMs`, `isOffsetSane`, `clampIntervalMinutes`, `parseIntervalMinutes`, `disciplinedUtcMs`, `shouldResubscribe`, `computeAppliedOffset`.
- Public API is unchanged: `getInstance(Context)`, `GridLocationUpdater.refresh(Context, MainViewModel)`, `GpsClockUpdater.refresh(Context)` — no caller edits (`ComposeMainActivity`, `SettingsScreen`, `TimeSyncSettings`, `DatabaseOpr` untouched).
- Behavior preserved to the letter: same check ordering (prepare → permission → manager → subscribe → bootstrap), same log messages, same exception handling, same `volatile running` race guard for a fix that lands after disable. One subtlety kept intentionally: the grid updater latches its `MainViewModel` only when a start actually proceeds, mirroring the old anonymous-listener capture (a `refresh()` while already running keeps writing through the originally captured view model).

## Tests

- New `LocationSubscriberTest` (11 tests) drives the shared lifecycle through a fake subclass: toggle dispatch both ways, prepare-gate short-circuit, permission veto, subscribe-failure (no bootstrap posted), main-looper bootstrap, live-fix dispatch, no-churn refresh while running, re-tune resubscribe path, and the late-fix-after-stop guard contract.
- `GridLocationUpdaterTest` and `GpsClockUpdaterTest` keep all existing pure-logic tests unchanged and gain toggle-off / permission-denied gating tests (the GPS one also asserts `UtcTimer.delay` is untouched by a vetoed start).
- Full suite: `gradlew testDebugUnitTest` — **1183 tests, 0 failures, 0 errors** (location package: 42 tests passing).

## Notes

Pure refactor — no user-facing change intended. Per the issue's acceptance note, on-device verification of grid auto-update and GPS clock discipline (enable / interval change / disable-restore) is still advised before relying on it in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)