### PR TITLE
Handle USB TX writes that die mid-message (device off the bus)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -833,9 +833,25 @@ public class FT8TransmitSignal {
                 playLength, GeneralVariables.audioSampleRate));
         boolean success = usbDev.writeAudio(unscaled, GeneralVariables.audioSampleRate);
         GeneralVariables.fileLog(buildWriteAudioResultLog(success));
+        // A drop is invisible at the rig (it keys and shows normal behavior but
+        // transmits dead air), so tell the operator — unless the "failure" is
+        // just the user pressing STOP mid-message.
+        if (shouldWarnTxDropped(success, UsbAudioNative.writeCancelled)) {
+            ToastMessage.show(GeneralVariables.getStringFromResource(R.string.tx_audio_dropped));
+        }
 
         usbDev.close();
         afterPlayAudio();
+    }
+
+    /**
+     * Whether a failed USB-audio write warrants the on-screen "TX dropped"
+     * warning. A cancelled write is the operator's own STOP, not a fault.
+     *
+     * <p>Package-visible for testing.
+     */
+    static boolean shouldWarnTxDropped(boolean success, boolean cancelled) {
+        return !success && !cancelled;
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -755,12 +755,15 @@ public class UsbAudioDevice {
                     fd, ifaceNum, altSet, epAddr, maxPkt,
                     pcmData.length, outputSampleRate, outputChannels));
 
-            long writeStartMs = System.currentTimeMillis();
+            // Monotonic clock: wall time can jump (NTP set, user change) and a
+            // backwards step would fake a fast failure, wrongly allowing the
+            // restart-from-zero fallback after audio already went to air.
+            long writeStartMs = android.os.SystemClock.elapsedRealtime();
             int rc = UsbAudioNative.nativeWrite(
                     fd, ifaceNum, altSet, epAddr, maxPkt,
                     outputSampleRate, outputChannels, /*bytesPerSample=*/2,
                     pcmData);
