### PR TITLE
Fix shared-log ADIF import dropping last char of truncated fields

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
@@ -105,10 +105,7 @@ public class ImportSharedLogs {
                                         continue;//Skip pathological field lengths
                                     }
                                     if (valueLen > 0) {
-                                        if (values[1].length() < valueLen) {
-                                            valueLen = values[1].length() - 1;
-                                        }
-                                        String value = values[1].substring(0, valueLen);//Field value
+                                        String value = extractFieldValue(values[1], valueLen);//Field value
                                         record.put(name.toUpperCase(), value);//Save field, key must be uppercase
                                     }
                                 }
@@ -124,6 +121,25 @@ public class ImportSharedLogs {
             }
         }
         return records;
+    }
+
+    /**
+     * Slice an ADIF field value to its declared length, clamping the length down to the
+     * characters actually present. ADIF stores a field as {@code <NAME:LEN>VALUE}, and the
+     * declared LEN can exceed the value that follows when a record is truncated or the writer
+     * padded the length. In that case the whole (shorter) value must be kept — the previous
+     * {@code values[1].length() - 1} clamp silently dropped the last character (turning a value
+     * such as "FN31" into "FN3"), and reduced a single-character value to "". This mirrors the
+     * clamp used by {@link LogFileImport#getLogRecords()}.
+     *
+     * @param raw         the raw field value (everything after the first {@code >} up to the
+     *                    next {@code <})
+     * @param declaredLen the length declared in the field header (already known to be &gt; 0)
+     * @return the value clamped to the declared length or to the raw length, whichever is smaller
+     */
+    static String extractFieldValue(String raw, int declaredLen) {
+        int len = Math.min(declaredLen, raw.length());
+        return len > 0 ? raw.substring(0, len) : "";
     }
 
     public void doImport(InputStream logFileStream, OnShareLogEvents onShareLogEvents) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
@@ -1,0 +1,52 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ImportSharedLogs#extractFieldValue(String, int)}, the ADIF
+ * field-value clamp used by the shared-log importer (the VIEW/SEND intent path that
+ * lets other apps hand a {@code .adi} file to FT8AF).
+ *
+ * The full {@link ImportSharedLogs#getLogRecords()} needs a {@code MainViewModel} and a
+ * populated {@code fileContext}; the field-slicing decision is extracted into the pure
+ * static {@code extractFieldValue} so it can be exercised directly (mirrors the
+ * "extract the logic, test the logic" pattern used elsewhere in this module).
+ */
+public class ImportSharedLogsTest {
+
+    @Test
+    public void valueMatchesDeclaredLength_isReturnedVerbatim() {
+        assertThat(ImportSharedLogs.extractFieldValue("W1AW", 4)).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void valueLongerThanDeclared_isTrimmedToDeclaredLength() {
+        // The raw slice runs up to the next '<', so it usually carries trailing
+        // whitespace/newline; the declared length trims it back to the real value.
+        assertThat(ImportSharedLogs.extractFieldValue("W1AW\n", 4)).isEqualTo("W1AW");
+        assertThat(ImportSharedLogs.extractFieldValue("FT8   ", 3)).isEqualTo("FT8");
+    }
+
+    @Test
+    public void valueShorterThanDeclared_keepsEveryCharacter() {
+        // Regression: the old `values[1].length() - 1` clamp dropped the last
+        // character of a truncated field, turning "FN31" into "FN3".
+        assertThat(ImportSharedLogs.extractFieldValue("FN31", 6)).isEqualTo("FN31");
+        assertThat(ImportSharedLogs.extractFieldValue("FN3", 4)).isEqualTo("FN3");
+    }
+
+    @Test
+    public void declaredLengthOneLongerThanValue_keepsWholeValue() {
+        // The exact case LogFileImportTest documents for the twin parser:
+        // <station_callsign:5> declared for the 4-char value "W1AW".
+        assertThat(ImportSharedLogs.extractFieldValue("W1AW", 5)).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void singleCharacterValueShorterThanDeclared_isNotEmptied() {
+        // Old clamp turned this into "" (length 1 - 1 = 0); the value must survive.
+        assertThat(ImportSharedLogs.extractFieldValue("X", 5)).isEqualTo("X");
+    }
+}


### PR DESCRIPTION
## Summary

`ImportSharedLogs.getLogRecords()` parses shared / externally-opened `.adi` files — the exported `VIEW`/`SEND` intent path that lets another app hand an ADIF log to FT8AF. When a field's **declared** length exceeded the value actually present in the record (`<NAME:LEN>VALUE` with fewer than `LEN` characters before the next `<`), the length clamp contained a stray `-1`:

```java
if (values[1].length() < valueLen) {
    valueLen = values[1].length() - 1;   // drops one real character
}
String value = values[1].substring(0, valueLen);
```

This silently discarded the **last character** of the value — an imported grid `FN31` became `FN3`, a callsign lost its last letter — and reduced a single-character value to `""`. Corrupted callsigns / grids then get written into the log DB on import.

## Root cause

A long-standing off-by-one in the shared-log importer (it predates the ADIF size/length hardening commit `a65c8343`). The twin parser `LogFileImport.getLogRecords()`, which does the identical job for the HTTP import path, clamps correctly to `values[1].length()` with **no** `-1`. `LogFileImportTest` even documents the correct behaviour for the `<station_callsign:5>` / 4-char-value case. The shared-log path simply diverged.

## Fix

Extract the clamp into a pure, unit-testable helper:

```java
static String extractFieldValue(String raw, int declaredLen) {
    int len = Math.min(declaredLen, raw.length());
    return len > 0 ? raw.substring(0, len) : "";
}
```

Behaviour is **unchanged** for:
- well-formed ADIF (value length == declared length),
- values longer than declared (trailing whitespace before the next `<` is still trimmed to the declared length).

Only the truncated-field case is corrected — the whole (shorter) value is now kept.

## Testing performed

- New `ImportSharedLogsTest` (pure JVM, no Robolectric needed) covering exact-length, longer-than-declared, shorter-than-declared, declared-one-longer (`<station_callsign:5>W1AW`), and single-character-value cases.
- Verified the new test **fails** against the old `-1` clamp (3 cases) and **passes** with the fix.
- Full `./gradlew :app:testDebugUnitTest` suite: green.
- `./gradlew :app:assembleDebug`: green.

## Risk assessment

Very low. Change is localized to one method on the shared-log import path; the extracted helper preserves all existing behaviour except the buggy truncation. No DSP, native, encoder/decoder, or protocol code touched. No performance impact (same `substring`, one `Math.min`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)