### PR TITLE
Order HamRecorder watchdog reads against capture writes with a buffer lock

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/HamRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/HamRecorder.java
@@ -261,6 +261,14 @@ public class HamRecorder {
         //produced no decode.
         private final java.util.concurrent.atomic.AtomicBoolean completed =
                 new java.util.concurrent.atomic.AtomicBoolean(false);
+        //Orders the capture thread's voiceData writes / dataCount increments against
+        //the watchdog thread's reads (issue #404). The capture thread copies each
+        //chunk under this lock; the watchdog takes it before inspecting dataCount and
+        //claiming delivery, so it (a) waits out an in-flight chunk copy rather than
+        //snapshotting a half-written buffer and (b) gets a happens-before on all
+        //samples written so far — an unlocked read could see a stale count and
+        //deliver a short/zero-tailed buffer while the final samples were landing.
+        private final Object bufferLock = new Object();
 
         //onHamRecord is the callback triggered when the recorder has data; it fills the voiceData buffer, and when the buffer is full, triggers the OnGetVoiceDataDone callback.
         public OnHamRecord onHamRecord;
@@ -270,7 +278,9 @@ public class HamRecorder {
 
         /** Samples collected so far (test/diagnostic visibility). */
         int collectedSamples() {
-            return dataCount;
+            synchronized (bufferLock) {
+                return dataCount;
+            }
         }
 
         /**
@@ -286,12 +296,22 @@ public class HamRecorder {
             if (!oneShot) {
                 return false;
             }
-            if (dataCount >= voiceData.length) {
-                return false; // filled; normal path delivered (or is delivering) it
+            synchronized (bufferLock) {
+                //Decide the winner under the lock, BEFORE the buffer is handed out:
+                //this waits for any in-flight chunk copy to finish and reads the
+                //capture thread's true progress, so a fill that completed (or is one
+                //chunk from completing) isn't clobbered by a stale-count delivery.
+                if (dataCount >= voiceData.length) {
+                    return false; // filled; normal path delivered (or is delivering) it
+                }
+                if (!completed.compareAndSet(false, true)) {
+                    return false;
+                }
             }
-            if (!completed.compareAndSet(false, true)) {
-                return false;
-            }
+            //completed is now set, and every subsequent chunk checks it under
+            //bufferLock before writing — the buffer can no longer change, so it is
+            //safe to deliver outside the lock (the decode handoff shouldn't stall
+            //the capture thread's next chunk).
             doneCallback.onGetDone(voiceData);
             if (recorder != null) {
                 recorder.deleteVoiceDataMonitor(voiceDataMonitor);
@@ -326,20 +346,27 @@ public class HamRecorder {
             onHamRecord = new OnHamRecord() {
                 @Override
                 public void OnReceiveData(float[] data, int size) {
-                    //Once a one-shot buffer has been delivered (normally or by the
-                    //stall watchdog), late-arriving audio must not keep mutating it
-                    //behind the consumer's back.
-                    if (afterDoneRemove && completed.get()) {
-                        return;
-                    }
-                    int remainingSize = size+dataCount-voiceData.length;//if greater than 0, this is the remaining data amount
+                    int remainingSize;
+                    boolean filled;
+                    synchronized (bufferLock) {
+                        //Once a one-shot buffer has been delivered (normally or by the
+                        //stall watchdog), late-arriving audio must not keep mutating it
+                        //behind the consumer's back. Checked under the lock, so a
+                        //watchdog that just claimed delivery can't interleave with this
+                        //chunk's copy (issue #404).
+                        if (afterDoneRemove && completed.get()) {
+                            return;
+                        }
+                        remainingSize = size+dataCount-voiceData.length;//if greater than 0, this is the remaining data amount
 
-                    for (int i = 0; (i < size) && (dataCount < voiceData.length); i++) {
-                            voiceData[dataCount] = data[i];//copy data from recording buffer to this monitor
-                            dataCount++;
+                        for (int i = 0; (i < size) && (dataCount < voiceData.length); i++) {
+                                voiceData[dataCount] = data[i];//copy data from recording buffer to this monitor
+                                dataCount++;
+                        }
+                        filled = dataCount >= voiceData.length;
                     }
 
-                    if (dataCount >= (voiceData.length)) {//when data amount reaches the required amount, trigger callback
+                    if (filled) {//when data amount reaches the required amount, trigger callback
                         if (afterDoneRemove) {//if this is a one-shot data acquisition, remove this monitor callback from the recorder's listener list
                             //guard against the stall watchdog racing a late normal fill
                             if (completed.compareAndSet(false, true)) {
@@ -350,7 +377,9 @@ public class HamRecorder {
                             }
                         } else {
                             onGetVoiceDataDone.onGetDone(voiceData);
-                            dataCount = 0;//if looping recording, reset the counter
+                            synchronized (bufferLock) {
+                                dataCount = 0;//if looping recording, reset the counter
+                            }
                             if (remainingSize>0) {//forward remaining data to subsequent events
                                 float[] remainingData = new float[remainingSize];
                                 System.arraycopy(data, size - remainingSize, remainingData, 0, remainingSize);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/VoiceDataMonitorStallTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/VoiceDataMonitorStallTest.java
@@ -20,8 +20,13 @@ public class VoiceDataMonitorStallTest {
     private static class RecordingCallback implements OnGetVoiceDataDone {
         final ArrayList<float[]> deliveries = new ArrayList<>();
 
+        // synchronized: the race tests below invoke this from either the
+        // capture thread or the watchdog thread. If a regression ever produced
+        // two near-simultaneous deliveries, the harness must record both and
+        // fail the hasSize(1) assertion cleanly — not corrupt an unsynchronized
+        // ArrayList and die with a confusing secondary error.
         @Override
-        public void onGetDone(float[] data) {
+        public synchronized void onGetDone(float[] data) {
             deliveries.add(data);
         }
     }
@@ -217,13 +222,18 @@ public class VoiceDataMonitorStallTest {
             assertThat(cb.deliveries).hasSize(1);
             float[] delivered = cb.deliveries.get(0);
             // Either outcome is legal, but the collected prefix must be intact and
-            // stable: at least the pre-fed 1100 samples, and if the fill won, all 1200.
+            // stable: at least the pre-fed 1100 samples...
             for (int i = 0; i < 1100; i++) {
                 assertThat(delivered[i]).isEqualTo(0.25f);
             }
-            boolean fullDelivery = delivered[1199] == 0.25f;
-            boolean shortDelivery = delivered[1199] == 0f;
-            assertThat(fullDelivery || shortDelivery).isTrue();
+            // ...and the final chunk must be all-or-nothing: every sample real
+            // (fill won the lock) or every sample zero (watchdog won). A torn
+            // half-copied chunk — some real samples then zeros — is exactly the
+            // failure the buffer lock exists to prevent.
+            boolean fullDelivery = delivered[1100] == 0.25f;
+            for (int i = 1100; i < 1200; i++) {
+                assertThat(delivered[i]).isEqualTo(fullDelivery ? 0.25f : 0f);
+            }
         }
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/VoiceDataMonitorStallTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/VoiceDataMonitorStallTest.java
@@ -117,4 +117,113 @@ public class VoiceDataMonitorStallTest {
         feed(m, 1200, 0.5f);
         assertThat(cb.deliveries).hasSize(2);
     }
+
+    // ---- capture-thread vs watchdog-thread races (issue #404) ----------------
+    // forceCompleteAfterStall used to read dataCount/voiceData with no
+    // happens-before against the capture thread's writes. Both sides now
+    // synchronize on the monitor's buffer lock: the watchdog waits out an
+    // in-flight chunk copy and decides the winner on the true count before the
+    // buffer is handed out.
+
+    @Test
+    public void concurrentFillAndWatchdog_exactlyOneDelivery_neverTorn() throws Exception {
+        // Race a chunked fill (capture thread) against the watchdog firing at an
+        // arbitrary point. Whatever the interleaving: exactly one delivery, and the
+        // delivered buffer is a clean prefix of real samples followed by zeros —
+        // never a zero hole inside the collected prefix.
+        for (int round = 0; round < 200; round++) {
+            RecordingCallback cb = new RecordingCallback();
+            HamRecorder.VoiceDataMonitor m = newMonitor(true, cb);
+
+            java.util.concurrent.CountDownLatch go = new java.util.concurrent.CountDownLatch(1);
+            Thread capture = new Thread(() -> {
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int fed = 0; fed < 1200; fed += 100) {
+                    feed(m, 100, 0.25f); // 12 chunks of 100 samples
+                }
+            });
+            Thread watchdog = new Thread(() -> {
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                m.forceCompleteAfterStall(null);
+            });
+            capture.start();
+            watchdog.start();
+            go.countDown();
+            capture.join();
+            watchdog.join();
+
+            assertThat(cb.deliveries).hasSize(1);
+            float[] delivered = cb.deliveries.get(0);
+            // Find the end of the real-sample prefix; everything after must be zero.
+            int prefixEnd = delivered.length;
+            while (prefixEnd > 0 && delivered[prefixEnd - 1] == 0f) {
+                prefixEnd--;
+            }
+            for (int i = 0; i < prefixEnd; i++) {
+                assertThat(delivered[i]).isEqualTo(0.25f);
+            }
+            // The prefix must be whole chunks: the watchdog may not snapshot a
+            // half-copied chunk.
+            assertThat(prefixEnd % 100).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void watchdogRacingFinalChunk_fullBufferIsNeverDeliveredShort() throws Exception {
+        // The issue's exact scenario: the buffer is one chunk from full when the
+        // watchdog fires. If the fill wins the lock, the watchdog must observe the
+        // completed count (not a stale one) and stand down; if the watchdog wins,
+        // the final chunk must not mutate the delivered buffer afterwards.
+        for (int round = 0; round < 200; round++) {
+            RecordingCallback cb = new RecordingCallback();
+            HamRecorder.VoiceDataMonitor m = newMonitor(true, cb);
+            feed(m, 1100, 0.25f); // all but the final 100 samples
+
+            java.util.concurrent.CountDownLatch go = new java.util.concurrent.CountDownLatch(1);
+            Thread capture = new Thread(() -> {
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                feed(m, 100, 0.25f); // the final chunk
+            });
+            Thread watchdog = new Thread(() -> {
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                m.forceCompleteAfterStall(null);
+            });
+            capture.start();
+            watchdog.start();
+            go.countDown();
+            capture.join();
+            watchdog.join();
+
+            assertThat(cb.deliveries).hasSize(1);
+            float[] delivered = cb.deliveries.get(0);
+            // Either outcome is legal, but the collected prefix must be intact and
+            // stable: at least the pre-fed 1100 samples, and if the fill won, all 1200.
+            for (int i = 0; i < 1100; i++) {
+                assertThat(delivered[i]).isEqualTo(0.25f);
+            }
+            boolean fullDelivery = delivered[1199] == 0.25f;
+            boolean shortDelivery = delivered[1199] == 0f;
+            assertThat(fullDelivery || shortDelivery).isTrue();
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`HamRecorder.VoiceDataMonitor.forceCompleteAfterStall` read `dataCount` and the `voiceData` buffer from the stall-watchdog thread with **no happens-before** against the capture thread's writes (issue #404). A one-shot decode monitor nearly complete when the watchdog fires at `duration + 2000 ms` could race it: the watchdog reads a stale `dataCount < length`, wins the `completed` CAS, and delivers the buffer while the capture thread's final samples are still landing — the decoder gets a short/zero-tailed buffer (potentially missing the last window of real audio) even though full audio had arrived.

## Fix

A per-monitor `bufferLock` now orders the two threads:

- The capture thread copies each chunk into `voiceData` and advances `dataCount` **under the lock**, and its already-delivered check (`completed.get()`) moved inside the lock too — a watchdog that just claimed delivery can no longer interleave with a chunk copy.
- `forceCompleteAfterStall` takes the lock **before** inspecting `dataCount` and claiming the `completed` CAS: it waits out any in-flight chunk copy and reads the capture thread's true progress, so a fill that completed (or completes first) wins and the watchdog stands down. The delivery callback itself runs outside the lock (the decode handoff must not stall the next chunk); that is safe because every later chunk checks `completed` under the lock before writing.
- `collectedSamples()` reads under the same lock.

Lock cost is one uncontended acquire per ~160 ms audio chunk; contention only ever comes from the (rare) watchdog firing.

## Tests

`VoiceDataMonitorStallTest` — all six existing cases unchanged and green, plus two new race tests (200 interleaving rounds each):

- `concurrentFillAndWatchdog_exactlyOneDelivery_neverTorn` — chunked fill races the watchdog at an arbitrary point: exactly one delivery, and the delivered buffer is always whole-chunk prefix + zero tail (the watchdog can never snapshot a half-copied chunk).
- `watchdogRacingFinalChunk_fullBufferIsNeverDeliveredShort` — the issue's exact scenario, one chunk from full: whichever side wins the lock, the collected prefix is intact and stable and there is exactly one delivery.

Full `testDebugUnitTest` suite green.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
