### PR TITLE
Fix crash: config hydration crashes on non-numeric imported backup values (remaining keys)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -848,11 +848,54 @@ public class DatabaseOpr extends SQLiteOpenHelper {
      * Package-private static so it is unit-testable without a database.
      */
     static int parseConfigInt(String value, int fallback) {
+        return parseConfigInt(value, fallback, 10);
+    }
+
+    /**
+     * Radix-aware variant of {@link #parseConfigInt(String, int)} for keys
+     * stored in a non-decimal base (e.g. the ICOM CI-V address, hex). Same
+     * empty/non-numeric fallback contract.
+     */
+    static int parseConfigInt(String value, int fallback, int radix) {
         if (value == null || value.isEmpty()) {
             return fallback;
         }
         try {
-            return Integer.parseInt(value.trim());
+            return Integer.parseInt(value.trim(), radix);
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /**
+     * {@code long} counterpart of {@link #parseConfigInt(String, int)} for
+     * config values that exceed {@code int} range (e.g. the band frequency in
+     * Hz). Same empty/non-numeric fallback contract.
+     */
+    static long parseConfigLong(String value, long fallback) {
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /**
+     * {@code float} counterpart of {@link #parseConfigInt(String, int)} for
+     * config values stored as a decimal (e.g. the output volume percent). Same
+     * empty/non-numeric fallback contract. Any scaling the caller applied to
+     * the old raw parse (e.g. {@code / 100f}) must be applied to the return
+     * value so the empty/garbage fallback lands on the intended default.
+     */
+    static float parseConfigFloat(String value, float fallback) {
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Float.parseFloat(value.trim());
         } catch (NumberFormatException e) {
             return fallback;
         }
@@ -2632,13 +2675,13 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
 
                 if (name.equalsIgnoreCase("civ")) {
-                    GeneralVariables.civAddress = result.equals("") ? 0xa4 : Integer.parseInt(result, 16);
+                    GeneralVariables.civAddress = parseConfigInt(result, 0xa4, 16);
                 }
                 if (name.equalsIgnoreCase("baudRate")) {
-                    GeneralVariables.baudRate = result.equals("") ? 19200 : Integer.parseInt(result);
+                    GeneralVariables.baudRate = parseConfigInt(result, 19200);
                 }
                 if (name.equalsIgnoreCase("bandFreq")) {
-                    GeneralVariables.band = result.equals("") ? 14074000 : Long.parseLong(result);
+                    GeneralVariables.band = parseConfigLong(result, 14074000L);
                     GeneralVariables.bandListIndex = OperationBand.getIndexByFreq(GeneralVariables.band);
                 }
 
@@ -2666,26 +2709,26 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
 
                 if (name.equalsIgnoreCase("ctrMode")) {
-                    GeneralVariables.controlMode = result.equals("") ? ControlMode.VOX : Integer.parseInt(result);
+                    GeneralVariables.controlMode = parseConfigInt(result, ControlMode.VOX);
                 }
                 if (name.equalsIgnoreCase("connectMode")) {
-                    GeneralVariables.connectMode = result.equals("") ? ConnectMode.USB_CABLE : Integer.parseInt(result);
+                    GeneralVariables.connectMode = parseConfigInt(result, ConnectMode.USB_CABLE);
                 }
                 if (name.equalsIgnoreCase("bluetoothDeviceAddress")) {//last-selected BT (SPP/CAT) device, for auto-reconnect
                     GeneralVariables.bluetoothDeviceAddress = result;
                 }
                 if (name.equalsIgnoreCase("model")) {//Radio model
-                    GeneralVariables.modelNo = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.modelNo = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("instruction")) {//Instruction set
-                    GeneralVariables.instructionSet = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.instructionSet = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("launchSupervision")) {//Transmit supervision
-                    GeneralVariables.launchSupervision = result.equals("") ?
-                            GeneralVariables.DEFAULT_LAUNCH_SUPERVISION : Integer.parseInt(result);
+                    GeneralVariables.launchSupervision =
+                            parseConfigInt(result, GeneralVariables.DEFAULT_LAUNCH_SUPERVISION);
                 }
                 if (name.equalsIgnoreCase("noReplyLimit")) {//
-                    GeneralVariables.noReplyLimit = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.noReplyLimit = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("autoFollowCQ")) {//Auto-follow CQ
                     GeneralVariables.autoFollowCQ = result.equals("1");
@@ -2707,7 +2750,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                             com.k1af.ft8af.location.GpsClockUpdater.parseIntervalMinutes(result);
                 }
                 if (name.equalsIgnoreCase("pttDelay")) {//PTT delay setting
-                    GeneralVariables.pttDelay = result.equals("") ? 100 : Integer.parseInt(result);
+                    GeneralVariables.pttDelay = parseConfigInt(result, 100);
                 }
                 if (name.equalsIgnoreCase("lateStartTolerance")) {//Late-start tolerance, ms (0-4000)
                     try {
@@ -2741,7 +2784,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.icomIp = result.equals("") ? "255.255.255.255" : result;
                 }
                 if (name.equalsIgnoreCase("icomPort")) {//ICOM port
-                    GeneralVariables.icomUdpPort = result.equals("") ? 50001 : Integer.parseInt(result);
+                    GeneralVariables.icomUdpPort = parseConfigInt(result, 50001);
                 }
                 if (name.equalsIgnoreCase("icomUserName")) {//ICOM username
                     GeneralVariables.icomUserName = result.equals("") ? "ic705" : result;
@@ -2750,7 +2793,8 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.icomPassword = result;
                 }
                 if (name.equalsIgnoreCase("volumeValue")) {//Output volume level
-                    GeneralVariables.volumePercent = result.equals("") ? 1.0f : Float.parseFloat(result) / 100f;
+                    // parseConfigFloat's fallback is pre-scaling: empty/garbage -> 100f -> 1.0f (unity).
+                    GeneralVariables.volumePercent = parseConfigFloat(result, 100f) / 100f;
                     GeneralVariables.mutableVolumePercent.postValue(GeneralVariables.volumePercent);
                 }
                 if (name.equalsIgnoreCase("inputVolume")) {//RX input gain (percent, 100 = unity)
@@ -2855,10 +2899,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.alertOnQsoComplete = result.equals("1");
                 }
                 if (name.equalsIgnoreCase("flexMaxRfPower")) {//Flex max RF power
-                    GeneralVariables.flexMaxRfPower = result.equals("") ? 10 : Integer.parseInt(result);
+                    GeneralVariables.flexMaxRfPower = parseConfigInt(result, 10);
                 }
                 if (name.equalsIgnoreCase("flexMaxTunePower")) {//Flex max tune power
-                    GeneralVariables.flexMaxTunePower = result.equals("") ? 10 : Integer.parseInt(result);
+                    GeneralVariables.flexMaxTunePower = parseConfigInt(result, 10);
                 }
                 if (name.equalsIgnoreCase("saveSWL")) {//Save decoded messages
                     GeneralVariables.saveSWLMessage = result.equals("1");
@@ -2877,22 +2921,22 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.audioSampleRate = parseConfigInt(result, 12000);
                 }
                 if (name.equalsIgnoreCase("audioInputDevice")) {//Audio input device ID
-                    GeneralVariables.audioInputDeviceId = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.audioInputDeviceId = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("audioOutputDevice")) {//Audio output device ID
-                    GeneralVariables.audioOutputDeviceId = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.audioOutputDeviceId = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("usbAudioInputVid")) {
-                    GeneralVariables.usbAudioInputVendorId = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.usbAudioInputVendorId = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("usbAudioInputPid")) {
-                    GeneralVariables.usbAudioInputProductId = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.usbAudioInputProductId = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("usbAudioOutputVid")) {
-                    GeneralVariables.usbAudioOutputVendorId = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.usbAudioOutputVendorId = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("usbAudioOutputPid")) {
-                    GeneralVariables.usbAudioOutputProductId = result.equals("") ? 0 : Integer.parseInt(result);
+                    GeneralVariables.usbAudioOutputProductId = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("deepMode")) {//Deep decode mode
                     GeneralVariables.deepDecodeMode =result.equals("1");
@@ -2966,16 +3010,16 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.swrHaltEnabled = result.equals("1");
                 }
                 if (name.equalsIgnoreCase("swrHaltThreshold")) {
-                    GeneralVariables.swrHaltThreshold = result.equals("") ? 120 : Integer.parseInt(result);
+                    GeneralVariables.swrHaltThreshold = parseConfigInt(result, 120);
                 }
                 if (name.equalsIgnoreCase("alcTargetLow")) {
-                    GeneralVariables.alcTargetLow = result.equals("") ? 60 : Integer.parseInt(result);
+                    GeneralVariables.alcTargetLow = parseConfigInt(result, 60);
                 }
                 if (name.equalsIgnoreCase("alcTargetHigh")) {
-                    GeneralVariables.alcTargetHigh = result.equals("") ? 100 : Integer.parseInt(result);
+                    GeneralVariables.alcTargetHigh = parseConfigInt(result, 100);
                 }
                 if (name.equalsIgnoreCase("spectrumWidth")) {
-                    GeneralVariables.setSpectrumWidth(result.equals("") ? 3500 : Integer.parseInt(result));
+                    GeneralVariables.setSpectrumWidth(parseConfigInt(result, 3500));
                 }
                 // FFT display developer knobs (issue #428). Parsed defensively:
                 // these are expected to survive hand-edited/stale backups, so a

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -45,12 +45,28 @@ public class DatabaseOprConfigHydrationTest {
     private int origSerialStopBits;
     private int origSerialParity;
 
+    private int origCivAddress;
+    private int origBaudRate;
+    private long origBand;
+    private int origBandListIndex;
+    private int origIcomUdpPort;
+    private float origVolumePercent;
+    private int origAlcTargetLow;
+
     @Before
     public void setUp() {
         origAudioSampleRate = GeneralVariables.audioSampleRate;
         origSerialDataBits = GeneralVariables.serialDataBits;
         origSerialStopBits = GeneralVariables.serialStopBits;
         origSerialParity = GeneralVariables.serialParity;
+
+        origCivAddress = GeneralVariables.civAddress;
+        origBaudRate = GeneralVariables.baudRate;
+        origBand = GeneralVariables.band;
+        origBandListIndex = GeneralVariables.bandListIndex;
+        origIcomUdpPort = GeneralVariables.icomUdpPort;
+        origVolumePercent = GeneralVariables.volumePercent;
+        origAlcTargetLow = GeneralVariables.alcTargetLow;
 
         opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 18);
     }
@@ -64,6 +80,14 @@ public class DatabaseOprConfigHydrationTest {
             GeneralVariables.serialDataBits = origSerialDataBits;
             GeneralVariables.serialStopBits = origSerialStopBits;
             GeneralVariables.serialParity = origSerialParity;
+
+            GeneralVariables.civAddress = origCivAddress;
+            GeneralVariables.baudRate = origBaudRate;
+            GeneralVariables.band = origBand;
+            GeneralVariables.bandListIndex = origBandListIndex;
+            GeneralVariables.icomUdpPort = origIcomUdpPort;
+            GeneralVariables.volumePercent = origVolumePercent;
+            GeneralVariables.alcTargetLow = origAlcTargetLow;
         }
     }
 
@@ -117,5 +141,63 @@ public class DatabaseOprConfigHydrationTest {
         assertThat(GeneralVariables.serialDataBits).isEqualTo(7);
         assertThat(GeneralVariables.serialStopBits).isEqualTo(2);
         assertThat(GeneralVariables.serialParity).isEqualTo(1);
+    }
+
+    /**
+     * The remaining hydration keys were {@code result.equals("") ? DEFAULT :
+     * parse(result)} — empty-guarded, so they survived an empty value like their
+     * fixed siblings, but a non-empty <em>non-numeric</em> value (which an
+     * imported or hand-edited backup can carry) still threw out of hydration and
+     * bricked the app. This covers a representative slice across every numeric
+     * type used: hex int (civ), decimal int (baudRate, icomPort, alcTargetLow),
+     * long (bandFreq) and float (volumeValue).
+     */
+    @Test
+    public void malformedRemainingNumericKeys_doNotCrashAndResetToDefaults() {
+        GeneralVariables.civAddress = 0x11;
+        GeneralVariables.baudRate = 1;
+        GeneralVariables.band = 1;
+        GeneralVariables.icomUdpPort = 1;
+        GeneralVariables.volumePercent = 9f;
+        GeneralVariables.alcTargetLow = 1;
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("civ", "zz");            // non-hex
+        config.put("baudRate", "fast");     // non-numeric
+        config.put("bandFreq", "lots");     // non-numeric
+        config.put("icomPort", "port");     // non-numeric
+        config.put("volumeValue", "loud");  // non-numeric
+        config.put("alcTargetLow", "lo");   // non-numeric
+        opr.writeConfigSync(config);
+
+        hydrate(); // must not throw
+
+        assertThat(GeneralVariables.civAddress).isEqualTo(0xa4);
+        assertThat(GeneralVariables.baudRate).isEqualTo(19200);
+        assertThat(GeneralVariables.band).isEqualTo(14074000L);
+        assertThat(GeneralVariables.icomUdpPort).isEqualTo(50001);
+        assertThat(GeneralVariables.volumePercent).isEqualTo(1.0f);
+        assertThat(GeneralVariables.alcTargetLow).isEqualTo(60);
+    }
+
+    @Test
+    public void validRemainingNumericKeys_areStillHonored() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("civ", "5e");            // hex -> 0x5e
+        config.put("baudRate", "9600");
+        config.put("bandFreq", "7074000");  // long
+        config.put("icomPort", "50002");
+        config.put("volumeValue", "50");    // -> 0.5f (scaled /100)
+        config.put("alcTargetLow", "70");
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.civAddress).isEqualTo(0x5e);
+        assertThat(GeneralVariables.baudRate).isEqualTo(9600);
+        assertThat(GeneralVariables.band).isEqualTo(7074000L);
+        assertThat(GeneralVariables.icomUdpPort).isEqualTo(50002);
+        assertThat(GeneralVariables.volumePercent).isEqualTo(0.5f);
+        assertThat(GeneralVariables.alcTargetLow).isEqualTo(70);
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprParseConfigIntTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprParseConfigIntTest.java
@@ -75,4 +75,54 @@ public class DatabaseOprParseConfigIntTest {
         assertThat(DatabaseOpr.parseConfigInt("eight", 8)).isEqualTo(8);
         assertThat(DatabaseOpr.parseConfigInt("none", 0)).isEqualTo(0);
     }
+
+    // --- Radix / long / float overloads --------------------------------------
+    // The remaining empty-guarded hydration parses (civ hex, bandFreq long,
+    // volumeValue float, and ~20 more decimal-int keys) were migrated to these
+    // same crash-safe helpers: they threw on a non-empty, non-numeric imported
+    // backup value where the fixed-4 already crashed on empty. Each overload
+    // keeps the empty/non-numeric -> fallback contract.
+
+    @Test
+    public void radixOverload_parsesHexAndFallsBack() {
+        assertThat(DatabaseOpr.parseConfigInt("a4", 0xa4, 16)).isEqualTo(0xa4); // civ default value
+        assertThat(DatabaseOpr.parseConfigInt("5e", 0xa4, 16)).isEqualTo(0x5e); // valid hex honored
+        assertThat(DatabaseOpr.parseConfigInt(" 5e ", 0xa4, 16)).isEqualTo(0x5e); // tolerates whitespace
+        assertThat(DatabaseOpr.parseConfigInt("", 0xa4, 16)).isEqualTo(0xa4);   // empty -> fallback
+        assertThat(DatabaseOpr.parseConfigInt(null, 0xa4, 16)).isEqualTo(0xa4); // null -> fallback
+        assertThat(DatabaseOpr.parseConfigInt("zz", 0xa4, 16)).isEqualTo(0xa4); // non-hex -> fallback
+    }
+
+    @Test
+    public void longOverload_parsesAndFallsBack() {
+        assertThat(DatabaseOpr.parseConfigLong("14074000", 14074000L)).isEqualTo(14074000L);
+        assertThat(DatabaseOpr.parseConfigLong("7074000", 14074000L)).isEqualTo(7074000L);
+        assertThat(DatabaseOpr.parseConfigLong(" 7074000 ", 14074000L)).isEqualTo(7074000L);
+        // A value that overflows int but is a valid long must be honored (why long, not int).
+        assertThat(DatabaseOpr.parseConfigLong("2400000000", 14074000L)).isEqualTo(2400000000L);
+        assertThat(DatabaseOpr.parseConfigLong("", 14074000L)).isEqualTo(14074000L);     // empty
+        assertThat(DatabaseOpr.parseConfigLong(null, 14074000L)).isEqualTo(14074000L);   // null
+        assertThat(DatabaseOpr.parseConfigLong("14.074MHz", 14074000L)).isEqualTo(14074000L); // garbage
+    }
+
+    @Test
+    public void floatOverload_parsesAndFallsBack() {
+        assertThat(DatabaseOpr.parseConfigFloat("50", 100f)).isEqualTo(50f);
+        assertThat(DatabaseOpr.parseConfigFloat("100", 100f)).isEqualTo(100f);
+        assertThat(DatabaseOpr.parseConfigFloat(" 50 ", 100f)).isEqualTo(50f);
+        assertThat(DatabaseOpr.parseConfigFloat("", 100f)).isEqualTo(100f);   // empty -> fallback
+        assertThat(DatabaseOpr.parseConfigFloat(null, 100f)).isEqualTo(100f); // null -> fallback
+        assertThat(DatabaseOpr.parseConfigFloat("loud", 100f)).isEqualTo(100f); // garbage -> fallback
+    }
+
+    /**
+     * volumeValue hydrates as {@code parseConfigFloat(result, 100f) / 100f}: the
+     * pre-scaling 100f fallback must land the empty/garbage case on unity (1.0f).
+     */
+    @Test
+    public void volumeValue_scalingKeepsUnityFallback() {
+        assertThat(DatabaseOpr.parseConfigFloat("", 100f) / 100f).isEqualTo(1.0f);     // empty
+        assertThat(DatabaseOpr.parseConfigFloat("loud", 100f) / 100f).isEqualTo(1.0f); // garbage
+        assertThat(DatabaseOpr.parseConfigFloat("50", 100f) / 100f).isEqualTo(0.5f);   // valid honored
+    }
 }


### PR DESCRIPTION
## Summary

Config hydration (`DatabaseOpr.GetAllConfigParameter.doInBackground`) parsed ~24 numeric config keys as `result.equals("") ? DEFAULT : Integer/Long/Float.parse(result)`. The empty guard let them tolerate an empty stored value, but a non-empty **non-numeric** value threw `NumberFormatException` straight out of `doInBackground` on the AsyncTask worker thread — the hydration loop is `try { … } finally { … }` with **no catch** — so the exception is uncaught and crashes the app.

This is a **persistent brick**: the settings backup/restore feature (issue #357 / PR #382) writes every imported config value into the `config` table verbatim with no numeric validation, then re-runs hydration both on import and on **every subsequent app launch**. A hand-edited or cross-version backup carrying one bad value (e.g. `baudRate=fast`) crashes on import and again on every relaunch until the app's data is cleared.

This is the direct follow-up to **PR #513**, which fixed the four keys (`audioRate`, `dataBits`, `stopBits`, `parityBits`) that had *no guard at all* (they crashed even on empty). Those remaining empty-guarded keys were explicitly deferred there to keep that PR focused; #513 has since merged, unblocking this.

## Root cause

`Integer.parseInt` / `Long.parseLong` / `Float.parseFloat` throw `NumberFormatException` on non-numeric input, and the hydration loop has no catch, so the throw propagates out of the worker and terminates the app.

## Fix

Route every remaining numeric hydration parse through the crash-safe `parseConfigInt(value, fallback)` helper introduced in PR #513, adding three sibling overloads for the non-`int`-decimal cases:

- `parseConfigInt(value, fallback, radix)` — the ICOM CI-V address (`civ`, hex)
- `parseConfigLong(value, fallback)` — the band frequency (`bandFreq`, exceeds `int`)
- `parseConfigFloat(value, fallback)` — the output volume percent (`volumeValue`)

Each helper returns the key's documented default on an empty/`null`/non-numeric value. The `fallback` passed at every call site is exactly the value the old `result.equals("") ? DEFAULT : …` ternary used, so:

- **valid** stored values are honored identically (no behavior change),
- **empty** values still fall back to the same default,
- previously-**crashing** non-numeric values now fall back to that default instead of throwing.

(As a side benefit, matching the `audioRate` migration in #513, the helpers `trim()` before parsing, so a stored value with stray whitespace no longer throws either.)

Keys migrated: `civ`, `baudRate`, `bandFreq`, `ctrMode`, `connectMode`, `model`, `instruction`, `launchSupervision`, `noReplyLimit`, `pttDelay`, `icomPort`, `volumeValue`, `flexMaxRfPower`, `flexMaxTunePower`, `audioInputDevice`, `audioOutputDevice`, `usbAudioInput{Vid,Pid}`, `usbAudioOutput{Vid,Pid}`, `swrHaltThreshold`, `alcTargetLow`, `alcTargetHigh`, `spectrumWidth`.

The two remaining numeric keys in the loop (`fieldDayNumTx`, `lateStartTolerance`) were already wrapped in their own try/catch and are unaffected.

## Testing

- `DatabaseOprParseConfigIntTest` — added cases for the radix/long/float overloads (valid, empty, `null`, non-numeric, whitespace, int-overflow-but-valid-long), plus the `volumeValue` `/100f` scaling contract landing empty/garbage on unity.
- `DatabaseOprConfigHydrationTest` — added an end-to-end pair driving the real `doInBackground` synchronously against a Robolectric in-memory DB: one with malformed values across every numeric type (hex int, decimal int, long, float) asserting hydration does **not** throw and each field resets to its default; one with valid values asserting they are honored.
- `./gradlew :app:testDebugUnitTest --tests "com.k1af.ft8af.database.*"` passes; full debug build compiles.

## Risk assessment

Low. Purely a defensive-parse change confined to config hydration; each substitution is semantics-preserving for valid and empty input and only alters the previously-crashing non-numeric path. No DSP, protocol, encoder/decoder, or wire behavior touched. No performance impact (startup-only, same number of parses).