### PR TITLE
Fix ADIF import corrupting/dropping records with over-declared field lengths

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
@@ -78,11 +78,31 @@ public class ImportSharedLogs {
      * @return Record list. ArrayList
      */
     public ArrayList<HashMap<String, String>> getLogRecords() {
-        String[] temp = getLogBody().split("[<][Ee][Oo][Rr][>]");//Extract the raw content of each record
+        return parseLogRecords(getLogBody());
+    }
+
+    /**
+     * Parse ADIF records from a log body (the text following the header's
+     * {@code <EOH>}). Each record becomes a HashMap keyed by upper-case field
+     * name.
+     *
+     * <p>Extracted as a static, Android-free helper so the field-length
+     * clamping can be unit-tested directly. It mirrors {@link LogFileImport}'s
+     * parser: when a field declares a length longer than the value actually
+     * present (a truncated or hand-edited record), the length is clamped to the
+     * value that is there and only then used for {@code substring}. The previous
+     * code clamped to {@code length() - 1}, which silently dropped the last
+     * character of such values and — for a zero-length value — made
+     * {@code substring(0, -1)} throw {@link StringIndexOutOfBoundsException},
+     * discarding the whole record.
+     *
+     * @param logBody raw record text (after {@code <EOH>})
+     * @return parsed records
+     */
+    static ArrayList<HashMap<String, String>> parseLogRecords(String logBody) {
+        String[] temp = logBody.split("[<][Ee][Oo][Rr][>]");//Extract the raw content of each record
         ArrayList<HashMap<String, String>> records = new ArrayList<>();
-        int count = 0;//Parsing counter
         for (String s : temp) {//Parse each raw record content
-            count++;
             if (!s.contains("<")) {
                 continue;
             }//No tags found, skip parsing
@@ -106,10 +126,12 @@ public class ImportSharedLogs {
                                     }
                                     if (valueLen > 0) {
                                         if (values[1].length() < valueLen) {
-                                            valueLen = values[1].length() - 1;
+                                            valueLen = values[1].length();//Clamp to what is actually present
                                         }
-                                        String value = values[1].substring(0, valueLen);//Field value
-                                        record.put(name.toUpperCase(), value);//Save field, key must be uppercase
+                                        if (valueLen > 0) {
+                                            String value = values[1].substring(0, valueLen);//Field value
+                                            record.put(name.toUpperCase(), value);//Save field, key must be uppercase
+                                        }
                                     }
                                 }
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
@@ -1,0 +1,98 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Pure-JVM coverage for {@link ImportSharedLogs#parseLogRecords(String)} — the
+ * ADIF field-length parser used by the "open shared .adi" import path.
+ *
+ * <p>Regression: the old clamp was {@code valueLen = values[1].length() - 1}
+ * with no re-check before {@code substring}. When a field declared a length
+ * longer than the value actually present (a truncated or hand-edited record)
+ * this silently dropped the last character of the value; for a zero-length
+ * value it made {@code substring(0, -1)} throw
+ * {@link StringIndexOutOfBoundsException}, which — caught at record scope —
+ * discarded the entire QSO. The sibling importer {@link LogFileImport} clamps
+ * to {@code values[1].length()} and re-checks {@code > 0}; these tests pin
+ * {@code ImportSharedLogs} to the same, correct behaviour.
+ *
+ * <p>{@code parseLogRecords} touches no Android types, so no Robolectric runner
+ * is needed.
+ */
+public class ImportSharedLogsTest {
+
+    @Test
+    public void wellFormedRecord_extractsValuesByDeclaredLength() {
+        ArrayList<HashMap<String, String>> records =
+                ImportSharedLogs.parseLogRecords("<call:5>K1ABC<gridsquare:4>FN42<eor>");
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).get("CALL")).isEqualTo("K1ABC");
+        assertThat(records.get(0).get("GRIDSQUARE")).isEqualTo("FN42");
+    }
+
+    @Test
+    public void declaredLengthLongerThanValue_keepsWholeValue() {
+        // Regression: value "K1" (2 chars) under a declared length of 5. The old
+        // code clamped to length()-1 == 1 and returned "K", silently dropping
+        // the last character. It must now return the full "K1".
+        ArrayList<HashMap<String, String>> records =
+                ImportSharedLogs.parseLogRecords("<call:5>K1<eor>");
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).get("CALL")).isEqualTo("K1");
+    }
+
+    @Test
+    public void zeroLengthValue_doesNotDiscardRecordOrCrash() {
+        // A stray '>' yields an empty value token under a positive declared
+        // length. The old code computed valueLen = -1 and threw
+        // StringIndexOutOfBoundsException from substring(0, -1); because the
+        // exception was caught at record scope, the WHOLE record (including the
+        // valid gridsquare) was lost. It must now skip only the empty field and
+        // still return the record with the good field intact.
+        ArrayList<HashMap<String, String>> records =
+                ImportSharedLogs.parseLogRecords("<call:3>>X<gridsquare:4>FN42<eor>");
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).get("GRIDSQUARE")).isEqualTo("FN42");
+        assertThat(records.get(0)).doesNotContainKey("CALL");
+    }
+
+    @Test
+    public void fieldKeysAreUppercased() {
+        HashMap<String, String> first =
+                ImportSharedLogs.parseLogRecords("<call:5>K1ABC<mode:3>FT8<eor>").get(0);
+        assertThat(first).containsKey("CALL");
+        assertThat(first).containsKey("MODE");
+        assertThat(first).doesNotContainKey("call");
+    }
+
+    @Test
+    public void multipleRecords_allParsed() {
+        ArrayList<HashMap<String, String>> records = ImportSharedLogs.parseLogRecords(
+                "<call:5>K1ABC<eor><call:4>W1AW<eor>");
+        assertThat(records).hasSize(2);
+        assertThat(records.get(0).get("CALL")).isEqualTo("K1ABC");
+        assertThat(records.get(1).get("CALL")).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void emptyOrTaglessBody_returnsNoRecords() {
+        assertThat(ImportSharedLogs.parseLogRecords("")).isEmpty();
+        assertThat(ImportSharedLogs.parseLogRecords("just some free text\n")).isEmpty();
+    }
+
+    @Test
+    public void pathologicalFieldLength_isSkipped() {
+        // A field claiming a multi-megabyte length is ignored (MAX_ADIF_FIELD_LEN
+        // guard) without dropping the surrounding, valid field.
+        ArrayList<HashMap<String, String>> records = ImportSharedLogs.parseLogRecords(
+                "<comment:9999999>x<call:5>K1ABC<eor>");
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).get("CALL")).isEqualTo("K1ABC");
+        assertThat(records.get(0)).doesNotContainKey("COMMENT");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a data-corruption / record-loss bug in the shared-ADIF importer (`ImportSharedLogs`, the path behind the Android VIEW / "open with .adi" intent).

