### PR TITLE
Fix crash: over-int network port value crashes ICOM/Xiegu login (isInteger root-cause)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -1221,17 +1221,30 @@ public class GeneralVariables {
     }
 
     /**
-     * Determine if it is an integer.
+     * Determine if it is an integer that fits in an {@code int}.
+     *
+     * <p>Callers use this as a guard immediately before {@code Integer.parseInt} /
+     * {@code toInt()} (e.g. the ICOM/Xiegu network-port fields). A digit-only
+     * regex is <em>not</em> sufficient for that contract: a string such as
+     * {@code "9999999999"} is all digits yet overflows {@code int}, so the
+     * subsequent parse throws {@link NumberFormatException}. Those parses run on
+     * the UI thread with no surrounding try/catch, so the mismatch was a hard
+     * crash. Verify the value actually parses so the guard cannot lie.
      *
      * @param str Input string
-     * @return Returns true if integer, false otherwise
+     * @return Returns true only if {@code str} is a non-empty run of digits that
+     *         parses into an {@code int}, false otherwise
      */
 
     public static boolean isInteger(String str) {
-        if (str != null && !"".equals(str.trim()))
-            return str.matches("^[0-9]*$");
-        else
+        if (str == null || "".equals(str.trim()) || !str.matches("^[0-9]*$"))
             return false;
+        try {
+            Integer.parseInt(str);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesIsIntegerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesIsIntegerTest.java
@@ -1,0 +1,61 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards {@link GeneralVariables#isInteger(String)} against reporting {@code true}
+ * for digit strings that overflow {@code int}.
+ *
+ * <p>{@code isInteger} is used as the sole guard immediately before an
+ * {@code Integer.parseInt} / Kotlin {@code toInt()} in the ICOM/Xiegu network
+ * port fields ({@code ConnectionDialogs.IcomLoginDialog} and the legacy
+ * {@code LoginIcomRadioDialog}), both of which run on the UI thread with no
+ * try/catch. The previous implementation returned {@code true} for any all-digit
+ * string via {@code "^[0-9]*$"}, so pasting/typing an over-{@code int} value such
+ * as {@code "9999999999"} passed the guard and then crashed the app inside the
+ * text-change handler. The guard must not lie about parseability.
+ *
+ * <p>Robolectric because {@link GeneralVariables} carries Android LiveData statics
+ * that must initialize before the static helper can be exercised.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesIsIntegerTest {
+
+    @Test
+    public void plainInRangeInteger_isTrue() {
+        assertThat(GeneralVariables.isInteger("0")).isTrue();
+        assertThat(GeneralVariables.isInteger("50002")).isTrue();
+        assertThat(GeneralVariables.isInteger("2147483647")).isTrue(); // Integer.MAX_VALUE
+    }
+
+    @Test
+    public void leadingZeros_stillParse_isTrue() {
+        assertThat(GeneralVariables.isInteger("007")).isTrue();
+    }
+
+    @Test
+    public void overIntRangeDigits_isFalse_andDoNotCrashCallers() {
+        // Regression: these are all digits yet overflow int, so the old
+        // "^[0-9]*$" guard returned true and the caller's toInt()/parseInt() threw.
+        assertThat(GeneralVariables.isInteger("2147483648")).isFalse(); // MAX_VALUE + 1
+        assertThat(GeneralVariables.isInteger("9999999999")).isFalse();
+        assertThat(GeneralVariables.isInteger("99999999999999999999")).isFalse();
+
+        // The whole point of the guard: a value it accepts must be parseable.
+        assertThat(Integer.parseInt("2147483647")).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void nonDigitOrEmpty_isFalse() {
+        assertThat(GeneralVariables.isInteger(null)).isFalse();
+        assertThat(GeneralVariables.isInteger("")).isFalse();
+        assertThat(GeneralVariables.isInteger("   ")).isFalse();
+        assertThat(GeneralVariables.isInteger("12a")).isFalse();
+        assertThat(GeneralVariables.isInteger("-5")).isFalse(); // sign rejected, as before
+        assertThat(GeneralVariables.isInteger("1.0")).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

The ICOM / Xiegu WiFi login **Port** field could crash the app with an uncaught `NumberFormatException` when a numeric value larger than `Integer.MAX_VALUE` was typed or pasted.

## Root cause

`GeneralVariables.isInteger(String)` is the guard used at every site that parses the port:

- `ui/settings/ConnectionDialogs.kt:603-604` (live Compose `IcomLoginDialog`, reached from `RadioAudioSettings`): `if (isInteger(trimmed)) { GeneralVariables.icomUdpPort = trimmed.toInt() ... }`
- `ui/LoginIcomRadioDialog.java:125-127` (legacy dialog, reached from `ConfigFragment`): `if (isInteger(...)) { ... Integer.parseInt(...) }`
- `ui/LoginIcomRadioDialog.java:189` (button-enable gating)

`isInteger` returned `true` for **any** run of digits via `"^[0-9]*$"`, ignoring magnitude. A value such as `9999999999` (or anything above `2147483647`, or 11+ digits) passed the guard, and the immediately-following `toInt()` / `Integer.parseInt()` overflowed and threw.

Both parse sites run **on the UI thread inside a text-change handler with no surrounding try/catch** (Compose `onValueChange`; Java `TextWatcher.afterTextChanged`). The `Number` keyboard type does not cap length, and paste bypasses it entirely — so a single over-long numeric entry crashed the app. (In `ConnectionDialogs.kt` the *error indicator* already used the magnitude-safe `toIntOrNull()`, but the crashing write path ran first.)

## Fix

Fix the guard at its root rather than patch each call site. After the existing digit-only check, `isInteger` now actually attempts `Integer.parseInt` and returns `false` if the value overflows `int`. This makes the method honour its documented contract ("true if integer") and protects all three callers at once.

- **No behaviour change** for any value previously accepted: every in-range digit string (including `0`, leading zeros, and `Integer.MAX_VALUE`) still returns `true` and stores the identical port.
- Only over-`int` digit strings flip from `true`→`false`, which now cleanly no-ops the write (matching the field's existing "invalid → don't write / show error" intent) instead of crashing.

## Testing

- New `GeneralVariablesIsIntegerTest` (Robolectric — `GeneralVariables` carries Android `LiveData` statics): in-range values, leading zeros, `Integer.MAX_VALUE`, and the over-range regression inputs (`2147483648`, `9999999999`, 20-digit) plus null/empty/non-digit/negative/decimal cases. The over-range assertions fail against the previous implementation.
- `./gradlew :app:testDebugUnitTest` — full suite green (Linux, JDK 17, NDK 27, cmake 3.22.1).

## Risk

Very low. Single self-contained method, tightened toward correctness; all existing accepted inputs behave identically. No DSP, protocol, or native code touched. No UI change (the field simply stops crashing on out-of-range input).