### PR TITLE
Fix cty.dat import silently dropping a country's callsigns on a stray ')'

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/callsign/CallsignFileOperation.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/callsign/CallsignFileOperation.java
@@ -66,7 +66,7 @@ public class CallsignFileOperation {
         String[] ls=s.replace("\n","").split(",");
         Set<String> callsigns=new HashSet<>();
         for (int i = 0; i < ls.length ; i++) {
-            if (ls[i].contains(")")) {
+            if (ls[i].contains("(")) {
                 //Log.d(TAG,ls[i]);
                 ls[i] = ls[i].substring(0, ls[i].indexOf("("));
                 //Log.d(TAG,ls[i]+"     (((");

--- a/ft8af/app/src/test/java/com/k1af/ft8af/callsign/CallsignFileOperationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/callsign/CallsignFileOperationTest.java
@@ -58,9 +58,11 @@ public class CallsignFileOperationTest {
         // and substring(0, -1) threw StringIndexOutOfBoundsException. Because
         // getCallsigns runs inside CallsignDatabase's per-country try/catch, that
         // exception silently dropped *every* callsign for the affected country.
-        // A stray ')' must not take the rest of the list down with it.
+        // A stray ')' must not take the rest of the list down with it. Since the
+        // token has no '(' (nor '['), nothing is stripped: the malformed prefix is
+        // left intact and the sibling survives — and only those two are returned.
         Set<String> calls = CallsignFileOperation.getCallsigns("BAD),VE7");
-        assertThat(calls).contains("VE7");
+        assertThat(calls).containsExactly("BAD)", "VE7");
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/callsign/CallsignFileOperationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/callsign/CallsignFileOperationTest.java
@@ -52,6 +52,18 @@ public class CallsignFileOperationTest {
     }
 
     @Test
+    public void getCallsigns_closingParenWithoutOpening_doesNotThrowAndKeepsSiblings() {
+        // A malformed cty.dat token that carries a ')' but no '(' used to crash:
+        // the guard tested for ')' yet the cut indexed '(', so indexOf("(") == -1
+        // and substring(0, -1) threw StringIndexOutOfBoundsException. Because
+        // getCallsigns runs inside CallsignDatabase's per-country try/catch, that
+        // exception silently dropped *every* callsign for the affected country.
+        // A stray ')' must not take the rest of the list down with it.
+        Set<String> calls = CallsignFileOperation.getCallsigns("BAD),VE7");
+        assertThat(calls).contains("VE7");
+    }
+
+    @Test
     public void getCallsigns_removesNewlinesAndTrims() {
         // Leading newline is stripped globally; per-token whitespace is trimmed.
         Set<String> calls = CallsignFileOperation.getCallsigns("\n K , W ");


### PR DESCRIPTION
## Root cause

`CallsignFileOperation.getCallsigns()` strips the per-prefix CQ-zone
annotation cty.dat writes as `(n)`. The guard checked for the **closing**
paren but the cut indexed the **opening** one:

```java
if (ls[i].contains(")")) {
    ls[i] = ls[i].substring(0, ls[i].indexOf("("));
}
```

For any token that contains a `)` without a `(`, `indexOf("(")` returns
`-1` and `substring(0, -1)` throws `StringIndexOutOfBoundsException`.

## Impact

`getCallsigns()` is called from `CallsignDatabase`'s import loop **inside
a per-country `try/catch`** (`CallsignDatabase.java:289-314`). The country
row is inserted first, then its callsign list is expanded. When the stray
`)` throws, the catch swallows it and the loop moves to the next country —
so **every callsign for the affected country is silently dropped** from the
`callsigns` table. That country then never resolves for grid/location
lookups, with no error surfaced to the user. This is the same class of
latent parser bug tracked for this codebase, and mirrors the correctly
written `[` branch immediately below it (which guards on `[`, the delimiter
it indexes).

## Fix

Guard on `(` — the delimiter actually indexed — matching the adjacent `[`
branch. Well-formed `PREFIX(cq)` tokens strip to `PREFIX` exactly as
before; a malformed `)`-only token is now left intact instead of crashing
and taking the rest of the country's list with it.

One-line change in `CallsignFileOperation.java`.

## Testing

- Added `getCallsigns_closingParenWithoutOpening_doesNotThrowAndKeepsSiblings`
  to `CallsignFileOperationTest`. Confirmed it **fails** on the old code
  with `StringIndexOutOfBoundsException` and **passes** after the fix.
- Existing `getCallsigns` cases (`(cq)`, `[itu]`, both, newlines/trim,
  dedup) still pass — the fix is behavior-preserving for well-formed data.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — builds clean.

## Risk

Minimal. Single-character guard change on the parse path, covered by unit
tests; no DSP, protocol, or threading behavior touched.