### PR TITLE
Export FT4/FT2 QSOs as MFSK submodes in ADIF

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -1185,9 +1185,17 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             }
 
             if (cursor.getString(cursor.getColumnIndex("mode")) != null) {
-                logStr.append(String.format("<mode:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("mode")).length()
-                        , cursor.getString(cursor.getColumnIndex("mode"))));
+                // FT4/FT2 are ADIF submodes of MFSK, not standalone modes — a bare
+                // <mode>FT2 is rejected as invalid by pota.app and other ADIF consumers.
+                String mode = cursor.getString(cursor.getColumnIndex("mode"));
+                String submode = AdifFormat.mfskSubmode(mode);
+                if (submode != null) {
+                    logStr.append(String.format("<mode:4>MFSK <submode:%d>%s "
+                            , submode.length(), submode));
+                } else {
+                    logStr.append(String.format("<mode:%d>%s "
+                            , mode.length(), mode));
+                }
             }
 
             if (cursor.getString(cursor.getColumnIndex("rst_sent")) != null) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -35,6 +35,28 @@ public final class AdifFormat {
         return String.format(Locale.US, "<call:%d>%s ", c.length(), c);
     }
 
+    /**
+     * The ADIF SUBMODE name for a stored mode string when ADIF models that mode as a submode of
+     * MFSK, or {@code null} for modes that stand alone as a MODE (FT8, SSB, CW, ...).
+     *
+     * <p>FT8 is a first-class ADIF MODE, but FT4 and FT2 are not — ADIF defines them as submodes
+     * of MFSK. A bare {@code <mode:3>FT2} is rejected as an invalid mode by pota.app (and other
+     * ADIF consumers); such QSOs must be exported as {@code MODE=MFSK} with {@code SUBMODE=FT2}
+     * (likewise FT4). Callers use a non-null result to emit that MODE/SUBMODE pair, and a null
+     * result to emit the mode verbatim. Match is case-insensitive; the returned token is
+     * upper-cased. FT2/FT4/MFSK are ASCII, so char length == UTF-8 byte length for the caller.
+     */
+    public static String mfskSubmode(String rawMode) {
+        if (rawMode == null) {
+            return null;
+        }
+        String upper = rawMode.trim().toUpperCase(Locale.US);
+        if (upper.equals("FT4") || upper.equals("FT2")) {
+            return upper;
+        }
+        return null;
+    }
+
     /** "No report" sentinels stored in the SNR int fields; left unformatted so the logbook's
      * empty-report check still recognises them. */
     private static final int NO_REPORT = -100;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ShareLogs.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ShareLogs.java
@@ -155,10 +155,18 @@ public class ShareLogs {
                             , cursor.getString(cursor.getColumnIndex("gridsquare"))).getBytes());
                 }
 
