### PR TITLE
Fix RejectedExecutionException crash on ViewModel teardown

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -24,6 +24,8 @@ package com.k1af.ft8af;
 
 import static com.k1af.ft8af.GeneralVariables.getStringFromResource;
 
+import com.k1af.ft8af.concurrent.SafeExecutor;
+
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.PendingIntent;
@@ -680,7 +682,11 @@ public class MainViewModel extends ViewModel {
 
 
                 getQTHRunnable.messages = messages;
-                getQTHThreadPool.execute(getQTHRunnable);//query location via thread pool
+                // Guard against the ViewModel-teardown race: a late deep-decode
+                // pass can deliver here after onCleared() shut the pool down,
+                // and a raw execute() on a terminated pool throws
+                // RejectedExecutionException on this decode thread (crash).
+                SafeExecutor.tryExecute(getQTHThreadPool, getQTHRunnable);//query location via thread pool
 
                 //this variable also notifies message list changes
                 mutable_Decoded_Counter.postValue(
@@ -797,7 +803,7 @@ public class MainViewModel extends ViewModel {
                             sendWaveDataRunnable.baseRig = baseRig;
                             sendWaveDataRunnable.message = msg;
                             //send network data packets via thread pool
-                            sendWaveDataThreadPool.execute(sendWaveDataRunnable);
+                            SafeExecutor.tryExecute(sendWaveDataThreadPool, sendWaveDataRunnable);
                         }
                     }
                 }
@@ -825,7 +831,7 @@ public class MainViewModel extends ViewModel {
                 }
                 sendWaveDataRunnable.baseRig = baseRig;
                 sendWaveDataRunnable.message = msg;
-                sendWaveDataThreadPool.execute(sendWaveDataRunnable);
+                SafeExecutor.tryExecute(sendWaveDataThreadPool, sendWaveDataRunnable);
             }
 
         }, new OnTransmitSuccess() {//when QSO is successful

--- a/ft8af/app/src/main/java/com/k1af/ft8af/concurrent/SafeExecutor.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/concurrent/SafeExecutor.java
@@ -1,0 +1,53 @@
+package com.k1af.ft8af.concurrent;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Submits work to an {@link ExecutorService} without letting a submission that
+ * loses the shutdown race crash the app.
+ *
+ * <p>The FT8 decode listener threads keep delivering passes for a short while
+ * after {@code MainViewModel.onCleared()} shuts its pools down — in particular a
+ * late deep-decode pass fires {@code afterDecode(...)} on a background decode
+ * thread, which submits a QTH-lookup task to {@code getQTHThreadPool}. A raw
+ * {@code execute()} on an already-terminated pool throws
+ * {@link RejectedExecutionException} on that decode thread (the default
+ * {@code AbortPolicy}), which is uncaught and takes the whole process down
+ * (observed crash: {@code MainViewModel.afterDecode} on ViewModel teardown).
+ *
+ * <p>{@link #tryExecute} swallows exactly that race: if the pool is shut down or
+ * otherwise rejects the task, the task is dropped and the caller is told via a
+ * {@code false} return instead of an exception.
+ */
+public final class SafeExecutor {
+
+    private SafeExecutor() {}
+
+    /**
+     * Execute {@code task} on {@code pool}, returning whether it was accepted.
+     *
+     * @return {@code true} if the pool accepted the task; {@code false} if
+     *     {@code pool}/{@code task} was null, the pool was already shut down, or
+     *     the pool rejected the submission (shutdown race / saturation). Never
+     *     throws {@link RejectedExecutionException}.
+     */
+    public static boolean tryExecute(ExecutorService pool, Runnable task) {
+        if (pool == null || task == null) {
+            return false;
+        }
+        // Fast path: skip the throw entirely once the pool is known-down.
+        if (pool.isShutdown()) {
+            return false;
+        }
+        try {
+            pool.execute(task);
+            return true;
+        } catch (RejectedExecutionException rejected) {
+            // The pool was shut down (or hit a bound) between the isShutdown()
+            // check above and execute() — the race with onCleared(). Drop the
+            // task rather than crash the decode thread.
+            return false;
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/concurrent/SafeExecutorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/concurrent/SafeExecutorTest.java
@@ -1,0 +1,72 @@
+package com.k1af.ft8af.concurrent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Pure-JVM tests for {@link SafeExecutor} — no Android types, so no Robolectric
+ * runner is needed. Covers the shutdown race that took the app down at
+ * MainViewModel.afterDecode.
+ */
+public class SafeExecutorTest {
+
+    @Test
+    public void tryExecute_runsTaskOnLivePool() throws InterruptedException {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            CountDownLatch ran = new CountDownLatch(1);
+            boolean accepted = SafeExecutor.tryExecute(pool, ran::countDown);
+
+            assertThat(accepted).isTrue();
+            assertThat(ran.await(2, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    public void tryExecute_onShutdownPool_returnsFalseAndDoesNotThrow() {
+        ExecutorService pool = Executors.newCachedThreadPool();
+        pool.shutdown();
+
+        AtomicBoolean ran = new AtomicBoolean(false);
+        // A raw pool.execute() here would throw RejectedExecutionException and,
+        // on the decode thread, crash the process. tryExecute must not.
+        boolean accepted = SafeExecutor.tryExecute(pool, () -> ran.set(true));
+
+        assertThat(accepted).isFalse();
+        assertThat(ran.get()).isFalse();
+    }
+
+    @Test
+    public void tryExecute_afterShutdownNow_returnsFalse() {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        pool.shutdownNow();
+
+        boolean accepted = SafeExecutor.tryExecute(pool, () -> { });
+
+        assertThat(accepted).isFalse();
+    }
+
+    @Test
+    public void tryExecute_nullPool_returnsFalse() {
+        assertThat(SafeExecutor.tryExecute(null, () -> { })).isFalse();
+    }
+
+    @Test
+    public void tryExecute_nullTask_returnsFalse() {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            assertThat(SafeExecutor.tryExecute(pool, null)).isFalse();
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Pulled from a crashing device (`debug.log` + logcat crash buffer, 07-05). One of two distinct app crashes found:

```
FATAL EXCEPTION: Thread-139
java.util.concurrent.RejectedExecutionException: Task
  com.k1af.ft8af.MainViewModel$GetQTHRunnable rejected from
  ThreadPoolExecutor[Terminated, pool size = 0, ...]
    at com.k1af.ft8af.MainViewModel$4.afterDecode(MainViewModel.java)
    at com.k1af.ft8af.ft8listener.FT8SignalListener$4.run(FT8SignalListener.java:251)
```

A late **deep-decode** pass delivers `afterDecode()` on a background decode thread *after* `MainViewModel.onCleared()` has shut `getQTHThreadPool` / `sendWaveDataThreadPool` down (ViewModel destroyed on activity teardown/recreate). The raw `execute()` on the terminated pool throws `RejectedExecutionException` (default `AbortPolicy`), which is uncaught on the decode thread and crashes the process.

## Fix

New `SafeExecutor.tryExecute(pool, task)` helper: fast-paths on `isShutdown()`, and wraps `execute()` in a `try/catch (RejectedExecutionException)` to cover the check→execute race with `onCleared()`. Drops the task and returns `false` instead of throwing.

Wired into all three submit sites in `MainViewModel` (1× `getQTHThreadPool`, 2× `sendWaveDataThreadPool`).

## Tests

`SafeExecutorTest` (pure JUnit + Truth, no Robolectric needed): live-pool execution, shutdown pool, `shutdownNow()`, null pool, null task. `:app:testDebugUnitTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)