### PR TITLE
Make QsoSyncGate check-and-mark atomic to close the TOCTOU race

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
@@ -32,21 +32,21 @@ internal class QsoSyncGate(private val minIntervalMs: Long = 15_000L) {
     private var inFlight = false
     private var lastStartedMs = Long.MIN_VALUE
 
-    /** True when a run is allowed to start right now. Does not mutate state. */
+    /**
+     * Atomically check the guards and, if a run is allowed, mark it started — all under
+     * one lock, so two racing triggers can never both pass (check-then-act done as two
+     * separate synchronized calls would let both see `inFlight == false`). Returns true
+     * when the caller owns the run and must eventually call [markFinished].
+     */
     @Synchronized
-    fun shouldRun(now: Long, anyServiceEnabled: Boolean): Boolean {
+    fun tryStart(now: Long, anyServiceEnabled: Boolean): Boolean {
         if (!anyServiceEnabled) return false
         if (inFlight) return false
         // Long.MIN_VALUE first-run sentinel: `now - MIN_VALUE` overflows, so special-case it.
         if (lastStartedMs != Long.MIN_VALUE && now - lastStartedMs < minIntervalMs) return false
-        return true
-    }
-
-    /** Mark a run as begun; subsequent [shouldRun] calls are gated until [markFinished]. */
-    @Synchronized
-    fun markStarted(now: Long) {
         inFlight = true
         lastStartedMs = now
+        return true
     }
 
     /** Mark the in-flight run complete, re-opening the single-flight guard. */
@@ -127,11 +127,10 @@ class QsoAutoSync(private val appContext: Context) {
         // interval; the gate compares deltas, never wall-clock dates.)
         val now = SystemClock.elapsedRealtime()
         val anyEnabled = GeneralVariables.enableCloudlog || GeneralVariables.enableQRZ
-        if (!gate.shouldRun(now, anyEnabled)) {
+        if (!gate.tryStart(now, anyEnabled)) {
             log("skip ($reason): enabled=$anyEnabled")
             return
         }
-        gate.markStarted(now)
         Thread {
             try {
                 // Pass our application Context (and the same db name MainViewModel

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoSyncGateTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoSyncGateTest.kt
@@ -1,6 +1,8 @@
 package radio.ks3ckc.ft8af.sync
 
 import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Test
 
 /**
@@ -13,53 +15,85 @@ class QsoSyncGateTest {
     @Test
     fun blocked_whenNoServiceEnabled() {
         val gate = QsoSyncGate(minIntervalMs = 1000)
-        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = false)).isFalse()
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = false)).isFalse()
     }
 
     @Test
     fun allowed_onFirstRun_whenEnabled() {
         val gate = QsoSyncGate(minIntervalMs = 1000)
-        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = true)).isTrue()
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = true)).isTrue()
+    }
+
+    @Test
+    fun deniedTryStart_doesNotMutateState() {
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        // Denied for no-service: must not mark anything started, so a later enabled
+        // trigger at the same instant is still allowed.
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = false)).isFalse()
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = true)).isTrue()
     }
 
     @Test
     fun singleFlight_blocksSecondRun_untilFinished() {
         val gate = QsoSyncGate(minIntervalMs = 1000)
-        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = true)).isTrue()
-        gate.markStarted(now = 0)
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = true)).isTrue()
 
         // A trigger arriving while the first run is in flight is rejected even though
         // the debounce window would otherwise allow it.
-        assertThat(gate.shouldRun(now = 5000, anyServiceEnabled = true)).isFalse()
+        assertThat(gate.tryStart(now = 5000, anyServiceEnabled = true)).isFalse()
 
         gate.markFinished()
         // markFinished re-opens the gate (5000 is past the 1000ms window from start@0).
-        assertThat(gate.shouldRun(now = 5000, anyServiceEnabled = true)).isTrue()
+        assertThat(gate.tryStart(now = 5000, anyServiceEnabled = true)).isTrue()
+    }
+
+    @Test
+    fun twoRacingTriggers_onlyOneWins() {
+        // The TOCTOU case from issue #399: app-start and network-available fire at the
+        // same instant. With check-and-mark in one atomic call, exactly one may win.
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = true)).isTrue()
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = true)).isFalse()
+    }
+
+    @Test
+    fun twoRacingTriggers_concurrentThreads_onlyOneWins() {
+        val gate = QsoSyncGate(minIntervalMs = 1000)
+        val ready = CountDownLatch(1)
+        val wins = AtomicInteger(0)
+        val threads = (1..2).map {
+            Thread {
+                ready.await()
+                if (gate.tryStart(now = 0, anyServiceEnabled = true)) wins.incrementAndGet()
+            }.apply { start() }
+        }
+        ready.countDown()
+        threads.forEach { it.join() }
+        assertThat(wins.get()).isEqualTo(1)
     }
 
     @Test
     fun debounce_blocksWithinWindow_allowsAfter() {
         val gate = QsoSyncGate(minIntervalMs = 1000)
-        assertThat(gate.shouldRun(now = 0, anyServiceEnabled = true)).isTrue()
-        gate.markStarted(now = 0)
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = true)).isTrue()
         gate.markFinished()
 
         // Within the 1000ms window from the last *started* run: blocked.
-        assertThat(gate.shouldRun(now = 999, anyServiceEnabled = true)).isFalse()
+        assertThat(gate.tryStart(now = 999, anyServiceEnabled = true)).isFalse()
         // Exactly at the window boundary: allowed.
-        assertThat(gate.shouldRun(now = 1000, anyServiceEnabled = true)).isTrue()
+        assertThat(gate.tryStart(now = 1000, anyServiceEnabled = true)).isTrue()
     }
 
     @Test
     fun debounce_measuredFromStart_notFinish() {
         val gate = QsoSyncGate(minIntervalMs = 1000)
-        gate.markStarted(now = 0)
+        assertThat(gate.tryStart(now = 0, anyServiceEnabled = true)).isTrue()
         gate.markFinished()
-        gate.markStarted(now = 1000)
+        assertThat(gate.tryStart(now = 1000, anyServiceEnabled = true)).isTrue()
         gate.markFinished()
 
         // Window is measured from the most recent start (1000), not the first.
-        assertThat(gate.shouldRun(now = 1500, anyServiceEnabled = true)).isFalse()
-        assertThat(gate.shouldRun(now = 2000, anyServiceEnabled = true)).isTrue()
+        assertThat(gate.tryStart(now = 1500, anyServiceEnabled = true)).isFalse()
+        assertThat(gate.tryStart(now = 2000, anyServiceEnabled = true)).isTrue()
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoSyncGateTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoSyncGateTest.kt
@@ -2,6 +2,7 @@ package radio.ks3ckc.ft8af.sync
 
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Test
 
@@ -60,15 +61,22 @@ class QsoSyncGateTest {
     fun twoRacingTriggers_concurrentThreads_onlyOneWins() {
         val gate = QsoSyncGate(minIntervalMs = 1000)
         val ready = CountDownLatch(1)
+        val done = CountDownLatch(2)
         val wins = AtomicInteger(0)
-        val threads = (1..2).map {
+        repeat(2) {
             Thread {
-                ready.await()
-                if (gate.tryStart(now = 0, anyServiceEnabled = true)) wins.incrementAndGet()
-            }.apply { start() }
+                try {
+                    ready.await()
+                    if (gate.tryStart(now = 0, anyServiceEnabled = true)) wins.incrementAndGet()
+                } finally {
+                    done.countDown()
+                }
+            }.start()
         }
         ready.countDown()
-        threads.forEach { it.join() }
+        // Bounded wait: a wedged thread fails this assertion instead of hanging
+        // the whole suite on an untimed join().
+        assertThat(done.await(5, TimeUnit.SECONDS)).isTrue()
         assertThat(wins.get()).isEqualTo(1)
     }
 


### PR DESCRIPTION
## Problem

`QsoSyncGate`'s single-flight guard had a check-then-act (TOCTOU) race: `shouldRun()` and `markStarted()` were two separate `@Synchronized` calls with no lock held between them. Two triggers arriving concurrently — the app-start `syncNow(app-start)` and the `ConnectivityManager` callback's `onAvailable(network-available)` on its own thread — could both see `inFlight == false`, both pass the gate, and both spawn a `ThirdPartyService.syncAllQSOs` pass, re-uploading the same `QSLTable` rows to QRZ + Cloudlog. That is exactly the scenario the gate's own docstring promises to prevent.

## Fix

Collapse check-and-mark into a single `@Synchronized fun tryStart(now, anyServiceEnabled): Boolean` that evaluates the enabled/single-flight/debounce guards and, only when allowed, sets `inFlight`/`lastStartedMs` — all under one lock. `requestSync` now does `if (!gate.tryStart(now, anyEnabled)) return`. A denied `tryStart` does not mutate state, so a blocked trigger doesn't consume the debounce window.

`shouldRun`/`markStarted` had no other callers and are removed; `markFinished` is unchanged.

## Tests

`QsoSyncGateTest` rewritten against the atomic API, keeping every prior behavior case (enabled gate, single-flight until finished, debounce window + boundary, debounce measured from start not finish) and adding:
- `twoRacingTriggers_onlyOneWins` — the issue's exact scenario, same-instant double trigger.
- `twoRacingTriggers_concurrentThreads_onlyOneWins` — two real threads released by a latch; exactly one wins.
- `deniedTryStart_doesNotMutateState`.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA