### PR TITLE
Replace deprecated AsyncTask in ComposeMainActivity.kt

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainActivity.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainActivity.java
@@ -517,7 +517,7 @@ public class MainActivity extends AppCompatActivity {
         });
 
         //load the callsign-to-grid mapping from historical successful QSOs
-        new DatabaseOpr.GetCallsignMapGrid(mainViewModel.databaseOpr.getDb()).execute();
+        DatabaseOpr.loadCallsignMapGridAsync(mainViewModel.databaseOpr.getDb());
 
         mainViewModel.getFollowCallsignsFromDataBase();
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2038,9 +2038,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 "order by ID ";
         Cursor cursor = db.rawQuery(querySQL, null);
         try {
+            int callsignIdx = cursor.getColumnIndex("callsign");
+            int gridIdx = cursor.getColumnIndex("grid");
             while (cursor.moveToNext()) {
-                GeneralVariables.addCallsignAndGrid(cursor.getString(cursor.getColumnIndex("callsign"))
-                        , cursor.getString(cursor.getColumnIndex("grid")));
+                GeneralVariables.addCallsignAndGrid(cursor.getString(callsignIdx), cursor.getString(gridIdx));
             }
         } finally {
             cursor.close();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -16,6 +16,9 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.AsyncTask;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import android.util.Log;
 
 import com.k1af.ft8af.FT8Common;
@@ -2014,31 +2017,43 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         }
     }
 
-    public static class GetCallsignMapGrid extends AsyncTask<Void, Void, Void> {
-        SQLiteDatabase db;
+    /**
+     * Single-thread executor backing {@link #loadCallsignMapGridAsync(SQLiteDatabase)}.
+     * Replaces the deprecated {@code GetCallsignMapGrid} AsyncTask (issue #455).
+     */
+    private static final Executor CALLSIGN_MAP_GRID_EXECUTOR =
+            Executors.newSingleThreadExecutor();
 
-        public GetCallsignMapGrid(SQLiteDatabase db) {
-            this.db = db;
-        }
-
-        @SuppressLint("Range")
-        @Override
-        protected Void doInBackground(Void... voids) {
-
-            String querySQL = "select DISTINCT callsign,grid from QslCallsigns qc \n" +
-                    "where LENGTH(grid)>3\n" +
-                    "order by ID ";
-            Cursor cursor = db.rawQuery(querySQL, null);
-            try {
-                while (cursor.moveToNext()) {
-                    GeneralVariables.addCallsignAndGrid(cursor.getString(cursor.getColumnIndex("callsign"))
-                            , cursor.getString(cursor.getColumnIndex("grid")));
-                }
-            } finally {
-                cursor.close();
+    /**
+     * Loads the callsign→grid map from the {@code QslCallsigns} table into
+     * {@link GeneralVariables#addCallsignAndGrid} synchronously on the caller's thread.
+     * Extracted from the old {@code GetCallsignMapGrid} AsyncTask so the query logic is
+     * directly unit-testable; production callers should use
+     * {@link #loadCallsignMapGridAsync(SQLiteDatabase)} to stay off the main thread.
+     */
+    @SuppressLint("Range")
+    public static void loadCallsignMapGrid(SQLiteDatabase db) {
+        String querySQL = "select DISTINCT callsign,grid from QslCallsigns qc \n" +
+                "where LENGTH(grid)>3\n" +
+                "order by ID ";
+        Cursor cursor = db.rawQuery(querySQL, null);
+        try {
+            while (cursor.moveToNext()) {
+                GeneralVariables.addCallsignAndGrid(cursor.getString(cursor.getColumnIndex("callsign"))
+                        , cursor.getString(cursor.getColumnIndex("grid")));
             }
-            return null;
+        } finally {
+            cursor.close();
         }
+    }
+
+    /**
+     * Runs {@link #loadCallsignMapGrid(SQLiteDatabase)} on a background executor. This
+     * is the non-deprecated replacement for the old
+     * {@code new GetCallsignMapGrid(db).execute()} AsyncTask call (issue #455).
+     */
+    public static void loadCallsignMapGridAsync(SQLiteDatabase db) {
+        CALLSIGN_MAP_GRID_EXECUTOR.execute(() -> loadCallsignMapGrid(db));
     }
 
     public interface OnGetQsoGrids {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -440,7 +440,7 @@ class ComposeMainActivity : AppCompatActivity() {
             }
         })
 
-        DatabaseOpr.GetCallsignMapGrid(mainViewModel.databaseOpr.db).execute()
+        DatabaseOpr.loadCallsignMapGridAsync(mainViewModel.databaseOpr.db)
         mainViewModel.getFollowCallsignsFromDataBase()
     }
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/LoadCallsignMapGridTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/LoadCallsignMapGridTest.java
@@ -1,0 +1,61 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import com.k1af.ft8af.GeneralVariables;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Covers {@link DatabaseOpr#loadCallsignMapGrid(SQLiteDatabase)}, the plain replacement
+ * for the deprecated {@code GetCallsignMapGrid} AsyncTask (issue #455). The query and its
+ * {@code LENGTH(grid) > 3} filter are exercised against an in-memory database so the
+ * behaviour that used to live in {@code doInBackground} stays verified.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LoadCallsignMapGridTest {
+
+    private SQLiteDatabase newQslCallsignsDb() {
+        SQLiteDatabase db = SQLiteDatabase.create(null);
+        db.execSQL("CREATE TABLE QslCallsigns (ID INTEGER PRIMARY KEY, callsign TEXT, grid TEXT)");
+        return db;
+    }
+
+    @Test
+    public void loads_callsign_grid_pairs_into_general_variables() {
+        SQLiteDatabase db = newQslCallsignsDb();
+        db.execSQL("INSERT INTO QslCallsigns (callsign, grid) VALUES ('LCMGT1', 'EM48')");
+
+        DatabaseOpr.loadCallsignMapGrid(db);
+
+        assertThat(GeneralVariables.getCallsignHasGrid("LCMGT1")).isTrue();
+        assertThat(GeneralVariables.getCallsignHasGrid("LCMGT1", "EM48")).isTrue();
+        db.close();
+    }
+
+    @Test
+    public void skips_grids_of_three_or_fewer_characters() {
+        SQLiteDatabase db = newQslCallsignsDb();
+        // LENGTH(grid) > 3 in SQL, mirrored by GeneralVariables' length >= 4 guard.
+        db.execSQL("INSERT INTO QslCallsigns (callsign, grid) VALUES ('LCMGT2', 'EM4')");
+
+        DatabaseOpr.loadCallsignMapGrid(db);
+
+        assertThat(GeneralVariables.getCallsignHasGrid("LCMGT2")).isFalse();
+        db.close();
+    }
+
+    @Test
+    public void handles_an_empty_table_without_error() {
+        SQLiteDatabase db = newQslCallsignsDb();
+
+        DatabaseOpr.loadCallsignMapGrid(db);
+
+        assertThat(GeneralVariables.getCallsignHasGrid("LCMGT_ABSENT")).isFalse();
+        db.close();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/LoadCallsignMapGridTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/LoadCallsignMapGridTest.java
@@ -6,6 +6,8 @@ import android.database.sqlite.SQLiteDatabase;
 
 import com.k1af.ft8af.GeneralVariables;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -19,43 +21,49 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class LoadCallsignMapGridTest {
 
-    private SQLiteDatabase newQslCallsignsDb() {
-        SQLiteDatabase db = SQLiteDatabase.create(null);
+    private SQLiteDatabase db;
+
+    @Before
+    public void setUp() {
+        // The callsign->grid map is process-global; clear it so each case starts clean
+        // and nothing leaks into other tests sharing the JVM.
+        GeneralVariables.callsignAndGrids.clear();
+        db = SQLiteDatabase.create(null);
         db.execSQL("CREATE TABLE QslCallsigns (ID INTEGER PRIMARY KEY, callsign TEXT, grid TEXT)");
-        return db;
+    }
+
+    @After
+    public void tearDown() {
+        if (db != null) {
+            db.close();
+        }
+        GeneralVariables.callsignAndGrids.clear();
     }
 
     @Test
     public void loads_callsign_grid_pairs_into_general_variables() {
-        SQLiteDatabase db = newQslCallsignsDb();
         db.execSQL("INSERT INTO QslCallsigns (callsign, grid) VALUES ('LCMGT1', 'EM48')");
 
         DatabaseOpr.loadCallsignMapGrid(db);
 
         assertThat(GeneralVariables.getCallsignHasGrid("LCMGT1")).isTrue();
         assertThat(GeneralVariables.getCallsignHasGrid("LCMGT1", "EM48")).isTrue();
-        db.close();
     }
 
     @Test
     public void skips_grids_of_three_or_fewer_characters() {
-        SQLiteDatabase db = newQslCallsignsDb();
         // LENGTH(grid) > 3 in SQL, mirrored by GeneralVariables' length >= 4 guard.
         db.execSQL("INSERT INTO QslCallsigns (callsign, grid) VALUES ('LCMGT2', 'EM4')");
 
         DatabaseOpr.loadCallsignMapGrid(db);
 
         assertThat(GeneralVariables.getCallsignHasGrid("LCMGT2")).isFalse();
-        db.close();
     }
 
     @Test
     public void handles_an_empty_table_without_error() {
-        SQLiteDatabase db = newQslCallsignsDb();
-
         DatabaseOpr.loadCallsignMapGrid(db);
 
         assertThat(GeneralVariables.getCallsignHasGrid("LCMGT_ABSENT")).isFalse();
-        db.close();
     }
 }


### PR DESCRIPTION
Closes #455.

`android.os.AsyncTask` is deprecated. The occurrence flagged in the issue is the callsign→grid map load kicked off at `ComposeMainActivity.kt:443` via `GetCallsignMapGrid(...).execute()`.

### Changes
- **`DatabaseOpr.java`** — the `GetCallsignMapGrid` AsyncTask is replaced by:
  - `loadCallsignMapGrid(db)` — the same query/`GeneralVariables.addCallsignAndGrid` logic, synchronous and directly unit-testable.
  - `loadCallsignMapGridAsync(db)` — runs it on a single-thread `Executor`.
- Both callers updated: `ComposeMainActivity` (Kotlin) and the legacy `MainActivity` (Java).

### Scope note
`DatabaseOpr` contains ~23 other `AsyncTask` subclasses. Converting all of them is a much larger, riskier sweep and is **intentionally out of scope** here — this PR removes only the class behind the flagged call site. The generic javac `Note: Some input files use or override a deprecated API` will therefore persist until that broader cleanup lands.

### Verification
- New Robolectric test `LoadCallsignMapGridTest` covers the happy path, the `LENGTH(grid) > 3` filter, and the empty-table case against an in-memory DB.
- `./gradlew testDebugUnitTest --tests …LoadCallsignMapGridTest` → **BUILD SUCCESSFUL**.
- `compileDebugKotlin` no longer emits the `execute()` deprecation warning at `ComposeMainActivity.kt:443`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)