### PR TITLE
Add Tune button: on-demand single-tone carrier for antenna/amplifier tuning

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -108,6 +108,18 @@ public class GeneralVariables {
     //Serialized band=level CSV ("20m=60,40m=85"); parsed/updated in PerBandOutputLevel.kt.
     public static volatile String perBandOutputLevels = "";
 
+    //Tune button (issue #408): hard cap on a single tune carrier in seconds
+    //(clamped by TuneController), whether the tune level is independent of the
+    //FT8 drive, the global independent level (0..100), and the per-band
+    //independent levels (same CSV format as perBandOutputLevels; gated on the
+    //same savePerBandOutputLevel toggle, separate backing store — see
+    //TuneLevel.kt). volatile: written from the config-load thread + Settings,
+    //read from the tune audio worker per chunk.
+    public static volatile int tuneMaxOnSeconds = 10;
+    public static volatile boolean tuneLevelIndependent = false;
+    public static volatile int tuneLevel = 25;
+    public static volatile String perBandTuneLevels = "";
+
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -688,8 +688,13 @@ public class MainViewModel extends ViewModel {
                         baseRig != null && baseRig.supportWaveOverCAT());
             }
 
-            @Override
-            public void onBeforeTransmit(Ft8Message message, int functionOder) {
+            /**
+             * Assert PTT (+ pause SCO) through the configured control path. Shared
+             * by the FT8 TX path and the tune carrier (issue #408) so the
+             * CAT/RTS/DTR branching lives in one place; with no control path
+             * (VOX), this is a no-op and the audio itself keys the rig.
+             */
+            private void beginKeying() {
                 if (GeneralVariables.controlMode == ControlMode.CAT
                         || GeneralVariables.controlMode == ControlMode.RTS
                         || GeneralVariables.controlMode == ControlMode.DTR) {
@@ -699,15 +704,10 @@ public class MainViewModel extends ViewModel {
                         baseRig.setPTT(true);
                     }
                 }
-                if (ft8TransmitSignal.isActivated()) {
-                    GeneralVariables.transmitMessages.add(message);
-                    //mutableTransmitMessages.postValue(GeneralVariables.transmitMessages);
-                    mutableTransmitMessagesCount.postValue(1);
-                }
             }
 
-            @Override
-            public void onAfterTransmit(Ft8Message message, int functionOder) {
+            /** Release PTT (+ restore SCO); counterpart of {@link #beginKeying()}. */
+            private void endKeying() {
                 if (GeneralVariables.controlMode == ControlMode.CAT
                         || GeneralVariables.controlMode == ControlMode.RTS
                         || GeneralVariables.controlMode == ControlMode.DTR) {
@@ -717,6 +717,31 @@ public class MainViewModel extends ViewModel {
                         if (needControlSco()) startSco();
                     }
                 }
+            }
+
+            @Override
+            public void onBeforeTransmit(Ft8Message message, int functionOder) {
+                beginKeying();
+                if (ft8TransmitSignal.isActivated()) {
+                    GeneralVariables.transmitMessages.add(message);
+                    //mutableTransmitMessages.postValue(GeneralVariables.transmitMessages);
+                    mutableTransmitMessagesCount.postValue(1);
+                }
+            }
+
+            @Override
+            public void onAfterTransmit(Ft8Message message, int functionOder) {
+                endKeying();
+            }
+
+            @Override
+            public void onTuneKeyDown() {
+                beginKeying();
+            }
+
+            @Override
+            public void onTuneKeyUp() {
+                endKeying();
             }
 
             @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2597,22 +2597,26 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 if (name.equalsIgnoreCase("tuneMaxOnSeconds")) {//Tune carrier hard cap (issue #408)
                     //Defensive parse: settings import (#382) can feed anything here.
-                    //Non-numeric keeps the default; TuneController clamps the range.
-                    try {
-                        GeneralVariables.tuneMaxOnSeconds =
-                                com.k1af.ft8af.ft8transmit.TuneController.clampMaxOnSeconds(
-                                        Integer.parseInt(result.trim()));
-                    } catch (NumberFormatException ignored) {
+                    //Null/non-numeric keeps the default; TuneController clamps the range.
+                    if (result != null) {
+                        try {
+                            GeneralVariables.tuneMaxOnSeconds =
+                                    com.k1af.ft8af.ft8transmit.TuneController.clampMaxOnSeconds(
+                                            Integer.parseInt(result.trim()));
+                        } catch (NumberFormatException ignored) {
+                        }
                     }
                 }
                 if (name.equalsIgnoreCase("tuneLevelIndependent")) {//Tune level decoupled from TX drive
-                    GeneralVariables.tuneLevelIndependent = result.equals("1");
+                    GeneralVariables.tuneLevelIndependent = "1".equals(result);
                 }
                 if (name.equalsIgnoreCase("tuneLevel")) {//Global independent tune level (0..100)
-                    try {
-                        GeneralVariables.tuneLevel =
-                                Math.max(0, Math.min(100, Integer.parseInt(result.trim())));
-                    } catch (NumberFormatException ignored) {
+                    if (result != null) {
+                        try {
+                            GeneralVariables.tuneLevel =
+                                    Math.max(0, Math.min(100, Integer.parseInt(result.trim())));
+                        } catch (NumberFormatException ignored) {
+                        }
                     }
                 }
                 if (name.equalsIgnoreCase("perBandTuneLevels")) {//Per-band independent tune levels

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2595,6 +2595,29 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("perBandOutputLevels")) {//Per-band TX output levels ("20m=60,40m=85")
                     GeneralVariables.perBandOutputLevels = result == null ? "" : result;
                 }
+                if (name.equalsIgnoreCase("tuneMaxOnSeconds")) {//Tune carrier hard cap (issue #408)
+                    //Defensive parse: settings import (#382) can feed anything here.
+                    //Non-numeric keeps the default; TuneController clamps the range.
+                    try {
+                        GeneralVariables.tuneMaxOnSeconds =
+                                com.k1af.ft8af.ft8transmit.TuneController.clampMaxOnSeconds(
+                                        Integer.parseInt(result.trim()));
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+                if (name.equalsIgnoreCase("tuneLevelIndependent")) {//Tune level decoupled from TX drive
+                    GeneralVariables.tuneLevelIndependent = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("tuneLevel")) {//Global independent tune level (0..100)
+                    try {
+                        GeneralVariables.tuneLevel =
+                                Math.max(0, Math.min(100, Integer.parseInt(result.trim())));
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+                if (name.equalsIgnoreCase("perBandTuneLevels")) {//Per-band independent tune levels
+                    GeneralVariables.perBandTuneLevels = result == null ? "" : result;
+                }
                 if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -137,6 +137,13 @@ public class FT8TransmitSignal {
         this.meterProtectionController = controller;
     }
 
+    // Tune carrier (issue #408): lifecycle/safety state machine + UI state.
+    // The controller enforces the hard max-on timeout and single-flight; the
+    // worker thread owns keying + AudioTrack teardown in a finally.
+    private final TuneController tuneController = new TuneController(System::currentTimeMillis);
+    public final MutableLiveData<Boolean> mutableIsTuning = new MutableLiveData<>();
+    public final MutableLiveData<Integer> mutableTuneRemainingSec = new MutableLiveData<>();
+
     private final OnDoTransmitted onDoTransmitted;// typically used for opening/closing PTT
     private final ExecutorService doTransmitThreadPool = Executors.newCachedThreadPool();
     private final DoTransmitRunnable doTransmitRunnable = new DoTransmitRunnable(this);
@@ -1780,6 +1787,11 @@ public class FT8TransmitSignal {
             ToastMessage.show(GeneralVariables.getStringFromResource(R.string.swr_lockout_toast));
             return;
         }
+        if (activated) {
+            // Tune and FT8 TX are mutually exclusive (issue #408): arming the
+            // sequencer ends a running tune so the scheduled TX can key cleanly.
+            tuneController.requestStop(TuneController.STOP_TX);
+        }
         this.activated = activated;
         if (!this.activated) {//force stop transmitting
             setTransmitting(false);
@@ -1840,6 +1852,10 @@ public class FT8TransmitSignal {
             mutableTransmittingMessage.postValue("");
         }
 
+        if (transmitting) {
+            // Tune must yield to a real transmission (issue #408).
+            tuneController.requestStop(TuneController.STOP_TX);
+        }
         mutableIsTransmitting.postValue(transmitting);
         isTransmitting = transmitting;
     }
@@ -2196,6 +2212,223 @@ public class FT8TransmitSignal {
      */
     static boolean shouldStopAfterOneShot(boolean transmitFreeText, boolean freeTextOneShot) {
         return transmitFreeText && freeTextOneShot;
+    }
+
+    // =========================================================================
+    // Tune: on-demand single-tone carrier for antenna/amplifier tuning
+    // (issue #408). Reuses the FT8 keying path (OnDoTransmitted.onTuneKeyDown/
+    // Up -> MainViewModel beginKeying/endKeying) and the chunked MODE_STREAM
+    // AudioTrack pattern from playFT8Signal; the samples come from
+    // TuneToneGenerator instead of the native FT8 encoder, and the loop runs
+    // until the operator stops it or TuneController's hard timeout fires.
+    // =========================================================================
+
+    /** Why a tune request was refused; NONE means it may start. */
+    enum TuneBlockReason {
+        NONE,
+        TX_ACTIVE,
+        SWR_LOCKED,
+        WSPR_FREQUENCY,
+        UNSUPPORTED_ROUTE,
+    }
+
+    /**
+     * Pure gate for starting the tune carrier. Ordered by severity: an armed or
+     * live FT8 TX wins (tune must never fight the sequencer for the rig), then
+     * the same protections the FT8 path applies (SWR lockout, WSPR sub-band
+     * blacklist — tune must not be a backdoor around TX inhibits), then route
+     * support (MVP plays through the Android AudioTrack sink only; the truSDX
+     * CAT-audio, network-rig, and USB-direct routes are follow-ups).
+     */
+    static TuneBlockReason tuneBlockReason(boolean txActiveOrArmed,
+                                           boolean swrLocked,
+                                           boolean wsprFrequency,
+                                           boolean catAudioRoute,
+                                           boolean networkRoute,
+                                           boolean usbDirectRoute) {
+        if (txActiveOrArmed) return TuneBlockReason.TX_ACTIVE;
+        if (swrLocked) return TuneBlockReason.SWR_LOCKED;
+        if (wsprFrequency) return TuneBlockReason.WSPR_FREQUENCY;
+        if (catAudioRoute || networkRoute || usbDirectRoute) {
+            return TuneBlockReason.UNSUPPORTED_ROUTE;
+        }
+        return TuneBlockReason.NONE;
+    }
+
+    public boolean isTuning() {
+        return tuneController.isActive();
+    }
+
+    /** Milliseconds until the tune safety timeout fires; 0 when not tuning. */
+    public long tuneRemainingMs() {
+        return tuneController.remainingMs();
+    }
+
+    /**
+     * Start the tune carrier: key PTT, play a steady tone at the current TX
+     * offset until {@link #stopTune()}, the max-on timeout, or an FT8 TX start.
+     * Returns false (with an operator toast) when blocked.
+     */
+    public boolean startTune() {
+        TuneBlockReason block = tuneBlockReason(
+                isTransmitting || activated,
+                meterProtectionController != null && meterProtectionController.isSwrLocked(),
+                BaseRigOperation.checkIsWSPR2(
+                        GeneralVariables.band + Math.round(GeneralVariables.getBaseFrequency())),
+                onDoTransmitted != null && onDoTransmitted.supportTransmitOverCAT(),
+                GeneralVariables.connectMode == ConnectMode.NETWORK,
+                GeneralVariables.audioOutputDeviceId == -1
+                        && GeneralVariables.usbAudioOutputVendorId != 0);
+        switch (block) {
+            case TX_ACTIVE:
+                ToastMessage.show(GeneralVariables.getStringFromResource(R.string.tune_blocked_tx));
+                return false;
+            case SWR_LOCKED:
+                ToastMessage.show(GeneralVariables.getStringFromResource(R.string.swr_lockout_toast));
+                return false;
+            case WSPR_FREQUENCY:
+                ToastMessage.show(String.format(
+                        GeneralVariables.getStringFromResource(R.string.use_wspr2_error)
+                        , BaseRigOperation.getFrequencyAllInfo(GeneralVariables.band)));
+                return false;
+            case UNSUPPORTED_ROUTE:
+                ToastMessage.show(GeneralVariables.getStringFromResource(
+                        R.string.tune_unavailable_route));
+                return false;
+            case NONE:
+            default:
+                break;
+        }
+        if (!tuneController.tryStart(GeneralVariables.tuneMaxOnSeconds)) {
+            return false; // already tuning
+        }
+        Thread worker = new Thread(this::playTuneTone, "TuneTone");
+        worker.start();
+        return true;
+    }
+
+    /** Operator stop: the worker ramps the tone down and unkeys. */
+    public void stopTune() {
+        tuneController.requestStop(TuneController.STOP_USER);
+    }
+
+    /** The tune level (0..100) resolved from settings, as an amplitude 0..1. */
+    private static float currentTuneAmplitude() {
+        return radio.ks3ckc.ft8af.TuneLevelKt.currentTuneLevel() / 100f;
+    }
+
+    /**
+     * Tune audio worker. Owns keying and the AudioTrack for its whole life;
+     * every exit path (stop, timeout, write error, exception) releases PTT and
+     * the track via the finally block — a stuck carrier is never acceptable.
+     */
+    private void playTuneTone() {
+        long startedAt = System.currentTimeMillis();
+        float offsetHz = GeneralVariables.getBaseFrequency();
+        AudioTrack track = null;
+        boolean keyed = false;
+        try {
+            GeneralVariables.fileLog(String.format(
+                    "TUNE: start offset=%.0fHz level=%d%% maxOn=%ds rate=%d",
+                    offsetHz, radio.ks3ckc.ft8af.TuneLevelKt.currentTuneLevel(),
+                    TuneController.clampMaxOnSeconds(GeneralVariables.tuneMaxOnSeconds),
+                    GeneralVariables.audioSampleRate));
+            onDoTransmitted.onTuneKeyDown();
+            keyed = true;
+            mutableIsTuning.postValue(true);
+
+            int sampleRate = GeneralVariables.audioSampleRate;
+            AudioAttributes tuneAttributes = new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                    .build();
+            int encoding = GeneralVariables.audioOutput32Bit
+                    ? AudioFormat.ENCODING_PCM_FLOAT : AudioFormat.ENCODING_PCM_16BIT;
+            AudioFormat tuneFormat = new AudioFormat.Builder().setSampleRate(sampleRate)
+                    .setEncoding(encoding)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build();
+            // Same small-buffer MODE_STREAM sizing as playFT8Signal: the buffer
+            // depth bounds the latency from a level change (or stop) to the air.
+            int bytesPerSample = GeneralVariables.audioOutput32Bit ? 4 : 2;
+            int targetBufBytes = (sampleRate / 5) * bytesPerSample;
+            int minBuf = AudioTrack.getMinBufferSize(sampleRate,
+                    AudioFormat.CHANNEL_OUT_MONO, encoding);
+            int bufBytes = Math.max(targetBufBytes, minBuf > 0 ? minBuf : targetBufBytes);
+            track = new AudioTrack(tuneAttributes, tuneFormat, bufBytes,
+                    AudioTrack.MODE_STREAM, 0);
+            if (GeneralVariables.audioOutputDeviceId > 0) {
+                AudioDeviceInfo deviceInfo = findAudioDeviceById(
+                        GeneralVariables.audioOutputDeviceId, AudioManager.GET_DEVICES_OUTPUTS);
+                track.setPreferredDevice(deviceInfo);
+            }
+            track.play();
+            track.setVolume(1.0f);
+
+            TuneToneGenerator generator = new TuneToneGenerator(offsetHz, sampleRate,
+                    Math.max(1, sampleRate / 200)); // ~5ms ramp
+            final int chunkSamples = Math.max(1, sampleRate / 20); // ~50ms
+            float[] chunk = new float[chunkSamples];
+            int lastPostedSec = -1;
+            while (true) {
+                if (!tuneController.shouldContinue()) {
+                    generator.requestStop(); // final chunk(s) ramp to zero
+                }
+                // Level read fresh per chunk so a settings change lands mid-tune,
+                // exactly like the FT8 volume slider.
+                int written = generator.nextChunk(chunk, chunkSamples, currentTuneAmplitude());
+                if (written <= 0) {
+                    break;
+                }
+                int writeResult;
+                if (GeneralVariables.audioOutput32Bit) {
+                    writeResult = track.write(chunk, 0, written, AudioTrack.WRITE_BLOCKING);
+                } else {
+                    short[] pcm = floatToInt16NoPad(chunk, written);
+                    writeResult = track.write(pcm, 0, written, AudioTrack.WRITE_BLOCKING);
+                }
+                if (writeResult < 0) {
+                    Log.e(TAG, "Tune playback error: " + writeResult);
+                    tuneController.requestStop(TuneController.STOP_ERROR);
+                    break;
+                }
+                int remainingSec = (int) Math.ceil(tuneController.remainingMs() / 1000.0);
+                if (remainingSec != lastPostedSec) {
+                    lastPostedSec = remainingSec;
+                    mutableTuneRemainingSec.postValue(remainingSec);
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Tune worker failed: " + e);
+            tuneController.requestStop(TuneController.STOP_ERROR);
+        } finally {
+            // Single point of teardown: whatever happened above, the carrier
+            // stops and PTT drops here.
+            tuneController.requestStop(TuneController.STOP_ERROR);
+            if (track != null) {
+                try {
+                    track.stop();
+                } catch (IllegalStateException ignored) {
+                }
+                track.release();
+            }
+            if (keyed) {
+                try {
+                    onDoTransmitted.onTuneKeyUp();
+                } catch (Exception e) {
+                    Log.e(TAG, "Tune key-up failed: " + e);
+                }
+            }
+            mutableIsTuning.postValue(false);
+            String reason = tuneController.lastStopReason();
+            GeneralVariables.fileLog(String.format(
+                    "TUNE: stop reason=%s durationMs=%d offset=%.0fHz",
+                    reason, System.currentTimeMillis() - startedAt, offsetHz));
+            if (TuneController.STOP_TIMEOUT.equals(reason)) {
+                ToastMessage.show(String.format(
+                        GeneralVariables.getStringFromResource(R.string.tune_stopped_timeout),
+                        TuneController.clampMaxOnSeconds(GeneralVariables.tuneMaxOnSeconds)));
+            }
+        }
     }
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/OnDoTransmitted.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/OnDoTransmitted.java
@@ -15,4 +15,11 @@ public interface OnDoTransmitted {
     //2023-08-16 Modification submitted by DS1UFX (based on v0.9), adding (tr)uSDX audio over CAT support.
     boolean supportTransmitOverCAT();
     void onTransmitOverCAT(Ft8Message message);
+
+    //Tune (issue #408): key/unkey the rig for the tune carrier without an
+    //Ft8Message. Default no-ops so existing implementers compile unchanged;
+    //MainViewModel routes these through the same CAT/RTS/DTR PTT + SCO logic
+    //as onBeforeTransmit/onAfterTransmit (VOX rigs key on the audio itself).
+    default void onTuneKeyDown() {}
+    default void onTuneKeyUp() {}
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/TuneController.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/TuneController.java
@@ -1,0 +1,132 @@
+package com.k1af.ft8af.ft8transmit;
+
+/**
+ * Lifecycle + safety state machine for the Tune function (issue #408).
+ *
+ * <p>A continuous carrier is the most dangerous thing a station-control app
+ * can emit (100% duty cycle, open-ended), so the invariants live here, in a
+ * plain class with an injected clock:
+ * <ul>
+ *   <li><b>Hard max-on timeout</b>: {@link #shouldContinue()} goes false once
+ *       the deadline passes even if the operator does nothing.</li>
+ *   <li><b>Single flight</b>: {@link #tryStart} is an atomic check-and-claim;
+ *       a double start is refused.</li>
+ *   <li><b>Deterministic stop reason</b>: the first stop cause wins and is
+ *       reported for logging/toasts.</li>
+ * </ul>
+ *
+ * The audio worker owns the actual teardown (PTT off, track release) in a
+ * {@code finally}; this class only decides <i>whether</i> the tone keeps
+ * going. Thread-safe: the UI thread starts/stops while the audio worker polls.
+ */
+public final class TuneController {
+
+    /** Default hard cap on a single tune carrier. */
+    public static final int DEFAULT_MAX_ON_SECONDS = 10;
+    /** Bounds for the configurable max-on time. */
+    public static final int MIN_MAX_ON_SECONDS = 2;
+    public static final int MAX_MAX_ON_SECONDS = 60;
+
+    /** Stop reasons, used for logging and operator feedback. */
+    public static final String STOP_USER = "user";
+    public static final String STOP_TIMEOUT = "timeout";
+    public static final String STOP_TX = "tx-start";
+    public static final String STOP_ERROR = "error";
+
+    /** Millisecond clock; injected so tests drive time explicitly. */
+    public interface Clock {
+        long nowMs();
+    }
+
+    private final Clock clock;
+
+    private boolean active = false;
+    private long startedAtMs;
+    private long deadlineMs;
+    private String stopReason = null;
+
+    public TuneController(Clock clock) {
+        this.clock = clock;
+    }
+
+    /** Clamp a configured max-on time (e.g. a persisted setting) to the legal range. */
+    public static int clampMaxOnSeconds(int seconds) {
+        if (seconds < MIN_MAX_ON_SECONDS) {
+            return seconds <= 0 ? DEFAULT_MAX_ON_SECONDS : MIN_MAX_ON_SECONDS;
+        }
+        return Math.min(seconds, MAX_MAX_ON_SECONDS);
+    }
+
+    /**
+     * Atomically claim the tune session and arm the timeout. Returns false when
+     * a session is already active (double start is a no-op for the caller).
+     */
+    public synchronized boolean tryStart(int maxOnSeconds) {
+        if (active) {
+            return false;
+        }
+        startedAtMs = clock.nowMs();
+        deadlineMs = startedAtMs + clampMaxOnSeconds(maxOnSeconds) * 1000L;
+        stopReason = null;
+        active = true;
+        return true;
+    }
+
+    /**
+     * Polled by the audio worker between chunks: true while the tone should
+     * keep playing. Enforces the max-on deadline as a side effect — this is
+     * the code-level guarantee that a forgotten tune cannot run past the cap.
+     */
+    public synchronized boolean shouldContinue() {
+        if (!active) {
+            return false;
+        }
+        if (clock.nowMs() >= deadlineMs) {
+            stopInternal(STOP_TIMEOUT);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Request the session end (operator tap, FT8 TX starting, worker error).
+     * The first reason wins; later calls are no-ops. Safe when not active.
+     */
+    public synchronized void requestStop(String reason) {
+        if (active) {
+            stopInternal(reason);
+        }
+    }
+
+    private void stopInternal(String reason) {
+        active = false;
+        if (stopReason == null) {
+            stopReason = reason;
+        }
+    }
+
+    public synchronized boolean isActive() {
+        return active;
+    }
+
+    /** Why the last session ended, or null if none ended yet. */
+    public synchronized String lastStopReason() {
+        return stopReason;
+    }
+
+    /** Milliseconds until the deadline; 0 when inactive or already past it. */
+    public synchronized long remainingMs() {
+        if (!active) {
+            return 0;
+        }
+        return Math.max(0, deadlineMs - clock.nowMs());
+    }
+
+    /** Milliseconds since the session started; 0 when inactive. */
+    public synchronized long elapsedMs() {
+        if (!active) {
+            return 0;
+        }
+        return Math.max(0, clock.nowMs() - startedAtMs);
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/TuneToneGenerator.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/TuneToneGenerator.java
@@ -1,0 +1,119 @@
+package com.k1af.ft8af.ft8transmit;
+
+/**
+ * Chunked, phase-continuous single-tone generator for the Tune function
+ * (issue #408): a pure sinusoid at the TX audio offset, held for as long as
+ * the operator tunes, with a raised-cosine ramp at start and stop so keying
+ * never clicks/splatters.
+ *
+ * <p>Unlike the FT8 waveform (generated whole by the native library), the tune
+ * tone is open-ended, so it is produced in short chunks; the caller polls
+ * "still tuning?" between chunks and requests the final ramp-down via
+ * {@link #requestStop()}. The phase accumulator carries across chunks, so
+ * there is no discontinuity at chunk boundaries.
+ *
+ * <p>Pure arithmetic with injected frequency/sample-rate/amplitude — no
+ * Android, no native code — so it is deterministic and unit-testable
+ * (CLAUDE.md testing rule).
+ */
+public final class TuneToneGenerator {
+
+    /** Ramp length: ~5 ms at 48 kHz. Long enough to kill the key click. */
+    public static final int DEFAULT_RAMP_SAMPLES = 240;
+
+    private final double phaseIncrement;
+    private final int rampSamples;
+
+    private double phase = 0.0;
+    /** Samples produced so far (drives the ramp-up envelope). */
+    private long produced = 0;
+    /** >=0 once stop was requested: samples of ramp-down already emitted. */
+    private int rampDownEmitted = -1;
+    private boolean finished = false;
+
+    /**
+     * @param frequencyHz tone frequency; non-positive values are clamped to 0
+     *                    (silence at constant phase) rather than throwing
+     * @param sampleRate  output sample rate in Hz (must be positive)
+     * @param rampSamples raised-cosine ramp length in samples (clamped to >= 1)
+     */
+    public TuneToneGenerator(float frequencyHz, int sampleRate, int rampSamples) {
+        if (sampleRate <= 0) {
+            throw new IllegalArgumentException("sampleRate must be positive: " + sampleRate);
+        }
+        float f = Math.max(0f, frequencyHz);
+        this.phaseIncrement = 2.0 * Math.PI * f / sampleRate;
+        this.rampSamples = Math.max(1, rampSamples);
+    }
+
+    /** Begin the raised-cosine ramp-down; the generator finishes one ramp later. */
+    public void requestStop() {
+        if (rampDownEmitted < 0) {
+            rampDownEmitted = 0;
+        }
+    }
+
+    /** True once the ramp-down has fully played out; no more samples will come. */
+    public boolean isFinished() {
+        return finished;
+    }
+
+    /**
+     * Fill {@code out[0..len)} with the next chunk of the tone at the given
+     * amplitude (clamped to [0, 1]; read fresh per chunk so a live level change
+     * takes effect within one chunk, like the FT8 volume slider).
+     *
+     * @return the number of samples written: {@code len} in steady state,
+     *     possibly fewer on the final ramp-down chunk, 0 when finished.
+     */
+    public int nextChunk(float[] out, int len, float amplitude) {
+        if (finished || out == null || len <= 0) {
+            return 0;
+        }
+        int n = Math.min(len, out.length);
+        float a = Math.max(0f, Math.min(1f, amplitude));
+        int written = 0;
+        for (int i = 0; i < n; i++) {
+            double env = envelope();
+            if (finished) {
+                break;
+            }
+            out[i] = (float) (a * env * Math.sin(phase));
+            phase += phaseIncrement;
+            if (phase >= 2.0 * Math.PI) {
+                phase -= 2.0 * Math.PI;
+            }
+            produced++;
+            if (rampDownEmitted >= 0) {
+                rampDownEmitted++;
+            }
+            written++;
+        }
+        return written;
+    }
+
+    /**
+     * Envelope for the sample about to be produced. Ramp-up and ramp-down are
+     * multiplied so a stop during the attack tapers cleanly from wherever the
+     * attack had reached.
+     */
+    private double envelope() {
+        double env = 1.0;
+        if (produced < rampSamples) {
+            env *= 0.5 * (1.0 - Math.cos(Math.PI * produced / (double) rampSamples));
+        }
+        if (rampDownEmitted >= 0) {
+            if (rampDownEmitted >= rampSamples) {
+                finished = true;
+                return 0.0;
+            }
+            env *= 0.5 * (1.0 + Math.cos(Math.PI * rampDownEmitted / (double) rampSamples));
+        }
+        return env;
+    }
+
+    /** Current phase in radians — exposed for the continuity unit test. */
+    double currentPhase() {
+        return phase;
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -601,6 +601,18 @@ class ComposeMainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onStop() {
+        // A tune carrier must never outlive the operator's attention (issue
+        // #408): backgrounding or swiping the app away mid-tune force-stops the
+        // tone and drops PTT. Normal FT8 TX is left alone — it is cycle-bounded
+        // and self-terminates.
+        try {
+            mainViewModel.ft8TransmitSignal.stopTune()
+        } catch (_: Exception) {
+        }
+        super.onStop()
+    }
+
     override fun onDestroy() {
         unregisterBluetoothReceiver()
         unregisterUsbDetachReceiver()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -92,6 +92,8 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
     // Observe transmit state
     val isTransmitting by mainViewModel.ft8TransmitSignal.mutableIsTransmitting.observeAsState(false)
     val isActivated by mainViewModel.ft8TransmitSignal.mutableIsActivated.observeAsState(false)
+    val isTuning by mainViewModel.ft8TransmitSignal.mutableIsTuning.observeAsState(false)
+    val tuneRemainingSec by mainViewModel.ft8TransmitSignal.mutableTuneRemainingSec.observeAsState(0)
     val txSlot by mainViewModel.ft8TransmitSignal.mutableSequential.observeAsState(mainViewModel.ft8TransmitSignal.sequential)
     val qsoCompletedAt by mainViewModel.ft8TransmitSignal.mutableQsoCompletedAt.observeAsState()
     // CAT connection status for the TX-strip chip. Hidden for VOX / audio-only
@@ -363,6 +365,17 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 cqModifier = cqModifier,
                 isFreeTextMode = isFreeTextMode,
                 fieldDayEnabled = fieldDayEnabled,
+                isTuning = isTuning,
+                tuneRemainingSec = tuneRemainingSec,
+                onToggleTune = {
+                    // Toggle (WSJT-X style latching Tune): tap to key the carrier,
+                    // tap again to stop. startTune() toasts the reason when blocked.
+                    if (isTuning) {
+                        mainViewModel.ft8TransmitSignal.stopTune()
+                    } else {
+                        mainViewModel.ft8TransmitSignal.startTune()
+                    }
+                },
                 onVolumeChange = { newVolume ->
                     txVolume = newVolume
                     GeneralVariables.volumePercent = newVolume / 100f
@@ -505,7 +518,9 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
 
         // Transmit breathing border — sibling overlay so its per-frame invalidations
         // don't bubble into the waterfall composable. Pointer events pass through.
-        TransmitGlow(isTransmitting = isTransmitting)
+        // The tune carrier is a real transmission too (issue #408): the operator
+        // must never be unsure whether the rig is keyed.
+        TransmitGlow(isTransmitting = isTransmitting || isTuning)
 
         // One-shot particle burst when a QSO completes.
         QsoCelebration(triggerAt = qsoCompletedAt)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/TuneLevel.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/TuneLevel.kt
@@ -1,0 +1,100 @@
+package radio.ks3ckc.ft8af
+
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.database.DatabaseOpr
+import com.k1af.ft8af.rigs.BaseRigOperation
+
+/**
+ * Tune audio level resolution (issue #408).
+ *
+ * The tune carrier's drive is settable independently of the FT8 TX drive: a
+ * 100% duty-cycle carrier is far more thermally stressful than intermittent
+ * FT8, and tuning at reduced power into a deliberately bad match is standard
+ * practice. Two modes:
+ *
+ *  - "Same as TX drive" (default): the tone uses whatever the FT8 path would
+ *    use right now — the live volume level. When "Save output level per band"
+ *    is on, that level is already the per-band FT8 level (band changes restore
+ *    it into the live volume), so no extra lookup is needed.
+ *  - "Independent": a distinct tune level stored under its own config key,
+ *    never touching the FT8 drive. When "Save output level per band" is on,
+ *    the tune level is remembered per band in a parallel map
+ *    ([PER_BAND_TUNE_LEVELS_KEY]) reusing the exact parse/serialize/resolve
+ *    helpers from [PerBandOutputLevel] — same toggle, separate backing store,
+ *    so the two maps never clobber each other.
+ *
+ * Pure decision logic up top (unit-tested); thin GeneralVariables/DatabaseOpr
+ * wiring at the bottom.
+ */
+
+/** Config key: tune max-on time in seconds (clamped by TuneController). */
+const val TUNE_MAX_ON_SECONDS_KEY = "tuneMaxOnSeconds"
+
+/** Config key: "1" = independent tune level, else same-as-TX-drive (default). */
+const val TUNE_LEVEL_INDEPENDENT_KEY = "tuneLevelIndependent"
+
+/** Config key: the global independent tune level, 0..100. */
+const val TUNE_LEVEL_KEY = "tuneLevel"
+
+/** Config key: the per-band independent tune levels ("20m=25,40m=40"). */
+const val PER_BAND_TUNE_LEVELS_KEY = "perBandTuneLevels"
+
+/**
+ * Resolve the level (0..100) the tune tone should play at.
+ *
+ * @param independent      independent-tune-level mode is enabled
+ * @param globalTuneLevel  the stored global tune level (0..100)
+ * @param perBandEnabled   the existing "Save output level per band" toggle
+ * @param band             current band label (e.g. "20m"), null when unknown
+ * @param serializedTuneLevels the persisted per-band tune map
+ * @param txLevel          the live FT8 TX level (0..100)
+ */
+internal fun resolveTuneLevel(
+    independent: Boolean,
+    globalTuneLevel: Int,
+    perBandEnabled: Boolean,
+    band: String?,
+    serializedTuneLevels: String?,
+    txLevel: Int,
+): Int {
+    if (!independent) return txLevel.coerceIn(0, 100)
+    if (perBandEnabled && !band.isNullOrBlank()) {
+        parsePerBandOutputLevels(serializedTuneLevels)[band]?.let { return it }
+    }
+    return globalTuneLevel.coerceIn(0, 100)
+}
+
+/** Serializes per-band tune-map read-modify-writes (settings UI thread today). */
+private val perBandTuneLevelLock = Any()
+
+/**
+ * Record [level] (0..100) as the saved independent tune level for the current
+ * band and persist the updated map. No-op when the per-band feature is
+ * disabled or the value is unchanged. Never touches the FT8 per-band map.
+ */
+fun saveTuneLevelForCurrentBand(databaseOpr: DatabaseOpr, level: Int) {
+    val band = BaseRigOperation.getMeterFromFreq(GeneralVariables.band)
+    synchronized(perBandTuneLevelLock) {
+        val serialized = recordPerBandOutputLevel(
+            GeneralVariables.savePerBandOutputLevel,
+            band,
+            level,
+            GeneralVariables.perBandTuneLevels,
+        ) ?: return
+        GeneralVariables.perBandTuneLevels = serialized
+        databaseOpr.writeConfig(PER_BAND_TUNE_LEVELS_KEY, serialized, null)
+    }
+}
+
+/**
+ * The level (0..100) the tune tone should play at right now, from live config.
+ * Called per audio chunk, so a level change mid-tune takes effect immediately.
+ */
+fun currentTuneLevel(): Int = resolveTuneLevel(
+    independent = GeneralVariables.tuneLevelIndependent,
+    globalTuneLevel = GeneralVariables.tuneLevel,
+    perBandEnabled = GeneralVariables.savePerBandOutputLevel,
+    band = BaseRigOperation.getMeterFromFreq(GeneralVariables.band),
+    serializedTuneLevels = GeneralVariables.perBandTuneLevels,
+    txLevel = outputLevelFromVolumePercent(GeneralVariables.volumePercent),
+)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -75,6 +75,14 @@ internal fun txStripActionState(isActivated: Boolean, huntEnabled: Boolean) = Tx
 )
 
 /**
+ * Label for the TUNE chip: the plain label when idle, "label countdown" while
+ * the carrier is up (e.g. "TUNE 7s") so the operator sees the safety timeout
+ * running. Extracted so it can be unit-tested without Compose.
+ */
+internal fun tuneChipLabel(label: String, isTuning: Boolean, remainingSec: Int): String =
+    if (isTuning) "$label ${remainingSec.coerceAtLeast(0)}s" else label
+
+/**
  * The small subtitle shown under "Call CQ" that reflects which CQ variant is queued.
  * Precedence: free-text > Field Day > custom modifier > none. Null while the button is
  * in its STOP state. Extracted so the precedence can be unit-tested without Compose.
@@ -111,6 +119,9 @@ fun TxStrip(
     cqModifier: String = "",
     isFreeTextMode: Boolean = false,
     fieldDayEnabled: Boolean = false,
+    isTuning: Boolean = false,
+    tuneRemainingSec: Int = 0,
+    onToggleTune: () -> Unit = {},
     onVolumeChange: (Int) -> Unit = {},
     onVolumeChangeFinished: () -> Unit = {},
     onCallCQ: () -> Unit,
@@ -249,6 +260,33 @@ fun TxStrip(
                     enabled = true,
                     onClick = onToggleDx,
                 )
+
+                // TUNE toggle pill (issue #408): tap keys a steady carrier at the
+                // TX offset for antenna/amplifier tuning; tap again stops it. While
+                // active it turns red and counts down the code-enforced safety
+                // timeout. Locked off while the sequencer is armed/transmitting —
+                // tune and FT8 TX are mutually exclusive.
+                val tuneDescription = stringResource(R.string.tune_content_description)
+                Box(modifier = Modifier.semantics { contentDescription = tuneDescription }) {
+                    TxChip(
+                        label = tuneChipLabel(
+                            stringResource(R.string.tune_button), isTuning, tuneRemainingSec,
+                        ),
+                        background = when {
+                            isTuning -> StatusBad
+                            isActivated || isTransmitting -> BgSurface3.copy(alpha = 0.4f)
+                            else -> BgSurface3
+                        },
+                        textColor = when {
+                            isTuning -> Color.White
+                            isActivated || isTransmitting -> TextMuted.copy(alpha = 0.4f)
+                            else -> TextMuted
+                        },
+                        bold = isTuning,
+                        enabled = isTuning || (!isActivated && !isTransmitting),
+                        onClick = onToggleTune,
+                    )
+                }
             }
         }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -23,6 +23,11 @@ import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
 import com.k1af.ft8af.ft8transmit.MeterProtectionController
+import com.k1af.ft8af.ft8transmit.TuneController
+import radio.ks3ckc.ft8af.TUNE_LEVEL_INDEPENDENT_KEY
+import radio.ks3ckc.ft8af.TUNE_LEVEL_KEY
+import radio.ks3ckc.ft8af.TUNE_MAX_ON_SECONDS_KEY
+import radio.ks3ckc.ft8af.saveTuneLevelForCurrentBand
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.FT8AFIconButton
 import radio.ks3ckc.ft8af.ui.components.FT8AFIcons
@@ -51,6 +56,11 @@ fun TransmissionSettings(
     var swrHaltThreshold by remember { mutableIntStateOf(GeneralVariables.swrHaltThreshold) }
     var alcTargetLow by remember { mutableIntStateOf(GeneralVariables.alcTargetLow) }
     var alcTargetHigh by remember { mutableIntStateOf(GeneralVariables.alcTargetHigh) }
+
+    // Tune state (issue #408)
+    var tuneMaxOnSeconds by remember { mutableIntStateOf(GeneralVariables.tuneMaxOnSeconds) }
+    var tuneLevelIndependent by remember { mutableStateOf(GeneralVariables.tuneLevelIndependent) }
+    var tuneLevel by remember { mutableIntStateOf(GeneralVariables.tuneLevel) }
 
     // Auto-sequence state
     var autoFollowCQ by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
@@ -406,6 +416,99 @@ fun TransmissionSettings(
                             Text(
                                 "7:1",
                                 style = TextStyle(fontSize = 12.sp, color = TextMuted),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // =====================================================================
+        // TUNE (issue #408)
+        // =====================================================================
+        SettingsSection(title = "TUNE") {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    SettingsRow(
+                        label = "Tune timeout",
+                        description = "Hard cap on the tune carrier — it always stops by itself",
+                        value = "${tuneMaxOnSeconds}s",
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                            .padding(bottom = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        IntSlider(
+                            value = tuneMaxOnSeconds,
+                            onValueChange = { v ->
+                                val clamped = TuneController.clampMaxOnSeconds(v)
+                                tuneMaxOnSeconds = clamped
+                                GeneralVariables.tuneMaxOnSeconds = clamped
+                            },
+                            onValueChangeFinished = {
+                                mainViewModel.databaseOpr.writeConfig(
+                                    TUNE_MAX_ON_SECONDS_KEY, tuneMaxOnSeconds.toString(), null,
+                                )
+                            },
+                            valueRange = TuneController.MIN_MAX_ON_SECONDS.toFloat()..
+                                TuneController.MAX_MAX_ON_SECONDS.toFloat(),
+                            modifier = Modifier.weight(1f),
+                            thumbColor = Accent,
+                            activeTrackColor = Accent,
+                        )
+                    }
+                    SectionDivider()
+                    SettingsRow(
+                        label = "Independent tune level",
+                        description = "Tune at its own drive level (e.g. reduced power) without touching the TX drive",
+                        toggle = tuneLevelIndependent,
+                        onToggleChange = { checked ->
+                            tuneLevelIndependent = checked
+                            GeneralVariables.tuneLevelIndependent = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                TUNE_LEVEL_INDEPENDENT_KEY, if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    if (tuneLevelIndependent) {
+                        SectionDivider()
+                        SettingsRow(
+                            label = "Tune audio level",
+                            description = if (GeneralVariables.savePerBandOutputLevel)
+                                "Remembered per band (Save output level per band is on)"
+                            else "Single level for all bands",
+                            value = "$tuneLevel%",
+                        )
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)
+                                .padding(bottom = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            IntSlider(
+                                value = tuneLevel,
+                                onValueChange = { v ->
+                                    val clamped = v.coerceIn(0, 100)
+                                    tuneLevel = clamped
+                                    GeneralVariables.tuneLevel = clamped
+                                },
+                                onValueChangeFinished = {
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        TUNE_LEVEL_KEY, tuneLevel.toString(), null,
+                                    )
+                                    // When per-band levels are on, the independent tune
+                                    // level is remembered for the current band too — in
+                                    // its own map, never the FT8 one (issue #408).
+                                    saveTuneLevelForCurrentBand(mainViewModel.databaseOpr, tuneLevel)
+                                },
+                                valueRange = 0f..100f,
+                                modifier = Modifier.weight(1f),
+                                thumbColor = Accent,
+                                activeTrackColor = Accent,
                             )
                         }
                     }

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -556,4 +556,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">فشل صوت الإرسال — لم تُرسل أي إشارة في هذه الدورة (خطأ في صوت USB)</string>
+    <string name="tune_content_description">Tune: يرسل موجة حاملة مستمرة لضبط الهوائي</string>
+    <string name="tune_stopped_timeout">توقف Tune بعد %1$d ث</string>
+    <string name="tune_blocked_tx">أوقف CQ/QSO قبل استخدام Tune</string>
+    <string name="tune_unavailable_route">Tune غير مدعوم بعد على مسار الصوت هذا</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -556,4 +556,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Selhalo TX audio — v tomto cyklu nebyl vyslán žádný signál (chyba USB audia)</string>
+    <string name="tune_content_description">Tune: vysílá souvislou nosnou pro ladění antény</string>
+    <string name="tune_stopped_timeout">Tune zastaven po %1$d s</string>
+    <string name="tune_blocked_tx">Před použitím Tune zastavte CQ/QSO</string>
+    <string name="tune_unavailable_route">Tune zatím není na této zvukové cestě podporován</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -513,4 +513,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Falló el audio de TX — no se transmitió señal en este ciclo (error de audio USB)</string>
+    <string name="tune_content_description">Tune: transmite una portadora continua para ajustar la antena</string>
+    <string name="tune_stopped_timeout">Tune detenido tras %1$d s</string>
+    <string name="tune_blocked_tx">Detén el CQ/QSO antes de usar Tune</string>
+    <string name="tune_unavailable_route">Tune aún no está disponible en esta ruta de audio</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -513,4 +513,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Échec audio TX — aucun signal émis ce cycle (erreur audio USB)</string>
+    <string name="tune_content_description">Tune : émet une porteuse continue pour l\'accord d\'antenne</string>
+    <string name="tune_stopped_timeout">Tune arrêté après %1$d s</string>
+    <string name="tune_blocked_tx">Arrêtez le CQ/QSO avant d\'utiliser Tune</string>
+    <string name="tune_unavailable_route">Tune n\'est pas encore disponible sur cette voie audio</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -556,4 +556,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Audio TX gagal — tidak ada sinyal terkirim pada siklus ini (kesalahan audio USB)</string>
+    <string name="tune_content_description">Tune: memancarkan gelombang pembawa kontinu untuk penalaan antena</string>
+    <string name="tune_stopped_timeout">Tune dihentikan setelah %1$d dtk</string>
+    <string name="tune_blocked_tx">Hentikan CQ/QSO sebelum menggunakan Tune</string>
+    <string name="tune_unavailable_route">Tune belum didukung pada jalur audio ini</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -545,4 +545,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Audio TX non riuscito — nessun segnale trasmesso in questo ciclo (errore audio USB)</string>
+    <string name="tune_content_description">Tune: trasmette una portante continua per l\'accordo dell\'antenna</string>
+    <string name="tune_stopped_timeout">Tune fermato dopo %1$d s</string>
+    <string name="tune_blocked_tx">Ferma il CQ/QSO prima di usare Tune</string>
+    <string name="tune_unavailable_route">Tune non è ancora disponibile su questo percorso audio</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -513,4 +513,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX音声に失敗 — このサイクルでは信号が送信されませんでした（USBオーディオエラー）</string>
+    <string name="tune_content_description">Tune：アンテナ調整用の連続キャリアを送信します</string>
+    <string name="tune_stopped_timeout">Tuneは%1$d秒後に停止しました</string>
+    <string name="tune_blocked_tx">Tuneの前にCQ/QSOを停止してください</string>
+    <string name="tune_unavailable_route">このオーディオ経路ではTuneはまだ利用できません</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -556,4 +556,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX 오디오 실패 — 이번 주기에 신호가 송신되지 않았습니다 (USB 오디오 오류)</string>
+    <string name="tune_content_description">Tune: 안테나 조정을 위한 연속 반송파를 송신합니다</string>
+    <string name="tune_stopped_timeout">Tune이 %1$d초 후 정지되었습니다</string>
+    <string name="tune_blocked_tx">Tune 전에 CQ/QSO를 정지하세요</string>
+    <string name="tune_unavailable_route">이 오디오 경로에서는 아직 Tune을 사용할 수 없습니다</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -556,4 +556,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX-audio mislukt — geen signaal verzonden deze cyclus (USB-audiofout)</string>
+    <string name="tune_content_description">Tune: zendt een continue draaggolf uit voor antenne-afstemming</string>
+    <string name="tune_stopped_timeout">Tune gestopt na %1$d s</string>
+    <string name="tune_blocked_tx">Stop de CQ/QSO voordat je Tune gebruikt</string>
+    <string name="tune_unavailable_route">Tune is nog niet beschikbaar op deze audioroute</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -545,4 +545,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Błąd audio TX — w tym cyklu nie wysłano sygnału (błąd audio USB)</string>
+    <string name="tune_content_description">Tune: nadaje ciągłą nośną do strojenia anteny</string>
+    <string name="tune_stopped_timeout">Tune zatrzymany po %1$d s</string>
+    <string name="tune_blocked_tx">Zatrzymaj CQ/QSO przed użyciem Tune</string>
+    <string name="tune_unavailable_route">Tune nie jest jeszcze dostępny na tej ścieżce audio</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -513,4 +513,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Сбой TX-аудио — в этом цикле сигнал не передан (ошибка USB-аудио)</string>
+    <string name="tune_content_description">Tune: передаёт непрерывную несущую для настройки антенны</string>
+    <string name="tune_stopped_timeout">Tune остановлен через %1$d с</string>
+    <string name="tune_blocked_tx">Остановите CQ/QSO перед использованием Tune</string>
+    <string name="tune_unavailable_route">Tune пока не поддерживается на этом аудиотракте</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -545,4 +545,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX sesi başarısız — bu döngüde sinyal gönderilmedi (USB ses hatası)</string>
+    <string name="tune_content_description">Tune: anten ayarı için sürekli taşıyıcı gönderir</string>
+    <string name="tune_stopped_timeout">Tune %1$d s sonra durduruldu</string>
+    <string name="tune_blocked_tx">Tune kullanmadan önce CQ/QSO\'yu durdurun</string>
+    <string name="tune_unavailable_route">Tune bu ses yolunda henüz desteklenmiyor</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -545,4 +545,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Збій TX-аудіо — у цьому циклі сигнал не передано (помилка USB-аудіо)</string>
+    <string name="tune_content_description">Tune: передає безперервну несучу для налаштування антени</string>
+    <string name="tune_stopped_timeout">Tune зупинено через %1$d с</string>
+    <string name="tune_blocked_tx">Зупиніть CQ/QSO перед використанням Tune</string>
+    <string name="tune_unavailable_route">Tune поки не підтримується на цьому аудіотракті</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -513,4 +513,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">发射音频失败 — 本周期未发出信号（USB 音频错误）</string>
+    <string name="tune_content_description">Tune：发射连续载波用于天线调谐</string>
+    <string name="tune_stopped_timeout">Tune已在%1$d秒后停止</string>
+    <string name="tune_blocked_tx">使用Tune前请先停止CQ/QSO</string>
+    <string name="tune_unavailable_route">此音频路径暂不支持Tune</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -513,4 +513,8 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">發射音訊失敗 — 本週期未發出訊號（USB 音訊錯誤）</string>
+    <string name="tune_content_description">Tune：發射連續載波用於天線調諧</string>
+    <string name="tune_stopped_timeout">Tune已在%1$d秒後停止</string>
+    <string name="tune_blocked_tx">使用Tune前請先停止CQ/QSO</string>
+    <string name="tune_unavailable_route">此音訊路徑暫不支援Tune</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -652,4 +652,9 @@
     <string name="language_name_ar" translatable="false">العربية</string>
 
     <string name="tx_audio_dropped">TX audio failed — no signal was sent this cycle (USB audio error)</string>
+    <string name="tune_button" translatable="false">TUNE</string>
+    <string name="tune_content_description">Tune — transmit a steady carrier for antenna tuning</string>
+    <string name="tune_stopped_timeout">Tune stopped after %1$d s</string>
+    <string name="tune_blocked_tx">Stop the CQ/QSO before tuning</string>
+    <string name="tune_unavailable_route">Tune is not yet supported on this audio route</string>
 </resources>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -396,6 +396,59 @@ public class FT8TransmitSignalTest {
         assertThat(FT8TransmitSignal.shouldStopAfterOneShot(false, true)).isFalse();
     }
 
+    // ---- tuneBlockReason (issue #408) ----------------------------------------
+    // The gate for starting the tune carrier. Ordered by severity: TX beats the
+    // protections, protections beat route support — and tune must never become
+    // a backdoor around a TX inhibit (SWR lockout, WSPR blacklist).
+
+    @Test
+    public void tune_allClear_mayStart() {
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                false, false, false, false, false, false))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.NONE);
+    }
+
+    @Test
+    public void tune_txActiveOrArmed_blocks() {
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                true, false, false, false, false, false))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.TX_ACTIVE);
+        // TX outranks every other reason.
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                true, true, true, true, true, true))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.TX_ACTIVE);
+    }
+
+    @Test
+    public void tune_swrLockout_blocks() {
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                false, true, false, false, false, false))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.SWR_LOCKED);
+    }
+
+    @Test
+    public void tune_wsprFrequency_blocks() {
+        // The WSPR sub-band TX inhibit applies to tune too.
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                false, false, true, false, false, false))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.WSPR_FREQUENCY);
+    }
+
+    @Test
+    public void tune_unsupportedRoutes_block() {
+        // MVP: AudioTrack sink only; CAT-audio (truSDX), network rigs, and the
+        // USB-direct path are Phase-2 follow-ups.
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                false, false, false, true, false, false))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.UNSUPPORTED_ROUTE);
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                false, false, false, false, true, false))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.UNSUPPORTED_ROUTE);
+        assertThat(FT8TransmitSignal.tuneBlockReason(
+                false, false, false, false, false, true))
+                .isEqualTo(FT8TransmitSignal.TuneBlockReason.UNSUPPORTED_ROUTE);
+    }
+
     // ---- shouldCompleteQso ---------------------------------------------------
     // Completion decision for the QSO state machine. The evidenceOnly flag marks
     // deep/late-pass parses: positive evidence (partner sent 73, partner moved

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TuneControllerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TuneControllerTest.java
@@ -1,0 +1,144 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link TuneController} — the safety state machine behind the
+ * Tune carrier (issue #408). Plain JUnit with an injected fake clock, so the
+ * hard max-on timeout is proven deterministically.
+ */
+public class TuneControllerTest {
+
+    /** Manually-advanced clock. */
+    private static final class FakeClock implements TuneController.Clock {
+        long now = 1_000_000L;
+
+        @Override
+        public long nowMs() {
+            return now;
+        }
+    }
+
+    @Test
+    public void startArmsTheSession() {
+        FakeClock clock = new FakeClock();
+        TuneController c = new TuneController(clock);
+        assertThat(c.isActive()).isFalse();
+        assertThat(c.tryStart(10)).isTrue();
+        assertThat(c.isActive()).isTrue();
+        assertThat(c.shouldContinue()).isTrue();
+        assertThat(c.remainingMs()).isEqualTo(10_000L);
+    }
+
+    @Test
+    public void doubleStart_isRefused() {
+        TuneController c = new TuneController(new FakeClock());
+        assertThat(c.tryStart(10)).isTrue();
+        assertThat(c.tryStart(10)).isFalse();
+    }
+
+    @Test
+    public void timeout_stopsExactlyAtTheDeadline() {
+        FakeClock clock = new FakeClock();
+        TuneController c = new TuneController(clock);
+        c.tryStart(10);
+
+        clock.now += 9_999;
+        assertThat(c.shouldContinue()).isTrue();
+
+        clock.now += 1; // exactly the deadline
+        assertThat(c.shouldContinue()).isFalse();
+        assertThat(c.isActive()).isFalse();
+        assertThat(c.lastStopReason()).isEqualTo(TuneController.STOP_TIMEOUT);
+    }
+
+    @Test
+    public void userStop_winsOverALaterTimeout() {
+        FakeClock clock = new FakeClock();
+        TuneController c = new TuneController(clock);
+        c.tryStart(10);
+        c.requestStop(TuneController.STOP_USER);
+        assertThat(c.isActive()).isFalse();
+
+        // A later poll (or defensive stop) must not overwrite the first reason.
+        clock.now += 60_000;
+        assertThat(c.shouldContinue()).isFalse();
+        c.requestStop(TuneController.STOP_ERROR);
+        assertThat(c.lastStopReason()).isEqualTo(TuneController.STOP_USER);
+    }
+
+    @Test
+    public void txStart_stopsTheSession() {
+        TuneController c = new TuneController(new FakeClock());
+        c.tryStart(10);
+        c.requestStop(TuneController.STOP_TX);
+        assertThat(c.shouldContinue()).isFalse();
+        assertThat(c.lastStopReason()).isEqualTo(TuneController.STOP_TX);
+    }
+
+    @Test
+    public void stopWhenIdle_isANoOp() {
+        TuneController c = new TuneController(new FakeClock());
+        c.requestStop(TuneController.STOP_USER); // nothing running
+        assertThat(c.lastStopReason()).isNull();
+        assertThat(c.isActive()).isFalse();
+    }
+
+    @Test
+    public void restartAfterStop_getsAFreshDeadlineAndReason() {
+        FakeClock clock = new FakeClock();
+        TuneController c = new TuneController(clock);
+        c.tryStart(10);
+        c.requestStop(TuneController.STOP_USER);
+
+        clock.now += 5_000;
+        assertThat(c.tryStart(20)).isTrue();
+        assertThat(c.remainingMs()).isEqualTo(20_000L);
+        clock.now += 20_000;
+        assertThat(c.shouldContinue()).isFalse();
+        assertThat(c.lastStopReason()).isEqualTo(TuneController.STOP_TIMEOUT);
+    }
+
+    @Test
+    public void elapsedAndRemaining_trackTheClock() {
+        FakeClock clock = new FakeClock();
+        TuneController c = new TuneController(clock);
+        c.tryStart(10);
+        clock.now += 3_000;
+        assertThat(c.elapsedMs()).isEqualTo(3_000L);
+        assertThat(c.remainingMs()).isEqualTo(7_000L);
+        c.requestStop(TuneController.STOP_USER);
+        assertThat(c.elapsedMs()).isEqualTo(0L);
+        assertThat(c.remainingMs()).isEqualTo(0L);
+    }
+
+    @Test
+    public void maxOnSeconds_isClampedToTheLegalRange() {
+        assertThat(TuneController.clampMaxOnSeconds(10)).isEqualTo(10);
+        assertThat(TuneController.clampMaxOnSeconds(TuneController.MIN_MAX_ON_SECONDS))
+                .isEqualTo(TuneController.MIN_MAX_ON_SECONDS);
+        assertThat(TuneController.clampMaxOnSeconds(TuneController.MAX_MAX_ON_SECONDS))
+                .isEqualTo(TuneController.MAX_MAX_ON_SECONDS);
+        // Below the minimum but positive: clamp up.
+        assertThat(TuneController.clampMaxOnSeconds(1))
+                .isEqualTo(TuneController.MIN_MAX_ON_SECONDS);
+        // Zero/negative (corrupted config): fall back to the default, never "forever".
+        assertThat(TuneController.clampMaxOnSeconds(0))
+                .isEqualTo(TuneController.DEFAULT_MAX_ON_SECONDS);
+        assertThat(TuneController.clampMaxOnSeconds(-5))
+                .isEqualTo(TuneController.DEFAULT_MAX_ON_SECONDS);
+        // Above the ceiling: clamp down.
+        assertThat(TuneController.clampMaxOnSeconds(600))
+                .isEqualTo(TuneController.MAX_MAX_ON_SECONDS);
+    }
+
+    @Test
+    public void tryStart_usesTheClampedTimeout() {
+        FakeClock clock = new FakeClock();
+        TuneController c = new TuneController(clock);
+        c.tryStart(600); // clamps to 60 s
+        assertThat(c.remainingMs()).isEqualTo(TuneController.MAX_MAX_ON_SECONDS * 1000L);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TuneToneGeneratorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TuneToneGeneratorTest.java
@@ -1,0 +1,150 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link TuneToneGenerator} — the pure-DSP sample source behind
+ * the Tune carrier (issue #408). Plain JUnit: deterministic arithmetic, no
+ * Android or native dependencies.
+ */
+public class TuneToneGeneratorTest {
+
+    private static final int SR = 12000;
+    private static final int RAMP = 60;
+
+    private static float[] collect(TuneToneGenerator gen, int chunkLen, int chunks, float amp) {
+        float[] all = new float[chunkLen * chunks];
+        int pos = 0;
+        float[] chunk = new float[chunkLen];
+        for (int c = 0; c < chunks; c++) {
+            int n = gen.nextChunk(chunk, chunkLen, amp);
+            System.arraycopy(chunk, 0, all, pos, n);
+            pos += n;
+        }
+        float[] out = new float[pos];
+        System.arraycopy(all, 0, out, 0, pos);
+        return out;
+    }
+
+    @Test
+    public void steadyState_matchesSineWithinTolerance() {
+        // Skip the ramp, then every sample must equal a*sin(2*pi*f*n/sr).
+        TuneToneGenerator gen = new TuneToneGenerator(1500f, SR, RAMP);
+        float[] samples = collect(gen, 300, 4, 0.8f);
+        for (int n = RAMP; n < samples.length; n++) {
+            double expected = 0.8 * Math.sin(2.0 * Math.PI * 1500.0 * n / SR);
+            assertThat((double) samples[n]).isWithin(1e-4).of(expected);
+        }
+    }
+
+    @Test
+    public void phaseIsContinuousAcrossChunkBoundaries() {
+        // Generate the same tone as one big chunk and as many small chunks;
+        // identical output means no discontinuity/click at chunk boundaries.
+        TuneToneGenerator one = new TuneToneGenerator(1000f, SR, RAMP);
+        TuneToneGenerator many = new TuneToneGenerator(1000f, SR, RAMP);
+        float[] whole = new float[1200];
+        one.nextChunk(whole, whole.length, 1f);
+        float[] pieces = collect(many, 100, 12, 1f);
+        assertThat(pieces.length).isEqualTo(whole.length);
+        for (int i = 0; i < whole.length; i++) {
+            assertThat(pieces[i]).isEqualTo(whole[i]);
+        }
+    }
+
+    @Test
+    public void rampUp_isMonotonicEnvelope() {
+        // Envelope check on a "frequency 3000 = sr/4" tone whose |sin| hits 1
+        // every 4th sample: peaks inside the ramp must rise monotonically and
+        // stay below full scale until the ramp ends.
+        TuneToneGenerator gen = new TuneToneGenerator(3000f, SR, RAMP);
+        float[] samples = collect(gen, RAMP * 2, 1, 1f);
+        float lastPeak = 0f;
+        for (int n = 1; n < RAMP; n += 4) { // |sin| == 1 at n = 1, 5, 9, ...
+            float peak = Math.abs(samples[n]);
+            assertThat(peak).isAtLeast(lastPeak);
+            assertThat(peak).isLessThan(1.0f);
+            lastPeak = peak;
+        }
+        // Past the ramp the same phase points sit at full amplitude.
+        assertThat(Math.abs(samples[RAMP + 1])).isWithin(1e-4f).of(1.0f);
+    }
+
+    @Test
+    public void requestStop_rampsToZeroAndFinishes() {
+        TuneToneGenerator gen = new TuneToneGenerator(1500f, SR, RAMP);
+        float[] chunk = new float[300];
+        gen.nextChunk(chunk, chunk.length, 1f); // past the attack
+
+        gen.requestStop();
+        float[] tail = new float[300];
+        int n = gen.nextChunk(tail, tail.length, 1f);
+        // Exactly one ramp of samples remains, then the generator is done.
+        assertThat(n).isEqualTo(RAMP);
+        assertThat(gen.isFinished()).isTrue();
+        assertThat(gen.nextChunk(tail, tail.length, 1f)).isEqualTo(0);
+        // The very last emitted samples are at/near zero — no key-up click.
+        assertThat(Math.abs(tail[n - 1])).isLessThan(0.01f);
+    }
+
+    @Test
+    public void stopDuringAttack_stillTapersAndFinishes() {
+        TuneToneGenerator gen = new TuneToneGenerator(1500f, SR, RAMP);
+        float[] chunk = new float[RAMP / 2];
+        gen.nextChunk(chunk, chunk.length, 1f); // mid-attack
+        gen.requestStop();
+        float[] tail = new float[RAMP * 2];
+        int n = gen.nextChunk(tail, tail.length, 1f);
+        assertThat(n).isEqualTo(RAMP);
+        assertThat(gen.isFinished()).isTrue();
+        for (int i = 0; i < n; i++) {
+            // The product of the two half-envelopes can never exceed either one.
+            assertThat(Math.abs(tail[i])).isLessThan(1.0f);
+        }
+    }
+
+    @Test
+    public void amplitudeIsClampedAndAppliedPerChunk() {
+        TuneToneGenerator gen = new TuneToneGenerator(3000f, SR, 1);
+        float[] chunk = new float[64];
+        gen.nextChunk(chunk, chunk.length, 5f); // clamps to 1.0
+        float peak = 0f;
+        for (float s : chunk) {
+            peak = Math.max(peak, Math.abs(s));
+        }
+        assertThat(peak).isAtMost(1.0f);
+        assertThat(peak).isWithin(1e-4f).of(1.0f);
+
+        // Live level change: next chunk at 25% has a proportional peak.
+        gen.nextChunk(chunk, chunk.length, 0.25f);
+        peak = 0f;
+        for (float s : chunk) {
+            peak = Math.max(peak, Math.abs(s));
+        }
+        assertThat(peak).isWithin(1e-4f).of(0.25f);
+    }
+
+    @Test
+    public void degenerateInputs_areSane() {
+        // Negative frequency clamps to 0 Hz: a silent (all-zero) carrier, not a crash.
+        TuneToneGenerator dc = new TuneToneGenerator(-100f, SR, RAMP);
+        float[] chunk = new float[64];
+        assertThat(dc.nextChunk(chunk, chunk.length, 1f)).isEqualTo(64);
+        for (float s : chunk) {
+            assertThat(s).isEqualTo(0f);
+        }
+        // Zero-length requests and null buffers are no-ops.
+        TuneToneGenerator gen = new TuneToneGenerator(1500f, SR, RAMP);
+        assertThat(gen.nextChunk(chunk, 0, 1f)).isEqualTo(0);
+        assertThat(gen.nextChunk(null, 10, 1f)).isEqualTo(0);
+        // Invalid sample rate is a programming error and throws.
+        try {
+            new TuneToneGenerator(1500f, 0, RAMP);
+            throw new AssertionError("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/TuneLevelTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/TuneLevelTest.kt
@@ -1,0 +1,127 @@
+package radio.ks3ckc.ft8af
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Coverage for [resolveTuneLevel] — the tune-drive decision matrix from issue
+ * #408. Pure logic, no runner. The four rows of the behavior matrix:
+ *
+ *  | mode          | per-band | tune uses                       |
+ *  |---------------|----------|---------------------------------|
+ *  | same as TX    | off      | live FT8 level                  |
+ *  | same as TX    | on       | live FT8 level (already per-band|
+ *  |               |          | restored on band change)        |
+ *  | independent   | off      | global tune level               |
+ *  | independent   | on       | per-band tune level, falling    |
+ *  |               |          | back to the global tune level   |
+ */
+class TuneLevelTest {
+
+    @Test
+    fun sameAsTxDrive_usesTheLiveTxLevel() {
+        assertThat(
+            resolveTuneLevel(
+                independent = false, globalTuneLevel = 25,
+                perBandEnabled = false, band = "20m",
+                serializedTuneLevels = "20m=40", txLevel = 80,
+            ),
+        ).isEqualTo(80)
+        // Per-band on changes nothing for this mode: the live TX level is
+        // already the per-band FT8 level (band changes restore it).
+        assertThat(
+            resolveTuneLevel(
+                independent = false, globalTuneLevel = 25,
+                perBandEnabled = true, band = "20m",
+                serializedTuneLevels = "20m=40", txLevel = 60,
+            ),
+        ).isEqualTo(60)
+    }
+
+    @Test
+    fun independent_perBandOff_usesTheGlobalTuneLevel() {
+        assertThat(
+            resolveTuneLevel(
+                independent = true, globalTuneLevel = 25,
+                perBandEnabled = false, band = "20m",
+                serializedTuneLevels = "20m=40", txLevel = 80,
+            ),
+        ).isEqualTo(25)
+    }
+
+    @Test
+    fun independent_perBandOn_usesTheBandsTuneLevel() {
+        assertThat(
+            resolveTuneLevel(
+                independent = true, globalTuneLevel = 25,
+                perBandEnabled = true, band = "20m",
+                serializedTuneLevels = "20m=40,40m=55", txLevel = 80,
+            ),
+        ).isEqualTo(40)
+        assertThat(
+            resolveTuneLevel(
+                independent = true, globalTuneLevel = 25,
+                perBandEnabled = true, band = "40m",
+                serializedTuneLevels = "20m=40,40m=55", txLevel = 80,
+            ),
+        ).isEqualTo(55)
+    }
+
+    @Test
+    fun independent_perBandOn_unknownBandFallsBackToGlobal() {
+        assertThat(
+            resolveTuneLevel(
+                independent = true, globalTuneLevel = 25,
+                perBandEnabled = true, band = "17m",
+                serializedTuneLevels = "20m=40", txLevel = 80,
+            ),
+        ).isEqualTo(25)
+        // Null/blank band (frequency outside any band table): global too.
+        assertThat(
+            resolveTuneLevel(
+                independent = true, globalTuneLevel = 25,
+                perBandEnabled = true, band = null,
+                serializedTuneLevels = "20m=40", txLevel = 80,
+            ),
+        ).isEqualTo(25)
+    }
+
+    @Test
+    fun levelsAreClampedToTheLegalRange() {
+        assertThat(
+            resolveTuneLevel(
+                independent = true, globalTuneLevel = 400,
+                perBandEnabled = false, band = null,
+                serializedTuneLevels = null, txLevel = 80,
+            ),
+        ).isEqualTo(100)
+        assertThat(
+            resolveTuneLevel(
+                independent = false, globalTuneLevel = 25,
+                perBandEnabled = false, band = null,
+                serializedTuneLevels = null, txLevel = -5,
+            ),
+        ).isEqualTo(0)
+    }
+
+    @Test
+    fun tuneMapAndTxMapAreIndependentStores() {
+        // The per-band recorder is the shared, already-tested helper; this pins
+        // the #408 requirement that recording a tune level builds a map that
+        // never contains or disturbs FT8 entries — they are separate strings.
+        val tuneMap = recordPerBandOutputLevel(
+            enabled = true, band = "20m", level = 30, serialized = "",
+        )
+        assertThat(tuneMap).isEqualTo("20m=30")
+        val txMap = "20m=80,40m=70"
+        // Resolving tune on 20m reads the tune map, not the TX map.
+        assertThat(
+            resolveTuneLevel(
+                independent = true, globalTuneLevel = 25,
+                perBandEnabled = true, band = "20m",
+                serializedTuneLevels = tuneMap, txLevel = 80,
+            ),
+        ).isEqualTo(30)
+        assertThat(txMap).isEqualTo("20m=80,40m=70") // untouched
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/TuneChipLabelTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/TuneChipLabelTest.kt
@@ -1,0 +1,37 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [tuneChipLabel] — the TUNE chip's label logic (issue #408).
+ * While the carrier is up, the label carries the live countdown of the
+ * code-enforced safety timeout so the operator sees it running. Pure logic,
+ * no runner needed.
+ */
+class TuneChipLabelTest {
+
+    @Test
+    fun idle_isJustTheLabel() {
+        assertThat(tuneChipLabel("TUNE", isTuning = false, remainingSec = 0))
+            .isEqualTo("TUNE")
+        // Whatever remaining value is left over from the last run is ignored.
+        assertThat(tuneChipLabel("TUNE", isTuning = false, remainingSec = 7))
+            .isEqualTo("TUNE")
+    }
+
+    @Test
+    fun active_appendsTheCountdown() {
+        assertThat(tuneChipLabel("TUNE", isTuning = true, remainingSec = 10))
+            .isEqualTo("TUNE 10s")
+        assertThat(tuneChipLabel("TUNE", isTuning = true, remainingSec = 1))
+            .isEqualTo("TUNE 1s")
+    }
+
+    @Test
+    fun active_negativeRemaining_clampsToZero() {
+        // A racing final post must never render "-1s".
+        assertThat(tuneChipLabel("TUNE", isTuning = true, remainingSec = -1))
+            .isEqualTo("TUNE 0s")
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **Tune button** (issue #408, Phase 1 MVP): a latching TUNE control that keys the rig and emits a steady, phase-continuous single-tone carrier at the current TX offset for antenna/amplifier tuning — WSJT-X-style, plus a mobile-specific hard safety timeout.

## What's included

**Tone source — `TuneToneGenerator`** (pure Java, unit-tested): chunked sinusoid at the TX offset with a phase accumulator carried across chunks (no boundary clicks) and raised-cosine ramp-up/ramp-down (~5 ms) so key-down/key-up never splatter. Amplitude is read fresh per chunk (live level changes land mid-tune, like the FT8 volume slider) and clamped to [0, 1].

**Safety — `TuneController`** (pure Java, injected clock, unit-tested): code-enforced max-on timeout (default 10 s, clamped 2–60 s even against corrupted config), atomic single-flight start, first-stop-reason-wins semantics (`user` / `timeout` / `tx-start` / `error`).

**Keying** — `OnDoTransmitted` gains default `onTuneKeyDown()/onTuneKeyUp()`; MainViewModel's CAT/RTS/DTR PTT + SCO logic is factored into shared `beginKeying()`/`endKeying()` used by both the FT8 path and tune, so every rig backend that implements `setPTT` keys for tune automatically; VOX rigs key on the tone itself.

**Playback** — `FT8TransmitSignal.startTune()/stopTune()`: the same small-buffer chunked `MODE_STREAM` AudioTrack pattern as `playFT8Signal`, driven by the generator. The worker owns keying and the track for its whole life; PTT release + track release live in a `finally`, so stop, timeout, write error, or exception all unkey. Start/stop are logged to `debug.log` with offset, level, duration, and stop reason.

**Guards** — pure `tuneBlockReason(...)` (unit-tested): armed/live FT8 TX blocks tune; SWR lockout and the WSPR sub-band blacklist apply (tune is not a backdoor around TX inhibits); MVP routes = Android AudioTrack sink only — truSDX CAT-audio, network rigs (Flex/ICOM WiFi), and the USB-direct libusb path are refused with a toast (Phase 2, per the issue's staged plan). Mutual exclusion the other way: `setActivated(true)`/`setTransmitting(true)` stop a running tune. Backgrounding the app (`onStop`) force-stops tune.

**UI** — a TUNE chip in the TxStrip (toggle, disabled while the sequencer is armed/transmitting); active state turns red and shows the live countdown ("TUNE 7s"); the global `TransmitGlow` shows during tune so the operator is never unsure the rig is keyed; content description for accessibility; timeout auto-stop toasts.

**Settings** (TRANSMISSION → TUNE): tune timeout slider (2–60 s), "Independent tune level" toggle, and — when independent — a tune level slider. With the existing **"Save output level per band"** toggle on, the independent tune level is remembered per band in its own `perBandTuneLevels` store (reusing the tested `PerBandOutputLevel` parse/serialize/record helpers), never touching the FT8 per-band map. Defaults: "same as TX drive", inert until opted in. All values persist through `DatabaseOpr` config with defensive parsing/clamping on load.

**Strings**: TUNE label (non-translatable ham term) + 4 operator-facing strings translated across all 16 locales.

## Tests (all green, full `testDebugUnitTest`)

- `TuneToneGeneratorTest`: sample-accurate sine match, phase continuity across chunk boundaries (bitwise vs. one big chunk), monotonic ramp-up, stop → exactly one ramp of taper then finished (last samples ~0), stop-mid-attack tapers, amplitude clamp + live per-chunk level, degenerate inputs (negative frequency → silence, zero-length/null chunks, invalid sample rate throws).
- `TuneControllerTest`: arm/refuse-double-start, timeout exactly at the deadline with a fake clock, first-reason-wins, TX preemption, idle stop no-op, restart gets a fresh deadline, elapsed/remaining tracking, full clamp matrix.
- `TuneLevelTest`: the issue's 4-row mode × per-band matrix, unknown/blank band fallback, clamping, and tune-map/TX-map store independence.
- `FT8TransmitSignalTest`: `tuneBlockReason` severity ordering (TX beats protections beats route) and every route/protection case.
- `TuneChipLabelTest`: idle label, active countdown, negative-remaining clamp.

## Deferred (Phase 2, per the issue's staged plan)

CAT-audio (truSDX) tune framing, network/WiFi-rig streaming, USB-direct libusb validation, press-and-hold interaction mode, fixed tune offset. On-device verification against a real rig/dummy load is still to be done on the next bench session (rig keys, steady SWR needle, clean unkey).

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
