### PR TITLE
Tune method setting: start the rig's internal ATU over CAT

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -124,6 +124,9 @@ public class GeneralVariables {
     public static volatile boolean tuneLevelIndependent = false;
     public static volatile int tuneLevel = 25;
     public static volatile String perBandTuneLevels = "";
+    //Tune method (issue #425): TuneMethod.AUTOMATIC/INTERNAL/TONE — whether the
+    //TUNE chip starts the rig's internal ATU over CAT or plays the carrier tone.
+    public static volatile int tuneMethod = 0;
 
     public static int flexMaxRfPower = 10;//Flex radio max transmit power
     public static int flexMaxTunePower = 10;//Flex radio max tune power

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -73,6 +73,7 @@ import com.k1af.ft8af.ft8transmit.FT8TransmitSignal;
 import com.k1af.ft8af.ft8transmit.MeterProtectionController;
 import com.k1af.ft8af.ft8transmit.OnDoTransmitted;
 import com.k1af.ft8af.ft8transmit.OnTransmitSuccess;
+import com.k1af.ft8af.ft8transmit.TuneMethod;
 import com.k1af.ft8af.html.LogHttpServer;
 import com.k1af.ft8af.icom.WifiRig;
 import com.k1af.ft8af.log.QSLCallsignRecord;
@@ -1153,6 +1154,33 @@ public class MainViewModel extends ViewModel {
         });
     }
 
