### PR TITLE
Replace deprecated BluetoothAdapter.getDefaultAdapter()

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -38,6 +38,7 @@ import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
 import radio.ks3ckc.ft8af.sync.QsoAutoSync
+import radio.ks3ckc.ft8af.util.bluetoothAdapter
 import com.k1af.ft8af.service.RxForegroundService
 import com.k1af.ft8af.service.RxServiceController
 import com.k1af.ft8af.bluetooth.BluetoothStateBroadcastReceive
@@ -666,7 +667,7 @@ class ComposeMainActivity : AppCompatActivity() {
      * so it is unit-testable; this method only collects Android state and acts on CONNECT.
      */
     private fun autoConnectBluetoothIfNeeded() {
-        val adapter = BluetoothAdapter.getDefaultAdapter()
+        val adapter = bluetoothAdapter(this)
         val addr = GeneralVariables.bluetoothDeviceAddress
         // A corrupted/legacy persisted value would make getRemoteDevice() throw
         // IllegalArgumentException and crash startup, so validate the MAC up front (PR #227 review).

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/ConnectionDialogs.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/ConnectionDialogs.kt
@@ -1,7 +1,6 @@
 package radio.ks3ckc.ft8af.ui.settings
 
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -37,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -61,6 +61,7 @@ import com.k1af.ft8af.x6100.XieguRadioFactory
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.CredentialFieldRole
 import radio.ks3ckc.ft8af.ui.components.autofill
+import radio.ks3ckc.ft8af.util.bluetoothAdapter
 
 // ─────────────────────────────────────────────────────────────────────
 // Shared helpers
@@ -122,9 +123,10 @@ fun BluetoothPickerDialog(
     mainViewModel: MainViewModel,
     onDismiss: () -> Unit,
 ) {
-    val devices = remember {
+    val context = LocalContext.current
+    val devices = remember(context) {
         val list = mutableListOf<BtDeviceInfo>()
-        val adapter = BluetoothAdapter.getDefaultAdapter()
+        val adapter = bluetoothAdapter(context)
         if (adapter != null) {
             for (device in adapter.bondedDevices) {
                 val spp = BluetoothConstants.checkIsSpp(device)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/util/BluetoothAdapters.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/util/BluetoothAdapters.kt
@@ -7,7 +7,8 @@ import android.content.Context
 /**
  * Returns the device's [BluetoothAdapter], obtained via the [BluetoothManager] system
  * service. This is the non-deprecated replacement for `BluetoothAdapter.getDefaultAdapter()`,
- * which is deprecated on API 18+ (issue #454).
+ * which was deprecated in Android 12 (API 31); the [BluetoothManager] route has been the
+ * recommended way to obtain the adapter since API 18 (issue #454).
  *
  * Returns `null` on devices without Bluetooth — either the `BLUETOOTH_SERVICE` is absent
  * or the manager reports no adapter — mirroring the null contract of the old API so call

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/util/BluetoothAdapters.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/util/BluetoothAdapters.kt
@@ -1,0 +1,19 @@
+package radio.ks3ckc.ft8af.util
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.Context
+
+/**
+ * Returns the device's [BluetoothAdapter], obtained via the [BluetoothManager] system
+ * service. This is the non-deprecated replacement for `BluetoothAdapter.getDefaultAdapter()`,
+ * which is deprecated on API 18+ (issue #454).
+ *
+ * Returns `null` on devices without Bluetooth — either the `BLUETOOTH_SERVICE` is absent
+ * or the manager reports no adapter — mirroring the null contract of the old API so call
+ * sites keep their existing null handling.
+ */
+fun bluetoothAdapter(context: Context): BluetoothAdapter? {
+    val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    return manager?.adapter
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/util/BluetoothAdaptersTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/util/BluetoothAdaptersTest.kt
@@ -1,0 +1,23 @@
+package radio.ks3ckc.ft8af.util
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Verifies [bluetoothAdapter] resolves the adapter through [android.bluetooth.BluetoothManager]
+ * (the non-deprecated path, issue #454) rather than `BluetoothAdapter.getDefaultAdapter()`.
+ * Robolectric provides a working BluetoothManager, so a non-null adapter proves the
+ * getSystemService → getAdapter chain is wired correctly.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BluetoothAdaptersTest {
+
+    @Test
+    fun resolves_adapter_via_bluetooth_manager() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        assertThat(bluetoothAdapter(context)).isNotNull()
+    }
+}


### PR DESCRIPTION
Closes #454.

`BluetoothAdapter.getDefaultAdapter()` is deprecated on API 18+; the adapter should be obtained from the `BluetoothManager` system service.

### Changes
- New `util/BluetoothAdapters.kt` — `bluetoothAdapter(context)` returns `getSystemService(BLUETOOTH_SERVICE).adapter`, preserving the old null contract (null when the device has no Bluetooth).
- Both call sites routed through it:
  - `ComposeMainActivity.autoConnectBluetoothIfNeeded()`
  - `ConnectionDialogs.BluetoothPickerDialog` (now reads `LocalContext.current`)

### Verification
- New Robolectric test `BluetoothAdaptersTest` asserts the helper resolves a non-null adapter via `BluetoothManager`.
- `./gradlew testDebugUnitTest --tests …BluetoothAdaptersTest` → **BUILD SUCCESSFUL**.
- `compileDebugKotlin` no longer emits the `getDefaultAdapter()` deprecation warnings at either call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)