### PR TITLE
Fix crash in getShortCallsign on all-slash callsigns (ArrayIndexOutOfBoundsException)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -814,6 +814,13 @@ public class GeneralVariables {
     static public String getShortCallsign(String callsign) {
         if (callsign.contains("/")) {
             String[] temp = callsign.split("/");
+            // An all-slash string ("/", "//", ...) splits to a zero-length array
+            // because Java strips trailing empty tokens; there is no segment to
+            // return, so fall back to the original rather than indexing temp[0]
+            // and throwing ArrayIndexOutOfBoundsException.
+            if (temp.length == 0) {
+                return callsign;
+            }
             int max = 0;
             int max_index = 0;
             for (int i = 0; i < temp.length; i++) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesShortCallsignTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesShortCallsignTest.java
@@ -11,7 +11,7 @@ import org.robolectric.RobolectricTestRunner;
  * {@link ArrayIndexOutOfBoundsException} on all-slash callsigns.
  *
  * <p>{@code "/".split("/")} and {@code "//".split("/")} both return a zero-length
- * array (Java strips trailing empty tokens), yet the method unconditionally read
+ * array (Java strips trailing empty tokens), yet the method unconditionally reads
  * {@code temp[max_index]} — index 0 into an empty array. This is reached with the
  * operator's own persisted callsign on the config-load background thread
  * ({@code DatabaseOpr} ReadConfig) and on every decode cycle via

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesShortCallsignTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesShortCallsignTest.java
@@ -1,0 +1,53 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards {@link GeneralVariables#getShortCallsign(String)} against an
+ * {@link ArrayIndexOutOfBoundsException} on all-slash callsigns.
+ *
+ * <p>{@code "/".split("/")} and {@code "//".split("/")} both return a zero-length
+ * array (Java strips trailing empty tokens), yet the method unconditionally read
+ * {@code temp[max_index]} — index 0 into an empty array. This is reached with the
+ * operator's own persisted callsign on the config-load background thread
+ * ({@code DatabaseOpr} ReadConfig) and on every decode cycle via
+ * {@code checkIsMyCallsign(...)}, so a stray-slash callsign turned into an
+ * uncaught crash that recurred on every launch.
+ *
+ * <p>Robolectric because {@link GeneralVariables} carries Android LiveData statics
+ * that must initialize before the pure string helper can be exercised.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesShortCallsignTest {
+
+    @Test
+    public void plainCallsign_returnedUnchanged() {
+        assertThat(GeneralVariables.getShortCallsign("W1AW")).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void compoundCallsign_returnsLongestSegment() {
+        // prefix and suffix forms both collapse to the base callsign
+        assertThat(GeneralVariables.getShortCallsign("DL/W1AW")).isEqualTo("W1AW");
+        assertThat(GeneralVariables.getShortCallsign("W1AW/P")).isEqualTo("W1AW");
+        assertThat(GeneralVariables.getShortCallsign("W1AW/QRP")).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void allSlashCallsign_doesNotThrow_returnsOriginal() {
+        // Regression: these previously threw ArrayIndexOutOfBoundsException.
+        assertThat(GeneralVariables.getShortCallsign("/")).isEqualTo("/");
+        assertThat(GeneralVariables.getShortCallsign("//")).isEqualTo("//");
+        assertThat(GeneralVariables.getShortCallsign("///")).isEqualTo("///");
+    }
+
+    @Test
+    public void leadingSlash_returnsLongestNonEmptySegment() {
+        // "/A".split("/") keeps the leading empty token -> ["", "A"]; longest is "A".
+        assertThat(GeneralVariables.getShortCallsign("/W1AW")).isEqualTo("W1AW");
+    }
+}


### PR DESCRIPTION
## Root cause

`GeneralVariables.getShortCallsign(String)` splits a compound callsign on `/`
and returns the longest segment:

```java
String[] temp = callsign.split("/");
...
return temp[max_index];   // max_index defaults to 0
```

For an **all-slash** input (`"/"`, `"//"`, `"///"`) Java's `String.split`
strips trailing empty tokens and returns a **zero-length array**, so
`temp[0]` throws `ArrayIndexOutOfBoundsException`. `String.contains("/")` is
true for these inputs, so the guarded branch is entered and the crash fires.

## Impact

`getShortCallsign` is only ever called on the operator's **own** callsign, but
that value is loaded from persisted config and used on real threads:

- `DatabaseOpr` `ReadConfig.doInBackground` (startup config load, background
  thread) — `getShortCallsign(myCallsign)` when the stored callsign contains
  `/`. An uncaught exception here crashes the app **on startup**, and because
  the value is persisted the crash **recurs on every launch**.
- `GeneralVariables.checkIsMyCallsign(...)` calls `getShortCallsign(myCallsign)`
  and runs on the **decode thread** for matching, so a stray-slash callsign
  also crashes each decode cycle.

A single stray `/` typed into (or migrated into) the callsign field turns into
a hard, recurring crash rather than being tolerated.

## Fix

Fall back to the original string when the split yields no usable segment,
instead of indexing `temp[0]`:

```java
String[] temp = callsign.split("/");
if (temp.length == 0) {
    return callsign;
}
```

Behavior is unchanged for every well-formed input — plain callsigns
(`W1AW`), prefix/suffix compounds (`DL/W1AW`, `W1AW/P`, `W1AW/QRP`), and
leading-slash forms (`/W1AW`) all return exactly what they did before.

## Testing

- New `GeneralVariablesShortCallsignTest` (JUnit4 + Truth, Robolectric because
  `GeneralVariables` carries Android `LiveData` statics) covers plain,
  compound, leading-slash, and the all-slash regression cases. The all-slash
  case fails with `ArrayIndexOutOfBoundsException` before the fix and passes
  after.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — APK builds.

## Risk

Minimal. One localized guard on a pathological input; no protocol, DSP, or
threading behavior changes, and all normal callsign shapes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)