+
+    /**
+     * Handle a TUNE tap according to the tune-method setting (issue #425).
+     * Returns true when the tap was handled here — either the rig's internal
+     * ATU was started (it keys its own carrier and stops by itself) or the
+     * operator chose Internal but no capable rig is connected (toast, no
+     * surprise carrier). Returns false when the caller should run the normal
+     * low-power carrier tune.
+     */
+    public boolean tryStartTuneViaAtu() {
+        boolean atuAvailable = baseRig != null && baseRig.isConnected()
+                && baseRig.supportsAtuTune() && !baseRig.isPttOn();
+        int action = TuneMethod.decide(GeneralVariables.tuneMethod, atuAvailable);
+        if (action == TuneMethod.ACTION_RIG_ATU) {
+            fileLog("tune: starting rig ATU (method=" + GeneralVariables.tuneMethod
+                    + ", rig=" + baseRig.getName() + ")");
+            baseRig.startAtuTune();
+            ToastMessage.show(getStringFromResource(R.string.tune_atu_started));
+            return true;
+        }
+        if (action == TuneMethod.ACTION_UNAVAILABLE) {
+            fileLog("tune: method=INTERNAL but no ATU-capable rig connected");
+            ToastMessage.show(getStringFromResource(R.string.tune_atu_unavailable));
+            return true;
+        }
+        return false;
+    }
 
     /**
      * Set the operating carrier frequency. Only operates if the rig is connected.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2625,6 +2625,16 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("perBandTuneLevels")) {//Per-band independent tune levels
                     GeneralVariables.perBandTuneLevels = result == null ? "" : result;
                 }
+                if (name.equalsIgnoreCase("tuneMethod")) {//Tune method: rig ATU vs carrier (issue #425)
+                    if (result != null) {
+                        try {
+                            GeneralVariables.tuneMethod =
+                                    com.k1af.ft8af.ft8transmit.TuneMethod.clamp(
+                                            Integer.parseInt(result.trim()));
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
+                }
                 if (name.equalsIgnoreCase("excludedCallsigns")) {//Blocklist: callsign prefixes
                     GeneralVariables.addExcludedCallsigns(result);
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/TuneMethod.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/TuneMethod.java
@@ -1,0 +1,54 @@
+package com.k1af.ft8af.ft8transmit;
+
+/**
+ * Tune method setting (issue #425): what the TUNE chip does when tapped.
+ *
+ * <ul>
+ *   <li>{@link #AUTOMATIC} — use the rig's internal ATU when a CAT rig whose
+ *       protocol has an ATU-start command is connected; otherwise fall back
+ *       to the low-power carrier tone.</li>
+ *   <li>{@link #INTERNAL} — always use the rig's internal ATU; if none is
+ *       available, do nothing but tell the operator (no surprise carrier).</li>
+ *   <li>{@link #TONE} — always the low-power carrier tone (pre-#425 behavior).</li>
+ * </ul>
+ *
+ * ATU capability can't be queried over CAT, so "available" only means the
+ * protocol defines the command; rigs without an ATU ignore it harmlessly.
+ */
+public final class TuneMethod {
+
+    public static final int AUTOMATIC = 0;
+    public static final int INTERNAL = 1;
+    public static final int TONE = 2;
+
+    /** What a TUNE tap should do, decided by {@link #decide}. */
+    public static final int ACTION_CARRIER = 0;
+    public static final int ACTION_RIG_ATU = 1;
+    public static final int ACTION_UNAVAILABLE = 2;
+
+    private TuneMethod() {
+    }
+
+    /** Clamp a persisted setting to a known method; unknown values mean AUTOMATIC. */
+    public static int clamp(int method) {
+        return (method == INTERNAL || method == TONE) ? method : AUTOMATIC;
+    }
+
+    /**
+     * Decide what a TUNE tap does.
+     *
+     * @param method       one of AUTOMATIC / INTERNAL / TONE (unknown = AUTOMATIC)
+     * @param atuAvailable a connected rig whose protocol has an ATU-start
+     *                     command, with PTT idle
+     */
+    public static int decide(int method, boolean atuAvailable) {
+        switch (clamp(method)) {
+            case INTERNAL:
+                return atuAvailable ? ACTION_RIG_ATU : ACTION_UNAVAILABLE;
+            case TONE:
+                return ACTION_CARRIER;
+            default://AUTOMATIC
+                return atuAvailable ? ACTION_RIG_ATU : ACTION_CARRIER;
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
@@ -149,6 +149,24 @@ public abstract class BaseRig {
     public void onDisconnecting() {
     }
 
+    /**
+     * Whether this rig's protocol has a CAT command to start the internal
+     * antenna tuner (ATU). Capability can't be queried over CAT, so "true"
+     * means the protocol family defines the command — rigs without an ATU
+     * ignore it harmlessly (CI-V NG / ASCII "?;").
+     */
+    public boolean supportsAtuTune() {
+        return false;
+    }
+
+    /**
+     * Fire-and-forget start of the rig's internal ATU tune cycle. The rig
+     * keys its own low-power carrier and stops by itself; no PTT or audio
+     * from the app is involved.
+     */
+    public void startAtuTune() {
+    }
+
     // Meter data callback for MeterProtectionController (ALC auto-volume, SWR halt)
     public interface OnMeterData {
         void onMeterUpdate(int normalizedAlc, int normalizedSwr);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -98,6 +98,16 @@ public class IcomRig extends BaseRig {
     }
 
     @Override
+    public boolean supportsAtuTune() {
+        return true;
+    }
+
+    @Override
+    public void startAtuTune() {
+        sendCivData(IcomRigConstant.startAtuTune(ctrAddress, getCivAddress()));
+    }
+
+    @Override
     public void setFreqToRig() {
         if (getConnector() != null) {
             getConnector().sendData(IcomRigConstant.setOperationFrequency(ctrAddress

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRigConstant.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRigConstant.java
@@ -116,6 +116,28 @@ public class IcomRigConstant {
     }
 
     /**
+     * Start the internal antenna tuner (CI-V command 0x1C, sub 0x01,
+     * value 0x02 = start tuning). The rig keys its own low-power carrier and
+     * stops by itself; rigs without an ATU reply NG (0xFA) and do nothing.
+     *
+     * @param ctrAddr controller address
+     * @param rigAddr rig address
+     * @return command data packet
+     */
+    public static byte[] startAtuTune(int ctrAddr, int rigAddr) {
+        byte[] data = new byte[8];
+        data[0] = (byte) 0xfe;
+        data[1] = (byte) 0xfe;
+        data[2] = (byte) rigAddr;
+        data[3] = (byte) ctrAddr;
+        data[4] = (byte) 0x1c;//main command code
+        data[5] = (byte) 0x01;//sub-command code: antenna tuner
+        data[6] = (byte) 0x02;//02=start tuning (00=off, 01=on)
+        data[7] = (byte) 0xfd;
+        return data;
+    }
+
+    /**
      * Read SWR meter
      *
      * @param ctrAddr controller address

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTK90RigConstant.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTK90RigConstant.java
@@ -43,6 +43,11 @@ public class KenwoodTK90RigConstant {
     private static final String TS570_PTT_OFF = "RX;";//KENWOOD TS570,PTT
     private static final String TS570_PTT_ON = "TX;";//KENWOOD TS570,PTT
 
+    // Start the internal antenna tuner (TS-590/TS-2000 AC command:
+    // P1=1 RX AT in, P2=1 TX AT in, P3=1 = start tuning). The rig keys its
+    // own carrier and stops by itself; rigs without an ATU answer "?;".
+    private static final String START_ATU_TUNE = "AC111;";
+
 
     // (tr)uSDX extensions
     private static final String TRUSDX_STREAMING_OFF = "UA0;";
@@ -78,6 +83,10 @@ public class KenwoodTK90RigConstant {
             return PTT_OFF.getBytes();
         }
 
+    }
+
+    public static byte[] startAtuTune() {
+        return START_ATU_TUNE.getBytes();
     }
 
     public static byte[] setTS590PTTState(boolean on) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS2000Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS2000Rig.java
@@ -98,6 +98,18 @@ public class KenwoodTS2000Rig extends BaseRig {
     }
 
     @Override
+    public boolean supportsAtuTune() {
+        return true;
+    }
+
+    @Override
+    public void startAtuTune() {
+        if (getConnector() != null) {
+            getConnector().sendData(KenwoodTK90RigConstant.startAtuTune());
+        }
+    }
+
+    @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
             getConnector().sendData(KenwoodTK90RigConstant.setTS590OperationUSBMode());

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS590Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS590Rig.java
@@ -97,6 +97,18 @@ public class KenwoodTS590Rig extends BaseRig {
     }
 
     @Override
+    public boolean supportsAtuTune() {
+        return true;
+    }
+
+    @Override
+    public void startAtuTune() {
+        if (getConnector() != null) {
+            getConnector().sendData(KenwoodTK90RigConstant.startAtuTune());
+        }
+    }
+
+    @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
             getConnector().sendData(KenwoodTK90RigConstant.setTS590OperationUSBMode());

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Rig.java
@@ -92,6 +92,18 @@ public class XieGu6100Rig extends BaseRig {
     }
 
     @Override
+    public boolean supportsAtuTune() {
+        return true;
+    }
+
+    @Override
+    public void startAtuTune() {
+        if (getConnector() != null) {
+            getConnector().sendData(IcomRigConstant.startAtuTune(ctrAddress, getCivAddress()));
+        }
+    }
+
+    @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
 //            getConnector().sendData(IcomRigConstant.setOperationMode(ctrAddress

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGuRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGuRig.java
@@ -85,6 +85,18 @@ public class XieGuRig extends BaseRig {
     }
 
     @Override
+    public boolean supportsAtuTune() {
+        return true;
+    }
+
+    @Override
+    public void startAtuTune() {
+        if (getConnector() != null) {
+            getConnector().sendData(IcomRigConstant.startAtuTune(ctrAddress, getCivAddress()));
+        }
+    }
+
+    @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
             getConnector().sendData(IcomRigConstant.setOperationMode(ctrAddress

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu39Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu39Rig.java
@@ -124,6 +124,18 @@ public class Yaesu39Rig extends BaseRig {
     }
 
     @Override
+    public boolean supportsAtuTune() {
+        return true;
+    }
+
+    @Override
+    public void startAtuTune() {
+        if (getConnector() != null) {
+            getConnector().sendData(Yaesu3RigConstant.startAtuTune());
+        }
+    }
+
+    @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
             if (isDataUsb) {//use DATA-USB mode

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3RigConstant.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3RigConstant.java
@@ -43,8 +43,14 @@ public class Yaesu3RigConstant {
     private static final String TX_ON = "TX1;";//for FT450 PTT
     private static final String TX_OFF = "TX0;";//for FT450 PTT
 
+    // Start the internal antenna tuner (FT-991/FTDX10/FT-710 AC command,
+    // P3=2 = tune start). The rig keys its own carrier and stops by itself;
+    // rigs without an ATU answer "?;" and do nothing.
+    private static final String START_ATU_TUNE = "AC002;";
 
-
+    public static byte[] startAtuTune() {
+        return START_ATU_TUNE.getBytes();
+    }
 
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/YaesuDX10Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/YaesuDX10Rig.java
@@ -117,6 +117,18 @@ public class YaesuDX10Rig extends BaseRig {
     }
 
     @Override
+    public boolean supportsAtuTune() {
+        return true;
+    }
+
+    @Override
+    public void startAtuTune() {
+        if (getConnector() != null) {
+            getConnector().sendData(Yaesu3RigConstant.startAtuTune());
+        }
+    }
+
+    @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
             getConnector().sendData(Yaesu3RigConstant.setOperationDATA_U_Mode());

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -370,9 +370,11 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 onToggleTune = {
                     // Toggle (WSJT-X style latching Tune): tap to key the carrier,
                     // tap again to stop. startTune() toasts the reason when blocked.
+                    // Per the tune-method setting the tap may instead fire the rig's
+                    // internal ATU (issue #425) — a one-shot command, nothing to latch.
                     if (isTuning) {
                         mainViewModel.ft8TransmitSignal.stopTune()
-                    } else {
+                    } else if (!mainViewModel.tryStartTuneViaAtu()) {
                         mainViewModel.ft8TransmitSignal.startTune()
                     }
                 },

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/TuneLevel.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/TuneLevel.kt
@@ -39,6 +39,9 @@ const val TUNE_LEVEL_KEY = "tuneLevel"
 /** Config key: the per-band independent tune levels ("20m=25,40m=40"). */
 const val PER_BAND_TUNE_LEVELS_KEY = "perBandTuneLevels"
 
+/** Config key: tune method — TuneMethod.AUTOMATIC/INTERNAL/TONE (issue #425). */
+const val TUNE_METHOD_KEY = "tuneMethod"
+
 /**
  * Resolve the level (0..100) the tune tone should play at.
  *

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -78,12 +78,16 @@ fun TransmissionSettings(
     var showTuneMethod by remember { mutableStateOf(false) }
 
     // Index == TuneMethod.AUTOMATIC/INTERNAL/TONE
-    val tuneMethodOptions = listOf("Automatic", "Internal tuner", "Low power tone")
+    val tuneMethodOptions = listOf(
+        stringResource(R.string.tune_method_automatic),
+        stringResource(R.string.tune_method_internal),
+        stringResource(R.string.tune_method_tone),
+    )
 
     // -- Tune Method Picker (issue #425) --
     if (showTuneMethod) {
         ListPickerDialog(
-            title = "Tune method",
+            title = stringResource(R.string.settings_tune_method),
             items = tuneMethodOptions,
             selectedIndex = TuneMethod.clamp(tuneMethod),
             onDismiss = { showTuneMethod = false },
@@ -457,9 +461,8 @@ fun TransmissionSettings(
             GlassCard(modifier = Modifier.fillMaxWidth()) {
                 Column {
                     SettingsRow(
-                        label = "Tune method",
-                        description = "Automatic starts the rig's internal tuner over CAT " +
-                            "when available, otherwise plays the low power tone",
+                        label = stringResource(R.string.settings_tune_method),
+                        description = stringResource(R.string.settings_tune_method_desc),
                         value = tuneMethodOptions[TuneMethod.clamp(tuneMethod)],
                         showChevron = true,
                         onClick = { showTuneMethod = true },

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -24,9 +24,11 @@ import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
 import com.k1af.ft8af.ft8transmit.MeterProtectionController
 import com.k1af.ft8af.ft8transmit.TuneController
+import com.k1af.ft8af.ft8transmit.TuneMethod
 import radio.ks3ckc.ft8af.TUNE_LEVEL_INDEPENDENT_KEY
 import radio.ks3ckc.ft8af.TUNE_LEVEL_KEY
 import radio.ks3ckc.ft8af.TUNE_MAX_ON_SECONDS_KEY
+import radio.ks3ckc.ft8af.TUNE_METHOD_KEY
 import radio.ks3ckc.ft8af.saveTuneLevelForCurrentBand
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.FT8AFIconButton
@@ -61,6 +63,7 @@ fun TransmissionSettings(
     var tuneMaxOnSeconds by remember { mutableIntStateOf(GeneralVariables.tuneMaxOnSeconds) }
     var tuneLevelIndependent by remember { mutableStateOf(GeneralVariables.tuneLevelIndependent) }
     var tuneLevel by remember { mutableIntStateOf(GeneralVariables.tuneLevel) }
+    var tuneMethod by remember { mutableIntStateOf(GeneralVariables.tuneMethod) }
 
     // Auto-sequence state
     var autoClearTxFreq by remember { mutableStateOf(GeneralVariables.autoClearTxFreq) }
@@ -72,6 +75,29 @@ fun TransmissionSettings(
 
     var showWatchdog by remember { mutableStateOf(false) }
     var showStopAfter by remember { mutableStateOf(false) }
+    var showTuneMethod by remember { mutableStateOf(false) }
+
+    // Index == TuneMethod.AUTOMATIC/INTERNAL/TONE
+    val tuneMethodOptions = listOf("Automatic", "Internal tuner", "Low power tone")
+
+    // -- Tune Method Picker (issue #425) --
+    if (showTuneMethod) {
+        ListPickerDialog(
+            title = "Tune method",
+            items = tuneMethodOptions,
+            selectedIndex = TuneMethod.clamp(tuneMethod),
+            onDismiss = { showTuneMethod = false },
+            onSelect = { index ->
+                showTuneMethod = false
+                val method = TuneMethod.clamp(index)
+                tuneMethod = method
+                GeneralVariables.tuneMethod = method
+                mainViewModel.databaseOpr.writeConfig(
+                    TUNE_METHOD_KEY, method.toString(), null,
+                )
+            },
+        )
+    }
 
     val watchdogMinutes = watchdogMs / 60000
     val watchdogStr = if (watchdogMinutes == 0) stringResource(R.string.common_off)
@@ -430,6 +456,15 @@ fun TransmissionSettings(
         SettingsSection(title = "TUNE") {
             GlassCard(modifier = Modifier.fillMaxWidth()) {
                 Column {
+                    SettingsRow(
+                        label = "Tune method",
+                        description = "Automatic starts the rig's internal tuner over CAT " +
+                            "when available, otherwise plays the low power tone",
+                        value = tuneMethodOptions[TuneMethod.clamp(tuneMethod)],
+                        showChevron = true,
+                        onClick = { showTuneMethod = true },
+                    )
+                    SectionDivider()
                     SettingsRow(
                         label = "Tune timeout",
                         description = "Hard cap on the tune carrier — it always stops by itself",

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -563,4 +563,6 @@
     <string name="tune_stopped_timeout">توقف Tune بعد %1$d ث</string>
     <string name="tune_blocked_tx">أوقف CQ/QSO قبل استخدام Tune</string>
     <string name="tune_unavailable_route">Tune غير مدعوم بعد على مسار الصوت هذا</string>
+    <string name="tune_atu_started">تم بدء موالف هوائي الجهاز</string>
+    <string name="tune_atu_unavailable">الموالف غير متاح — قم بتوصيل جهاز CAT مزوّد بموالف داخلي</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -559,10 +559,15 @@
     <string name="cq_offset_moved">تم نقل إزاحة CQ إلى موضع خالٍ: %1$d هرتز</string>
     <string name="settings_auto_clear_tx">اختيار إزاحة إرسال خالية تلقائيًا</string>
     <string name="settings_auto_clear_tx_desc">عند نداء CQ يختار موضعًا خاليًا وفق نشاط النطاق الأخير وينتقل إذا أصبح مشغولًا</string>
-    <string name="tune_content_description">Tune: يرسل موجة حاملة مستمرة لضبط الهوائي</string>
+    <string name="tune_content_description">Tune: يبدأ موالف الجهاز أو يرسل موجة حاملة مستمرة لضبط الهوائي</string>
     <string name="tune_stopped_timeout">توقف Tune بعد %1$d ث</string>
     <string name="tune_blocked_tx">أوقف CQ/QSO قبل استخدام Tune</string>
     <string name="tune_unavailable_route">Tune غير مدعوم بعد على مسار الصوت هذا</string>
     <string name="tune_atu_started">تم بدء موالف هوائي الجهاز</string>
     <string name="tune_atu_unavailable">الموالف غير متاح — قم بتوصيل جهاز CAT مزوّد بموالف داخلي</string>
+    <string name="settings_tune_method">طريقة Tune</string>
+    <string name="settings_tune_method_desc">التلقائي يبدأ الموالف الداخلي للجهاز عبر CAT عند توفره، وإلا يرسل نغمة منخفضة القدرة</string>
+    <string name="tune_method_automatic">تلقائي</string>
+    <string name="tune_method_internal">الموالف الداخلي</string>
+    <string name="tune_method_tone">نغمة منخفضة القدرة</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -563,4 +563,6 @@
     <string name="tune_stopped_timeout">Tune zastaven po %1$d s</string>
     <string name="tune_blocked_tx">Před použitím Tune zastavte CQ/QSO</string>
     <string name="tune_unavailable_route">Tune zatím není na této zvukové cestě podporován</string>
+    <string name="tune_atu_started">Anténní tuner rádia spuštěn</string>
+    <string name="tune_atu_unavailable">Tuner není k dispozici — připojte CAT rádio s interním tunerem</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -559,10 +559,15 @@
     <string name="cq_offset_moved">Offset CQ přesunut na volné místo: %1$d Hz</string>
     <string name="settings_auto_clear_tx">Automaticky volný TX offset</string>
     <string name="settings_auto_clear_tx_desc">Při volání CQ vybere volné místo podle nedávné aktivity v pásmu a uhne, pokud se obsadí</string>
-    <string name="tune_content_description">Tune: vysílá souvislou nosnou pro ladění antény</string>
+    <string name="tune_content_description">Tune: spustí tuner rádia nebo vysílá souvislou nosnou pro ladění antény</string>
     <string name="tune_stopped_timeout">Tune zastaven po %1$d s</string>
     <string name="tune_blocked_tx">Před použitím Tune zastavte CQ/QSO</string>
     <string name="tune_unavailable_route">Tune zatím není na této zvukové cestě podporován</string>
     <string name="tune_atu_started">Anténní tuner rádia spuštěn</string>
     <string name="tune_atu_unavailable">Tuner není k dispozici — připojte CAT rádio s interním tunerem</string>
+    <string name="settings_tune_method">Metoda Tune</string>
+    <string name="settings_tune_method_desc">Automaticky spustí interní tuner rádia přes CAT, je-li k dispozici, jinak přehraje tón s nízkým výkonem</string>
+    <string name="tune_method_automatic">Automaticky</string>
+    <string name="tune_method_internal">Interní tuner</string>
+    <string name="tune_method_tone">Tón s nízkým výkonem</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -520,4 +520,6 @@
     <string name="tune_stopped_timeout">Tune detenido tras %1$d s</string>
     <string name="tune_blocked_tx">Detén el CQ/QSO antes de usar Tune</string>
     <string name="tune_unavailable_route">Tune aún no está disponible en esta ruta de audio</string>
+    <string name="tune_atu_started">Sintonizador de antena del equipo iniciado</string>
+    <string name="tune_atu_unavailable">Sintonizador no disponible — conecta un equipo CAT con sintonizador interno</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -516,10 +516,15 @@
     <string name="cq_offset_moved">Desplazamiento de CQ movido a un hueco libre: %1$d Hz</string>
     <string name="settings_auto_clear_tx">Offset de TX libre automático</string>
     <string name="settings_auto_clear_tx_desc">Al llamar CQ, elige un hueco libre según la actividad reciente de la banda y se aparta si se ocupa</string>
-    <string name="tune_content_description">Tune: transmite una portadora continua para ajustar la antena</string>
+    <string name="tune_content_description">Tune: inicia el sintonizador del equipo o transmite una portadora continua para ajustar la antena</string>
     <string name="tune_stopped_timeout">Tune detenido tras %1$d s</string>
     <string name="tune_blocked_tx">Detén el CQ/QSO antes de usar Tune</string>
     <string name="tune_unavailable_route">Tune aún no está disponible en esta ruta de audio</string>
     <string name="tune_atu_started">Sintonizador de antena del equipo iniciado</string>
     <string name="tune_atu_unavailable">Sintonizador no disponible — conecta un equipo CAT con sintonizador interno</string>
+    <string name="settings_tune_method">Método de Tune</string>
+    <string name="settings_tune_method_desc">Automático inicia el sintonizador interno del equipo por CAT cuando está disponible; si no, reproduce el tono de baja potencia</string>
+    <string name="tune_method_automatic">Automático</string>
+    <string name="tune_method_internal">Sintonizador interno</string>
+    <string name="tune_method_tone">Tono de baja potencia</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -520,4 +520,6 @@
     <string name="tune_stopped_timeout">Tune arrêté après %1$d s</string>
     <string name="tune_blocked_tx">Arrêtez le CQ/QSO avant d\'utiliser Tune</string>
     <string name="tune_unavailable_route">Tune n\'est pas encore disponible sur cette voie audio</string>
+    <string name="tune_atu_started">Coupleur d\'antenne de la radio démarré</string>
+    <string name="tune_atu_unavailable">Coupleur indisponible — connectez une radio CAT avec coupleur interne</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -516,10 +516,15 @@
     <string name="cq_offset_moved">Décalage CQ déplacé vers un créneau libre : %1$d Hz</string>
     <string name="settings_auto_clear_tx">Décalage TX libre automatique</string>
     <string name="settings_auto_clear_tx_desc">En appelant CQ, choisit un créneau libre selon l\'activité récente de la bande et se déplace s\'il devient occupé</string>
-    <string name="tune_content_description">Tune : émet une porteuse continue pour l\'accord d\'antenne</string>
+    <string name="tune_content_description">Tune : démarre le coupleur de la radio ou émet une porteuse continue pour l\'accord d\'antenne</string>
     <string name="tune_stopped_timeout">Tune arrêté après %1$d s</string>
     <string name="tune_blocked_tx">Arrêtez le CQ/QSO avant d\'utiliser Tune</string>
     <string name="tune_unavailable_route">Tune n\'est pas encore disponible sur cette voie audio</string>
     <string name="tune_atu_started">Coupleur d\'antenne de la radio démarré</string>
     <string name="tune_atu_unavailable">Coupleur indisponible — connectez une radio CAT avec coupleur interne</string>
+    <string name="settings_tune_method">Méthode de Tune</string>
+    <string name="settings_tune_method_desc">Automatique démarre le coupleur interne de la radio via CAT s\'il est disponible, sinon émet la tonalité à faible puissance</string>
+    <string name="tune_method_automatic">Automatique</string>
+    <string name="tune_method_internal">Coupleur interne</string>
+    <string name="tune_method_tone">Tonalité à faible puissance</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -559,10 +559,15 @@
     <string name="cq_offset_moved">Offset CQ dipindahkan ke tempat kosong: %1$d Hz</string>
     <string name="settings_auto_clear_tx">Offset TX kosong otomatis</string>
     <string name="settings_auto_clear_tx_desc">Saat memanggil CQ, memilih tempat kosong dari aktivitas band terkini dan berpindah jika terisi</string>
-    <string name="tune_content_description">Tune: memancarkan gelombang pembawa kontinu untuk penalaan antena</string>
+    <string name="tune_content_description">Tune: memulai tuner radio atau memancarkan gelombang pembawa kontinu untuk penalaan antena</string>
     <string name="tune_stopped_timeout">Tune dihentikan setelah %1$d dtk</string>
     <string name="tune_blocked_tx">Hentikan CQ/QSO sebelum menggunakan Tune</string>
     <string name="tune_unavailable_route">Tune belum didukung pada jalur audio ini</string>
     <string name="tune_atu_started">Tuner antena radio dimulai</string>
     <string name="tune_atu_unavailable">Tuner tidak tersedia — hubungkan radio CAT dengan tuner internal</string>
+    <string name="settings_tune_method">Metode Tune</string>
+    <string name="settings_tune_method_desc">Otomatis memulai tuner internal radio lewat CAT bila tersedia, jika tidak memainkan nada daya rendah</string>
+    <string name="tune_method_automatic">Otomatis</string>
+    <string name="tune_method_internal">Tuner internal</string>
+    <string name="tune_method_tone">Nada daya rendah</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -563,4 +563,6 @@
     <string name="tune_stopped_timeout">Tune dihentikan setelah %1$d dtk</string>
     <string name="tune_blocked_tx">Hentikan CQ/QSO sebelum menggunakan Tune</string>
     <string name="tune_unavailable_route">Tune belum didukung pada jalur audio ini</string>
+    <string name="tune_atu_started">Tuner antena radio dimulai</string>
+    <string name="tune_atu_unavailable">Tuner tidak tersedia — hubungkan radio CAT dengan tuner internal</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -548,10 +548,15 @@
     <string name="cq_offset_moved">Offset CQ spostato in uno spazio libero: %1$d Hz</string>
     <string name="settings_auto_clear_tx">Offset TX libero automatico</string>
     <string name="settings_auto_clear_tx_desc">Chiamando CQ, sceglie uno spazio libero dall\'attività recente della banda e si sposta se viene occupato</string>
-    <string name="tune_content_description">Tune: trasmette una portante continua per l\'accordo dell\'antenna</string>
+    <string name="tune_content_description">Tune: avvia l\'accordatore della radio o trasmette una portante continua per l\'accordo dell\'antenna</string>
     <string name="tune_stopped_timeout">Tune fermato dopo %1$d s</string>
     <string name="tune_blocked_tx">Ferma il CQ/QSO prima di usare Tune</string>
     <string name="tune_unavailable_route">Tune non è ancora disponibile su questo percorso audio</string>
     <string name="tune_atu_started">Accordatore d\'antenna della radio avviato</string>
     <string name="tune_atu_unavailable">Accordatore non disponibile — collega una radio CAT con accordatore interno</string>
+    <string name="settings_tune_method">Metodo di Tune</string>
+    <string name="settings_tune_method_desc">Automatico avvia l\'accordatore interno della radio via CAT quando disponibile, altrimenti riproduce il tono a bassa potenza</string>
+    <string name="tune_method_automatic">Automatico</string>
+    <string name="tune_method_internal">Accordatore interno</string>
+    <string name="tune_method_tone">Tono a bassa potenza</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -552,4 +552,6 @@
     <string name="tune_stopped_timeout">Tune fermato dopo %1$d s</string>
     <string name="tune_blocked_tx">Ferma il CQ/QSO prima di usare Tune</string>
     <string name="tune_unavailable_route">Tune non è ancora disponibile su questo percorso audio</string>
+    <string name="tune_atu_started">Accordatore d\'antenna della radio avviato</string>
+    <string name="tune_atu_unavailable">Accordatore non disponibile — collega una radio CAT con accordatore interno</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -520,4 +520,6 @@
     <string name="tune_stopped_timeout">Tuneは%1$d秒後に停止しました</string>
     <string name="tune_blocked_tx">Tuneの前にCQ/QSOを停止してください</string>
     <string name="tune_unavailable_route">このオーディオ経路ではTuneはまだ利用できません</string>
+    <string name="tune_atu_started">無線機のアンテナチューナーを開始しました</string>
+    <string name="tune_atu_unavailable">チューナーを使用できません — 内蔵チューナー付きのCAT無線機を接続してください</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -516,10 +516,15 @@
     <string name="cq_offset_moved">CQオフセットを空いている周波数へ移動：%1$d Hz</string>
     <string name="settings_auto_clear_tx">空きTXオフセット自動選択</string>
     <string name="settings_auto_clear_tx_desc">CQ呼び出し時に直近のバンド活動から空き周波数を選び、占有されたら移動します</string>
-    <string name="tune_content_description">Tune：アンテナ調整用の連続キャリアを送信します</string>
+    <string name="tune_content_description">Tune：無線機のチューナーを開始、またはアンテナ調整用の連続キャリアを送信します</string>
     <string name="tune_stopped_timeout">Tuneは%1$d秒後に停止しました</string>
     <string name="tune_blocked_tx">Tuneの前にCQ/QSOを停止してください</string>
     <string name="tune_unavailable_route">このオーディオ経路ではTuneはまだ利用できません</string>
     <string name="tune_atu_started">無線機のアンテナチューナーを開始しました</string>
     <string name="tune_atu_unavailable">チューナーを使用できません — 内蔵チューナー付きのCAT無線機を接続してください</string>
+    <string name="settings_tune_method">Tune方式</string>
+    <string name="settings_tune_method_desc">自動は利用可能な場合CAT経由で無線機の内蔵チューナーを開始し、そうでなければ低出力トーンを送信します</string>
+    <string name="tune_method_automatic">自動</string>
+    <string name="tune_method_internal">内蔵チューナー</string>
+    <string name="tune_method_tone">低出力トーン</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -559,10 +559,15 @@
     <string name="cq_offset_moved">CQ 오프셋을 빈 자리로 이동: %1$d Hz</string>
     <string name="settings_auto_clear_tx">빈 TX 오프셋 자동 선택</string>
     <string name="settings_auto_clear_tx_desc">CQ 호출 시 최근 밴드 활동을 바탕으로 빈 자리를 선택하고, 점유되면 이동합니다</string>
-    <string name="tune_content_description">Tune: 안테나 조정을 위한 연속 반송파를 송신합니다</string>
+    <string name="tune_content_description">Tune: 무전기 튜너를 시작하거나 안테나 조정용 연속 반송파를 송신합니다</string>
     <string name="tune_stopped_timeout">Tune이 %1$d초 후 정지되었습니다</string>
     <string name="tune_blocked_tx">Tune 전에 CQ/QSO를 정지하세요</string>
     <string name="tune_unavailable_route">이 오디오 경로에서는 아직 Tune을 사용할 수 없습니다</string>
     <string name="tune_atu_started">무전기 안테나 튜너 시작됨</string>
     <string name="tune_atu_unavailable">튜너를 사용할 수 없습니다 — 내장 튜너가 있는 CAT 무전기를 연결하세요</string>
+    <string name="settings_tune_method">Tune 방식</string>
+    <string name="settings_tune_method_desc">자동은 가능할 때 CAT으로 무전기 내장 튜너를 시작하고, 아니면 저출력 톤을 송신합니다</string>
+    <string name="tune_method_automatic">자동</string>
+    <string name="tune_method_internal">내장 튜너</string>
+    <string name="tune_method_tone">저출력 톤</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -563,4 +563,6 @@
     <string name="tune_stopped_timeout">Tune이 %1$d초 후 정지되었습니다</string>
     <string name="tune_blocked_tx">Tune 전에 CQ/QSO를 정지하세요</string>
     <string name="tune_unavailable_route">이 오디오 경로에서는 아직 Tune을 사용할 수 없습니다</string>
+    <string name="tune_atu_started">무전기 안테나 튜너 시작됨</string>
+    <string name="tune_atu_unavailable">튜너를 사용할 수 없습니다 — 내장 튜너가 있는 CAT 무전기를 연결하세요</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -563,4 +563,6 @@
     <string name="tune_stopped_timeout">Tune gestopt na %1$d s</string>
     <string name="tune_blocked_tx">Stop de CQ/QSO voordat je Tune gebruikt</string>
     <string name="tune_unavailable_route">Tune is nog niet beschikbaar op deze audioroute</string>
+    <string name="tune_atu_started">Antennetuner van de radio gestart</string>
+    <string name="tune_atu_unavailable">Tuner niet beschikbaar — sluit een CAT-radio met interne tuner aan</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -559,10 +559,15 @@
     <string name="cq_offset_moved">CQ-offset verplaatst naar een vrije plek: %1$d Hz</string>
     <string name="settings_auto_clear_tx">Automatisch vrije TX-offset</string>
     <string name="settings_auto_clear_tx_desc">Kiest bij het roepen van CQ een vrije plek op basis van recente bandactiviteit en wijkt uit als die bezet raakt</string>
-    <string name="tune_content_description">Tune: zendt een continue draaggolf uit voor antenne-afstemming</string>
+    <string name="tune_content_description">Tune: start de tuner van de radio of zendt een continue draaggolf uit voor antenne-afstemming</string>
     <string name="tune_stopped_timeout">Tune gestopt na %1$d s</string>
     <string name="tune_blocked_tx">Stop de CQ/QSO voordat je Tune gebruikt</string>
     <string name="tune_unavailable_route">Tune is nog niet beschikbaar op deze audioroute</string>
     <string name="tune_atu_started">Antennetuner van de radio gestart</string>
     <string name="tune_atu_unavailable">Tuner niet beschikbaar — sluit een CAT-radio met interne tuner aan</string>
+    <string name="settings_tune_method">Tune-methode</string>
+    <string name="settings_tune_method_desc">Automatisch start de interne tuner van de radio via CAT indien beschikbaar, anders klinkt de toon met laag vermogen</string>
+    <string name="tune_method_automatic">Automatisch</string>
+    <string name="tune_method_internal">Interne tuner</string>
+    <string name="tune_method_tone">Toon met laag vermogen</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -548,10 +548,15 @@
     <string name="cq_offset_moved">Offset CQ przeniesiony w wolne miejsce: %1$d Hz</string>
     <string name="settings_auto_clear_tx">Automatyczny wolny offset TX</string>
     <string name="settings_auto_clear_tx_desc">Przy wołaniu CQ wybiera wolne miejsce na podstawie ostatniej aktywności pasma i przenosi się, gdy zostanie zajęte</string>
-    <string name="tune_content_description">Tune: nadaje ciągłą nośną do strojenia anteny</string>
+    <string name="tune_content_description">Tune: uruchamia tuner radia lub nadaje ciągłą nośną do strojenia anteny</string>
     <string name="tune_stopped_timeout">Tune zatrzymany po %1$d s</string>
     <string name="tune_blocked_tx">Zatrzymaj CQ/QSO przed użyciem Tune</string>
     <string name="tune_unavailable_route">Tune nie jest jeszcze dostępny na tej ścieżce audio</string>
     <string name="tune_atu_started">Uruchomiono tuner antenowy radia</string>
     <string name="tune_atu_unavailable">Tuner niedostępny — podłącz radio CAT z wewnętrznym tunerem</string>
+    <string name="settings_tune_method">Metoda Tune</string>
+    <string name="settings_tune_method_desc">Automatycznie uruchamia wewnętrzny tuner radia przez CAT, gdy jest dostępny, w przeciwnym razie nadaje ton małej mocy</string>
+    <string name="tune_method_automatic">Automatycznie</string>
+    <string name="tune_method_internal">Tuner wewnętrzny</string>
+    <string name="tune_method_tone">Ton małej mocy</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -552,4 +552,6 @@
     <string name="tune_stopped_timeout">Tune zatrzymany po %1$d s</string>
     <string name="tune_blocked_tx">Zatrzymaj CQ/QSO przed użyciem Tune</string>
     <string name="tune_unavailable_route">Tune nie jest jeszcze dostępny na tej ścieżce audio</string>
+    <string name="tune_atu_started">Uruchomiono tuner antenowy radia</string>
+    <string name="tune_atu_unavailable">Tuner niedostępny — podłącz radio CAT z wewnętrznym tunerem</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -520,4 +520,6 @@
     <string name="tune_stopped_timeout">Tune остановлен через %1$d с</string>
     <string name="tune_blocked_tx">Остановите CQ/QSO перед использованием Tune</string>
     <string name="tune_unavailable_route">Tune пока не поддерживается на этом аудиотракте</string>
+    <string name="tune_atu_started">Антенный тюнер трансивера запущен</string>
+    <string name="tune_atu_unavailable">Тюнер недоступен — подключите CAT-трансивер со встроенным тюнером</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -516,10 +516,15 @@
     <string name="cq_offset_moved">Смещение CQ перенесено на свободное место: %1$d Гц</string>
     <string name="settings_auto_clear_tx">Автовыбор свободного смещения TX</string>
     <string name="settings_auto_clear_tx_desc">При вызове CQ выбирает свободное место по недавней активности диапазона и уходит, если оно занимается</string>
-    <string name="tune_content_description">Tune: передаёт непрерывную несущую для настройки антенны</string>
+    <string name="tune_content_description">Tune: запускает тюнер трансивера или передаёт непрерывную несущую для настройки антенны</string>
     <string name="tune_stopped_timeout">Tune остановлен через %1$d с</string>
     <string name="tune_blocked_tx">Остановите CQ/QSO перед использованием Tune</string>
     <string name="tune_unavailable_route">Tune пока не поддерживается на этом аудиотракте</string>
     <string name="tune_atu_started">Антенный тюнер трансивера запущен</string>
     <string name="tune_atu_unavailable">Тюнер недоступен — подключите CAT-трансивер со встроенным тюнером</string>
+    <string name="settings_tune_method">Метод Tune</string>
+    <string name="settings_tune_method_desc">Автоматически запускает встроенный тюнер трансивера через CAT, если доступен, иначе передаёт маломощный тон</string>
+    <string name="tune_method_automatic">Автоматически</string>
+    <string name="tune_method_internal">Встроенный тюнер</string>
+    <string name="tune_method_tone">Маломощный тон</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -548,10 +548,15 @@
     <string name="cq_offset_moved">CQ ofseti boş bir noktaya taşındı: %1$d Hz</string>
     <string name="settings_auto_clear_tx">Otomatik boş TX ofseti</string>
     <string name="settings_auto_clear_tx_desc">CQ çağrılırken son bant etkinliğine göre boş bir nokta seçer ve doldurulursa başka yere taşınır</string>
-    <string name="tune_content_description">Tune: anten ayarı için sürekli taşıyıcı gönderir</string>
+    <string name="tune_content_description">Tune: telsizin tunerini başlatır veya anten ayarı için sürekli taşıyıcı gönderir</string>
     <string name="tune_stopped_timeout">Tune %1$d s sonra durduruldu</string>
     <string name="tune_blocked_tx">Tune kullanmadan önce CQ/QSO\'yu durdurun</string>
     <string name="tune_unavailable_route">Tune bu ses yolunda henüz desteklenmiyor</string>
     <string name="tune_atu_started">Telsizin anten tuneri başlatıldı</string>
     <string name="tune_atu_unavailable">Tuner kullanılamıyor — dahili tunerli bir CAT telsizi bağlayın</string>
+    <string name="settings_tune_method">Tune yöntemi</string>
+    <string name="settings_tune_method_desc">Otomatik, mevcutsa telsizin dahili tunerini CAT üzerinden başlatır, aksi halde düşük güçlü ton çalar</string>
+    <string name="tune_method_automatic">Otomatik</string>
+    <string name="tune_method_internal">Dahili tuner</string>
+    <string name="tune_method_tone">Düşük güçlü ton</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -552,4 +552,6 @@
     <string name="tune_stopped_timeout">Tune %1$d s sonra durduruldu</string>
     <string name="tune_blocked_tx">Tune kullanmadan önce CQ/QSO\'yu durdurun</string>
     <string name="tune_unavailable_route">Tune bu ses yolunda henüz desteklenmiyor</string>
+    <string name="tune_atu_started">Telsizin anten tuneri başlatıldı</string>
+    <string name="tune_atu_unavailable">Tuner kullanılamıyor — dahili tunerli bir CAT telsizi bağlayın</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -548,10 +548,15 @@
     <string name="cq_offset_moved">Зсув CQ перенесено на вільне місце: %1$d Гц</string>
     <string name="settings_auto_clear_tx">Автовибір вільного зсуву TX</string>
     <string name="settings_auto_clear_tx_desc">Під час виклику CQ обирає вільне місце за нещодавньою активністю діапазону і зміщується, якщо воно займається</string>
-    <string name="tune_content_description">Tune: передає безперервну несучу для налаштування антени</string>
+    <string name="tune_content_description">Tune: запускає тюнер трансивера або передає безперервну несучу для налаштування антени</string>
     <string name="tune_stopped_timeout">Tune зупинено через %1$d с</string>
     <string name="tune_blocked_tx">Зупиніть CQ/QSO перед використанням Tune</string>
     <string name="tune_unavailable_route">Tune поки не підтримується на цьому аудіотракті</string>
     <string name="tune_atu_started">Антенний тюнер трансивера запущено</string>
     <string name="tune_atu_unavailable">Тюнер недоступний — підключіть CAT-трансивер із вбудованим тюнером</string>
+    <string name="settings_tune_method">Метод Tune</string>
+    <string name="settings_tune_method_desc">Автоматично запускає вбудований тюнер трансивера через CAT, якщо доступний, інакше передає малопотужний тон</string>
+    <string name="tune_method_automatic">Автоматично</string>
+    <string name="tune_method_internal">Вбудований тюнер</string>
+    <string name="tune_method_tone">Малопотужний тон</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -552,4 +552,6 @@
     <string name="tune_stopped_timeout">Tune зупинено через %1$d с</string>
     <string name="tune_blocked_tx">Зупиніть CQ/QSO перед використанням Tune</string>
     <string name="tune_unavailable_route">Tune поки не підтримується на цьому аудіотракті</string>
+    <string name="tune_atu_started">Антенний тюнер трансивера запущено</string>
+    <string name="tune_atu_unavailable">Тюнер недоступний — підключіть CAT-трансивер із вбудованим тюнером</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -516,10 +516,15 @@
     <string name="cq_offset_moved">CQ频偏已移至空闲位置：%1$d Hz</string>
     <string name="settings_auto_clear_tx">自动选择空闲TX频偏</string>
     <string name="settings_auto_clear_tx_desc">呼叫CQ时根据近期频段活动选择空闲位置，被占用时自动移开</string>
-    <string name="tune_content_description">Tune：发射连续载波用于天线调谐</string>
+    <string name="tune_content_description">Tune：启动电台调谐器或发射连续载波用于天线调谐</string>
     <string name="tune_stopped_timeout">Tune已在%1$d秒后停止</string>
     <string name="tune_blocked_tx">使用Tune前请先停止CQ/QSO</string>
     <string name="tune_unavailable_route">此音频路径暂不支持Tune</string>
     <string name="tune_atu_started">已启动电台天线调谐器</string>
     <string name="tune_atu_unavailable">调谐器不可用 — 请连接具有内置调谐器的CAT电台</string>
+    <string name="settings_tune_method">Tune方式</string>
+    <string name="settings_tune_method_desc">自动：可用时通过CAT启动电台内置调谐器，否则发射低功率音频</string>
+    <string name="tune_method_automatic">自动</string>
+    <string name="tune_method_internal">内置调谐器</string>
+    <string name="tune_method_tone">低功率音频</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -520,4 +520,6 @@
     <string name="tune_stopped_timeout">Tune已在%1$d秒后停止</string>
     <string name="tune_blocked_tx">使用Tune前请先停止CQ/QSO</string>
     <string name="tune_unavailable_route">此音频路径暂不支持Tune</string>
+    <string name="tune_atu_started">已启动电台天线调谐器</string>
+    <string name="tune_atu_unavailable">调谐器不可用 — 请连接具有内置调谐器的CAT电台</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -516,10 +516,15 @@
     <string name="cq_offset_moved">CQ頻偏已移至空閒位置：%1$d Hz</string>
     <string name="settings_auto_clear_tx">自動選擇空閒TX頻偏</string>
     <string name="settings_auto_clear_tx_desc">呼叫CQ時根據近期頻段活動選擇空閒位置，被佔用時自動移開</string>
-    <string name="tune_content_description">Tune：發射連續載波用於天線調諧</string>
+    <string name="tune_content_description">Tune：啟動電台調諧器或發射連續載波用於天線調諧</string>
     <string name="tune_stopped_timeout">Tune已在%1$d秒後停止</string>
     <string name="tune_blocked_tx">使用Tune前請先停止CQ/QSO</string>
     <string name="tune_unavailable_route">此音訊路徑暫不支援Tune</string>
     <string name="tune_atu_started">已啟動電台天線調諧器</string>
     <string name="tune_atu_unavailable">調諧器不可用 — 請連接具有內建調諧器的CAT電台</string>
+    <string name="settings_tune_method">Tune方式</string>
+    <string name="settings_tune_method_desc">自動：可用時透過CAT啟動電台內建調諧器，否則發射低功率音頻</string>
+    <string name="tune_method_automatic">自動</string>
+    <string name="tune_method_internal">內建調諧器</string>
+    <string name="tune_method_tone">低功率音頻</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -520,4 +520,6 @@
     <string name="tune_stopped_timeout">Tune已在%1$d秒後停止</string>
     <string name="tune_blocked_tx">使用Tune前請先停止CQ/QSO</string>
     <string name="tune_unavailable_route">此音訊路徑暫不支援Tune</string>
+    <string name="tune_atu_started">已啟動電台天線調諧器</string>
+    <string name="tune_atu_unavailable">調諧器不可用 — 請連接具有內建調諧器的CAT電台</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -660,4 +660,6 @@
     <string name="tune_stopped_timeout">Tune stopped after %1$d s</string>
     <string name="tune_blocked_tx">Stop the CQ/QSO before tuning</string>
     <string name="tune_unavailable_route">Tune is not yet supported on this audio route</string>
+    <string name="tune_atu_started">Rig antenna tuner started</string>
+    <string name="tune_atu_unavailable">Rig tuner unavailable — connect a CAT radio with an internal tuner</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -656,10 +656,15 @@
     <string name="settings_auto_clear_tx">Auto clear TX offset</string>
     <string name="settings_auto_clear_tx_desc">When calling CQ, pick a clear spot from recent band activity and move away if it becomes occupied</string>
     <string name="tune_button" translatable="false">TUNE</string>
-    <string name="tune_content_description">Tune — transmit a steady carrier for antenna tuning</string>
+    <string name="tune_content_description">Tune — start the rig\'s tuner or transmit a steady carrier for antenna tuning</string>
     <string name="tune_stopped_timeout">Tune stopped after %1$d s</string>
     <string name="tune_blocked_tx">Stop the CQ/QSO before tuning</string>
     <string name="tune_unavailable_route">Tune is not yet supported on this audio route</string>
     <string name="tune_atu_started">Rig antenna tuner started</string>
     <string name="tune_atu_unavailable">Rig tuner unavailable — connect a CAT radio with an internal tuner</string>
+    <string name="settings_tune_method">Tune method</string>
+    <string name="settings_tune_method_desc">Automatic starts the rig\'s internal tuner over CAT when available, otherwise plays the low power tone</string>
+    <string name="tune_method_automatic">Automatic</string>
+    <string name="tune_method_internal">Internal tuner</string>
+    <string name="tune_method_tone">Low power tone</string>
 </resources>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TuneMethodTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TuneMethodTest.java
@@ -1,0 +1,67 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link TuneMethod} — the decision behind the TUNE chip
+ * (issue #425): rig internal ATU vs. low-power carrier tone.
+ */
+public class TuneMethodTest {
+
+    @Test
+    public void automatic_prefersAtuWhenAvailable() {
+        assertThat(TuneMethod.decide(TuneMethod.AUTOMATIC, true))
+                .isEqualTo(TuneMethod.ACTION_RIG_ATU);
+    }
+
+    @Test
+    public void automatic_fallsBackToCarrierWhenNoAtu() {
+        assertThat(TuneMethod.decide(TuneMethod.AUTOMATIC, false))
+                .isEqualTo(TuneMethod.ACTION_CARRIER);
+    }
+
+    @Test
+    public void internal_usesAtuWhenAvailable() {
+        assertThat(TuneMethod.decide(TuneMethod.INTERNAL, true))
+                .isEqualTo(TuneMethod.ACTION_RIG_ATU);
+    }
+
+    @Test
+    public void internal_neverFallsBackToCarrier() {
+        //The operator explicitly chose the rig's tuner; keying a surprise
+        //carrier instead would be the one thing they asked us not to do.
+        assertThat(TuneMethod.decide(TuneMethod.INTERNAL, false))
+                .isEqualTo(TuneMethod.ACTION_UNAVAILABLE);
+    }
+
+    @Test
+    public void tone_alwaysUsesCarrier() {
+        assertThat(TuneMethod.decide(TuneMethod.TONE, true))
+                .isEqualTo(TuneMethod.ACTION_CARRIER);
+        assertThat(TuneMethod.decide(TuneMethod.TONE, false))
+                .isEqualTo(TuneMethod.ACTION_CARRIER);
+    }
+
+    @Test
+    public void clamp_keepsKnownMethods() {
+        assertThat(TuneMethod.clamp(TuneMethod.AUTOMATIC)).isEqualTo(TuneMethod.AUTOMATIC);
+        assertThat(TuneMethod.clamp(TuneMethod.INTERNAL)).isEqualTo(TuneMethod.INTERNAL);
+        assertThat(TuneMethod.clamp(TuneMethod.TONE)).isEqualTo(TuneMethod.TONE);
+    }
+
+    @Test
+    public void clamp_unknownValuesMeanAutomatic() {
+        //Settings import (#382) can feed anything into the persisted value.
+        assertThat(TuneMethod.clamp(-1)).isEqualTo(TuneMethod.AUTOMATIC);
+        assertThat(TuneMethod.clamp(3)).isEqualTo(TuneMethod.AUTOMATIC);
+        assertThat(TuneMethod.clamp(99)).isEqualTo(TuneMethod.AUTOMATIC);
+    }
+
+    @Test
+    public void decide_unknownMethodBehavesLikeAutomatic() {
+        assertThat(TuneMethod.decide(99, true)).isEqualTo(TuneMethod.ACTION_RIG_ATU);
+        assertThat(TuneMethod.decide(99, false)).isEqualTo(TuneMethod.ACTION_CARRIER);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/AtuTuneCommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/AtuTuneCommandTest.java
@@ -1,0 +1,73 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Byte-exact coverage for the ATU-start CAT commands (issue #425). These are
+ * radio-facing wire bytes — a wrong sub-command on CI-V (0x00 is PTT!) or a
+ * wrong AC parameter on the ASCII rigs would key the transmitter instead of
+ * the tuner, so the exact frames are pinned here.
+ */
+public class AtuTuneCommandTest {
+
+    @Test
+    public void icomAtuStart_isCiv1c01_02() {
+        //FE FE <rig> <ctr> 1C 01 02 FD — tuner start, NOT 1C 00 (PTT)
+        byte[] cmd = IcomRigConstant.startAtuTune(0xE0, 0xA4);
+        assertThat(cmd).isEqualTo(new byte[]{
+                (byte) 0xfe, (byte) 0xfe, (byte) 0xa4, (byte) 0xe0,
+                (byte) 0x1c, (byte) 0x01, (byte) 0x02, (byte) 0xfd});
+    }
+
+    @Test
+    public void icomAtuStart_usesGivenAddresses() {
+        byte[] cmd = IcomRigConstant.startAtuTune(0x00, 0x70);//XieGu-style addresses
+        assertThat(cmd[2]).isEqualTo((byte) 0x70);
+        assertThat(cmd[3]).isEqualTo((byte) 0x00);
+    }
+
+    @Test
+    public void yaesu3AtuStart_isAC002() {
+        assertThat(new String(Yaesu3RigConstant.startAtuTune())).isEqualTo("AC002;");
+    }
+
+    @Test
+    public void kenwoodAtuStart_isAC111() {
+        assertThat(new String(KenwoodTK90RigConstant.startAtuTune())).isEqualTo("AC111;");
+    }
+
+    @Test
+    public void baseRig_defaultsToNoAtuSupport() {
+        BaseRig rig = new BaseRig() {
+            @Override
+            public boolean isConnected() {
+                return true;
+            }
+
+            @Override
+            public void setUsbModeToRig() {
+            }
+
+            @Override
+            public void setFreqToRig() {
+            }
+
+            @Override
+            public void onReceiveData(byte[] data) {
+            }
+
+            @Override
+            public void readFreqFromRig() {
+            }
+
+            @Override
+            public String getName() {
+                return "test";
+            }
+        };
+        assertThat(rig.supportsAtuTune()).isFalse();
+        rig.startAtuTune();//default is a no-op — must not throw with no connector
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/AtuTuneCommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/AtuTuneCommandTest.java
@@ -4,6 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Byte-exact coverage for the ATU-start CAT commands (issue #425). These are
  * radio-facing wire bytes — a wrong sub-command on CI-V (0x00 is PTT!) or a
@@ -30,12 +32,14 @@ public class AtuTuneCommandTest {
 
     @Test
     public void yaesu3AtuStart_isAC002() {
-        assertThat(new String(Yaesu3RigConstant.startAtuTune())).isEqualTo("AC002;");
+        assertThat(new String(Yaesu3RigConstant.startAtuTune(), StandardCharsets.US_ASCII))
+                .isEqualTo("AC002;");
     }
 
     @Test
     public void kenwoodAtuStart_isAC111() {
-        assertThat(new String(KenwoodTK90RigConstant.startAtuTune())).isEqualTo("AC111;");
+        assertThat(new String(KenwoodTK90RigConstant.startAtuTune(), StandardCharsets.US_ASCII))
+                .isEqualTo("AC111;");
     }
 
     @Test


### PR DESCRIPTION
Closes #425

## What

The TUNE chip can now start the rig's **internal antenna tuner** instead of keying the low-power carrier. A new three-way **Tune method** picker in Settings → Transmission → TUNE controls it:

| Method | Behavior |
|---|---|
| **Automatic** (default) | Use the rig's ATU when a connected CAT rig's protocol has an ATU-start command; otherwise fall back to the carrier tone |
| **Internal tuner** | Always the rig ATU; if no capable rig is connected, toast and do nothing — never a surprise carrier |
| **Low power tone** | Always the carrier (previous behavior) |

## How

- **Rig layer**: `BaseRig.supportsAtuTune()` / `startAtuTune()` defaults (false / no-op) with overrides:
  - Icom + Xiegu serial CI-V: `FE FE <addr> E0 1C 01 02 FD` (tuner start)
  - Yaesu gen-3 (`Yaesu39Rig`, `YaesuDX10Rig`): `AC002;`
  - Kenwood TS-590 / TS-2000: `AC111;`
- The command is **fire-and-forget**: the rig keys its own reduced-power carrier and stops by itself — no PTT, audio, or `TuneController` session from the app. ATU capability can't be queried over CAT, so "supported" means the protocol defines the command; rigs without an ATU ignore it harmlessly (CI-V NG / ASCII `?;`).
- **Decision logic** extracted to `TuneMethod.decide()` (pure), consumed by `MainViewModel.tryStartTuneViaAtu()`; the TUNE chip tap in `FT8AFApp.kt` falls through to the normal carrier tune when it returns false.
- Setting persisted as `tuneMethod` (0/1/2, clamped defensively on load per the settings-import pattern).
- Toast strings (`tune_atu_started`, `tune_atu_unavailable`) added to base + all 15 locales.

## Tests

- `TuneMethodTest` — full decision matrix + clamp of unknown persisted values.
- `AtuTuneCommandTest` — byte-exact pins on the CI-V/ASCII frames (a wrong CI-V sub-command `1C 00` would key PTT instead of the tuner) + `BaseRig` defaults.
- Full `testDebugUnitTest` suite green; `assembleDebug` builds.

## Out of scope (tracked in #425)

Elecraft (`SWT` family), Flex (SmartSDR `atu start`), `XieGu6100NetRig` (network transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA