### PR TITLE
Desktop: optionally set operator grid from OS location service (opt-in)

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -82,6 +82,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +323,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -405,6 +549,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -855,6 +1008,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1049,37 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1003,6 +1214,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "ureq",
+ "windows 0.58.0",
+ "zbus",
 ]
 
 [[package]]
@@ -1036,6 +1249,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1419,6 +1645,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1958,6 +2190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2682,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2715,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2557,6 +2811,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2864,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2944,6 +3223,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.12.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,6 +3535,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3704,6 +4006,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4020,7 +4335,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4081,6 +4408,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unescaper"
@@ -4470,8 +4808,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4554,6 +4892,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4586,12 +4934,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4603,8 +4964,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4623,9 +4984,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4676,6 +5059,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -4690,6 +5082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5174,6 +5576,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,3 +5715,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
+]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,17 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # async runtime for the UTC scheduler
 tokio = { version = "1", features = ["rt-multi-thread", "time", "sync", "macros"] }
 
+# Optional, opt-in OS location service -> operator grid (issue #471). Each
+# platform's native geolocation API is pulled in only for that target so the
+# other OSes never compile it.
+[target.'cfg(target_os = "linux")'.dependencies]
+# GeoClue 2 over D-Bus (system bus).
+zbus = "5"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+# Windows.Devices.Geolocation Geolocator + IAsyncOperation.
+windows = { version = "0.58", features = ["Devices_Geolocation", "Foundation"] }
+
 # The C FT8 DSP core (kgoba ft8_lib @ 6f528128 + ft8af_glue/gfsk.c) is compiled
 # from source in build.rs via the `cc` crate — no prebuilt .so, so this links
 # natively on Windows/macOS/Linux.

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod bands;
 pub mod db;
 pub mod dsp;
 pub mod engine;
