### PR TITLE
Generalize compound-call hash recovery to all contest decoders

### DIFF
--- a/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
@@ -399,10 +399,16 @@ FT2JNI(jboolean, DecoderFt2Analysis)(JNIEnv* env, jobject, jint idx, jlong handl
             ft2_set_string(env, ft8Message, FF.maidenGrid, extra);
         ft2_set_call_hashes(env, ft8Message, call_to, FF.callToHash10, FF.callToHash12, FF.callToHash22);
         ft2_set_call_hashes(env, ft8Message, call_de, FF.callFromHash10, FF.callFromHash12, FF.callFromHash22);
+    }
 
-        // Recover the raw hash of an unresolved compound call ("<...>") from the
-        // frame so Java's seeded MessageHashMap can resolve it (issue #392); see
-        // the matching block in ft8_decode_jni.cpp for the full rationale.
+    // Post-decode hash-recovery pass, for EVERY message type (issue #402):
+    // recover the raw hash of an unresolved compound call ("<...>", or a
+    // contest frame whose calls never surface as callsign fields) straight
+    // from the frame so Java's seeded MessageHashMap can resolve it (issue
+    // #392) — keyed on the type's field layout in ft8af_call_hash22; see the
+    // matching block in ft8_decode_jni.cpp for the full rationale.
+    if (ok)
+    {
         if (type == FTX_MESSAGE_TYPE_NONSTD_CALL)
         {
             uint32_t n12 = 0;
@@ -412,12 +418,14 @@ FT2JNI(jboolean, DecoderFt2Analysis)(JNIEnv* env, jobject, jint idx, jlong handl
                                   is_to ? FF.callToHash12 : FF.callFromHash12,
                                   (jlong)n12);
         }
-        else // FTX_MESSAGE_TYPE_STANDARD
+        else
         {
             uint32_t n22 = 0;
-            if (call_to[0] == '<' && ft8af_std_hash22(&message, 0, &n22))
+            if ((call_to[0] == '\0' || call_to[0] == '<')
+                    && ft8af_call_hash22(&message, 0, &n22))
                 env->SetLongField(ft8Message, FF.callToHash22, (jlong)n22);
-            if (call_de[0] == '<' && ft8af_std_hash22(&message, 1, &n22))
+            if ((call_de[0] == '\0' || call_de[0] == '<')
+                    && ft8af_call_hash22(&message, 1, &n22))
                 env->SetLongField(ft8Message, FF.callFromHash22, (jlong)n22);
         }
     }

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_call_hash.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_call_hash.h
@@ -41,26 +41,65 @@
 #define FT8AF_NTOKENS 2063592u
 #define FT8AF_MAX22 4194304u
 
-// Standard message (i3 in {1,2}): if the callsign at position `which`
-// (0 = call_to / n28a, 1 = call_de / n28b) was transmitted as a 22-bit hash,
-// write that hash to *n22 and return true. Returns false when the field is a
-// real callsign or a directed token (nothing to resolve). Mirrors the
-// n28 - NTOKENS < MAX22 test in unpack28().
-static inline bool ft8af_std_hash22(const ftx_message_t* msg, int which, uint32_t* n22)
+// Read the 28-bit callsign field starting at payload bit `start_bit`
+// (MSB-first, the convention every decoder in ft8_lib's message.c uses).
+static inline uint32_t ft8af_get_field28(const ftx_message_t* msg, int start_bit)
 {
-    // n29a/n29b as extracted by ftx_message_decode_std; the 28-bit field is the
-    // top 28 bits (n29 >> 1); the low bit is the /R /P suffix flag.
-    uint32_t n29a = ((uint32_t)msg->payload[0] << 21) |
-                    ((uint32_t)msg->payload[1] << 13) |
-                    ((uint32_t)msg->payload[2] << 5) |
-                    ((uint32_t)msg->payload[3] >> 3);
-    uint32_t n29b = (((uint32_t)msg->payload[3] & 0x07u) << 26) |
-                    ((uint32_t)msg->payload[4] << 18) |
-                    ((uint32_t)msg->payload[5] << 10) |
-                    ((uint32_t)msg->payload[6] << 2) |
-                    ((uint32_t)msg->payload[7] >> 6);
-    uint32_t n28 = (which == 0 ? n29a : n29b) >> 1;
+    uint32_t v = 0;
+    for (int i = 0; i < 28; ++i)
+    {
+        int b = start_bit + i;
+        v = (v << 1) | ((uint32_t)(msg->payload[b >> 3] >> (7 - (b & 7))) & 1u);
+    }
+    return v;
+}
 
+// Generalized recovery (issue #402): if the c28 callsign field at position
+// `which` (0 = call_to, 1 = call_de) of ANY known message type was transmitted
+// as a 22-bit hash, write that hash to *n22 and return true. Returns false when
+// the message type carries no such field, the field is a directed token
+// (CQ/DE/QRZ), or a packed standard callsign (mirrors the
+// n28 - NTOKENS < MAX22 test in unpack28()).
+//
+// Field offsets per type, straight from the decoders in ft8_lib's message.c:
+//   STANDARD (i3=1,2)     n29a bits 0-28, n29b bits 29-57; c28 = n29 >> 1,
+//                         i.e. plain 28-bit reads at bits 0 and 29
+//   ARRL_FD (0.3/0.4),
+//   DXPEDITION (0.1),
+//   CONTESTING (0.6)      c28a bits 0-27, c28b bits 28-55
+//   EU_VHF (0.2)          a single c28 at bits 0-27 — the reporting station,
+//                         surfaced as call_de (which == 1)
+//   ARRL_RTTY (i3=3),
+//   WWROF (i3=5)          t1 at bit 0, c28a bits 1-28, c28b bits 29-56
+// New decoders that carry c28 fields only need a case here to get hash
+// recovery — instead of re-implementing the #392 backstop per JNI branch.
+static inline bool ft8af_call_hash22(const ftx_message_t* msg, int which, uint32_t* n22)
+{
+    int off;
+    switch (ftx_message_get_type(msg))
+    {
+    case FTX_MESSAGE_TYPE_STANDARD:
+        off = (which == 0) ? 0 : 29;
+        break;
+    case FTX_MESSAGE_TYPE_ARRL_FD:
+    case FTX_MESSAGE_TYPE_DXPEDITION:
+    case FTX_MESSAGE_TYPE_CONTESTING:
+        off = (which == 0) ? 0 : 28;
+        break;
+    case FTX_MESSAGE_TYPE_EU_VHF:
+        if (which != 1)
+            return false; // only one call in the frame: the reporting station
+        off = 0;
+        break;
+    case FTX_MESSAGE_TYPE_ARRL_RTTY:
+    case FTX_MESSAGE_TYPE_WWROF:
+        off = (which == 0) ? 1 : 29;
+        break;
+    default:
+        return false; // free text / telemetry / type-4 (see ft8af_nonstd_hash12)
+    }
+
+    uint32_t n28 = ft8af_get_field28(msg, off);
     if (n28 < FT8AF_NTOKENS)
         return false; // directed token (CQ/DE/QRZ), not a hash
     n28 -= FT8AF_NTOKENS;
@@ -69,6 +108,18 @@ static inline bool ft8af_std_hash22(const ftx_message_t* msg, int which, uint32_
     if (n22 != NULL)
         *n22 = n28;
     return true;
+}
+
+// Standard message (i3 in {1,2}): if the callsign at position `which`
+// (0 = call_to / n28a, 1 = call_de / n28b) was transmitted as a 22-bit hash,
+// write that hash to *n22 and return true. Kept as the historical entry point;
+// now a thin wrapper over the generalized type-keyed recovery above.
+static inline bool ft8af_std_hash22(const ftx_message_t* msg, int which, uint32_t* n22)
+{
+    ftx_message_type_t type = ftx_message_get_type(msg);
+    if (type != FTX_MESSAGE_TYPE_STANDARD)
+        return false;
+    return ft8af_call_hash22(msg, which, n22);
 }
 
 // Non-standard message (Type 4, i3=4): the frame carries exactly one 12-bit

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -722,11 +722,18 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Analysis(
             ft8_set_string(env, ft8Message, FF8.maidenGrid, extra);
         ft8_set_call_hashes(env, ft8Message, call_to, FF8.callToHash10, FF8.callToHash12, FF8.callToHash22);
         ft8_set_call_hashes(env, ft8Message, call_de, FF8.callFromHash10, FF8.callFromHash12, FF8.callFromHash22);
+    }
 
-        // A hashed compound call (e.g. answers to SV8/DM5HF) that the decoder's
-        // own hash table couldn't resolve comes back as "<...>", and the call
-        // above zeroed its hash fields. Recover the raw hash straight from the
-        // frame so Java's seeded MessageHashMap can resolve it (issue #392).
+    // Post-decode hash-recovery pass, for EVERY message type (issue #402). A
+    // hashed compound call (e.g. answers to SV8/DM5HF) that the decoder's own
+    // hash table couldn't resolve comes back as "<...>" with zeroed hash fields
+    // (ft8_set_call_hashes can't hash a placeholder). Recover the raw hash
+    // straight from the frame so Java's seeded MessageHashMap can resolve it
+    // (issue #392) — keyed on the message type's field layout inside
+    // ft8af_call_hash22, so FD/RTTY/WWROF/EU_VHF/CONTESTING (and any future
+    // decoder with c28 fields) get the backstop without a per-branch copy.
+    if (ok)
+    {
         if (type == FTX_MESSAGE_TYPE_NONSTD_CALL)
         {
             uint32_t n12 = 0;
@@ -736,12 +743,17 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderFt8Analysis(
                                   is_to ? FF8.callToHash12 : FF8.callFromHash12,
                                   (jlong)n12);
         }
-        else // FTX_MESSAGE_TYPE_STANDARD
+        else
         {
+            // Only overwrite when the decoder did NOT produce a plain call for
+            // the field: "<...>"/"<>" (unresolved hash) or "" (the generic-text
+            // contest path, which never surfaces callsign fields at all).
             uint32_t n22 = 0;
-            if (call_to[0] == '<' && ft8af_std_hash22(&message, 0, &n22))
+            if ((call_to[0] == '\0' || call_to[0] == '<')
+                    && ft8af_call_hash22(&message, 0, &n22))
                 env->SetLongField(ft8Message, FF8.callToHash22, (jlong)n22);
-            if (call_de[0] == '<' && ft8af_std_hash22(&message, 1, &n22))
+            if ((call_de[0] == '\0' || call_de[0] == '<')
+                    && ft8af_call_hash22(&message, 1, &n22))
                 env->SetLongField(ft8Message, FF8.callFromHash22, (jlong)n22);
         }
     }

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_call_hash.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_call_hash.c
@@ -157,6 +157,124 @@ int main(void)
         CHECK(!ft8af_nonstd_hash12(&msg, NULL, NULL));
     }
 
+    // ---- Generalized recovery across the contest decoders (issue #402) ------
+    // The #392 backstop is now keyed on the message type's field layout
+    // (ft8af_call_hash22), so FD/RTTY/WWROF/EU_VHF/CONTESTING frames carrying a
+    // hashed compound call recover it too. Assemble each frame with an
+    // MSB-first bit writer and place NTOKENS + n22 in a c28 field.
+    {
+        const uint32_t n22 = ref_n22(COMPOUND);
+        const uint32_t hashed_c28 = FT8AF_NTOKENS + n22;
+        // A packed standard callsign for the non-hashed side (any value past
+        // the hash range); mined from the real packer below where it matters,
+        // here an arbitrary in-range constant suffices for "not a hash".
+        const uint32_t plain_c28 = FT8AF_NTOKENS + FT8AF_MAX22 + 12345u;
+
+        ftx_message_t msg;
+        uint32_t got = 0;
+
+        // Local MSB-first bit writer (bit b -> payload[b>>3], mask 0x80>>(b&7)).
+        #define PUT_BITS(payload, start, nbits, value)                          \
+            do {                                                                \
+                for (int _i = 0; _i < (nbits); ++_i) {                          \
+                    int _b = (start) + _i;                                      \
+                    if (((uint64_t)(value) >> ((nbits) - 1 - _i)) & 1u)         \
+                        (payload)[_b >> 3] |= (uint8_t)(0x80u >> (_b & 7));     \
+                }                                                               \
+            } while (0)
+
+        // ARRL_FD (i3=0 n3=3): c28a 0-27 hashed, c28b 28-55 plain.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        PUT_BITS(msg.payload, 0, 28, hashed_c28);
+        PUT_BITS(msg.payload, 28, 28, plain_c28);
+        PUT_BITS(msg.payload, 71, 3, 3);
+        PUT_BITS(msg.payload, 74, 3, 0);
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_ARRL_FD);
+        CHECK(ft8af_call_hash22(&msg, 0, &got) && got == n22);
+        CHECK(!ft8af_call_hash22(&msg, 1, &got)); // plain call: nothing to resolve
+
+        // CONTESTING (i3=0 n3=6): c28b 28-55 hashed this time.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        PUT_BITS(msg.payload, 0, 28, plain_c28);
+        PUT_BITS(msg.payload, 28, 28, hashed_c28);
+        PUT_BITS(msg.payload, 71, 3, 6);
+        PUT_BITS(msg.payload, 74, 3, 0);
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_CONTESTING);
+        CHECK(!ft8af_call_hash22(&msg, 0, &got));
+        CHECK(ft8af_call_hash22(&msg, 1, &got) && got == n22);
+
+        // DXPEDITION (i3=0 n3=1): same 0/28 layout as FD/CONTESTING.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        PUT_BITS(msg.payload, 0, 28, hashed_c28);
+        PUT_BITS(msg.payload, 28, 28, hashed_c28);
+        PUT_BITS(msg.payload, 71, 3, 1);
+        PUT_BITS(msg.payload, 74, 3, 0);
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_DXPEDITION);
+        CHECK(ft8af_call_hash22(&msg, 0, &got) && got == n22);
+        CHECK(ft8af_call_hash22(&msg, 1, &got) && got == n22);
+
+        // EU_VHF (i3=0 n3=2): single c28 at 0-27, surfaced as call_de.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        PUT_BITS(msg.payload, 0, 28, hashed_c28);
+        PUT_BITS(msg.payload, 71, 3, 2);
+        PUT_BITS(msg.payload, 74, 3, 0);
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_EU_VHF);
+        CHECK(!ft8af_call_hash22(&msg, 0, &got)); // no call_to in the frame
+        CHECK(ft8af_call_hash22(&msg, 1, &got) && got == n22);
+
+        // ARRL_RTTY (i3=3): t1 at bit 0 shifts the fields to 1-28 / 29-56.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        PUT_BITS(msg.payload, 0, 1, 1); // t1 ("TU;") set — must not corrupt c28a
+        PUT_BITS(msg.payload, 1, 28, hashed_c28);
+        PUT_BITS(msg.payload, 29, 28, plain_c28);
+        PUT_BITS(msg.payload, 74, 3, 3);
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_ARRL_RTTY);
+        CHECK(ft8af_call_hash22(&msg, 0, &got) && got == n22);
+        CHECK(!ft8af_call_hash22(&msg, 1, &got));
+
+        // WWROF (i3=5): same t1-shifted layout as RTTY.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        PUT_BITS(msg.payload, 1, 28, plain_c28);
+        PUT_BITS(msg.payload, 29, 28, hashed_c28);
+        PUT_BITS(msg.payload, 74, 3, 5);
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_WWROF);
+        CHECK(!ft8af_call_hash22(&msg, 0, &got));
+        CHECK(ft8af_call_hash22(&msg, 1, &got) && got == n22);
+
+        // FREE_TEXT (i3=0 n3=0): no callsign fields at all -> never recovers.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        CHECK(ftx_message_get_type(&msg) == FTX_MESSAGE_TYPE_FREE_TEXT);
+        CHECK(!ft8af_call_hash22(&msg, 0, &got));
+        CHECK(!ft8af_call_hash22(&msg, 1, &got));
+
+        // A directed token (CQ, c28 == 2) in a contest frame: not a hash.
+        memset(msg.payload, 0, sizeof(msg.payload));
+        PUT_BITS(msg.payload, 0, 28, 2); // "CQ"
+        PUT_BITS(msg.payload, 28, 28, hashed_c28);
+        PUT_BITS(msg.payload, 71, 3, 6);
+        PUT_BITS(msg.payload, 74, 3, 0);
+        CHECK(!ft8af_call_hash22(&msg, 0, &got));
+        CHECK(ft8af_call_hash22(&msg, 1, &got) && got == n22);
+
+        #undef PUT_BITS
+    }
+
+    // ---- The standard-frame wrapper still agrees with the general pass ------
+    // ft8af_std_hash22 is now a thin wrapper over ft8af_call_hash22; re-run the
+    // packer-produced standard frame through BOTH entry points.
+    {
+        ftx_message_t msg;
+        ftx_message_rc_t rc =
+            ftx_message_encode_std(&msg, &g_hash_if, COMPOUND, "K1ABC", "JN35");
+        CHECK(rc == FTX_MESSAGE_RC_OK);
+
+        uint32_t via_std = 0, via_general = 0;
+        CHECK(ft8af_std_hash22(&msg, 0, &via_std));
+        CHECK(ft8af_call_hash22(&msg, 0, &via_general));
+        CHECK(via_std == via_general);
+        CHECK(via_general == ref_n22(COMPOUND));
+    }
+
     // ---- WSJT-X interop golden vectors -------------------------------------
     // The 77-bit payloads below were produced by WSJT-X's own reference packer
     // (ft8code, WSJT-X 2.x) for the two frames a station sends when answering


