### PR TITLE
Fix latent decode-thread hang in callsign hash table (bounded linear probe)

### DIFF
--- a/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
@@ -34,6 +34,7 @@ int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
 }
 
 #include "ft8_call_hash.h"
+#include "ftx_hash_store.h"
 
 // ---------------------------------------------------------------------------
 // 22-bit WSJT-X callsign hash (copy of jni_ft8af.cpp's compute_n22, kept local so
@@ -62,15 +63,8 @@ static uint32_t ft2_compute_n22(const char* call)
 static const int kMaxCandidates = 140;
 static const int kMinScore = 10;
 
-// ---------------------------------------------------------------------------
-// Per-decoder callsign hash table (mirrors ft8_decoder.cpp).
-// ---------------------------------------------------------------------------
-#define FT2_HASHTABLE_SIZE 256
-typedef struct
-{
-    char callsign[12];
-    uint32_t hash; // 22-bit
-} ft2_hash_entry_t;
+// The per-decoder callsign hash table (ftx_hash_store_t) is shared with
+// ft8_decode_jni.cpp; see ftx_hash_store.h.
 
 struct ft2_decoder_state
 {
@@ -90,8 +84,7 @@ struct ft2_decoder_state
     ftx_message_t last_message; // populated by the most recent successful Analysis
     bool have_last;
 
-    ft2_hash_entry_t hashtable[FT2_HASHTABLE_SIZE];
-    int hashtable_count;
+    ftx_hash_store_t hashstore;
 };
 
 // --- hash interface callbacks (operate on the current decoder_state) --------
@@ -100,20 +93,9 @@ static __thread ft2_decoder_state* g_active = nullptr;
 static void ft2_hash_save(const char* callsign, uint32_t n22)
 {
     ft2_decoder_state* d = g_active;
-    if (!d || callsign[0] == '\0' || callsign[0] == '<')
+    if (!d)
         return;
-    uint16_t h10 = (n22 >> 12) & 0x3FF;
-    int idx = (h10 * 23) % FT2_HASHTABLE_SIZE;
-    while (d->hashtable[idx].callsign[0] != '\0')
-    {
-        if (d->hashtable[idx].hash == n22)
-            return; // already stored
-        idx = (idx + 1) % FT2_HASHTABLE_SIZE;
-    }
-    strncpy(d->hashtable[idx].callsign, callsign, 11);
-    d->hashtable[idx].callsign[11] = '\0';
-    d->hashtable[idx].hash = n22;
-    d->hashtable_count++;
+    ftx_hash_store_save(&d->hashstore, callsign, n22);
 }
 
 static bool ft2_hash_lookup(ftx_callsign_hash_type_e type, uint32_t hash, char* callsign)
@@ -124,19 +106,7 @@ static bool ft2_hash_lookup(ftx_callsign_hash_type_e type, uint32_t hash, char* 
         callsign[0] = '\0';
         return false;
     }
-    uint8_t shift = (type == FTX_CALLSIGN_HASH_10_BITS) ? 12 : (type == FTX_CALLSIGN_HASH_12_BITS ? 10 : 0);
-    for (int i = 0; i < FT2_HASHTABLE_SIZE; ++i)
-    {
-        if (d->hashtable[i].callsign[0] == '\0')
-            continue;
-        if (((d->hashtable[i].hash & 0x3FFFFFu) >> shift) == hash)
-        {
-            strcpy(callsign, d->hashtable[i].callsign);
-            return true;
-        }
-    }
-    callsign[0] = '\0';
-    return false;
+    return ftx_hash_store_lookup(&d->hashstore, type, hash, callsign);
 }
 
 // ---------------------------------------------------------------------------

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -31,6 +31,7 @@ int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
 #include "ft8_subtract.h"
 #include "ft8_xslot.h"
 #include "ft8_call_hash.h"
+#include "ftx_hash_store.h"
 
 // ---------------------------------------------------------------------------
 // 22-bit WSJT-X callsign hash (same as ft2_decode_jni.cpp / test_golden_encode.c).
@@ -56,15 +57,8 @@ static uint32_t ft8_compute_n22(const char* call)
 
 static const int kMaxCandidates = FT8AF_MAX_CANDIDATES;
 
