### PR TITLE
Save TX output level per band (issue #355)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -92,7 +92,10 @@ public class GeneralVariables {
     public static MutableLiveData<Boolean> mutableShowTxVolumeSlider = new MutableLiveData<>(true);
 
     //Save TX output level per band (issue #355), defaults off (global level only).
-    public static boolean savePerBandOutputLevel = false;
+    // volatile: written from DatabaseOpr's background config-load thread and the
+    // Settings toggle, read from UI + MeterProtectionController threads (same
+    // convention as zoneMapReady/huntPotaOnly/perBandOutputLevels below).
+    public static volatile boolean savePerBandOutputLevel = false;
     //Serialized band=level CSV ("20m=60,40m=85"); parsed/updated in PerBandOutputLevel.kt.
     public static volatile String perBandOutputLevels = "";
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -91,6 +91,11 @@ public class GeneralVariables {
     public static boolean showTxVolumeSlider = true;//Show inline TX volume slider on main screen
     public static MutableLiveData<Boolean> mutableShowTxVolumeSlider = new MutableLiveData<>(true);
 
+    //Save TX output level per band (issue #355), defaults off (global level only).
+    public static boolean savePerBandOutputLevel = false;
+    //Serialized band=level CSV ("20m=60,40m=85"); parsed/updated in PerBandOutputLevel.kt.
+    public static volatile String perBandOutputLevels = "";
+
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2577,6 +2577,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.showTxVolumeSlider = !result.equals("0");
                     GeneralVariables.mutableShowTxVolumeSlider.postValue(GeneralVariables.showTxVolumeSlider);
                 }
+                if (name.equalsIgnoreCase("perBandOutputLevel")) {//Save TX output level per band, defaults off
+                    GeneralVariables.savePerBandOutputLevel = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("perBandOutputLevels")) {//Per-band TX output levels ("20m=60,40m=85")
+                    GeneralVariables.perBandOutputLevels = result == null ? "" : result;
+                }
                 if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/MeterProtectionController.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/MeterProtectionController.java
@@ -224,7 +224,8 @@ public class MeterProtectionController {
             com.k1af.ft8af.database.DatabaseOpr db =
                     com.k1af.ft8af.database.DatabaseOpr.getInstance(ctx, "data.db");
             if (db != null) {
-                int pct = Math.round(GeneralVariables.volumePercent * 100);
+                int pct = radio.ks3ckc.ft8af.PerBandOutputLevelKt
+                        .outputLevelFromVolumePercent(GeneralVariables.volumePercent);
                 db.writeConfig("volumeValue", String.valueOf(pct), null);
                 // Keep the per-band map in step with a protective auto-reduction
                 // (high SWR/ALC is band/antenna specific) so re-entering the band

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/MeterProtectionController.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/MeterProtectionController.java
@@ -226,6 +226,11 @@ public class MeterProtectionController {
             if (db != null) {
                 int pct = Math.round(GeneralVariables.volumePercent * 100);
                 db.writeConfig("volumeValue", String.valueOf(pct), null);
+                // Keep the per-band map in step with a protective auto-reduction
+                // (high SWR/ALC is band/antenna specific) so re-entering the band
+                // doesn't restore the level that tripped protection. No-op when
+                // per-band levels are disabled.
+                radio.ks3ckc.ft8af.PerBandOutputLevelKt.saveOutputLevelForCurrentBand(db, pct);
             }
         } catch (Exception e) {
             Log.w(TAG, "Failed to persist volume", e);

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -698,6 +698,7 @@ class ComposeMainActivity : AppCompatActivity() {
                 val intVal = (newVol * 100).toInt()
                 mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(intVal)
+                saveOutputLevelForCurrentBand(mainViewModel.databaseOpr, intVal)
 
                 // Also adjust system music stream so audio is actually audible
                 val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -695,7 +695,9 @@ class ComposeMainActivity : AppCompatActivity() {
                 val newVol = (GeneralVariables.volumePercent + delta).coerceIn(0.0f, 1.0f)
                 GeneralVariables.volumePercent = newVol
                 GeneralVariables.mutableVolumePercent.postValue(newVol)
-                val intVal = (newVol * 100).toInt()
+                // Math.round via the shared helper (not toInt/floor) so this
+                // producer agrees with the per-band restore/compare logic.
+                val intVal = outputLevelFromVolumePercent(newVol)
                 mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(intVal)
                 saveOutputLevelForCurrentBand(mainViewModel.databaseOpr, intVal)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -371,6 +371,7 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 onVolumeChangeFinished = {
                     mainViewModel.databaseOpr.writeConfig("volumeValue", txVolume.toString(), null)
                     mainViewModel.baseRig?.connector?.setRFVolume(txVolume)
+                    saveOutputLevelForCurrentBand(mainViewModel.databaseOpr, txVolume)
                 },
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevel.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevel.kt
@@ -91,20 +91,49 @@ internal fun recordPerBandOutputLevel(
 }
 
 /**
+ * Convert a 0.0-1.0 volume fraction to the 0-100 integer level used by the
+ * "volumeValue" config and the per-band map. Uses Math.round (not toInt/floor)
+ * so every producer and consumer of the level agrees on the same integer —
+ * float representation error (e.g. 0.7f * 100 == 69.99999...) would otherwise
+ * make a floored writer disagree with a rounding comparer by one, causing
+ * spurious per-band writes/restore toasts.
+ */
+fun outputLevelFromVolumePercent(volumePercent: Float): Int =
+    Math.round(volumePercent * 100).coerceIn(0, 100)
+
+/** Serializes all per-band map read-modify-writes (UI thread + MeterProtectionController). */
+private val perBandOutputLevelLock = Any()
+
+/**
  * Record [level] (0-100) as the saved output level for the current band and
  * persist the updated map. No-op when the per-band feature is disabled or
  * the value is unchanged. Call wherever the output level is adjusted.
  */
 fun saveOutputLevelForCurrentBand(databaseOpr: DatabaseOpr, level: Int) {
     val band = BaseRigOperation.getMeterFromFreq(GeneralVariables.band)
-    val serialized = recordPerBandOutputLevel(
-        GeneralVariables.savePerBandOutputLevel,
-        band,
-        level,
-        GeneralVariables.perBandOutputLevels,
-    ) ?: return
-    GeneralVariables.perBandOutputLevels = serialized
-    databaseOpr.writeConfig(PER_BAND_OUTPUT_LEVELS_KEY, serialized, null)
+    saveOutputLevelForBand(band, level) { serialized ->
+        databaseOpr.writeConfig(PER_BAND_OUTPUT_LEVELS_KEY, serialized, null)
+    }
+}
+
+/**
+ * Synchronized read-modify-write of GeneralVariables.perBandOutputLevels.
+ * Callers race (a TxStrip/Settings adjustment on the UI thread vs a
+ * MeterProtectionController auto-reduction on a background thread); without
+ * the lock a stale read could drop the other writer's band entry. [persist]
+ * runs inside the lock, only when the map actually changed.
+ */
+internal fun saveOutputLevelForBand(band: String?, level: Int, persist: (String) -> Unit) {
+    synchronized(perBandOutputLevelLock) {
+        val serialized = recordPerBandOutputLevel(
+            GeneralVariables.savePerBandOutputLevel,
+            band,
+            level,
+            GeneralVariables.perBandOutputLevels,
+        ) ?: return
+        GeneralVariables.perBandOutputLevels = serialized
+        persist(serialized)
+    }
 }
 
 /**
@@ -116,5 +145,5 @@ fun restoredOutputLevelForBand(band: String?): Int? = resolvePerBandOutputLevel(
     GeneralVariables.savePerBandOutputLevel,
     band,
     GeneralVariables.perBandOutputLevels,
-    Math.round(GeneralVariables.volumePercent * 100),
+    outputLevelFromVolumePercent(GeneralVariables.volumePercent),
 )

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevel.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevel.kt
@@ -1,0 +1,120 @@
+package radio.ks3ckc.ft8af
+
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.database.DatabaseOpr
+import com.k1af.ft8af.rigs.BaseRigOperation
+
+/**
+ * Per-band TX output level support (issue #355).
+ *
+ * When "Save output level per band" is enabled, the app remembers the TX
+ * output level (0-100, same scale as the "volumeValue" config) separately
+ * for each band and restores it when the operator switches bands. Bands
+ * with no saved value fall back to the current global level, unchanged.
+ *
+ * Persistence follows the excludedBands convention: a single config row
+ * holding a comma-separated list, here of "band=level" pairs
+ * (e.g. "20m=60,40m=85") under the key [PER_BAND_OUTPUT_LEVELS_KEY].
+ *
+ * The decision logic below is pure (no Android types) so it can be
+ * unit-tested directly; the two `*ForCurrentBand` helpers at the bottom
+ * are thin wiring around GeneralVariables/DatabaseOpr.
+ */
+
+/** Config key for the feature toggle ("1" = enabled, default off). */
+const val PER_BAND_OUTPUT_LEVEL_KEY = "perBandOutputLevel"
+
+/** Config key for the serialized band-to-level map. */
+const val PER_BAND_OUTPUT_LEVELS_KEY = "perBandOutputLevels"
+
+/**
+ * Parse a serialized "band=level" CSV ("20m=60,40m=85") into an ordered map.
+ * Malformed entries (missing '=', non-numeric level, blank band) are skipped;
+ * levels are clamped to 0..100. Null/blank input yields an empty map.
+ */
+internal fun parsePerBandOutputLevels(serialized: String?): LinkedHashMap<String, Int> {
+    val levels = LinkedHashMap<String, Int>()
+    if (serialized.isNullOrBlank()) return levels
+    for (entry in serialized.split(',')) {
+        val idx = entry.indexOf('=')
+        if (idx <= 0) continue
+        val band = entry.substring(0, idx).trim()
+        if (band.isEmpty()) continue
+        val level = entry.substring(idx + 1).trim().toIntOrNull() ?: continue
+        levels[band] = level.coerceIn(0, 100)
+    }
+    return levels
+}
+
+/** Serialize a band-to-level map back to the "20m=60,40m=85" config format. */
+internal fun serializePerBandOutputLevels(levels: Map<String, Int>): String =
+    levels.entries.joinToString(",") { (band, level) -> "$band=$level" }
+
+/**
+ * Decide whether switching to [band] should restore a saved output level.
+ *
+ * @return the saved level (0-100) to apply, or null when nothing should
+ *   change: feature disabled, unknown band, no saved value for the band
+ *   (global fallback), or the saved value already equals [currentLevel].
+ */
+internal fun resolvePerBandOutputLevel(
+    enabled: Boolean,
+    band: String?,
+    serialized: String?,
+    currentLevel: Int,
+): Int? {
+    if (!enabled || band.isNullOrBlank()) return null
+    val saved = parsePerBandOutputLevels(serialized)[band] ?: return null
+    return if (saved == currentLevel) null else saved
+}
+
+/**
+ * Decide whether an output-level adjustment to [level] on [band] changes the
+ * persisted per-band map.
+ *
+ * @return the new serialized map to persist, or null when nothing needs
+ *   persisting (feature disabled, unknown band, or the band already stores
+ *   this exact level).
+ */
+internal fun recordPerBandOutputLevel(
+    enabled: Boolean,
+    band: String?,
+    level: Int,
+    serialized: String?,
+): String? {
+    if (!enabled || band.isNullOrBlank()) return null
+    val clamped = level.coerceIn(0, 100)
+    val levels = parsePerBandOutputLevels(serialized)
+    if (levels[band] == clamped) return null
+    levels[band] = clamped
+    return serializePerBandOutputLevels(levels)
+}
+
+/**
+ * Record [level] (0-100) as the saved output level for the current band and
+ * persist the updated map. No-op when the per-band feature is disabled or
+ * the value is unchanged. Call wherever the output level is adjusted.
+ */
+fun saveOutputLevelForCurrentBand(databaseOpr: DatabaseOpr, level: Int) {
+    val band = BaseRigOperation.getMeterFromFreq(GeneralVariables.band)
+    val serialized = recordPerBandOutputLevel(
+        GeneralVariables.savePerBandOutputLevel,
+        band,
+        level,
+        GeneralVariables.perBandOutputLevels,
+    ) ?: return
+    GeneralVariables.perBandOutputLevels = serialized
+    databaseOpr.writeConfig(PER_BAND_OUTPUT_LEVELS_KEY, serialized, null)
+}
+
+/**
+ * Look up the saved output level for [band], or null when the current level
+ * should be kept (feature off, no saved value, or already at that level).
+ * Pure lookup — the caller applies/persists/toasts the result.
+ */
+fun restoredOutputLevelForBand(band: String?): Int? = resolvePerBandOutputLevel(
+    GeneralVariables.savePerBandOutputLevel,
+    band,
+    GeneralVariables.perBandOutputLevels,
+    Math.round(GeneralVariables.volumePercent * 100),
+)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
@@ -63,6 +63,23 @@ fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) 
         mainViewModel.clearDecodesAndTarget()
     }
 
+    // Per-band output level (issue #355): when enabled and this band has a
+    // saved level that differs from the current one, restore it and tell the
+    // operator where the change came from. Bands with no saved value keep the
+    // current (global) level.
+    val restoredLevel = radio.ks3ckc.ft8af.restoredOutputLevelForBand(newWaveLength)
+    if (restoredLevel != null) {
+        GeneralVariables.volumePercent = restoredLevel / 100f
+        GeneralVariables.mutableVolumePercent.postValue(restoredLevel / 100f)
+        mainViewModel.databaseOpr.writeConfig("volumeValue", restoredLevel.toString(), null)
+        mainViewModel.baseRig?.connector?.setRFVolume(restoredLevel)
+        android.widget.Toast.makeText(
+            context,
+            context.getString(R.string.per_band_volume_restored, restoredLevel, newWaveLength),
+            android.widget.Toast.LENGTH_SHORT,
+        ).show()
+    }
+
     val cm = GeneralVariables.controlMode
     val connected = mainViewModel.isRigConnected()
     android.util.Log.d(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -45,6 +45,7 @@ import com.k1af.ft8af.rigs.BaseRigOperation
 import com.k1af.ft8af.rigs.InstructionSet
 import com.k1af.ft8af.ui.AudioDeviceSpinnerAdapter
 import radio.ks3ckc.ft8af.PER_BAND_OUTPUT_LEVEL_KEY
+import radio.ks3ckc.ft8af.outputLevelFromVolumePercent
 import radio.ks3ckc.ft8af.saveOutputLevelForCurrentBand
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.FT8AFIconButton
@@ -654,7 +655,7 @@ fun RadioAudioSettings(
                                 if (enabled) {
                                     saveOutputLevelForCurrentBand(
                                         mainViewModel.databaseOpr,
-                                        Math.round(GeneralVariables.volumePercent * 100),
+                                        outputLevelFromVolumePercent(GeneralVariables.volumePercent),
                                     )
                                 }
                             },

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -44,6 +44,8 @@ import com.k1af.ft8af.database.RigNameList
 import com.k1af.ft8af.rigs.BaseRigOperation
 import com.k1af.ft8af.rigs.InstructionSet
 import com.k1af.ft8af.ui.AudioDeviceSpinnerAdapter
+import radio.ks3ckc.ft8af.PER_BAND_OUTPUT_LEVEL_KEY
+import radio.ks3ckc.ft8af.saveOutputLevelForCurrentBand
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.FT8AFIconButton
 import radio.ks3ckc.ft8af.ui.components.FT8AFIcons
@@ -431,6 +433,7 @@ fun RadioAudioSettings(
                 showTxVolume = false
                 mainViewModel.databaseOpr.writeConfig("volumeValue", txVolume.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(txVolume)
+                saveOutputLevelForCurrentBand(mainViewModel.databaseOpr, txVolume)
             },
         )
     }
@@ -627,6 +630,33 @@ fun RadioAudioSettings(
                                 mainViewModel.databaseOpr.writeConfig(
                                     "showTxVolumeSlider", if (enabled) "1" else "0", null,
                                 )
+                            },
+                        )
+                    }
+                    SectionDivider()
+                    run {
+                        var perBand by remember {
+                            mutableStateOf(GeneralVariables.savePerBandOutputLevel)
+                        }
+                        SettingsRow(
+                            label = stringResource(R.string.settings_per_band_volume),
+                            description = stringResource(R.string.settings_per_band_volume_desc),
+                            toggle = perBand,
+                            onToggleChange = { enabled ->
+                                perBand = enabled
+                                GeneralVariables.savePerBandOutputLevel = enabled
+                                mainViewModel.databaseOpr.writeConfig(
+                                    PER_BAND_OUTPUT_LEVEL_KEY, if (enabled) "1" else "0", null,
+                                )
+                                // Seed the current band with the current (global) level so
+                                // it is remembered from the moment the feature turns on;
+                                // other bands fall back to the global level until adjusted.
+                                if (enabled) {
+                                    saveOutputLevelForCurrentBand(
+                                        mainViewModel.databaseOpr,
+                                        Math.round(GeneralVariables.volumePercent * 100),
+                                    )
+                                }
                             },
                         )
                     }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -456,6 +456,9 @@
     <string name="settings_tx_volume_desc" formatted="false">Transmit audio level (hardware buttons ±5%)</string>
     <string name="settings_show_volume_slider">Show Volume Slider</string>
     <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_per_band_volume">Save Output Level per Band</string>
+    <string name="settings_per_band_volume_desc">Remember the TX volume separately for each band and restore it on band change</string>
+    <string name="per_band_volume_restored">TX volume %1$d%% restored for %2$s</string>
 
     <!-- ===== Settings: transmission ===== -->
     <string name="settings_tx_rx_split">TX/RX Split</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevelTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevelTest.kt
@@ -156,4 +156,49 @@ class PerBandOutputLevelTest {
         // On 17m (never saved): fall back to current/global level.
         assertThat(resolvePerBandOutputLevel(true, "17m", serialized, 85)).isNull()
     }
+
+    // ---- outputLevelFromVolumePercent (shared percent -> 0-100 conversion) ----
+
+    @Test
+    fun outputLevel_roundsInsteadOfFlooring() {
+        // volumePercent is not always an exact multiple of 0.01 (slider drags
+        // and accumulated 0.05f key-steps produce arbitrary fractions). For a
+        // value like 0.699, toInt() (the old hardware-volume-key path) floors
+        // 69.9 to 69 while the per-band restore/compare used Math.round -> 70,
+        // producing off-by-one map entries and spurious restore toasts. The
+        // shared helper must round like the comparer does.
+        assertThat((0.699f * 100).toInt()).isEqualTo(69) // documents the floor/round divergence
+        assertThat(outputLevelFromVolumePercent(0.699f)).isEqualTo(70)
+        assertThat(outputLevelFromVolumePercent(0.7f)).isEqualTo(70)
+    }
+
+    @Test
+    fun outputLevel_matchesEveryFivePercentVolumeKeyStep() {
+        // The hardware volume keys step by 0.05; every reachable step must map
+        // to the exact multiple of 5 the user sees in the toast.
+        var vol = 0.0f
+        for (step in 0..20) {
+            assertThat(outputLevelFromVolumePercent(vol)).isEqualTo(step * 5)
+            vol = (vol + 0.05f).coerceIn(0.0f, 1.0f)
+        }
+    }
+
+    @Test
+    fun outputLevel_agreesWithRestoreComparison() {
+        // A level produced by the helper and stored in the map must compare
+        // equal in resolve (no restore) for the same volumePercent.
+        val level = outputLevelFromVolumePercent(0.7f)
+        val serialized = recordPerBandOutputLevel(true, "20m", level, "")!!
+        assertThat(
+            resolvePerBandOutputLevel(true, "20m", serialized, outputLevelFromVolumePercent(0.7f)),
+        ).isNull()
+    }
+
+    @Test
+    fun outputLevel_clampsToValidRange() {
+        assertThat(outputLevelFromVolumePercent(-0.2f)).isEqualTo(0)
+        assertThat(outputLevelFromVolumePercent(0.0f)).isEqualTo(0)
+        assertThat(outputLevelFromVolumePercent(1.0f)).isEqualTo(100)
+        assertThat(outputLevelFromVolumePercent(1.2f)).isEqualTo(100)
+    }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevelTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevelTest.kt
@@ -1,0 +1,159 @@
+package radio.ks3ckc.ft8af
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Tests for the per-band TX output level decision logic (issue #355):
+ * parse/serialize of the "20m=60,40m=85" config format, the restore
+ * decision on band change, and the record decision on level adjustment.
+ * Pure logic — no Android types, no Robolectric.
+ */
+class PerBandOutputLevelTest {
+
+    // ---- parsePerBandOutputLevels ----
+
+    @Test
+    fun parse_nullOrBlank_returnsEmptyMap() {
+        assertThat(parsePerBandOutputLevels(null)).isEmpty()
+        assertThat(parsePerBandOutputLevels("")).isEmpty()
+        assertThat(parsePerBandOutputLevels("   ")).isEmpty()
+    }
+
+    @Test
+    fun parse_readsBandLevelPairs() {
+        val levels = parsePerBandOutputLevels("20m=60,40m=85")
+        assertThat(levels).containsExactly("20m", 60, "40m", 85).inOrder()
+    }
+
+    @Test
+    fun parse_skipsMalformedEntries() {
+        // Missing '=', empty band, non-numeric level — all skipped, valid kept.
+        val levels = parsePerBandOutputLevels("20m,=50,40m=abc,80m=70,17m=")
+        assertThat(levels).containsExactly("80m", 70)
+    }
+
+    @Test
+    fun parse_clampsLevelsTo0To100() {
+        val levels = parsePerBandOutputLevels("20m=150,40m=-5")
+        assertThat(levels).containsExactly("20m", 100, "40m", 0)
+    }
+
+    @Test
+    fun parse_trimsWhitespaceAroundBandAndLevel() {
+        val levels = parsePerBandOutputLevels(" 20m = 60 , 40m = 85 ")
+        assertThat(levels).containsExactly("20m", 60, "40m", 85)
+    }
+
+    @Test
+    fun parse_lastDuplicateWins() {
+        val levels = parsePerBandOutputLevels("20m=60,20m=75")
+        assertThat(levels).containsExactly("20m", 75)
+    }
+
+    // ---- serializePerBandOutputLevels ----
+
+    @Test
+    fun serialize_roundTripsThroughParse() {
+        val original = linkedMapOf("20m" to 60, "40m" to 85, "70cm" to 30)
+        val serialized = serializePerBandOutputLevels(original)
+        assertThat(serialized).isEqualTo("20m=60,40m=85,70cm=30")
+        assertThat(parsePerBandOutputLevels(serialized)).isEqualTo(original)
+    }
+
+    @Test
+    fun serialize_emptyMap_isEmptyString() {
+        assertThat(serializePerBandOutputLevels(emptyMap())).isEmpty()
+    }
+
+    // ---- resolvePerBandOutputLevel (restore on band change) ----
+
+    @Test
+    fun resolve_disabled_returnsNull() {
+        assertThat(
+            resolvePerBandOutputLevel(false, "20m", "20m=60", currentLevel = 80),
+        ).isNull()
+    }
+
+    @Test
+    fun resolve_unknownBand_returnsNull() {
+        assertThat(resolvePerBandOutputLevel(true, null, "20m=60", 80)).isNull()
+        assertThat(resolvePerBandOutputLevel(true, "", "20m=60", 80)).isNull()
+    }
+
+    @Test
+    fun resolve_bandWithoutSavedValue_fallsBackToGlobal() {
+        // No entry for 40m — return null so the caller keeps the current level.
+        assertThat(resolvePerBandOutputLevel(true, "40m", "20m=60", 80)).isNull()
+        assertThat(resolvePerBandOutputLevel(true, "40m", "", 80)).isNull()
+    }
+
+    @Test
+    fun resolve_savedValueDiffers_returnsSavedLevel() {
+        assertThat(
+            resolvePerBandOutputLevel(true, "20m", "20m=60,40m=85", currentLevel = 80),
+        ).isEqualTo(60)
+    }
+
+    @Test
+    fun resolve_savedValueEqualsCurrent_returnsNull() {
+        // Already at the saved level — nothing to restore, no toast.
+        assertThat(
+            resolvePerBandOutputLevel(true, "20m", "20m=80", currentLevel = 80),
+        ).isNull()
+    }
+
+    // ---- recordPerBandOutputLevel (save on level adjustment) ----
+
+    @Test
+    fun record_disabled_returnsNull() {
+        assertThat(recordPerBandOutputLevel(false, "20m", 60, "")).isNull()
+    }
+
+    @Test
+    fun record_unknownBand_returnsNull() {
+        assertThat(recordPerBandOutputLevel(true, null, 60, "")).isNull()
+        assertThat(recordPerBandOutputLevel(true, "", 60, "")).isNull()
+    }
+
+    @Test
+    fun record_newBand_appendsEntry() {
+        assertThat(recordPerBandOutputLevel(true, "40m", 85, "20m=60"))
+            .isEqualTo("20m=60,40m=85")
+    }
+
+    @Test
+    fun record_firstEntry_fromEmptyConfig() {
+        assertThat(recordPerBandOutputLevel(true, "20m", 60, null)).isEqualTo("20m=60")
+        assertThat(recordPerBandOutputLevel(true, "20m", 60, "")).isEqualTo("20m=60")
+    }
+
+    @Test
+    fun record_existingBand_updatesInPlace() {
+        assertThat(recordPerBandOutputLevel(true, "20m", 45, "20m=60,40m=85"))
+            .isEqualTo("20m=45,40m=85")
+    }
+
+    @Test
+    fun record_unchangedLevel_returnsNullSoNothingIsPersisted() {
+        assertThat(recordPerBandOutputLevel(true, "20m", 60, "20m=60,40m=85")).isNull()
+    }
+
+    @Test
+    fun record_clampsLevelBeforeComparingAndStoring() {
+        assertThat(recordPerBandOutputLevel(true, "20m", 150, "")).isEqualTo("20m=100")
+        // Clamped value already stored — no persist needed.
+        assertThat(recordPerBandOutputLevel(true, "20m", 150, "20m=100")).isNull()
+    }
+
+    @Test
+    fun record_thenResolve_restoresWhatWasRecorded() {
+        // Full save/switch-away/switch-back cycle at the logic level.
+        var serialized = recordPerBandOutputLevel(true, "20m", 60, "")!!
+        serialized = recordPerBandOutputLevel(true, "40m", 85, serialized)!!
+        // Back on 20m at some other level: the saved 60 comes back.
+        assertThat(resolvePerBandOutputLevel(true, "20m", serialized, 85)).isEqualTo(60)
+        // On 17m (never saved): fall back to current/global level.
+        assertThat(resolvePerBandOutputLevel(true, "17m", serialized, 85)).isNull()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevelWiringTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/PerBandOutputLevelWiringTest.kt
@@ -1,0 +1,111 @@
+package radio.ks3ckc.ft8af
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.GeneralVariables
+import java.lang.reflect.Modifier
+import java.util.concurrent.CountDownLatch
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for the stateful per-band output level wiring (issue #355, PR #386
+ * review): [saveOutputLevelForBand]'s synchronized read-modify-write of
+ * GeneralVariables.perBandOutputLevels, and the cross-thread visibility
+ * (volatile) contract of the backing statics. Robolectric because
+ * GeneralVariables carries Android LiveData statics.
+ */
+@RunWith(RobolectricTestRunner::class)
+class PerBandOutputLevelWiringTest {
+
+    private var savedEnabled = false
+    private var savedLevels = ""
+
+    @Before
+    fun saveGlobals() {
+        savedEnabled = GeneralVariables.savePerBandOutputLevel
+        savedLevels = GeneralVariables.perBandOutputLevels
+    }
+
+    @After
+    fun restoreGlobals() {
+        GeneralVariables.savePerBandOutputLevel = savedEnabled
+        GeneralVariables.perBandOutputLevels = savedLevels
+    }
+
+    // ---- volatile contract (review comment: stale reads across threads) ----
+
+    @Test
+    fun perBandStatics_areVolatile_forCrossThreadVisibility() {
+        // Written from DatabaseOpr's background config-load thread, read from
+        // UI + MeterProtectionController threads. Both must stay volatile.
+        val toggle = GeneralVariables::class.java.getField("savePerBandOutputLevel")
+        val map = GeneralVariables::class.java.getField("perBandOutputLevels")
+        assertThat(Modifier.isVolatile(toggle.modifiers)).isTrue()
+        assertThat(Modifier.isVolatile(map.modifiers)).isTrue()
+    }
+
+    // ---- saveOutputLevelForBand (synchronized read-modify-write) ----
+
+    @Test
+    fun save_disabled_changesNothingAndDoesNotPersist() {
+        GeneralVariables.savePerBandOutputLevel = false
+        GeneralVariables.perBandOutputLevels = "20m=60"
+        var persisted: String? = null
+        saveOutputLevelForBand("40m", 85) { persisted = it }
+        assertThat(GeneralVariables.perBandOutputLevels).isEqualTo("20m=60")
+        assertThat(persisted).isNull()
+    }
+
+    @Test
+    fun save_enabled_updatesMapAndPersistsSameValue() {
+        GeneralVariables.savePerBandOutputLevel = true
+        GeneralVariables.perBandOutputLevels = "20m=60"
+        var persisted: String? = null
+        saveOutputLevelForBand("40m", 85) { persisted = it }
+        assertThat(GeneralVariables.perBandOutputLevels).isEqualTo("20m=60,40m=85")
+        assertThat(persisted).isEqualTo("20m=60,40m=85")
+    }
+
+    @Test
+    fun save_unchangedLevel_doesNotPersist() {
+        GeneralVariables.savePerBandOutputLevel = true
+        GeneralVariables.perBandOutputLevels = "20m=60"
+        var persistCalls = 0
+        saveOutputLevelForBand("20m", 60) { persistCalls++ }
+        assertThat(persistCalls).isEqualTo(0)
+        assertThat(GeneralVariables.perBandOutputLevels).isEqualTo("20m=60")
+    }
+
+    @Test
+    fun save_concurrentWritersOnDifferentBands_loseNoUpdates() {
+        // UI adjustments and MeterProtectionController auto-reductions can run
+        // concurrently. Unsynchronized, the read-modify-write of the serialized
+        // map lets one writer clobber another band's entry (last writer wins on
+        // stale input). With the lock, every band's final write must survive.
+        GeneralVariables.savePerBandOutputLevel = true
+        GeneralVariables.perBandOutputLevels = ""
+        val bands = (1..8).map { "b$it" }
+        val finalLevelFor = { i: Int -> 90 + i } // distinct per band, within 0..100
+        val start = CountDownLatch(1)
+        val threads = bands.mapIndexed { i, band ->
+            Thread {
+                start.await()
+                // Churn the shared map, then land on this band's final value.
+                repeat(200) { n -> saveOutputLevelForBand(band, n % 90) {} }
+                saveOutputLevelForBand(band, finalLevelFor(i)) {}
+            }
+        }
+        threads.forEach { it.start() }
+        start.countDown()
+        threads.forEach { it.join(30_000) }
+
+        val result = parsePerBandOutputLevels(GeneralVariables.perBandOutputLevels)
+        assertThat(result.keys).containsExactlyElementsIn(bands)
+        bands.forEachIndexed { i, band ->
+            assertThat(result[band]).isEqualTo(finalLevelFor(i))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #355

## What

Adds a **"Save Output Level per Band"** toggle to Settings > Audio (below "Show Volume Slider"). Default **off** — with the toggle off, nothing changes from today's single global output level.

When enabled:

- **Persistence** — a band→level map is stored in the existing config table under `perBandOutputLevels`, serialized excludedBands-style as a CSV of `band=level` pairs (e.g. `20m=60,40m=85`). The toggle persists under `perBandOutputLevel`. Both keys ride along in the settings backup export automatically (it dumps the whole config table).
- **Restore on band change** — `selectBandIndex` (the shared band-switch path used by both the Settings band picker and the TxStrip frequency picker) looks up the new band's saved level and, if it differs from the current level, applies it everywhere: `GeneralVariables.volumePercent`, the persisted `volumeValue`, the rig's RF volume, and the inline TxStrip slider (via `mutableVolumePercent`). A short toast ("TX volume 60% restored for 20m") tells the operator the change came from the saved band setting.
- **Fallback** — bands with no saved value keep the current (global) level; no toast, no writes.
- **Save on adjust** — adjusting the level from the TxStrip inline slider, the Settings TX Volume dialog, or the hardware volume keys immediately records it for the current band. A meter-protection auto-reduction also updates the band's entry, so re-entering the band doesn't restore the level that tripped SWR/ALC protection. Turning the toggle on seeds the current band with the current global level.

## How

Per repo convention, the decision logic is extracted into pure top-level functions in `PerBandOutputLevel.kt` (`parsePerBandOutputLevels`, `serializePerBandOutputLevels`, `resolvePerBandOutputLevel`, `recordPerBandOutputLevel`) with thin wiring helpers; the Compose/Java call sites just call those. Malformed config entries are skipped and levels are clamped to 0–100 on parse.

## Tests

- New `PerBandOutputLevelTest.kt`: 21 tests covering parse (malformed entries, clamping, duplicates, whitespace), serialize round-trip, restore decision (disabled / unknown band / no saved value fallback / differing value / already-equal value), and record decision (disabled, new band, update-in-place, unchanged no-op, clamping, full save→switch→restore cycle). All pass, no Robolectric needed (pure logic).
- Full `testDebugUnitTest` suite: **BUILD SUCCESSFUL**, 0 failures.
- `assembleDebug`: **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)