### PR TITLE
Fix app crash on malformed Flex discovery broadcast (bare "serial" token)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadioFactory.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadioFactory.java
@@ -107,10 +107,18 @@ public class FlexRadioFactory {
      * @param s data
      * @return serial number
      */
-    private String getSerialNum(String s){
+    static String getSerialNum(String s){
+        if (s==null){return "";}
         String[] strings=s.split(" ");
         for (int i = 0; i <strings.length ; i++) {
-            if (strings[i].toLowerCase().startsWith("serial")){
+            // Real discovery tokens look like "serial=1234-5678"; skip the
+            // "serial=" prefix. A bare/truncated "serial" token (6 chars, no
+            // value) must not reach substring() — this runs on the
+            // RadioUdpClient receive thread, whose loop catches only
+            // IOException, so a StringIndexOutOfBoundsException here would kill
+            // the thread and crash the app on a malformed broadcast packet.
+            if (strings[i].toLowerCase().startsWith("serial")
+                    && strings[i].length() > "serial".length()){
                 return strings[i].substring("serial".length()+1);
             }
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioFactoryTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioFactoryTest.java
@@ -1,0 +1,75 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link FlexRadioFactory#getSerialNum(String)} — the
+ * crash fix for a truncated/garbled FlexRadio discovery broadcast.
+ *
+ * <p>The discovery payload is parsed from a UDP packet received on the
+ * {@link RadioUdpClient} receive thread. That read loop catches only
+ * {@code IOException}, so any {@link RuntimeException} thrown while parsing
+ * escapes, kills the receive thread, and crashes the whole app.
+ *
+ * <p>The old code did {@code token.substring("serial".length() + 1)} guarded
+ * only by {@code startsWith("serial")}: a bare {@code "serial"} token (6 chars,
+ * no {@code =value}) made {@code substring(7)} throw
+ * {@link StringIndexOutOfBoundsException}. These tests pin the guarded
+ * behaviour and confirm well-formed payloads still parse.
+ *
+ * <p>{@code getSerialNum} touches no Android types, so no Robolectric runner is
+ * needed.
+ */
+public class FlexRadioFactoryTest {
+
+    /** A representative well-formed discovery payload. */
+    private static final String DISCOVERY =
+            "discovery_protocol_version=3.0.0.1 model=FLEX-6400 "
+                    + "serial=1234-5678-9012-3456 version=3.2.39.12345 "
+                    + "nickname=Shack callsign=K1AF status=Available";
+
+    @Test
+    public void parsesSerialFromWellFormedPayload() {
+        assertThat(FlexRadioFactory.getSerialNum(DISCOVERY))
+                .isEqualTo("1234-5678-9012-3456");
+    }
+
+    @Test
+    public void bareSerialToken_doesNotCrash() {
+        // Regression: a "serial" token with no "=value" (6 chars) made
+        // substring(7) throw StringIndexOutOfBoundsException on the receive
+        // thread. It must now be skipped and yield the empty serial.
+        assertThat(FlexRadioFactory.getSerialNum("model=FLEX-6400 serial"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void emptySerialValue_isEmpty() {
+        // "serial=" (7 chars) -> substring(7) == "" must not throw.
+        assertThat(FlexRadioFactory.getSerialNum("model=FLEX serial= version=1"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void payloadWithoutSerial_isEmpty() {
+        assertThat(FlexRadioFactory.getSerialNum("model=FLEX-6400 version=3.2"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void nullPayload_isEmpty() {
+        // new String(vita.payload) is never null in practice, but guard anyway
+        // so a future caller can't trip a NullPointerException on the thread.
+        assertThat(FlexRadioFactory.getSerialNum(null)).isEqualTo("");
+    }
+
+    @Test
+    public void serialTokenIsCaseInsensitive_valuePreserved() {
+        // The prefix match lower-cases the token, but the returned value keeps
+        // its original case.
+        assertThat(FlexRadioFactory.getSerialNum("SERIAL=AB12-CD34"))
+                .isEqualTo("AB12-CD34");
+    }
+}


### PR DESCRIPTION
## Summary

Hardens the FlexRadio network discovery parser against a malformed UDP broadcast that crashes the whole app.

## Root cause

`FlexRadioFactory.getSerialNum()` returned `strings[i].substring("serial".length() + 1)` (i.e. `substring(7)`), guarded only by `startsWith("serial")`. A discovery token that begins with `serial` but is shorter than 7 characters — a bare `serial` with no `=value`, as produced by a truncated or garbled UDP packet — makes `substring(7)` throw `StringIndexOutOfBoundsException`.

This parser runs on the `RadioUdpClient` **receive thread**, whose read loop (`RadioUdpClient.ReceiveRunnable.run()`) catches only `IOException`. A `RuntimeException` therefore escapes the loop, kills the receive thread, and — via Android's default uncaught-exception handler — **crashes the whole app**. Because Flex discovery listens on a broadcast port (4992), any device on the LAN can trigger this by sending a malformed packet.

This is the same class of Flex-network-parser hardening as PR #499 (`VITA`), PR #500 (`FlexResponse` `'M'` branch), and PR #491 (`FlexMeterInfos`), all of which fixed uncaught parse exceptions on Flex read threads. The sibling `FlexRadioFactory.getParameterStr` already guards with `startsWith(prefix + "=")`; `getSerialNum` was the odd one out.

## Fix

Skip the token unless it is longer than `"serial"`, so `substring()` only runs when there is a value to return; also null-guard the payload. **Behaviour is unchanged for every input that did not previously crash**: a well-formed `serial=1234-5678` still parses to `1234-5678`, and `serial=` still yields `""`.

`getSerialNum` is made package-private `static` (it uses no instance state) so the new pure-JVM test can exercise it directly.

## Testing

- New `FlexRadioFactoryTest` (pure JVM, no Robolectric — the method touches no Android types). Verified TDD: against the pre-fix code the `bareSerialToken_doesNotCrash` and `nullPayload_isEmpty` cases fail with `StringIndexOutOfBoundsException`/NPE; with the fix all 6 pass.
- Cases: well-formed payload, bare `serial` (regression), empty `serial=` value, no serial token, `null` payload, case-insensitive prefix with value case preserved.
- `./gradlew :app:testDebugUnitTest --tests 'com.k1af.ft8af.flex.*'` — green.
- `./gradlew :app:assembleDebug` — builds clean.

## Risk assessment

Very low. Single-method change confined to the Flex discovery serial parser; strictly narrows when `substring()` executes without altering any previously-successful parse. No DSP, encoder/decoder, waterfall, or protocol behaviour is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)