### PR TITLE
Feed deep/late-pass decodes to the QSO auto-sequencer

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -211,6 +211,8 @@ public class MainViewModel extends ViewModel {
     public HamRecorder hamRecorder;//recording object
     public FT8SignalListener ft8SignalListener;//object for listening to and decoding FT8 signals
     public FT8TransmitSignal ft8TransmitSignal;//object for transmitting signals
+    // Deep-pass decodes that arrived mid-TX, replayed to the sequencer after key-up
+    private final PendingSequencerDecodes pendingSequencerDecodes = new PendingSequencerDecodes();
     public MeterProtectionController meterProtectionController;//ALC auto-volume + SWR halt
     public SpectrumListener spectrumListener;//object for drawing the spectrum
     public boolean markMessage = true;//whether to mark messages toggle
@@ -584,12 +586,36 @@ public class MainViewModel extends ViewModel {
                 //if exceeded cycle by 2 seconds, should not parse
                 int autoReplyBudgetMs = Math.max(2000, GeneralVariables.lateStartTolerance);
                 if (!ft8TransmitSignal.isTransmitting()
-                        && !isDeep//block deep decode from activating auto procedure
-                        //deep decode list should be added to the new message list without deep decode
+                        && !isDeep//deep passes go through the evidence-only path below
                         && (ft8SignalListener.timeSec
                         + GeneralVariables.pttDelay
                         + GeneralVariables.transmitDelay <= autoReplyBudgetMs)) {//budget scales with late-start tolerance
                     ft8TransmitSignal.parseMessageToFunction(messages);//parse messages and process
+                }
+
+                // Deep/subtraction/late passes routinely find replies the fast
+                // pass missed; feed them to the sequencer as positive evidence
+                // (advance/RR73/complete/enqueue — never no-reply counting, see
+                // parseMessageToFunction(list, true)). When they land before TX
+                // keys (~:29.0-:29.8 vs key-up ~:29.9) this upgrades the very
+                // next transmission; when TX is already playing they are
+                // stashed and replayed after key-up so the evidence still
+                // advances the next cycle instead of being dropped.
+                if (isDeep) {
+                    if (ft8TransmitSignal.isTransmitting()) {
+                        pendingSequencerDecodes.stash(messages, System.currentTimeMillis());
+                    } else {
+                        ft8TransmitSignal.parseMessageToFunction(messages, true);
+                    }
+                }
+                // First delivery with TX idle (typically the own-slot fast pass
+                // ~1s after key-up): replay anything stashed mid-TX.
+                if (!ft8TransmitSignal.isTransmitting() && !pendingSequencerDecodes.isEmpty()) {
+                    ArrayList<Ft8Message> stashed =
+                            pendingSequencerDecodes.drain(System.currentTimeMillis());
+                    if (!stashed.isEmpty()) {
+                        ft8TransmitSignal.parseMessageToFunction(stashed, true);
+                    }
                 }
 
                 currentMessages = WaterfallLabelMessages.afterPass(currentMessages, messages, isDeep);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -603,7 +603,11 @@ public class MainViewModel extends ViewModel {
                 // advances the next cycle instead of being dropped.
                 if (isDeep) {
                     if (ft8TransmitSignal.isTransmitting()) {
-                        pendingSequencerDecodes.stash(messages, System.currentTimeMillis());
+                        // UtcTimer.getSystemTime(), not System.currentTimeMillis():
+                        // Ft8Message.utcTime is in the NTP/GPS-corrected time base,
+                        // and the stash ages entries against it — mixing bases would
+                        // shift eviction by the (possibly large) clock correction.
+                        pendingSequencerDecodes.stash(messages, UtcTimer.getSystemTime());
                     } else {
                         ft8TransmitSignal.parseMessageToFunction(messages, true);
                     }
@@ -612,7 +616,7 @@ public class MainViewModel extends ViewModel {
                 // ~1s after key-up): replay anything stashed mid-TX.
                 if (!ft8TransmitSignal.isTransmitting() && !pendingSequencerDecodes.isEmpty()) {
                     ArrayList<Ft8Message> stashed =
-                            pendingSequencerDecodes.drain(System.currentTimeMillis());
+                            pendingSequencerDecodes.drain(UtcTimer.getSystemTime());
                     if (!stashed.isEmpty()) {
                         ft8TransmitSignal.parseMessageToFunction(stashed, true);
                     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
@@ -1,0 +1,73 @@
+package com.k1af.ft8af;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Holds deep/late-pass decodes that arrived while a transmission was in
+ * progress, so the QSO auto-sequencer can replay them as positive evidence at
+ * the first opportunity after key-up.
+ *
+ * <p>Deep and subtraction-loop passes typically finish 0.5–3&nbsp;s after the
+ * slot's fast pass — i.e. right around or after TX keys up. Before this class
+ * existed those decodes reached the UI but never the sequencer, so a reply the
+ * fast pass missed (found only by a deep pass) left the QSO stalled repeating
+ * the previous message. Results that land while transmitting are stashed here
+ * and drained by {@code MainViewModel.afterDecode} on the next delivery with TX
+ * idle (typically the own-slot fast pass ~1&nbsp;s after key-up), then handed to
+ * {@code FT8TransmitSignal.parseMessageToFunction(list, true)}.
+ *
+ * <p>Entries older than {@link #MAX_AGE_MS} are evicted on every stash/drain:
+ * a reply is only evidence for the QSO it belongs to, and after two full
+ * cycles the fast pass has since made its own calls — acting on an older
+ * stashed report could advance a state it no longer describes. Matching is
+ * additionally guarded by the sequencer itself (from/to callsign and slot
+ * parity checks), so the age cap is a backstop, not the primary filter.
+ *
+ * <p>Thread-safe: a late full-slot pass delivers from the previous slot's
+ * decode thread while the current slot's thread may be delivering its own
+ * passes.
+ */
+public final class PendingSequencerDecodes {
+    /**
+     * Maximum age of a stashed decode, measured from the message's slot time
+     * ({@code Ft8Message.utcTime}). Two full FT8 cycles (4 slots) — long enough
+     * to survive TX plus one silent delivery gap, short enough that a stale
+     * report can't leak into a later QSO.
+     */
+    static final long MAX_AGE_MS = 60_000;
+
+    private final ArrayList<Ft8Message> pending = new ArrayList<>();
+
+    /** Stash one pass's decodes for replay after TX ends. */
+    public synchronized void stash(List<Ft8Message> messages, long nowMs) {
+        evictStale(nowMs);
+        pending.addAll(messages);
+    }
+
+    /**
+     * Remove and return all stashed decodes still fresh at {@code nowMs}.
+     * Returns an empty list when nothing is pending.
+     */
+    public synchronized ArrayList<Ft8Message> drain(long nowMs) {
+        evictStale(nowMs);
+        ArrayList<Ft8Message> out = new ArrayList<>(pending);
+        pending.clear();
+        return out;
+    }
+
+    /** True when nothing is stashed (stale entries are not counted out). */
+    public synchronized boolean isEmpty() {
+        return pending.isEmpty();
+    }
+
+    private void evictStale(long nowMs) {
+        Iterator<Ft8Message> it = pending.iterator();
+        while (it.hasNext()) {
+            if (nowMs - it.next().utcTime > MAX_AGE_MS) {
+                it.remove();
+            }
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
@@ -40,7 +40,14 @@ public final class PendingSequencerDecodes {
 
     private final ArrayList<Ft8Message> pending = new ArrayList<>();
 
-    /** Stash one pass's decodes for replay after TX ends. */
+    /**
+     * Stash one pass's decodes for replay after TX ends.
+     *
+     * @param nowMs current time in the same base as {@code Ft8Message.utcTime},
+     *              i.e. {@code UtcTimer.getSystemTime()} (NTP/GPS-corrected) —
+     *              not the raw system clock, whose correction offset would skew
+     *              the age comparison
+     */
     public synchronized void stash(List<Ft8Message> messages, long nowMs) {
         evictStale(nowMs);
         pending.addAll(messages);
@@ -49,6 +56,9 @@ public final class PendingSequencerDecodes {
     /**
      * Remove and return all stashed decodes still fresh at {@code nowMs}.
      * Returns an empty list when nothing is pending.
+     *
+     * @param nowMs current time in the {@code UtcTimer.getSystemTime()} base
+     *              (see {@link #stash})
      */
     public synchronized ArrayList<Ft8Message> drain(long nowMs) {
         evictStale(nowMs);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -184,6 +184,11 @@ public class FT8TransmitSignal {
 
     }
 
+    /** Current message order (1-6). Package-visible for tests. */
+    int getFunctionOrder() {
+        return functionOrder;
+    }
+
     /** The cycle-trigger callback, shared between the constructor and {@link #rebuildTimer}. */
     private OnUtcTimer makeTimerCallback() {
         return new OnUtcTimer() {
@@ -1349,18 +1354,40 @@ public class FT8TransmitSignal {
      */
     //@RequiresApi(api = Build.VERSION_CODES.N)
     public void parseMessageToFunction(ArrayList<Ft8Message> msgList) {
+        parseMessageToFunction(msgList, false);
+    }
+
+    /**
+     * Parse decoded messages and drive the QSO state machine.
+     *
+     * <p>When {@code evidenceOnly} is true (deep / subtraction / late-pass decodes,
+     * see issue: sequencer blind to deep decodes), the messages may contribute
+     * <em>positive evidence</em> — the partner replied, someone is calling me —
+     * but never <em>absence-of-evidence</em> decisions (no-reply counting,
+     * give-up, "partner went silent" completions). The fast pass already made
+     * this cycle's absence calls; letting a deep pass repeat them would
+     * double-count no-replies within one cycle.
+     *
+     * @param msgList      message list (a single decode pass's deliveries)
+     * @param evidenceOnly true for deep/late-pass decodes
+     */
+    public void parseMessageToFunction(ArrayList<Ft8Message> msgList, boolean evidenceOnly) {
         if (GeneralVariables.myCallsign.length() < 3) {
             return;
         }
         if (msgList.size() == 0) return;// no messages to parse, return
 
-        if (msgList.get(0).getSequence() == sequential) {
+        // Own-slot early-out: only for the fast pass. An evidence list can mix
+        // slots (stashed deep decodes replayed after TX ends), so it relies on
+        // the per-message sequence checks inside the matchers instead.
+        if (!evidenceOnly && msgList.get(0).getSequence() == sequential) {
             GeneralVariables.fileLog("QSO: skip cycle, newest decode in own slot " + sequential);
             return;
         }
         ArrayList<Ft8Message> messages = new ArrayList<>(msgList);// prevent thread conflicts
 
         if (GeneralVariables.houndMode) {// DXpedition Hound: dedicated QSO handler
+            if (evidenceOnly) return;// Hound sequencing stays fast-pass-only
             handleHoundCycle(messages);
             return;
         }
@@ -1368,7 +1395,8 @@ public class FT8TransmitSignal {
         int newOrder = checkFunctionOrdFromMessages(messages);// check reply message sequence from the other party; -1 means not received
         // Per-cycle spine of the QSO trace: current state, what (if anything) the
         // other party sent us this cycle, who we're working, and the no-reply count.
-        GeneralVariables.fileLog(String.format("QSO: cycle slot=%d order=%d newOrder=%d to=%s noReply=%d/%d",
+        GeneralVariables.fileLog(String.format("QSO: cycle%s slot=%d order=%d newOrder=%d to=%s noReply=%d/%d",
+                evidenceOnly ? "(deep)" : "",
                 sequential, functionOrder, newOrder,
                 toCallsign != null ? toCallsign.callsign : "null",
                 GeneralVariables.noReplyCount, GeneralVariables.noReplyLimit));
@@ -1395,18 +1423,9 @@ public class FT8TransmitSignal {
         // determine QSO success: other party replied 73 (5) || I am at 73 (5) and other party did not reply (-1)
         // or I am at RR73 (4) and no-reply threshold reached with no-reply limit enabled
         // or I am at RR73 (4) and the other party started calling someone else, to prevent RR73 deadlock
-        if (newOrder == 5// target replied 73 to me
-                || (functionOrder == 5 && newOrder == -1)// QSO success: other party replied 73 (5) || I am at 73 (5) and no reply (-1)
-                || (functionOrder == 4 &&
-                (GeneralVariables.noReplyCount > GeneralVariables.noReplyLimit * 2)
-                && (GeneralVariables.noReplyLimit > 0)) // or I am at RR73 (4), reached no-reply threshold, with no-reply limit enabled
-
-                || (functionOrder == 4 && checkTargetCallMe(messages) > 1)// or I am at RR73 (4) and target started calling others (>1 means target is calling others)
-
-                || (functionOrder == 4 && (GeneralVariables.noReplyCount > RR73_GIVEUP_CYCLES)
-                && (GeneralVariables.noReplyLimit == 0))// when no-reply is "ignore" and I am at RR73 (4): the QSO is already logged, so reset after a few unacknowledged RR73s instead of holding the run frequency for minutes
-
-        ) {
+        if (shouldCompleteQso(evidenceOnly, functionOrder, newOrder,
+                GeneralVariables.noReplyCount, GeneralVariables.noReplyLimit,
+                functionOrder == 4 && checkTargetCallMe(messages) > 1)) {
             GeneralVariables.fileLog("QSO: complete with "
                     + (toCallsign != null ? toCallsign.callsign : "?")
                     + " (order=" + functionOrder + " newOrder=" + newOrder + ") -> reset to CQ");
@@ -1463,6 +1482,13 @@ public class FT8TransmitSignal {
             return;
         }
 
+        // Everything below reacts to the ABSENCE of a reply this cycle (queue
+        // rotation while CQing, no-reply counting, give-up). Those decisions
+        // belong to the fast pass alone; a deep pass finding nothing new is not
+        // a second no-reply.
+        if (evidenceOnly) {
+            return;
+        }
 
         // at this point, no reply messages were received
         // if I am in CQ state, newOrder must be -1
@@ -1941,6 +1967,39 @@ public class FT8TransmitSignal {
      */
     static boolean shouldGiveUpTarget(int noReplyLimit, int noReplyCount) {
         return noReplyLimit > 0 && noReplyCount >= noReplyLimit;
+    }
+
+    /**
+     * Whether the current cycle completes the QSO (reset to CQ / next caller).
+     *
+     * <p>The first two arms are positive evidence — the partner sent 73, or (at
+     * RR73) started calling someone else — and apply to every pass. The
+     * remaining arms conclude the QSO from the partner's <em>silence</em>
+     * (order 5 with no reply, RR73 no-reply caps); those are fast-pass-only
+     * decisions, so they are suppressed when {@code evidenceOnly} is set: a
+     * deep pass that merely failed to find anything new must not complete a
+     * QSO.
+     *
+     * <p>Package-visible for testing.
+     *
+     * @param evidenceOnly        this is a deep/late-pass parse (positive evidence only)
+     * @param functionOrder       my current message order (1-6)
+     * @param newOrder            order of the partner's message this pass, -1 if none
+     * @param noReplyCount        consecutive cycles without a reply
+     * @param noReplyLimit        user no-reply limit (0 = unlimited)
+     * @param targetCallingOthers at RR73 and the partner is calling someone else
+     */
+    static boolean shouldCompleteQso(boolean evidenceOnly, int functionOrder, int newOrder,
+                                     int noReplyCount, int noReplyLimit,
+                                     boolean targetCallingOthers) {
+        if (newOrder == 5) return true;// target replied 73 to me
+        if (targetCallingOthers) return true;// RR73 deadlock: target moved on
+        if (evidenceOnly) return false;// absence-of-evidence arms below are fast-pass-only
+        return (functionOrder == 5 && newOrder == -1)// I am at 73 and no reply
+                || (functionOrder == 4 && (noReplyCount > noReplyLimit * 2)
+                && (noReplyLimit > 0))// I am at RR73, no-reply threshold reached, limit enabled
+                || (functionOrder == 4 && (noReplyCount > RR73_GIVEUP_CYCLES)
+                && (noReplyLimit == 0));// no-reply "ignore" at RR73: QSO already logged, don't hold the run frequency for minutes
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/PendingSequencerDecodesTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/PendingSequencerDecodesTest.java
@@ -1,0 +1,97 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+/**
+ * Coverage for {@link PendingSequencerDecodes}, the stash that holds deep-pass
+ * decodes arriving mid-TX until the sequencer can replay them after key-up.
+ *
+ * Plain JUnit: the class is pure Java and Ft8Message construction here touches
+ * no Android framework types.
+ */
+public class PendingSequencerDecodesTest {
+
+    private static Ft8Message msgAt(long utcTime) {
+        Ft8Message msg = new Ft8Message("K1AF", "N2JFD", "R-18");
+        msg.utcTime = utcTime;
+        return msg;
+    }
+
+    private static ArrayList<Ft8Message> list(Ft8Message... msgs) {
+        ArrayList<Ft8Message> out = new ArrayList<>();
+        for (Ft8Message m : msgs) out.add(m);
+        return out;
+    }
+
+    @Test
+    public void startsEmpty() {
+        PendingSequencerDecodes pending = new PendingSequencerDecodes();
+        assertThat(pending.isEmpty()).isTrue();
+        assertThat(pending.drain(0)).isEmpty();
+    }
+
+    @Test
+    public void drainReturnsStashedMessagesAndClears() {
+        PendingSequencerDecodes pending = new PendingSequencerDecodes();
+        Ft8Message a = msgAt(1_000);
+        Ft8Message b = msgAt(2_000);
+        pending.stash(list(a, b), 3_000);
+
+        assertThat(pending.isEmpty()).isFalse();
+        assertThat(pending.drain(3_000)).containsExactly(a, b).inOrder();
+        assertThat(pending.isEmpty()).isTrue();
+        assertThat(pending.drain(3_000)).isEmpty();
+    }
+
+    @Test
+    public void multipleStashesAccumulateInOrder() {
+        // A slot can deliver several deep passes (first deep + subtraction
+        // loop + late pass) before TX ends; all of them must survive.
+        PendingSequencerDecodes pending = new PendingSequencerDecodes();
+        Ft8Message a = msgAt(1_000);
+        Ft8Message b = msgAt(1_000);
+        pending.stash(list(a), 2_000);
+        pending.stash(list(b), 3_000);
+
+        assertThat(pending.drain(4_000)).containsExactly(a, b).inOrder();
+    }
+
+    @Test
+    public void drainEvictsMessagesOlderThanMaxAge() {
+        PendingSequencerDecodes pending = new PendingSequencerDecodes();
+        Ft8Message stale = msgAt(0);
+        Ft8Message fresh = msgAt(PendingSequencerDecodes.MAX_AGE_MS);
+        pending.stash(list(stale, fresh), PendingSequencerDecodes.MAX_AGE_MS);
+
+        // One tick past the stale message's allowed age: only fresh survives.
+        assertThat(pending.drain(PendingSequencerDecodes.MAX_AGE_MS + 1))
+                .containsExactly(fresh);
+    }
+
+    @Test
+    public void messageExactlyAtMaxAgeIsKept() {
+        PendingSequencerDecodes pending = new PendingSequencerDecodes();
+        Ft8Message edge = msgAt(0);
+        pending.stash(list(edge), 0);
+
+        assertThat(pending.drain(PendingSequencerDecodes.MAX_AGE_MS))
+                .containsExactly(edge);
+    }
+
+    @Test
+    public void stashEvictsStaleEntriesBeforeAdding() {
+        PendingSequencerDecodes pending = new PendingSequencerDecodes();
+        Ft8Message stale = msgAt(0);
+        pending.stash(list(stale), 0);
+
+        Ft8Message fresh = msgAt(PendingSequencerDecodes.MAX_AGE_MS + 5_000);
+        long now = PendingSequencerDecodes.MAX_AGE_MS + 10_000;
+        pending.stash(list(fresh), now);
+
+        assertThat(pending.drain(now)).containsExactly(fresh);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/EvidenceOnlyParseTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/EvidenceOnlyParseTest.java
@@ -1,0 +1,204 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.log.QSLRecord;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+
+/**
+ * Coverage for the evidence-only parse path,
+ * {@link FT8TransmitSignal#parseMessageToFunction(ArrayList, boolean)} with
+ * {@code evidenceOnly=true} — how deep/subtraction/late-pass decodes drive the
+ * QSO sequencer.
+ *
+ * <p>Background (POTA field report): the sequencer only ever saw the fast
+ * decode pass, so a reply found only by a deep pass was displayed in the UI
+ * but never advanced the QSO — the app repeated its previous message while the
+ * partner re-sent the same report for several cycles. Deep passes must now
+ * contribute <em>positive evidence</em> (advance, RR73→73, completion on 73,
+ * caller enqueue) but never <em>absence-of-evidence</em> decisions (no-reply
+ * counting, give-up) that the fast pass already made for the cycle.
+ *
+ * <p>Robolectric: the sequencer posts LiveData and logs through
+ * {@code GeneralVariables.fileLog} (android.util.Log).
+ */
+@RunWith(RobolectricTestRunner.class)
+public class EvidenceOnlyParseTest {
+
+    /** Slot-1 (odd) utcTime for FT8: (15000+750)/1000/15 == 1. */
+    private static final long RX_SLOT_UTC = 15_000L;
+    /** Slot-0 (even) utcTime — the parity our test QSO transmits in. */
+    private static final long OWN_SLOT_UTC = 0L;
+
+    private FT8TransmitSignal signal;
+
+    @Before
+    public void setUp() {
+        GeneralVariables.myCallsign = "K1AF";
+        GeneralVariables.noReplyCount = 0;
+        GeneralVariables.noReplyLimit = 3;
+        GeneralVariables.houndMode = false;
+        GeneralVariables.autoFollowCQ = false;
+        GeneralVariables.autoCallFollow = false;
+        GeneralVariables.autoCQAfterQSO = false;
+        // TX=RX mode would make setTransmit persist the base frequency through
+        // the (null) database; keep the offset fixed instead.
+        GeneralVariables.synFrequency = false;
+        GeneralVariables.qslRecordList.clear();
+        GeneralVariables.transmitMessages.clear();
+        // doComplete()/updateQSlRecordList resolve the partner's grid through
+        // the database when it's not cached; seed the cache since there is no
+        // database in these tests.
+        GeneralVariables.addCallsignAndGrid("N2JFD", "FN20");
+
+        // Null callbacks: nothing transmits in these tests, and a null
+        // onDoTransmitted makes doComplete() skip its save/toast side effects
+        // (which would otherwise reach the absent database).
+        signal = new FT8TransmitSignal(null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.myCallsign = "";
+        GeneralVariables.noReplyCount = 0;
+        GeneralVariables.houndMode = false;
+        GeneralVariables.qslRecordList.clear();
+        GeneralVariables.callsignAndGrids.remove("N2JFD");
+    }
+
+    /**
+     * Put the sequencer mid-QSO with N2JFD at the given order, transmitting in
+     * slot 0 (the partner called in slot 1). Seeds the in-progress QSL record
+     * so updateQSlRecordList never takes its record-creation branch, which
+     * resolves the grid through the (absent) database.
+     */
+    private void startQsoAtOrder(int order) {
+        QSLRecord record = new QSLRecord(0, 0, "K1AF", "EM28", "N2JFD", "FM09",
+                -17, -18, "FT8", GeneralVariables.band, 14074000);
+        GeneralVariables.qslRecordList.addQSLRecord(record);
+        signal.setTransmit(new TransmitCallsign(1, 0, "N2JFD", 1500f, 1, -17), order, "");
+    }
+
+    /** A decoded message in the partner's (odd) slot. */
+    private static Ft8Message rxMsg(String to, String from, String extra) {
+        Ft8Message msg = new Ft8Message(1, 0, to, from, extra);
+        msg.utcTime = RX_SLOT_UTC;
+        msg.band = GeneralVariables.band;
+        msg.snr = -10;
+        return msg;
+    }
+
+    private static ArrayList<Ft8Message> list(Ft8Message... msgs) {
+        ArrayList<Ft8Message> out = new ArrayList<>();
+        for (Ft8Message m : msgs) out.add(m);
+        return out;
+    }
+
+    // ---- positive evidence advances the QSO ---------------------------------
+
+    @Test
+    public void deepReport_advancesOrderToRR73() {
+        // The exact field failure: we sent a report (order 2), the partner's
+        // R-report only decoded in a deep pass. It must advance us to RR73 (4).
+        startQsoAtOrder(2);
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "R-18")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(4);
+        assertThat(GeneralVariables.noReplyCount).isEqualTo(0);
+    }
+
+    @Test
+    public void deepReport_resetsNoReplyCount() {
+        // A deep-decoded reply is a reply: the fast pass's no-reply count for
+        // this target must clear.
+        startQsoAtOrder(2);
+        GeneralVariables.noReplyCount = 2;
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "R-18")), true);
+        assertThat(GeneralVariables.noReplyCount).isEqualTo(0);
+    }
+
+    @Test
+    public void deepRR73_advancesTo73Reply() {
+        startQsoAtOrder(4);
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "RR73")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(5);
+    }
+
+    @Test
+    public void deep73_completesQsoToCQ() {
+        startQsoAtOrder(5);
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "73")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(6);
+    }
+
+    @Test
+    public void deepCallerDuringQso_isQueued() {
+        // A station calling us that only a deep pass decoded must still land in
+        // the caller queue (the "decoded messages to me aren't answered" report).
+        startQsoAtOrder(2);
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "KN6KI", "EM12")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(2);// current QSO untouched
+        assertThat(signal.dequeueSpecificCaller("KN6KI")).isTrue();
+    }
+
+    // ---- absence-of-evidence decisions stay fast-pass-only ------------------
+
+    @Test
+    public void deepPassWithNothingNew_doesNotIncrementNoReply() {
+        startQsoAtOrder(2);
+        GeneralVariables.noReplyCount = 1;
+        signal.parseMessageToFunction(list(rxMsg("CQ", "W1XYZ", "FN42")), true);
+        assertThat(GeneralVariables.noReplyCount).isEqualTo(1);
+        assertThat(signal.getFunctionOrder()).isEqualTo(2);
+    }
+
+    @Test
+    public void fastPassWithNothingNew_stillIncrementsNoReply() {
+        // Contrast case: the normal path's no-reply accounting must be intact.
+        startQsoAtOrder(2);
+        GeneralVariables.noReplyCount = 1;
+        signal.parseMessageToFunction(list(rxMsg("CQ", "W1XYZ", "FN42")), false);
+        assertThat(GeneralVariables.noReplyCount).isEqualTo(2);
+        assertThat(signal.getFunctionOrder()).isEqualTo(2);
+    }
+
+    @Test
+    public void deepPassAt73WithNothingNew_doesNotCompleteQso() {
+        // functionOrder==5 && newOrder==-1 completes on the fast pass; a deep
+        // pass finding nothing must NOT conclude "partner went silent".
+        startQsoAtOrder(5);
+        signal.parseMessageToFunction(list(rxMsg("CQ", "W1XYZ", "FN42")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(5);
+    }
+
+    // ---- slot and mode guards ------------------------------------------------
+
+    @Test
+    public void deepOwnSlotDecodes_doNotAdvance() {
+        // Evidence lists bypass the newest-in-own-slot early-out (they can mix
+        // slots), so the per-message parity check must still reject own-slot
+        // decodes.
+        startQsoAtOrder(2);
+        Ft8Message ownSlot = rxMsg("K1AF", "N2JFD", "R-18");
+        ownSlot.utcTime = OWN_SLOT_UTC;
+        signal.parseMessageToFunction(list(ownSlot), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(2);
+        assertThat(GeneralVariables.noReplyCount).isEqualTo(0);
+    }
+
+    @Test
+    public void houndMode_ignoresDeepPasses() {
+        startQsoAtOrder(2);
+        GeneralVariables.houndMode = true;
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "R-18")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(2);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -395,4 +395,70 @@ public class FT8TransmitSignalTest {
         // The one-shot flag without an active free-text message can't trigger a stop.
         assertThat(FT8TransmitSignal.shouldStopAfterOneShot(false, true)).isFalse();
     }
+
+    // ---- shouldCompleteQso ---------------------------------------------------
+    // Completion decision for the QSO state machine. The evidenceOnly flag marks
+    // deep/late-pass parses: positive evidence (partner sent 73, partner moved
+    // on) completes from any pass, but silence-based completions belong to the
+    // fast pass alone — a deep pass that found nothing new is not "no reply".
+
+    @Test
+    public void complete_partner73_completesOnAnyPass() {
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                /*evidenceOnly*/ false, /*order*/ 5, /*newOrder*/ 5, 0, 3, false)).isTrue();
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                /*evidenceOnly*/ true, /*order*/ 5, /*newOrder*/ 5, 0, 3, false)).isTrue();
+    }
+
+    @Test
+    public void complete_targetCallingOthers_completesOnAnyPass() {
+        // RR73 deadlock breaker: the partner started calling someone else.
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                false, 4, -1, 0, 3, /*targetCallingOthers*/ true)).isTrue();
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                true, 4, -1, 0, 3, /*targetCallingOthers*/ true)).isTrue();
+    }
+
+    @Test
+    public void complete_at73WithNoReply_fastPassOnly() {
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                false, 5, -1, 0, 3, false)).isTrue();
+        // A deep pass finding nothing must not conclude the partner went silent.
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                true, 5, -1, 0, 3, false)).isFalse();
+    }
+
+    @Test
+    public void complete_rr73NoReplyCapWithLimit_fastPassOnly() {
+        // order 4, limit 3: cap is noReplyCount > 6.
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                false, 4, -1, /*noReplyCount*/ 7, /*noReplyLimit*/ 3, false)).isTrue();
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                true, 4, -1, 7, 3, false)).isFalse();
+    }
+
+    @Test
+    public void complete_rr73NoReplyCapWithLimit_belowThresholdKeepsGoing() {
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                false, 4, -1, /*noReplyCount*/ 6, /*noReplyLimit*/ 3, false)).isFalse();
+    }
+
+    @Test
+    public void complete_rr73GiveupWhenLimitIgnored_fastPassOnly() {
+        // noReplyLimit 0 ("ignore"): RR73 still resets after RR73_GIVEUP_CYCLES (3).
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                false, 4, -1, /*noReplyCount*/ 4, /*noReplyLimit*/ 0, false)).isTrue();
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                true, 4, -1, 4, 0, false)).isFalse();
+    }
+
+    @Test
+    public void complete_midQsoWithReply_neverCompletes() {
+        // A normal advance (partner sent R-report while we're at order 2) is not
+        // a completion on either pass.
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                false, 2, 3, 0, 3, false)).isFalse();
+        assertThat(FT8TransmitSignal.shouldCompleteQso(
+                true, 2, 3, 0, 3, false)).isFalse();
+    }
 }


### PR DESCRIPTION
## Problem

Field report from the 2026-07-03 POTA activation (K1AF): QSOs stalled repeating the previous message while the partner's reply was visible on screen, and some stations calling K1AF were never answered.

The pulled `debug.log` pins it down: **the auto-sequencer only ever saw the fast decode pass.** `MainViewModel.afterDecode` gated `parseMessageToFunction` on `!isDeep`, so every deep, subtraction-loop, and late/cross-slot pass (routine since the decode-gap work, #367–#370) reached the UI and QSO panel but never the sequencer.

Evidence from the log (local = UTC−5):
- **N2JFD**: `K1AF N2JFD R-18` received 20:25:15/:45/20:26:15; sequencer logged `newOrder=-1` (`no-reply 1`, `2`) for two cycles and only advanced on the third.
- **K3VAT**: identical pattern for `R-23`, with the smoking gun `15:35:28 DECODE: kept=24 ... replyToMe=false slot=1` — the fast pass contained no message addressed to us while the QSO panel displayed the R-23 (deep-pass decode).
- 60 `no-reply` events at orders 2–3 across the day.

## Fix

Deep passes now drive the sequencer through an **evidence-only** parse variant (`parseMessageToFunction(list, true)`):

- **May do:** advance the QSO on the partner's reply, trigger the RR73→73 reply, complete on a received 73 (or the partner moving on at RR73), enqueue/answer callers.
- **May not do:** no-reply counting, give-up, or silence-based completions (`order 5 + newOrder −1`, RR73 no-reply caps) — those absence-of-evidence calls stay fast-pass-only, so a deep pass that finds nothing new is not a second no-reply. The completion decision is extracted into `shouldCompleteQso(...)` for testability.

Deep results arriving **before TX keys** (~:29.0–:29.8 vs key-up ~:29.9) are parsed immediately and can upgrade the very next transmission (send RR73 instead of repeating the report in the same cycle). Results arriving **mid-TX** are stashed in the new `PendingSequencerDecodes` (age-capped at 60 s) and replayed at the first delivery after key-up.

Evidence parses log as `QSO: cycle(deep) ...` so the effect is auditable from a pulled `debug.log` on the next activation.

## Tests

- `EvidenceOnlyParseTest` (Robolectric, full sequencer instance): deep R-report advances 2→4 and resets the no-reply counter; deep RR73 → 73; deep 73 completes to CQ; deep caller lands in the queue; deep pass with nothing new does **not** increment no-reply (with the fast-pass contrast case) and does **not** complete an order-5 QSO; own-slot decodes are rejected; Hound mode ignores deep passes.
- `FT8TransmitSignalTest`: `shouldCompleteQso` arms — positive evidence completes on any pass, silence-based arms fast-pass-only, thresholds honoured.
- `PendingSequencerDecodesTest`: stash/drain/clear, ordering, age eviction (boundary included).
- Full `testDebugUnitTest` suite green.

## Field verification

Next activation: watch for QSOs advancing on the first received R-report and `QSO: cycle(deep)` lines in `debug.log`. (Note: two of this outing's stalls were compounded by a separate USB TX-drop bug — fix in a follow-up PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)