### PR TITLE
Migrate off deprecated Compose Autofill API in AutofillModifier.kt

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/AutofillModifier.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/AutofillModifier.kt
@@ -1,23 +1,17 @@
 package radio.ks3ckc.ft8af.ui.components
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.AutofillNode
-import androidx.compose.ui.autofill.AutofillType
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalAutofill
-import androidx.compose.ui.platform.LocalAutofillTree
+import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.onAutofillText
+import androidx.compose.ui.semantics.semantics
 
 /**
  * The credential fields we advertise to the Android Autofill framework. Each role
- * maps to a standard [AutofillType] so password managers (1Password, Bitwarden,
+ * maps to a standard [ContentType] so password managers (1Password, Bitwarden,
  * Google Password Manager, …) can classify the field and offer fill / save.
  *
  * API-key / single-secret fields (QRZ Logbook, Cloudlog) are intentionally absent:
@@ -37,67 +31,45 @@ enum class CredentialFieldRole {
 
 /**
  * Pure mapping from a credential field's [role][CredentialFieldRole] to the
- * autofill hint(s) it should advertise. Extracted so the decision is unit-testable
- * without touching the experimental Compose autofill glue below.
- *
- * [AutofillType] carries an error-level experimental opt-in, so this — and any test
- * that inspects the result — must opt in; keeping the type inside this function (the
- * public [autofill] modifier takes a plain [CredentialFieldRole]) stops that opt-in
- * from spreading into every dialog call site.
+ * [ContentType] it should advertise. Extracted so the decision is unit-testable
+ * without touching the Compose autofill glue below.
  */
