### PR TITLE
Derive USB channel count from the actual sample rate, not a 48 kHz constant

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -209,10 +209,14 @@ public class UsbAudioDevice {
      * endpoint carries 44/45 samples per frame, so its packet size is not an exact multiple
      * of the per-channel byte rate. Clamped to [1, 2] — this pipeline handles mono/stereo.
      *
+     * <p>An implausible rate (see {@link #isPlausibleRate}: outside the 8-768 kHz UAC
+     * hardware range, e.g. from garbage descriptor data) fails safe to mono rather than
+     * letting a tiny divisor round up to "stereo".
+     *
      * <p>Package-visible for tests.
      */
     static int channelsForMaxPacketSize(int maxPacketSize, int sampleRateHz) {
-        if (sampleRateHz <= 0) return 1;
+        if (!isPlausibleRate(sampleRateHz)) return 1;
         double bytesPerFramePerChannel = (sampleRateHz / 1000.0) * 2.0;
         int channels = (int) Math.round(maxPacketSize / bytesPerFramePerChannel);
         if (channels < 1) return 1;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -48,6 +48,10 @@ public class UsbAudioDevice {
     private UsbEndpoint endpointIn;
     private int inputSampleRate = 48000;
     private int inputChannels = 1;
+    // True when inputChannels came from parsed UAC descriptors (authoritative); false
+    // while it is only the wMaxPacketSize-derived guess, which must be re-derived once
+    // the real sample rate is known (issue #400).
+    private boolean inputChannelsFromDescriptors = false;
     // UAC format descriptors parsed during selectInputAltSetting(); consulted again
     // when SET_CUR fails to work out what rate the device is actually running.
     private List<UacAudioFormats.StreamFormat> inputFormats = Collections.emptyList();
@@ -183,24 +187,37 @@ public class UsbAudioDevice {
             }
         }
 
-        // Detect channel count from max packet size
-        // USB audio at 48kHz, 16-bit: mono=96 bytes/ms, stereo=192 bytes/ms
+        // Detect channel count from max packet size, provisionally assuming the default
+        // 48 kHz until a stream is activated — activateInput()/activateOutput() re-derive
+        // the count from the rate actually in use (issue #400: a 44.1 kHz stereo endpoint
+        // judged against the 48 kHz frame size counts as mono).
         if (endpointIn != null) {
-            int mps = endpointIn.getMaxPacketSize();
-            // samples_per_ms = sampleRate / 1000 = 48
-            // bytes_per_ms = samples_per_ms * channels * 2 (16-bit)
-            inputChannels = mps / (48 * 2);
-            if (inputChannels < 1) inputChannels = 1;
-            if (inputChannels > 2) inputChannels = 2;
+            inputChannels = channelsForMaxPacketSize(endpointIn.getMaxPacketSize(), 48000);
+            inputChannelsFromDescriptors = false;
             Log.d(TAG, "Input channels detected: " + inputChannels);
         }
         if (endpointOut != null) {
-            int mps = endpointOut.getMaxPacketSize();
-            outputChannels = mps / (48 * 2);
-            if (outputChannels < 1) outputChannels = 1;
-            if (outputChannels > 2) outputChannels = 2;
+            outputChannels = channelsForMaxPacketSize(endpointOut.getMaxPacketSize(), 48000);
             Log.d(TAG, "Output channels detected: " + outputChannels);
         }
+    }
+
+    /**
+     * Channel count implied by an isochronous audio endpoint's {@code wMaxPacketSize} at a
+     * given sample rate (16-bit samples, full-speed USB: one packet per 1 ms frame, sized
+     * to carry {@code rate/1000} samples per channel). Rounded, not truncated: a 44.1 kHz
+     * endpoint carries 44/45 samples per frame, so its packet size is not an exact multiple
+     * of the per-channel byte rate. Clamped to [1, 2] — this pipeline handles mono/stereo.
+     *
+     * <p>Package-visible for tests.
+     */
+    static int channelsForMaxPacketSize(int maxPacketSize, int sampleRateHz) {
+        if (sampleRateHz <= 0) return 1;
+        double bytesPerFramePerChannel = (sampleRateHz / 1000.0) * 2.0;
+        int channels = (int) Math.round(maxPacketSize / bytesPerFramePerChannel);
+        if (channels < 1) return 1;
+        if (channels > 2) return 2;
+        return channels;
     }
 
     /**
@@ -246,6 +263,23 @@ public class UsbAudioDevice {
                             + "alt setting offers %s — assuming %d Hz for resampling",
                     negotiatedRate, endpointIn.getAddress(), reportedRate,
                     java.util.Arrays.toString(altRates), inputSampleRate));
+        }
+
+        // The findEndpoints() channel-count guess divides wMaxPacketSize by the 48 kHz
+        // frame size. When descriptor parsing yielded no channel count (the legacy
+        // fallback paths above) and the stream actually runs at another rate, that guess
+        // is wrong — a 44.1 kHz stereo endpoint (~180-byte packets) counts as mono and
+        // the capture loop de-interleaves garbage (issue #400). Re-derive from the rate
+        // we just settled on.
+        if (!inputChannelsFromDescriptors) {
+            int detected = channelsForMaxPacketSize(endpointIn.getMaxPacketSize(), inputSampleRate);
+            if (detected != inputChannels) {
+                com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                        "UsbAudioDevice: input channel guess corrected %d -> %d "
+                                + "(wMaxPacketSize=%d at %d Hz)",
+                        inputChannels, detected, endpointIn.getMaxPacketSize(), inputSampleRate));
+                inputChannels = detected;
+            }
         }
 
         Log.d(TAG, "Input activated at " + inputSampleRate + " Hz");
@@ -378,6 +412,7 @@ public class UsbAudioDevice {
 
         if (choice.channels == 1 || choice.channels == 2) {
             inputChannels = choice.channels;
+            inputChannelsFromDescriptors = true;
         }
         com.k1af.ft8af.GeneralVariables.fileLog(String.format(
                 "UsbAudioDevice: UAC alt-setting select — iface %d alt %d rate %d ch %d "
@@ -402,6 +437,10 @@ public class UsbAudioDevice {
 
         outputSampleRate = sampleRate;
         setSampleRate(endpointOut.getAddress(), sampleRate);
+
+        // Same correction as the input side (issue #400): the findEndpoints() guess
+        // assumed 48 kHz; re-derive the channel count from the rate actually requested.
+        outputChannels = channelsForMaxPacketSize(endpointOut.getMaxPacketSize(), sampleRate);
 
         Log.d(TAG, "Output activated at " + outputSampleRate + " Hz");
         return true;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioChannelCountTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioChannelCountTest.java
@@ -1,0 +1,96 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link UsbAudioDevice#channelsForMaxPacketSize(int, int)} — the channel count
+ * implied by an isochronous endpoint's wMaxPacketSize at a given sample rate.
+ *
+ * <p>Background (issue #400): the old guess divided wMaxPacketSize by a hard-coded
+ * 48 kHz frame size (96 bytes per channel-ms) with integer truncation, so a 44.1 kHz
+ * stereo endpoint (~180-byte packets, 88.2 bytes per channel-ms) counted as mono —
+ * 180 / 192-per-stereo-frame truncates to 1 — and the capture loop de-interleaved
+ * garbage on exactly the 44.1 kHz device class issue #364 exists to support. The
+ * helper is now rate-aware and rounds (a 44.1 kHz endpoint alternates 44/45 samples
+ * per frame, so packets are not an exact multiple of the per-channel rate).
+ */
+public class UsbAudioChannelCountTest {
+
+    // --- 48 kHz (the historical assumption keeps working) ----------------------
+
+    @Test
+    public void mono48k() {
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(96, 48000)).isEqualTo(1);
+    }
+
+    @Test
+    public void stereo48k() {
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, 48000)).isEqualTo(2);
+    }
+
+    @Test
+    public void cm108StylePacketSize_countsStereo() {
+        // CM108-family chips report ~200-byte max packets for 48 kHz stereo.
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(200, 48000)).isEqualTo(2);
+    }
+
+    // --- 44.1 kHz (the issue-#400 device class) --------------------------------
+
+    @Test
+    public void stereo44k1_atItsRealRate() {
+        // 44.1 kHz stereo 16-bit: 176.4 bytes/frame nominal, 180 worst-case (45-sample
+        // frames). Both must count as stereo.
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(176, 44100)).isEqualTo(2);
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(180, 44100)).isEqualTo(2);
+    }
+
+    @Test
+    public void mono44k1_atItsRealRate() {
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(88, 44100)).isEqualTo(1);
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(90, 44100)).isEqualTo(1);
+    }
+
+    @Test
+    public void stereo44k1_evenUnderTheLegacy48kGuess() {
+        // The exact failure from the issue: 180-byte packets judged against the 48 kHz
+        // frame size. Truncating division said 1 (mono); rounding says 2. The rate-aware
+        // re-derivation in activateInput() is still the real fix, but the initial guess
+        // no longer miscounts this device either.
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(180, 48000)).isEqualTo(2);
+    }
+
+    // --- other rates ------------------------------------------------------------
+
+    @Test
+    public void stereo32k_atItsRealRate() {
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(128, 32000)).isEqualTo(2);
+    }
+
+    @Test
+    public void mono96k_atItsRealRate() {
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, 96000)).isEqualTo(1);
+    }
+
+    // --- clamping / degenerate inputs -------------------------------------------
+
+    @Test
+    public void tinyPacket_clampsToMono() {
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(0, 48000)).isEqualTo(1);
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(10, 48000)).isEqualTo(1);
+    }
+
+    @Test
+    public void hugePacket_clampsToStereo() {
+        // High-speed endpoints or multi-channel interfaces: clamp to the stereo this
+        // pipeline handles rather than reporting 4+ channels.
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(1024, 48000)).isEqualTo(2);
+    }
+
+    @Test
+    public void nonPositiveRate_fallsBackToMono() {
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, 0)).isEqualTo(1);
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, -1)).isEqualTo(1);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioChannelCountTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioChannelCountTest.java
@@ -9,12 +9,13 @@ import org.junit.Test;
  * implied by an isochronous endpoint's wMaxPacketSize at a given sample rate.
  *
  * <p>Background (issue #400): the old guess divided wMaxPacketSize by a hard-coded
- * 48 kHz frame size (96 bytes per channel-ms) with integer truncation, so a 44.1 kHz
- * stereo endpoint (~180-byte packets, 88.2 bytes per channel-ms) counted as mono —
- * 180 / 192-per-stereo-frame truncates to 1 — and the capture loop de-interleaved
- * garbage on exactly the 44.1 kHz device class issue #364 exists to support. The
- * helper is now rate-aware and rounds (a 44.1 kHz endpoint alternates 44/45 samples
- * per frame, so packets are not an exact multiple of the per-channel rate).
+ * 48 kHz per-channel frame size (mps / (48 * 2), i.e. mps / 96) with integer
+ * truncation, so a 44.1 kHz stereo endpoint (~180-byte packets, 88.2 bytes per
+ * channel-ms) counted as mono — 180 / 96 == 1.875 truncates to 1 — and the capture
+ * loop de-interleaved garbage on exactly the 44.1 kHz device class issue #364 exists
+ * to support. The helper is now rate-aware and rounds (a 44.1 kHz endpoint alternates
+ * 44/45 samples per frame, so packets are not an exact multiple of the per-channel
+ * rate).
  */
 public class UsbAudioChannelCountTest {
 
@@ -92,5 +93,18 @@ public class UsbAudioChannelCountTest {
     public void nonPositiveRate_fallsBackToMono() {
         assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, 0)).isEqualTo(1);
         assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, -1)).isEqualTo(1);
