### PR TITLE
Fix CAT meter parser crash on non-numeric rig replies

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/ElecraftCommand.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/ElecraftCommand.java
@@ -71,7 +71,16 @@ public class ElecraftCommand {
     }
 
     public static int getSWRMeter(ElecraftCommand command) {
-        return  Integer.parseInt(command.data.substring(0,3));
+        if (command.data.length() < 3) return 0;
+        // Meter replies are parsed on the main thread with no surrounding
+        // try/catch on the Bluetooth SPP path, so a garbled or non-numeric byte
+        // sequence must not be allowed to throw and crash the app.
+        try {
+            return Integer.parseInt(command.data.substring(0, 3));
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "Non-numeric SWR meter value: " + command.data);
+            return 0;
+        }
     }
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
@@ -77,7 +77,7 @@ public class Yaesu3Command {
      */
     public static int getALCOrSWR38(Yaesu3Command command) {
         if (command.data.length() < 7) return 0;
-        return Integer.parseInt(command.data.substring(1, 4));
+        return parseMeterValue(command.data.substring(1, 4));
     }
 
     public static boolean isSWRMeter38(Yaesu3Command command) {
@@ -99,7 +99,7 @@ public class Yaesu3Command {
      */
     public static int getSWROrALC39(Yaesu3Command command) {
         if (command.data.length() < 4) return 0;
-        return Integer.parseInt(command.data.substring(1, 4));
+        return parseMeterValue(command.data.substring(1, 4));
     }
 
     public static boolean isSWRMeter39(Yaesu3Command command) {
@@ -119,7 +119,24 @@ public class Yaesu3Command {
      * @return value
      */
     public static int get590ALCOrSWR(Yaesu3Command command) {
-        return Integer.parseInt(command.data.substring(1, 5));
+        if (command.data.length() < 5) return 0;
+        return parseMeterValue(command.data.substring(1, 5));
+    }
+
+    /**
+     * Parse a numeric CAT meter token, returning 0 ("no reading") for any
+     * non-numeric value. The rig's meter replies are read on the main thread
+     * with no surrounding try/catch on the Bluetooth SPP path, so a garbled or
+     * non-numeric byte sequence must not be allowed to throw
+     * {@link NumberFormatException} and crash the app.
+     */
+    private static int parseMeterValue(String token) {
+        try {
+            return Integer.parseInt(token);
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "Non-numeric CAT meter value: " + token);
+            return 0;
+        }
     }
 
     public static boolean is590MeterALC(Yaesu3Command command){

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatMeterParserTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatMeterParserTest.java
@@ -1,0 +1,107 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for the numeric CAT meter parsers on {@link Yaesu3Command} and
+ * {@link ElecraftCommand}.
+ *
+ * These parsers run per-CAT-poll on {@code onReceiveData}, which on the
+ * Bluetooth SPP path executes on the main thread with no surrounding try/catch
+ * ({@code BluetoothSerialService} -> {@code BluetoothRigConnector.onSerialRead}
+ * -> {@code BaseRig.onReceiveData}). A garbled or non-numeric meter reply from
+ * the rig therefore used to throw {@link NumberFormatException} (or, for
+ * {@code get590ALCOrSWR}, {@link StringIndexOutOfBoundsException}) and hard-crash
+ * the app. The parsers must instead treat malformed data as "no reading" (0).
+ *
+ * Plain JUnit: the tested code only touches {@code android.util.Log}, which is
+ * stubbed by {@code testOptions.unitTests.returnDefaultValues}.
+ */
+public class CatMeterParserTest {
+
+    // ---- Yaesu3Command.getALCOrSWR38 (FTDX / FT-950 family, data length >= 7) ----
+
+    @Test
+    public void getALCOrSWR38_parsesNumericValue() {
+        // "RM6100000;" -> commandID "RM", data "6100000"; substring(1,4) = "100".
+        Yaesu3Command c = new Yaesu3Command("RM", "6100000");
+        assertThat(Yaesu3Command.getALCOrSWR38(c)).isEqualTo(100);
+    }
+
+    @Test
+    public void getALCOrSWR38_returnsZeroOnNonNumericData() {
+        Yaesu3Command c = new Yaesu3Command("RM", "6xy0000");
+        assertThat(Yaesu3Command.getALCOrSWR38(c)).isEqualTo(0);
+    }
+
+    @Test
+    public void getALCOrSWR38_returnsZeroOnShortData() {
+        Yaesu3Command c = new Yaesu3Command("RM", "61");
+        assertThat(Yaesu3Command.getALCOrSWR38(c)).isEqualTo(0);
+    }
+
+    // ---- Yaesu3Command.getSWROrALC39 (FT-891 family, data length >= 4) ----
+
+    @Test
+    public void getSWROrALC39_parsesNumericValue() {
+        Yaesu3Command c = new Yaesu3Command("RM", "6100");
+        assertThat(Yaesu3Command.getSWROrALC39(c)).isEqualTo(100);
+    }
+
+    @Test
+    public void getSWROrALC39_returnsZeroOnNonNumericData() {
+        Yaesu3Command c = new Yaesu3Command("RM", "6xyz");
+        assertThat(Yaesu3Command.getSWROrALC39(c)).isEqualTo(0);
+    }
+
+    @Test
+    public void getSWROrALC39_returnsZeroOnShortData() {
+        Yaesu3Command c = new Yaesu3Command("RM", "61");
+        assertThat(Yaesu3Command.getSWROrALC39(c)).isEqualTo(0);
+    }
+
+    // ---- Yaesu3Command.get590ALCOrSWR (Kenwood TS-590/2000/570, substring(1,5)) ----
+
+    @Test
+    public void get590ALCOrSWR_parsesNumericValue() {
+        // data "01300" -> substring(1,5) = "1300".
+        Yaesu3Command c = new Yaesu3Command("RM", "01300");
+        assertThat(Yaesu3Command.get590ALCOrSWR(c)).isEqualTo(1300);
+    }
+
+    @Test
+    public void get590ALCOrSWR_returnsZeroOnNonNumericData() {
+        Yaesu3Command c = new Yaesu3Command("RM", "0abcd");
+        assertThat(Yaesu3Command.get590ALCOrSWR(c)).isEqualTo(0);
+    }
+
+    @Test
+    public void get590ALCOrSWR_returnsZeroOnShortData() {
+        // Shorter than 5 chars: substring(1,5) would previously throw
+        // StringIndexOutOfBoundsException.
+        Yaesu3Command c = new Yaesu3Command("RM", "013");
+        assertThat(Yaesu3Command.get590ALCOrSWR(c)).isEqualTo(0);
+    }
+
+    // ---- ElecraftCommand.getSWRMeter (substring(0,3)) ----
+
+    @Test
+    public void elecraftGetSWRMeter_parsesNumericValue() {
+        ElecraftCommand c = new ElecraftCommand("SW", "012");
+        assertThat(ElecraftCommand.getSWRMeter(c)).isEqualTo(12);
+    }
+
+    @Test
+    public void elecraftGetSWRMeter_returnsZeroOnNonNumericData() {
+        ElecraftCommand c = new ElecraftCommand("SW", "abc");
+        assertThat(ElecraftCommand.getSWRMeter(c)).isEqualTo(0);
+    }
+
+    @Test
+    public void elecraftGetSWRMeter_returnsZeroOnShortData() {
+        ElecraftCommand c = new ElecraftCommand("SW", "ab");
+        assertThat(ElecraftCommand.getSWRMeter(c)).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Root cause

The numeric CAT meter parsers validate the reply's token **length** but never that the substring is actually numeric before calling `Integer.parseInt`:

- `Yaesu3Command.getALCOrSWR38` — `parseInt(data.substring(1,4))` (FTDX/FT-950 family)
- `Yaesu3Command.getSWROrALC39` — `parseInt(data.substring(1,4))` (FT-891 family)
- `Yaesu3Command.get590ALCOrSWR` — `parseInt(data.substring(1,5))` (Kenwood TS-590/2000/570) — **also had no length guard at all**
- `ElecraftCommand.getSWRMeter` — `parseInt(data.substring(0,3))`

These parsers run per-CAT-poll inside `onReceiveData`. On the **Bluetooth SPP path** the reply is dispatched to the parser on the **main thread with no surrounding try/catch**:

```
BluetoothSerialService.onSerialRead -> mainLooper.post
  -> BluetoothRigConnector.onSerialRead -> onData
  -> BaseRig.onReceiveData -> <Rig>.onReceiveData -> Yaesu3Command/ElecraftCommand
```

So a garbled or non-numeric meter reply from the rig threw `NumberFormatException` (or `StringIndexOutOfBoundsException` for the unguarded `get590ALCOrSWR`) and **hard-crashed the app**. (The USB path is caught by `SerialInputOutputManager.run()`, which only tears down the CAT thread — hence this bites Bluetooth-connected rigs.)

## Fix

Treat malformed meter data as *"no reading"* (return `0`) instead of throwing, matching the existing `getFrequency()` convention already used in the same two files. Added a length guard to `get590ALCOrSWR` to match its sibling parsers.

`0` is the safe sentinel: it never falsely trips the SWR-halt / ALC auto-volume protection (`MeterProtectionController`), which key off *high* values.

## Testing

- New `CatMeterParserTest` covers numeric, non-numeric, and short data for all four parsers (12 cases). Verified the 6 malformed-data cases fail with `NumberFormatException`/`StringIndexOutOfBoundsException` against the old code, and all 12 pass after the fix.
- Full `:app:testDebugUnitTest` suite passes.
- `:app:assembleDebug` (including native build) succeeds.

## Risk

Very low. Behavior is unchanged for valid meter replies (same parsed integer); only malformed/garbled input changes from *crash* to *0*. No protocol, DSP, or threading behavior touched. No device was attached in this environment, so no on-device verification was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)