### PR TITLE
Fix 6-char Maidenhead grid decode: subsquares divide by 24, not 18

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
@@ -19,6 +19,16 @@ import java.util.List;
 public class MaidenheadGrid {
     private static final String TAG = "MaidenheadGrid";
     private static final double EARTH_RADIUS = 6371393; // Mean radius in meters; not the equatorial radius, which is about 6378 km
+    /**
+     * Maidenhead subsquares (the third pair, letters a–x) divide each square into
+     * 24 parts along each axis — not 18. The 6-character decode below must agree
+     * with the {@link #getGridSquare} encoder, which steps by 2/24° of longitude
+     * and 1/24° of latitude per subsquare. Dividing by 18 stretched every
+     * subsquare offset by 24/18 = 1.33×, misplacing 6-character grids by up to
+     * ~0.6° (~45 km) of longitude for the high subsquare letters (e.g. IO91wm
+     * landed at +0.5° instead of the true −0.125°).
+     */
+    private static final float SUBSQUARES = 24f;
 
     /**
      * Calculate latitude/longitude from a 4-character or 6-character Maidenhead grid. Returns null if grid data is invalid. For 4-character grids, 'll' is appended to use the center position.
@@ -55,7 +65,7 @@ public class MaidenheadGrid {
 
         if (grid.length()==6){
             z=grid.toUpperCase().getBytes()[5]-'A'+0.5f;
-            z=z*(1/18f);
+            z=z*(1/SUBSQUARES);
         }
         lat=x+y+z-90;
 
@@ -78,7 +88,7 @@ public class MaidenheadGrid {
         y*=2;
         if (grid.length()==6){
             z=grid.toUpperCase().getBytes()[4]-'A'+0.5;
-            z=z*(2/18f);
+            z=z*(2/SUBSQUARES);
         }
         lng=x+y+z-180;
         if (lat>85) lat=85;//Prevent going out of bounds on the map
@@ -113,7 +123,7 @@ public class MaidenheadGrid {
         }
         if (grid.length() > 4) {
             z = grid.toUpperCase().getBytes()[5] - 'A';
-            z = z * (1f / 18f);
+            z = z * (1f / SUBSQUARES);
         }
         lat1 = x + y + z - 90;
         if (lat1<-85.0){
@@ -141,7 +151,7 @@ public class MaidenheadGrid {
         }
         if (grid.length() == 6) {
             z = grid.toUpperCase().getBytes()[5] - 'A' + 1;
-            z = z * (1f / 18f);
+            z = z * (1f / SUBSQUARES);
         }
         lat2 = x + y + z - 90;
         if (lat2<-85.0){
@@ -164,7 +174,7 @@ public class MaidenheadGrid {
         }
         if (grid.length()>4){
             z=grid.toUpperCase().getBytes()[4]-'A';
-            z=z*2/18f;
+            z=z*2/SUBSQUARES;
         }
         lng1=x+y+z-180;
 
@@ -185,7 +195,7 @@ public class MaidenheadGrid {
         y*=2;
         if (grid.length()==6){
             z=grid.toUpperCase().getBytes()[4]-'A'+1;
-            z=z*2/18f;
+            z=z*2/SUBSQUARES;
         }
         lng2=x+y+z-180;
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/maidenhead/MaidenheadGridTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/maidenhead/MaidenheadGridTest.java
@@ -36,13 +36,47 @@ public class MaidenheadGridTest {
 
     @Test
     public void gridToLatLng_sixChar_narrowsToSubsquare() {
-        // FN42aa: south-west corner of FN42.
+        // FN42aa: the south-west subsquare of FN42. Subsquares span 1/24° lat and
+        // 2/24° lng (letters a–x), so the 'aa' centroid sits half a subsquare in.
         LatLng p = MaidenheadGrid.gridToLatLng("FN42aa");
         assertThat(p).isNotNull();
-        // Sub-square centroid lat: 42 + (0.5 * 1/18) ≈ 42.0278
-        assertThat(p.latitude).isWithin(POS_TOL).of(42.028);
-        // Sub-square centroid lng: -72 + (0.5 * 2/18) ≈ -71.944
-        assertThat(p.longitude).isWithin(POS_TOL).of(-71.944);
+        // Sub-square centroid lat: 42 + (0.5 * 1/24) ≈ 42.0208
+        assertThat(p.latitude).isWithin(POS_TOL).of(42.021);
+        // Sub-square centroid lng: -72 + (0.5 * 2/24) ≈ -71.9583
+        assertThat(p.longitude).isWithin(POS_TOL).of(-71.958);
+    }
+
+    @Test
+    public void gridToLatLng_sixChar_highSubsquareMatchesRealLocation() {
+        // Regression for the subsquare divisor: the a–x third pair has 24
+        // divisions per axis, not 18. The +0.5 centre offset masks the error for
+        // the low letters ('aa'), so use a high subsquare — IO91wm is the classic
+        // central-London locator, true centre ≈ (51.52, -0.125). With the old /18
+        // divisor this resolved to (51.69, +0.5): ~45 km east and into the wrong
+        // hemisphere of the prime meridian.
+        LatLng p = MaidenheadGrid.gridToLatLng("IO91wm");
+        assertThat(p).isNotNull();
+        assertThat(p.latitude).isWithin(POS_TOL).of(51.521);
+        assertThat(p.longitude).isWithin(POS_TOL).of(-0.125);
+    }
+
+    @Test
+    public void gridToPolygon_sixChar_cellSpansOneSubsquare() {
+        // A 6-char cell outline must be exactly one subsquare: 1/24° tall and
+        // 2/24° wide. The /18 divisor inflated it to 1/18° × 2/18° (≈33% too big),
+        // drawing overlapping grid squares on the map.
+        LatLng[] poly = MaidenheadGrid.gridToPolygon("IO91wm");
+        assertThat(poly).isNotNull();
+        double minLat = Math.min(Math.min(poly[0].latitude, poly[1].latitude),
+                Math.min(poly[2].latitude, poly[3].latitude));
+        double maxLat = Math.max(Math.max(poly[0].latitude, poly[1].latitude),
+                Math.max(poly[2].latitude, poly[3].latitude));
+        double minLng = Math.min(Math.min(poly[0].longitude, poly[1].longitude),
+                Math.min(poly[2].longitude, poly[3].longitude));
+        double maxLng = Math.max(Math.max(poly[0].longitude, poly[1].longitude),
+                Math.max(poly[2].longitude, poly[3].longitude));
+        assertThat(maxLat - minLat).isWithin(1e-4).of(1.0 / 24.0);
+        assertThat(maxLng - minLng).isWithin(1e-4).of(2.0 / 24.0);
     }
 
     @Test


### PR DESCRIPTION
## Root cause

`MaidenheadGrid.gridToLatLng` and `gridToPolygon` computed the third-pair
(subsquare) offset for 6-character grids with a divisor of **18**. Maidenhead
subsquares are the 24 letters `a`–`x`, so each square is divided into **24**
parts along each axis (2/24° of longitude, 1/24° of latitude per subsquare).

The divisor was inconsistent with:
- the **Maidenhead standard** (24 subsquare divisions), and
- this same file's own **encoder** `getGridSquare`, which already steps by
  `/0.083333` (= 2/24°) longitude and `/0.0416665` (= 1/24°) latitude.

## Effect

Any 6-character grid was mislocated. The `+0.5` subsquare-centre offset masks
the error for the low subsquare letter `a` (which is why the pre-existing
`FN42aa` test and all 2/4-char grids looked correct), but the error grows with
the subsquare index:

| Grid | True centre | Old `/18` result | New `/24` result |
|------|-------------|------------------|------------------|
| `IO91wm` (central London) | 51.52, −0.125 | **51.69, +0.50** (~45 km east, wrong side of the prime meridian) | 51.52, −0.125 ✓ |

This affected:
- **Map markers** and station placement (`GridOsmMapView`, `MapScreen`, `PskReporterClient`, car/QSO-sheet views).
- **Grid-square outlines** — `gridToPolygon` drew each 6-char cell `24/18 = 1.33×` too large (overlapping neighbours).
- **Distance** (same-/cross-grid) shown in the log, calling list and QSO sheet.

6-character grids reach these paths from real peer/log data: **ADIF-imported QSL
records** (`gridsquare` / `my_gridsquare`) and **PSKReporter reception reports**
(`PskReporterClient` explicitly documents handling 2/4/6-char grids).

## Fix

Introduce a `SUBSQUARES = 24` constant and use it for all six subsquare-offset
computations in `gridToLatLng` and `gridToPolygon`. The 2/4-char grid math and
the encoder are untouched, so no protocol/interop behaviour changes for the
common FT8 4-char grid.

## Testing

- `./gradlew :app:testDebugUnitTest` — full suite green (39/39 in `MaidenheadGridTest`).
- Added `gridToLatLng_sixChar_highSubsquareMatchesRealLocation` (IO91wm → 51.52, −0.125; **fails on the old `/18` divisor**).
- Added `gridToPolygon_sixChar_cellSpansOneSubsquare` (asserts a `1/24° × 2/24°` cell).
- Corrected the existing `FN42aa` subsquare test's expected centroid and comment to the `/24` values (it still passed under the old code only because `aa` sits within the 0.05° tolerance).

## Risk

Low. Localized to the 6-char subsquare offset in one file; 2/4-char grids,
the encoder, distance formula, and all clamps are unchanged. No native/DSP or
decoder-sensitivity impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)