## Root cause

`ImportSharedLogs.getLogRecords()` clamped an ADIF field's declared length to `values[1].length() - 1` when the declared length exceeded the value actually present, then called `substring(0, valueLen)` with no re-check. On a truncated or hand-edited record — where the declared `<name:LEN>` is larger than the real value (common at a record boundary or in an edited log):

- **value length ≥ 2** → the **last character of the value is silently dropped** (a callsign or grid imported one character short);
- **value length == 1** → the value becomes empty;
- **value length == 0** → `valueLen = -1` → `substring(0, -1)` throws `StringIndexOutOfBoundsException`. That is caught at record scope, so the **entire QSO record (all its fields) is discarded** instead of imported.

The sibling importer `LogFileImport` parses the identical ADIF grammar **correctly**: it clamps to `values[1].length()` (no `-1`) and re-checks `valueLen > 0` before `substring`. `ImportSharedLogs` is a copy that introduced the off-by-one; the two importers must behave identically.

## Fix

Mirror `LogFileImport`'s clamp and guard. **Behaviour is unchanged for every well-formed record** — when the value length already matches or exceeds the declared length, the clamp branch never runs. Runs on the import worker thread spawned in `doImport`.

The parsing loop is extracted into a static, Android-free `parseLogRecords(String logBody)` (following this repo's convention of extracting logic into a testable top-level function) so the field-length clamping can be unit-tested directly; `getLogRecords()` now delegates to it. A dead, unused `count` counter was dropped in the move.

## Testing

- New `ImportSharedLogsTest` (pure JVM, no Robolectric — `parseLogRecords` touches no Android types). TDD-verified: against the pre-fix `-1` clamp, `declaredLengthLongerThanValue_keepsWholeValue` (last-char truncation) and `zeroLengthValue_doesNotDiscardRecordOrCrash` (the `substring(0,-1)` crash that dropped the whole record) both fail; with the fix all 7 pass. The 5 well-formed cases pass either way, confirming zero behaviour change on valid input.
- `LogFileImportTest` (the twin) still passes.
- `./gradlew :app:assembleDebug` builds clean.

## Risk assessment

Very low. Localized to one parser method; strictly widens the value kept and prevents a crash on malformed input, with no change to any previously-successful parse. No DSP, decoder, waterfall, or protocol behaviour is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)