-            long writeElapsedMs = System.currentTimeMillis() - writeStartMs;
+            long writeElapsedMs = android.os.SystemClock.elapsedRealtime() - writeStartMs;
 
             if (rc == 0) {
                 com.k1af.ft8af.GeneralVariables.fileLog(

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -755,15 +755,30 @@ public class UsbAudioDevice {
                     fd, ifaceNum, altSet, epAddr, maxPkt,
                     pcmData.length, outputSampleRate, outputChannels));
 
+            long writeStartMs = System.currentTimeMillis();
             int rc = UsbAudioNative.nativeWrite(
                     fd, ifaceNum, altSet, epAddr, maxPkt,
                     outputSampleRate, outputChannels, /*bytesPerSample=*/2,
                     pcmData);
+            long writeElapsedMs = System.currentTimeMillis() - writeStartMs;
 
             if (rc == 0) {
                 com.k1af.ft8af.GeneralVariables.fileLog(
                         "UsbAudioDevice: libusb native write OK");
                 return true;
+            }
+            if (!shouldFallbackToUsbRequest(rc, writeElapsedMs)) {
+                // Mid-stream death (part of the message already went to air) or
+                // the device left the bus: the UsbRequest loop below restarts
+                // the message from byte 0, which this deep into the slot would
+                // transmit an off-grid, overlapping mess — drop the cycle
+                // instead. The QSO sequencer self-corrects next cycle.
+                com.k1af.ft8af.GeneralVariables.fileLog(
+                        "UsbAudioDevice: libusb native write FAILED ("
+                                + describeLibusbWriteError(rc)
+                                + ") after " + writeElapsedMs
+                                + "ms, no UsbRequest fallback (mid-stream or device gone)");
+                return false;
             }
             com.k1af.ft8af.GeneralVariables.fileLog(
                     "UsbAudioDevice: libusb native write FAILED ("
@@ -899,15 +914,17 @@ public class UsbAudioDevice {
 
     /**
      * Maps a {@link UsbAudioNative#nativeWrite} return code to a readable label
-     * for the debug log. {@code nativeWrite} returns 0 on success or a libusb
-     * {@code libusb_error} code (always negative) on failure; naming the code
-     * makes a dropped TX cycle diagnosable instead of an opaque {@code rc=-4}.
-     * A device-level error ({@code NO_DEVICE}, {@code NOT_FOUND}) means the
-     * UsbRequest fallback below will almost certainly fail too.
+     * for the debug log. {@code nativeWrite} returns 0 on success, a libusb
+     * {@code libusb_error} code (negative) for setup failures, or — when a
+     * transfer dies after streaming started — the failing transfer's
+     * {@code libusb_transfer_status} (positive, stored by
+     * {@code onOutputComplete} in {@code usb_audio_capture.cpp}). The positive
+     * statuses were previously logged as {@code UNKNOWN}, which hid the actual
+     * field failure mode: {@code rc=5 TRANSFER_NO_DEVICE}, the device falling
+     * off the bus mid-transmission (typically RF into the USB link at TX
+     * power). Naming the code makes a dropped TX cycle diagnosable.
      *
-     * <p>Any value outside the known enum (e.g. an unexpected positive code) is
-     * labelled {@code UNKNOWN} rather than guessed at. Package-visible for
-     * testing.
+     * <p>Package-visible for testing.
      */
     static String describeLibusbWriteError(int rc) {
         String name;
@@ -926,10 +943,53 @@ public class UsbAudioDevice {
             case -11: name = "NO_MEM"; break;
             case -12: name = "NOT_SUPPORTED"; break;
             case -99: name = "OTHER"; break;
+            // libusb_transfer_status values (positive) from a mid-stream death:
+            case 1:   name = "TRANSFER_ERROR"; break;
+            case 2:   name = "TRANSFER_TIMED_OUT"; break;
+            case 3:   name = "TRANSFER_CANCELLED"; break;
+            case 4:   name = "TRANSFER_STALL"; break;
+            case 5:   name = "TRANSFER_NO_DEVICE"; break;
+            case 6:   name = "TRANSFER_OVERFLOW"; break;
             default:  name = "UNKNOWN"; break;
         }
         return "rc=" + rc + " " + name;
     }
+
+    /**
+     * Whether a failed libusb native write should be retried through the
+     * Android {@code UsbRequest} fallback loop.
+     *
+     * <p>The fallback restarts the message from byte 0. That is only sane when
+     * the native attempt failed <em>before anything went to air</em> — e.g. the
+     * libusb context/wrap/submit failed immediately on a kernel where libusb
+     * can't run (the fallback's original purpose). Once the native write has
+     * streamed for a while ({@code elapsedMs} beyond
+     * {@link #MAX_FALLBACK_ELAPSED_MS}), part of the FT8 message has already
+     * been transmitted; restarting from the beginning mid-slot would key an
+     * off-grid, overlapping signal that no receiver can decode — worse than
+     * dropping the cycle. Device-gone ({@code NO_DEVICE}/{@code
+     * TRANSFER_NO_DEVICE}) and cancelled ({@code TRANSFER_CANCELLED}, the user
+     * pressed STOP) failures never retry either, regardless of timing.
+     *
+     * <p>Package-visible for testing.
+     *
+     * @param rc        non-zero {@link UsbAudioNative#nativeWrite} return code
+     * @param elapsedMs how long the native write ran before failing
+     */
+    static boolean shouldFallbackToUsbRequest(int rc, long elapsedMs) {
+        if (rc == 0) return false;// success — nothing to fall back from
+        if (rc == -4 || rc == 5) return false;// device left the bus
+        if (rc == 3) return false;// cancelled: the user stopped the TX
+        return elapsedMs <= MAX_FALLBACK_ELAPSED_MS;
+    }
+
+    /**
+     * Longest a failed native write may have run and still be treated as
+     * "failed before streaming": ~1 s is far below the earliest point where
+     * restarted audio could still produce a decodable message, and far above
+     * any immediate setup failure.
+     */
+    static final long MAX_FALLBACK_ELAPSED_MS = 1_000;
 
     public boolean hasInput() { return endpointIn != null; }
     public boolean hasOutput() { return endpointOut != null; }

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -555,5 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">فشل صوت الإرسال — لم تُرسل أي إشارة في هذه الدورة (انقطع جهاز الصوت USB)</string>
+    <string name="tx_audio_dropped">فشل صوت الإرسال — لم تُرسل أي إشارة في هذه الدورة (خطأ في صوت USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -555,4 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">فشل صوت الإرسال — لم تُرسل أي إشارة في هذه الدورة (انقطع جهاز الصوت USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -555,5 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Selhalo TX audio — v tomto cyklu nebyl vyslán žádný signál (USB audio zařízení se odpojilo)</string>
+    <string name="tx_audio_dropped">Selhalo TX audio — v tomto cyklu nebyl vyslán žádný signál (chyba USB audia)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -555,4 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Selhalo TX audio — v tomto cyklu nebyl vyslán žádný signál (USB audio zařízení se odpojilo)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -512,4 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Falló el audio de TX — no se transmitió señal en este ciclo (se desconectó el audio USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -512,5 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Falló el audio de TX — no se transmitió señal en este ciclo (se desconectó el audio USB)</string>
+    <string name="tx_audio_dropped">Falló el audio de TX — no se transmitió señal en este ciclo (error de audio USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -512,5 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Échec audio TX — aucun signal émis ce cycle (périphérique audio USB déconnecté)</string>
+    <string name="tx_audio_dropped">Échec audio TX — aucun signal émis ce cycle (erreur audio USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -512,4 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Échec audio TX — aucun signal émis ce cycle (périphérique audio USB déconnecté)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -555,5 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Audio TX gagal — tidak ada sinyal terkirim pada siklus ini (perangkat audio USB terputus)</string>
+    <string name="tx_audio_dropped">Audio TX gagal — tidak ada sinyal terkirim pada siklus ini (kesalahan audio USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -555,4 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Audio TX gagal — tidak ada sinyal terkirim pada siklus ini (perangkat audio USB terputus)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -544,5 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Audio TX non riuscito — nessun segnale trasmesso in questo ciclo (dispositivo audio USB disconnesso)</string>
+    <string name="tx_audio_dropped">Audio TX non riuscito — nessun segnale trasmesso in questo ciclo (errore audio USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -544,4 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Audio TX non riuscito — nessun segnale trasmesso in questo ciclo (dispositivo audio USB disconnesso)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -512,5 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">TX音声に失敗 — このサイクルでは信号が送信されませんでした（USBオーディオが切断）</string>
+    <string name="tx_audio_dropped">TX音声に失敗 — このサイクルでは信号が送信されませんでした（USBオーディオエラー）</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -512,4 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">TX音声に失敗 — このサイクルでは信号が送信されませんでした（USBオーディオが切断）</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -555,4 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">TX 오디오 실패 — 이번 주기에 신호가 송신되지 않았습니다 (USB 오디오 연결 끊김)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -555,5 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">TX 오디오 실패 — 이번 주기에 신호가 송신되지 않았습니다 (USB 오디오 연결 끊김)</string>
+    <string name="tx_audio_dropped">TX 오디오 실패 — 이번 주기에 신호가 송신되지 않았습니다 (USB 오디오 오류)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -555,4 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">TX-audio mislukt — geen signaal verzonden deze cyclus (USB-audioapparaat losgekoppeld)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -555,5 +555,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">TX-audio mislukt — geen signaal verzonden deze cyclus (USB-audioapparaat losgekoppeld)</string>
+    <string name="tx_audio_dropped">TX-audio mislukt — geen signaal verzonden deze cyclus (USB-audiofout)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -544,5 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Błąd audio TX — w tym cyklu nie wysłano sygnału (urządzenie audio USB odłączone)</string>
+    <string name="tx_audio_dropped">Błąd audio TX — w tym cyklu nie wysłano sygnału (błąd audio USB)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -544,4 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Błąd audio TX — w tym cyklu nie wysłano sygnału (urządzenie audio USB odłączone)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -512,5 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Сбой TX-аудио — в этом цикле сигнал не передан (USB-аудиоустройство отключилось)</string>
+    <string name="tx_audio_dropped">Сбой TX-аудио — в этом цикле сигнал не передан (ошибка USB-аудио)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -512,4 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Сбой TX-аудио — в этом цикле сигнал не передан (USB-аудиоустройство отключилось)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -544,4 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">TX sesi başarısız — bu döngüde sinyal gönderilmedi (USB ses aygıtı koptu)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -544,5 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">TX sesi başarısız — bu döngüde sinyal gönderilmedi (USB ses aygıtı koptu)</string>
+    <string name="tx_audio_dropped">TX sesi başarısız — bu döngüde sinyal gönderilmedi (USB ses hatası)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -544,4 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">Збій TX-аудіо — у цьому циклі сигнал не передано (USB-аудіопристрій відключено)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -544,5 +544,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">Збій TX-аудіо — у цьому циклі сигнал не передано (USB-аудіопристрій відключено)</string>
+    <string name="tx_audio_dropped">Збій TX-аудіо — у цьому циклі сигнал не передано (помилка USB-аудіо)</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -512,5 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">发射音频失败 — 本周期未发出信号（USB 音频设备断开）</string>
+    <string name="tx_audio_dropped">发射音频失败 — 本周期未发出信号（USB 音频错误）</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -512,4 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">发射音频失败 — 本周期未发出信号（USB 音频设备断开）</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -512,5 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
-    <string name="tx_audio_dropped">發射音訊失敗 — 本週期未發出訊號（USB 音訊裝置斷開）</string>
+    <string name="tx_audio_dropped">發射音訊失敗 — 本週期未發出訊號（USB 音訊錯誤）</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -512,4 +512,5 @@
     <string name="settings_hunt_cq_desc">Call CQ when Hunt is idle (no stations heard). When a CQ is detected, automatically stop CQ and answer it.</string>
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
+    <string name="tx_audio_dropped">發射音訊失敗 — 本週期未發出訊號（USB 音訊裝置斷開）</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -651,5 +651,5 @@
     <string name="language_name_uk" translatable="false">Українська</string>
     <string name="language_name_ar" translatable="false">العربية</string>
 
-    <string name="tx_audio_dropped">TX audio failed — no signal was sent this cycle (USB audio device dropped)</string>
+    <string name="tx_audio_dropped">TX audio failed — no signal was sent this cycle (USB audio error)</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -651,4 +651,5 @@
     <string name="language_name_uk" translatable="false">Українська</string>
     <string name="language_name_ar" translatable="false">العربية</string>
 
+    <string name="tx_audio_dropped">TX audio failed — no signal was sent this cycle (USB audio device dropped)</string>
 </resources>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -395,26 +395,4 @@ public class FT8TransmitSignalTest {
         // The one-shot flag without an active free-text message can't trigger a stop.
         assertThat(FT8TransmitSignal.shouldStopAfterOneShot(false, true)).isFalse();
     }
-
-    // ---- shouldWarnTxDropped -------------------------------------------------
-    // A dropped USB TX write is invisible at the rig (it keys and transmits
-    // dead air), so the operator gets an on-screen warning — but only for real
-    // failures, not for their own STOP press.
-
-    @Test
-    public void warnTxDropped_realFailure_warns() {
-        assertThat(FT8TransmitSignal.shouldWarnTxDropped(
-                /*success*/ false, /*cancelled*/ false)).isTrue();
-    }
-
-    @Test
-    public void warnTxDropped_userStop_doesNotWarn() {
-        assertThat(FT8TransmitSignal.shouldWarnTxDropped(false, true)).isFalse();
-    }
-
-    @Test
-    public void warnTxDropped_success_doesNotWarn() {
-        assertThat(FT8TransmitSignal.shouldWarnTxDropped(true, false)).isFalse();
-        assertThat(FT8TransmitSignal.shouldWarnTxDropped(true, true)).isFalse();
-    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -395,4 +395,26 @@ public class FT8TransmitSignalTest {
         // The one-shot flag without an active free-text message can't trigger a stop.
         assertThat(FT8TransmitSignal.shouldStopAfterOneShot(false, true)).isFalse();
     }
+
+    // ---- shouldWarnTxDropped -------------------------------------------------
+    // A dropped USB TX write is invisible at the rig (it keys and transmits
+    // dead air), so the operator gets an on-screen warning — but only for real
+    // failures, not for their own STOP press.
+
+    @Test
+    public void warnTxDropped_realFailure_warns() {
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(
+                /*success*/ false, /*cancelled*/ false)).isTrue();
+    }
+
+    @Test
+    public void warnTxDropped_userStop_doesNotWarn() {
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(false, true)).isFalse();
+    }
+
+    @Test
+    public void warnTxDropped_success_doesNotWarn() {
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(true, false)).isFalse();
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(true, true)).isFalse();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TxDropWarningTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TxDropWarningTest.java
@@ -1,0 +1,36 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link FT8TransmitSignal#shouldWarnTxDropped(boolean, boolean)}.
+ *
+ * <p>A dropped USB TX write is invisible at the rig (it keys and transmits dead
+ * air), so the operator gets an on-screen warning — but only for real failures,
+ * not for their own STOP press.
+ *
+ * <p>Plain JUnit: the helper is pure logic. Kept in its own file (rather than
+ * appended to {@code FT8TransmitSignalTest}) so this PR doesn't collide with
+ * concurrent test additions to that class.
+ */
+public class TxDropWarningTest {
+
+    @Test
+    public void warnTxDropped_realFailure_warns() {
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(
+                /*success*/ false, /*cancelled*/ false)).isTrue();
+    }
+
+    @Test
+    public void warnTxDropped_userStop_doesNotWarn() {
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(false, true)).isFalse();
+    }
+
+    @Test
+    public void warnTxDropped_success_doesNotWarn() {
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(true, false)).isFalse();
+        assertThat(FT8TransmitSignal.shouldWarnTxDropped(true, true)).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioWriteErrorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioWriteErrorTest.java
@@ -6,16 +6,23 @@ import org.junit.Test;
 
 /**
  * Tests {@link UsbAudioDevice#describeLibusbWriteError(int)} — the human-readable
- * label attached to a failed {@code nativeWrite} in the debug log.
+ * label attached to a failed {@code nativeWrite} in the debug log — and
+ * {@link UsbAudioDevice#shouldFallbackToUsbRequest(int, long)} — whether a failed
+ * native write may be retried through the UsbRequest loop.
  *
  * <p>Background: when the libusb native TX write fails, the bare {@code rc=-4}
  * in the log gave no clue whether the device vanished, the endpoint claim was
  * stale, or it was a transient I/O error — all of which present as the rig
- * keying up and transmitting silence. Naming the libusb_error code makes the
- * dropped cycle diagnosable. {@code nativeWrite} returns 0 or a (negative)
- * libusb_error code, so anything else is reported as UNKNOWN rather than guessed.
+ * keying up and transmitting silence. {@code nativeWrite} returns 0, a negative
+ * {@code libusb_error} (setup failure), or a positive
+ * {@code libusb_transfer_status} when a transfer dies after streaming started —
+ * the field failure mode from the 2026-07-03 POTA log was {@code rc=5}
+ * TRANSFER_NO_DEVICE (device fell off the bus mid-TX, RF into the USB link),
+ * which used to be logged as UNKNOWN.
  */
 public class UsbAudioWriteErrorTest {
+
+    // ---- describeLibusbWriteError -------------------------------------------
 
     @Test
     public void ioError_named() {
@@ -47,17 +54,91 @@ public class UsbAudioWriteErrorTest {
     }
 
     @Test
-    public void unexpectedPositiveCode_isUnknownNotGuessed() {
-        // nativeWrite on this branch never returns a positive code; if a
-        // differently-built lib ever does, label it honestly rather than
-        // pretending to know what it means.
+    public void transferNoDevice_named() {
+        // The real-world drop: onOutputComplete stores the transfer's status
+        // (positive libusb_transfer_status) as firstError when the device
+        // leaves the bus mid-write.
         assertThat(UsbAudioDevice.describeLibusbWriteError(5))
-                .isEqualTo("rc=5 UNKNOWN");
+                .isEqualTo("rc=5 TRANSFER_NO_DEVICE");
+    }
+
+    @Test
+    public void transferError_named() {
+        assertThat(UsbAudioDevice.describeLibusbWriteError(1))
+                .isEqualTo("rc=1 TRANSFER_ERROR");
+    }
+
+    @Test
+    public void transferCancelled_named() {
+        assertThat(UsbAudioDevice.describeLibusbWriteError(3))
+                .isEqualTo("rc=3 TRANSFER_CANCELLED");
+    }
+
+    @Test
+    public void transferStall_named() {
+        assertThat(UsbAudioDevice.describeLibusbWriteError(4))
+                .isEqualTo("rc=4 TRANSFER_STALL");
+    }
+
+    @Test
+    public void unmappedPositiveCode_isUnknown() {
+        assertThat(UsbAudioDevice.describeLibusbWriteError(7))
+                .isEqualTo("rc=7 UNKNOWN");
     }
 
     @Test
     public void unmappedNegativeCode_isUnknown() {
         assertThat(UsbAudioDevice.describeLibusbWriteError(-42))
                 .isEqualTo("rc=-42 UNKNOWN");
+    }
+
+    // ---- shouldFallbackToUsbRequest -----------------------------------------
+    // The UsbRequest fallback restarts the message from byte 0, so it is only
+    // allowed for failures that happened before anything went to air.
+
+    @Test
+    public void fallback_immediateSetupFailure_allowed() {
+        // The fallback's original purpose: libusb can't run on this kernel and
+        // fails instantly — Android's own iso path may still work.
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(-99, 20)).isTrue();
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(-12, 0)).isTrue();
+    }
+
+    @Test
+    public void fallback_midStreamFailure_denied() {
+        // 6.5s into a 12.6s message (the field case): part of the audio already
+        // transmitted; a restart-from-zero would send an undecodable overlap.
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(1, 6_500)).isFalse();
+    }
+
+    @Test
+    public void fallback_justPastThreshold_denied() {
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(
+                -1, UsbAudioDevice.MAX_FALLBACK_ELAPSED_MS + 1)).isFalse();
+    }
+
+    @Test
+    public void fallback_atThreshold_allowed() {
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(
+                -1, UsbAudioDevice.MAX_FALLBACK_ELAPSED_MS)).isTrue();
+    }
+
+    @Test
+    public void fallback_deviceGone_deniedRegardlessOfTiming() {
+        // Device off the bus: the fallback would fail too (and a fast NO_DEVICE
+        // must not slip under the elapsed-time threshold).
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(5, 10)).isFalse();
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(-4, 10)).isFalse();
+    }
+
+    @Test
+    public void fallback_userCancelled_denied() {
+        // STOP pressed: not a fault, nothing to retry.
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(3, 10)).isFalse();
+    }
+
+    @Test
+    public void fallback_success_neverFallsBack() {
+        assertThat(UsbAudioDevice.shouldFallbackToUsbRequest(0, 10)).isFalse();
     }
 }


