### PR TITLE
Fix StringIndexOutOfBounds crash in Ft8Message.getCallsignTo()

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/Ft8Message.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/Ft8Message.java
@@ -454,11 +454,16 @@ t71     Telemetry data, up to 18 hex digits
         if (callsignTo == null) {
             return "";
         }
-        if (callsignTo.length() < 2) {
-            return "";
-        }
-        if (callsignTo.substring(0, 2).equals("CQ") || callsignTo.substring(0, 2).equals("DE")
-                || callsignTo.substring(0, 3).equals("QRZ")) {
+        // A calling token (CQ / CQ DX / DE / QRZ) is not an addressable "to"
+        // callsign. Use startsWith rather than substring(0, n): the previous
+        // length<2 guard did not cover the substring(0, 3) "QRZ" comparison, so a
+        // callsignTo of exactly length 2 that was neither "CQ" nor "DE" threw
+        // StringIndexOutOfBoundsException. The decoder can render a short junk
+        // token into callsignTo on a CRC-collision false decode, and this method
+        // runs on essentially every decoded message, so that crashed the
+        // decode-handling path. startsWith is safe for any length.
+        if (callsignTo.startsWith("CQ") || callsignTo.startsWith("DE")
+                || callsignTo.startsWith("QRZ")) {
             return "";
         }
         return callsignTo.replace("<", "").replace(">", "");

--- a/ft8af/app/src/test/java/com/k1af/ft8af/Ft8MessageTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/Ft8MessageTest.java
@@ -260,6 +260,25 @@ public class Ft8MessageTest {
         assertThat(msg.getCallsignTo()).isEqualTo("K1ABC");
     }
 
+    @Test
+    public void getCallsignTo_twoCharToken_doesNotCrash() {
+        // Regression: the calling-token check ran substring(0, 3) (for "QRZ")
+        // after only a length<2 guard, so a callsignTo of exactly length 2 that
+        // is neither "CQ" nor "DE" threw StringIndexOutOfBoundsException. The
+        // native decoder can render such a short junk token into callsignTo on a
+        // CRC-collision false decode, and getCallsignTo() runs on essentially
+        // every decoded message, so this crashed the decode-handling path.
+        Ft8Message msg = new Ft8Message("W1", "K1ABC", "FN42");
+        assertThat(msg.getCallsignTo()).isEqualTo("W1");
+    }
+
+    @Test
+    public void getCallsignTo_singleCharToken_doesNotCrash() {
+        // A length-1 field must also be handled without an index exception.
+        Ft8Message msg = new Ft8Message("A", "K1ABC", "FN42");
+        assertThat(msg.getCallsignTo()).isEqualTo("A");
+    }
+
     // ---- isPlausibleCallsign / isJunkDecode ---------------------------------
 
     @Test


### PR DESCRIPTION
## Root cause

`Ft8Message.getCallsignTo()` filters out calling tokens (CQ/DE/QRZ) before returning the addressed callsign. The length guard only checked `callsignTo.length() < 2`, but the "QRZ" comparison uses `callsignTo.substring(0, 3)`, which needs `length() >= 3`:

```java
if (callsignTo.length() < 2) {
    return "";
}
if (callsignTo.substring(0, 2).equals("CQ") || callsignTo.substring(0, 2).equals("DE")
        || callsignTo.substring(0, 3).equals("QRZ")) {   // <-- needs length >= 3
    return "";
}
```

Because `||` short-circuits, the `substring(0, 3)` is only reached when the first two comparisons are false. So **any `callsignTo` of exactly length 2 that is not `"CQ"` or `"DE"`** (e.g. `"W1"`) falls through to `substring(0, 3)` and throws `StringIndexOutOfBoundsException`.

## Why it matters

`callsignTo` is populated directly by the native decoder (`ft8af_glue/ft8_decode_jni.cpp`). FT8 frames are protected by only a 14-bit CRC, so roughly one noise event in 16k slips through as a "valid" decode and can render a short junk token into the callsign field — exactly the CRC-collision garbage the class already guards against for the *sender* field via `isPlausibleCallsign` / `isJunkDecode`.

`getCallsignTo()` is a public accessor called on essentially every decoded message and mostly *before* any junk filtering — `alert/DxAlertNotifier`, `ft8transmit/FT8TransmitSignal`, `callsign/CallsignDatabase`, and the UI list adapters — so this is an unguarded crash on the decode-handling hot path, not a rare corner.

## Fix

Replace the fragile `substring(0, n)` comparisons with `startsWith`, which is safe for strings of any length and preserves the existing calling-token semantics (CQ / CQ DX / DE / QRZ → not addressable). The now-redundant length guard is removed.

```java
if (callsignTo.startsWith("CQ") || callsignTo.startsWith("DE")
        || callsignTo.startsWith("QRZ")) {
    return "";
}
```

## Testing performed

- Added two regression tests to `Ft8MessageTest` (`getCallsignTo_twoCharToken_doesNotCrash`, `getCallsignTo_singleCharToken_doesNotCrash`). Both **fail on the pre-fix code** — the 2-char case throws `StringIndexOutOfBoundsException`, the 1-char case returns `""` instead of the token — and pass after the fix.
- `./gradlew :app:testDebugUnitTest` — full unit-test suite green (includes the native cmake/NDK build).

## Risk assessment

Very low. The change is confined to one accessor; behavior is identical for all previously-non-crashing inputs (null → `""`, CQ/DE/QRZ tokens → `""`, real calls → bracket-stripped). The only behavior change is that very short junk tokens (length 1–2) are now returned as-is instead of crashing or being silently blanked — downstream consumers already treat non-matching callsigns as no-ops. No DSP/protocol behavior is affected.