### PR TITLE
USB audio: true rational resampling for non-48 kHz capture devices

### DIFF
--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -114,6 +114,18 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (fir_decimator)." }
 $firExit = $LASTEXITCODE
 
 # ---------------------------------------------------------------------------
+# Rational resampler tests (C++): true polyphase L/M resampling for non-48 kHz
+# USB capture devices (issue #364 — a floored 44.1k/12k ratio shifted every
+# FT8 tone off the 6.25 Hz grid). Header-only, no ft8_lib deps.
+# ---------------------------------------------------------------------------
+$ratSrc = Join-Path $here "test_rational_resampler.cpp"
+$ratOut = Join-Path $env:TEMP "ft8_rational_test.exe"
+& $clangxx -std=c++14 -O2 -x c++ $ratSrc -o $ratOut
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (rational_resampler)." }
+& $ratOut
+$ratExit = $LASTEXITCODE
+
+# ---------------------------------------------------------------------------
 # Decode benchmark / regression harness: replays the committed FT8 WAV corpus
 # through the app's exact decode pipeline (same monitor config, candidate
 # search, LDPC settings, dedup, and subtract-and-redecode loop as
@@ -233,6 +245,7 @@ $xslotExit = $LASTEXITCODE
 if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
 if ($firExit -ne 0) { exit $firExit }
+if ($ratExit -ne 0) { exit $ratExit }
 if ($benchSelfExit -ne 0) { exit $benchSelfExit }
 if ($benchExit -ne 0) { exit $benchExit }
 if ($subExit -ne 0) { exit $subExit }

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -86,6 +86,13 @@ fir_out="$tmp/ft8_fir_test"
 "$CXX" -std=c++14 -O2 -Wall "$here/test_fir_decimator.cpp" -lm -o "$fir_out"
 "$fir_out"
 