-// ---------------------------------------------------------------------------
-// Per-decoder callsign hash table.
-// ---------------------------------------------------------------------------
-#define FT8_HASHTABLE_SIZE 256
-typedef struct
-{
-    char callsign[12];
-    uint32_t hash; // 22-bit
-} ft8_hash_entry_t;
+// The per-decoder callsign hash table (ftx_hash_store_t) is shared with
+// ft2_decode_jni.cpp; see ftx_hash_store.h.
 
 struct ft8_decoder_state
 {
@@ -102,8 +96,7 @@ struct ft8_decoder_state
     uint8_t sub_done[kMaxCandidates][10];
     int sub_done_count;
 
-    ft8_hash_entry_t hashtable[FT8_HASHTABLE_SIZE];
-    int hashtable_count;
+    ftx_hash_store_t hashstore;
 };
 
 // --- hash interface callbacks (TLS pointer to current decoder_state) --------
@@ -112,20 +105,9 @@ static __thread ft8_decoder_state* g_active = nullptr;
 static void ft8_hash_save(const char* callsign, uint32_t n22)
 {
     ft8_decoder_state* d = g_active;
-    if (!d || callsign[0] == '\0' || callsign[0] == '<')
+    if (!d)
         return;
-    uint16_t h10 = (n22 >> 12) & 0x3FF;
-    int idx = (h10 * 23) % FT8_HASHTABLE_SIZE;
-    while (d->hashtable[idx].callsign[0] != '\0')
-    {
-        if (d->hashtable[idx].hash == n22)
-            return;
-        idx = (idx + 1) % FT8_HASHTABLE_SIZE;
-    }
-    strncpy(d->hashtable[idx].callsign, callsign, 11);
-    d->hashtable[idx].callsign[11] = '\0';
-    d->hashtable[idx].hash = n22;
-    d->hashtable_count++;
+    ftx_hash_store_save(&d->hashstore, callsign, n22);
 }
 
 static bool ft8_hash_lookup(ftx_callsign_hash_type_e type, uint32_t hash, char* callsign)
@@ -136,19 +118,7 @@ static bool ft8_hash_lookup(ftx_callsign_hash_type_e type, uint32_t hash, char* 
         callsign[0] = '\0';
         return false;
     }
-    uint8_t shift = (type == FTX_CALLSIGN_HASH_10_BITS) ? 12 : (type == FTX_CALLSIGN_HASH_12_BITS ? 10 : 0);
-    for (int i = 0; i < FT8_HASHTABLE_SIZE; ++i)
-    {
-        if (d->hashtable[i].callsign[0] == '\0')
-            continue;
-        if (((d->hashtable[i].hash & 0x3FFFFFu) >> shift) == hash)
-        {
-            strcpy(callsign, d->hashtable[i].callsign);
-            return true;
-        }
-    }
-    callsign[0] = '\0';
-    return false;
+    return ftx_hash_store_lookup(&d->hashstore, type, hash, callsign);
 }
 
 // ---------------------------------------------------------------------------

