### PR TITLE
Fix NPE crash in ICOM CI-V frequency/meter decoders on short frames

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomCommand.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomCommand.java
@@ -157,7 +157,7 @@ public class IcomCommand {
      */
     public long getFrequency(boolean hasSubCommand) {
         byte[] data = getData(hasSubCommand);
-        if (data.length < 5) {
+        if (data == null || data.length < 5) {//short/garbled frame with no data section
             return -1;
         }
         return (int) (data[0] & 0x0f)//ones digit 1Hz

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRigConstant.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRigConstant.java
@@ -288,7 +288,7 @@ public class IcomRigConstant {
     }
 
     public static int twoByteBcdToInt(byte[] data) {
-        if (data.length < 2) return 0;
+        if (data == null || data.length < 2) return 0;
         return (int) (data[1] & 0x0f)//ones digit
                 + ((int) (data[1] >> 4) & 0xf) * 10//tens digit
                 + (int) (data[0] & 0x0f) * 100//hundreds
@@ -296,7 +296,7 @@ public class IcomRigConstant {
 
     }
     public static int twoByteBcdToIntBigEnd(byte[] data) {
-        if (data.length < 2) return 0;
+        if (data == null || data.length < 2) return 0;
         return (int) (data[0] & 0x0f)//ones digit
                 + ((int) (data[0] >> 4) & 0xf) * 10//tens digit
                 + (int) (data[1] & 0x0f) * 100//hundreds

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomCommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomCommandTest.java
@@ -81,6 +81,20 @@ public class IcomCommandTest {
     }
 
     @Test
+    public void getFrequency_missingDataSectionReturnsMinusOne() {
+        // A short/garbled frame that matches the preamble and cmd 03 but carries
+        // no data payload: FE FE E0 A4 03 FD. getData(false) has nothing after the
+        // command byte and returns null, so getFrequency must not dereference it.
+        IcomCommand cmd = IcomCommand.getCommand(CTRL, RIG,
+                new byte[]{(byte) 0xFE, (byte) 0xFE, (byte) CTRL, (byte) RIG,
+                        (byte) 0x03, (byte) 0xFD});
+        assertThat(cmd).isNotNull();
+        assertThat(cmd.getCommandID()).isEqualTo(0x03);
+        assertThat(cmd.getData(false)).isNull();
+        assertThat(cmd.getFrequency(false)).isEqualTo(-1L);
+    }
+
+    @Test
     public void getData_returnsPayloadAfterCommand() {
         IcomCommand cmd = IcomCommand.getCommand(CTRL, RIG, freqFrame14074());
         assertThat(cmd).isNotNull();

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigConstantTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigConstantTest.java
@@ -108,4 +108,13 @@ public class IcomRigConstantTest {
         assertThat(IcomRigConstant.twoByteBcdToInt(new byte[]{0x12})).isEqualTo(0);
         assertThat(IcomRigConstant.twoByteBcdToIntBigEnd(new byte[0])).isEqualTo(0);
     }
+
+    @Test
+    public void twoByteBcd_nullInputReturnsZero() {
+        // A meter reply with no data section yields a null payload
+        // (IcomCommand.getData). The BCD decoders must treat that as "no reading"
+        // rather than crashing the CAT thread with an NPE.
+        assertThat(IcomRigConstant.twoByteBcdToInt(null)).isEqualTo(0);
+        assertThat(IcomRigConstant.twoByteBcdToIntBigEnd(null)).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a `NullPointerException` in the ICOM CI-V response decoders that can crash the app when a short or garbled CI-V frame arrives from the rig.

`IcomCommand.getData()` returns `null` when a CI-V frame carries no data section — e.g. a truncated/echoed/collision frame such as `FE FE E0 A4 03 FD` (a valid preamble + command byte, but no payload before the `FD` terminator). Three shared decoders dereferenced that result without a null check:

- `IcomCommand.getFrequency()` — read `data.length`
- `IcomRigConstant.twoByteBcdToInt()` / `twoByteBcdToIntBigEnd()` — read `data.length`

## Root cause

These decoders already guarded the *too-short* case (`data.length < 5` → return `-1`; `data.length < 2` → return `0`), but the guards missed the `null` case that `getData()` can legitimately return. A malformed serial response therefore threw an NPE.

Impact by transport:
- **USB** — the exception is caught by `SerialInputOutputManager.run()`, but that tears down the CAT thread, silently killing rig control until reconnect.
- **Bluetooth** — RX bytes are parsed on the **main thread** with no surrounding try/catch, so the NPE is a hard app crash.

Both paths are exercised **per CAT poll** via `IcomRig`/`XieGuRig` operating-frequency handling (`getFrequency`) and ALC/SWR meter handling (`twoByteBcdToInt*`).

## Fix

Extend each existing guard to also cover `null`, so a bad frame is ignored (returns the same sentinel as the too-short case) rather than crashing:

```java
if (data == null || data.length < 5) { return -1; }   // getFrequency
if (data == null || data.length < 2) return 0;         // twoByteBcdToInt*
```

Minimal and localized; no protocol/behavioral change for well-formed frames.

## Testing

- Added `IcomCommandTest.getFrequency_missingDataSectionReturnsMinusOne` — asserts a `FE FE E0 A4 03 FD` frame decodes to `-1` instead of throwing.
- Added `IcomRigConstantTest.twoByteBcd_nullInputReturnsZero` — asserts both BCD decoders return `0` for a null payload.
- Both tests **fail with NPE before the fix** and pass after.
- `./gradlew :app:testDebugUnitTest --tests 'com.k1af.ft8af.rigs.*'` — all green.

## Risk

Very low. The change only relaxes existing sentinel-returning guards to also accept `null`; behavior for valid frames is unchanged.