### PR TITLE
Fix dead SWL QSO deduplication (HashTable stub re-logged every QSO)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/HashTable.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/HashTable.java
@@ -1,7 +1,20 @@
 package com.k1af.ft8af.log;
 /**
- * Hash table type used for recording SWL QSOs. Since the callsign above needs to be recorded,
- * two String KEYs are required, making HashMap unsuitable. Google's guava:31.1-jre library is used here.
+ * Two-key ("row" + "column") map used to record which SWL QSOs have already been
+ * logged, so the same C1-&gt;C2 contact is not written to the database on every
+ * decode cycle. A plain HashMap cannot key on two callsigns, so this delegates to
+ * Google guava's {@link com.google.common.collect.HashBasedTable}.
+ *
+ * <p>Historically this class was a stub whose {@code contains(...)} always returned
+ * {@code false} and whose {@code put(...)} was a no-op. That silently disabled SWL
+ * QSO deduplication ({@link SWLQsoList#findSwlQso} keys off it): every repeat of a
+ * closing marker re-logged the same QSO. Delegating to a real table restores the
+ * dedup.
+ *
+ * <p>The callers relied on the stub tolerating null keys. guava tables reject null
+ * keys/values, but an SWL callsign can be absent, and the detector runs on the
+ * decode thread, so a lookup/mutation on a null key is treated as
+ * "not present"/no-op instead of throwing.
  *
  * BG7YOZ
  * 2023-03-20
@@ -10,108 +23,118 @@ package com.k1af.ft8af.log;
 
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class HashTable implements Table {
+    // Raw Table so the delegated return types erase to the same raw types the raw
+    // Table interface this class implements expects (e.g. Set<Cell>, Map).
+    private final Table delegate = HashBasedTable.create();
+
     @Override
     public boolean contains(@Nullable Object rowKey, @Nullable Object columnKey) {
-        return false;
+        if (rowKey == null || columnKey == null) return false;
+        return delegate.contains(rowKey, columnKey);
     }
 
     @Override
     public boolean containsRow(@Nullable Object rowKey) {
-        return false;
+        return rowKey != null && delegate.containsRow(rowKey);
     }
 
     @Override
     public boolean containsColumn(@Nullable Object columnKey) {
-        return false;
+        return columnKey != null && delegate.containsColumn(columnKey);
     }
 
     @Override
     public boolean containsValue(@Nullable Object value) {
-        return false;
+        return value != null && delegate.containsValue(value);
     }
 
     @Nullable
     @Override
-    public @org.checkerframework.checker.nullness.qual.Nullable Object get(@Nullable Object rowKey, @Nullable Object columnKey) {
-        return null;
+    public Object get(@Nullable Object rowKey, @Nullable Object columnKey) {
+        if (rowKey == null || columnKey == null) return null;
+        return delegate.get(rowKey, columnKey);
     }
 
     @Override
     public boolean isEmpty() {
-        return false;
+        return delegate.isEmpty();
     }
 
     @Override
     public int size() {
-        return 0;
+        return delegate.size();
     }
 
     @Override
     public void clear() {
-
+        delegate.clear();
     }
 
     @Nullable
     @Override
-    public @org.checkerframework.checker.nullness.qual.Nullable Object put(Object rowKey, Object columnKey, Object value) {
-        return null;
+    public Object put(Object rowKey, Object columnKey, Object value) {
+        if (rowKey == null || columnKey == null || value == null) return null;
+        return delegate.put(rowKey, columnKey, value);
     }
 
     @Override
     public void putAll(Table table) {
-
+        delegate.putAll(table);
     }
 
     @Nullable
     @Override
-    public @org.checkerframework.checker.nullness.qual.Nullable Object remove(@Nullable Object rowKey, @Nullable Object columnKey) {
-        return null;
+    public Object remove(@Nullable Object rowKey, @Nullable Object columnKey) {
+        if (rowKey == null || columnKey == null) return null;
+        return delegate.remove(rowKey, columnKey);
     }
 
     @Override
     public Map row(Object rowKey) {
-        return null;
+        return delegate.row(rowKey);
     }
 
     @Override
     public Map column(Object columnKey) {
-        return null;
+        return delegate.column(columnKey);
     }
 
     @Override
     public Set<Cell> cellSet() {
-        return null;
+        return delegate.cellSet();
     }
 
     @Override
     public Set rowKeySet() {
-        return null;
+        return delegate.rowKeySet();
     }
 
     @Override
     public Set columnKeySet() {
-        return null;
+        return delegate.columnKeySet();
     }
 
     @Override
     public Collection values() {
-        return null;
+        return delegate.values();
     }
 
     @Override
     public Map rowMap() {
-        return null;
+        return delegate.rowMap();
     }
 
     @Override
     public Map columnMap() {
-        return null;
+        return delegate.columnMap();
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/HashTable.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/HashTable.java
@@ -25,8 +25,10 @@ import androidx.annotation.Nullable;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,7 +36,13 @@ import java.util.Set;
 public class HashTable implements Table {
     // Raw Table so the delegated return types erase to the same raw types the raw
     // Table interface this class implements expects (e.g. Set<Cell>, Map).
-    private final Table delegate = HashBasedTable.create();
+    //
+    // findSwlQso runs on the decode thread, and concurrent decode passes can
+    // overlap (MainViewModel: slot N's late/deep pass vs slot N+1's early pass,
+    // #398), so contains/put/remove can be called from two threads at once.
+    // HashBasedTable is not thread-safe, so wrap it in a synchronized view to
+    // keep concurrent mutation from corrupting the backing HashMap.
+    private final Table delegate = Tables.synchronizedTable(HashBasedTable.create());
 
     @Override
     public boolean contains(@Nullable Object rowKey, @Nullable Object columnKey) {
@@ -100,11 +108,13 @@ public class HashTable implements Table {
 
     @Override
     public Map row(Object rowKey) {
+        if (rowKey == null) return Collections.emptyMap();
         return delegate.row(rowKey);
     }
 
     @Override
     public Map column(Object columnKey) {
+        if (columnKey == null) return Collections.emptyMap();
         return delegate.column(columnKey);
     }
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/HashTableTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/HashTableTest.java
@@ -46,4 +46,17 @@ public class HashTableTest {
         assertThat(table.get(null, null)).isNull();
         assertThat(table.remove(null, "K1ABC")).isNull();
     }
+
+    @Test
+    public void nullKeyRowAndColumn_returnEmptyMapNotThrow() {
+        HashTable table = new HashTable();
+        table.put("W1AW", "K1ABC", true);
+        // row(null)/column(null) would throw NPE if forwarded straight to guava;
+        // to match the documented null-tolerance they report "nothing present".
+        assertThat(table.row(null)).isEmpty();
+        assertThat(table.column(null)).isEmpty();
+        // Non-null keys still resolve normally.
+        assertThat(table.row("W1AW")).containsKey("K1ABC");
+        assertThat(table.column("K1ABC")).containsKey("W1AW");
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/HashTableTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/HashTableTest.java
@@ -1,0 +1,49 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit coverage for {@link HashTable}, the two-key table that backs SWL QSO
+ * deduplication. The class was previously a stub (contains() == false, put() ==
+ * no-op) which silently disabled dedup; these tests lock in that it now stores
+ * and reports entries while still tolerating null keys handed in on the decode
+ * thread. Pure JVM — no Android types involved.
+ */
+public class HashTableTest {
+
+    @Test
+    public void putThenContains_isTrueForSameKeyPair() {
+        HashTable table = new HashTable();
+        assertThat(table.contains("W1AW", "K1ABC")).isFalse();
+        table.put("W1AW", "K1ABC", true);
+        assertThat(table.contains("W1AW", "K1ABC")).isTrue();
+        assertThat(table.get("W1AW", "K1ABC")).isEqualTo(true);
+        assertThat(table.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void keysAreDirectional() {
+        HashTable table = new HashTable();
+        table.put("W1AW", "K1ABC", true);
+        // Reversed row/column is a different contact and must not read as present.
+        assertThat(table.contains("K1ABC", "W1AW")).isFalse();
+    }
+
+    @Test
+    public void nullKeys_areToleratedNotThrown() {
+        HashTable table = new HashTable();
+        // guava's backing table rejects null keys; SWL callsigns can be absent and
+        // the detector runs on the decode thread, so null lookups/puts are treated
+        // as "not present"/no-op instead of throwing.
+        assertThat(table.contains(null, "K1ABC")).isFalse();
+        assertThat(table.contains("W1AW", null)).isFalse();
+        table.put(null, "K1ABC", true);   // must not throw
+        table.put("W1AW", null, true);     // must not throw
+        table.put("W1AW", "K1ABC", null);  // null value: no-op, must not throw
+        assertThat(table.size()).isEqualTo(0);
+        assertThat(table.get(null, null)).isNull();
+        assertThat(table.remove(null, "K1ABC")).isNull();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/SWLQsoListTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/SWLQsoListTest.java
@@ -129,6 +129,32 @@ public class SWLQsoListTest {
     }
 
     @Test
+    public void repeatedClosingMarker_isDedupedAcrossCycles() {
+        // The same closing marker decoded again in a later cycle must not re-log the
+        // QSO. Reusing one SWLQsoList instance across two findSwlQso calls exercises
+        // the two-key table that tracks already-logged contacts; a stub table (dedup
+        // disabled) fires the callback on every call.
+        Ft8Message reportSent = msg("W1AW", "K1ABC", "R-05");
+        Ft8Message reportRcvd = msg("K1ABC", "W1AW", "-10");
+        Ft8Message ending = msg("W1AW", "DL1XYZ", "RR73");
+
+        ArrayList<Ft8Message> all = new ArrayList<>();
+        all.add(reportSent);
+        all.add(reportRcvd);
+        all.add(ending);
+
+        ArrayList<Ft8Message> fresh = new ArrayList<>();
+        fresh.add(ending);
+
+        SWLQsoList list = new SWLQsoList();
+        CapturingCallback cb = new CapturingCallback();
+        list.findSwlQso(fresh, all, cb);   // cycle 1: QSO found and logged
+        list.findSwlQso(fresh, all, cb);   // cycle 2: same contact, must be deduped
+
+        assertThat(cb.found).hasSize(1);
+    }
+
+    @Test
     public void scanningACopyMatchesScanningTheLiveList() {
         // The MainViewModel fix scans a defensive copy of ft8Messages instead of
         // the live instance. findSwlQso depends only on list *contents*, so a copy


### PR DESCRIPTION
## Summary

`com.k1af.ft8af.log.HashTable` — the two-key (row/column) table `SWLQsoList` uses to remember which SWL QSOs have already been logged — was a **stub**: `contains()` always returned `false` and `put()` was a no-op. As a result the dedup guard in `SWLQsoList.findSwlQso`:

```java
if (GeneralVariables.checkFun4_5(msg.extraInfo)              // RRR / RR73 / 73
        && !qsoList.contains(msg.callsignFrom, msg.callsignTo)) { ... qsoList.put(...); }
```

was **always true** and the `put()` recorded nothing. With **Save SWL QSO** enabled, every repeat of a closing marker for the same contact — routine, since stations resend RR73/73 until answered and the marker keeps decoding across cycles — re-detected the QSO, re-wrote it to the database (`databaseOpr.addSWL_QSO`) and re-showed the toast. The SWL QSO log filled with duplicates of the same contact.

## Root cause

The class was never implemented against a real backing store, despite its Javadoc stating it uses guava for a dual-key map — and `app/build.gradle` declares `com.google.guava:guava` with the comment *"Used for HashTable (multi-key HashMap)"*. The intent was present; the implementation was a placeholder.

## Fix

Back `HashTable` with guava's `HashBasedTable`, delegating every `Table` method. `HashTable` is only referenced by `SWLQsoList`, so the change is localized and the public type is preserved (no call-site churn).

Callsign keys can be absent and `findSwlQso` runs on the decode thread, so null keys/values are treated as *"not present" / no-op* instead of throwing — guava tables reject nulls, and the previous stub silently tolerated them. This keeps the decode thread crash-free while restoring real dedup.

## Testing

- **`HashTableTest`** (pure JVM): put/contains round-trip, directional keys (row/column order matters), null-key tolerance.
- **`SWLQsoListTest.repeatedClosingMarker_isDedupedAcrossCycles`**: two `findSwlQso` passes on one instance now fire the callback exactly once.
- Both new assertions **fail against the old stub** and pass with the fix (verified by reverting `HashTable.java` and re-running).
- Full `:app:testDebugUnitTest` passes; `:app:assembleDebug` builds clean (native + APK).

## Risk

Low. No protocol/DSP/native change. Behavior change is confined to SWL QSO logging (an opt-in feature): the same contact is now logged once instead of repeatedly. Null-key handling preserves prior non-crashing behavior on the decode thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)