-@OptIn(ExperimentalComposeUiApi::class)
-internal fun credentialAutofillTypes(role: CredentialFieldRole): List<AutofillType> =
+internal fun credentialContentType(role: CredentialFieldRole): ContentType =
     when (role) {
-        CredentialFieldRole.USERNAME -> listOf(AutofillType.Username)
-        CredentialFieldRole.EMAIL -> listOf(AutofillType.EmailAddress)
-        CredentialFieldRole.PASSWORD -> listOf(AutofillType.Password)
+        CredentialFieldRole.USERNAME -> ContentType.Username
+        CredentialFieldRole.EMAIL -> ContentType.EmailAddress
+        CredentialFieldRole.PASSWORD -> ContentType.Password
     }
 
 /**
  * Attaches Android autofill metadata to a text field so the OS autofill service can
  * classify it and offer to fill / save credentials.
  *
- * On the current Compose toolchain (BOM 2024.02.00, Compose UI ~1.6) the autofill
- * API is experimental: we register an [AutofillNode] in [LocalAutofillTree], track
- * its on-screen bounds via [onGloballyPositioned], and request / cancel autofill as
- * the field gains / loses focus. Once the BOM is bumped to ~1.8+ (issue #440) this
- * can be replaced by the declarative `Modifier.semantics { contentType = … }`.
+ * On Compose UI 1.8+ (BOM 2025.04.01, issue #440) autofill is declarative: we tag the
+ * field's semantics with its [ContentType] so the framework classifies it, and register
+ * an [onAutofillText] handler that pushes any filled value into the field's existing
+ * state. This replaces the old imperative `AutofillNode` / `LocalAutofillTree` glue
+ * (which tracked on-screen bounds and requested / cancelled autofill on focus by hand).
  *
- * The node is [remember]ed (not recreated per recomposition) and a [DisposableEffect]
- * removes it from the tree when the field leaves composition, so recompositions don't
- * leak orphaned nodes into [LocalAutofillTree]. [onFill] is captured through
- * [rememberUpdatedState] so the stable node always invokes the latest lambda.
+ * [onFill] is captured through [rememberUpdatedState] so the stable semantics handler
+ * always invokes the latest lambda.
  *
- * @param role which credential this field holds; maps to the advertised hint(s) via
- *   [credentialAutofillTypes].
+ * @param role which credential this field holds; maps to the advertised [ContentType]
+ *   via [credentialContentType].
  * @param onFill invoked with the value the autofill service supplied; push it into
  *   the field's existing state exactly as `onValueChange` would.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun Modifier.autofill(
     role: CredentialFieldRole,
     onFill: (String) -> Unit,
 ): Modifier {
-    val autofill = LocalAutofill.current
-    val autofillTree = LocalAutofillTree.current
     val currentOnFill by rememberUpdatedState(onFill)
-    val node = remember(role) {
-        AutofillNode(
-            autofillTypes = credentialAutofillTypes(role),
-            onFill = { currentOnFill(it) },
-        )
-    }
-    DisposableEffect(autofillTree, node) {
-        autofillTree += node
-        onDispose { autofillTree.children.remove(node.id) }
-    }
-    return this
-        .onGloballyPositioned { node.boundingBox = it.boundsInWindow() }
-        .onFocusChanged { state ->
-            autofill?.run {
-                if (state.isFocused) requestAutofillForNode(node)
-                else cancelAutofillForNode(node)
-            }
+    return this.semantics {
+        contentType = credentialContentType(role)
+        onAutofillText { text ->
+            currentOnFill(text.text)
+            true
         }
+    }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/CredentialAutofillTypesTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/CredentialAutofillTypesTest.kt
@@ -1,54 +1,52 @@
 package radio.ks3ckc.ft8af.ui.settings
 
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.autofill.ContentType
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import radio.ks3ckc.ft8af.ui.components.CredentialFieldRole
-import radio.ks3ckc.ft8af.ui.components.credentialAutofillTypes
+import radio.ks3ckc.ft8af.ui.components.credentialContentType
 
 /**
- * Covers the field-role → autofill-hint mapping used by the QRZ, ICOM, and POTA
- * login dialogs (issue #439). The `Modifier.autofill` glue can't be unit-tested, so
- * the decision is extracted into `credentialAutofillTypes`, which is what's tested
- * here.
+ * Covers the field-role → autofill [ContentType] mapping used by the QRZ, ICOM, and
+ * POTA login dialogs (issue #439). The `Modifier.autofill` glue can't be unit-tested,
+ * so the decision is extracted into `credentialContentType`, which is what's tested
+ * here. Migrated to the semantics-based autofill API in issue #453.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 class CredentialAutofillTypesTest {
 
     @Test
-    fun username_role_advertises_username_only() {
-        assertThat(credentialAutofillTypes(CredentialFieldRole.USERNAME))
-            .containsExactly(AutofillType.Username)
+    fun username_role_advertises_username() {
+        assertThat(credentialContentType(CredentialFieldRole.USERNAME))
+            .isEqualTo(ContentType.Username)
     }
 
     @Test
-    fun email_role_advertises_email_address_only() {
+    fun email_role_advertises_email_address() {
         // POTA logs in with an email; EmailAddress lets managers offer the account.
-        assertThat(credentialAutofillTypes(CredentialFieldRole.EMAIL))
-            .containsExactly(AutofillType.EmailAddress)
+        assertThat(credentialContentType(CredentialFieldRole.EMAIL))
+            .isEqualTo(ContentType.EmailAddress)
     }
 
     @Test
-    fun password_role_advertises_password_only() {
-        assertThat(credentialAutofillTypes(CredentialFieldRole.PASSWORD))
-            .containsExactly(AutofillType.Password)
+    fun password_role_advertises_password() {
+        assertThat(credentialContentType(CredentialFieldRole.PASSWORD))
+            .isEqualTo(ContentType.Password)
     }
 
     @Test
-    fun username_role_never_advertises_email_address() {
+    fun username_role_is_not_email_address() {
         // QRZ usernames are callsigns, not emails — mislabeling would let a manager
         // fill an email address into the callsign field.
-        assertThat(credentialAutofillTypes(CredentialFieldRole.USERNAME))
-            .doesNotContain(AutofillType.EmailAddress)
+        assertThat(credentialContentType(CredentialFieldRole.USERNAME))
+            .isNotEqualTo(ContentType.EmailAddress)
     }
 
     @Test
-    fun every_role_maps_to_exactly_one_hint() {
+    fun every_role_maps_to_a_content_type() {
         // Each credential field advertises a single, unambiguous type so the autofill
         // service classifies it deterministically.
         for (role in CredentialFieldRole.entries) {
-            assertThat(credentialAutofillTypes(role)).hasSize(1)
+            assertThat(credentialContentType(role)).isNotNull()
         }
     }
 }


### PR DESCRIPTION
Closes #453.

Compose UI 1.8 (BOM `2025.04.01`, already on `dev`) deprecates the imperative `AutofillNode` / `AutofillType` / `LocalAutofill` / `LocalAutofillTree` API in favor of the semantics-based `androidx.compose.ui.autofill.ContentType` API.

### Changes
- **`AutofillModifier.kt`** — `Modifier.autofill` now tags the field's semantics with its `ContentType` (`semantics { contentType = … }`) for classification and receives filled values via `onAutofillText`, replacing the hand-rolled node registration, `onGloballyPositioned` bounds tracking, and focus-driven request/cancel bookkeeping.
- The pure role→type mapping `credentialAutofillTypes(): List<AutofillType>` becomes `credentialContentType(): ContentType`.
- **`CredentialAutofillTypesTest.kt`** updated to assert on `ContentType`.

### Verification
- `./gradlew testDebugUnitTest --tests …CredentialAutofillTypesTest` → **BUILD SUCCESSFUL**.
- `compileDebugKotlin` no longer emits any of the `AutofillModifier.kt` deprecation warnings listed in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)