### PR TITLE
Fix MicRecorder reinitialize races (startup NPE + native releaseBuffer abort)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -36,6 +36,21 @@ public class MicRecorder {
     private volatile boolean isRunning = false;//whether currently in recording state
     private OnDataListener onDataListener;
 
+    // AudioRecord capture-thread handoff. reinitialize() can be called from
+    // several threads at once (USB onCaptureStopped, one usbDetach event per
+    // interface of a composite device, the reader thread's DEAD_OBJECT path) —
+    // a real cable unplug fires three within ~150ms. Each used to release/null
+    // the shared audioRecord field and spawn a fresh reader thread while the
+    // previous one was still blocked in read(), which is exactly the NPE at
+    // read() and the fatal native 'releaseBuffer: mUnreleased out of range'
+    // abort seen in the field. Now: lifecycle methods are synchronized, the
+    // reader thread only ever touches the AudioRecord instance it was started
+    // with, checks its generation each pass, and reinitialize() stops + joins
+    // the old thread before releasing the old AudioRecord.
+    private Thread captureThread = null;
+    private volatile int captureGeneration = 0;
+    private static final long CAPTURE_JOIN_TIMEOUT_MS = 1000;
+
     // USB-audio death-loop guard. On some hosts (notably car-dash Android
     // tablets) UsbRequest.requestWait() returns null on first iteration and
     // onCaptureStopped() fires immediately. Without this, MicRecorder would
@@ -197,7 +212,7 @@ public class MicRecorder {
         return null;
     }
 
-    public void start(){
+    public synchronized void start(){
         if (isRunning) return;
 
         if (useUsbAudio && usbAudioDevice != null) {
@@ -286,28 +301,38 @@ public class MicRecorder {
     }
 
     private void startAudioRecordCapture() {
+        // The reader thread works exclusively on these locals. reinitialize()
+        // releases and reassigns the audioRecord/bufferSize *fields* from other
+        // threads; reading the fields from the loop is what crashed (NPE at
+        // read(), native releaseBuffer abort from two threads on one instance).
+        final AudioRecord rec = audioRecord;
+        final int myGeneration = captureGeneration;
         float[] buffer = new float[bufferSize];
         try {
-            audioRecord.startRecording();//start recording
+            rec.startRecording();//start recording
         }catch (Exception e){
             ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
                     R.string.recorder_cannot_record),e.getMessage()));
             Log.d(TAG, "startRecord: "+e.getMessage() );
         }
 
-        new Thread(new Runnable() {
+        captureThread = new Thread(new Runnable() {
             @Override
             public void run() {
-                while (isRunning) {
+                while (captureLoopShouldContinue(isRunning, myGeneration, captureGeneration)) {
                     //check if in recording state; state!=3 means not in recording state
-                    if (audioRecord.getRecordingState() != AudioRecord.RECORDSTATE_RECORDING) {
-                        isRunning = false;
-                        Log.d(TAG, String.format("Recording failed, state code: %d", audioRecord.getRecordingState()));
+                    if (rec.getRecordingState() != AudioRecord.RECORDSTATE_RECORDING) {
+                        // A stale generation means reinitialize() owns the lifecycle
+                        // now; only a current-generation thread may stop the capture.
+                        if (myGeneration == captureGeneration) {
+                            isRunning = false;
+                        }
+                        Log.d(TAG, String.format("Recording failed, state code: %d", rec.getRecordingState()));
                         break;
                     }
 
                     //read recording data
-                    int bufferReadResult = audioRecord.read(buffer, 0, bufferSize,AudioRecord.READ_BLOCKING);
+                    int bufferReadResult = rec.read(buffer, 0, buffer.length,AudioRecord.READ_BLOCKING);
 
                     if (bufferReadResult < 0) {
                         // Error codes (ERROR_INVALID_OPERATION=-3, ERROR_BAD_VALUE=-2,
@@ -316,6 +341,12 @@ public class MicRecorder {
                         GeneralVariables.fileLog(
                                 "MicRecorder: AudioRecord.read error " + bufferReadResult);
                         if (bufferReadResult == AudioRecord.ERROR_DEAD_OBJECT) {
+                            // A stale thread must not drive lifecycle — a reinit
+                            // already replaced it and killing its AudioRecord here
+                            // is how the double-reader abort happened. Just exit.
+                            if (myGeneration != captureGeneration) {
+                                break;
+                            }
                             // Route audio server death through the same throttled
                             // reinitialize used by the USB capture-stopped path.
                             isRunning = false;
@@ -342,8 +373,8 @@ public class MicRecorder {
                     }
                 }
                 try {
-                    if (audioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
-                        audioRecord.stop();//stop recording
+                    if (rec.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
+                        rec.stop();//stop recording
                     }
                 }catch (Exception e){
                     ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
@@ -351,13 +382,14 @@ public class MicRecorder {
                     Log.d(TAG, "startRecord: "+e.getMessage() );
                 }
             }
-        }).start();
+        });
+        captureThread.start();
     }
 
     /**
      * Stop recording. When recording stops, all monitors in the listener list are removed.
      */
-    public void stopRecord() {
+    public synchronized void stopRecord() {
         isRunning = false;
         if (useUsbAudio && usbAudioDevice != null) {
             usbAudioDevice.stopCapture();
@@ -379,15 +411,28 @@ public class MicRecorder {
      * was originally constructed.
      */
     @SuppressLint("MissingPermission")
-    public void reinitialize() {
+    public synchronized void reinitialize() {
         boolean wasRunning = isRunning;
         OnDataListener savedListener = onDataListener;
 
-        // Stop current capture
+        // Supersede the running reader thread's generation, then stop capture.
+        captureGeneration++;
         stopRecord();
 
-        // Release old AudioRecord (stopRecord only sets isRunning=false)
+        // Release old AudioRecord (stopRecord only sets isRunning=false). The
+        // reader thread may still be inside a blocking read() on it: stop()
+        // unblocks that read, and we must wait for the thread to exit before
+        // release() — releasing mid-read is a fatal native abort
+        // ('releaseBuffer: mUnreleased out of range'), not a catchable exception.
         if (audioRecord != null) {
+            try {
+                if (audioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
+                    audioRecord.stop();
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "reinitialize: error stopping AudioRecord: " + e.getMessage());
+            }
+            joinCaptureThread();
             try {
                 audioRecord.release();
             } catch (Exception e) {
@@ -460,6 +505,55 @@ public class MicRecorder {
         if (wasRunning) {
             start();
         }
+    }
+
+    /**
+     * Wait for the AudioRecord reader thread to exit before its AudioRecord is
+     * released. Bounded by {@link #CAPTURE_JOIN_TIMEOUT_MS} so a thread stuck
+     * waiting to enter this object's monitor (the reader's DEAD_OBJECT path
+     * re-enters reinitialize()) can never deadlock the reinit.
+     */
+    private void joinCaptureThread() {
+        Thread t = captureThread;
+        if (!shouldJoinCaptureThread(t, Thread.currentThread())) {
+            return;
+        }
+        try {
+            t.join(CAPTURE_JOIN_TIMEOUT_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        if (t.isAlive()) {
+            GeneralVariables.fileLog("MicRecorder: capture thread still alive after "
+                    + CAPTURE_JOIN_TIMEOUT_MS + "ms join; releasing anyway");
+        }
+    }
+
+    /**
+     * Whether the AudioRecord reader loop may run another pass: recording must
+     * still be on AND no reinitialize() has superseded this thread's generation.
+     * The generation check is what stops a stale thread that never observed
+     * {@code isRunning == false} (it was blocked in read() across a full
+     * stop/start cycle) from sharing the *new* AudioRecord with the replacement
+     * thread — two concurrent readers trip a fatal native abort in libaudioclient.
+     *
+     * <p>Package-visible for testing.
+     */
+    static boolean captureLoopShouldContinue(boolean running, int loopGeneration,
+                                             int currentGeneration) {
+        return running && loopGeneration == currentGeneration;
+    }
+
+    /**
+     * Whether reinitialize() must wait for the capture thread before releasing
+     * the AudioRecord: only when a live reader thread exists and it isn't the
+     * calling thread itself — the reader's DEAD_OBJECT path calls
+     * reinitialize() from inside the loop, and joining yourself never returns.
+     *
+     * <p>Package-visible for testing.
+     */
+    static boolean shouldJoinCaptureThread(Thread capture, Thread current) {
+        return capture != null && capture != current && capture.isAlive();
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/MicRecorderCaptureHandoffTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/MicRecorderCaptureHandoffTest.java
@@ -1,0 +1,103 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the two predicates behind the MicRecorder capture-thread handoff that
+ * fixes the field crashes from concurrent {@code reinitialize()} calls (USB
+ * onCaptureStopped + one usbDetach per interface of a composite device fire
+ * three reinits within ~150ms of a cable unplug):
+ *
+ * <ul>
+ *   <li>{@link MicRecorder#captureLoopShouldContinue} — a reader thread whose
+ *       generation was superseded by a reinit must exit even if it never saw
+ *       {@code isRunning == false}, otherwise two threads end up read()ing the
+ *       same AudioRecord and libaudioclient aborts the process
+ *       ('releaseBuffer: mUnreleased out of range').</li>
+ *   <li>{@link MicRecorder#shouldJoinCaptureThread} — reinitialize() waits for
+ *       the reader thread before release() (releasing mid-read is that same
+ *       native abort), but must never join the calling thread itself: the
+ *       reader's DEAD_OBJECT path re-enters reinitialize() from inside the
+ *       loop, and a self-join never returns.</li>
+ * </ul>
+ */
+public class MicRecorderCaptureHandoffTest {
+
+    // ---- captureLoopShouldContinue -----------------------------------------
+
+    @Test
+    public void loopContinues_whenRunningAndGenerationCurrent() {
+        assertThat(MicRecorder.captureLoopShouldContinue(true, 3, 3)).isTrue();
+    }
+
+    @Test
+    public void loopExits_whenStopped() {
+        assertThat(MicRecorder.captureLoopShouldContinue(false, 3, 3)).isFalse();
+    }
+
+    @Test
+    public void loopExits_whenGenerationSuperseded() {
+        // The stale-thread case: reinitialize() bumped the generation while this
+        // thread was blocked in read(); isRunning may already be true again for
+        // the replacement thread, so the flag alone cannot stop the stale one.
+        assertThat(MicRecorder.captureLoopShouldContinue(true, 3, 4)).isFalse();
+    }
+
+    @Test
+    public void loopExits_whenStoppedAndSuperseded() {
+        assertThat(MicRecorder.captureLoopShouldContinue(false, 3, 4)).isFalse();
+    }
+
+    // ---- shouldJoinCaptureThread -------------------------------------------
+
+    @Test
+    public void noJoin_whenNoCaptureThread() {
+        assertThat(MicRecorder.shouldJoinCaptureThread(null, Thread.currentThread()))
+                .isFalse();
+    }
+
+    @Test
+    public void noJoin_whenCallerIsTheCaptureThread() {
+        // DEAD_OBJECT path: the reader thread itself calls reinitialize().
+        Thread self = Thread.currentThread();
+        assertThat(MicRecorder.shouldJoinCaptureThread(self, self)).isFalse();
+    }
+
+    @Test
+    public void noJoin_whenCaptureThreadAlreadyExited() {
+        Thread neverStarted = new Thread(() -> { });
+        assertThat(MicRecorder.shouldJoinCaptureThread(neverStarted, Thread.currentThread()))
+                .isFalse();
+    }
+
+    @Test
+    public void joins_whenLiveCaptureThreadBelongsToAnotherCaller() throws Exception {
+        CountDownLatch running = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Thread reader = new Thread(() -> {
+            running.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        reader.start();
+        try {
+            assertThat(running.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(MicRecorder.shouldJoinCaptureThread(reader, Thread.currentThread()))
+                    .isTrue();
+        } finally {
+            release.countDown();
+            reader.join(5000);
+        }
+        // Once the thread has exited there is nothing left to wait for.
+        assertThat(MicRecorder.shouldJoinCaptureThread(reader, Thread.currentThread()))
+                .isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two of the crashes from the 2026-07-04 POTA activation (Pixel 8, `dumpsys dropbox`):

1. **`NullPointerException` at `MicRecorder$2.run` (2x at app launch, 07:23):** the app starts on the default mic, and ~1.5s later the USB scan finds the CM108 and calls `reinitialize()`, which released and **nulled the shared `audioRecord` field** while the reader thread was between its recording-state check and `read()`.

2. **Native `SIGABRT` — `releaseBuffer: mUnreleased out of range` (09:44, cable unplug):** an unplug fires **three `reinitialize()` calls within ~150ms** (USB `onCaptureStopped` + one `usbDetach` per interface of the composite device; confirmed in `debug.log`). Each spawned a new reader thread without stopping the previous one — two threads `read()`ing one `AudioRecord`, and `release()` during a blocking read, are fatal native aborts in libaudioclient, not catchable exceptions.

## Fix

- `start()` / `stopRecord()` / `reinitialize()` are now `synchronized`, so concurrent reinit storms serialize.
- The reader thread works exclusively on the `AudioRecord` instance it was started with (locals, not fields) and checks a **capture generation** each pass, so a superseded thread exits even if it never observed `isRunning == false` (it was blocked in `read()` across a full stop/start cycle).
- `reinitialize()` now `stop()`s the AudioRecord (unblocks an in-flight `read()`) and **joins the reader thread before `release()`**. The join is bounded (1s) and never self-joins — the reader''s `ERROR_DEAD_OBJECT` path re-enters `reinitialize()` from inside the loop.
- A stale-generation thread no longer drives lifecycle (no `isRunning` flips, no reinit) on its way out.

## Testing

- New `MicRecorderCaptureHandoffTest` covers the two extracted predicates (`captureLoopShouldContinue`, `shouldJoinCaptureThread`), including the stale-generation case and the self-join guard (the threading itself is not JVM-testable — `AudioRecord` is framework).
- Full `testDebugUnitTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA