### PR TITLE
Add host tests for the EU_VHF and CONTESTING native decoders

### DIFF
--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -120,6 +120,27 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_call_hash)." }
 $callHashExit = $LASTEXITCODE
 
 # ---------------------------------------------------------------------------
+# EU_VHF / CONTESTING decoder tests (issue #403): the hand-rolled bit
+# extraction + direct formatting for i3=0 n3=2 and i3=0 n3=6 frames. Payloads
+# are assembled by an independent bit writer; callsign bits come from the
+# vendored packer, so shift/mask regressions in message.c change the rendered
+# text and fail here.
+# ---------------------------------------------------------------------------
+$contestSrcs = @(
+    "ft8\pack.c","ft8\encode.c","ft8\crc.c","ft8\constants.c",
+    "ft8\text.c","ft8\message.c"
+) | ForEach-Object { Join-Path $ft8 $_ }
+
+$srcContest = Join-Path $here "test_contest_decode.c"
+$outContest = Join-Path $env:TEMP "ft8_contest_decode_test.exe"
+
+& $Clang @common $srcContest @contestSrcs -o $outContest
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_contest_decode)." }
+
+& $outContest
+$contestExit = $LASTEXITCODE
+
+# ---------------------------------------------------------------------------
 # FIR decimator tests (C++): anti-aliasing downsample that replaced the box
 # filter in usb_audio_capture.cpp. Header-only, no ft8_lib deps; compiled with
 # clang++ (the header is C++). Own main(); exit 0 == all pass.
@@ -265,6 +286,7 @@ $xslotExit = $LASTEXITCODE
 if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
 if ($callHashExit -ne 0) { exit $callHashExit }
+if ($contestExit -ne 0) { exit $contestExit }
 if ($firExit -ne 0) { exit $firExit }
 if ($ratExit -ne 0) { exit $ratExit }
 if ($benchSelfExit -ne 0) { exit $benchSelfExit }

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -98,6 +98,26 @@ call_hash_out="$tmp/ft8_call_hash_test"
     -I "$ft8" "${call_hash_srcs[@]}" -lm -o "$call_hash_out"
 "$call_hash_out"
 
+# EU_VHF / CONTESTING decoder tests (issue #403): the hand-rolled bit
+# extraction + direct formatting for i3=0 n3=2 and i3=0 n3=6 frames. Payloads
+# are assembled by an independent bit writer; callsign bits come from the
+# vendored packer, so shift/mask regressions in message.c change the rendered
+# text and fail here.
+contest_srcs=(
+    "$here/test_contest_decode.c"
+    "$ft8/ft8/pack.c"
+    "$ft8/ft8/encode.c"
+    "$ft8/ft8/crc.c"
+    "$ft8/ft8/constants.c"
+    "$ft8/ft8/text.c"
+    "$ft8/ft8/message.c"
+)
+contest_out="$tmp/ft8_contest_decode_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" "${contest_srcs[@]}" -lm -o "$contest_out"
+"$contest_out"
+
 # FIR decimator tests (C++): anti-aliasing downsample that replaced the box filter
 # in usb_audio_capture.cpp. Header-only, no ft8_lib deps. Compiled as C++.
 CXX="${CXX:-clang++}"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_contest_decode.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_contest_decode.c
