### PR TITLE
Configurable FFT display pipeline (window / averaging / bin-combine) — issue #428

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -99,3 +99,32 @@ The frontend builds independently with `npm run build` (emits to `desktop/dist`)
   waveform. Leading audio is clipped only when starting late
   (`ms_late = max(0, into_cycle - 2360)`) to preserve the Costas sync arrays.
 - **Logging:** completed QSOs are written to SQLite and exportable as ADIF.
+
+## Waterfall display pipeline (developer settings)
+
+The live waterfall is computed in Rust (`src-tauri/src/wf.rs`, driven from
+`engine.rs::emit_waterfall_row`) — it is separate from the decoder's internal
+FFT, so none of these settings affect decoding. Per row (~10×/s):
+
+1. Peek the most recent `fft_size + (avg-1)*fft_size/2` samples (12 kHz mono).
+2. Welch average: `avg` overlapping segments (50% overlap), each windowed and
+   FFT'd; power `re²+im²` summed per bin.
+3. `mag = sqrt(power/avg) * 2 / fft_size`, `dB = 20·log10(mag + 1e-12)`.
+4. Noise floor = 30th-percentile dB, smoothed over time with an EMA
+   (`floor = 0.9·floor + 0.1·pct`, initialized at −60 dB).
+5. Brightness: 0 at `floor + 4 dB` (black offset), 255 at 26 dB above that
+   (span); linear in between.
+6. Emitted as `WaterfallRow { bins, hz_per_col }` up to 3500 Hz; the canvas
+   draws 1 bin = 1 column and the browser scales to CSS pixels, so there is no
+   bins-per-pixel aggregation step on desktop (unlike Android's spectrum strip).
+
+Settings → *Developer — waterfall FFT* exposes the window function
+(Rect/Hann/Hamming/Blackman/Blackman-Harris), FFT size (512–8192), and
+averaging count (1–16) for issue #428 experiments. Defaults — **Hann, 2048
+(≈5.86 Hz/bin), 6 averages** — reproduce the previous hard-coded pipeline
+exactly and intentionally match the iOS app. Changing a knob rebuilds the FFT
+plan immediately and persists to the config table (`wf_window`, `wf_fft_size`,
+`wf_avg`); the noise-floor EMA restarts and reconverges within ~2 s.
+
+Note: `EngineEvent::Waterfall` / `dsp/decoder.rs::waterfall_heatmap` is a dead
+legacy path (never emitted); the live path above is the only one rendered.

--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -8,8 +8,6 @@ use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::sync::Arc;
 use std::time::Duration;
 
-use rustfft::num_complex::Complex;
-use rustfft::{Fft, FftPlanner};
 use serde::{Deserialize, Serialize};
 
 use crate::audio::{output, AudioInput, SlotAccumulator};
@@ -19,6 +17,7 @@ use crate::dsp::{DecodedMessage, Decoder, SAMPLE_RATE};
 use crate::qso::{QsoEngine, QsoOutcome, QsoStatus};
 use crate::rig::{RigConfig, RigConnection};
 use crate::util;
+use crate::wf::{WfConfig, WfProcessor, WfWindow};
 
 const CYCLE_MS: i64 = 15_000;
 const TX_SLACK_MS: i64 = 2_360; // 12.64 s audio in a 15 s slot
@@ -44,12 +43,8 @@ const DEFAULT_TX_GAIN: f32 = 0.9;
 fn clamp_tx_gain(g: f32) -> f32 {
     g.clamp(0.0, 1.0)
 }
-const WF_FFT_SIZE: usize = 2048; // ~5.86 Hz/bin at 12 kHz
-const WF_AVG: usize = 6; // averaged FFT segments per row (Welch) to smooth the noise floor
-const WF_STEP: usize = WF_FFT_SIZE / 2; // 50% overlap between averaged segments
-const WF_MAX_HZ: f32 = 3_500.0; // displayed top of the audio band (matches decoder f_max)
-const WF_SPAN_DB: f32 = 26.0; // dB above the black point that maps to full brightness
-const WF_BLACK_OFFSET_DB: f32 = 4.0; // push the black point above the noise floor so noise stays dark
+// Live-waterfall FFT parameters (window/size/averaging + display constants)
+// live in `crate::wf` and are runtime-configurable via SetWaterfallConfig.
 // Input RMS at/below this (dBFS) counts as silence — no audio reaching the app.
 // Real RX audio through a soundcard/DAX sits well above this even on a quiet band;
 // a fully-routed-but-silent virtual device floors near -100 dBFS.
@@ -121,6 +116,8 @@ pub enum EngineCommand {
     SetClockOffset(i64),
     /// Kick off an immediate one-shot NTP re-sync (manual "Resync" button).
     ResyncTime,
+    /// Apply new live-waterfall FFT parameters (developer knobs, issue #428).
+    SetWaterfallConfig(WfConfig),
     Shutdown,
 }
 
@@ -288,10 +285,8 @@ struct Engine {
     /// `!Send`); polled each loop tick so completion drops PTT, and dropped to
     /// stop audio immediately on Stop TX.
     tx_playback: Option<output::PreparedTx>,
-    // live waterfall FFT
-    fft: Arc<dyn Fft<f32>>,
-    hann: Vec<f32>,
-    wf_floor_db: f32, // smoothed noise-floor estimate for auto color scaling
+    // live waterfall FFT (plan + window table + floor state; rebuilt on config change)
+    wf: WfProcessor,
     last_wf_slot: i64, // last cycle slot marked on the live waterfall (rx-corrected)
 }
 
@@ -326,12 +321,25 @@ impl Engine {
         qso.band = bands::band_for_freq_hz(dial_hz).to_string();
         qso.freq_mhz = bands::freq_mhz_string(dial_hz);
 
-        let fft = FftPlanner::<f32>::new().plan_fft_forward(WF_FFT_SIZE);
-        let hann: Vec<f32> = (0..WF_FFT_SIZE)
-            .map(|i| {
-                0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / WF_FFT_SIZE as f32).cos()
-            })
-            .collect();
+        // Restore persisted waterfall FFT knobs (issue #428); defaults match
+        // the historical hard-coded pipeline (Hann, 2048, 6-segment Welch).
+        let wf_defaults = WfConfig::default();
+        let wf_cfg = WfConfig {
+            window: db
+                .get_config("wf_window")
+                .map(|s| WfWindow::parse(&s))
+                .unwrap_or(wf_defaults.window),
+            fft_size: db
+                .get_config("wf_fft_size")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(wf_defaults.fft_size),
+            avg: db
+                .get_config("wf_avg")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(wf_defaults.avg),
+        }
+        .sanitize();
+        let wf = WfProcessor::new(wf_cfg);
 
         // Decode worker: owns the (!Send) Decoder on its own thread so the heavy
         // per-slot DSP never blocks the engine loop (which drives the live
@@ -376,9 +384,7 @@ impl Engine {
             cmd_tx,
             ptt: false,
             tx_playback: None,
-            fft,
-            hann,
-            wf_floor_db: -60.0,
+            wf,
             last_wf_slot: -1,
         }
     }
