### PR TITLE
Consolidate RX input-level metering onto one classifier

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioInputLevel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioInputLevel.java
@@ -105,11 +105,18 @@ public final class AudioInputLevel {
      * exactly one set of thresholds.
      */
     public static Reading fromPeakRms(float peak, float rms) {
-        float p = Math.max(0f, peak);
-        float r = Math.max(0f, rms);
+        // Sanitize non-finite inputs to digital silence: Math.max(0f, NaN) is
+        // NaN, which would flow into toDbfs/classify (where every comparison
+        // against a NaN is false) and misreport GOOD with NaN dB values.
+        float p = isFinite(peak) ? Math.max(0f, peak) : 0f;
+        float r = isFinite(rms) ? Math.max(0f, rms) : 0f;
         float peakDbfs = toDbfs(p);
         float rmsDbfs = toDbfs(r);
         return new Reading(p, r, peakDbfs, rmsDbfs, classify(p, peakDbfs, rmsDbfs));
+    }
+
+    private static boolean isFinite(float v) {
+        return !Float.isNaN(v) && !Float.isInfinite(v);
     }
 
     /** Linear magnitude (>=0) to dBFS, with a {@link #MIN_DBFS} floor for silence. */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioInputLevel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/spectrum/AudioInputLevel.java
@@ -93,10 +93,23 @@ public final class AudioInputLevel {
             sumSquares += (double) s * (double) s;
         }
         float rms = (float) Math.sqrt(sumSquares / samples.length);
+        return fromPeakRms(peak, rms);
+    }
 
-        float peakDbfs = toDbfs(peak);
-        float rmsDbfs = toDbfs(rms);
-        return new Reading(peak, rms, peakDbfs, rmsDbfs, classify(peak, peakDbfs, rmsDbfs));
+    /**
+     * Meter from an already-accumulated linear peak/RMS pair — e.g. the 250&nbsp;ms
+     * window snapshots {@code InputAudioLevel} produces for the Compose waterfall
+     * strip. This is the single classification entry point for every RX level UI
+     * (issue #405): the spectrum fragment's per-buffer {@link #compute} and the
+     * windowed Compose meter both land here, so the "healthy gain window" lives in
+     * exactly one set of thresholds.
+     */
+    public static Reading fromPeakRms(float peak, float rms) {
+        float p = Math.max(0f, peak);
+        float r = Math.max(0f, rms);
+        float peakDbfs = toDbfs(p);
+        float rmsDbfs = toDbfs(r);
+        return new Reading(p, r, peakDbfs, rmsDbfs, classify(p, peakDbfs, rmsDbfs));
     }
 
     /** Linear magnitude (>=0) to dBFS, with a {@link #MIN_DBFS} floor for silence. */

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicator.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicator.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.k1af.ft8af.R
+import com.k1af.ft8af.spectrum.AudioInputLevel
 import com.k1af.ft8af.wave.InputAudioLevel
 import radio.ks3ckc.ft8af.theme.BgSurface3
 import radio.ks3ckc.ft8af.theme.GeistMonoFamily
@@ -32,30 +33,18 @@ import radio.ks3ckc.ft8af.theme.TextMuted
 import kotlin.math.roundToInt
 
 /**
- * RX input-level classification (issue #356). Thresholds are on the window
- * PEAK as a fraction of full scale:
- *  - below [INPUT_LEVEL_LOW] .................. too low
- *  - [INPUT_LEVEL_LOW]..[INPUT_LEVEL_HIGH] .... just right
- *  - above [INPUT_LEVEL_HIGH] ................. too high
- *  - at/above [INPUT_LEVEL_CLIP] .............. clipping (full-scale hit)
+ * Classify a metering-window snapshot into the color-coded status shown next
+ * to the meter. Delegates to [AudioInputLevel], the app's single RX
+ * level classifier (issue #405): this strip and the legacy spectrum meter now
+ * judge the same audio with the same peak/RMS dBFS thresholds, so the two UIs
+ * can never disagree and the healthy-gain window is tuned in one place.
  */
