### PR TITLE
fix: About screen shows "FT8US" instead of "FT8AF"

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AboutSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AboutSettings.kt
@@ -88,7 +88,7 @@ fun AboutSettings(
             GlassCard(modifier = Modifier.fillMaxWidth()) {
                 Column {
                     SettingsRow(
-                        label = "FT8US",
+                        label = stringResource(R.string.app_name),
                         description = stringResource(
                             R.string.settings_build_date_format,
                             GeneralVariables.BUILD_DATE,

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/AboutAppNameTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/AboutAppNameTest.kt
@@ -1,0 +1,26 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import com.k1af.ft8af.R
+
+/**
+ * Guards the app-name label shown on the Settings > About screen.
+ *
+ * The original implementation had a hardcoded "FT8US" typo in AboutSettings.
+ * This test verifies that the string resource used for that label resolves to the
+ * correct app name "FT8AF", so a future accidental rename or resource-ID swap will
+ * be caught before it ships.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AboutAppNameTest {
+
+    @Test
+    fun appName_stringResource_resolves_to_FT8AF() {
+        val context = RuntimeEnvironment.getApplication()
+        assertThat(context.getString(R.string.app_name)).isEqualTo("FT8AF")
+    }
+}


### PR DESCRIPTION
The Settings → About screen displayed the hardcoded typo `"FT8US"` as the app name label instead of `"FT8AF"`.

## Changes

- **`AboutSettings.kt`** — replace hardcoded `"FT8US"` with `stringResource(R.string.app_name)` so the label stays in sync with the canonical app name.
- **`AboutAppNameTest.kt`** (new) — Robolectric regression test asserting `R.string.app_name` resolves to `"FT8AF"`, guarding against future resource renames or wrong ID references.

## Notes

Re-lands the change from #448 on a clean branch cut from `dev`. That PR was opened from a branch based on `main`, so it carried main’s entire merge history and showed 1067 files / merge conflicts against `dev`. Supersedes and closes #448.

Test passes locally (`testDebugUnitTest --tests …AboutAppNameTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)