### PR TITLE
Add Exit action to the RX foreground notification

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/service/RxForegroundService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/service/RxForegroundService.java
@@ -37,6 +37,18 @@ public class RxForegroundService extends Service {
 
     private PowerManager.WakeLock wakeLock;
 
+    /**
+     * Cleanup hook run when the notification's Exit button is tapped. The activity registers
+     * its {@code closeApp()} here (and clears it on destroy) because the full shutdown —
+     * disconnect rig, stop listener/recorder/timer — needs the activity-scoped ViewModel,
+     * which this service can't reach.
+     */
+    private static volatile Runnable exitHandler;
+
+    public static void setExitHandler(Runnable handler) {
+        exitHandler = handler;
+    }
+
     public static void start(Context context) {
         ContextCompat.startForegroundService(
                 context, new Intent(context, RxForegroundService.class));
@@ -59,6 +71,21 @@ public class RxForegroundService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        String action = intent == null ? null : intent.getAction();
+        if (RxServiceController.commandForAction(action) == RxServiceController.Command.EXIT) {
+            GeneralVariables.fileLog("RxForegroundService: notification Exit tapped");
+            Runnable handler = exitHandler;
+            if (handler != null) {
+                // closeApp(): stops TX/RX, disconnects the rig, stops this service, then
+                // System.exit(0) — does not return.
+                handler.run();
+            } else {
+                // Activity already destroyed; nothing left to clean up beyond the process.
+                stopSelf();
+                System.exit(0);
+            }
+            return START_NOT_STICKY;
+        }
         Notification notification = buildNotification();
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -127,6 +154,9 @@ public class RxForegroundService extends Service {
             piFlags |= PendingIntent.FLAG_IMMUTABLE;
         }
         PendingIntent pi = PendingIntent.getActivity(this, 0, intent, piFlags);
+        Intent exitIntent = new Intent(this, RxForegroundService.class)
+                .setAction(RxServiceController.ACTION_EXIT);
+        PendingIntent exitPi = PendingIntent.getService(this, 1, exitIntent, piFlags);
         return new NotificationCompat.Builder(this, CHANNEL_ID)
                 .setSmallIcon(R.mipmap.ic_launcher)
                 .setContentTitle(getString(R.string.rx_service_title))
@@ -135,6 +165,7 @@ public class RxForegroundService extends Service {
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setCategory(NotificationCompat.CATEGORY_SERVICE)
                 .setContentIntent(pi)
+                .addAction(0, getString(R.string.action_exit), exitPi)
                 .build();
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/service/RxForegroundService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/service/RxForegroundService.java
@@ -165,7 +165,7 @@ public class RxForegroundService extends Service {
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setCategory(NotificationCompat.CATEGORY_SERVICE)
                 .setContentIntent(pi)
-                .addAction(0, getString(R.string.action_exit), exitPi)
+                .addAction(R.drawable.ic_baseline_close_32, getString(R.string.action_exit), exitPi)
                 .build();
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/service/RxServiceController.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/service/RxServiceController.java
@@ -8,6 +8,15 @@ public final class RxServiceController {
     private RxServiceController() {}
 
     /**
+     * Intent action for the notification's Exit button. Defined here (not on the service) so
+     * the action-dispatch policy stays Android-free and unit-testable.
+     */
+    public static final String ACTION_EXIT = "com.k1af.ft8af.service.EXIT";
+
+    /** What an incoming start command asks the service to do. */
+    public enum Command { RUN, EXIT }
+
+    /**
      * The RX foreground service should run only when receiving is active AND the microphone
      * permission is granted — starting a microphone-typed foreground service without
      * RECORD_AUDIO throws on Android 14.
@@ -16,4 +25,12 @@ public final class RxServiceController {
         return rxActive && micGranted;
     }
 
+    /**
+     * Maps a start-command intent action to a {@link Command}. Anything other than the exact
+     * exit action (including null, from plain {@code start()} intents or a system restart)
+     * means "run normally".
+     */
+    public static Command commandForAction(String action) {
+        return ACTION_EXIT.equals(action) ? Command.EXIT : Command.RUN;
+    }
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -110,6 +110,10 @@ class ComposeMainActivity : AppCompatActivity() {
         // permission-result callback re-invokes this once the user grants it).
         startRxServiceIfPermitted()
 
+        // The notification's Exit button routes here so it runs the same shutdown as the
+        // in-app exit; cleared in onDestroy so a destroyed activity isn't leaked.
+        RxForegroundService.setExitHandler { closeApp() }
+
         // Forward every TX-volume change to the native USB-direct write loop so a
         // slider move (or hardware-button / ALC auto-volume change) attenuates the
         // in-progress transmission live, protecting the rig from overdrive. Every
@@ -614,6 +618,7 @@ class ComposeMainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        RxForegroundService.setExitHandler(null)
         unregisterBluetoothReceiver()
         unregisterUsbDetachReceiver()
         qsoAutoSync?.unregister()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -106,13 +106,16 @@ class ComposeMainActivity : AppCompatActivity() {
         mainViewModel = MainViewModel.getInstance(this)
         ToastMessage.getInstance()
 
+        // The notification's Exit button routes here so it runs the same shutdown as the
+        // in-app exit; cleared in onDestroy so a destroyed activity isn't leaked. Registered
+        // BEFORE the service starts so there's no window where the notification can appear
+        // and be tapped before the handler exists (which would fall back to a bare
+        // stopSelf()/System.exit(0) that skips rig disconnect and RX teardown).
+        RxForegroundService.setExitHandler { closeApp() }
+
         // Keep RX alive in the background (no-op until RECORD_AUDIO is granted; the
         // permission-result callback re-invokes this once the user grants it).
         startRxServiceIfPermitted()
-
-        // The notification's Exit button routes here so it runs the same shutdown as the
-        // in-app exit; cleared in onDestroy so a destroyed activity isn't leaked.
-        RxForegroundService.setExitHandler { closeApp() }
 
         // Forward every TX-volume change to the native USB-direct write loop so a
         // slider move (or hardware-button / ALC auto-volume change) attenuates the

--- a/ft8af/app/src/test/java/com/k1af/ft8af/service/RxServiceControllerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/service/RxServiceControllerTest.java
@@ -14,4 +14,21 @@ public class RxServiceControllerTest {
         assertThat(RxServiceController.shouldRunService(false, true)).isFalse();
         assertThat(RxServiceController.shouldRunService(false, false)).isFalse();
     }
+
+    @Test
+    public void commandForAction_exitOnlyOnExactExitAction() {
+        assertThat(RxServiceController.commandForAction(RxServiceController.ACTION_EXIT))
+                .isEqualTo(RxServiceController.Command.EXIT);
+    }
+
+    @Test
+    public void commandForAction_runsNormallyForAnythingElse() {
+        // null covers plain start() intents and system restarts of the service.
+        assertThat(RxServiceController.commandForAction(null))
+                .isEqualTo(RxServiceController.Command.RUN);
+        assertThat(RxServiceController.commandForAction(""))
+                .isEqualTo(RxServiceController.Command.RUN);
+        assertThat(RxServiceController.commandForAction("com.k1af.ft8af.service.OTHER"))
+                .isEqualTo(RxServiceController.Command.RUN);
+    }
 }


### PR DESCRIPTION
## Summary

The ongoing "Decoding in the background" notification from `RxForegroundService` had no way to stop the app — the only exits were reopening the app and using the exit dialog, or force-stopping from system settings. This adds an **Exit** action button to that notification.

## How it works

- The button fires a `PendingIntent.getService` with a dedicated `EXIT` action on `RxForegroundService`.
- Action dispatch policy (`commandForAction`: exact exit action → `EXIT`, anything else including `null` → `RUN`) lives in the Android-free `RxServiceController`, keeping the service thin per the existing pattern.
- `ComposeMainActivity` registers its private `closeApp()` as the service's exit handler in `onCreate` and clears it in `onDestroy` (no activity leak). Tapping Exit therefore runs the exact same shutdown as the in-app exit dialog: deactivate TX, disconnect the rig, stop the signal listener/recorder/UTC timer, stop the service, `System.exit(0)`.
- Fallback: if no handler is registered (activity already destroyed but process alive), the service stops itself and exits the process directly.

Reuses the existing `action_exit` ("Exit") string, so no new translations are needed.

## Testing

- `testDebugUnitTest --tests com.k1af.ft8af.service.RxServiceControllerTest` — passes; new tests cover `commandForAction` for the exit action, `null`, empty, and unrelated actions.
- Not yet verified on a device (none attached at the time) — worth a quick manual check that the button appears and exits cleanly before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