--- a/ft8af/app/src/main/cpp/ft8af_glue/ftx_hash_store.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ftx_hash_store.h
@@ -1,0 +1,99 @@
+// ftx_hash_store.h — the per-decoder callsign hash table shared by the FT8 and
+// FT4/FT2 decoders.
+//
+// WHY THIS EXISTS
+// ------------------------------------------------------------------
+// ft8_lib's decoder resolves compound/nonstandard callsigns (sent on the air as
+// a 10-/12-/22-bit hash) back to their full text using a small hash table that
+// it accumulates from calls heard in full. Both ft8_decode_jni.cpp and
+// ft2_decode_jni.cpp kept a byte-for-byte identical copy of that table plus its
+// save/lookup routines (a fixed-size open-addressing table with linear probing).
+//
+// Two copies meant the same latent defect lived in both: the save routine's
+// linear probe had no loop bound, so once the table filled with no matching
+// entry it would probe forever — an infinite loop that hangs the decode thread
+// (an ANR on Android). It cannot happen in a normal slot (a fresh, zeroed table
+// holds far more calls than one slot decodes), but nothing guaranteed
+// termination, so a pathological or adversarial slot could wedge the decoder.
+//
+// This header collapses the two copies into one bounded, host-tested
+// implementation (test_hash_store.c). The behaviour is identical to the old
+// inline copies for every non-saturated table; the only change is that a full
+// table now drops the insert instead of spinning — mirroring how lookup already
+// degrades to a graceful miss.
+
+#ifndef FT8AF_FTX_HASH_STORE_H
+#define FT8AF_FTX_HASH_STORE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ft8/message.h" // ftx_callsign_hash_type_e
+
+// Open-addressing table capacity. 256 slots comfortably exceed the distinct
+// hashed callsigns any single decode slot produces.
+#define FTX_HASH_STORE_SIZE 256
+
+typedef struct
+{
+    char callsign[12];
+    uint32_t hash; // 22-bit
+} ftx_hash_entry_t;
+
+typedef struct
+{
+    ftx_hash_entry_t entries[FTX_HASH_STORE_SIZE];
+    int count;
+} ftx_hash_store_t;
+
+// Insert callsign->hash into the table (idempotent on the 22-bit hash). Skips
+// empty and placeholder ("<...>") callsigns, exactly as the decoders require.
+//
+// The linear probe is bounded to at most one full pass: on a saturated table
+// with no matching entry the insert is dropped rather than looping forever.
+static inline void ftx_hash_store_save(ftx_hash_store_t* store, const char* callsign, uint32_t n22)
+{
+    if (callsign[0] == '\0' || callsign[0] == '<')
+        return;
+    uint16_t h10 = (n22 >> 12) & 0x3FF;
+    int idx = (h10 * 23) % FTX_HASH_STORE_SIZE;
+    // Stop after one full pass so a full table degrades to a dropped insert.
+    for (int probes = 0; probes < FTX_HASH_STORE_SIZE; ++probes)
+    {
+        if (store->entries[idx].callsign[0] == '\0')
+            break; // found a free slot
+        if (store->entries[idx].hash == n22)
+            return; // already stored
+        idx = (idx + 1) % FTX_HASH_STORE_SIZE;
+    }
+    if (store->entries[idx].callsign[0] != '\0')
+        return; // table full — drop rather than overwrite a live entry
+    strncpy(store->entries[idx].callsign, callsign, 11);
+    store->entries[idx].callsign[11] = '\0';
+    store->entries[idx].hash = n22;
+    store->count++;
+}
+
+// Resolve a 10-/12-/22-bit hash back to a stored callsign. Writes the callsign
+// into `out` (which must hold at least 12 bytes) and returns true on a hit; on a
+// miss writes an empty string and returns false.
+static inline bool ftx_hash_store_lookup(const ftx_hash_store_t* store,
+                                         ftx_callsign_hash_type_e type, uint32_t hash, char* out)
+{
+    uint8_t shift = (type == FTX_CALLSIGN_HASH_10_BITS) ? 12 : (type == FTX_CALLSIGN_HASH_12_BITS ? 10 : 0);
+    for (int i = 0; i < FTX_HASH_STORE_SIZE; ++i)
+    {
+        if (store->entries[i].callsign[0] == '\0')
+            continue;
+        if (((store->entries[i].hash & 0x3FFFFFu) >> shift) == hash)
+        {
+            strcpy(out, store->entries[i].callsign);
+            return true;
+        }
+    }
+    out[0] = '\0';
+    return false;
+}
+
+#endif // FT8AF_FTX_HASH_STORE_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -139,6 +139,22 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_call_hash)." }
 $callHashExit = $LASTEXITCODE
 
 # ---------------------------------------------------------------------------
+# Callsign hash-store tests: the per-decoder open-addressing table shared by
+# ft8_decode_jni.cpp and ft2_decode_jni.cpp (ftx_hash_store.h). Guards the
+# save/lookup semantics and, crucially, that a saturated table drops the insert
+# instead of probing forever (the unbounded loop that used to hang the decode
+# thread). Header-only under test; needs only the ft8_lib include path.
+# ---------------------------------------------------------------------------
+$srcHashStore = Join-Path $here "test_hash_store.c"
+$outHashStore = Join-Path $env:TEMP "ft8_hash_store_test.exe"
+
+& $Clang @common $srcHashStore -o $outHashStore
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_hash_store)." }
+
+& $outHashStore
+$hashStoreExit = $LASTEXITCODE
+
+# ---------------------------------------------------------------------------
 # EU_VHF / CONTESTING decoder tests (issue #403): the hand-rolled bit
 # extraction + direct formatting for i3=0 n3=2 and i3=0 n3=6 frames. Payloads
 # are assembled by an independent bit writer; callsign bits come from the
@@ -306,6 +322,7 @@ if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
 if ($fftWinExit -ne 0) { exit $fftWinExit }
 if ($callHashExit -ne 0) { exit $callHashExit }
+if ($hashStoreExit -ne 0) { exit $hashStoreExit }
 if ($contestExit -ne 0) { exit $contestExit }
 if ($firExit -ne 0) { exit $firExit }
 if ($ratExit -ne 0) { exit $ratExit }

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -113,6 +113,21 @@ call_hash_out="$tmp/ft8_call_hash_test"
     -I "$ft8" "${call_hash_srcs[@]}" -lm -o "$call_hash_out"
 "$call_hash_out"
 
