### PR TITLE
Serialize afterDecode shared state behind a synchronized DecodeCycleState

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/DecodeCycleState.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/DecodeCycleState.java
@@ -1,0 +1,68 @@
+package com.k1af.ft8af;
+
+import com.k1af.ft8af.ui.WaterfallLabelMessages;
+
+import java.util.ArrayList;
+
+/**
+ * Per-cycle decode results shared between decode threads and the UI: the waterfall
+ * label overlay list and the decoded-message counter.
+ *
+ * <p>Since the late full-slot pass (#363), two decode threads routinely overlap —
+ * slot N's late/deep pass delivers at ~the slot boundary while slot N+1's early
+ * pass is already running — and both call {@code MainViewModel.afterDecode}. The
+ * overlay list and the counter are read-modify-written there, so without a common
+ * monitor one pass's update clobbers the other's (stale label set, wrong decoded
+ * count) and a reader can iterate a list reference mid-reassignment. All access
+ * goes through this class's synchronized methods, serializing the RMWs and giving
+ * readers a happens-before on the latest published snapshot.
+ *
+ * <p>The label lists themselves are never mutated after publication
+ * ({@link WaterfallLabelMessages#afterPass} builds fresh lists), so a reader
+ * holding a snapshot can iterate it safely while the next pass publishes a new one.
+ */
+public final class DecodeCycleState {
+
+    private ArrayList<Ft8Message> messages = null;
+    private int decodeCount = 0;
+
+    /**
+     * Fold a decode pass's kept messages into the waterfall label overlay
+     * (normal pass replaces, deep pass augments — see
+     * {@link WaterfallLabelMessages#afterPass}).
+     */
+    public synchronized void labelsAfterPass(ArrayList<Ft8Message> kept, boolean isDeep) {
+        messages = WaterfallLabelMessages.afterPass(messages, kept, isDeep);
+    }
+
+    /**
+     * Fold a decode pass's kept-message count into the cycle total (normal pass
+     * replaces, deep pass accumulates) and return the new total, so the caller
+     * posts the same value this call produced rather than re-reading a field
+     * another pass may have already advanced.
+     */
+    public synchronized int countAfterPass(int keptCount, boolean isDeep) {
+        decodeCount = isDeep ? decodeCount + keptCount : keptCount;
+        return decodeCount;
+    }
+
+    /** The current waterfall label overlay; null when nothing is stamped. */
+    public synchronized ArrayList<Ft8Message> getMessages() {
+        return messages;
+    }
+
+    /** The current cycle's decoded-message count. */
+    public synchronized int getDecodeCount() {
+        return decodeCount;
+    }
+
+    /** Drop the label overlay (spectrum views clear it when they (re)attach). */
+    public synchronized void clearMessages() {
+        messages = null;
+    }
+
+    /** Reset the counter (start-of-cycle wipe, mode changes). */
+    public synchronized void resetCount() {
+        decodeCount = 0;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/DecodeCycleState.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/DecodeCycleState.java
@@ -17,9 +17,11 @@ import java.util.ArrayList;
  * goes through this class's synchronized methods, serializing the RMWs and giving
  * readers a happens-before on the latest published snapshot.
  *
- * <p>The label lists themselves are never mutated after publication
- * ({@link WaterfallLabelMessages#afterPass} builds fresh lists), so a reader
- * holding a snapshot can iterate it safely while the next pass publishes a new one.
+ * <p>The label lists themselves are never mutated after publication:
+ * {@link WaterfallLabelMessages#afterPass} either passes a list through unchanged
+ * (the normal pass's own {@code kept} list, or {@code previous} on an empty deep
+ * pass) or builds a new merged list — it never appends into a list a reader may
+ * already hold. So a reader iterating a snapshot can't be torn by the next pass.
  */
 public final class DecodeCycleState {
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -111,7 +111,6 @@ import com.k1af.ft8af.spectrum.SpectrumListener;
 import com.k1af.ft8af.timer.OnUtcTimer;
 import com.k1af.ft8af.timer.UtcTimer;
 import com.k1af.ft8af.ui.ToastMessage;
-import com.k1af.ft8af.ui.WaterfallLabelMessages;
 import com.k1af.ft8af.wave.HamRecorder;
 import com.k1af.ft8af.wave.OnGetVoiceDataDone;
 import com.k1af.ft8af.x6100.X6100Radio;
@@ -163,7 +162,9 @@ public class MainViewModel extends ViewModel {
 
 
     public MutableLiveData<Integer> mutable_Decoded_Counter = new MutableLiveData<>();//total decoded count
-    public int currentDecodeCount = 0;//number of decoded items in this cycle
+    // Per-cycle decode state (label overlay + decode count). Synchronized: slot N's
+    // late/deep pass and slot N+1's early pass call afterDecode concurrently (#398).
+    private final DecodeCycleState decodeCycleState = new DecodeCycleState();
     public MutableLiveData<ArrayList<Ft8Message>> mutableFt8MessageList = new MutableLiveData<>();//message list
     // Needed-DX alerts: posts sound+vibrate notifications for new DXCC/state CQ stations.
     public final com.k1af.ft8af.alert.DxAlertNotifier dxAlertNotifier =
@@ -177,7 +178,20 @@ public class MainViewModel extends ViewModel {
     public MutableLiveData<Float> mutableTimerOffset = new MutableLiveData<>();//time delay of this cycle
     public MutableLiveData<Boolean> mutableIsDecoding = new MutableLiveData<>();//triggers marker action in spectrum display
     public MutableLiveData<Integer> mutableOperatingMode = new MutableLiveData<>(GeneralVariables.operatingMode);//current mode (FT8/FT4) for Compose observers
-    public ArrayList<Ft8Message> currentMessages = null;//decoded messages in this cycle (used for drawing on spectrum)
+    /** Decoded messages in this cycle (used for drawing on spectrum). */
+    public ArrayList<Ft8Message> getCurrentMessages() {
+        return decodeCycleState.getMessages();
+    }
+
+    /** Number of decoded items in this cycle. */
+    public int getCurrentDecodeCount() {
+        return decodeCycleState.getDecodeCount();
+    }
+
+    /** Clear the waterfall label overlay (spectrum views call this when they (re)attach). */
+    public void clearCurrentMessages() {
+        decodeCycleState.clearMessages();
+    }
 
     public MutableLiveData<Boolean> mutableIsFlexRadio = new MutableLiveData<>();//whether it's a Flex radio
     public MutableLiveData<Boolean> mutableIsXieguRadio = new MutableLiveData<>();//whether it's a XieGu radio
@@ -503,7 +517,7 @@ public class MainViewModel extends ViewModel {
                     synchronized (ft8Messages) {
                         ft8Messages.clear();
                     }
-                    currentDecodeCount = 0;
+                    decodeCycleState.resetCount();
                     mutable_Decoded_Counter.postValue(0);
                     publishFt8MessageList();
                 }
@@ -522,8 +536,7 @@ public class MainViewModel extends ViewModel {
                     // clear the previous slot's labels so they aren't re-stamped onto the
                     // waterfall every cycle (worst on the fast FT4/FT2 slots). A silent deep
                     // pass keeps the normal pass's labels. See WaterfallLabelMessages.
-                    currentMessages = WaterfallLabelMessages.afterPass(
-                            currentMessages, new ArrayList<>(), isDeep);
+                    decodeCycleState.labelsAfterPass(new ArrayList<>(), isDeep);
                     mutableIsDecoding.postValue(decodingMarkerAfterPass(0, 0));
                     return;//no messages decoded, don't trigger action
                 }
@@ -550,8 +563,7 @@ public class MainViewModel extends ViewModel {
                     // Same overlay refresh as the no-decode case: an all-filtered slot is
                     // visually silent, so clear the previous slot's labels (normal pass)
                     // rather than leaving them to be re-stamped.
-                    currentMessages = WaterfallLabelMessages.afterPass(
-                            currentMessages, new ArrayList<>(), isDeep);
+                    decodeCycleState.labelsAfterPass(new ArrayList<>(), isDeep);
                     mutableIsDecoding.postValue(decodingMarkerAfterPass(decoded.size(), 0));
                     return;
                 }
@@ -622,13 +634,11 @@ public class MainViewModel extends ViewModel {
                     }
                 }
 
-                currentMessages = WaterfallLabelMessages.afterPass(currentMessages, messages, isDeep);
+                decodeCycleState.labelsAfterPass(messages, isDeep);
 
-                if (isDeep) {
-                    currentDecodeCount += messages.size();
-                } else {
-                    currentDecodeCount = messages.size();
-                }
+                // Take the count from the same atomic update we made, not a re-read of
+                // shared state a concurrently-delivering pass may have advanced since.
+                int decodeCountAfterPass = decodeCycleState.countAfterPass(messages.size(), isDeep);
 
                 //decode state, triggers marker action in spectrum display
                 mutableIsDecoding.postValue(decodingMarkerAfterPass(decoded.size(), messages.size()));
@@ -639,7 +649,7 @@ public class MainViewModel extends ViewModel {
 
                 //this variable also notifies message list changes
                 mutable_Decoded_Counter.postValue(
-                        currentDecodeCount);//notify the UI of the total message count
+                        decodeCountAfterPass);//notify the UI of the total message count
 
                 if (GeneralVariables.saveSWLMessage) {
                     databaseOpr.writeMessage(messages);//write SWL messages to database
@@ -894,7 +904,7 @@ public class MainViewModel extends ViewModel {
         synchronized (ft8Messages) {
             ft8Messages.clear();
         }
-        currentDecodeCount = 0;
+        decodeCycleState.resetCount();
         mutable_Decoded_Counter.postValue(0);
         publishFt8MessageList();
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridTrackerMainActivity.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridTrackerMainActivity.java
@@ -206,8 +206,9 @@ public class GridTrackerMainActivity extends AppCompatActivity {
             @SuppressLint("NotifyDataSetChanged")
             @Override
             public void onChanged(ArrayList<Ft8Message> messages) {
-                if (mainViewModel.currentMessages == null) return;
-                ArrayList<Ft8Message> tempMsg = new ArrayList<>(mainViewModel.currentMessages);
+                ArrayList<Ft8Message> currentMessages = mainViewModel.getCurrentMessages();
+                if (currentMessages == null) return;
+                ArrayList<Ft8Message> tempMsg = new ArrayList<>(currentMessages);
                 callingListAdapter.notifyDataSetChanged();
                 if (callMessagesRecyclerView.computeVerticalScrollRange()
                         - callMessagesRecyclerView.computeVerticalScrollExtent()
@@ -218,7 +219,7 @@ public class GridTrackerMainActivity extends AppCompatActivity {
                 binding.gridMessageTextView.setText(String.format("%s %s"
                         , String.format(GeneralVariables.getStringFromResource(
                                         R.string.tracker_decoded_new)
-                                , mainViewModel.currentDecodeCount), String.format(
+                                , mainViewModel.getCurrentDecodeCount()), String.format(
                                 getString(R.string.decoding_takes_milliseconds)
                                 , mainViewModel.ft8SignalListener.decodeTimeSec.getValue())));
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -593,7 +593,7 @@ public class LogHttpServer extends NanoHTTPD {
 
         HtmlContext.tableKeyRow(result, true
                 , GeneralVariables.getStringFromResource(R.string.html_decodes_in_this_cycle)
-                , String.format("%d", mainViewModel.currentDecodeCount));
+                , String.format("%d", mainViewModel.getCurrentDecodeCount()));
 
         HtmlContext.tableKeyRow(result, false
                 , GeneralVariables.getStringFromResource(R.string.decode_mode_text)
@@ -1716,8 +1716,9 @@ public class LogHttpServer extends NanoHTTPD {
         HtmlContext.tableRowEnd(result).append("\n");
 
         int order = 0;
-        if (mainViewModel.currentMessages != null) {
-            for (Ft8Message message : mainViewModel.currentMessages) {
+        ArrayList<Ft8Message> currentMessages = mainViewModel.getCurrentMessages();
+        if (currentMessages != null) {
+            for (Ft8Message message : currentMessages) {
                 HtmlContext.tableRowBegin(result, true, order % 2 != 0)
                         .append("\n").append(message.toHtml());
                 HtmlContext.tableRowEnd(result).append("\n");

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListFragment.java
@@ -105,7 +105,7 @@ public class CallingListFragment extends Fragment {
             public void onChanged(Integer integer) {
                 binding.decoderCounterTextView.setText(
                         String.format(GeneralVariables.getStringFromResource(R.string.message_count_count)
-                                , mainViewModel.currentDecodeCount, mainViewModel.ft8Messages.size()));
+                                , mainViewModel.getCurrentDecodeCount(), mainViewModel.ft8Messages.size()));
 
 
             }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumFragment.java
@@ -62,7 +62,7 @@ public class SpectrumFragment extends Fragment {
         setMarkMessageSwitchState();
 
         binding.rulerFrequencyView.setFreq(Math.round(GeneralVariables.getBaseFrequency()));
-        mainViewModel.currentMessages=null;
+        mainViewModel.clearCurrentMessages();
 
 
         //Raw spectrum switch
@@ -71,7 +71,7 @@ public class SpectrumFragment extends Fragment {
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 mainViewModel.deNoise = b;
                 setDeNoiseSwitchState();
-                mainViewModel.currentMessages=null;
+                mainViewModel.clearCurrentMessages();
             }
         });
         //Mark message switch
@@ -194,7 +194,7 @@ public class SpectrumFragment extends Fragment {
         }
         binding.columnarView.setWaveData(fft);
         if (mainViewModel.markMessage) {//Whether to mark messages
-            binding.waterfallView.setWaveData(fft, mainViewModel.currentMessages);
+            binding.waterfallView.setWaveData(fft, mainViewModel.getCurrentMessages());
         } else {
             binding.waterfallView.setWaveData(fft, null);
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumView.java
@@ -69,7 +69,7 @@ public class SpectrumView extends ConstraintLayout {
         setMarkMessageSwitchState();
 
         rulerFrequencyView.setFreq(Math.round(GeneralVariables.getBaseFrequency()));
-        mainViewModel.currentMessages=null;
+        mainViewModel.clearCurrentMessages();
 
 
         //Raw spectrum switch
@@ -78,7 +78,7 @@ public class SpectrumView extends ConstraintLayout {
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 mainViewModel.deNoise = b;
                 setDeNoiseSwitchState();
-                mainViewModel.currentMessages=null;
+                mainViewModel.clearCurrentMessages();
             }
         });
         //Mark message switch
@@ -190,7 +190,7 @@ public class SpectrumView extends ConstraintLayout {
         }
         columnarView.setWaveData(fft);
         if (mainViewModel.markMessage) {//Whether to mark messages
-            waterfallView.setWaveData(fft, mainViewModel.currentMessages);
+            waterfallView.setWaveData(fft, mainViewModel.getCurrentMessages());
         } else {
             waterfallView.setWaveData(fft, null);
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/DecodeCycleStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/DecodeCycleStateTest.java
@@ -1,0 +1,148 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Unit tests for {@link DecodeCycleState} — the synchronized holder for the
+ * per-cycle waterfall label overlay and decode count (issue #398). The late
+ * full-slot pass (#363) makes slot N's deep delivery overlap slot N+1's early
+ * pass, so the read-modify-writes these fields need must be atomic and the
+ * posted count must come from the caller's own update, not a re-read.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DecodeCycleStateTest {
+
+    private ArrayList<Ft8Message> listOf(int n) {
+        ArrayList<Ft8Message> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(new Ft8Message(FT8Common.FT8_MODE));
+        }
+        return list;
+    }
+
+    @Test
+    public void normalPass_replacesLabelsAndCount() {
+        DecodeCycleState state = new DecodeCycleState();
+        state.labelsAfterPass(listOf(3), false);
+        assertThat(state.countAfterPass(3, false)).isEqualTo(3);
+
+        state.labelsAfterPass(listOf(2), false);
+        assertThat(state.countAfterPass(2, false)).isEqualTo(2);
+        assertThat(state.getMessages()).hasSize(2);
+        assertThat(state.getDecodeCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void deepPass_augmentsLabelsAndAccumulatesCount() {
+        DecodeCycleState state = new DecodeCycleState();
+        state.labelsAfterPass(listOf(3), false);
+        state.countAfterPass(3, false);
+
+        state.labelsAfterPass(listOf(2), true);
+        assertThat(state.countAfterPass(2, true)).isEqualTo(5);
+        assertThat(state.getMessages()).hasSize(5);
+        assertThat(state.getDecodeCount()).isEqualTo(5);
+    }
+
+    @Test
+    public void emptyDeepPass_keepsLabels() {
+        DecodeCycleState state = new DecodeCycleState();
+        ArrayList<Ft8Message> kept = listOf(3);
+        state.labelsAfterPass(kept, false);
+
+        state.labelsAfterPass(new ArrayList<>(), true);
+        assertThat(state.getMessages()).isSameInstanceAs(kept);
+    }
+
+    @Test
+    public void emptyNormalPass_clearsLabels() {
+        DecodeCycleState state = new DecodeCycleState();
+        state.labelsAfterPass(listOf(3), false);
+
+        state.labelsAfterPass(new ArrayList<>(), false);
+        assertThat(state.getMessages()).isEmpty();
+    }
+
+    @Test
+    public void clearAndReset() {
+        DecodeCycleState state = new DecodeCycleState();
+        state.labelsAfterPass(listOf(3), false);
+        state.countAfterPass(3, false);
+
+        state.clearMessages();
+        state.resetCount();
+        assertThat(state.getMessages()).isNull();
+        assertThat(state.getDecodeCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void concurrentDeepCounts_neverLoseAnIncrement() throws InterruptedException {
+        // The issue's failure mode: currentDecodeCount += size as an unsynchronized
+        // RMW loses increments when two passes overlap. With the monitor, every
+        // increment must land.
+        DecodeCycleState state = new DecodeCycleState();
+        final int threads = 4;
+        final int perThread = 500;
+        CountDownLatch ready = new CountDownLatch(1);
+        ArrayList<Thread> pool = new ArrayList<>();
+        for (int t = 0; t < threads; t++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    ready.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < perThread; i++) {
+                    state.countAfterPass(1, true);
+                }
+            });
+            thread.start();
+            pool.add(thread);
+        }
+        ready.countDown();
+        for (Thread thread : pool) {
+            thread.join();
+        }
+        assertThat(state.getDecodeCount()).isEqualTo(threads * perThread);
+    }
+
+    @Test
+    public void concurrentDeepLabelMerges_neverLoseAPass() throws InterruptedException {
+        // currentMessages = afterPass(currentMessages, ...) as an unsynchronized RMW
+        // lets one pass's assignment clobber the other's merge. With the monitor,
+        // every deep pass's messages must survive into the final overlay.
+        DecodeCycleState state = new DecodeCycleState();
+        final int threads = 4;
+        final int perThread = 100;
+        CountDownLatch ready = new CountDownLatch(1);
+        ArrayList<Thread> pool = new ArrayList<>();
+        for (int t = 0; t < threads; t++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    ready.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < perThread; i++) {
+                    state.labelsAfterPass(listOf(1), true);
+                }
+            });
+            thread.start();
+            pool.add(thread);
+        }
+        ready.countDown();
+        for (Thread thread : pool) {
+            thread.join();
+        }
+        assertThat(state.getMessages()).hasSize(threads * perThread);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/DecodeCycleStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/DecodeCycleStateTest.java
@@ -8,6 +8,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Unit tests for {@link DecodeCycleState} — the synchronized holder for the
@@ -90,12 +91,17 @@ public class DecodeCycleStateTest {
         DecodeCycleState state = new DecodeCycleState();
         final int threads = 4;
         final int perThread = 500;
-        CountDownLatch ready = new CountDownLatch(1);
+        // Two-latch start: every worker signals it has reached the line before
+        // all are released together — otherwise late-starting threads run mostly
+        // sequentially and the test loses the overlap it exists to create.
+        CountDownLatch allReady = new CountDownLatch(threads);
+        CountDownLatch go = new CountDownLatch(1);
         ArrayList<Thread> pool = new ArrayList<>();
         for (int t = 0; t < threads; t++) {
             Thread thread = new Thread(() -> {
+                allReady.countDown();
                 try {
-                    ready.await();
+                    go.await();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return;
@@ -107,9 +113,11 @@ public class DecodeCycleStateTest {
             thread.start();
             pool.add(thread);
         }
-        ready.countDown();
+        assertThat(allReady.await(5, TimeUnit.SECONDS)).isTrue();
+        go.countDown();
         for (Thread thread : pool) {
-            thread.join();
+            thread.join(10_000);
+            assertThat(thread.isAlive()).isFalse();
         }
         assertThat(state.getDecodeCount()).isEqualTo(threads * perThread);
     }
@@ -122,12 +130,15 @@ public class DecodeCycleStateTest {
         DecodeCycleState state = new DecodeCycleState();
         final int threads = 4;
         final int perThread = 100;
-        CountDownLatch ready = new CountDownLatch(1);
+        // Same two-latch start as the count test, for the same overlap reason.
+        CountDownLatch allReady = new CountDownLatch(threads);
+        CountDownLatch go = new CountDownLatch(1);
         ArrayList<Thread> pool = new ArrayList<>();
         for (int t = 0; t < threads; t++) {
             Thread thread = new Thread(() -> {
+                allReady.countDown();
                 try {
-                    ready.await();
+                    go.await();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return;
@@ -139,9 +150,11 @@ public class DecodeCycleStateTest {
             thread.start();
             pool.add(thread);
         }
-        ready.countDown();
+        assertThat(allReady.await(5, TimeUnit.SECONDS)).isTrue();
+        go.countDown();
         for (Thread thread : pool) {
-            thread.join();
+            thread.join(10_000);
+            assertThat(thread.isAlive()).isFalse();
         }
         assertThat(state.getMessages()).hasSize(threads * perThread);
     }


### PR DESCRIPTION
## Problem

`MainViewModel.afterDecode()` mutated `currentMessages` and `currentDecodeCount` with no synchronization (only `ft8Messages` was guarded). Since the late full-slot pass (#363), slot N's deep delivery lands at ~the slot boundary while slot N+1's early decode thread is already running, so two threads execute `afterDecode` concurrently:

- `currentMessages = WaterfallLabelMessages.afterPass(currentMessages, ...)` is a read-modify-write — one pass's assignment clobbers the other's merge (stale/incomplete waterfall label set).
- `currentDecodeCount +=` is a non-atomic RMW — increments are lost and the wrong count is posted to `mutable_Decoded_Counter`.
- Readers (LogHttpServer, GridTracker) could iterate a reference another thread reassigns mid-read.

## Fix

Both values move into a new `DecodeCycleState` whose synchronized methods serialize every read-modify-write on one monitor and give readers a happens-before on the latest published snapshot:

- `labelsAfterPass(kept, isDeep)` — folds a pass into the overlay via the existing (unchanged) `WaterfallLabelMessages.afterPass` rule.
- `countAfterPass(keptCount, isDeep)` — replaces (normal) / accumulates (deep) and **returns the new total**, so `afterDecode` posts the value its own update produced rather than re-reading a field a concurrently-delivering pass may have advanced.
- `getMessages()` / `getDecodeCount()` / `clearMessages()` / `resetCount()` for the readers and the start-of-cycle / mode-change resets.

The label lists themselves are never mutated after publication (`afterPass` builds fresh lists), so a reader iterating a snapshot can't be torn by the next pass.

The public fields are replaced with accessors; all readers updated (`LogHttpServer`, `GridTrackerMainActivity`, `CallingListFragment`, `SpectrumView`, `SpectrumFragment`). The Kotlin `WaterfallScreen` site binds to `getCurrentMessages()` through Kotlin's synthetic property syntax unchanged.

## Tests

New `DecodeCycleStateTest` (Robolectric, since it builds `Ft8Message`):
- Normal pass replaces labels+count; deep pass augments/accumulates; empty deep keeps labels; empty normal clears; clear/reset.
- `concurrentDeepCounts_neverLoseAnIncrement` — 4 threads x 500 deep counts land exactly.
- `concurrentDeepLabelMerges_neverLoseAPass` — 4 threads x 100 deep merges all survive into the final overlay.

Full `testDebugUnitTest` suite green.

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA