### PR TITLE
Fix CAT chip falsely turning red after FT8 transmit

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -356,6 +356,9 @@ public class MainViewModel extends ViewModel {
     private Timer catLivenessTimer;
     private volatile long lastRigResponseMs = 0;
     private volatile boolean sawRigResponseSinceConnect = false;
+    // Transmit state observed on the previous tick, used to detect the TX->RX edge so we can
+    // re-arm lastRigResponseMs (which freezes during TX) before judging staleness.
+    private volatile boolean wasTransmittingLastTick = false;
 
     /** Record that the rig just demonstrably responded (called from onRigResponded). */
     private void markRigResponded() {
@@ -367,6 +370,7 @@ public class MainViewModel extends ViewModel {
         stopCatLivenessWatchdog();
         lastRigResponseMs = System.currentTimeMillis();
         sawRigResponseSinceConnect = false;
+        wasTransmittingLastTick = false;
         catLivenessTimer = new Timer("cat-liveness");
         catLivenessTimer.schedule(new TimerTask() {
             @Override
@@ -396,6 +400,13 @@ public class MainViewModel extends ViewModel {
             if (CatLiveness.shouldProbe(connected, transmitting) && baseRig != null) {
                 baseRig.readFreqFromRig();
             }
+            // Transmit freezes lastRigResponseMs (we don't probe while keyed). On the TX->RX
+            // edge, restart the quiet window from now so the just-sent probe has time to reply
+            // before we judge staleness — otherwise a >8s FT8 over falsely trips ERROR.
+            if (CatLiveness.shouldRearmAfterTx(wasTransmittingLastTick, transmitting)) {
+                lastRigResponseMs = System.currentTimeMillis();
+            }
+            wasTransmittingLastTick = transmitting;
             if (CatLiveness.isRigStale(connected, transmitting, sawRigResponseSinceConnect,
                     System.currentTimeMillis(), lastRigResponseMs, CatLiveness.DEFAULT_TIMEOUT_MS)) {
                 stopCatLivenessWatchdog();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -391,6 +391,9 @@ public class MainViewModel extends ViewModel {
     /** One watchdog tick: probe the rig, then declare it dead if it's gone quiet too long. */
     private void catLivenessTick() {
         try {
+            // Sample the wall clock once per tick so the re-arm and staleness check reason
+            // about the same instant — a clock change mid-tick can't skew the comparison.
+            long nowMs = System.currentTimeMillis();
             boolean connected = isRigConnected();
             boolean transmitting = ft8TransmitSignal != null && ft8TransmitSignal.isTransmitting();
             // Actively probe (a frequency read); the reply lands in onRigResponded ->
@@ -404,11 +407,11 @@ public class MainViewModel extends ViewModel {
             // edge, restart the quiet window from now so the just-sent probe has time to reply
             // before we judge staleness — otherwise a >8s FT8 over falsely trips ERROR.
             if (CatLiveness.shouldRearmAfterTx(wasTransmittingLastTick, transmitting)) {
-                lastRigResponseMs = System.currentTimeMillis();
+                lastRigResponseMs = nowMs;
             }
             wasTransmittingLastTick = transmitting;
             if (CatLiveness.isRigStale(connected, transmitting, sawRigResponseSinceConnect,
-                    System.currentTimeMillis(), lastRigResponseMs, CatLiveness.DEFAULT_TIMEOUT_MS)) {
+                    nowMs, lastRigResponseMs, CatLiveness.DEFAULT_TIMEOUT_MS)) {
                 stopCatLivenessWatchdog();
                 setCatConnectionState(CatConnectionState.ERROR);
                 ToastMessage.show(String.format(

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CatLiveness.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CatLiveness.java
@@ -19,6 +19,14 @@ package com.k1af.ft8af.rigs;
  *       reply, so a rig that never answers a frequency read (or a transport that doesn't
  *       support it) can't be falsely marked dead.</li>
  * </ul>
+ *
+ * <p>A third guard handles the transmit→receive edge (see {@link #shouldRearmAfterTx}). We
+ * don't probe during TX, so the last-response timestamp freezes for the whole transmit
+ * window. An FT8 over is 12.64&nbsp;s — longer than {@link #DEFAULT_TIMEOUT_MS} — so the very
+ * first tick after TX would otherwise judge the (pre-TX) timestamp as stale and flip the chip
+ * red even though the rig is perfectly responsive. On the TX→RX edge the caller re-arms the
+ * timestamp so the quiet timer restarts from the moment transmit ends, giving the freshly-sent
+ * probe time to get a reply.
  */
 public final class CatLiveness {
 
@@ -33,6 +41,24 @@ public final class CatLiveness {
      */
     public static boolean shouldProbe(boolean connected, boolean transmitting) {
         return connected && !transmitting;
+    }
+
+    /**
+     * Whether the last-response timestamp should be re-armed this tick because transmit just
+     * ended. True only on the falling edge (was transmitting last tick, not transmitting now).
+     *
+     * <p>Probing is suppressed during TX, so {@code lastResponseMs} is frozen for the whole
+     * over. FT8 transmits for 12.64&nbsp;s — longer than {@link #DEFAULT_TIMEOUT_MS} — so
+     * without this re-arm the first post-TX tick sees a &gt;8&nbsp;s-old timestamp and
+     * {@link #isRigStale} fires a false positive. Re-arming to "now" on the TX→RX edge restarts
+     * the quiet window from the end of transmit, so the probe sent this same tick has time to
+     * reply before any staleness judgement.
+     *
+     * @param wasTransmitting whether we were transmitting on the previous tick
+     * @param transmitting    whether we are transmitting now
+     */
+    public static boolean shouldRearmAfterTx(boolean wasTransmitting, boolean transmitting) {
+        return wasTransmitting && !transmitting;
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLivenessTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLivenessTest.java
@@ -21,6 +21,36 @@ public class CatLivenessTest {
         assertThat(CatLiveness.shouldProbe(false, true)).isFalse();
     }
 
+    // ---- shouldRearmAfterTx -------------------------------------------------
+
+    @Test
+    public void rearm_onlyOnTxToRxEdge() {
+        // Falling edge: was transmitting last tick, no longer transmitting -> re-arm.
+        assertThat(CatLiveness.shouldRearmAfterTx(true, false)).isTrue();
+        // Still transmitting -> nothing to re-arm yet.
+        assertThat(CatLiveness.shouldRearmAfterTx(true, true)).isFalse();
+        // Steady receive (never transmitting) -> no edge.
+        assertThat(CatLiveness.shouldRearmAfterTx(false, false)).isFalse();
+        // Rising edge (RX->TX) -> not our concern; only the falling edge re-arms.
+        assertThat(CatLiveness.shouldRearmAfterTx(false, true)).isFalse();
+    }
+
+    @Test
+    public void rearm_preventsFalseStaleAfterLongTransmit() {
+        // Reproduces the FT8 red-chip bug: an over is 12.64s, longer than the 8s timeout, so
+        // lastResponseMs is frozen ~13s in the past when TX ends. Without a re-arm the first
+        // post-TX tick would judge the rig stale...
+        long now = 100_000;
+        long frozenDuringTx = now - 13_000;
+        assertThat(CatLiveness.isRigStale(true, false, true, now, frozenDuringTx, TIMEOUT))
+                .isTrue();
+        // ...but on the TX->RX edge we re-arm the timestamp to "now", after which the same tick
+        // no longer sees the rig as stale.
+        assertThat(CatLiveness.shouldRearmAfterTx(true, false)).isTrue();
+        long rearmed = now; // re-arm sets lastResponseMs = now
+        assertThat(CatLiveness.isRigStale(true, false, true, now, rearmed, TIMEOUT)).isFalse();
+    }
+
     // ---- isRigStale ---------------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Problem

Several users reported the CAT status chip turns **red even when CAT is fully functional** — PTT keys, frequency sets, and reads all work, but the indicator is stuck red until a manual reconnect.

## Root cause

The liveness watchdog (`MainViewModel.catLivenessTick`, every 3s) flips the chip to `ERROR` if the rig has been quiet longer than `DEFAULT_TIMEOUT_MS = 8000` ms. During transmit, probing and the stale check are both suppressed, so `lastRigResponseMs` **freezes for the entire over**.

An **FT8 transmit is 12.64 s — longer than the 8 s timeout.** The instant TX ends, the next tick sends a fresh probe but *immediately* evaluates staleness against the pre-TX timestamp (~13 s old) → `> 8000` → sets `ERROR` and calls `stopCatLivenessWatchdog()`. The probe's reply lands a moment later but the watchdog has already stopped, and `ERROR` is sticky (`CatConnectionState.afterDisconnect` preserves it), so it never self-clears.

FT4 (~4.48 s TX) stays under 8 s, so this manifested specifically on FT8.

## Fix

Re-arm `lastRigResponseMs` on the **TX→RX edge** so the quiet window restarts from the end of transmit, giving the probe sent that same tick time to reply before any staleness judgement. Edge detection lives in a pure, testable `CatLiveness.shouldRearmAfterTx(wasTransmitting, transmitting)` predicate (returns true only on the falling edge), consistent with the existing `shouldProbe` / `isRigStale` decision-logic split.

## Tests

Added `rearm_onlyOnTxToRxEdge` and `rearm_preventsFalseStaleAfterLongTransmit` to `CatLivenessTest` (the latter reproduces the 13-s-frozen-timestamp scenario and asserts the re-arm clears it). Full `CatLivenessTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)