### PR TITLE
Auto-select a clear FT8 TX offset for CQ calling

### DIFF
--- a/docs/clear-cq-slot-selection.md
+++ b/docs/clear-cq-slot-selection.md
@@ -1,0 +1,92 @@
+# Auto-selecting a clear FT8 TX offset for CQ (issue #418)
+
+## Problem
+
+When calling CQ, transmitting on an offset that is already occupied (or hemmed
+in by strong neighbours) raises the collision rate at every receiver on the
+band: two overlapping FT8 signals within ~50 Hz usually cost both decodes.
+Manual slot selection from the waterfall is error-prone — the operator sees one
+cycle of one parity and has to eyeball guard spacing.
+
+## Background: what "occupied" means on FT8
+
+- An FT8 signal is 8-GFSK with 6.25 Hz tone spacing: it occupies **50 Hz**
+  starting at its base offset. Two signals collide when those 50 Hz intervals
+  overlap at a receiver; decode probability also degrades with a strong signal
+  immediately adjacent (AGC/splatter), which is why operators keep extra
+  clearance beyond the nominal bandwidth.
+- Activity is **slot-parity split** (even/odd 15 s slots). A station colliding
+  with us is one transmitting in *our* slot — exactly the stations we cannot
+  hear *while* we transmit. But before we start CQing we are receiving in both
+  parities, and while CQing we still see the opposite parity every cycle. This
+  is the core reason to score occupancy over a **multi-cycle history** rather
+  than the last decode pass alone: a short window still captures both parities
+  from the pre-TX observation period, and same-parity stations reappear in the
+  history whenever we skip a transmission or they shift timing.
+- Activity moves. A slot that was clear four cycles ago may be a pile-up now,
+  and vice versa; conversely a single stale hit should not condemn a slot
+  forever. A window of ~4 slots (1 minute of FT8) balances both.
+
+## Algorithm
+
+All logic lives in `ClearFrequencyFinder` (pure Java, unit-tested); the
+tunables below are constructor parameters with the defaults shown.
+
+1. **Occupancy history.** Every kept decode (own-echo-filtered) is recorded as
+   `(freqHz, utcMs)`. Entries older than `historyCycles` × slot length
+   (default **4 cycles**) are evicted against the newest UTC seen, so the
+   window is mode-aware (60 s on FT8, 30 s on FT4).
+2. **Occupied intervals.** Each recorded signal blocks
+   `[f − guardHz, f + 50 + guardHz]` (default guard **10 Hz** per side —
+   nominal bandwidth plus a margin for drift and splatter).
+3. **Candidates.** A grid from `minOffset` to `maxOffset` (default
+   **200–2800 Hz**, inside every rig's SSB passband and the decoder range) in
+   `stepHz` (default **10 Hz**) increments. A candidate's own 50 Hz interval
+   must fit inside the range.
+4. **Scoring.** For each candidate: `clearance` = distance from the candidate's
+   50 Hz interval to the nearest occupied interval in the window (0 when they
+   intersect = occupied). Rank by:
+   - larger clearance first, capped at `clearanceCap` (default **200 Hz** —
+     beyond that more empty space buys nothing, and the cap stops the picker
+     from always racing to the extreme band edges);
+   - tie-break toward the band centre (**1500 Hz**), where every rig's passband
+     is flat and most receivers listen;
+   - final tie-break: lower offset (determinism).
+5. **Keep-current bias.** If the operator's current offset is already clear, no
+   move is suggested — a gratuitous QSY costs callers that had already spotted
+   us. Selection also returns "no move" when there is no history at all (no
+   information ≠ occupied).
+6. **Retry / backoff.** While CQing (order 6, no station locked, not
+   transmitting), each decode delivery re-checks the current offset. If it has
+   become occupied, the finder relocates — but at most once per
+   `moveHolddownMs` (default **45 s** ≈ 3 FT8 cycles), so a marginal decode
+   can't make the CQ hop every cycle (each hop orphans answers already in
+   flight). Fallback when the whole band is busy: the least-bad candidate
+   (max clearance) is used only if it strictly beats the current offset's
+   clearance; otherwise stay put.
+
+## Integration
+
+- `MainViewModel.afterDecode` feeds every kept decode (all passes — deep passes
+  see signals the fast pass missed) to the finder via
+  `FT8TransmitSignal.recordBandActivity`.
+- Pressing **CQ** (`userResetToCQ`) applies a selection when the "Auto clear
+  TX offset" setting is on: the chosen offset goes through the existing
+  `setBaseFrequency` path (same as a waterfall tap), with a toast and a
+  `debug.log` line (`CLEARFREQ: ...`) recording the decision inputs.
+- The re-check hook runs from the same decode delivery, guarded to the
+  CQ-idle state so a live QSO never QSYs.
+- Off by default (config key `autoClearTxFreq`); the manual waterfall tap
+  always wins — it just becomes the new "current" offset that the keep-current
+  bias protects.
+
+## Validation
+
+- Unit tests (`ClearFrequencyFinderTest`) cover: interval overlap/guard math,
+  window eviction by mode slot length, clearance ranking + centre tie-break,
+  keep-current and no-history behaviour, full-band fallback, hold-down pacing,
+  and the CQ-idle gate predicate.
+- On-air validation: start CQ on a busy band, confirm the chosen offset lands
+  in a gap on the waterfall and `debug.log` shows the candidate scoring; park a
+  strong signal on the CQ offset and confirm exactly one relocation per
+  hold-down window.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -108,6 +108,11 @@ public class GeneralVariables {
     //Serialized band=level CSV ("20m=60,40m=85"); parsed/updated in PerBandOutputLevel.kt.
     public static volatile String perBandOutputLevels = "";
 
+    //Auto-select a clear TX offset when calling CQ (issue #418), defaults off.
+    //volatile: written from the config-load thread + Settings toggle, read from
+    //the decode-delivery thread inside recordBandActivity.
+    public static volatile boolean autoClearTxFreq = false;
+
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -316,6 +316,12 @@ public class MainViewModel extends ViewModel {
             GeneralVariables.mutableBandChange.postValue(GeneralVariables.bandListIndex);
             String newWaveLength = BaseRigOperation.getMeterFromFreq(freq);
 
+            // A real band hop invalidates the clear-CQ-slot occupancy history —
+            // the recorded offsets belong to the old band's activity (issue #418).
+            if (ft8TransmitSignal != null && !newWaveLength.equals(oldWaveLength)) {
+                ft8TransmitSignal.clearBandActivity();
+            }
+
             // The rig reported a band change (e.g. the operator turned the dial) —
             // optionally clear the stale decodes + reset the TX target.
             if (shouldClearOnBandChange(GeneralVariables.clearOnBandModeChange,
@@ -593,6 +599,12 @@ public class MainViewModel extends ViewModel {
 
 
                 findIncludedCallsigns(messages);//find matching messages and add to the call list
+
+                // Clear-CQ-slot occupancy (issue #418): every kept decode (all
+                // passes — deep passes see signals the fast pass missed) feeds
+                // the history; a CQ idling on a now-occupied offset relocates
+                // from inside this call, hold-down-paced.
+                ft8TransmitSignal.recordBandActivity(messages);
 
                 //check transmit procedure. Parse transmit procedure from message list
                 //if exceeded cycle by 2 seconds, should not parse
@@ -1161,6 +1173,9 @@ public class MainViewModel extends ViewModel {
         }
         if (ft8TransmitSignal != null) {
             ft8TransmitSignal.rebuildTimer(mode);
+            // Mode switch changes the slot length and usually the dial: the
+            // clear-CQ-slot occupancy history no longer applies (issue #418).
+            ft8TransmitSignal.clearBandActivity();
         }
 
         // Retune within the SAME band to the new mode's dial (see safety note above).

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2595,6 +2595,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("perBandOutputLevels")) {//Per-band TX output levels ("20m=60,40m=85")
                     GeneralVariables.perBandOutputLevels = result == null ? "" : result;
                 }
+                if (name.equalsIgnoreCase("autoClearTxFreq")) {//Auto-select clear CQ offset (issue #418)
+                    GeneralVariables.autoClearTxFreq = "1".equals(result);
+                }
                 if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinder.java
@@ -88,6 +88,10 @@ public final class ClearFrequencyFinder {
     public synchronized void clear() {
         history.clear();
         newestUtcMs = Long.MIN_VALUE;
+        // The hold-down protected callers on the OLD band's offset; carrying it
+        // across a band/mode hop would wrongly suppress the first relocation on
+        // the new band for up to moveHolddownMs.
+        lastMoveUtcMs = Long.MIN_VALUE;
     }
 
     /** Observations currently inside the window (test/diagnostic visibility). */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinder.java
@@ -1,0 +1,208 @@
+package com.k1af.ft8af.ft8transmit;
+
+import java.util.ArrayDeque;
+import java.util.Iterator;
+
+/**
+ * Picks a clear FT8/FT4 TX audio offset for CQ calling (issue #418).
+ *
+ * <p>Records every kept decode as an occupancy observation, keeps a sliding
+ * multi-cycle window of them, and scores candidate offsets by their clearance
+ * from occupied spectrum. See {@code docs/clear-cq-slot-selection.md} for the
+ * research/design note behind the defaults; every tunable is a constructor
+ * parameter so the tests (and future settings) can drive them explicitly.
+ *
+ * <p>Pure Java, no Android types. Thread-safe: decodes arrive on decoder
+ * threads while selection runs from the UI thread.
+ */
+public final class ClearFrequencyFinder {
+
+    /** An FT8/FT4 signal occupies 8 tones x 6.25 Hz starting at its offset. */
+    public static final float SIGNAL_BANDWIDTH_HZ = 50f;
+
+    // ---- default tunables (see the design note for the rationale) -----------
+    public static final int DEFAULT_HISTORY_CYCLES = 4;
+    public static final float DEFAULT_GUARD_HZ = 10f;
+    public static final float DEFAULT_MIN_OFFSET_HZ = 200f;
+    public static final float DEFAULT_MAX_OFFSET_HZ = 2800f;
+    public static final float DEFAULT_STEP_HZ = 10f;
+    public static final float DEFAULT_CLEARANCE_CAP_HZ = 200f;
+    public static final float PREFERRED_CENTER_HZ = 1500f;
+    public static final long DEFAULT_MOVE_HOLDDOWN_MS = 45_000L;
+
+    /** One observed signal: base offset + the slot UTC it was decoded in. */
+    private static final class Observation {
+        final float freqHz;
+        final long utcMs;
+
+        Observation(float freqHz, long utcMs) {
+            this.freqHz = freqHz;
+            this.utcMs = utcMs;
+        }
+    }
+
+    private final int historyCycles;
+    private final float guardHz;
+    private final float minOffsetHz;
+    private final float maxOffsetHz;
+    private final float stepHz;
+    private final float clearanceCapHz;
+    private final long moveHolddownMs;
+
+    private final ArrayDeque<Observation> history = new ArrayDeque<>();
+    private long newestUtcMs = Long.MIN_VALUE;
+    private long lastMoveUtcMs = Long.MIN_VALUE;
+
+    public ClearFrequencyFinder() {
+        this(DEFAULT_HISTORY_CYCLES, DEFAULT_GUARD_HZ, DEFAULT_MIN_OFFSET_HZ,
+                DEFAULT_MAX_OFFSET_HZ, DEFAULT_STEP_HZ, DEFAULT_CLEARANCE_CAP_HZ,
+                DEFAULT_MOVE_HOLDDOWN_MS);
+    }
+
+    public ClearFrequencyFinder(int historyCycles, float guardHz, float minOffsetHz,
+                                float maxOffsetHz, float stepHz, float clearanceCapHz,
+                                long moveHolddownMs) {
+        this.historyCycles = Math.max(1, historyCycles);
+        this.guardHz = Math.max(0f, guardHz);
+        this.minOffsetHz = minOffsetHz;
+        this.maxOffsetHz = Math.max(minOffsetHz + SIGNAL_BANDWIDTH_HZ, maxOffsetHz);
+        this.stepHz = Math.max(1f, stepHz);
+        this.clearanceCapHz = Math.max(0f, clearanceCapHz);
+        this.moveHolddownMs = Math.max(0L, moveHolddownMs);
+    }
+
+    /**
+     * Record one kept decode as an occupancy observation and evict everything
+     * older than the history window (measured against the newest UTC seen, so
+     * the window length follows the mode's slot length).
+     */
+    public synchronized void record(float freqHz, long utcMs, long slotMillis) {
+        history.addLast(new Observation(freqHz, utcMs));
+        if (utcMs > newestUtcMs) {
+            newestUtcMs = utcMs;
+        }
+        evict(slotMillis);
+    }
+
+    /** Drop the whole history (band/mode change: old occupancy is meaningless). */
+    public synchronized void clear() {
+        history.clear();
+        newestUtcMs = Long.MIN_VALUE;
+    }
+
+    /** Observations currently inside the window (test/diagnostic visibility). */
+    synchronized int observationCount() {
+        return history.size();
+    }
+
+    private void evict(long slotMillis) {
+        long cutoff = newestUtcMs - (long) historyCycles * Math.max(1L, slotMillis);
+        Iterator<Observation> it = history.iterator();
+        while (it.hasNext()) {
+            if (it.next().utcMs < cutoff) {
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Clearance of the candidate's 50 Hz interval from the nearest occupied
+     * interval in the window: 0 when they intersect (occupied), otherwise the
+     * gap in Hz, capped at {@link #DEFAULT_CLEARANCE_CAP_HZ} (constructor
+     * value) — beyond the cap more empty space buys nothing, and the cap stops
+     * the ranking from always racing to the extreme band edges.
+     */
+    public synchronized float clearanceAt(float offsetHz) {
+        float lo = offsetHz;
+        float hi = offsetHz + SIGNAL_BANDWIDTH_HZ;
+        float best = clearanceCapHz;
+        for (Observation o : history) {
+            float occLo = o.freqHz - guardHz;
+            float occHi = o.freqHz + SIGNAL_BANDWIDTH_HZ + guardHz;
+            if (hi >= occLo && lo <= occHi) {
+                return 0f; // intersects an occupied interval
+            }
+            float gap = (lo > occHi) ? lo - occHi : occLo - hi;
+            if (gap < best) {
+                best = gap;
+            }
+        }
+        return best;
+    }
+
+    /** True when the offset's signal interval touches occupied spectrum. */
+    public synchronized boolean isOccupied(float offsetHz) {
+        return !history.isEmpty() && clearanceAt(offsetHz) <= 0f;
+    }
+
+    /**
+     * Pick the offset a fresh CQ should transmit on.
+     *
+     * @return the chosen offset, or {@code null} when no move is warranted:
+     *     the current offset is already clear, there is no history to judge by
+     *     (no information is not "occupied"), or nothing on the grid beats the
+     *     current offset's clearance.
+     */
+    public synchronized Float selectClearOffset(float currentOffsetHz) {
+        if (history.isEmpty()) {
+            return null;
+        }
+        float currentClearance = clearanceAt(currentOffsetHz);
+        if (currentClearance > 0f) {
+            return null; // already clear: a gratuitous QSY loses spotted callers
+        }
+        Candidate best = bestCandidate();
+        if (best == null || best.clearance <= currentClearance) {
+            return null; // whole band as bad or worse: stay put
+        }
+        return best.offsetHz;
+    }
+
+    private static final class Candidate {
+        final float offsetHz;
+        final float clearance;
+
+        Candidate(float offsetHz, float clearance) {
+            this.offsetHz = offsetHz;
+            this.clearance = clearance;
+        }
+    }
+
+    /**
+     * Best candidate on the grid: max clearance, ties broken toward the band
+     * centre (1500 Hz, flat in every rig's passband), then toward the lower
+     * offset for determinism.
+     */
+    private Candidate bestCandidate() {
+        Candidate best = null;
+        for (float f = minOffsetHz; f + SIGNAL_BANDWIDTH_HZ <= maxOffsetHz; f += stepHz) {
+            float clearance = clearanceAt(f);
+            if (best == null
+                    || clearance > best.clearance
+                    || (clearance == best.clearance
+                        && Math.abs(f - PREFERRED_CENTER_HZ)
+                            < Math.abs(best.offsetHz - PREFERRED_CENTER_HZ))) {
+                best = new Candidate(f, clearance);
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Retry/backoff gate for a CQ already in progress: relocate only when the
+     * current offset has become occupied AND the last move is at least the
+     * hold-down ago — hopping every cycle orphans answers already in flight.
+     */
+    public synchronized boolean shouldRelocate(float currentOffsetHz, long nowUtcMs) {
+        if (!isOccupied(currentOffsetHz)) {
+            return false;
+        }
+        return lastMoveUtcMs == Long.MIN_VALUE
+                || nowUtcMs - lastMoveUtcMs >= moveHolddownMs;
+    }
+
+    /** Record that a move happened (starts the hold-down window). */
+    public synchronized void noteMoved(long utcMs) {
+        lastMoveUtcMs = utcMs;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -137,6 +137,11 @@ public class FT8TransmitSignal {
         this.meterProtectionController = controller;
     }
 
+    // Clear-CQ-slot picker (issue #418): multi-cycle occupancy history + candidate
+    // scoring. Fed from afterDecode via recordBandActivity; consulted at CQ start
+    // and re-checked (with hold-down) while CQing. See docs/clear-cq-slot-selection.md.
+    private final ClearFrequencyFinder clearFrequencyFinder = new ClearFrequencyFinder();
+
     private final OnDoTransmitted onDoTransmitted;// typically used for opening/closing PTT
     private final ExecutorService doTransmitThreadPool = Executors.newCachedThreadPool();
     private final DoTransmitRunnable doTransmitRunnable = new DoTransmitRunnable(this);
@@ -1915,12 +1920,103 @@ public class FT8TransmitSignal {
      * auto-follow or dequeue — the CQ message transmits cleanly first.
      */
     public void userResetToCQ() {
+        // Pick a clear TX offset BEFORE the CQ baseline is generated so the very
+        // first CQ already transmits in the gap (issue #418). No-op unless the
+        // auto-clear setting is on and the history says the current spot is taken.
+        maybeSelectClearCqOffset();
         resetToCQ();
         clearCallerQueue();
         pendingUserCQ = true;
         // A user-initiated CQ run is not a single tapped QSO: it should keep
         // calling CQ after each contact, so clear the one-shot flag.
         singleQsoMode = false;
+    }
+
+    // =========================================================================
+    // Clear-CQ-slot selection (issue #418). The scoring/occupancy logic lives
+    // in ClearFrequencyFinder (pure, unit-tested); this is the wiring: decode
+    // deliveries feed the history, CQ start consults it, and a mid-CQ re-check
+    // relocates (hold-down-paced) when the chosen spot becomes occupied.
+    // See docs/clear-cq-slot-selection.md for the design note.
+    // =========================================================================
+
+    /**
+     * Feed one decode delivery's kept messages into the occupancy history and,
+     * when a CQ run is idling on an offset that has become occupied, relocate
+     * it (at most once per hold-down window). Called from afterDecode for every
+     * pass — deep passes see signals the fast pass missed.
+     */
+    public void recordBandActivity(ArrayList<Ft8Message> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return;
+        }
+        long slotMillis = GeneralVariables.currentMode().slotMillis;
+        long newestUtc = Long.MIN_VALUE;
+        for (Ft8Message m : messages) {
+            clearFrequencyFinder.record(m.freq_hz, m.utcTime, slotMillis);
+            if (m.utcTime > newestUtc) {
+                newestUtc = m.utcTime;
+            }
+        }
+        if (shouldAutoPickCqOffset(GeneralVariables.autoClearTxFreq, activated,
+                isTransmitting, functionOrder, toCallsign)
+                && clearFrequencyFinder.shouldRelocate(
+                        GeneralVariables.getBaseFrequency(), newestUtc)) {
+            Float pick = clearFrequencyFinder.selectClearOffset(
+                    GeneralVariables.getBaseFrequency());
+            if (pick != null) {
+                applyClearCqOffset(pick, newestUtc, "occupied");
+            }
+        }
+    }
+
+    /** Band or mode changed: the accumulated occupancy belongs to another band. */
+    public void clearBandActivity() {
+        clearFrequencyFinder.clear();
+    }
+
+    /**
+     * Gate for the mid-CQ relocation: only while the auto-clear setting is on
+     * and the sequencer is idling at the CQ baseline (order 6, no station
+     * locked) between transmissions — a live QSO must never QSY. Pure
+     * predicate so it can be unit-tested without the Android runtime.
+     */
+    static boolean shouldAutoPickCqOffset(boolean enabled, boolean activated,
+                                          boolean transmitting, int functionOrder,
+                                          TransmitCallsign toCallsign) {
+        if (!enabled || !activated || transmitting) {
+            return false;
+        }
+        if (functionOrder != 6) {
+            return false;
+        }
+        // "no target" == null or the CQ placeholder (same convention as
+        // isHuntListeningIdle / TransmitCallsign.haveTargetCallsign).
+        return toCallsign == null || !toCallsign.haveTargetCallsign();
+    }
+
+    /** CQ-start hook: apply a clear-slot pick when the feature is enabled. */
+    private void maybeSelectClearCqOffset() {
+        if (!GeneralVariables.autoClearTxFreq) {
+            return;
+        }
+        Float pick = clearFrequencyFinder.selectClearOffset(
+                GeneralVariables.getBaseFrequency());
+        if (pick != null) {
+            applyClearCqOffset(pick, UtcTimer.getSystemTime(), "cq-start");
+        }
+    }
+
+    private void applyClearCqOffset(float offsetHz, long utcMs, String reason) {
+        float from = GeneralVariables.getBaseFrequency();
+        setBaseFrequency(offsetHz);
+        clearFrequencyFinder.noteMoved(utcMs);
+        GeneralVariables.fileLog(String.format(
+                "CLEARFREQ: %s moved TX offset %.0f -> %.0f Hz (history=%d)",
+                reason, from, offsetHz, clearFrequencyFinder.observationCount()));
+        ToastMessage.show(String.format(
+                GeneralVariables.getStringFromResource(R.string.cq_offset_moved),
+                Math.round(offsetHz)));
     }
 
     /**

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
@@ -54,6 +54,10 @@ fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) 
     // Notify observers (TxStrip pill, Settings band picker) so the UI updates
     // without waiting for a rig onFreqChanged round-trip.
     GeneralVariables.mutableBandChange.postValue(index)
+    // A real band hop invalidates the clear-CQ-slot occupancy history (issue #418).
+    if (newWaveLength != oldWaveLength) {
+        mainViewModel.ft8TransmitSignal.clearBandActivity()
+    }
     // The operator picked a new band — optionally clear the stale decodes + reset
     // the TX target so the decode screen reflects the new band (tester request).
     if (MainViewModel.shouldClearOnBandChange(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -53,6 +53,7 @@ fun TransmissionSettings(
     var alcTargetHigh by remember { mutableIntStateOf(GeneralVariables.alcTargetHigh) }
 
     // Auto-sequence state
+    var autoClearTxFreq by remember { mutableStateOf(GeneralVariables.autoClearTxFreq) }
     var autoFollowCQ by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
     var huntCallsCQ by remember { mutableStateOf(GeneralVariables.huntCallsCQ) }
     var autoCallFollow by remember { mutableStateOf(GeneralVariables.autoCallFollow) }
@@ -419,6 +420,19 @@ fun TransmissionSettings(
         SettingsSection(title = stringResource(R.string.settings_section_auto_sequence)) {
             GlassCard(modifier = Modifier.fillMaxWidth()) {
                 Column {
+                    SettingsRow(
+                        label = "Auto clear TX offset",
+                        description = "When calling CQ, pick a clear spot from recent band activity and move away if it becomes occupied",
+                        toggle = autoClearTxFreq,
+                        onToggleChange = { checked ->
+                            autoClearTxFreq = checked
+                            GeneralVariables.autoClearTxFreq = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "autoClearTxFreq", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
                     SettingsRow(
                         label = stringResource(R.string.settings_hunt),
                         description = stringResource(R.string.settings_hunt_desc),

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -421,8 +421,8 @@ fun TransmissionSettings(
             GlassCard(modifier = Modifier.fillMaxWidth()) {
                 Column {
                     SettingsRow(
-                        label = "Auto clear TX offset",
-                        description = "When calling CQ, pick a clear spot from recent band activity and move away if it becomes occupied",
+                        label = stringResource(R.string.settings_auto_clear_tx),
+                        description = stringResource(R.string.settings_auto_clear_tx_desc),
                         toggle = autoClearTxFreq,
                         onToggleChange = { checked ->
                             autoClearTxFreq = checked

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -557,4 +557,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">فشل صوت الإرسال — لم تُرسل أي إشارة في هذه الدورة (خطأ في صوت USB)</string>
     <string name="cq_offset_moved">تم نقل إزاحة CQ إلى موضع خالٍ: %1$d هرتز</string>
+    <string name="settings_auto_clear_tx">اختيار إزاحة إرسال خالية تلقائيًا</string>
+    <string name="settings_auto_clear_tx_desc">عند نداء CQ يختار موضعًا خاليًا وفق نشاط النطاق الأخير وينتقل إذا أصبح مشغولًا</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -556,4 +556,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">فشل صوت الإرسال — لم تُرسل أي إشارة في هذه الدورة (خطأ في صوت USB)</string>
+    <string name="cq_offset_moved">تم نقل إزاحة CQ إلى موضع خالٍ: %1$d هرتز</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -556,4 +556,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Selhalo TX audio — v tomto cyklu nebyl vyslán žádný signál (chyba USB audia)</string>
+    <string name="cq_offset_moved">Offset CQ přesunut na volné místo: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -557,4 +557,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Selhalo TX audio — v tomto cyklu nebyl vyslán žádný signál (chyba USB audia)</string>
     <string name="cq_offset_moved">Offset CQ přesunut na volné místo: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Automaticky volný TX offset</string>
+    <string name="settings_auto_clear_tx_desc">Při volání CQ vybere volné místo podle nedávné aktivity v pásmu a uhne, pokud se obsadí</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -514,4 +514,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Falló el audio de TX — no se transmitió señal en este ciclo (error de audio USB)</string>
     <string name="cq_offset_moved">Desplazamiento de CQ movido a un hueco libre: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Offset de TX libre automático</string>
+    <string name="settings_auto_clear_tx_desc">Al llamar CQ, elige un hueco libre según la actividad reciente de la banda y se aparta si se ocupa</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -513,4 +513,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Falló el audio de TX — no se transmitió señal en este ciclo (error de audio USB)</string>
+    <string name="cq_offset_moved">Desplazamiento de CQ movido a un hueco libre: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -514,4 +514,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Échec audio TX — aucun signal émis ce cycle (erreur audio USB)</string>
     <string name="cq_offset_moved">Décalage CQ déplacé vers un créneau libre : %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Décalage TX libre automatique</string>
+    <string name="settings_auto_clear_tx_desc">En appelant CQ, choisit un créneau libre selon l\'activité récente de la bande et se déplace s\'il devient occupé</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -513,4 +513,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Échec audio TX — aucun signal émis ce cycle (erreur audio USB)</string>
+    <string name="cq_offset_moved">Décalage CQ déplacé vers un créneau libre : %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -557,4 +557,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Audio TX gagal — tidak ada sinyal terkirim pada siklus ini (kesalahan audio USB)</string>
     <string name="cq_offset_moved">Offset CQ dipindahkan ke tempat kosong: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Offset TX kosong otomatis</string>
+    <string name="settings_auto_clear_tx_desc">Saat memanggil CQ, memilih tempat kosong dari aktivitas band terkini dan berpindah jika terisi</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -556,4 +556,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Audio TX gagal — tidak ada sinyal terkirim pada siklus ini (kesalahan audio USB)</string>
+    <string name="cq_offset_moved">Offset CQ dipindahkan ke tempat kosong: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -545,4 +545,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Audio TX non riuscito — nessun segnale trasmesso in questo ciclo (errore audio USB)</string>
+    <string name="cq_offset_moved">Offset CQ spostato in uno spazio libero: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -546,4 +546,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Audio TX non riuscito — nessun segnale trasmesso in questo ciclo (errore audio USB)</string>
     <string name="cq_offset_moved">Offset CQ spostato in uno spazio libero: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Offset TX libero automatico</string>
+    <string name="settings_auto_clear_tx_desc">Chiamando CQ, sceglie uno spazio libero dall\'attività recente della banda e si sposta se viene occupato</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -513,4 +513,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX音声に失敗 — このサイクルでは信号が送信されませんでした（USBオーディオエラー）</string>
+    <string name="cq_offset_moved">CQオフセットを空いている周波数へ移動：%1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -514,4 +514,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX音声に失敗 — このサイクルでは信号が送信されませんでした（USBオーディオエラー）</string>
     <string name="cq_offset_moved">CQオフセットを空いている周波数へ移動：%1$d Hz</string>
+    <string name="settings_auto_clear_tx">空きTXオフセット自動選択</string>
+    <string name="settings_auto_clear_tx_desc">CQ呼び出し時に直近のバンド活動から空き周波数を選び、占有されたら移動します</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -556,4 +556,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX 오디오 실패 — 이번 주기에 신호가 송신되지 않았습니다 (USB 오디오 오류)</string>
+    <string name="cq_offset_moved">CQ 오프셋을 빈 자리로 이동: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -557,4 +557,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX 오디오 실패 — 이번 주기에 신호가 송신되지 않았습니다 (USB 오디오 오류)</string>
     <string name="cq_offset_moved">CQ 오프셋을 빈 자리로 이동: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">빈 TX 오프셋 자동 선택</string>
+    <string name="settings_auto_clear_tx_desc">CQ 호출 시 최근 밴드 활동을 바탕으로 빈 자리를 선택하고, 점유되면 이동합니다</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -557,4 +557,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX-audio mislukt — geen signaal verzonden deze cyclus (USB-audiofout)</string>
     <string name="cq_offset_moved">CQ-offset verplaatst naar een vrije plek: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Automatisch vrije TX-offset</string>
+    <string name="settings_auto_clear_tx_desc">Kiest bij het roepen van CQ een vrije plek op basis van recente bandactiviteit en wijkt uit als die bezet raakt</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -556,4 +556,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX-audio mislukt — geen signaal verzonden deze cyclus (USB-audiofout)</string>
+    <string name="cq_offset_moved">CQ-offset verplaatst naar een vrije plek: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -545,4 +545,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Błąd audio TX — w tym cyklu nie wysłano sygnału (błąd audio USB)</string>
+    <string name="cq_offset_moved">Offset CQ przeniesiony w wolne miejsce: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -546,4 +546,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Błąd audio TX — w tym cyklu nie wysłano sygnału (błąd audio USB)</string>
     <string name="cq_offset_moved">Offset CQ przeniesiony w wolne miejsce: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Automatyczny wolny offset TX</string>
+    <string name="settings_auto_clear_tx_desc">Przy wołaniu CQ wybiera wolne miejsce na podstawie ostatniej aktywności pasma i przenosi się, gdy zostanie zajęte</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -513,4 +513,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Сбой TX-аудио — в этом цикле сигнал не передан (ошибка USB-аудио)</string>
+    <string name="cq_offset_moved">Смещение CQ перенесено на свободное место: %1$d Гц</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -514,4 +514,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Сбой TX-аудио — в этом цикле сигнал не передан (ошибка USB-аудио)</string>
     <string name="cq_offset_moved">Смещение CQ перенесено на свободное место: %1$d Гц</string>
+    <string name="settings_auto_clear_tx">Автовыбор свободного смещения TX</string>
+    <string name="settings_auto_clear_tx_desc">При вызове CQ выбирает свободное место по недавней активности диапазона и уходит, если оно занимается</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -546,4 +546,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX sesi başarısız — bu döngüde sinyal gönderilmedi (USB ses hatası)</string>
     <string name="cq_offset_moved">CQ ofseti boş bir noktaya taşındı: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Otomatik boş TX ofseti</string>
+    <string name="settings_auto_clear_tx_desc">CQ çağrılırken son bant etkinliğine göre boş bir nokta seçer ve doldurulursa başka yere taşınır</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -545,4 +545,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">TX sesi başarısız — bu döngüde sinyal gönderilmedi (USB ses hatası)</string>
+    <string name="cq_offset_moved">CQ ofseti boş bir noktaya taşındı: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -546,4 +546,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Збій TX-аудіо — у цьому циклі сигнал не передано (помилка USB-аудіо)</string>
     <string name="cq_offset_moved">Зсув CQ перенесено на вільне місце: %1$d Гц</string>
+    <string name="settings_auto_clear_tx">Автовибір вільного зсуву TX</string>
+    <string name="settings_auto_clear_tx_desc">Під час виклику CQ обирає вільне місце за нещодавньою активністю діапазону і зміщується, якщо воно займається</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -545,4 +545,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">Збій TX-аудіо — у цьому циклі сигнал не передано (помилка USB-аудіо)</string>
+    <string name="cq_offset_moved">Зсув CQ перенесено на вільне місце: %1$d Гц</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -514,4 +514,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">发射音频失败 — 本周期未发出信号（USB 音频错误）</string>
     <string name="cq_offset_moved">CQ频偏已移至空闲位置：%1$d Hz</string>
+    <string name="settings_auto_clear_tx">自动选择空闲TX频偏</string>
+    <string name="settings_auto_clear_tx_desc">呼叫CQ时根据近期频段活动选择空闲位置，被占用时自动移开</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -513,4 +513,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">发射音频失败 — 本周期未发出信号（USB 音频错误）</string>
+    <string name="cq_offset_moved">CQ频偏已移至空闲位置：%1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -513,4 +513,5 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">發射音訊失敗 — 本週期未發出訊號（USB 音訊錯誤）</string>
+    <string name="cq_offset_moved">CQ頻偏已移至空閒位置：%1$d Hz</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -514,4 +514,6 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_audio_dropped">發射音訊失敗 — 本週期未發出訊號（USB 音訊錯誤）</string>
     <string name="cq_offset_moved">CQ頻偏已移至空閒位置：%1$d Hz</string>
+    <string name="settings_auto_clear_tx">自動選擇空閒TX頻偏</string>
+    <string name="settings_auto_clear_tx_desc">呼叫CQ時根據近期頻段活動選擇空閒位置，被佔用時自動移開</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -653,4 +653,6 @@
 
     <string name="tx_audio_dropped">TX audio failed — no signal was sent this cycle (USB audio error)</string>
     <string name="cq_offset_moved">CQ offset moved to a clear spot: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Auto clear TX offset</string>
+    <string name="settings_auto_clear_tx_desc">When calling CQ, pick a clear spot from recent band activity and move away if it becomes occupied</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -652,4 +652,5 @@
     <string name="language_name_ar" translatable="false">العربية</string>
 
     <string name="tx_audio_dropped">TX audio failed — no signal was sent this cycle (USB audio error)</string>
+    <string name="cq_offset_moved">CQ offset moved to a clear spot: %1$d Hz</string>
 </resources>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinderTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinderTest.java
@@ -81,6 +81,19 @@ public class ClearFrequencyFinderTest {
         assertThat(f.selectClearOffset(1500f)).isNull(); // back to no-information
     }
 
+    @Test
+    public void clearAlsoResetsTheHoldDown() {
+        // A band/mode hop invalidates the hold-down along with the history: the
+        // old band's move must not suppress the first relocation on the new band.
+        ClearFrequencyFinder f = finder();
+        occupy(f, 1500f, T0);
+        f.noteMoved(T0);
+        f.clear();
+
+        occupy(f, 1500f, T0 + FT8_SLOT_MS); // new band, occupied right away
+        assertThat(f.shouldRelocate(1500f, T0 + FT8_SLOT_MS)).isTrue();
+    }
+
     // ---- selection ------------------------------------------------------------
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinderTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/ClearFrequencyFinderTest.java
@@ -1,0 +1,203 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link ClearFrequencyFinder} — the clear-CQ-slot occupancy and
+ * scoring logic behind issue #418 (see docs/clear-cq-slot-selection.md). Plain
+ * JUnit: pure arithmetic, deterministic, no Android types.
+ */
+public class ClearFrequencyFinderTest {
+
+    private static final long FT8_SLOT_MS = 15_000L;
+    private static final long T0 = 1_000_000L;
+
+    /** A finder with the shipping defaults. */
+    private static ClearFrequencyFinder finder() {
+        return new ClearFrequencyFinder();
+    }
+
+    private static void occupy(ClearFrequencyFinder f, float freq, long utc) {
+        f.record(freq, utc, FT8_SLOT_MS);
+    }
+
+    // ---- occupancy intervals + guard spacing ---------------------------------
+
+    @Test
+    public void signalBlocksItsBandwidthPlusGuard() {
+        ClearFrequencyFinder f = finder();
+        occupy(f, 1500f, T0);
+
+        // The signal itself: occupied.
+        assertThat(f.isOccupied(1500f)).isTrue();
+        // Candidate whose 50 Hz interval touches [1490, 1560] (10 Hz guard): occupied.
+        assertThat(f.isOccupied(1440f)).isTrue();  // [1440,1490] touches 1490
+        assertThat(f.isOccupied(1560f)).isTrue();  // [1560,1610] touches 1560
+        // Just beyond the guard on either side: clear.
+        assertThat(f.isOccupied(1439f)).isFalse();
+        assertThat(f.isOccupied(1561f)).isFalse();
+    }
+
+    @Test
+    public void emptyHistory_isNeverOccupied() {
+        // No information is not "occupied" — and selection must not move either.
+        ClearFrequencyFinder f = finder();
+        assertThat(f.isOccupied(1500f)).isFalse();
+        assertThat(f.selectClearOffset(1500f)).isNull();
+    }
+
+    // ---- multi-cycle window ---------------------------------------------------
+
+    @Test
+    public void observationsExpireAfterTheHistoryWindow() {
+        ClearFrequencyFinder f = finder();
+        occupy(f, 1500f, T0);
+        assertThat(f.isOccupied(1500f)).isTrue();
+
+        // 4-cycle window (default): a new observation 5 slots later evicts it.
+        occupy(f, 300f, T0 + 5 * FT8_SLOT_MS);
+        assertThat(f.isOccupied(1500f)).isFalse();
+        assertThat(f.observationCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void windowFollowsTheModeSlotLength() {
+        // Same timestamps, FT4 slot length (7.5 s): 4 cycles is only 30 s, so an
+        // observation 40 s old is gone where FT8's 60 s window would keep it.
+        ClearFrequencyFinder f = finder();
+        f.record(1500f, T0, 7_500L);
+        f.record(300f, T0 + 40_000L, 7_500L);
+        assertThat(f.isOccupied(1500f)).isFalse();
+    }
+
+    @Test
+    public void clearDropsEverything() {
+        ClearFrequencyFinder f = finder();
+        occupy(f, 1500f, T0);
+        f.clear();
+        assertThat(f.observationCount()).isEqualTo(0);
+        assertThat(f.selectClearOffset(1500f)).isNull(); // back to no-information
+    }
+
+    // ---- selection ------------------------------------------------------------
+
+    @Test
+    public void keepsTheCurrentOffsetWhenItIsClear() {
+        ClearFrequencyFinder f = finder();
+        occupy(f, 500f, T0);
+        // 1500 is nowhere near 500: no move suggested (a gratuitous QSY loses
+        // callers that had already spotted us).
+        assertThat(f.selectClearOffset(1500f)).isNull();
+    }
+
+    @Test
+    public void movesOffAnOccupiedOffsetIntoAClearSpot() {
+        ClearFrequencyFinder f = finder();
+        occupy(f, 1500f, T0);
+        Float pick = f.selectClearOffset(1510f); // we sit inside the occupied interval
+        assertThat(pick).isNotNull();
+        assertThat(f.isOccupied(pick)).isFalse();
+        // The pick's own interval fits the candidate range.
+        assertThat(pick).isAtLeast(ClearFrequencyFinder.DEFAULT_MIN_OFFSET_HZ);
+        assertThat(pick + ClearFrequencyFinder.SIGNAL_BANDWIDTH_HZ)
+                .isAtMost(ClearFrequencyFinder.DEFAULT_MAX_OFFSET_HZ);
+    }
+
+    @Test
+    public void prefersTheWidestGap_thenTheBandCenter() {
+        // Occupy everything except two gaps: a narrow one near 600 and a wide
+        // one around 2000. The pick must land in the wide gap.
+        ClearFrequencyFinder f = finder();
+        for (float freq = 200f; freq <= 2800f; freq += 60f) {
+            boolean inNarrowGap = freq > 550f && freq < 700f;
+            boolean inWideGap = freq > 1700f && freq < 2300f;
+            if (!inNarrowGap && !inWideGap) {
+                occupy(f, freq, T0);
+            }
+        }
+        Float pick = f.selectClearOffset(300f);
+        assertThat(pick).isNotNull();
+        assertThat(pick).isGreaterThan(1700f);
+        assertThat(pick).isLessThan(2300f);
+    }
+
+    @Test
+    public void centerTieBreak_picksMidBandOnAnEmptyishBand() {
+        // One lone signal at 400: huge clear space everywhere, so many candidates
+        // hit the clearance cap. The tie-break must pull the pick toward 1500,
+        // not the band edges.
+        ClearFrequencyFinder f = finder();
+        occupy(f, 400f, T0);
+        Float pick = f.selectClearOffset(410f); // current is occupied
+        assertThat(pick).isNotNull();
+        assertThat(Math.abs(pick - ClearFrequencyFinder.PREFERRED_CENTER_HZ))
+                .isLessThan(300f);
+    }
+
+    @Test
+    public void fullBand_staysPutWhenNothingIsBetter() {
+        // Signals every 40 Hz across the whole candidate range: every candidate
+        // interval intersects something, so clearance is 0 everywhere — no move
+        // is suggested (hopping between equally-bad spots helps nobody).
+        ClearFrequencyFinder f = finder();
+        for (float freq = 150f; freq <= 2850f; freq += 40f) {
+            occupy(f, freq, T0);
+        }
+        assertThat(f.selectClearOffset(1500f)).isNull();
+    }
+
+    // ---- retry / hold-down ------------------------------------------------------
+
+    @Test
+    public void relocatesOnlyWhenOccupied() {
+        ClearFrequencyFinder f = finder();
+        occupy(f, 500f, T0);
+        assertThat(f.shouldRelocate(1500f, T0)).isFalse(); // clear: stay
+        assertThat(f.shouldRelocate(510f, T0)).isTrue();   // occupied: go
+    }
+
+    @Test
+    public void holdDownPacesRepeatedMoves() {
+        ClearFrequencyFinder f = finder();
+        occupy(f, 1500f, T0);
+        assertThat(f.shouldRelocate(1500f, T0)).isTrue();
+        f.noteMoved(T0);
+
+        // Still occupied one cycle later: hold-down (45 s default) blocks the hop.
+        occupy(f, 1500f, T0 + FT8_SLOT_MS);
+        assertThat(f.shouldRelocate(1500f, T0 + FT8_SLOT_MS)).isFalse();
+
+        // Past the hold-down: allowed again.
+        occupy(f, 1500f, T0 + ClearFrequencyFinder.DEFAULT_MOVE_HOLDDOWN_MS);
+        assertThat(f.shouldRelocate(1500f,
+                T0 + ClearFrequencyFinder.DEFAULT_MOVE_HOLDDOWN_MS)).isTrue();
+    }
+
+    // ---- the CQ-idle gate (wiring predicate on FT8TransmitSignal) --------------
+
+    @Test
+    public void autoPickGate_requiresEnabledActivatedIdleCq() {
+        TransmitCallsign cq = new TransmitCallsign(1, 0, "CQ", 0);
+        TransmitCallsign station = new TransmitCallsign(1, 0, "K1ABC", 0);
+
+        // The happy path: enabled, armed, not transmitting, CQ baseline, no target.
+        assertThat(FT8TransmitSignal.shouldAutoPickCqOffset(
+                true, true, false, 6, cq)).isTrue();
+        assertThat(FT8TransmitSignal.shouldAutoPickCqOffset(
+                true, true, false, 6, null)).isTrue();
+
+        // Each precondition individually kills it.
+        assertThat(FT8TransmitSignal.shouldAutoPickCqOffset(
+                false, true, false, 6, cq)).isFalse();   // setting off
+        assertThat(FT8TransmitSignal.shouldAutoPickCqOffset(
+                true, false, false, 6, cq)).isFalse();   // not armed
+        assertThat(FT8TransmitSignal.shouldAutoPickCqOffset(
+                true, true, true, 6, cq)).isFalse();     // mid-transmission
+        assertThat(FT8TransmitSignal.shouldAutoPickCqOffset(
+                true, true, false, 2, station)).isFalse(); // mid-QSO: never QSY
+        assertThat(FT8TransmitSignal.shouldAutoPickCqOffset(
+                true, true, false, 6, station)).isFalse(); // caller locked
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #418: when calling CQ, the app can now automatically pick a clear TX audio offset from recent band activity, and relocate (with backoff) if the chosen spot becomes occupied. Off by default (Settings → Transmission → Auto-sequence → "Auto clear TX offset").

## Deliverable 1 — design note

`docs/clear-cq-slot-selection.md` documents the research and the algorithm: why occupancy must be observed over a **multi-cycle window** (slot-parity split — colliders transmit in *our* slot, which we only hear while not transmitting, so the pre-TX observation period and skipped cycles are what capture them), the 50 Hz FT8 signal bandwidth + guard-spacing model, the clearance-capped scoring with a band-centre tie-break, the keep-current bias, and the hold-down-paced retry.

## Deliverable 2/3 — implementation with tunable parameters

**`ClearFrequencyFinder`** (pure Java, thread-safe, every tunable a constructor parameter):
- **Occupancy history**: every kept (own-echo-filtered) decode is recorded as `(freqHz, utcMs)`; entries older than `historyCycles` (default **4**) × slot length are evicted, so the window is mode-aware (60 s FT8 / 30 s FT4).
- **Occupied intervals**: each signal blocks `[f − guard, f + 50 + guard]` (guard default **10 Hz**/side).
- **Candidates**: a **10 Hz** grid across **200–2800 Hz** whose 50 Hz interval must fit in range.
- **Scoring**: clearance to the nearest occupied interval, capped at **200 Hz** (stops the picker racing to band edges), tie-broken toward **1500 Hz**, then lower offset (deterministic).
- **Keep-current bias**: no move when the current offset is already clear, when there is no history (no information ≠ occupied), or when nothing on the grid strictly beats the current offset (full-band fallback).
- **Retry/backoff**: `shouldRelocate` fires only when the current offset is occupied **and** the last move is ≥ `moveHolddownMs` (default **45 s** ≈ 3 FT8 cycles) ago, so a marginal decode can't make the CQ hop every cycle.

**Wiring** (`FT8TransmitSignal` + `MainViewModel`):
- `afterDecode` feeds every pass's kept messages via `recordBandActivity` (deep passes see signals the fast pass missed).
- Pressing CQ (`userResetToCQ`) applies a selection *before* the CQ baseline is generated, so the first CQ already transmits in the gap.
- The mid-CQ re-check runs from the same decode delivery, gated by the pure predicate `shouldAutoPickCqOffset` — only while armed, **not transmitting**, at the CQ baseline (order 6) with **no station locked**, so a live QSO never QSYs.
- Moves go through the existing `setBaseFrequency` path (same as a waterfall tap), toast the operator (`cq_offset_moved`, translated in all 16 locales), and log `CLEARFREQ: <reason> moved TX offset A -> B Hz (history=N)` to `debug.log` for field auditing.
- The occupancy history clears on a real band hop (rig dial, frequency picker) and on FT8/FT4/FT2 mode switches — old activity is meaningless there. Config key `autoClearTxFreq`, loaded null-safely.

## Tests (`ClearFrequencyFinderTest`, plain JUnit — all green, full `testDebugUnitTest` suite green)

- Guard-spacing interval math including exact boundary offsets on both sides.
- No-history behavior: never occupied, never moves.
- Window eviction at the FT8 slot length and the mode-aware FT4 window.
- `clear()` reset.
- Selection: keep-current when clear; move off an occupied offset into a verified-clear, in-range pick; widest-gap-wins ranking; centre tie-break on an empty-ish band; full-band stay-put fallback.
- Retry: relocate only when occupied; hold-down pacing (blocked one cycle after a move, allowed after 45 s).
- The CQ-idle gate predicate matrix (setting off / not armed / mid-transmission / mid-QSO / caller locked each individually block).

## Validation guidance (from the design note)

On a busy band: enable the setting, press CQ, confirm the chosen offset lands in a waterfall gap and `debug.log` shows the `CLEARFREQ` line; park a strong signal on the CQ offset and confirm exactly one relocation per hold-down window.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
