### PR TITLE
Wavelog per-location station: signature + create_station client + cache (increment 1 of ~5) (#437)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -42,6 +42,10 @@ public class GeneralVariables {
     public static boolean enableCloudlog = false;//Whether Cloudlog auto-sync is enabled
     public static boolean enableQRZ = false;//Whether QRZ auto-sync is enabled
     public static boolean enablePskReporter = true;//Whether PSKReporter spot upload is enabled
+    // Dark feature flag for issue #437 (auto per-location Wavelog station profiles).
+    // Default false and NOT branched into any live upload path yet — this increment
+    // only lands the pure LocationSignature/resolver/create_station/cache foundation.
+    public static boolean perLocationStationEnabled = false;
 
     public static boolean distanceInMiles = true;//Display distances in miles (true) or kilometers (false)
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -58,7 +58,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
     public static synchronized DatabaseOpr getInstance(@Nullable Context context, @Nullable String databaseName) {
         if (instance == null) {
-            instance = new DatabaseOpr(context, databaseName, null, 18);
+            instance = new DatabaseOpr(context, databaseName, null, 19);
         }
         return instance;
     }
@@ -103,6 +103,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         //Create POTA activation history table
         createPotaTables(sqLiteDatabase);
 
+        //Create per-location Wavelog station cache table (issue #437)
+        createLocationStationTables(sqLiteDatabase);
+
         //Create indexes
         createIndex(sqLiteDatabase);
 
@@ -130,6 +133,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
         //Create POTA activation history table
         createPotaTables(sqLiteDatabase);
+
+        //Create per-location Wavelog station cache table (issue #437)
+        createLocationStationTables(sqLiteDatabase);
 
         //Create indexes
         createIndex(sqLiteDatabase);
@@ -484,6 +490,96 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     "ended_at INTEGER,\n" +//null while in progress
                     "qso_count INTEGER DEFAULT 0,\n" +
                     "notes TEXT)");