@@ -1,0 +1,264 @@
+// Host unit tests for the EU_VHF (i3=0 n3=2) and CONTESTING (i3=0 n3=6) message
+// decoders in ft8_lib/ft8/message.c — issue #403.
+//
+// Both decoders are dozens of lines of hand-rolled bit extraction (c28/p1/R1/r3/
+// s12/g25 shifts, base-24/18/10 grid6 reconstruction) with early-return direct
+// formatting, and shipped with no coverage: a wrong shift or mask would silently
+// mis-render every EU-VHF / contesting contact.
+//
+// Method: assemble 77-bit payloads with an independent MSB-first bit writer that
+// follows the documented field layout (a deliberately separate code path from the
+// decoder's shift/mask arithmetic), take the c28 callsign encoding from the
+// vendored packer itself (extracted out of a standard frame it produced, so the
+// callsign bits are pack28's real output, not a re-implementation), and assert
+// the fully-formatted decode. If any shift/mask in either decoder regresses, the
+// rendered text changes and this fails.
+//
+// Build/run: added to run_host_tests.ps1 / run_host_tests.sh. Standalone:
+//   clang -std=c11 -I ../ft8_lib -include host_compat.h test_contest_decode.c \
+//       ../ft8_lib/ft8/{pack,encode,crc,constants,text,message}.c -o /tmp/t && /tmp/t
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "ft8/message.h"
+#include "ft8/text.h"
+#include "ft8/constants.h"
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);        \
+            ++g_failures;                                                 \
+        }                                                                 \
+    } while (0)
+
+#define CHECK_STREQ(actual, expected)                                     \
+    do {                                                                  \
+        if (strcmp((actual), (expected)) != 0) {                          \
+            printf("FAIL %s:%d  got [%s] want [%s]\n",                    \
+                   __FILE__, __LINE__, (actual), (expected));             \
+            ++g_failures;                                                 \
+        }                                                                 \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// MSB-first payload bit writer/reader. Bit index b lives in payload[b >> 3] at
+// mask 0x80 >> (b & 7) — the same convention every decoder in message.c reads
+// with, but implemented via a loop rather than per-field shift/mask soup, so
+// the two sides are independent.
+// ---------------------------------------------------------------------------
+static void put_bits(uint8_t* payload, int start, int nbits, uint64_t value)
+{
+    for (int i = 0; i < nbits; ++i)
+    {
+        int b = start + i;
+        uint64_t bit = (value >> (nbits - 1 - i)) & 1u;
+        if (bit)
+            payload[b >> 3] |= (uint8_t)(0x80u >> (b & 7));
+        else
+            payload[b >> 3] &= (uint8_t)~(0x80u >> (b & 7));
+    }
+}
+
+static uint64_t get_bits(const uint8_t* payload, int start, int nbits)
+{
+    uint64_t v = 0;
+    for (int i = 0; i < nbits; ++i)
+    {
+        int b = start + i;
+        v = (v << 1) | ((payload[b >> 3] >> (7 - (b & 7))) & 1u);
+    }
+    return v;
+}
+
+// The vendored packer's own c28 encoding of a standard callsign: encode a
+// standard (type 1) frame "CQ <call> <grid>" and pull c28b out of bits 29..56.
+// Using pack28's real output (rather than re-implementing the callsign base
+// conversion) makes these tests an encode/decode consistency check.
+static uint32_t c28_of(const char* call)
+{
+    ftx_message_t msg;
+    ftx_message_init(&msg);
+    ftx_message_rc_t rc = ftx_message_encode_std(&msg, NULL, "CQ", call, "AA00");
+    CHECK(rc == FTX_MESSAGE_RC_OK);
+    return (uint32_t)get_bits(msg.payload, 29, 28);
+}
+
+// g25 for a 6-character grid, per the EU_VHF layout comment in message.c:
+// successive bases 18, 10, 10, 24, 24 (letters A-R, digits, digits, letters A-X).
+static uint32_t g25_of(const char* grid6)
+{
+    uint32_t g = (uint32_t)(grid6[0] - 'A');
+    g = g * 18 + (uint32_t)(grid6[1] - 'A');
+    g = g * 10 + (uint32_t)(grid6[2] - '0');
+    g = g * 10 + (uint32_t)(grid6[3] - '0');
+    g = g * 24 + (uint32_t)(grid6[4] - 'A');
+    g = g * 24 + (uint32_t)(grid6[5] - 'A');
+    return g;
+}
+
+// g15 for a 4-character grid, matching unpackgrid(): bases 18, 18, 10, 10.
+static uint16_t g15_of(const char* grid4)
+{
+    uint16_t g = (uint16_t)(grid4[0] - 'A');
+    g = (uint16_t)(g * 18 + (grid4[1] - 'A'));
+    g = (uint16_t)(g * 10 + (grid4[2] - '0'));
+    g = (uint16_t)(g * 10 + (grid4[3] - '0'));
+    return g;
+}
+
+// ---------------------------------------------------------------------------
+// EU_VHF: c28 (0-27) p1 (28) R1 (29) r3 (30-32) s12 (33-44) g25 (45-69),
+// n3=2 (71-73), i3=0 (74-76). Rendered "call[/P] [R ]5<r3+2><serial:4> grid6".
+// ---------------------------------------------------------------------------
+static void build_eu_vhf(ftx_message_t* msg, const char* call, int p1, int R1,
+                         int r3, int s12, const char* grid6)
+{
+    ftx_message_init(msg);
+    put_bits(msg->payload, 0, 28, c28_of(call));
+    put_bits(msg->payload, 28, 1, (uint64_t)p1);
+    put_bits(msg->payload, 29, 1, (uint64_t)R1);
+    put_bits(msg->payload, 30, 3, (uint64_t)r3);
+    put_bits(msg->payload, 33, 12, (uint64_t)s12);
+    put_bits(msg->payload, 45, 25, g25_of(grid6));
+    put_bits(msg->payload, 71, 3, 2); // n3 = 2
+    put_bits(msg->payload, 74, 3, 0); // i3 = 0
+}
+
+// ---------------------------------------------------------------------------
+// CONTESTING: c28a (0-27) c28b (28-55) g15 (56-70), n3=6 (71-73), i3=0 (74-76).
+// Rendered "call_to RR73; CQ call_de grid4".
+// ---------------------------------------------------------------------------
+static void build_contesting(ftx_message_t* msg, const char* call_to,
+                             const char* call_de, const char* grid4)
+{
+    ftx_message_init(msg);
+    put_bits(msg->payload, 0, 28, c28_of(call_to));
+    put_bits(msg->payload, 28, 28, c28_of(call_de));
+    put_bits(msg->payload, 56, 15, g15_of(grid4));
+    put_bits(msg->payload, 71, 3, 6); // n3 = 6
+    put_bits(msg->payload, 74, 3, 0); // i3 = 0
+}
+
+int main(void)
+{
+    // ---- sanity: the c28 extraction really is the packer's callsign ---------
+    // Decode the standard frame we mine c28 from; if the bit positions were
+    // wrong, everything downstream would be garbage in a confusing way.
+    {
+        ftx_message_t msg;
+        ftx_message_init(&msg);
+        CHECK(ftx_message_encode_std(&msg, NULL, "CQ", "G4ABC", "IO91")
+              == FTX_MESSAGE_RC_OK);
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "CQ G4ABC IO91");
+    }
+
+    // ---- type routing --------------------------------------------------------
+    {
+        ftx_message_t msg;
+        build_eu_vhf(&msg, "G4ABC", 0, 0, 5, 1, "IO91AB");
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_EU_VHF);
+        CHECK(ftx_message_get_i3(&msg) == 0);
+        CHECK(ftx_message_get_n3(&msg) == 2);
+
+        build_contesting(&msg, "K1ABC", "W9XYZ", "FN42");
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_CONTESTING);
+        CHECK(ftx_message_get_i3(&msg) == 0);
+        CHECK(ftx_message_get_n3(&msg) == 6);
+    }
+
+    // ---- EU_VHF: full exchange with /P and R ---------------------------------
+    // r3=7 -> strength 9 -> RST "59"; serial 1234 -> "591234" (EU VHF sends
+    // RST+serial as one 6-digit group).
+    {
+        ftx_message_t msg;
+        build_eu_vhf(&msg, "G4ABC", 1, 1, 7, 1234, "JO62QL");
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "G4ABC/P R 591234 JO62QL");
+    }
+
+    // ---- EU_VHF: plain call, no R, low report, zero-padded serial ------------
+    // r3=0 -> strength 2 -> "52"; serial 7 -> "0007".
+    {
+        ftx_message_t msg;
+        build_eu_vhf(&msg, "OK1XYZ", 0, 0, 0, 7, "JN79GG");
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "OK1XYZ 520007 JN79GG");
+    }
+
+    // ---- EU_VHF: serial field boundaries --------------------------------------
+    // s12 is 12 bits; 4095 must render in full, and the grid arithmetic must be
+    // unaffected by all-ones neighbours (shift/mask bleed shows up here).
+    {
+        ftx_message_t msg;
+        build_eu_vhf(&msg, "DL1AAA", 0, 1, 7, 4095, "JO31AA");
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "DL1AAA R 594095 JO31AA");
+    }
+
+    // ---- EU_VHF: grid6 extremes ------------------------------------------------
+    // AA00AA is g25 == 0 (all the base conversions bottom out); IR99XX pushes
+    // every digit to its maximum legal value.
+    {
+        ftx_message_t msg;
+        build_eu_vhf(&msg, "F1ABC", 0, 0, 3, 42, "AA00AA");
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "F1ABC 550042 AA00AA");
+
+        build_eu_vhf(&msg, "F1ABC", 0, 0, 3, 42, "IR99XX");
+        text[0] = '\0';
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "F1ABC 550042 IR99XX");
+    }
+
+    // ---- CONTESTING: the Fox-style combo message ------------------------------
+    {
+        ftx_message_t msg;
+        build_contesting(&msg, "K1ABC", "W9XYZ", "FN42");
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "K1ABC RR73; CQ W9XYZ FN42");
+    }
+
+    // ---- CONTESTING: c28a/c28b field independence -----------------------------
+    // Swap the calls: proves the two 28-bit fields don't bleed into each other
+    // across the byte-3 nibble boundary (c28a ends and c28b starts mid-byte).
+    {
+        ftx_message_t msg;
+        build_contesting(&msg, "W9XYZ", "K1ABC", "EM12");
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "W9XYZ RR73; CQ K1ABC EM12");
+    }
+
+    // ---- CONTESTING: grid extremes --------------------------------------------
+    {
+        ftx_message_t msg;
+        build_contesting(&msg, "JA1AAA", "VK9ZZZ", "AA00");
+        char text[64] = {0};
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "JA1AAA RR73; CQ VK9ZZZ AA00");
+
+        build_contesting(&msg, "JA1AAA", "VK9ZZZ", "RR99");
+        text[0] = '\0';
+        CHECK(ftx_message_decode(&msg, NULL, text) == FTX_MESSAGE_RC_OK);
+        CHECK_STREQ(text, "JA1AAA RR73; CQ VK9ZZZ RR99");
+    }
+
+    if (g_failures == 0)
+        printf("test_contest_decode: all checks passed\n");
+    else
+        printf("test_contest_decode: %d check(s) FAILED\n", g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

The EU_VHF (i3=0 n3=2) and CONTESTING (i3=0 n3=6) native decoders in `ft8_lib/ft8/message.c` shipped with no unit test (issue #403), violating the repo's "every new code path requires a test" rule. Both are dozens of lines of hand-rolled bit extraction (c28/p1/R1/r3/s12/g25 shifts, base-24/18/10 grid6 reconstruction) with early-return direct formatting — a wrong shift or mask would silently mis-render every EU-VHF / contesting contact, with nothing to catch the regression. Every other native DSP addition in this release got a host test (`test_call_hash.c`, `test_subtract.c`, `test_fine.c`, `test_xslot.c`, `test_osd.c`); these two were the exception.

## What this adds

New host test `ft8af_glue/test_contest_decode.c`, following the `test_call_hash.c` pattern:

- **Independent payload assembly**: a generic MSB-first bit writer builds 77-bit payloads from the documented field layouts — a deliberately separate code path from the decoder's per-field shift/mask arithmetic, so the two sides check each other.
- **Packer-sourced callsign bits**: the c28 for each callsign is mined out of a standard frame produced by the vendored packer itself (`ftx_message_encode_std`, bits 29–56), making the tests a real encode/decode consistency property rather than a re-implementation. A sanity case decodes that standard frame first.
- **EU_VHF coverage**: type routing (i3/n3); full exchange with `/P` and `R` (`G4ABC/P R 591234 JO62QL`); plain call with low report and zero-padded serial (`520007`); the s12 all-ones boundary (serial 4095 with max r3 — shift/mask bleed between neighbouring fields shows up here); grid6 extremes `AA00AA` (g25 == 0) and `IR99XX` (every digit at max).
- **CONTESTING coverage**: type routing; the Fox-style combo rendering (`K1ABC RR73; CQ W9XYZ FN42`); swapped calls proving c28a/c28b don't bleed across the mid-byte boundary; grid extremes `AA00` and `RR99`.

Wired into both `run_host_tests.ps1` and `run_host_tests.sh` (CI) as its own executable, linking only the pack/encode/message path it exercises.

## Verification

- `test_contest_decode: all checks passed` standalone.
- Full `run_host_tests.ps1` suite green end-to-end (golden encode, dev-625, call-hash, contest-decode, FIR, resampler, decode bench incl. floors, subtract, OSD, fine, cross-slot).

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
