### PR TITLE
Fix Flex TCP read-thread crash on truncated 'M' message frame

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
@@ -1123,7 +1123,9 @@ public class FlexRadio {
                     getHeadAndContent(line, "\\|");
                     try {
                         //Log.e(TAG, "FlexResponse: "+line );
-                        this.message_num = Integer.parseInt(head.substring(2), 16);//Message number, 32-bit, hex
+                        if (head.length() >= 2) {//Guard: a truncated/garbled frame ("M" or "M|...") would throw
+                            this.message_num = Integer.parseInt(head.substring(2), 16);//Message number, 32-bit, hex
+                        }
                     } catch (NumberFormatException e) {
                         e.printStackTrace();
                         Log.e(TAG, "FlexResponse parseInt message_num exception: " + e.getMessage());

--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
@@ -1123,7 +1123,12 @@ public class FlexRadio {
                     getHeadAndContent(line, "\\|");
                     try {
                         //Log.e(TAG, "FlexResponse: "+line );
-                        if (head.length() >= 2) {//Guard: a truncated/garbled frame ("M" or "M|...") would throw
+                        // Guard: substring(2) needs len > 2 to yield a non-empty
+                        // token. A truncated/garbled frame ("M"/"M|...") would throw
+                        // StringIndexOutOfBoundsException (uncaught -> read-thread
+                        // crash); "M1"/"M1|..." would yield "" and a needless
+                        // NumberFormatException. Mirrors the 'C' branch's length guard.
+                        if (head.length() > 2) {
                             this.message_num = Integer.parseInt(head.substring(2), 16);//Message number, 32-bit, hex
                         }
                     } catch (NumberFormatException e) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexResponseMessageTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexResponseMessageTest.java
@@ -48,6 +48,15 @@ public class FlexResponseMessageTest {
     }
 
     @Test
+    public void twoCharHeader_leavesDefaultWithoutParsing() {
+        // head "M1" -> substring(2) == "" -> the guard skips the parse entirely
+        // rather than driving control flow through NumberFormatException.
+        FlexResponse r = new FlexResponse("M1|only one hex digit");
+        assertThat(r.responseStyle).isEqualTo(FlexResponseStyle.MESSAGE);
+        assertThat(r.message_num).isEqualTo(0);
+    }
+
+    @Test
     public void wellFormedMessage_stillParses() {
         // Real frame: 'M' + 32-bit hex message id + '|' + text. The guard must
         // not change parsing of valid frames.

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexResponseMessageTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexResponseMessageTest.java
@@ -1,0 +1,68 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.flex.FlexRadio.FlexResponse;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link FlexRadio.FlexResponse}'s {@code 'M'} (message)
+ * branch — a crash fix for a truncated/garbled FlexRadio message frame.
+ *
+ * <p>{@code FlexResponse} is constructed on the FlexRadio TCP read thread
+ * ({@link RadioTcpClient}) for every line the radio sends. That read loop
+ * catches only {@code SocketException}/{@code IOException}, so any
+ * {@link RuntimeException} thrown while parsing a line escapes the loop, kills
+ * the read thread and crashes the whole app.
+ *
+ * <p>The {@code 'M'} branch did {@code head.substring(2)} inside a
+ * {@code try/catch (NumberFormatException)}. The catch does not cover
+ * {@link StringIndexOutOfBoundsException}, so a message frame whose header
+ * token (the part before the first {@code '|'}) is shorter than two characters
+ * — a bare {@code "M"} or {@code "M|text"} — threw and crashed. The sibling
+ * {@code 'C'} branch already length-guards before indexing; this pins the same
+ * guard on {@code 'M'} while keeping the parse of well-formed frames unchanged.
+ *
+ * <p>{@code android.util.Log} returns defaults under plain JUnit
+ * ({@code returnDefaultValues = true}), so no Robolectric runner is needed.
+ */
+public class FlexResponseMessageTest {
+
+    @Test
+    public void bareMHeader_doesNotCrash() {
+        // Regression: head == "M" -> substring(2) threw
+        // StringIndexOutOfBoundsException on the read thread.
+        FlexResponse r = new FlexResponse("M");
+        assertThat(r.responseStyle).isEqualTo(FlexResponseStyle.MESSAGE);
+        assertThat(r.message_num).isEqualTo(0);
+    }
+
+    @Test
+    public void shortHeaderWithBody_doesNotCrash() {
+        // head is the part before the first '|'; "M|text" -> head "M" -> the
+        // old substring(2) threw before the '|' body was even considered.
+        FlexResponse r = new FlexResponse("M|no message number here");
+        assertThat(r.responseStyle).isEqualTo(FlexResponseStyle.MESSAGE);
+        assertThat(r.message_num).isEqualTo(0);
+    }
+
+    @Test
+    public void wellFormedMessage_stillParses() {
+        // Real frame: 'M' + 32-bit hex message id + '|' + text. The guard must
+        // not change parsing of valid frames.
+        FlexResponse r = new FlexResponse("M10000001|client connected");
+        assertThat(r.responseStyle).isEqualTo(FlexResponseStyle.MESSAGE);
+        // Existing behaviour parses head.substring(2) as hex ("0000001" -> 1).
+        assertThat(r.message_num).isEqualTo(0x0000001);
+    }
+
+    @Test
+    public void nonNumericMessageNumber_isSwallowed() {
+        // A long-enough header that is not valid hex must still be tolerated
+        // (NumberFormatException path), leaving message_num at its default.
+        FlexResponse r = new FlexResponse("MZZ|garbled");
+        assertThat(r.responseStyle).isEqualTo(FlexResponseStyle.MESSAGE);
+        assertThat(r.message_num).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a whole-app crash in the FlexRadio TCP CAT/status parser. A truncated or garbled **message** frame from a Flex 6000-series radio (or anything on the network sending to the Flex TCP port) crashes the app.

## Root cause

`FlexRadio.FlexResponse`'s `'M'` (message) branch parses the message number with:

```java
this.message_num = Integer.parseInt(head.substring(2), 16);
```

inside a `try/catch (NumberFormatException)`. `head` is the part of the line before the first `|`. When that token is shorter than two characters — a bare `"M"` or `"M|text"` — `head.substring(2)` throws **`StringIndexOutOfBoundsException`**, which the `NumberFormatException` catch does **not** cover.

`FlexResponse` is constructed on the FlexRadio TCP read thread (`RadioTcpClient.SocketThread.run`), whose read loop catches only `SocketException`/`IOException` (`RadioTcpClient.java:151-158`). Any `RuntimeException` escaping the parser propagates out of `run()`, kills the read thread, and triggers the default uncaught-exception handler → **app crash**.

This is the same class of network-parser hardening as the recently merged Flex fixes (#488 Xiegu handle, #491 `FlexMeterInfos`, #495 `FlexMeterList`, #499 VITA enum). The sibling `'S'`/`'R'`/`'C'` branches in the same `switch` are already safe — `'C'` length-guards before indexing; `'M'` was the odd one out.

## Fix

Guard the substring with a length check, mirroring the `'C'` branch:

```java
if (head.length() >= 2) {
    this.message_num = Integer.parseInt(head.substring(2), 16);
}
```

- Parsing of **well-formed** frames (`M<32-bit hex id>|text`) is unchanged.
- A too-short frame now leaves `message_num` at its default `0`. `message_num` is assigned but has **no downstream consumer** anywhere in the codebase, so this has no functional effect beyond not crashing.
- The existing `substring(2)` offset is deliberately left untouched (no evidence-backed reason to change protocol parsing, and the value is unused).

## Testing performed

- New `FlexResponseMessageTest` (pure JVM — `android.util.Log` returns defaults under `returnDefaultValues = true`):
  - `bareMHeader_doesNotCrash` and `shortHeaderWithBody_doesNotCrash` — the two regressions; **verified failing with `StringIndexOutOfBoundsException` before the fix**, passing after.
  - `wellFormedMessage_stillParses` — pins unchanged parse of a valid frame.
  - `nonNumericMessageNumber_isSwallowed` — the existing `NumberFormatException` path still tolerates junk.
- `./gradlew :app:testDebugUnitTest` — full suite green.

## Risk assessment

Very low. One-line defensive guard on a network-input path, no protocol/DSP behavior change, no native code touched. Failure mode fixed is a hard crash; new behavior is a silently-ignored malformed frame (consistent with the sibling branches and the existing `NumberFormatException` catch).