+        }
+    }
+
+    /**
+     * Create the per-location Wavelog station cache table (issue #437). Maps a
+     * canonical {@link com.k1af.ft8af.log.LocationSignature} string to the
+     * {@code station_profile_id} that covers that location, so revisiting a place
+     * reuses its station profile instead of creating a duplicate. Persisted across
+     * sessions. Idempotent (guarded by {@link #checkTableExists}) so it is safe to
+     * call from both onCreate and onUpgrade.
+     */
+    private void createLocationStationTables(SQLiteDatabase sqLiteDatabase) {
+        if (!checkTableExists(sqLiteDatabase, "location_station_cache")) {
+            sqLiteDatabase.execSQL("CREATE TABLE location_station_cache (\n" +
+                    "signature TEXT PRIMARY KEY,\n" +
+                    "station_profile_id TEXT NOT NULL,\n" +
+                    "updated_at INTEGER NOT NULL)");//epoch millis
+        }
+    }
+
+    /**
+     * Upsert a {@code signature -> station_profile_id} mapping. Thin DAO wrapper;
+     * the signature must already be canonicalized by
+     * {@link com.k1af.ft8af.log.LocationSignature#signature()}. No-op on null args.
+     * Part of the dark issue-#437 foundation — not yet called from any live path.
+     */
+    public void putStationForSignature(String signature, String profileId) {
+        if (db == null || signature == null || profileId == null) {
+            return;
+        }
+        try {
+            db.execSQL("INSERT OR REPLACE INTO location_station_cache "
+                            + "(signature, station_profile_id, updated_at) VALUES (?,?,?)",
+                    new Object[]{signature, profileId, System.currentTimeMillis()});
+        } catch (Exception e) {
+            Log.w(TAG, "putStationForSignature failed: " + e.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Look up the cached {@code station_profile_id} for a canonical signature, or
+     * null when there is no mapping (or on error / null input).
+     */
+    public String getStationForSignature(String signature) {
+        if (db == null || signature == null) {
+            return null;
+        }
+        try (Cursor cursor = db.rawQuery(
+                "SELECT station_profile_id FROM location_station_cache WHERE signature = ?",
+                new String[]{signature})) {
+            if (cursor.moveToFirst()) {
+                return cursor.getString(0);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "getStationForSignature failed: " + e.getClass().getSimpleName());
+        }
+        return null;
+    }
+
+    /**
+     * Every cached {@code signature -> station_profile_id} mapping, ordered by
+     * signature for a deterministic read-back. Primarily for inspection/testing.
+     */
+    public java.util.List<com.k1af.ft8af.log.LocationStationCacheEntry> getAllStationSignatures() {
+        java.util.List<com.k1af.ft8af.log.LocationStationCacheEntry> out = new ArrayList<>();
+        if (db == null) {
+            return out;
+        }
+        try (Cursor cursor = db.rawQuery(
+                "SELECT signature, station_profile_id FROM location_station_cache "
+                        + "ORDER BY signature", null)) {
+            while (cursor.moveToNext()) {
+                out.add(new com.k1af.ft8af.log.LocationStationCacheEntry(
+                        cursor.getString(0), cursor.getString(1)));
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "getAllStationSignatures failed: " + e.getClass().getSimpleName());
+        }
+        return out;
+    }
+
+    /** Drop every cached signature mapping (e.g. on server/logbook switch). */
+    public void clearLocationStationCache() {
+        if (db == null) {
+            return;
+        }
+        try {
+            db.execSQL("DELETE FROM location_station_cache");
+        } catch (Exception e) {
+            Log.w(TAG, "clearLocationStationCache failed: " + e.getClass().getSimpleName());
         }
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationSignature.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationSignature.java
@@ -1,0 +1,210 @@
+package com.k1af.ft8af.log;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A pure, canonical description of a physical operating location, used as the
+ * dedup key for the "one Wavelog station_profile per unique location" feature
+ * (issue #437).
+ *
+ * <p>The type holds the user-selectable location fields (grid, state, DXCC,
+ * county, city, CQ/ITU zone) plus an optional POTA reference, together with a
+ * configurable set of {@link Field}s that decide which of those fields actually
+ * participate in the signature. From only the enabled fields (plus the POTA
+ * reference whenever one is present) it computes a stable, normalized
+ * {@link #signature()} string: two physically-identical locations always yield
+ * the exact same string, so it can key a cache or match an existing profile.
+ *
+ * <p>This class is intentionally free of any Android dependency so it unit-tests
+ * without Robolectric. It performs no network or persistence work — callers feed
+ * it already-derived field values.
+ *
+ * <p><b>Dark feature.</b> Nothing in the live upload path constructs or consults
+ * a {@code LocationSignature} yet; this is foundation only (guarded by
+ * {@code GeneralVariables.perLocationStationEnabled}, default false).
+ */
+public final class LocationSignature {
+
+    /** The toggleable location fields. The POTA reference is intentionally NOT a
+     *  member: per the design it is always included when present, regardless of
+     *  which of these are enabled. */
+    public enum Field {
+        GRIDSQUARE("GRID"),
+        STATE("STATE"),
+        DXCC("DXCC"),
+        COUNTY("COUNTY"),
+        CITY("CITY"),
+        CQ_ZONE("CQZ"),
+        ITU_ZONE("ITUZ");
+
+        /** Stable token used in the canonical signature string. Never change these
+         *  without invalidating every persisted signature. */
+        final String token;
+
+        Field(String token) {
+            this.token = token;
+        }
+    }
+
+    /** All location fields enabled (the finest-grained default). */
+    public static final Set<Field> ALL_FIELDS = EnumSet.allOf(Field.class);
+
+    private final String gridsquare;
+    private final String state;
+    private final String dxcc;
+    private final String county;
+    private final String city;
+    private final String cqZone;
+    private final String ituZone;
+    private final String potaRef;
+    private final EnumSet<Field> enabledFields;
+
+    private LocationSignature(Builder b) {
+        this.gridsquare = b.gridsquare;
+        this.state = b.state;
+        this.dxcc = b.dxcc;
+        this.county = b.county;
+        this.city = b.city;
+        this.cqZone = b.cqZone;
+        this.ituZone = b.ituZone;
+        this.potaRef = b.potaRef;
+        // Defensive copy so a caller mutating their set can't change our signature.
+        this.enabledFields = b.enabledFields.isEmpty()
+                ? EnumSet.noneOf(Field.class)
+                : EnumSet.copyOf(b.enabledFields);
+    }
+
+    /**
+     * Normalizes a single field value: null/blank become {@code null} (the field
+     * is omitted from the signature), otherwise the value is trimmed, internal
+     * whitespace runs are collapsed to a single space, and it is upper-cased with
+     * a fixed locale so casing/spacing differences never split one location into
+     * two signatures.
+     */
+    static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String collapsed = value.trim().replaceAll("\\s+", " ");
+        if (collapsed.isEmpty()) {
+            return null;
+        }
+        return collapsed.toUpperCase(Locale.ROOT);
+    }
+
+    private String rawFor(Field f) {
+        switch (f) {
+            case GRIDSQUARE: return gridsquare;
+            case STATE:      return state;
+            case DXCC:       return dxcc;
+            case COUNTY:     return county;
+            case CITY:       return city;
+            case CQ_ZONE:    return cqZone;
+            case ITU_ZONE:   return ituZone;
+            default:         return null;
+        }
+    }
+
+    /** The configured set of participating fields (unmodifiable snapshot). */
+    public Set<Field> enabledFields() {
+        return EnumSet.copyOf(enabledFields.isEmpty()
+                ? EnumSet.noneOf(Field.class) : enabledFields);
+    }
+
+    /** The (normalized) POTA reference participating in this signature, or null. */
+    public String potaRef() {
+        return normalize(potaRef);
+    }
+
+    /**
+     * The canonical, stable dedup key. Emits only the enabled, non-empty fields in
+     * a fixed order (the {@link Field} enum declaration order), each as
+     * {@code TOKEN=VALUE}, joined by {@code |}. The POTA reference — when present —
+     * is always appended last as {@code POTA=VALUE}, independent of the enabled
+     * set. Two {@code LocationSignature}s describing the same physical location
+     * (same enabled config, same values modulo case/whitespace) produce byte-for-
+     * byte identical strings; an all-disabled, POTA-less signature is the empty
+     * string.
+     */
+    public String signature() {
+        List<String> parts = new ArrayList<>();
+        // Iterate the enum (not the set) so ordering is always the declaration order
+        // regardless of how the caller built their EnumSet.
+        for (Field f : Field.values()) {
+            if (!enabledFields.contains(f)) {
+                continue;
+            }
+            String v = normalize(rawFor(f));
+            if (v != null) {
+                parts.add(f.token + "=" + v);
+            }
+        }
+        String pota = normalize(potaRef);
+        if (pota != null) {
+            parts.add("POTA=" + pota);
+        }
+        return String.join("|", parts);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LocationSignature)) return false;
+        // Equality is defined purely by the canonical signature: same key == same
+        // location for dedup purposes, even if disabled fields differ.
+        return signature().equals(((LocationSignature) o).signature());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(signature());
+    }
+
+    @Override
+    public String toString() {
+        return "LocationSignature{" + signature() + "}";
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Fluent builder. Enabled fields default to {@link #ALL_FIELDS}. */
+    public static final class Builder {
+        private String gridsquare;
+        private String state;
+        private String dxcc;
+        private String county;
+        private String city;
+        private String cqZone;
+        private String ituZone;
+        private String potaRef;
+        private EnumSet<Field> enabledFields = EnumSet.allOf(Field.class);
+
+        public Builder gridsquare(String v) { this.gridsquare = v; return this; }
+        public Builder state(String v) { this.state = v; return this; }
+        public Builder dxcc(String v) { this.dxcc = v; return this; }
+        public Builder county(String v) { this.county = v; return this; }
+        public Builder city(String v) { this.city = v; return this; }
+        public Builder cqZone(String v) { this.cqZone = v; return this; }
+        public Builder ituZone(String v) { this.ituZone = v; return this; }
+        public Builder potaRef(String v) { this.potaRef = v; return this; }
+
+        /** Replace the participating-field set (a copy is taken). Null clears it. */
+        public Builder enabledFields(Set<Field> fields) {
+            this.enabledFields = (fields == null || fields.isEmpty())
+                    ? EnumSet.noneOf(Field.class)
+                    : EnumSet.copyOf(fields);
+            return this;
+        }
+
+        public LocationSignature build() {
+            return new LocationSignature(this);
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationSignature.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationSignature.java
@@ -1,6 +1,7 @@
 package com.k1af.ft8af.log;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -51,8 +52,11 @@ public final class LocationSignature {
         }
     }
 
-    /** All location fields enabled (the finest-grained default). */
-    public static final Set<Field> ALL_FIELDS = EnumSet.allOf(Field.class);
+    /** All location fields enabled (the finest-grained default). Unmodifiable so a
+     *  caller can't mutate this shared constant; take {@code EnumSet.copyOf(ALL_FIELDS)}
+     *  if you need a mutable copy. */
+    public static final Set<Field> ALL_FIELDS =
+            Collections.unmodifiableSet(EnumSet.allOf(Field.class));
 
     private final String gridsquare;
     private final String state;
@@ -63,6 +67,10 @@ public final class LocationSignature {
     private final String ituZone;
     private final String potaRef;
     private final EnumSet<Field> enabledFields;
+    /** Canonical signature computed once at construction (the type is immutable) so
+     *  the repeated {@link #signature()}/{@link #equals}/{@link #hashCode} calls made
+     *  when this is used as a map key don't re-run the regex whitespace collapse. */
+    private final String signature;
 
     private LocationSignature(Builder b) {
         this.gridsquare = b.gridsquare;
@@ -77,6 +85,7 @@ public final class LocationSignature {
         this.enabledFields = b.enabledFields.isEmpty()
                 ? EnumSet.noneOf(Field.class)
                 : EnumSet.copyOf(b.enabledFields);
+        this.signature = computeSignature();
     }
 
     /**
@@ -132,6 +141,11 @@ public final class LocationSignature {
      * string.
      */
     public String signature() {
+        return signature;
+    }
+
+    /** Computes the canonical signature string; called once from the constructor. */
+    private String computeSignature() {
         List<String> parts = new ArrayList<>();
         // Iterate the enum (not the set) so ordering is always the declaration order
         // regardless of how the caller built their EnumSet.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationStationCacheEntry.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationStationCacheEntry.java
@@ -1,0 +1,40 @@
+package com.k1af.ft8af.log;
+
+import java.util.Objects;
+
+/**
+ * One persisted {@code signature -> station_profile_id} mapping row for the
+ * per-location Wavelog station cache (issue #437). Plain immutable value type; the
+ * SQLite-backed DAO lives in {@code DatabaseOpr}.
+ */
+public final class LocationStationCacheEntry {
+    /** The canonical {@link LocationSignature#signature()} string (the dedup key). */
+    public final String signature;
+    /** The Wavelog {@code station_profile_id} that covers this location. */
+    public final String stationProfileId;
+
+    public LocationStationCacheEntry(String signature, String stationProfileId) {
+        this.signature = signature;
+        this.stationProfileId = stationProfileId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LocationStationCacheEntry)) return false;
+        LocationStationCacheEntry that = (LocationStationCacheEntry) o;
+        return Objects.equals(signature, that.signature)
+                && Objects.equals(stationProfileId, that.stationProfileId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(signature, stationProfileId);
+    }
+
+    @Override
+    public String toString() {
+        return "LocationStationCacheEntry{signature=" + signature
+                + ", stationProfileId=" + stationProfileId + "}";
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationStationResolver.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/LocationStationResolver.java
@@ -1,0 +1,100 @@
+package com.k1af.ft8af.log;
+
+import com.k1af.ft8af.log.ThirdPartyService.StationProfile;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pure find-or-create decision logic for the per-location Wavelog station feature
+ * (issue #437). Given a target {@link LocationSignature} (as its canonical
+ * string), a persisted {@code signature -> station_profile_id} cache, and the
+ * list of station profiles that currently exist on the server, it decides whether
+ * an existing profile already covers this location (return its id) or a new one
+ * must be created.
+ *
+ * <p>Matching is by the exact canonical signature string, which is the dedup
+ * contract: how coarse or fine "the same location" is (grid-only vs.
+ * grid+county+city+…) is governed entirely by which {@link LocationSignature.Field}s
+ * the signature was built with, not by this resolver. That keeps this class a
+ * trivially testable pure function.
+ *
+ * <p>The cached id is validated against {@code existingProfiles}: a cache entry
+ * whose profile no longer exists on the server (deleted station, restored from a
+ * stale backup, wrong server) is treated as a miss so the caller recreates it
+ * rather than logging against a dangling id.
+ *
+ * <p><b>Dark feature.</b> No live code calls this yet.
+ */
+public final class LocationStationResolver {
+
+    private LocationStationResolver() {
+    }
+
+    /** Outcome of {@link #resolve}. Exactly one of the two states holds. */
+    public static final class Resolution {
+        /** The existing station_profile_id to log against, or null when a create is needed. */
+        public final String stationId;
+        /** True when no existing profile matched and a new station must be created. */
+        public final boolean needsCreate;
+
+        private Resolution(String stationId, boolean needsCreate) {
+            this.stationId = stationId;
+            this.needsCreate = needsCreate;
+        }
+
+        static Resolution matched(String stationId) {
+            return new Resolution(stationId, false);
+        }
+
+        static Resolution create() {
+            return new Resolution(null, true);
+        }
+
+        @Override
+        public String toString() {
+            return needsCreate ? "Resolution{needsCreate}" : "Resolution{stationId=" + stationId + "}";
+        }
+    }
+
+    /**
+     * Decide whether {@code signature} maps to an existing station profile.
+     *
+     * @param signature       canonical signature string (from {@link LocationSignature#signature()});
+     *                        null is treated as the empty signature.
+     * @param signatureCache  persisted {@code signature -> station_profile_id} map; null == empty.
+     * @param existingProfiles station profiles currently on the server (from
+     *                        {@link ThirdPartyService#FetchCloudlogStations}); null == empty.
+     * @return a {@link Resolution}: an existing id when the cache maps this signature to a
+     *         profile that still exists on the server, otherwise a needs-create result.
+     */
+    public static Resolution resolve(String signature,
+                                     Map<String, String> signatureCache,
+                                     List<StationProfile> existingProfiles) {
+        String key = signature == null ? "" : signature;
+        if (signatureCache == null) {
+            return Resolution.create();
+        }
+        String cachedId = signatureCache.get(key);
+        if (cachedId == null || cachedId.isEmpty()) {
+            return Resolution.create();
+        }
+        if (profileExists(cachedId, existingProfiles)) {
+            return Resolution.matched(cachedId);
+        }
+        // Cache points at a profile the server no longer has — recreate.
+        return Resolution.create();
+    }
+
+    private static boolean profileExists(String stationId, List<StationProfile> profiles) {
+        if (profiles == null) {
+            return false;
+        }
+        for (StationProfile p : profiles) {
+            if (p != null && stationId.equals(p.stationId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -126,6 +126,12 @@ public class ThirdPartyService {
         try {
             String body = buildCreateStationRequestJson(
                     gridsquare, callsign, city, dxcc, linkActiveLogbook);
+            if (body == null) {
+                // Fail fast: never POST an empty/malformed body, which could create a
+                // blank station profile on the server.
+                Log.d(TAG, "createCloudlogStation aborted: could not build request body");
+                return null;
+            }
             String url = address + "api/create_station/" + apiKey;
             String result = sendPostRequest(url, body);
             String id = parseCreateStationResponse(result);
@@ -144,6 +150,9 @@ public class ThirdPartyService {
      * <p>Field set is provisional (see {@link #createCloudlogStation}). Null field
      * values are emitted as empty strings; {@code link_active_logbook} is emitted as
      * {@code "1"}/{@code "0"} (Wavelog treats the API booleans as string flags).
+     *
+     * <p>Returns {@code null} if the body cannot be built, so the caller can fail fast
+     * rather than POST an empty/malformed body that might create a blank station.
      */
     static String buildCreateStationRequestJson(String gridsquare, String callsign,
                                                 String city, String dxcc,
@@ -160,7 +169,7 @@ public class ThirdPartyService {
                     .toString();
         } catch (Exception e) {
             Log.d(TAG, "buildCreateStationRequestJson error: " + e.getClass().getSimpleName());
-            return "{}";
+            return null;
         }
     }
 
@@ -630,6 +639,20 @@ public class ThirdPartyService {
         }
     }
 
+    /**
+     * Redacts a Cloudlog/Wavelog API key from a URL before it is logged. The key is a
+     * path segment following {@code create_station/}, {@code station_info/}, or
+     * {@code auth/}; this replaces that segment with {@code ***} so the credential never
+     * reaches logcat. Only the LOGGED string is redacted — the real request URL is
+     * unchanged. Returns null unchanged.
+     */
+    static String redactUrlApiKey(String url) {
+        if (url == null) {
+            return null;
+        }
+        return url.replaceAll("(create_station/|station_info/|auth/)[^/?#\\s]+", "$1***");
+    }
+
     public static String sendPostRequest(String url, String json) throws IOException {
         // HttpURLConnection does not auto-follow 30x on a POST. Walk redirects manually
         // (capped) so deployments that rewrite trailing slashes, http→https, or move
@@ -668,14 +691,14 @@ public class ThirdPartyService {
                         || responseCode == 308) {
                     String loc = conn.getHeaderField("Location");
                     if (loc == null || loc.isEmpty()) {
-                        Log.d(TAG, "POST " + currentUrl + " -> HTTP " + responseCode
-                                + " (no Location header)");
+                        Log.d(TAG, "POST " + redactUrlApiKey(currentUrl) + " -> HTTP "
+                                + responseCode + " (no Location header)");
                         return null;
                     }
                     // Resolve relative redirect against the previous URL.
                     URL resolved = new URL(urlObj, loc);
-                    Log.d(TAG, "POST " + currentUrl + " -> HTTP " + responseCode
-                            + " redirect to " + resolved);
+                    Log.d(TAG, "POST " + redactUrlApiKey(currentUrl) + " -> HTTP " + responseCode
+                            + " redirect to " + redactUrlApiKey(resolved.toString()));
                     currentUrl = resolved.toString();
                     continue;
                 }
@@ -695,7 +718,7 @@ public class ThirdPartyService {
                         eread.close();
                     }
                 } catch (Exception ignored) {}
-                Log.d(TAG, "POST " + currentUrl + " -> HTTP " + responseCode
+                Log.d(TAG, "POST " + redactUrlApiKey(currentUrl) + " -> HTTP " + responseCode
                         + (err.length() > 0 ? " body=" + err : ""));
                 return null;
             } finally {
@@ -707,7 +730,7 @@ public class ThirdPartyService {
                 }
             }
         }
-        Log.d(TAG, "POST " + url + " exceeded redirect limit");
+        Log.d(TAG, "POST " + redactUrlApiKey(url) + " exceeded redirect limit");
         return null;
     }
     public static String sendPostFormRequest(String url, String formBody) throws IOException {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -95,6 +95,124 @@ public class ThirdPartyService {
         return stations;
     }
 
+    /**
+     * Creates a new station profile ("station location") on a Wavelog server and
+     * returns its {@code station_profile_id}, or null on failure. Mirrors
+     * {@link #FetchCloudlogStations}: the API key is a path segment
+     * ({@code POST api/create_station/[key]}) and the station fields are the JSON body.
+     *
+     * <p><b>Provisional wire shape.</b> We could not verify the exact live
+     * request/response against a running server, so the request-building and
+     * response-parsing are isolated into the pure, unit-tested helpers
+     * {@link #buildCreateStationRequestJson} and {@link #parseCreateStationResponse}.
+     * The field names ({@code station_gridsquare, station_callsign, station_city,
+     * station_dxcc, link_active_logbook}) and endpoint follow the Wavelog API docs
+     * and must be confirmed against a live Wavelog &ge; 2.1.2 server before this is
+     * wired into any live path.
+     *
+     * <p><b>Not yet called from any live path</b> — foundation only for issue #437,
+     * gated by {@code GeneralVariables.perLocationStationEnabled} (default false).
+     */
+    public static String createCloudlogStation(String address, String apiKey,
+                                               String gridsquare, String callsign,
+                                               String city, String dxcc,
+                                               boolean linkActiveLogbook) {
+        if (address == null || address.isEmpty() || apiKey == null || apiKey.isEmpty()) {
+            return null;
+        }
+        if (!address.endsWith("/")) {
+            address += "/";
+        }
+        try {
+            String body = buildCreateStationRequestJson(
+                    gridsquare, callsign, city, dxcc, linkActiveLogbook);
+            String url = address + "api/create_station/" + apiKey;
+            String result = sendPostRequest(url, body);
+            String id = parseCreateStationResponse(result);
+            Log.d(TAG, "createCloudlogStation " + (id != null ? "created id" : "failed/no id"));
+            return id;
+        } catch (Exception e) {
+            Log.d(TAG, "createCloudlogStation error: " + e.getClass().getSimpleName());
+            return null;
+        }
+    }
+
+    /**
+     * Builds the JSON request body for {@link #createCloudlogStation}. Pure and
+     * network-free so it can be unit-tested against captured/example payloads.
+     *
+     * <p>Field set is provisional (see {@link #createCloudlogStation}). Null field
+     * values are emitted as empty strings; {@code link_active_logbook} is emitted as
+     * {@code "1"}/{@code "0"} (Wavelog treats the API booleans as string flags).
+     */
+    static String buildCreateStationRequestJson(String gridsquare, String callsign,
+                                                String city, String dxcc,
+                                                boolean linkActiveLogbook) {
+        JSONStringer js = new JSONStringer();
+        try {
+            return js.object()
+                    .key("station_gridsquare").value(nullToEmpty(gridsquare))
+                    .key("station_callsign").value(nullToEmpty(callsign))
+                    .key("station_city").value(nullToEmpty(city))
+                    .key("station_dxcc").value(nullToEmpty(dxcc))
+                    .key("link_active_logbook").value(linkActiveLogbook ? "1" : "0")
+                    .endObject()
+                    .toString();
+        } catch (Exception e) {
+            Log.d(TAG, "buildCreateStationRequestJson error: " + e.getClass().getSimpleName());
+            return "{}";
+        }
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    /**
+     * Extracts the newly-created {@code station_profile_id} from a create_station
+     * response, or null if the response is null/empty/unparseable or carries no id.
+     * Pure and network-free for unit testing.
+     *
+     * <p><b>Provisional.</b> The exact response envelope is unconfirmed, so this
+     * probes the id under several plausible keys — top-level {@code station_profile_id}
+     * / {@code station_id} / {@code id}, and the same keys nested under a {@code data}
+     * or {@code station} object — and returns the first non-empty one found.
+     */
+    static String parseCreateStationResponse(String json) {
+        if (json == null || json.isEmpty()) {
+            return null;
+        }
+        try {
+            JSONObject obj = new JSONObject(json);
+            String top = idFromObject(obj);
+            if (top != null) {
+                return top;
+            }
+            for (String nestKey : new String[]{"data", "station", "result"}) {
+                JSONObject nested = obj.optJSONObject(nestKey);
+                if (nested != null) {
+                    String id = idFromObject(nested);
+                    if (id != null) {
+                        return id;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.d(TAG, "parseCreateStationResponse error: " + e.getClass().getSimpleName());
+        }
+        return null;
+    }
+
+    private static String idFromObject(JSONObject obj) {
+        for (String key : new String[]{"station_profile_id", "station_id", "id"}) {
+            String v = obj.optString(key, "");
+            if (v != null && !v.isEmpty()) {
+                return v;
+            }
+        }
+        return null;
+    }
+
     private static String QSLRecordToADIF(QSLRecord qslRecord, ServiceType serv){
         StringBuilder logStr = new StringBuilder();
         logStr.append(AdifFormat.callField(qslRecord.getToCallsign()));

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesPerLocationFlagTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesPerLocationFlagTest.java
@@ -1,0 +1,22 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards the dark-launch invariant for the per-location Wavelog station feature
+ * (issue #437): the {@code perLocationStationEnabled} flag must default to false so
+ * this increment ships fully disabled and cannot alter live QSO upload behavior.
+ * Robolectric because {@link GeneralVariables} carries Android LiveData statics.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesPerLocationFlagTest {
+
+    @Test
+    public void perLocationStationEnabled_defaultsFalse() {
+        assertThat(GeneralVariables.perLocationStationEnabled).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprLocationStationCacheTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprLocationStationCacheTest.java
@@ -1,0 +1,89 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.k1af.ft8af.log.LocationStationCacheEntry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.List;
+
+/**
+ * Round-trip tests for the per-location Wavelog station cache DAO (issue #437):
+ * {@code putStationForSignature} / {@code getStationForSignature} /
+ * {@code getAllStationSignatures} / {@code clearLocationStationCache}. Uses a
+ * Robolectric in-memory database (name=null) so no on-disk state is touched.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseOprLocationStationCacheTest {
+
+    private DatabaseOpr opr;
+
+    @Before
+    public void setUp() {
+        opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 19);
+    }
+
+    @After
+    public void tearDown() {
+        opr.close();
+    }
+
+    @Test
+    public void putThenGet_roundTrips() {
+        opr.putStationForSignature("GRID=FN42", "7");
+        assertThat(opr.getStationForSignature("GRID=FN42")).isEqualTo("7");
+    }
+
+    @Test
+    public void get_returnsNullForUnknownSignature() {
+        assertThat(opr.getStationForSignature("GRID=EN61")).isNull();
+    }
+
+    @Test
+    public void put_upsertsExistingSignatureInsteadOfDuplicating() {
+        opr.putStationForSignature("GRID=FN42", "7");
+        opr.putStationForSignature("GRID=FN42", "8");
+        assertThat(opr.getStationForSignature("GRID=FN42")).isEqualTo("8");
+        assertThat(opr.getAllStationSignatures()).hasSize(1);
+    }
+
+    @Test
+    public void getAll_returnsAllEntriesSortedBySignature() {
+        opr.putStationForSignature("GRID=ZZ99", "3");
+        opr.putStationForSignature("GRID=AA00", "1");
+        List<LocationStationCacheEntry> all = opr.getAllStationSignatures();
+        assertThat(all).hasSize(2);
+        assertThat(all.get(0).signature).isEqualTo("GRID=AA00");
+        assertThat(all.get(0).stationProfileId).isEqualTo("1");
+        assertThat(all.get(1).signature).isEqualTo("GRID=ZZ99");
+    }
+
+    @Test
+    public void clear_removesEverything() {
+        opr.putStationForSignature("GRID=FN42", "7");
+        opr.clearLocationStationCache();
+        assertThat(opr.getStationForSignature("GRID=FN42")).isNull();
+        assertThat(opr.getAllStationSignatures()).isEmpty();
+    }
+
+    @Test
+    public void put_ignoresNullArguments() {
+        opr.putStationForSignature(null, "7");
+        opr.putStationForSignature("GRID=FN42", null);
+        assertThat(opr.getAllStationSignatures()).isEmpty();
+    }
+
+    @Test
+    public void emptySignatureKey_roundTrips() {
+        // The all-disabled/no-POTA signature is the empty string; it must still persist.
+        opr.putStationForSignature("", "5");
+        assertThat(opr.getStationForSignature("")).isEqualTo("5");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/LocationSignatureTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/LocationSignatureTest.java
@@ -1,0 +1,153 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.EnumSet;
+
+/**
+ * Pure unit tests for {@link LocationSignature}: canonical signature computation,
+ * field-subset control, POTA handling, normalization stability, and equality.
+ * No Android types, so a bare JUnit runner suffices.
+ */
+public class LocationSignatureTest {
+
+    private LocationSignature.Builder full() {
+        return LocationSignature.builder()
+                .gridsquare("FN42")
+                .state("NY")
+                .dxcc("291")
+                .county("Albany")
+                .city("Albany")
+                .cqZone("5")
+                .ituZone("8");
+    }
+
+    @Test
+    public void signature_allFields_fixedOrderAndTokens() {
+        assertThat(full().build().signature())
+                .isEqualTo("GRID=FN42|STATE=NY|DXCC=291|COUNTY=ALBANY|CITY=ALBANY|CQZ=5|ITUZ=8");
+    }
+
+    @Test
+    public void signature_onlyEnabledFieldsParticipate() {
+        String sig = full()
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .build()
+                .signature();
+        assertThat(sig).isEqualTo("GRID=FN42");
+    }
+
+    @Test
+    public void signature_emptyWhenNoFieldsEnabledAndNoPota() {
+        assertThat(full().enabledFields(EnumSet.noneOf(LocationSignature.Field.class))
+                .build().signature()).isEmpty();
+    }
+
+    @Test
+    public void signature_potaAlwaysAppendedEvenWithNoEnabledFields() {
+        String sig = full()
+                .enabledFields(EnumSet.noneOf(LocationSignature.Field.class))
+                .potaRef("k-1234")
+                .build()
+                .signature();
+        assertThat(sig).isEqualTo("POTA=K-1234");
+    }
+
+    @Test
+    public void signature_potaAppendedLast() {
+        String sig = LocationSignature.builder()
+                .gridsquare("FN42")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .potaRef("K-1234")
+                .build()
+                .signature();
+        assertThat(sig).isEqualTo("GRID=FN42|POTA=K-1234");
+    }
+
+    @Test
+    public void signature_skipsNullAndBlankFields() {
+        String sig = LocationSignature.builder()
+                .gridsquare("FN42")
+                .state(null)
+                .city("   ")
+                .county("")
+                .build()
+                .signature();
+        // Only grid survives; null/blank/whitespace-only are omitted.
+        assertThat(sig).isEqualTo("GRID=FN42");
+    }
+
+    @Test
+    public void normalization_upperCasesTrimsAndCollapsesWhitespace() {
+        String sig = LocationSignature.builder()
+                .city("  new   york  ")
+                .enabledFields(EnumSet.of(LocationSignature.Field.CITY))
+                .build()
+                .signature();
+        assertThat(sig).isEqualTo("CITY=NEW YORK");
+    }
+
+    @Test
+    public void sameLocation_differentCasingAndSpacing_yieldsIdenticalSignature() {
+        LocationSignature a = LocationSignature.builder()
+                .gridsquare("fn42").city("albany")
+                .enabledFields(EnumSet.of(
+                        LocationSignature.Field.GRIDSQUARE, LocationSignature.Field.CITY))
+                .build();
+        LocationSignature b = LocationSignature.builder()
+                .gridsquare(" FN42 ").city(" Albany ")
+                .enabledFields(EnumSet.of(
+                        LocationSignature.Field.GRIDSQUARE, LocationSignature.Field.CITY))
+                .build();
+        assertThat(a.signature()).isEqualTo(b.signature());
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    public void equality_definedBySignatureNotByDisabledFields() {
+        // Different county values but county disabled in both -> same signature -> equal.
+        LocationSignature a = LocationSignature.builder()
+                .gridsquare("FN42").county("Albany")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .build();
+        LocationSignature b = LocationSignature.builder()
+                .gridsquare("FN42").county("Rensselaer")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .build();
+        assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    public void differentPota_producesDifferentSignatures() {
+        LocationSignature a = LocationSignature.builder()
+                .gridsquare("FN42")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .potaRef("K-1234").build();
+        LocationSignature b = LocationSignature.builder()
+                .gridsquare("FN42")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .potaRef("K-5678").build();
+        assertThat(a.signature()).isNotEqualTo(b.signature());
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    public void builderEnabledSet_isDefensivelyCopied() {
+        EnumSet<LocationSignature.Field> fields =
+                EnumSet.of(LocationSignature.Field.GRIDSQUARE);
+        LocationSignature sig = full().enabledFields(fields).build();
+        // Mutating the caller's set after build must not change the signature.
+        fields.add(LocationSignature.Field.STATE);
+        assertThat(sig.signature()).isEqualTo("GRID=FN42");
+    }
+
+    @Test
+    public void normalize_helper_handlesNullBlankAndValue() {
+        assertThat(LocationSignature.normalize(null)).isNull();
+        assertThat(LocationSignature.normalize("   ")).isNull();
+        assertThat(LocationSignature.normalize(" ab  cd ")).isEqualTo("AB CD");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/LocationStationResolverTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/LocationStationResolverTest.java
@@ -1,0 +1,141 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.log.ThirdPartyService.StationProfile;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pure unit tests for {@link LocationStationResolver#resolve}: the find-or-create
+ * decision for the per-location Wavelog station feature (issue #437). No Android
+ * types, so a bare JUnit runner suffices.
+ */
+public class LocationStationResolverTest {
+
+    private static StationProfile profile(String id) {
+        return new StationProfile(id, "Home", "K1AF", "FN42");
+    }
+
+    private static List<StationProfile> profiles(String... ids) {
+        List<StationProfile> list = new ArrayList<>();
+        for (String id : ids) {
+            list.add(profile(id));
+        }
+        return list;
+    }
+
+    @Test
+    public void matchFound_whenCacheHitAndProfileExists() {
+        Map<String, String> cache = new HashMap<>();
+        cache.put("GRID=FN42", "7");
+        LocationStationResolver.Resolution r =
+                LocationStationResolver.resolve("GRID=FN42", cache, profiles("7", "8"));
+        assertThat(r.needsCreate).isFalse();
+        assertThat(r.stationId).isEqualTo("7");
+    }
+
+    @Test
+    public void needsCreate_whenCacheMiss() {
+        Map<String, String> cache = new HashMap<>();
+        cache.put("GRID=EN61", "3");
+        LocationStationResolver.Resolution r =
+                LocationStationResolver.resolve("GRID=FN42", cache, profiles("3"));
+        assertThat(r.needsCreate).isTrue();
+        assertThat(r.stationId).isNull();
+    }
+
+    @Test
+    public void needsCreate_whenCachedProfileNoLongerExistsOnServer() {
+        Map<String, String> cache = new HashMap<>();
+        cache.put("GRID=FN42", "99");
+        // Server only has 1 and 2 — cached id 99 is stale.
+        LocationStationResolver.Resolution r =
+                LocationStationResolver.resolve("GRID=FN42", cache, profiles("1", "2"));
+        assertThat(r.needsCreate).isTrue();
+    }
+
+    @Test
+    public void needsCreate_whenCacheNull() {
+        LocationStationResolver.Resolution r =
+                LocationStationResolver.resolve("GRID=FN42", null, profiles("1"));
+        assertThat(r.needsCreate).isTrue();
+    }
+
+    @Test
+    public void needsCreate_whenExistingProfilesNull() {
+        Map<String, String> cache = new HashMap<>();
+        cache.put("GRID=FN42", "1");
+        LocationStationResolver.Resolution r =
+                LocationStationResolver.resolve("GRID=FN42", cache, null);
+        assertThat(r.needsCreate).isTrue();
+    }
+
+    @Test
+    public void nullSignature_treatedAsEmptyKey() {
+        Map<String, String> cache = new HashMap<>();
+        cache.put("", "5");
+        LocationStationResolver.Resolution r =
+                LocationStationResolver.resolve(null, cache, profiles("5"));
+        assertThat(r.needsCreate).isFalse();
+        assertThat(r.stationId).isEqualTo("5");
+    }
+
+    @Test
+    public void potaRefDifference_resolvesIndependently() {
+        // Two POTA-bearing signatures for the same grid: only one is cached.
+        String sigA = LocationSignature.builder()
+                .gridsquare("FN42")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .potaRef("K-1234").build().signature();
+        String sigB = LocationSignature.builder()
+                .gridsquare("FN42")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .potaRef("K-5678").build().signature();
+
+        Map<String, String> cache = new HashMap<>();
+        cache.put(sigA, "10");
+        List<StationProfile> existing = profiles("10");
+
+        assertThat(LocationStationResolver.resolve(sigA, cache, existing).stationId)
+                .isEqualTo("10");
+        // Same grid, different park -> not the cached one -> needs create.
+        assertThat(LocationStationResolver.resolve(sigB, cache, existing).needsCreate)
+                .isTrue();
+    }
+
+    @Test
+    public void fieldSubset_collapsesTwoLocationsToSameCacheHit() {
+        // Grid-only granularity: two cities in the same grid share a signature and
+        // therefore the same cached station profile.
+        String sigCityA = LocationSignature.builder()
+                .gridsquare("FN42").city("Albany")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .build().signature();
+        String sigCityB = LocationSignature.builder()
+                .gridsquare("FN42").city("Troy")
+                .enabledFields(EnumSet.of(LocationSignature.Field.GRIDSQUARE))
+                .build().signature();
+        assertThat(sigCityA).isEqualTo(sigCityB);
+
+        Map<String, String> cache = new HashMap<>();
+        cache.put(sigCityA, "42");
+        assertThat(LocationStationResolver.resolve(sigCityB, cache, profiles("42")).stationId)
+                .isEqualTo("42");
+    }
+
+    @Test
+    public void emptyCachedId_treatedAsMiss() {
+        Map<String, String> cache = new HashMap<>();
+        cache.put("GRID=FN42", "");
+        LocationStationResolver.Resolution r =
+                LocationStationResolver.resolve("GRID=FN42", cache, profiles("1"));
+        assertThat(r.needsCreate).isTrue();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCreateStationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCreateStationTest.java
@@ -1,0 +1,91 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Tests for the pure JSON helpers behind {@link ThirdPartyService#createCloudlogStation}:
+ * {@link ThirdPartyService#buildCreateStationRequestJson} and
+ * {@link ThirdPartyService#parseCreateStationResponse}. These touch {@code org.json},
+ * which is an Android framework type stubbed on the plain JVM, so the test runs under
+ * Robolectric for a real JSON implementation. No network is exercised.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ThirdPartyServiceCreateStationTest {
+
+    @Test
+    public void buildRequest_emitsExpectedFields() throws Exception {
+        String json = ThirdPartyService.buildCreateStationRequestJson(
+                "FN42", "K1AF", "Albany", "291", true);
+        JSONObject obj = new JSONObject(json);
+        assertThat(obj.getString("station_gridsquare")).isEqualTo("FN42");
+        assertThat(obj.getString("station_callsign")).isEqualTo("K1AF");
+        assertThat(obj.getString("station_city")).isEqualTo("Albany");
+        assertThat(obj.getString("station_dxcc")).isEqualTo("291");
+        assertThat(obj.getString("link_active_logbook")).isEqualTo("1");
+    }
+
+    @Test
+    public void buildRequest_linkFalseEmitsZeroAndNullsBecomeEmpty() throws Exception {
+        String json = ThirdPartyService.buildCreateStationRequestJson(
+                null, "K1AF", null, "291", false);
+        JSONObject obj = new JSONObject(json);
+        assertThat(obj.getString("station_gridsquare")).isEmpty();
+        assertThat(obj.getString("station_city")).isEmpty();
+        assertThat(obj.getString("link_active_logbook")).isEqualTo("0");
+    }
+
+    @Test
+    public void parseResponse_topLevelStationProfileId() {
+        assertThat(ThirdPartyService.parseCreateStationResponse(
+                "{\"station_profile_id\":\"12\"}")).isEqualTo("12");
+    }
+
+    @Test
+    public void parseResponse_fallsBackToStationIdThenId() {
+        assertThat(ThirdPartyService.parseCreateStationResponse(
+                "{\"station_id\":\"7\"}")).isEqualTo("7");
+        assertThat(ThirdPartyService.parseCreateStationResponse(
+                "{\"id\":\"9\"}")).isEqualTo("9");
+    }
+
+    @Test
+    public void parseResponse_numericIdIsStringified() {
+        // Some servers return the id as a JSON number, not a string.
+        assertThat(ThirdPartyService.parseCreateStationResponse(
+                "{\"station_profile_id\":15}")).isEqualTo("15");
+    }
+
+    @Test
+    public void parseResponse_nestedUnderData() {
+        assertThat(ThirdPartyService.parseCreateStationResponse(
+                "{\"status\":\"created\",\"data\":{\"station_profile_id\":\"3\"}}"))
+                .isEqualTo("3");
+    }
+
+    @Test
+    public void parseResponse_returnsNullWhenNoId() {
+        assertThat(ThirdPartyService.parseCreateStationResponse(
+                "{\"status\":\"error\",\"reason\":\"bad key\"}")).isNull();
+    }
+
+    @Test
+    public void parseResponse_returnsNullForNullEmptyOrGarbage() {
+        assertThat(ThirdPartyService.parseCreateStationResponse(null)).isNull();
+        assertThat(ThirdPartyService.parseCreateStationResponse("")).isNull();
+        assertThat(ThirdPartyService.parseCreateStationResponse("not json")).isNull();
+    }
+
+    @Test
+    public void createCloudlogStation_returnsNullOnMissingCredentials() {
+        // No network reached: blank address/key short-circuits to null.
+        assertThat(ThirdPartyService.createCloudlogStation(
+                "", "key", "FN42", "K1AF", "Albany", "291", true)).isNull();
+        assertThat(ThirdPartyService.createCloudlogStation(
+                "https://example.org/", "", "FN42", "K1AF", "Albany", "291", true)).isNull();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCreateStationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCreateStationTest.java
@@ -88,4 +88,49 @@ public class ThirdPartyServiceCreateStationTest {
         assertThat(ThirdPartyService.createCloudlogStation(
                 "https://example.org/", "", "FN42", "K1AF", "Albany", "291", true)).isNull();
     }
+
+    @Test
+    public void buildRequest_returnsParseableObjectNotEmptySentinel() throws Exception {
+        // Fail-fast contract: a valid build must yield a real object, never a "{}" or
+        // null sentinel that the caller would blindly POST.
+        String json = ThirdPartyService.buildCreateStationRequestJson(
+                "FN42", "K1AF", "Albany", "291", true);
+        assertThat(json).isNotNull();
+        assertThat(json).isNotEqualTo("{}");
+        assertThat(new JSONObject(json).length()).isGreaterThan(0);
+    }
+
+    @Test
+    public void redactUrlApiKey_hidesCreateStationKey() {
+        String key = "s3cr3t-api-key-value";
+        String url = "https://example.org/api/create_station/" + key;
+        String redacted = ThirdPartyService.redactUrlApiKey(url);
+        assertThat(redacted).doesNotContain(key);
+        assertThat(redacted).isEqualTo("https://example.org/api/create_station/***");
+    }
+
+    @Test
+    public void redactUrlApiKey_hidesStationInfoAndAuthKeys() {
+        String key = "ABC123DEF456";
+        assertThat(ThirdPartyService.redactUrlApiKey(
+                "https://example.org/api/station_info/" + key))
+                .doesNotContain(key);
+        assertThat(ThirdPartyService.redactUrlApiKey(
+                "https://example.org/api/auth/" + key))
+                .doesNotContain(key);
+    }
+
+    @Test
+    public void redactUrlApiKey_keepsTrailingPathAndQueryButHidesKey() {
+        String key = "topsecret";
+        String redacted = ThirdPartyService.redactUrlApiKey(
+                "https://example.org/api/create_station/" + key + "?x=1");
+        assertThat(redacted).doesNotContain(key);
+        assertThat(redacted).isEqualTo("https://example.org/api/create_station/***?x=1");
+    }
+
+    @Test
+    public void redactUrlApiKey_nullPassesThrough() {
+        assertThat(ThirdPartyService.redactUrlApiKey(null)).isNull();
+    }
 }


### PR DESCRIPTION
Part of #437.

This is **increment 1 of ~5** toward auto-creating/selecting a Wavelog station location per unique GPS location. It delivers only the **dark, pure foundation** — it changes **NO live upload behavior**. The feature is gated by a new default-false flag and nothing in the live `uploadAdifToCloudlog` path consults any of the new code, so this is safe to merge with zero behavioral risk.

## What's in this PR
- **`LocationSignature`** (pure, no Android deps): holds the user-selectable location fields (gridsquare, state, DXCC, county, city, CQ zone, ITU zone) plus an optional POTA reference, with a configurable `EnumSet<Field>` of which fields participate. Computes a stable, normalized (uppercase/trim/whitespace-collapse/fixed field order) canonical **signature string** — the dedup key. The same physical location always yields the same string.
- **`ThirdPartyService.createCloudlogStation(...)`** mirroring `FetchCloudlogStations` (`POST api/create_station/[key]`), with the request-building and response-parsing isolated into pure, unit-tested static helpers `buildCreateStationRequestJson(...)` and `parseCreateStationResponse(...)`. **The wire shape is provisional** (fields `station_gridsquare, station_callsign, station_city, station_dxcc, link_active_logbook`) and must be confirmed against a live Wavelog ≥ 2.1.2 server. **Not called from any live path.**
- **`LocationStationResolver.resolve(...)`** (pure): find-or-create decision over the persisted signature cache and the existing `List<StationProfile>` — returns an existing `station_profile_id` on a cache hit whose profile still exists on the server, otherwise a needs-create result (stale cached ids are treated as misses).
- **Persistent signature→station_profile_id cache**: new `location_station_cache` SQLite table (DB version 18 → 19, created idempotently in both `onCreate` and `onUpgrade` like the POTA table) with a thin DAO (`putStationForSignature` / `getStationForSignature` / `getAllStationSignatures` / `clearLocationStationCache`) plus a small `LocationStationCacheEntry` model.
- **`GeneralVariables.perLocationStationEnabled`** flag, default **false**. Not branched into any live upload code in this PR.

## Hard constraint honored
No change to existing QSO upload behavior — the flag is false, and no live path references the new code. A test asserts the flag defaults false.

## Tests (all new)
- `LocationSignatureTest` — field subsets, POTA ref (always appended, order), normalization stability, same-location equality, defensive copy of the enabled set.
- `LocationStationResolverTest` — match found, cache miss, stale-cache miss, null cache/profiles, POTA-ref differences, field-subset collapse, empty cached id.
- `ThirdPartyServiceCreateStationTest` (Robolectric, org.json) — request JSON field emission, `link_active_logbook` 1/0, null→empty, response parsing across top-level/nested/numeric id shapes, missing-id and garbage → null, missing-credential short-circuit.
- `DatabaseOprLocationStationCacheTest` (Robolectric) — put/get round-trip, upsert, sorted getAll, clear, null-arg no-op, empty-key key.
- `GeneralVariablesPerLocationFlagTest` (Robolectric) — flag default false.

Full unit-test suite green (1583 tests).

## Deferred to later increments
- GPS → location-field derivation (grid/DXCC/zones/county/city from a fix).
- Swapping the live upload path to resolve/create-and-select a station behind the flag.
- A "station defaults" template for newly created stations.
- Any UI (settings toggle, field-granularity picker, cache management).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1egpdNWafvAksJCn1tMA
