### PR TITLE
Add RX input volume control + live input-level indicator (#356)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -88,6 +88,15 @@ public class GeneralVariables {
     public static MutableLiveData<Float> mutableVolumePercent = new MutableLiveData<>();
     public static float volumePercent = 0.8f;//Audio playback volume, as a percentage
 
+    // RX input gain (issue #356): multiplier applied to incoming audio samples
+    // before resampling/decoding. 1.0 = 100% = unchanged behavior. Persisted
+    // under the "inputVolume" config key as a percent (0..200).
+    public static volatile float inputGainPercent = 1.0f;
+    // Live RX input level (peak + short-term RMS of post-gain samples),
+    // published by HamRecorder once per metering window for the UI meter.
+    public static final MutableLiveData<com.k1af.ft8af.wave.InputAudioLevel.Levels>
+            mutableInputLevel = new MutableLiveData<>();
+
     public static boolean showTxVolumeSlider = true;//Show inline TX volume slider on main screen
     public static MutableLiveData<Boolean> mutableShowTxVolumeSlider = new MutableLiveData<>(true);
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -34,6 +34,7 @@ import com.k1af.ft8af.log.QSLRecord;
 import com.k1af.ft8af.log.QSLRecordStr;
 import com.k1af.ft8af.rigs.BaseRigOperation;
 import com.k1af.ft8af.timer.UtcTimer;
+import com.k1af.ft8af.wave.InputAudioLevel;
 
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
@@ -2574,8 +2575,11 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.mutableVolumePercent.postValue(GeneralVariables.volumePercent);
                 }
                 if (name.equalsIgnoreCase("inputVolume")) {//RX input gain (percent, 100 = unity)
-                    GeneralVariables.inputGainPercent =
-                            result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
+                    //Defensive parse + clamp: the config value is a free-form
+                    //string and settings import (#382) can feed a corrupted or
+                    //out-of-range value through here at startup. Non-numeric
+                    //falls back to unity; numeric clamps to 0..200%.
+                    GeneralVariables.inputGainPercent = InputAudioLevel.parseGainPercent(result);
                 }
                 if (name.equalsIgnoreCase("showTxVolumeSlider")) {//Inline TX volume slider visibility
                     GeneralVariables.showTxVolumeSlider = !result.equals("0");

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2573,6 +2573,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.volumePercent = result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
                     GeneralVariables.mutableVolumePercent.postValue(GeneralVariables.volumePercent);
                 }
