### PR TITLE
Add Android Auto read-only QSO status display

### DIFF
--- a/ft8af/app/build.gradle
+++ b/ft8af/app/build.gradle
@@ -195,6 +195,10 @@ dependencies {
     implementation 'androidx.compose.runtime:runtime-livedata'
     debugImplementation 'androidx.compose.ui:ui-tooling'
 
+    // Android Auto (phone projection) templated status screen. 1.4.0 is the last
+    // stable line compatible with AGP 8.7.3 / Kotlin 1.9.22; its minSdk (23) matches ours.
+    implementation 'androidx.car.app:app:1.4.0'
+
     // Image loading for QRZ profile avatars
     implementation 'io.coil-kt:coil-compose:2.6.0'
 

--- a/ft8af/app/src/main/AndroidManifest.xml
+++ b/ft8af/app/src/main/AndroidManifest.xml
@@ -106,6 +106,27 @@
                 android:value="true" />
         </service>
 
+        <!-- Android Auto (phone projection): read-only QSO status screens rendered
+             with car-app-library templates. Exported so the Android Auto host can
+             bind; access is gated by FT8AFCarAppService's HostValidator. -->
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+        <!-- Level 1 = every templates-capable Android Auto host; we use no newer
+             template features. -->
+        <meta-data
+            android:name="androidx.car.app.minCarApiLevel"
+            android:value="1" />
+
+        <service
+            android:name="radio.ks3ckc.ft8af.car.FT8AFCarAppService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.car.app.CarAppService" />
+                <category android:name="androidx.car.app.category.IOT" />
+            </intent-filter>
+        </service>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="radio.ks3ckc.ft8af.fileprovider"

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -44,6 +44,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
@@ -444,6 +445,17 @@ public class MainViewModel extends ViewModel {
         if (viewModel == null) {
             viewModel = new ViewModelProvider(owner).get(MainViewModel.class);
         }
+        return viewModel;
+    }
+
+    /**
+     * Nullable peek at the singleton for observers that must never boot the engine —
+     * only ComposeMainActivity may create the instance. The Android Auto screens use
+     * this: null means the phone UI hasn't run yet this process, and the car display
+     * shows an "open the app on your phone" message instead.
+     */
+    @Nullable
+    public static MainViewModel peekInstance() {
         return viewModel;
     }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
@@ -16,7 +16,7 @@ internal enum class CarTxState { OFF, ARMED_RX, TRANSMITTING }
 internal data class CarQsoStatus(
     /** "Calling CQ" / "QSOing with W1XYZ" / "Waiting for W1XYZ" / "Monitoring — TX off". */
     val headline: CarStringSpec,
-    /** Target SNR ("−12 dB"), null when there is no target or its SNR is unknown. */
+    /** Target SNR ("-12 dB", ASCII hyphen), null when there is no target or its SNR is unknown. */
     val snrLabel: String?,
     val txState: CarTxState,
     /** The message text going out right now; null when not transmitting. */
@@ -106,7 +106,7 @@ internal fun carBandLine(freqHz: Long, bandName: String, modeName: String): Stri
     append(modeName)
 }
 
-/** "+3 dB" / "−12 dB"; null in (SNR unknown) gives null out. */
+/** "+3 dB" / "-12 dB" (ASCII hyphen from Int.toString); null in (SNR unknown) gives null out. */
 internal fun formatSnrLabel(snr: Int?): String? = snr?.let { if (it > 0) "+$it dB" else "$it dB" }
 
 /** One row of the car's recent-decodes list. */
@@ -126,7 +126,7 @@ internal fun buildCarDecodeRows(
         .take(maxRows.coerceAtLeast(0))
         .map { (utc, text, snr) -> CarDecodeRow(utc, text, formatSnrLabel(snr)) }
 
-/** Secondary line of a decode row: "12:34:45 UTC · −12 dB" (SNR omitted when unknown). */
+/** Secondary line of a decode row: "12:34:45 UTC · -12 dB" (SNR omitted when unknown). */
 internal fun carDecodeSecondary(utcTimeMs: Long, snrLabel: String?): String {
     val fmt = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.US)
     fmt.timeZone = java.util.TimeZone.getTimeZone("UTC")

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
@@ -1,0 +1,141 @@
+package radio.ks3ckc.ft8af.car
+
+import com.k1af.ft8af.R
+import radio.ks3ckc.ft8af.ui.components.formatMhz
+
+/**
+ * A localizable string as (resource id, format args), resolved with
+ * `carContext.getString(resId, *args)` at render time. Keeps this mapper free of
+ * Android types so it stays plain-JVM unit-testable.
+ */
+internal data class CarStringSpec(val resId: Int, val args: List<Any> = emptyList())
+
+internal enum class CarTxState { OFF, ARMED_RX, TRANSMITTING }
+
+/** Everything the Android Auto status pane renders, pre-decided and testable. */
+internal data class CarQsoStatus(
+    /** "Calling CQ" / "QSOing with W1XYZ" / "Waiting for W1XYZ" / "Monitoring — TX off". */
+    val headline: CarStringSpec,
+    /** Target SNR ("−12 dB"), null when there is no target or its SNR is unknown. */
+    val snrLabel: String?,
+    val txState: CarTxState,
+    /** The message text going out right now; null when not transmitting. */
+    val messageLine: String?,
+    /** "Step RR73 (4/6)"; null when TX is not activated. */
+    val seqLine: CarStringSpec?,
+    /** "TX slot · 7 s" or "RX slot · 7 s". */
+    val slotLine: CarStringSpec,
+    /** "14.074 MHz · 20m · FT8". */
+    val bandLine: String,
+)
+
+/**
+ * Maps the raw engine LiveData values to the car status pane. The target rule
+ * (a real target is a non-empty callsign other than "CQ") and the headline
+ * selection mirror ActiveQsoPanel's StationHeader so phone and car agree.
+ */
+internal fun buildCarQsoStatus(
+    isActivated: Boolean,
+    isTransmitting: Boolean,
+    functionOrder: Int,
+    toCallsign: String?,
+    snr: Int?,
+    transmittingMessage: String?,
+    myTxSequential: Int,
+    currentSlot: Int,
+    secondsRemaining: Int,
+    freqHz: Long,
+    bandName: String,
+    modeName: String,
+): CarQsoStatus {
+    val target = toCallsign?.takeIf { it.isNotEmpty() && it != "CQ" }
+    val headline = when {
+        isActivated && target == null -> CarStringSpec(R.string.qsopanel_calling_cq)
+        target == null -> CarStringSpec(R.string.car_monitoring)
+        isTransmitting -> CarStringSpec(R.string.qsopanel_qsoing_with, listOf(target))
+        else -> CarStringSpec(R.string.qsopanel_waiting_for, listOf(target))
+    }
+    val txState = when {
+        isTransmitting -> CarTxState.TRANSMITTING
+        isActivated -> CarTxState.ARMED_RX
+        else -> CarTxState.OFF
+    }
+    val slotResId = if (currentSlot % 2 == myTxSequential) R.string.car_slot_tx else R.string.car_slot_rx
+    return CarQsoStatus(
+        headline = headline,
+        snrLabel = if (target != null) formatSnrLabel(snr) else null,
+        txState = txState,
+        messageLine = transmittingMessage?.takeIf { isTransmitting && it.isNotEmpty() },
+        seqLine = if (isActivated) {
+            CarStringSpec(R.string.car_seq_step, listOf(txFunctionLabel(functionOrder), functionOrder, TX_FUNCTION_COUNT))
+        } else {
+            null
+        },
+        slotLine = CarStringSpec(slotResId, listOf(secondsRemaining)),
+        bandLine = carBandLine(freqHz, bandName, modeName),
+    )
+}
+
+/** The six TX sequence steps (functionOrder 1..6). */
+internal const val TX_FUNCTION_COUNT = 6
+
+/**
+ * Short label for a TX sequence step, matching the phone UI's TxSelector chips
+ * (that map is a local inside a private composable, so it is duplicated here).
+ * Unknown orders fall back to "TX n" rather than crashing the car screen.
+ */
+internal fun txFunctionLabel(functionOrder: Int): String = when (functionOrder) {
+    1 -> "GRID"
+    2 -> "RPT"
+    3 -> "R-RPT"
+    4 -> "RR73"
+    5 -> "73"
+    6 -> "CQ"
+    else -> "TX $functionOrder"
+}
+
+/** "14.074 MHz · 20m · FT8"; the band segment is omitted when [bandName] is blank. */
+internal fun carBandLine(freqHz: Long, bandName: String, modeName: String): String = buildString {
+    append(formatMhz(freqHz))
+    append(" MHz")
+    if (bandName.isNotBlank()) {
+        append(" · ")
+        append(bandName)
+    }
+    append(" · ")
+    append(modeName)
+}
+
+/** "+3 dB" / "−12 dB"; null in (SNR unknown) gives null out. */
+internal fun formatSnrLabel(snr: Int?): String? = snr?.let { if (it > 0) "+$it dB" else "$it dB" }
+
+/** One row of the car's recent-decodes list. */
+internal data class CarDecodeRow(val utcTimeMs: Long, val text: String, val snrLabel: String?)
+
+/**
+ * Rows for the recent-decodes ListTemplate: newest first, truncated to [maxRows]
+ * (the host's content limit). Input triples are (utcTimeMs, messageText, snr-or-null)
+ * so the mapper never touches Ft8Message — the Screen extracts the primitives.
+ */
+internal fun buildCarDecodeRows(
+    decodes: List<Triple<Long, String, Int?>>,
+    maxRows: Int,
+): List<CarDecodeRow> =
+    decodes
+        .sortedByDescending { it.first }
+        .take(maxRows.coerceAtLeast(0))
+        .map { (utc, text, snr) -> CarDecodeRow(utc, text, formatSnrLabel(snr)) }
+
+/** Secondary line of a decode row: "12:34:45 UTC · −12 dB" (SNR omitted when unknown). */
+internal fun carDecodeSecondary(utcTimeMs: Long, snrLabel: String?): String {
+    val fmt = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.US)
+    fmt.timeZone = java.util.TimeZone.getTimeZone("UTC")
+    val time = "${fmt.format(java.util.Date(utcTimeMs))} UTC"
+    return if (snrLabel != null) "$time · $snrLabel" else time
+}
+
+/**
+ * The 1 Hz tick only refreshes the template when the visible countdown second
+ * actually changed, so a jittery handler can't spam the host with no-op renders.
+ */
+internal fun shouldInvalidateForTick(lastSecond: Int, newSecond: Int): Boolean = newSecond != lastSecond

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/FT8AFCarAppService.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/FT8AFCarAppService.kt
@@ -20,6 +20,11 @@ class FT8AFCarAppService : CarAppService() {
             // Debug builds accept any host so the Desktop Head Unit works.
             HostValidator.ALLOW_ALL_HOSTS_VALIDATOR
         } else {
+            // Despite the "sample" name, hosts_allowlist_sample is the
+            // library-shipped list of official Google host signatures
+            // (gearhead, Automotive OS) and the production pattern in the
+            // Android for Cars docs; it updates with the library, unlike an
+            // app-owned copy, which would go stale.
             HostValidator.Builder(applicationContext)
                 .addAllowedHosts(androidx.car.app.R.array.hosts_allowlist_sample)
                 .build()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/FT8AFCarAppService.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/FT8AFCarAppService.kt
@@ -1,0 +1,33 @@
+package radio.ks3ckc.ft8af.car
+
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import androidx.car.app.CarAppService
+import androidx.car.app.Screen
+import androidx.car.app.Session
+import androidx.car.app.validation.HostValidator
+
+/**
+ * Android Auto entry point: a read-only projection of the running FT8 QSO
+ * sequence (see [QsoStatusScreen]). Runs in the same process as the engine, so
+ * the screens observe the MainViewModel singleton's LiveData directly — this
+ * service never starts or controls the engine itself.
+ */
+class FT8AFCarAppService : CarAppService() {
+
+    override fun createHostValidator(): HostValidator =
+        if (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
+            // Debug builds accept any host so the Desktop Head Unit works.
+            HostValidator.ALLOW_ALL_HOSTS_VALIDATOR
+        } else {
+            HostValidator.Builder(applicationContext)
+                .addAllowedHosts(androidx.car.app.R.array.hosts_allowlist_sample)
+                .build()
+        }
+
+    override fun onCreateSession(): Session = FT8AFCarSession()
+}
+
+class FT8AFCarSession : Session() {
+    override fun onCreateScreen(intent: Intent): Screen = QsoStatusScreen(carContext)
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
@@ -1,0 +1,196 @@
+package radio.ks3ckc.ft8af.car
+
+import android.os.Handler
+import android.os.Looper
+import androidx.car.app.CarContext
+import androidx.car.app.Screen
+import androidx.car.app.constraints.ConstraintManager
+import androidx.car.app.model.Action
+import androidx.car.app.model.ActionStrip
+import androidx.car.app.model.MessageTemplate
+import androidx.car.app.model.Pane
+import androidx.car.app.model.PaneTemplate
+import androidx.car.app.model.Row
+import androidx.car.app.model.Template
+import androidx.car.app.versioning.CarAppApiLevels
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
+import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.MainViewModel
+import com.k1af.ft8af.ModeProfile
+import com.k1af.ft8af.R
+import com.k1af.ft8af.database.OperationBand
+import com.k1af.ft8af.rigs.BaseRigOperation
+import com.k1af.ft8af.timer.UtcTimer
+import radio.ks3ckc.ft8af.ui.components.slotTimerState
+
+/**
+ * The main Android Auto screen: a read-only pane mirroring the live QSO
+ * sequence (headline, current TX message, sequence step, slot countdown,
+ * band/mode). All decisions live in [buildCarQsoStatus]; this class only
+ * observes the engine's LiveData and renders.
+ *
+ * The engine is never started from here: until ComposeMainActivity has created
+ * the [MainViewModel] singleton, [MainViewModel.peekInstance] is null and the
+ * screen shows an "open the app on your phone" message, re-checking on its
+ * 1 Hz tick.
+ */
+class QsoStatusScreen(carContext: CarContext) : Screen(carContext), DefaultLifecycleObserver {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var attachedVm: MainViewModel? = null
+    private var lastRenderedSecond = -1
+
+    private val tick = object : Runnable {
+        override fun run() {
+            maybeAttach()
+            val vm = attachedVm
+            if (vm != null) {
+                val slotMillis = currentSlotMillis(vm)
+                val seconds = slotTimerState(UtcTimer.getSystemTime(), slotMillis).secondsRemaining
+                if (shouldInvalidateForTick(lastRenderedSecond, seconds)) {
+                    invalidate()
+                }
+            }
+            handler.postDelayed(this, TICK_MS)
+        }
+    }
+
+    init {
+        lifecycle.addObserver(this)
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        handler.post(tick)
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        handler.removeCallbacks(tick)
+    }
+
+    /**
+     * Attach LiveData observers once the engine singleton exists. Observers use
+     * the Screen's own lifecycle, so they detach automatically on destroy, and
+     * registration itself delivers the current values (triggering a render).
+     */
+    private fun maybeAttach() {
+        if (attachedVm != null) return
+        val vm = MainViewModel.peekInstance() ?: return
+        attachedVm = vm
+        val onChange = Observer<Any?> { invalidate() }
+        vm.ft8TransmitSignal.mutableToCallsign.observe(this, onChange)
+        vm.ft8TransmitSignal.mutableFunctionOrder.observe(this, onChange)
+        vm.ft8TransmitSignal.mutableIsActivated.observe(this, onChange)
+        vm.ft8TransmitSignal.mutableIsTransmitting.observe(this, onChange)
+        vm.ft8TransmitSignal.mutableTransmittingMessage.observe(this, onChange)
+        vm.ft8TransmitSignal.mutableSequential.observe(this, onChange)
+        vm.mutableOperatingMode.observe(this, onChange)
+        GeneralVariables.mutableBandChange.observe(this, onChange)
+    }
+
+    override fun onGetTemplate(): Template {
+        val vm = MainViewModel.peekInstance() ?: return openPhoneTemplate(carContext)
+        val ts = vm.ft8TransmitSignal
+        val mode = ModeProfile.fromId(vm.mutableOperatingMode.value ?: GeneralVariables.operatingMode)
+        val slot = slotTimerState(UtcTimer.getSystemTime(), mode.slotMillis.toLong())
+        lastRenderedSecond = slot.secondsRemaining
+
+        val toCallsign = ts.mutableToCallsign.value
+        val status = buildCarQsoStatus(
+            isActivated = ts.mutableIsActivated.value ?: false,
+            isTransmitting = ts.mutableIsTransmitting.value ?: false,
+            functionOrder = ts.mutableFunctionOrder.value ?: TX_FUNCTION_COUNT,
+            toCallsign = toCallsign?.callsign,
+            snr = toCallsign?.snr?.takeIf { it != Ft8Message.SNR_UNKNOWN },
+            transmittingMessage = ts.mutableTransmittingMessage.value,
+            myTxSequential = ts.mutableSequential.value ?: ts.sequential,
+            currentSlot = slot.currentSlot,
+            secondsRemaining = slot.secondsRemaining,
+            freqHz = GeneralVariables.band,
+            bandName = currentBandName(),
+            modeName = mode.displayName,
+        )
+
+        val headline = resolve(status.headline) +
+            (status.snrLabel?.let { " · $it" } ?: "")
+        val rows = mutableListOf(
+            Row.Builder()
+                .setTitle(headline)
+                .addText(status.messageLine ?: carContext.getString(R.string.car_no_tx))
+                .build(),
+            Row.Builder()
+                .setTitle(status.seqLine?.let { resolve(it) } ?: resolve(status.slotLine))
+                .apply { if (status.seqLine != null) addText(resolve(status.slotLine)) }
+                .build(),
+            Row.Builder().setTitle(status.bandLine).build(),
+        )
+        val pane = Pane.Builder().apply {
+            rows.take(paneRowLimit(carContext)).forEach { addRow(it) }
+        }.build()
+        return PaneTemplate.Builder(pane)
+            .setTitle(carContext.getString(R.string.car_screen_title))
+            .setHeaderAction(Action.APP_ICON)
+            .setActionStrip(
+                ActionStrip.Builder()
+                    .addAction(
+                        Action.Builder()
+                            .setTitle(carContext.getString(R.string.car_decodes_action))
+                            .setOnClickListener {
+                                screenManager.push(RecentDecodesScreen(carContext))
+                            }
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    private fun resolve(spec: CarStringSpec): String =
+        carContext.getString(spec.resId, *spec.args.toTypedArray())
+
+    private companion object {
+        const val TICK_MS = 1000L
+    }
+}
+
+/** The slot length of the engine's current operating mode, in milliseconds. */
+internal fun currentSlotMillis(vm: MainViewModel): Long =
+    ModeProfile.fromId(vm.mutableOperatingMode.value ?: GeneralVariables.operatingMode)
+        .slotMillis.toLong()
+
+/**
+ * The band name for the frequency pill, mirroring the fallback chain the phone
+ * UI uses (FT8AFApp): tuned band-list entry, then a band-list match by exact
+ * frequency, then the generic meters-from-frequency lookup.
+ */
+internal fun currentBandName(): String {
+    val bandIndex = GeneralVariables.mutableBandChange.value ?: GeneralVariables.bandListIndex
+    val freq = GeneralVariables.band
+    return OperationBand.bandList.getOrNull(bandIndex)?.waveLength
+        ?: OperationBand.bandList.firstOrNull { it.band == freq }?.waveLength
+        ?: BaseRigOperation.getMeterFromFreq(freq)
+        ?: ""
+}
+
+/** Shown while the engine singleton doesn't exist yet (phone app not opened). */
+internal fun openPhoneTemplate(carContext: CarContext): MessageTemplate =
+    MessageTemplate.Builder(carContext.getString(R.string.car_open_phone))
+        .setTitle(carContext.getString(R.string.car_screen_title))
+        .setHeaderAction(Action.APP_ICON)
+        .build()
+
+private const val DEFAULT_PANE_ROWS = 3
+
+/**
+ * The host's pane row limit. ConstraintManager needs car app API level 2+;
+ * older hosts get the conservative default.
+ */
+internal fun paneRowLimit(carContext: CarContext): Int =
+    if (carContext.carAppApiLevel >= CarAppApiLevels.LEVEL_2) {
+        carContext.getCarService(ConstraintManager::class.java)
+            .getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_PANE)
+    } else {
+        DEFAULT_PANE_ROWS
+    }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/RecentDecodesScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/RecentDecodesScreen.kt
@@ -1,0 +1,67 @@
+package radio.ks3ckc.ft8af.car
+
+import androidx.car.app.CarContext
+import androidx.car.app.Screen
+import androidx.car.app.constraints.ConstraintManager
+import androidx.car.app.model.Action
+import androidx.car.app.model.ItemList
+import androidx.car.app.model.ListTemplate
+import androidx.car.app.model.Row
+import androidx.car.app.model.Template
+import androidx.car.app.versioning.CarAppApiLevels
+import com.k1af.ft8af.MainViewModel
+import com.k1af.ft8af.R
+
+/**
+ * Read-only list of the most recent decoded messages, newest first. Pushed from
+ * [QsoStatusScreen]'s action strip; rows are not clickable.
+ */
+class RecentDecodesScreen(carContext: CarContext) : Screen(carContext) {
+
+    init {
+        // Fires on every decode pass (the engine re-posts the list after each
+        // cycle); observer detaches with the Screen's lifecycle.
+        MainViewModel.peekInstance()?.mutableFt8MessageList?.observe(this) { invalidate() }
+    }
+
+    override fun onGetTemplate(): Template {
+        val vm = MainViewModel.peekInstance() ?: return openPhoneTemplate(carContext)
+        // Snapshot: the engine mutates and re-posts the same ArrayList instance.
+        val messages = vm.mutableFt8MessageList.value?.toList().orEmpty()
+        val rows = buildCarDecodeRows(
+            decodes = messages.map {
+                Triple(it.utcTime, it.getMessageText(), if (it.hasSnr()) it.snr else null)
+            },
+            maxRows = listRowLimit(carContext),
+        )
+        val itemList = ItemList.Builder().apply {
+            if (rows.isEmpty()) {
+                setNoItemsMessage(carContext.getString(R.string.car_no_decodes))
+            }
+            rows.forEach { row ->
+                addItem(
+                    Row.Builder()
+                        .setTitle(row.text)
+                        .addText(carDecodeSecondary(row.utcTimeMs, row.snrLabel))
+                        .build(),
+                )
+            }
+        }.build()
+        return ListTemplate.Builder()
+            .setSingleList(itemList)
+            .setTitle(carContext.getString(R.string.car_decodes_title))
+            .setHeaderAction(Action.BACK)
+            .build()
+    }
+}
+
+private const val DEFAULT_LIST_ROWS = 6
+
+/** The host's list row limit; older hosts (car app API < 2) get a safe default. */
+internal fun listRowLimit(carContext: CarContext): Int =
+    if (carContext.carAppApiLevel >= CarAppApiLevels.LEVEL_2) {
+        carContext.getCarService(ConstraintManager::class.java)
+            .getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_LIST)
+    } else {
+        DEFAULT_LIST_ROWS
+    }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/RecentDecodesScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/RecentDecodesScreen.kt
@@ -18,16 +18,27 @@ import com.k1af.ft8af.R
  */
 class RecentDecodesScreen(carContext: CarContext) : Screen(carContext) {
 
-    init {
-        // Fires on every decode pass (the engine re-posts the list after each
-        // cycle); observer detaches with the Screen's lifecycle.
-        MainViewModel.peekInstance()?.mutableFt8MessageList?.observe(this) { invalidate() }
+    private var attached = false
+
+    /**
+     * Observe the decode list once the engine singleton exists. Attached lazily
+     * from [onGetTemplate] rather than in init, so a Screen that somehow renders
+     * before the engine is up still hooks the list on a later render instead of
+     * staying stale forever. Fires on every decode pass; the observer detaches
+     * with the Screen's lifecycle.
+     */
+    private fun maybeAttach(vm: MainViewModel) {
+        if (attached) return
+        attached = true
+        vm.mutableFt8MessageList.observe(this) { invalidate() }
     }
 
     override fun onGetTemplate(): Template {
         val vm = MainViewModel.peekInstance() ?: return openPhoneTemplate(carContext)
-        // Snapshot: the engine mutates and re-posts the same ArrayList instance.
-        val messages = vm.mutableFt8MessageList.value?.toList().orEmpty()
+        maybeAttach(vm)
+        // publishFt8MessageList() posts a defensive copy that is never mutated
+        // after posting, so the value is safe to iterate directly.
+        val messages = vm.mutableFt8MessageList.value.orEmpty()
         val rows = buildCarDecodeRows(
             decodes = messages.map {
                 Triple(it.utcTime, it.getMessageText(), if (it.hasSnr()) it.snr else null)

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -687,4 +687,16 @@
     <string name="tune_method_automatic">Automatic</string>
     <string name="tune_method_internal">Internal tuner</string>
     <string name="tune_method_tone">Low power tone</string>
+
+    <!-- Android Auto status screens (read-only). Headlines reuse the qsopanel_* strings. -->
+    <string name="car_screen_title" translatable="false">FT8AF</string>
+    <string name="car_open_phone">Open FT8AF on your phone to start the FT8 engine</string>
+    <string name="car_monitoring">Monitoring — TX off</string>
+    <string name="car_no_tx">No transmission queued</string>
+    <string name="car_seq_step">Step %1$s (%2$d/%3$d)</string>
+    <string name="car_slot_tx">TX slot · %1$d s</string>
+    <string name="car_slot_rx">RX slot · %1$d s</string>
+    <string name="car_decodes_action">Decodes</string>
+    <string name="car_decodes_title">Recent decodes</string>
+    <string name="car_no_decodes">No decodes yet</string>
 </resources>

--- a/ft8af/app/src/main/res/xml/automotive_app_desc.xml
+++ b/ft8af/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+    Declares to the Android Auto host that this app renders car-app-library
+    templates (see FT8AFCarAppService). Referenced from the manifest via the
+    com.google.android.gms.car.application meta-data entry.
+-->
+<automotiveApp>
+    <uses name="template" />
+</automotiveApp>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarAppManifestWiringTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarAppManifestWiringTest.kt
@@ -1,0 +1,48 @@
+package radio.ks3ckc.ft8af.car
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Pins the Android Auto manifest wiring: the host discovers the app through the
+ * CarAppService intent filter plus the automotive_app_desc meta-data, and a
+ * silently dropped entry would only show up as "app missing from the car
+ * launcher" — a failure mode adb/unit tests can't otherwise see.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CarAppManifestWiringTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun carAppService_isDeclaredExported_withIotCategory() {
+        val intent = Intent("androidx.car.app.CarAppService").setPackage(context.packageName)
+        val services = context.packageManager.queryIntentServices(
+            intent,
+            PackageManager.GET_RESOLVED_FILTER,
+        )
+        assertThat(services).hasSize(1)
+        val resolved = services[0]
+        assertThat(resolved.serviceInfo.name).isEqualTo("radio.ks3ckc.ft8af.car.FT8AFCarAppService")
+        assertThat(resolved.serviceInfo.exported).isTrue()
+        assertThat(resolved.filter.hasCategory("androidx.car.app.category.IOT")).isTrue()
+    }
+
+    @Test
+    fun automotiveAppDescriptor_andMinCarApiLevel_areDeclared() {
+        val appInfo = context.packageManager.getApplicationInfo(
+            context.packageName,
+            PackageManager.GET_META_DATA,
+        )
+        assertThat(appInfo.metaData.getInt("com.google.android.gms.car.application"))
+            .isEqualTo(R.xml.automotive_app_desc)
+        assertThat(appInfo.metaData.getInt("androidx.car.app.minCarApiLevel")).isEqualTo(1)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatusTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatusTest.kt
@@ -1,0 +1,187 @@
+package radio.ks3ckc.ft8af.car
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import org.junit.Test
+
+/**
+ * Tests for the pure Android Auto status mapper. [buildCarQsoStatus] is the
+ * decision logic behind the car pane — the Screen only resolves the returned
+ * specs — so these tests pin the headline/row selection rules.
+ */
+class CarQsoStatusTest {
+
+    private fun build(
+        isActivated: Boolean = false,
+        isTransmitting: Boolean = false,
+        functionOrder: Int = 6,
+        toCallsign: String? = null,
+        snr: Int? = null,
+        transmittingMessage: String? = null,
+        myTxSequential: Int = 0,
+        currentSlot: Int = 0,
+        secondsRemaining: Int = 7,
+        freqHz: Long = 14_074_000L,
+        bandName: String = "20m",
+        modeName: String = "FT8",
+    ) = buildCarQsoStatus(
+        isActivated = isActivated,
+        isTransmitting = isTransmitting,
+        functionOrder = functionOrder,
+        toCallsign = toCallsign,
+        snr = snr,
+        transmittingMessage = transmittingMessage,
+        myTxSequential = myTxSequential,
+        currentSlot = currentSlot,
+        secondsRemaining = secondsRemaining,
+        freqHz = freqHz,
+        bandName = bandName,
+        modeName = modeName,
+    )
+
+    @Test
+    fun notActivated_headlineIsMonitoring_seqLineNull_txStateOff() {
+        val status = build(isActivated = false)
+        assertThat(status.headline.resId).isEqualTo(R.string.car_monitoring)
+        assertThat(status.seqLine).isNull()
+        assertThat(status.txState).isEqualTo(CarTxState.OFF)
+    }
+
+    @Test
+    fun activatedWithoutTarget_headlineIsCallingCq() {
+        for (callsign in listOf(null, "", "CQ")) {
+            val status = build(isActivated = true, toCallsign = callsign)
+            assertThat(status.headline.resId).isEqualTo(R.string.qsopanel_calling_cq)
+            assertThat(status.snrLabel).isNull()
+        }
+    }
+
+    @Test
+    fun targetAndTransmitting_headlineQsoingWith_messageLineSet() {
+        val status = build(
+            isActivated = true,
+            isTransmitting = true,
+            toCallsign = "W1XYZ",
+            transmittingMessage = "W1XYZ KS3CKC R-12",
+        )
+        assertThat(status.headline.resId).isEqualTo(R.string.qsopanel_qsoing_with)
+        assertThat(status.headline.args).containsExactly("W1XYZ")
+        assertThat(status.messageLine).isEqualTo("W1XYZ KS3CKC R-12")
+        assertThat(status.txState).isEqualTo(CarTxState.TRANSMITTING)
+    }
+
+    @Test
+    fun targetNotTransmitting_headlineWaitingFor_messageLineNull() {
+        val status = build(
+            isActivated = true,
+            toCallsign = "W1XYZ",
+            transmittingMessage = "W1XYZ KS3CKC R-12",
+        )
+        assertThat(status.headline.resId).isEqualTo(R.string.qsopanel_waiting_for)
+        assertThat(status.headline.args).containsExactly("W1XYZ")
+        assertThat(status.messageLine).isNull()
+        assertThat(status.txState).isEqualTo(CarTxState.ARMED_RX)
+    }
+
+    @Test
+    fun transmittingWithEmptyOrNullMessage_messageLineNull() {
+        for (message in listOf(null, "")) {
+            val status = build(isActivated = true, isTransmitting = true, transmittingMessage = message)
+            assertThat(status.messageLine).isNull()
+        }
+    }
+
+    @Test
+    fun snrLabel_onlyWithTarget_andFormatsSign() {
+        assertThat(build(toCallsign = "W1XYZ", snr = -12).snrLabel).isEqualTo("-12 dB")
+        assertThat(build(toCallsign = "W1XYZ", snr = 3).snrLabel).isEqualTo("+3 dB")
+        assertThat(build(toCallsign = "W1XYZ", snr = null).snrLabel).isNull()
+        assertThat(build(toCallsign = "CQ", snr = -12).snrLabel).isNull()
+    }
+
+    @Test
+    fun txFunctionLabel_mapsAllSixSteps_andFallsBackForUnknown() {
+        assertThat(txFunctionLabel(1)).isEqualTo("GRID")
+        assertThat(txFunctionLabel(2)).isEqualTo("RPT")
+        assertThat(txFunctionLabel(3)).isEqualTo("R-RPT")
+        assertThat(txFunctionLabel(4)).isEqualTo("RR73")
+        assertThat(txFunctionLabel(5)).isEqualTo("73")
+        assertThat(txFunctionLabel(6)).isEqualTo("CQ")
+        assertThat(txFunctionLabel(0)).isEqualTo("TX 0")
+        assertThat(txFunctionLabel(7)).isEqualTo("TX 7")
+    }
+
+    @Test
+    fun seqLine_carriesLabelOrdinalAndTotal() {
+        val seqLine = build(isActivated = true, functionOrder = 4).seqLine
+        assertThat(seqLine).isNotNull()
+        assertThat(seqLine!!.resId).isEqualTo(R.string.car_seq_step)
+        assertThat(seqLine.args).containsExactly("RR73", 4, 6).inOrder()
+    }
+
+    @Test
+    fun slotLine_txWhenSlotParityMatchesMySequential() {
+        assertThat(build(myTxSequential = 0, currentSlot = 0).slotLine.resId)
+            .isEqualTo(R.string.car_slot_tx)
+        assertThat(build(myTxSequential = 0, currentSlot = 1).slotLine.resId)
+            .isEqualTo(R.string.car_slot_rx)
+        assertThat(build(myTxSequential = 1, currentSlot = 3).slotLine.resId)
+            .isEqualTo(R.string.car_slot_tx)
+        assertThat(build(myTxSequential = 1, currentSlot = 2).slotLine.resId)
+            .isEqualTo(R.string.car_slot_rx)
+    }
+
+    @Test
+    fun slotLine_carriesSecondsRemaining() {
+        assertThat(build(secondsRemaining = 11).slotLine.args).containsExactly(11)
+    }
+
+    @Test
+    fun carBandLine_joinsFreqBandAndMode() {
+        assertThat(carBandLine(14_074_000L, "20m", "FT8")).isEqualTo("14.074 MHz · 20m · FT8")
+    }
+
+    @Test
+    fun carBandLine_omitsBlankBandName() {
+        assertThat(carBandLine(7_074_000L, "", "FT4")).isEqualTo("7.074 MHz · FT4")
+    }
+
+    @Test
+    fun buildCarDecodeRows_newestFirst_truncated_snrFormatted() {
+        val rows = buildCarDecodeRows(
+            decodes = listOf(
+                Triple(1000L, "CQ K1ABC FN42", -12),
+                Triple(3000L, "K1ABC W9XYZ EN52", 3),
+                Triple(2000L, "K1ABC W9XYZ R-08", null),
+            ),
+            maxRows = 2,
+        )
+        assertThat(rows).hasSize(2)
+        assertThat(rows[0].text).isEqualTo("K1ABC W9XYZ EN52")
+        assertThat(rows[0].snrLabel).isEqualTo("+3 dB")
+        assertThat(rows[1].text).isEqualTo("K1ABC W9XYZ R-08")
+        assertThat(rows[1].snrLabel).isNull()
+    }
+
+    @Test
+    fun buildCarDecodeRows_emptyInputAndNonPositiveLimit() {
+        assertThat(buildCarDecodeRows(emptyList(), 6)).isEmpty()
+        assertThat(buildCarDecodeRows(listOf(Triple(1L, "CQ K1ABC", -1)), 0)).isEmpty()
+        assertThat(buildCarDecodeRows(listOf(Triple(1L, "CQ K1ABC", -1)), -3)).isEmpty()
+    }
+
+    @Test
+    fun carDecodeSecondary_formatsUtcTime_withAndWithoutSnr() {
+        // 1970-01-01 01:02:03 UTC
+        val ms = ((1 * 60 + 2) * 60 + 3) * 1000L
+        assertThat(carDecodeSecondary(ms, "-12 dB")).isEqualTo("01:02:03 UTC · -12 dB")
+        assertThat(carDecodeSecondary(ms, null)).isEqualTo("01:02:03 UTC")
+    }
+
+    @Test
+    fun shouldInvalidateForTick_onlyWhenSecondChanges() {
+        assertThat(shouldInvalidateForTick(lastSecond = 7, newSecond = 7)).isFalse()
+        assertThat(shouldInvalidateForTick(lastSecond = 7, newSecond = 6)).isTrue()
+        assertThat(shouldInvalidateForTick(lastSecond = -1, newSecond = 15)).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Implements #209 (read-only first pass).

Adds Android Auto (phone projection) support: a **read-only** status display for the running FT8 QSO sequence on the car head unit.

- **Main screen** (`QsoStatusScreen`, PaneTemplate): headline (Calling CQ / QSOing with W1XYZ / Waiting for W1XYZ / Monitoring — TX off, with target SNR), the message currently being transmitted, sequence step (`Step RR73 (4/6)`), TX/RX slot countdown, and band · frequency · mode.
- **Decodes screen** (`RecentDecodesScreen`, ListTemplate): most recent decoded messages, newest first, with UTC time and SNR. Reached from the action strip; rows are not clickable.
- **Read-only by design** — no radio control from the car. The only action is screen navigation.

## How it works

- The engine state is already exposed as `MutableLiveData` on the process-scoped `MainViewModel`/`FT8TransmitSignal` singletons (kept alive in the background by `RxForegroundService`), so the `CarAppService` runs in the same process and observes it directly — no IPC, no engine changes.
- New nullable `MainViewModel.peekInstance()`: the car UI **never boots the engine**. Until `ComposeMainActivity` has created the singleton, the car shows "Open FT8AF on your phone" and re-checks on its 1 Hz tick.
- All display decisions are in pure mappers (`buildCarQsoStatus`, `buildCarDecodeRows`, `txFunctionLabel`, `carBandLine`, …) in `CarQsoStatus.kt`; the Screens only observe and render. Reuses `slotTimerState`, `formatMhz`, and the localized `qsopanel_*` headline strings.
- Countdown refresh: same-template `invalidate()` is an unquoted refresh on AA hosts, and the tick only fires when the visible second changes (`shouldInvalidateForTick`).
- Category: `androidx.car.app.category.IOT` (status-style app; not nav/media/messaging). `minCarApiLevel` 1; `ConstraintManager` row limits used when the host supports them (API ≥ 2).

## Testing

- `CarQsoStatusTest` (plain JVM): headline selection incl. no-target/"CQ" rule, TX message gating, seq-step labels 1–6 + fallback, slot TX/RX parity, band line formatting, decode rows ordering/truncation/SNR, tick guard, UTC secondary line.
- `CarAppManifestWiringTest` (Robolectric): CarAppService declared+exported with the IOT category; `automotive_app_desc` + `minCarApiLevel` meta-data present — a dropped entry only manifests as "app missing from the car launcher", which nothing else catches.
- `peekInstance()` is deliberately not unit-tested in isolation: the process-lifetime static would leak across tests in the same JVM (order-dependent flakes); its null branch is exercised by the Screens' open-phone template.
- Full `testDebugUnitTest` and `assembleDebug` pass. detekt/ktlint report no findings in the new files (existing findings are pre-baseline / unformatted legacy code; CI runs both warn-only).

## Trying it without a car

Desktop Head Unit: install "Android Auto Desktop Head Unit Emulator" from SDK Manager, enable AA developer mode + **Unknown sources** on the phone (required for sideloaded car apps), `adb forward tcp:5277 tcp:5277`, run `desktop-head-unit.exe`. Launch FT8AF on the phone to start the engine; the car screen goes live and keeps updating while the phone app is backgrounded.

Play-distribution note: shipping this on Play later requires opting into the Android Auto form in Play Console + car-quality review for IOT apps. Sideloaded builds work now with the developer setting above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