-internal const val INPUT_LEVEL_LOW = 0.25f
-internal const val INPUT_LEVEL_HIGH = 0.75f
-internal const val INPUT_LEVEL_CLIP = 0.99f
-
-internal enum class InputLevelStatus { TOO_LOW, JUST_RIGHT, TOO_HIGH, CLIPPING }
-
-/**
- * Classify a metering-window peak (1.0 = full scale) into the color-coded
- * status shown next to the meter. Boundary values 25% and 75% both count as
- * "just right" so the advertised 25–75% window is inclusive.
- */
-internal fun classifyInputLevel(peak: Float): InputLevelStatus = when {
-    peak >= INPUT_LEVEL_CLIP -> InputLevelStatus.CLIPPING
-    peak > INPUT_LEVEL_HIGH -> InputLevelStatus.TOO_HIGH
-    peak < INPUT_LEVEL_LOW -> InputLevelStatus.TOO_LOW
-    else -> InputLevelStatus.JUST_RIGHT
-}
+internal fun classifyInputLevel(levels: InputAudioLevel.Levels?): AudioInputLevel.Status =
+    if (levels == null) {
+        AudioInputLevel.Status.SILENT
+    } else {
+        AudioInputLevel.fromPeakRms(levels.peak, levels.rms).status
+    }
 
 /** Meter-bar fill fraction for a sample level, clamped to 0..1. */
 internal fun inputLevelFraction(level: Float): Float = level.coerceIn(0f, 1f)
@@ -77,16 +66,9 @@ internal fun InputLevelIndicator(
 ) {
     val peak = levels?.peak ?: 0f
     val rms = levels?.rms ?: 0f
-    val status = classifyInputLevel(peak)
+    val status = classifyInputLevel(levels)
     val color = inputLevelColor(status)
-    val statusText = stringResource(
-        when (status) {
-            InputLevelStatus.TOO_LOW -> R.string.input_level_too_low
-            InputLevelStatus.JUST_RIGHT -> R.string.input_level_good
-            InputLevelStatus.TOO_HIGH -> R.string.input_level_too_high
-            InputLevelStatus.CLIPPING -> R.string.input_level_clipping
-        },
-    )
+    val statusText = stringResource(inputLevelStatusText(status))
 
     Row(
         modifier = modifier,
@@ -147,10 +129,28 @@ internal fun InputLevelIndicator(
     }
 }
 
-/** Status color: blue = too low, green = good, yellow = hot, red = clipping. */
-internal fun inputLevelColor(status: InputLevelStatus): Color = when (status) {
-    InputLevelStatus.TOO_LOW -> StatusWorked
-    InputLevelStatus.JUST_RIGHT -> StatusConfirmed
-    InputLevelStatus.TOO_HIGH -> StatusWarn
-    InputLevelStatus.CLIPPING -> StatusBad
+/**
+ * Status color: grey = no input, blue = too low, green = good, yellow = hot,
+ * red = clipping. Same semantics as the legacy meter's AudioLevelDisplay
+ * palette, in this theme's colors.
+ */
+internal fun inputLevelColor(status: AudioInputLevel.Status): Color = when (status) {
+    AudioInputLevel.Status.SILENT -> TextMuted
+    AudioInputLevel.Status.LOW -> StatusWorked
+    AudioInputLevel.Status.GOOD -> StatusConfirmed
+    AudioInputLevel.Status.HIGH -> StatusWarn
+    AudioInputLevel.Status.CLIPPING -> StatusBad
+}
+
+/**
+ * Status word resource. SILENT reuses the "too low" wording — the actionable
+ * advice (turn the input up / check the cable) is the same, and the muted
+ * color already distinguishes a dead input from a merely-quiet one.
+ */
+internal fun inputLevelStatusText(status: AudioInputLevel.Status): Int = when (status) {
+    AudioInputLevel.Status.SILENT,
+    AudioInputLevel.Status.LOW -> R.string.input_level_too_low
+    AudioInputLevel.Status.GOOD -> R.string.input_level_good
+    AudioInputLevel.Status.HIGH -> R.string.input_level_too_high
+    AudioInputLevel.Status.CLIPPING -> R.string.input_level_clipping
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioInputLevelTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioInputLevelTest.java
@@ -33,6 +33,44 @@ public class AudioInputLevelTest {
         }
     }
 
+    // ---- fromPeakRms (issue #405: the shared entry point for windowed meters) ----
+
+    @Test
+    public void fromPeakRms_agreesWithComputeOnTheSameAudio() {
+        // The Compose strip feeds window peak/RMS pairs through fromPeakRms;
+        // classification must be identical to compute() over the raw buffer.
+        float[][] buffers = {
+                constant(0.001f, 256), // LOW
+                constant(0.1f, 256),   // GOOD
+                constant(0.9f, 256),   // HIGH
+                constant(1.0f, 64),    // CLIPPING
+        };
+        for (float[] buffer : buffers) {
+            Reading direct = AudioInputLevel.compute(buffer);
+            Reading viaPair = AudioInputLevel.fromPeakRms(direct.peak, direct.rms);
+            assertThat(viaPair.status).isEqualTo(direct.status);
+            assertThat(viaPair.peakDbfs).isEqualTo(direct.peakDbfs);
+            assertThat(viaPair.rmsDbfs).isEqualTo(direct.rmsDbfs);
+        }
+    }
+
+    @Test
+    public void fromPeakRms_zeroPair_isSilent() {
+        Reading r = AudioInputLevel.fromPeakRms(0f, 0f);
+        assertThat(r.status).isEqualTo(Status.SILENT);
+        assertThat(r.peakDbfs).isEqualTo(AudioInputLevel.MIN_DBFS);
+        assertThat(r.rmsDbfs).isEqualTo(AudioInputLevel.MIN_DBFS);
+    }
+
+    @Test
+    public void fromPeakRms_negativeInputs_clampToSilence() {
+        // Defensive: a corrupted snapshot must not produce NaN dBFS.
+        Reading r = AudioInputLevel.fromPeakRms(-0.5f, -0.5f);
+        assertThat(r.peak).isEqualTo(0f);
+        assertThat(r.rms).isEqualTo(0f);
+        assertThat(r.status).isEqualTo(Status.SILENT);
+    }
+
     @Test
     public void peakAndRms_ofConstantMagnitude() {
         // |sample| == 0.1 everywhere, so peak == rms == 0.1, i.e. -20 dBFS.

--- a/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioInputLevelTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/spectrum/AudioInputLevelTest.java
@@ -72,6 +72,26 @@ public class AudioInputLevelTest {
     }
 
     @Test
+    public void fromPeakRms_nonFiniteInputs_sanitizeToSilence() {
+        // Math.max(0f, NaN) is NaN, and every classify() comparison against NaN
+        // is false — which would misreport GOOD with NaN dB values. Non-finite
+        // inputs (corrupted upstream math) must read as digital silence instead.
+        float[] poison = {Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY};
+        for (float bad : poison) {
+            Reading r = AudioInputLevel.fromPeakRms(bad, bad);
+            assertThat(r.peak).isEqualTo(0f);
+            assertThat(r.rms).isEqualTo(0f);
+            assertThat(r.peakDbfs).isEqualTo(AudioInputLevel.MIN_DBFS);
+            assertThat(r.rmsDbfs).isEqualTo(AudioInputLevel.MIN_DBFS);
+            assertThat(r.status).isEqualTo(Status.SILENT);
+        }
+        // One poisoned field doesn't corrupt the other's value.
+        Reading mixed = AudioInputLevel.fromPeakRms(Float.NaN, 0.05f);
+        assertThat(mixed.peak).isEqualTo(0f);
+        assertThat(mixed.rms).isWithin(1e-6f).of(0.05f);
+    }
+
+    @Test
     public void peakAndRms_ofConstantMagnitude() {
         // |sample| == 0.1 everywhere, so peak == rms == 0.1, i.e. -20 dBFS.
         Reading r = AudioInputLevel.compute(constant(0.1f, 256));

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicatorTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/InputLevelIndicatorTest.kt
@@ -1,74 +1,88 @@
 package radio.ks3ckc.ft8af.ui.components
 
 import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import com.k1af.ft8af.spectrum.AudioInputLevel
+import com.k1af.ft8af.wave.InputAudioLevel
 import org.junit.Test
 import radio.ks3ckc.ft8af.theme.StatusBad
 import radio.ks3ckc.ft8af.theme.StatusConfirmed
 import radio.ks3ckc.ft8af.theme.StatusWarn
 import radio.ks3ckc.ft8af.theme.StatusWorked
+import radio.ks3ckc.ft8af.theme.TextMuted
 
 /**
  * Tests the extracted decision/geometry logic behind the RX input-level
- * indicator (issue #356): peak -> status classification, meter fill fraction,
- * percent readout, and status -> color mapping. Pure logic — no runner needed.
+ * indicator. Since issue #405 the classification delegates to
+ * [AudioInputLevel] — the same peak/RMS dBFS thresholds the legacy spectrum
+ * meter uses — so these cases pin the delegation and the strip's own mappers
+ * (fill fraction, percent readout, color, status text). Pure logic — no
+ * runner needed.
  */
 class InputLevelIndicatorTest {
 
+    private fun levels(peak: Float, rms: Float) = InputAudioLevel.Levels(peak, rms)
+
     // ------------------------------------------------------------------
-    // classifyInputLevel
+    // classifyInputLevel — one classifier with the legacy meter (issue #405)
     // ------------------------------------------------------------------
 
     @Test
-    fun silence_isTooLow() {
-        assertThat(classifyInputLevel(0f)).isEqualTo(InputLevelStatus.TOO_LOW)
+    fun nullLevels_isSilent() {
+        assertThat(classifyInputLevel(null)).isEqualTo(AudioInputLevel.Status.SILENT)
     }
 
     @Test
-    fun belowLowThreshold_isTooLow() {
-        assertThat(classifyInputLevel(0.249f)).isEqualTo(InputLevelStatus.TOO_LOW)
+    fun digitalSilence_isSilent() {
+        assertThat(classifyInputLevel(levels(0f, 0f)))
+            .isEqualTo(AudioInputLevel.Status.SILENT)
     }
 
     @Test
-    fun lowBoundary_isJustRight() {
-        // 25% is inclusive: the advertised window is 25-75%.
-        assertThat(classifyInputLevel(0.25f)).isEqualTo(InputLevelStatus.JUST_RIGHT)
+    fun quietInput_isLow() {
+        // RMS -60 dBFS: audible but below the -45 dBFS weak-signal floor.
+        assertThat(classifyInputLevel(levels(0.01f, 0.001f)))
+            .isEqualTo(AudioInputLevel.Status.LOW)
     }
 
     @Test
-    fun midRange_isJustRight() {
-        assertThat(classifyInputLevel(0.5f)).isEqualTo(InputLevelStatus.JUST_RIGHT)
+    fun healthyInput_isGood() {
+        // RMS ~ -26 dBFS with peaks well under the -3 dBFS hot line.
+        assertThat(classifyInputLevel(levels(0.3f, 0.05f)))
+            .isEqualTo(AudioInputLevel.Status.GOOD)
     }
 
     @Test
-    fun highBoundary_isJustRight() {
-        // 75% is inclusive too.
-        assertThat(classifyInputLevel(0.75f)).isEqualTo(InputLevelStatus.JUST_RIGHT)
+    fun hotPeaks_areHigh() {
+        // Peak -0.9 dBFS: above the -3 dBFS hot threshold, below the clip point.
+        assertThat(classifyInputLevel(levels(0.9f, 0.1f)))
+            .isEqualTo(AudioInputLevel.Status.HIGH)
     }
 
     @Test
-    fun aboveHighThreshold_isTooHigh() {
-        assertThat(classifyInputLevel(0.76f)).isEqualTo(InputLevelStatus.TOO_HIGH)
-    }
-
-    @Test
-    fun justBelowClip_isTooHigh() {
-        assertThat(classifyInputLevel(0.989f)).isEqualTo(InputLevelStatus.TOO_HIGH)
-    }
-
-    @Test
-    fun clipThreshold_isClipping() {
-        assertThat(classifyInputLevel(INPUT_LEVEL_CLIP)).isEqualTo(InputLevelStatus.CLIPPING)
-    }
-
-    @Test
-    fun fullScale_isClipping() {
-        assertThat(classifyInputLevel(1.0f)).isEqualTo(InputLevelStatus.CLIPPING)
-    }
-
-    @Test
-    fun beyondFullScale_isClipping() {
+    fun pinnedPeaks_areClipping() {
+        assertThat(classifyInputLevel(levels(0.99f, 0.3f)))
+            .isEqualTo(AudioInputLevel.Status.CLIPPING)
         // Gain > 100% can push samples past +/-1.0.
-        assertThat(classifyInputLevel(1.8f)).isEqualTo(InputLevelStatus.CLIPPING)
+        assertThat(classifyInputLevel(levels(1.8f, 0.5f)))
+            .isEqualTo(AudioInputLevel.Status.CLIPPING)
+    }
+
+    @Test
+    fun agreesWithTheLegacyMeterOnTheSameAudio() {
+        // The whole point of issue #405: the same peak/RMS pair must classify
+        // identically to AudioInputLevel (what SpectrumFragment shows).
+        val cases = listOf(
+            0f to 0f,
+            0.01f to 0.001f,
+            0.3f to 0.05f,
+            0.9f to 0.1f,
+            0.99f to 0.3f,
+        )
+        for ((peak, rms) in cases) {
+            assertThat(classifyInputLevel(levels(peak, rms)))
+                .isEqualTo(AudioInputLevel.fromPeakRms(peak, rms).status)
+        }
     }
 
     // ------------------------------------------------------------------
@@ -107,14 +121,29 @@ class InputLevelIndicatorTest {
     }
 
     // ------------------------------------------------------------------
-    // inputLevelColor
+    // inputLevelColor / inputLevelStatusText
     // ------------------------------------------------------------------
 
     @Test
     fun colors_matchStatusSemantics() {
-        assertThat(inputLevelColor(InputLevelStatus.TOO_LOW)).isEqualTo(StatusWorked)
-        assertThat(inputLevelColor(InputLevelStatus.JUST_RIGHT)).isEqualTo(StatusConfirmed)
-        assertThat(inputLevelColor(InputLevelStatus.TOO_HIGH)).isEqualTo(StatusWarn)
-        assertThat(inputLevelColor(InputLevelStatus.CLIPPING)).isEqualTo(StatusBad)
+        assertThat(inputLevelColor(AudioInputLevel.Status.SILENT)).isEqualTo(TextMuted)
+        assertThat(inputLevelColor(AudioInputLevel.Status.LOW)).isEqualTo(StatusWorked)
+        assertThat(inputLevelColor(AudioInputLevel.Status.GOOD)).isEqualTo(StatusConfirmed)
+        assertThat(inputLevelColor(AudioInputLevel.Status.HIGH)).isEqualTo(StatusWarn)
+        assertThat(inputLevelColor(AudioInputLevel.Status.CLIPPING)).isEqualTo(StatusBad)
+    }
+
+    @Test
+    fun statusText_coversEveryStatus() {
+        assertThat(inputLevelStatusText(AudioInputLevel.Status.SILENT))
+            .isEqualTo(R.string.input_level_too_low)
+        assertThat(inputLevelStatusText(AudioInputLevel.Status.LOW))
+            .isEqualTo(R.string.input_level_too_low)
+        assertThat(inputLevelStatusText(AudioInputLevel.Status.GOOD))
+            .isEqualTo(R.string.input_level_good)
+        assertThat(inputLevelStatusText(AudioInputLevel.Status.HIGH))
+            .isEqualTo(R.string.input_level_too_high)
+        assertThat(inputLevelStatusText(AudioInputLevel.Status.CLIPPING))
+            .isEqualTo(R.string.input_level_clipping)
     }
 }


### PR DESCRIPTION
## Problem

The app shipped **two** parallel RX input-level metering/classification stacks judging the same 12 kHz RX audio for the same purpose (help the operator set radio gain) on **different thresholds** (issue #405):

- **Stack A** (legacy View / SpectrumFragment): `AudioInputLevel` (peak/RMS/dBFS, 5-state `Status`) + `AudioLevelDisplay` — judges "too quiet"/"good" on **RMS dBFS** (SILENT < -75, LOW < -45, HIGH ≥ -3 dBFS peak, CLIP ≥ 0.985 linear peak).
- **Stack B** (Compose waterfall strip): `InputAudioLevel` windowing + `classifyInputLevel` in `InputLevelIndicator.kt` — judged everything on **linear peak fraction** (25% / 75% / 99%), a 4-state enum, and its own color map.

An operator saw different verdicts on the same audio depending on which screen they looked at, and a maintainer tuning the healthy-gain window had to edit two classifiers, two enums, and two color maps.

## Fix

`AudioInputLevel` is now the single classifier:

- New `AudioInputLevel.fromPeakRms(peak, rms)` entry point classifies an already-accumulated linear peak/RMS pair (what `InputAudioLevel`'s 250 ms windows produce) through the exact thresholds `compute()` uses — `compute()` itself now delegates to it, so the two entry points cannot drift. Negative inputs clamp to silence rather than producing NaN dBFS.
- `InputLevelIndicator.kt`: the private threshold constants (`INPUT_LEVEL_LOW/HIGH/CLIP`) and the 4-state `InputLevelStatus` enum are **deleted**. `classifyInputLevel(levels)` is a thin delegate to `AudioInputLevel.fromPeakRms(...).status`; `inputLevelColor`/`inputLevelStatusText` map the shared 5-state `AudioInputLevel.Status` to this theme's colors and existing strings (SILENT gets the muted color and reuses the "too low" wording — same actionable advice, visually distinct, no new strings across 16 locales).
- `InputAudioLevel`'s windowing (250 ms peak/RMS snapshots, gain handling) and the legacy `AudioLevelDisplay` label/color mappers are unchanged — both UIs are now thin mappers over one unit-tested classifier, exactly as the issue suggested.

The Compose strip's verdicts change by design: it now judges on RMS dBFS + peak dBFS like the spectrum meter (and WSJT-X-style metering), instead of raw peak fractions.

## Tests

- `AudioInputLevelTest`: `fromPeakRms` agrees with `compute()` on the same audio across LOW/GOOD/HIGH/CLIPPING buffers (status and dBFS values), zero pair is SILENT, negative inputs clamp to silence.
- `InputLevelIndicatorTest`: rewritten against the unified classifier — null/silent/quiet/healthy/hot/pinned cases, an explicit `agreesWithTheLegacyMeterOnTheSameAudio` cross-check, geometry helpers unchanged, color and status-text maps cover all five states.
- `AudioLevelDisplayTest` and the rest of the suite: green (full `testDebugUnitTest`).

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