-                if (cursor.getString(cursor.getColumnIndex("mode")) != null) {
-                    fileOutputStream.write(String.format("<mode:%d>%s "
-                            , cursor.getString(cursor.getColumnIndex("mode")).length()
-                            , cursor.getString(cursor.getColumnIndex("mode"))).getBytes());
+                String mode = cursor.getString(cursor.getColumnIndex("mode"));
+                if (mode != null) {
+                    // FT4/FT2 are ADIF submodes of MFSK, not standalone modes — a bare
+                    // <mode>FT2 is rejected as invalid by pota.app and other ADIF consumers.
+                    String submode = AdifFormat.mfskSubmode(mode);
+                    if (submode != null) {
+                        fileOutputStream.write(String.format("<mode:4>MFSK <submode:%d>%s "
+                                , submode.length(), submode).getBytes());
+                    } else {
+                        fileOutputStream.write(String.format("<mode:%d>%s "
+                                , mode.length(), mode).getBytes());
+                    }
                 }
 
                 if (cursor.getString(cursor.getColumnIndex("rst_sent")) != null) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -222,7 +222,8 @@ public class ThirdPartyService {
         return null;
     }
 
-    private static String QSLRecordToADIF(QSLRecord qslRecord, ServiceType serv){
+    // Package-private (not private) so the ADIF payload can be unit-tested directly.
+    static String QSLRecordToADIF(QSLRecord qslRecord, ServiceType serv){
         StringBuilder logStr = new StringBuilder();
         logStr.append(AdifFormat.callField(qslRecord.getToCallsign()));
 
@@ -233,9 +234,17 @@ public class ThirdPartyService {
         }
 
         if (qslRecord.getMode() != null) {
-            logStr.append(String.format("<mode:%d>%s "
-                    , qslRecord.getMode().length()
-                    , qslRecord.getMode()));
+            // FT4/FT2 are ADIF submodes of MFSK, not standalone modes — a bare
+            // <mode>FT2 is rejected as invalid by QRZ/Cloudlog and other ADIF consumers.
+            String submode = AdifFormat.mfskSubmode(qslRecord.getMode());
+            if (submode != null) {
+                logStr.append(String.format("<mode:4>MFSK <submode:%d>%s "
+                        , submode.length(), submode));
+            } else {
+                logStr.append(String.format("<mode:%d>%s "
+                        , qslRecord.getMode().length()
+                        , qslRecord.getMode()));
+            }
         }
 
         String rstSent = AdifFormat.formatReport(qslRecord.getSendReport());

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporter.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporter.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
 import androidx.core.content.FileProvider
 import com.k1af.ft8af.MainViewModel
+import com.k1af.ft8af.log.AdifFormat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -118,7 +119,7 @@ object PotaAdifExporter {
             for (r in rows) {
                 adifField(sb, "CALL", r.call)
                 adifField(sb, "GRIDSQUARE", r.grid)
-                adifField(sb, "MODE", r.mode)
+                adifMode(sb, r.mode)
                 adifField(sb, "BAND", r.band)
                 adifField(sb, "FREQ", r.freq)
                 adifField(sb, "RST_SENT", r.rstSent)
@@ -195,6 +196,26 @@ object PotaAdifExporter {
                 e.printStackTrace()
                 onResult(false)
             }
+        }
+    }
+
+    /**
+     * Emit the ADIF MODE (and SUBMODE where required) for a stored mode string.
+     *
+     * FT8 is a standalone ADIF mode, but FT4 and FT2 are submodes of MFSK — a bare
+     * `<MODE:3>FT2` is what pota.app rejects as invalid. For those, emit MODE=MFSK
+     * plus SUBMODE=FT2/FT4 (per POTA support's guidance); every other mode passes
+     * through as MODE unchanged. The MFSK classification is shared with the general
+     * logbook export via [AdifFormat.mfskSubmode].
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun adifMode(sb: StringBuilder, mode: String?) {
+        val submode = AdifFormat.mfskSubmode(mode)
+        if (submode != null) {
+            adifField(sb, "MODE", "MFSK")
+            adifField(sb, "SUBMODE", submode)
+        } else {
+            adifField(sb, "MODE", mode)
         }
     }
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifModeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifModeTest.java
@@ -1,0 +1,73 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.database.MatrixCursor;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Verifies the mode/submode ADIF mapping in {@link DatabaseOpr#downQSLTable}, the logbook's
+ * ADIF text export. FT2/FT4 are ADIF submodes of MFSK, so a bare {@code <mode>FT2}/{@code
+ * <mode>FT4} is rejected as invalid by pota.app and other ADIF consumers; they must be exported
+ * as {@code MODE=MFSK} + {@code SUBMODE}, while FT8 stays a standalone mode.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseOprAdifModeTest {
+
+    /** Columns downQSLTable reads unconditionally; comment must be non-null (it is dereferenced). */
+    private static final String[] COLUMNS = {
+            "call", "isLotW_QSL", "isQSL", "gridsquare", "mode", "rst_sent", "rst_rcvd",
+            "qso_date", "time_on", "qso_date_off", "time_off", "band", "freq",
+            "station_callsign", "my_gridsquare", "comment"
+    };
+
+    private DatabaseOpr opr;
+
+    @Before
+    public void setUp() {
+        opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 19);
+    }
+
+    @After
+    public void tearDown() {
+        opr.close();
+    }
+
+    private String exportWithMode(String mode) {
+        MatrixCursor cursor = new MatrixCursor(COLUMNS);
+        cursor.addRow(new Object[]{
+                "W1AW", 0, 0, null, mode, null, null,
+                null, null, null, null, null, null,
+                null, null, "QSO by FT8AF"
+        });
+        return opr.downQSLTable(cursor, false);
+    }
+
+    @Test
+    public void ft2ExportsAsMfskSubmode() {
+        String adif = exportWithMode("FT2");
+        assertThat(adif).contains("<mode:4>MFSK <submode:3>FT2 ");
+        assertThat(adif).doesNotContain("<mode:3>FT2 ");
+    }
+
+    @Test
+    public void ft4ExportsAsMfskSubmode() {
+        String adif = exportWithMode("FT4");
+        assertThat(adif).contains("<mode:4>MFSK <submode:3>FT4 ");
+        assertThat(adif).doesNotContain("<mode:3>FT4 ");
+    }
+
+    @Test
+    public void ft8StaysStandaloneMode() {
+        String adif = exportWithMode("FT8");
+        assertThat(adif).contains("<mode:3>FT8 ");
+        assertThat(adif).doesNotContain("submode");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
@@ -50,6 +50,33 @@ public class AdifFormatTest {
     }
 
     @Test
+    public void mfskSubmode_ft4AndFt2AreMfskSubmodes() {
+        // The bug: exporting a bare <mode>FT2 — pota.app rejects it. FT4/FT2 are
+        // ADIF submodes of MFSK, so the caller must emit MODE=MFSK + SUBMODE.
+        assertThat(AdifFormat.mfskSubmode("FT2")).isEqualTo("FT2");
+        assertThat(AdifFormat.mfskSubmode("FT4")).isEqualTo("FT4");
+    }
+
+    @Test
+    public void mfskSubmode_standaloneModesReturnNull() {
+        // FT8 is a first-class ADIF MODE; these pass through verbatim (null result).
+        assertThat(AdifFormat.mfskSubmode("FT8")).isNull();
+        assertThat(AdifFormat.mfskSubmode("SSB")).isNull();
+        assertThat(AdifFormat.mfskSubmode("CW")).isNull();
+    }
+
+    @Test
+    public void mfskSubmode_isCaseInsensitiveAndTrimmedAndUpperCased() {
+        assertThat(AdifFormat.mfskSubmode(" ft2 ")).isEqualTo("FT2");
+        assertThat(AdifFormat.mfskSubmode("Ft4")).isEqualTo("FT4");
+    }
+
+    @Test
+    public void mfskSubmode_nullReturnsNull() {
+        assertThat(AdifFormat.mfskSubmode(null)).isNull();
+    }
+
+    @Test
     public void formatReport_alwaysSignedAndTwoDigits() {
         // The bug: bare String.valueOf(int) gave "5"/"-5"/"0" — no sign on positives, no padding.
         assertThat(AdifFormat.formatReport(5)).isEqualTo("+05");

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceAdifModeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceAdifModeTest.java
@@ -1,0 +1,49 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.HashMap;
+
+/**
+ * Verifies the mode/submode ADIF mapping in {@link ThirdPartyService#QSLRecordToADIF}, the payload
+ * shared by the Cloudlog and QRZ uploaders. FT2/FT4 are ADIF submodes of MFSK, so a bare
+ * {@code <mode>FT2}/{@code <mode>FT4} is rejected as invalid by those consumers; they must be
+ * emitted as {@code MODE=MFSK} + {@code SUBMODE}. FT8 stays a standalone mode. Runs under
+ * Robolectric because {@link QSLRecord} and the exporter touch Android {@code Log}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ThirdPartyServiceAdifModeTest {
+
+    private static QSLRecord recordWithMode(String mode) {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("STATION_CALLSIGN", "K1AF");
+        map.put("MODE", mode);
+        return new QSLRecord(map);
+    }
+
+    @Test
+    public void ft2ExportsAsMfskSubmode() {
+        String adif = ThirdPartyService.QSLRecordToADIF(recordWithMode("FT2"), ServiceType.QRZ);
+        assertThat(adif).contains("<mode:4>MFSK <submode:3>FT2 ");
+        assertThat(adif).doesNotContain("<mode:3>FT2 ");
+    }
+
+    @Test
+    public void ft4ExportsAsMfskSubmode() {
+        String adif = ThirdPartyService.QSLRecordToADIF(recordWithMode("FT4"), ServiceType.Cloudlog);
+        assertThat(adif).contains("<mode:4>MFSK <submode:3>FT4 ");
+        assertThat(adif).doesNotContain("<mode:3>FT4 ");
+    }
+
+    @Test
+    public void ft8StaysStandaloneMode() {
+        String adif = ThirdPartyService.QSLRecordToADIF(recordWithMode("FT8"), ServiceType.QRZ);
+        assertThat(adif).contains("<mode:3>FT8 ");
+        assertThat(adif).doesNotContain("submode");
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/BuildActivationAdifTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/BuildActivationAdifTest.kt
@@ -251,6 +251,30 @@ class BuildActivationAdifTest {
     }
 
     @Test
+    fun ft2Qso_isExportedAsMfskWithSubmode_notBareFt2() {
+        // The reported bug: an FT2 QSO exported with <MODE:3>FT2 was rejected by
+        // pota.app as an invalid mode. FT2 is a submode of MFSK, so the record
+        // must carry MODE=MFSK + SUBMODE=FT2.
+        insertQso("W1AW", "20240601", "123500", mySigInfo = "K-1234", mode = "FT2")
+
+        val content = PotaAdifExporter.buildActivationAdif(db, activation("K-1234")).single().content
+
+        assertThat(content).contains("<MODE:4>MFSK ")
+        assertThat(content).contains("<SUBMODE:3>FT2 ")
+        assertThat(content).doesNotContain("<MODE:3>FT2 ")
+    }
+
+    @Test
+    fun ft8Qso_keepsBareFt8Mode_withNoSubmode() {
+        insertQso("W1AW", "20240601", "123500", mySigInfo = "K-1234", mode = "FT8")
+
+        val content = PotaAdifExporter.buildActivationAdif(db, activation("K-1234")).single().content
+
+        assertThat(content).contains("<MODE:3>FT8 ")
+        assertThat(content).doesNotContain("SUBMODE")
+    }
+
+    @Test
     fun onlyPotaRowsMatchingTheParkAreIncluded() {
         insertQso("INPARK", "20240601", "123500", mySigInfo = "K-1234")
         // Different park — must not bleed into K-1234's document.

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporterTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporterTest.kt
@@ -48,4 +48,34 @@ class PotaAdifExporterTest {
         PotaAdifExporter.adifField(sb, "MODE", "FT8")
         assertThat(sb.toString()).isEqualTo("<CALL:4>W1AW <MODE:3>FT8 ")
     }
+
+    @Test
+    fun adifMode_ft8PassesThroughAsMode() {
+        val sb = StringBuilder()
+        PotaAdifExporter.adifMode(sb, "FT8")
+        assertThat(sb.toString()).isEqualTo("<MODE:3>FT8 ")
+    }
+
+    @Test
+    fun adifMode_ft2EmitsMfskModeWithSubmode() {
+        // The reported bug: a bare <MODE:3>FT2 is rejected by pota.app. FT2 is a
+        // submode of MFSK, so we must emit MODE=MFSK + SUBMODE=FT2.
+        val sb = StringBuilder()
+        PotaAdifExporter.adifMode(sb, "FT2")
+        assertThat(sb.toString()).isEqualTo("<MODE:4>MFSK <SUBMODE:3>FT2 ")
+    }
+
+    @Test
+    fun adifMode_ft4EmitsMfskModeWithSubmode() {
+        val sb = StringBuilder()
+        PotaAdifExporter.adifMode(sb, "FT4")
+        assertThat(sb.toString()).isEqualTo("<MODE:4>MFSK <SUBMODE:3>FT4 ")
+    }
+
+    @Test
+    fun adifMode_nullEmitsNothing() {
+        val sb = StringBuilder()
+        PotaAdifExporter.adifMode(sb, null)
+        assertThat(sb.toString()).isEmpty()
+    }
 }


### PR DESCRIPTION
## Problem

Uploading an **FT2** POTA activation to pota.app fails with an "invalid mode" error. POTA support's guidance: set `MODE=MFSK` and `SUBMODE=FT2`.

**Root cause:** in ADIF, `FT8` is a first-class mode, but `FT4` and `FT2` are *submodes of `MFSK`*. Both of the app's ADIF writers copied the stored mode name (`ModeProfile` display name — `"FT2"`, `"FT4"`, `"FT8"`) straight into the `MODE` field with no submode, so an FT2 QSO exported as a bare `<MODE:3>FT2`, which pota.app rejects.

## Fix

Added `AdifFormat.mfskSubmode(mode)` as the single, tested source of truth for which stored modes ADIF models as MFSK submodes (returns `"FT2"`/`"FT4"`, else `null`), and routed both export paths through it:

- **`PotaAdifExporter`** (POTA authed upload *and* share-sheet — both share `buildActivationAdif`): new `adifMode()` emits `MODE=MFSK` + `SUBMODE=FT2/FT4` for those modes, otherwise `MODE` verbatim. This is the path that failed.
- **`ShareLogs`** (general logbook ADIF export to QRZ/LoTW/etc.): same mapping — fixes the identical latent bug there.

FT8 output is unchanged (`<MODE:3>FT8`), so existing FT8 uploads are unaffected.

## Tests

All passing (`testDebugUnitTest`):
- `AdifFormatTest` — FT4/FT2 → MFSK submode classification, standalone-mode pass-through (FT8/SSB/CW), case/trim/null handling.
- `PotaAdifExporterTest` — `adifMode` emits `<MODE:4>MFSK <SUBMODE:3>FT2 ` for FT2/FT4 and bare `<MODE:3>FT8 ` for FT8.
- `BuildActivationAdifTest` — end-to-end: an FT2 QSO exports as MFSK+SUBMODE (no bare `<MODE:3>FT2`); FT8 stays bare with no SUBMODE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)