@@ -644,58 +650,14 @@ impl Engine {
     /// it for the scrolling waterfall. Color is auto-scaled relative to a smoothed
     /// noise-floor estimate so the floor stays blue regardless of input gain.
     fn emit_waterfall_row(&mut self) {
-        // Average WF_AVG overlapping FFTs (Welch) to cut the per-bin variance of
-        // a single FFT, so the noise floor reads as a smooth blue instead of
-        // speckled yellow.
-        let need = WF_FFT_SIZE + (WF_AVG - 1) * WF_STEP;
-        let samples = self.accum.peek_recent(need);
-        if samples.len() < need {
+        let samples = self.accum.peek_recent(self.wf.samples_needed());
+        let Some((bins, hz_per_col)) = self.wf.process_row(&samples, SAMPLE_RATE as f32) else {
             return; // still warming up
-        }
-
-        let bin_hz = SAMPLE_RATE as f32 / WF_FFT_SIZE as f32;
-        let cols = ((WF_MAX_HZ / bin_hz) as usize).min(WF_FFT_SIZE / 2).max(1);
-
-        let mut power = vec![0f32; cols];
-        let mut buf: Vec<Complex<f32>> = vec![Complex { re: 0.0, im: 0.0 }; WF_FFT_SIZE];
-        for seg in 0..WF_AVG {
-            let off = seg * WF_STEP;
-            for i in 0..WF_FFT_SIZE {
-                buf[i] = Complex { re: samples[off + i] * self.hann[i], im: 0.0 };
-            }
-            self.fft.process(&mut buf);
-            for (i, p) in power.iter_mut().enumerate() {
-                *p += buf[i].re * buf[i].re + buf[i].im * buf[i].im;
-            }
-        }
-
-        // Averaged power -> dB magnitude per bin.
-        let mut dbs = vec![0f32; cols];
-        for (i, &p) in power.iter().enumerate() {
-            let avg = p / WF_AVG as f32;
-            let mag = (avg.sqrt() * 2.0) / WF_FFT_SIZE as f32;
-            dbs[i] = 20.0 * (mag + 1e-12).log10();
-        }
-
-        // Estimate the noise floor from the 30th-percentile dB (robust even on a
-        // busy band where signals fill much of the spectrum), smoothed over time.
-        let mut sorted = dbs.clone();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let pct = sorted[((cols as f32 * 0.30) as usize).min(cols - 1)];
-        self.wf_floor_db = self.wf_floor_db * 0.9 + pct * 0.1;
-
-        // Black point sits a few dB above the floor so the noise renders dark and
-        // only signals above it take on color.
-        let black_point = self.wf_floor_db + WF_BLACK_OFFSET_DB;
-        let mut bins = vec![0u8; cols];
-        for (i, &db) in dbs.iter().enumerate() {
-            let t = ((db - black_point) / WF_SPAN_DB).clamp(0.0, 1.0);
-            bins[i] = (t * 255.0) as u8;
-        }
+        };
         // Mark this row if it's the first at/after a cycle boundary on the same
         // rx-corrected clock the decoder uses, so the grid line aligns with DT.
         let boundary = wf_boundary_row(self.now() - self.rx_offset_ms, &mut self.last_wf_slot);
-        self.emit(EngineEvent::WaterfallRow(WaterfallRow { bins, hz_per_col: bin_hz, boundary }));
+        self.emit(EngineEvent::WaterfallRow(WaterfallRow { bins, hz_per_col, boundary }));
     }
 
     fn publish_decodes(&self, decoded: &[DecodedMessage]) {
@@ -790,6 +752,21 @@ impl Engine {
             EngineCommand::SetTxGain(g) => {
                 self.tx_gain = clamp_tx_gain(g);
                 let _ = self.db.set_config("tx_gain", &self.tx_gain.to_string());
+            }
+            EngineCommand::SetWaterfallConfig(cfg) => {
+                let cfg = cfg.sanitize();
+                let _ = self.db.set_config("wf_window", cfg.window.as_str());
+                let _ = self.db.set_config("wf_fft_size", &cfg.fft_size.to_string());
+                let _ = self.db.set_config("wf_avg", &cfg.avg.to_string());
+                // Rebuild plan + window table; the noise-floor EMA restarts and
+                // reconverges within a couple of seconds.
+                self.wf = WfProcessor::new(cfg);
+                self.emit(EngineEvent::Info(format!(
+                    "waterfall: {} {} avg {}",
+                    cfg.window.as_str(),
+                    cfg.fft_size,
+                    cfg.avg
+                )));
             }
             EngineCommand::SetInputDevice(name) => {
                 self.input_device = name.clone();

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -13,3 +13,4 @@ pub mod qso;
 pub mod rig;
 pub mod timesync;
 pub mod util;
+pub mod wf;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ use ft8af::bands;
 use ft8af::db::{Db, QsoRecord};
 use ft8af::engine::{self, AnswerArgs, EngineCommand, EngineHandle};
 use ft8af::rig::{self, HamlibRig, RigConfig, SerialPortInfo};
+use ft8af::wf::WfConfig;
 
 struct AppState {
     engine: EngineHandle,
@@ -183,6 +184,13 @@ fn all_config(state: State<AppState>) -> Vec<(String, String)> {
     state.db.all_config()
 }
 
+#[tauri::command]
+fn set_waterfall_config(state: State<AppState>, config: WfConfig) {
+    // The engine sanitizes, persists (wf_window/wf_fft_size/wf_avg), and
+    // rebuilds its FFT plan; see EngineCommand::SetWaterfallConfig.
+    state.engine.send(EngineCommand::SetWaterfallConfig(config));
+}
+
 fn main() {
     // Debug helper: `ft8af --list-rigs` prints the Hamlib-enumerated rig count
     // and exits — verifies the bundled Hamlib library loads without the GUI.
@@ -259,6 +267,7 @@ fn main() {
             get_config,
             set_config,
             all_config,
+            set_waterfall_config,
         ])
         .run(tauri::generate_context!())
         .expect("error running FT8AF");

--- a/desktop/src-tauri/src/wf.rs
+++ b/desktop/src-tauri/src/wf.rs
@@ -1,0 +1,362 @@
+//! Live waterfall spectrum pipeline: windowed Welch-averaged FFT → dB →
+//! noise-floor-referenced u8 rows (issue #428 developer knobs).
+//!
+//! Extracted from `engine.rs::emit_waterfall_row` so the row math is pure and
+//! unit-testable, and so the window function, FFT size, and averaging count can
+//! be changed at runtime. Defaults reproduce the previous hard-coded pipeline
+//! byte-for-byte (Hann, 2048, 6 segments at 50% overlap). Display-only: the
+//! decoder runs its own FFT inside the C core and is unaffected.
+
+use std::sync::Arc;
+
+use rustfft::num_complex::Complex;
+use rustfft::{Fft, FftPlanner};
+use serde::{Deserialize, Serialize};
+
+/// Displayed top of the audio band (matches decoder f_max).
+pub const WF_MAX_HZ: f32 = 3_500.0;
+/// dB above the black point that maps to full brightness.
+pub const WF_SPAN_DB: f32 = 26.0;
+/// Black point sits this far above the noise floor so noise stays dark.
+pub const WF_BLACK_OFFSET_DB: f32 = 4.0;
+
+/// FFT sizes the developer knob may select. Anything else sanitizes to 2048.
+pub const ALLOWED_FFT_SIZES: [usize; 5] = [512, 1024, 2048, 4096, 8192];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WfWindow {
+    Rect,
+    Hann,
+    Hamming,
+    Blackman,
+    BlackmanHarris,
+}
+
+impl WfWindow {
+    /// Window coefficients in the periodic form (denominator N, not N-1),
+    /// matching the Hann table the engine has always used:
+    /// `0.5 - 0.5*cos(2πi/N)`.
+    pub fn coeffs(self, n: usize) -> Vec<f32> {
+        let n_f = n as f32;
+        (0..n)
+            .map(|i| {
+                let x = 2.0 * std::f32::consts::PI * i as f32 / n_f;
+                match self {
+                    WfWindow::Rect => 1.0,
+                    WfWindow::Hann => 0.5 - 0.5 * x.cos(),
+                    WfWindow::Hamming => 0.54 - 0.46 * x.cos(),
+                    WfWindow::Blackman => 0.42 - 0.5 * x.cos() + 0.08 * (2.0 * x).cos(),
+                    WfWindow::BlackmanHarris => {
+                        0.35875 - 0.48829 * x.cos() + 0.14128 * (2.0 * x).cos()
+                            - 0.01168 * (3.0 * x).cos()
+                    }
+                }
+            })
+            .collect()
+    }
+
+    /// Stable string form used as the `wf_window` config value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WfWindow::Rect => "rect",
+            WfWindow::Hann => "hann",
+            WfWindow::Hamming => "hamming",
+            WfWindow::Blackman => "blackman",
+            WfWindow::BlackmanHarris => "blackman_harris",
+        }
+    }
+
+    /// Parse a config value; unknown strings fall back to the default (Hann).
+    pub fn parse(s: &str) -> WfWindow {
+        match s {
+            "rect" => WfWindow::Rect,
+            "hann" => WfWindow::Hann,
+            "hamming" => WfWindow::Hamming,
+            "blackman" => WfWindow::Blackman,
+            "blackman_harris" => WfWindow::BlackmanHarris,
+            _ => WfWindow::Hann,
+        }
+    }
+}
+
+/// Developer-tunable waterfall FFT parameters (issue #428). Persisted in the
+/// config table as `wf_window` / `wf_fft_size` / `wf_avg`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct WfConfig {
+    pub window: WfWindow,
+    pub fft_size: usize,
+    /// Welch segments averaged per emitted row (50% overlap).
+    pub avg: usize,
+}
+
+impl Default for WfConfig {
+    fn default() -> Self {
+        WfConfig { window: WfWindow::Hann, fft_size: 2048, avg: 6 }
+    }
+}
+
+impl WfConfig {
+    /// Clamp out-of-range values to safe ones. Applied to anything arriving
+    /// from the config table or the UI before it reaches the processor.
+    pub fn sanitize(mut self) -> Self {
+        if !ALLOWED_FFT_SIZES.contains(&self.fft_size) {
+            self.fft_size = WfConfig::default().fft_size;
+        }
+        self.avg = self.avg.clamp(1, 16);
+        self
+    }
+
+    /// Hop between averaged segments (50% overlap).
+    pub fn step(&self) -> usize {
+        self.fft_size / 2
+    }
+
+    /// Samples of recent audio one row consumes.
+    pub fn samples_needed(&self) -> usize {
+        self.fft_size + (self.avg - 1) * self.step()
+    }
+}
+
+/// Owns the FFT plan, window table, and smoothed noise-floor state for the
+/// live waterfall. Rebuilt whenever the config changes.
+pub struct WfProcessor {
+    cfg: WfConfig,
+    fft: Arc<dyn Fft<f32>>,
+    window: Vec<f32>,
+    /// Smoothed noise-floor estimate for auto color scaling. Restarts at
+    /// -60 dB on rebuild and reconverges within a couple of seconds.
+    floor_db: f32,
+}
+
+impl WfProcessor {
+    pub fn new(cfg: WfConfig) -> Self {
+        let cfg = cfg.sanitize();
+        let fft = FftPlanner::<f32>::new().plan_fft_forward(cfg.fft_size);
+        let window = cfg.window.coeffs(cfg.fft_size);
+        WfProcessor { cfg, fft, window, floor_db: -60.0 }
+    }
+
+    pub fn config(&self) -> WfConfig {
+        self.cfg
+    }
+
+    pub fn samples_needed(&self) -> usize {
+        self.cfg.samples_needed()
+    }
+
+    /// Turn the most recent `samples_needed()` samples into one waterfall row:
+    /// (u8 brightness per column, Hz per column). Returns None while the ring
+    /// buffer is still warming up. Color is auto-scaled relative to a smoothed
+    /// noise-floor estimate so the floor stays dark regardless of input gain.
+    pub fn process_row(&mut self, samples: &[f32], sample_rate: f32) -> Option<(Vec<u8>, f32)> {
+        let need = self.samples_needed();
+        if samples.len() < need {
+            return None;
+        }
+        let n = self.cfg.fft_size;
+        let avg = self.cfg.avg;
+        let step = self.cfg.step();
+
+        let bin_hz = sample_rate / n as f32;
+        let cols = ((WF_MAX_HZ / bin_hz) as usize).min(n / 2).max(1);
+
+        // Average `avg` overlapping FFTs (Welch) to cut the per-bin variance of
+        // a single FFT, so the noise floor reads smooth instead of speckled.
+        let mut power = vec![0f32; cols];
+        let mut buf: Vec<Complex<f32>> = vec![Complex { re: 0.0, im: 0.0 }; n];
+        for seg in 0..avg {
+            let off = seg * step;
+            for i in 0..n {
+                buf[i] = Complex { re: samples[off + i] * self.window[i], im: 0.0 };
+            }
+            self.fft.process(&mut buf);
+            for (i, p) in power.iter_mut().enumerate() {
+                *p += buf[i].re * buf[i].re + buf[i].im * buf[i].im;
+            }
+        }
+
+        // Averaged power -> dB magnitude per bin. Normalization is kept
+        // identical to the legacy pipeline (2/N, no window-gain correction):
+        // the floor-relative mapping below absorbs the window's constant gain.
+        let mut dbs = vec![0f32; cols];
+        for (i, &p) in power.iter().enumerate() {
+            let a = p / avg as f32;
+            let mag = (a.sqrt() * 2.0) / n as f32;
+            dbs[i] = 20.0 * (mag + 1e-12).log10();
+        }
+
+        // Estimate the noise floor from the 30th-percentile dB (robust even on
+        // a busy band where signals fill much of the spectrum), smoothed over time.
+        let mut sorted = dbs.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let pct = sorted[((cols as f32 * 0.30) as usize).min(cols - 1)];
+        self.floor_db = self.floor_db * 0.9 + pct * 0.1;
+
+        let black_point = self.floor_db + WF_BLACK_OFFSET_DB;
+        Some((map_to_u8(&dbs, black_point, WF_SPAN_DB), bin_hz))
+    }
+}
+
+/// Map per-bin dB to display brightness: 0 at/below the black point, 255 at
+/// black point + span, linear in between.
+fn map_to_u8(dbs: &[f32], black_point: f32, span_db: f32) -> Vec<u8> {
+    dbs.iter()
+        .map(|&db| {
+            let t = ((db - black_point) / span_db).clamp(0.0, 1.0);
+            (t * 255.0) as u8
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: f32 = 12_000.0;
+
+    fn tone(freq: f32, len: usize) -> Vec<f32> {
+        (0..len)
+            .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / SR).sin())
+            .collect()
+    }
+
+    #[test]
+    fn window_coefficients_match_definitions() {
+        let n = 16;
+        for w in [
+            WfWindow::Rect,
+            WfWindow::Hann,
+            WfWindow::Hamming,
+            WfWindow::Blackman,
+            WfWindow::BlackmanHarris,
+        ] {
+            let c = w.coeffs(n);
+            assert_eq!(c.len(), n);
+            // Periodic windows: w[i] == w[n-i] for i in 1..n.
+            for i in 1..n {
+                assert!(
+                    (c[i] - c[n - i]).abs() < 1e-5,
+                    "{w:?} not symmetric at {i}: {} vs {}",
+                    c[i],
+                    c[n - i]
+                );
+            }
+        }
+        assert!(WfWindow::Rect.coeffs(n).iter().all(|&v| v == 1.0));
+        let hann = WfWindow::Hann.coeffs(n);
+        assert!(hann[0].abs() < 1e-6);
+        assert!((hann[n / 2] - 1.0).abs() < 1e-6);
+        let hamming = WfWindow::Hamming.coeffs(n);
+        assert!((hamming[0] - 0.08).abs() < 1e-6);
+        assert!((hamming[n / 2] - 1.0).abs() < 1e-6);
+        let blackman = WfWindow::Blackman.coeffs(n);
+        assert!((blackman[n / 2] - 1.0).abs() < 1e-5);
+        let bh = WfWindow::BlackmanHarris.coeffs(n);
+        assert!(bh[0].abs() < 1e-4); // 4-term BH endpoint ≈ 6e-5
+        assert!((bh[n / 2] - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn window_string_round_trip() {
+        for w in [
+            WfWindow::Rect,
+            WfWindow::Hann,
+            WfWindow::Hamming,
+            WfWindow::Blackman,
+            WfWindow::BlackmanHarris,
+        ] {
+            assert_eq!(WfWindow::parse(w.as_str()), w);
+        }
+        assert_eq!(WfWindow::parse("bogus"), WfWindow::Hann);
+    }
+
+    #[test]
+    fn tone_lands_in_correct_bin_across_sizes() {
+        for fft_size in [1024usize, 2048, 4096] {
+            let cfg = WfConfig { window: WfWindow::Hann, fft_size, avg: 1 }.sanitize();
+            let mut p = WfProcessor::new(cfg);
+            let samples = tone(1000.0, p.samples_needed());
+            let (bins, hz_per_col) = p.process_row(&samples, SR).unwrap();
+            assert!((hz_per_col - SR / fft_size as f32).abs() < 1e-3);
+            // Strong tones clamp several adjacent bins to 255, so instead of
+            // comparing argmax indices, require the expected bin to be at the
+            // maximum and bins a few away from it to be strictly darker.
+            let expected = (1000.0 / hz_per_col).round() as usize;
+            let max = *bins.iter().max().unwrap();
+            assert_eq!(
+                bins[expected], max,
+                "fft {fft_size}: expected bin {expected} not at max"
+            );
+            assert!(
+                bins[expected - 10] < max && bins[expected + 10] < max,
+                "fft {fft_size}: tone energy not localized around bin {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn u8_mapping_is_monotonic_and_clamped() {
+        let dbs: Vec<f32> = (0..100).map(|i| -80.0 + i as f32).collect();
+        let out = map_to_u8(&dbs, -50.0, WF_SPAN_DB);
+        for w in out.windows(2) {
+            assert!(w[1] >= w[0]);
+        }
+        assert_eq!(out[0], 0); // well below black point
+        assert_eq!(*out.last().unwrap(), 255); // above black + span
+        assert_eq!(map_to_u8(&[-50.0 + WF_SPAN_DB], -50.0, WF_SPAN_DB)[0], 255);
+    }
+
+    #[test]
+    fn averaging_dilutes_a_step_transient() {
+        // A tone present only in the newest FFT-length of audio: with 6-segment
+        // Welch averaging its power is diluted vs a single-segment row. This is
+        // the temporal-smearing mechanism issue #428 asks to make observable.
+        // Amplitude is kept small so brightness stays inside the linear span
+        // instead of clamping to 255 in both cases.
+        let brightness_at_1k = |avg: usize| -> f32 {
+            let cfg = WfConfig { window: WfWindow::Rect, fft_size: 2048, avg };
+            let mut p = WfProcessor::new(cfg);
+            let need = p.samples_needed();
+            let mut samples = vec![0f32; need];
+            let t: Vec<f32> = tone(1000.0, 2048).iter().map(|v| v * 1e-3).collect();
+            samples[need - 2048..].copy_from_slice(&t);
+            let (bins, hz) = p.process_row(&samples, SR).unwrap();
+            bins[(1000.0 / hz).round() as usize] as f32
+        };
+        let single = brightness_at_1k(1);
+        let averaged = brightness_at_1k(6);
+        assert!(single > 0.0);
+        assert!(
+            averaged < single,
+            "expected 6-segment average ({averaged}) below single segment ({single})"
+        );
+    }
+
+    #[test]
+    fn samples_needed_and_sanitize() {
+        assert_eq!(WfConfig::default().samples_needed(), 7168); // 2048 + 5*1024
+        let s = WfConfig { window: WfWindow::Hann, fft_size: 3000, avg: 0 }.sanitize();
+        assert_eq!(s.fft_size, 2048);
+        assert_eq!(s.avg, 1);
+        let s = WfConfig { window: WfWindow::Rect, fft_size: 512, avg: 99 }.sanitize();
+        assert_eq!(s.fft_size, 512);
+        assert_eq!(s.avg, 16);
+    }
+
+    #[test]
+    fn default_config_matches_legacy_constants() {
+        let d = WfConfig::default();
+        assert_eq!(d.window, WfWindow::Hann);
+        assert_eq!(d.fft_size, 2048);
+        assert_eq!(d.avg, 6);
+        assert_eq!(d.step(), 1024);
+        // The Hann table must match the old inline formula from engine.rs.
+        let table = WfWindow::Hann.coeffs(2048);
+        for &i in &[0usize, 1, 511, 1024, 2047] {
+            let legacy =
+                0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / 2048.0).cos();
+            assert!((table[i] - legacy).abs() < 1e-7, "hann mismatch at {i}");
+        }
+    }
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -15,6 +15,8 @@ import {
   type TxStage,
   type TxStateEvent,
   type UiMessage,
+  type WaterfallConfig,
+  type WfWindow,
 } from "./ipc";
 
 type Tab = "decode" | "log" | "settings";
@@ -611,6 +613,13 @@ function SettingsScreen(props: {
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
   const [baseFreq, setBaseFreq] = useState(1500);
+  // Live-waterfall FFT developer knobs (issue #428). Defaults mirror
+  // WfConfig::default() on the Rust side: hann / 2048 / 6.
+  const [wfCfg, setWfCfg] = useState<WaterfallConfig>({
+    window: "hann",
+    fft_size: 2048,
+    avg: 6,
+  });
   const [rigCfg, setRigCfg] = useState<RigConfig>({
     backend: "hamlib",
     model: "none",
@@ -645,7 +654,24 @@ function SettingsScreen(props: {
       }
     });
     api.getConfig("rig_label").then((v) => v && setRigLabel(v));
+    // Restore persisted waterfall knobs (written by the engine on change).
+    Promise.all([
+      api.getConfig("wf_window"),
+      api.getConfig("wf_fft_size"),
+      api.getConfig("wf_avg"),
+    ]).then(([w, size, avg]) =>
+      setWfCfg((prev) => ({
+        window: (w as WfWindow) || prev.window,
+        fft_size: size ? parseInt(size, 10) : prev.fft_size,
+        avg: avg ? parseInt(avg, 10) : prev.avg,
+      })),
+    );
   }, []);
+
+  function applyWfCfg(next: WaterfallConfig) {
+    setWfCfg(next);
+    api.setWaterfallConfig(next);
+  }
 
   const refreshPorts = () => api.listSerialPorts().then(setPorts);
 
@@ -1022,6 +1048,55 @@ function SettingsScreen(props: {
           >
             Disconnect
           </button>
+        </div>
+      </div>
+
+      <div className="panel">
+        <h3>Developer — waterfall FFT</h3>
+        <div className="col">
+          <div className="muted">
+            Spectrum/waterfall rendering experiments (issue #428) — affects the
+            display only, never decoding. Defaults: Hann, 2048, 6 averages.
+          </div>
+          <div className="field">
+            <label>Window function</label>
+            <select
+              value={wfCfg.window}
+              onChange={(e) => applyWfCfg({ ...wfCfg, window: e.target.value as WfWindow })}
+            >
+              <option value="rect">Rectangular (none)</option>
+              <option value="hann">Hann (default)</option>
+              <option value="hamming">Hamming</option>
+              <option value="blackman">Blackman</option>
+              <option value="blackman_harris">Blackman-Harris</option>
+            </select>
+          </div>
+          <div className="field">
+            <label>FFT size</label>
+            <select
+              value={wfCfg.fft_size}
+              onChange={(e) => applyWfCfg({ ...wfCfg, fft_size: parseInt(e.target.value, 10) })}
+            >
+              {[512, 1024, 2048, 4096, 8192].map((n) => (
+                <option key={n} value={n}>
+                  {n} — {(12000 / n).toFixed(1)} Hz/bin{n === 2048 ? " (default)" : ""}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="field">
+            <label>Averaging (Welch segments per row)</label>
+            <select
+              value={wfCfg.avg}
+              onChange={(e) => applyWfCfg({ ...wfCfg, avg: parseInt(e.target.value, 10) })}
+            >
+              {[1, 2, 3, 4, 6, 8, 12, 16].map((n) => (
+                <option key={n} value={n}>
+                  {n}{n === 6 ? " (default)" : n === 1 ? " (off)" : ""}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
     </div>

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -597,6 +597,21 @@ function LogScreen() {
   );
 }
 
+// Waterfall FFT developer-knob option lists (issue #428). Single source of
+// truth for both the <select> options and validation of persisted config —
+// raw config strings are untrusted (hand-edited DB, older builds), so
+// anything outside these lists falls back to the defaults.
+const WF_WINDOWS: WfWindow[] = ["rect", "hann", "hamming", "blackman", "blackman_harris"];
+const WF_WINDOW_LABELS: Record<WfWindow, string> = {
+  rect: "Rectangular (none)",
+  hann: "Hann (default)",
+  hamming: "Hamming",
+  blackman: "Blackman",
+  blackman_harris: "Blackman-Harris",
+};
+const WF_FFT_SIZES = [512, 1024, 2048, 4096, 8192];
+const WF_AVG_OPTIONS = [1, 2, 3, 4, 6, 8, 12, 16];
+
 function SettingsScreen(props: {
   onStatus: (s: string) => void;
   clock: ClockSyncEvent | null;
@@ -654,18 +669,23 @@ function SettingsScreen(props: {
       }
     });
     api.getConfig("rig_label").then((v) => v && setRigLabel(v));
-    // Restore persisted waterfall knobs (written by the engine on change).
+    // Restore persisted waterfall knobs (written by the engine on change),
+    // keeping only values from the option lists — an unknown window string or
+    // NaN size would leave the <select>s blank and push an invalid config
+    // back through applyWfCfg.
     Promise.all([
       api.getConfig("wf_window"),
       api.getConfig("wf_fft_size"),
       api.getConfig("wf_avg"),
-    ]).then(([w, size, avg]) =>
+    ]).then(([w, size, avg]) => {
+      const fftSize = parseInt(size ?? "", 10);
+      const avgN = parseInt(avg ?? "", 10);
       setWfCfg((prev) => ({
-        window: (w as WfWindow) || prev.window,
-        fft_size: size ? parseInt(size, 10) : prev.fft_size,
-        avg: avg ? parseInt(avg, 10) : prev.avg,
-      })),
-    );
+        window: WF_WINDOWS.includes(w as WfWindow) ? (w as WfWindow) : prev.window,
+        fft_size: WF_FFT_SIZES.includes(fftSize) ? fftSize : prev.fft_size,
+        avg: WF_AVG_OPTIONS.includes(avgN) ? avgN : prev.avg,
+      }));
+    });
   }, []);
 
   function applyWfCfg(next: WaterfallConfig) {
@@ -1064,11 +1084,11 @@ function SettingsScreen(props: {
               value={wfCfg.window}
               onChange={(e) => applyWfCfg({ ...wfCfg, window: e.target.value as WfWindow })}
             >
-              <option value="rect">Rectangular (none)</option>
-              <option value="hann">Hann (default)</option>
-              <option value="hamming">Hamming</option>
-              <option value="blackman">Blackman</option>
-              <option value="blackman_harris">Blackman-Harris</option>
+              {WF_WINDOWS.map((w) => (
+                <option key={w} value={w}>
+                  {WF_WINDOW_LABELS[w]}
+                </option>
+              ))}
             </select>
           </div>
           <div className="field">
@@ -1077,7 +1097,7 @@ function SettingsScreen(props: {
               value={wfCfg.fft_size}
               onChange={(e) => applyWfCfg({ ...wfCfg, fft_size: parseInt(e.target.value, 10) })}
             >
-              {[512, 1024, 2048, 4096, 8192].map((n) => (
+              {WF_FFT_SIZES.map((n) => (
                 <option key={n} value={n}>
                   {n} — {(12000 / n).toFixed(1)} Hz/bin{n === 2048 ? " (default)" : ""}
                 </option>
@@ -1090,7 +1110,7 @@ function SettingsScreen(props: {
               value={wfCfg.avg}
               onChange={(e) => applyWfCfg({ ...wfCfg, avg: parseInt(e.target.value, 10) })}
             >
-              {[1, 2, 3, 4, 6, 8, 12, 16].map((n) => (
+              {WF_AVG_OPTIONS.map((n) => (
                 <option key={n} value={n}>
                   {n}{n === 6 ? " (default)" : n === 1 ? " (off)" : ""}
                 </option>

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -99,6 +99,16 @@ export interface BandInfo {
   dial_hz: number;
 }
 
+/** Waterfall FFT window (developer setting, issue #428). */
+export type WfWindow = "rect" | "hann" | "hamming" | "blackman" | "blackman_harris";
+
+/** Live-waterfall FFT parameters. Defaults: hann / 2048 / 6. */
+export interface WaterfallConfig {
+  window: WfWindow;
+  fft_size: number;
+  avg: number;
+}
+
 export type RigBackend = "none" | "serial" | "flrig" | "hamlib";
 export type RigModel = "yaesu" | "kenwood" | "icom" | "none";
 export type PttMethod = "cat" | "rts" | "dtr" | "none";
@@ -173,4 +183,8 @@ export const api = {
   getConfig: (key: string) => invoke<string | null>("get_config", { key }),
   setConfig: (key: string, value: string) => invoke("set_config", { key, value }),
   allConfig: () => invoke<[string, string][]>("all_config"),
+
+  /** Apply + persist live-waterfall FFT parameters (Rust side persists). */
+  setWaterfallConfig: (config: WaterfallConfig) =>
+    invoke("set_waterfall_config", { config }),
 };

--- a/docs/fft-display.md
+++ b/docs/fft-display.md
@@ -1,0 +1,120 @@
+# FFT display pipeline & developer knobs (issue #428)
+
+Issue #428 reports ringing/smearing/ghosting on the spectrum and waterfall when
+the received signal jumps from near-silence to strong. This document records
+how each platform turns audio into the on-screen spectrum/waterfall, what the
+defaults are and why, and which parameters are configurable so the artifact can
+be evaluated without code changes.
+
+**Everything here is display-only.** On every platform the FT8/FT4 decoder runs
+its own independent FFT (Hann-windowed `monitor.c` inside the C core); none of
+these knobs affect decoding.
+
+## The likely mechanism
+
+Before #428, Android applied **no window function** (rectangular) to the
+display FFT. A strong tone that isn't exactly on a bin boundary then leaks
+sinc-shaped sidelobes across the entire row — measured in the host test
+(`test_fft_window.c`): skirts only ~28 dB below the peak with a rectangular
+window vs ~70 dB with Hann, at the display path's exact geometry (1920 samples
+@ 12 kHz). On a dB-scaled waterfall with a 50 dB visible range, a signal
+~30 dB above the floor paints the whole row — which reads as "false energy /
+smearing when a strong signal starts". Desktop and iOS always used Hann.
+
+Android's default is now **Hann**, matching the other platforms; rectangular
+remains selectable to reproduce the old behavior for A/B comparison.
+
+## Defaults per platform
+
+| Parameter | Android | Desktop | iOS (unchanged, for reference) |
+|---|---|---|---|
+| Window | **Hann** (was: none) — configurable | Hann — configurable | Hann — fixed |
+| FFT size | 1920 (= 160 ms @ 12 kHz, 6.25 Hz/bin) — fixed, see below | 2048 (≈5.86 Hz/bin) — configurable 512–8192 | 2048 — fixed |
+| Averaging | Off — configurable (cross-frame EMA 0.5 / 0.25) | 6-segment Welch, 50 % overlap — configurable 1–16 | 6-segment Welch — fixed |
+| Scaling | dB, median-bin noise floor, 50 dB range (`fft_display.c`) | dB, 30th-pct floor + EMA 0.9/0.1, 26 dB span, 4 dB black offset | same as desktop |
+| Bins→pixels | Spectrum strip: pair combine (Max default) — configurable Max/Avg/RMS. Waterfall: LinearGradient interpolation (see below) | 1 bin = 1 canvas column; browser scales. No aggregation step | 1 bin = 1 column |
+
+## Android
+
+Pipeline: `SpectrumListener` (1920 float samples per 160 ms, ~6 fps) →
+`WaterfallScreen.kt` observer → `FFTBridge` → JNI `getFFTData*`
+(`ft8af_glue/ft8_fft_jni.cpp`) → window (`ft8af_window_fill/apply`) → kissfft
+real FFT → optional cross-frame EMA (`ft8af_mag_ema`) →
+`ft8af_magnitudes_to_display` (dB, median noise floor, 0–255) →
+`ColumnarView` (spectrum strip) + `WaterfallView` (scrolling bitmap).
+
+Settings → Advanced → **FFT / Waterfall (developer)**:
+
+- **FFT window function** — Rectangular / Hann (default) / Hamming / Blackman /
+  Blackman-Harris. Applied in native code before the FFT; the window's constant
+  coherent gain cancels in the noise-floor-relative dB mapping, so no
+  renormalization is needed.
+- **Frame averaging** — Off (default) / Light (EMA α=0.5) / Heavy (EMA α=0.25),
+  applied to linear magnitudes across successive display frames. Off is the
+  default deliberately: temporal smoothing is precisely the effect under
+  investigation, so it must be opt-in. (Welch averaging *within* a frame, as
+  desktop does, isn't possible on Android: there is exactly one 1920-sample
+  buffer per display frame.)
+- **Spectrum bin combining** — Maximum (default, the legacy behavior) / Average
+  / RMS: how `ColumnarView` merges each FFT bin with its right neighbor into
+  one bar (`BinAggregation.java`). Inputs are already dB-scaled 0–255 display
+  intensities, so Avg/RMS are display heuristics for comparison, not physics.
+
+Persisted as config keys `fftWindowType`, `fftAveragingMode`,
+`spectrumBinAggregation`; hydrated in `DatabaseOpr.getAllConfigParameter` with
+clamping setters in `GeneralVariables`, and included in settings
+backup/restore automatically.
+
+**Why FFT size is not a knob on Android.** The FFT length equals the capture
+frame (1920 samples), giving 6.25 Hz bins — exactly the FT8 tone spacing, which
+is a meaningful, defensible resolution. Zero-padding to 2048/4096 adds
+interpolation but no resolution, and breaks the `input.size/2` output-array
+contract at three call sites; capturing longer frames would gain resolution but
+halve the update rate and *increase* temporal smear — the opposite of what the
+issue asks for. If a future need arises, zero-padding is the practical option.
+
+**Waterfall interpolation note.** `WaterfallView` renders each row as a
+`LinearGradient` with one color stop per bin; the GPU interpolates between
+stops. That is itself a smoothing step (bins never map 1:1 to pixels there),
+worth remembering when judging "smearing" by eye — the spectrum strip, which
+has the configurable combine, is the more faithful per-bin view.
+
+Tests: `ft8af_glue/test_fft_window.c` (window shapes, unknown-type fallback,
+rect-vs-Hann leakage, EMA math; run via `run_host_tests.ps1`/`.sh`),
+`BinAggregationTest.java`, `GeneralVariablesFftSettingsTest.kt`,
+`FftDisplaySettingsTest.kt`.
+
+## Desktop
+
+See the "Waterfall display pipeline (developer settings)" section of
+`desktop/README.md`. Summary: the row math lives in the pure, unit-tested
+`desktop/src-tauri/src/wf.rs`; Settings → *Developer — waterfall FFT* exposes
+window / FFT size / averaging count; changes apply live via
+`EngineCommand::SetWaterfallConfig` and persist as `wf_window`, `wf_fft_size`,
+`wf_avg`. Defaults (Hann / 2048 / 6) reproduce the previous hard-coded pipeline
+byte-for-byte. Bins-per-pixel aggregation doesn't exist on desktop (1 bin =
+1 canvas column, scaled by the browser) — documented rather than knobbed.
+
+## iOS
+
+Out of scope for the #428 implementation round (no Mac in the loop); its
+pipeline (`FFTProcessor.swift` + `WaterfallRowBuilder.swift`) already matches
+the desktop defaults (Hann, 2048, Welch×6, same dB/floor mapping), so the
+cross-platform default behavior is consistent today. Making its parameters
+configurable can follow the desktop pattern (thread a config through
+`LiveEngine.runWaterfallLoop`) in a later PR.
+
+## Evaluating configurations
+
+Reproduce the reported artifact with a controlled signal (near-silence, then a
+strong FT8 transmission or tone burst mid-band, slightly off a 6.25 Hz
+multiple):
+
+- **Rect vs Hann (Android):** with Rectangular, the onset of the strong signal
+  brightens the entire row; with Hann the energy stays within a few bins.
+- **Averaging:** desktop `avg 6 → 1` restores per-row speckle and sharpens
+  signal onsets; Android `Off → Heavy` visibly delays onset/decay (ghosting) —
+  useful to bracket how much smear averaging alone can cause.
+- **FFT size (desktop):** larger sizes narrow each signal and slow the row
+  cadence; watch for the artifact scaling (leakage) vs staying constant
+  (rendering).

--- a/ft8af/app/src/main/cpp/ft8af_glue/fft_display.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/fft_display.c
@@ -21,6 +21,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 // dB above the noise floor that maps to full (255) brightness.
 #define FT8AF_DISPLAY_DB_RANGE 50.0f
 // Intensity assigned to the noise floor itself. In the raw view we keep the floor
@@ -107,4 +111,54 @@ void ft8af_magnitudes_to_display(const float* mag, int n_bins, int* output, int 
     }
 
     free(db);
+}
+
+// --- FFT display window functions + frame averaging (issue #428) -----------
+
+void ft8af_window_fill(int type, float* w, int n)
+{
+    if (n <= 0)
+        return;
+    if (n == 1)
+    {
+        w[0] = 1.0f;
+        return;
+    }
+    for (int i = 0; i < n; ++i)
+    {
+        // Symmetric form: x sweeps 0..2π across the n samples.
+        float x = 2.0f * (float)M_PI * (float)i / (float)(n - 1);
+        switch (type)
+        {
+        case FT8AF_WIN_HANN:
+            w[i] = 0.5f - 0.5f * cosf(x);
+            break;
+        case FT8AF_WIN_HAMMING:
+            w[i] = 0.54f - 0.46f * cosf(x);
+            break;
+        case FT8AF_WIN_BLACKMAN:
+            w[i] = 0.42f - 0.5f * cosf(x) + 0.08f * cosf(2.0f * x);
+            break;
+        case FT8AF_WIN_BLACKMAN_HARRIS:
+            w[i] = 0.35875f - 0.48829f * cosf(x) + 0.14128f * cosf(2.0f * x)
+                   - 0.01168f * cosf(3.0f * x);
+            break;
+        case FT8AF_WIN_RECT:
+        default: // unknown types read as "no window"
+            w[i] = 1.0f;
+            break;
+        }
+    }
+}
+
+void ft8af_window_apply(const float* w, const float* in, float* out, int n)
+{
+    for (int i = 0; i < n; ++i)
+        out[i] = in[i] * w[i];
+}
+
+void ft8af_mag_ema(float* acc, const float* mag, int n, float alpha)
+{
+    for (int i = 0; i < n; ++i)
+        acc[i] = alpha * mag[i] + (1.0f - alpha) * acc[i];
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/fft_display.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/fft_display.h
@@ -20,6 +20,36 @@ extern "C" {
 //                          noise floor to black.
 void ft8af_magnitudes_to_display(const float* mag, int n_bins, int* output, int denoise);
 
+// --- FFT display window functions + frame averaging (issue #428) -----------
+//
+// Developer-selectable pre-FFT windows for the display path. Values are wire
+// format: they are stored in the config DB and passed through JNI as ints, so
+// they must stay stable.
+typedef enum {
+    FT8AF_WIN_RECT = 0,            // no window (the pre-#428 behavior)
+    FT8AF_WIN_HANN = 1,            // default; matches the desktop/iOS pipeline
+    FT8AF_WIN_HAMMING = 2,
+    FT8AF_WIN_BLACKMAN = 3,
+    FT8AF_WIN_BLACKMAN_HARRIS = 4, // 4-term minimum-sidelobe
+} ft8af_window_type;
+
+// Fill w[0..n-1] with window coefficients (symmetric form, denominator n-1).
+// Unknown types fall back to rectangular. No-op if n <= 0; n == 1 yields 1.0.
+//
+// Windowing scales every bin by the window's coherent gain (~0.5 for Hann),
+// but ft8af_magnitudes_to_display() maps dB RELATIVE to the frame's median
+// noise floor, so the constant gain cancels — no renormalization is needed.
+void ft8af_window_fill(int type, float* w, int n);
+
+// out[i] = in[i] * w[i]. out may alias in. No-op if n <= 0.
+void ft8af_window_apply(const float* w, const float* in, float* out, int n);
+
+// Exponential moving average across display frames, on linear magnitudes
+// (the closest cross-frame analog to Welch power averaging):
+//   acc[i] = alpha*mag[i] + (1-alpha)*acc[i]
+// alpha in (0,1]; alpha == 1 is a passthrough copy. No-op if n <= 0.
+void ft8af_mag_ema(float* acc, const float* mag, int n, float alpha);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ft8af/app/src/main/cpp/ft8af_glue/fft_display.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/fft_display.h
@@ -33,6 +33,22 @@ typedef enum {
     FT8AF_WIN_BLACKMAN_HARRIS = 4, // 4-term minimum-sidelobe
 } ft8af_window_type;
 
+// Clamp wire values arriving at the native boundary (JNI / persisted config)
+// to their valid ranges; anything else falls back to the default. Without
+// this, an out-of-range averaging mode would silently enable EMA with the
+// heavy alpha (any mode > 0 reads as "on", any mode != 1 as "heavy").
+static inline int ft8af_sanitize_window_type(int type)
+{
+    return (type >= FT8AF_WIN_RECT && type <= FT8AF_WIN_BLACKMAN_HARRIS)
+               ? type
+               : FT8AF_WIN_HANN;
+}
+
+static inline int ft8af_sanitize_avg_mode(int mode)
+{
+    return (mode >= 0 && mode <= 2) ? mode : 0; // 0=off 1=EMA 0.5 2=EMA 0.25
+}
+
 // Fill w[0..n-1] with window coefficients (symmetric form, denominator n-1).
 // Unknown types fall back to rectangular. No-op if n <= 0; n == 1 yields 1.0.
 //

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
@@ -61,9 +61,13 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_k1af_ft8af_ui_SpectrumFragment_setFFTDisplayParams(
         JNIEnv*, jclass, jint windowType, jint averagingMode)
 {
-    g_window_type = (int)windowType;
-    if ((int)averagingMode != g_avg_mode) {
-        g_avg_mode = (int)averagingMode;
+    // The Java setters already clamp, but this is the native trust boundary:
+    // sanitize again so a caller bypassing GeneralVariables (or corrupted
+    // persisted state) can't select an undefined window/averaging mode.
+    g_window_type = ft8af_sanitize_window_type((int)windowType);
+    int avg = ft8af_sanitize_avg_mode((int)averagingMode);
+    if (avg != g_avg_mode) {
+        g_avg_mode = avg;
         g_ema_primed = false; // restart smoothing cleanly on mode change
     }
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_fft_jni.cpp
@@ -13,6 +13,17 @@
 // Java side:
 //   com.k1af.ft8af.ui.SpectrumView    (instance methods)
 //   com.k1af.ft8af.ui.SpectrumFragment (instance methods)
+//
+// DISPLAY KNOBS (issue #428): before the FFT the input is multiplied by a
+// selectable window function (default Hann; rectangular reproduces the
+// pre-#428 behavior, whose spectral leakage smears strong-signal onsets across
+// the row), and after the FFT the linear magnitudes can be smoothed with a
+// cross-frame EMA (default off). Both are process-wide state set via the
+// static native SpectrumFragment.setFFTDisplayParams(windowType, avgMode) —
+// the existing getFFTData* signatures mirror the retired prebuilt libft8cn.so
+// and are left untouched. All calls (setter + compute) happen on the app's
+// main thread (the WaterfallScreen LiveData observer), so the globals need no
+// locking.
 
 #include <jni.h>
 #include <stdint.h>
@@ -26,6 +37,36 @@ extern "C" {
 // fft_display.h guards its own C linkage (extern "C"), so include it outside the
 // kissfft block rather than nesting it under this one.
 #include "fft_display.h"
+
+// ---------------------------------------------------------------------------
+// Display-pipeline state (issue #428). Main-thread only — the setter and every
+// getFFTData* call run on the WaterfallScreen LiveData observer's thread.
+// ---------------------------------------------------------------------------
+static int g_window_type = FT8AF_WIN_HANN; // default matches desktop/iOS
+static int g_avg_mode = 0;                 // 0=off, 1=EMA a=0.5, 2=EMA a=0.25
+
+// Window coefficient cache, rebuilt when (type, nfft) changes.
+static float* g_window = nullptr;
+static int g_window_type_cached = -1;
+static int g_window_n = 0;
+
+// Cross-frame EMA accumulator over linear magnitudes; reset (re-primed from
+// the next frame) when the bin count or the averaging mode changes.
+static float* g_ema_acc = nullptr;
+static int g_ema_n = 0;
+static int g_ema_mode = 0;
+static bool g_ema_primed = false;
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_k1af_ft8af_ui_SpectrumFragment_setFFTDisplayParams(
+        JNIEnv*, jclass, jint windowType, jint averagingMode)
+{
+    g_window_type = (int)windowType;
+    if ((int)averagingMode != g_avg_mode) {
+        g_avg_mode = (int)averagingMode;
+        g_ema_primed = false; // restart smoothing cleanly on mode change
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Core FFT computation: time-domain samples → magnitude array.
@@ -54,7 +95,32 @@ static void compute_fft_magnitudes(const float* input, int n, int* output, bool 
         return;
     }
 
-    kiss_fftr(cfg, input, freq);
+    // Apply the selected pre-FFT window (issue #428). Rect skips the multiply
+    // and any (re)allocation. The window's constant coherent gain cancels in
+    // ft8af_magnitudes_to_display's noise-floor-relative mapping.
+    const float* fft_in = input;
+    float* windowed = nullptr;
+    if (g_window_type != FT8AF_WIN_RECT) {
+        if (g_window_type != g_window_type_cached || nfft != g_window_n) {
+            float* w = (float*)realloc(g_window, nfft * sizeof(float));
+            if (w) {
+                g_window = w;
+                ft8af_window_fill(g_window_type, g_window, nfft);
+                g_window_type_cached = g_window_type;
+                g_window_n = nfft;
+            }
+        }
+        if (g_window && g_window_n == nfft) {
+            windowed = (float*)malloc(nfft * sizeof(float));
+            if (windowed) {
+                ft8af_window_apply(g_window, input, windowed, nfft);
+                fft_in = windowed;
+            }
+        }
+    }
+
+    kiss_fftr(cfg, fft_in, freq);
+    free(windowed);
 
     // Compute the linear magnitude for each bin.
     float* mag = (float*)malloc(n_bins * sizeof(float));
@@ -65,6 +131,32 @@ static void compute_fft_magnitudes(const float* input, int n, int* output, bool 
     }
     for (int i = 0; i < n_bins; ++i)
         mag[i] = sqrtf(freq[i].r * freq[i].r + freq[i].i * freq[i].i);
+
+    // Optional cross-frame EMA over linear magnitudes (issue #428) — the
+    // closest cross-frame analog to the desktop's within-capture Welch
+    // averaging. Off by default: temporal smoothing is exactly the effect
+    // under investigation, so it must be opt-in.
+    if (g_avg_mode > 0) {
+        if (g_ema_n != n_bins || g_ema_mode != g_avg_mode) {
+            float* acc = (float*)realloc(g_ema_acc, n_bins * sizeof(float));
+            if (acc) {
+                g_ema_acc = acc;
+                g_ema_n = n_bins;
+                g_ema_mode = g_avg_mode;
+                g_ema_primed = false;
+            }
+        }
+        if (g_ema_acc && g_ema_n == n_bins) {
+            if (!g_ema_primed) {
+                memcpy(g_ema_acc, mag, n_bins * sizeof(float)); // copy-through prime
+                g_ema_primed = true;
+            } else {
+                ft8af_mag_ema(g_ema_acc, mag, n_bins,
+                              g_avg_mode == 1 ? 0.5f : 0.25f);
+            }
+            memcpy(mag, g_ema_acc, n_bins * sizeof(float));
+        }
+    }
 
     // Map to 0..255 on a logarithmic (dB), noise-floor-referenced scale. Linear
     // scaling here made the waterfall blank; see fft_display.c.

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -100,6 +100,25 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (dev625)." }
 $dev625Exit = $LASTEXITCODE
 
 # ---------------------------------------------------------------------------
+# FFT display window / averaging tests (issue #428): the pre-FFT window
+# functions + cross-frame magnitude EMA in fft_display.c, plus a rect-vs-Hann
+# spectral-leakage comparison through the same kissfft path the display uses.
+# ---------------------------------------------------------------------------
+$fftWinSrcs = @(
+    "fft\kiss_fft.c","fft\kiss_fftr.c"
+) | ForEach-Object { Join-Path $ft8 $_ }
+$fftWinSrcs += (Join-Path $here "fft_display.c")
+
+$srcFftWin = Join-Path $here "test_fft_window.c"
+$outFftWin = Join-Path $env:TEMP "ft8_fft_window_test.exe"
+
+& $Clang @common $srcFftWin @fftWinSrcs -o $outFftWin
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_fft_window)." }
+
+& $outFftWin
+$fftWinExit = $LASTEXITCODE
+
+# ---------------------------------------------------------------------------
 # Callsign-hash recovery tests (issue #392): the pure helpers in ft8_call_hash.h
 # that pull a compound call's 12-/22-bit hash out of a decoded frame so the
 # seeded Java MessageHashMap can resolve an answer that the decoder returns as
@@ -285,6 +304,7 @@ $xslotExit = $LASTEXITCODE
 
 if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
+if ($fftWinExit -ne 0) { exit $fftWinExit }
 if ($callHashExit -ne 0) { exit $callHashExit }
 if ($contestExit -ne 0) { exit $contestExit }
 if ($firExit -ne 0) { exit $firExit }

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -79,6 +79,21 @@ out625="$tmp/ft8_dev625_test"
 # Not exec'd, so the EXIT trap cleans up $tmp. set -e propagates a failure.
 "$out625"
 
+# FFT display window / averaging tests (issue #428): the pre-FFT window
+# functions + cross-frame magnitude EMA in fft_display.c, plus a rect-vs-Hann
+# spectral-leakage comparison through the same kissfft path the display uses.
+fft_window_srcs=(
+    "$here/test_fft_window.c"
+    "$here/fft_display.c"
+    "$ft8/fft/kiss_fft.c"
+    "$ft8/fft/kiss_fftr.c"
+)
+fft_window_out="$tmp/ft8_fft_window_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" "${fft_window_srcs[@]}" -lm -o "$fft_window_out"
+"$fft_window_out"
+
 # Callsign-hash recovery tests (issue #392): the pure helpers in ft8_call_hash.h
 # that pull a compound call's 12-/22-bit hash out of a decoded frame so the
 # seeded Java MessageHashMap can resolve an answer that the decoder returns as

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_fft_window.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_fft_window.c
@@ -1,0 +1,251 @@
+// Tests for the issue-#428 FFT display knobs: the pre-FFT window functions
+// (ft8af_window_fill / ft8af_window_apply) and the cross-frame magnitude EMA
+// (ft8af_mag_ema) in fft_display.c.
+//
+// Includes a behavioral leakage test that pins the mechanism issue #428 is
+// about: an off-grid tone FFT'd with no window (the pre-#428 display path)
+// splatters energy across the whole row, while a Hann window keeps the skirts
+// tens of dB down. Uses the same kissfft real FFT as the display JNI path.
+//
+// HOST BUILD (no device): run_host_tests.ps1 / run_host_tests.sh build and run
+// this alongside the other suites. Exit code 0 == all pass.
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fft/kiss_fftr.h"
+
+#include "fft_display.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+static int g_failures = 0;
+
+#define CHECK_TRUE(cond, label)                                                 \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            printf("  FAIL: %s\n", (label));                                    \
+            ++g_failures;                                                       \
+        } else {                                                                \
+            printf("  ok:   %s\n", (label));                                    \
+        }                                                                       \
+    } while (0)
+
+#define CHECK_NEAR(actual, expected, tol, label)                                \
+    do {                                                                        \
+        float a_ = (actual), e_ = (expected);                                   \
+        if (fabsf(a_ - e_) > (tol)) {                                           \
+            printf("  FAIL: %s: got %f, expected %f (tol %f)\n", (label),       \
+                   (double)a_, (double)e_, (double)(tol));                      \
+            ++g_failures;                                                       \
+        } else {                                                                \
+            printf("  ok:   %s ~= %f\n", (label), (double)e_);                  \
+        }                                                                       \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// Window coefficient shapes: endpoints, midpoint, symmetry, coherent gain.
+// ---------------------------------------------------------------------------
+static void test_window_coefficients(void)
+{
+    printf("window coefficients:\n");
+    enum { N = 64 };
+    float w[N];
+
+    ft8af_window_fill(FT8AF_WIN_RECT, w, N);
+    int all_ones = 1;
+    for (int i = 0; i < N; ++i)
+        if (w[i] != 1.0f)
+            all_ones = 0;
+    CHECK_TRUE(all_ones, "rect: all coefficients 1.0");
+
+    struct {
+        int type;
+        const char* name;
+        float endpoint;   // w[0] == w[N-1] for the symmetric form
+        float coherent;   // mean coefficient (coherent gain)
+    } cases[] = {
+        { FT8AF_WIN_HANN, "hann", 0.0f, 0.5f },
+        { FT8AF_WIN_HAMMING, "hamming", 0.08f, 0.54f },
+        { FT8AF_WIN_BLACKMAN, "blackman", 0.0f, 0.42f },
+        { FT8AF_WIN_BLACKMAN_HARRIS, "blackman-harris", 6e-5f, 0.35875f },
+    };
+    for (int c = 0; c < 4; ++c)
+    {
+        char label[96];
+        ft8af_window_fill(cases[c].type, w, N);
+
+        snprintf(label, sizeof label, "%s: endpoint w[0]", cases[c].name);
+        CHECK_NEAR(w[0], cases[c].endpoint, 1e-4f, label);
+
+        int symmetric = 1;
+        for (int i = 0; i < N; ++i)
+            if (fabsf(w[i] - w[N - 1 - i]) > 1e-5f)
+                symmetric = 0;
+        snprintf(label, sizeof label, "%s: symmetric", cases[c].name);
+        CHECK_TRUE(symmetric, label);
+
+        // Midpoint of the symmetric form: for even N the peak straddles
+        // N/2-1 and N/2; both sit within a hair of 1.0.
+        snprintf(label, sizeof label, "%s: midpoint ~1", cases[c].name);
+        CHECK_TRUE(w[N / 2] > 0.99f && w[N / 2 - 1] > 0.99f, label);
+
+        float sum = 0.0f;
+        for (int i = 0; i < N; ++i)
+            sum += w[i];
+        snprintf(label, sizeof label, "%s: coherent gain", cases[c].name);
+        // Symmetric (N-1 denominator) windows have mean slightly above the
+        // periodic-form gain; 2% relative tolerance covers N=64.
+        CHECK_NEAR(sum / N, cases[c].coherent, cases[c].coherent * 0.02f + 1e-3f, label);
+    }
+
+    // Unknown type falls back to rectangular.
+    ft8af_window_fill(99, w, N);
+    int fallback_rect = 1;
+    for (int i = 0; i < N; ++i)
+        if (w[i] != 1.0f)
+            fallback_rect = 0;
+    CHECK_TRUE(fallback_rect, "unknown type -> rect");
+
+    // n == 1 is a defined edge: single coefficient 1.0 (no 0/0 from N-1).
+    float one = -1.0f;
+    ft8af_window_fill(FT8AF_WIN_HANN, &one, 1);
+    CHECK_NEAR(one, 1.0f, 1e-6f, "n==1 -> 1.0");
+
+    // n <= 0 must be a no-op (must not crash / write).
+    ft8af_window_fill(FT8AF_WIN_HANN, NULL, 0);
+    CHECK_TRUE(1, "n==0 no-op");
+}
+
+// ---------------------------------------------------------------------------
+// ft8af_window_apply: elementwise multiply; aliasing allowed.
+// ---------------------------------------------------------------------------
+static void test_window_apply(void)
+{
+    printf("window apply:\n");
+    float w[4] = { 0.0f, 0.5f, 1.0f, 2.0f };
+    float in[4] = { 4.0f, 4.0f, 4.0f, 4.0f };
+    float out[4];
+    ft8af_window_apply(w, in, out, 4);
+    CHECK_TRUE(out[0] == 0.0f && out[1] == 2.0f && out[2] == 4.0f && out[3] == 8.0f,
+               "elementwise multiply");
+
+    // In-place (out aliases in).
+    ft8af_window_apply(w, in, in, 4);
+    CHECK_TRUE(in[1] == 2.0f && in[3] == 8.0f, "in-place multiply");
+
+    ft8af_window_apply(w, NULL, NULL, 0);
+    CHECK_TRUE(1, "n==0 no-op");
+}
+
+// ---------------------------------------------------------------------------
+// Behavioral leakage test: off-grid tone, rect vs Hann, same FFT size as the
+// Android display path (1920 samples @ 12 kHz -> 6.25 Hz bins).
+// ---------------------------------------------------------------------------
+static void test_leakage_rect_vs_hann(void)
+{
+    printf("spectral leakage (rect vs hann):\n");
+    enum { N = 1920, NBINS = N / 2 };
+    const float fs = 12000.0f;
+    const float f_tone = 1003.7f; // deliberately off the 6.25 Hz grid
+
+    float* samples = (float*)malloc(N * sizeof(float));
+    float* windowed = (float*)malloc(N * sizeof(float));
+    float* w = (float*)malloc(N * sizeof(float));
+    kiss_fft_cpx* freq = (kiss_fft_cpx*)malloc((NBINS + 1) * sizeof(kiss_fft_cpx));
+    float* db_rect = (float*)malloc(NBINS * sizeof(float));
+    float* db_hann = (float*)malloc(NBINS * sizeof(float));
+    if (!samples || !windowed || !w || !freq || !db_rect || !db_hann)
+    {
+        printf("  FAIL: alloc\n");
+        ++g_failures;
+        return;
+    }
+
+    for (int i = 0; i < N; ++i)
+        samples[i] = sinf(2.0f * (float)M_PI * f_tone * (float)i / fs);
+
+    kiss_fftr_cfg cfg = kiss_fftr_alloc(N, 0, NULL, NULL);
+
+    for (int pass = 0; pass < 2; ++pass)
+    {
+        float* db = pass == 0 ? db_rect : db_hann;
+        ft8af_window_fill(pass == 0 ? FT8AF_WIN_RECT : FT8AF_WIN_HANN, w, N);
+        ft8af_window_apply(w, samples, windowed, N);
+        kiss_fftr(cfg, windowed, freq);
+        for (int i = 0; i < NBINS; ++i)
+        {
+            float m = sqrtf(freq[i].r * freq[i].r + freq[i].i * freq[i].i);
+            db[i] = 20.0f * log10f(m + 1e-12f);
+        }
+    }
+    kiss_fftr_free(cfg);
+
+    int peak = (int)(f_tone * N / fs + 0.5f); // ~bin 161
+    // Compare the skirt 10+ bins from the peak, relative to each pass's own
+    // peak level: rect's sinc sidelobes decay slowly, Hann's fall off fast.
+    float rect_skirt = -1e9f, hann_skirt = -1e9f;
+    for (int i = 0; i < NBINS; ++i)
+    {
+        if (abs(i - peak) <= 10)
+            continue;
+        if (db_rect[i] > rect_skirt) rect_skirt = db_rect[i];
+        if (db_hann[i] > hann_skirt) hann_skirt = db_hann[i];
+    }
+    float rect_rel = db_rect[peak] - rect_skirt; // how far the skirt sits below the peak
+    float hann_rel = db_hann[peak] - hann_skirt;
+    printf("  info: skirt below peak: rect %.1f dB, hann %.1f dB\n",
+           (double)rect_rel, (double)hann_rel);
+    CHECK_TRUE(hann_rel >= rect_rel + 20.0f,
+               "hann suppresses off-grid skirts >= 20 dB more than rect");
+}
+
+// ---------------------------------------------------------------------------
+// ft8af_mag_ema: passthrough at alpha 1, two-step arithmetic, convergence.
+// ---------------------------------------------------------------------------
+static void test_mag_ema(void)
+{
+    printf("magnitude EMA:\n");
+    float acc[3] = { 10.0f, 20.0f, 30.0f };
+    float m1[3] = { 1.0f, 2.0f, 3.0f };
+
+    // alpha == 1: passthrough copy.
+    ft8af_mag_ema(acc, m1, 3, 1.0f);
+    CHECK_TRUE(acc[0] == 1.0f && acc[1] == 2.0f && acc[2] == 3.0f, "alpha=1 passthrough");
+
+    // Two-step numeric check at alpha 0.5: acc = 0.5*new + 0.5*old.
+    float m2[3] = { 3.0f, 6.0f, 9.0f };
+    ft8af_mag_ema(acc, m2, 3, 0.5f);
+    CHECK_NEAR(acc[0], 2.0f, 1e-6f, "alpha=0.5 step: 0.5*3 + 0.5*1");
+    CHECK_NEAR(acc[2], 6.0f, 1e-6f, "alpha=0.5 step: 0.5*9 + 0.5*3");
+
+    // Repeated constant input converges to that input.
+    float target[3] = { 5.0f, 5.0f, 5.0f };
+    for (int i = 0; i < 60; ++i)
+        ft8af_mag_ema(acc, target, 3, 0.25f);
+    CHECK_NEAR(acc[0], 5.0f, 1e-3f, "converges to constant input");
+
+    ft8af_mag_ema(NULL, NULL, 0, 0.5f);
+    CHECK_TRUE(1, "n==0 no-op");
+}
+
+int main(void)
+{
+    printf("=== FFT display window / averaging tests (issue #428) ===\n");
+    test_window_coefficients();
+    test_window_apply();
+    test_leakage_rect_vs_hann();
+    test_mag_ema();
+
+    if (g_failures)
+    {
+        printf("=== %d FAILURE(S) ===\n", g_failures);
+        return 1;
+    }
+    printf("=== all passed ===\n");
+    return 0;
+}

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_fft_window.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_fft_window.c
@@ -35,6 +35,17 @@ static int g_failures = 0;
         }                                                                       \
     } while (0)
 
+#define CHECK_EQ_INT(actual, expected, label)                                   \
+    do {                                                                        \
+        int a_ = (actual), e_ = (expected);                                     \
+        if (a_ != e_) {                                                         \
+            printf("  FAIL: %s: got %d, expected %d\n", (label), a_, e_);       \
+            ++g_failures;                                                       \
+        } else {                                                                \
+            printf("  ok:   %s\n", (label));                                    \
+        }                                                                       \
+    } while (0)
+
 #define CHECK_NEAR(actual, expected, tol, label)                                \
     do {                                                                        \
         float a_ = (actual), e_ = (expected);                                   \
@@ -205,6 +216,26 @@ static void test_leakage_rect_vs_hann(void)
 }
 
 // ---------------------------------------------------------------------------
+// Wire-value sanitizers: the JNI boundary must clamp out-of-range knob values
+// to the defaults (Hann / off) instead of trusting persisted state.
+// ---------------------------------------------------------------------------
+static void test_sanitizers(void)
+{
+    printf("wire-value sanitizers:\n");
+    for (int v = FT8AF_WIN_RECT; v <= FT8AF_WIN_BLACKMAN_HARRIS; ++v)
+        CHECK_EQ_INT(ft8af_sanitize_window_type(v), v, "valid window passes through");
+    CHECK_EQ_INT(ft8af_sanitize_window_type(-1), FT8AF_WIN_HANN, "window -1 -> hann");
+    CHECK_EQ_INT(ft8af_sanitize_window_type(5), FT8AF_WIN_HANN, "window 5 -> hann");
+    CHECK_EQ_INT(ft8af_sanitize_window_type(99), FT8AF_WIN_HANN, "window 99 -> hann");
+
+    for (int v = 0; v <= 2; ++v)
+        CHECK_EQ_INT(ft8af_sanitize_avg_mode(v), v, "valid avg mode passes through");
+    CHECK_EQ_INT(ft8af_sanitize_avg_mode(-1), 0, "avg -1 -> off");
+    CHECK_EQ_INT(ft8af_sanitize_avg_mode(3), 0, "avg 3 -> off (not heavy EMA)");
+    CHECK_EQ_INT(ft8af_sanitize_avg_mode(99), 0, "avg 99 -> off");
+}
+
+// ---------------------------------------------------------------------------
 // ft8af_mag_ema: passthrough at alpha 1, two-step arithmetic, convergence.
 // ---------------------------------------------------------------------------
 static void test_mag_ema(void)
@@ -239,6 +270,7 @@ int main(void)
     test_window_coefficients();
     test_window_apply();
     test_leakage_rect_vs_hann();
+    test_sanitizers();
     test_mag_ema();
 
     if (g_failures)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -407,6 +407,14 @@ public class GeneralVariables {
     private static int spectrumWidth = 3500;//Spectrum display width in Hz
     public static MutableLiveData<Integer> mutableSpectrumWidth = new MutableLiveData<>();
 
+    // FFT display developer knobs (issue #428). Wire values shared with the
+    // native side (SpectrumFragment.setFFTDisplayParams) and the config DB;
+    // read fresh every display frame, so no LiveData needed (same pattern as
+    // pttDelay). Display-only — the decoder's FFT is unaffected.
+    private static int fftWindowType = 1;//0=Rect 1=Hann(default, matches desktop/iOS) 2=Hamming 3=Blackman 4=Blackman-Harris
+    private static int fftAveragingMode = 0;//0=Off(default) 1=EMA a=0.5 (light) 2=EMA a=0.25 (heavy)
+    private static int spectrumBinAggregation = 0;//Spectrum-strip bin combine: 0=Max(default, legacy) 1=Average 2=RMS
+
     public static String cloudlogServerAddress = "";//Cloudlog server address
     public static String cloudlogApiKey = "";//Cloudlog API key
     public static String cloudlogStationID = "";//Cloudlog station ID
@@ -619,6 +627,33 @@ public class GeneralVariables {
     public static void setSpectrumWidth(int width) {
         mutableSpectrumWidth.postValue(width);
         GeneralVariables.spectrumWidth = width;
+    }
+
+    public static int getFftWindowType() {
+        return fftWindowType;
+    }
+
+    /** Out-of-range values clamp to the default (1 = Hann). */
+    public static void setFftWindowType(int type) {
+        fftWindowType = (type >= 0 && type <= 4) ? type : 1;
+    }
+
+    public static int getFftAveragingMode() {
+        return fftAveragingMode;
+    }
+
+    /** Out-of-range values clamp to the default (0 = off). */
+    public static void setFftAveragingMode(int mode) {
+        fftAveragingMode = (mode >= 0 && mode <= 2) ? mode : 0;
+    }
+
+    public static int getSpectrumBinAggregation() {
+        return spectrumBinAggregation;
+    }
+
+    /** Out-of-range values clamp to the default (0 = max, the legacy combine). */
+    public static void setSpectrumBinAggregation(int mode) {
+        spectrumBinAggregation = (mode >= 0 && mode <= 2) ? mode : 0;
     }
 
     public static String getCloudlogServerAddress() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -743,6 +743,23 @@ public class DatabaseOpr extends SQLiteOpenHelper {
     }
 
     /**
+     * Parses a config-table int value, falling back when the stored string is
+     * empty or not a number (a hand-edited or stale backup must not crash
+     * startup hydration). Range clamping is the caller's (setter's) job.
+     * Package-private static so it is unit-testable without a database.
+     */
+    static int parseConfigInt(String value, int fallback) {
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /**
      * Read every config key/value pair synchronously into an insertion-ordered map.
      * Backs the settings-export feature (issue #357). Must be called off the main
      * thread (it touches SQLite directly).
@@ -2790,15 +2807,18 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("spectrumWidth")) {
                     GeneralVariables.setSpectrumWidth(result.equals("") ? 3500 : Integer.parseInt(result));
                 }
-                // FFT display developer knobs (issue #428); setters clamp bad values.
+                // FFT display developer knobs (issue #428). Parsed defensively:
+                // these are expected to survive hand-edited/stale backups, so a
+                // non-numeric value must fall back to the default instead of
+                // crashing hydration; the setters then clamp the range.
                 if (name.equalsIgnoreCase("fftWindowType")) {
-                    GeneralVariables.setFftWindowType(result.equals("") ? 1 : Integer.parseInt(result));
+                    GeneralVariables.setFftWindowType(parseConfigInt(result, 1));
                 }
                 if (name.equalsIgnoreCase("fftAveragingMode")) {
-                    GeneralVariables.setFftAveragingMode(result.equals("") ? 0 : Integer.parseInt(result));
+                    GeneralVariables.setFftAveragingMode(parseConfigInt(result, 0));
                 }
                 if (name.equalsIgnoreCase("spectrumBinAggregation")) {
-                    GeneralVariables.setSpectrumBinAggregation(result.equals("") ? 0 : Integer.parseInt(result));
+                    GeneralVariables.setSpectrumBinAggregation(parseConfigInt(result, 0));
                 }
 
                 if (name.equalsIgnoreCase("highlightNewDxcc")) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2780,6 +2780,16 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("spectrumWidth")) {
                     GeneralVariables.setSpectrumWidth(result.equals("") ? 3500 : Integer.parseInt(result));
                 }
+                // FFT display developer knobs (issue #428); setters clamp bad values.
+                if (name.equalsIgnoreCase("fftWindowType")) {
+                    GeneralVariables.setFftWindowType(result.equals("") ? 1 : Integer.parseInt(result));
+                }
+                if (name.equalsIgnoreCase("fftAveragingMode")) {
+                    GeneralVariables.setFftAveragingMode(result.equals("") ? 0 : Integer.parseInt(result));
+                }
+                if (name.equalsIgnoreCase("spectrumBinAggregation")) {
+                    GeneralVariables.setSpectrumBinAggregation(result.equals("") ? 0 : Integer.parseInt(result));
+                }
 
                 if (name.equalsIgnoreCase("highlightNewDxcc")) {
                     GeneralVariables.highlightNewDxcc = result.equals("1");

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/BinAggregation.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/BinAggregation.java
@@ -1,0 +1,55 @@
+package com.k1af.ft8af.ui;
+
+/**
+ * Spectrum-strip bin combining (issue #428): how ColumnarView merges an FFT
+ * bin with its right neighbor into one drawn bar.
+ *
+ * <p>Extracted from ColumnarView so the decision logic is JVM-testable and the
+ * mode is a developer setting (GeneralVariables.getSpectrumBinAggregation()).
+ * MODE_MAX reproduces the legacy expression bit-for-bit, including the
+ * last-index tail case.
+ *
+ * <p>Inputs are dB-scaled 0..255 display intensities (fft_display.c output),
+ * not linear magnitudes — so AVG/RMS here are display heuristics for A/B
+ * comparison, not physically meaningful power averages.
+ */
+public final class BinAggregation {
+
+    /** Max of the pair — the legacy (pre-#428) behavior and default. */
+    public static final int MODE_MAX = 0;
+    /** Arithmetic mean of the pair. */
+    public static final int MODE_AVG = 1;
+    /** Root-mean-square of the pair (emphasizes the stronger bin less than MAX). */
+    public static final int MODE_RMS = 2;
+
+    private BinAggregation() {
+    }
+
+    /**
+     * Combines bin {@code i} with its right neighbor (the last bin stands
+     * alone) under the given mode, clamped to 0..255. Unknown modes fall back
+     * to MAX so a bad persisted value can never blank the strip.
+     */
+    public static int combine(int[] data, int i, int mode) {
+        int a = data[i];
+        if (i + 1 >= data.length) {
+            return clamp(a);
+        }
+        int b = data[i + 1];
+        switch (mode) {
+            case MODE_AVG:
+                return clamp((a + b + 1) / 2); // +1: round half up, keeps 255+255 -> 255
+            case MODE_RMS:
+                return clamp((int) Math.round(Math.sqrt((a * (double) a + b * (double) b) / 2.0)));
+            case MODE_MAX:
+            default:
+                return clamp(Math.max(a, b));
+        }
+    }
+
+    private static int clamp(int v) {
+        if (v < 0) return 0;
+        if (v > 255) return 255;
+        return v;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
@@ -125,7 +125,7 @@ public class ColumnarView extends View {
             } else {
                 colRect.left = i * getWidth() / binsToShow;
             }
-            int val = (i + 1 < data.length) ? Math.max(data[i], data[i + 1]) : data[i];
+            int val = BinAggregation.combine(data, i, GeneralVariables.getSpectrumBinAggregation());
             colRect.top = getHeight() - Math.round(val * rateHeight);
             // Guarantee at least a 1px-wide bar. With a wide spectrum span the
             // bin count can exceed the pixel width (e.g. 560 bins across ~1080px

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumFragment.java
@@ -224,4 +224,14 @@ public class SpectrumFragment extends Fragment {
     public native void getFFTDataRaw(int[] data, int fftData[]);
     public native void getFFTDataRawFloat(float[] data,int fftData[]);
 
+    /**
+     * Sets the display FFT window function and cross-frame averaging mode
+     * (issue #428). Values are the wire format shared with the native side:
+     * window 0=Rect 1=Hann 2=Hamming 3=Blackman 4=Blackman-Harris;
+     * averaging 0=off 1=EMA(0.5) 2=EMA(0.25). Affects the waterfall/spectrum
+     * display only, never decoding. Must be called on the same thread as the
+     * getFFTData* methods (both run on the main-thread LiveData observer).
+     */
+    public static native void setFFTDisplayParams(int windowType, int averagingMode);
+
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
@@ -106,6 +106,44 @@ internal fun currentLanguageNameRes(currentTags: String): Int =
         ?: R.string.settings_language_system
 
 /**
+ * FFT display developer knobs (issue #428): label resources indexed by the
+ * wire value stored in GeneralVariables / the config DB. Out-of-range values
+ * fall back to each knob's default, mirroring the clamping setters. Pure
+ * logic, unit-tested.
+ */
+internal val FFT_WINDOW_NAME_RES: List<Int> = listOf(
+    R.string.settings_fft_window_rect,           // 0
+    R.string.settings_fft_window_hann,           // 1 (default)
+    R.string.settings_fft_window_hamming,        // 2
+    R.string.settings_fft_window_blackman,       // 3
+    R.string.settings_fft_window_blackman_harris, // 4
+)
+
+@StringRes
+internal fun fftWindowLabelRes(mode: Int): Int =
+    FFT_WINDOW_NAME_RES.getOrElse(mode) { FFT_WINDOW_NAME_RES[1] }
+
+internal val FFT_AVERAGING_NAME_RES: List<Int> = listOf(
+    R.string.settings_fft_avg_off,   // 0 (default)
+    R.string.settings_fft_avg_light, // 1: EMA a=0.5
+    R.string.settings_fft_avg_heavy, // 2: EMA a=0.25
+)
+
+@StringRes
+internal fun fftAveragingLabelRes(mode: Int): Int =
+    FFT_AVERAGING_NAME_RES.getOrElse(mode) { FFT_AVERAGING_NAME_RES[0] }
+
+internal val BIN_AGGREGATION_NAME_RES: List<Int> = listOf(
+    R.string.settings_bin_agg_max, // 0 (default, legacy behavior)
+    R.string.settings_bin_agg_avg, // 1
+    R.string.settings_bin_agg_rms, // 2
+)
+
+@StringRes
+internal fun binAggregationLabelRes(mode: Int): Int =
+    BIN_AGGREGATION_NAME_RES.getOrElse(mode) { BIN_AGGREGATION_NAME_RES[0] }
+
+/**
  * Advanced settings: PTT/TX timing delays, late-start tolerance, and the
  * in-app language picker.
  */
@@ -126,6 +164,14 @@ fun AdvancedSettings(
     var showLateStart by remember { mutableStateOf(false) }
     var showLanguagePicker by remember { mutableStateOf(false) }
     var showThemePicker by remember { mutableStateOf(false) }
+
+    // FFT display developer knobs (issue #428)
+    var fftWindow by remember { mutableIntStateOf(GeneralVariables.getFftWindowType()) }
+    var fftAveraging by remember { mutableIntStateOf(GeneralVariables.getFftAveragingMode()) }
+    var binAggregation by remember { mutableIntStateOf(GeneralVariables.getSpectrumBinAggregation()) }
+    var showFftWindowPicker by remember { mutableStateOf(false) }
+    var showFftAveragingPicker by remember { mutableStateOf(false) }
+    var showBinAggregationPicker by remember { mutableStateOf(false) }
 
     // -- Backup & restore (issue #357) --
     val scope = rememberCoroutineScope()
@@ -320,6 +366,66 @@ fun AdvancedSettings(
         )
     }
 
+    // -- FFT Window Picker (issue #428) --
+    if (showFftWindowPicker) {
+        val labels = ArrayList<String>(FFT_WINDOW_NAME_RES.size)
+        for (res in FFT_WINDOW_NAME_RES) {
+            labels.add(stringResource(res))
+        }
+        ListPickerDialog(
+            title = stringResource(R.string.settings_fft_window),
+            items = labels,
+            selectedIndex = fftWindow.coerceIn(0, FFT_WINDOW_NAME_RES.size - 1),
+            onDismiss = { showFftWindowPicker = false },
+            onSelect = { index ->
+                showFftWindowPicker = false
+                GeneralVariables.setFftWindowType(index)
+                fftWindow = GeneralVariables.getFftWindowType()
+                mainViewModel.databaseOpr.writeConfig("fftWindowType", index.toString(), null)
+            },
+        )
+    }
+
+    // -- FFT Frame Averaging Picker (issue #428) --
+    if (showFftAveragingPicker) {
+        val labels = ArrayList<String>(FFT_AVERAGING_NAME_RES.size)
+        for (res in FFT_AVERAGING_NAME_RES) {
+            labels.add(stringResource(res))
+        }
+        ListPickerDialog(
+            title = stringResource(R.string.settings_fft_averaging),
+            items = labels,
+            selectedIndex = fftAveraging.coerceIn(0, FFT_AVERAGING_NAME_RES.size - 1),
+            onDismiss = { showFftAveragingPicker = false },
+            onSelect = { index ->
+                showFftAveragingPicker = false
+                GeneralVariables.setFftAveragingMode(index)
+                fftAveraging = GeneralVariables.getFftAveragingMode()
+                mainViewModel.databaseOpr.writeConfig("fftAveragingMode", index.toString(), null)
+            },
+        )
+    }
+
+    // -- Spectrum Bin Aggregation Picker (issue #428) --
+    if (showBinAggregationPicker) {
+        val labels = ArrayList<String>(BIN_AGGREGATION_NAME_RES.size)
+        for (res in BIN_AGGREGATION_NAME_RES) {
+            labels.add(stringResource(res))
+        }
+        ListPickerDialog(
+            title = stringResource(R.string.settings_bin_agg),
+            items = labels,
+            selectedIndex = binAggregation.coerceIn(0, BIN_AGGREGATION_NAME_RES.size - 1),
+            onDismiss = { showBinAggregationPicker = false },
+            onSelect = { index ->
+                showBinAggregationPicker = false
+                GeneralVariables.setSpectrumBinAggregation(index)
+                binAggregation = GeneralVariables.getSpectrumBinAggregation()
+                mainViewModel.databaseOpr.writeConfig("spectrumBinAggregation", index.toString(), null)
+            },
+        )
+    }
+
     // -- Language Picker --
     // Index 0 = "System default" (empty locale list → follow system). Selecting a
     // language calls AppCompatDelegate.setApplicationLocales, which persists the
@@ -412,6 +518,39 @@ fun AdvancedSettings(
                         value = stringResource(R.string.settings_milliseconds_format, lateStartMs),
                         showChevron = true,
                         onClick = { showLateStart = true },
+                    )
+                }
+            }
+        }
+
+        // =====================================================================
+        // FFT / WATERFALL (developer knobs, issue #428)
+        // =====================================================================
+        SettingsSection(title = stringResource(R.string.settings_section_fft_waterfall)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    SettingsRow(
+                        label = stringResource(R.string.settings_fft_window),
+                        description = stringResource(R.string.settings_fft_window_desc),
+                        value = stringResource(fftWindowLabelRes(fftWindow)),
+                        showChevron = true,
+                        onClick = { showFftWindowPicker = true },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_fft_averaging),
+                        description = stringResource(R.string.settings_fft_averaging_desc),
+                        value = stringResource(fftAveragingLabelRes(fftAveraging)),
+                        showChevron = true,
+                        onClick = { showFftAveragingPicker = true },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_bin_agg),
+                        description = stringResource(R.string.settings_bin_agg_desc),
+                        value = stringResource(binAggregationLabelRes(binAggregation)),
+                        showChevron = true,
+                        onClick = { showBinAggregationPicker = true },
                     )
                 }
             }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/waterfall/WaterfallScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/waterfall/WaterfallScreen.kt
@@ -499,6 +499,14 @@ private object FFTBridge {
 
     fun compute(audioData: FloatArray, fftOut: IntArray, deNoise: Boolean) {
         try {
+            // Push the current display knobs (issue #428) before each frame:
+            // two int stores per 160 ms, and a settings change takes effect on
+            // the next frame with no lifecycle wiring. Safe without locking —
+            // this observer and the native reads run on the main thread only.
+            SpectrumFragment.setFFTDisplayParams(
+                GeneralVariables.getFftWindowType(),
+                GeneralVariables.getFftAveragingMode(),
+            )
             if (deNoise) {
                 fragment.getFFTDataFloat(audioData, fftOut)
             } else {

--- a/ft8af/app/src/main/res/values-ar/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ar/strings_compose.xml
@@ -563,4 +563,24 @@
     <string name="tune_stopped_timeout">توقف Tune بعد %1$d ث</string>
     <string name="tune_blocked_tx">أوقف CQ/QSO قبل استخدام Tune</string>
     <string name="tune_unavailable_route">Tune غير مدعوم بعد على مسار الصوت هذا</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / الشلال (للمطورين)</string>
+    <string name="settings_fft_window">دالة نافذة FFT</string>
+    <string name="settings_fft_window_desc">نافذة ما قبل FFT لعرض الطيف/الشلال؛ تقلل نافذة Hann من التسرب الطيفي</string>
+    <string name="settings_fft_window_rect">مستطيلة (بدون)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">متوسط الإطارات</string>
+    <string name="settings_fft_averaging_desc">ينعّم العرض عبر إطارات FFT؛ «إيقاف» يعرض كل إطار كما هو</string>
+    <string name="settings_fft_avg_off">إيقاف</string>
+    <string name="settings_fft_avg_light">خفيف (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">قوي (EMA 0.25)</string>
+    <string name="settings_bin_agg">دمج حاويات الطيف</string>
+    <string name="settings_bin_agg_desc">كيفية دمج حاويات FFT المتجاورة في عمود طيف واحد</string>
+    <string name="settings_bin_agg_max">الحد الأقصى</string>
+    <string name="settings_bin_agg_avg">المتوسط</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-cs/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-cs/strings_compose.xml
@@ -563,4 +563,24 @@
     <string name="tune_stopped_timeout">Tune zastaven po %1$d s</string>
     <string name="tune_blocked_tx">Před použitím Tune zastavte CQ/QSO</string>
     <string name="tune_unavailable_route">Tune zatím není na této zvukové cestě podporován</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / VODOPÁD (VÝVOJÁŘ)</string>
+    <string name="settings_fft_window">Okénková funkce FFT</string>
+    <string name="settings_fft_window_desc">Okno před FFT pro zobrazení spektra/vodopádu; Hann omezuje spektrální únik</string>
+    <string name="settings_fft_window_rect">Obdélníkové (žádné)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Průměrování snímků</string>
+    <string name="settings_fft_averaging_desc">Vyhlazuje zobrazení mezi snímky FFT; Vypnuto zobrazuje každý snímek beze změny</string>
+    <string name="settings_fft_avg_off">Vypnuto</string>
+    <string name="settings_fft_avg_light">Lehké (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Silné (EMA 0.25)</string>
+    <string name="settings_bin_agg">Slučování binů spektra</string>
+    <string name="settings_bin_agg_desc">Jak se sousední biny FFT slučují do jednoho sloupce spektra</string>
+    <string name="settings_bin_agg_max">Maximum</string>
+    <string name="settings_bin_agg_avg">Průměr</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-es/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-es/strings_compose.xml
@@ -520,4 +520,24 @@
     <string name="tune_stopped_timeout">Tune detenido tras %1$d s</string>
     <string name="tune_blocked_tx">Detén el CQ/QSO antes de usar Tune</string>
     <string name="tune_unavailable_route">Tune aún no está disponible en esta ruta de audio</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / CASCADA (DESARROLLADOR)</string>
+    <string name="settings_fft_window">Función de ventana FFT</string>
+    <string name="settings_fft_window_desc">Ventana previa a la FFT para el espectro/cascada; Hann reduce la fuga espectral</string>
+    <string name="settings_fft_window_rect">Rectangular (ninguna)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Promediado de cuadros</string>
+    <string name="settings_fft_averaging_desc">Suaviza la pantalla entre cuadros FFT; Desactivado muestra cada cuadro tal cual</string>
+    <string name="settings_fft_avg_off">Desactivado</string>
+    <string name="settings_fft_avg_light">Ligero (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Fuerte (EMA 0.25)</string>
+    <string name="settings_bin_agg">Combinación de bins del espectro</string>
+    <string name="settings_bin_agg_desc">Cómo se combinan bins FFT adyacentes en una barra del espectro</string>
+    <string name="settings_bin_agg_max">Máximo</string>
+    <string name="settings_bin_agg_avg">Promedio</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-fr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-fr/strings_compose.xml
@@ -520,4 +520,24 @@
     <string name="tune_stopped_timeout">Tune arrêté après %1$d s</string>
     <string name="tune_blocked_tx">Arrêtez le CQ/QSO avant d\'utiliser Tune</string>
     <string name="tune_unavailable_route">Tune n\'est pas encore disponible sur cette voie audio</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / CASCADE (DÉVELOPPEUR)</string>
+    <string name="settings_fft_window">Fonction de fenêtrage FFT</string>
+    <string name="settings_fft_window_desc">Fenêtre appliquée avant la FFT pour l\'affichage spectre/cascade ; Hann réduit les fuites spectrales</string>
+    <string name="settings_fft_window_rect">Rectangulaire (aucune)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Moyennage des trames</string>
+    <string name="settings_fft_averaging_desc">Lisse l\'affichage entre les trames FFT ; Désactivé affiche chaque trame telle quelle</string>
+    <string name="settings_fft_avg_off">Désactivé</string>
+    <string name="settings_fft_avg_light">Léger (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Fort (EMA 0.25)</string>
+    <string name="settings_bin_agg">Combinaison des bins du spectre</string>
+    <string name="settings_bin_agg_desc">Comment les bins FFT adjacents fusionnent en une barre du spectre</string>
+    <string name="settings_bin_agg_max">Maximum</string>
+    <string name="settings_bin_agg_avg">Moyenne</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-in/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-in/strings_compose.xml
@@ -563,4 +563,24 @@
     <string name="tune_stopped_timeout">Tune dihentikan setelah %1$d dtk</string>
     <string name="tune_blocked_tx">Hentikan CQ/QSO sebelum menggunakan Tune</string>
     <string name="tune_unavailable_route">Tune belum didukung pada jalur audio ini</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / WATERFALL (PENGEMBANG)</string>
+    <string name="settings_fft_window">Fungsi jendela FFT</string>
+    <string name="settings_fft_window_desc">Jendela pra-FFT untuk tampilan spektrum/waterfall; Hann mengurangi kebocoran spektral</string>
+    <string name="settings_fft_window_rect">Persegi (tanpa jendela)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Rata-rata frame</string>
+    <string name="settings_fft_averaging_desc">Menghaluskan tampilan antar frame FFT; Nonaktif menampilkan setiap frame apa adanya</string>
+    <string name="settings_fft_avg_off">Nonaktif</string>
+    <string name="settings_fft_avg_light">Ringan (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Kuat (EMA 0.25)</string>
+    <string name="settings_bin_agg">Penggabungan bin spektrum</string>
+    <string name="settings_bin_agg_desc">Cara bin FFT yang berdekatan digabung menjadi satu batang spektrum</string>
+    <string name="settings_bin_agg_max">Maksimum</string>
+    <string name="settings_bin_agg_avg">Rata-rata</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-it/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-it/strings_compose.xml
@@ -552,4 +552,24 @@
     <string name="tune_stopped_timeout">Tune fermato dopo %1$d s</string>
     <string name="tune_blocked_tx">Ferma il CQ/QSO prima di usare Tune</string>
     <string name="tune_unavailable_route">Tune non è ancora disponibile su questo percorso audio</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / CASCATA (SVILUPPATORE)</string>
+    <string name="settings_fft_window">Funzione finestra FFT</string>
+    <string name="settings_fft_window_desc">Finestra pre-FFT per la visualizzazione spettro/cascata; Hann riduce la dispersione spettrale</string>
+    <string name="settings_fft_window_rect">Rettangolare (nessuna)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Media dei fotogrammi</string>
+    <string name="settings_fft_averaging_desc">Attenua la visualizzazione tra fotogrammi FFT; Off mostra ogni fotogramma senza modifiche</string>
+    <string name="settings_fft_avg_off">Off</string>
+    <string name="settings_fft_avg_light">Leggera (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Forte (EMA 0.25)</string>
+    <string name="settings_bin_agg">Combinazione dei bin dello spettro</string>
+    <string name="settings_bin_agg_desc">Come i bin FFT adiacenti si combinano in una barra dello spettro</string>
+    <string name="settings_bin_agg_max">Massimo</string>
+    <string name="settings_bin_agg_avg">Media</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ja/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ja/strings_compose.xml
@@ -520,4 +520,24 @@
     <string name="tune_stopped_timeout">Tuneは%1$d秒後に停止しました</string>
     <string name="tune_blocked_tx">Tuneの前にCQ/QSOを停止してください</string>
     <string name="tune_unavailable_route">このオーディオ経路ではTuneはまだ利用できません</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT／ウォーターフォール（開発者向け）</string>
+    <string name="settings_fft_window">FFT窓関数</string>
+    <string name="settings_fft_window_desc">スペクトラム／ウォーターフォール表示のFFT前窓関数。Hannはスペクトル漏れを低減します</string>
+    <string name="settings_fft_window_rect">矩形（なし）</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">フレーム平均化</string>
+    <string name="settings_fft_averaging_desc">FFTフレーム間で表示を平滑化します。オフは各フレームをそのまま表示します</string>
+    <string name="settings_fft_avg_off">オフ</string>
+    <string name="settings_fft_avg_light">弱（EMA 0.5）</string>
+    <string name="settings_fft_avg_heavy">強（EMA 0.25）</string>
+    <string name="settings_bin_agg">スペクトラムのビン結合</string>
+    <string name="settings_bin_agg_desc">隣接するFFTビンを1本のバーにまとめる方法</string>
+    <string name="settings_bin_agg_max">最大値</string>
+    <string name="settings_bin_agg_avg">平均</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ko/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ko/strings_compose.xml
@@ -563,4 +563,24 @@
     <string name="tune_stopped_timeout">Tune이 %1$d초 후 정지되었습니다</string>
     <string name="tune_blocked_tx">Tune 전에 CQ/QSO를 정지하세요</string>
     <string name="tune_unavailable_route">이 오디오 경로에서는 아직 Tune을 사용할 수 없습니다</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / 워터폴 (개발자)</string>
+    <string name="settings_fft_window">FFT 창 함수</string>
+    <string name="settings_fft_window_desc">스펙트럼/워터폴 표시용 FFT 전 창 함수. Hann은 스펙트럼 누설을 줄입니다</string>
+    <string name="settings_fft_window_rect">직사각형(없음)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">프레임 평균</string>
+    <string name="settings_fft_averaging_desc">FFT 프레임 간 표시를 부드럽게 합니다. 끄면 각 프레임을 그대로 표시합니다</string>
+    <string name="settings_fft_avg_off">끄기</string>
+    <string name="settings_fft_avg_light">약하게 (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">강하게 (EMA 0.25)</string>
+    <string name="settings_bin_agg">스펙트럼 빈 결합</string>
+    <string name="settings_bin_agg_desc">인접한 FFT 빈을 하나의 막대로 결합하는 방법</string>
+    <string name="settings_bin_agg_max">최대</string>
+    <string name="settings_bin_agg_avg">평균</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-nl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-nl/strings_compose.xml
@@ -563,4 +563,24 @@
     <string name="tune_stopped_timeout">Tune gestopt na %1$d s</string>
     <string name="tune_blocked_tx">Stop de CQ/QSO voordat je Tune gebruikt</string>
     <string name="tune_unavailable_route">Tune is nog niet beschikbaar op deze audioroute</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / WATERVAL (ONTWIKKELAAR)</string>
+    <string name="settings_fft_window">FFT-vensterfunctie</string>
+    <string name="settings_fft_window_desc">Venster vóór de FFT voor de spectrum-/watervalweergave; Hann vermindert spectrale lekkage</string>
+    <string name="settings_fft_window_rect">Rechthoekig (geen)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Frame-middeling</string>
+    <string name="settings_fft_averaging_desc">Maakt de weergave vloeiender over FFT-frames; Uit toont elk frame ongewijzigd</string>
+    <string name="settings_fft_avg_off">Uit</string>
+    <string name="settings_fft_avg_light">Licht (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Sterk (EMA 0.25)</string>
+    <string name="settings_bin_agg">Spectrum-bin-combinatie</string>
+    <string name="settings_bin_agg_desc">Hoe aangrenzende FFT-bins samenvoegen tot één spectrumbalk</string>
+    <string name="settings_bin_agg_max">Maximum</string>
+    <string name="settings_bin_agg_avg">Gemiddelde</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-pl/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pl/strings_compose.xml
@@ -552,4 +552,24 @@
     <string name="tune_stopped_timeout">Tune zatrzymany po %1$d s</string>
     <string name="tune_blocked_tx">Zatrzymaj CQ/QSO przed użyciem Tune</string>
     <string name="tune_unavailable_route">Tune nie jest jeszcze dostępny na tej ścieżce audio</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / WODOSPAD (DEWELOPER)</string>
+    <string name="settings_fft_window">Funkcja okna FFT</string>
+    <string name="settings_fft_window_desc">Okno przed FFT dla wyświetlania widma/wodospadu; Hann ogranicza przeciek widmowy</string>
+    <string name="settings_fft_window_rect">Prostokątne (brak)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Uśrednianie ramek</string>
+    <string name="settings_fft_averaging_desc">Wygładza wyświetlanie między ramkami FFT; Wył. pokazuje każdą ramkę bez zmian</string>
+    <string name="settings_fft_avg_off">Wył.</string>
+    <string name="settings_fft_avg_light">Lekkie (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Mocne (EMA 0.25)</string>
+    <string name="settings_bin_agg">Łączenie binów widma</string>
+    <string name="settings_bin_agg_desc">Jak sąsiednie biny FFT łączą się w jeden słupek widma</string>
+    <string name="settings_bin_agg_max">Maksimum</string>
+    <string name="settings_bin_agg_avg">Średnia</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-ru/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-ru/strings_compose.xml
@@ -520,4 +520,24 @@
     <string name="tune_stopped_timeout">Tune остановлен через %1$d с</string>
     <string name="tune_blocked_tx">Остановите CQ/QSO перед использованием Tune</string>
     <string name="tune_unavailable_route">Tune пока не поддерживается на этом аудиотракте</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / ВОДОПАД (ДЛЯ РАЗРАБОТЧИКОВ)</string>
+    <string name="settings_fft_window">Оконная функция БПФ</string>
+    <string name="settings_fft_window_desc">Окно перед БПФ для отображения спектра/водопада; окно Ханна уменьшает растекание спектра</string>
+    <string name="settings_fft_window_rect">Прямоугольное (нет)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Усреднение кадров</string>
+    <string name="settings_fft_averaging_desc">Сглаживает отображение между кадрами БПФ; «Выкл.» показывает каждый кадр как есть</string>
+    <string name="settings_fft_avg_off">Выкл.</string>
+    <string name="settings_fft_avg_light">Лёгкое (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Сильное (EMA 0.25)</string>
+    <string name="settings_bin_agg">Объединение бинов спектра</string>
+    <string name="settings_bin_agg_desc">Как соседние бины БПФ объединяются в один столбец спектра</string>
+    <string name="settings_bin_agg_max">Максимум</string>
+    <string name="settings_bin_agg_avg">Среднее</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-tr/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-tr/strings_compose.xml
@@ -552,4 +552,24 @@
     <string name="tune_stopped_timeout">Tune %1$d s sonra durduruldu</string>
     <string name="tune_blocked_tx">Tune kullanmadan önce CQ/QSO\'yu durdurun</string>
     <string name="tune_unavailable_route">Tune bu ses yolunda henüz desteklenmiyor</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / ŞELALE (GELİŞTİRİCİ)</string>
+    <string name="settings_fft_window">FFT pencere fonksiyonu</string>
+    <string name="settings_fft_window_desc">Spektrum/şelale görüntüsü için FFT öncesi pencere; Hann spektral sızıntıyı azaltır</string>
+    <string name="settings_fft_window_rect">Dikdörtgen (yok)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Kare ortalaması</string>
+    <string name="settings_fft_averaging_desc">Görüntüyü FFT kareleri arasında yumuşatır; Kapalı her kareyi olduğu gibi gösterir</string>
+    <string name="settings_fft_avg_off">Kapalı</string>
+    <string name="settings_fft_avg_light">Hafif (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Güçlü (EMA 0.25)</string>
+    <string name="settings_bin_agg">Spektrum bin birleştirme</string>
+    <string name="settings_bin_agg_desc">Bitişik FFT binlerinin tek spektrum çubuğuna birleştirilme yöntemi</string>
+    <string name="settings_bin_agg_max">Maksimum</string>
+    <string name="settings_bin_agg_avg">Ortalama</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-uk/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-uk/strings_compose.xml
@@ -552,4 +552,24 @@
     <string name="tune_stopped_timeout">Tune зупинено через %1$d с</string>
     <string name="tune_blocked_tx">Зупиніть CQ/QSO перед використанням Tune</string>
     <string name="tune_unavailable_route">Tune поки не підтримується на цьому аудіотракті</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / ВОДОСПАД (ДЛЯ РОЗРОБНИКІВ)</string>
+    <string name="settings_fft_window">Віконна функція ШПФ</string>
+    <string name="settings_fft_window_desc">Вікно перед ШПФ для відображення спектра/водоспаду; вікно Ганна зменшує розтікання спектра</string>
+    <string name="settings_fft_window_rect">Прямокутне (немає)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Усереднення кадрів</string>
+    <string name="settings_fft_averaging_desc">Згладжує відображення між кадрами ШПФ; «Вимк.» показує кожен кадр як є</string>
+    <string name="settings_fft_avg_off">Вимк.</string>
+    <string name="settings_fft_avg_light">Легке (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Сильне (EMA 0.25)</string>
+    <string name="settings_bin_agg">Об\'єднання бінів спектра</string>
+    <string name="settings_bin_agg_desc">Як сусідні біни ШПФ об\'єднуються в один стовпець спектра</string>
+    <string name="settings_bin_agg_max">Максимум</string>
+    <string name="settings_bin_agg_avg">Середнє</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rCN/strings_compose.xml
@@ -520,4 +520,24 @@
     <string name="tune_stopped_timeout">Tune已在%1$d秒后停止</string>
     <string name="tune_blocked_tx">使用Tune前请先停止CQ/QSO</string>
     <string name="tune_unavailable_route">此音频路径暂不支持Tune</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / 瀑布图（开发者）</string>
+    <string name="settings_fft_window">FFT 窗函数</string>
+    <string name="settings_fft_window_desc">频谱/瀑布图显示的 FFT 前加窗；Hann 窗可减少频谱泄漏</string>
+    <string name="settings_fft_window_rect">矩形（无窗）</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">帧平均</string>
+    <string name="settings_fft_averaging_desc">在 FFT 帧之间平滑显示；关闭时按原样显示每一帧</string>
+    <string name="settings_fft_avg_off">关闭</string>
+    <string name="settings_fft_avg_light">轻度 (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">重度 (EMA 0.25)</string>
+    <string name="settings_bin_agg">频谱柱合并</string>
+    <string name="settings_bin_agg_desc">相邻 FFT 频点如何合并为一根频谱柱</string>
+    <string name="settings_bin_agg_max">最大值</string>
+    <string name="settings_bin_agg_avg">平均值</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-zh-rTW/strings_compose.xml
@@ -520,4 +520,24 @@
     <string name="tune_stopped_timeout">Tune已在%1$d秒後停止</string>
     <string name="tune_blocked_tx">使用Tune前請先停止CQ/QSO</string>
     <string name="tune_unavailable_route">此音訊路徑暫不支援Tune</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_section_fft_waterfall">FFT / 瀑布圖（開發者）</string>
+    <string name="settings_fft_window">FFT 視窗函數</string>
+    <string name="settings_fft_window_desc">頻譜/瀑布圖顯示的 FFT 前加窗；Hann 窗可減少頻譜洩漏</string>
+    <string name="settings_fft_window_rect">矩形（無窗）</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">幀平均</string>
+    <string name="settings_fft_averaging_desc">在 FFT 幀之間平滑顯示；關閉時按原樣顯示每一幀</string>
+    <string name="settings_fft_avg_off">關閉</string>
+    <string name="settings_fft_avg_light">輕度 (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">重度 (EMA 0.25)</string>
+    <string name="settings_bin_agg">頻譜柱合併</string>
+    <string name="settings_bin_agg_desc">相鄰 FFT 頻點如何合併為一根頻譜柱</string>
+    <string name="settings_bin_agg_max">最大值</string>
+    <string name="settings_bin_agg_avg">平均值</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -380,6 +380,26 @@
     <string name="settings_section_language">LANGUAGE</string>
     <string name="settings_section_appearance">APPEARANCE</string>
     <string name="settings_section_backup">BACKUP &amp; RESTORE</string>
+    <string name="settings_section_fft_waterfall">FFT / WATERFALL (DEVELOPER)</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_fft_window">FFT window function</string>
+    <string name="settings_fft_window_desc">Pre-FFT window for the spectrum/waterfall display; Hann reduces spectral leakage</string>
+    <string name="settings_fft_window_rect">Rectangular (none)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Frame averaging</string>
+    <string name="settings_fft_averaging_desc">Smooth the display across FFT frames; Off shows each frame as-is</string>
+    <string name="settings_fft_avg_off">Off</string>
+    <string name="settings_fft_avg_light">Light (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Heavy (EMA 0.25)</string>
+    <string name="settings_bin_agg">Spectrum bin combining</string>
+    <string name="settings_bin_agg_desc">How adjacent FFT bins merge into one spectrum bar</string>
+    <string name="settings_bin_agg_max">Maximum</string>
+    <string name="settings_bin_agg_avg">Average</string>
+    <string name="settings_bin_agg_rms">RMS</string>
 
     <!-- ===== Settings: backup / restore (export & import config) ===== -->
     <string name="settings_export">Export settings</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprParseConfigIntTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprParseConfigIntTest.java
@@ -1,0 +1,39 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Tests for {@link DatabaseOpr#parseConfigInt} (PR #429 review): the FFT
+ * display knobs are hydrated from config values that may come from
+ * hand-edited or stale backups, so a non-numeric string must fall back to
+ * the default instead of throwing NumberFormatException and crashing startup
+ * hydration. Robolectric because DatabaseOpr extends SQLiteOpenHelper.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseOprParseConfigIntTest {
+
+    @Test
+    public void parsesValidIntegers() {
+        assertThat(DatabaseOpr.parseConfigInt("0", 9)).isEqualTo(0);
+        assertThat(DatabaseOpr.parseConfigInt("4", 9)).isEqualTo(4);
+        assertThat(DatabaseOpr.parseConfigInt("-2", 9)).isEqualTo(-2);
+        assertThat(DatabaseOpr.parseConfigInt(" 3 ", 9)).isEqualTo(3); // tolerates stray whitespace
+    }
+
+    @Test
+    public void emptyAndNullFallBack() {
+        assertThat(DatabaseOpr.parseConfigInt("", 7)).isEqualTo(7);
+        assertThat(DatabaseOpr.parseConfigInt(null, 7)).isEqualTo(7);
+    }
+
+    @Test
+    public void nonNumericFallsBackInsteadOfThrowing() {
+        assertThat(DatabaseOpr.parseConfigInt("hann", 1)).isEqualTo(1);
+        assertThat(DatabaseOpr.parseConfigInt("2.5", 0)).isEqualTo(0);
+        assertThat(DatabaseOpr.parseConfigInt("99999999999999999999", 0)).isEqualTo(0); // overflow
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/BinAggregationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/BinAggregationTest.java
@@ -1,0 +1,83 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link BinAggregation} (issue #428): the spectrum-strip pair
+ * combine extracted from ColumnarView. MODE_MAX must reproduce the legacy
+ * inline expression bit-for-bit (including the last-index tail case) so the
+ * default renders identically to pre-#428 builds. Pure math — no Robolectric.
+ */
+public class BinAggregationTest {
+
+    /** The exact pre-#428 ColumnarView expression, kept as the oracle. */
+    private static int legacyMax(int[] data, int i) {
+        return (i + 1 < data.length) ? Math.max(data[i], data[i + 1]) : data[i];
+    }
+
+    @Test
+    public void maxModeMatchesLegacyExpressionAtEveryIndex() {
+        int[] data = {0, 255, 17, 17, 200, 3, 128};
+        for (int i = 0; i < data.length; i++) {
+            assertThat(BinAggregation.combine(data, i, BinAggregation.MODE_MAX))
+                    .isEqualTo(legacyMax(data, i));
+        }
+    }
+
+    @Test
+    public void lastBinStandsAloneInEveryMode() {
+        int[] data = {10, 20, 42};
+        assertThat(BinAggregation.combine(data, 2, BinAggregation.MODE_MAX)).isEqualTo(42);
+        assertThat(BinAggregation.combine(data, 2, BinAggregation.MODE_AVG)).isEqualTo(42);
+        assertThat(BinAggregation.combine(data, 2, BinAggregation.MODE_RMS)).isEqualTo(42);
+    }
+
+    @Test
+    public void avgModeRoundsHalfUpAndKeepsEndpointsStable() {
+        assertThat(BinAggregation.combine(new int[] {10, 20}, 0, BinAggregation.MODE_AVG))
+                .isEqualTo(15);
+        // Half up: (10 + 15 + 1) / 2 == 13.
+        assertThat(BinAggregation.combine(new int[] {10, 15}, 0, BinAggregation.MODE_AVG))
+                .isEqualTo(13);
+        // Saturated input stays saturated (no off-by-one dimming at full scale).
+        assertThat(BinAggregation.combine(new int[] {255, 255}, 0, BinAggregation.MODE_AVG))
+                .isEqualTo(255);
+        assertThat(BinAggregation.combine(new int[] {0, 0}, 0, BinAggregation.MODE_AVG))
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void rmsModeSitsBetweenAvgAndMax() {
+        // RMS(0, 255) = 255/sqrt(2) ~= 180.
+        int rms = BinAggregation.combine(new int[] {0, 255}, 0, BinAggregation.MODE_RMS);
+        assertThat(rms).isEqualTo(180);
+        int avg = BinAggregation.combine(new int[] {0, 255}, 0, BinAggregation.MODE_AVG);
+        int max = BinAggregation.combine(new int[] {0, 255}, 0, BinAggregation.MODE_MAX);
+        assertThat(rms).isAtLeast(avg);
+        assertThat(rms).isAtMost(max);
+        // Equal inputs are a fixed point in every mode.
+        assertThat(BinAggregation.combine(new int[] {77, 77}, 0, BinAggregation.MODE_RMS))
+                .isEqualTo(77);
+    }
+
+    @Test
+    public void unknownModeFallsBackToMax() {
+        int[] data = {5, 9};
+        assertThat(BinAggregation.combine(data, 0, 99)).isEqualTo(legacyMax(data, 0));
+        assertThat(BinAggregation.combine(data, 0, -1)).isEqualTo(legacyMax(data, 0));
+    }
+
+    @Test
+    public void resultIsClampedTo0To255() {
+        // Display ints should already be 0..255, but a bad frame must not
+        // produce an out-of-range bar height.
+        assertThat(BinAggregation.combine(new int[] {300, 400}, 0, BinAggregation.MODE_MAX))
+                .isEqualTo(255);
+        assertThat(BinAggregation.combine(new int[] {-20, -5}, 0, BinAggregation.MODE_MAX))
+                .isEqualTo(0);
+        assertThat(BinAggregation.combine(new int[] {-20, -5}, 0, BinAggregation.MODE_AVG))
+                .isEqualTo(0);
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/GeneralVariablesFftSettingsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/GeneralVariablesFftSettingsTest.kt
@@ -1,0 +1,94 @@
+package radio.ks3ckc.ft8af
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.GeneralVariables
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests the clamping setters for the FFT display developer knobs (issue #428)
+ * in [GeneralVariables]. These values arrive from the config DB (possibly a
+ * hand-edited or stale backup), so out-of-range input must fall back to each
+ * knob's default rather than reach the native side. Robolectric because
+ * GeneralVariables carries Android LiveData statics.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GeneralVariablesFftSettingsTest {
+
+    private var savedWindow = 0
+    private var savedAveraging = 0
+    private var savedAggregation = 0
+
+    @Before
+    fun saveGlobals() {
+        savedWindow = GeneralVariables.getFftWindowType()
+        savedAveraging = GeneralVariables.getFftAveragingMode()
+        savedAggregation = GeneralVariables.getSpectrumBinAggregation()
+    }
+
+    @After
+    fun restoreGlobals() {
+        GeneralVariables.setFftWindowType(savedWindow)
+        GeneralVariables.setFftAveragingMode(savedAveraging)
+        GeneralVariables.setSpectrumBinAggregation(savedAggregation)
+    }
+
+    @Test
+    fun `defaults are hann, averaging off, max aggregation`() {
+        // Wire values: window 1=Hann, averaging 0=off, aggregation 0=max.
+        assertThat(savedWindow).isEqualTo(1)
+        assertThat(savedAveraging).isEqualTo(0)
+        assertThat(savedAggregation).isEqualTo(0)
+    }
+
+    @Test
+    fun `window setter accepts every valid value`() {
+        for (v in 0..4) {
+            GeneralVariables.setFftWindowType(v)
+            assertThat(GeneralVariables.getFftWindowType()).isEqualTo(v)
+        }
+    }
+
+    @Test
+    fun `window setter clamps out-of-range to hann`() {
+        GeneralVariables.setFftWindowType(5)
+        assertThat(GeneralVariables.getFftWindowType()).isEqualTo(1)
+        GeneralVariables.setFftWindowType(-1)
+        assertThat(GeneralVariables.getFftWindowType()).isEqualTo(1)
+    }
+
+    @Test
+    fun `averaging setter accepts every valid value`() {
+        for (v in 0..2) {
+            GeneralVariables.setFftAveragingMode(v)
+            assertThat(GeneralVariables.getFftAveragingMode()).isEqualTo(v)
+        }
+    }
+
+    @Test
+    fun `averaging setter clamps out-of-range to off`() {
+        GeneralVariables.setFftAveragingMode(3)
+        assertThat(GeneralVariables.getFftAveragingMode()).isEqualTo(0)
+        GeneralVariables.setFftAveragingMode(-7)
+        assertThat(GeneralVariables.getFftAveragingMode()).isEqualTo(0)
+    }
+
+    @Test
+    fun `aggregation setter accepts every valid value`() {
+        for (v in 0..2) {
+            GeneralVariables.setSpectrumBinAggregation(v)
+            assertThat(GeneralVariables.getSpectrumBinAggregation()).isEqualTo(v)
+        }
+    }
+
+    @Test
+    fun `aggregation setter clamps out-of-range to max`() {
+        GeneralVariables.setSpectrumBinAggregation(42)
+        assertThat(GeneralVariables.getSpectrumBinAggregation()).isEqualTo(0)
+        GeneralVariables.setSpectrumBinAggregation(-1)
+        assertThat(GeneralVariables.getSpectrumBinAggregation()).isEqualTo(0)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/FftDisplaySettingsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/FftDisplaySettingsTest.kt
@@ -1,0 +1,70 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import org.junit.Test
+
+/**
+ * Guards the FFT/waterfall developer-knob label mappings (issue #428) in
+ * AdvancedSettings: list sizes must match the wire-value ranges the
+ * GeneralVariables setters accept, and out-of-range values must fall back to
+ * each knob's default label (Hann / Off / Max) — mirroring the clamping
+ * setters, so the row never shows a label for a value the pipeline won't use.
+ *
+ * No Robolectric: R.string.* are plain int constants and the mappings are pure.
+ */
+class FftDisplaySettingsTest {
+
+    @Test
+    fun `window label list covers wire values 0-4 in order`() {
+        assertThat(FFT_WINDOW_NAME_RES).containsExactly(
+            R.string.settings_fft_window_rect,
+            R.string.settings_fft_window_hann,
+            R.string.settings_fft_window_hamming,
+            R.string.settings_fft_window_blackman,
+            R.string.settings_fft_window_blackman_harris,
+        ).inOrder()
+    }
+
+    @Test
+    fun `averaging label list covers wire values 0-2 in order`() {
+        assertThat(FFT_AVERAGING_NAME_RES).containsExactly(
+            R.string.settings_fft_avg_off,
+            R.string.settings_fft_avg_light,
+            R.string.settings_fft_avg_heavy,
+        ).inOrder()
+    }
+
+    @Test
+    fun `aggregation label list covers wire values 0-2 in order`() {
+        assertThat(BIN_AGGREGATION_NAME_RES).containsExactly(
+            R.string.settings_bin_agg_max,
+            R.string.settings_bin_agg_avg,
+            R.string.settings_bin_agg_rms,
+        ).inOrder()
+    }
+
+    @Test
+    fun `every valid wire value round-trips to its own label`() {
+        for (i in FFT_WINDOW_NAME_RES.indices) {
+            assertThat(fftWindowLabelRes(i)).isEqualTo(FFT_WINDOW_NAME_RES[i])
+        }
+        for (i in FFT_AVERAGING_NAME_RES.indices) {
+            assertThat(fftAveragingLabelRes(i)).isEqualTo(FFT_AVERAGING_NAME_RES[i])
+        }
+        for (i in BIN_AGGREGATION_NAME_RES.indices) {
+            assertThat(binAggregationLabelRes(i)).isEqualTo(BIN_AGGREGATION_NAME_RES[i])
+        }
+    }
+
+    @Test
+    fun `out-of-range values fall back to each knob's default label`() {
+        for (bad in listOf(-1, 5, 99)) {
+            assertThat(fftWindowLabelRes(bad)).isEqualTo(R.string.settings_fft_window_hann)
+        }
+        for (bad in listOf(-1, 3, 99)) {
+            assertThat(fftAveragingLabelRes(bad)).isEqualTo(R.string.settings_fft_avg_off)
+            assertThat(binAggregationLabelRes(bad)).isEqualTo(R.string.settings_bin_agg_max)
+        }
+    }
+}


### PR DESCRIPTION
Closes #428 (Android + Desktop; iOS deferred — see Platform notes).

## What & why

Users reported ringing/smearing/ghosting on the spectrum and waterfall when the signal jumps from near-silence to strong. Rather than guessing, this PR makes the FFT display pipeline observable and configurable on Android and Desktop, documents current behavior/defaults, and fixes the strongest suspect it uncovered:

**Android's display FFT applied no window function at all** (rectangular). Measured at the display path's exact geometry (1920 samples @ 12 kHz, off-grid tone), the skirts sit only **~28 dB below the peak across the whole row** — with Hann they're **~70 dB down** (pinned by a new host test). On a dB waterfall with a 50 dB visible span, a signal ~30 dB above the floor paints the entire row: exactly "false energy / smearing when a strong signal starts". Desktop and iOS always used Hann.

## Android

- **Window function** (new default **Hann**, matching desktop/iOS): Rect / Hann / Hamming / Blackman / Blackman-Harris. Pure C helpers (`ft8af_window_fill/apply`) in `fft_display.c`, applied in `compute_fft_magnitudes` so all 8 JNI entry points are covered. No renormalization needed — the median-noise-floor-relative dB mapping cancels the window's constant gain.
- **Frame averaging** (default **Off**): cross-frame EMA on linear magnitudes (`ft8af_mag_ema`), Light α=0.5 / Heavy α=0.25. Off by default because temporal smoothing is precisely the effect under investigation.
- **Spectrum bin combining** (default **Max** = the legacy expression bit-for-bit): extracted to `BinAggregation.java` with Avg/RMS alternatives; `ColumnarView` delegates.
- Params reach native via a new static `SpectrumFragment.setFFTDisplayParams(window, avgMode)` pushed per-frame by `FFTBridge` (main-thread only; the 8 prebuilt-compatible `getFFTData*` signatures are untouched).
- Settings → Advanced → **FFT / Waterfall (developer)**: three pickers; keys `fftWindowType` / `fftAveragingMode` / `spectrumBinAggregation` with clamping setters + `DatabaseOpr` hydration; strings in all 16 locales; rides along in settings backup/restore automatically.
- **FFT size intentionally not a knob**: 1920 samples → 6.25 Hz bins = exactly FT8 tone spacing; zero-padding adds interpolation not resolution (and breaks the `n/2` output contract at 3 call sites); longer capture would halve the update rate and increase smear. Rationale in `docs/fft-display.md`.

## Desktop

- Live-waterfall row math extracted from `engine.rs` into a pure, unit-tested `wf.rs` (`WfWindow` / `WfConfig` / `WfProcessor`). Defaults (Hann / 2048 / 6-segment Welch) reproduce the old hard-coded pipeline **byte-for-byte**.
- New `EngineCommand::SetWaterfallConfig` + `set_waterfall_config` Tauri command: window (5 options), FFT size (512–8192), averaging (1–16) apply live (FFT plan + window table rebuilt) and persist as `wf_window` / `wf_fft_size` / `wf_avg` (engine persists, matching the `SetTxGain` pattern).
- New **Developer — waterfall FFT** panel in Settings. No canvas changes needed: `drawWaterfallRow` already sizes the canvas from `bins.length`, so FFT-size changes adapt automatically.
- Bins-per-pixel aggregation is N/A on desktop (1 bin = 1 canvas column; browser scales) — documented instead of knobbed. Dead legacy `waterfall_heatmap` path noted in docs, left untouched.

## Platform notes (acceptance criteria)

- Defaults are now consistent where the platforms overlap: **Hann everywhere**. Remaining differences (FFT size 1920 vs 2048, within-capture Welch vs opt-in cross-frame EMA, scaling constants) are documented side-by-side in `docs/fft-display.md` with reasoning.
- **iOS is deferred** (no Mac available this round): its pipeline already matches the desktop defaults (Hann / 2048 / Welch×6), so default behavior is consistent today; making its params configurable can follow the desktop pattern in a later PR.
- Decoding is unaffected on every platform — the decoder runs its own independent FFT inside the C core.

## Tests

- **Host C** (`test_fft_window.c`, wired into `run_host_tests.ps1`/`.sh`): window coefficient shapes/symmetry/coherent gains, unknown-type→rect fallback, apply/EMA math, and the behavioral rect-vs-Hann leakage comparison (≥20 dB requirement; measures ~42 dB delta).
- **Rust** (`wf.rs`): 7 tests — coefficients, config string round-trip, tone-bin location across sizes, u8 mapping monotonic/clamped, step-transient dilution under Welch averaging, sanitize/samples_needed, defaults == legacy constants (incl. Hann table vs the old inline formula).
- **JVM**: `BinAggregationTest` (Max == legacy oracle at every index incl. tail; Avg/RMS math; unknown-mode fallback; clamping), `GeneralVariablesFftSettingsTest` (clamping setters), `FftDisplaySettingsTest` (label mappings). Full `testDebugUnitTest` suite green.

## Verification

- `cargo test` + `cargo build` (desktop), `npm run build` (tsc + vite) — green.
- `run_host_tests.ps1` full suite (incl. decode-bench floors) — green.
- `gradlew testDebugUnitTest` — green; `installDebug` on a Pixel 8: waterfall renders with the Hann default, new settings section shows Hann/Off/Maximum, pickers open and persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA