### PR TITLE
Fix ConcurrentModificationException from live lists published to Compose

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -506,7 +506,14 @@ public class MainViewModel extends ViewModel {
         //synchronize time. Microsoft's NTP server
         UtcTimer.syncTime(null);
 
-        mutableFt8MessageList.setValue(ft8Messages);
+        // Seed with a snapshot, never the live ft8Messages instance. observeAsState
+        // compares structurally, and every later snapshot published from
+        // publishFt8MessageList() is content-equal to the live list it was copied
+        // from — so a UI seeded with the live list stays pinned to it forever
+        // (equal values are skipped, the state keeps the old reference) and Compose
+        // ends up iterating the very list the decode thread mutates:
+        // ConcurrentModificationException in buildQsoLog during recomposition.
+        mutableFt8MessageList.setValue(uiSeedSnapshot(ft8Messages));
 
         //create listener object; callback actions handle decoding, transmitting, adding to followed callsign list, etc.
         ft8SignalListener = new FT8SignalListener(databaseOpr, new OnFt8Listen() {
@@ -589,10 +596,13 @@ public class MainViewModel extends ViewModel {
 
                 synchronized (ft8Messages) {
                     // "Clear every cycle" mode does its wipe in beforeListen (start of the
-                    // cycle), so by here the list is already fresh — just append.
+                    // cycle), so by here the list is already fresh — just append. The
+                    // excess-trim must hold the same lock: it removes from the list, and
+                    // an unguarded removal can race the snapshot copy in
+                    // publishFt8MessageList().
                     ft8Messages.addAll(messages);//add messages to list
+                    GeneralVariables.deleteArrayListMore(ft8Messages);//remove excess messages; FT8CN limits the total displayable messages
                 }
-                GeneralVariables.deleteArrayListMore(ft8Messages);//remove excess messages; FT8CN limits the total displayable messages
 
                 publishFt8MessageList();//post an immutable snapshot so the UI recomposes immediately
                 mutableTimerOffset.postValue(time_sec);//this cycle's time offset
@@ -957,6 +967,19 @@ public class MainViewModel extends ViewModel {
      */
     public static boolean shouldClearOnBandChange(boolean enabled, String oldWaveLength, String newWaveLength) {
         return enabled && !java.util.Objects.equals(oldWaveLength, newWaveLength);
+    }
+
+    /**
+     * Copy used to seed {@code mutableFt8MessageList} — the UI must never be
+     * handed the live {@code ft8Messages} instance. Because observeAsState
+     * compares structurally and every snapshot published later is content-equal
+     * to the live list it was copied from, a UI seeded with the live list keeps
+     * that reference forever (equal writes are skipped) and Compose iterates the
+     * very list the decode thread mutates — ConcurrentModificationException
+     * during recomposition. Package-visible for testing.
+     */
+    static ArrayList<Ft8Message> uiSeedSnapshot(ArrayList<Ft8Message> live) {
+        return new ArrayList<>(live);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -504,6 +504,23 @@ public class FT8TransmitSignal {
     }
 
     /**
+     * Mark the entry matching {@code order} as current, under the list's own
+     * monitor. setCurrentFunctionOrder() is called from the UI (TxSelector tap)
+     * while the auto-sequencer may be mid-rebuild in {@link #generateFun()};
+     * an unguarded index iteration can read a size from before the rebuild's
+     * clear() and then get(i) past the shrunken list — IndexOutOfBoundsException.
+     * The LiveData publication stays outside the lock (callers post a
+     * {@link #snapshotForUi} copy afterwards). Package-visible for testing.
+     */
+    static void markCurrentOrder(ArrayList<FunctionOfTransmit> live, int order) {
+        synchronized (live) {
+            for (int i = 0; i < live.size(); i++) {
+                live.get(i).setCurrentOrder(order);
+            }
+        }
+    }
+
+    /**
      * Scale a slice of the generated waveform by the TX volume, returning a new
      * buffer of exactly {@code playLength} samples.
      *
@@ -1010,9 +1027,7 @@ public class FT8TransmitSignal {
      */
     public void setCurrentFunctionOrder(int order) {
         functionOrder = order;
-        for (int i = 0; i < functionList.size(); i++) {
-            functionList.get(i).setCurrentOrder(order);
-        }
+        markCurrentOrder(functionList, order);
         if (order == 1) {
             resetTargetReport();// reset signal reports
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -306,7 +306,7 @@ public class FT8TransmitSignal {
                 + " msg=[" + getFunctionCommand(functionOrder).getMessageText() + "]");
         doTransmitThreadPool.execute(doTransmitRunnable);
 
-        mutableFunctions.postValue(functionList);
+        mutableFunctions.postValue(snapshotForUi(functionList));
     }
 
     /**
@@ -470,17 +470,37 @@ public class FT8TransmitSignal {
             GeneralVariables.noReplyCount = 0;
             lastNoReplyTarget = currentTarget;
         }
-        functionList.clear();
-        for (int i = 1; i <= 6; i++) {
-            if (functionOrder == 6) {// if current command is 6 (CQ), generate only one message
-                functionList.add(new FunctionOfTransmit(6, getFunctionCommand(6), false));
-                break;
-            } else {
-                functionList.add(new FunctionOfTransmit(i, getFunctionCommand(i), false));
+        synchronized (functionList) {
+            functionList.clear();
+            for (int i = 1; i <= 6; i++) {
+                if (functionOrder == 6) {// if current command is 6 (CQ), generate only one message
+                    functionList.add(new FunctionOfTransmit(6, getFunctionCommand(6), false));
+                    break;
+                } else {
+                    functionList.add(new FunctionOfTransmit(i, getFunctionCommand(i), false));
+                }
             }
         }
-        mutableFunctions.postValue(functionList);
+        mutableFunctions.postValue(snapshotForUi(functionList));
         setCurrentFunctionOrder(functionOrder);// set current message
+    }
+
+    /**
+     * Defensive copy of {@link #functionList} for LiveData publication. The live
+     * list is rebuilt in place (clear() + add() in {@link #generateFun()}) by the
+     * auto-sequencer on background threads, while Compose's TxSelector iterates
+     * whatever instance it last observed — publishing the live list is a
+     * ConcurrentModificationException during recomposition (seen in the field).
+     * Every {@code mutableFunctions.postValue} must go through this, mirroring
+     * the caller-queue publications which already post copies.
+     *
+     * <p>Synchronizes on the list so a snapshot taken while another thread is
+     * mid-rebuild doesn't itself throw. Package-visible for testing.
+     */
+    static ArrayList<FunctionOfTransmit> snapshotForUi(ArrayList<FunctionOfTransmit> live) {
+        synchronized (live) {
+            return new ArrayList<>(live);
+        }
     }
 
     /**
@@ -999,7 +1019,7 @@ public class FT8TransmitSignal {
         if (order == 4 || order == 5) {
             updateQSlRecordList(order, toCallsign);
         }
-        mutableFunctions.postValue(functionList);
+        mutableFunctions.postValue(snapshotForUi(functionList));
     }
 
 
@@ -1442,7 +1462,7 @@ public class FT8TransmitSignal {
             GeneralVariables.fileLog("QSO: rx RR73 from "
                     + (toCallsign != null ? toCallsign.callsign : "?") + " -> reply 73");
             functionOrder = 5;
-            mutableFunctions.postValue(functionList);
+            mutableFunctions.postValue(snapshotForUi(functionList));
             mutableFunctionOrder.postValue(functionOrder);
             setCurrentFunctionOrder(functionOrder);
             return;
@@ -1497,7 +1517,7 @@ public class FT8TransmitSignal {
             GeneralVariables.fileLog("QSO: advance order " + functionOrder + "->" + (newOrder + 1)
                     + " with " + (toCallsign != null ? toCallsign.callsign : "?"));
             functionOrder = newOrder + 1;// execute the next message in sequence
-            mutableFunctions.postValue(functionList);
+            mutableFunctions.postValue(snapshotForUi(functionList));
             mutableFunctionOrder.postValue(functionOrder);
             setCurrentFunctionOrder(functionOrder);// set current message
             return;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/UiSeedSnapshotTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/UiSeedSnapshotTest.java
@@ -1,0 +1,42 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+/**
+ * Tests {@link MainViewModel#uiSeedSnapshot} — the copy that seeds
+ * {@code mutableFt8MessageList}. Seeding with the live {@code ft8Messages}
+ * instance pins the Compose UI to it permanently: observeAsState compares
+ * structurally, and every snapshot later published by
+ * {@code publishFt8MessageList()} is content-equal to the live list it was
+ * copied from, so the state write is skipped and the old (live) reference is
+ * kept. Compose then iterates the list the decode thread mutates —
+ * the ConcurrentModificationException in buildQsoLog seen in the field
+ * (2026-07-04). The seed must be a copy the decode thread can never touch.
+ */
+public class UiSeedSnapshotTest {
+
+    @Test
+    public void seed_isDistinctInstanceWithSameContent() {
+        ArrayList<Ft8Message> live = new ArrayList<>();
+        live.add(new Ft8Message("CQ", "K1ABC", "FN42"));
+
+        ArrayList<Ft8Message> seed = MainViewModel.uiSeedSnapshot(live);
+
+        assertThat(seed).isNotSameInstanceAs(live);
+        assertThat(seed).containsExactlyElementsIn(live).inOrder();
+    }
+
+    @Test
+    public void seed_isIsolatedFromDecodeThreadMutation() {
+        ArrayList<Ft8Message> live = new ArrayList<>();
+        ArrayList<Ft8Message> seed = MainViewModel.uiSeedSnapshot(live);
+
+        live.add(new Ft8Message("CQ", "VE3XY", "EN85"));
+
+        assertThat(seed).isEmpty();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FunctionListSnapshotTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FunctionListSnapshotTest.java
@@ -57,6 +57,59 @@ public class FunctionListSnapshotTest {
     }
 
     @Test
+    public void markCurrentOrder_flagsOnlyTheMatchingEntry() {
+        ArrayList<FunctionOfTransmit> live = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            live.add(fun(i));
+        }
+
+        FT8TransmitSignal.markCurrentOrder(live, 2);
+
+        assertThat(live.get(0).isCurrentOrder()).isFalse();
+        assertThat(live.get(1).isCurrentOrder()).isTrue();
+        assertThat(live.get(2).isCurrentOrder()).isFalse();
+    }
+
+    @Test
+    public void markCurrentOrder_onEmptyList_isNoOp() {
+        ArrayList<FunctionOfTransmit> live = new ArrayList<>();
+        FT8TransmitSignal.markCurrentOrder(live, 2);
+        assertThat(live).isEmpty();
+    }
+
+    @Test
+    public void markCurrentOrder_isSafeAgainstConcurrentRebuild() throws Exception {
+        // The Copilot-flagged race: a TxSelector tap marks the current order
+        // while the auto-sequencer rebuilds the list. Both sides hold the list's
+        // monitor now, so the index iteration can never see a size from before a
+        // clear() — no IndexOutOfBoundsException, no torn iteration.
+        final ArrayList<FunctionOfTransmit> live = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            live.add(fun(i));
+        }
+        final int rounds = 2000;
+        Thread sequencer = new Thread(() -> {
+            for (int n = 0; n < rounds; n++) {
+                synchronized (live) {
+                    live.clear();
+                    for (int i = 1; i <= 5; i++) {
+                        live.add(fun(i));
+                    }
+                }
+            }
+        });
+        sequencer.start();
+        try {
+            for (int n = 0; n < rounds; n++) {
+                FT8TransmitSignal.markCurrentOrder(live, (n % 5) + 1);
+            }
+        } finally {
+            sequencer.join(10000);
+        }
+        assertThat(sequencer.isAlive()).isFalse();
+    }
+
+    @Test
     public void snapshot_isSafeAgainstConcurrentRebuild() throws Exception {
         // Rebuilds hold the list's own monitor (generateFun does the same), so a
         // snapshot taken mid-rebuild must neither throw nor observe a torn list:

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FunctionListSnapshotTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FunctionListSnapshotTest.java
@@ -1,0 +1,90 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+/**
+ * Tests {@link FT8TransmitSignal#snapshotForUi} — the defensive copy behind
+ * every {@code mutableFunctions.postValue}. The live {@code functionList} is
+ * rebuilt in place (clear() + add()) by the auto-sequencer on background
+ * threads; publishing the live instance crashed recomposition with
+ * ConcurrentModificationException in TxSelector's iteration (field crash,
+ * 2026-07-04). The UI must only ever receive copies that later rebuilds cannot
+ * touch, and taking the copy must itself be safe against a concurrent rebuild.
+ */
+public class FunctionListSnapshotTest {
+
+    private static FunctionOfTransmit fun(int order) {
+        return new FunctionOfTransmit(order, new Ft8Message("CQ", "K1ABC", "FN42"), false);
+    }
+
+    @Test
+    public void snapshot_isDistinctInstanceWithSameContent() {
+        ArrayList<FunctionOfTransmit> live = new ArrayList<>();
+        live.add(fun(1));
+        live.add(fun(2));
+
+        ArrayList<FunctionOfTransmit> snap = FT8TransmitSignal.snapshotForUi(live);
+
+        assertThat(snap).isNotSameInstanceAs(live);
+        assertThat(snap).containsExactlyElementsIn(live).inOrder();
+    }
+
+    @Test
+    public void snapshot_isIsolatedFromLaterRebuild() {
+        // The regression: the sequencer clear()+add()s the live list after the
+        // UI observed it. The observed value must not change underneath the UI.
+        ArrayList<FunctionOfTransmit> live = new ArrayList<>();
+        FunctionOfTransmit original = fun(6);
+        live.add(original);
+
+        ArrayList<FunctionOfTransmit> snap = FT8TransmitSignal.snapshotForUi(live);
+        live.clear();
+        live.add(fun(1));
+        live.add(fun(2));
+
+        assertThat(snap).containsExactly(original);
+    }
+
+    @Test
+    public void snapshot_ofEmptyList_isEmpty() {
+        assertThat(FT8TransmitSignal.snapshotForUi(new ArrayList<>())).isEmpty();
+    }
+
+    @Test
+    public void snapshot_isSafeAgainstConcurrentRebuild() throws Exception {
+        // Rebuilds hold the list's own monitor (generateFun does the same), so a
+        // snapshot taken mid-rebuild must neither throw nor observe a torn list:
+        // every snapshot sees a whole number of complete rebuilds — 3 elements.
+        final ArrayList<FunctionOfTransmit> live = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            live.add(fun(i));
+        }
+        final int rebuilds = 2000;
+        Thread sequencer = new Thread(() -> {
+            for (int n = 0; n < rebuilds; n++) {
+                synchronized (live) {
+                    live.clear();
+                    for (int i = 1; i <= 3; i++) {
+                        live.add(fun(i));
+                    }
+                }
+            }
+        });
+        sequencer.start();
+        try {
+            for (int n = 0; n < rebuilds; n++) {
+                ArrayList<FunctionOfTransmit> snap = FT8TransmitSignal.snapshotForUi(live);
+                assertThat(snap).hasSize(3);
+            }
+        } finally {
+            sequencer.join(10000);
+        }
+        assertThat(sequencer.isAlive()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the two `ConcurrentModificationException` crashes from the 2026-07-04 POTA activation (07:39 in `buildQsoLog`, 09:01 in `TxSelector` — both during recomposition of `ActiveQsoPanel`). Both were Compose iterating a **live `ArrayList` that a background thread mutates in place**.

## Root causes

**Decode list (`buildQsoLog`):** `MainViewModel` seeds `mutableFt8MessageList` with the live `ft8Messages` instance. `observeAsState` compares structurally, and every snapshot later posted by `publishFt8MessageList()` is content-equal to the live list it was copied from — so the state write is skipped and the UI keeps the **live reference forever**, iterating the very list the decode thread `addAll`s into. The 1.1.0-dev build that crashed already had snapshot publishing; the seed was the leak.

**TX function list (`TxSelector`):** all five `mutableFunctions.postValue` sites published the live `functionList` that `generateFun()` rebuilds in place (`clear()` + `add()`) on sequencer threads.

## Fix

- Seed `mutableFt8MessageList` with a copy (`uiSeedSnapshot`), never the live list; move the excess-message trim (`deleteArrayListMore`) inside the `ft8Messages` lock so it can''t race the snapshot copy.
- All `mutableFunctions` publications go through `snapshotForUi()`, a defensive copy that holds the list monitor — as does the `generateFun()` rebuild — so a snapshot taken mid-rebuild is itself safe. Mirrors the caller-queue publications, which already post copies.
- Verified the other observers (`DecodeScreen`, `MapScreen`, `CallingListFragment`, `GridTrackerMainActivity`) don''t mutate the lists they receive.

## Testing

- `UiSeedSnapshotTest` — seed is a distinct instance, isolated from later decode-thread mutation.
- `FunctionListSnapshotTest` — snapshot isolation from sequencer rebuilds, plus a concurrent rebuild/snapshot stress test asserting no tearing (always a whole number of complete rebuilds).
- Full `testDebugUnitTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA