### PR TITLE
Save output level per band (#355)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -91,6 +91,15 @@ public class GeneralVariables {
     public static boolean showTxVolumeSlider = true;//Show inline TX volume slider on main screen
     public static MutableLiveData<Boolean> mutableShowTxVolumeSlider = new MutableLiveData<>(true);
 
+    // Save output level per band (issue #355). When on, the app remembers the TX
+    // output level for each wavelength band and restores it on band change.
+    // Off by default to preserve the single-global-level behavior.
+    public static boolean saveOutputLevelPerBand = false;
+    public static MutableLiveData<Boolean> mutableSaveOutputLevelPerBand = new MutableLiveData<>(false);
+    // JSON map of {bandWaveLength -> outputLevelPercent}, persisted under the
+    // "perBandOutputLevels" config key. Parsed on demand via PerBandVolume.
+    public static String perBandOutputLevels = "";
+
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -80,6 +80,7 @@ import com.k1af.ft8af.log.QSLRecord;
 import com.k1af.ft8af.log.SWLQsoList;
 import com.k1af.ft8af.log.ThirdPartyService;
 import com.k1af.ft8af.rigs.BaseRig;
+import com.k1af.ft8af.audio.PerBandVolume;
 import com.k1af.ft8af.rigs.BaseRigOperation;
 import com.k1af.ft8af.rigs.CatConnectionState;
 import com.k1af.ft8af.rigs.CatLiveness;
@@ -305,6 +306,18 @@ public class MainViewModel extends ViewModel {
             if (shouldClearOnBandChange(GeneralVariables.clearOnBandModeChange,
                     oldWaveLength, newWaveLength)) {
                 clearDecodesAndTarget();
+            }
+
+            // Restore the saved per-band output level, but only on a real band hop
+            // (wavelength changed) — an in-band dial nudge must not stomp a level the
+            // operator just set on this band (#355).
+            if (!oldWaveLength.equals(newWaveLength)) {
+                int restored = restorePerBandOutputLevel();
+                if (restored >= 0) {
+                    ToastMessage.show(String.format(
+                            getStringFromResource(R.string.per_band_volume_restored),
+                            restored, newWaveLength));
+                }
             }
 
             databaseOpr.getAllQSLCallsigns();//read out successfully contacted callsigns
@@ -1078,6 +1091,58 @@ public class MainViewModel extends ViewModel {
                 baseRig.setFreqToRig();
             }
         }, 800);