+pub mod os_location;
 pub mod qso;
 pub mod rig;
 pub mod timesync;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -190,8 +190,9 @@ fn all_config(state: State<AppState>) -> Vec<(String, String)> {
 /// Resolve the operator grid from the OS location service. Opt-in only: refuses
 /// unless the user has turned on the `location_service_enabled` flag, so nothing
 /// requests location (and no permission prompt appears) until they explicitly
-/// opt in. Returns lat/lon + the derived Maidenhead grid, or a human-readable
-/// error the UI shows without touching the manual field.
+/// opt in. Returns only the coarse derived Maidenhead grid (the raw fix is
+/// discarded inside the backend), or a human-readable error the UI shows without
+/// touching the manual field.
 #[tauri::command]
 fn get_os_location(state: State<AppState>) -> Result<OsLocation, String> {
     let enabled = os_location::location_enabled(

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ use ft8af::audio::{self, AudioDevice};
 use ft8af::bands;
 use ft8af::db::{Db, QsoRecord};
 use ft8af::engine::{self, AnswerArgs, EngineCommand, EngineHandle};
+use ft8af::os_location::{self, OsLocation};
 use ft8af::rig::{self, HamlibRig, RigConfig, SerialPortInfo};
 use ft8af::wf::WfConfig;
 
@@ -184,6 +185,31 @@ fn all_config(state: State<AppState>) -> Vec<(String, String)> {
     state.db.all_config()
 }
 
+// --- optional OS location -> grid (issue #471) ------------------------------
+
+/// Resolve the operator grid from the OS location service. Opt-in only: refuses
+/// unless the user has turned on the `location_service_enabled` flag, so nothing
+/// requests location (and no permission prompt appears) until they explicitly
+/// opt in. Returns lat/lon + the derived Maidenhead grid, or a human-readable
+/// error the UI shows without touching the manual field.
+#[tauri::command]
+fn get_os_location(state: State<AppState>) -> Result<OsLocation, String> {
+    let enabled = os_location::location_enabled(
+        state
+            .db
+            .get_config(os_location::LOCATION_ENABLED_KEY)
+            .as_deref(),
+    );
+    if !enabled {
+        return Err(
+            "Location service is off. Turn on \"Use OS location service\" in \
+             Settings → Station first."
+                .into(),
+        );
+    }
+    os_location::resolve()
+}
+
 #[tauri::command]
 fn set_waterfall_config(state: State<AppState>, config: WfConfig) {
     // The engine sanitizes, persists (wf_window/wf_fft_size/wf_avg), and
@@ -268,6 +294,7 @@ fn main() {
             set_config,
             all_config,
             set_waterfall_config,
+            get_os_location,
         ])
         .run(tauri::generate_context!())
         .expect("error running FT8AF");

--- a/desktop/src-tauri/src/os_location.rs
+++ b/desktop/src-tauri/src/os_location.rs
@@ -13,6 +13,7 @@
 //!     to manual entry (see the module docs / PR for the CoreLocation plan).
 
 use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::util;
@@ -29,11 +30,12 @@ pub const OS_GRID_PRECISION: usize = 6;
 /// "Use my location" button can never hang the app.
 const QUERY_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// A resolved OS location plus the derived Maidenhead grid handed to the UI.
+/// The result handed to the UI: only the coarse derived Maidenhead grid. The raw
+/// latitude/longitude fix is used to compute the grid and then dropped inside the
+/// backend, so precise coordinates never cross the IPC boundary — the exposed
+/// value is a ~2.5 × 5 km subsquare, not a pinpoint QTH.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OsLocation {
-    pub lat: f64,
-    pub lon: f64,
     pub grid: String,
 }
 
@@ -46,13 +48,12 @@ pub fn location_enabled(value: Option<&str>) -> bool {
     matches!(value, Some("true"))
 }
 
-/// Convert a raw OS fix into the [`OsLocation`] returned to the UI. Kept separate
+/// Convert a raw OS fix into the [`OsLocation`] returned to the UI, coarsening it
+/// to a Maidenhead subsquare and discarding the precise lat/lon. Kept separate
 /// from the platform query so the lat/lon -> grid step is unit-testable without
 /// touching any OS API.
 pub fn to_os_location(lat: f64, lon: f64) -> OsLocation {
     OsLocation {
-        lat,
-        lon,
         grid: util::latlon_to_maidenhead(lat, lon, OS_GRID_PRECISION),
     }
 }
@@ -67,17 +68,52 @@ pub fn resolve() -> Result<OsLocation, String> {
     Ok(to_os_location(lat, lon))
 }
 
+/// At most one OS location query runs at a time.
+///
+/// On timeout we return to the caller while the helper thread is still parked on
+/// the (possibly wedged) platform service — a blocking D-Bus / WinRT call can't
+/// be cancelled from outside. Without a guard, mashing "Use my location" would
+/// spawn a fresh thread per press and leak them (and their OS handles). This flag
+/// makes a second press reject fast instead, so a stuck service leaks at most one
+/// helper thread rather than one per click. The claiming thread releases it once
+/// `platform::query()` finally returns.
+static QUERY_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// Try to claim the single in-flight slot. Returns `true` if this caller claimed
+/// it (and must later call [`end_query`]), `false` if a query is already running.
+fn begin_query() -> bool {
+    !QUERY_IN_FLIGHT.swap(true, Ordering::SeqCst)
+}
+
+/// Release the in-flight slot claimed by [`begin_query`].
+fn end_query() {
+    QUERY_IN_FLIGHT.store(false, Ordering::SeqCst);
+}
+
 /// Run the platform query on a helper thread and bound it with [`QUERY_TIMEOUT`]
 /// so a stuck location service can never wedge the caller.
 fn query_with_timeout() -> Result<(f64, f64), String> {
+    if !begin_query() {
+        return Err(
+            "A location query is already in progress — please wait for it to \
+             finish."
+                .into(),
+        );
+    }
     let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::Builder::new()
+    let spawn = std::thread::Builder::new()
         .name("ft8af-os-location".into())
         .spawn(move || {
             // The receiver may already be gone (timed out); ignore send errors.
             let _ = tx.send(platform::query());
-        })
-        .map_err(|e| format!("could not start location query: {e}"))?;
+            // Release the slot only once the (possibly long) query has returned,
+            // so no second thread is spawned while this one is still parked.
+            end_query();
+        });
+    if let Err(e) = spawn {
+        end_query();
+        return Err(format!("could not start location query: {e}"));
+    }
     match rx.recv_timeout(QUERY_TIMEOUT) {
         Ok(result) => result,
         Err(_) => Err(
@@ -153,9 +189,14 @@ mod platform {
             .and_then(|b| b.build())
             .map_err(|e| format!("could not create a GeoClue client: {e}"))?;
         // DesktopId must match an installed .desktop file for GeoClue's authority
-        // check; the app id doubles as the identifier here.
-        let _ = client.set_desktop_id("ft8af");
-        let _ = client.set_requested_accuracy_level(ACCURACY_CITY);
+        // check; the app id doubles as the identifier here. Surface failures here
+        // rather than letting a later start() fail with a less obvious cause.
+        client
+            .set_desktop_id("ft8af")
+            .map_err(|e| format!("could not set the GeoClue desktop id: {e}"))?;
+        client
+            .set_requested_accuracy_level(ACCURACY_CITY)
+            .map_err(|e| format!("could not set the GeoClue accuracy level: {e}"))?;
 
         // Subscribe before Start() so we can't miss the first LocationUpdated.
         let updates = client
@@ -236,12 +277,22 @@ mod tests {
     }
 
     #[test]
-    fn to_os_location_derives_six_char_grid() {
-        // Munich -> JN58td (see util::latlon_to_maidenhead tests).
+    fn to_os_location_derives_six_char_grid_and_drops_coordinates() {
+        // Munich -> JN58td (see util::latlon_to_maidenhead tests). Only the coarse
+        // grid is exposed; the raw lat/lon is discarded inside the backend.
         let loc = to_os_location(48.14666, 11.60833);
         assert_eq!(loc.grid, "JN58td");
         assert_eq!(loc.grid.len(), OS_GRID_PRECISION);
-        assert_eq!(loc.lat, 48.14666);
-        assert_eq!(loc.lon, 11.60833);
+    }
+
+    #[test]
+    fn only_one_query_in_flight_at_a_time() {
+        // First caller claims the slot; a second is rejected until the first
+        // releases, so mashing the button can't spawn overlapping helper threads.
+        assert!(begin_query());
+        assert!(!begin_query());
+        end_query();
+        assert!(begin_query());
+        end_query();
     }
 }

--- a/desktop/src-tauri/src/os_location.rs
+++ b/desktop/src-tauri/src/os_location.rs
@@ -1,0 +1,247 @@
+//! Optional, opt-in OS location service -> operator grid (issue #471).
+//!
+//! Nothing in here runs until the user turns on the [`LOCATION_ENABLED_KEY`]
+//! config flag (default off) in Settings -> Station and presses "Use my
+//! location". The Tauri command layer (`main.rs::get_os_location`) enforces that
+//! gate; querying the platform service is the only thing that triggers the OS
+//! location-permission prompt, so a fresh install never requests location.
+//!
+//! Platform backends:
+//!   - Linux   — GeoClue 2 over D-Bus (may be unavailable on headless installs).
+//!   - Windows — Windows.Devices.Geolocation `Geolocator`.
+//!   - macOS / other — not wired yet; returns a clear error so the UI falls back
+//!     to manual entry (see the module docs / PR for the CoreLocation plan).
+
+use serde::Serialize;
+use std::time::Duration;
+
+use crate::util;
+
+/// Config key that gates the whole feature. Absent or anything other than the
+/// exact string `"true"` means disabled.
+pub const LOCATION_ENABLED_KEY: &str = "location_service_enabled";
+
+/// Grid precision for OS-derived locations: 6 chars (subsquare, ~2.5 × 5 km) is
+/// coarse enough not to leak a pinpoint home QTH but still useful for FT8.
+pub const OS_GRID_PRECISION: usize = 6;
+
+/// Upper bound on how long the OS query may block before we give up, so the UI
+/// "Use my location" button can never hang the app.
+const QUERY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// A resolved OS location plus the derived Maidenhead grid handed to the UI.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct OsLocation {
+    pub lat: f64,
+    pub lon: f64,
+    pub grid: String,
+}
+
+/// Whether the OS-location feature is enabled, given the stored config value.
+///
+/// The default (`None`) and any non-`"true"` string are treated as disabled, so
+/// a fresh install — or a hand-edited/garbage config value — never opts the user
+/// in silently.
+pub fn location_enabled(value: Option<&str>) -> bool {
+    matches!(value, Some("true"))
+}
+
+/// Convert a raw OS fix into the [`OsLocation`] returned to the UI. Kept separate
+/// from the platform query so the lat/lon -> grid step is unit-testable without
+/// touching any OS API.
+pub fn to_os_location(lat: f64, lon: f64) -> OsLocation {
+    OsLocation {
+        lat,
+        lon,
+        grid: util::latlon_to_maidenhead(lat, lon, OS_GRID_PRECISION),
+    }
+}
+
+/// Query the OS location service and resolve it to an [`OsLocation`].
+///
+/// Returns a human-readable error (permission denied, service unavailable /
+/// headless, timeout) on failure. Blocking; call off the UI thread — Tauri
+/// commands already run on a worker thread.
+pub fn resolve() -> Result<OsLocation, String> {
+    let (lat, lon) = query_with_timeout()?;
+    Ok(to_os_location(lat, lon))
+}
+
+/// Run the platform query on a helper thread and bound it with [`QUERY_TIMEOUT`]
+/// so a stuck location service can never wedge the caller.
+fn query_with_timeout() -> Result<(f64, f64), String> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name("ft8af-os-location".into())
+        .spawn(move || {
+            // The receiver may already be gone (timed out); ignore send errors.
+            let _ = tx.send(platform::query());
+        })
+        .map_err(|e| format!("could not start location query: {e}"))?;
+    match rx.recv_timeout(QUERY_TIMEOUT) {
+        Ok(result) => result,
+        Err(_) => Err(
+            "Timed out waiting for the location service. Check that location \
+             access is allowed, or enter your grid manually."
+                .into(),
+        ),
+    }
+}
+
+// --- Linux: GeoClue 2 over D-Bus -------------------------------------------
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use zbus::blocking::Connection;
+    use zbus::proxy;
+    use zbus::zvariant::OwnedObjectPath;
+
+    // GeoClue accuracy levels (see GClueAccuracyLevel). 4 = "city" — coarse, which
+    // is all a Maidenhead subsquare needs and the least intrusive prompt.
+    const ACCURACY_CITY: u32 = 4;
+
+    #[proxy(
+        interface = "org.freedesktop.GeoClue2.Manager",
+        default_service = "org.freedesktop.GeoClue2",
+        default_path = "/org/freedesktop/GeoClue2/Manager"
+    )]
+    trait Manager {
+        fn get_client(&self) -> zbus::Result<OwnedObjectPath>;
+    }
+
+    #[proxy(
+        interface = "org.freedesktop.GeoClue2.Client",
+        default_service = "org.freedesktop.GeoClue2"
+    )]
+    trait Client {
+        #[zbus(property)]
+        fn set_desktop_id(&self, id: &str) -> zbus::Result<()>;
+        #[zbus(property)]
+        fn set_requested_accuracy_level(&self, level: u32) -> zbus::Result<()>;
+        fn start(&self) -> zbus::Result<()>;
+        fn stop(&self) -> zbus::Result<()>;
+        #[zbus(signal)]
+        fn location_updated(
+            &self,
+            old: OwnedObjectPath,
+            new: OwnedObjectPath,
+        ) -> zbus::Result<()>;
+    }
+
+    #[proxy(
+        interface = "org.freedesktop.GeoClue2.Location",
+        default_service = "org.freedesktop.GeoClue2"
+    )]
+    trait Location {
+        #[zbus(property)]
+        fn latitude(&self) -> zbus::Result<f64>;
+        #[zbus(property)]
+        fn longitude(&self) -> zbus::Result<f64>;
+    }
+
+    pub fn query() -> Result<(f64, f64), String> {
+        let conn = Connection::system().map_err(|e| {
+            format!("could not reach the system D-Bus (GeoClue unavailable): {e}")
+        })?;
+        let manager = ManagerProxyBlocking::new(&conn)
+            .map_err(|e| format!("GeoClue location service is not available: {e}"))?;
+        let client_path = manager
+            .get_client()
+            .map_err(|e| format!("GeoClue refused a client (permission denied?): {e}"))?;
+        let client = ClientProxyBlocking::builder(&conn)
+            .path(client_path)
+            .and_then(|b| b.build())
+            .map_err(|e| format!("could not create a GeoClue client: {e}"))?;
+        // DesktopId must match an installed .desktop file for GeoClue's authority
+        // check; the app id doubles as the identifier here.
+        let _ = client.set_desktop_id("ft8af");
+        let _ = client.set_requested_accuracy_level(ACCURACY_CITY);
+
+        // Subscribe before Start() so we can't miss the first LocationUpdated.
+        let updates = client
+            .receive_location_updated()
+            .map_err(|e| format!("could not subscribe to location updates: {e}"))?;
+        client
+            .start()
+            .map_err(|e| format!("could not start the location client: {e}"))?;
+
+        for signal in updates {
+            let args = signal
+                .args()
+                .map_err(|e| format!("malformed location update: {e}"))?;
+            let loc = LocationProxyBlocking::builder(&conn)
+                .path(args.new().clone())
+                .and_then(|b| b.build())
+                .map_err(|e| format!("could not read the location: {e}"))?;
+            let lat = loc.latitude().map_err(|e| e.to_string())?;
+            let lon = loc.longitude().map_err(|e| e.to_string())?;
+            let _ = client.stop();
+            return Ok((lat, lon));
+        }
+        let _ = client.stop();
+        Err("the location service returned no fix".into())
+    }
+}
+
+// --- Windows: Windows.Devices.Geolocation ----------------------------------
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use windows::Devices::Geolocation::Geolocator;
+
+    pub fn query() -> Result<(f64, f64), String> {
+        // Constructing the Geolocator + first GetGeopositionAsync is what raises
+        // the Windows location-permission prompt.
+        let locator = Geolocator::new().map_err(|e| e.message())?;
+        let pos = locator
+            .GetGeopositionAsync()
+            .and_then(|op| op.get())
+            .map_err(|e| e.message())?;
+        let coord = pos.Coordinate().map_err(|e| e.message())?;
+        let point = coord.Point().map_err(|e| e.message())?;
+        let basic = point.Position().map_err(|e| e.message())?;
+        Ok((basic.Latitude, basic.Longitude))
+    }
+}
+
+// --- macOS / everything else: not wired yet --------------------------------
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+mod platform {
+    pub fn query() -> Result<(f64, f64), String> {
+        // CoreLocation needs a CLLocationManager delegate driven from a run loop
+        // plus an NSLocationUsageDescription Info.plist key; that on-device work
+        // is tracked as a follow-up. Until then macOS users enter their grid by
+        // hand (the manual field is untouched on this error).
+        Err("Automatic location isn't available on this platform yet — \
+             enter your grid manually."
+            .into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_only_for_exact_true() {
+        assert!(location_enabled(Some("true")));
+        // Default off: no stored value.
+        assert!(!location_enabled(None));
+        // Anything else is off — including the string "false" and stray values.
+        assert!(!location_enabled(Some("false")));
+        assert!(!location_enabled(Some("1")));
+        assert!(!location_enabled(Some("TRUE")));
+        assert!(!location_enabled(Some("")));
+    }
+
+    #[test]
+    fn to_os_location_derives_six_char_grid() {
+        // Munich -> JN58td (see util::latlon_to_maidenhead tests).
+        let loc = to_os_location(48.14666, 11.60833);
+        assert_eq!(loc.grid, "JN58td");
+        assert_eq!(loc.grid.len(), OS_GRID_PRECISION);
+        assert_eq!(loc.lat, 48.14666);
+        assert_eq!(loc.lon, 11.60833);
+    }
+}

--- a/desktop/src-tauri/src/util.rs
+++ b/desktop/src-tauri/src/util.rs
@@ -37,3 +37,106 @@ pub fn now_unix_ms() -> i64 {
 pub fn grid4(grid: &str) -> String {
     grid.chars().take(4).collect()
 }
+
+/// Convert a latitude/longitude (degrees) to a Maidenhead locator.
+///
+/// `precision` is the number of characters and must be even and >= 2 (2 = field,
+/// 4 = square, 6 = subsquare, 8 = extended square); other values are clamped into
+/// the 2..=8 range and rounded down to even. Inputs outside the valid coordinate
+/// range are clamped (lat to ±90, lon to ±180) so a bad OS reading still yields a
+/// well-formed grid rather than an out-of-alphabet character.
+///
+/// Mirrors the 6-char precision the app stores elsewhere (see [`grid4`]); the OS
+/// location path defaults to 6 (subsquare, ~2.5 × 5 km) so it never leaks a
+/// pinpoint home location.
+pub fn latlon_to_maidenhead(lat: f64, lon: f64, precision: usize) -> String {
+    // Clamp precision to an even value in 2..=8.
+    let precision = precision.clamp(2, 8) & !1;
+
+    // Clamp to valid ranges. 180.0/90.0 exactly would overflow the final field
+    // (index 18/9) so nudge the top edge just inside the last cell.
+    let lon = lon.clamp(-180.0, 179.999_999);
+    let lat = lat.clamp(-90.0, 89.999_999);
+
+    // Shift into positive space: longitude 0..360, latitude 0..180.
+    let mut adj_lon = lon + 180.0;
+    let mut adj_lat = lat + 90.0;
+
+    let mut out = String::with_capacity(precision);
+
+    // Field: A..R (20° lon / 10° lat per cell).
+    out.push((b'A' + (adj_lon / 20.0) as u8) as char);
+    out.push((b'A' + (adj_lat / 10.0) as u8) as char);
+    adj_lon %= 20.0;
+    adj_lat %= 10.0;
+    if precision == 2 {
+        return out;
+    }
+
+    // Square: 0..9 (2° lon / 1° lat per cell).
+    out.push((b'0' + (adj_lon / 2.0) as u8) as char);
+    out.push((b'0' + adj_lat as u8) as char);
+    adj_lon %= 2.0;
+    adj_lat %= 1.0;
+    if precision == 4 {
+        return out;
+    }
+
+    // Subsquare: a..x (5' lon / 2.5' lat per cell).
+    out.push((b'a' + (adj_lon * 12.0) as u8) as char);
+    out.push((b'a' + (adj_lat * 24.0) as u8) as char);
+    if precision == 6 {
+        return out;
+    }
+
+    // Extended square: 0..9 (subdividing the subsquare 10×10).
+    adj_lon = (adj_lon * 12.0) % 1.0;
+    adj_lat = (adj_lat * 24.0) % 1.0;
+    out.push((b'0' + (adj_lon * 10.0) as u8) as char);
+    out.push((b'0' + (adj_lat * 10.0) as u8) as char);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maidenhead_reference_points() {
+        // Munich (JN58td) is the canonical Wikipedia worked example.
+        assert_eq!(latlon_to_maidenhead(48.14666, 11.60833, 6), "JN58td");
+        // 4-char truncations of the same point.
+        assert_eq!(latlon_to_maidenhead(48.14666, 11.60833, 4), "JN58");
+        assert_eq!(latlon_to_maidenhead(48.14666, 11.60833, 2), "JN");
+        // A few other known squares.
+        assert_eq!(latlon_to_maidenhead(42.3, -71.1, 4), "FN42"); // Boston
+        assert_eq!(latlon_to_maidenhead(45.0, -93.5, 4), "EN35"); // Minneapolis area
+    }
+
+    #[test]
+    fn maidenhead_origin_and_extremes() {
+        // The Maidenhead origin sits at lon -180, lat -90 -> "AA00aa".
+        assert_eq!(latlon_to_maidenhead(-90.0, -180.0, 6), "AA00aa");
+        // Null Island.
+        assert_eq!(latlon_to_maidenhead(0.0, 0.0, 4), "JJ00");
+        // Out-of-range input is clamped, not allowed to run off the alphabet.
+        let g = latlon_to_maidenhead(1000.0, 1000.0, 6);
+        assert_eq!(g.len(), 6);
+        assert!(g.chars().next().unwrap().is_ascii_uppercase());
+    }
+
+    #[test]
+    fn maidenhead_precision_is_clamped_even() {
+        // Odd / zero / oversized precisions clamp to the nearest even in 2..=8.
+        assert_eq!(latlon_to_maidenhead(48.14666, 11.60833, 0).len(), 2);
+        assert_eq!(latlon_to_maidenhead(48.14666, 11.60833, 5).len(), 4);
+        assert_eq!(latlon_to_maidenhead(48.14666, 11.60833, 99).len(), 8);
+    }
+
+    #[test]
+    fn maidenhead_is_grid4_compatible() {
+        // The 6-char result truncates to the same 4-char locator grid4() expects.
+        let g6 = latlon_to_maidenhead(48.14666, 11.60833, 6);
+        assert_eq!(grid4(&g6), "JN58");
+    }
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -737,6 +737,11 @@ function SettingsScreen(props: {
     setLocating(true);
     setLocError(null);
     try {
+      // The checkbox persists this flag asynchronously; the button only appears
+      // once locEnabled is true, so re-assert and AWAIT the write here before
+      // querying. Otherwise "enable then immediately click" can reach the backend
+      // gate before the flag is committed, and get_os_location would reject.
+      await api.setConfig("location_service_enabled", "true");
       const loc = await api.getOsLocation();
       setGrid(loc.grid);
       onStatus(`Location set grid to ${loc.grid}`);

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -779,7 +779,7 @@ function SettingsScreen(props: {
             )}
           </div>
           <div className="field">
-            <label className="row" style={{ alignItems: "center", gap: 6 }}>
+            <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
               <input
                 type="checkbox"
                 checked={locEnabled}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -621,6 +621,12 @@ function SettingsScreen(props: {
   const [call, setCall] = useState("");
   const [rigLabel, setRigLabel] = useState("");
   const [grid, setGrid] = useState("");
+  // OS location service (opt-in, issue #471). Disabled by default: the button
+  // only appears once locEnabled is on, and nothing requests location until the
+  // user presses it.
+  const [locEnabled, setLocEnabled] = useState(false);
+  const [locating, setLocating] = useState(false);
+  const [locError, setLocError] = useState<string | null>(null);
   const [inputs, setInputs] = useState<AudioDevice[]>([]);
   const [outputs, setOutputs] = useState<AudioDevice[]>([]);
   const [ports, setPorts] = useState<SerialPortInfo[]>([]);
@@ -656,6 +662,9 @@ function SettingsScreen(props: {
     api.listHamlibRigs().then(setHamlibRigs);
     api.getConfig("my_call").then((v) => v && setCall(v));
     api.getConfig("my_grid").then((v) => v && setGrid(v));
+    // Restore the opt-in flag; only the exact string "true" enables it, so a
+    // missing/garbage value keeps the feature off.
+    api.getConfig("location_service_enabled").then((v) => setLocEnabled(v === "true"));
     api.getConfig("input_device").then((v) => v && setInput(v));
     api.getConfig("output_device").then((v) => v && setOutput(v));
     api.getConfig("base_freq").then((v) => v && setBaseFreq(parseInt(v, 10)));
@@ -713,6 +722,32 @@ function SettingsScreen(props: {
     onStatus(`Station set: ${call} ${grid}`);
   }
 
+  // Persist the opt-in flag. Turning it off never runs location code again; it
+  // does not itself request location (only the button does), so no permission
+  // prompt appears here.
+  function toggleLocEnabled(on: boolean) {
+    setLocEnabled(on);
+    setLocError(null);
+    api.setConfig("location_service_enabled", on ? "true" : "false");
+  }
+
+  // One-shot on demand: query the OS location service and fill the (still
+  // editable) Grid field. This press is what triggers the OS permission prompt.
+  async function useMyLocation() {
+    setLocating(true);
+    setLocError(null);
+    try {
+      const loc = await api.getOsLocation();
+      setGrid(loc.grid);
+      onStatus(`Location set grid to ${loc.grid}`);
+    } catch (e) {
+      // The manual field is left untouched on failure.
+      setLocError(typeof e === "string" ? e : String(e));
+    } finally {
+      setLocating(false);
+    }
+  }
+
   return (
     <div className="grid2">
       <div className="panel">
@@ -724,7 +759,42 @@ function SettingsScreen(props: {
           </div>
           <div className="field">
             <label>Grid (Maidenhead)</label>
-            <input value={grid} onChange={(e) => setGrid(e.target.value.toUpperCase())} placeholder="EN37" />
+            <div className="row">
+              <input value={grid} onChange={(e) => setGrid(e.target.value.toUpperCase())} placeholder="EN37" />
+              {locEnabled && (
+                <button
+                  type="button"
+                  onClick={useMyLocation}
+                  disabled={locating}
+                  title="Fill the grid from your computer's location service"
+                >
+                  {locating ? "Locating…" : "📍 Use my location"}
+                </button>
+              )}
+            </div>
+            {locError && (
+              <span className="muted" style={{ display: "block", marginTop: 4, color: "var(--tx)" }}>
+                ⚠ {locError}
+              </span>
+            )}
+          </div>
+          <div className="field">
+            <label className="row" style={{ alignItems: "center", gap: 6 }}>
+              <input
+                type="checkbox"
+                checked={locEnabled}
+                onChange={(e) => toggleLocEnabled(e.target.checked)}
+                style={{ width: "auto" }}
+              />
+              Use OS location service
+            </label>
+            <span className="muted" style={{ display: "block", marginTop: 4 }}>
+              Off by default. When on, a “Use my location” button appears above to
+              fill your grid from the operating system’s location service (asks for
+              permission the first time). Coarse, city-level accuracy — a 6-char
+              subsquare, ~2.5 × 5 km. Linux uses GeoClue; Windows uses the system
+              geolocator; on macOS enter your grid manually for now.
+            </span>
           </div>
           <button className="primary" onClick={saveStation}>Save station</button>
         </div>

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -99,10 +99,10 @@ export interface BandInfo {
   dial_hz: number;
 }
 
-/** Result of resolving the operator grid from the OS location service (issue #471). */
+/** Result of resolving the operator grid from the OS location service (issue #471).
+ *  Only the coarse grid is returned — the backend derives it from the raw fix and
+ *  discards the precise coordinates, so no pinpoint location crosses the IPC. */
 export interface OsLocation {
-  lat: number;
-  lon: number;
   /** Derived Maidenhead grid (6-char subsquare). */
   grid: string;
 }

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -99,6 +99,14 @@ export interface BandInfo {
   dial_hz: number;
 }
 
+/** Result of resolving the operator grid from the OS location service (issue #471). */
+export interface OsLocation {
+  lat: number;
+  lon: number;
+  /** Derived Maidenhead grid (6-char subsquare). */
+  grid: string;
+}
+
 /** Waterfall FFT window (developer setting, issue #428). */
 export type WfWindow = "rect" | "hann" | "hamming" | "blackman" | "blackman_harris";
 
@@ -183,6 +191,10 @@ export const api = {
   getConfig: (key: string) => invoke<string | null>("get_config", { key }),
   setConfig: (key: string, value: string) => invoke("set_config", { key, value }),
   allConfig: () => invoke<[string, string][]>("all_config"),
+
+  /** Resolve the operator grid from the OS location service (opt-in, issue #471).
+   * Rejects unless `location_service_enabled` is on. */
+  getOsLocation: () => invoke<OsLocation>("get_os_location"),
 
   /** Apply + persist live-waterfall FFT parameters (Rust side persists). */
   setWaterfallConfig: (config: WaterfallConfig) =>


### PR DESCRIPTION
## Summary

Adds an **opt-in** "Use my location" flow to the desktop app's **Settings → Station** that fills the operator's Maidenhead grid from the computer's OS location service, instead of only manual entry. Closes #471.

The feature is **off by default** — manual grid entry is completely unchanged for anyone who never turns it on.

## What changed

**Frontend (`desktop/src`)**
- New **"Use OS location service"** checkbox in Settings → Station, persisted as config key `location_service_enabled` (default `false`).
- A **"📍 Use my location"** button appears next to the Grid field *only when the checkbox is on*. Pressing it (a one-shot, on demand) is what triggers the OS permission prompt.
- Button shows a "Locating…" state while resolving; on failure the error (permission denied / service unavailable / timeout) is shown inline and the manual field is left untouched. The result is still editable before saving.
- `api.getOsLocation()` IPC wrapper + `OsLocation` type in `ipc.ts`.

**Backend (`desktop/src-tauri`)**
- New `get_os_location` Tauri command: refuses with a clear error unless `location_service_enabled` is `"true"` (defense in depth — the backend never queries location when disabled), then returns `{ lat, lon, grid }`.
- New `os_location` module with the opt-in gate, a 15 s timeout wrapper (so the button can't hang the app), and target-gated platform backends:
  - **Linux** — GeoClue 2 over D-Bus (`zbus`).
  - **Windows** — `Windows.Devices.Geolocation` `Geolocator` (`windows` crate).
  - **macOS / other** — returns a clear "enter manually" error (see *Assumptions* below).
- `latlon_to_maidenhead(lat, lon, precision)` helper added to `util.rs` (mirrors the existing grid handling); OS locations resolve to a **6-char subsquare** (~2.5 × 5 km) so they don't leak a pinpoint home QTH.

## Tests

Rust unit tests (run under the desktop `cargo llvm-cov` job):
- `util::tests` — `latlon_to_maidenhead` against reference points (Munich `JN58td`, Boston `FN42`, the `AA00aa` origin, Null Island), out-of-range clamping, even-precision clamping, and `grid4` compatibility.
- `os_location::tests` — `location_enabled` gating (default/`None` → off, only the exact string `"true"` enables, `"false"`/`"1"`/`"TRUE"` → off) and `to_os_location` 6-char grid derivation.

The conversion math was additionally cross-checked against an independent implementation, and each platform target (linux / windows / macOS) was confirmed to compile.

## Assumptions / notes

- **macOS is stubbed in this PR.** A correct CoreLocation integration needs a `CLLocationManager` delegate driven from a run loop plus an `NSLocationUsageDescription` Info.plist key, which can't be verified without on-device testing; rather than ship code that might hang the location button, macOS shows a clear message directing manual entry. The integration points are documented in `os_location.rs`. Linux + Windows are fully wired.
- No JS test runner is configured for `desktop/` (the desktop CI runs `tauri build` + Rust coverage only), so the gating guarantee is covered by the Rust `location_enabled` tests and the backend command refusing when the flag is off; the frontend button is a thin conditional wrapper over that.
- Scope is the desktop (Tauri) app only; the Android GPS/grid path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)