### PR DESCRIPTION
## Problem

From the 2026-07-03 POTA activation log: **5 of 265 transmissions silently died** — `libusb native write FAILED (rc=5 UNKNOWN) ... TX DROPPED, no audio sent this cycle (rig keyed but silent)`. Two were load-bearing (the first RR73 to N2JFD at 15:26:29 and the first R-13 to W5TRL at 15:33:29 went out as dead air), stretching those QSOs by several cycles. Companion fix to #406.

`rc=5` was mislabelled: `onOutputComplete` (in `usb_audio_capture.cpp`) stores the failing transfer's **positive** `libusb_transfer_status` as `nativeWrite`'s return value, but `describeLibusbWriteError` only mapped the negative `LIBUSB_ERROR_*` codes. 5 = `LIBUSB_TRANSFER_NO_DEVICE`: the USB sound card fell off the bus mid-transmission — classic RF-into-the-USB-cable at TX power in a portable setup (a re-enumeration follows the 15:09:07 drop in the log). Field mitigation: ferrite chokes on the USB leg.

## Changes

1. **Correct diagnostics** — `describeLibusbWriteError` now names the positive transfer statuses (`rc=5 TRANSFER_NO_DEVICE` instead of `UNKNOWN`).
2. **No restart-from-zero on air** — the `UsbRequest` fallback rewrites the whole message from byte 0. That's only sane when the native attempt failed *before streaming began* (its original purpose: kernels where libusb can't run). New `shouldFallbackToUsbRequest(rc, elapsedMs)` gate: mid-stream deaths (>1 s in), device-gone (`NO_DEVICE`/`TRANSFER_NO_DEVICE`), and user-cancelled writes drop the cycle cleanly. Previously this only "worked" because `request.initialize()` happens to fail fast when the device is gone.
3. **Operator visibility** — a dropped TX write now shows an on-screen warning ("TX audio failed — no signal was sent this cycle"); at the rig everything looks normal, so the operator otherwise can't tell they transmitted silence. The user's own STOP press does not warn (`shouldWarnTxDropped`). String added to all 16 locales.

No attempt to salvage the in-flight message: a mid-message gap breaks the FT8 symbol grid, and the protocol-level repeat already handles the retry.

## Tests

- `UsbAudioWriteErrorTest`: transfer-status names (including the previously-asserted-wrong `rc=5 UNKNOWN` case, now `TRANSFER_NO_DEVICE`), and the full `shouldFallbackToUsbRequest` matrix (setup failure allowed, mid-stream/boundary/device-gone/cancelled/success denied).
- `FT8TransmitSignalTest`: `shouldWarnTxDropped` matrix.
- Full `testDebugUnitTest` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)