### PR TITLE
Refuse to arm the free-text one-shot when the callsign can't transmit

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -251,7 +251,7 @@ public class FT8TransmitSignal {
      */
     //@RequiresApi(api = Build.VERSION_CODES.N)
     public void transmitNow() {
-        if (GeneralVariables.myCallsign.length() < 3) {
+        if (!isCallsignReadyToTransmit(GeneralVariables.myCallsign)) {
             ToastMessage.show(GeneralVariables.getStringFromResource(R.string.callsign_error));
             return;
         }
@@ -1797,9 +1797,27 @@ public class FT8TransmitSignal {
         return isTransmitting;
     }
 
+    /**
+     * Whether {@code myCallsign} is a callsign transmit can start with — the guard
+     * {@link #setTransmitting} and {@link #transmitNow} apply before keying. Extracted
+     * as a pure predicate so the free-text one-shot arming check (issue #401) provably
+     * matches the check that would otherwise silently block the transmission.
+     */
+    static boolean isCallsignReadyToTransmit(String myCallsign) {
+        return myCallsign != null && myCallsign.length() >= 3;
+    }
+
     public void setTransmitting(boolean transmitting) {
-        if (GeneralVariables.myCallsign.length() < 3 && transmitting) {
+        if (!isCallsignReadyToTransmit(GeneralVariables.myCallsign) && transmitting) {
             ToastMessage.show(GeneralVariables.getStringFromResource(R.string.callsign_error));
+            // A refused TX start never reaches afterPlayAudio(), whose
+            // shouldStopAfterOneShot() is what normally clears an armed free-text
+            // one-shot — so disarm it here or the stale free text leaks into the
+            // next standard/CQ over (issue #401).
+            if (freeTextOneShot) {
+                freeTextOneShot = false;
+                transmitFreeText = false;
+            }
             return;
         }
 
@@ -1849,7 +1867,7 @@ public class FT8TransmitSignal {
      */
     //@RequiresApi(api = Build.VERSION_CODES.N)
     public void restTransmitting() {
-        if (GeneralVariables.myCallsign.length() < 3) {
+        if (!isCallsignReadyToTransmit(GeneralVariables.myCallsign)) {
             return;
         }
         clearCallerQueue();
@@ -2165,13 +2183,21 @@ public class FT8TransmitSignal {
      * auto-stops in {@link #afterPlayAudio()} instead of keying up again each cycle.
      */
     public void sendFreeTextOnce(String text) {
+        // Check the callsign BEFORE arming: setActivated() doesn't validate it (only
+        // SWR lockout), so with a short/empty callsign activation would "succeed" and
+        // the guard below wouldn't clean up — while setTransmitting()/transmitNow()
+        // would refuse to key, so afterPlayAudio()/shouldStopAfterOneShot() never runs
+        // and the armed free text would leak into the next standard/CQ over (issue #401).
+        if (!isCallsignReadyToTransmit(GeneralVariables.myCallsign)) {
+            ToastMessage.show(GeneralVariables.getStringFromResource(R.string.callsign_error));
+            return;
+        }
         setFreeText(text);
         transmitFreeText = true;
         freeTextOneShot = true;
         setActivated(true);
         if (!activated) {
-            // SWR lockout or invalid callsign blocked activation — don't leave the
-            // one-shot armed.
+            // SWR lockout blocked activation — don't leave the one-shot armed.
             freeTextOneShot = false;
             transmitFreeText = false;
             return;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -396,6 +396,26 @@ public class FT8TransmitSignalTest {
         assertThat(FT8TransmitSignal.shouldStopAfterOneShot(false, true)).isFalse();
     }
 
+    // ---- isCallsignReadyToTransmit -------------------------------------------
+    // The guard setTransmitting/transmitNow apply before keying. sendFreeTextOnce
+    // must apply the SAME predicate before arming its one-shot (issue #401), or a
+    // blocked transmission leaves the free text armed to leak into the next over.
+
+    @Test
+    public void callsignReady_realCalls_ready() {
+        assertThat(FT8TransmitSignal.isCallsignReadyToTransmit("K1AF")).isTrue();
+        assertThat(FT8TransmitSignal.isCallsignReadyToTransmit("2E0ABC")).isTrue();
+        // Exactly the 3-character minimum the keying guard enforces.
+        assertThat(FT8TransmitSignal.isCallsignReadyToTransmit("K1A")).isTrue();
+    }
+
+    @Test
+    public void callsignReady_shortOrMissing_notReady() {
+        assertThat(FT8TransmitSignal.isCallsignReadyToTransmit("K1")).isFalse();
+        assertThat(FT8TransmitSignal.isCallsignReadyToTransmit("")).isFalse();
+        assertThat(FT8TransmitSignal.isCallsignReadyToTransmit(null)).isFalse();
+    }
+
     // ---- shouldCompleteQso ---------------------------------------------------
     // Completion decision for the QSO state machine. The evidenceOnly flag marks
     // deep/late-pass parses: positive evidence (partner sent 73, partner moved

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FreeTextOneShotArmingTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FreeTextOneShotArmingTest.java
@@ -1,0 +1,108 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.GeneralVariables;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Field;
+
+/**
+ * Coverage for issue #401: a one-shot free-text send must not stay armed when a
+ * short/empty callsign blocks the transmission.
+ *
+ * <p>Before the fix, {@code sendFreeTextOnce} armed {@code transmitFreeText}/
+ * {@code freeTextOneShot} and called {@code setActivated(true)}, which only checks
+ * SWR lockout — so with a bad callsign the cleanup guard was skipped, while
+ * {@code setTransmitting(true)} refused to key and {@code afterPlayAudio()} (the
+ * normal disarm point via {@code shouldStopAfterOneShot}) never ran. The stale free
+ * text then replaced the operator's next CQ/standard message once they fixed their
+ * callsign.
+ *
+ * <p>Robolectric: the flows post toasts/LiveData through the Android runtime.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class FreeTextOneShotArmingTest {
+
+    private FT8TransmitSignal signal;
+
+    @Before
+    public void setUp() {
+        GeneralVariables.myCallsign = "";
+        signal = new FT8TransmitSignal(null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.myCallsign = "";
+    }
+
+    private boolean freeTextOneShotFlag() throws Exception {
+        Field f = FT8TransmitSignal.class.getDeclaredField("freeTextOneShot");
+        f.setAccessible(true);
+        return f.getBoolean(signal);
+    }
+
+    private void armOneShotFlags() throws Exception {
+        Field oneShot = FT8TransmitSignal.class.getDeclaredField("freeTextOneShot");
+        oneShot.setAccessible(true);
+        oneShot.setBoolean(signal, true);
+        Field freeText = FT8TransmitSignal.class.getDeclaredField("transmitFreeText");
+        freeText.setAccessible(true);
+        freeText.setBoolean(signal, true);
+    }
+
+    @Test
+    public void sendFreeTextOnce_shortCallsign_doesNotArm() throws Exception {
+        GeneralVariables.myCallsign = "K1";
+
+        signal.sendFreeTextOnce("TEST MSG");
+
+        // The issue's exact leak: these staying true is what injected the stale
+        // free text into the next CQ over.
+        assertThat(signal.isTransmitFreeText()).isFalse();
+        assertThat(freeTextOneShotFlag()).isFalse();
+        // And activation must not have been flipped on for a send that can't start.
+        assertThat(signal.isActivated()).isFalse();
+    }
+
+    @Test
+    public void sendFreeTextOnce_emptyCallsign_doesNotArm() throws Exception {
+        GeneralVariables.myCallsign = "";
+
+        signal.sendFreeTextOnce("TEST MSG");
+
+        assertThat(signal.isTransmitFreeText()).isFalse();
+        assertThat(freeTextOneShotFlag()).isFalse();
+        assertThat(signal.isActivated()).isFalse();
+    }
+
+    @Test
+    public void refusedTransmitStart_disarmsAnArmedOneShot() throws Exception {
+        // Defense in depth: if the one-shot is already armed (e.g. the callsign was
+        // cleared between arming and the slot boundary), a refused setTransmitting(true)
+        // must disarm it rather than leave it for the next over.
+        GeneralVariables.myCallsign = "K1";
+        armOneShotFlags();
+
+        signal.setTransmitting(true);
+
+        assertThat(signal.isTransmitting()).isFalse();
+        assertThat(signal.isTransmitFreeText()).isFalse();
+        assertThat(freeTextOneShotFlag()).isFalse();
+    }
+
+    @Test
+    public void refusedTransmitStop_isUnaffectedByGuard() {
+        // setTransmitting(false) must keep working with any callsign (stop is always
+        // allowed) and must not touch free-text state it didn't set.
+        GeneralVariables.myCallsign = "";
+        signal.setTransmitting(false);
+        assertThat(signal.isTransmitting()).isFalse();
+    }
+}


### PR DESCRIPTION
## Problem

A one-shot free-text send could stay armed when TX was blocked by a short/empty callsign, leaking the free text into the next standard/CQ over (issue #401).

`sendFreeTextOnce` armed `transmitFreeText`/`freeTextOneShot`, called `setActivated(true)`, and used `if (!activated)` as its cleanup guard — with a comment claiming "SWR lockout or invalid callsign blocked activation". But `setActivated` only blocks on **SWR lockout**; it never checks the callsign. So with `myCallsign.length() < 3`: activation "succeeded", the cleanup guard was skipped, `transmitNow()`/`setTransmitting(true)` refused to key with a toast, and `afterPlayAudio()`/`shouldStopAfterOneShot()` — the normal disarm point — never ran. When the operator later fixed their callsign and pressed CQ, `DoTransmitRunnable` saw `transmitFreeText == true` and sent the stale free text instead of the CQ.

## Fix

- Extract the keying guard into a pure predicate `isCallsignReadyToTransmit(String)`, now shared by `setTransmitting`, `transmitNow`, `restTransmitting`, and the new arming check — so the arming precondition provably matches the check that would otherwise block the transmission.
- `sendFreeTextOnce` validates the callsign **before** arming anything (same callsign-error toast the keying path shows) and returns without touching activation state.
- Defense in depth: a refused `setTransmitting(true)` now disarms an already-armed one-shot (covers a callsign cleared between arming and the slot boundary).
- The misleading comment is corrected — the remaining `if (!activated)` guard is documented as SWR-lockout-only, which is what it actually catches.

## Tests

- `FT8TransmitSignalTest`: `isCallsignReadyToTransmit` matrix (real calls, exact 3-char minimum, short/empty/null).
- New `FreeTextOneShotArmingTest` (Robolectric, full sequencer instance): short and empty callsign sends arm nothing and leave activation off (the issue's exact leak); a refused TX start disarms an armed one-shot; `setTransmitting(false)` is unaffected by the guard.
- Full `testDebugUnitTest` suite green.

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
