### PR TITLE
Enable Hold Tx freq by default (issue #498)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -431,7 +431,7 @@ public class GeneralVariables {
     public static String qrzXmlPassword = ""; //QRZ XML API password
     public static boolean pskOverlayEnabled = false; //PSK Reporter map overlay (issue #33)
     public static boolean synFrequency = false;//Same-frequency transmit
-    public static boolean holdTxFreq = false;//Hold TX freq: don't move the TX offset to a station you answer (WSJT-X "Hold Tx Freq")
+    public static boolean holdTxFreq = true;//Hold TX freq: don't move the TX offset to a station you answer (WSJT-X "Hold Tx Freq"). Enabled by default (issue #498) to keep TX frequency stable; the config DB only overrides this when the user has explicitly toggled it.
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -431,7 +431,10 @@ public class GeneralVariables {
     public static String qrzXmlPassword = ""; //QRZ XML API password
     public static boolean pskOverlayEnabled = false; //PSK Reporter map overlay (issue #33)
     public static boolean synFrequency = false;//Same-frequency transmit
-    public static boolean holdTxFreq = true;//Hold TX freq: don't move the TX offset to a station you answer (WSJT-X "Hold Tx Freq"). Enabled by default (issue #498) to keep TX frequency stable; the config DB only overrides this when the user has explicitly toggled it.
+    // Hold TX freq: don't move the TX offset to a station you answer (WSJT-X
+    // "Hold Tx Freq"). Enabled by default (issue #498) to keep the TX frequency
+    // stable; the config DB only overrides this once the user explicitly toggles it.
+    public static boolean holdTxFreq = true;
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/HoldTxFreqDefaultTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/HoldTxFreqDefaultTest.kt
@@ -3,6 +3,7 @@ package radio.ks3ckc.ft8af
 import com.google.common.truth.Truth.assertThat
 import com.k1af.ft8af.GeneralVariables
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -18,10 +19,17 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class HoldTxFreqDefaultTest {
 
+    private var savedHoldTxFreq = false
+
+    @Before
+    fun saveState() {
+        savedHoldTxFreq = GeneralVariables.holdTxFreq
+    }
+
     @After
-    fun restoreDefault() {
-        // Other suites read GeneralVariables.holdTxFreq; leave it at the default.
-        GeneralVariables.holdTxFreq = true
+    fun restoreState() {
+        // Other suites read GeneralVariables.holdTxFreq; restore the pre-test value.
+        GeneralVariables.holdTxFreq = savedHoldTxFreq
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/HoldTxFreqDefaultTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/HoldTxFreqDefaultTest.kt
@@ -1,0 +1,31 @@
+package radio.ks3ckc.ft8af
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.GeneralVariables
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the default for "Hold Tx freq" (WSJT-X "Hold Tx Freq") in
+ * [GeneralVariables] (issue #498). The config DB only writes a holdTxFreq row
+ * once the user toggles the switch, so on a fresh install the static default is
+ * what takes effect — it must be enabled so the TX offset stays put unless the
+ * operator opts out. Robolectric because GeneralVariables carries Android
+ * LiveData statics that load with the class.
+ */
+@RunWith(RobolectricTestRunner::class)
+class HoldTxFreqDefaultTest {
+
+    @After
+    fun restoreDefault() {
+        // Other suites read GeneralVariables.holdTxFreq; leave it at the default.
+        GeneralVariables.holdTxFreq = true
+    }
+
+    @Test
+    fun `hold tx freq is enabled by default`() {
+        assertThat(GeneralVariables.holdTxFreq).isTrue()
+    }
+}


### PR DESCRIPTION
Closes #498

## Summary
Enables the **Settings > Transmission > "Hold Tx freq"** option by default (issue #498).

Previously `GeneralVariables.holdTxFreq` defaulted to `false`, so on every fresh install operators had to manually re-enable it to stop the app from moving their TX offset onto a station they answer (WSJT-X "Hold Tx Freq"). This flips the default to `true`.

## Why this is the right place to change it
The config DB loader (`DatabaseOpr`) only assigns `holdTxFreq` when a stored `holdTxFreq` row exists, and that row is written **only** when the user toggles the switch in `TransmissionSettings.kt`. So:

- **Fresh install / never toggled** → no DB row → the static `GeneralVariables` default applies → now enabled. ✅
- **User explicitly enabled** (`"1"`) → loads `true`. ✅
- **User explicitly disabled** (`"0"`) → loads `false`, override still wins. ✅

The UI (`TransmissionSettings.kt`) already reads its initial toggle state from `GeneralVariables.holdTxFreq`, so it reflects the new default with no further change.

## Testing
- Added `HoldTxFreqDefaultTest` (Robolectric, since `GeneralVariables` carries Android LiveData statics) asserting the default is enabled.
- `./gradlew :app:testDebugUnitTest --tests radio.ks3ckc.ft8af.HoldTxFreqDefaultTest` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)