### PR TITLE
Add Hamlib NET rigctl rig control (issue #508)

### DIFF
--- a/ft8af/app/src/main/assets/rigaddress.txt
+++ b/ft8af/app/src/main/assets/rigaddress.txt
@@ -73,3 +73,4 @@ UA3REO Wolf SDR(DIGU),00,4800,15
 UA3REO Wolf SDR(USB),00,4800,16
 (tr)uSDX (audio over cat),00,115200,17
 (tr)uSDX (TS-480),00,9600,7
+Hamlib NET (rigctld),00,00,26

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -477,6 +477,10 @@ public class GeneralVariables {
     public static String icomUserName = "ic705";
     public static String icomPassword = "";
 
+    //Hamlib NET rigctl connection: rigctld host and TCP port (Hamlib default 4532)
+    public static String hamlibHost = "192.168.1.1";
+    public static int hamlibPort = com.k1af.ft8af.rigs.HamlibRigctl.DEFAULT_PORT;
+
 
     public static boolean autoFollowCQ = false;//Auto-follow CQ
     public static boolean huntCallsCQ = false;//Hunt+CQ hybrid: call CQ when idle, answer CQs when heard

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -61,6 +61,7 @@ import com.k1af.ft8af.connector.CableConnector;
 import com.k1af.ft8af.connector.CableSerialPort;
 import com.k1af.ft8af.connector.ConnectMode;
 import com.k1af.ft8af.connector.FlexConnector;
+import com.k1af.ft8af.connector.HamlibConnector;
 import com.k1af.ft8af.connector.IComWifiConnector;
 import com.k1af.ft8af.connector.X6100Connector;
 import com.k1af.ft8af.database.ControlMode;
@@ -92,6 +93,7 @@ import com.k1af.ft8af.rigs.ElecraftRig;
 import com.k1af.ft8af.rigs.Flex6000Rig;
 import com.k1af.ft8af.rigs.FlexNetworkRig;
 import com.k1af.ft8af.rigs.GuoHeQ900Rig;
+import com.k1af.ft8af.rigs.HamlibNetRig;
 import com.k1af.ft8af.rigs.IcomRig;
 import com.k1af.ft8af.rigs.InstructionSet;
 import com.k1af.ft8af.rigs.KenwoodKT90Rig;
@@ -839,6 +841,14 @@ public class MainViewModel extends ViewModel {
             }
 
             @Override
+            public boolean usesNetworkAudio() {
+                // A Hamlib NET rigctl rig moves only CAT over TCP; its audio uses
+                // the local sound path, so TX must not be diverted to the
+                // network transmit branch (which would leave the air silent).
+                return baseRig == null || baseRig.usesNetworkAudio();
+            }
+
+            @Override
             public void onTransmitOverCAT(Ft8Message msg) {//send audio message via CAT
                 if (!supportTransmitOverCAT()) {
                     return;
@@ -1511,6 +1521,40 @@ public class MainViewModel extends ViewModel {
     }
 
     /**
+     * Connect to a Hamlib {@code rigctld} daemon over the network. Only CAT
+     * (frequency/PTT/mode) crosses the TCP link; audio keeps using the local
+     * sound path, so this is CAT control mode, not the audio-over-network mode.
+     *
+     * @param host rigctld host name or IP address
+     * @param port rigctld TCP port (Hamlib default 4532)
+     */
+    public void connectHamlibRig(String host, int port) {
+        if (host == null || host.trim().isEmpty() || port < 1 || port > 65535) {
+            return;//guarded UI can't submit this, but never open a socket on a bad target
+        }
+        if (baseRig != null && baseRig.getConnector() != null) {
+            baseRig.getConnector().disconnect();
+        }
+        GeneralVariables.controlMode = ControlMode.CAT;//CAT over the rigctld link
+        connectRig();//builds a HamlibNetRig for InstructionSet.HAMLIB_NET
+        if (baseRig == null) {
+            return;
+        }
+        HamlibConnector connector = new HamlibConnector(host, port, GeneralVariables.controlMode);
+        baseRig.setControlMode(GeneralVariables.controlMode);
+        baseRig.setOnRigStateChanged(onRigStateChanged);
+        baseRig.setConnector(connector);
+        connector.connect();
+
+        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {//connection takes time, wait before setting frequency
+            @Override
+            public void run() {
+                setOperationBand();//set carrier frequency
+            }
+        }, 1000);
+    }
+
+    /**
      * Connect to XieGu Radio
      *
      * @param context   context
@@ -1651,6 +1695,9 @@ public class MainViewModel extends ViewModel {
                 break;
             case InstructionSet.KENWOOD_TS440:
                 baseRig = new KenwoodTS440Rig();//KENWOOD TS-440S (TS-570 CAT, USB mode)
+                break;
+            case InstructionSet.HAMLIB_NET:
+                baseRig = new HamlibNetRig();//Hamlib NET rigctl: CAT over TCP to a rigctld daemon
                 break;
         }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/HamlibConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/HamlibConnector.java
@@ -1,0 +1,140 @@
+package com.k1af.ft8af.connector;
+
+import android.util.Log;
+
+import com.k1af.ft8af.rigs.OnConnectReceiveData;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+/**
+ * TCP transport to a Hamlib {@code rigctld} daemon. Opens the socket on a
+ * background thread, streams reply bytes back to the rig via
+ * {@link OnConnectReceiveData}, and writes CAT command lines built by
+ * {@code HamlibRigctl}. Kept intentionally thin (no protocol knowledge lives
+ * here) to mirror the other network connectors; all wire-format logic and its
+ * unit tests live in {@code HamlibRigctl}.
+ */
+public class HamlibConnector extends BaseRigConnector {
+    private static final String TAG = "HamlibConnector";
+    private static final int CONNECT_TIMEOUT_MS = 5000;
+
+    private final String host;
+    private final int port;
+
+    private volatile Socket socket;
+    private volatile OutputStream outputStream;
+    private volatile boolean running;
+    private Thread readerThread;
+
+    public HamlibConnector(String host, int port, int controlMode) {
+        super(controlMode);
+        this.host = host;
+        this.port = port;
+    }
+
+    @Override
+    public void connect() {
+        if (getOnConnectorStateChanged() != null) {
+            getOnConnectorStateChanged().onConnecting();
+        }
+        new Thread(this::openSocket, "HamlibConnector-connect").start();
+    }
+
+    private void openSocket() {
+        try {
+            Socket s = new Socket();
+            s.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT_MS);
+            s.setTcpNoDelay(true);
+            socket = s;
+            outputStream = s.getOutputStream();
+            running = true;
+            if (getOnConnectorStateChanged() != null) {
+                getOnConnectorStateChanged().onConnected();
+            }
+            startReader(s);
+        } catch (IOException e) {
+            Log.e(TAG, "connect failed: " + e.getMessage());
+            running = false;
+            if (getOnConnectorStateChanged() != null) {
+                getOnConnectorStateChanged().onRunError(e.getMessage());
+            }
+        }
+    }
+
+    private void startReader(Socket s) {
+        readerThread = new Thread(() -> {
+            byte[] chunk = new byte[512];
+            try {
+                InputStream in = s.getInputStream();
+                int read;
+                while (running && (read = in.read(chunk)) != -1) {
+                    OnConnectReceiveData receiver = getOnConnectReceiveData();
+                    if (receiver != null) {
+                        byte[] slice = new byte[read];
+                        System.arraycopy(chunk, 0, slice, 0, read);
+                        receiver.onData(slice);
+                    }
+                }
+            } catch (IOException e) {
+                if (running) {
+                    Log.e(TAG, "read failed: " + e.getMessage());
+                }
+            } finally {
+                boolean wasRunning = running;
+                running = false;
+                if (wasRunning && getOnConnectorStateChanged() != null) {
+                    getOnConnectorStateChanged().onDisconnected();
+                }
+            }
+        }, "HamlibConnector-reader");
+        readerThread.start();
+    }
+
+    @Override
+    public synchronized void sendData(byte[] data) {
+        OutputStream out = outputStream;
+        if (out == null) {
+            return;
+        }
+        try {
+            out.write(data);
+            out.flush();
+        } catch (IOException e) {
+            Log.e(TAG, "write failed: " + e.getMessage());
+            running = false;
+            if (getOnConnectorStateChanged() != null) {
+                getOnConnectorStateChanged().onRunError(e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void setPttOn(byte[] command) {
+        sendData(command);
+    }
+
+    @Override
+    public boolean isConnected() {
+        Socket s = socket;
+        return running && s != null && s.isConnected() && !s.isClosed();
+    }
+
+    @Override
+    public void disconnect() {
+        running = false;
+        Socket s = socket;
+        if (s != null) {
+            try {
+                s.close();
+            } catch (IOException e) {
+                Log.e(TAG, "close failed: " + e.getMessage());
+            }
+        }
+        socket = null;
+        outputStream = null;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2716,6 +2716,14 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("icomPassword")) {//ICOM password
                     GeneralVariables.icomPassword = result;
                 }
+                if (name.equalsIgnoreCase("hamlibHost")) {//Hamlib rigctld host
+                    GeneralVariables.hamlibHost = result.equals("") ? "192.168.1.1" : result;
+                }
+                if (name.equalsIgnoreCase("hamlibPort")) {//Hamlib rigctld TCP port
+                    GeneralVariables.hamlibPort = result.equals("")
+                            ? com.k1af.ft8af.rigs.HamlibRigctl.DEFAULT_PORT
+                            : Integer.parseInt(result);
+                }
                 if (name.equalsIgnoreCase("volumeValue")) {//Output volume level
                     GeneralVariables.volumePercent = result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
                     GeneralVariables.mutableVolumePercent.postValue(GeneralVariables.volumePercent);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -587,9 +587,21 @@ public class FT8TransmitSignal {
         return out;
     }
 
+    /**
+     * Whether TX audio should be streamed over the rig's network control link
+     * instead of played through the local sound path. True only for network
+     * rigs that actually carry audio (FlexRadio / ICOM / XieGu Wi-Fi); a Hamlib
+     * NET rigctl link moves only CAT, so {@code rigUsesNetworkAudio} is false
+     * there and audio plays locally like a wired CAT rig.
+     */
+    static boolean transmitAudioOverNetwork(int connectMode, boolean rigUsesNetworkAudio) {
+        return connectMode == ConnectMode.NETWORK && rigUsesNetworkAudio;
+    }
+
     private void playFT8Signal(Ft8Message msg) {
 
-        if (GeneralVariables.connectMode == ConnectMode.NETWORK) {// network mode does not play audio locally
+        boolean rigUsesNetworkAudio = onDoTransmitted == null || onDoTransmitted.usesNetworkAudio();
+        if (transmitAudioOverNetwork(GeneralVariables.connectMode, rigUsesNetworkAudio)) {// network mode does not play audio locally
             Log.d(TAG, "playFT8Signal: Entering network transmit mode, waiting for audio to send.");
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/OnDoTransmitted.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/OnDoTransmitted.java
@@ -22,4 +22,13 @@ public interface OnDoTransmitted {
     //as onBeforeTransmit/onAfterTransmit (VOX rigs key on the audio itself).
     default void onTuneKeyDown() {}
     default void onTuneKeyUp() {}
+
+    /**
+     * Whether the connected rig carries TX audio over its network control link
+     * (FlexRadio / ICOM / XieGu Wi-Fi) rather than the local sound path. A
+     * Hamlib NET rigctl link moves only CAT over TCP, so it returns false and TX
+     * audio plays locally like a wired CAT rig. Defaults true so existing
+     * network-rig behaviour is unchanged for implementers that don't override.
+     */
+    default boolean usesNetworkAudio() { return true; }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
@@ -150,6 +150,17 @@ public abstract class BaseRig {
     }
 
     /**
+     * Whether this rig carries TX/RX audio over its control link (network
+     * rigs such as FlexRadio and the ICOM/XieGu Wi-Fi radios) rather than
+     * through the local sound path. Consulted only in network connect mode; a
+     * Hamlib NET rigctl link, which moves only CAT over TCP, overrides this to
+     * {@code false} so audio keeps flowing through the local sound card.
+     */
+    public boolean usesNetworkAudio() {
+        return true;
+    }
+
+    /**
      * Whether this rig's protocol has a CAT command to start the internal
      * antenna tuner (ATU). Capability can't be queried over CAT, so "true"
      * means the protocol family defines the command — rigs without an ATU

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibNetRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibNetRig.java
@@ -1,0 +1,145 @@
+package com.k1af.ft8af.rigs;
+
+import static com.k1af.ft8af.GeneralVariables.QUERY_FREQ_TIMEOUT;
+import static com.k1af.ft8af.GeneralVariables.START_QUERY_FREQ_DELAY;
+
+import android.util.Log;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Rig control over a Hamlib {@code rigctld} daemon reached across the network.
+ *
+ * <p>CAT (frequency, PTT, mode) travels over a TCP socket to rigctld using the
+ * text protocol built by {@link HamlibRigctl}; rigctld in turn drives whatever
+ * radio it was launched against, so this one backend covers every Hamlib rig.
+ * Only CAT crosses the link — audio still flows through the local sound path
+ * (USB sound card / AudioTrack), exactly like a wired CAT rig — which is why
+ * {@link #usesNetworkAudio()} stays {@code false}.</p>
+ */
+public class HamlibNetRig extends BaseRig {
+    private static final String TAG = "HamlibNetRig";
+
+    private final StringBuilder buffer = new StringBuilder();
+    private Timer readFreqTimer = new Timer();
+
+    public HamlibNetRig() {
+        Log.d(TAG, "HamlibNetRig: create.");
+        readFreqTimer.schedule(readTask(), START_QUERY_FREQ_DELAY, QUERY_FREQ_TIMEOUT);
+    }
+
+    private TimerTask readTask() {
+        return new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    // Hamlib has no meter read here; only poll the dial when
+                    // idle. READ_METERS (PTT on) falls through to no-op so we
+                    // never poll while transmitting.
+                    if (ReadTaskAction.decide(isConnected(), isPttOn())
+                            == ReadTaskAction.Action.READ_FREQ) {
+                        readFreqFromRig();
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "readFreq error:" + e.getMessage());
+                }
+            }
+        };
+    }
+
+    @Override
+    public void onDisconnecting() {
+        if (readFreqTimer != null) {
+            readFreqTimer.cancel();
+            readFreqTimer.purge();
+            readFreqTimer = null;
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        if (getConnector() == null) {
+            return false;
+        }
+        return getConnector().isConnected();
+    }
+
+    @Override
+    public void setPTT(boolean on) {
+        super.setPTT(on);
+        if (getConnector() != null) {
+            getConnector().sendData(HamlibRigctl.setPtt(on));
+        }
+    }
+
+    @Override
+    public void setUsbModeToRig() {
+        if (getConnector() != null) {
+            getConnector().sendData(HamlibRigctl.setDataUsbMode());
+        }
+    }
+
+    @Override
+    public void setFreqToRig() {
+        if (getConnector() != null) {
+            getConnector().sendData(HamlibRigctl.setFreq(getFreq()));
+        }
+    }
+
+    @Override
+    public void readFreqFromRig() {
+        if (getConnector() != null) {
+            getConnector().sendData(HamlibRigctl.readFreq());
+        }
+    }
+
+    @Override
+    public void onReceiveData(byte[] data) {
+        buffer.append(new String(data, StandardCharsets.US_ASCII));
+        // Guard against an endless partial line if the peer never sends a newline.
+        if (buffer.length() > 1000) {
+            buffer.setLength(0);
+            return;
+        }
+        HamlibRigctl.Scan scan = HamlibRigctl.scanLines(buffer.toString());
+        buffer.setLength(0);
+        buffer.append(scan.remainder);
+        for (String line : scan.lines) {
+            handleLine(line);
+        }
+    }
+
+    /**
+     * Dispatch one complete reply line. A bare frequency updates the dial (and,
+     * via {@link BaseRig#setFreq(long)}, feeds the CAT-liveness watchdog); an
+     * {@code RPRT} report just proves the link is alive.
+     */
+    private void handleLine(String line) {
+        long freq = HamlibRigctl.parseFreqReply(line);
+        if (freq > 0) {
+            setFreq(freq);
+            return;
+        }
+        if (HamlibRigctl.parseReport(line) != HamlibRigctl.NO_REPORT
+                && getOnRigStateChanged() != null) {
+            getOnRigStateChanged().onRigResponded();
+        }
+    }
+
+    /**
+     * Hamlib NET rigctl carries only CAT over TCP; TX/RX audio uses the local
+     * sound path just like a wired CAT rig, so audio must never be diverted to
+     * the network transmit path.
+     */
+    @Override
+    public boolean usesNetworkAudio() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "Hamlib NET rigctl";
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibRigctl.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibRigctl.java
@@ -1,0 +1,173 @@
+package com.k1af.ft8af.rigs;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pure-logic helper for talking to a <a href="https://hamlib.github.io/">Hamlib</a>
+ * {@code rigctld} daemon over TCP. {@code rigctld} exposes Hamlib's full rig
+ * catalogue (200+ radios) through a tiny line-based text protocol on port
+ * {@value #DEFAULT_PORT}; this is exactly how WSJT-X / JTDX "use Hamlib" for
+ * network rig control. Running rigctld on a PC or Raspberry Pi next to the radio
+ * lets the Android app drive any Hamlib-supported rig without bundling the
+ * native library.
+ *
+ * <p>Only the handful of commands this app needs are modelled — set/read
+ * frequency, set PTT and set the FT8 data mode — plus parsers for the replies.
+ * Everything here is deliberately free of Android and I/O dependencies so the
+ * wire format and reply parsing can be unit-tested directly; {@link HamlibNetRig}
+ * and {@code HamlibConnector} are thin wrappers that only move bytes.</p>
+ *
+ * <p>The rigctld single-shot protocol used here:</p>
+ * <pre>
+ *   set frequency   "F 14074000\n"      -&gt; "RPRT 0\n"
+ *   get frequency   "f\n"               -&gt; "14074000\n"
+ *   set PTT         "T 1\n" / "T 0\n"   -&gt; "RPRT 0\n"
+ *   set mode        "M PKTUSB 0\n"      -&gt; "RPRT 0\n"
+ * </pre>
+ */
+public final class HamlibRigctl {
+
+    /** Default TCP port a {@code rigctld} instance listens on. */
+    public static final int DEFAULT_PORT = 4532;
+
+    /**
+     * FT8 is upper-sideband data. rigctld's packet/data-USB mode ("PKTUSB")
+     * keeps the rig on the tone grid WSJT-X expects, the same reason the wired
+     * drivers select DATA-U rather than plain USB.
+     */
+    public static final String MODE_DATA_USB = "PKTUSB";
+
+    /**
+     * Passband width argument for a mode change. {@code 0} tells rigctld to keep
+     * the rig's current/default passband for that mode instead of forcing one.
+     */
+    public static final int DEFAULT_PASSBAND = 0;
+
+    /** Sentinel returned by {@link #parseReport(String)} when a line is not an RPRT reply. */
+    public static final int NO_REPORT = Integer.MIN_VALUE;
+
+    /**
+     * rigctld reports PTT and split status as a bare {@code 0}/{@code 1}. A real
+     * dial frequency in Hz is always far larger, so this threshold lets a
+     * frequency reply be told apart from those other bare-number replies.
+     */
+    static final long MIN_PLAUSIBLE_FREQ_HZ = 1000L;
+
+    private HamlibRigctl() {
+    } // utility class
+
+    /** Build the "set frequency" command line ({@code F <hz>}). */
+    public static byte[] setFreq(long hz) {
+        return line("F " + hz);
+    }
+
+    /** Build the "read frequency" command line ({@code f}). */
+    public static byte[] readFreq() {
+        return line("f");
+    }
+
+    /** Build the "set PTT" command line ({@code T 1} / {@code T 0}). */
+    public static byte[] setPtt(boolean on) {
+        return line("T " + (on ? "1" : "0"));
+    }
+
+    /** Build a "set mode" command line ({@code M <mode> <passbandHz>}). */
+    public static byte[] setMode(String mode, int passbandHz) {
+        return line("M " + mode + " " + passbandHz);
+    }
+
+    /** Build the FT8 data-USB mode command ({@code M PKTUSB 0}). */
+    public static byte[] setDataUsbMode() {
+        return setMode(MODE_DATA_USB, DEFAULT_PASSBAND);
+    }
+
+    /** Terminate a command with the newline rigctld expects and encode as ASCII. */
+    static byte[] line(String command) {
+        return (command + "\n").getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Parse a single response line as a frequency reply.
+     *
+     * @param line one line of rigctld output (newline already stripped)
+     * @return the frequency in Hz, or {@code -1} when the line is not a bare
+     * number that looks like a dial frequency (e.g. an {@code RPRT} report, a
+     * mode name, PTT {@code 0}/{@code 1}, or empty)
+     */
+    public static long parseFreqReply(String line) {
+        if (line == null) {
+            return -1;
+        }
+        String trimmed = line.trim();
+        if (trimmed.isEmpty()) {
+            return -1;
+        }
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (!Character.isDigit(trimmed.charAt(i))) {
+                return -1;
+            }
+        }
+        try {
+            long value = Long.parseLong(trimmed);
+            return value >= MIN_PLAUSIBLE_FREQ_HZ ? value : -1;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Parse a single response line as an {@code RPRT} report.
+     *
+     * @param line one line of rigctld output (newline already stripped)
+     * @return the report code ({@code 0} success, negative Hamlib error), or
+     * {@link #NO_REPORT} when the line is not an {@code RPRT} reply
+     */
+    public static int parseReport(String line) {
+        if (line == null) {
+            return NO_REPORT;
+        }
+        String trimmed = line.trim();
+        if (!trimmed.startsWith("RPRT")) {
+            return NO_REPORT;
+        }
+        try {
+            return Integer.parseInt(trimmed.substring(4).trim());
+        } catch (NumberFormatException e) {
+            return NO_REPORT;
+        }
+    }
+
+    /**
+     * Split a streamed, possibly-partial buffer into complete newline-terminated
+     * lines plus a trailing remainder. TCP hands data over in arbitrary chunks,
+     * so a reply can arrive split across reads or several replies can arrive
+     * together; the caller keeps {@link Scan#remainder} and prepends it to the
+     * next chunk.
+     */
+    public static Scan scanLines(String buffered) {
+        List<String> lines = new ArrayList<>();
+        if (buffered == null || buffered.isEmpty()) {
+            return new Scan(lines, "");
+        }
+        int start = 0;
+        int idx;
+        while ((idx = buffered.indexOf('\n', start)) >= 0) {
+            lines.add(buffered.substring(start, idx));
+            start = idx + 1;
+        }
+        return new Scan(lines, buffered.substring(start));
+    }
+
+    /** Result of {@link #scanLines(String)}: complete lines and any partial tail. */
+    public static final class Scan {
+        public final List<String> lines;
+        public final String remainder;
+
+        Scan(List<String> lines, String remainder) {
+            this.lines = lines;
+            this.remainder = remainder;
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/InstructionSet.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/InstructionSet.java
@@ -29,6 +29,7 @@ public class InstructionSet {
     public static final int YAESU_FT710=23;//FT-710, currently reuses DX10 instruction set; CAT read loop must stay off
     public static final int DISCOVERY_TX500=24;//Lab599 Discovery TX-500, TS-2000 compatible, DATA mode (MD6;)
     public static final int KENWOOD_TS440=25;//KENWOOD TS-440S, original Kenwood CAT, TS-570 compatible (TX;/RX; PTT)
+    public static final int HAMLIB_NET=26;//Hamlib NET rigctl: CAT over TCP to a rigctld daemon; audio stays on the local sound path
 
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ConfigFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ConfigFragment.java
@@ -1529,6 +1529,8 @@ public class ConfigFragment extends Fragment {
                     // Open network radio list dialog
                     if (GeneralVariables.instructionSet== InstructionSet.FLEX_NETWORK) {
                         new SelectFlexRadioDialog(requireContext(), mainViewModel).show();
+                    }else if (GeneralVariables.instructionSet== InstructionSet.HAMLIB_NET) {
+                        new HamlibConnectDialog(requireContext(), mainViewModel).show();
                     }else if (GeneralVariables.instructionSet== InstructionSet.XIEGU_6100_FT8CNS) {
                         new SelectXieguRadioDialog(requireContext(), mainViewModel).show();
                     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/HamlibConnectDialog.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/HamlibConnectDialog.java
@@ -1,0 +1,145 @@
+package com.k1af.ft8af.ui;
+
+/**
+ * Dialog for connecting to a Hamlib {@code rigctld} daemon over the network.
+ * Collects a host and TCP port, then hands them to
+ * {@link MainViewModel#connectHamlibRig(String, int)}.
+ *
+ * @author FT8AF
+ */
+
+import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+
+import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.MainViewModel;
+import com.k1af.ft8af.R;
+
+public class HamlibConnectDialog extends Dialog {
+    private final MainViewModel mainViewModel;
+    private EditText inputHostEdit;
+    private EditText inputPortEdit;
+    private Button connectButton;
+
+    public HamlibConnectDialog(@NonNull Context context, MainViewModel mainViewModel) {
+        super(context);
+        this.mainViewModel = mainViewModel;
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.hamlib_connect_dialog_layout);
+        inputHostEdit = findViewById(R.id.inputHamlibHostEdit);
+        inputPortEdit = findViewById(R.id.inputHamlibPortEdit);
+        connectButton = findViewById(R.id.hamlibConnectButton);
+
+        inputHostEdit.setText(GeneralVariables.hamlibHost);
+        inputPortEdit.setText(String.valueOf(GeneralVariables.hamlibPort));
+        checkInput();
+
+        connectButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                String host = inputHostEdit.getText().toString().trim();
+                int port = parsePort(inputPortEdit.getText().toString().trim());
+                ToastMessage.show(String.format(
+                        GeneralVariables.getStringFromResource(R.string.connect_hamlib), host));
+                mainViewModel.connectHamlibRig(host, port);
+                dismiss();
+            }
+        });
+
+        inputHostEdit.addTextChangedListener(new SimpleTextWatcher() {
+            @Override
+            public void afterTextChanged(Editable editable) {
+                checkInput();
+                GeneralVariables.hamlibHost = inputHostEdit.getText().toString().trim();
+                writeConfig("hamlibHost", GeneralVariables.hamlibHost);
+            }
+        });
+
+        inputPortEdit.addTextChangedListener(new SimpleTextWatcher() {
+            @Override
+            public void afterTextChanged(Editable editable) {
+                checkInput();
+                int port = parsePort(inputPortEdit.getText().toString().trim());
+                if (port != -1) {
+                    GeneralVariables.hamlibPort = port;
+                    writeConfig("hamlibPort", String.valueOf(port));
+                }
+            }
+        });
+    }
+
+    private void checkInput() {
+        connectButton.setEnabled(isValidInput(
+                inputHostEdit.getText().toString().trim(),
+                inputPortEdit.getText().toString().trim()));
+    }
+
+    /**
+     * Whether the entered host + port form a connectable pair: a non-empty host
+     * and a port in the valid TCP range. Pure so it can be unit-tested without
+     * inflating the dialog.
+     */
+    public static boolean isValidInput(String host, String portText) {
+        return host != null && !host.isEmpty() && parsePort(portText) != -1;
+    }
+
+    /**
+     * Parse a TCP port string, returning {@code -1} when it is missing,
+     * non-numeric, or outside the valid 1..65535 range.
+     */
+    public static int parsePort(String portText) {
+        if (portText == null || portText.trim().isEmpty()) {
+            return -1;
+        }
+        try {
+            int port = Integer.parseInt(portText.trim());
+            return (port >= 1 && port <= 65535) ? port : -1;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private void writeConfig(String keyName, String value) {
+        mainViewModel.databaseOpr.writeConfig(keyName, value, null);
+    }
+
+    @Override
+    public void show() {
+        super.show();
+        WindowManager.LayoutParams params = getWindow().getAttributes();
+        int height = getWindow().getWindowManager().getDefaultDisplay().getHeight();
+        int width = getWindow().getWindowManager().getDefaultDisplay().getWidth();
+        if (width > height) {
+            params.width = (int) (width * 0.6);
+        } else {
+            params.width = (int) (width * 0.8);
+        }
+        getWindow().setAttributes(params);
+    }
+
+    /** TextWatcher with no-op before/on-changed hooks to cut boilerplate. */
+    private abstract static class SimpleTextWatcher implements TextWatcher {
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        }
+
+        @Override
+        public void onTextChanged(CharSequence s, int start, int before, int count) {
+        }
+    }
+}

--- a/ft8af/app/src/main/res/layout/hamlib_connect_dialog_layout.xml
+++ b/ft8af/app/src/main/res/layout/hamlib_connect_dialog_layout.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/hamlibDialogLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/select_bluetooth_dialog_style"
+    android:minWidth="300dp"
+    android:minHeight="200dp">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="@drawable/icon_background_style"
+        android:contentDescription="@string/help"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ft8af_icon" />
+
+    <TextView
+        android:id="@+id/hamlibHelpMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:text="@string/hamlib_connect_help"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/image" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/hamlibHostConstraintLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/editor_layout_style"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/hamlibHelpMessage">
+
+        <TextView
+            android:id="@+id/hamlibHostText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/hamlib_host"
+            android:textAlignment="textEnd"
+            android:textColor="#FFFFFF"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@+id/inputHamlibHostEdit"
+            app:layout_constraintEnd_toStartOf="@+id/inputHamlibHostEdit"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/inputHamlibHostEdit"
+            tools:ignore="TextContrastCheck" />
+
+        <EditText
+            android:id="@+id/inputHamlibHostEdit"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="6dp"
+            android:autofillHints=""
+            android:background="@drawable/editor_style"
+            android:ems="10"
+            android:hint="@string/pl_input_hamlib_host"
+            android:inputType="textUri|numberDecimal"
+            android:minHeight="32dp"
+            android:textColor="#FFFFFF"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/hamlibGuideline1"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="TextContrastCheck,TouchTargetSizeCheck" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/hamlibGuideline1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="90dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/hamlibPortConstraintLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/editor_layout_style"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/hamlibHostConstraintLayout">
+
+        <TextView
+            android:id="@+id/hamlibPortText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/hamlib_port"
+            android:textAlignment="textEnd"
+            android:textColor="#FFFFFF"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@+id/inputHamlibPortEdit"
+            app:layout_constraintEnd_toStartOf="@+id/hamlibGuideline2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/inputHamlibPortEdit"
+            tools:ignore="TextContrastCheck" />
+
+        <EditText
+            android:id="@+id/inputHamlibPortEdit"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="6dp"
+            android:autofillHints=""
+            android:background="@drawable/editor_style"
+            android:ems="10"
+            android:hint="@string/pl_input_hamlib_port"
+            android:inputType="number"
+            android:minHeight="32dp"
+            android:textColor="#FFFFFF"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/hamlibGuideline2"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="TextContrastCheck,TouchTargetSizeCheck" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/hamlibGuideline2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="90dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <Button
+        android:id="@+id/hamlibConnectButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:enabled="false"
+        android:text="@string/hamlib_connect_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/hamlibPortConstraintLayout" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ft8af/app/src/main/res/values/strings.xml
+++ b/ft8af/app/src/main/res/values/strings.xml
@@ -353,6 +353,13 @@
     <string name="icom_login_button">Login</string>
     <string name="show_password">Password is visibility</string>
     <string name="connect_icom_ip">Connect ICom Radio %s …</string>
+    <string name="hamlib_connect_help">Connect to a Hamlib rigctld daemon</string>
+    <string name="hamlib_host">Host</string>
+    <string name="pl_input_hamlib_host">rigctld host or IP</string>
+    <string name="hamlib_port">Port</string>
+    <string name="pl_input_hamlib_port">rigctld port (default 4532)</string>
+    <string name="hamlib_connect_button">Connect</string>
+    <string name="connect_hamlib">Connect Hamlib rigctld %s …</string>
     <string name="connect_xiegu_ip">Connect XIEGU Radio %s …</string>
     <string name="network_exception">%s : Network transmission exception : %s</string>
     <string name="login_succeed">Login succeeded !</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TransmitAudioRoutingTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/TransmitAudioRoutingTest.java
@@ -1,0 +1,38 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.connector.ConnectMode;
+
+import org.junit.Test;
+
+/**
+ * The TX audio router decides whether samples go over the rig's network control
+ * link or through the local sound path. A Hamlib NET rigctl rig carries only CAT
+ * over TCP, so its audio must play locally — routing it to the network branch
+ * would leave the air silent (the exact failure the {@code usesNetworkAudio}
+ * flag guards against).
+ */
+public class TransmitAudioRoutingTest {
+
+    @Test
+    public void networkAudioRig_inNetworkMode_transmitsOverNetwork() {
+        assertThat(FT8TransmitSignal.transmitAudioOverNetwork(ConnectMode.NETWORK, true))
+                .isTrue();
+    }
+
+    @Test
+    public void hamlibRig_inNetworkMode_playsLocally() {
+        // rigUsesNetworkAudio == false for Hamlib NET rigctl (CAT-only link).
+        assertThat(FT8TransmitSignal.transmitAudioOverNetwork(ConnectMode.NETWORK, false))
+                .isFalse();
+    }
+
+    @Test
+    public void wiredModes_alwaysPlayLocally() {
+        assertThat(FT8TransmitSignal.transmitAudioOverNetwork(ConnectMode.USB_CABLE, true))
+                .isFalse();
+        assertThat(FT8TransmitSignal.transmitAudioOverNetwork(ConnectMode.BLUE_TOOTH, true))
+                .isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibNetRigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibNetRigTest.java
@@ -1,0 +1,145 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.connector.BaseRigConnector;
+import com.k1af.ft8af.database.ControlMode;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Behavioural coverage for {@link HamlibNetRig}: it must emit the exact rigctld
+ * command lines and route bare-frequency replies into the dial while treating
+ * {@code RPRT} reports only as liveness. Robolectric because {@link BaseRig}
+ * touches {@code MutableLiveData} on {@link BaseRig#setFreq(long)}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class HamlibNetRigTest {
+
+    /** Connector that records every byte the rig hands it and reports "connected". */
+    private static final class CapturingConnector extends BaseRigConnector {
+        final List<String> sent = new ArrayList<>();
+
+        CapturingConnector() {
+            super(ControlMode.CAT);
+        }
+
+        @Override
+        public synchronized void sendData(byte[] data) {
+            sent.add(new String(data, StandardCharsets.US_ASCII));
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        String last() {
+            return sent.get(sent.size() - 1);
+        }
+    }
+
+    /** OnRigStateChanged that records the callbacks the rig fires. */
+    private static final class RecordingState implements OnRigStateChanged {
+        Long lastFreq = null;
+        Boolean lastPtt = null;
+        int respondedCount = 0;
+
+        @Override public void onDisconnected() {}
+        @Override public void onConnected() {}
+        @Override public void onPttChanged(boolean isOn) { lastPtt = isOn; }
+        @Override public void onFreqChanged(long freq) { lastFreq = freq; }
+        @Override public void onRunError(String message) {}
+        @Override public void onRigResponded() { respondedCount++; }
+    }
+
+    private HamlibNetRig newRig(CapturingConnector connector, RecordingState state) {
+        HamlibNetRig rig = new HamlibNetRig();
+        rig.onDisconnecting();// stop the polling timer so tests see only their own sends
+        rig.setOnRigStateChanged(state);
+        rig.setConnector(connector);
+        return rig;
+    }
+
+    @Test
+    public void setFreqToRig_sendsFCommand() {
+        CapturingConnector connector = new CapturingConnector();
+        HamlibNetRig rig = newRig(connector, new RecordingState());
+        rig.setFreq(14_074_000L);
+        rig.setFreqToRig();
+        assertThat(connector.last()).isEqualTo("F 14074000\n");
+    }
+
+    @Test
+    public void readFreqFromRig_sendsPollCommand() {
+        CapturingConnector connector = new CapturingConnector();
+        HamlibNetRig rig = newRig(connector, new RecordingState());
+        rig.readFreqFromRig();
+        assertThat(connector.last()).isEqualTo("f\n");
+    }
+
+    @Test
+    public void setUsbModeToRig_sendsPktUsbMode() {
+        CapturingConnector connector = new CapturingConnector();
+        HamlibNetRig rig = newRig(connector, new RecordingState());
+        rig.setUsbModeToRig();
+        assertThat(connector.last()).isEqualTo("M PKTUSB 0\n");
+    }
+
+    @Test
+    public void setPtt_sendsCommandAndFiresCallback() {
+        CapturingConnector connector = new CapturingConnector();
+        RecordingState state = new RecordingState();
+        HamlibNetRig rig = newRig(connector, state);
+        rig.setPTT(true);
+        assertThat(connector.last()).isEqualTo("T 1\n");
+        assertThat(state.lastPtt).isTrue();
+        assertThat(rig.isPttOn()).isTrue();
+        rig.setPTT(false);
+        assertThat(connector.last()).isEqualTo("T 0\n");
+        assertThat(state.lastPtt).isFalse();
+    }
+
+    @Test
+    public void onReceiveData_frequencyReplyUpdatesDial() {
+        CapturingConnector connector = new CapturingConnector();
+        RecordingState state = new RecordingState();
+        HamlibNetRig rig = newRig(connector, state);
+        rig.onReceiveData("14074000\n".getBytes(StandardCharsets.US_ASCII));
+        assertThat(state.lastFreq).isEqualTo(14_074_000L);
+        assertThat(rig.getFreq()).isEqualTo(14_074_000L);
+    }
+
+    @Test
+    public void onReceiveData_reassemblesSplitReply() {
+        CapturingConnector connector = new CapturingConnector();
+        RecordingState state = new RecordingState();
+        HamlibNetRig rig = newRig(connector, state);
+        // TCP can split a reply across reads; the rig must buffer until the newline.
+        rig.onReceiveData("1407".getBytes(StandardCharsets.US_ASCII));
+        assertThat(state.lastFreq).isNull();
+        rig.onReceiveData("4000\n".getBytes(StandardCharsets.US_ASCII));
+        assertThat(state.lastFreq).isEqualTo(14_074_000L);
+    }
+
+    @Test
+    public void onReceiveData_reportIsLivenessOnly() {
+        CapturingConnector connector = new CapturingConnector();
+        RecordingState state = new RecordingState();
+        HamlibNetRig rig = newRig(connector, state);
+        rig.onReceiveData("RPRT 0\n".getBytes(StandardCharsets.US_ASCII));
+        assertThat(state.lastFreq).isNull();// no dial change from a report
+        assertThat(state.respondedCount).isEqualTo(1);// but it proves the link is alive
+    }
+
+    @Test
+    public void usesNetworkAudio_isFalseSoAudioStaysLocal() {
+        assertThat(new HamlibNetRig().usesNetworkAudio()).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibRigctlTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibRigctlTest.java
@@ -1,0 +1,124 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Wire-format and reply-parsing coverage for the Hamlib {@code rigctld} network
+ * protocol. These bytes go to a daemon that keys a real transmitter, so the
+ * exact command strings (and the frequency-vs-report parsing that drives the
+ * dial and the CAT-liveness watchdog) are pinned here.
+ */
+public class HamlibRigctlTest {
+
+    private static String str(byte[] bytes) {
+        return new String(bytes, StandardCharsets.US_ASCII);
+    }
+
+    @Test
+    public void setFreq_buildsFCommandInHz() {
+        assertThat(str(HamlibRigctl.setFreq(14_074_000L))).isEqualTo("F 14074000\n");
+    }
+
+    @Test
+    public void readFreq_buildsLowercaseF() {
+        assertThat(str(HamlibRigctl.readFreq())).isEqualTo("f\n");
+    }
+
+    @Test
+    public void setPtt_onAndOff() {
+        assertThat(str(HamlibRigctl.setPtt(true))).isEqualTo("T 1\n");
+        assertThat(str(HamlibRigctl.setPtt(false))).isEqualTo("T 0\n");
+    }
+
+    @Test
+    public void setMode_buildsModeAndPassband() {
+        assertThat(str(HamlibRigctl.setMode("USB", 2400))).isEqualTo("M USB 2400\n");
+    }
+
+    @Test
+    public void setDataUsbMode_usesPktUsbWithDefaultPassband() {
+        // FT8 is data/packet USB; a wrong mode would push the tones off WSJT-X's grid.
+        assertThat(str(HamlibRigctl.setDataUsbMode())).isEqualTo("M PKTUSB 0\n");
+    }
+
+    @Test
+    public void parseFreqReply_parsesBareNumber() {
+        assertThat(HamlibRigctl.parseFreqReply("14074000")).isEqualTo(14_074_000L);
+    }
+
+    @Test
+    public void parseFreqReply_trimsWhitespace() {
+        assertThat(HamlibRigctl.parseFreqReply("  7074000  ")).isEqualTo(7_074_000L);
+    }
+
+    @Test
+    public void parseFreqReply_rejectsPttStatusAndTinyNumbers() {
+        // rigctld reports PTT/split as bare 0/1 — must not be read as a frequency.
+        assertThat(HamlibRigctl.parseFreqReply("0")).isEqualTo(-1);
+        assertThat(HamlibRigctl.parseFreqReply("1")).isEqualTo(-1);
+        assertThat(HamlibRigctl.parseFreqReply("999")).isEqualTo(-1);
+    }
+
+    @Test
+    public void parseFreqReply_rejectsNonNumericAndReports() {
+        assertThat(HamlibRigctl.parseFreqReply("RPRT 0")).isEqualTo(-1);
+        assertThat(HamlibRigctl.parseFreqReply("PKTUSB")).isEqualTo(-1);
+        assertThat(HamlibRigctl.parseFreqReply("")).isEqualTo(-1);
+        assertThat(HamlibRigctl.parseFreqReply(null)).isEqualTo(-1);
+        assertThat(HamlibRigctl.parseFreqReply("-14074000")).isEqualTo(-1);
+    }
+
+    @Test
+    public void parseReport_success() {
+        assertThat(HamlibRigctl.parseReport("RPRT 0")).isEqualTo(0);
+    }
+
+    @Test
+    public void parseReport_errorCode() {
+        assertThat(HamlibRigctl.parseReport("RPRT -1")).isEqualTo(-1);
+    }
+
+    @Test
+    public void parseReport_notAReportReturnsSentinel() {
+        assertThat(HamlibRigctl.parseReport("14074000")).isEqualTo(HamlibRigctl.NO_REPORT);
+        assertThat(HamlibRigctl.parseReport("")).isEqualTo(HamlibRigctl.NO_REPORT);
+        assertThat(HamlibRigctl.parseReport(null)).isEqualTo(HamlibRigctl.NO_REPORT);
+    }
+
+    @Test
+    public void parseReport_malformedCodeReturnsSentinel() {
+        assertThat(HamlibRigctl.parseReport("RPRT x")).isEqualTo(HamlibRigctl.NO_REPORT);
+    }
+
+    @Test
+    public void scanLines_splitsCompleteLinesAndKeepsRemainder() {
+        HamlibRigctl.Scan scan = HamlibRigctl.scanLines("14074000\nRPRT 0\n707");
+        assertThat(scan.lines).containsExactly("14074000", "RPRT 0").inOrder();
+        assertThat(scan.remainder).isEqualTo("707");
+    }
+
+    @Test
+    public void scanLines_noNewlineIsAllRemainder() {
+        HamlibRigctl.Scan scan = HamlibRigctl.scanLines("1407");
+        assertThat(scan.lines).isEmpty();
+        assertThat(scan.remainder).isEqualTo("1407");
+    }
+
+    @Test
+    public void scanLines_trailingNewlineLeavesEmptyRemainder() {
+        HamlibRigctl.Scan scan = HamlibRigctl.scanLines("14074000\n");
+        assertThat(scan.lines).containsExactly("14074000");
+        assertThat(scan.remainder).isEmpty();
+    }
+
+    @Test
+    public void scanLines_emptyOrNull() {
+        assertThat(HamlibRigctl.scanLines("").lines).isEmpty();
+        assertThat(HamlibRigctl.scanLines(null).lines).isEmpty();
+        assertThat(HamlibRigctl.scanLines(null).remainder).isEmpty();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/HamlibConnectDialogTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/HamlibConnectDialogTest.java
@@ -1,0 +1,44 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Input validation for the Hamlib connect dialog: a connectable pair needs a
+ * non-empty host and a TCP port in 1..65535. Pure static helpers so the gate is
+ * tested without inflating the dialog view.
+ */
+public class HamlibConnectDialogTest {
+
+    @Test
+    public void parsePort_acceptsValidRange() {
+        assertThat(HamlibConnectDialog.parsePort("4532")).isEqualTo(4532);
+        assertThat(HamlibConnectDialog.parsePort(" 1 ")).isEqualTo(1);
+        assertThat(HamlibConnectDialog.parsePort("65535")).isEqualTo(65535);
+    }
+
+    @Test
+    public void parsePort_rejectsOutOfRangeAndGarbage() {
+        assertThat(HamlibConnectDialog.parsePort("0")).isEqualTo(-1);
+        assertThat(HamlibConnectDialog.parsePort("65536")).isEqualTo(-1);
+        assertThat(HamlibConnectDialog.parsePort("-4532")).isEqualTo(-1);
+        assertThat(HamlibConnectDialog.parsePort("abc")).isEqualTo(-1);
+        assertThat(HamlibConnectDialog.parsePort("")).isEqualTo(-1);
+        assertThat(HamlibConnectDialog.parsePort(null)).isEqualTo(-1);
+    }
+
+    @Test
+    public void isValidInput_requiresHostAndPort() {
+        assertThat(HamlibConnectDialog.isValidInput("192.168.1.10", "4532")).isTrue();
+        assertThat(HamlibConnectDialog.isValidInput("rig.local", "4532")).isTrue();
+    }
+
+    @Test
+    public void isValidInput_rejectsMissingHostOrBadPort() {
+        assertThat(HamlibConnectDialog.isValidInput("", "4532")).isFalse();
+        assertThat(HamlibConnectDialog.isValidInput(null, "4532")).isFalse();
+        assertThat(HamlibConnectDialog.isValidInput("192.168.1.10", "")).isFalse();
+        assertThat(HamlibConnectDialog.isValidInput("192.168.1.10", "notaport")).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Hamlib rig control** to the Android app via the **Hamlib NET rigctl** protocol — the same network path WSJT-X and JTDX expose for "use Hamlib". The app connects over TCP to a `rigctld` daemon (default port 4532) running next to the radio (PC, Raspberry Pi, etc.), which in turn drives any of Hamlib's 200+ supported rigs. This delivers broad Hamlib coverage without cross-compiling and bundling the native `libhamlib` per ABI.

Only **CAT** (frequency / PTT / mode) crosses the TCP link. **Audio stays on the local sound path** (USB sound card / AudioTrack) exactly like a wired CAT rig, so this behaves as a CAT-control link, *not* the audio-over-network mode used by the Flex/ICOM/XieGu Wi-Fi rigs.

Closes #508.

## What's included

- **`HamlibRigctl`** — pure, dependency-free rigctld protocol: command builders (`F`, `f`, `T`, `M PKTUSB 0`) and reply parsing (frequency vs. `RPRT` report), plus a streamed line-scanner for TCP chunk reassembly. Fully unit-tested.
- **`HamlibNetRig` / `HamlibConnector`** — thin `BaseRig` + TCP transport wrappers (all wire logic lives in `HamlibRigctl`).
- **`InstructionSet.HAMLIB_NET` (26)** + a `rigaddress.txt` entry ("Hamlib NET (rigctld)"), wired through the `MainViewModel` rig factory and `connectHamlibRig(host, port)`.
- **`HamlibConnectDialog`** + layout — host/port entry reached from Settings → CAT → Network, with validation.
- **`BaseRig.usesNetworkAudio()` / `OnDoTransmitted.usesNetworkAudio()`** — lets the TX router (`FT8TransmitSignal.transmitAudioOverNetwork`) play audio locally for the CAT-only Hamlib link instead of diverting it to the network transmit branch (which would key the rig but put nothing on the air). Default `true` keeps existing network rigs unchanged.

## FT8 correctness notes

- Mode is set with `M PKTUSB 0` (packet/data USB) so tones land on WSJT-X's grid, matching the wired drivers' DATA-U choice.
- A bare numeric reply is only treated as a dial frequency when ≥ 1 kHz, so rigctld's bare `0`/`1` PTT/split status can't be misread as a frequency.

## Testing

New unit tests (JUnit4 + Truth; Robolectric where Android types are touched):
- `HamlibRigctlTest` — command bytes, frequency/report parsing, line scanning.
- `HamlibNetRigTest` — command emission, split-reply reassembly, report-as-liveness, local-audio flag.
- `TransmitAudioRoutingTest` — TX audio routing decision across rig/connect-mode combinations.
- `HamlibConnectDialogTest` — host/port validation.

Full `:app:testDebugUnitTest` suite and `:app:assembleDebug` pass locally.

## Assumptions / scope

- Uses the rigctld **network** protocol rather than embedding native `libhamlib`; bundling the native library per ABI is a possible future enhancement. Tune (carrier) remains blocked on the network route as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)