+# Rational resampler tests (C++): true polyphase L/M resampling for non-48 kHz
+# USB capture devices (issue #364 — a floored 44.1k/12k ratio shifted every FT8
+# tone off the 6.25 Hz grid). Header-only, no ft8_lib deps.
+rat_out="$tmp/ft8_rational_test"
+"$CXX" -std=c++14 -O2 -Wall "$here/test_rational_resampler.cpp" -lm -o "$rat_out"
+"$rat_out"
+
 # Decode benchmark / regression harness: replays the committed FT8 WAV corpus
 # through the app's exact decode pipeline (same monitor config, candidate
 # search, LDPC settings, dedup, and subtract-and-redecode loop as

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_rational_resampler.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_rational_resampler.cpp
@@ -1,0 +1,175 @@
+// Host tests for rational_resampler.h, the polyphase L/M resampler behind the
+// non-48 kHz USB capture fix (issue #364).
+//
+// The bug this guards against: a device that only streams 44.1 kHz used to get
+// its decimation ratio floored (44100/12000 -> 3), producing 14.7 kHz audio
+// labeled 12 kHz — every FT8 tone shifted down by the 12000/14700 ratio and off
+// the 6.25 Hz grid, so nothing decoded. These tests pin the properties that
+// matter: exact rational output rate (no drift), tone frequency preserved,
+// unity passband gain, deep alias rejection, and streaming-state correctness.
+//
+// HOST BUILD (no device): run_host_tests.ps1 / run_host_tests.sh compile this
+// with a host clang++ and run it. Exit code 0 == all pass.
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include "../rational_resampler.h"
+
+static int g_failures = 0;
+
+static void check(bool cond, const char* label) {
+    if (cond) {
+        printf("  ok:   %s\n", label);
+    } else {
+        printf("  FAIL: %s\n", label);
+        ++g_failures;
+    }
+}
+
+// Resample `seconds` of a sine at freqHz/inRate through L/M and return the
+// output. Shared by the frequency / gain / alias assertions.
+static std::vector<float> resampledTone(int inRate, int L, int M,
+                                        double freqHz, double seconds) {
+    RationalResampler rs(L, M);
+    const int n = static_cast<int>(inRate * seconds);
+    std::vector<float> in(n);
+    for (int i = 0; i < n; ++i) {
+        in[i] = static_cast<float>(std::sin(2.0 * M_PI * freqHz * i / inRate));
+    }
+    std::vector<float> out;
+    rs.process(in.data(), n, out);
+    return out;
+}
+
+// Peak amplitude over the back half of the output (skips filter warm-up).
+static float steadyPeak(const std::vector<float>& out) {
+    float peak = 0.0f;
+    for (std::size_t i = out.size() / 2; i < out.size(); ++i) {
+        peak = std::max(peak, std::fabs(out[i]));
+    }
+    return peak;
+}
+
+// Estimate the dominant frequency of the back half of `out` (rate outRate)
+// by counting zero crossings — robust for a clean single tone.
+static double zeroCrossFreq(const std::vector<float>& out, int outRate) {
+    std::size_t start = out.size() / 2;
+    int crossings = 0;
+    for (std::size_t i = start + 1; i < out.size(); ++i) {
+        if ((out[i - 1] < 0.0f) != (out[i] < 0.0f)) ++crossings;
+    }
+    const double seconds = (double)(out.size() - start) / outRate;
+    return crossings / (2.0 * seconds);
+}
+
+int main() {
+    printf("rational_resampler tests:\n");
+
+    // 1. Ratio reduction + guards (mirrors decimationRatioFor's degenerate cases).
+    {
+        RationalRatio r = rationalRatioFor(48000, 12000);
+        check(r.L == 1 && r.M == 4, "48k/12k -> L/M = 1/4 (integer path)");
+        r = rationalRatioFor(44100, 12000);
+        check(r.L == 40 && r.M == 147, "44.1k/12k -> L/M = 40/147");
+        r = rationalRatioFor(96000, 12000);
+        check(r.L == 1 && r.M == 8, "96k/12k -> L/M = 1/8");
+        r = rationalRatioFor(48000, 0);
+        check(r.L == 1 && r.M == 1, "zero target rate -> pass-through 1/1");
+        r = rationalRatioFor(48000, -12000);
+        check(r.L == 1 && r.M == 1, "negative target rate -> pass-through 1/1");
+        r = rationalRatioFor(8000, 12000);
+        check(r.L == 1 && r.M == 1, "input below target -> pass-through 1/1 (no upsample)");
+        r = rationalRatioFor(12000, 12000);
+        check(r.L == 1 && r.M == 1, "equal rates -> pass-through 1/1");
+    }
+
+    // 2. Exact output count over a long stream — the floored decimator produced
+    //    22.5% too few samples per second; the rational one must not drift.
+    {
+        RationalResampler rs(40, 147);
+        const int n = 441000;  // 10 s at 44.1 kHz
+        std::vector<float> in(n, 0.0f), out;
+        rs.process(in.data(), n, out);
+        // Outputs live at upsampled indices 0, M, 2M, ... <= (n-1)*L.
+        const long expected = (long)((std::int64_t)(n - 1) * 40 / 147) + 1;  // 120000
+        printf("  info: 10 s @44.1k -> %zu outputs (expected %ld)\n", out.size(), expected);
+        check((long)out.size() == expected, "10 s of 44.1k input -> exactly 120000 outputs at 12k");
+    }
+
+    // 3. Unity DC gain — per-branch normalization must hold for every phase.
+    {
+        RationalResampler rs(40, 147);
+        const int n = 44100;
+        std::vector<float> in(n, 1.0f), out;
+        rs.process(in.data(), n, out);
+        float worst = 0.0f;
+        for (std::size_t i = out.size() / 2; i < out.size(); ++i) {
+            worst = std::max(worst, std::fabs(out[i] - 1.0f));
+        }
+        printf("  info: DC worst-case deviation %.6f\n", worst);
+        check(worst < 1e-3f, "unity DC gain on all output phases");
+    }
+
+    // 4. The core #364 property: a 1500 Hz tone at 44.1 kHz stays 1500 Hz at
+    //    12 kHz. (With the old floored /3 path it would land at ~1224 Hz.)
+    {
+        std::vector<float> out = resampledTone(44100, 40, 147, 1500.0, 1.0);
+        const double f = zeroCrossFreq(out, 12000);
+        printf("  info: 1500 Hz tone measured at %.2f Hz after 44.1k->12k\n", f);
+        check(std::fabs(f - 1500.0) < 5.0, "1500 Hz tone stays 1500 Hz through 44.1k->12k");
+        const float peak = steadyPeak(out);
+        printf("  info: 1500 Hz passband gain %.4f\n", peak);
+        check(peak > 0.95f && peak < 1.05f, "1500 Hz passband tone passes near unity");
+    }
+
+    // 5. A 2.5 kHz tone (upper FT8 band) also survives with correct frequency.
+    {
+        std::vector<float> out = resampledTone(44100, 40, 147, 2500.0, 1.0);
+        const double f = zeroCrossFreq(out, 12000);
+        check(std::fabs(f - 2500.0) < 5.0, "2500 Hz tone stays 2500 Hz through 44.1k->12k");
+    }
+
+    // 6. Alias rejection: 10 kHz at 44.1k would fold to |10000 - 12000| = 2 kHz —
+    //    mid-FT8-band — without the low-pass. Must be crushed.
+    {
+        std::vector<float> out = resampledTone(44100, 40, 147, 10000.0, 1.0);
+        const float peak = steadyPeak(out);
+        printf("  info: 10 kHz alias residue %.5f\n", peak);
+        check(peak < 0.01f, "10 kHz alias tone rejected > 40 dB");
+    }
+
+    // 7. Streaming across buffers matches a single call (state carries over —
+    //    the capture loop feeds ~1 ms USB packets).
+    {
+        const int n = 44100 / 5;
+        std::vector<float> in(n);
+        for (int i = 0; i < n; ++i) {
+            in[i] = static_cast<float>(std::sin(2.0 * M_PI * 700.0 * i / 44100.0));
+        }
+        RationalResampler whole(40, 147);
+        std::vector<float> outWhole;
+        whole.process(in.data(), n, outWhole);
+
+        RationalResampler chunked(40, 147);
+        std::vector<float> outChunks;
+        const int chunk = 97;  // deliberately not aligned to L or M
+        for (int off = 0; off < n; off += chunk) {
+            const int len = std::min(chunk, n - off);
+            chunked.process(in.data() + off, len, outChunks);
+        }
+        bool same = outWhole.size() == outChunks.size();
+        for (std::size_t i = 0; same && i < outWhole.size(); ++i) {
+            same = outWhole[i] == outChunks[i];
+        }
+        check(same, "chunked streaming output identical to single-call output");
+    }
+
+    if (g_failures) {
+        printf("%d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("all rational_resampler tests passed\n");
+    return 0;
+}

--- a/ft8af/app/src/main/cpp/rational_resampler.h
+++ b/ft8af/app/src/main/cpp/rational_resampler.h
@@ -1,0 +1,190 @@
+// Streaming polyphase rational (L/M) resampler for the USB audio capture path.
+//
+// The FT8 decoder wants 12 kHz mono. Most USB codecs stream 48 kHz, which the
+// integer FirDecimator (fir_decimator.h) handles with a /4 decimation. But a
+// device that only supports e.g. 44.1 kHz used to get its ratio floored
+// (44100/12000 -> 3), so the capture path actually produced 14.7 kHz audio
+// labeled 12 kHz — every FT8 tone shifted off the 6.25 Hz grid and nothing
+// decoded (issue #364). This class resamples by the exact rational factor
+// instead: interpolate by L, low-pass, decimate by M (44.1k -> 12k is
+// L/M = 40/147), implemented as a polyphase FIR so the zero-stuffed samples
+// are never materialized (~numTaps()/L multiplies per output sample).
+//
+// Kernel: Blackman-windowed sinc at the conceptual upsampled rate
+// (inputRate * L), cutoff 0.45 / max(L, M) so it sits below both the input
+// and the output Nyquist, with each polyphase branch normalized to unity DC
+// sum (exact unity DC gain at every output phase; the xL zero-stuffing gain
+// is baked in).
+//
+// Header-only and free of JNI/libusb/Android deps on purpose, so the DSP can
+// be unit-tested on the host (see ft8af_glue/test_rational_resampler.cpp +
+// run_host_tests). RationalResampler.java is a line-for-line port for the
+// UsbRequest fallback capture path — keep the two in sync.
+
+#ifndef FT8AF_RATIONAL_RESAMPLER_H
+#define FT8AF_RATIONAL_RESAMPLER_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Reduced interpolate/decimate pair: outputRate/inputRate == L/M exactly.
+struct RationalRatio {
+    int L;  // interpolation factor
+    int M;  // decimation factor
+};
+
+// gcd via Euclid; local so the header stays C++14 (std::gcd is C++17).
+inline int rationalResamplerGcd(int a, int b) {
+    while (b != 0) {
+        int t = a % b;
+        a = b;
+        b = t;
+    }
+    return a;
+}
+
+// Rational ratio for an input/target sample-rate pair. Mirrors the guards of
+// decimationRatioFor (fir_decimator.h): a zero/negative target or a target
+// above the input rate degrades to {1, 1} (pass-through) instead of trying to
+// upsample audio that has no content above the input Nyquist anyway; callers
+// should warn. 48000/12000 -> {1, 4} (use the integer FirDecimator fast path
+// for that); 44100/12000 -> {40, 147}.
+inline RationalRatio rationalRatioFor(int inputRate, int targetRate) {
+    if (targetRate <= 0 || inputRate < targetRate) {
+        return {1, 1};
+    }
+    const int g = rationalResamplerGcd(inputRate, targetRate);
+    return {targetRate / g, inputRate / g};
+}
+
+class RationalResampler {
+public:
+    // interpolation (L) / decimation (M): outputRate = inputRate * L / M.
+    // tapsPerPhase scales the FIR length (2 * tapsPerPhase * max(L, M) + 1
+    // taps at the upsampled rate, i.e. ~2*tapsPerPhase taps per polyphase
+    // branch); 8 with a Blackman window gives ~ -58 dB stopband, matching
+    // FirDecimator.
+    explicit RationalResampler(int interpolation = 1, int decimation = 1,
+                               int tapsPerPhase = 8) {
+        configure(interpolation, decimation, tapsPerPhase);
+    }
+
+    // Rebuild for a new ratio and clear state. Safe to call before the rate
+    // pair is known.
+    void configure(int interpolation, int decimation, int tapsPerPhase = 8) {
+        L_ = interpolation < 1 ? 1 : interpolation;
+        M_ = decimation < 1 ? 1 : decimation;
+        buildKernel(tapsPerPhase < 1 ? 1 : tapsPerPhase);
+        // Enough input history for the deepest tap any output phase reaches.
+        histLen_ = static_cast<int>((kernel_.size() - 1)) / L_ + 2;
+        history_.assign(histLen_, 0.0f);
+        reset();
+    }
+
+    // Drop all filter state (e.g. on stream restart) without rebuilding.
+    void reset() {
+        std::fill(history_.begin(), history_.end(), 0.0f);
+        pos_ = 0;
+        inCount_ = 0;
+        nextT_ = 0;
+    }
+
+    int interpolation() const { return L_; }
+    int decimation() const { return M_; }
+    std::size_t numTaps() const { return kernel_.size(); }
+
+    // Push `n` input samples; append each resampled output sample to `out`.
+    // Streaming-safe: call repeatedly across buffers, state carries over.
+    // Produces about n*L/M outputs per call.
+    void process(const float* in, int n, std::vector<float>& out) {
+        for (int i = 0; i < n; ++i) {
+            history_[pos_] = in[i];
+            pos_ = (pos_ + 1 == histLen_) ? 0 : pos_ + 1;
+            ++inCount_;
+            // Output sample k lives at upsampled index k*M; it is computable
+            // once the newest input sample (upsampled index (inCount_-1)*L)
+            // has arrived, because the FIR only looks backward from there.
+            const std::int64_t newestT = (inCount_ - 1) * static_cast<std::int64_t>(L_);
+            while (nextT_ <= newestT) {
+                out.push_back(interpolateAt(nextT_));
+                nextT_ += M_;
+            }
+        }
+    }
+
+private:
+    // Evaluate the polyphase FIR at upsampled index t: with w[] the
+    // zero-stuffed input (w[j*L] = x[j], 0 elsewhere), the output is
+    // sum_k h[k] * w[t - k]; only k = phase + m*L hit non-zero samples, so we
+    // walk taps h[phase], h[phase+L], ... against inputs x[t/L], x[t/L - 1],...
+    float interpolateAt(std::int64_t t) const {
+        const int N = static_cast<int>(kernel_.size());
+        std::int64_t j = t / L_;                       // newest input index used
+        int k = static_cast<int>(t - j * L_);          // kernel phase
+        int back = static_cast<int>(inCount_ - 1 - j); // 0 == newest sample
+        int idx = pos_ - 1 - back;
+        while (idx < 0) idx += histLen_;
+        float acc = 0.0f;
+        while (k < N && j >= 0 && back < histLen_) {
+            acc += history_[idx] * kernel_[k];
+            k += L_;
+            --j;
+            ++back;
+            idx = (idx == 0) ? histLen_ - 1 : idx - 1;
+        }
+        return acc;
+    }
+
+    void buildKernel(int tapsPerPhase) {
+        const int lm = L_ > M_ ? L_ : M_;
+        const int N = 2 * tapsPerPhase * lm + 1;  // odd -> exact symmetry
+        const int Mid = N - 1;
+        // Cutoff below both Nyquists in cycles per *upsampled* sample: the
+        // input Nyquist is 0.5/L, the output Nyquist is 0.5/M; 0.45/max keeps
+        // a small transition band under the binding one. For 44.1k -> 12k
+        // (L=40, M=147) that is ~5.4 kHz — well above FT8's ~3 kHz top.
+        const double fc = 0.45 / static_cast<double>(lm);
+
+        kernel_.resize(N);
+        for (int k = 0; k < N; ++k) {
+            const double m = k - Mid / 2.0;
+            const double sinc = (std::abs(m) < 1e-9)
+                    ? 2.0 * fc
+                    : std::sin(2.0 * M_PI * fc * m) / (M_PI * m);
+            // Blackman window for a deep, smooth stopband.
+            const double w = 0.42
+                    - 0.5 * std::cos(2.0 * M_PI * k / Mid)
+                    + 0.08 * std::cos(4.0 * M_PI * k / Mid);
+            kernel_[k] = static_cast<float>(sinc * w);
+        }
+        // Normalize each polyphase branch (taps k ≡ p mod L) to unity DC sum:
+        // every output phase then has exactly unity DC gain, and the xL gain
+        // that compensates zero-stuffing is baked in. For L == 1 this reduces
+        // to FirDecimator's whole-kernel normalization.
+        for (int p = 0; p < L_; ++p) {
+            double sum = 0.0;
+            for (int k = p; k < N; k += L_) sum += kernel_[k];
+            if (std::abs(sum) < 1e-12) continue;
+            const float norm = static_cast<float>(1.0 / sum);
+            for (int k = p; k < N; k += L_) kernel_[k] *= norm;
+        }
+    }
+
+    int L_ = 1;
+    int M_ = 1;
+    std::vector<float> kernel_;
+    std::vector<float> history_;
+    int histLen_ = 2;
+    int pos_ = 0;
+    std::int64_t inCount_ = 0;
+    std::int64_t nextT_ = 0;
+};
+
+#endif  // FT8AF_RATIONAL_RESAMPLER_H

--- a/ft8af/app/src/main/cpp/usb_audio_capture.cpp
+++ b/ft8af/app/src/main/cpp/usb_audio_capture.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "fir_decimator.h"
+#include "rational_resampler.h"
 
 #define TAG "ft8af_usb_capture"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  TAG, __VA_ARGS__)
@@ -71,6 +72,14 @@ struct CaptureSession {
     // result. Both are reused across iso callbacks (which fire every ~8ms) so the hot capture
     // path does no per-transfer heap allocation.
     FirDecimator        decimator{4};
+    // True rational resampling for devices whose rate is not an integer multiple
+    // of the target (issue #364): 44.1 kHz -> 12 kHz used to be floored to /3,
+    // producing 14.7 kHz audio labeled 12 kHz — every FT8 tone off the 6.25 Hz
+    // grid, zero decodes. When `useRational` is set, `resampler` (polyphase
+    // L/M, e.g. 40/147) replaces `decimator`; the 48 kHz integer fast path is
+    // untouched.
+    RationalResampler   resampler;
+    bool                useRational = false;
     std::vector<float>  monoScratch;
     std::vector<float>  outScratch;
 };
@@ -187,14 +196,19 @@ void LIBUSB_CALL onTransferComplete(libusb_transfer* xfer) {
         }
     }
 
-    // Anti-alias + decimate to the target rate. The FIR carries state across transfers, so
-    // partial input is fine — it just emits ~frames/ratio output samples per call.
+    // Anti-alias + resample to the target rate. Both stages carry state across transfers, so
+    // partial input is fine — they just emit ~frames*L/M output samples per call.
     if (!s->monoScratch.empty()) {
         // Reused buffer: clear() keeps the capacity from prior callbacks, so process()'s
         // push_backs don't reallocate on the hot path.
         s->outScratch.clear();
-        s->decimator.process(s->monoScratch.data(),
-                             (int)s->monoScratch.size(), s->outScratch);
+        if (s->useRational) {
+            s->resampler.process(s->monoScratch.data(),
+                                 (int)s->monoScratch.size(), s->outScratch);
+        } else {
+            s->decimator.process(s->monoScratch.data(),
+                                 (int)s->monoScratch.size(), s->outScratch);
+        }
         if (!s->outScratch.empty()) {
             emitAudioData(s, s->outScratch.data(), (int)s->outScratch.size());
         }
@@ -298,24 +312,36 @@ Java_com_k1af_ft8af_wave_UsbAudioNative_nativeStart(
     s->inputBytesPerSample = inputBytesPerSample > 0 ? inputBytesPerSample : 2;
     s->targetRate          = targetSampleRate;
     // Integer decimation ratio (e.g. 48k/12k = 4), computed defensively so a bad
-    // rate pair can't divide-by-zero or mis-rate the decoder. Warn on the two
-    // degenerate cases the helper folds into a pass-through ratio of 1.
+    // rate pair can't divide-by-zero or mis-rate the decoder. Warn on the
+    // degenerate cases the helper folds into a pass-through ratio of 1. A rate
+    // pair that isn't an integer multiple (e.g. a 44.1 kHz-only codec) gets the
+    // exact polyphase rational resampler instead of a floored ratio, which used
+    // to mislabel 14.7 kHz audio as 12 kHz and shift every FT8 tone off the
+    // 6.25 Hz grid (issue #364).
     const int ratio = decimationRatioFor(inputSampleRate, targetSampleRate);
     if (targetSampleRate <= 0 || inputSampleRate < targetSampleRate) {
         LOGE("invalid sample rates input=%d target=%d; disabling decimation "
              "(ratio=1, audio passed through unchanged)",
              inputSampleRate, targetSampleRate);
     } else if (inputSampleRate % targetSampleRate != 0) {
-        LOGE("input rate %d is not an integer multiple of target %d; using floor "
-             "ratio %d (output rate %d != expected %d, decode may suffer)",
-             inputSampleRate, targetSampleRate, ratio,
-             inputSampleRate / ratio, targetSampleRate);
+        s->useRational = true;
     }
     s->decimationRatio     = ratio;
-    // Build the anti-aliasing FIR for the actual integer ratio.
-    s->decimator.configure(ratio);
+    if (s->useRational) {
+        const RationalRatio lm = rationalRatioFor(inputSampleRate, targetSampleRate);
+        s->resampler.configure(lm.L, lm.M);
+        LOGI("input rate %d is not an integer multiple of target %d; using rational "
+             "polyphase resampler L/M=%d/%d (exact output rate %d)",
+             inputSampleRate, targetSampleRate, lm.L, lm.M,
+             (int)((int64_t)inputSampleRate * lm.L / lm.M));
+    } else {
+        // Build the anti-aliasing FIR for the actual integer ratio.
+        s->decimator.configure(ratio);
+    }
     s->monoScratch.reserve(inputSampleRate / 100);  // ~10ms of input headroom
-    s->outScratch.reserve(inputSampleRate / 100 / ratio + 1);  // decimated headroom
+    s->outScratch.reserve(targetSampleRate > 0
+            ? targetSampleRate / 100 + 2
+            : inputSampleRate / 100 + 2);           // resampled headroom
 
     jclass cbClass = env->GetObjectClass(callback);
     s->onData    = env->GetMethodID(cbClass, "onAudioData",       "([FI)V");
@@ -376,9 +402,12 @@ Java_com_k1af_ft8af_wave_UsbAudioNative_nativeStart(
     }
 
     LOGI("started capture: fd=%d ep=0x%02x maxPkt=%d inputRate=%d ch=%d targetRate=%d "
-         "decim=%d transfers=%zu packets/xfer=%d",
+         "L/M=%d/%d transfers=%zu packets/xfer=%d",
          fd, s->endpoint, s->maxPacketSize, s->inputRate, s->inputChannels,
-         s->targetRate, s->decimationRatio, s->transfers.size(), kPacketsPerTransfer);
+         s->targetRate,
+         s->useRational ? s->resampler.interpolation() : 1,
+         s->useRational ? s->resampler.decimation() : s->decimationRatio,
+         s->transfers.size(), kPacketsPerTransfer);
 
     s->eventThread = std::thread(eventLoop, s);
     return reinterpret_cast<jlong>(s);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -175,7 +175,8 @@ public class MicRecorder {
             return null;
         }
 
-        GeneralVariables.fileLog("openUsbAudioInput: SUCCESS at 48000 Hz");
+        GeneralVariables.fileLog("openUsbAudioInput: SUCCESS at "
+                + usbDev.getInputSampleRate() + " Hz");
         return usbDev;
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/RationalResampler.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/RationalResampler.java
@@ -1,0 +1,190 @@
+package com.k1af.ft8af.wave;
+
+/**
+ * Streaming polyphase rational (L/M) resampler — Java port of
+ * {@code cpp/rational_resampler.h} (same Blackman windowed-sinc kernel, cutoff, per-branch
+ * normalization, and streaming behavior), for the {@code UsbRequest} fallback capture path in
+ * {@link UsbAudioDevice}.
+ *
+ * <p>Why it exists (issue #364): both USB capture paths used to floor the decimation ratio, so
+ * a device that only streams 44.1 kHz got {@code 44100/12000 -> 3} and actually produced
+ * 14.7 kHz audio labeled 12 kHz — every FT8 tone shifted off the 6.25 Hz grid and nothing
+ * decoded. This class resamples by the exact rational factor instead: interpolate by L,
+ * low-pass, decimate by M (44.1 kHz -> 12 kHz is L/M = 40/147), implemented as a polyphase FIR
+ * so the zero-stuffed samples are never materialized (~{@code numTaps()/L} multiplies per
+ * output sample). The 48 kHz integer path keeps using {@link FirDecimator} untouched.
+ *
+ * <p>Streaming-safe: call {@link #process} repeatedly across buffers; filter state carries
+ * over. This is also the host-testable reference implementation of the native kernel — keep
+ * the two in sync (the C++ side is covered by {@code ft8af_glue/test_rational_resampler.cpp}).
+ */
+public final class RationalResampler {
+
+    private int interpolation;   // L
+    private int decimation;      // M
+    private float[] kernel;
+    private float[] history;
+    private int histLen;
+    private int pos;
+    private long inCount;
+    private long nextT;
+
+    /**
+     * Reduced interpolate/decimate pair {@code {L, M}} for an input/target rate pair
+     * ({@code outputRate == inputRate * L / M} exactly). Mirrors the guards of
+     * {@link FirDecimator#decimationRatioFor}: a zero/negative target or a target above the
+     * input rate degrades to {@code {1, 1}} (pass-through) instead of trying to upsample audio
+     * that has no content above the input Nyquist anyway; callers should warn.
+     * 48000/12000 -> {@code {1, 4}} (use the integer {@link FirDecimator} fast path for that);
+     * 44100/12000 -> {@code {40, 147}}.
+     */
+    public static int[] ratioFor(int inputRate, int targetRate) {
+        if (targetRate <= 0 || inputRate < targetRate) {
+            return new int[] {1, 1};
+        }
+        int g = gcd(inputRate, targetRate);
+        return new int[] {targetRate / g, inputRate / g};
+    }
+
+    private static int gcd(int a, int b) {
+        while (b != 0) {
+            int t = a % b;
+            a = b;
+            b = t;
+        }
+        return a;
+    }
+
+    public RationalResampler(int interpolation, int decimation) {
+        this(interpolation, decimation, 8);
+    }
+
+    /**
+     * @param tapsPerPhase scales the FIR length ({@code 2*tapsPerPhase*max(L,M) + 1} taps at
+     *     the conceptual upsampled rate, i.e. ~{@code 2*tapsPerPhase} taps per polyphase
+     *     branch); 8 with a Blackman window gives ~-58 dB stopband, matching
+     *     {@link FirDecimator}.
+     */
+    public RationalResampler(int interpolation, int decimation, int tapsPerPhase) {
+        configure(interpolation, decimation, tapsPerPhase);
+    }
+
+    /** Rebuild for a new L/M pair and clear state. */
+    public void configure(int interpolation, int decimation, int tapsPerPhase) {
+        this.interpolation = Math.max(1, interpolation);
+        this.decimation = Math.max(1, decimation);
+        buildKernel(Math.max(1, tapsPerPhase));
+        // Enough input history for the deepest tap any output phase reaches.
+        histLen = (kernel.length - 1) / this.interpolation + 2;
+        history = new float[histLen];
+        reset();
+    }
+
+    /** Drop all filter state (e.g. on stream restart) without rebuilding the kernel. */
+    public void reset() {
+        java.util.Arrays.fill(history, 0f);
+        pos = 0;
+        inCount = 0;
+        nextT = 0;
+    }
+
+    public int interpolation() {
+        return interpolation;
+    }
+
+    public int decimation() {
+        return decimation;
+    }
+
+    public int numTaps() {
+        return kernel.length;
+    }
+
+    /** Upper bound on the number of outputs one {@link #process} call can emit for n inputs. */
+    public int maxOutputFor(int n) {
+        return (int) ((long) n * interpolation / decimation) + 2;
+    }
+
+    /**
+     * Push {@code n} input samples; write resampled output samples into {@code out} from
+     * index 0. Produces about {@code n*L/M} outputs (never more than
+     * {@link #maxOutputFor(int)}); {@code out} must be at least that large.
+     *
+     * @return the number of output samples written
+     */
+    public int process(float[] in, int n, float[] out) {
+        int produced = 0;
+        for (int i = 0; i < n; i++) {
+            history[pos] = in[i];
+            pos = (pos + 1 == histLen) ? 0 : pos + 1;
+            inCount++;
+            // Output sample k lives at upsampled index k*M; it is computable once the newest
+            // input sample (upsampled index (inCount-1)*L) has arrived, because the FIR only
+            // looks backward from there.
+            long newestT = (inCount - 1) * interpolation;
+            while (nextT <= newestT) {
+                out[produced++] = interpolateAt(nextT);
+                nextT += decimation;
+            }
+        }
+        return produced;
+    }
+
+    // Evaluate the polyphase FIR at upsampled index t: with w[] the zero-stuffed input
+    // (w[j*L] = x[j], 0 elsewhere), the output is sum_k h[k]*w[t-k]; only k = phase + m*L hit
+    // non-zero samples, so we walk taps h[phase], h[phase+L], ... against x[t/L], x[t/L-1], ...
+    private float interpolateAt(long t) {
+        final int taps = kernel.length;
+        long j = t / interpolation;              // newest input index used
+        int k = (int) (t - j * interpolation);   // kernel phase
+        int back = (int) (inCount - 1 - j);      // 0 == newest sample
+        int idx = pos - 1 - back;
+        while (idx < 0) idx += histLen;
+        float acc = 0f;
+        while (k < taps && j >= 0 && back < histLen) {
+            acc += history[idx] * kernel[k];
+            k += interpolation;
+            j--;
+            back++;
+            idx = (idx == 0) ? histLen - 1 : idx - 1;
+        }
+        return acc;
+    }
+
+    private void buildKernel(int tapsPerPhase) {
+        final int lm = Math.max(interpolation, decimation);
+        final int n = 2 * tapsPerPhase * lm + 1;  // odd -> exact symmetry about center
+        final int m = n - 1;
+        // Cutoff below both Nyquists in cycles per *upsampled* sample: input Nyquist is 0.5/L,
+        // output Nyquist is 0.5/M; 0.45/max keeps a small transition band under the binding
+        // one. For 44.1k -> 12k (L=40, M=147) that is ~5.4 kHz — well above FT8's ~3 kHz top.
+        final double fc = 0.45 / lm;
+
+        kernel = new float[n];
+        for (int k = 0; k < n; k++) {
+            final double x = k - m / 2.0;
+            final double sinc = (Math.abs(x) < 1e-9)
+                    ? 2.0 * fc
+                    : Math.sin(2.0 * Math.PI * fc * x) / (Math.PI * x);
+            // Blackman window for a deep, smooth stopband.
+            final double w = 0.42
+                    - 0.5 * Math.cos(2.0 * Math.PI * k / m)
+                    + 0.08 * Math.cos(4.0 * Math.PI * k / m);
+            kernel[k] = (float) (sinc * w);
+        }
+        // Normalize each polyphase branch (taps k ≡ p mod L) to unity DC sum: every output
+        // phase then has exactly unity DC gain, and the xL gain that compensates zero-stuffing
+        // is baked in. For L == 1 this reduces to FirDecimator's whole-kernel normalization.
+        for (int p = 0; p < interpolation; p++) {
+            double sum = 0.0;
+            for (int k = p; k < n; k += interpolation) {
+                sum += kernel[k];
+            }
+            if (Math.abs(sum) < 1e-12) continue;
+            final float norm = (float) (1.0 / sum);
+            for (int k = p; k < n; k += interpolation) {
+                kernel[k] *= norm;
+            }
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UacAudioFormats.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UacAudioFormats.java
@@ -1,0 +1,268 @@
+package com.k1af.ft8af.wave;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * USB Audio Class 1.0 format-descriptor parsing and alt-setting selection (issue #364).
+ *
+ * <p>{@link UsbAudioDevice} used to assume every capture device streams 48 kHz/16-bit. Most
+ * CM108-class codecs do, but a device that only offers 44.1 kHz got captured at the wrong rate
+ * and nothing decoded. The fix has two halves; this class is the first: parse the raw
+ * configuration descriptors ({@code UsbDeviceConnection.getRawDescriptors()}) for the
+ * class-specific AS FORMAT_TYPE descriptors (bDescriptorType 0x24, subtype 0x02) that list
+ * each alt setting's supported sample rates, then {@link #choose} an alt setting that really
+ * supports 48 kHz — or, when none does, the best rate the device offers so the capture path
+ * can resample rationally.
+ *
+ * <p>Deliberately plain Java operating on {@code byte[]} (no {@code android.hardware.usb}
+ * types) so both the parsing and the selection decision are unit-testable on the host.
+ */
+public final class UacAudioFormats {
+
+    private UacAudioFormats() {}
+
+    // USB / UAC1 descriptor constants.
+    private static final int DT_INTERFACE = 0x04;          // standard interface descriptor
+    private static final int DT_CS_INTERFACE = 0x24;       // class-specific interface descriptor
+    private static final int SUBTYPE_FORMAT_TYPE = 0x02;   // AS FORMAT_TYPE
+    private static final int FORMAT_TYPE_I = 0x01;         // PCM
+    private static final int CLASS_AUDIO = 0x01;
+    private static final int SUBCLASS_AUDIOSTREAMING = 0x02;
+
+    /** One FORMAT_TYPE_I descriptor: what a given (interface, alt setting) can stream. */
+    public static final class StreamFormat {
+        public final int interfaceId;
+        public final int altSetting;
+        public final int channels;
+        public final int subframeSize;   // bytes per sample per channel (2 == 16-bit)
+        public final int bitResolution;
+        /** Discrete supported rates (empty when {@link #continuous}). */
+        public final int[] discreteRates;
+        /** True when the device reports a continuous min..max range instead of a table. */
+        public final boolean continuous;
+        public final int minRate;
+        public final int maxRate;
+
+        StreamFormat(int interfaceId, int altSetting, int channels, int subframeSize,
+                     int bitResolution, int[] discreteRates, boolean continuous,
+                     int minRate, int maxRate) {
+            this.interfaceId = interfaceId;
+            this.altSetting = altSetting;
+            this.channels = channels;
+            this.subframeSize = subframeSize;
+            this.bitResolution = bitResolution;
+            this.discreteRates = discreteRates;
+            this.continuous = continuous;
+            this.minRate = minRate;
+            this.maxRate = maxRate;
+        }
+
+        public boolean supportsRate(int rate) {
+            if (rate <= 0) return false;
+            if (continuous) {
+                return rate >= minRate && rate <= maxRate;
+            }
+            for (int r : discreteRates) {
+                if (r == rate) return true;
+            }
+            return false;
+        }
+
+        boolean hasAnyRate() {
+            if (continuous) return minRate > 0 && maxRate >= minRate;
+            for (int r : discreteRates) {
+                if (r > 0) return true;
+            }
+            return false;
+        }
+
+        /**
+         * Best rate this format offers when {@code preferredRate} isn't supported: prefers
+         * rates that can feed the decoder ({@code >= decoderRate}), then integer multiples of
+         * {@code decoderRate} (FirDecimator fast path), then proximity to the preferred rate.
+         */
+        int bestRateFor(int preferredRate, int decoderRate) {
+            if (supportsRate(preferredRate)) return preferredRate;
+            if (continuous) {
+                if (!hasAnyRate()) return -1;
+                // Largest integer multiple of the decoder rate that fits both the range and
+                // the preferred ceiling: exact integer decimation beats a rational ratio.
+                if (decoderRate > 0) {
+                    long hi = Math.min((long) maxRate, (long) preferredRate);
+                    long multiple = (hi / decoderRate) * decoderRate;
+                    if (multiple >= minRate && multiple >= decoderRate) {
+                        return (int) multiple;
+                    }
+                }
+                // Otherwise clamp the preferred rate into the range.
+                return preferredRate < minRate ? minRate : maxRate;
+            }
+            int best = -1;
+            long bestKey = Long.MIN_VALUE;
+            for (int r : discreteRates) {
+                if (r <= 0) continue;
+                long key = rateKey(r, preferredRate, decoderRate, false);
+                if (key > bestKey) {
+                    bestKey = key;
+                    best = r;
+                }
+            }
+            return best;
+        }
+    }
+
+    /** The selection result: which alt setting to activate and at what rate. */
+    public static final class Choice {
+        public final int altSetting;
+        public final int sampleRate;
+        public final int channels;
+
+        Choice(int altSetting, int sampleRate, int channels) {
+            this.altSetting = altSetting;
+            this.sampleRate = sampleRate;
+            this.channels = channels;
+        }
+    }
+
+    /**
+     * Walk a raw descriptor blob (device + configuration descriptors, as returned by
+     * {@code UsbDeviceConnection.getRawDescriptors()}) and collect every FORMAT_TYPE_I
+     * descriptor found inside an AudioStreaming interface, attributed to that interface's
+     * (id, alt setting). Malformed input (zero {@code bLength}, truncated descriptor) stops
+     * the walk and returns whatever parsed cleanly — never throws.
+     */
+    public static List<StreamFormat> parse(byte[] raw) {
+        List<StreamFormat> out = new ArrayList<>();
+        if (raw == null) return out;
+
+        int i = 0;
+        int ifaceId = -1;
+        int altSetting = -1;
+        boolean inAudioStreaming = false;
+
+        while (i + 2 <= raw.length) {
+            int len = raw[i] & 0xFF;
+            int type = raw[i + 1] & 0xFF;
+            if (len < 2 || i + len > raw.length) break;  // malformed; keep what we have
+
+            if (type == DT_INTERFACE && len >= 9) {
+                ifaceId = raw[i + 2] & 0xFF;
+                altSetting = raw[i + 3] & 0xFF;
+                int cls = raw[i + 5] & 0xFF;
+                int sub = raw[i + 6] & 0xFF;
+                inAudioStreaming = (cls == CLASS_AUDIO && sub == SUBCLASS_AUDIOSTREAMING);
+            } else if (type == DT_CS_INTERFACE && inAudioStreaming && len >= 8
+                    && (raw[i + 2] & 0xFF) == SUBTYPE_FORMAT_TYPE
+                    && (raw[i + 3] & 0xFF) == FORMAT_TYPE_I) {
+                int channels = raw[i + 4] & 0xFF;
+                int subframe = raw[i + 5] & 0xFF;
+                int bits = raw[i + 6] & 0xFF;
+                int nFreq = raw[i + 7] & 0xFF;
+                if (nFreq == 0) {
+                    // Continuous range: 3-byte little-endian lower + upper bounds.
+                    if (len >= 8 + 6) {
+                        int lo = u24(raw, i + 8);
+                        int hi = u24(raw, i + 11);
+                        out.add(new StreamFormat(ifaceId, altSetting, channels, subframe,
+                                bits, new int[0], true, lo, hi));
+                    }
+                } else if (len >= 8 + 3 * nFreq) {
+                    int[] rates = new int[nFreq];
+                    for (int k = 0; k < nFreq; k++) {
+                        rates[k] = u24(raw, i + 8 + 3 * k);
+                    }
+                    out.add(new StreamFormat(ifaceId, altSetting, channels, subframe,
+                            bits, rates, false, 0, 0));
+                }
+            }
+            i += len;
+        }
+        return out;
+    }
+
+    /**
+     * Pick the alt setting (and rate) to activate for a streaming interface.
+     *
+     * <ol>
+     *   <li>Only 16-bit PCM formats are considered — the capture path is hardwired to
+     *       2-byte samples.</li>
+     *   <li>An alt setting supporting {@code preferredRate} (48 kHz) wins; the currently
+     *       selected alt is kept when it qualifies, otherwise the lowest qualifying alt
+     *       number is used.</li>
+     *   <li>Otherwise the best-supported rate wins, ranked: can feed the decoder
+     *       ({@code >= decoderRate}) &gt; integer multiple of {@code decoderRate} (integer
+     *       FIR fast path) &gt; closest to {@code preferredRate} &gt; current alt setting.
+     *       A non-multiple winner (e.g. 44.1 kHz) is handled downstream by
+     *       {@link RationalResampler}.</li>
+     * </ol>
+     *
+     * @return the choice, or {@code null} when nothing usable was parsed — callers must then
+     *     keep the legacy assume-48-kHz behavior.
+     */
+    public static Choice choose(List<StreamFormat> formats, int interfaceId,
+                                int currentAltSetting, int preferredRate, int decoderRate) {
+        if (formats == null || formats.isEmpty()) return null;
+
+        List<StreamFormat> candidates = new ArrayList<>();
+        for (StreamFormat f : formats) {
+            if (f.interfaceId != interfaceId) continue;
+            if (f.subframeSize != 2) continue;  // capture path is 16-bit PCM only
+            if (!f.hasAnyRate()) continue;
+            candidates.add(f);
+        }
+        if (candidates.isEmpty()) return null;
+
+        // 1) Preferred rate available: keep the current alt when it qualifies, else the
+        //    lowest qualifying alt setting.
+        StreamFormat atPreferred = null;
+        for (StreamFormat f : candidates) {
+            if (!f.supportsRate(preferredRate)) continue;
+            if (f.altSetting == currentAltSetting) {
+                atPreferred = f;
+                break;
+            }
+            if (atPreferred == null || f.altSetting < atPreferred.altSetting) {
+                atPreferred = f;
+            }
+        }
+        if (atPreferred != null) {
+            return new Choice(atPreferred.altSetting, preferredRate, atPreferred.channels);
+        }
+
+        // 2) Fallback: best rate the device really supports.
+        StreamFormat bestFormat = null;
+        int bestRate = -1;
+        long bestKey = Long.MIN_VALUE;
+        for (StreamFormat f : candidates) {
+            int r = f.bestRateFor(preferredRate, decoderRate);
+            if (r <= 0) continue;
+            long key = rateKey(r, preferredRate, decoderRate, f.altSetting == currentAltSetting);
+            if (key > bestKey) {
+                bestKey = key;
+                bestFormat = f;
+                bestRate = r;
+            }
+        }
+        if (bestFormat == null) return null;
+        return new Choice(bestFormat.altSetting, bestRate, bestFormat.channels);
+    }
+
+    // Ranking for fallback rates; larger is better. Bit 62: rate can feed the decoder at all.
+    // Bit 61: integer multiple of the decoder rate (FirDecimator fast path, no rational
+    // stage). Then proximity to the preferred rate, then a current-alt tiebreak (avoid an
+    // alt-setting switch when it buys nothing).
+    private static long rateKey(int rate, int preferredRate, int decoderRate,
+                                boolean isCurrentAlt) {
+        long key = 0;
+        if (rate >= decoderRate) key |= 1L << 62;
+        if (decoderRate > 0 && rate % decoderRate == 0) key |= 1L << 61;
+        key += ((long) Integer.MAX_VALUE - Math.abs((long) rate - (long) preferredRate)) << 1;
+        if (isCurrentAlt) key += 1;
+        return key;
+    }
+
+    private static int u24(byte[] raw, int off) {
+        return (raw[off] & 0xFF) | ((raw[off + 1] & 0xFF) << 8) | ((raw[off + 2] & 0xFF) << 16);
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UacAudioFormats.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UacAudioFormats.java
@@ -248,6 +248,44 @@ public final class UacAudioFormats {
         return new Choice(bestFormat.altSetting, bestRate, bestFormat.channels);
     }
 
+    /**
+     * The set of sample rates a given (interface, alt setting) can run, when that set is
+     * finite and known: the union of the discrete-rate tables of its FORMAT_TYPE
+     * descriptors, with a degenerate continuous range ({@code min == max}) counting as a
+     * single rate. Returns an empty array when the alt setting reports a genuinely
+     * continuous range ({@code min < max}) or nothing was parsed for it — the caller must
+     * then treat the device's current rate as unknowable from descriptors alone.
+     *
+     * <p>Used by {@code UsbAudioDevice} to decide what rate to assume when the
+     * SAMPLING_FREQ SET_CUR control transfer fails: a single-rate alt setting runs its
+     * one rate regardless of whether SET_CUR is even implemented.
+     */
+    public static int[] discreteRatesFor(List<StreamFormat> formats, int interfaceId,
+                                         int altSetting) {
+        List<Integer> rates = new ArrayList<>();
+        if (formats != null) {
+            for (StreamFormat f : formats) {
+                if (f.interfaceId != interfaceId || f.altSetting != altSetting) continue;
+                if (f.continuous) {
+                    if (f.minRate == f.maxRate && f.minRate > 0) {
+                        if (!rates.contains(f.minRate)) rates.add(f.minRate);
+                    } else {
+                        return new int[0];  // continuous range: not enumerable
+                    }
+                } else {
+                    for (int r : f.discreteRates) {
+                        if (r > 0 && !rates.contains(r)) rates.add(r);
+                    }
+                }
+            }
+        }
+        int[] out = new int[rates.size()];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = rates.get(i);
+        }
+        return out;
+    }
+
     // Ranking for fallback rates; larger is better. Bit 62: rate can feed the decoder at all.
     // Bit 61: integer multiple of the decoder rate (FirDecimator fast path, no rational
     // stage). Then proximity to the preferred rate, then a current-alt tiebreak (avoid an

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -29,6 +29,7 @@ public class UsbAudioDevice {
     public static final int USB_SUBCLASS_AUDIOSTREAMING = 0x02;
 
     private static final int SET_CUR = 0x01;
+    private static final int GET_CUR = 0x81;
     private static final int SAMPLING_FREQ_CONTROL = 0x01;
 
     // The FT8 decoder's sample rate; used to rank fallback rates when a device
@@ -47,6 +48,9 @@ public class UsbAudioDevice {
     private UsbEndpoint endpointIn;
     private int inputSampleRate = 48000;
     private int inputChannels = 1;
+    // UAC format descriptors parsed during selectInputAltSetting(); consulted again
+    // when SET_CUR fails to work out what rate the device is actually running.
+    private List<UacAudioFormats.StreamFormat> inputFormats = Collections.emptyList();
     private volatile boolean capturing = false;
     // Non-zero when the libusb-backed capture session is live; in that case
     // captureLoop() is bypassed and stopCapture() routes through native.
@@ -221,13 +225,78 @@ public class UsbAudioDevice {
 
         connection.setInterface(streamingInterfaceIn);
 
-        inputSampleRate = negotiatedRate;
-        setSampleRate(endpointIn.getAddress(), negotiatedRate);
-        // If setSampleRate fails, the device may use its default rate (usually 48kHz)
-        // which is fine — we resample anyway
+        if (setSampleRate(endpointIn.getAddress(), negotiatedRate)) {
+            inputSampleRate = negotiatedRate;
+        } else {
+            // SET_CUR failed, so the device is not necessarily running negotiatedRate —
+            // and the downstream resample ratio is derived from inputSampleRate, so
+            // assuming wrong here re-creates exactly the mislabeled-stream failure of
+            // issue #364. Fall back to the most defensible rate: ask the device via
+            // GET_CUR; else, if the active alt setting supports exactly one rate, the
+            // device must be running that (SET_CUR is often unimplemented precisely
+            // because there is nothing to choose); else keep the negotiated assumption.
+            int reportedRate = getCurrentSampleRate(endpointIn.getAddress());
+            int[] altRates = UacAudioFormats.discreteRatesFor(
+                    inputFormats, streamingInterfaceIn.getId(),
+                    streamingInterfaceIn.getAlternateSetting());
+            inputSampleRate = resolveRateAfterSetCurFailure(
+                    negotiatedRate, reportedRate, altRates);
+            com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                    "UsbAudioDevice: SET_CUR %d Hz FAILED on ep 0x%02x — GET_CUR says %d, "
+                            + "alt setting offers %s — assuming %d Hz for resampling",
+                    negotiatedRate, endpointIn.getAddress(), reportedRate,
+                    java.util.Arrays.toString(altRates), inputSampleRate));
+        }
 
         Log.d(TAG, "Input activated at " + inputSampleRate + " Hz");
         return true;
+    }
+
+    /**
+     * Decides the sample rate to report for the input stream after the
+     * SAMPLING_FREQ_CONTROL SET_CUR request failed, i.e. when the rate we asked for was
+     * not acknowledged by the device. Ranked by how much each source can be trusted:
+     *
+     * <ol>
+     *   <li>{@code reportedRate} — what the device itself says it is running (GET_CUR on
+     *       the sampling-frequency control), when the readback succeeded and the value is
+     *       plausible. A live answer from the device beats any inference.</li>
+     *   <li>The active alt setting's sole supported rate, when its descriptors list
+     *       exactly one: a single-rate endpoint runs that rate no matter what — such
+     *       devices commonly omit SAMPLING_FREQ_CONTROL entirely, which is why the
+     *       SET_CUR (and GET_CUR) fail in the first place.</li>
+     *   <li>{@code requestedRate} — with multiple candidate rates and no readback the
+     *       truth is genuinely unknown; keep the negotiated assumption (it at least came
+     *       from the device's own descriptors) and let the caller log loudly.</li>
+     * </ol>
+     *
+     * <p>Package-visible for testing.
+     *
+     * @param requestedRate    the rate SET_CUR tried to set (from descriptor negotiation)
+     * @param reportedRate     GET_CUR readback, or negative when the readback failed
+     * @param altSettingRates  the active alt setting's known discrete rates (empty when
+     *                         unknown or continuous)
+     */
+    static int resolveRateAfterSetCurFailure(int requestedRate, int reportedRate,
+                                             int[] altSettingRates) {
+        if (isPlausibleRate(reportedRate)) {
+            return reportedRate;
+        }
+        if (altSettingRates != null && altSettingRates.length == 1
+                && isPlausibleRate(altSettingRates[0])) {
+            return altSettingRates[0];
+        }
+        return requestedRate;
+    }
+
+    /**
+     * Whether a GET_CUR readback (or descriptor value) looks like a real audio sample
+     * rate. UAC 1.0 hardware spans 8 kHz telephony codecs to 384/768 kHz DACs; anything
+     * outside that is a failed or garbage control transfer, not a rate. Package-visible
+     * for testing.
+     */
+    static boolean isPlausibleRate(int rate) {
+        return rate >= 8000 && rate <= 768000;
     }
 
     /**
@@ -249,6 +318,7 @@ public class UsbAudioDevice {
             Log.w(TAG, "getRawDescriptors threw: " + e.getMessage());
         }
         List<UacAudioFormats.StreamFormat> formats = UacAudioFormats.parse(raw);
+        inputFormats = formats;
         final int ifaceId = streamingInterfaceIn.getId();
         final int currentAlt = streamingInterfaceIn.getAlternateSetting();
 
@@ -337,7 +407,8 @@ public class UsbAudioDevice {
         return true;
     }
 
-    private void setSampleRate(int endpointAddress, int sampleRate) {
+    /** @return true when the device acknowledged the SET_CUR request. */
+    private boolean setSampleRate(int endpointAddress, int sampleRate) {
         byte[] data = new byte[3];
         data[0] = (byte) (sampleRate & 0xFF);
         data[1] = (byte) ((sampleRate >> 8) & 0xFF);
@@ -355,6 +426,26 @@ public class UsbAudioDevice {
                     + " endpoint 0x" + Integer.toHexString(endpointAddress)
                     + " result=" + result);
         }
+        return result >= 0;
+    }
+
+    /**
+     * Reads back the endpoint's current sampling frequency (UAC 1.0 GET_CUR on the
+     * sampling-frequency control).
+     *
+     * @return the device-reported rate in Hz, or -1 when the request failed or returned
+     *     fewer than the 3 bytes the control is defined to carry
+     */
+    private int getCurrentSampleRate(int endpointAddress) {
+        byte[] data = new byte[3];
+        int result = connection.controlTransfer(
+                0xA2, // USB_DIR_IN | USB_TYPE_CLASS | USB_RECIP_ENDPOINT
+                GET_CUR,
+                SAMPLING_FREQ_CONTROL << 8,
+                endpointAddress,
+                data, data.length, 1000);
+        if (result < 3) return -1;
+        return (data[0] & 0xFF) | ((data[1] & 0xFF) << 8) | ((data[2] & 0xFF) << 16);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -31,6 +31,11 @@ public class UsbAudioDevice {
     private static final int SET_CUR = 0x01;
     private static final int SAMPLING_FREQ_CONTROL = 0x01;
 
+    // The FT8 decoder's sample rate; used to rank fallback rates when a device
+    // can't stream the preferred 48 kHz (integer multiples of this avoid the
+    // rational resampling stage entirely).
+    private static final int FT8_DECODER_RATE = 12000;
+
     // Number of URBs for isochronous ring buffer
     private static final int NUM_URBS = 16;
 
@@ -196,9 +201,18 @@ public class UsbAudioDevice {
 
     /**
      * Activate the audio input (microphone) stream.
+     *
+     * <p>{@code preferredRate} (48 kHz in practice) is a preference, not an assumption
+     * (issue #364): the device's UAC format descriptors are parsed and an alt setting that
+     * actually supports the preferred rate is selected when one exists. When the device can't
+     * do it at 16-bit, the best rate it really supports is negotiated instead and
+     * {@link #getInputSampleRate()} reports it, so the capture path can resample rationally
+     * (e.g. 44.1 kHz -> 12 kHz via a 40/147 polyphase) rather than mislabeling the stream.
      */
-    public boolean activateInput(int sampleRate) {
+    public boolean activateInput(int preferredRate) {
         if (streamingInterfaceIn == null || endpointIn == null) return false;
+
+        int negotiatedRate = selectInputAltSetting(preferredRate);
 
         if (!connection.claimInterface(streamingInterfaceIn, true)) {
             Log.e(TAG, "Failed to claim input interface");
@@ -207,13 +221,100 @@ public class UsbAudioDevice {
 
         connection.setInterface(streamingInterfaceIn);
 
-        inputSampleRate = sampleRate;
-        setSampleRate(endpointIn.getAddress(), sampleRate);
+        inputSampleRate = negotiatedRate;
+        setSampleRate(endpointIn.getAddress(), negotiatedRate);
         // If setSampleRate fails, the device may use its default rate (usually 48kHz)
         // which is fine — we resample anyway
 
         Log.d(TAG, "Input activated at " + inputSampleRate + " Hz");
         return true;
+    }
+
+    /**
+     * Parse the device's UAC descriptors and prefer an alt setting of the input streaming
+     * interface that supports {@code preferredRate}; otherwise fall back to the best rate it
+     * does support. May reassign {@link #streamingInterfaceIn}/{@link #endpointIn} to a
+     * different alt setting of the same interface, and {@link #inputChannels} to the
+     * descriptor-reported channel count (more reliable than the packet-size guess in
+     * {@link #findEndpoints()}, which assumes 48 kHz).
+     *
+     * @return the sample rate to negotiate; when descriptor parsing yields nothing usable,
+     *     returns {@code preferredRate} and leaves the selection untouched (legacy behavior).
+     */
+    private int selectInputAltSetting(int preferredRate) {
+        byte[] raw = null;
+        try {
+            raw = connection.getRawDescriptors();
+        } catch (Exception e) {
+            Log.w(TAG, "getRawDescriptors threw: " + e.getMessage());
+        }
+        List<UacAudioFormats.StreamFormat> formats = UacAudioFormats.parse(raw);
+        final int ifaceId = streamingInterfaceIn.getId();
+        final int currentAlt = streamingInterfaceIn.getAlternateSetting();
+
+        UacAudioFormats.Choice choice = UacAudioFormats.choose(
+                formats, ifaceId, currentAlt, preferredRate, FT8_DECODER_RATE);
+        if (choice == null) {
+            com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                    "UsbAudioDevice: no usable UAC format descriptors for iface %d — "
+                            + "assuming %d Hz (legacy behavior)", ifaceId, preferredRate));
+            return preferredRate;
+        }
+
+        if (choice.altSetting != currentAlt) {
+            UsbInterface target = null;
+            UsbEndpoint targetEp = null;
+            for (int i = 0; i < usbDevice.getInterfaceCount(); i++) {
+                UsbInterface iface = usbDevice.getInterface(i);
+                if (iface.getId() != ifaceId
+                        || iface.getAlternateSetting() != choice.altSetting) {
+                    continue;
+                }
+                for (int j = 0; j < iface.getEndpointCount(); j++) {
+                    UsbEndpoint ep = iface.getEndpoint(j);
+                    if (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_ISOC
+                            && ep.getDirection() == UsbConstants.USB_DIR_IN) {
+                        targetEp = ep;
+                        break;
+                    }
+                }
+                if (targetEp != null) target = iface;
+                break;
+            }
+            if (target != null) {
+                streamingInterfaceIn = target;
+                endpointIn = targetEp;
+            } else {
+                // Android's view doesn't expose the alt setting the raw descriptors
+                // promised; re-choose among the current alt setting only.
+                final int wantedAlt = choice.altSetting;
+                List<UacAudioFormats.StreamFormat> currentOnly = new ArrayList<>();
+                for (UacAudioFormats.StreamFormat f : formats) {
+                    if (f.interfaceId == ifaceId && f.altSetting == currentAlt) {
+                        currentOnly.add(f);
+                    }
+                }
+                choice = UacAudioFormats.choose(
+                        currentOnly, ifaceId, currentAlt, preferredRate, FT8_DECODER_RATE);
+                if (choice == null) {
+                    com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                            "UsbAudioDevice: alt %d not visible via UsbManager and current "
+                                    + "alt %d has no usable format — assuming %d Hz (legacy)",
+                            wantedAlt, currentAlt, preferredRate));
+                    return preferredRate;
+                }
+            }
+        }
+
+        if (choice.channels == 1 || choice.channels == 2) {
+            inputChannels = choice.channels;
+        }
+        com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                "UsbAudioDevice: UAC alt-setting select — iface %d alt %d rate %d ch %d "
+                        + "(preferred %d, was alt %d)",
+                ifaceId, streamingInterfaceIn.getAlternateSetting(), choice.sampleRate,
+                inputChannels, preferredRate, currentAlt));
+        return choice.sampleRate;
     }
 
     /**
@@ -323,15 +424,14 @@ public class UsbAudioDevice {
         // Fallback: original UsbRequest-based loop. Kept so devices that work
         // with Android's iso path don't regress on the new native lib.
         final int packetSize = endpointIn.getMaxPacketSize();
-        final int ratio = inputSampleRate / targetSampleRate;
 
         new Thread(() -> {
-            captureLoop(targetSampleRate, ratio, packetSize, callback);
+            captureLoop(targetSampleRate, packetSize, callback);
         }, "USB-Audio-Capture").start();
     }
 
     @SuppressWarnings("deprecation")
-    private void captureLoop(int targetRate, int ratio, int packetSize,
+    private void captureLoop(int targetRate, int packetSize,
                              AudioInputCallback callback) {
         ByteBuffer[] buffers = new ByteBuffer[NUM_URBS];
         UsbRequest[] requests = new UsbRequest[NUM_URBS];
@@ -352,19 +452,37 @@ public class UsbAudioDevice {
                 }
             }
 
-            // Anti-aliased decimation (same windowed-sinc FIR as the native libusb
-            // path) — the old per-window average was a box filter whose ~12 dB
-            // stopband folded hiss into the FT8 passband whenever this fallback ran.
-            // One clamped ratio drives both the FIR and the mismatch warning, so a
-            // degenerate ratio (0/negative) is reported with the value actually used.
-            final int decimRatio = Math.max(1, ratio);
-            FirDecimator decimator = new FirDecimator(decimRatio);
-            if (decimRatio * targetRate != inputSampleRate) {
+            // Rate conversion (same DSP as the native libusb path): integer FIR
+            // decimation when the input rate is an exact multiple of the target
+            // (48k -> 12k), otherwise a true rational polyphase resampler (e.g.
+            // 44.1k -> 12k = interpolate 40 / decimate 147). Flooring the ratio
+            // here used to mislabel 14.7 kHz audio as 12 kHz and shift every FT8
+            // tone off the 6.25 Hz grid (issue #364).
+            final boolean rational = targetRate > 0 && inputSampleRate > targetRate
+                    && inputSampleRate % targetRate != 0;
+            final FirDecimator decimator;
+            final RationalResampler resampler;
+            if (rational) {
+                int[] lm = RationalResampler.ratioFor(inputSampleRate, targetRate);
+                resampler = new RationalResampler(lm[0], lm[1]);
+                decimator = null;
                 com.k1af.ft8af.GeneralVariables.fileLog(String.format(
-                        "UsbAudio.captureLoop: input %d Hz is not %dx target %d Hz "
-                                + "(raw ratio %d) — decode may suffer from the "
-                                + "resulting rate error",
-                        inputSampleRate, decimRatio, targetRate, ratio));
+                        "UsbAudio.captureLoop: input %d Hz is not an integer multiple "
+                                + "of target %d Hz — using rational polyphase "
+                                + "resampler L/M=%d/%d",
+                        inputSampleRate, targetRate, lm[0], lm[1]));
+            } else {
+                final int decimRatio =
+                        FirDecimator.decimationRatioFor(inputSampleRate, targetRate);
+                decimator = new FirDecimator(decimRatio);
+                resampler = null;
+                if (decimRatio * targetRate != inputSampleRate) {
+                    com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                            "UsbAudio.captureLoop: degenerate rates (input %d Hz, "
+                                    + "target %d Hz) — passing audio through at "
+                                    + "ratio %d, decode may suffer",
+                            inputSampleRate, targetRate, decimRatio));
+                }
             }
             float[] monoBuffer = new float[1];
             float[] outputBuffer = new float[1];
@@ -378,10 +496,10 @@ public class UsbAudioDevice {
                                 "UsbAudio.captureLoop: requestWait returned null "
                                         + "after %d iterations (target=%dHz "
                                         + "input=%dHz channels=%d packetSize=%d "
-                                        + "ratio=%d) — host likely cannot drive "
+                                        + "rational=%b) — host likely cannot drive "
                                         + "isochronous transfers via UsbRequest",
                                 iterations, targetRate, inputSampleRate,
-                                inputChannels, packetSize, ratio));
+                                inputChannels, packetSize, rational));
                     }
                     break;
                 }
@@ -414,14 +532,18 @@ public class UsbAudioDevice {
                     }
                 }
 
-                // FIR-decimate and deliver; the decimator carries state across
-                // packets, so no leftover-sample bookkeeping is needed.
+                // Resample and deliver; both stages carry state across packets,
+                // so no leftover-sample bookkeeping is needed.
                 if (monoCount > 0) {
-                    int maxOut = monoCount / decimator.ratio() + 1;
+                    int maxOut = (resampler != null)
+                            ? resampler.maxOutputFor(monoCount)
+                            : monoCount / decimator.ratio() + 1;
                     if (outputBuffer.length < maxOut) {
                         outputBuffer = new float[maxOut];
                     }
-                    int outputSamples = decimator.process(monoBuffer, monoCount, outputBuffer);
+                    int outputSamples = (resampler != null)
+                            ? resampler.process(monoBuffer, monoCount, outputBuffer)
+                            : decimator.process(monoBuffer, monoCount, outputBuffer);
                     if (outputSamples > 0) {
                         callback.onAudioData(outputBuffer, outputSamples);
                     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/RationalResamplerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/RationalResamplerTest.java
@@ -1,0 +1,165 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Java port of the assertions in {@code cpp/test_rational_resampler.cpp}: the
+ * {@link RationalResampler} used by the {@code UsbRequest} fallback capture path must behave
+ * like the native polyphase resampler in {@code usb_audio_capture.cpp} (issue #364). The bug
+ * this guards against: a 44.1 kHz-only device used to get its ratio floored (44100/12000 -> 3),
+ * producing 14.7 kHz audio labeled 12 kHz — every FT8 tone off the 6.25 Hz grid, zero decodes.
+ */
+public class RationalResamplerTest {
+
+    private static final int IN_RATE = 44100;
+    private static final int OUT_RATE = 12000;
+    private static final int L = 40;
+    private static final int M = 147;
+
+    private static float[] tone(int rate, double freqHz, double seconds) {
+        int n = (int) (rate * seconds);
+        float[] in = new float[n];
+        for (int i = 0; i < n; i++) {
+            in[i] = (float) Math.sin(2.0 * Math.PI * freqHz * i / rate);
+        }
+        return in;
+    }
+
+    private static float[] resampled(float[] in, RationalResampler rs) {
+        float[] out = new float[rs.maxOutputFor(in.length)];
+        int produced = rs.process(in, in.length, out);
+        return java.util.Arrays.copyOf(out, produced);
+    }
+
+    /** Peak amplitude over the back half of the output (skips filter warm-up). */
+    private static float steadyPeak(float[] out) {
+        float peak = 0f;
+        for (int i = out.length / 2; i < out.length; i++) {
+            peak = Math.max(peak, Math.abs(out[i]));
+        }
+        return peak;
+    }
+
+    /** Dominant frequency of the back half via zero-crossing count (clean single tone). */
+    private static double zeroCrossFreq(float[] out, int outRate) {
+        int start = out.length / 2;
+        int crossings = 0;
+        for (int i = start + 1; i < out.length; i++) {
+            if ((out[i - 1] < 0f) != (out[i] < 0f)) crossings++;
+        }
+        double seconds = (double) (out.length - start) / outRate;
+        return crossings / (2.0 * seconds);
+    }
+
+    @Test
+    public void ratioForReducesByGcd() {
+        assertThat(RationalResampler.ratioFor(48000, 12000)).isEqualTo(new int[] {1, 4});
+        assertThat(RationalResampler.ratioFor(44100, 12000)).isEqualTo(new int[] {40, 147});
+        assertThat(RationalResampler.ratioFor(96000, 12000)).isEqualTo(new int[] {1, 8});
+        assertThat(RationalResampler.ratioFor(32000, 12000)).isEqualTo(new int[] {3, 8});
+    }
+
+    @Test
+    public void ratioForGuardsDegenerateRates() {
+        assertThat(RationalResampler.ratioFor(48000, 0)).isEqualTo(new int[] {1, 1});
+        assertThat(RationalResampler.ratioFor(48000, -12000)).isEqualTo(new int[] {1, 1});
+        assertThat(RationalResampler.ratioFor(8000, 12000)).isEqualTo(new int[] {1, 1});
+        assertThat(RationalResampler.ratioFor(12000, 12000)).isEqualTo(new int[] {1, 1});
+    }
+
+    @Test
+    public void ratioIsExact_outputRateEqualsTarget() {
+        // The whole point of #364: inputRate * L / M must equal the target rate exactly,
+        // with no rounding — the floored integer ratio was off by 22.5% at 44.1 kHz.
+        int[] lm = RationalResampler.ratioFor(IN_RATE, OUT_RATE);
+        assertThat((long) IN_RATE * lm[0] % lm[1]).isEqualTo(0);
+        assertThat((long) IN_RATE * lm[0] / lm[1]).isEqualTo(OUT_RATE);
+    }
+
+    @Test
+    public void exactOutputCountOverTenSeconds_noDrift() {
+        RationalResampler rs = new RationalResampler(L, M);
+        int n = IN_RATE * 10;
+        float[] in = new float[n];
+        float[] out = new float[rs.maxOutputFor(n)];
+        int produced = rs.process(in, n, out);
+        // Outputs live at upsampled indices 0, M, 2M, ... <= (n-1)*L.
+        long expected = (long) (n - 1) * L / M + 1;  // exactly 120000
+        assertThat(expected).isEqualTo(OUT_RATE * 10L);
+        assertThat((long) produced).isEqualTo(expected);
+    }
+
+    @Test
+    public void unityDcGainOnAllOutputPhases() {
+        RationalResampler rs = new RationalResampler(L, M);
+        float[] in = new float[IN_RATE];
+        java.util.Arrays.fill(in, 1.0f);
+        float[] out = resampled(in, rs);
+        // Per-branch kernel normalization must make every output phase exactly unity at DC.
+        for (int i = out.length / 2; i < out.length; i++) {
+            assertThat((double) out[i]).isWithin(1e-3).of(1.0);
+        }
+    }
+
+    @Test
+    public void tone1500HzStays1500Hz() {
+        // The core regression: through the old floored /3 path a 1500 Hz tone came out at
+        // ~1224 Hz (1500 * 12000/14700). The rational path must preserve it.
+        float[] out = resampled(tone(IN_RATE, 1500.0, 1.0), new RationalResampler(L, M));
+        assertThat(zeroCrossFreq(out, OUT_RATE)).isWithin(5.0).of(1500.0);
+        assertThat((double) steadyPeak(out)).isWithin(0.05).of(1.0);
+    }
+
+    @Test
+    public void tone2500HzStays2500Hz() {
+        float[] out = resampled(tone(IN_RATE, 2500.0, 1.0), new RationalResampler(L, M));
+        assertThat(zeroCrossFreq(out, OUT_RATE)).isWithin(5.0).of(2500.0);
+    }
+
+    @Test
+    public void aliasToneIsStronglyRejected() {
+        // 10 kHz at 44.1k folds to |10000 - 12000| = 2 kHz — mid-FT8-band — without the
+        // low-pass. Require > 40 dB rejection.
+        float[] out = resampled(tone(IN_RATE, 10000.0, 1.0), new RationalResampler(L, M));
+        assertThat(steadyPeak(out)).isLessThan(0.01f);
+    }
+
+    @Test
+    public void streamingAcrossBuffersMatchesSingleCall() {
+        // The capture loop feeds ~1 ms USB packets; state must carry across process() calls.
+        int n = IN_RATE / 5;
+        float[] in = tone(IN_RATE, 700.0, 0.2);
+        RationalResampler whole = new RationalResampler(L, M);
+        float[] outWhole = new float[whole.maxOutputFor(n)];
+        int producedWhole = whole.process(in, n, outWhole);
+
+        RationalResampler chunked = new RationalResampler(L, M);
+        float[] outChunks = new float[chunked.maxOutputFor(n)];
+        int producedChunks = 0;
+        int chunk = 97;  // deliberately not aligned to L or M
+        for (int off = 0; off < n; off += chunk) {
+            int len = Math.min(chunk, n - off);
+            float[] piece = java.util.Arrays.copyOfRange(in, off, off + len);
+            float[] out = new float[chunked.maxOutputFor(len)];
+            int p = chunked.process(piece, len, out);
+            System.arraycopy(out, 0, outChunks, producedChunks, p);
+            producedChunks += p;
+        }
+        assertThat(producedChunks).isEqualTo(producedWhole);
+        for (int i = 0; i < producedWhole; i++) {
+            assertThat(outChunks[i]).isEqualTo(outWhole[i]);
+        }
+    }
+
+    @Test
+    public void integerRatioStillWorksThroughRationalPath() {
+        // L=1 degenerates to a plain FIR decimator (the capture path uses FirDecimator for
+        // this case, but the rational kernel must still be correct if configured that way).
+        RationalResampler rs = new RationalResampler(1, 4);
+        float[] out = resampled(tone(48000, 1000.0, 0.5), rs);
+        assertThat(out.length).isEqualTo(48000 / 2 / 4);
+        assertThat(zeroCrossFreq(out, 12000)).isWithin(5.0).of(1000.0);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UacAudioFormatsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UacAudioFormatsTest.java
@@ -1,0 +1,292 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link UacAudioFormats}: UAC 1.0 FORMAT_TYPE descriptor parsing and the
+ * alt-setting selection that prefers 48 kHz capture (issue #364). Descriptor blobs are built
+ * byte-for-byte the way {@code UsbDeviceConnection.getRawDescriptors()} returns them.
+ */
+public class UacAudioFormatsTest {
+
+    private static final int PREFERRED = 48000;
+    private static final int DECODER = 12000;
+
+    // --- descriptor builders -------------------------------------------------
+
+    /** Standard interface descriptor (bLength 9, bDescriptorType 4). */
+    private static byte[] iface(int id, int alt, int cls, int subclass) {
+        return new byte[] {9, 4, (byte) id, (byte) alt, 1, (byte) cls, (byte) subclass, 0, 0};
+    }
+
+    private static byte[] audioStreamingIface(int id, int alt) {
+        return iface(id, alt, 0x01, 0x02);
+    }
+
+    /** Class-specific AS FORMAT_TYPE_I descriptor with a discrete sample-rate table. */
+    private static byte[] formatTypeI(int channels, int subframeSize, int bits, int... rates) {
+        int len = 8 + 3 * rates.length;
+        byte[] d = new byte[len];
+        d[0] = (byte) len;
+        d[1] = 0x24;             // CS_INTERFACE
+        d[2] = 0x02;             // FORMAT_TYPE
+        d[3] = 0x01;             // FORMAT_TYPE_I (PCM)
+        d[4] = (byte) channels;
+        d[5] = (byte) subframeSize;
+        d[6] = (byte) bits;
+        d[7] = (byte) rates.length;
+        for (int i = 0; i < rates.length; i++) {
+            put24(d, 8 + 3 * i, rates[i]);
+        }
+        return d;
+    }
+
+    /** FORMAT_TYPE_I with a continuous min..max range (bSamFreqType == 0). */
+    private static byte[] formatTypeIContinuous(int channels, int subframeSize, int bits,
+                                                int minRate, int maxRate) {
+        byte[] d = new byte[14];
+        d[0] = 14;
+        d[1] = 0x24;
+        d[2] = 0x02;
+        d[3] = 0x01;
+        d[4] = (byte) channels;
+        d[5] = (byte) subframeSize;
+        d[6] = (byte) bits;
+        d[7] = 0;
+        put24(d, 8, minRate);
+        put24(d, 11, maxRate);
+        return d;
+    }
+
+    private static void put24(byte[] d, int off, int v) {
+        d[off] = (byte) (v & 0xFF);
+        d[off + 1] = (byte) ((v >> 8) & 0xFF);
+        d[off + 2] = (byte) ((v >> 16) & 0xFF);
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        for (byte[] p : parts) {
+            bos.write(p, 0, p.length);
+        }
+        return bos.toByteArray();
+    }
+
+    /** Typical CM108-style blob: iface 2, alt 0 = zero-bandwidth, alt 1 = 48/44.1 kHz mono. */
+    private static byte[] cm108Style() {
+        return concat(
+                audioStreamingIface(2, 0),
+                audioStreamingIface(2, 1),
+                formatTypeI(1, 2, 16, 48000, 44100));
+    }
+
+    // --- parse ---------------------------------------------------------------
+
+    @Test
+    public void parseAttributesFormatToInterfaceAndAltSetting() {
+        List<UacAudioFormats.StreamFormat> formats = UacAudioFormats.parse(cm108Style());
+        assertThat(formats).hasSize(1);
+        UacAudioFormats.StreamFormat f = formats.get(0);
+        assertThat(f.interfaceId).isEqualTo(2);
+        assertThat(f.altSetting).isEqualTo(1);
+        assertThat(f.channels).isEqualTo(1);
+        assertThat(f.subframeSize).isEqualTo(2);
+        assertThat(f.bitResolution).isEqualTo(16);
+        assertThat(f.continuous).isFalse();
+        assertThat(f.discreteRates).isEqualTo(new int[] {48000, 44100});
+        assertThat(f.supportsRate(48000)).isTrue();
+        assertThat(f.supportsRate(44100)).isTrue();
+        assertThat(f.supportsRate(96000)).isFalse();
+    }
+
+    @Test
+    public void parseCollectsMultipleAltSettings() {
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 2, 16, 44100),
+                audioStreamingIface(1, 2),
+                formatTypeI(2, 2, 16, 48000));
+        List<UacAudioFormats.StreamFormat> formats = UacAudioFormats.parse(raw);
+        assertThat(formats).hasSize(2);
+        assertThat(formats.get(0).altSetting).isEqualTo(1);
+        assertThat(formats.get(0).discreteRates).isEqualTo(new int[] {44100});
+        assertThat(formats.get(1).altSetting).isEqualTo(2);
+        assertThat(formats.get(1).channels).isEqualTo(2);
+    }
+
+    @Test
+    public void parseReadsContinuousRange() {
+        byte[] raw = concat(
+                audioStreamingIface(3, 1),
+                formatTypeIContinuous(1, 2, 16, 8000, 48000));
+        List<UacAudioFormats.StreamFormat> formats = UacAudioFormats.parse(raw);
+        assertThat(formats).hasSize(1);
+        UacAudioFormats.StreamFormat f = formats.get(0);
+        assertThat(f.continuous).isTrue();
+        assertThat(f.minRate).isEqualTo(8000);
+        assertThat(f.maxRate).isEqualTo(48000);
+        assertThat(f.supportsRate(24000)).isTrue();
+        assertThat(f.supportsRate(96000)).isFalse();
+    }
+
+    @Test
+    public void parseIgnoresFormatsOutsideAudioStreamingInterfaces() {
+        byte[] raw = concat(
+                iface(0, 0, 0x01, 0x01),            // AudioControl, not AudioStreaming
+                formatTypeI(1, 2, 16, 48000),
+                iface(4, 0, 0x03, 0x00),            // HID
+                formatTypeI(1, 2, 16, 44100));
+        assertThat(UacAudioFormats.parse(raw)).isEmpty();
+    }
+
+    @Test
+    public void parseSurvivesMalformedInput() {
+        assertThat(UacAudioFormats.parse(null)).isEmpty();
+        assertThat(UacAudioFormats.parse(new byte[0])).isEmpty();
+        // Zero bLength must not loop forever.
+        assertThat(UacAudioFormats.parse(new byte[] {0, 0, 0, 0})).isEmpty();
+        // Truncated descriptor: bLength runs past the end of the blob.
+        byte[] good = cm108Style();
+        byte[] truncated = java.util.Arrays.copyOf(good, good.length - 2);
+        assertThat(UacAudioFormats.parse(truncated)).isEmpty();
+        // A valid descriptor before the truncation still parses.
+        byte[] partly = concat(cm108Style(), new byte[] {20, 0x24});
+        assertThat(UacAudioFormats.parse(partly)).hasSize(1);
+    }
+
+    // --- choose --------------------------------------------------------------
+
+    @Test
+    public void choosePicksAltSettingSupporting48k() {
+        // Device offers alt 1 = 44.1 kHz only, alt 2 = 48 kHz: alt 2 must win even though
+        // enumeration found alt 1 first.
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 2, 16, 44100),
+                audioStreamingIface(1, 2),
+                formatTypeI(1, 2, 16, 48000));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.altSetting).isEqualTo(2);
+        assertThat(c.sampleRate).isEqualTo(48000);
+        assertThat(c.channels).isEqualTo(1);
+    }
+
+    @Test
+    public void chooseKeepsCurrentAltWhenItAlreadySupports48k() {
+        // Both alts support 48 kHz: don't switch away from the one already selected.
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 2, 16, 48000, 44100),
+                audioStreamingIface(1, 2),
+                formatTypeI(2, 2, 16, 48000));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 2, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.altSetting).isEqualTo(2);
+        assertThat(c.sampleRate).isEqualTo(48000);
+    }
+
+    @Test
+    public void chooseFallsBackTo44100WhenNo48k() {
+        // The issue-#364 device: 44.1 kHz only. Must return the true rate (for the rational
+        // resampler downstream), not pretend 48 kHz works.
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 2, 16, 44100));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.altSetting).isEqualTo(1);
+        assertThat(c.sampleRate).isEqualTo(44100);
+    }
+
+    @Test
+    public void choosePrefersIntegerMultipleOfDecoderRateOverCloserRate() {
+        // No 48 kHz. 24000 is an exact multiple of 12000 (integer FIR fast path) and must
+        // beat 44100 even though 44100 is closer to the preferred rate.
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 2, 16, 44100),
+                audioStreamingIface(1, 2),
+                formatTypeI(1, 2, 16, 24000));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.altSetting).isEqualTo(2);
+        assertThat(c.sampleRate).isEqualTo(24000);
+    }
+
+    @Test
+    public void chooseSkipsNon16BitAltSettings() {
+        // Alt 2 has 48 kHz but at 24-bit (subframe 3); the capture path is hardwired to
+        // 16-bit PCM, so the 16-bit 44.1 kHz alt must win.
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 2, 16, 44100),
+                audioStreamingIface(1, 2),
+                formatTypeI(1, 3, 24, 48000));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.altSetting).isEqualTo(1);
+        assertThat(c.sampleRate).isEqualTo(44100);
+    }
+
+    @Test
+    public void choosePicks48kFromContinuousRange() {
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeIContinuous(1, 2, 16, 8000, 96000));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.sampleRate).isEqualTo(48000);
+    }
+
+    @Test
+    public void choosePicksDecoderMultipleFromContinuousRangeBelow48k() {
+        // Range tops out at 44.1 kHz: the largest decoder multiple inside the range (36000)
+        // beats clamping to 44100, because it keeps the integer FIR fast path.
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeIContinuous(1, 2, 16, 8000, 44100));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.sampleRate).isEqualTo(36000);
+    }
+
+    @Test
+    public void chooseReturnsNullWhenNothingUsable() {
+        assertThat(UacAudioFormats.choose(null, 1, 0, PREFERRED, DECODER)).isNull();
+        assertThat(UacAudioFormats.choose(
+                UacAudioFormats.parse(new byte[0]), 1, 0, PREFERRED, DECODER)).isNull();
+        // Formats exist but for a different interface.
+        List<UacAudioFormats.StreamFormat> other = UacAudioFormats.parse(cm108Style());
+        assertThat(UacAudioFormats.choose(other, 7, 0, PREFERRED, DECODER)).isNull();
+        // Only non-16-bit formats.
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 3, 24, 48000));
+        assertThat(UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER)).isNull();
+    }
+
+    @Test
+    public void chooseHonorsChannelCountFromDescriptor() {
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(2, 2, 16, 48000));
+        UacAudioFormats.Choice c = UacAudioFormats.choose(
+                UacAudioFormats.parse(raw), 1, 1, PREFERRED, DECODER);
+        assertThat(c).isNotNull();
+        assertThat(c.channels).isEqualTo(2);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UacAudioFormatsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UacAudioFormatsTest.java
@@ -289,4 +289,59 @@ public class UacAudioFormatsTest {
         assertThat(c).isNotNull();
         assertThat(c.channels).isEqualTo(2);
     }
