### PR TITLE
Add USB Diagnostics debug page in Settings (#515)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -388,6 +388,11 @@ public class MainViewModel extends ViewModel {
             catLivenessTimer.purge();
             catLivenessTimer = null;
         }
+        // Clear the "rig has answered" flag when the watchdog stops (disconnect, error,
+        // or teardown) so hasRigRespondedToCat() can't report a stale true after the rig
+        // is unplugged — the USB Diagnostics page would otherwise show "CAT Response: pass"
+        // alongside "Device Found: fail". A fresh connect re-arms it in start...().
+        sawRigResponseSinceConnect = false;
     }
 
     /** One watchdog tick: probe the rig, then declare it dead if it's gone quiet too long. */
@@ -1721,6 +1726,20 @@ public class MainViewModel extends ViewModel {
         } else {
             return baseRig.isConnected();
         }
+    }
+
+    /**
+     * Whether the connected rig has answered at least one CAT probe since the
+     * current connection came up. Backs the USB Diagnostics "CAT Response" check:
+     * the serial port can open ({@link #isRigConnected()}) while the rig never
+     * replies — wrong baud rate, wrong CAT protocol, or a powered-but-silent
+     * adapter — and this flag distinguishes "link up" from "rig actually talking".
+     * Reset to false on every (re)connect and set true in {@link #markRigResponded()}.
+     *
+     * @return true once a valid CAT reply has been seen on the live connection
+     */
+    public boolean hasRigRespondedToCat() {
+        return sawRigResponseSinceConnect;
     }
 
     /**

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/SettingsScreen.kt
@@ -70,6 +70,7 @@ private enum class SettingsCategory {
     DECODE_FILTERS,
     LOGGING,
     ADVANCED,
+    USB_DIAGNOSTICS,
     ABOUT,
 }
 
@@ -143,6 +144,8 @@ fun SettingsScreen(
                 LoggingSettings(mainViewModel, onBack = { currentCategory = null })
             SettingsCategory.ADVANCED ->
                 AdvancedSettings(mainViewModel, onBack = { currentCategory = null })
+            SettingsCategory.USB_DIAGNOSTICS ->
+                UsbDiagnosticsScreen(mainViewModel, onBack = { currentCategory = null })
             SettingsCategory.ABOUT ->
                 AboutSettings(mainViewModel, onBack = { currentCategory = null })
         }
@@ -324,6 +327,13 @@ private fun SettingsLanding(
                         label = stringResource(R.string.settings_cat_advanced),
                         showChevron = true,
                         onClick = { onOpenCategory(SettingsCategory.ADVANCED) },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_cat_usb_diagnostics),
+                        description = stringResource(R.string.settings_cat_usb_diagnostics_desc),
+                        showChevron = true,
+                        onClick = { onOpenCategory(SettingsCategory.USB_DIAGNOSTICS) },
                     )
                     SectionDivider()
                     SettingsRow(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/UsbDiagnosticsScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/UsbDiagnosticsScreen.kt
@@ -1,0 +1,348 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import android.content.Context
+import android.hardware.usb.UsbManager
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.MainViewModel
+import com.k1af.ft8af.R
+import com.k1af.ft8af.serialport.UsbSerialProber
+import com.k1af.ft8af.wave.UsbAudioDevice
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8af.theme.GeistMonoFamily
+import radio.ks3ckc.ft8af.theme.StatusBad
+import radio.ks3ckc.ft8af.theme.StatusConfirmed
+import radio.ks3ckc.ft8af.theme.TextMuted
+import radio.ks3ckc.ft8af.theme.TextPrimary
+import radio.ks3ckc.ft8af.ui.components.GlassCard
+
+// ---------------------------------------------------------------------------
+// Pure diagnostic logic (unit-tested — kept free of Android/Compose runtime types)
+// ---------------------------------------------------------------------------
+
+/** Default CAT vendor id the wired-serial path matches on (ICOM), see CableSerialPort. */
+internal const val DEFAULT_CAT_VENDOR_ID = 0x0c26
+
+/**
+ * Outcome of a single diagnostic check. [PASS]/[FAIL] render a coloured tick/cross;
+ * [INFO] is a neutral value-only row (used for the Vendor/Product ID readouts, which
+ * are data, not a pass/fail).
+ */
+internal enum class DiagnosticStatus { PASS, FAIL, INFO }
+
+/** One row in the diagnostics list: a label, a status, and an optional detail value. */
+internal data class UsbDiagnosticItem(
+    val labelRes: Int,
+    val status: DiagnosticStatus,
+    val value: String? = null,
+)
+
+/** A single attached USB device reduced to the facts the diagnostics care about. */
+internal data class UsbDeviceSummary(
+    val vendorId: Int,
+    val productId: Int,
+    val hasSerialDriver: Boolean,
+    val hasAudioInterface: Boolean,
+    val hasPermission: Boolean,
+)
+
+/** The full set of USB/CAT facts a single diagnostics refresh gathers. */
+internal data class UsbDiagnosticsData(
+    val deviceFound: Boolean,
+    val vendorId: Int?,
+    val productId: Int?,
+    val hasPermission: Boolean,
+    val cdcSerialFound: Boolean,
+    val audioDeviceFound: Boolean,
+    val portOpen: Boolean,
+    val catResponded: Boolean,
+)
+
+/** Formats a USB id as the conventional 16-bit hex (e.g. 0x0C26); null passes through. */
+internal fun formatUsbId(id: Int?): String? =
+    id?.let { String.format("0x%04X", it and 0xFFFF) }
+
+/**
+ * Picks which attached device the diagnostics describe. Prefers one a serial driver
+ * can drive (that's the rig's CAT port), then one matching the default CAT vendor id,
+ * then one exposing a USB-audio interface, then simply the first device. Returns null
+ * when nothing is attached.
+ */
+internal fun selectDiagnosticDevice(devices: List<UsbDeviceSummary>): UsbDeviceSummary? =
+    devices.firstOrNull { it.hasSerialDriver }
+        ?: devices.firstOrNull { it.vendorId == DEFAULT_CAT_VENDOR_ID }
+        ?: devices.firstOrNull { it.hasAudioInterface }
+        ?: devices.firstOrNull()
+
+/**
+ * Collapses the raw per-device facts (plus the rig-link/CAT signals read from the
+ * ViewModel) into the flat [UsbDiagnosticsData] the row builder consumes. Pure so it
+ * can be exercised without a UsbManager.
+ */
+internal fun assembleUsbDiagnosticsData(
+    devices: List<UsbDeviceSummary>,
+    portOpen: Boolean,
+    catResponded: Boolean,
+): UsbDiagnosticsData {
+    val target = selectDiagnosticDevice(devices)
+    return UsbDiagnosticsData(
+        deviceFound = target != null,
+        vendorId = target?.vendorId,
+        productId = target?.productId,
+        hasPermission = target?.hasPermission == true,
+        cdcSerialFound = devices.any { it.hasSerialDriver },
+        audioDeviceFound = devices.any { it.hasAudioInterface },
+        portOpen = portOpen,
+        catResponded = catResponded,
+    )
+}
+
+/**
+ * Maps gathered facts to the ordered list of display rows, matching the layout in the
+ * task: device found, VID, PID, permission, CDC serial, audio, port open, CAT response.
+ * The VID/PID rows are informational (no tick/cross) and only carry a value once a
+ * device is actually found.
+ */
+internal fun buildUsbDiagnostics(data: UsbDiagnosticsData): List<UsbDiagnosticItem> {
+    fun passFail(ok: Boolean) = if (ok) DiagnosticStatus.PASS else DiagnosticStatus.FAIL
+    return listOf(
+        UsbDiagnosticItem(R.string.usb_diag_device_found, passFail(data.deviceFound)),
+        UsbDiagnosticItem(
+            R.string.usb_diag_vendor_id,
+            DiagnosticStatus.INFO,
+            if (data.deviceFound) formatUsbId(data.vendorId) else null,
+        ),
+        UsbDiagnosticItem(
+            R.string.usb_diag_product_id,
+            DiagnosticStatus.INFO,
+            if (data.deviceFound) formatUsbId(data.productId) else null,
+        ),
+        UsbDiagnosticItem(R.string.usb_diag_permission, passFail(data.hasPermission)),
+        UsbDiagnosticItem(R.string.usb_diag_cdc_serial, passFail(data.cdcSerialFound)),
+        UsbDiagnosticItem(R.string.usb_diag_audio_device, passFail(data.audioDeviceFound)),
+        UsbDiagnosticItem(R.string.usb_diag_port_open, passFail(data.portOpen)),
+        UsbDiagnosticItem(R.string.usb_diag_cat_response, passFail(data.catResponded)),
+    )
+}
+
+/** Glyph shown for a status; INFO rows carry no glyph (value only). */
+internal fun diagnosticStatusGlyph(status: DiagnosticStatus): String = when (status) {
+    DiagnosticStatus.PASS -> "✔"
+    DiagnosticStatus.FAIL -> "✖"
+    DiagnosticStatus.INFO -> ""
+}
+
+/** Colour for a status glyph: green = pass, red = fail. INFO has no glyph so is neutral. */
+internal fun diagnosticStatusColor(status: DiagnosticStatus): Color = when (status) {
+    DiagnosticStatus.PASS -> StatusConfirmed
+    DiagnosticStatus.FAIL -> StatusBad
+    DiagnosticStatus.INFO -> TextMuted
+}
+
+/** The TalkBack status-res for a status, or null for INFO (nothing to announce). */
+internal fun diagnosticStatusContentDescriptionRes(status: DiagnosticStatus): Int? = when (status) {
+    DiagnosticStatus.PASS -> R.string.usb_diag_status_pass
+    DiagnosticStatus.FAIL -> R.string.usb_diag_status_fail
+    DiagnosticStatus.INFO -> null
+}
+
+/**
+ * The value string shown on a row: the row's own value when it has one, a dash
+ * placeholder for INFO rows with no value (VID/PID before a device is attached), and
+ * nothing for PASS/FAIL rows (their glyph is the whole story). [noneValue] is the
+ * localized "—".
+ */
+internal fun resolveDiagnosticDisplayValue(item: UsbDiagnosticItem, noneValue: String): String? =
+    when {
+        item.value != null -> item.value
+        item.status == DiagnosticStatus.INFO -> noneValue
+        else -> null
+    }
+
+/**
+ * TalkBack description for a row. PASS/FAIL announce "<label>, <pass|fail>"; INFO rows
+ * (no spoken status) announce "<label>, <value>" so the VID/PID readout is still spoken.
+ * [statusWord] is the localized "pass"/"fail", or null for INFO.
+ */
+internal fun buildRowContentDescription(label: String, statusWord: String?, value: String?): String =
+    if (statusWord != null) {
+        "$label, $statusWord"
+    } else {
+        listOfNotNull(label, value).joinToString(", ")
+    }
+
+// ---------------------------------------------------------------------------
+// Android collector (thin adapter over the read-only USB/CAT runtime APIs)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads the live USB/CAT state and reduces it to [UsbDiagnosticsData]. Only enumeration
+ * and permission checks touch the framework here; everything with a decision in it lives
+ * in the pure helpers above. Every framework/ViewModel call is guarded so a flaky USB
+ * stack or a rig reconnect racing the poll degrades to a failing check rather than
+ * crashing the diagnostics screen.
+ */
+internal fun collectUsbDiagnostics(
+    context: Context,
+    mainViewModel: MainViewModel,
+): UsbDiagnosticsData {
+    val usbManager = context.getSystemService(Context.USB_SERVICE) as? UsbManager
+    val summaries: List<UsbDeviceSummary> = if (usbManager == null) {
+        emptyList()
+    } else {
+        val audioDeviceIds: Set<Int> = runCatching {
+            UsbAudioDevice.findUsbAudioDevices(context).map { it.device.deviceId }.toSet()
+        }.getOrDefault(emptySet())
+        val prober = UsbSerialProber.getDefaultProber()
+        usbManager.deviceList.values.map { device ->
+            UsbDeviceSummary(
+                vendorId = device.vendorId,
+                productId = device.productId,
+                hasSerialDriver = runCatching { prober.probeDevice(device) != null }
+                    .getOrDefault(false),
+                hasAudioInterface = audioDeviceIds.contains(device.deviceId),
+                hasPermission = runCatching { usbManager.hasPermission(device) }
+                    .getOrDefault(false),
+            )
+        }
+    }
+    return assembleUsbDiagnosticsData(
+        devices = summaries,
+        // Guarded like the USB calls above: baseRig is reassigned (nulled then rebuilt)
+        // during a reconnect, so a poll landing mid-reconnect could otherwise NPE and kill
+        // the polling coroutine, freezing the screen on stale data.
+        portOpen = runCatching { mainViewModel.isRigConnected() }.getOrDefault(false),
+        catResponded = runCatching { mainViewModel.hasRigRespondedToCat() }.getOrDefault(false),
+    )
+}
+
+private val EMPTY_DIAGNOSTICS = UsbDiagnosticsData(
+    deviceFound = false,
+    vendorId = null,
+    productId = null,
+    hasPermission = false,
+    cdcSerialFound = false,
+    audioDeviceFound = false,
+    portOpen = false,
+    catResponded = false,
+)
+
+// ---------------------------------------------------------------------------
+// Composable (thin — polls the collector and renders the rows)
+// ---------------------------------------------------------------------------
+
+/**
+ * USB Diagnostics settings page. Shows a live pass/fail readout for each stage of the
+ * USB → serial → CAT chain so an operator can tell at a glance where a rig connection is
+ * breaking down. Re-collected every 1.5 s (off the main thread) so plugging/unplugging or
+ * granting permission updates without leaving the screen.
+ */
+@Composable
+fun UsbDiagnosticsScreen(
+    mainViewModel: MainViewModel,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    var items by remember { mutableStateOf(buildUsbDiagnostics(EMPTY_DIAGNOSTICS)) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            val data = withContext(Dispatchers.IO) { collectUsbDiagnostics(context, mainViewModel) }
+            items = buildUsbDiagnostics(data)
+            delay(1_500)
+        }
+    }
+
+    // The scaffold's top bar already shows "USB Diagnostics", so the description and card
+    // sit directly under it — no redundant section header repeating the title.
+    SettingsDetailScaffold(
+        title = stringResource(R.string.usb_diag_title),
+        onBack = onBack,
+    ) {
+        Text(
+            text = stringResource(R.string.usb_diag_desc),
+            color = TextMuted,
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+        GlassCard(modifier = Modifier.fillMaxWidth()) {
+            Column {
+                items.forEachIndexed { index, item ->
+                    if (index > 0) SectionDivider()
+                    UsbDiagnosticRow(item)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UsbDiagnosticRow(item: UsbDiagnosticItem) {
+    val label = stringResource(item.labelRes)
+    val value = resolveDiagnosticDisplayValue(item, stringResource(R.string.usb_diag_value_none))
+    val statusWord = diagnosticStatusContentDescriptionRes(item.status)?.let { stringResource(it) }
+    val rowDescription = buildRowContentDescription(label, statusWord, value)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            // clearAndSetSemantics (not semantics): the Row isn't a merge root, so without
+            // it TalkBack would read the label and the raw "✔"/"✖" glyph as separate nodes.
+            // This replaces the subtree with one clean "<label>, <pass|fail|value>" phrase.
+            .clearAndSetSemantics { contentDescription = rowDescription }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            color = TextPrimary,
+            fontSize = 14.sp,
+            modifier = Modifier.weight(1f),
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (value != null) {
+                Text(
+                    text = value,
+                    color = TextMuted,
+                    fontSize = 13.sp,
+                    fontFamily = GeistMonoFamily,
+                )
+            }
+            if (item.status != DiagnosticStatus.INFO) {
+                Text(
+                    text = diagnosticStatusGlyph(item.status),
+                    color = diagnosticStatusColor(item.status),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/UsbDiagnosticsScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/UsbDiagnosticsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
+import com.k1af.ft8af.serialport.UsbId
 import com.k1af.ft8af.serialport.UsbSerialProber
 import com.k1af.ft8af.wave.UsbAudioDevice
 import kotlinx.coroutines.Dispatchers
@@ -39,11 +40,12 @@ import radio.ks3ckc.ft8af.theme.TextPrimary
 import radio.ks3ckc.ft8af.ui.components.GlassCard
 
 // ---------------------------------------------------------------------------
-// Pure diagnostic logic (unit-tested — kept free of Android/Compose runtime types)
+// Pure diagnostic logic (unit-tested — no Android framework dependencies; the
+// Compose value classes used below, e.g. Color, are fine on the JVM under test)
 // ---------------------------------------------------------------------------
 
 /** Default CAT vendor id the wired-serial path matches on (ICOM), see CableSerialPort. */
-internal const val DEFAULT_CAT_VENDOR_ID = 0x0c26
+internal val DEFAULT_CAT_VENDOR_ID = UsbId.VENDOR_ICOM
 
 /**
  * Outcome of a single diagnostic check. [PASS]/[FAIL] render a coloured tick/cross;
@@ -304,7 +306,9 @@ private fun UsbDiagnosticRow(item: UsbDiagnosticItem) {
     val label = stringResource(item.labelRes)
     val value = resolveDiagnosticDisplayValue(item, stringResource(R.string.usb_diag_value_none))
     val statusWord = diagnosticStatusContentDescriptionRes(item.status)?.let { stringResource(it) }
-    val rowDescription = buildRowContentDescription(label, statusWord, value)
+    // Announce the raw item.value (null until a real VID/PID exists), NOT the rendered
+    // `value` — otherwise TalkBack would read the visual "—" placeholder as "Vendor ID, —".
+    val rowDescription = buildRowContentDescription(label, statusWord, item.value)
 
     Row(
         modifier = Modifier

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -439,6 +439,24 @@
     <string name="settings_cat_about">About</string>
     <string name="settings_cat_time_sync">Time Sync</string>
     <string name="settings_cat_time_sync_desc">Manual clock correction for offline operating</string>
+    <string name="settings_cat_usb_diagnostics">USB Diagnostics</string>
+    <string name="settings_cat_usb_diagnostics_desc">Check USB device discovery and CAT communication</string>
+
+    <!-- ===== Settings: USB Diagnostics (issue #515) ===== -->
+    <string name="usb_diag_title">USB Diagnostics</string>
+    <string name="usb_diag_desc">Live status of USB device discovery and CAT communication. Use it to pinpoint where a rig connection is failing.</string>
+    <string name="usb_diag_device_found">Device Found</string>
+    <string name="usb_diag_vendor_id">Vendor ID</string>
+    <string name="usb_diag_product_id">Product ID</string>
+    <string name="usb_diag_permission">USB Permission</string>
+    <string name="usb_diag_cdc_serial">CDC Serial Found</string>
+    <string name="usb_diag_audio_device">Audio Device Found</string>
+    <string name="usb_diag_port_open">Port Open</string>
+    <string name="usb_diag_cat_response">CAT Response</string>
+    <string name="usb_diag_value_none">—</string>
+    <!-- Spoken status suffixes for TalkBack (e.g. "Device Found, pass") -->
+    <string name="usb_diag_status_pass">pass</string>
+    <string name="usb_diag_status_fail">fail</string>
 
     <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
     <string name="settings_time_correction_section">Manual Correction</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/UsbDiagnosticsLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/UsbDiagnosticsLogicTest.kt
@@ -1,0 +1,294 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import org.junit.Test
+import radio.ks3ckc.ft8af.theme.StatusBad
+import radio.ks3ckc.ft8af.theme.StatusConfirmed
+import radio.ks3ckc.ft8af.theme.TextMuted
+
+/**
+ * Unit tests for the pure USB-diagnostics logic extracted from
+ * [UsbDiagnosticsScreen] so the Composable stays a thin wrapper. No Android
+ * runtime needed: everything under test is plain data classes, ints and the
+ * JVM-value-class Compose [androidx.compose.ui.graphics.Color].
+ */
+class UsbDiagnosticsLogicTest {
+    private fun summary(
+        vendorId: Int = 0x1234,
+        productId: Int = 0x0001,
+        hasSerialDriver: Boolean = false,
+        hasAudioInterface: Boolean = false,
+        hasPermission: Boolean = false,
+    ) = UsbDeviceSummary(
+        vendorId = vendorId,
+        productId = productId,
+        hasSerialDriver = hasSerialDriver,
+        hasAudioInterface = hasAudioInterface,
+        hasPermission = hasPermission,
+    )
+
+    // --- formatUsbId ---
+
+    @Test
+    fun formatUsbId_padsToFourHexDigits() {
+        assertThat(formatUsbId(0x0c26)).isEqualTo("0x0C26")
+        assertThat(formatUsbId(0x20)).isEqualTo("0x0020")
+    }
+
+    @Test
+    fun formatUsbId_masksToSixteenBits() {
+        // UsbDevice ids are unsigned 16-bit; a sign-extended int must not print extra digits.
+        assertThat(formatUsbId(0xFFFF)).isEqualTo("0xFFFF")
+        assertThat(formatUsbId(-1)).isEqualTo("0xFFFF")
+    }
+
+    @Test
+    fun formatUsbId_nullPassesThrough() {
+        assertThat(formatUsbId(null)).isNull()
+    }
+
+    // --- selectDiagnosticDevice ---
+
+    @Test
+    fun selectDevice_emptyReturnsNull() {
+        assertThat(selectDiagnosticDevice(emptyList())).isNull()
+    }
+
+    @Test
+    fun selectDevice_prefersSerialDriverOverEverythingElse() {
+        val audio = summary(vendorId = 0x0c26, hasAudioInterface = true)
+        val serial = summary(vendorId = 0x9999, hasSerialDriver = true)
+        assertThat(selectDiagnosticDevice(listOf(audio, serial))).isEqualTo(serial)
+    }
+
+    @Test
+    fun selectDevice_prefersCatVendorWhenNoSerialDriver() {
+        val other = summary(vendorId = 0x1111)
+        val cat = summary(vendorId = DEFAULT_CAT_VENDOR_ID)
+        assertThat(selectDiagnosticDevice(listOf(other, cat))).isEqualTo(cat)
+    }
+
+    @Test
+    fun selectDevice_prefersAudioWhenNoSerialOrCatVendor() {
+        val plain = summary(vendorId = 0x1111)
+        val audio = summary(vendorId = 0x2222, hasAudioInterface = true)
+        assertThat(selectDiagnosticDevice(listOf(plain, audio))).isEqualTo(audio)
+    }
+
+    @Test
+    fun selectDevice_fallsBackToFirstDevice() {
+        val first = summary(vendorId = 0x1111)
+        val second = summary(vendorId = 0x2222)
+        assertThat(selectDiagnosticDevice(listOf(first, second))).isEqualTo(first)
+    }
+
+    // --- assembleUsbDiagnosticsData ---
+
+    @Test
+    fun assemble_noDevices_allNegative() {
+        val data = assembleUsbDiagnosticsData(emptyList(), portOpen = false, catResponded = false)
+        assertThat(data.deviceFound).isFalse()
+        assertThat(data.vendorId).isNull()
+        assertThat(data.productId).isNull()
+        assertThat(data.hasPermission).isFalse()
+        assertThat(data.cdcSerialFound).isFalse()
+        assertThat(data.audioDeviceFound).isFalse()
+    }
+
+    @Test
+    fun assemble_reportsTargetDeviceVidPidAndPermission() {
+        val target = summary(
+            vendorId = 0x0c26,
+            productId = 0x0020,
+            hasSerialDriver = true,
+            hasPermission = true,
+        )
+        val data = assembleUsbDiagnosticsData(listOf(target), portOpen = true, catResponded = false)
+        assertThat(data.deviceFound).isTrue()
+        assertThat(data.vendorId).isEqualTo(0x0c26)
+        assertThat(data.productId).isEqualTo(0x0020)
+        assertThat(data.hasPermission).isTrue()
+        assertThat(data.cdcSerialFound).isTrue()
+        assertThat(data.portOpen).isTrue()
+        assertThat(data.catResponded).isFalse()
+    }
+
+    @Test
+    fun assemble_serialAndAudioAggregateAcrossDevices() {
+        // The audio device is a different device than the serial one; both flags should trip.
+        val serial = summary(vendorId = 0x0c26, hasSerialDriver = true)
+        val audio = summary(vendorId = 0x08bb, hasAudioInterface = true)
+        val data = assembleUsbDiagnosticsData(listOf(serial, audio), portOpen = false, catResponded = false)
+        assertThat(data.cdcSerialFound).isTrue()
+        assertThat(data.audioDeviceFound).isTrue()
+        // The serial device is the chosen target.
+        assertThat(data.vendorId).isEqualTo(0x0c26)
+    }
+
+    @Test
+    fun assemble_permissionFromTargetOnly() {
+        // Target (serial) lacks permission even though another device has it.
+        val serial = summary(vendorId = 0x0c26, hasSerialDriver = true, hasPermission = false)
+        val audio = summary(vendorId = 0x08bb, hasAudioInterface = true, hasPermission = true)
+        val data = assembleUsbDiagnosticsData(listOf(serial, audio), portOpen = false, catResponded = false)
+        assertThat(data.hasPermission).isFalse()
+    }
+
+    // --- buildUsbDiagnostics ---
+
+    private fun fullData(
+        deviceFound: Boolean = true,
+        vendorId: Int? = 0x0c26,
+        productId: Int? = 0x0020,
+        hasPermission: Boolean = true,
+        cdcSerialFound: Boolean = true,
+        audioDeviceFound: Boolean = true,
+        portOpen: Boolean = true,
+        catResponded: Boolean = true,
+    ) = UsbDiagnosticsData(
+        deviceFound = deviceFound,
+        vendorId = vendorId,
+        productId = productId,
+        hasPermission = hasPermission,
+        cdcSerialFound = cdcSerialFound,
+        audioDeviceFound = audioDeviceFound,
+        portOpen = portOpen,
+        catResponded = catResponded,
+    )
+
+    @Test
+    fun build_producesEightRowsInTaskOrder() {
+        val rows = buildUsbDiagnostics(fullData())
+        assertThat(rows.map { it.labelRes }).containsExactly(
+            R.string.usb_diag_device_found,
+            R.string.usb_diag_vendor_id,
+            R.string.usb_diag_product_id,
+            R.string.usb_diag_permission,
+            R.string.usb_diag_cdc_serial,
+            R.string.usb_diag_audio_device,
+            R.string.usb_diag_port_open,
+            R.string.usb_diag_cat_response,
+        ).inOrder()
+    }
+
+    @Test
+    fun build_vidPidRowsAreInformationalWithHexValues() {
+        val rows = buildUsbDiagnostics(fullData()).associateBy { it.labelRes }
+        val vid = rows.getValue(R.string.usb_diag_vendor_id)
+        val pid = rows.getValue(R.string.usb_diag_product_id)
+        assertThat(vid.status).isEqualTo(DiagnosticStatus.INFO)
+        assertThat(vid.value).isEqualTo("0x0C26")
+        assertThat(pid.status).isEqualTo(DiagnosticStatus.INFO)
+        assertThat(pid.value).isEqualTo("0x0020")
+    }
+
+    @Test
+    fun build_vidPidHaveNoValueWhenNoDevice() {
+        val rows = buildUsbDiagnostics(fullData(deviceFound = false, vendorId = null, productId = null))
+            .associateBy { it.labelRes }
+        assertThat(rows.getValue(R.string.usb_diag_vendor_id).value).isNull()
+        assertThat(rows.getValue(R.string.usb_diag_product_id).value).isNull()
+    }
+
+    @Test
+    fun build_passFailReflectsData() {
+        // Mirrors the task's example: everything up passes except CAT response.
+        val rows = buildUsbDiagnostics(fullData(catResponded = false)).associateBy { it.labelRes }
+        assertThat(rows.getValue(R.string.usb_diag_device_found).status).isEqualTo(DiagnosticStatus.PASS)
+        assertThat(rows.getValue(R.string.usb_diag_permission).status).isEqualTo(DiagnosticStatus.PASS)
+        assertThat(rows.getValue(R.string.usb_diag_cdc_serial).status).isEqualTo(DiagnosticStatus.PASS)
+        assertThat(rows.getValue(R.string.usb_diag_audio_device).status).isEqualTo(DiagnosticStatus.PASS)
+        assertThat(rows.getValue(R.string.usb_diag_port_open).status).isEqualTo(DiagnosticStatus.PASS)
+        assertThat(rows.getValue(R.string.usb_diag_cat_response).status).isEqualTo(DiagnosticStatus.FAIL)
+    }
+
+    @Test
+    fun build_allFailWhenNothingConnected() {
+        val rows = buildUsbDiagnostics(
+            fullData(
+                deviceFound = false,
+                vendorId = null,
+                productId = null,
+                hasPermission = false,
+                cdcSerialFound = false,
+                audioDeviceFound = false,
+                portOpen = false,
+                catResponded = false,
+            ),
+        ).associateBy { it.labelRes }
+        assertThat(rows.getValue(R.string.usb_diag_device_found).status).isEqualTo(DiagnosticStatus.FAIL)
+        assertThat(rows.getValue(R.string.usb_diag_port_open).status).isEqualTo(DiagnosticStatus.FAIL)
+        // VID/PID stay INFO regardless — they are readouts, not checks.
+        assertThat(rows.getValue(R.string.usb_diag_vendor_id).status).isEqualTo(DiagnosticStatus.INFO)
+    }
+
+    // --- status presentation helpers ---
+
+    @Test
+    fun statusGlyph_mapsPassFailInfo() {
+        assertThat(diagnosticStatusGlyph(DiagnosticStatus.PASS)).isEqualTo("✔")
+        assertThat(diagnosticStatusGlyph(DiagnosticStatus.FAIL)).isEqualTo("✖")
+        assertThat(diagnosticStatusGlyph(DiagnosticStatus.INFO)).isEmpty()
+    }
+
+    @Test
+    fun statusColor_passIsGreenFailIsRed() {
+        assertThat(diagnosticStatusColor(DiagnosticStatus.PASS)).isEqualTo(StatusConfirmed)
+        assertThat(diagnosticStatusColor(DiagnosticStatus.FAIL)).isEqualTo(StatusBad)
+        assertThat(diagnosticStatusColor(DiagnosticStatus.INFO)).isEqualTo(TextMuted)
+    }
+
+    @Test
+    fun statusContentDescription_nullForInfoOnly() {
+        assertThat(diagnosticStatusContentDescriptionRes(DiagnosticStatus.PASS))
+            .isEqualTo(R.string.usb_diag_status_pass)
+        assertThat(diagnosticStatusContentDescriptionRes(DiagnosticStatus.FAIL))
+            .isEqualTo(R.string.usb_diag_status_fail)
+        assertThat(diagnosticStatusContentDescriptionRes(DiagnosticStatus.INFO)).isNull()
+    }
+
+    // --- resolveDiagnosticDisplayValue ---
+
+    @Test
+    fun displayValue_usesItemValueWhenPresent() {
+        val item = UsbDiagnosticItem(R.string.usb_diag_vendor_id, DiagnosticStatus.INFO, "0x0C26")
+        assertThat(resolveDiagnosticDisplayValue(item, "—")).isEqualTo("0x0C26")
+    }
+
+    @Test
+    fun displayValue_infoWithoutValueFallsBackToNone() {
+        val item = UsbDiagnosticItem(R.string.usb_diag_vendor_id, DiagnosticStatus.INFO, null)
+        assertThat(resolveDiagnosticDisplayValue(item, "—")).isEqualTo("—")
+    }
+
+    @Test
+    fun displayValue_passFailRowsShowNoValue() {
+        val pass = UsbDiagnosticItem(R.string.usb_diag_device_found, DiagnosticStatus.PASS, null)
+        val fail = UsbDiagnosticItem(R.string.usb_diag_port_open, DiagnosticStatus.FAIL, null)
+        assertThat(resolveDiagnosticDisplayValue(pass, "—")).isNull()
+        assertThat(resolveDiagnosticDisplayValue(fail, "—")).isNull()
+    }
+
+    // --- buildRowContentDescription ---
+
+    @Test
+    fun rowDescription_passFailAnnouncesLabelAndStatusWord() {
+        assertThat(buildRowContentDescription("Device Found", "pass", null))
+            .isEqualTo("Device Found, pass")
+        assertThat(buildRowContentDescription("CAT Response", "fail", null))
+            .isEqualTo("CAT Response, fail")
+    }
+
+    @Test
+    fun rowDescription_infoAnnouncesLabelAndValue() {
+        // No spoken status word (INFO) — the VID/PID value must still be announced.
+        assertThat(buildRowContentDescription("Vendor ID", null, "0x0C26"))
+            .isEqualTo("Vendor ID, 0x0C26")
+    }
+
+    @Test
+    fun rowDescription_infoWithoutValueIsJustLabel() {
+        assertThat(buildRowContentDescription("Vendor ID", null, null)).isEqualTo("Vendor ID")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #515. Adds a **USB Diagnostics** page under Settings that shows a live pass/fail readout for each stage of the USB → serial → CAT chain, so an operator can pinpoint where a rig connection is failing during troubleshooting.

Rows, in the order the issue specifies:

| Check | Meaning |
|---|---|
| Device Found | a USB device is attached |
| Vendor ID / Product ID | hex readout of the selected device (shown once a device is found) |
| USB Permission | `UsbManager.hasPermission` for that device |
| CDC Serial Found | a serial driver was probed for some attached device |
| Audio Device Found | a USB Audio Class device is present |
| Port Open | the rig serial link is open (`MainViewModel.isRigConnected()`) |
| CAT Response | the rig has actually answered a CAT probe on the live connection |

Passed checks render a green ✔, failed checks a red ✖ (visually distinguishable per the acceptance criteria). VID/PID are neutral hex readouts. The page lives as its own drill-down category on the Settings landing, so it's easy to find during troubleshooting.

## How it works

- State is re-collected every 1.5 s off the main thread from the existing **read-only** USB APIs (`UsbManager.getDeviceList`, `UsbSerialProber.probeDevice`, `UsbAudioDevice.findUsbAudioDevices`) plus the rig-link/CAT signals on `MainViewModel`. No connection is required to open the page.
- **Port Open vs CAT Response** are deliberately distinct: the serial port can open while the rig never replies (wrong baud, wrong CAT protocol, powered-but-silent adapter). `MainViewModel.hasRigRespondedToCat()` exposes the "rig actually answered a probe" flag for this. The flag is now also cleared when the CAT liveness watchdog stops, so it can't report a stale pass after a disconnect.

## Testing / conventions

- Per CLAUDE.md, all decision/format logic is extracted into pure top-level `internal` functions (`selectDiagnosticDevice`, `assembleUsbDiagnosticsData`, `buildUsbDiagnostics`, `formatUsbId`, and the status/value/description helpers); the `@Composable` is a thin wrapper. New `UsbDiagnosticsLogicTest` covers them (26 tests, JUnit4 + Truth, no Android runtime needed).
- `./gradlew :app:testDebugUnitTest` and `:app:assembleDebug` both pass.

## Notes / assumptions

- "CDC Serial Found" reflects the app's own notion of a serial port being discoverable (the default `UsbSerialProber`, the same probe the connect path uses), which matches on the driver table rather than the raw CDC interface class.
- New strings were added to the default `values/` locale only, matching how several recent features (GPS clock, free-text CQ, FFT knobs) shipped; untranslated strings fall back to English at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)