+    }
+
+    @Test
+    public void implausibleRate_failsSafeToMono() {
+        // A positive but garbage rate (malformed descriptor data) would make the
+        // per-channel divisor tiny and round any packet size up to "stereo";
+        // outside the plausible 8-768 kHz UAC range we fail safe to mono instead.
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, 5)).isEqualTo(1);
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, 7999)).isEqualTo(1);
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(192, 10_000_000)).isEqualTo(1);
+        // The plausible-range floor itself still computes normally.
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(16, 8000)).isEqualTo(1);
+        assertThat(UsbAudioDevice.channelsForMaxPacketSize(32, 8000)).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## Problem

USB input channel-count detection hard-coded the 48 kHz frame size: `inputChannels = mps / (48 * 2)` with truncating integer division in `findEndpoints()`. The descriptor-parsing path later corrects it, but `selectInputAltSetting` returns early (legacy fallback) when `UacAudioFormats.choose(...)` yields nothing usable — and on that path the 48 kHz guess sticks.

A 44.1 kHz **stereo** capture endpoint reports wMaxPacketSize ~ 180, so `180 / 96 = 1` — mono. The capture loop then treats interleaved L/R 16-bit frames as consecutive mono samples: garbled audio at the wrong effective rate, zero decodes. That is precisely the 44.1 kHz device class issue #364 exists to support.