+
+    // --- discreteRatesFor (SET_CUR-failure rate resolution input) -------------
+
+    @Test
+    public void discreteRatesForReturnsTheAltSettingsRateTable() {
+        List<UacAudioFormats.StreamFormat> formats = UacAudioFormats.parse(cm108Style());
+        assertThat(UacAudioFormats.discreteRatesFor(formats, 2, 1))
+                .isEqualTo(new int[] {48000, 44100});
+    }
+
+    @Test
+    public void discreteRatesForIsScopedToTheRequestedInterfaceAndAlt() {
+        byte[] raw = concat(
+                audioStreamingIface(1, 1),
+                formatTypeI(1, 2, 16, 44100),
+                audioStreamingIface(1, 2),
+                formatTypeI(1, 2, 16, 48000));
+        List<UacAudioFormats.StreamFormat> formats = UacAudioFormats.parse(raw);
+        assertThat(UacAudioFormats.discreteRatesFor(formats, 1, 1))
+                .isEqualTo(new int[] {44100});
+        assertThat(UacAudioFormats.discreteRatesFor(formats, 1, 2))
+                .isEqualTo(new int[] {48000});
+        // Other interface / alt with no formats: unknown, not someone else's rates.
+        assertThat(UacAudioFormats.discreteRatesFor(formats, 7, 1)).isEmpty();
+        assertThat(UacAudioFormats.discreteRatesFor(formats, 1, 0)).isEmpty();
+    }
+
+    @Test
+    public void discreteRatesForTreatsContinuousRangeAsUnknown() {
+        // A genuinely continuous range can't be enumerated — after a SET_CUR failure the
+        // device's rate is unknowable from descriptors, so the set must come back empty.
+        byte[] raw = concat(
+                audioStreamingIface(3, 1),
+                formatTypeIContinuous(1, 2, 16, 8000, 48000));
+        assertThat(UacAudioFormats.discreteRatesFor(UacAudioFormats.parse(raw), 3, 1))
+                .isEmpty();
+    }
+
+    @Test
+    public void discreteRatesForTreatsDegenerateContinuousRangeAsSingleRate() {
+        // min == max is a single-rate device that chose the continuous encoding; the one
+        // rate it can run is known.
+        byte[] raw = concat(
+                audioStreamingIface(3, 1),
+                formatTypeIContinuous(1, 2, 16, 44100, 44100));
+        assertThat(UacAudioFormats.discreteRatesFor(UacAudioFormats.parse(raw), 3, 1))
+                .isEqualTo(new int[] {44100});
+    }
+
+    @Test
+    public void discreteRatesForHandlesNullAndEmpty() {
+        assertThat(UacAudioFormats.discreteRatesFor(null, 1, 0)).isEmpty();
+        assertThat(UacAudioFormats.discreteRatesFor(
+                UacAudioFormats.parse(new byte[0]), 1, 0)).isEmpty();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioRateResolutionTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioRateResolutionTest.java
@@ -1,0 +1,105 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link UsbAudioDevice#resolveRateAfterSetCurFailure(int, int, int[])} — the rate
+ * reported for the input stream when the SAMPLING_FREQ SET_CUR control transfer fails.
+ *
+ * <p>Background (PR #389 review): {@code activateInput()} used to set
+ * {@code inputSampleRate} to the negotiated rate unconditionally, even when the device
+ * NAKed SET_CUR. The downstream resampling ratio is derived from that field, so a wrong
+ * assumption here re-creates the mislabeled-stream failure of issue #364 (every FT8 tone
+ * shifted off the 6.25 Hz grid). The resolution order is: trust a plausible GET_CUR
+ * readback from the device, else a single-rate alt setting's sole rate (such endpoints
+ * run it regardless — SET_CUR is often unimplemented precisely because there is nothing
+ * to choose), else keep the negotiated assumption and log loudly.
+ */
+public class UsbAudioRateResolutionTest {
+
+    private static final int[] NO_RATES = new int[0];
+
+    // --- 1) a plausible GET_CUR readback wins ---------------------------------
+
+    @Test
+    public void getCurReadback_trusted() {
+        // Device says it's running 44.1 kHz even though we asked for 48 kHz: believe it.
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, 44100, new int[] {44100, 48000})).isEqualTo(44100);
+    }
+
+    @Test
+    public void getCurReadback_trustedEvenWithoutDescriptorRates() {
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, 44100, NO_RATES)).isEqualTo(44100);
+    }
+
+    @Test
+    public void getCurReadback_beatsSingleDescriptorRate() {
+        // A live answer from the device outranks descriptor inference.
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, 48000, new int[] {44100})).isEqualTo(48000);
+    }
+
+    // --- 2) failed/garbage GET_CUR falls through ------------------------------
+
+    @Test
+    public void failedGetCur_singleRateAltSetting_usesThatRate() {
+        // GET_CUR failed (-1). The alt setting supports exactly one rate, so the device
+        // must be running it no matter what SET_CUR said.
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, -1, new int[] {44100})).isEqualTo(44100);
+    }
+
+    @Test
+    public void garbageGetCur_isNotMistakenForARate() {
+        // Zero, tiny, and absurd readbacks are failed/garbage control transfers.
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, 0, new int[] {44100})).isEqualTo(44100);
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, 100, new int[] {44100})).isEqualTo(44100);
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, 10_000_000, new int[] {44100})).isEqualTo(44100);
+    }
+
+    // --- 3) genuinely unknown: keep the negotiated assumption ------------------
+
+    @Test
+    public void failedGetCur_multiRateAltSetting_keepsNegotiatedRate() {
+        // Multiple candidate rates and no readback: the truth is unknown; the negotiated
+        // rate at least came from the device's own descriptors.
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, -1, new int[] {44100, 48000})).isEqualTo(48000);
+    }
+
+    @Test
+    public void failedGetCur_noDescriptorRates_keepsNegotiatedRate() {
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, -1, NO_RATES)).isEqualTo(48000);
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, -1, null)).isEqualTo(48000);
+    }
+
+    @Test
+    public void bogusSingleDescriptorRate_isIgnored() {
+        // A single descriptor rate that isn't a plausible audio rate must not be trusted
+        // just because it's alone in the table.
+        assertThat(UsbAudioDevice.resolveRateAfterSetCurFailure(
+                48000, -1, new int[] {0})).isEqualTo(48000);
+    }
+
+    // --- isPlausibleRate bounds ------------------------------------------------
+
+    @Test
+    public void plausibleRate_bounds() {
+        assertThat(UsbAudioDevice.isPlausibleRate(7999)).isFalse();
+        assertThat(UsbAudioDevice.isPlausibleRate(8000)).isTrue();   // telephony codecs
+        assertThat(UsbAudioDevice.isPlausibleRate(44100)).isTrue();
+        assertThat(UsbAudioDevice.isPlausibleRate(48000)).isTrue();
+        assertThat(UsbAudioDevice.isPlausibleRate(768000)).isTrue(); // top-end UAC DACs
+        assertThat(UsbAudioDevice.isPlausibleRate(768001)).isFalse();
+        assertThat(UsbAudioDevice.isPlausibleRate(-1)).isFalse();
+    }
+}


