### PR TITLE
Fix whole-app crash on truncated FlexRadio discovery 'serial' token

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadioFactory.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadioFactory.java
@@ -107,11 +107,19 @@ public class FlexRadioFactory {
      * @param s data
      * @return serial number
      */
-    private String getSerialNum(String s){
+    static String getSerialNum(String s){
         String[] strings=s.split(" ");
         for (int i = 0; i <strings.length ; i++) {
-            if (strings[i].toLowerCase().startsWith("serial")){
-                return strings[i].substring("serial".length()+1);
+            // Require the "serial=" prefix (not just "serial") before reading the
+            // value. The old code matched startsWith("serial") and then did
+            // substring(7) unconditionally, so a bare "serial" token (length 6, as
+            // in a truncated/garbled discovery broadcast) threw
+            // StringIndexOutOfBoundsException. This runs on the UDP discovery read
+            // thread (RadioUdpClient), whose loop catches only IOException, so that
+            // RuntimeException escaped and crashed the whole app. Requiring the '='
+            // also matches how FlexRadio.getParameterStr reads "serial=".
+            if (strings[i].toLowerCase().startsWith("serial=")){
+                return strings[i].substring("serial=".length());
             }
         }
         return "";

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioFactoryTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioFactoryTest.java
@@ -1,0 +1,77 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link FlexRadioFactory#getSerialNum(String)} — the crash
+ * fix for a truncated/garbled FlexRadio VITA discovery payload.
+ *
+ * <p>The discovery payload is parsed on the UDP discovery read thread
+ * ({@link RadioUdpClient}). That receive loop catches only {@code IOException},
+ * so any {@link RuntimeException} thrown while parsing escapes the loop, kills
+ * the discovery thread, and crashes the whole app.
+ *
+ * <p>The old code matched {@code startsWith("serial")} and then did
+ * {@code substring("serial".length() + 1)} == {@code substring(7)}
+ * unconditionally. A bare {@code "serial"} token (length 6, case-insensitive) —
+ * as in a corrupt or partial broadcast — made {@code substring(7)} throw
+ * {@link StringIndexOutOfBoundsException}. Requiring the {@code "serial="} prefix
+ * removes the crash and matches how {@code FlexRadio.getParameterStr} reads the
+ * same field. These tests pin both the guarded behaviour and correct parsing.
+ *
+ * <p>{@code getSerialNum} touches no Android types, so no Robolectric runner is
+ * needed.
+ */
+public class FlexRadioFactoryTest {
+
+    /** A representative well-formed Flex discovery payload. */
+    private static final String DISCOVERY =
+            "discovery_protocol_version=3.0.0.2 model=FLEX-6400 "
+                    + "serial=1418-6579-6400-0461 version=3.3.32.8203 nickname=FlexRADIO "
+                    + "callsign=FlexRADIO ip=192.168.3.86 port=4992 status=Available";
+
+    @Test
+    public void wellFormedDiscovery_returnsSerial() {
+        assertThat(FlexRadioFactory.getSerialNum(DISCOVERY))
+                .isEqualTo("1418-6579-6400-0461");
+    }
+
+    @Test
+    public void serialAsFirstToken_returnsSerial() {
+        assertThat(FlexRadioFactory.getSerialNum("serial=1234-5678 model=FLEX-6600"))
+                .isEqualTo("1234-5678");
+    }
+
+    @Test
+    public void bareSerialToken_doesNotCrash() {
+        // Regression: token "serial" (length 6) -> substring(7) threw
+        // StringIndexOutOfBoundsException on the UDP discovery thread.
+        assertThat(FlexRadioFactory.getSerialNum("model=FLEX-6400 serial status=Available"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void bareSerialTokenUppercase_doesNotCrash() {
+        // startsWith is applied to toLowerCase(), so "SERIAL" would also have matched.
+        assertThat(FlexRadioFactory.getSerialNum("SERIAL")).isEqualTo("");
+    }
+
+    @Test
+    public void serialWithEmptyValue_returnsEmpty() {
+        // "serial=" -> substring(7) == "" is valid; not a serial, treated as absent.
+        assertThat(FlexRadioFactory.getSerialNum("serial= model=FLEX-6400")).isEqualTo("");
+    }
+
+    @Test
+    public void noSerialToken_returnsEmpty() {
+        assertThat(FlexRadioFactory.getSerialNum("model=FLEX-6400 status=Available"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void emptyPayload_returnsEmpty() {
+        assertThat(FlexRadioFactory.getSerialNum("")).isEqualTo("");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a whole-app crash triggered by a truncated or garbled FlexRadio VITA **discovery** broadcast arriving on the UDP discovery port.

> Note: this PR originally duplicated the `case 'M'` fix already covered by #500. It has been repurposed for a distinct, still-unfixed crash in the same Flex network-parsing area (one logical bug per PR).

## Root cause

`FlexRadioFactory.getSerialNum` reads the radio serial from a space-separated discovery payload:

```java
if (strings[i].toLowerCase().startsWith("serial")){
    return strings[i].substring("serial".length()+1);   // substring(7)
}
```

`startsWith("serial")` matches a token that is exactly `"serial"` (length 6, case-insensitive), but `substring(7)` is then called unconditionally. For a bare `"serial"` token — as produced by a truncated/garbled broadcast — `substring(7)` throws **`StringIndexOutOfBoundsException`**.

`getSerialNum` runs on the UDP discovery read thread (`RadioUdpClient.ReceiveRunnable.run`), whose receive loop catches only `IOException`:

```java
try {
    client.sendSocket.receive(packet);
    ... client.onUdpEvents.OnReceiveData(...);   // -> updateFlexRadioList -> getSerialNum
} catch (IOException e) { ... }
```

The `StringIndexOutOfBoundsException` therefore propagates out of `run()` uncaught → the discovery thread dies → Android's default uncaught-exception handler **crashes the whole app**. (Same failure mode and thread as the VITA discovery-parser crash fixed in #499.)

## Fix

Require the `"serial="` prefix before reading the value:

```java
if (strings[i].toLowerCase().startsWith("serial=")){
    return strings[i].substring("serial=".length());
}
```

Any token matching `startsWith("serial=")` is at least 7 chars, so the substring offset is always valid — the crash is impossible. This mirrors `FlexRadio.getParameterStr` (which reads `serial=` the same way) and `updateFlexRadioList`'s own `new FlexRadio(s)` parse, so a stray `serialfoo` token is no longer misread as a serial either. Well-formed discovery payloads are parsed identically.

`getSerialNum` is made package-private `static` (it uses no instance state) so it can be unit-tested directly — constructing `FlexRadioFactory` binds a UDP socket and starts a thread, which is unsuitable for a unit test.

## Testing

- New `FlexRadioFactoryTest` (pure JVM, no Robolectric): bare `"serial"`/`"SERIAL"` tokens (regression), empty value `"serial="`, missing token, empty payload, serial-as-first-token, and a realistic full discovery payload to pin the preserved parsing (`serial=1418-6579-6400-0461` → `1418-6579-6400-0461`).
- Verified the defect concretely: the old logic throws `StringIndexOutOfBoundsException` on a bare `serial` token; the new logic returns `""` and parses well-formed payloads identically.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full build incl. native C++ compilation succeeds.

## Risk assessment

Very low. A guard on one parse in an error path plus new tests; the only visibility change is `private` → package-private `static` on a stateless helper. No protocol/DSP/encoder/UI behaviour changes — a well-formed `serial=<value>` is parsed exactly as before; a malformed frame now degrades to "no serial found" (skipped) instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)