### PR TITLE
Fix crash: Grid Tracker dereferences null overlay from addGridPolygon under heavy log volume

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridOsmMapView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridOsmMapView.java
@@ -303,6 +303,14 @@ public class GridOsmMapView {
         if (gridPolygon == null) {
             gridPolygon = addGridPolygon(grid, GridMode.QSX);
         }
+        if (gridPolygon == null) {
+            // addGridPolygon returns null when the overlay can't be built - the map
+            // is not ready yet, or the GridPolygon constructor threw and was swallowed
+            // by its own guard ("when log volume is too large, a crash can occur").
+            // This runs on the UI thread from a LiveData observer with no try/catch,
+            // so dereferencing the null here would crash the whole app; skip instead.
+            return null;
+        }
         gridPolygon.setSnippet(msg);
         gridPolygon.setSubDescription(subDetail);
         //gridPolygon.showInfoWindow();
@@ -323,6 +331,12 @@ public class GridOsmMapView {
             } else {
                 gridPolygon = addGridPolygon(recordStr.getGridsquare(), GridMode.QSO);
             }
+        }
+        if (gridPolygon == null) {
+            // Same guard as the message overload: addGridPolygon can return null
+            // (map not ready, or a swallowed GridPolygon-constructor crash). Bail
+            // out instead of dereferencing null on the UI thread.
+            return null;
         }
 
         gridPolygon.setSnippet(String.format(String.format("%s %s",

--- a/ft8af/app/src/test/java/com/k1af/ft8af/grid_tracker/GridOsmMapViewUpgradeGridInfoTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/grid_tracker/GridOsmMapViewUpgradeGridInfoTest.java
@@ -1,0 +1,51 @@
+package com.k1af.ft8af.grid_tracker;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.log.QSLRecordStr;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards {@link GridOsmMapView#upgradeGridInfo} against a NullPointerException on the
+ * UI thread when the underlying overlay cannot be built.
+ *
+ * <p>{@link GridOsmMapView#addGridPolygon} deliberately returns {@code null} when the
+ * map view is not ready, or when the {@code GridPolygon} constructor throws and is
+ * swallowed by its own guard ("when log volume is too large, a crash can occur").
+ * Both {@code upgradeGridInfo} overloads used to dereference that null immediately
+ * ({@code gridPolygon.setSnippet(...)}). They are invoked from {@code drawMessage} on
+ * the Activity main thread via a LiveData observer with no surrounding try/catch, so a
+ * null overlay turned the swallowed crash into a hard, whole-app crash — exactly the
+ * heavy-log condition the {@code addGridPolygon} catch was added to survive.
+ *
+ * <p>A {@code GridOsmMapView} built with a {@code null} map view makes {@code
+ * addGridPolygon} take its early {@code gridMapView == null} return, so this exercises
+ * the null-overlay path without instantiating osmdroid. Robolectric because the class
+ * pulls in Android/Play-Services types on its classpath.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GridOsmMapViewUpgradeGridInfoTest {
+
+    @Test
+    public void messageOverload_nullOverlay_doesNotThrow_returnsNull() {
+        // null map view -> addGridPolygon returns null -> must not deref it.
+        GridOsmMapView view = new GridOsmMapView(null, null, null);
+        assertThat(view.upgradeGridInfo("AA00", "message", "sub detail")).isNull();
+    }
+
+    @Test
+    public void recordOverload_nullOverlay_doesNotThrow_returnsNull() {
+        GridOsmMapView view = new GridOsmMapView(null, null, null);
+
+        QSLRecordStr record = new QSLRecordStr();
+        record.setGridsquare("AA00");
+        record.isQSL = true;
+        assertThat(view.upgradeGridInfo(record)).isNull();
+
+        record.isQSL = false;
+        assertThat(view.upgradeGridInfo(record)).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a hard, whole-app crash (uncaught `NullPointerException`) in the Grid Tracker map.

`GridOsmMapView.addGridPolygon()` intentionally returns `null` when an overlay can't be built:

- the `MapView` isn't ready (`gridMapView == null`),
- its tile repository is null (`gridMapView.getRepository() == null`), or
- the `GridPolygon` constructor throws and is swallowed by its own `try/catch`, whose comment states *"When log volume is too large, a crash can occur; catch the exception here to prevent it."*

Both `upgradeGridInfo(...)` overloads then dereferenced that `null` result immediately (`gridPolygon.setSnippet(...)` / `setSubDescription(...)`), defeating the very guard that was added to survive the heavy-log condition.

## Root cause

`upgradeGridInfo()` is invoked from `GridTrackerMainActivity.drawMessage()` on the Activity **main thread**, driven by a `LiveData` observer (`mutableFt8MessageList` → iterate each decoded `Ft8Message` → `drawMessage` → `upgradeGridInfo`). That observer body has **no surrounding try/catch**. So under the exact "log volume too large" scenario the `addGridPolygon` catch was written for, the swallowed overlay-build failure produced a `null`, and the caller's unconditional `gridPolygon.setSnippet(...)` turned it into an uncaught main-thread crash. The second overload (`upgradeGridInfo(QSLRecordStr)`, run via `gridMapView.post(...)` when redrawing historical QSOs) has the identical defect.

## Fix

Guard both overloads: after attempting `addGridPolygon(...)`, if the overlay is still `null`, return `null` instead of dereferencing it. This completes the defensive intent already present in `addGridPolygon`. The happy path (overlay built successfully) is byte-for-byte unchanged, and the return value is already ignored by both call sites, so skipping a single un-drawable overlay is safe and non-visible.

## Testing

- New `GridOsmMapViewUpgradeGridInfoTest` (Robolectric). A `GridOsmMapView` constructed with a `null` `MapView` forces `addGridPolygon`'s early `gridMapView == null` return, exercising the null-overlay path in both overloads without instantiating osmdroid. Each overload is asserted to return `null` without throwing.
  - Verified the test **fails before the fix** with the exact defect: `NullPointerException: Cannot invoke "...GridPolygon.setSnippet(String)" because "gridPolygon" is null`, and **passes after**.
- `./gradlew :app:testDebugUnitTest` — full unit-test suite green.
- `./gradlew :app:assembleDebug` — full Java + native (NDK/CMake) build succeeds.

## Risk assessment

Very low. Two localized null-guards on an error path; no protocol, DSP, or happy-path behavior changes. No performance impact. Backwards compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)