+# Callsign hash-store tests: the per-decoder open-addressing table shared by
+# ft8_decode_jni.cpp and ft2_decode_jni.cpp (ftx_hash_store.h). Guards the
+# save/lookup semantics and, crucially, that a saturated table drops the insert
+# instead of probing forever (the unbounded loop that used to hang the decode
+# thread). Header-only under test; links just the ft8_lib message path for the
+# hash-type enum.
+hash_store_srcs=(
+    "$here/test_hash_store.c"
+)
+hash_store_out="$tmp/ft8_hash_store_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" "${hash_store_srcs[@]}" -lm -o "$hash_store_out"
+"$hash_store_out"
+
 # EU_VHF / CONTESTING decoder tests (issue #403): the hand-rolled bit
 # extraction + direct formatting for i3=0 n3=2 and i3=0 n3=6 frames. Payloads
 # are assembled by an independent bit writer; callsign bits come from the

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_hash_store.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_hash_store.c
@@ -1,0 +1,129 @@
+// Host unit tests for ftx_hash_store.h — the callsign hash table shared by the
+// FT8 and FT4/FT2 decoders. Run by run_host_tests.sh / .ps1.
+//
+// Covered:
+//   1. Save then resolve the same call by its 10-, 12- and 22-bit hash (the
+//      three widths ft8_lib's decoder queries).
+//   2. Idempotence: saving the same 22-bit hash twice keeps one entry.
+//   3. Rejection of empty and "<...>" placeholder callsigns.
+//   4. 11-character truncation with a guaranteed NUL terminator.
+//   5. Lookup miss returns false and empties the output buffer.
+//   6. REGRESSION (the reason this file exists): saving into a completely full
+//      table must TERMINATE and drop the insert. The previous inline copies in
+//      ft8_decode_jni.cpp / ft2_decode_jni.cpp probed with an unbounded
+//      `while (slot occupied)` loop, so a saturated table spun forever and hung
+//      the decode thread. This test fills all 256 slots and then saves one more
+//      distinct call; it can only pass if the probe is bounded.
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ftx_hash_store.h"
+
+static int g_failures = 0;
+
+static void check(bool ok, const char* what)
+{
+    printf("  %s %s\n", ok ? "ok:  " : "FAIL:", what);
+    if (!ok)
+        g_failures++;
+}
+
+int main(void)
+{
+    char out[16];
+
+    // 1. Save then resolve by each hash width. A stored 22-bit hash answers a
+    //    10-bit query on its top 10 bits, a 12-bit query on its top 12 bits, and
+    //    a 22-bit query on all 22.
+    {
+        ftx_hash_store_t s;
+        memset(&s, 0, sizeof(s));
+        uint32_t n22 = 0x2ABCDEu & 0x3FFFFFu; // arbitrary 22-bit value
+        ftx_hash_store_save(&s, "SV8/DM5HF", n22);
+        check(s.count == 1, "one entry after a single save");
+
+        check(ftx_hash_store_lookup(&s, FTX_CALLSIGN_HASH_22_BITS, n22, out) &&
+                  strcmp(out, "SV8/DM5HF") == 0,
+              "resolves by 22-bit hash");
+        check(ftx_hash_store_lookup(&s, FTX_CALLSIGN_HASH_12_BITS, n22 >> 10, out) &&
+                  strcmp(out, "SV8/DM5HF") == 0,
+              "resolves by 12-bit hash");
+        check(ftx_hash_store_lookup(&s, FTX_CALLSIGN_HASH_10_BITS, n22 >> 12, out) &&
+                  strcmp(out, "SV8/DM5HF") == 0,
+              "resolves by 10-bit hash");
+    }
+
+    // 2. Idempotence on the 22-bit key.
+    {
+        ftx_hash_store_t s;
+        memset(&s, 0, sizeof(s));
+        ftx_hash_store_save(&s, "K1ABC", 0x1234u);
+        ftx_hash_store_save(&s, "K1ABC", 0x1234u);
+        check(s.count == 1, "repeated save of the same hash is idempotent");
+    }
+
+    // 3. Empty and placeholder callsigns are skipped.
+    {
+        ftx_hash_store_t s;
+        memset(&s, 0, sizeof(s));
+        ftx_hash_store_save(&s, "", 0x55u);
+        ftx_hash_store_save(&s, "<...>", 0x56u);
+        check(s.count == 0, "empty and <...> callsigns are not stored");
+    }
+
+    // 4. Callsigns longer than 11 chars are truncated and NUL-terminated.
+    {
+        ftx_hash_store_t s;
+        memset(&s, 0, sizeof(s));
+        ftx_hash_store_save(&s, "ABCDEFGHIJKLMNOP", 0x77u); // 16 chars
+        check(ftx_hash_store_lookup(&s, FTX_CALLSIGN_HASH_22_BITS, 0x77u, out),
+              "long callsign is stored");
+        check(strlen(out) == 11 && strcmp(out, "ABCDEFGHIJK") == 0,
+              "long callsign truncated to 11 chars");
+    }
+
+    // 5. Miss on an empty table.
+    {
+        ftx_hash_store_t s;
+        memset(&s, 0, sizeof(s));
+        strcpy(out, "DIRTY");
+        check(!ftx_hash_store_lookup(&s, FTX_CALLSIGN_HASH_22_BITS, 0x99u, out),
+              "lookup miss returns false");
+        check(out[0] == '\0', "lookup miss empties the output buffer");
+    }
+
+    // 6. REGRESSION: a full table must not hang, and drops further inserts.
+    {
+        ftx_hash_store_t s;
+        memset(&s, 0, sizeof(s));
+        char call[8];
+        for (int i = 0; i < FTX_HASH_STORE_SIZE; ++i)
+        {
+            snprintf(call, sizeof(call), "C%d", i);
+            ftx_hash_store_save(&s, call, (uint32_t)(i + 1)); // distinct hashes
+        }
+        check(s.count == FTX_HASH_STORE_SIZE, "table fills to capacity");
+
+        // The following save, with a distinct hash absent from a now-full table,
+        // is exactly the case that looped forever before the probe was bounded.
+        ftx_hash_store_save(&s, "OVERFLOW", 0xFFFFFu);
+        check(s.count == FTX_HASH_STORE_SIZE, "insert into a full table is dropped");
+        check(!ftx_hash_store_lookup(&s, FTX_CALLSIGN_HASH_22_BITS, 0xFFFFFu, out),
+              "the dropped call is not resolvable");
+        // Entries stored before saturation remain intact.
+        check(ftx_hash_store_lookup(&s, FTX_CALLSIGN_HASH_22_BITS, 1u, out) &&
+                  strcmp(out, "C0") == 0,
+              "pre-saturation entries survive the dropped insert");
+    }
+
+    if (g_failures == 0)
+    {
+        printf("all hash-store tests passed\n");
+        return 0;
+    }
+    printf("%d hash-store test(s) FAILED\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

The FT8 and FT4/FT2 decoders each kept a **byte-for-byte identical copy** of the per-decoder callsign hash table (`ft8_decode_jni.cpp` and `ft2_decode_jni.cpp`) — a fixed-size, open-addressing table with linear probing. The save routine's probe loop had **no bound**:

```c
while (d->hashtable[idx].callsign[0] != '\0') {
    if (d->hashtable[idx].hash == n22) return;
    idx = (idx + 1) % HASHTABLE_SIZE;
}
```

If the table ever fills with no matching entry, this **probes forever** — an infinite loop on the decode thread (an ANR/hang on Android). Nothing guaranteed termination.

## Root cause

Classic open-addressing insert with a missing full-table guard. The table's 256 slots comfortably exceed the distinct hashed callsigns a normal 15-second slot produces (the state is `calloc`'d fresh per slot), so the hang is **latent** — but a pathological or adversarial slot could saturate it and wedge the decoder. `lookup` already degrades to a graceful miss when the call isn't present; `save` did not.

## Fix

- Collapse the two duplicated copies into one shared, host-tested header `ftx_hash_store.h`.
- **Bound the probe to at most one full pass.** On a saturated table the insert is now dropped instead of spinning.
- Behaviour is otherwise **byte-for-byte identical** to the old inline copies for every non-saturated table: same start index, same probe order, same 22-bit dedup, same 11-char truncation + NUL. Decoder output is unchanged.
- Both JNI files become thin wrappers that keep their thread-local null-guard and delegate to the shared store.

## Testing performed

- **New host unit test** `test_hash_store.c` (wired into `run_host_tests.sh` and `run_host_tests.ps1`): covers save/lookup across the 10/12/22-bit query widths, idempotence, placeholder/empty rejection, 11-char truncation, and the regression — filling all 256 slots then saving one more **must terminate and drop the insert**. Confirmed this test **times out against the old unbounded loop** and passes with the bound.
- **Full native host suite passes**, including the `decode_bench` floor assertions → **no decoder-sensitivity regression**.
- **Gradle native build succeeds for all four ABIs** (arm64-v8a, armeabi-v7a, x86, x86_64) and `testDebugUnitTest` passes.

## Risk assessment

Low. No protocol/DSP behaviour change; the only observable difference is that a full table drops the insert rather than hanging. Also removes ~50 lines of duplicated native code.

## Performance notes

None. The bounded loop performs the same work as before for every realistic (non-saturated) table; the bound only caps the previously-unbounded pathological case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)