+    }
+
+    /**
+     * Per-band output level (issue #355): when {@link GeneralVariables#saveOutputLevelPerBand}
+     * is on, restore the saved TX output level for the band {@link GeneralVariables#band} now
+     * sits in. Applies the level in-memory, persists it as the new global {@code volumeValue},
+     * pushes it to the rig, and notifies observers.
+     *
+     * @return the restored level (0-100), or -1 if nothing was restored (feature off, no rig
+     *         band, or no saved value for this band — in which case the current level stands).
+     */
+    public int restorePerBandOutputLevel() {
+        if (!GeneralVariables.saveOutputLevelPerBand) {
+            return -1;
+        }
+        java.util.Map<String, Integer> levels =
+                PerBandVolume.parse(GeneralVariables.perBandOutputLevels);
+        String band = BaseRigOperation.getMeterFromFreq(GeneralVariables.band);
+        Integer saved = PerBandVolume.lookup(levels, band);
+        if (saved == null) {
+            return -1;
+        }
+        applyOutputLevel(saved);
+        return saved;
+    }
+
+    /**
+     * Persist {@code percent} as the saved output level for the current band, but only when
+     * per-band saving is enabled. Called whenever the user commits a volume change so the
+     * active band's stored value tracks the slider.
+     */
+    public void savePerBandOutputLevel(int percent) {
+        if (!GeneralVariables.saveOutputLevelPerBand) {
+            return;
+        }
+        java.util.Map<String, Integer> levels =
+                PerBandVolume.parse(GeneralVariables.perBandOutputLevels);
+        String band = BaseRigOperation.getMeterFromFreq(GeneralVariables.band);
+        java.util.Map<String, Integer> updated = PerBandVolume.put(levels, band, percent);
+        String json = PerBandVolume.serialize(updated);
+        GeneralVariables.perBandOutputLevels = json;
+        databaseOpr.writeConfig("perBandOutputLevels", json, null);
+    }
+
+    /** Apply an output level everywhere: in-memory, observers, persisted global, and the rig. */
+    private void applyOutputLevel(int percent) {
+        GeneralVariables.volumePercent = percent / 100f;
+        GeneralVariables.mutableVolumePercent.postValue(percent / 100f);
+        databaseOpr.writeConfig("volumeValue", String.valueOf(percent), null);
+        if (baseRig != null && baseRig.getConnector() != null) {
+            baseRig.getConnector().setRFVolume(percent);
+        }
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/audio/PerBandVolume.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/audio/PerBandVolume.java
@@ -1,0 +1,117 @@
+package com.k1af.ft8af.audio;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Pure logic for the "save output level per band" feature (issue #355).
+ *
+ * The per-band output levels are persisted in the app's {@code config} table as a
+ * single JSON object under the key {@code perBandOutputLevels}, mapping a
+ * wavelength band name (e.g. {@code "20m"}, as returned by
+ * {@code BaseRigOperation.getMeterFromFreq}) to an output level percentage
+ * (0-100). The effectful wiring (reading the current band, pushing the level to
+ * the rig, persisting) lives in {@code MainViewModel}; everything here is a pure
+ * function so it can be unit-tested without Android.
+ */
+public final class PerBandVolume {
+
+    private PerBandVolume() {
+    }
+
+    /**
+     * Parse the stored JSON map. Robust to null/empty/malformed input and to
+     * non-numeric values — anything unparseable is skipped, yielding (at worst)
+     * an empty map rather than throwing. Percentages are clamped to 0-100.
+     */
+    @NonNull
+    public static Map<String, Integer> parse(@Nullable String json) {
+        TreeMap<String, Integer> levels = new TreeMap<>();
+        if (json == null || json.trim().isEmpty()) {
+            return levels;
+        }
+        JSONObject obj;
+        try {
+            obj = new JSONObject(json);
+        } catch (JSONException e) {
+            return levels;
+        }
+        Iterator<String> keys = obj.keys();
+        while (keys.hasNext()) {
+            String band = keys.next();
+            if (band == null || band.trim().isEmpty()) {
+                continue;
+            }
+            int value = obj.optInt(band, Integer.MIN_VALUE);
+            if (value == Integer.MIN_VALUE) {
+                continue; // non-numeric / missing
+            }
+            levels.put(band, clampPercent(value));
+        }
+        return levels;
+    }
+
+    /**
+     * Serialize the map back to a deterministic JSON string (keys sorted, which a
+     * {@link TreeMap} gives us for free) so exports/backups are diff-friendly.
+     */
+    @NonNull
+    public static String serialize(@NonNull Map<String, Integer> levels) {
+        JSONObject obj = new JSONObject();
+        for (Map.Entry<String, Integer> e : new TreeMap<>(levels).entrySet()) {
+            if (e.getKey() == null || e.getKey().trim().isEmpty() || e.getValue() == null) {
+                continue;
+            }
+            try {
+                obj.put(e.getKey(), clampPercent(e.getValue()));
+            } catch (JSONException ignored) {
+                // A well-formed String key can't actually throw here.
+            }
+        }
+        return obj.toString();
+    }
+
+    /**
+     * The saved level for {@code band}, or {@code null} if none is stored (the
+     * caller should then keep the current/global level as the fallback).
+     */
+    @Nullable
+    public static Integer lookup(@NonNull Map<String, Integer> levels, @Nullable String band) {
+        if (band == null || band.trim().isEmpty()) {
+            return null;
+        }
+        return levels.get(band);
+    }
+
+    /**
+     * Return a copy of {@code levels} with {@code band} set to {@code percent}
+     * (clamped to 0-100). A blank band name is a no-op — we never want to key an
+     * entry under "" for an unknown/out-of-range frequency.
+     */
+    @NonNull
+    public static Map<String, Integer> put(
+            @NonNull Map<String, Integer> levels, @Nullable String band, int percent) {
+        TreeMap<String, Integer> updated = new TreeMap<>(levels);
+        if (band != null && !band.trim().isEmpty()) {
+            updated.put(band, clampPercent(percent));
+        }
+        return updated;
+    }
+
+    private static int clampPercent(int percent) {
+        if (percent < 0) {
+            return 0;
+        }
+        if (percent > 100) {
+            return 100;
+        }
+        return percent;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2577,6 +2577,13 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.showTxVolumeSlider = !result.equals("0");
                     GeneralVariables.mutableShowTxVolumeSlider.postValue(GeneralVariables.showTxVolumeSlider);
                 }
+                if (name.equalsIgnoreCase("saveOutputLevelPerBand")) {//Per-band output level saving (#355)
+                    GeneralVariables.saveOutputLevelPerBand = result.equals("1");
+                    GeneralVariables.mutableSaveOutputLevelPerBand.postValue(GeneralVariables.saveOutputLevelPerBand);
+                }
+                if (name.equalsIgnoreCase("perBandOutputLevels")) {//Per-band output level map (JSON, #355)
+                    GeneralVariables.perBandOutputLevels = result == null ? "" : result;
+                }
                 if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -695,7 +695,7 @@ class ComposeMainActivity : AppCompatActivity() {
                 val newVol = (GeneralVariables.volumePercent + delta).coerceIn(0.0f, 1.0f)
                 GeneralVariables.volumePercent = newVol
                 GeneralVariables.mutableVolumePercent.postValue(newVol)
-                val intVal = (newVol * 100).toInt()
+                val intVal = radio.ks3ckc.ft8af.ui.components.volumePercentToDisplay(newVol)
                 mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(intVal)
                 // Track this band's saved level when per-band saving is on (#355).

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -698,6 +698,8 @@ class ComposeMainActivity : AppCompatActivity() {
                 val intVal = (newVol * 100).toInt()
                 mainViewModel.databaseOpr.writeConfig("volumeValue", intVal.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(intVal)
+                // Track this band's saved level when per-band saving is on (#355).
+                mainViewModel.savePerBandOutputLevel(intVal)
 
                 // Also adjust system music stream so audio is actually audible
                 val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -50,6 +50,7 @@ import radio.ks3ckc.ft8af.ui.components.FT8AFTab
 import radio.ks3ckc.ft8af.ui.components.FrequencyPickerSheet
 import radio.ks3ckc.ft8af.ui.components.HoundSetupSheet
 import radio.ks3ckc.ft8af.ui.components.formatMhz
+import radio.ks3ckc.ft8af.ui.components.volumePercentToDisplay
 import radio.ks3ckc.ft8af.ui.components.QsoCelebration
 import radio.ks3ckc.ft8af.ui.components.SlotTimerBar
 import radio.ks3ckc.ft8af.ui.components.TabBar
@@ -108,9 +109,9 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
     val volumeLive by GeneralVariables.mutableVolumePercent.observeAsState(
         GeneralVariables.volumePercent,
     )
-    var txVolume by remember { mutableIntStateOf((GeneralVariables.volumePercent * 100).toInt()) }
+    var txVolume by remember { mutableIntStateOf(volumePercentToDisplay(GeneralVariables.volumePercent)) }
     LaunchedEffect(volumeLive) {
-        txVolume = ((volumeLive ?: GeneralVariables.volumePercent) * 100).toInt()
+        txVolume = volumePercentToDisplay(volumeLive ?: GeneralVariables.volumePercent)
     }
 
     // Inline volume slider visibility — observed so toggling in Settings

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -371,6 +371,8 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 onVolumeChangeFinished = {
                     mainViewModel.databaseOpr.writeConfig("volumeValue", txVolume.toString(), null)
                     mainViewModel.baseRig?.connector?.setRFVolume(txVolume)
+                    // Track this band's saved level when per-band saving is on (#355).
+                    mainViewModel.savePerBandOutputLevel(txVolume)
                 },
                 onCallCQ = {
                     if (GeneralVariables.myCallsign.isNullOrEmpty()) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
@@ -86,6 +86,20 @@ fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) 
     if (cm == ControlMode.CAT || cm == ControlMode.RTS || cm == ControlMode.DTR) {
         mainViewModel.setOperationBand()
     }
+
+    // Restore the saved per-band output level, but only on a real band hop so an
+    // alternate-frequency pick within the same wavelength band doesn't stomp the
+    // level the operator set there (#355).
+    if (oldWaveLength != newWaveLength) {
+        val restored = mainViewModel.restorePerBandOutputLevel()
+        if (restored >= 0) {
+            android.widget.Toast.makeText(
+                context,
+                context.getString(R.string.per_band_volume_restored, restored, newWaveLength),
+                android.widget.Toast.LENGTH_SHORT,
+            ).show()
+        }
+    }
 }
 
 private data class BandGroup(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -67,6 +67,16 @@ internal data class TxStripActionState(
 internal fun clampVolume(current: Int, delta: Int): Int =
     (current + delta).coerceIn(0, 100)
 
+/**
+ * Convert a 0.0–1.0 volume fraction (GeneralVariables.volumePercent) to the
+ * whole-percent value shown on the slider. Rounds rather than truncates so a
+ * stored level round-trips to the same integer: e.g. 59 -> 0.59f -> 58.999… would
+ * truncate back to 58, making the per-band restore toast (which reports the stored
+ * int) disagree with the slider by 1. Extracted for unit-testing.
+ */
+internal fun volumePercentToDisplay(fraction: Float): Int =
+    Math.round(fraction * 100).coerceIn(0, 100)
+
 internal fun txStripActionState(isActivated: Boolean, huntEnabled: Boolean) = TxStripActionState(
     huntDisabled = isActivated && !huntEnabled,
     huntActive = huntEnabled,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -48,6 +48,7 @@ import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.FT8AFIconButton
 import radio.ks3ckc.ft8af.ui.components.FT8AFIcons
 import radio.ks3ckc.ft8af.ui.components.IntSlider
+import radio.ks3ckc.ft8af.ui.components.volumePercentToDisplay
 import radio.ks3ckc.ft8af.ui.components.GlassCard
 import radio.ks3ckc.ft8af.ui.components.SettingsRow
 import radio.ks3ckc.ft8af.ui.components.Toggle
@@ -88,10 +89,10 @@ fun RadioAudioSettings(
     val volumeLive by GeneralVariables.mutableVolumePercent.observeAsState(
         GeneralVariables.volumePercent,
     )
-    var txVolume by remember { mutableIntStateOf((GeneralVariables.volumePercent * 100).toInt()) }
+    var txVolume by remember { mutableIntStateOf(volumePercentToDisplay(GeneralVariables.volumePercent)) }
     // Keep txVolume in sync when hardware buttons (or other sources) update the LiveData
     LaunchedEffect(volumeLive) {
-        txVolume = ((volumeLive ?: GeneralVariables.volumePercent) * 100).toInt()
+        txVolume = volumePercentToDisplay(volumeLive ?: GeneralVariables.volumePercent)
     }
 
     // Observe serial ports for USB Cable picker

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -431,6 +431,8 @@ fun RadioAudioSettings(
                 showTxVolume = false
                 mainViewModel.databaseOpr.writeConfig("volumeValue", txVolume.toString(), null)
                 mainViewModel.baseRig?.connector?.setRFVolume(txVolume)
+                // Track this band's saved level when per-band saving is on (#355).
+                mainViewModel.savePerBandOutputLevel(txVolume)
             },
         )
     }
@@ -627,6 +629,31 @@ fun RadioAudioSettings(
                                 mainViewModel.databaseOpr.writeConfig(
                                     "showTxVolumeSlider", if (enabled) "1" else "0", null,
                                 )
+                            },
+                        )
+                    }
+                    SectionDivider()
+                    run {
+                        var perBand by remember {
+                            mutableStateOf(GeneralVariables.saveOutputLevelPerBand)
+                        }
+                        SettingsRow(
+                            label = stringResource(R.string.settings_per_band_volume),
+                            description = stringResource(R.string.settings_per_band_volume_desc),
+                            toggle = perBand,
+                            onToggleChange = { enabled ->
+                                perBand = enabled
+                                GeneralVariables.saveOutputLevelPerBand = enabled
+                                GeneralVariables.mutableSaveOutputLevelPerBand.postValue(enabled)
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "saveOutputLevelPerBand", if (enabled) "1" else "0", null,
+                                )
+                                // Seed the current band with the active level so it has a
+                                // saved value straight away instead of only after the next
+                                // slider move (#355).
+                                if (enabled) {
+                                    mainViewModel.savePerBandOutputLevel(txVolume)
+                                }
                             },
                         )
                     }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -456,6 +456,9 @@
     <string name="settings_tx_volume_desc" formatted="false">Transmit audio level (hardware buttons ±5%)</string>
     <string name="settings_show_volume_slider">Show Volume Slider</string>
     <string name="settings_show_volume_slider_desc">Display TX volume slider on main screen</string>
+    <string name="settings_per_band_volume">Save Output Level Per Band</string>
+    <string name="settings_per_band_volume_desc">Remember the TX output level for each band and restore it when you switch bands</string>
+    <string name="per_band_volume_restored" formatted="false">Restored %1$d%% output level for %2$s</string>
 
     <!-- ===== Settings: transmission ===== -->
     <string name="settings_tx_rx_split">TX/RX Split</string>

--- a/ft8af/app/src/test/kotlin/com/k1af/ft8af/audio/PerBandVolumeTest.kt
+++ b/ft8af/app/src/test/kotlin/com/k1af/ft8af/audio/PerBandVolumeTest.kt
@@ -1,0 +1,125 @@
+package com.k1af.ft8af.audio
+
+import com.google.common.truth.Truth.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for the per-band output level logic (issue #355). These touch org.json (an
+ * Android type), so they run under Robolectric per the project's testing convention.
+ */
+@RunWith(RobolectricTestRunner::class)
+class PerBandVolumeTest {
+
+    // -- parse --
+
+    @Test
+    fun `parse null yields empty map`() {
+        assertThat(PerBandVolume.parse(null)).isEmpty()
+    }
+
+    @Test
+    fun `parse blank yields empty map`() {
+        assertThat(PerBandVolume.parse("   ")).isEmpty()
+    }
+
+    @Test
+    fun `parse malformed json yields empty map`() {
+        assertThat(PerBandVolume.parse("{not valid")).isEmpty()
+    }
+
+    @Test
+    fun `parse reads band to percent entries`() {
+        val levels = PerBandVolume.parse("""{"20m":80,"40m":65}""")
+        assertThat(levels).containsExactly("20m", 80, "40m", 65)
+    }
+
+    @Test
+    fun `parse skips non-numeric values`() {
+        val levels = PerBandVolume.parse("""{"20m":80,"40m":"loud"}""")
+        assertThat(levels).containsExactly("20m", 80)
+    }
+
+    @Test
+    fun `parse clamps out-of-range percentages`() {
+        val levels = PerBandVolume.parse("""{"20m":150,"40m":-10}""")
+        assertThat(levels).containsExactly("20m", 100, "40m", 0)
+    }
+
+    // -- serialize --
+
+    @Test
+    fun `serialize round-trips through parse`() {
+        val original = mapOf("20m" to 80, "40m" to 65, "80m" to 50)
+        val json = PerBandVolume.serialize(original)
+        assertThat(PerBandVolume.parse(json)).containsExactlyEntriesIn(original)
+    }
+
+    @Test
+    fun `serialize sorts keys deterministically`() {
+        val json = PerBandVolume.serialize(mapOf("80m" to 50, "20m" to 80, "40m" to 65))
+        // TreeMap ordering: keys are emitted sorted, so the output is stable.
+        assertThat(json).isEqualTo("""{"20m":80,"40m":65,"80m":50}""")
+    }
+
+    @Test
+    fun `serialize empty map is empty object`() {
+        assertThat(PerBandVolume.serialize(emptyMap())).isEqualTo("{}")
+    }
+
+    @Test
+    fun `serialize skips blank band keys`() {
+        val json = PerBandVolume.serialize(mapOf("" to 80, "20m" to 65))
+        assertThat(JSONObject(json).has("")).isFalse()
+        assertThat(JSONObject(json).getInt("20m")).isEqualTo(65)
+    }
+
+    // -- lookup --
+
+    @Test
+    fun `lookup returns saved value`() {
+        val levels = mapOf("20m" to 80)
+        assertThat(PerBandVolume.lookup(levels, "20m")).isEqualTo(80)
+    }
+
+    @Test
+    fun `lookup returns null when band absent`() {
+        assertThat(PerBandVolume.lookup(mapOf("20m" to 80), "40m")).isNull()
+    }
+
+    @Test
+    fun `lookup returns null for blank band`() {
+        assertThat(PerBandVolume.lookup(mapOf("20m" to 80), "")).isNull()
+        assertThat(PerBandVolume.lookup(mapOf("20m" to 80), null)).isNull()
+    }
+
+    // -- put --
+
+    @Test
+    fun `put adds a new band without mutating the input`() {
+        val original = mapOf("20m" to 80)
+        val updated = PerBandVolume.put(original, "40m", 65)
+        assertThat(updated).containsExactly("20m", 80, "40m", 65)
+        assertThat(original).containsExactly("20m", 80) // unchanged
+    }
+
+    @Test
+    fun `put overwrites an existing band`() {
+        val updated = PerBandVolume.put(mapOf("20m" to 80), "20m", 55)
+        assertThat(updated).containsExactly("20m", 55)
+    }
+
+    @Test
+    fun `put clamps the percent`() {
+        assertThat(PerBandVolume.put(emptyMap(), "20m", 250)).containsExactly("20m", 100)
+        assertThat(PerBandVolume.put(emptyMap(), "20m", -5)).containsExactly("20m", 0)
+    }
+
+    @Test
+    fun `put ignores a blank band`() {
+        assertThat(PerBandVolume.put(mapOf("20m" to 80), "", 65)).containsExactly("20m", 80)
+        assertThat(PerBandVolume.put(mapOf("20m" to 80), null, 65)).containsExactly("20m", 80)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/TxStripVolumeTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/TxStripVolumeTest.kt
@@ -73,4 +73,30 @@ class TxStripVolumeTest {
     fun `boundary value 0 with zero delta`() {
         assertThat(clampVolume(0, 0)).isEqualTo(0)
     }
+
+    // -- volumePercentToDisplay --
+
+    @Test
+    fun `display rounds 0_59 fraction to 59 not 58`() {
+        // Regression: 0.59f * 100 == 58.999… truncates to 58, disagreeing with the
+        // stored int 59 that the per-band restore toast reports (#355).
+        assertThat(volumePercentToDisplay(0.59f)).isEqualTo(59)
+    }
+
+    @Test
+    fun `display round-trips every whole percent`() {
+        for (p in 0..100) {
+            assertThat(volumePercentToDisplay(p / 100f)).isEqualTo(p)
+        }
+    }
+
+    @Test
+    fun `display clamps above 1_0`() {
+        assertThat(volumePercentToDisplay(1.5f)).isEqualTo(100)
+    }
+
+    @Test
+    fun `display clamps below 0`() {
+        assertThat(volumePercentToDisplay(-0.2f)).isEqualTo(0)
+    }
 }


### PR DESCRIPTION
Closes #355.

Adds an opt-in **Save Output Level Per Band** toggle (Settings → Radio & Audio). When enabled, the app remembers the TX output level for each wavelength band and restores it automatically on a band change, with a toast affordance. Off by default, so existing single-global-level behavior is unchanged.

## Implementation
- **`PerBandVolume`** — pure, unit-tested logic to parse/serialize the `band→level%` JSON map, look up a band's saved level, and update it (with clamping).
- **`GeneralVariables` + `DatabaseOpr`** — new `saveOutputLevelPerBand` flag and `perBandOutputLevels` JSON config keys (both ride the existing settings backup automatically since it exports the whole config table).
- **`MainViewModel`** — `restorePerBandOutputLevel()` / `savePerBandOutputLevel()` wire the pure logic to the rig, config, and observers.
- **Restore** fires on real band hops only (wavelength changed), from both the in-app band picker and rig-driven `onFreqChanged`.
- **Save** fires wherever a volume change is committed: inline slider, settings dialog, and hardware volume buttons.

## Behavior
- Default disabled; bands with no saved value fall back to the current global level.
- Enabling the toggle seeds the current band with the active level.

## Rounding fix
On-device testing surfaced a pre-existing bug: the restore toast reported the stored level (e.g. 59%) while the slider showed 58%, because `0.59f * 100 = 58.999…` was truncated. Extracted `volumePercentToDisplay()` (rounds instead of truncating) and used it at every fraction→percent display/save site so a stored level round-trips to the same integer.

## Testing
- `PerBandVolumeTest` (17) + `TxStripVolumeTest` (17, incl. new rounding cases) pass.
- **Verified end-to-end on a physical phone** (Moto G Stylus 5G): toggle persists, per-band save + restore across band switches with matching toast, correct global fallback, and persistence across a cold app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)