### PR TITLE
Fix Yaesu FT-817/857/897/847 frequency decode of sub-kHz digits

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu2Command.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu2Command.java
@@ -11,8 +11,8 @@ public class Yaesu2Command {
                     +(int) (rawData[1] & 0x0f) * 100000
                     +((int) (rawData[2] >> 4) & 0xf) * 10000
                     +(int) (rawData[2] & 0x0f) * 1000
-                    +((int) (rawData[3] >> 4) & 0xf) * 10000
-                    +(int) (rawData[3] & 0x0f) * 1000;
+                    +((int) (rawData[3] >> 4) & 0xf) * 100
+                    +(int) (rawData[3] & 0x0f) * 10;
         }else {
             return -1;
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2CommandTest.java
@@ -9,9 +9,12 @@ import org.junit.Test;
  *
  * The rig reports frequency as 4 BCD bytes (8 nibbles, most-significant first)
  * followed by a mode byte. The eight nibbles are a strictly descending decimal
- * sequence with weights 1e8, 1e7, 1e6, 1e5, 1e4, 1e3, 1e2, 1e1 (10 Hz LSB) — the
- * exact inverse of {@link Yaesu2RigConstant#setOperationFreq}, which encodes those
- * same digit places.
+ * sequence with weights 1e8, 1e7, 1e6, 1e5, 1e4, 1e3, 1e2, 1e1 (10 Hz LSB).
+ *
+ * This inverts {@link Yaesu2RigConstant#setOperationFreq} exactly for
+ * 100 Hz-aligned dials. The encoder packs the last nibble as {@code freq % 100}
+ * rather than a clean tens-of-Hz digit, so for frequencies with a non-zero
+ * sub-100 Hz remainder the encoder and decoder are not exact inverses.
  */
 public class Yaesu2CommandTest {
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2CommandTest.java
@@ -8,20 +8,42 @@ import org.junit.Test;
  * Pure-logic coverage for the Yaesu gen-2 (FT-817/857/897) BCD frequency decoder.
  *
  * The rig reports frequency as 4 BCD bytes (8 nibbles, most-significant first)
- * followed by a mode byte. Expected values below are computed directly from the
- * production nibble weights in {@link Yaesu2Command#getFrequency} (note the
- * decoder's own weighting is asserted as-is, not idealised).
+ * followed by a mode byte. The eight nibbles are a strictly descending decimal
+ * sequence with weights 1e8, 1e7, 1e6, 1e5, 1e4, 1e3, 1e2, 1e1 (10 Hz LSB) — the
+ * exact inverse of {@link Yaesu2RigConstant#setOperationFreq}, which encodes those
+ * same digit places.
  */
 public class Yaesu2CommandTest {
 
     @Test
     public void getFrequency_decodesFourBcdNibbleBytes() {
-        // Bytes 14 07 40 00 + mode byte 00.
-        // Per production weights:
+        // Bytes 14 07 40 00 + mode byte 00:
         //   (1)*1e8 + (4)*1e7 + (0)*1e6 + (7)*1e5 + (4)*1e4 + (0)*1e3
-        //   + (0)*1e4 + (0)*1e3  =  140_740_000
+        //   + (0)*1e2 + (0)*1e1  =  140_740_000
         byte[] raw = {(byte) 0x14, (byte) 0x07, (byte) 0x40, (byte) 0x00, (byte) 0x00};
         assertThat(Yaesu2Command.getFrequency(raw)).isEqualTo(140_740_000L);
+    }
+
+    @Test
+    public void getFrequency_decodesHundredsAndTensOfHzDigits() {
+        // Bytes 14 07 43 21 + mode byte 00. The last byte carries the hundreds-of-Hz
+        // (nibble 2 -> 200) and tens-of-Hz (nibble 1 -> 10) digits, which the previous
+        // copy-pasted weights (1e4, 1e3) inflated by 100x, corrupting the reported VFO
+        // frequency by tens of kHz:
+        //   (1)*1e8 + (4)*1e7 + (0)*1e6 + (7)*1e5 + (4)*1e4 + (3)*1e3
+        //   + (2)*1e2 + (1)*1e1  =  140_743_210
+        byte[] raw = {(byte) 0x14, (byte) 0x07, (byte) 0x43, (byte) 0x21, (byte) 0x00};
+        assertThat(Yaesu2Command.getFrequency(raw)).isEqualTo(140_743_210L);
+    }
+
+    @Test
+    public void getFrequency_roundTripsSetOperationFreqEncoding() {
+        // The decoder must invert the encoder. Use a 100 Hz-aligned dial so the
+        // round trip isolates the decoder weights (the encoder packs the two
+        // sub-100 Hz digits into a single nibble, an unrelated limitation).
+        long dial = 14_074_300L; // 14.074 MHz + 300 Hz, exercises the low nibbles
+        byte[] encoded = Yaesu2RigConstant.setOperationFreq(dial);
+        assertThat(Yaesu2Command.getFrequency(encoded)).isEqualTo(dial);
     }
 
     @Test


### PR DESCRIPTION
## Summary

`Yaesu2Command.getFrequency` decodes the 4 BCD frequency bytes the FT-817-family CAT protocol reports for the operating VFO. The eight nibbles form a strictly descending decimal sequence (`1e8, 1e7, 1e6, 1e5, 1e4, 1e3, 1e2, 1e1`), but the **last two nibbles** (byte 3 — the hundreds- and tens-of-Hz digits) carried copy-pasted weights of `10000` and `1000` instead of `100` and `10` — a duplicate of byte 2's 10 kHz / 1 kHz weights.

## Root cause

Copy-paste error in the multipliers for `rawData[3]`:

```java
// before
+((int) (rawData[3] >> 4) & 0xf) * 10000
+(int)  (rawData[3] & 0x0f)      * 1000;
// after
+((int) (rawData[3] >> 4) & 0xf) * 100
+(int)  (rawData[3] & 0x0f)      * 10;
```

The corrected weights make the decoder the exact inverse of `Yaesu2RigConstant.setOperationFreq` for 10 Hz-aligned frequencies.

## Impact

Whenever the rig reported a non-zero hundreds- or tens-of-Hz digit (a dial not on an exact-kHz boundary), the decoded VFO frequency was corrupted by tens of kHz — e.g. bytes `14 07 43 21` decoded to `140_764_000` instead of the correct `140_743_210`. That can mis-detect the band and mis-display the operating frequency.

Exact-kHz dials (the common FT8 case) have byte 3 == `0x00`, so both buggy terms were 0 and the frequency read correctly — which is why the bug went unnoticed and the pre-existing unit test (which used byte 3 == `0x00`) still passed.

The decoder is shared by `Yaesu2Rig` (FT-817/857/897) and `Yaesu2_847Rig` (FT-847), so both rig families are fixed by this one change.

## Testing

- Added `getFrequency_decodesHundredsAndTensOfHzDigits` (non-zero byte 3) and `getFrequency_roundTripsSetOperationFreqEncoding` (encoder⇄decoder inverse) to `Yaesu2CommandTest`. Both **failed before** the fix and **pass after**; the two existing tests (exact-kHz and wrong-length) continue to pass unchanged.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — green.

## Risk assessment

Very low. Single-method arithmetic change with no behavioral difference for exact-kHz dials (the dominant case); purely corrects the sub-kHz digit weights. No protocol/DSP/threading surface touched. No UI changes.