### PR DESCRIPTION
Fixes #364

Both USB capture paths assumed the device streams 48 kHz/16-bit. A device negotiating 44.1 kHz got its decimation ratio floored (`44100/12000 -> 3`), i.e. it actually produced 14.7 kHz audio labeled 12 kHz — every FT8 tone shifted off the 6.25 Hz grid and nothing decoded. Until now this was only warned about (native rate check in `usb_audio_capture.cpp`; the Java fallback logged too). This PR fixes both halves.

## 1. Preferred path: pick a 48 kHz alt setting during enumeration

- **`UacAudioFormats.java`** (new, plain Java on `byte[]` so it is host-testable): parses the raw configuration descriptors from `UsbDeviceConnection.getRawDescriptors()` for UAC 1.0 class-specific AS FORMAT_TYPE descriptors (`bDescriptorType 0x24`, subtype `0x02`, FORMAT_TYPE_I) — both discrete sample-rate tables and continuous min/max ranges — attributed to their (interface id, alt setting).
- `choose()` selects the alt setting to activate: an alt that really supports 48 kHz at 16-bit wins (keeping the currently selected alt when it qualifies). When none does, fallback rates are ranked: can feed the decoder (>= 12 kHz) > integer multiple of 12 kHz (keeps the integer FIR fast path, e.g. 24 k/96 k) > closest to 48 kHz > current alt.
- **`UsbAudioDevice.activateInput()`** now treats its rate argument as a *preference*: it may swap `streamingInterfaceIn`/`endpointIn` to a different alt setting of the same interface (most CM108-class codecs do offer 48 kHz), negotiates the chosen rate via SET_CUR, and reports the truth through `getInputSampleRate()`. Channel count now comes from the descriptor's `bNrChannels` instead of the packet-size guess that assumed 48 kHz. If descriptor parsing yields nothing usable, behavior is exactly the legacy assume-48-kHz path.

