### PR TITLE
Fix decode-thread IndexOutOfBounds in SWL QSO scan (off-lock live-list read)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -711,7 +711,21 @@ public class MainViewModel extends ViewModel {
                 }
                 //check QSO of SWL, and save to the QSO list in SWLQSOTable
                 if (GeneralVariables.saveSWL_QSO) {
-                    swlQsoList.findSwlQso(messages, ft8Messages, new SWLQsoList.OnFoundSwlQso() {
+                    // findSwlQso scans the "all messages" list with index-based backward
+                    // loops (checkPart1/checkPart2: for i = size()-1 .. 0, get(i)). Passing
+                    // the live ft8Messages let it iterate off-lock while a concurrent decode
+                    // pass (slot N's late/deep pass vs slot N+1's early pass, #398) held
+                    // synchronized(ft8Messages) running addAll + deleteArrayListMore's
+                    // remove(0), shrinking the list mid-scan -> IndexOutOfBoundsException on
+                    // the decode thread. Scan a snapshot copied under the same monitor the
+                    // writers use (mirrors publishFt8MessageList). The freshly decoded
+                    // `messages` were appended to ft8Messages under lock above, so they are
+                    // already in this snapshot and QSO detection is unchanged.
+                    final ArrayList<Ft8Message> allMessagesSnapshot;
+                    synchronized (ft8Messages) {
+                        allMessagesSnapshot = new ArrayList<>(ft8Messages);
+                    }
+                    swlQsoList.findSwlQso(messages, allMessagesSnapshot, new SWLQsoList.OnFoundSwlQso() {
                         @Override
                         public void doFound(QSLRecord record) {
                             databaseOpr.addSWL_QSO(record);//save SWL QSO to database

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/SWLQsoListTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/SWLQsoListTest.java
@@ -1,0 +1,160 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+import com.k1af.ft8af.GeneralVariables;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Behavior coverage for {@link SWLQsoList#findSwlQso}, the SWL QSO detector that
+ * runs on the decode thread when {@code GeneralVariables.saveSWL_QSO} is enabled.
+ *
+ * <p>findSwlQso scans the "all messages" list with index-based backward loops
+ * ({@code for i = size()-1 .. 0; get(i)}) inside checkPart1/checkPart2. In
+ * MainViewModel the list handed in used to be the live, concurrently-mutated
+ * {@code ft8Messages}; that let the scan hit IndexOutOfBounds when a concurrent
+ * decode pass trimmed the list mid-loop. The fix copies the list under the
+ * writers' lock before calling findSwlQso. These tests lock in that findSwlQso is
+ * a pure function of the two lists it is given, so scanning a snapshot instead of
+ * the live instance is behavior-preserving.
+ *
+ * <p>Plain JUnit is enough (mirrors {@link QSLRecordTest}): the only Android touch
+ * is {@code android.util.Log}, which returns defaults under
+ * {@code testOptions.unitTests.returnDefaultValues}.
+ */
+public class SWLQsoListTest {
+
+    private String savedMyCallsign;
+
+    @Before
+    public void setUp() {
+        savedMyCallsign = GeneralVariables.myCallsign;
+        GeneralVariables.myCallsign = "K1ABC";
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.myCallsign = savedMyCallsign;
+    }
+
+    /** Collects every QSO the detector reports back. */
+    private static final class CapturingCallback implements SWLQsoList.OnFoundSwlQso {
+        final List<QSLRecord> found = new ArrayList<>();
+
+        @Override
+        public void doFound(QSLRecord record) {
+            found.add(record);
+        }
+    }
+
+    // callTo, callFrom, extraInfo (Ft8Message ctor order) — the sender is callFrom.
+    private static Ft8Message msg(String to, String from, String extra) {
+        return new Ft8Message(to, from, extra);
+    }
+
+    @Test
+    public void completeQso_firesCallbackWithBothReports() {
+        // Two stations exchange reports and one closes with RR73. The report
+        // matching keys off checkIsMyCallsign, so K1ABC appears on the reporting
+        // side of both exchanges.
+        Ft8Message reportSent = msg("W1AW", "K1ABC", "R-05");  // K1ABC -> W1AW, R-05
+        Ft8Message reportRcvd = msg("K1ABC", "W1AW", "-10");   // W1AW -> K1ABC, -10
+        Ft8Message ending = msg("W1AW", "DL1XYZ", "RR73");     // closing marker
+
+        ArrayList<Ft8Message> all = new ArrayList<>();
+        all.add(reportSent);
+        all.add(reportRcvd);
+        all.add(ending);
+
+        ArrayList<Ft8Message> fresh = new ArrayList<>();
+        fresh.add(ending);
+
+        CapturingCallback cb = new CapturingCallback();
+        new SWLQsoList().findSwlQso(fresh, all, cb);
+
+        assertThat(cb.found).hasSize(1);
+        QSLRecord record = cb.found.get(0);
+        assertThat(record.getToCallsign()).isEqualTo("W1AW");
+        assertThat(record.getSendReport()).isEqualTo(-5);
+        assertThat(record.getReceivedReport()).isEqualTo(-10);
+    }
+
+    @Test
+    public void missingOneReport_noQso() {
+        // Only one direction of the report exchange is present, so checkPart2
+        // fails and no QSO is recorded.
+        Ft8Message reportSent = msg("W1AW", "K1ABC", "R-05");
+        Ft8Message ending = msg("W1AW", "DL1XYZ", "RR73");
+
+        ArrayList<Ft8Message> all = new ArrayList<>();
+        all.add(reportSent);
+        all.add(ending);
+
+        ArrayList<Ft8Message> fresh = new ArrayList<>();
+        fresh.add(ending);
+
+        CapturingCallback cb = new CapturingCallback();
+        new SWLQsoList().findSwlQso(fresh, all, cb);
+
+        assertThat(cb.found).isEmpty();
+    }
+
+    @Test
+    public void endingInMyCall_isSkipped() {
+        // A closing marker that involves my own callsign is not an SWL QSO and
+        // must be skipped, even with both reports present.
+        Ft8Message reportSent = msg("W1AW", "K1ABC", "R-05");
+        Ft8Message reportRcvd = msg("K1ABC", "W1AW", "-10");
+        Ft8Message ending = msg("K1ABC", "W1AW", "RR73");      // to == my callsign
+
+        ArrayList<Ft8Message> all = new ArrayList<>();
+        all.add(reportSent);
+        all.add(reportRcvd);
+        all.add(ending);
+
+        ArrayList<Ft8Message> fresh = new ArrayList<>();
+        fresh.add(ending);
+
+        CapturingCallback cb = new CapturingCallback();
+        new SWLQsoList().findSwlQso(fresh, all, cb);
+
+        assertThat(cb.found).isEmpty();
+    }
+
+    @Test
+    public void scanningACopyMatchesScanningTheLiveList() {
+        // The MainViewModel fix scans a defensive copy of ft8Messages instead of
+        // the live instance. findSwlQso depends only on list *contents*, so a copy
+        // yields an identical result — this guards that equivalence.
+        Ft8Message reportSent = msg("W1AW", "K1ABC", "R-05");
+        Ft8Message reportRcvd = msg("K1ABC", "W1AW", "-10");
+        Ft8Message ending = msg("W1AW", "DL1XYZ", "RR73");
+
+        ArrayList<Ft8Message> live = new ArrayList<>();
+        live.add(reportSent);
+        live.add(reportRcvd);
+        live.add(ending);
+
+        ArrayList<Ft8Message> fresh = new ArrayList<>();
+        fresh.add(ending);
+
+        CapturingCallback liveCb = new CapturingCallback();
+        new SWLQsoList().findSwlQso(fresh, live, liveCb);
+
+        CapturingCallback copyCb = new CapturingCallback();
+        new SWLQsoList().findSwlQso(fresh, new ArrayList<>(live), copyCb);
+
+        assertThat(copyCb.found).hasSize(liveCb.found.size());
+        assertThat(copyCb.found.get(0).getSendReport())
+                .isEqualTo(liveCb.found.get(0).getSendReport());
+        assertThat(copyCb.found.get(0).getReceivedReport())
+                .isEqualTo(liveCb.found.get(0).getReceivedReport());
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/SWLQsoListTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/SWLQsoListTest.java
@@ -151,7 +151,10 @@ public class SWLQsoListTest {
         CapturingCallback copyCb = new CapturingCallback();
         new SWLQsoList().findSwlQso(fresh, new ArrayList<>(live), copyCb);
 
-        assertThat(copyCb.found).hasSize(liveCb.found.size());
+        // Assert the exact count on both sides first, so a regression to 0 records
+        // fails on this clear assertion rather than an IndexOutOfBounds on get(0).
+        assertThat(liveCb.found).hasSize(1);
+        assertThat(copyCb.found).hasSize(1);
         assertThat(copyCb.found.get(0).getSendReport())
                 .isEqualTo(liveCb.found.get(0).getSendReport());
         assertThat(copyCb.found.get(0).getReceivedReport())


### PR DESCRIPTION
## Summary

Fixes a decode-thread crash (`IndexOutOfBoundsException`) that can occur when the **Save SWL QSO** option (`GeneralVariables.saveSWL_QSO`) is enabled.

`MainViewModel.afterDecode` passed the live, shared `ft8Messages` list into `SWLQsoList.findSwlQso` as the "all messages" argument. `findSwlQso` scans that list with index-based backward loops (`checkPart1`/`checkPart2`: `for i = size()-1 .. 0; get(i)`) — and did so **outside** the `synchronized(ft8Messages)` block.

## Root cause

The decode pipeline intentionally runs two decode threads concurrently: slot N's late full-slot / deep pass overlaps slot N+1's early pass (issue #398; see `MainViewModel:169-170` and `FT8SignalListener`'s late full-slot pass). Both call `afterDecode`. The writer holds `synchronized(ft8Messages)` while doing `addAll(...)` + `GeneralVariables.deleteArrayListMore(...)`, whose `remove(0)` shifts and shrinks the list.

With the SWL scan reading `get(i)` **off-lock** on the other decode thread, a concurrent `remove(0)` can drop the list size below an already-computed index → `IndexOutOfBoundsException`, crashing the decode thread.

## Fix

Copy `ft8Messages` into a snapshot **under the same monitor the writers use** — the exact copy-under-lock pattern `publishFt8MessageList()` already uses — and scan the snapshot instead of the live instance.

The freshly decoded messages were appended to `ft8Messages` under lock earlier in the same handler, so they are already in the snapshot; QSO detection is unchanged.

The fix belongs at the call site rather than inside `findSwlQso`: the snapshot must be taken while holding the writers' lock, and a copy made *inside* `findSwlQso` would itself race the live list during the copy.

## Testing

- New `SWLQsoListTest` covers `findSwlQso`'s QSO-detection branches:
  - complete QSO with both signal reports → callback fires with the parsed reports
  - one report missing → no QSO
  - closing marker involving my own callsign → skipped
  - an explicit equivalence test showing `findSwlQso` is a pure function of the two lists it is given, so scanning a defensive copy yields the same result as scanning the live list (this is what makes the snapshot substitution provably behavior-preserving).
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — builds (incl. native).

## Risk

Very low. Pure-Java change, no DSP/protocol/native impact. Adds one bounded list copy per decode pass, only when `saveSWL_QSO` is enabled. Behavior of QSO detection is unchanged.

## Notes / out of scope

While investigating I found that `SWLQsoList`'s dedup table (`log/HashTable`) is a stub whose `contains(...)` always returns `false` and `put(...)` is a no-op, so SWL-QSO dedup does not currently work (duplicate SWL QSO records). That is a separate, pre-existing functional bug and is intentionally left out of this crash-focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)