### PR TITLE
Add autofill hints to Compose login fields so password managers work (#439)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/AutofillModifier.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/AutofillModifier.kt
@@ -1,6 +1,10 @@
 package radio.ks3ckc.ft8af.ui.components
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillNode
@@ -59,6 +63,11 @@ internal fun credentialAutofillTypes(role: CredentialFieldRole): List<AutofillTy
  * the field gains / loses focus. Once the BOM is bumped to ~1.8+ (issue #440) this
  * can be replaced by the declarative `Modifier.semantics { contentType = … }`.
  *
+ * The node is [remember]ed (not recreated per recomposition) and a [DisposableEffect]
+ * removes it from the tree when the field leaves composition, so recompositions don't
+ * leak orphaned nodes into [LocalAutofillTree]. [onFill] is captured through
+ * [rememberUpdatedState] so the stable node always invokes the latest lambda.
+ *
  * @param role which credential this field holds; maps to the advertised hint(s) via
  *   [credentialAutofillTypes].
  * @param onFill invoked with the value the autofill service supplied; push it into
@@ -71,8 +80,18 @@ fun Modifier.autofill(
     onFill: (String) -> Unit,
 ): Modifier {
     val autofill = LocalAutofill.current
-    val node = AutofillNode(autofillTypes = credentialAutofillTypes(role), onFill = onFill)
-    LocalAutofillTree.current += node
+    val autofillTree = LocalAutofillTree.current
+    val currentOnFill by rememberUpdatedState(onFill)
+    val node = remember(role) {
+        AutofillNode(
+            autofillTypes = credentialAutofillTypes(role),
+            onFill = { currentOnFill(it) },
+        )
+    }
+    DisposableEffect(autofillTree, node) {
+        autofillTree += node
+        onDispose { autofillTree.children.remove(node.id) }
+    }
     return this
         .onGloballyPositioned { node.boundingBox = it.boundsInWindow() }
         .onFocusChanged { state ->

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/AutofillModifier.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/AutofillModifier.kt
@@ -1,0 +1,84 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillNode
+import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalAutofill
+import androidx.compose.ui.platform.LocalAutofillTree
+
+/**
+ * The credential fields we advertise to the Android Autofill framework. Each role
+ * maps to a standard [AutofillType] so password managers (1Password, Bitwarden,
+ * Google Password Manager, …) can classify the field and offer fill / save.
+ *
+ * API-key / single-secret fields (QRZ Logbook, Cloudlog) are intentionally absent:
+ * the framework has no "API key" type, so mislabeling them as a password would be
+ * misleading. See issue #439, open questions — option (a).
+ */
+enum class CredentialFieldRole {
+    /** Login name that is not an email — e.g. a QRZ callsign or ICOM username. */
+    USERNAME,
+
+    /** Email-address login — e.g. the POTA account. */
+    EMAIL,
+
+    /** Secret password field. */
+    PASSWORD,
+}
+
+/**
+ * Pure mapping from a credential field's [role][CredentialFieldRole] to the
+ * autofill hint(s) it should advertise. Extracted so the decision is unit-testable
+ * without touching the experimental Compose autofill glue below.
+ *
+ * [AutofillType] carries an error-level experimental opt-in, so this — and any test
+ * that inspects the result — must opt in; keeping the type inside this function (the
+ * public [autofill] modifier takes a plain [CredentialFieldRole]) stops that opt-in
+ * from spreading into every dialog call site.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun credentialAutofillTypes(role: CredentialFieldRole): List<AutofillType> =
+    when (role) {
+        CredentialFieldRole.USERNAME -> listOf(AutofillType.Username)
+        CredentialFieldRole.EMAIL -> listOf(AutofillType.EmailAddress)
+        CredentialFieldRole.PASSWORD -> listOf(AutofillType.Password)
+    }
+
+/**
+ * Attaches Android autofill metadata to a text field so the OS autofill service can
+ * classify it and offer to fill / save credentials.
+ *
+ * On the current Compose toolchain (BOM 2024.02.00, Compose UI ~1.6) the autofill
+ * API is experimental: we register an [AutofillNode] in [LocalAutofillTree], track
+ * its on-screen bounds via [onGloballyPositioned], and request / cancel autofill as
+ * the field gains / loses focus. Once the BOM is bumped to ~1.8+ (issue #440) this
+ * can be replaced by the declarative `Modifier.semantics { contentType = … }`.
+ *
+ * @param role which credential this field holds; maps to the advertised hint(s) via
+ *   [credentialAutofillTypes].
+ * @param onFill invoked with the value the autofill service supplied; push it into
+ *   the field's existing state exactly as `onValueChange` would.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun Modifier.autofill(
+    role: CredentialFieldRole,
+    onFill: (String) -> Unit,
+): Modifier {
+    val autofill = LocalAutofill.current
+    val node = AutofillNode(autofillTypes = credentialAutofillTypes(role), onFill = onFill)
+    LocalAutofillTree.current += node
+    return this
+        .onGloballyPositioned { node.boundingBox = it.boundsInWindow() }
+        .onFocusChanged { state ->
+            autofill?.run {
+                if (state.isFocused) requestAutofillForNode(node)
+                else cancelAutofillForNode(node)
+            }
+        }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaScreen.kt
@@ -93,6 +93,8 @@ import radio.ks3ckc.ft8af.theme.BorderStrong
 import radio.ks3ckc.ft8af.theme.StatusConfirmed
 import radio.ks3ckc.ft8af.theme.TextMuted
 import radio.ks3ckc.ft8af.theme.TextPrimary
+import radio.ks3ckc.ft8af.ui.components.CredentialFieldRole
+import radio.ks3ckc.ft8af.ui.components.autofill
 
 private enum class PotaSubTab(@StringRes val labelRes: Int) {
     ACTIVATE(R.string.pota_tab_activate),
@@ -768,7 +770,11 @@ private fun PotaLoginDialog(
                     enabled = !submitting,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
                     colors = textFieldColors(),
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .autofill(CredentialFieldRole.EMAIL) {
+                            email = it.trim()
+                        },
                 )
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
@@ -780,7 +786,11 @@ private fun PotaLoginDialog(
                     visualTransformation = PasswordVisualTransformation(),
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                     colors = textFieldColors(),
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .autofill(CredentialFieldRole.PASSWORD) {
+                            password = it
+                        },
                 )
                 Spacer(Modifier.height(12.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/ConnectionDialogs.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/ConnectionDialogs.kt
@@ -59,6 +59,8 @@ import com.k1af.ft8af.ui.ToastMessage
 import com.k1af.ft8af.x6100.X6100Radio
 import com.k1af.ft8af.x6100.XieguRadioFactory
 import radio.ks3ckc.ft8af.theme.*
+import radio.ks3ckc.ft8af.ui.components.CredentialFieldRole
+import radio.ks3ckc.ft8af.ui.components.autofill
 
 // ─────────────────────────────────────────────────────────────────────
 // Shared helpers
@@ -622,7 +624,13 @@ fun IcomLoginDialog(
                 label = { Text(stringResource(R.string.icom_user_name)) },
                 singleLine = true,
                 colors = fieldColors,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .autofill(CredentialFieldRole.USERNAME) {
+                        username = it
+                        GeneralVariables.icomUserName = it.trim()
+                        mainViewModel.databaseOpr.writeConfig("icomUserName", it.trim(), null)
+                    },
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -653,7 +661,13 @@ fun IcomLoginDialog(
                     }
                 },
                 colors = fieldColors,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .autofill(CredentialFieldRole.PASSWORD) {
+                        password = it
+                        GeneralVariables.icomPassword = it
+                        mainViewModel.databaseOpr.writeConfig("icomPassword", it, null)
+                    },
             )
 
             Spacer(modifier = Modifier.height(20.dp))

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -697,7 +698,7 @@ private fun QrzCredsDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .autofill(CredentialFieldRole.USERNAME) {
-                        userInput = TextFieldValue(it); testResult = null
+                        userInput = TextFieldValue(it, selection = TextRange(it.length)); testResult = null
                     },
             )
 
@@ -713,7 +714,7 @@ private fun QrzCredsDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .autofill(CredentialFieldRole.PASSWORD) {
-                        passInput = TextFieldValue(it); testResult = null
+                        passInput = TextFieldValue(it, selection = TextRange(it.length)); testResult = null
                     },
             )
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
@@ -44,8 +44,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import radio.ks3ckc.ft8af.theme.*
+import radio.ks3ckc.ft8af.ui.components.CredentialFieldRole
 import radio.ks3ckc.ft8af.ui.components.GlassCard
 import radio.ks3ckc.ft8af.ui.components.SettingsRow
+import radio.ks3ckc.ft8af.ui.components.autofill
 
 /**
  * Logging & awards settings: SWL logging, PSKReporter, QRZ.com logging + profile
@@ -691,7 +693,12 @@ private fun QrzCredsDialog(
                 singleLine = true,
                 colors = fieldColors,
                 textStyle = TextStyle(fontSize = 14.sp),
-                modifier = Modifier.fillMaxWidth(),
+                // QRZ usernames are callsigns, so advertise Username (not EmailAddress).
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .autofill(CredentialFieldRole.USERNAME) {
+                        userInput = TextFieldValue(it); testResult = null
+                    },
             )
 
             OutlinedTextField(
@@ -703,7 +710,11 @@ private fun QrzCredsDialog(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                 colors = fieldColors,
                 textStyle = TextStyle(fontSize = 14.sp),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .autofill(CredentialFieldRole.PASSWORD) {
+                        passInput = TextFieldValue(it); testResult = null
+                    },
             )
 
             // Test Connection

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/CredentialAutofillTypesTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/CredentialAutofillTypesTest.kt
@@ -1,0 +1,54 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.autofill.AutofillType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import radio.ks3ckc.ft8af.ui.components.CredentialFieldRole
+import radio.ks3ckc.ft8af.ui.components.credentialAutofillTypes
+
+/**
+ * Covers the field-role → autofill-hint mapping used by the QRZ, ICOM, and POTA
+ * login dialogs (issue #439). The `Modifier.autofill` glue can't be unit-tested, so
+ * the decision is extracted into `credentialAutofillTypes`, which is what's tested
+ * here.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class CredentialAutofillTypesTest {
+
+    @Test
+    fun username_role_advertises_username_only() {
+        assertThat(credentialAutofillTypes(CredentialFieldRole.USERNAME))
+            .containsExactly(AutofillType.Username)
+    }
+
+    @Test
+    fun email_role_advertises_email_address_only() {
+        // POTA logs in with an email; EmailAddress lets managers offer the account.
+        assertThat(credentialAutofillTypes(CredentialFieldRole.EMAIL))
+            .containsExactly(AutofillType.EmailAddress)
+    }
+
+    @Test
+    fun password_role_advertises_password_only() {
+        assertThat(credentialAutofillTypes(CredentialFieldRole.PASSWORD))
+            .containsExactly(AutofillType.Password)
+    }
+
+    @Test
+    fun username_role_never_advertises_email_address() {
+        // QRZ usernames are callsigns, not emails — mislabeling would let a manager
+        // fill an email address into the callsign field.
+        assertThat(credentialAutofillTypes(CredentialFieldRole.USERNAME))
+            .doesNotContain(AutofillType.EmailAddress)
+    }
+
+    @Test
+    fun every_role_maps_to_exactly_one_hint() {
+        // Each credential field advertises a single, unambiguous type so the autofill
+        // service classifies it deterministically.
+        for (role in CredentialFieldRole.entries) {
+            assertThat(credentialAutofillTypes(role)).hasSize(1)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #439.

## Problem

Password managers (1Password, Bitwarden, Google Password Manager, …) work through the Android **Autofill framework**, which classifies a field by the *autofill hints* it advertises (`username`, `emailAddress`, `password`). The QRZ, ICOM, and POTA login dialogs are plain Compose `OutlinedTextField`s with no autofill metadata, so the OS sees anonymous text boxes and never offers to fill or save credentials. (`PasswordVisualTransformation` + `KeyboardType.Password` only affect masking/keyboard — not autofill classification.)

## Change

- **New `ui/components/AutofillModifier.kt`** — `Modifier.autofill(role, onFill)` registers an `AutofillNode` in `LocalAutofillTree`, tracks its bounds, and requests/cancels autofill on focus change. This is the experimental-node approach appropriate for the current Compose 1.6 toolchain.
- The field→`AutofillType` decision is extracted into the pure, unit-tested `credentialAutofillTypes(role)`.
- Applied to the three reachable credential dialogs:
  | Dialog | Fields |
  | --- | --- |
  | QRZ Profile Lookup (`LoggingSettings.kt`) | username → `Username`, password → `Password` |
  | ICOM/Xiegu login (`ConnectionDialogs.kt`) | username → `Username`, password → `Password` |
  | POTA login (`PotaScreen.kt`) | email → `EmailAddress`, password → `Password` |
  Each `onFill` mirrors the existing `onValueChange` (including the ICOM `writeConfig` persistence).

### Decisions
- **QRZ usernames are callsigns**, so `Username` (not `EmailAddress`) is advertised.
- **API-key fields (QRZ Logbook, Cloudlog) left as-is** — the framework has no API-key type; mislabeling as `Password` would be misleading (issue open question, **option a**, per @Reid-n0rc's comment).
- The experimental `AutofillType` is kept out of the public modifier signature (it takes `CredentialFieldRole`) so its error-level opt-in doesn't spread across every call site.

## Testing

New `CredentialAutofillTypesTest` covers the role→hint mapping (Username-only for callsigns, EmailAddress for POTA, Password for secrets, one hint per role). `:app:testDebugUnitTest` passes; full debug build compiles.

Manual on-device verification with 1Password as the autofill service (focus each field → suggestion bar appears → fill → "save login?" prompt) still to be done on the test phone.

## Follow-up
Blocked-only-for-cleanup by #440: once the Compose BOM reaches ~1.8, replace the experimental node API with declarative `Modifier.semantics { contentType = … }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)