### PR TITLE
Fix waterfall labels stamping twice when deep passes cross the slot boundary

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallLabelGate.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallLabelGate.java
@@ -32,7 +32,11 @@ import java.util.List;
  * lets them through, and the same slot's labels are stamped again a few scrolled rows
  * lower — every label on the waterfall appears doubled/garbled.
  *
- * <p>Plain Java (no Android), so the once-per-slot rule can be unit-tested directly.
+ * <p>Makes no Android framework calls of its own, so the once-per-slot rule is unit-tested
+ * directly. The {@link #shouldStamp(long, List)} overload does reference {@link Ft8Message},
+ * whose fields pull in Android/Play-Services types — tests exercising that overload run
+ * under Robolectric (see {@code WaterfallLabelGateSlotKeyTest}); the index-keyed overloads
+ * stay testable on plain JUnit.
  */
 public final class WaterfallLabelGate {
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallLabelGate.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallLabelGate.java
@@ -1,5 +1,9 @@
 package com.k1af.ft8af.ui;
 
+import com.k1af.ft8af.Ft8Message;
+
+import java.util.List;
+
 /**
  * Gates the waterfall's decoded-message labels to one stamp per decode slot.
  *
@@ -18,6 +22,15 @@ package com.k1af.ft8af.ui;
  * index already stamped under the previous mode and wrongly suppress the new mode's first
  * label. Including {@code slotMillis} makes any mode change a distinct key, so the first
  * slot after the switch always stamps once.
+ *
+ * <p>The slot index must be derived from the <em>decoded</em> slot (the messages' own
+ * {@link Ft8Message#utcTime}), NOT from the wall clock at stamp time — use
+ * {@link #shouldStamp(long, List)}. The deep-decode subtraction/cross-slot passes run on a
+ * budget of most of a slot ({@code ModeProfile#deepDecodeBudgetMillis}) starting near the
+ * end of the slot, so late passes routinely finish <em>after</em> the slot boundary. Each
+ * one re-arms the stamp; keyed on wall clock they land in a fresh slot index, the gate
+ * lets them through, and the same slot's labels are stamped again a few scrolled rows
+ * lower — every label on the waterfall appears doubled/garbled.
  *
  * <p>Plain Java (no Android), so the once-per-slot rule can be unit-tested directly.
  */
@@ -52,6 +65,28 @@ public final class WaterfallLabelGate {
      */
     public boolean shouldStamp(long period) {
         return shouldStamp(NO_MODE, period);
+    }
+
+    /**
+     * Whether the labels for {@code messages} should be stamped now, keyed on the slot the
+     * messages were <em>decoded from</em> ({@link Ft8Message#utcTime}, the slot-start UTC the
+     * listener stamps on every decode of a run) rather than the wall clock at stamp time.
+     * All passes over one slot's audio share that utcTime, so a deep/subtraction pass that
+     * finishes after the slot boundary maps to the already-stamped key and is suppressed,
+     * instead of restamping the same labels at a new scroll offset.
+     *
+     * <p>An empty (or null) list never stamps and — unlike the index overloads — does not
+     * consume the gate: there is nothing to draw, and marking the key would collide with a
+     * later pass of the slot that does find messages (the wall-clock fallback of a silent
+     * slot shares the index space with the message-derived keys).
+     */
+    public boolean shouldStamp(long slotMillis, List<Ft8Message> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return false;
+        }
+        long decodedUtcMs = messages.get(0).utcTime;
+        long period = slotMillis > 0 ? decodedUtcMs / slotMillis : decodedUtcMs;
+        return shouldStamp(slotMillis, period);
     }
 
     /** Forget the last stamped slot (e.g. when the bitmap is recreated). */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
@@ -328,20 +328,20 @@ public class WaterfallView extends View {
         //Messages have 3 types: normal, CQ, and involving me
         if (drawMessage && messages != null) {
             drawMessage = false;//Consume the one-shot arming
-            // FT8 decodes in more than one pass per cycle (a normal pass and a slower deep
-            // pass), and every completed pass re-arms drawMessage. Without this guard the
-            // same labels get stamped onto the scrolling bitmap several times per cycle, at
-            // different scroll offsets, so they appear to repeat down the waterfall —
-            // including over the next cycle's not-yet-populated rows where the signal is
-            // gone. Stamp at most once per decode slot. Key the gate on the current mode's
-            // slot length (NOT a fixed 15s) so FT4 (7.5s) and FT2 (3.75s) each get one stamp
-            // per slot instead of one stamp per two-or-more slots. Pass slotMillis as part
-            // of the key too: this view (and its gate) is reused across mode changes, and a
-            // new mode's slotPeriod can collide with one already stamped under the old mode,
-            // which would wrongly suppress the first label after the switch.
+            // FT8 decodes in more than one pass per cycle (a normal pass, a deep pass, then
+            // a budgeted subtraction/cross-slot loop), and every completed pass re-arms
+            // drawMessage. Without this guard the same labels get stamped onto the scrolling
+            // bitmap several times per cycle, at different scroll offsets, so they appear to
+            // repeat down the waterfall. Stamp at most once per decode slot, keyed on the
+            // slot the messages were DECODED FROM (their utcTime), not the wall clock now:
+            // the deep loop's budget (~0.75 slot) starts near the end of the slot, so late
+            // passes routinely finish after the slot boundary — a wall-clock key would land
+            // in a fresh slot index and restamp every label a few scrolled rows lower,
+            // doubling/garbling all of them. slotMillis stays part of the key so a mode
+            // change (FT8/FT4/FT2 divide utc differently) can't collide with a slot already
+            // stamped under the previous mode.
             long slotMillis = GeneralVariables.currentMode().slotMillis;
-            long slotPeriod = slotMillis > 0 ? utcMs / slotMillis : period;
-            if (messageGate.shouldStamp(slotMillis, slotPeriod)) {
+            if (messageGate.shouldStamp(slotMillis, messages)) {
                 Log.d(TAG, String.format("Drawing %d messages on waterfall", messages.size()));
                 for (Ft8Message msg : messages) {
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallLabelGateSlotKeyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallLabelGateSlotKeyTest.java
@@ -1,0 +1,116 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.FT8Common;
+import com.k1af.ft8af.Ft8Message;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+
+/**
+ * Unit tests for {@link WaterfallLabelGate#shouldStamp(long, java.util.List)}: the label
+ * stamp is keyed on the slot the messages were <em>decoded from</em> (their utcTime), not
+ * on the wall clock at stamp time.
+ *
+ * <p>Regression guard for the doubled/garbled waterfall labels that appeared with the
+ * deep-decode speedups (#367&ndash;#370): the subtraction/cross-slot loop runs on a budget of
+ * ~0.75 of a slot starting near the slot's end, so late passes finish <em>after</em> the slot
+ * boundary. Each pass re-arms the stamp; keyed on wall clock the late ones landed in a fresh
+ * slot index, so the gate let the same merged label list stamp again a few scrolled rows
+ * lower and every callsign on the waterfall was written more than once.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class WaterfallLabelGateSlotKeyTest {
+
+    private static final long FT8_SLOT_MS = 15_000;
+    private static final long FT4_SLOT_MS = 7_500;
+
+    /** A decode result whose messages all carry the given decoded-slot start UTC. */
+    private ArrayList<Ft8Message> decodedAt(long slotStartUtcMs, int n) {
+        ArrayList<Ft8Message> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+            msg.utcTime = slotStartUtcMs;
+            list.add(msg);
+        }
+        return list;
+    }
+
+    @Test
+    public void firstStampOfADecodedSlotIsAllowed() {
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 3))).isTrue();
+    }
+
+    @Test
+    public void latePassAfterTheSlotBoundaryDoesNotRestamp() {
+        // The bug: the normal pass stamps ~13s into slot N; subtraction/cross-slot passes
+        // keep re-arming into slot N+1 wall time with the same decoded slot's (merged,
+        // grown) message list. All of them must be suppressed — the wall clock at stamp
+        // time plays no part in the key.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        long slotStart = 150_000;
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(slotStart, 3))).isTrue();
+        // deep pass, still inside the slot
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(slotStart, 5))).isFalse();
+        // subtraction passes finishing 1..9s into the NEXT slot
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(slotStart, 7))).isFalse();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(slotStart, 8))).isFalse();
+    }
+
+    @Test
+    public void theNextSlotsDecodeStampsOnce() {
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 3))).isTrue();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 6))).isFalse();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(165_000, 2))).isTrue();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(165_000, 4))).isFalse();
+    }
+
+    @Test
+    public void emptyListNeverStampsAndDoesNotConsumeTheGate() {
+        // A pass with nothing to draw must not mark the slot as stamped: a later pass of
+        // the same slot that does find messages still gets its one stamp.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, new ArrayList<>())).isFalse();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 1))).isTrue();
+    }
+
+    @Test
+    public void nullListNeverStamps() {
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, (ArrayList<Ft8Message>) null)).isFalse();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 1))).isTrue();
+    }
+
+    @Test
+    public void modeChangeStampsEvenWhenTheSlotIndexCollides() {
+        // FT8 slot index 150000/15000 == 10; FT4 index 75000/7500 == 10. The mode's slot
+        // length stays part of the key, so the first FT4 slot after a switch still stamps.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 2))).isTrue();
+        assertThat(gate.shouldStamp(FT4_SLOT_MS, decodedAt(75_000, 2))).isTrue();
+        assertThat(gate.shouldStamp(FT4_SLOT_MS, decodedAt(75_000, 3))).isFalse();
+    }
+
+    @Test
+    public void nonPositiveSlotMillisFallsBackToRawUtcKey() {
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(0, decodedAt(150_000, 1))).isTrue();
+        assertThat(gate.shouldStamp(0, decodedAt(150_000, 2))).isFalse();
+        assertThat(gate.shouldStamp(0, decodedAt(165_000, 1))).isTrue();
+    }
+
+    @Test
+    public void resetAllowsTheSameDecodedSlotToStampAgain() {
+        // A bitmap recreate wipes the stamped labels; the current slot must re-stamp.
+        WaterfallLabelGate gate = new WaterfallLabelGate();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 2))).isTrue();
+        gate.reset();
+        assertThat(gate.shouldStamp(FT8_SLOT_MS, decodedAt(150_000, 2))).isTrue();
+    }
+}


### PR DESCRIPTION
## Problem

Since the decode-gap work (#367–#370), every callsign label on the waterfall appears doubled/garbled — the same message text written more than once on each signal, offset by a few pixels:

The deep-decode subtraction/cross-slot loop now runs on a budget of ~0.75 of a slot (`ModeProfile#deepDecodeBudgetMillis`), and the decode starts near the end of the slot, so late passes routinely finish **after** the slot boundary. Each completed pass re-arms the waterfall's one-shot label stamp, and `WaterfallLabelGate` was keyed on the **wall clock at stamp time** (`utcMs / slotMillis`): a pass finishing 1–9 s into the next slot landed on a fresh slot index, the gate let it through, and the same slot's (merged) label list was stamped onto the scrolling bitmap again a few rows lower. Before the decode work the late passes rarely found anything new, so the re-arms never happened and the bug stayed hidden.

## Fix

Key the gate on the slot the messages were **decoded from** instead of the wall clock. The listener stamps the slot-start UTC on every message of a decode run (`Ft8Message.utcTime`, set in `FT8SignalListener.runDecode`), so all passes over one slot's audio — normal, deep, subtraction, cross-slot, no matter when they finish — map to the same gate key, and only the first one stamps.

- `WaterfallLabelGate.shouldStamp(long slotMillis, List<Ft8Message>)`: new message-keyed overload. An empty/null list never stamps and does **not** consume the gate (nothing to draw, and marking the key could collide with a later pass of the same slot that does find messages).
- `WaterfallView.setWaveData`: use the new overload; drop the wall-clock `slotPeriod`.
- `slotMillis` stays part of the key, so the FT8→FT4/FT2 mode-change collision case is unchanged.

## Tests

New `WaterfallLabelGateSlotKeyTest` covers the regression directly: late passes after the slot boundary with the same decoded slot's messages are suppressed, the next slot stamps once, empty/null lists don't consume the gate, the mode-change slot-index collision still stamps, and reset re-allows the current slot. Full `testDebugUnitTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)