### PR TITLE
Late full-slot decode: recover DT > +0.86s signals when earlyDecode is on

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -46,9 +46,11 @@ public class FT8SignalListener {
     // inside DecoderFt8Analysis. The late full-slot pass (issue #363) lets a previous
     // slot's decode thread overlap the next slot's decode thread, so candidate analysis
     // must be serialized across threads. All other native decode state is per-decoder
-    // (or thread-local), so per-candidate granularity is enough — the concurrent thread
-    // waits at most one candidate's decode.
-    private static final Object DECODE_ANALYSIS_LOCK = new Object();
+    // (or thread-local), so per-candidate granularity is enough. The gate is asymmetric:
+    // the time-critical early path blocks (bounded by one candidate), the best-effort
+    // late path tries briefly and aborts its remaining candidates on contention, so late
+    // work never slows the next slot's early decode. See LateDecode.AnalysisGate.
+    private static final LateDecode.AnalysisGate ANALYSIS_GATE = new LateDecode.AnalysisGate();
 
 
     static {
@@ -137,36 +139,34 @@ public class FT8SignalListener {
         Log.d(TAG, "Starting recording...");
 
         if (onWaveDataListener != null) {
-            // Fast turnaround: collect a shorter window so decoding finishes (and CQ
-            // decodes appear) ~1s before the cycle boundary, leaving time to answer
-            // on the next slot. Off = full slot window (max sensitivity).
-            ModeProfile mode = GeneralVariables.currentMode();
-            int recordMs = GeneralVariables.earlyDecode
-                    ? mode.earlyDecodeMillis
-                    : mode.slotMillis;
-            // Late full-slot pass (issue #363): the early window loses signals whose DT
-            // pushes them past its end (~+0.86s for FT8). When eligible, also record the
-            // WHOLE slot into a second one-shot monitor; the decode thread picks that
-            // buffer up after the early passes finish and decodes only the new messages
-            // as an extra late (isDeep) delivery. See LateDecode.
-            final LateDecode.Handoff lateHandoff =
-                    LateDecode.shouldRunLatePass(GeneralVariables.earlyDecode, mode)
-                            ? new LateDecode.Handoff(System.currentTimeMillis(), mode.slotMillis)
-                            : null;
-            onWaveDataListener.getVoiceData(recordMs, true
+            // Freeze the whole cycle's decode plan NOW, at the slot boundary: the record
+            // window (fast turnaround = shorter window so decoding finishes ~1s before
+            // the cycle boundary; off = full slot for max sensitivity), whether a late
+            // full-slot pass runs (issue #363: the early window loses signals whose DT
+            // pushes them past its end, ~+0.86s for FT8), and — critically — the
+            // OPERATING MODE every decode pass of this slot must use. A mid-slot mode
+            // switch must not retroactively change how this slot's buffers are decoded;
+            // see LateDecode.planSlot.
+            final LateDecode.SlotPlan plan = LateDecode.planSlot(
+                    GeneralVariables.earlyDecode, GeneralVariables.currentMode(),
+                    System.currentTimeMillis());
+            onWaveDataListener.getVoiceData(plan.recordMillis, true
                     , new OnGetVoiceDataDone() {
                         @Override
                         public void onGetDone(float[] data) {
                             Log.d(TAG, String.format("Starting decode...###, data length: %d",data.length));
-                            decodeFt8(utc, data, lateHandoff);
+                            decodeFt8(utc, data, plan.mode, plan.lateHandoff);
                         }
                     });
-            if (lateHandoff != null) {
-                onWaveDataListener.getVoiceData(mode.slotMillis, true
+            if (plan.lateHandoff != null) {
+                // Second one-shot monitor over the WHOLE slot; the decode thread picks
+                // the buffer up after the early passes finish and decodes only the new
+                // messages as an extra late (isDeep) delivery. See LateDecode.
+                onWaveDataListener.getVoiceData(plan.mode.slotMillis, true
                         , new OnGetVoiceDataDone() {
                             @Override
                             public void onGetDone(float[] data) {
-                                lateHandoff.offer(data);
+                                plan.lateHandoff.offer(data);
                             }
                         });
             }
@@ -174,15 +174,23 @@ public class FT8SignalListener {
     }
 
     public void decodeFt8(long utc, float[] voiceData) {
-        decodeFt8(utc, voiceData, null);
+        decodeFt8(utc, voiceData, GeneralVariables.currentMode(), null);
     }
 
     /**
+     * @param mode        the operating mode {@code voiceData} was RECORDED under, captured
+     *                    at the slot boundary (see {@link LateDecode#planSlot}). Every
+     *                    decode pass of this slot — decoder init, protocol, deep budget,
+     *                    late pass — uses this snapshot, never
+     *                    {@code GeneralVariables.currentMode()}: a mid-slot mode switch
+     *                    must not make an in-flight decode reinterpret its buffer under
+     *                    the new mode's protocol.
      * @param lateHandoff when non-null, the source of a second full-slot buffer to decode
      *                    after the early passes finish (late full-slot pass, issue #363);
      *                    null = no late pass this cycle
      */
-    public void decodeFt8(long utc, float[] voiceData, LateDecode.Handoff lateHandoff) {
+    public void decodeFt8(long utc, float[] voiceData, ModeProfile mode,
+                          LateDecode.Handoff lateHandoff) {
 
         // Test code below -------------------------
 //        String fileName = getCacheFileName("test_01.wav");
@@ -206,9 +214,10 @@ public class FT8SignalListener {
                 // Note: decoding must complete within one cycle, otherwise a new decode cycle will begin
                 // Both decoders are from-source in libft8af.so: FT2/FT4 use the *Ft2 entry
                 // points (ft2_decode_jni.cpp), FT8 the plain ones (ft8_decode_jni.cpp). All
-                // native ops dispatch through the *Decode helpers on this flag.
-                final boolean fromSource = GeneralVariables.currentMode().usesFromSourceDecoder();
-                long ft8Decoder = initDecoder(utc, voiceData.length, fromSource);
+                // native ops dispatch through the *Decode helpers on this flag — derived
+                // from the RECORD-TIME mode snapshot, not the live global.
+                final boolean fromSource = mode.usesFromSourceDecoder();
+                long ft8Decoder = initDecoder(utc, voiceData.length, mode);
 //                        , tempData.length, true);
                 pressFloatDecode(voiceData, ft8Decoder, fromSource);// load audio data
 //                DecoderMonitorPressFloat(tempData, ft8Decoder);// load audio data
@@ -221,8 +230,8 @@ public class FT8SignalListener {
                 final A91List a91List = new A91List();
                 ArrayList<Ft8Message> allMsg = new ArrayList<>();
 //                ArrayList<Ft8Message> msgs = runDecode(utc, voiceData,false);
-                ArrayList<Ft8Message> msgs = runDecode(ft8Decoder, utc, false, fromSource,
-                        DeepDecodeBudget.NO_DEADLINE, a91List);
+                ArrayList<Ft8Message> msgs = runDecode(ft8Decoder, utc, false, mode,
+                        DeepDecodeBudget.NO_DEADLINE, a91List, null);
                 addMsgToList(allMsg, msgs);
                 timeSec = System.currentTimeMillis() - time;
                 decodeTimeSec.postValue(timeSec);// decode elapsed time
@@ -233,8 +242,8 @@ public class FT8SignalListener {
 
                 if (GeneralVariables.deepDecodeMode) {// enter deep decode mode
                     //float[] newSignal=tempData;
-                    msgs = runDecode(ft8Decoder, utc, true, fromSource,
-                            DeepDecodeBudget.NO_DEADLINE, a91List);
+                    msgs = runDecode(ft8Decoder, utc, true, mode,
+                            DeepDecodeBudget.NO_DEADLINE, a91List, null);
                     addMsgToList(allMsg, msgs);
                     timeSec = System.currentTimeMillis() - time;
                     decodeTimeSec.postValue(timeSec);// decode elapsed time
@@ -242,7 +251,7 @@ public class FT8SignalListener {
                         onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
                     }
 
-                    final long deepDecodeBudgetMs = GeneralVariables.currentMode().deepDecodeBudgetMillis();
+                    final long deepDecodeBudgetMs = mode.deepDecodeBudgetMillis();
                     // Budget the subtract-and-redecode loop by ITS OWN elapsed time, not the total
                     // decode time. On a slow device the initial fast + first deep pass can already
                     // exceed the budget, which would abort subtraction before it ran even once.
@@ -256,7 +265,7 @@ public class FT8SignalListener {
                         subtractDecode(ft8Decoder, a91List, fromSource);
 
                         // perform another decode pass
-                        msgs = runDecode(ft8Decoder, utc, true, fromSource, passDeadline, a91List);
+                        msgs = runDecode(ft8Decoder, utc, true, mode, passDeadline, a91List, null);
                         addMsgToList(allMsg, msgs);
                         timeSec = System.currentTimeMillis() - time;
                         decodeTimeSec.postValue(timeSec);// decode elapsed time
@@ -278,7 +287,7 @@ public class FT8SignalListener {
                 // delivered. Runs into the next slot's cycle by design; the next slot's
                 // decode uses its own thread, decoder, and a91 list.
                 if (lateHandoff != null) {
-                    runLateFullSlotPass(utc, allMsg, a91List, fromSource, lateHandoff);
+                    runLateFullSlotPass(utc, allMsg, a91List, mode, lateHandoff);
                 }
 
             }
@@ -296,28 +305,37 @@ public class FT8SignalListener {
      * <p>Deliberately does NOT touch {@link #timeSec}/{@link #decodeTimeSec}: by the time
      * this runs the next slot may already be decoding, and clobbering the shared elapsed
      * time could make MainViewModel's auto-reply budget check misjudge that slot.
+     *
+     * @param mode the RECORD-TIME mode snapshot for this slot; the late buffer must be
+     *             decoded under the mode it was captured in, even if the user has since
+     *             switched modes
      */
     private void runLateFullSlotPass(long utc, ArrayList<Ft8Message> allMsg, A91List a91List,
-                                     boolean fromSource, LateDecode.Handoff handoff) {
+                                     ModeProfile mode, LateDecode.Handoff handoff) {
         float[] fullData = handoff.awaitBuffer(System.currentTimeMillis());
         if (fullData == null) {
             // Capture stopped mid-slot (or never started); the buffer is not coming.
             Log.w(TAG, "late full-slot pass skipped: full-slot buffer never arrived");
             return;
         }
+        final boolean fromSource = mode.usesFromSourceDecoder();
         long time = System.currentTimeMillis();
-        long lateDecoder = initDecoder(utc, fullData.length, fromSource);
+        long lateDecoder = initDecoder(utc, fullData.length, mode);
         try {
             pressFloatDecode(fullData, lateDecoder, fromSource);
             // Bound the whole late pass (fast + deep candidate loops) by the mode's deep
             // budget so a slow device can't chain late work across multiple later slots.
             final long deadline = DeepDecodeBudget.passDeadline(time,
-                    GeneralVariables.currentMode().deepDecodeBudgetMillis());
+                    mode.deepDecodeBudgetMillis());
+            // Best-effort priority: the first analysis-gate contention with the next
+            // slot's early decode trips this and the late pass gives up the rest of its
+            // candidates (and the deep pass). See LateDecode.AnalysisGate.
+            final LateDecode.LateAbort lateAbort = new LateDecode.LateAbort();
             deliverLateMessages(utc, allMsg,
-                    runDecode(lateDecoder, utc, false, fromSource, deadline, a91List));
-            if (GeneralVariables.deepDecodeMode) {
+                    runDecode(lateDecoder, utc, false, mode, deadline, a91List, lateAbort));
+            if (GeneralVariables.deepDecodeMode && !lateAbort.tripped()) {
                 deliverLateMessages(utc, allMsg,
-                        runDecode(lateDecoder, utc, true, fromSource, deadline, a91List));
+                        runDecode(lateDecoder, utc, true, mode, deadline, a91List, lateAbort));
             }
         } finally {
             deleteDecoder(lateDecoder, fromSource);
@@ -343,10 +361,19 @@ public class FT8SignalListener {
     }
 
 
-    private ArrayList<Ft8Message> runDecode(long ft8Decoder, long utc, boolean isDeep, boolean fromSource,
-                                            long deadlineEpochMs, A91List a91List) {
+    /**
+     * @param mode      the RECORD-TIME mode snapshot for the slot being decoded (never the
+     *                  live {@code GeneralVariables.currentMode()})
+     * @param lateAbort non-null only for late full-slot passes: candidate analysis then
+     *                  yields to the next slot's early decode, tripping this flag (and
+     *                  stopping the scan) on the first analysis-gate contention
+     */
+    private ArrayList<Ft8Message> runDecode(long ft8Decoder, long utc, boolean isDeep, ModeProfile mode,
+                                            long deadlineEpochMs, A91List a91List,
+                                            LateDecode.LateAbort lateAbort) {
+        final boolean fromSource = mode.usesFromSourceDecoder();
         ArrayList<Ft8Message> ft8Messages = new ArrayList<>();
-        Ft8Message ft8Message = new Ft8Message(GeneralVariables.operatingMode);
+        Ft8Message ft8Message = new Ft8Message(mode.id);
 
         ft8Message.utcTime = utc;
         ft8Message.band = GeneralVariables.band;
@@ -360,9 +387,14 @@ public class FT8SignalListener {
                 Log.d(TAG, "pass deadline hit at candidate " + idx + "/" + num_candidates);
                 break;
             }
+            if (lateAbort != null && lateAbort.tripped()) {
+                Log.d(TAG, "late pass aborted by analysis-gate contention at candidate "
+                        + idx + "/" + num_candidates);
+                break;
+            }
             ft8Message.snr = Ft8Message.SNR_UNKNOWN; // reset before each candidate
             try {// protect against decode failure
-                if (analysisDecode(idx, ft8Decoder, ft8Message, fromSource)) {
+                if (analysisDecode(idx, ft8Decoder, ft8Message, fromSource, lateAbort)) {
 
                     if (ft8Message.isValid) {
                         if (!ft8Message.hasSnr()) {
@@ -399,13 +431,19 @@ public class FT8SignalListener {
     // (= ModeProfile.usesFromSourceDecoder()). The from-source init takes the ftx protocol
     // so it configures the monitor for FT2 vs FT4 symbol timing.
 
-    private long initDecoder(long utc, int numSamples, boolean fromSource) {
-        if (fromSource) {
-            return InitDecoderFt2(utc, FT8Common.SAMPLE_RATE, numSamples,
-                    GeneralVariables.currentMode().ftxProtocol());
+    /**
+     * @param mode the RECORD-TIME mode snapshot: selects the entry-point family AND the
+     *             protocol/flags. Must never read {@code GeneralVariables.currentMode()} —
+     *             the late full-slot pass inits its decoder well after the slot boundary
+     *             (possibly into the next slot), by which time the user may have switched
+     *             modes, and initializing with the new mode's protocol against the old
+     *             mode's buffer would decode garbage.
+     */
+    private long initDecoder(long utc, int numSamples, ModeProfile mode) {
+        if (mode.usesFromSourceDecoder()) {
+            return InitDecoderFt2(utc, FT8Common.SAMPLE_RATE, numSamples, mode.ftxProtocol());
         }
-        return InitDecoder(utc, FT8Common.SAMPLE_RATE, numSamples,
-                GeneralVariables.currentMode().isFt8);
+        return InitDecoder(utc, FT8Common.SAMPLE_RATE, numSamples, mode.isFt8);
     }
 
     private void pressFloatDecode(float[] data, long decoder, boolean fromSource) {
@@ -422,13 +460,31 @@ public class FT8SignalListener {
         return fromSource ? DecoderFt2FindSync(decoder) : DecoderFt8FindSync(decoder);
     }
 
-    private boolean analysisDecode(int idx, long decoder, Ft8Message msg, boolean fromSource) {
-        // Serialized: DecoderFt8Analysis reads/writes the process-global cross-slot cache
-        // (ft8_xslot.c), and the late full-slot pass can overlap the next slot's decode
-        // thread. See DECODE_ANALYSIS_LOCK.
-        synchronized (DECODE_ANALYSIS_LOCK) {
+    /**
+     * Serialized: DecoderFt8Analysis reads/writes the process-global cross-slot cache
+     * (ft8_xslot.c), and the late full-slot pass can overlap the next slot's decode
+     * thread — no two analysis calls may ever run concurrently. The gate is asymmetric
+     * so the late pass can never stall the time-critical early path: early/primary calls
+     * ({@code lateAbort == null}) block unconditionally (bounded by one candidate), late
+     * calls only try briefly and on contention trip {@code lateAbort} and bail — the
+     * caller's candidate loop then aborts. See {@link LateDecode.AnalysisGate}.
+     *
+     * @return true if the candidate decoded; false if it didn't OR the late path yielded
+     *         (in which case {@code lateAbort} is tripped)
+     */
+    private boolean analysisDecode(int idx, long decoder, Ft8Message msg, boolean fromSource,
+                                   LateDecode.LateAbort lateAbort) {
+        if (lateAbort == null) {
+            ANALYSIS_GATE.acquireBlocking();
+        } else if (!ANALYSIS_GATE.tryAcquireForLate()) {
+            lateAbort.trip();
+            return false;
+        }
+        try {
             return fromSource ? DecoderFt2Analysis(idx, decoder, msg)
                     : DecoderFt8Analysis(idx, decoder, msg);
+        } finally {
+            ANALYSIS_GATE.release();
         }
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -41,7 +41,14 @@ public class FT8SignalListener {
 
     private DatabaseOpr db;
 
-    private final A91List a91List = new A91List();// a91 list
+    // The FT8 cross-slot recall cache (cpp/ft8af_glue/ft8_xslot.c) is process-global and,
+    // by its own contract, NOT thread-safe; in the app it is only ever touched from
+    // inside DecoderFt8Analysis. The late full-slot pass (issue #363) lets a previous
+    // slot's decode thread overlap the next slot's decode thread, so candidate analysis
+    // must be serialized across threads. All other native decode state is per-decoder
+    // (or thread-local), so per-candidate granularity is enough — the concurrent thread
+    // waits at most one candidate's decode.
+    private static final Object DECODE_ANALYSIS_LOCK = new Object();
 
 
     static {
@@ -137,18 +144,45 @@ public class FT8SignalListener {
             int recordMs = GeneralVariables.earlyDecode
                     ? mode.earlyDecodeMillis
                     : mode.slotMillis;
+            // Late full-slot pass (issue #363): the early window loses signals whose DT
+            // pushes them past its end (~+0.86s for FT8). When eligible, also record the
+            // WHOLE slot into a second one-shot monitor; the decode thread picks that
+            // buffer up after the early passes finish and decodes only the new messages
+            // as an extra late (isDeep) delivery. See LateDecode.
+            final LateDecode.Handoff lateHandoff =
+                    LateDecode.shouldRunLatePass(GeneralVariables.earlyDecode, mode)
+                            ? new LateDecode.Handoff(System.currentTimeMillis(), mode.slotMillis)
+                            : null;
             onWaveDataListener.getVoiceData(recordMs, true
                     , new OnGetVoiceDataDone() {
                         @Override
                         public void onGetDone(float[] data) {
                             Log.d(TAG, String.format("Starting decode...###, data length: %d",data.length));
-                            decodeFt8(utc, data);
+                            decodeFt8(utc, data, lateHandoff);
                         }
                     });
+            if (lateHandoff != null) {
+                onWaveDataListener.getVoiceData(mode.slotMillis, true
+                        , new OnGetVoiceDataDone() {
+                            @Override
+                            public void onGetDone(float[] data) {
+                                lateHandoff.offer(data);
+                            }
+                        });
+            }
         }
     }
 
     public void decodeFt8(long utc, float[] voiceData) {
+        decodeFt8(utc, voiceData, null);
+    }
+
+    /**
+     * @param lateHandoff when non-null, the source of a second full-slot buffer to decode
+     *                    after the early passes finish (late full-slot pass, issue #363);
+     *                    null = no late pass this cycle
+     */
+    public void decodeFt8(long utc, float[] voiceData, LateDecode.Handoff lateHandoff) {
 
         // Test code below -------------------------
 //        String fileName = getCacheFileName("test_01.wav");
@@ -180,10 +214,15 @@ public class FT8SignalListener {
 //                DecoderMonitorPressFloat(tempData, ft8Decoder);// load audio data
 
 
+                // The a91 list is LOCAL to this decode thread (not instance state): the
+                // late full-slot pass keeps this thread alive into the next slot, whose
+                // own decode thread must be able to run concurrently without either
+                // corrupting the other's subtract bookkeeping.
+                final A91List a91List = new A91List();
                 ArrayList<Ft8Message> allMsg = new ArrayList<>();
 //                ArrayList<Ft8Message> msgs = runDecode(utc, voiceData,false);
                 ArrayList<Ft8Message> msgs = runDecode(ft8Decoder, utc, false, fromSource,
-                        DeepDecodeBudget.NO_DEADLINE);
+                        DeepDecodeBudget.NO_DEADLINE, a91List);
                 addMsgToList(allMsg, msgs);
                 timeSec = System.currentTimeMillis() - time;
                 decodeTimeSec.postValue(timeSec);// decode elapsed time
@@ -195,7 +234,7 @@ public class FT8SignalListener {
                 if (GeneralVariables.deepDecodeMode) {// enter deep decode mode
                     //float[] newSignal=tempData;
                     msgs = runDecode(ft8Decoder, utc, true, fromSource,
-                            DeepDecodeBudget.NO_DEADLINE);
+                            DeepDecodeBudget.NO_DEADLINE, a91List);
                     addMsgToList(allMsg, msgs);
                     timeSec = System.currentTimeMillis() - time;
                     decodeTimeSec.postValue(timeSec);// decode elapsed time
@@ -217,7 +256,7 @@ public class FT8SignalListener {
                         subtractDecode(ft8Decoder, a91List, fromSource);
 
                         // perform another decode pass
-                        msgs = runDecode(ft8Decoder, utc, true, fromSource, passDeadline);
+                        msgs = runDecode(ft8Decoder, utc, true, fromSource, passDeadline, a91List);
                         addMsgToList(allMsg, msgs);
                         timeSec = System.currentTimeMillis() - time;
                         decodeTimeSec.postValue(timeSec);// decode elapsed time
@@ -233,13 +272,79 @@ public class FT8SignalListener {
 
                 Log.d(TAG, String.format("Decode took: %d ms", System.currentTimeMillis() - time));
 
+                // Late full-slot pass (issue #363): runs after the early buffer has been
+                // fully processed and its decoder freed, on this same thread, so the late
+                // decodes share the slot's allMsg dedup scope and only NEW messages get
+                // delivered. Runs into the next slot's cycle by design; the next slot's
+                // decode uses its own thread, decoder, and a91 list.
+                if (lateHandoff != null) {
+                    runLateFullSlotPass(utc, allMsg, a91List, fromSource, lateHandoff);
+                }
+
             }
         }).start();
     }
 
+    /**
+     * Decode the full-slot buffer captured alongside the early window, recovering signals
+     * whose DT pushed them past the early window's end. Deliveries reuse the slot's
+     * {@code allMsg} dedup scope, so everything the early passes already reported is
+     * filtered out and only genuinely new messages reach {@code afterDecode} — flagged
+     * isDeep=true so the auto-sequencer (which already acted on the early results) is not
+     * triggered a second time.
+     *
+     * <p>Deliberately does NOT touch {@link #timeSec}/{@link #decodeTimeSec}: by the time
+     * this runs the next slot may already be decoding, and clobbering the shared elapsed
+     * time could make MainViewModel's auto-reply budget check misjudge that slot.
+     */
+    private void runLateFullSlotPass(long utc, ArrayList<Ft8Message> allMsg, A91List a91List,
+                                     boolean fromSource, LateDecode.Handoff handoff) {
+        float[] fullData = handoff.awaitBuffer(System.currentTimeMillis());
+        if (fullData == null) {
+            // Capture stopped mid-slot (or never started); the buffer is not coming.
+            Log.w(TAG, "late full-slot pass skipped: full-slot buffer never arrived");
+            return;
+        }
+        long time = System.currentTimeMillis();
+        long lateDecoder = initDecoder(utc, fullData.length, fromSource);
+        try {
+            pressFloatDecode(fullData, lateDecoder, fromSource);
+            // Bound the whole late pass (fast + deep candidate loops) by the mode's deep
+            // budget so a slow device can't chain late work across multiple later slots.
+            final long deadline = DeepDecodeBudget.passDeadline(time,
+                    GeneralVariables.currentMode().deepDecodeBudgetMillis());
+            deliverLateMessages(utc, allMsg,
+                    runDecode(lateDecoder, utc, false, fromSource, deadline, a91List));
+            if (GeneralVariables.deepDecodeMode) {
+                deliverLateMessages(utc, allMsg,
+                        runDecode(lateDecoder, utc, true, fromSource, deadline, a91List));
+            }
+        } finally {
+            deleteDecoder(lateDecoder, fromSource);
+        }
+        Log.d(TAG, String.format("Late full-slot pass took: %d ms",
+                System.currentTimeMillis() - time));
+    }
+
+    /**
+     * Merge one late pass's decodes into the slot's dedup scope and deliver only the NEW
+     * messages. An empty remainder is not delivered at all — the late pass runs during the
+     * next slot's cycle, and a no-op afterDecode would clear that slot's decoding marker
+     * and waterfall labels behind its back.
+     */
+    private void deliverLateMessages(long utc, ArrayList<Ft8Message> allMsg,
+                                     ArrayList<Ft8Message> msgs) {
+        addMsgToList(allMsg, msgs);// drops everything the early passes already delivered
+        if (msgs.isEmpty() || onFt8Listen == null) {
+            return;
+        }
+        // isDeep=true: MainViewModel appends these without re-triggering auto-sequence.
+        onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
+    }
+
 
     private ArrayList<Ft8Message> runDecode(long ft8Decoder, long utc, boolean isDeep, boolean fromSource,
-                                            long deadlineEpochMs) {
+                                            long deadlineEpochMs, A91List a91List) {
         ArrayList<Ft8Message> ft8Messages = new ArrayList<>();
         Ft8Message ft8Message = new Ft8Message(GeneralVariables.operatingMode);
 
@@ -318,8 +423,13 @@ public class FT8SignalListener {
     }
 
     private boolean analysisDecode(int idx, long decoder, Ft8Message msg, boolean fromSource) {
-        return fromSource ? DecoderFt2Analysis(idx, decoder, msg)
-                : DecoderFt8Analysis(idx, decoder, msg);
+        // Serialized: DecoderFt8Analysis reads/writes the process-global cross-slot cache
+        // (ft8_xslot.c), and the late full-slot pass can overlap the next slot's decode
+        // thread. See DECODE_ANALYSIS_LOCK.
+        synchronized (DECODE_ANALYSIS_LOCK) {
+            return fromSource ? DecoderFt2Analysis(idx, decoder, msg)
+                    : DecoderFt8Analysis(idx, decoder, msg);
+        }
     }
 
     private byte[] getA91Decode(long decoder, boolean fromSource) {
@@ -353,12 +463,17 @@ public class FT8SignalListener {
     }
 
     /**
-     * Add messages to the list.
+     * Merge {@code newMsg} into {@code allMsg}, the slot-wide dedup scope: messages whose
+     * text is already in {@code allMsg} are REMOVED from {@code newMsg} (upgrading the
+     * kept copy's SNR where better, see {@link #checkMessageSame}); the rest are appended
+     * to {@code allMsg}. After the call {@code newMsg} holds only the genuinely new
+     * messages — which is what makes the late full-slot pass deliver only messages the
+     * early passes missed. Static (no instance state) so it is unit-testable.
      *
      * @param allMsg message list
      * @param newMsg new messages
      */
-    private void addMsgToList(ArrayList<Ft8Message> allMsg, ArrayList<Ft8Message> newMsg) {
+    static void addMsgToList(ArrayList<Ft8Message> allMsg, ArrayList<Ft8Message> newMsg) {
         for (int i = newMsg.size() - 1; i >= 0; i--) {
             if (checkMessageSame(allMsg, newMsg.get(i))) {
                 newMsg.remove(i);
@@ -375,7 +490,7 @@ public class FT8SignalListener {
      * @param ft8Message  message
      * @return boolean
      */
-    private boolean checkMessageSame(ArrayList<Ft8Message> ft8Messages, Ft8Message ft8Message) {
+    static boolean checkMessageSame(ArrayList<Ft8Message> ft8Messages, Ft8Message ft8Message) {
         for (Ft8Message msg : ft8Messages) {
             if (msg.getMessageText().equals(ft8Message.getMessageText())) {
                 // Prefer known SNR over unknown; when both are known, keep the higher value.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
@@ -4,6 +4,7 @@ import com.k1af.ft8af.ModeProfile;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Policy and buffer handoff for the late full-slot decode pass (issue #363).
@@ -48,6 +49,48 @@ public final class LateDecode {
      */
     public static boolean shouldRunLatePass(boolean earlyDecode, ModeProfile mode) {
         return earlyDecode && mode.isFt8 && mode.earlyDecodeMillis < mode.slotMillis;
+    }
+
+    /**
+     * Capture one cycle's decode plan at record time. Everything the decode thread (and
+     * its late full-slot pass) needs from the operating mode is frozen HERE, at the slot
+     * boundary: the user can switch modes mid-slot (rebuilding the cycle timers does not
+     * interrupt an in-flight decode thread, and the late pass deliberately runs into the
+     * next slot), and a decode that re-read {@code GeneralVariables.currentMode()} later
+     * would then initialize the decoder with the NEW mode's protocol/flags against a
+     * buffer recorded under the OLD mode — producing garbage. Thread {@link SlotPlan#mode}
+     * through the whole decode instead of re-reading the global.
+     *
+     * @param earlyDecode current value of {@code GeneralVariables.earlyDecode}
+     * @param mode        the operating mode at the slot boundary
+     * @param nowMs       wall-clock time the monitors are being registered
+     */
+    public static SlotPlan planSlot(boolean earlyDecode, ModeProfile mode, long nowMs) {
+        int recordMillis = earlyDecode ? mode.earlyDecodeMillis : mode.slotMillis;
+        Handoff lateHandoff = shouldRunLatePass(earlyDecode, mode)
+                ? new Handoff(nowMs, mode.slotMillis)
+                : null;
+        return new SlotPlan(mode, recordMillis, lateHandoff);
+    }
+
+    /**
+     * Immutable per-cycle decode plan, captured by {@link #planSlot} at the slot boundary:
+     * the mode every decode pass of this slot must use, the primary record window, and the
+     * late full-slot handoff (null = no late pass this cycle).
+     */
+    public static final class SlotPlan {
+        /** The operating mode frozen at record time; ALL of this slot's decode passes use it. */
+        public final ModeProfile mode;
+        /** Primary capture window: early window when fast decode is on, else the full slot. */
+        public final int recordMillis;
+        /** Buffer handoff for the late full-slot pass, or null when no late pass runs. */
+        public final Handoff lateHandoff;
+
+        SlotPlan(ModeProfile mode, int recordMillis, Handoff lateHandoff) {
+            this.mode = mode;
+            this.recordMillis = recordMillis;
+            this.lateHandoff = lateHandoff;
+        }
     }
 
     /**
@@ -110,6 +153,73 @@ public final class LateDecode {
                 Thread.currentThread().interrupt();
                 return null;
             }
+        }
+    }
+
+    /**
+     * Serializes per-candidate native analysis across decode threads. The FT8 cross-slot
+     * recall cache (cpp/ft8af_glue/ft8_xslot.c) is process-global and NOT thread-safe, and
+     * the late full-slot pass lets a previous slot's decode thread overlap the next slot's
+     * decode thread — so no two analysis calls may ever run concurrently.
+     *
+     * <p>The gate is asymmetric so best-effort late work can never stall time-critical
+     * early work: the early/primary path always blocks (its wait is bounded by ONE
+     * in-flight candidate, since the late holder releases between candidates), while the
+     * late path only tries briefly and treats failure as "the next slot's early decode has
+     * started" — its cue to abort the remaining late candidates entirely.
+     */
+    public static final class AnalysisGate {
+        /**
+         * How long the late pass waits for the gate before declaring contention. Long
+         * enough to absorb a micro-race for a free lock, far shorter than one candidate's
+         * analysis — so a late pass genuinely overlapping an early decode aborts on the
+         * first collision instead of interleaving with (and slowing) every early candidate.
+         */
+        static final long LATE_TRYLOCK_TIMEOUT_MS = 10;
+
+        private final ReentrantLock lock = new ReentrantLock();
+
+        /** Early/primary path: always acquires; waits at most one candidate's analysis. */
+        public void acquireBlocking() {
+            lock.lock();
+        }
+
+        /**
+         * Late path: best-effort acquire bounded by {@link #LATE_TRYLOCK_TIMEOUT_MS}.
+         *
+         * @return true if acquired (caller MUST {@link #release()}); false on contention
+         *         or interrupt — the caller must NOT release, and should abort its
+         *         remaining late candidates
+         */
+        public boolean tryAcquireForLate() {
+            try {
+                return lock.tryLock(LATE_TRYLOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        public void release() {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Sticky abort flag for one late full-slot pass. Tripped on the first analysis-gate
+     * contention; once tripped, the late pass stops scanning candidates and skips any
+     * remaining late passes (e.g. the deep pass) — the next slot's early decode has
+     * priority and re-contending per candidate would just burn CPU against it.
+     */
+    public static final class LateAbort {
+        private volatile boolean tripped;
+
+        public void trip() {
+            tripped = true;
+        }
+
+        public boolean tripped() {
+            return tripped;
         }
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
@@ -1,0 +1,115 @@
+package com.k1af.ft8af.ft8listener;
+
+import com.k1af.ft8af.ModeProfile;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Policy and buffer handoff for the late full-slot decode pass (issue #363).
+ *
+ * <p>With early decode on (the default), the primary decode only sees the first
+ * {@link ModeProfile#earlyDecodeMillis} of the slot so replies can go out on the very next
+ * slot. The price: a signal that starts later than {@code slotMillis - earlyDecodeMillis}
+ * minus the audio slack (about DT &gt; +0.86 s for FT8) is truncated past decodability and
+ * silently lost. To recover those, the cycle also records the <em>whole</em> slot into a
+ * second buffer; the still-running decode thread picks that buffer up after the early
+ * passes finish and decodes it as an extra, late delivery.
+ *
+ * <p>This class holds the parts of that feature that are decisions/state rather than
+ * native-decoder plumbing, so they stay unit-testable: the should-run predicate, the
+ * bounded-wait math, and the one-shot buffer handoff between the recorder's monitor
+ * thread and the decode thread.
+ */
+public final class LateDecode {
+
+    /**
+     * Extra wait past the slot boundary for the full-slot buffer to arrive. The buffer is
+     * normally delivered right at the boundary (the monitor fills after exactly
+     * {@code slotMillis}); if capture stalls mid-slot, HamRecorder's one-shot stall
+     * watchdog force-delivers a partial buffer 2 s after the requested duration. 3 s
+     * covers that plus scheduling jitter; past it the buffer is never coming (e.g. the
+     * recorder was stopped before the monitor could even register).
+     */
+    static final long DELIVERY_GRACE_MS = 3000;
+
+    private LateDecode() {}
+
+    /**
+     * Whether this cycle should schedule the second, full-slot decode pass.
+     *
+     * <p>FT8 only: its 1.5 s early-window gap is the reported loss (DT &gt; +0.86 s).
+     * FT4/FT2 have smaller gaps (1.0 s / 0.75 s) on much shorter slots, where a second
+     * full decode roughly doubles per-slot CPU and the late thread would routinely chain
+     * across several subsequent slots — not worth it for those modes.
+     *
+     * @param earlyDecode current value of {@code GeneralVariables.earlyDecode}
+     * @param mode        the cycle's operating mode
+     */
+    public static boolean shouldRunLatePass(boolean earlyDecode, ModeProfile mode) {
+        return earlyDecode && mode.isFt8 && mode.earlyDecodeMillis < mode.slotMillis;
+    }
+
+    /**
+     * Absolute wall-clock instant after which waiting for the full-slot buffer is
+     * pointless (see {@link #DELIVERY_GRACE_MS}).
+     *
+     * @param registeredAtMs wall-clock time the full-slot monitor was registered
+     *                       (the slot boundary)
+     * @param slotMillis     the mode's slot length
+     */
+    static long deliveryDeadlineMillis(long registeredAtMs, int slotMillis) {
+        return registeredAtMs + slotMillis + DELIVERY_GRACE_MS;
+    }
+
+    /** Milliseconds still worth waiting for the buffer; never negative. */
+    static long remainingWaitMillis(long deadlineEpochMs, long nowMs) {
+        return Math.max(0, deadlineEpochMs - nowMs);
+    }
+
+    /**
+     * One-shot handoff of the full-slot audio buffer from the recorder's monitor thread
+     * to the decode thread (which is still busy with the early passes when the buffer
+     * completes). Exactly one buffer is ever accepted; the consumer's wait is bounded by
+     * the delivery deadline so a capture stopped mid-slot cannot leave the decode thread
+     * hanging.
+     */
+    public static final class Handoff {
+        private final ArrayBlockingQueue<float[]> queue = new ArrayBlockingQueue<>(1);
+        private final long deadlineEpochMs;
+
+        /**
+         * @param registeredAtMs wall-clock time the full-slot voice monitor was registered
+         * @param slotMillis     the mode's slot length (== the monitor's duration)
+         */
+        public Handoff(long registeredAtMs, int slotMillis) {
+            this.deadlineEpochMs = deliveryDeadlineMillis(registeredAtMs, slotMillis);
+        }
+
+        /**
+         * Recorder side: deliver the full-slot buffer. Only the first non-null offer is
+         * accepted.
+         *
+         * @return true if the buffer was accepted
+         */
+        public boolean offer(float[] fullSlotData) {
+            return fullSlotData != null && queue.offer(fullSlotData);
+        }
+
+        /**
+         * Decode-thread side: wait for the buffer, bounded by the delivery deadline.
+         *
+         * @param nowMs current wall-clock time ({@code System.currentTimeMillis()})
+         * @return the full-slot buffer, or null on timeout/interrupt (skip the late pass)
+         */
+        public float[] awaitBuffer(long nowMs) {
+            try {
+                return queue.poll(remainingWaitMillis(deadlineEpochMs, nowMs),
+                        TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateAnalysisGateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateAnalysisGateTest.java
@@ -1,0 +1,133 @@
+package com.k1af.ft8af.ft8listener;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Coverage for the asymmetric analysis gate + late-abort policy that lets the late
+ * full-slot pass share the (not thread-safe) native cross-slot cache with the next slot's
+ * early decode WITHOUT ever stalling it: the early path always blocks (bounded by one
+ * candidate), the late path gives up quickly under contention and its abort flag then
+ * cancels the rest of the late work.
+ */
+public class LateAnalysisGateTest {
+
+    private static final long JOIN_TIMEOUT_MS = 5_000;
+
+    // ---- AnalysisGate ------------------------------------------------------------------
+
+    @Test
+    public void lateTryAcquire_succeedsWhenUncontended() {
+        LateDecode.AnalysisGate gate = new LateDecode.AnalysisGate();
+        assertThat(gate.tryAcquireForLate()).isTrue();
+        gate.release();
+    }
+
+    @Test
+    public void lateTryAcquire_failsWhileEarlyHoldsGate_thenSucceedsAfterRelease()
+            throws Exception {
+        LateDecode.AnalysisGate gate = new LateDecode.AnalysisGate();
+        CountDownLatch held = new CountDownLatch(1);
+        CountDownLatch releaseNow = new CountDownLatch(1);
+        Thread early = new Thread(() -> {
+            gate.acquireBlocking();
+            held.countDown();
+            try {
+                releaseNow.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            gate.release();
+        });
+        early.start();
+        assertThat(held.await(JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+
+        // Contended: the early path holds the gate longer than the late timeout, so the
+        // late pass must give up (this is its cue to abort remaining candidates) ...
+        assertThat(gate.tryAcquireForLate()).isFalse();
+
+        releaseNow.countDown();
+        early.join(JOIN_TIMEOUT_MS);
+        assertThat(early.isAlive()).isFalse();
+
+        // ... and once the gate is free again a late acquire succeeds.
+        assertThat(gate.tryAcquireForLate()).isTrue();
+        gate.release();
+    }
+
+    @Test
+    public void earlyAcquire_waitsOutLateHolder_neverGivesUp() throws Exception {
+        LateDecode.AnalysisGate gate = new LateDecode.AnalysisGate();
+        // Late pass holds the gate (one candidate in flight).
+        assertThat(gate.tryAcquireForLate()).isTrue();
+
+        CountDownLatch acquired = new CountDownLatch(1);
+        Thread early = new Thread(() -> {
+            gate.acquireBlocking();
+            acquired.countDown();
+            gate.release();
+        });
+        early.start();
+
+        // The early path has no timeout: well past the late path's trylock window it is
+        // still (correctly) waiting rather than failing.
+        assertThat(acquired.await(
+                5 * LateDecode.AnalysisGate.LATE_TRYLOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                .isFalse();
+
+        // The late holder releases between candidates; the early path then proceeds.
+        gate.release();
+        assertThat(acquired.await(JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)).isTrue();
+        early.join(JOIN_TIMEOUT_MS);
+        assertThat(early.isAlive()).isFalse();
+    }
+
+    @Test
+    public void lateTryAcquire_whileInterrupted_returnsFalseAndKeepsInterruptFlag() {
+        LateDecode.AnalysisGate gate = new LateDecode.AnalysisGate();
+        Thread.currentThread().interrupt();
+        try {
+            // A late decode thread interrupted mid-pass must treat it like contention
+            // (abort), not crash — and the interrupt status must survive for the caller.
+            assertThat(gate.tryAcquireForLate()).isFalse();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();// clear the flag so it can't leak into other tests
+        }
+    }
+
+    // ---- LateAbort ---------------------------------------------------------------------
+
+    @Test
+    public void lateAbort_startsUntripped() {
+        assertThat(new LateDecode.LateAbort().tripped()).isFalse();
+    }
+
+    @Test
+    public void lateAbort_tripIsSticky() {
+        // Once contention is detected the WHOLE remaining late pass (including the deep
+        // pass) stays cancelled; nothing may reset the flag.
+        LateDecode.LateAbort abort = new LateDecode.LateAbort();
+        abort.trip();
+        assertThat(abort.tripped()).isTrue();
+        abort.trip();
+        assertThat(abort.tripped()).isTrue();
+    }
+
+    @Test
+    public void lateAbort_visibleAcrossThreads() throws Exception {
+        // The flag is tripped inside analysisDecode's gate path but read by the candidate
+        // loop; with the late pass and next slot's early decode on different threads the
+        // write must publish. (volatile — this guards against regression to a plain field.)
+        LateDecode.LateAbort abort = new LateDecode.LateAbort();
+        Thread tripper = new Thread(abort::trip);
+        tripper.start();
+        tripper.join(JOIN_TIMEOUT_MS);
+        assertThat(tripper.isAlive()).isFalse();
+        assertThat(abort.tripped()).isTrue();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateDecodeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateDecodeTest.java
@@ -1,0 +1,132 @@
+package com.k1af.ft8af.ft8listener;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.ModeProfile;
+
+import org.junit.Test;
+
+/**
+ * Coverage for the late full-slot decode pass policy and buffer handoff (issue #363):
+ * which cycles schedule the pass, how long the decode thread may wait for the full-slot
+ * buffer, and the one-shot handoff between the recorder's monitor thread and the decode
+ * thread.
+ */
+public class LateDecodeTest {
+
+    // ---- shouldRunLatePass -------------------------------------------------------------
+
+    @Test
+    public void latePass_runs_forFt8WithEarlyDecodeOn() {
+        assertThat(LateDecode.shouldRunLatePass(true, ModeProfile.FT8)).isTrue();
+    }
+
+    @Test
+    public void latePass_skipped_whenEarlyDecodeOff() {
+        // With earlyDecode off the primary decode already covers the whole slot; a second
+        // full-slot pass would be a pure duplicate.
+        assertThat(LateDecode.shouldRunLatePass(false, ModeProfile.FT8)).isFalse();
+    }
+
+    @Test
+    public void latePass_skipped_forFt4AndFt2() {
+        // Deliberate policy: the fast modes' early gaps (1.0s / 0.75s) are small relative
+        // to the doubling of per-slot decode work, and their late threads would routinely
+        // chain across several subsequent slots.
+        assertThat(LateDecode.shouldRunLatePass(true, ModeProfile.FT4)).isFalse();
+        assertThat(LateDecode.shouldRunLatePass(true, ModeProfile.FT2)).isFalse();
+    }
+
+    // ---- wait-bound math ---------------------------------------------------------------
+
+    @Test
+    public void deliveryDeadline_isSlotEndPlusGrace() {
+        // Monitor registered at the slot boundary; buffer completes slotMillis later;
+        // HamRecorder's stall watchdog force-delivers a partial at +2s; 3s covers both.
+        assertThat(LateDecode.deliveryDeadlineMillis(1_000_000L, 15_000))
+                .isEqualTo(1_000_000L + 15_000 + LateDecode.DELIVERY_GRACE_MS);
+    }
+
+    @Test
+    public void remainingWait_countsDownToDeadline() {
+        assertThat(LateDecode.remainingWaitMillis(1_018_000L, 1_016_500L)).isEqualTo(1_500L);
+    }
+
+    @Test
+    public void remainingWait_neverNegative_pastDeadline() {
+        // A decode thread that finishes its early passes after the deadline must not be
+        // handed a negative timeout (poll would throw / wait forever depending on impl).
+        assertThat(LateDecode.remainingWaitMillis(1_018_000L, 1_020_000L)).isEqualTo(0L);
+        assertThat(LateDecode.remainingWaitMillis(1_018_000L, 1_018_000L)).isEqualTo(0L);
+    }
+
+    // ---- Handoff state machine -----------------------------------------------------------
+
+    private static LateDecode.Handoff handoffWithLiveDeadline() {
+        // Registered "now": deadline is ~18s away, so an offered buffer is returned
+        // immediately and no test ever actually waits that long.
+        return new LateDecode.Handoff(System.currentTimeMillis(), 15_000);
+    }
+
+    private static LateDecode.Handoff handoffWithExpiredDeadline() {
+        // Registered far enough in the past that the deadline has already elapsed:
+        // awaitBuffer must return null without blocking.
+        return new LateDecode.Handoff(
+                System.currentTimeMillis() - 15_000 - LateDecode.DELIVERY_GRACE_MS - 1_000,
+                15_000);
+    }
+
+    @Test
+    public void handoff_offerThenAwait_deliversSameBuffer() {
+        LateDecode.Handoff handoff = handoffWithLiveDeadline();
+        float[] buffer = new float[]{0.1f, 0.2f};
+        assertThat(handoff.offer(buffer)).isTrue();
+        assertThat(handoff.awaitBuffer(System.currentTimeMillis())).isSameInstanceAs(buffer);
+    }
+
+    @Test
+    public void handoff_isOneShot_secondOfferRejected() {
+        LateDecode.Handoff handoff = handoffWithLiveDeadline();
+        assertThat(handoff.offer(new float[]{1f})).isTrue();
+        assertThat(handoff.offer(new float[]{2f})).isFalse();
+    }
+
+    @Test
+    public void handoff_rejectsNullBuffer() {
+        LateDecode.Handoff handoff = handoffWithLiveDeadline();
+        assertThat(handoff.offer(null)).isFalse();
+    }
+
+    @Test
+    public void handoff_await_pastDeadline_returnsNullWithoutBlocking() {
+        // Capture stopped mid-slot: the buffer never arrives. The decode thread's wait is
+        // bounded by the delivery deadline, so it gives up (and skips the late pass).
+        LateDecode.Handoff handoff = handoffWithExpiredDeadline();
+        long before = System.currentTimeMillis();
+        assertThat(handoff.awaitBuffer(before)).isNull();
+        // "Without blocking": far under the 18s a naive unbounded wait would burn.
+        assertThat(System.currentTimeMillis() - before).isLessThan(1_000L);
+    }
+
+    @Test
+    public void handoff_bufferOfferedBeforeLateAwait_stillDelivered() {
+        // Early passes may finish AFTER the deadline (slow device, deep decode): a buffer
+        // that already arrived must still be consumed even though the remaining wait is 0.
+        LateDecode.Handoff handoff = handoffWithExpiredDeadline();
+        float[] buffer = new float[]{0.5f};
+        assertThat(handoff.offer(buffer)).isTrue();
+        assertThat(handoff.awaitBuffer(System.currentTimeMillis())).isSameInstanceAs(buffer);
+    }
+
+    @Test
+    public void handoff_awaitWhileInterrupted_returnsNullAndKeepsInterruptFlag() {
+        LateDecode.Handoff handoff = handoffWithLiveDeadline();
+        Thread.currentThread().interrupt();
+        try {
+            assertThat(handoff.awaitBuffer(System.currentTimeMillis())).isNull();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();// clear the flag so it can't leak into other tests
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateDecodeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateDecodeTest.java
@@ -129,4 +129,49 @@ public class LateDecodeTest {
             Thread.interrupted();// clear the flag so it can't leak into other tests
         }
     }
+
+    // ---- planSlot: the record-time capture of the whole cycle's decode parameters ------
+    // A mid-slot mode switch must not retroactively change how an in-flight slot decodes,
+    // so EVERYTHING mode-derived is frozen into the SlotPlan at the slot boundary.
+
+    @Test
+    public void planSlot_ft8WithEarlyDecode_freezesModeEarlyWindowAndLateHandoff() {
+        LateDecode.SlotPlan plan = LateDecode.planSlot(true, ModeProfile.FT8, 1_000_000L);
+        assertThat(plan.mode).isEqualTo(ModeProfile.FT8);
+        assertThat(plan.recordMillis).isEqualTo(ModeProfile.FT8.earlyDecodeMillis);
+        assertThat(plan.lateHandoff).isNotNull();
+    }
+
+    @Test
+    public void planSlot_earlyDecodeOff_recordsFullSlotWithNoLatePass() {
+        // With early decode off the primary window already covers the whole slot; a late
+        // pass would be a pure duplicate.
+        LateDecode.SlotPlan plan = LateDecode.planSlot(false, ModeProfile.FT8, 1_000_000L);
+        assertThat(plan.mode).isEqualTo(ModeProfile.FT8);
+        assertThat(plan.recordMillis).isEqualTo(ModeProfile.FT8.slotMillis);
+        assertThat(plan.lateHandoff).isNull();
+    }
+
+    @Test
+    public void planSlot_fastModes_earlyWindowButNoLatePass() {
+        // Matches shouldRunLatePass: FT4/FT2 keep a single early-window pass.
+        for (ModeProfile mode : new ModeProfile[]{ModeProfile.FT4, ModeProfile.FT2}) {
+            LateDecode.SlotPlan plan = LateDecode.planSlot(true, mode, 1_000_000L);
+            assertThat(plan.mode).isEqualTo(mode);
+            assertThat(plan.recordMillis).isEqualTo(mode.earlyDecodeMillis);
+            assertThat(plan.lateHandoff).isNull();
+        }
+    }
+
+    @Test
+    public void planSlot_handoffDeadline_anchoredAtPlanTime() {
+        LateDecode.SlotPlan plan = LateDecode.planSlot(true, ModeProfile.FT8, 1_000_000L);
+        // Past the plan-time-anchored deadline (slot end + grace) the wait is zero: a
+        // decode thread that finishes its early passes very late must not block at all.
+        long pastDeadline = 1_000_000L + ModeProfile.FT8.slotMillis
+                + LateDecode.DELIVERY_GRACE_MS + 1;
+        long before = System.currentTimeMillis();
+        assertThat(plan.lateHandoff.awaitBuffer(pastDeadline)).isNull();
+        assertThat(System.currentTimeMillis() - before).isLessThan(1_000L);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateMessageMergeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateMessageMergeTest.java
@@ -1,0 +1,118 @@
+package com.k1af.ft8af.ft8listener;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+
+/**
+ * The late full-slot pass (issue #363) merges its decodes into the slot's {@code allMsg}
+ * dedup scope via {@code FT8SignalListener.addMsgToList}, and delivers ONLY what survives
+ * the merge — otherwise every message the early passes already reported would be
+ * duplicated into the UI list, SWL database, and PSKReporter uploads. These tests pin the
+ * merge semantics that delivery decision rests on.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LateMessageMergeTest {
+
+    /** A message whose text is unique per {@code text} (free-text path of getMessageText). */
+    private static Ft8Message msg(String text) {
+        return new Ft8Message("CQ", "K1ABC", text);
+    }
+
+    private static Ft8Message msg(String text, int snr) {
+        Ft8Message m = msg(text);
+        m.snr = snr;
+        return m;
+    }
+
+    private static ArrayList<Ft8Message> listOf(Ft8Message... msgs) {
+        ArrayList<Ft8Message> list = new ArrayList<>();
+        for (Ft8Message m : msgs) {
+            list.add(m);
+        }
+        return list;
+    }
+
+    @Test
+    public void merge_dropsMessagesTheEarlyPassAlreadyDelivered() {
+        ArrayList<Ft8Message> allMsg = listOf(msg("EARLY1"), msg("EARLY2"));
+        // Late pass re-decodes both early messages plus one genuinely new late signal.
+        ArrayList<Ft8Message> late = listOf(msg("EARLY1"), msg("LATE1"), msg("EARLY2"));
+
+        FT8SignalListener.addMsgToList(allMsg, late);
+
+        // Only the new message survives in the delivery list...
+        assertThat(late).hasSize(1);
+        assertThat(late.get(0).getMessageText()).isEqualTo(msg("LATE1").getMessageText());
+        // ...and the dedup scope now also contains it (so a later deep pass can't
+        // re-deliver it either).
+        assertThat(allMsg).hasSize(3);
+    }
+
+    @Test
+    public void merge_allDuplicates_leavesNothingToDeliver() {
+        // The common case: the full-slot buffer re-decodes exactly what the early window
+        // held. The delivery list must end up empty — the late pass then skips
+        // afterDecode entirely.
+        ArrayList<Ft8Message> allMsg = listOf(msg("EARLY1"), msg("EARLY2"));
+        ArrayList<Ft8Message> late = listOf(msg("EARLY2"), msg("EARLY1"));
+
+        FT8SignalListener.addMsgToList(allMsg, late);
+
+        assertThat(late).isEmpty();
+        assertThat(allMsg).hasSize(2);
+    }
+
+    @Test
+    public void merge_intoEmptyScope_keepsEverything() {
+        ArrayList<Ft8Message> allMsg = new ArrayList<>();
+        ArrayList<Ft8Message> late = listOf(msg("LATE1"), msg("LATE2"));
+
+        FT8SignalListener.addMsgToList(allMsg, late);
+
+        assertThat(late).hasSize(2);
+        assertThat(allMsg).hasSize(2);
+    }
+
+    @Test
+    public void merge_duplicateWithBetterSnr_upgradesTheKeptCopy() {
+        // The full 15s buffer can yield a better SNR estimate for the same signal; the
+        // duplicate is still dropped, but its stronger SNR is folded into the copy the UI
+        // already shows.
+        Ft8Message early = msg("EARLY1", -18);
+        ArrayList<Ft8Message> allMsg = listOf(early);
+        ArrayList<Ft8Message> late = listOf(msg("EARLY1", -12));
+
+        FT8SignalListener.addMsgToList(allMsg, late);
+
+        assertThat(late).isEmpty();
+        assertThat(early.snr).isEqualTo(-12);
+    }
+
+    @Test
+    public void merge_duplicateWithUnknownSnr_doesNotDowngradeKnownSnr() {
+        Ft8Message early = msg("EARLY1", -18);
+        ArrayList<Ft8Message> allMsg = listOf(early);
+        ArrayList<Ft8Message> late = listOf(msg("EARLY1"));// SNR_UNKNOWN
+
+        FT8SignalListener.addMsgToList(allMsg, late);
+
+        assertThat(late).isEmpty();
+        assertThat(early.snr).isEqualTo(-18);
+    }
+
+    @Test
+    public void checkMessageSame_matchesOnTextOnly() {
+        Ft8Message a = msg("SAME TEXT");
+        Ft8Message b = msg("SAME TEXT");
+        b.freq_hz = 1500f;// different frequency, same content -> still the same message
+        assertThat(FT8SignalListener.checkMessageSame(listOf(a), b)).isTrue();
+        assertThat(FT8SignalListener.checkMessageSame(listOf(a), msg("OTHER"))).isFalse();
+    }
+}


### PR DESCRIPTION
Fixes #363

With earlyDecode on (the default), FT8 decodes only the first 13.5 s of the 15 s slot (`ModeProfile.FT8.earlyDecodeMillis`) so replies can go out on the very next slot. The price: a signal whose DT pushes it past the early window's end (~DT > +0.86 s) is truncated past decodability and silently lost. This PR adds a second, late decode pass over the full 15 s slot, delivered late, without touching the early path's timing.

## Design

**Buffer handoff.** `runRecorde` registers a *second* one-shot full-slot (15 s) voice monitor alongside the early 13.5 s one. `HamRecorder` monitors are independent buffers on a `CopyOnWriteArrayList`, so two outstanding `getVoiceData` requests coexist with no recorder changes needed. The full buffer is handed to the still-running decode thread via `LateDecode.Handoff` — a one-shot `ArrayBlockingQueue(1)` whose consumer wait is bounded by an absolute deadline (slot end + 3 s grace, covering `HamRecorder`'s 2 s stall watchdog that force-delivers a partial buffer if capture stalls). If the buffer never arrives (capture stopped mid-slot before the monitor registered), the wait times out and the late pass is skipped — the thread can never hang.

**Dedup scope.** The late pass runs on the *same* decode thread, after the early passes finish and their decoder is freed, so its decodes merge into the same `allMsg` scope via `addMsgToList`. Everything the early passes already delivered is dropped (upgrading the kept copy's SNR when the full buffer yields a better estimate); only genuinely NEW messages reach `afterDecode` — no duplicates in the UI list, SWL DB writes, or PSKReporter uploads. An all-duplicate late pass delivers nothing at all (no empty `afterDecode` call, which would otherwise clear the *next* slot's decoding marker and waterfall labels behind its back).

**Auto-sequence stays blocked.** Late deliveries use `afterDecode(..., isDeep=true)`. Verified in `MainViewModel.afterDecode`: `isDeep` messages are appended to the list, written to SWL/PSKReporter, but explicitly excluded from `parseMessageToFunction` (the auto-sequencer), which already acted on the early results.

**Thread safety for the overlap with the next slot's decode:**
- `a91List` was shared instance state read by `subtractDecode` while `runDecode` clears/fills it; it is now a per-decode-thread local threaded through `runDecode`/`subtractDecode`, so the late pass and the next slot's decode can't corrupt each other's subtract bookkeeping.
- The late pass uses its own freshly-initialized decoder instance (the early decoder was sized for the 13.5 s buffer and is deleted first). Audited the native side for cross-instance shared state: everything is per-decoder or thread-local *except* the FT8 cross-slot recall cache (`ft8_xslot.c`), which is process-global, documented as not thread-safe, and touched on every successful `DecoderFt8Analysis` (`ft8_xslot_remember`). The Java-side `analysisDecode` helper is now serialized on a static lock — per-candidate granularity, so the concurrent slot waits at most one candidate's decode.
- The late pass deliberately does **not** update `timeSec`/`decodeTimeSec`: by the time it runs the next slot may be decoding, and clobbering the shared elapsed time could make MainViewModel's auto-reply budget check misjudge that slot.

**Bounded runtime.** The whole late pass (fast + optional deep candidate loops) shares one deadline of `deepDecodeBudgetMillis()` (11.25 s for FT8), so a slow device can't chain late work across multiple later slots.

**Gating.** FT8 only, and only when earlyDecode is on (`LateDecode.shouldRunLatePass`). Decision from the `ModeProfile` numbers: FT8's early gap is 1.5 s of a 15 s slot — the reported loss; FT4/FT2 gaps are 1.0 s / 0.75 s on 7.5 s / 3.75 s slots, where a second full decode roughly doubles per-slot CPU and the late thread would routinely chain across several subsequent slots. Not worth it for the fast modes.

## Tests

- `LateDecodeTest` (12 tests): the should-run-late-pass predicate (FT8 on / earlyDecode off / FT4 / FT2), delivery-deadline and remaining-wait math (never-negative clamp), and the handoff state machine (offer/await roundtrip, one-shot second-offer rejection, null rejection, past-deadline non-blocking timeout, buffer-before-late-await still delivered, interrupt handling).
- `LateMessageMergeTest` (6 tests, Robolectric): the dedup-merge semantics the late delivery rests on — duplicates dropped, new messages kept and added to the scope, all-duplicate passes leaving nothing to deliver, SNR upgrade/no-downgrade on duplicates, text-only matching.

`gradlew testDebugUnitTest`: BUILD SUCCESSFUL, all 18 new tests ran and passed (0 failures/errors across the suite). `gradlew assembleDebug` (including the NDK build): BUILD SUCCESSFUL.

**On-air verification is advised** before relying on this: confirm late-DT stations (DT in roughly the +0.9…+2.4 s range) now appear one delivery late, that no duplicates show up in the message list / PSKReporter, and that next-slot auto-replies still fire on time with earlyDecode on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)