### PR DESCRIPTION
## Problem

The issue-#392 raw-hash recovery backstop (pull a compound call's 22-/12-bit hash out of the payload when the decoder yields `<...>`) was wired into only the `STANDARD` and `NONSTD_CALL` branches of `ft8_decode_jni.cpp` / `ft2_decode_jni.cpp`. The contest decoders added in this release (`ARRL_FD`, `ARRL_RTTY`, `WWROF`, `EU_VHF`, `CONTESTING`, plus `DXPEDITION`) call `ft8_set_call_hashes`, which zeroes the hash fields for a `<...>` placeholder, and never attempt recovery — so a compound call inside a contest exchange resolves to `<...>` with no way for Java's seeded `MessageHashMap` to fix it. #392 re-introduced once per message type, and every future decoder would have to remember to re-add the recovery call.

## Fix

One generalized, type-keyed recovery pass instead of per-branch copies:

- **`ft8_call_hash.h`**: new `ft8af_call_hash22(msg, which, &n22)` — looks up the message type's c28 field offsets (STANDARD 0/29 via the n29>>1 equivalence; FD/DXpedition/CONTESTING 0/28; EU_VHF single call at 0, surfaced as call_de; RTTY/WWROF t1-shifted 1/29 — all straight from the decoders in `message.c`), extracts the field with a generic MSB-first reader, and applies the same `NTOKENS`/`MAX22` hash-range test as `unpack28`. A new decoder with c28 fields only needs a `case` here. `ft8af_std_hash22` remains as a thin wrapper (returns false for non-standard types, so existing callers are unchanged); `ft8af_nonstd_hash12` is untouched.
- **`ft8_decode_jni.cpp` / `ft2_decode_jni.cpp`**: the recovery block moves out of the `STANDARD || NONSTD_CALL` gate into a post-decode pass that runs for **every** successfully decoded type. The hash is only written when the decoder did not produce a plain call for that field (`<...>`/`<>` unresolved placeholder, or the generic-text contest path which never surfaces callsign fields); a call the decoder's own table resolved is left alone, exactly as before.

Behavior for STANDARD/NONSTD frames is bit-for-bit what it was; the contest types gain the backstop.

## Tests

`test_call_hash.c` extended (host suite, both runners):
- Generalized recovery across all five contest layouts plus DXpedition: hashed c28 in each documented field position recovers exactly the reference WSJT-X hash, including the t1-shifted RTTY/WWROF layouts (t1 set, proving no bleed) and EU_VHF's single-call mapping.
- Negatives: plain packed callsigns and the `CQ` token recover nothing; FREE_TEXT recovers nothing on either side; EU_VHF has no call_to.
- Wrapper equivalence: a packer-produced standard frame yields the same hash through `ft8af_std_hash22` and `ft8af_call_hash22`.
- All pre-existing checks (packer frames, WSJT-X golden interop vectors) unchanged and green.

`test_call_hash: all checks passed`; Android build (`assembleDebug`, all four ABIs) compiles the JNI changes clean.

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
