### PR TITLE
Fix crash: config hydration parses audioRate/serial keys without a guard

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2870,7 +2870,11 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.audioOutput32Bit = result.equals("1");
                 }
                 if (name.equalsIgnoreCase("audioRate")) {//Output audio sample rate
-                    GeneralVariables.audioSampleRate =Integer.parseInt( result);
+                    // Defensive parse (like the FFT/serial keys): settings import (#382)
+                    // can feed an empty or non-numeric value through here, and this key
+                    // had no guard at all, so a hand-edited/corrupted backup crashed
+                    // startup hydration (and every relaunch). Fall back to the default.
+                    GeneralVariables.audioSampleRate = parseConfigInt(result, 12000);
                 }
                 if (name.equalsIgnoreCase("audioInputDevice")) {//Audio input device ID
                     GeneralVariables.audioInputDeviceId = result.equals("") ? 0 : Integer.parseInt(result);
@@ -2896,14 +2900,19 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("debugModeEnabled")) {//Hidden debug screen unlock
                     GeneralVariables.debugModeEnabled = result.equals("1");
                 }
+                // Serial line params: same defensive parse as audioRate above. These
+                // three keys were the only remaining hydration parses with no guard,
+                // so an empty or non-numeric value from an imported backup (#382) threw
+                // NumberFormatException and crashed hydration. Fall back to the defaults
+                // (8-N-1) that GeneralVariables initializes to.
                 if (name.equalsIgnoreCase("dataBits")) {//Serial data bits
-                    GeneralVariables.serialDataBits =Integer.parseInt(result);
+                    GeneralVariables.serialDataBits = parseConfigInt(result, 8);
                 }
                 if (name.equalsIgnoreCase("stopBits")) {//Serial stop bits
-                    GeneralVariables.serialStopBits =Integer.parseInt(result);
+                    GeneralVariables.serialStopBits = parseConfigInt(result, 1);
                 }
                 if (name.equalsIgnoreCase("parityBits")) {//Serial parity bits
-                    GeneralVariables.serialParity =Integer.parseInt(result);
+                    GeneralVariables.serialParity = parseConfigInt(result, 0);
                 }
 
                 // cloudlogs

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -40,14 +40,31 @@ public class DatabaseOprConfigHydrationTest {
 
     private DatabaseOpr opr;
 
+    private int origAudioSampleRate;
+    private int origSerialDataBits;
+    private int origSerialStopBits;
+    private int origSerialParity;
+
     @Before
     public void setUp() {
+        origAudioSampleRate = GeneralVariables.audioSampleRate;
+        origSerialDataBits = GeneralVariables.serialDataBits;
+        origSerialStopBits = GeneralVariables.serialStopBits;
+        origSerialParity = GeneralVariables.serialParity;
+
         opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 18);
     }
 
     @After
     public void tearDown() {
-        opr.close();
+        try {
+            opr.close();
+        } finally {
+            GeneralVariables.audioSampleRate = origAudioSampleRate;
+            GeneralVariables.serialDataBits = origSerialDataBits;
+            GeneralVariables.serialStopBits = origSerialStopBits;
+            GeneralVariables.serialParity = origSerialParity;
+        }
     }
 
     private void hydrate() {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -1,0 +1,104 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.k1af.ft8af.GeneralVariables;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * End-to-end hydration test for the four config keys that were parsed with a
+ * raw, unguarded {@code Integer.parseInt(result)}: {@code audioRate},
+ * {@code dataBits}, {@code stopBits} and {@code parityBits}.
+ *
+ * <p>The settings backup/restore feature (issue #357 / PR #382) writes every
+ * imported config value into the {@code config} table verbatim, then re-runs
+ * config hydration ({@link DatabaseOpr.GetAllConfigParameter}) both on import
+ * and on every subsequent app launch. A hand-edited or cross-version backup can
+ * therefore carry an empty or non-numeric value for one of these keys, and
+ * before the fix that threw {@link NumberFormatException} out of
+ * {@code doInBackground} on the AsyncTask worker thread — an uncaught crash that
+ * recurred on every relaunch (a persistent brick) until the app's data was
+ * cleared. After the fix each key falls back to its documented default.
+ *
+ * <p>The hydration logic lives in an AsyncTask; we drive its
+ * {@code doInBackground} synchronously (same package) so the assertions are
+ * deterministic and any thrown exception fails the test directly rather than
+ * being swallowed by the executor.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseOprConfigHydrationTest {
+
+    private DatabaseOpr opr;
+
+    @Before
+    public void setUp() {
+        opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 18);
+    }
+
+    @After
+    public void tearDown() {
+        opr.close();
+    }
+
+    private void hydrate() {
+        // Invoke the real hydration path synchronously on the test thread.
+        new DatabaseOpr.GetAllConfigParameter(opr.getWritableDatabase(), null)
+                .doInBackground();
+    }
+
+    @Test
+    public void malformedSerialAndAudioRate_doNotCrashAndResetToDefaults() {
+        // Pre-set the fields to non-default sentinels so we can prove the bad
+        // value forces a reset to the documented default (not just "unchanged").
+        GeneralVariables.audioSampleRate = 99999;
+        GeneralVariables.serialDataBits = 99;
+        GeneralVariables.serialStopBits = 99;
+        GeneralVariables.serialParity = 99;
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("audioRate", "");      // empty (the case its guarded siblings tolerated)
+        config.put("dataBits", "eight");  // non-numeric garbage
+        config.put("stopBits", "");       // empty
+        config.put("parityBits", "none"); // non-numeric garbage
+        opr.writeConfigSync(config);
+
+        hydrate(); // must not throw
+
+        assertThat(GeneralVariables.audioSampleRate).isEqualTo(12000);
+        assertThat(GeneralVariables.serialDataBits).isEqualTo(8);
+        assertThat(GeneralVariables.serialStopBits).isEqualTo(1);
+        assertThat(GeneralVariables.serialParity).isEqualTo(0);
+    }
+
+    @Test
+    public void validSerialAndAudioRate_areStillHonored() {
+        GeneralVariables.audioSampleRate = 0;
+        GeneralVariables.serialDataBits = 0;
+        GeneralVariables.serialStopBits = 0;
+        GeneralVariables.serialParity = 0;
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("audioRate", "48000");
+        config.put("dataBits", "7");
+        config.put("stopBits", "2");
+        config.put("parityBits", "1");
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.audioSampleRate).isEqualTo(48000);
+        assertThat(GeneralVariables.serialDataBits).isEqualTo(7);
+        assertThat(GeneralVariables.serialStopBits).isEqualTo(2);
+        assertThat(GeneralVariables.serialParity).isEqualTo(1);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprParseConfigIntTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprParseConfigIntTest.java
@@ -12,6 +12,14 @@ import org.robolectric.RobolectricTestRunner;
  * hand-edited or stale backups, so a non-numeric string must fall back to
  * the default instead of throwing NumberFormatException and crashing startup
  * hydration. Robolectric because DatabaseOpr extends SQLiteOpenHelper.
+ *
+ * <p>The {@code audioRate}, {@code dataBits}, {@code stopBits} and
+ * {@code parityBits} hydration keys were later migrated to this same helper
+ * (they were the last hydration parses with no guard at all — a raw
+ * {@code Integer.parseInt(result)} that crashed on both an empty and a
+ * non-numeric value from an imported backup, bricking the app on every
+ * relaunch until its data was cleared). The cases below pin the fallback
+ * contract for each of their documented defaults.
  */
 @RunWith(RobolectricTestRunner.class)
 public class DatabaseOprParseConfigIntTest {
@@ -35,5 +43,36 @@ public class DatabaseOprParseConfigIntTest {
         assertThat(DatabaseOpr.parseConfigInt("hann", 1)).isEqualTo(1);
         assertThat(DatabaseOpr.parseConfigInt("2.5", 0)).isEqualTo(0);
         assertThat(DatabaseOpr.parseConfigInt("99999999999999999999", 0)).isEqualTo(0); // overflow
+    }
+
+    /**
+     * audioRate/dataBits/stopBits/parityBits: a valid stored value is honored
+     * exactly as the old raw parse did (no behavior change on good input)...
+     */
+    @Test
+    public void serialAndAudioRateKeys_honorValidStoredValues() {
+        assertThat(DatabaseOpr.parseConfigInt("48000", 12000)).isEqualTo(48000); // audioRate
+        assertThat(DatabaseOpr.parseConfigInt("7", 8)).isEqualTo(7);             // dataBits
+        assertThat(DatabaseOpr.parseConfigInt("2", 1)).isEqualTo(2);             // stopBits
+        assertThat(DatabaseOpr.parseConfigInt("1", 0)).isEqualTo(1);             // parityBits
+    }
+
+    /**
+     * ...while an empty or non-numeric value (as an imported/hand-edited backup
+     * can carry) now falls back to each key's documented default instead of
+     * throwing NumberFormatException out of hydration.
+     */
+    @Test
+    public void serialAndAudioRateKeys_fallBackToDefaultsOnBadInput() {
+        // empty (the value that made these keys crash where their guarded
+        // siblings did not)
+        assertThat(DatabaseOpr.parseConfigInt("", 12000)).isEqualTo(12000); // audioRate default
+        assertThat(DatabaseOpr.parseConfigInt("", 8)).isEqualTo(8);         // dataBits default
+        assertThat(DatabaseOpr.parseConfigInt("", 1)).isEqualTo(1);         // stopBits default
+        assertThat(DatabaseOpr.parseConfigInt("", 0)).isEqualTo(0);         // parityBits default
+        // non-numeric garbage
+        assertThat(DatabaseOpr.parseConfigInt("48k", 12000)).isEqualTo(12000);
+        assertThat(DatabaseOpr.parseConfigInt("eight", 8)).isEqualTo(8);
+        assertThat(DatabaseOpr.parseConfigInt("none", 0)).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## Summary
`audioRate`, `dataBits`, `stopBits` and `parityBits` were the **only** remaining config-hydration keys in `DatabaseOpr.GetAllConfigParameter.doInBackground` that called `Integer.parseInt(result)` with **no guard at all** — every sibling audio/serial key (`audioInputDevice`, `audioOutputDevice`, `usbAudio*`, …) is at least empty-guarded, and the FFT knobs already route through the defensive `parseConfigInt` helper added in PR #429. These four were simply missed.

An empty **or** non-numeric stored value therefore threw `NumberFormatException` straight out of the AsyncTask worker thread's `doInBackground` → uncaught → **process crash**.

## Root cause / reachability
The settings backup/restore feature (issue #357 / PR #382) makes this externally reachable:
1. `SettingsBackup.parseBackupJson` reads every `config` value as a raw string via `optString(key, "")` — no numeric validation, no key filtering.
2. On import, `DatabaseOpr.writeConfigSync` persists each value verbatim into the `config` table.
3. `AdvancedSettings` then calls `getAllConfigParameter(...)` to re-hydrate — and this runs **outside** the `runCatching` that wraps only the write, on the AsyncTask's own worker thread.
4. `MainActivity` / `ComposeMainActivity` also re-run this loop on **every launch**.

So a hand-edited, corrupted, or cross-version backup carrying e.g. `"audioRate":""` or `"dataBits":"eight"` crashes on import **and then on every relaunch** until the app's data is cleared — a persistent brick, not a one-shot failure. (Unlike their guarded siblings, these four crash even on the *empty* string, the easiest corruption to produce.)

## Fix
Route the four keys through the existing `parseConfigInt(value, fallback)` helper (PR #429 — created for exactly this hand-edited/stale-backup hydration hazard), falling back to each field's initializer default: `audioSampleRate=12000`, `serialDataBits=8`, `serialStopBits=1`, `serialParity=0` (8-N-1). **Valid values behave identically to before**; only the crash-on-bad-input case changes to a safe fallback.

## Testing
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full app + native (all ABIs) build succeeds.
- Extended `DatabaseOprParseConfigIntTest` with the four keys' valid/empty/garbage fallback contracts.
- Added `DatabaseOprConfigHydrationTest`, which drives the real `doInBackground` hydration synchronously against a Robolectric in-memory DB seeded with malformed values and asserts it no longer throws and resets each field to its default (and still honours valid values).

## Risk assessment
Very low. One-file, four-line change in Java only; no DSP/decoder/native/protocol code touched. Behaviour is unchanged for all valid and empty-string-guarded paths that already worked; the change strictly removes a crash path. No performance impact (`parseConfigInt` is the same `Integer.parseInt` wrapped in a null/empty check + try/catch).

## Scope note
The empty-guarded siblings (`baudRate`, `civ`, `spectrumWidth`, etc.) still assume a *non-empty* value is numeric and could be hardened the same way, but they don't crash on the common empty/default value and are left for a separate focused PR to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)