### PR TITLE
Fix StringIndexOutOfBounds crash in FT8Package.formatCallsign()

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
@@ -362,7 +362,11 @@ public class FT8Package {
      * @param callsign callsign
      * @return the C28 value represented as an int
      */
-    private static String formatCallsign(String callsign) {
+    // Package-private (not private) so FT8PackagePackingTest can exercise the
+    // short-callsign guard below directly: pack_c28 routes a non-standard
+    // callsign into the native getHash22 path, which a plain-JVM unit test
+    // cannot load, so the crash-safety of this formatter has to be tested here.
+    static String formatCallsign(String callsign) {
         String c6 = callsign;
         // fix Swaziland callsign prefix issue: 3DA0XYZ -> 3D0XYZ
         if (callsign.length() > 3 && callsign.substring(0, 4).equals("3DA0") && callsign.length() <= 7) {
@@ -372,7 +376,14 @@ public class FT8Package {
             c6 = "Q" + callsign.substring(2);
         } else {
             // if position 2 is a digit and position 3 is a letter, left-pad with a space: A0XYZ -> " A0XYZ" (except A6 prefix)
-            if (callsign.substring(0, 3).matches("[A-Z][0-9][A-Z]")) {
+            // The length>=3 guard is required: pack_c28 calls formatCallsign on
+            // the raw callsign BEFORE the standard-callsign check, and a decoder
+            // CRC-collision false decode can render a 1-2 char junk token into a
+            // callsign field (the same garbage getCallsignTo() already guards
+            // against). Without the guard, substring(0, 3) threw
+            // StringIndexOutOfBoundsException on the TX-encode path (e.g. calling
+            // a station whose decoded callsign came back as "W1").
+            if (callsign.length() >= 3 && callsign.substring(0, 3).matches("[A-Z][0-9][A-Z]")) {
                 c6 = " " + callsign;
             }
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
@@ -351,16 +351,21 @@ public class FT8Package {
 
 
     /**
-     * Format a standard callsign.
-     * A standard callsign is 6 characters: 1-2 letter prefix + 1 digit, suffix up to 3 letters.
-     * Formatting rules:
+     * Normalize a callsign into the 6-character {@code c6} field used by
+     * {@link #pack_c28}.
+     * <p>
+     * {@code pack_c28} calls this on the raw callsign <em>before</em> deciding
+     * whether the callsign is standard, so the input is not guaranteed to be a
+     * well-formed standard callsign — short/junk tokens (e.g. a CRC-collision
+     * false decode) reach here too and must pass through without crashing.
+     * Formatting rules (applied only when the input matches):
      * 1. Swaziland callsign prefix issue: 3DA0XYZ -> 3D0XYZ
      * 2. Guinea callsign prefix issue: 3XA0XYZ -> QA0XYZ
      * 3. Callsigns with a digit in position 2 are left-padded with a space: A0XYZ -> " A0XYZ"
-     * 4. Suffixes shorter than 3 characters are right-padded with spaces: BA2BI -> "BA2BI "
+     * 4. Results shorter than 6 characters are right-padded with spaces: BA2BI -> "BA2BI "
      *
-     * @param callsign callsign
-     * @return the C28 value represented as an int
+     * @param callsign callsign (may be a short/non-standard token)
+     * @return the space-padded 6-character {@code c6} string
      */
     // Package-private (not private) so FT8PackagePackingTest can exercise the
     // short-callsign guard below directly: pack_c28 routes a non-standard

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackagePackingTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackagePackingTest.java
@@ -145,4 +145,42 @@ public class FT8PackagePackingTest {
         assertThat((long) w1aw).isAtLeast(boundary);
         assertThat(k1abc).isNotEqualTo(w1aw);
     }
+
+    // ---- formatCallsign (short-callsign crash guard) -------------------------
+    // pack_c28 calls formatCallsign on the raw callsign BEFORE deciding whether
+    // it is standard, so the formatter has to tolerate any string. A decoder
+    // CRC-collision false decode can render a 1-2 char junk token into a
+    // callsign field, and encoding a reply to such a station (pack_c28(toCall))
+    // reaches formatCallsign. Its else branch ran substring(0, 3) with no length
+    // guard, throwing StringIndexOutOfBoundsException for length &lt; 3. We test
+    // formatCallsign directly because pack_c28 on a non-standard callsign falls
+    // through to the native getHash22 branch, which the bare JVM cannot load.
+
+    @Test
+    public void formatCallsign_twoCharToken_doesNotCrash() {
+        // Regression: "W1" (length 2) fell into the else branch's substring(0, 3)
+        // after only length>3 guards on the earlier branches, so it threw.
+        // Short non-standard input is passed through and right-padded to 6.
+        assertThat(FT8Package.formatCallsign("W1")).isEqualTo("W1    ");
+    }
+
+    @Test
+    public void formatCallsign_singleCharToken_doesNotCrash() {
+        // A length-1 field must also be handled without an index exception.
+        assertThat(FT8Package.formatCallsign("A")).isEqualTo("A     ");
+    }
+
+    @Test
+    public void formatCallsign_threeCharPrefix_stillLeftPads() {
+        // The length-3 [A-Z][0-9][A-Z] case is exactly the boundary the guard
+        // must still admit: "A0X" gets the leading-space pad, unchanged by the fix.
+        assertThat(FT8Package.formatCallsign("A0X")).isEqualTo(" A0X  ");
+    }
+
+    @Test
+    public void formatCallsign_standardCallsign_unchangedByGuard() {
+        // The common standard-callsign path (digit in position 2) is unaffected:
+        // "K1ABC" -> leading-space pad to the 6-char c6 field.
+        assertThat(FT8Package.formatCallsign("K1ABC")).isEqualTo(" K1ABC");
+    }
 }


### PR DESCRIPTION
## Root cause

`FT8Package.formatCallsign()` formats a callsign into the 6-character `c6`
field used by `pack_c28`. Its `else` branch ran `substring(0, 3)` guarded only
by the `length() > 3` checks on the *earlier* Swaziland (`3DA0…`) and Guinea
(`3X…`) branches:

```java
} else {
    if (callsign.substring(0, 3).matches("[A-Z][0-9][A-Z]")) {  // throws for length < 3
        c6 = " " + callsign;
    }
}
```

Any callsign of length **1 or 2** that is not a `CQ`/`DE`/`QRZ` token (those are
short-circuited earlier in `pack_c28`) falls into this branch and throws
`StringIndexOutOfBoundsException`.

## Why it's reachable (technical explanation)

`pack_c28()` calls `formatCallsign(callsign)` on the **raw** callsign *before* it
decides whether the callsign is standard, and `generatePack77_i1` / `_fd` feed it
the message's `callsignTo` / `callsignFrom`. FT8 frames carry only a 14-bit CRC,
so a noise-driven false decode can render a short junk token into a callsign
field — the exact CRC-collision garbage that `getCallsignTo()` /
`isPlausibleCallsign()` already guard against on the **decode** side (fixed in
731e0ebc). This PR is the sibling fix on the **encode** side.

Concretely: replying to / calling a station whose decoded callsign came back as
e.g. `"W1"` runs `generatePack77_i1` → `pack_c28("W1")` → `formatCallsign("W1")`
→ crash. The old `callsignFrom.length() < 3` guard in
`GenerateFT8.generateFt8` is commented out, and it never covered the "to" field
regardless.

## Fix

Add a `length() >= 3` guard before the `substring(0, 3)` comparison. A valid
`[A-Z][0-9][A-Z]` prefix requires 3 characters, so short callsigns simply pass
through unchanged and get space-padded; `pack_c28` then routes them to its
non-standard (hash22) path. **Behavior for length ≥ 3 is unchanged.**

`formatCallsign` is made package-private (was `private`) so the regression tests
can call it directly — `pack_c28` on a non-standard callsign falls through to the
native `getHash22` branch, which a plain-JVM unit test cannot load, so the
crash-safety of the formatter is tested at the formatter itself.

## Testing performed

- Added 4 regression tests to `FT8PackagePackingTest`:
  - `formatCallsign_twoCharToken_doesNotCrash` (`"W1"` → `"W1    "`) — fails with
    `StringIndexOutOfBoundsException` before the fix
  - `formatCallsign_singleCharToken_doesNotCrash` (`"A"` → `"A     "`)
  - `formatCallsign_threeCharPrefix_stillLeftPads` (`"A0X"` → `" A0X  "`) — the
    length-3 boundary the guard must still admit
  - `formatCallsign_standardCallsign_unchangedByGuard` (`"K1ABC"` → `" K1ABC"`)
- `./gradlew :app:testDebugUnitTest` — full suite green (0 failures, 0 errors).

## Risk assessment

Low. Single-method change; the added condition only *narrows* when the
leading-space pad is applied, and only for inputs (length < 3) that previously
crashed. No protocol/DSP behavior changes — standard callsign encoding is
byte-for-byte identical (existing `pack_c28("K1ABC")` golden-value test still
passes). The visibility change from `private` to package-private is
test-only exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)