## 2. Fallback: rational resampling instead of integer flooring

- **`rational_resampler.h`** (new, header-only, no JNI/libusb/Android deps): streaming polyphase interpolate-by-L / decimate-by-M resampler. 44.1 kHz -> 12 kHz is L/M = 40/147, computed by `rationalRatioFor()` (gcd reduction with the same degenerate-rate guards as `decimationRatioFor`). Blackman windowed-sinc kernel at the conceptual upsampled rate, cutoff `0.45/max(L,M)` (~5.4 kHz for 44.1k->12k, well above FT8's ~3 kHz top), each polyphase branch normalized to unity DC sum. ~59 multiplies per output sample at 40/147 — no zero-stuffed samples are ever materialized. No libsamplerate dependency added.
- **`usb_audio_capture.cpp`**: when `inputRate % targetRate != 0`, the capture session uses the rational resampler; the 48 kHz integer `FirDecimator` fast path is untouched.
- **`RationalResampler.java`** (new): line-for-line port for the `UsbRequest` fallback capture loop in `UsbAudioDevice.captureLoop()`, which did its own floored decimation. It doubles as the host-testable reference implementation of the native kernel.

## Tests

- **Native host test** `ft8af_glue/test_rational_resampler.cpp`, wired into `run_host_tests.ps1` and `run_host_tests.sh` (so CI's native-tests workflow runs it): exact L/M reduction + guards, drift-free output count (10 s of 44.1 k input -> exactly 120 000 samples at 12 k), unity DC gain on every output phase, **a 1500 Hz (and 2500 Hz) sine through 44.1k->12k stays at 1500 Hz** (zero-crossing measure; the old floored path would have shifted it to ~1224 Hz), >40 dB rejection of a 10 kHz tone that would alias to 2 kHz mid-FT8-band, and chunked-vs-single-call streaming equivalence. Full `run_host_tests.ps1` suite passes locally (exit 0), including the decode-bench floors.
- **`RationalResamplerTest.java`** (10 tests): Java port of the same assertions, including the 1500 Hz sine frequency-preservation check and `ratioFor` exactness (48000 -> {1,4} integer path, 44100 -> {40,147}, output rate exactly 12 000).
- **`UacAudioFormatsTest.java`** (14 tests): descriptor parsing (attribution to interface/alt, multiple alt settings, continuous ranges, AudioControl/HID descriptors ignored, malformed/truncated/zero-length input safety) and selection policy (prefer the 48 kHz alt, keep the current alt when it qualifies, fall back to 44.1 kHz truthfully, prefer integer multiples of 12 kHz over closer rates, skip non-16-bit alts, pick 48 kHz or the best decoder multiple from continuous ranges, null when nothing usable).

`gradlew testDebugUnitTest` (all unit tests) and `gradlew assembleDebug` (NDK/C++ build) both pass.

## Notes

- TX output alt-setting selection is out of scope; this issue is about capture. The write path keeps its existing behavior.
- **Real-hardware verification with a 44.1-kHz-only capture device is advised** — the alt-setting swap and SET_CUR negotiation were validated against synthetic descriptors, not a physical non-48 kHz codec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)