### PR TITLE
Flex/Xiegu: reject VITA packets with reserved packet-type instead of crashing

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/VITA.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/VITA.java
@@ -332,7 +332,18 @@ public class VITA {
         if (data.length < VITAmin) return;
 
         isAvailable = true;//Data length reaches 28 bytes, indicating it is valid
-        packetType = VitaPacketType.values()[(data[0] >> 4) & 0x0f];
+        //The VITA49 packet-type field is 4 bits (0..15), but only 6 types are
+        //defined. Reserved values (6..15) must not index the enum or they throw
+        //ArrayIndexOutOfBoundsException. That exception would escape the UDP/TCP
+        //read loops (which catch only IOException) and crash the whole app, so
+        //treat an unrecognized packet type as an invalid packet and bail out.
+        int packetTypeIndex = (data[0] >> 4) & 0x0f;
+        VitaPacketType[] packetTypes = VitaPacketType.values();
+        if (packetTypeIndex >= packetTypes.length) {
+            isAvailable = false;
+            return;
+        }
+        packetType = packetTypes[packetTypeIndex];
         classIdPresent = (data[0] & 0x8) == 0x8;//Indicates whether the packet contains a class identifier (class ID) field
         trailerPresent = (data[0] & 0x4) == 0x4;//Indicates whether the packet contains a trailer
         tsi = VitaTSI.values()[(data[1] >> 6) & 0x3];//If timestamp exists, indicates the type of the integer part

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/VITATest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/VITATest.java
@@ -1,0 +1,81 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for the {@link VITA#VITA(byte[])} decoder — specifically the
+ * crash fix for the 4-bit packet-type field.
+ *
+ * <p>A VITA49 header's packet-type field is 4 bits wide (values {@code 0..15}),
+ * but {@link VitaPacketType} defines only 6 constants. The decoder previously did
+ * {@code VitaPacketType.values()[(data[0] >> 4) & 0x0f]} with no bounds check, so
+ * any packet whose first-byte high nibble was {@code >= 6} threw
+ * {@link ArrayIndexOutOfBoundsException}.
+ *
+ * <p>VITA packets are decoded on the Flex/Xiegu discovery and stream read loops
+ * ({@link RadioUdpClient} / {@code RadioTcpClient}), which catch only
+ * {@code IOException}. An {@code ArrayIndexOutOfBoundsException} therefore escaped
+ * the loop and crashed the whole app — any stray broadcast UDP datagram of at
+ * least 28 bytes on the discovery port could trigger it. These tests pin the
+ * guarded behaviour: reserved packet types are rejected (not crashed on) while all
+ * six defined types still decode.
+ *
+ * <p>{@link VITA} touches no Android runtime types, so no Robolectric runner is
+ * needed.
+ */
+public class VITATest {
+
+    /** Build a minimal 28-byte VITA packet whose header sets the given nibbles. */
+    private static byte[] packet(int packetTypeNibble) {
+        byte[] data = new byte[VITA_MIN];
+        // High nibble = packet type, low nibble (class/trailer bits) left clear.
+        data[0] = (byte) ((packetTypeNibble & 0x0f) << 4);
+        // data[1] = 0 -> TSI_NONE / TSF_NONE, so no timestamp fields are read.
+        return data;
+    }
+
+    private static final int VITA_MIN = 28;
+
+    @Test
+    public void allDefinedPacketTypesDecode() {
+        VitaPacketType[] types = VitaPacketType.values();
+        for (int i = 0; i < types.length; i++) {
+            VITA vita = new VITA(packet(i));
+            assertThat(vita.isAvailable).isTrue();
+            assertThat(vita.packetType).isEqualTo(types[i]);
+        }
+    }
+
+    @Test
+    public void reservedPacketType_isRejectedNotCrashed() {
+        // Regression: nibble 6..15 indexed a 6-element enum -> AIOOBE on the read
+        // thread -> whole-app crash. Must now be treated as an invalid packet.
+        for (int nibble = VitaPacketType.values().length; nibble <= 0x0f; nibble++) {
+            VITA vita = new VITA(packet(nibble));
+            assertThat(vita.isAvailable).isFalse();
+            assertThat(vita.packetType).isNull();
+        }
+    }
+
+    @Test
+    public void highBitPacketType_doesNotCrash() {
+        // data[0] = (byte) 0xF0 is negative; (data[0] >> 4) is sign-extended, so
+        // the & 0x0f mask matters. Nibble 0xF must still be rejected cleanly.
+        VITA vita = new VITA(packet(0x0f));
+        assertThat(vita.isAvailable).isFalse();
+    }
+
+    @Test
+    public void tooShortPacket_isUnavailable() {
+        VITA vita = new VITA(new byte[VITA_MIN - 1]);
+        assertThat(vita.isAvailable).isFalse();
+    }
+
+    @Test
+    public void nullPacket_isUnavailable() {
+        VITA vita = new VITA((byte[]) null);
+        assertThat(vita.isAvailable).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a whole-app crash in the Flex/Xiegu VITA49 network decoder. `VITA(byte[])` read the 4-bit packet-type field and indexed the 6-constant `VitaPacketType` enum with it **without a bounds check**:

```java
packetType = VitaPacketType.values()[(data[0] >> 4) & 0x0f];   // 0..15 indexes a 6-element enum
```

Any packet whose first byte's high nibble is `>= 6` (VITA49 reserves types 6..15) throws `ArrayIndexOutOfBoundsException`.

## Root cause / why it crashes the whole app

VITA packets are decoded on the Flex/Xiegu discovery and stream read loops:
- `FlexRadioFactory` / `X6100Radio` / `FlexRadio` → `new VITA(data)` inside `RadioUdpClient.ReceiveRunnable.run()` (and the TCP equivalent).
- Those read loops catch **only `IOException`** (`RadioUdpClient.java:117`).

An `ArrayIndexOutOfBoundsException` is a `RuntimeException`, so it escapes the loop as an uncaught thread exception → Android's default handler tears down the process → **whole-app crash**. Because the discovery client is a broadcast UDP listener, any stray datagram of ≥28 bytes on the discovery port with a reserved packet-type nibble can trigger it; it is not limited to genuine Flex traffic.

## Fix

Bounds-check the packet-type nibble against `VitaPacketType.values().length`. A reserved/unrecognized type is treated as an **invalid packet**: `isAvailable = false` and the constructor returns early — exactly mirroring the existing too-short / null-buffer early returns. Callers already gate every use on `vita.isAvailable`, so behavior is unchanged for all six defined packet types.

The 2-bit `tsi`/`tsf` fields (`& 0x3` into 4-constant enums) are already safe and untouched.

## Testing

- New `VITATest` (pure JVM, no Robolectric — `VITA` touches no Android runtime types):
  - all six defined packet types still decode with `isAvailable == true`;
  - reserved nibbles `6..15` are rejected (`isAvailable == false`, no throw) — this is the regression case;
  - high-bit first byte (`0xF0`, negative — exercises the sign-extension + mask) is rejected;
  - too-short and null packets stay unavailable.
- Verified the new test **fails with `ArrayIndexOutOfBoundsException`** against the unpatched decoder and **passes** with the fix.
- `./gradlew :app:testDebugUnitTest` builds and runs green (JDK 17 / NDK 27 / cmake — native build included).

## Risk

Very low. Localized to one decode path; no protocol/DSP/timing behavior changes; adds a guard on a path that previously could only crash.