+                if (name.equalsIgnoreCase("inputVolume")) {//RX input gain (percent, 100 = unity)
+                    GeneralVariables.inputGainPercent =
+                            result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
+                }
                 if (name.equalsIgnoreCase("showTxVolumeSlider")) {//Inline TX volume slider visibility
                     GeneralVariables.showTxVolumeSlider = !result.equals("0");
                     GeneralVariables.mutableShowTxVolumeSlider.postValue(GeneralVariables.showTxVolumeSlider);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/HamRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/HamRecorder.java
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint;
 import android.media.AudioFormat;
 import android.util.Log;
 
+import com.k1af.ft8af.GeneralVariables;
+
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -59,6 +61,12 @@ public class HamRecorder {
     private boolean isMicRecord=true;
     private MicRecorder micRecorder=new MicRecorder();
 
+    //RX input-level meter (issue #356). Fed post-gain samples in
+    //doOnWaveDataReceived; emits one Levels snapshot per 250ms window which we
+    //publish for the Compose input-level indicator. Only touched on the audio
+    //dispatch path, so no synchronization needed.
+    private final InputAudioLevel inputLevelMeter = new InputAudioLevel();
+
 
     public HamRecorder(OnVoiceMonitorChanged onVoiceMonitorChanged){
         this.onVoiceMonitorChanged=onVoiceMonitorChanged;
@@ -81,6 +89,22 @@ public class HamRecorder {
      */
     public void doOnWaveDataReceived(int bufferLen,float[] buffer){
         if (!isRunning) return;
+
+        //RX input gain (issue #356): every audio source funnels through here
+        //(mic AudioRecord, direct-USB capture, network connectors), so this is
+        //the single point where the user's input volume is applied before the
+        //samples reach the decoders and the waterfall. Buffers arrive freshly
+        //read/decoded and are copied by each monitor downstream, so the
+        //in-place multiply is safe. Unity gain is a no-op.
+        InputAudioLevel.applyGain(buffer, bufferLen, GeneralVariables.inputGainPercent);
+
+        //Meter the post-gain samples; one snapshot per ~250ms window keeps
+        //the LiveData/main-thread traffic bounded.
+        InputAudioLevel.Levels levels = inputLevelMeter.process(buffer, bufferLen);
+        if (levels != null) {
+            GeneralVariables.mutableInputLevel.postValue(levels);
+        }
+
         //for-each over the CopyOnWriteArrayList iterates one consistent
         //snapshot even if a monitor is added/removed concurrently
         for (VoiceDataMonitor monitor : voiceDataMonitorList) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/InputAudioLevel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/InputAudioLevel.java
@@ -1,0 +1,97 @@
+package com.k1af.ft8af.wave;
+
+/**
+ * RX input gain + input-level metering (issue #356).
+ *
+ * <p>{@link #applyGain} multiplies incoming float samples by the user's
+ * configured input volume before they reach the resampler / slot accumulator /
+ * decoder. It is called from {@link HamRecorder#doOnWaveDataReceived}, the
+ * single choke point every RX audio path funnels through (built-in mic
+ * AudioRecord, direct-USB capture, and the network-audio connectors), so the
+ * decoder, the waterfall FFT, and the level meter all see the same post-gain
+ * samples.
+ *
+ * <p>The instance side is a short-sliding-window level meter: it accumulates
+ * peak (max absolute sample) and sum-of-squares over {@link #WINDOW_SAMPLES}
+ * post-gain samples and emits one {@link Levels} snapshot per completed
+ * window (~4 per second at 12 kHz), which the caller posts to LiveData for
+ * the Compose UI. Emitting once per window instead of once per audio buffer
+ * keeps main-thread traffic bounded regardless of capture buffer size.
+ *
+ * <p>Plain Java with no Android dependencies so it is unit-testable on the
+ * host JVM.
+ */
+public final class InputAudioLevel {
+
+    /**
+     * Sliding-window length in samples. 3000 samples at the app-wide 12 kHz
+     * RX rate is 250 ms — short enough that the meter tracks a single FT8
+     * transmission appearing mid-slot, long enough to smooth per-buffer
+     * jitter.
+     */
+    public static final int WINDOW_SAMPLES = 3000;
+
+    /** Immutable level snapshot for one completed metering window. */
+    public static final class Levels {
+        /** Max absolute sample value in the window (1.0 = full scale). */
+        public final float peak;
+        /** Root-mean-square sample value in the window (1.0 = full scale). */
+        public final float rms;
+
+        public Levels(float peak, float rms) {
+            this.peak = peak;
+            this.rms = rms;
+        }
+    }
+
+    private double sumSquares = 0.0;
+    private float windowPeak = 0f;
+    private int count = 0;
+
+    /**
+     * Multiply the first {@code len} samples of {@code data} in place by
+     * {@code gain}. Unity gain is an exact no-op so the default 100% setting
+     * leaves the audio path bit-identical to previous releases.
+     */
+    public static void applyGain(float[] data, int len, float gain) {
+        if (data == null || gain == 1.0f) {
+            return;
+        }
+        int n = Math.min(len, data.length);
+        for (int i = 0; i < n; i++) {
+            data[i] *= gain;
+        }
+    }
+
+    /**
+     * Feed post-gain samples into the meter. Returns a {@link Levels}
+     * snapshot each time a full {@link #WINDOW_SAMPLES} window completes
+     * (possibly the last of several windows when {@code len} is huge),
+     * otherwise {@code null}. Not thread-safe; call from the single audio
+     * dispatch thread.
+     */
+    public Levels process(float[] data, int len) {
+        if (data == null) {
+            return null;
+        }
+        int n = Math.min(len, data.length);
+        Levels result = null;
+        for (int i = 0; i < n; i++) {
+            float v = data[i];
+            float abs = Math.abs(v);
+            if (abs > windowPeak) {
+                windowPeak = abs;
+            }
+            sumSquares += (double) v * v;
+            count++;
+            if (count >= WINDOW_SAMPLES) {
+                result = new Levels(windowPeak,
+                        (float) Math.sqrt(sumSquares / count));
+                sumSquares = 0.0;
+                windowPeak = 0f;
+                count = 0;
+            }
+        }
+        return result;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/InputAudioLevel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/InputAudioLevel.java
@@ -64,6 +64,45 @@ public final class InputAudioLevel {
     }
 
     /**
+     * Maximum RX input gain: the settings slider tops out at 200%, i.e. a
+     * 2.0x multiplier. {@link #parseGainPercent} clamps to this so a
+     * corrupted persisted value can never push metering or the decoders
+     * beyond what the UI can express.
+     */
+    public static final float MAX_GAIN = 2.0f;
+
+    /**
+     * Defensively parse a persisted "inputVolume" config value (a percent
+     * string, legal range 0..200) into a gain multiplier.
+     *
+     * <p>The config table stores free-form strings, and the settings
+     * backup/import feature (issue #357 / PR #382) means a hand-edited or
+     * corrupted file can feed anything through here at startup. Non-numeric,
+     * empty, or NaN input falls back to unity gain (1.0 = 100%, the
+     * default); numeric input is clamped to [0, {@link #MAX_GAIN}].
+     */
+    public static float parseGainPercent(String raw) {
+        if (raw == null) {
+            return 1.0f;
+        }
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) {
+            return 1.0f;
+        }
+        float percent;
+        try {
+            percent = Float.parseFloat(trimmed);
+        } catch (NumberFormatException nfe) {
+            return 1.0f;
+        }
+        if (Float.isNaN(percent)) {
+            return 1.0f;
+        }
+        float gain = percent / 100f;
+        return Math.max(0f, Math.min(MAX_GAIN, gain));
+    }
+
+    /**
      * Feed post-gain samples into the meter. Returns a {@link Levels}
      * snapshot each time a full {@link #WINDOW_SAMPLES} window completes
      * (possibly the last of several windows when {@code len} is huge),

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicator.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicator.kt
@@ -1,0 +1,156 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.R
+import com.k1af.ft8af.wave.InputAudioLevel
+import radio.ks3ckc.ft8af.theme.BgSurface3
+import radio.ks3ckc.ft8af.theme.GeistMonoFamily
+import radio.ks3ckc.ft8af.theme.StatusBad
+import radio.ks3ckc.ft8af.theme.StatusConfirmed
+import radio.ks3ckc.ft8af.theme.StatusWarn
+import radio.ks3ckc.ft8af.theme.StatusWorked
+import radio.ks3ckc.ft8af.theme.TextMuted
+import kotlin.math.roundToInt
+
+/**
+ * RX input-level classification (issue #356). Thresholds are on the window
+ * PEAK as a fraction of full scale:
+ *  - below [INPUT_LEVEL_LOW] .................. too low
+ *  - [INPUT_LEVEL_LOW]..[INPUT_LEVEL_HIGH] .... just right
+ *  - above [INPUT_LEVEL_HIGH] ................. too high
+ *  - at/above [INPUT_LEVEL_CLIP] .............. clipping (full-scale hit)
+ */
+internal const val INPUT_LEVEL_LOW = 0.25f
+internal const val INPUT_LEVEL_HIGH = 0.75f
+internal const val INPUT_LEVEL_CLIP = 0.99f
+
+internal enum class InputLevelStatus { TOO_LOW, JUST_RIGHT, TOO_HIGH, CLIPPING }
+
+/**
+ * Classify a metering-window peak (1.0 = full scale) into the color-coded
+ * status shown next to the meter. Boundary values 25% and 75% both count as
+ * "just right" so the advertised 25–75% window is inclusive.
+ */
+internal fun classifyInputLevel(peak: Float): InputLevelStatus = when {
+    peak >= INPUT_LEVEL_CLIP -> InputLevelStatus.CLIPPING
+    peak > INPUT_LEVEL_HIGH -> InputLevelStatus.TOO_HIGH
+    peak < INPUT_LEVEL_LOW -> InputLevelStatus.TOO_LOW
+    else -> InputLevelStatus.JUST_RIGHT
+}
+
+/** Meter-bar fill fraction for a sample level, clamped to 0..1. */
+internal fun inputLevelFraction(level: Float): Float = level.coerceIn(0f, 1f)
+
+/** Numeric readout: level as an integer percent of full scale, 0..100. */
+internal fun inputLevelPercent(level: Float): Int =
+    (inputLevelFraction(level) * 100f).roundToInt()
+
+/**
+ * Compact live RX input-level meter for the waterfall bottom strip: an
+ * RMS-filled bar with a peak tick, a percent readout of the window peak, and
+ * a color-coded status word. All decision/geometry logic lives in the plain
+ * functions above; this composable only draws.
+ */
+@Composable
+internal fun InputLevelIndicator(
+    levels: InputAudioLevel.Levels?,
+    modifier: Modifier = Modifier,
+) {
+    val peak = levels?.peak ?: 0f
+    val rms = levels?.rms ?: 0f
+    val status = classifyInputLevel(peak)
+    val color = inputLevelColor(status)
+    val statusText = stringResource(
+        when (status) {
+            InputLevelStatus.TOO_LOW -> R.string.input_level_too_low
+            InputLevelStatus.JUST_RIGHT -> R.string.input_level_good
+            InputLevelStatus.TOO_HIGH -> R.string.input_level_too_high
+            InputLevelStatus.CLIPPING -> R.string.input_level_clipping
+        },
+    )
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.input_level_rx_label),
+            color = TextMuted,
+            fontFamily = GeistMonoFamily,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.06.sp,
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        // Meter bar: RMS fill + peak tick.
+        Box(
+            modifier = Modifier
+                .width(44.dp)
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(BgSurface3),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(inputLevelFraction(rms))
+                    .fillMaxHeight()
+                    .background(color),
+            )
+            Box(
+                modifier = Modifier
+                    .offset(x = 44.dp * inputLevelFraction(peak) - 1.dp)
+                    .width(1.dp)
+                    .fillMaxHeight()
+                    .background(color),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        Text(
+            text = stringResource(R.string.settings_percent_format, inputLevelPercent(peak)),
+            color = TextMuted,
+            fontFamily = GeistMonoFamily,
+            fontSize = 9.sp,
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        Text(
+            text = statusText,
+            color = color,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.06.sp,
+        )
+    }
+}
+
+/** Status color: blue = too low, green = good, yellow = hot, red = clipping. */
+internal fun inputLevelColor(status: InputLevelStatus): Color = when (status) {
+    InputLevelStatus.TOO_LOW -> StatusWorked
+    InputLevelStatus.JUST_RIGHT -> StatusConfirmed
+    InputLevelStatus.TOO_HIGH -> StatusWarn
+    InputLevelStatus.CLIPPING -> StatusBad
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -95,8 +95,12 @@ fun RadioAudioSettings(
     }
 
     // RX input volume (issue #356): percent, 0..200, 100 = unity gain.
+    // Clamped on read so an out-of-range in-memory value (e.g. set before the
+    // defensive config-load clamp existed) can't start the row/slider invalid.
     var inputVolume by remember {
-        mutableIntStateOf((GeneralVariables.inputGainPercent * 100).toInt())
+        mutableIntStateOf(
+            clampVolumePercent((GeneralVariables.inputGainPercent * 100).toInt(), INPUT_VOLUME_MAX),
+        )
     }
 
     // Observe serial ports for USB Cable picker
@@ -453,7 +457,7 @@ fun RadioAudioSettings(
             title = stringResource(R.string.settings_input_volume),
             advice = stringResource(R.string.settings_input_volume_advice),
             initialValue = inputVolume,
-            maxValue = 200,
+            maxValue = INPUT_VOLUME_MAX,
             onChange = { value ->
                 inputVolume = value
                 GeneralVariables.inputGainPercent = value / 100f
@@ -830,7 +834,17 @@ private fun VolumeSliderDialog(
     onChange: (Int) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var current by remember { mutableIntStateOf(initialValue) }
+    // Clamp the starting value: a persisted/imported config value outside
+    // 0..maxValue must not start the slider in an invalid state.
+    var current by remember { mutableIntStateOf(clampVolumePercent(initialValue, maxValue)) }
+    // If clamping changed the value, sync it back to the caller immediately so
+    // dismissing without touching the slider persists the clamped value
+    // instead of re-persisting the out-of-range one.
+    LaunchedEffect(Unit) {
+        if (current != initialValue) {
+            onChange(current)
+        }
+    }
     Dialog(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
@@ -861,7 +875,7 @@ private fun VolumeSliderDialog(
             ) {
                 FT8AFIconButton(
                     onClick = {
-                        val clamped = (current - 5).coerceIn(0, maxValue)
+                        val clamped = clampVolumePercent(current - 5, maxValue)
                         if (clamped != current) {
                             current = clamped
                             onChange(clamped)
@@ -874,7 +888,7 @@ private fun VolumeSliderDialog(
                 IntSlider(
                     value = current,
                     onValueChange = { v ->
-                        val clamped = v.coerceIn(0, maxValue)
+                        val clamped = clampVolumePercent(v, maxValue)
                         if (clamped != current) {
                             current = clamped
                             onChange(clamped)
@@ -887,7 +901,7 @@ private fun VolumeSliderDialog(
                 )
                 FT8AFIconButton(
                     onClick = {
-                        val clamped = (current + 5).coerceIn(0, maxValue)
+                        val clamped = clampVolumePercent(current + 5, maxValue)
                         if (clamped != current) {
                             current = clamped
                             onChange(clamped)
@@ -941,3 +955,20 @@ private fun AudioDevicePickerDialog(
         onSelect = onSelect,
     )
 }
+
+/**
+ * Upper bound of the RX input volume slider, in percent (200% = 2.0x gain).
+ * Must stay in step with [com.k1af.ft8af.wave.InputAudioLevel.MAX_GAIN],
+ * which clamps the persisted value on config load.
+ */
+internal const val INPUT_VOLUME_MAX = 200
+
+/**
+ * Clamp a volume percent to a slider's legal range [0, maxValue].
+ *
+ * Used by [VolumeSliderDialog] both for the +/-/drag steps and, defensively,
+ * for the initial value: a persisted config value outside the range (possible
+ * via settings import, issue #357) must not start the slider invalid or be
+ * re-persisted unchanged on dismiss.
+ */
+internal fun clampVolumePercent(value: Int, maxValue: Int): Int = value.coerceIn(0, maxValue)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -94,6 +94,11 @@ fun RadioAudioSettings(
         txVolume = ((volumeLive ?: GeneralVariables.volumePercent) * 100).toInt()
     }
 
+    // RX input volume (issue #356): percent, 0..200, 100 = unity gain.
+    var inputVolume by remember {
+        mutableIntStateOf((GeneralVariables.inputGainPercent * 100).toInt())
+    }
+
     // Observe serial ports for USB Cable picker
     val serialPorts by mainViewModel.mutableSerialPorts.observeAsState()
 
@@ -121,6 +126,7 @@ fun RadioAudioSettings(
     var showAudioInputPicker by remember { mutableStateOf(false) }
     var showAudioOutputPicker by remember { mutableStateOf(false) }
     var showTxVolume by remember { mutableStateOf(false) }
+    var showInputVolume by remember { mutableStateOf(false) }
     var showSerialPortPicker by remember { mutableStateOf(false) }
     var showBluetoothPicker by remember { mutableStateOf(false) }
     var showFlexRadioPicker by remember { mutableStateOf(false) }
@@ -420,8 +426,11 @@ fun RadioAudioSettings(
     // in-memory volumePercent immediately so the next TX uses the new level,
     // and we persist to the config DB on dismiss.
     if (showTxVolume) {
-        TxVolumeSliderDialog(
+        VolumeSliderDialog(
+            title = stringResource(R.string.settings_tx_volume),
+            advice = stringResource(R.string.settings_tx_volume_advice),
             initialValue = txVolume,
+            maxValue = 100,
             onChange = { value ->
                 txVolume = value
                 GeneralVariables.volumePercent = value / 100f
@@ -431,6 +440,27 @@ fun RadioAudioSettings(
                 showTxVolume = false
                 mainViewModel.databaseOpr.writeConfig("volumeValue", txVolume.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(txVolume)
+            },
+        )
+    }
+
+    // -- Input Volume Editor (issue #356) --
+    // RX gain applied to incoming samples before resampling/decoding. Live
+    // update while dragging (the very next audio buffer uses the new gain);
+    // persisted to the config DB on dismiss, mirroring the TX volume dialog.
+    if (showInputVolume) {
+        VolumeSliderDialog(
+            title = stringResource(R.string.settings_input_volume),
+            advice = stringResource(R.string.settings_input_volume_advice),
+            initialValue = inputVolume,
+            maxValue = 200,
+            onChange = { value ->
+                inputVolume = value
+                GeneralVariables.inputGainPercent = value / 100f
+            },
+            onDismiss = {
+                showInputVolume = false
+                mainViewModel.databaseOpr.writeConfig("inputVolume", inputVolume.toString(), null)
             },
         )
     }
@@ -607,6 +637,14 @@ fun RadioAudioSettings(
                     )
                     SectionDivider()
                     SettingsRow(
+                        label = stringResource(R.string.settings_input_volume),
+                        description = stringResource(R.string.settings_input_volume_desc),
+                        value = stringResource(R.string.settings_percent_format, inputVolume),
+                        showChevron = true,
+                        onClick = { showInputVolume = true },
+                    )
+                    SectionDivider()
+                    SettingsRow(
                         label = stringResource(R.string.settings_tx_volume),
                         description = stringResource(R.string.settings_tx_volume_desc),
                         value = stringResource(R.string.settings_percent_format, txVolume),
@@ -778,13 +816,17 @@ private fun SerialPortPickerDialog(
 }
 
 /**
- * Slider-based TX volume editor with live update. Dragging commits the new
- * level immediately (no Save/Cancel friction — the next TX uses what you
- * dialed); we persist to the config DB only on dismiss.
+ * Slider-based volume editor with live update. Dragging commits the new
+ * level immediately (no Save/Cancel friction — the next TX / next RX buffer
+ * uses what you dialed); we persist to the config DB only on dismiss.
+ * Used for both TX volume (0–100%) and RX input volume (0–200%).
  */
 @Composable
-private fun TxVolumeSliderDialog(
+private fun VolumeSliderDialog(
+    title: String,
+    advice: String,
     initialValue: Int,
+    maxValue: Int,
     onChange: (Int) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -799,7 +841,7 @@ private fun TxVolumeSliderDialog(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = stringResource(R.string.settings_tx_volume),
+                text = title,
                 color = TextPrimary,
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 18.sp,
@@ -819,7 +861,7 @@ private fun TxVolumeSliderDialog(
             ) {
                 FT8AFIconButton(
                     onClick = {
-                        val clamped = (current - 5).coerceIn(0, 100)
+                        val clamped = (current - 5).coerceIn(0, maxValue)
                         if (clamped != current) {
                             current = clamped
                             onChange(clamped)
@@ -832,20 +874,20 @@ private fun TxVolumeSliderDialog(
                 IntSlider(
                     value = current,
                     onValueChange = { v ->
-                        val clamped = v.coerceIn(0, 100)
+                        val clamped = v.coerceIn(0, maxValue)
                         if (clamped != current) {
                             current = clamped
                             onChange(clamped)
                         }
                     },
-                    valueRange = 0f..100f,
+                    valueRange = 0f..maxValue.toFloat(),
                     modifier = Modifier.weight(1f),
                     thumbColor = Accent,
                     activeTrackColor = Accent,
                 )
                 FT8AFIconButton(
                     onClick = {
-                        val clamped = (current + 5).coerceIn(0, 100)
+                        val clamped = (current + 5).coerceIn(0, maxValue)
                         if (clamped != current) {
                             current = clamped
                             onChange(clamped)
@@ -858,7 +900,7 @@ private fun TxVolumeSliderDialog(
             }
 
             Text(
-                text = stringResource(R.string.settings_tx_volume_advice),
+                text = advice,
                 color = TextMuted,
                 fontSize = 12.sp,
                 lineHeight = 16.sp,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/waterfall/WaterfallScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/waterfall/WaterfallScreen.kt
@@ -44,6 +44,7 @@ import com.k1af.ft8af.ui.ColumnarView
 import com.k1af.ft8af.ui.SpectrumFragment
 import com.k1af.ft8af.ui.WaterfallView
 import radio.ks3ckc.ft8af.theme.*
+import radio.ks3ckc.ft8af.ui.components.InputLevelIndicator
 import radio.ks3ckc.ft8af.ui.components.TopBar
 
 /**
@@ -89,6 +90,9 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
     var updateCount by remember { mutableIntStateOf(0) }
 
     val isTransmitting by mainViewModel.ft8TransmitSignal.mutableIsTransmitting.observeAsState(false)
+    // Live RX input level (post-gain peak + RMS), published by HamRecorder
+    // once per ~250ms metering window (issue #356).
+    val inputLevels by GeneralVariables.mutableInputLevel.observeAsState()
     val txFreq by GeneralVariables.mutableBaseFrequency.observeAsState(GeneralVariables.getBaseFrequency())
     val spectrumWidth by GeneralVariables.mutableSpectrumWidth.observeAsState(GeneralVariables.getSpectrumWidth())
     var deNoise by remember { mutableStateOf(mainViewModel.deNoise) }
@@ -271,6 +275,12 @@ fun WaterfallScreen(mainViewModel: MainViewModel) {
                     mainViewModel.markMessage = showMessages
                 },
             )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            // Live RX input-level meter: too low / just right / too high, with
+            // clipping indication when peaks hit full scale.
+            InputLevelIndicator(levels = inputLevels)
 
             Spacer(modifier = Modifier.weight(1f))
 

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -535,6 +535,13 @@
     <string name="settings_enabled_bands_dialog_desc">لن تظهر النطاقات المخفية في منتقيات التردد.</string>
     <string name="settings_select_serial_port">اختر المنفذ التسلسلي</string>
     <string name="settings_tx_volume_advice">عدِّل مباشرة — يستخدم TX التالي هذا المستوى. راقب ALC في راديوك وخفِّضه حتى يلامس الخط بالكاد.</string>
+    <string name="settings_input_volume">مستوى صوت الإدخال</string>
+    <string name="settings_input_volume_desc" formatted="false">كسب صوت الاستقبال المطبق قبل فك التشفير (100% = بدون تغيير)</string>
+    <string name="settings_input_volume_advice">يُطبق على الصوت الوارد قبل فك التشفير. راقب مقياس مستوى الاستقبال على الشلال واستهدف المنطقة الخضراء؛ الأحمر يعني تشبع الإشارة.</string>
+    <string name="input_level_too_low">منخفض</string>
+    <string name="input_level_good">جيد</string>
+    <string name="input_level_too_high">مرتفع</string>
+    <string name="input_level_clipping">تشبع</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">اللغة</string>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -535,6 +535,13 @@
     <string name="settings_enabled_bands_dialog_desc">Skrytá pásma se neobjeví ve výběru frekvencí.</string>
     <string name="settings_select_serial_port">Vyberte sériový port</string>
     <string name="settings_tx_volume_advice">Upravujte naživo — vaše příští TX použije tuto úroveň. Sledujte ALC svého rádia a stahujte, dokud se právě nedotýká čáry.</string>
+    <string name="settings_input_volume">Vstupní hlasitost</string>
+    <string name="settings_input_volume_desc" formatted="false">Zesílení přijímaného zvuku před dekódováním (100 % = beze změny)</string>
+    <string name="settings_input_volume_advice">Použije se na příchozí zvuk před dekódováním. Sledujte měřič úrovně RX na vodopádu a mířte do zelené zóny; červená znamená ořezávání.</string>
+    <string name="input_level_too_low">Nízká</string>
+    <string name="input_level_good">Dobrá</string>
+    <string name="input_level_too_high">Vysoká</string>
+    <string name="input_level_clipping">Ořez</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Jazyk</string>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -457,6 +457,13 @@
     <string name="settings_enabled_bands_dialog_desc">Las bandas ocultas no aparecerán en los selectores de frecuencia.</string>
     <string name="settings_select_serial_port">Seleccionar puerto serie</string>
     <string name="settings_tx_volume_advice">Ajústalo en vivo — tu próximo TX usa este nivel. Vigila el ALC de tu radio y bájalo hasta que apenas roce la línea.</string>
+    <string name="settings_input_volume">Volumen de entrada</string>
+    <string name="settings_input_volume_desc" formatted="false">Ganancia del audio RX aplicada antes de decodificar (100% = sin cambios)</string>
+    <string name="settings_input_volume_advice">Se aplica al audio entrante antes de decodificar. Observa el medidor de nivel RX en la cascada y apunta a la zona verde; el rojo indica recorte.</string>
+    <string name="input_level_too_low">Bajo</string>
+    <string name="input_level_good">Bien</string>
+    <string name="input_level_too_high">Alto</string>
+    <string name="input_level_clipping">Recorte</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Idioma</string>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -457,6 +457,13 @@
     <string name="settings_enabled_bands_dialog_desc">Les bandes masquées n\'apparaîtront pas dans les sélecteurs de fréquence.</string>
     <string name="settings_select_serial_port">Sélectionner le port série</string>
     <string name="settings_tx_volume_advice">Ajustez en direct — votre prochain TX utilise ce niveau. Surveillez l\'ALC de votre radio et réduisez jusqu\'à ce qu\'il effleure tout juste la ligne.</string>
+    <string name="settings_input_volume">Volume d\'entrée</string>
+    <string name="settings_input_volume_desc" formatted="false">Gain audio RX appliqué avant le décodage (100 % = inchangé)</string>
+    <string name="settings_input_volume_advice">Appliqué à l\'audio entrant avant le décodage. Surveillez l\'indicateur de niveau RX sur la cascade et visez la zone verte ; le rouge signale l\'écrêtage.</string>
+    <string name="input_level_too_low">Faible</string>
+    <string name="input_level_good">Bon</string>
+    <string name="input_level_too_high">Élevé</string>
+    <string name="input_level_clipping">Clip</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Langue</string>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -535,6 +535,13 @@
     <string name="settings_enabled_bands_dialog_desc">Band yang disembunyikan tidak akan muncul di pemilih frekuensi.</string>
     <string name="settings_select_serial_port">Pilih Port Serial</string>
     <string name="settings_tx_volume_advice">Sesuaikan langsung — TX berikutnya menggunakan tingkat ini. Perhatikan ALC radio Anda dan turunkan sampai hanya menyentuh garis.</string>
+    <string name="settings_input_volume">Volume Masukan</string>
+    <string name="settings_input_volume_desc" formatted="false">Penguatan audio RX yang diterapkan sebelum dekode (100% = tidak berubah)</string>
+    <string name="settings_input_volume_advice">Diterapkan pada audio masuk sebelum dekode. Perhatikan meter level RX di waterfall dan bidik zona hijau; merah berarti clipping.</string>
+    <string name="input_level_too_low">Rendah</string>
+    <string name="input_level_good">Baik</string>
+    <string name="input_level_too_high">Tinggi</string>
+    <string name="input_level_clipping">Clip</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Bahasa</string>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -524,6 +524,13 @@
     <string name="settings_enabled_bands_dialog_desc">Le bande nascoste non appariranno nei selettori di frequenza.</string>
     <string name="settings_select_serial_port">Seleziona porta seriale</string>
     <string name="settings_tx_volume_advice">Regola in tempo reale — il tuo prossimo TX usa questo livello. Osserva l\'ALC della radio e abbassa finché tocca appena la linea.</string>
+    <string name="settings_input_volume">Volume di ingresso</string>
+    <string name="settings_input_volume_desc" formatted="false">Guadagno audio RX applicato prima della decodifica (100% = invariato)</string>
+    <string name="settings_input_volume_advice">Applicato all\'audio in ingresso prima della decodifica. Osserva l\'indicatore di livello RX sul waterfall e punta alla zona verde; il rosso indica clipping.</string>
+    <string name="input_level_too_low">Basso</string>
+    <string name="input_level_good">Buono</string>
+    <string name="input_level_too_high">Alto</string>
+    <string name="input_level_clipping">Clip</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Lingua</string>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -457,6 +457,13 @@
     <string name="settings_enabled_bands_dialog_desc">非表示のバンドは周波数ピッカーに表示されません。</string>
     <string name="settings_select_serial_port">シリアルポートを選択</string>
     <string name="settings_tx_volume_advice">ライブで調整してください — 次の TX でこのレベルが使われます。無線機の ALC を見ながら、ラインに軽く触れる程度まで下げてください。</string>
+    <string name="settings_input_volume">入力音量</string>
+    <string name="settings_input_volume_desc" formatted="false">デコード前に適用される受信音声ゲイン（100% = 変更なし）</string>
+    <string name="settings_input_volume_advice">デコード前の受信音声に適用されます。ウォーターフォールのRXレベルメーターを見ながら緑のゾーンを目指してください。赤はクリッピングを示します。</string>
+    <string name="input_level_too_low">低</string>
+    <string name="input_level_good">適正</string>
+    <string name="input_level_too_high">高</string>
+    <string name="input_level_clipping">クリップ</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">言語</string>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -535,6 +535,13 @@
     <string name="settings_enabled_bands_dialog_desc">숨겨진 밴드는 주파수 선택기에 나타나지 않습니다.</string>
     <string name="settings_select_serial_port">시리얼 포트 선택</string>
     <string name="settings_tx_volume_advice">실시간으로 조정하세요 — 다음 TX가 이 레벨을 사용합니다. 무전기의 ALC를 지켜보며 선에 살짝 닿을 때까지 낮추세요.</string>
+    <string name="settings_input_volume">입력 볼륨</string>
+    <string name="settings_input_volume_desc" formatted="false">디코딩 전에 적용되는 수신 오디오 게인 (100% = 변경 없음)</string>
+    <string name="settings_input_volume_advice">디코딩 전에 수신 오디오에 적용됩니다. 워터폴의 RX 레벨 미터를 보면서 녹색 구간을 목표로 하세요. 빨간색은 클리핑을 의미합니다.</string>
+    <string name="input_level_too_low">낮음</string>
+    <string name="input_level_good">적정</string>
+    <string name="input_level_too_high">높음</string>
+    <string name="input_level_clipping">클립</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">언어</string>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -535,6 +535,13 @@
     <string name="settings_enabled_bands_dialog_desc">Verborgen banden verschijnen niet in de frequentiekiezers.</string>
     <string name="settings_select_serial_port">Seriële poort selecteren</string>
     <string name="settings_tx_volume_advice">Pas live aan — je volgende TX gebruikt dit niveau. Houd de ALC van je radio in de gaten en draai terug tot deze net de lijn raakt.</string>
+    <string name="settings_input_volume">Ingangsvolume</string>
+    <string name="settings_input_volume_desc" formatted="false">RX-audioversterking toegepast vóór het decoderen (100% = ongewijzigd)</string>
+    <string name="settings_input_volume_advice">Toegepast op binnenkomende audio vóór het decoderen. Houd de RX-niveaumeter op de waterval in de gaten en mik op de groene zone; rood betekent clipping.</string>
+    <string name="input_level_too_low">Laag</string>
+    <string name="input_level_good">Goed</string>
+    <string name="input_level_too_high">Hoog</string>
+    <string name="input_level_clipping">Clip</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Taal</string>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -524,6 +524,13 @@
     <string name="settings_enabled_bands_dialog_desc">Ukryte pasma nie pojawią się w wyborze częstotliwości.</string>
     <string name="settings_select_serial_port">Wybierz port szeregowy</string>
     <string name="settings_tx_volume_advice">Dostosuj na żywo — następne TX użyje tego poziomu. Obserwuj ALC radia i zmniejszaj, aż ledwo dotyka linii.</string>
+    <string name="settings_input_volume">Głośność wejścia</string>
+    <string name="settings_input_volume_desc" formatted="false">Wzmocnienie audio RX stosowane przed dekodowaniem (100% = bez zmian)</string>
+    <string name="settings_input_volume_advice">Stosowane do przychodzącego dźwięku przed dekodowaniem. Obserwuj miernik poziomu RX na wodospadzie i celuj w zieloną strefę; czerwony oznacza przesterowanie.</string>
+    <string name="input_level_too_low">Niski</string>
+    <string name="input_level_good">Dobry</string>
+    <string name="input_level_too_high">Wysoki</string>
+    <string name="input_level_clipping">Przester</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Język</string>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -457,6 +457,13 @@
     <string name="settings_enabled_bands_dialog_desc">Скрытые диапазоны не появятся в выборе частоты.</string>
     <string name="settings_select_serial_port">Выберите последовательный порт</string>
     <string name="settings_tx_volume_advice">Регулируйте вживую — следующая передача использует этот уровень. Следите за ALC трансивера и убавляйте, пока он лишь слегка касается линии.</string>
+    <string name="settings_input_volume">Громкость входа</string>
+    <string name="settings_input_volume_desc" formatted="false">Усиление принимаемого звука перед декодированием (100% = без изменений)</string>
+    <string name="settings_input_volume_advice">Применяется к входящему звуку перед декодированием. Следите за индикатором уровня RX на водопаде и держитесь зелёной зоны; красный означает клиппинг.</string>
+    <string name="input_level_too_low">Низкий</string>
+    <string name="input_level_good">Норма</string>
+    <string name="input_level_too_high">Высокий</string>
+    <string name="input_level_clipping">Клип</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Язык</string>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -524,6 +524,13 @@
     <string name="settings_enabled_bands_dialog_desc">Gizli bantlar frekans seçicilerde görünmez.</string>
     <string name="settings_select_serial_port">Seri Port Seç</string>
     <string name="settings_tx_volume_advice">Canlı ayarlayın — bir sonraki TX\'iniz bu düzeyi kullanır. Radyonuzun ALC\'sini izleyin ve çizgiye değecek kadar düşürün.</string>
+    <string name="settings_input_volume">Giriş Ses Düzeyi</string>
+    <string name="settings_input_volume_desc" formatted="false">Kod çözmeden önce uygulanan RX ses kazancı (%100 = değişmez)</string>
+    <string name="settings_input_volume_advice">Kod çözmeden önce gelen sese uygulanır. Şelaledeki RX seviye göstergesini izleyin ve yeşil bölgeyi hedefleyin; kırmızı kırpılma demektir.</string>
+    <string name="input_level_too_low">Düşük</string>
+    <string name="input_level_good">İyi</string>
+    <string name="input_level_too_high">Yüksek</string>
+    <string name="input_level_clipping">Kırpma</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Dil</string>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -524,6 +524,13 @@
     <string name="settings_enabled_bands_dialog_desc">Приховані діапазони не з’являтимуться у виборі частоти.</string>
     <string name="settings_select_serial_port">Виберіть послідовний порт</string>
     <string name="settings_tx_volume_advice">Регулюйте наживо — ваш наступний TX використає цей рівень. Стежте за ALC радіо й зменшуйте, доки воно лише торкається лінії.</string>
+    <string name="settings_input_volume">Гучність входу</string>
+    <string name="settings_input_volume_desc" formatted="false">Підсилення прийнятого звуку перед декодуванням (100% = без змін)</string>
+    <string name="settings_input_volume_advice">Застосовується до вхідного звуку перед декодуванням. Стежте за індикатором рівня RX на водоспаді та тримайтеся зеленої зони; червоний означає кліпінг.</string>
+    <string name="input_level_too_low">Низький</string>
+    <string name="input_level_good">Добре</string>
+    <string name="input_level_too_high">Високий</string>
+    <string name="input_level_clipping">Кліпінг</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Мова</string>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -457,6 +457,13 @@
     <string name="settings_enabled_bands_dialog_desc">隐藏的波段不会出现在频率选择器中。</string>
     <string name="settings_select_serial_port">选择串口</string>
     <string name="settings_tx_volume_advice">实时调整 — 您的下一次 TX 将使用此电平。注意您电台的 ALC，逐渐调低直到刚好触及临界线。</string>
+    <string name="settings_input_volume">输入音量</string>
+    <string name="settings_input_volume_desc" formatted="false">解码前应用的接收音频增益（100% = 不变）</string>
+    <string name="settings_input_volume_advice">在解码前应用于输入音频。请观察瀑布图上的 RX 电平表，并将其保持在绿色区域；红色表示削波。</string>
+    <string name="input_level_too_low">过低</string>
+    <string name="input_level_good">良好</string>
+    <string name="input_level_too_high">过高</string>
+    <string name="input_level_clipping">削波</string>
 
     <!-- ===== 设置：语言选择器 ===== -->
     <string name="settings_language">语言</string>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -457,6 +457,13 @@
     <string name="settings_enabled_bands_dialog_desc">隱藏的波段不會出現在頻率選擇器中。</string>
     <string name="settings_select_serial_port">選擇序列埠</string>
     <string name="settings_tx_volume_advice">即時調整 — 您下次 TX 將使用此音量。注意您無線電的 ALC，並向下調整直到剛好碰到界線。</string>
+    <string name="settings_input_volume">輸入音量</string>
+    <string name="settings_input_volume_desc" formatted="false">解碼前套用的接收音訊增益（100% = 不變）</string>
+    <string name="settings_input_volume_advice">在解碼前套用於輸入音訊。請觀察瀑布圖上的 RX 電平表，並保持在綠色區域；紅色表示削波。</string>
+    <string name="input_level_too_low">過低</string>
+    <string name="input_level_good">良好</string>
+    <string name="input_level_too_high">過高</string>
+    <string name="input_level_clipping">削波</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">語言</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -616,6 +616,14 @@
     <string name="settings_enabled_bands_dialog_desc">Hidden bands won\'t appear in the frequency pickers.</string>
     <string name="settings_select_serial_port">Select Serial Port</string>
     <string name="settings_tx_volume_advice">Adjust live — your next TX uses this level. Watch your radio\'s ALC and dial down until it\'s just kissing the line.</string>
+    <string name="settings_input_volume">Input Volume</string>
+    <string name="settings_input_volume_desc" formatted="false">RX audio gain applied before decoding (100% = unchanged)</string>
+    <string name="settings_input_volume_advice">Applied to incoming audio before decoding. Watch the RX level meter on the waterfall and aim for the green zone; red means clipping.</string>
+    <string name="input_level_rx_label" translatable="false">RX</string>
+    <string name="input_level_too_low">Low</string>
+    <string name="input_level_good">Good</string>
+    <string name="input_level_too_high">High</string>
+    <string name="input_level_clipping">Clip</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Language</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/InputAudioLevelTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/InputAudioLevelTest.java
@@ -157,4 +157,58 @@ public class InputAudioLevelTest {
         assertThat(levels).isNotNull();
         assertThat(levels.peak).isWithin(1e-6f).of(0.3f);
     }
+
+    // ------------------------------------------------------------------
+    // parseGainPercent (defensive config-value parsing, Copilot review
+    // on PR #387: settings import #382 can feed corrupted strings here)
+    // ------------------------------------------------------------------
+
+    @Test
+    public void parseGainPercent_validPercentIsScaled() {
+        assertThat(InputAudioLevel.parseGainPercent("150")).isWithin(1e-6f).of(1.5f);
+        assertThat(InputAudioLevel.parseGainPercent("100")).isWithin(1e-6f).of(1.0f);
+        assertThat(InputAudioLevel.parseGainPercent("0")).isEqualTo(0f);
+    }
+
+    @Test
+    public void parseGainPercent_emptyOrNullDefaultsToUnity() {
+        assertThat(InputAudioLevel.parseGainPercent("")).isEqualTo(1.0f);
+        assertThat(InputAudioLevel.parseGainPercent(null)).isEqualTo(1.0f);
+        assertThat(InputAudioLevel.parseGainPercent("   ")).isEqualTo(1.0f);
+    }
+
+    @Test
+    public void parseGainPercent_nonNumericDefaultsToUnity() {
+        assertThat(InputAudioLevel.parseGainPercent("garbage")).isEqualTo(1.0f);
+        assertThat(InputAudioLevel.parseGainPercent("12abc")).isEqualTo(1.0f);
+        assertThat(InputAudioLevel.parseGainPercent("1,5")).isEqualTo(1.0f);
+    }
+
+    @Test
+    public void parseGainPercent_clampsAboveMax() {
+        // > 200% (e.g. a hand-edited or corrupted import) clamps to MAX_GAIN,
+        // never crashes and never exceeds what the slider can express.
+        assertThat(InputAudioLevel.parseGainPercent("500")).isEqualTo(InputAudioLevel.MAX_GAIN);
+        assertThat(InputAudioLevel.parseGainPercent("200.0001")).isEqualTo(InputAudioLevel.MAX_GAIN);
+        assertThat(InputAudioLevel.parseGainPercent("Infinity")).isEqualTo(InputAudioLevel.MAX_GAIN);
+    }
+
+    @Test
+    public void parseGainPercent_clampsBelowZero() {
+        assertThat(InputAudioLevel.parseGainPercent("-50")).isEqualTo(0f);
+        assertThat(InputAudioLevel.parseGainPercent("-Infinity")).isEqualTo(0f);
+    }
+
+    @Test
+    public void parseGainPercent_nanDefaultsToUnity() {
+        // Float.parseFloat("NaN") succeeds, so NaN needs its own guard: a NaN
+        // gain would silently zero the whole audio path.
+        assertThat(InputAudioLevel.parseGainPercent("NaN")).isEqualTo(1.0f);
+    }
+
+    @Test
+    public void parseGainPercent_toleratesWhitespaceAndFractions() {
+        assertThat(InputAudioLevel.parseGainPercent(" 75 ")).isWithin(1e-6f).of(0.75f);
+        assertThat(InputAudioLevel.parseGainPercent("12.5")).isWithin(1e-6f).of(0.125f);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/InputAudioLevelTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/InputAudioLevelTest.java
@@ -1,0 +1,160 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Tests {@link InputAudioLevel} — the RX input-gain multiply and the
+ * sliding-window peak/RMS meter behind the input-level indicator (issue #356).
+ */
+public class InputAudioLevelTest {
+
+    // ------------------------------------------------------------------
+    // applyGain
+    // ------------------------------------------------------------------
+
+    @Test
+    public void applyGain_multipliesSamples() {
+        float[] data = {0.1f, -0.2f, 0.5f};
+        InputAudioLevel.applyGain(data, data.length, 2.0f);
+        assertThat(data[0]).isWithin(1e-7f).of(0.2f);
+        assertThat(data[1]).isWithin(1e-7f).of(-0.4f);
+        assertThat(data[2]).isWithin(1e-7f).of(1.0f);
+    }
+
+    @Test
+    public void applyGain_unityGainIsExactNoOp() {
+        float[] data = {0.1f, -0.30000001f, 0.7f};
+        float[] before = Arrays.copyOf(data, data.length);
+        InputAudioLevel.applyGain(data, data.length, 1.0f);
+        // Bit-identical, not just approximately equal: default 100% must not
+        // perturb the audio path at all.
+        assertThat(data).isEqualTo(before);
+    }
+
+    @Test
+    public void applyGain_respectsLength() {
+        float[] data = {0.5f, 0.5f, 0.5f};
+        InputAudioLevel.applyGain(data, 2, 0.5f);
+        assertThat(data[0]).isWithin(1e-7f).of(0.25f);
+        assertThat(data[1]).isWithin(1e-7f).of(0.25f);
+        assertThat(data[2]).isWithin(1e-7f).of(0.5f); // untouched past len
+    }
+
+    @Test
+    public void applyGain_lengthBeyondArrayIsClamped() {
+        float[] data = {0.5f};
+        InputAudioLevel.applyGain(data, 100, 2.0f); // must not throw
+        assertThat(data[0]).isWithin(1e-7f).of(1.0f);
+    }
+
+    @Test
+    public void applyGain_nullBufferIsNoOp() {
+        InputAudioLevel.applyGain(null, 10, 2.0f); // must not throw
+    }
+
+    @Test
+    public void applyGain_zeroGainSilences() {
+        float[] data = {0.9f, -0.9f};
+        InputAudioLevel.applyGain(data, data.length, 0f);
+        assertThat(data[0]).isEqualTo(0f);
+        assertThat(data[1]).isEqualTo(-0f);
+    }
+
+    // ------------------------------------------------------------------
+    // process (windowed peak/RMS meter)
+    // ------------------------------------------------------------------
+
+    @Test
+    public void process_returnsNullUntilWindowFills() {
+        InputAudioLevel meter = new InputAudioLevel();
+        float[] data = new float[InputAudioLevel.WINDOW_SAMPLES - 1];
+        assertThat(meter.process(data, data.length)).isNull();
+    }
+
+    @Test
+    public void process_emitsPeakAndRmsWhenWindowCompletes() {
+        InputAudioLevel meter = new InputAudioLevel();
+        float[] data = new float[InputAudioLevel.WINDOW_SAMPLES];
+        Arrays.fill(data, 0.5f);
+        data[7] = -0.8f; // peak is max ABSOLUTE value
+
+        InputAudioLevel.Levels levels = meter.process(data, data.length);
+        assertThat(levels).isNotNull();
+        assertThat(levels.peak).isWithin(1e-6f).of(0.8f);
+        // RMS of N-1 samples at 0.5 plus one at 0.8 is just above 0.5.
+        double expectedRms = Math.sqrt(
+                ((InputAudioLevel.WINDOW_SAMPLES - 1) * 0.25 + 0.64)
+                        / InputAudioLevel.WINDOW_SAMPLES);
+        assertThat(levels.rms).isWithin(1e-6f).of((float) expectedRms);
+    }
+
+    @Test
+    public void process_accumulatesAcrossSmallBuffers() {
+        InputAudioLevel meter = new InputAudioLevel();
+        float[] chunk = new float[InputAudioLevel.WINDOW_SAMPLES / 2];
+        Arrays.fill(chunk, 0.4f);
+        assertThat(meter.process(chunk, chunk.length)).isNull();
+        InputAudioLevel.Levels levels = meter.process(chunk, chunk.length);
+        assertThat(levels).isNotNull();
+        assertThat(levels.peak).isWithin(1e-6f).of(0.4f);
+        assertThat(levels.rms).isWithin(1e-6f).of(0.4f);
+    }
+
+    @Test
+    public void process_resetsBetweenWindows() {
+        InputAudioLevel meter = new InputAudioLevel();
+        float[] loud = new float[InputAudioLevel.WINDOW_SAMPLES];
+        Arrays.fill(loud, 0.9f);
+        InputAudioLevel.Levels first = meter.process(loud, loud.length);
+        assertThat(first.peak).isWithin(1e-6f).of(0.9f);
+
+        // A quiet second window must not inherit the first window's peak.
+        float[] quiet = new float[InputAudioLevel.WINDOW_SAMPLES];
+        Arrays.fill(quiet, 0.1f);
+        InputAudioLevel.Levels second = meter.process(quiet, quiet.length);
+        assertThat(second.peak).isWithin(1e-6f).of(0.1f);
+        assertThat(second.rms).isWithin(1e-6f).of(0.1f);
+    }
+
+    @Test
+    public void process_respectsLengthArgument() {
+        InputAudioLevel meter = new InputAudioLevel();
+        float[] data = new float[InputAudioLevel.WINDOW_SAMPLES + 500];
+        Arrays.fill(data, 0.2f);
+        data[InputAudioLevel.WINDOW_SAMPLES - 1] = 1.5f; // inside len
+
+        // Only feed WINDOW_SAMPLES of the larger buffer.
+        InputAudioLevel.Levels levels =
+                meter.process(data, InputAudioLevel.WINDOW_SAMPLES);
+        assertThat(levels).isNotNull();
+        assertThat(levels.peak).isWithin(1e-6f).of(1.5f);
+        // The 500 samples past len were not consumed: the next window starts
+        // empty, so a fresh full window of 0.2 reads exactly 0.2 peak.
+        float[] next = new float[InputAudioLevel.WINDOW_SAMPLES];
+        Arrays.fill(next, 0.2f);
+        InputAudioLevel.Levels levels2 = meter.process(next, next.length);
+        assertThat(levels2.peak).isWithin(1e-6f).of(0.2f);
+    }
+
+    @Test
+    public void process_nullBufferReturnsNull() {
+        InputAudioLevel meter = new InputAudioLevel();
+        assertThat(meter.process(null, 100)).isNull();
+    }
+
+    @Test
+    public void process_oneBufferSpanningMultipleWindows_emitsLastWindow() {
+        InputAudioLevel meter = new InputAudioLevel();
+        float[] data = new float[InputAudioLevel.WINDOW_SAMPLES * 2];
+        Arrays.fill(data, 0, InputAudioLevel.WINDOW_SAMPLES, 0.9f);
+        Arrays.fill(data, InputAudioLevel.WINDOW_SAMPLES, data.length, 0.3f);
+        InputAudioLevel.Levels levels = meter.process(data, data.length);
+        // The snapshot reflects the most recently completed window.
+        assertThat(levels).isNotNull();
+        assertThat(levels.peak).isWithin(1e-6f).of(0.3f);
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicatorTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicatorTest.kt
@@ -1,0 +1,120 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import radio.ks3ckc.ft8af.theme.StatusBad
+import radio.ks3ckc.ft8af.theme.StatusConfirmed
+import radio.ks3ckc.ft8af.theme.StatusWarn
+import radio.ks3ckc.ft8af.theme.StatusWorked
+
+/**
+ * Tests the extracted decision/geometry logic behind the RX input-level
+ * indicator (issue #356): peak -> status classification, meter fill fraction,
+ * percent readout, and status -> color mapping. Pure logic — no runner needed.
+ */
+class InputLevelIndicatorTest {
+
+    // ------------------------------------------------------------------
+    // classifyInputLevel
+    // ------------------------------------------------------------------
+
+    @Test
+    fun silence_isTooLow() {
+        assertThat(classifyInputLevel(0f)).isEqualTo(InputLevelStatus.TOO_LOW)
+    }
+
+    @Test
+    fun belowLowThreshold_isTooLow() {
+        assertThat(classifyInputLevel(0.249f)).isEqualTo(InputLevelStatus.TOO_LOW)
+    }
+
+    @Test
+    fun lowBoundary_isJustRight() {
+        // 25% is inclusive: the advertised window is 25-75%.
+        assertThat(classifyInputLevel(0.25f)).isEqualTo(InputLevelStatus.JUST_RIGHT)
+    }
+
+    @Test
+    fun midRange_isJustRight() {
+        assertThat(classifyInputLevel(0.5f)).isEqualTo(InputLevelStatus.JUST_RIGHT)
+    }
+
+    @Test
+    fun highBoundary_isJustRight() {
+        // 75% is inclusive too.
+        assertThat(classifyInputLevel(0.75f)).isEqualTo(InputLevelStatus.JUST_RIGHT)
+    }
+
+    @Test
+    fun aboveHighThreshold_isTooHigh() {
+        assertThat(classifyInputLevel(0.76f)).isEqualTo(InputLevelStatus.TOO_HIGH)
+    }
+
+    @Test
+    fun justBelowClip_isTooHigh() {
+        assertThat(classifyInputLevel(0.989f)).isEqualTo(InputLevelStatus.TOO_HIGH)
+    }
+
+    @Test
+    fun clipThreshold_isClipping() {
+        assertThat(classifyInputLevel(INPUT_LEVEL_CLIP)).isEqualTo(InputLevelStatus.CLIPPING)
+    }
+
+    @Test
+    fun fullScale_isClipping() {
+        assertThat(classifyInputLevel(1.0f)).isEqualTo(InputLevelStatus.CLIPPING)
+    }
+
+    @Test
+    fun beyondFullScale_isClipping() {
+        // Gain > 100% can push samples past +/-1.0.
+        assertThat(classifyInputLevel(1.8f)).isEqualTo(InputLevelStatus.CLIPPING)
+    }
+
+    // ------------------------------------------------------------------
+    // inputLevelFraction / inputLevelPercent
+    // ------------------------------------------------------------------
+
+    @Test
+    fun fraction_passesThroughInRange() {
+        assertThat(inputLevelFraction(0.42f)).isEqualTo(0.42f)
+    }
+
+    @Test
+    fun fraction_clampsAboveFullScale() {
+        assertThat(inputLevelFraction(1.7f)).isEqualTo(1.0f)
+    }
+
+    @Test
+    fun fraction_clampsNegative() {
+        assertThat(inputLevelFraction(-0.3f)).isEqualTo(0f)
+    }
+
+    @Test
+    fun percent_roundsToInt() {
+        assertThat(inputLevelPercent(0.499f)).isEqualTo(50)
+        assertThat(inputLevelPercent(0.254f)).isEqualTo(25)
+    }
+
+    @Test
+    fun percent_clampsTo100() {
+        assertThat(inputLevelPercent(2.0f)).isEqualTo(100)
+    }
+
+    @Test
+    fun percent_zeroForSilence() {
+        assertThat(inputLevelPercent(0f)).isEqualTo(0)
+    }
+
+    // ------------------------------------------------------------------
+    // inputLevelColor
+    // ------------------------------------------------------------------
+
+    @Test
+    fun colors_matchStatusSemantics() {
+        assertThat(inputLevelColor(InputLevelStatus.TOO_LOW)).isEqualTo(StatusWorked)
+        assertThat(inputLevelColor(InputLevelStatus.JUST_RIGHT)).isEqualTo(StatusConfirmed)
+        assertThat(inputLevelColor(InputLevelStatus.TOO_HIGH)).isEqualTo(StatusWarn)
+        assertThat(inputLevelColor(InputLevelStatus.CLIPPING)).isEqualTo(StatusBad)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/VolumeClampTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/VolumeClampTest.kt
@@ -1,0 +1,56 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Tests [clampVolumePercent], the range guard behind [VolumeSliderDialog]
+ * (Copilot review on PR #387).
+ *
+ * The dialog serves two ranges — TX volume 0..100 and RX input volume 0..200 —
+ * and initializes from a persisted config value. A corrupted or imported
+ * out-of-range value (settings import, issue #357) must start the slider at a
+ * legal position, and the clamped value is what gets synced back and
+ * re-persisted on dismiss.
+ */
+class VolumeClampTest {
+
+    @Test
+    fun inRangeValueIsUnchanged() {
+        assertThat(clampVolumePercent(0, 100)).isEqualTo(0)
+        assertThat(clampVolumePercent(55, 100)).isEqualTo(55)
+        assertThat(clampVolumePercent(100, 100)).isEqualTo(100)
+        assertThat(clampVolumePercent(150, INPUT_VOLUME_MAX)).isEqualTo(150)
+        assertThat(clampVolumePercent(INPUT_VOLUME_MAX, INPUT_VOLUME_MAX)).isEqualTo(INPUT_VOLUME_MAX)
+    }
+
+    @Test
+    fun aboveMaxClampsToMax() {
+        // TX dialog (max 100): a persisted 150 must not start the slider at 150.
+        assertThat(clampVolumePercent(150, 100)).isEqualTo(100)
+        // Input dialog (max 200): a corrupted 500% import clamps to 200.
+        assertThat(clampVolumePercent(500, INPUT_VOLUME_MAX)).isEqualTo(INPUT_VOLUME_MAX)
+        assertThat(clampVolumePercent(Int.MAX_VALUE, INPUT_VOLUME_MAX)).isEqualTo(INPUT_VOLUME_MAX)
+    }
+
+    @Test
+    fun belowZeroClampsToZero() {
+        assertThat(clampVolumePercent(-1, 100)).isEqualTo(0)
+        assertThat(clampVolumePercent(Int.MIN_VALUE, INPUT_VOLUME_MAX)).isEqualTo(0)
+    }
+
+    @Test
+    fun stepArithmeticStaysInRange() {
+        // The dialog's -5/+5 buttons route through the same clamp.
+        assertThat(clampVolumePercent(3 - 5, 100)).isEqualTo(0)
+        assertThat(clampVolumePercent(198 + 5, INPUT_VOLUME_MAX)).isEqualTo(INPUT_VOLUME_MAX)
+    }
+
+    @Test
+    fun inputVolumeMaxMatchesNativeGainCap() {
+        // The Kotlin slider bound and the Java config-load clamp
+        // (InputAudioLevel.MAX_GAIN) must describe the same limit: 200% = 2.0x.
+        assertThat(INPUT_VOLUME_MAX / 100f)
+            .isEqualTo(com.k1af.ft8af.wave.InputAudioLevel.MAX_GAIN)
+    }
+}


### PR DESCRIPTION
Fixes #356

## What

Adds an in-app RX input gain control and a live input-level indicator so operators on line-in / USB audio / the phone mic can dial the app's receive level into a healthy range without touching hardware gain.

## Gain path

- New plain-Java `InputAudioLevel.applyGain()` multiplies incoming float samples in place in `HamRecorder.doOnWaveDataReceived` — the **single choke point** every RX audio path funnels through: the built-in mic `AudioRecord` loop and the direct-USB capture callback (both via `MicRecorder`'s data listener), plus the CAT-audio / ICOM-WiFi / Flex / Xiegu network connectors (which call `doOnWaveDataReceived` directly). The decoder, slot accumulator, waterfall FFT, and the level meter all see the same post-gain samples.
- Unity gain (100%) is an **exact no-op** — the default leaves the audio path bit-identical to previous releases.
- No OEM AGC/processing is enabled; `chooseAudioSource` (UNPROCESSED / VOICE_RECOGNITION) semantics are untouched.

## Settings UI

- Settings → Radio & Audio → Audio: new **Input Volume** row with a slider dialog, range **0–200%** (100% = 1.0x default), big numeric percent readout, ±5% step buttons. Changes apply live (the very next audio buffer uses the new gain); the value is persisted on dismiss.
- The existing TX volume slider dialog was generalized (`VolumeSliderDialog` with title/advice/max params) rather than duplicated.

## Persistence

- `DatabaseOpr.writeConfig("inputVolume", <percent>)` on dialog dismiss; restored at startup by the existing config loader into `GeneralVariables.inputGainPercent` (missing key → 100%). Included automatically in the new settings backup/export (#357) since that serializes the whole config table.

## Live meter

- `InputAudioLevel` accumulates peak + RMS over a 250 ms (3000-sample @ 12 kHz) window of the post-gain samples and publishes one snapshot per window via `GeneralVariables.mutableInputLevel` (LiveData), keeping main-thread traffic bounded regardless of capture buffer size.
- `InputLevelIndicator` in the waterfall screen's bottom strip renders an RMS-filled bar with a peak tick, a percent readout of the window peak, and a color-coded status word.

## Thresholds (on window peak, 1.0 = full scale)

| Status | Range | Color |
|---|---|---|
| Too low | < 25% | blue |
| Just right | 25–75% (inclusive) | green |
| Too high | > 75% | yellow |
| Clipping | ≥ 99% | red |

## Strings

New strings (`settings_input_volume*`, `input_level_*`) added to `strings_compose.xml` in all 16 locales (en, ar, cs, es, fr, in, it, ja, ko, nl, pl, ru, tr, uk, zh-rCN, zh-rTW).

## Tests

Decision logic is extracted into plain testable units per repo convention:

- `InputAudioLevelTest` (Java, 13 tests): gain multiply, unity-gain exactness, length clamping, null safety, windowed peak/RMS emission, window reset, multi-window buffers.
- `InputLevelIndicatorTest` (Kotlin, 17 tests): peak→status classification incl. boundary values (25%/75% inclusive, 99% clip), fraction/percent clamping, status→color mapping.

`gradlew testDebugUnitTest`: **1198 tests, 0 failures, 0 errors**. `assembleDebug` builds clean.

## Manual verification advised

The direct-libusb USB-audio capture path and the network-audio paths were verified by code inspection only — a quick on-air check with a USB audio interface (meter responsive, gain audibly affecting decode levels, no regression at 100%) is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)