## Fix

- New rate-aware helper `channelsForMaxPacketSize(maxPacketSize, sampleRateHz)`: bytes-per-frame-per-channel is `(rate/1000) * 2`, count is **rounded** (a 44.1 kHz endpoint alternates 44/45 samples per frame, so packets are not exact multiples), clamped to [1, 2], degenerate rates fall back to mono.
- `findEndpoints()` uses it for the provisional 48 kHz guess (unchanged results for real 48 kHz devices; the rounding alone already rescues the 180-byte case).
- `activateInput()` re-derives the count from the **settled** `inputSampleRate` whenever the descriptors did not supply a channel count (tracked by a new `inputChannelsFromDescriptors` flag), logging any correction to `debug.log`.
- `activateOutput()` re-derives against the requested output rate (same hard-coded 48 existed on the output side).

The descriptor-parsing path remains authoritative when it works, exactly as before.

## Tests

New `UsbAudioChannelCountTest` (pure static math, no runner): 48 kHz mono/stereo, CM108-style 200-byte packets, 44.1 kHz mono/stereo at nominal and worst-case packet sizes, the issue's exact 180-bytes-judged-at-48-kHz case, 32 kHz stereo / 96 kHz mono, and clamping/degenerate inputs. Existing `UsbAudioRateResolutionTest` still green; full `testDebugUnitTest` suite green.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA