### PR TITLE
Fix spectrum-strip peak-block crash when bin count grows between frames

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
@@ -101,7 +101,7 @@ public class ColumnarView extends View {
             // below). Drive the peak-hold state off those bars, sized to them,
             // so a bin-count change between frames can't index out of bounds.
             int bars = newData.size();
-            if (bars > 0) {
+            if (PeakBlocks.canReusePreviousBlocks(bars, binsToShow)) {
                 int floorTop = getHeight() - blockHeight;
                 int[] barTops = new int[bars];
                 for (int i = 0; i < bars; i++) {
@@ -122,6 +122,13 @@ public class ColumnarView extends View {
                     block.top = blockTops[i];
                     block.bottom = blockTops[i] + blockHeight;
                 }
+            } else {
+                // First frame, or the bin count changed this frame (spectrum-width
+                // / sample-rate change). The held blocks belong to the previous
+                // grid, so drop them instead of drawing them misaligned over the
+                // new bars; peak-hold restarts from the floor next frame.
+                blockData.clear();
+                blockTops = new int[0];
             }
         }
         newData.clear();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
@@ -43,6 +43,9 @@ public class ColumnarView extends View {
     private final Paint paint = new Paint();
     private final List<Rect> newData = new ArrayList<>();
     private final List<Rect> blockData = new ArrayList<>();
+    // Peak-hold state, one top per drawn bar. Sized to newData every frame by
+    // PeakBlocks.update so a bin-count change can never index past the bars.
+    private int[] blockTops = new int[0];
 
     private int spectrumWidth = 3500;//Spectrum display width in Hz
 
@@ -94,25 +97,30 @@ public class ColumnarView extends View {
 
         width = getWidth() / binsToShow;
         if (drawblock) {// Whether to show the peak block
-            if (newData.size() > 0) {
-                if (blockData.size() == 0 || newData.size() != blockData.size()) {
+            // newData still holds the PREVIOUS frame's bars here (it is rebuilt
+            // below). Drive the peak-hold state off those bars, sized to them,
+            // so a bin-count change between frames can't index out of bounds.
+            int bars = newData.size();
+            if (bars > 0) {
+                int floorTop = getHeight() - blockHeight;
+                int[] barTops = new int[bars];
+                for (int i = 0; i < bars; i++) {
+                    barTops[i] = newData.get(i).top;
+                }
+                blockTops = PeakBlocks.update(blockTops, barTops, floorTop,
+                        blockHeight, blockSpeed, distance);
+                if (blockData.size() != bars) {
                     blockData.clear();
-                    for (int i = 0; i < binsToShow; i++) {
-                        Rect blockRect = new Rect();
-                        blockRect.top =getHeight()- blockHeight;
-                        blockRect.bottom = getHeight();
-                        blockData.add(blockRect);
+                    for (int i = 0; i < bars; i++) {
+                        blockData.add(new Rect());
                     }
                 }
-                for (int i = 0; i < blockData.size(); i++) {
-                    blockData.get(i).left = newData.get(i).left;
-                    blockData.get(i).right = newData.get(i).right;
-                    if (newData.get(i).top < blockData.get(i).top) {
-                        blockData.get(i).top = newData.get(i).top - blockHeight - distance;
-                    } else {
-                        blockData.get(i).top = blockData.get(i).top + blockSpeed;
-                    }
-                    blockData.get(i).bottom = blockData.get(i).top + blockHeight;
+                for (int i = 0; i < bars; i++) {
+                    Rect block = blockData.get(i);
+                    block.left = newData.get(i).left;
+                    block.right = newData.get(i).right;
+                    block.top = blockTops[i];
+                    block.bottom = blockTops[i] + blockHeight;
                 }
             }
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/PeakBlocks.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/PeakBlocks.java
@@ -1,0 +1,61 @@
+package com.k1af.ft8af.ui;
+
+import java.util.Arrays;
+
+/**
+ * Peak-hold "falling block" geometry for the spectrum strip. Extracted from
+ * {@link ColumnarView} so the sizing/index decision is JVM-testable.
+ *
+ * <p>The old inline code rebuilt the block list to the CURRENT frame's bin
+ * count ({@code binsToShow}) but the fall loop read the PREVIOUS frame's bars
+ * ({@code newData}). When the bin count grew between two frames the loop indexed
+ * past the previous bars and threw {@link IndexOutOfBoundsException} on the UI
+ * thread (drawing is not wrapped in try/catch, so that is a hard crash). The
+ * trigger is any change to the bin count between frames — a spectrum-width or
+ * audio-sample-rate change while the peak blocks are shown.
+ *
+ * <p>The fix: size the block state to the bars we actually have this frame.
+ * When the count changes the peak-hold state resets to the floor (matching the
+ * legacy full-rebuild); when it is unchanged the geometry is bit-for-bit
+ * identical to the pre-fix code.
+ */
+public final class PeakBlocks {
+
+    private PeakBlocks() {
+    }
+
+    /**
+     * Recomputes the peak-hold block tops for one frame.
+     *
+     * @param prevTops    previous frame's block tops (peak-hold state); its
+     *                    length may differ from {@code barTops} after a
+     *                    bin-count change.
+     * @param barTops     current frame's bar tops, one per drawn bar.
+     * @param floorTop    the resting top of a block ({@code height - blockHeight}).
+     * @param blockHeight block thickness in px.
+     * @param blockSpeed  how far a block falls each frame when its bar is quiet.
+     * @param distance    gap kept between a rising block and its bar.
+     * @return new block tops, always {@code barTops.length} long.
+     */
+    public static int[] update(int[] prevTops, int[] barTops, int floorTop,
+                               int blockHeight, int blockSpeed, int distance) {
+        int n = barTops.length;
+        int[] tops = prevTops;
+        if (tops.length != n) {
+            // Bin count changed (or first frame): reset peak-hold to the floor,
+            // matching the legacy full-rebuild. Sizing to barTops (not the new
+            // bin count read from the previous bars) is the crash fix.
+            tops = new int[n];
+            Arrays.fill(tops, floorTop);
+        }
+        int[] out = new int[n];
+        for (int i = 0; i < n; i++) {
+            if (barTops[i] < tops[i]) {
+                out[i] = barTops[i] - blockHeight - distance;
+            } else {
+                out[i] = tops[i] + blockSpeed;
+            }
+        }
+        return out;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/PeakBlocks.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/PeakBlocks.java
@@ -25,6 +25,26 @@ public final class PeakBlocks {
     }
 
     /**
+     * Whether the peak-hold blocks carried over from the previous frame are still
+     * valid for the frame about to be drawn.
+     *
+     * <p>The block geometry is built from the previous frame's bars but drawn over
+     * the current frame's bars, so it is only aligned when the grid is unchanged.
+     * A differing bin count — a spectrum-width or audio-sample-rate change — or the
+     * very first frame (no previous bars) means the held blocks belong to a stale
+     * grid; drawing them would smear misaligned blocks over the new bars for one
+     * frame. In that case the caller drops the blocks and lets peak-hold restart
+     * from the floor on the next frame.
+     *
+     * @param previousBarCount number of bars drawn last frame (the held block count).
+     * @param binsToShow       number of bars to be drawn this frame.
+     * @return {@code true} only when the grid is unchanged and blocks can be reused.
+     */
+    public static boolean canReusePreviousBlocks(int previousBarCount, int binsToShow) {
+        return previousBarCount > 0 && previousBarCount == binsToShow;
+    }
+
+    /**
      * Recomputes the peak-hold block tops for one frame.
      *
      * @param prevTops    previous frame's block tops (peak-hold state); its

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/PeakBlocksTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/PeakBlocksTest.java
@@ -1,0 +1,137 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link PeakBlocks}: the spectrum-strip peak-hold "falling block"
+ * geometry extracted from ColumnarView.
+ *
+ * <p>The extraction fixes a UI-thread crash. The legacy inline code rebuilt the
+ * block list to the CURRENT frame's bin count ({@code binsToShow}) while the
+ * fall loop read from the PREVIOUS frame's bar list ({@code newData}), so when
+ * the bin count GREW between two frames the loop indexed past the previous
+ * bars and threw {@link IndexOutOfBoundsException} on the main thread (no
+ * try/catch around draw). {@link #legacyBuggy} reproduces that throw; the new
+ * code sizes everything to the current bars, so it can't. Pure math — no
+ * Robolectric.
+ */
+public class PeakBlocksTest {
+
+    private static final int FLOOR = 95;      // getHeight() - blockHeight
+    private static final int BLOCK_HEIGHT = 5;
+    private static final int BLOCK_SPEED = 5;
+    private static final int DISTANCE = 2;
+
+    /**
+     * The pre-fix ColumnarView block loop, kept as the oracle for the stable
+     * case and to demonstrate the crash. {@code prevBlockTops} is the retained
+     * block state; {@code barTops} the previous frame's {@code newData} bar
+     * tops; {@code binsToShow} the current bin count the list was
+     * (incorrectly) rebuilt to when the size differed.
+     */
+    private static int[] legacyBuggy(int[] prevBlockTops, int[] barTops, int binsToShow) {
+        int[] blockTops = prevBlockTops;
+        if (blockTops.length == 0 || barTops.length != blockTops.length) {
+            // Rebuild block list to binsToShow when the size differs (the bug:
+            // the rebuild uses the CURRENT bin count, the loop reads barTops).
+            blockTops = new int[binsToShow];
+            for (int i = 0; i < binsToShow; i++) {
+                blockTops[i] = FLOOR;
+            }
+        }
+        for (int i = 0; i < blockTops.length; i++) {
+            // Reads barTops (the previous frame's bars) at every block index.
+            if (barTops[i] < blockTops[i]) {
+                blockTops[i] = barTops[i] - BLOCK_HEIGHT - DISTANCE;
+            } else {
+                blockTops[i] = blockTops[i] + BLOCK_SPEED;
+            }
+        }
+        return blockTops;
+    }
+
+    private static int[] update(int[] prevTops, int[] barTops) {
+        return PeakBlocks.update(prevTops, barTops, FLOOR, BLOCK_HEIGHT, BLOCK_SPEED, DISTANCE);
+    }
+
+    @Test
+    public void growingBinCountDoesNotThrow() {
+        // The bin count grew to 6 this frame while newData still holds the
+        // previous frame's 3 bars, and the block state size does not match
+        // (empty here, e.g. the first frame blocks are built). The legacy code
+        // rebuilt to 6 blocks and read barTops[3..5] of a length-3 array.
+        int[] prevBlockTops = new int[0];
+        int[] barTops = {10, 20, 30};   // only the 3 previous bars available
+
+        try {
+            legacyBuggy(prevBlockTops, barTops, 6);
+            throw new AssertionError("expected the legacy code to crash on a grown bin count");
+        } catch (IndexOutOfBoundsException expected) {
+            // This is the bug we are fixing.
+        }
+
+        // The extracted logic sizes to the bars it actually has: no throw, and
+        // exactly one block per current bar.
+        int[] out = update(prevBlockTops, barTops);
+        assertThat(out).hasLength(barTops.length);
+    }
+
+    @Test
+    public void firstFrameStartsFromTheFloor() {
+        // No prior state (empty peak-hold): each block falls one step from the
+        // floor unless its bar rises above it.
+        int[] barTops = {FLOOR + 100, FLOOR + 100};   // bars below the floor
+        int[] out = update(new int[0], barTops);
+        assertThat(out).hasLength(2);
+        assertThat(out[0]).isEqualTo(FLOOR + BLOCK_SPEED);
+        assertThat(out[1]).isEqualTo(FLOOR + BLOCK_SPEED);
+    }
+
+    @Test
+    public void stableSizeMatchesLegacyMath() {
+        // When the bin count is unchanged the new code must reproduce the
+        // legacy geometry bit-for-bit.
+        int[] prevTops = {FLOOR, 40, 88};
+        int[] barTops = {12, 200, 3};
+        // legacyBuggy mutates its block-state array in place, so give each call
+        // its own copy of the inputs.
+        int[] expected = legacyBuggy(prevTops.clone(), barTops.clone(), prevTops.length);
+        assertThat(update(prevTops.clone(), barTops.clone())).isEqualTo(expected);
+    }
+
+    @Test
+    public void tallBarPushesBlockUpAboveIt() {
+        // A bar whose top is above the current block snaps the block up to
+        // barTop - blockHeight - distance.
+        int[] prevTops = {FLOOR};
+        int[] barTops = {30};   // 30 < FLOOR, so the block rises
+        int[] out = update(prevTops, barTops);
+        assertThat(out[0]).isEqualTo(30 - BLOCK_HEIGHT - DISTANCE);
+    }
+
+    @Test
+    public void quietBarLetsBlockFallByOneStep() {
+        int[] prevTops = {30};
+        int[] barTops = {80};   // 80 > 30, so the block falls
+        int[] out = update(prevTops, barTops);
+        assertThat(out[0]).isEqualTo(30 + BLOCK_SPEED);
+    }
+
+    @Test
+    public void shrinkingBinCountResetsToFloor() {
+        // Bar count shrank; sizes differ so peak-hold resets to the floor
+        // (legacy full-rebuild behavior), then falls one step.
+        int[] prevTops = {10, 10, 10, 10, 10};
+        int[] barTops = {FLOOR + 50, FLOOR + 50};
+        int[] out = update(prevTops, barTops);
+        assertThat(out).hasLength(2);
+        assertThat(out[0]).isEqualTo(FLOOR + BLOCK_SPEED);
+    }
+
+    @Test
+    public void emptyBarsProduceEmptyResult() {
+        assertThat(update(new int[] {1, 2, 3}, new int[0])).isEmpty();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/PeakBlocksTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/PeakBlocksTest.java
@@ -134,4 +134,18 @@ public class PeakBlocksTest {
     public void emptyBarsProduceEmptyResult() {
         assertThat(update(new int[] {1, 2, 3}, new int[0])).isEmpty();
     }
+
+    @Test
+    public void reusePreviousBlocks_onlyWhenGridUnchanged() {
+        // Steady state: previous bar count matches the bins to draw -> reuse the
+        // held blocks (bit-for-bit legacy behavior).
+        assertThat(PeakBlocks.canReusePreviousBlocks(64, 64)).isTrue();
+        // First frame: no previous bars -> nothing to reuse.
+        assertThat(PeakBlocks.canReusePreviousBlocks(0, 64)).isFalse();
+        // Bin count grew (spectrum-width / sample-rate change) -> stale grid.
+        assertThat(PeakBlocks.canReusePreviousBlocks(32, 64)).isFalse();
+        // Bin count shrank -> stale grid; blocks from the wider grid would smear
+        // over the new narrower bars, so they must be dropped, not reused.
+        assertThat(PeakBlocks.canReusePreviousBlocks(64, 32)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary

`ColumnarView` (the spectrum strip's bar view) can throw an
`IndexOutOfBoundsException` on the **UI thread** — an unrecoverable app crash —
while drawing the peak-hold "falling block" overlay. This fixes the root cause
and adds tests.

## Root cause

In `ColumnarView.setWaveData(int[])` the peak-block section rebuilt its block
list to the **current** frame's bin count (`binsToShow`) whenever the size
changed:

```java
for (int i = 0; i < binsToShow; i++) { blockData.add(new Rect(...)); }
for (int i = 0; i < blockData.size(); i++) {
    blockData.get(i).left = newData.get(i).left;   // <-- newData is the PREVIOUS frame
    ...
}
```

but the copy loop reads geometry from `newData`, which at that point still
holds the **previous** frame's (smaller) bar set — `newData` is not rebuilt
until later in the method. When the visible bin count **grows** between two
frames, the loop indexes past the previous bars → `IndexOutOfBoundsException`.
Drawing is not wrapped in try/catch, so it crashes the app.

The bin count changes whenever `binsToShow = min(len, round(spectrumWidth /
nyquist * len))` changes — i.e. on a **spectrum-width change** (the
`NumberInputDialog`, 2500–5000 Hz, in Radio/Audio settings) or an **audio
sample-rate change** — both reachable at runtime while the peak blocks are
shown (`setShowBlock(true)` is set on the waterfall's `ColumnarView`).

## Fix

Drive the peak-hold state off the bars actually present this frame. The
sizing/geometry decision is extracted into a pure, JVM-testable `PeakBlocks`
helper (mirroring the existing `BinAggregation` extraction). It always returns
exactly one block per current bar, so the copy can never over-index. A
bin-count change resets the peak-hold to the floor (matching the legacy
full-rebuild); when the count is unchanged the geometry is **bit-for-bit
identical** to the pre-fix code. The `Composable`/`View` wrapper stays a thin
caller, per the project's testability guidance.

## Testing

- `PeakBlocksTest` (pure JVM, no Robolectric):
  - `growingBinCountDoesNotThrow` — asserts the reconstructed legacy inline
    logic **throws** on a grown bin count and the fix does **not**.
  - `stableSizeMatchesLegacyMath` — bit-for-bit parity with the legacy math
    when the size is unchanged.
  - first-frame floor start, rise-snap, fall-by-one-step, shrinking-bin-count
    reset, empty-bars cases.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — native cpp + APK build succeeds.

## Risk

Low and localized to `ColumnarView`'s peak-block overlay. No DSP, decoder,
encoder, protocol, or CAT behavior touched. Steady-state rendering is
unchanged (verified by the parity test); only the previously-crashing
size-change transient now renders instead of throwing. Same per-frame `Rect`
reuse as before, so no allocation/perf regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)