### PR TITLE
Opt-in Sentry crash reporting with deobfuscated release traces

### DIFF
--- a/ft8af/app/build.gradle
+++ b/ft8af/app/build.gradle
@@ -12,6 +12,9 @@ plugins {
     // Static analysis (issue #63).
     id 'io.gitlab.arturbosch.detekt'
     id 'org.jlleitschuh.gradle.ktlint'
+    // Sentry crash reporting: applied only for R8 mapping-file upload (see the
+    // sentry { } block below). The SDK is initialised manually in Kotlin.
+    id 'io.sentry.android.gradle'
 }
 
 def currentTime = getCurrentTime()
@@ -58,6 +61,13 @@ android {
         def ciVersionName = project.findProperty('VERSION_NAME_OVERRIDE')
         versionName ciVersionName ?: '1.1.0'
 
+        // Sentry DSN, supplied out-of-band so it never lives in committed source:
+        // a -PSENTRY_DSN=… flag, a SENTRY_DSN line in ~/.gradle/gradle.properties,
+        // or a SENTRY_DSN env var (CI). Absent → empty string → crash reporting
+        // stays disabled at runtime regardless of the user's opt-in toggle, so a
+        // fresh clone / contributor build never reports into anyone's project.
+        def sentryDsn = project.findProperty('SENTRY_DSN') ?: System.getenv('SENTRY_DSN') ?: ''
+        buildConfigField "String", "SENTRY_DSN", "\"${sentryDsn}\""
 
         externalNativeBuild {
             cmake {
@@ -165,6 +175,30 @@ android {
     namespace 'com.k1af.ft8af'
 }
 
+// Sentry Gradle plugin — used ONLY to upload the R8 mapping file so obfuscated
+// release stack traces deobfuscate in Sentry (same mapping.txt already sent to
+// Play Console). Everything else the plugin can do is turned off:
+//   * autoInstallation off — we declare io.sentry:sentry-android explicitly and
+//     initialise it by hand (opt-in gated), so the plugin must not add its own
+//     copy or a version we didn't choose.
+//   * tracingInstrumentation off — no performance tracing (crashes + ANRs +
+//     breadcrumbs only).
+// The upload only runs on a release (minified) build AND only when CI supplies
+// SENTRY_AUTH_TOKEN (+ SENTRY_ORG / SENTRY_PROJECT, which the plugin reads from
+// the environment). A local or token-less release build still embeds the
+// mapping UUID but skips the network upload, so it never fails for want of a
+// token.
+sentry {
+    autoInstallation {
+        enabled = false
+    }
+    tracingInstrumentation {
+        enabled = false
+    }
+    includeProguardMapping = true
+    autoUploadProguardMapping = System.getenv('SENTRY_AUTH_TOKEN') != null
+}
+
 dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
@@ -220,6 +254,11 @@ dependencies {
     // Keystore-backed EncryptedSharedPreferences for the POTA refresh token —
     // a long-lived credential that must not sit in plaintext app storage.
     implementation 'androidx.security:security-crypto:1.1.0-alpha06'
+
+    // Sentry crash reporting (opt-in). Initialised manually in
+    // crash/CrashReporting.kt — the Gradle plugin's auto-installation is turned
+    // off (see the sentry { } block) so this is the single source of the SDK.
+    implementation 'io.sentry:sentry-android:8.16.0'
 
     // --- JVM unit + Robolectric tests ---
     testImplementation 'junit:junit:4.13.2'

--- a/ft8af/app/src/main/AndroidManifest.xml
+++ b/ft8af/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="androidx.car.app.ACCESS_SURFACE" />
 
     <application
+        android:name="radio.ks3ckc.ft8af.FT8AFApplication"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:networkSecurityConfig="@xml/network_security_config"
@@ -45,6 +46,13 @@
         android:supportsRtl="true"
         android:localeConfig="@xml/locales_config"
         android:theme="@style/Theme.Ft8AF">
+        <!-- Sentry ships a ContentProvider that auto-inits at process start and
+             requires a manifest DSN. We init manually and only after the user
+             opts in (see CrashReporting), so disable that auto-init here — with
+             it on, the SDK crashes on launch with "DSN is required". -->
+        <meta-data
+            android:name="io.sentry.auto-init"
+            android:value="false" />
         <!-- New Compose-based main activity -->
         <activity
             android:name="radio.ks3ckc.ft8af.ComposeMainActivity"

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -253,7 +253,13 @@ class ComposeMainActivity : AppCompatActivity() {
             com.k1af.ft8af.alert.DxAlertNotifier.EXTRA_CALLSIGN,
         ) ?: return
         if (callsign.isBlank()) return
-        fileLog("handleAlertIntent: preselect $callsign")
+        // The full callsign goes to the local debug.log, but a callsign is PII in
+        // this app, so the Sentry breadcrumb is redacted (see fileLog / the
+        // "callsign is never sent" promise).
+        fileLog(
+            "handleAlertIntent: preselect $callsign",
+            breadcrumbMsg = "handleAlertIntent: preselect <redacted>",
+        )
         mainViewModel.mutablePreselectCallsign.postValue(callsign)
     }
 
@@ -699,13 +705,20 @@ class ComposeMainActivity : AppCompatActivity() {
         }
     }
 
-    /** Write a line to /sdcard/Android/data/com.k1af.ft8af/files/debug.log */
-    private fun fileLog(msg: String) {
-        // Mirror every debug.log line into Sentry as a breadcrumb so a crash
+    /**
+     * Write a line to /sdcard/Android/data/com.k1af.ft8af/files/debug.log.
+     *
+     * The full [msg] always goes to the on-device debug.log and logcat, but only
+     * [breadcrumbMsg] is mirrored into Sentry — pass a redacted string (or null) for
+     * lines carrying PII (callsign, grid, location) so it never rides along with a
+     * crash report, keeping the "callsign/location are never sent" promise.
+     */
+    private fun fileLog(msg: String, breadcrumbMsg: String? = msg) {
+        // Mirror the (possibly redacted) line into Sentry as a breadcrumb so a crash
         // report carries the same event trail (CAT sends, band changes, USB
         // attach…). No-op unless crash reporting is enabled. First, so it fires
         // even when the external dir is unavailable and the file write is skipped.
-        CrashReporting.breadcrumb(msg)
+        breadcrumbMsg?.let { CrashReporting.breadcrumb(it) }
         try {
             val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
             val dir = getExternalFilesDir(null) ?: return

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.Observer
 import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
+import radio.ks3ckc.ft8af.crash.CrashReporting
 import radio.ks3ckc.ft8af.sync.QsoAutoSync
 import radio.ks3ckc.ft8af.util.bluetoothAdapter
 import com.k1af.ft8af.service.RxForegroundService
@@ -700,6 +701,11 @@ class ComposeMainActivity : AppCompatActivity() {
 
     /** Write a line to /sdcard/Android/data/com.k1af.ft8af/files/debug.log */
     private fun fileLog(msg: String) {
+        // Mirror every debug.log line into Sentry as a breadcrumb so a crash
+        // report carries the same event trail (CAT sends, band changes, USB
+        // attach…). No-op unless crash reporting is enabled. First, so it fires
+        // even when the external dir is unavailable and the file write is skipped.
+        CrashReporting.breadcrumb(msg)
         try {
             val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
             val dir = getExternalFilesDir(null) ?: return

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApplication.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApplication.kt
@@ -1,0 +1,19 @@
+package radio.ks3ckc.ft8af
+
+import android.app.Application
+import radio.ks3ckc.ft8af.crash.CrashReporting
+
+/**
+ * Process-wide entry point. Exists so opt-in Sentry crash reporting can be
+ * installed in [onCreate] — before any Activity/Service starts — which is the
+ * only place an uncaught-exception handler catches early-startup crashes.
+ *
+ * [CrashReporting.init] is a no-op unless the user opted in and a DSN was
+ * compiled in, so this stays inert for contributor builds and un-consented users.
+ */
+class FT8AFApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        CrashReporting.init(this)
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/crash/CrashReporting.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/crash/CrashReporting.kt
@@ -85,12 +85,20 @@ object CrashReporting {
     /** Bring the SDK up. Idempotent — a second call while already running is ignored. */
     private fun start(context: Context) {
         if (Sentry.isEnabled()) return
-        SentryAndroid.init(context) { options ->
+        // Always init with the application context: setEnabled() can be called from
+        // a Settings Activity, and the SDK holds the context for its lifetime, so an
+        // Activity/Service context would leak.
+        SentryAndroid.init(context.applicationContext) { options ->
             options.dsn = BuildConfig.SENTRY_DSN
             // Callsign + GPS live in this app; never let the SDK attach IP / user
             // identifiers on its own. Only breadcrumbs we choose are sent.
             options.isSendDefaultPii = false
-            options.release = "${BuildConfig.APPLICATION_ID}@${BuildConfig.VERSION_NAME}"
+            // Include versionCode so the runtime release matches the Sentry Gradle
+            // plugin's default (<applicationId>@<versionName>+<versionCode>) that the
+            // mapping.txt upload is tagged with — otherwise release-scoped views and
+            // release health can't line the two up.
+            options.release =
+                "${BuildConfig.APPLICATION_ID}@${BuildConfig.VERSION_NAME}+${BuildConfig.VERSION_CODE}"
             options.environment = if (BuildConfig.DEBUG) "debug" else "release"
             options.isDebug = BuildConfig.DEBUG
         }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/crash/CrashReporting.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/crash/CrashReporting.kt
@@ -1,0 +1,114 @@
+package radio.ks3ckc.ft8af.crash
+
+import android.content.Context
+import com.k1af.ft8af.BuildConfig
+import io.sentry.Breadcrumb
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+import io.sentry.android.core.SentryAndroid
+
+/**
+ * Opt-in Sentry crash reporting.
+ *
+ * Reporting is off until BOTH of these hold:
+ *   1. a DSN was compiled in (BuildConfig.SENTRY_DSN, supplied at build time — a
+ *      contributor build with no DSN can never report), and
+ *   2. the user turned on "Send crash reports" in Advanced Settings.
+ *
+ * The user's choice lives in a tiny [android.content.SharedPreferences] file (not
+ * the config DB) so it can be read in [Application.onCreate][android.app.Application.onCreate]
+ * — before the DB is open — which is where an uncaught-exception handler has to be
+ * installed to catch early crashes.
+ *
+ * This app knows the operator's callsign and GPS/grid location, so PII is never
+ * attached automatically (`isSendDefaultPii = false`) and only [breadcrumb]s we
+ * explicitly hand it (the same lines that go to debug.log) ride along with a crash.
+ */
+object CrashReporting {
+    private const val PREFS_NAME = "crash_reporting"
+    private const val KEY_OPT_IN = "sentry_opt_in"
+
+    /**
+     * The single gate for whether crash reporting may run: the user opted in AND a
+     * DSN is configured. Pure logic, unit-tested — everything else defers to it.
+     */
+    internal fun shouldEnable(
+        dsn: String?,
+        optedIn: Boolean,
+    ): Boolean = optedIn && !dsn.isNullOrBlank()
+
+    /** True when a DSN was compiled in, i.e. crash reporting is offerable at all. */
+    fun isAvailable(): Boolean = BuildConfig.SENTRY_DSN.isNotBlank()
+
+    /** The persisted user opt-in choice (defaults to off — reporting is opt-in). */
+    fun isOptedIn(context: Context): Boolean =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_OPT_IN, false)
+
+    private fun saveOptIn(
+        context: Context,
+        optedIn: Boolean,
+    ) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_OPT_IN, optedIn)
+            .apply()
+    }
+
+    /**
+     * Called once from [FT8AFApplication.onCreate][radio.ks3ckc.ft8af.FT8AFApplication].
+     * A no-op unless the user has opted in and a DSN is present.
+     */
+    fun init(context: Context) {
+        if (shouldEnable(BuildConfig.SENTRY_DSN, isOptedIn(context))) {
+            start(context)
+        }
+    }
+
+    /**
+     * Persist the Settings toggle and start/stop the SDK live so the change takes
+     * effect without an app restart. Turning it off calls [Sentry.close]; turning
+     * it on with no DSN compiled in just records the preference.
+     */
+    fun setEnabled(
+        context: Context,
+        enabled: Boolean,
+    ) {
+        saveOptIn(context, enabled)
+        if (shouldEnable(BuildConfig.SENTRY_DSN, enabled)) {
+            start(context)
+        } else {
+            Sentry.close()
+        }
+    }
+
+    /** Bring the SDK up. Idempotent — a second call while already running is ignored. */
+    private fun start(context: Context) {
+        if (Sentry.isEnabled()) return
+        SentryAndroid.init(context) { options ->
+            options.dsn = BuildConfig.SENTRY_DSN
+            // Callsign + GPS live in this app; never let the SDK attach IP / user
+            // identifiers on its own. Only breadcrumbs we choose are sent.
+            options.isSendDefaultPii = false
+            options.release = "${BuildConfig.APPLICATION_ID}@${BuildConfig.VERSION_NAME}"
+            options.environment = if (BuildConfig.DEBUG) "debug" else "release"
+            options.isDebug = BuildConfig.DEBUG
+        }
+    }
+
+    /**
+     * Record a breadcrumb — the timeline of events attached to the next crash. Fed
+     * the same lines as debug.log (see ComposeMainActivity.fileLog). A no-op when
+     * reporting is disabled, so callers need no guard of their own.
+     */
+    fun breadcrumb(message: String) {
+        if (!Sentry.isEnabled()) return
+        Sentry.addBreadcrumb(
+            Breadcrumb().apply {
+                this.message = message
+                level = SentryLevel.INFO
+                category = "app"
+            },
+        )
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
@@ -40,6 +40,7 @@ import com.k1af.ft8af.database.OnAfterQueryConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8af.crash.CrashReporting
 import radio.ks3ckc.ft8af.theme.Accent
 import radio.ks3ckc.ft8af.theme.BgSurface2
 import radio.ks3ckc.ft8af.theme.TextMuted
@@ -158,6 +159,9 @@ fun AdvancedSettings(
     var txDelay by remember { mutableIntStateOf(GeneralVariables.transmitDelay) }
     var lateStartMs by remember { mutableIntStateOf(GeneralVariables.lateStartTolerance) }
     var currentTheme by remember { mutableStateOf(loadTheme(context)) }
+
+    // Opt-in crash reporting (Sentry). Only surfaced when a DSN was compiled in.
+    var crashReportingEnabled by remember { mutableStateOf(CrashReporting.isOptedIn(context)) }
 
     var showPttDelay by remember { mutableStateOf(false) }
     var showTxDelay by remember { mutableStateOf(false) }
@@ -606,6 +610,27 @@ fun AdvancedSettings(
                         description = stringResource(R.string.settings_import_desc),
                         showChevron = true,
                         onClick = { importLauncher.launch(arrayOf("application/json", "*/*")) },
+                    )
+                }
+            }
+        }
+
+        // =====================================================================
+        // DIAGNOSTICS (opt-in crash reporting)
+        // =====================================================================
+        // Only shown when a Sentry DSN was compiled in — a contributor build with
+        // no DSN has nowhere to report, so the toggle would be dead weight.
+        if (CrashReporting.isAvailable()) {
+            SettingsSection(title = stringResource(R.string.settings_section_diagnostics)) {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    SettingsRow(
+                        label = stringResource(R.string.settings_crash_reporting),
+                        description = stringResource(R.string.settings_crash_reporting_desc),
+                        toggle = crashReportingEnabled,
+                        onToggleChange = { enabled ->
+                            crashReportingEnabled = enabled
+                            CrashReporting.setEnabled(context, enabled)
+                        },
                     )
                 }
             }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -424,6 +424,11 @@
     <string name="settings_import_success">Settings imported — restart the app to apply all changes</string>
     <string name="settings_import_failed">Import failed: %1$s</string>
 
+    <!-- ===== Settings: diagnostics (opt-in crash reporting) ===== -->
+    <string name="settings_section_diagnostics">DIAGNOSTICS</string>
+    <string name="settings_crash_reporting">Send crash reports</string>
+    <string name="settings_crash_reporting_desc">Share anonymous crash and error reports to help fix bugs. Your callsign and location are never sent.</string>
+
     <!-- ===== Settings: appearance / theme ===== -->
     <string name="settings_theme">Theme</string>
     <string name="settings_theme_desc">App color theme</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/crash/CrashReportingTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/crash/CrashReportingTest.kt
@@ -66,7 +66,10 @@ class CrashReportingTest {
 
     @Test
     fun isAvailable_reflectsCompiledInDsn() {
-        // Test builds compile in no DSN, so reporting is never offerable here.
+        // isAvailable() must exactly track whether a DSN was compiled in — regardless
+        // of whether this particular build has one. SENTRY_DSN comes from a Gradle
+        // prop / env var, so it may be blank (typical) or present (local/CI); either
+        // way isAvailable() equals SENTRY_DSN.isNotBlank().
         assertThat(CrashReporting.isAvailable()).isEqualTo(BuildConfig.SENTRY_DSN.isNotBlank())
     }
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/crash/CrashReportingTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/crash/CrashReportingTest.kt
@@ -1,0 +1,95 @@
+package radio.ks3ckc.ft8af.crash
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.BuildConfig
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Covers the crash-reporting gate ([CrashReporting.shouldEnable]) and the opt-in
+ * persistence. Robolectric is only needed for the SharedPreferences-backed paths;
+ * the truth-table cases are pure logic that happen to run under the same runner.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CrashReportingTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    // --- shouldEnable: the single gate. Enabled only when opted in AND a DSN exists. ---
+
+    @Test
+    fun shouldEnable_trueOnlyWhenOptedInAndDsnPresent() {
+        assertThat(CrashReporting.shouldEnable("https://k@o0.ingest.sentry.io/1", true)).isTrue()
+    }
+
+    @Test
+    fun shouldEnable_falseWhenNotOptedIn() {
+        assertThat(CrashReporting.shouldEnable("https://k@o0.ingest.sentry.io/1", false)).isFalse()
+    }
+
+    @Test
+    fun shouldEnable_falseWhenDsnNull() {
+        assertThat(CrashReporting.shouldEnable(null, true)).isFalse()
+    }
+
+    @Test
+    fun shouldEnable_falseWhenDsnEmpty() {
+        assertThat(CrashReporting.shouldEnable("", true)).isFalse()
+    }
+
+    @Test
+    fun shouldEnable_falseWhenDsnBlankWhitespace() {
+        assertThat(CrashReporting.shouldEnable("   ", true)).isFalse()
+    }
+
+    // --- opt-in persistence ---
+
+    @Test
+    fun optIn_defaultsToOff() {
+        assertThat(CrashReporting.isOptedIn(context)).isFalse()
+    }
+
+    @Test
+    fun setEnabled_persistsTheChoice() {
+        CrashReporting.setEnabled(context, true)
+        assertThat(CrashReporting.isOptedIn(context)).isTrue()
+
+        CrashReporting.setEnabled(context, false)
+        assertThat(CrashReporting.isOptedIn(context)).isFalse()
+    }
+
+    // --- build-time availability + safety of the disabled paths ---
+
+    @Test
+    fun isAvailable_reflectsCompiledInDsn() {
+        // Test builds compile in no DSN, so reporting is never offerable here.
+        assertThat(CrashReporting.isAvailable()).isEqualTo(BuildConfig.SENTRY_DSN.isNotBlank())
+    }
+
+    @Test
+    fun breadcrumb_isNoOpWhenReportingDisabled() {
+        // With the SDK uninitialised, breadcrumb() must swallow rather than throw
+        // so every fileLog() caller is safe without its own guard.
+        CrashReporting.breadcrumb("late-start skip 320ms")
+    }
+
+    // --- manifest wiring: Sentry's auto-init ContentProvider must be OFF ---
+
+    @Test
+    fun manifest_disablesSentryAutoInit() {
+        // The SDK bundles a SentryInitProvider that inits at process start and, with
+        // no manifest DSN, crashes on launch ("DSN is required"). We init manually and
+        // only after opt-in, so the manifest MUST carry io.sentry.auto-init=false.
+        // Re-adding it (or dropping this meta-data) reintroduces a boot crash.
+        val appInfo =
+            context.packageManager.getApplicationInfo(
+                context.packageName,
+                PackageManager.GET_META_DATA,
+            )
+        assertThat(appInfo.metaData.getBoolean("io.sentry.auto-init", true)).isFalse()
+    }
+}

--- a/ft8af/build.gradle
+++ b/ft8af/build.gradle
@@ -22,6 +22,12 @@ plugins {
     // 2.0 sources cleanly, so no engine bump is needed.
     id 'io.gitlab.arturbosch.detekt' version '1.23.8' apply false
     id 'org.jlleitschuh.gradle.ktlint' version '12.1.2' apply false
+    // Sentry crash reporting (opt-in). The Gradle plugin is applied in
+    // app/build.gradle purely to upload the R8 mapping file so release stack
+    // traces deobfuscate in Sentry; the SDK itself is a normal dependency and
+    // is initialised manually (see crash/CrashReporting.kt). Plugin 5.x pairs
+    // with SDK 8.x.
+    id 'io.sentry.android.gradle' version '5.8.0' apply false
 }
 task clean(type: Delete) {
     delete rootProject.buildDir


### PR DESCRIPTION
## What

Wires Sentry.io crash + ANR reporting into the app. **Off by default** — nothing is sent until the user opts in via a new **Send crash reports** toggle in Advanced Settings **and** a DSN was compiled in. A fresh clone / contributor build (no DSN) never reports into anyone's project and the toggle is hidden.

## How it works

- **`crash/CrashReporting.kt`** — manual, opt-in-gated SDK init. `shouldEnable(dsn, optedIn)` is the single pure gate (unit-tested). The opt-in flag lives in its own `SharedPreferences` file so it's readable in `Application.onCreate`, before the config DB opens.
- **`FT8AFApplication`** — new `Application` subclass that inits reporting on startup; registered in the manifest.
- **Manifest** — disables Sentry's auto-init `ContentProvider`. It runs at process start and requires a manifest DSN, **crashing the app on launch** (`DSN is required`) since we init manually. Covered by a Robolectric regression test.
- **Breadcrumbs** — `ComposeMainActivity.fileLog()` mirrors each `debug.log` line into Sentry. **PII off** (`isSendDefaultPii=false`) — operator callsign and GPS/grid are never auto-attached.
- **DSN** — supplied out-of-band via `-PSENTRY_DSN` / `SENTRY_DSN` (gradle prop or env) → `BuildConfig`; never committed.
- **Deobfuscation** — Sentry Gradle plugin (SDK `8.16.0` / plugin `5.8.0`) applied **only** to upload the R8 `mapping.txt`. Auto-install and tracing are off. Upload runs only when `SENTRY_AUTH_TOKEN` (+ `SENTRY_ORG` / `SENTRY_PROJECT`) is present, so token-less builds never fail.

## Testing

New unit tests: `shouldEnable` truth table, opt-in persistence, disabled-path safety, and the manifest auto-init-off regression guard. All pass.

**Verified end-to-end on-device** (emulator, real DSN): a real crash is caught by our `UncaughtExceptionHandler` and the envelope is **accepted by the live Sentry project** (`release`/`environment` tagged correctly); release-build `mapping.txt` upload succeeds; no-DSN build boots clean with Sentry inert.

## CI setup needed to enable in production

Set these as CI secrets/vars (kept out of source): `SENTRY_DSN`, and for mapping upload `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)