### PR TITLE
Fix native heap OOB in TX audio when audioRate isn't a multiple of the symbol rate

### DIFF
--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_encode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_encode_jni.cpp
@@ -144,8 +144,11 @@ Java_com_k1af_ft8af_ft8transmit_GenerateFT8_synth_1gfsk(
     // Mirrors the GetArrayLength(tones) >= FT8_NN guards above.
     jsize sig_len = env->GetArrayLength(signal);
     int out_len = synth_gfsk_output_len(count, symbol_period, signal_rate);
+    // int64_t (not long): `long` is 32-bit on 32-bit Android ABIs (armeabi-v7a/x86),
+    // so offset+out_len could overflow and wrap past this guard. jlong/int64 is 64-bit
+    // on every ABI, keeping the trust-boundary end-index check honest for hostile input.
     if (offset < 0 || out_len <= 0
-            || (long)offset + (long)out_len > (long)sig_len) {
+            || (int64_t)offset + (int64_t)out_len > (int64_t)sig_len) {
         return;
     }
 

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_encode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_encode_jni.cpp
@@ -19,6 +19,7 @@ extern "C" {
 void synth_gfsk_offset(const uint8_t* symbols, int n_sym, float f0,
                        float symbol_bt, float symbol_period,
                        int signal_rate, float* signal, int offset);
+int synth_gfsk_output_len(int n_sym, float symbol_period, int signal_rate);
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +132,22 @@ Java_com_k1af_ft8af_ft8transmit_GenerateFT8_synth_1gfsk(
     jsize sym_len = env->GetArrayLength(symbols);
     if (sym_len <= 0 || n_sym <= 0) return;
     int count = (n_sym < sym_len) ? n_sym : sym_len;
+
+    // Native trust boundary: synth_gfsk_offset writes exactly
+    // synth_gfsk_output_len(count, symbol_period, signal_rate) samples starting at
+    // `offset`. If the caller's output array is too small — e.g. a Java float[] sized
+    // as round(count*symbol_period*signal_rate) rather than count*round(...), which
+    // diverges whenever signal_rate*symbol_period is not integral — writing anyway is
+    // a heap out-of-bounds write (uncatchable native corruption). Refuse rather than
+    // corrupt memory; the well-formed Java caller (GenerateFT8.waveformSampleCount)
+    // sizes the buffer to exactly this length, so this never trips in normal use.
+    // Mirrors the GetArrayLength(tones) >= FT8_NN guards above.
+    jsize sig_len = env->GetArrayLength(signal);
+    int out_len = synth_gfsk_output_len(count, symbol_period, signal_rate);
+    if (offset < 0 || out_len <= 0
+            || (long)offset + (long)out_len > (long)sig_len) {
+        return;
+    }
 
     // Get the tone bytes (Java byte is signed; cast to uint8_t for the C API).
     jbyte* sym_j = env->GetByteArrayElements(symbols, nullptr);

--- a/ft8af/app/src/main/cpp/ft8af_glue/gfsk.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/gfsk.c
@@ -118,7 +118,13 @@ int synth_gfsk_output_len(int n_sym, float symbol_period, int signal_rate)
     int n_spsym = (int)(0.5f + signal_rate * symbol_period);
     if (n_spsym <= 0)
         return 0;
-    return n_sym * n_spsym;
+    // Compute in int64 so a corrupted, out-of-range signal_rate can't overflow the
+    // signed int multiply (UB, and it would hand a bogus length back to the JNI bounds
+    // check that trusts this). Return 0 on overflow rather than a wrapped value.
+    int64_t n_wave = (int64_t)n_sym * n_spsym;
+    if (n_wave > INT32_MAX)
+        return 0;
+    return (int)n_wave;
 }
 
 // Synthesise a GFSK waveform from a tone sequence, writing into

--- a/ft8af/app/src/main/cpp/ft8af_glue/gfsk.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/gfsk.c
@@ -102,6 +102,25 @@ float *synth_gfsk_dphi_alloc(const uint8_t *symbols, int n_sym, float f0,
     return dphi;
 }
 
+// Number of output samples synth_gfsk_offset writes for a tone sequence at the
+// given rate: n_sym * n_spsym, where n_spsym is rounded EXACTLY as
+// synth_gfsk_dphi_alloc above computes it ((int)(0.5f + signal_rate *
+// symbol_period)). Callers size / bounds-check the output buffer with this so a
+// buffer sized with a different rounding — e.g. a Java float[] sized as
+// round(n_sym * symbol_period * signal_rate) instead of n_sym * round(...),
+// which diverges whenever signal_rate*symbol_period is not integral — can never
+// drive an out-of-bounds write in synth_gfsk_offset. Returns 0 for degenerate
+// input (matching synth_gfsk_dphi_alloc, which then produces no samples).
+int synth_gfsk_output_len(int n_sym, float symbol_period, int signal_rate)
+{
+    if (n_sym <= 0 || signal_rate <= 0 || symbol_period <= 0)
+        return 0;
+    int n_spsym = (int)(0.5f + signal_rate * symbol_period);
+    if (n_spsym <= 0)
+        return 0;
+    return n_sym * n_spsym;
+}
+
 // Synthesise a GFSK waveform from a tone sequence, writing into
 // signal[offset .. offset + n_sym*n_spsym).
 //

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -318,6 +318,25 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_xslot)." }
 & $outXslot
 $xslotExit = $LASTEXITCODE
 
+# ---------------------------------------------------------------------------
+# GFSK output-length tests: the synth_gfsk_output_len helper (gfsk.c) that the
+# TX buffer sizing on both the Java side (GenerateFT8.waveformSampleCount) and
+# the native synth_gfsk JNI guard must agree on, plus a canary check that
+# synth_gfsk_offset writes exactly that many samples. Guards the heap OOB write a
+# non-integral audioRate (e.g. 44100) in FT4/FT2 used to trigger. No ft8_lib deps.
+# ---------------------------------------------------------------------------
+$gfskLenSrcs = @()
+$gfskLenSrcs += (Join-Path $here "gfsk.c")
+
+$srcGfskLen = Join-Path $here "test_gfsk_len.c"
+$outGfskLen = Join-Path $env:TEMP "ft8_gfsk_len_test.exe"
+
+& $Clang @common $srcGfskLen @gfskLenSrcs -o $outGfskLen
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_gfsk_len)." }
+
+& $outGfskLen
+$gfskLenExit = $LASTEXITCODE
+
 if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
 if ($fftWinExit -ne 0) { exit $fftWinExit }
@@ -331,4 +350,5 @@ if ($benchExit -ne 0) { exit $benchExit }
 if ($subExit -ne 0) { exit $subExit }
 if ($osdExit -ne 0) { exit $osdExit }
 if ($fineExit -ne 0) { exit $fineExit }
-exit $xslotExit
+if ($xslotExit -ne 0) { exit $xslotExit }
+exit $gfskLenExit

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -292,3 +292,18 @@ xslot_out="$tmp/ft8_xslot_test"
     -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
     -I "$ft8" "${xslot_srcs[@]}" -lm -o "$xslot_out"
 "$xslot_out"
+
+# GFSK output-length tests: the synth_gfsk_output_len helper (gfsk.c) that the
+# TX buffer sizing on both the Java side (GenerateFT8.waveformSampleCount) and
+# the native synth_gfsk JNI guard must agree on, plus a canary check that
+# synth_gfsk_offset writes exactly that many samples. Guards the heap OOB write a
+# non-integral audioRate (e.g. 44100) in FT4/FT2 used to trigger. No ft8_lib deps.
+gfsk_len_srcs=(
+    "$here/test_gfsk_len.c"
+    "$here/gfsk.c"
+)
+gfsk_len_out="$tmp/ft8_gfsk_len_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" "${gfsk_len_srcs[@]}" -lm -o "$gfsk_len_out"
+"$gfsk_len_out"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_gfsk_len.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_gfsk_len.c
@@ -1,0 +1,104 @@
+// Host test for the GFSK output-length helper and the no-overrun property of
+// synth_gfsk_offset (gfsk.c).
+//
+// The Java TX path (GenerateFT8) and the native synthesiser must agree on the
+// output sample count. Native writes synth_gfsk_output_len(n_sym, period, rate)
+// = n_sym * (int)(0.5f + rate*period) samples. If a caller sizes the buffer with
+// a different rounding — the old Java bug used round(n_sym*period*rate) — and
+// that total rounds down while the native per-symbol product rounds up, the
+// synthesiser writes past the end of the buffer (heap OOB). These tests pin the
+// helper's counts (including a non-integral rate where it diverges from the old
+// sizing) and verify synth_gfsk_offset writes EXACTLY output_len samples, leaving
+// a trailing canary region untouched.
+//
+// Built/run by run_host_tests.sh / run_host_tests.ps1. No ft8_lib deps.
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int synth_gfsk_output_len(int n_sym, float symbol_period, int signal_rate);
+void synth_gfsk_offset(const unsigned char *symbols, int n_sym, float f0,
+                       float symbol_bt, float symbol_period,
+                       int signal_rate, float *signal, int offset);
+
+static int failures = 0;
+
+static void check(int cond, const char *msg) {
+    if (cond) {
+        printf("  ok: %s\n", msg);
+    } else {
+        printf("  FAIL: %s\n", msg);
+        failures++;
+    }
+}
+
+// The previous (buggy) Java buffer sizing: round the total once.
+static int legacy_java_len(int n_sym, float period, int rate) {
+    return (int)(0.5f + n_sym * period * rate);
+}
+
+int main(void) {
+    printf("test_gfsk_len:\n");
+
+    // 1. Supported rates: helper matches n_sym * round(rate*period).
+    check(synth_gfsk_output_len(79, 0.160f, 12000) == 151680, "FT8@12000 -> 151680");
+    check(synth_gfsk_output_len(79, 0.160f, 48000) == 606720, "FT8@48000 -> 606720");
+    check(synth_gfsk_output_len(105, 0.048f, 12000) == 60480, "FT4@12000 -> 60480");
+    check(synth_gfsk_output_len(105, 0.024f, 48000) == 120960, "FT2@48000 -> 120960");
+
+    // 2. Degenerate input -> 0 (no synthesis), never negative.
+    check(synth_gfsk_output_len(0, 0.16f, 12000) == 0, "zero tones -> 0");
+    check(synth_gfsk_output_len(79, 0.16f, 0) == 0, "zero rate -> 0");
+    check(synth_gfsk_output_len(79, -1.0f, 12000) == 0, "negative period -> 0");
+    check(synth_gfsk_output_len(79, 0.0f, 12000) == 0, "zero period -> 0");
+
+    // 3. The divergence at a non-integral rate (44100 Hz FT4): native writes MORE
+    //    than the old Java sizing allocated — the source of the OOB write.
+    int native_len = synth_gfsk_output_len(105, 0.048f, 44100);
+    check(native_len == 222285, "FT4@44100 -> 222285 (105 * round(0.048*44100))");
+    check(native_len > legacy_java_len(105, 0.048f, 44100),
+          "FT4@44100 native len exceeds old Java alloc (OOB source)");
+
+    // 4. synth_gfsk_offset writes EXACTLY output_len samples: a canary past the
+    //    end stays intact. Run at the divergent rate that triggered the bug.
+    {
+        const int n_sym = 105, rate = 44100;
+        const float period = 0.048f;
+        int len = synth_gfsk_output_len(n_sym, period, rate);
+        const int canary = 32;
+        float *buf = (float *)malloc(sizeof(float) * (size_t)(len + canary));
+        if (!buf) {
+            printf("  FAIL: malloc\n");
+            return 1;
+        }
+        for (int i = 0; i < len + canary; ++i) buf[i] = -999.0f;
+
+        unsigned char syms[105];
+        for (int i = 0; i < n_sym; ++i) syms[i] = (unsigned char)(i % 4);
+
+        synth_gfsk_offset(syms, n_sym, 1000.0f, 1.0f, period, rate, buf, 0);
+
+        int canary_intact = 1;
+        for (int i = len; i < len + canary; ++i) {
+            if (buf[i] != -999.0f) { canary_intact = 0; break; }
+        }
+        check(canary_intact,
+              "synth_gfsk_offset writes exactly output_len samples (no overrun)");
+
+        // And it did write something into the buffer (not a no-op).
+        int wrote = 0;
+        for (int i = 0; i < len; ++i) {
+            if (buf[i] != -999.0f) { wrote = 1; break; }
+        }
+        check(wrote, "synth_gfsk_offset populated the output buffer");
+        free(buf);
+    }
+
+    if (failures) {
+        printf("test_gfsk_len: %d FAILURE(S)\n", failures);
+        return 1;
+    }
+    printf("test_gfsk_len: all passed\n");
+    return 0;
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
@@ -258,8 +258,9 @@ public class GenerateFT8 {
         // a91 is the 12-byte (91+7)/8 payload; the native encoder fills the tone array
         mode.encode(a91, tones);
 
-        // convert FSK tones to audio signal
-        int num_samples = (int) (0.5f + mode.numTones * mode.symbolPeriod * sample_rate); // FT8: 0.5+79*0.16*12000
+        // Size the output buffer to EXACTLY the number of samples the native GFSK
+        // synthesiser (synth_gfsk, gfsk.c) will write — see waveformSampleCount.
+        int num_samples = waveformSampleCount(mode.numTones, mode.symbolPeriod, sample_rate);
 
         float[] signal = new float[num_samples];
         for (int i = 0; i < num_samples; i++)// silence all data
@@ -270,6 +271,42 @@ public class GenerateFT8 {
         // generate audio from the symbol array
         synth_gfsk(tones, mode.numTones, frequency, mode.symbolBt, mode.symbolPeriod, sample_rate, signal, 0);
         return signal;
+    }
+
+    /**
+     * Number of audio samples the native GFSK synthesiser writes for {@code numTones}
+     * symbols at {@code sampleRate}: {@code numTones * samplesPerSymbol}, where
+     * {@code samplesPerSymbol} is rounded the <em>same</em> way the native code rounds it
+     * (see {@code synth_gfsk_dphi_alloc} in {@code gfsk.c}:
+     * {@code n_spsym = (int)(0.5f + signal_rate * symbol_period)}, then
+     * {@code n_wave = n_sym * n_spsym}).
+     *
+     * <p>The Java output buffer handed to {@code synth_gfsk} MUST be sized exactly this
+     * way. Sizing it as {@code round(numTones * symbolPeriod * sampleRate)} instead — the
+     * previous behaviour — rounds the total once rather than per-symbol, so the two counts
+     * diverge whenever {@code sampleRate * symbolPeriod} is not an integer. When the total
+     * rounds <em>down</em> while the native per-symbol product rounds up, the native writer
+     * runs past the end of the Java {@code float[]} — a heap out-of-bounds write on the TX
+     * thread (native memory corruption, uncatchable). This bites at any audio rate that is
+     * not a clean multiple of the symbol rate, e.g. a 44100 Hz {@code audioRate} restored
+     * from a settings backup while running FT4/FT2 (the UI only offers 12/24/48 kHz, where
+     * {@code sampleRate * symbolPeriod} is always integral and the two formulas agree
+     * bit-for-bit, so this is byte-identical for every supported configuration).
+     *
+     * <p>Package-visible and free of JNI/global state so the sizing is unit-testable.
+     *
+     * @param numTones     channel symbols in the mode (79 FT8, 105 FT4/FT2)
+     * @param symbolPeriod GFSK symbol period in seconds (0.160 FT8, 0.048 FT4, 0.024 FT2)
+     * @param sampleRate   output audio sample rate in Hz
+     * @return the exact sample count native {@code synth_gfsk} writes, or 0 for a
+     *         degenerate (non-positive) rate/period/tone count
+     */
+    static int waveformSampleCount(int numTones, float symbolPeriod, int sampleRate) {
+        int samplesPerSymbol = Math.round(symbolPeriod * sampleRate);
+        if (numTones <= 0 || samplesPerSymbol <= 0) {
+            return 0;
+        }
+        return numTones * samplesPerSymbol;
     }
 
     /** Encode an a91 payload into 79 FT8 tones (native ft8_encode). */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/GenerateFT8.java
@@ -299,14 +299,23 @@ public class GenerateFT8 {
      * @param symbolPeriod GFSK symbol period in seconds (0.160 FT8, 0.048 FT4, 0.024 FT2)
      * @param sampleRate   output audio sample rate in Hz
      * @return the exact sample count native {@code synth_gfsk} writes, or 0 for a
-     *         degenerate (non-positive) rate/period/tone count
+     *         degenerate (non-positive) rate/period/tone count, or a product that
+     *         overflows a 32-bit {@code int} (a corrupted/hand-edited backup rate)
      */
     static int waveformSampleCount(int numTones, float symbolPeriod, int sampleRate) {
         int samplesPerSymbol = Math.round(symbolPeriod * sampleRate);
         if (numTones <= 0 || samplesPerSymbol <= 0) {
             return 0;
         }
-        return numTones * samplesPerSymbol;
+        // Compute in long so a corrupted, out-of-range sampleRate (round-tripped
+        // verbatim through a settings backup) can't overflow the int multiply into a
+        // negative/too-small length — which would reintroduce the very OOB/NegativeArraySize
+        // failure this sizing guards against. Refuse (0) rather than hand back a bogus size.
+        long total = (long) numTones * samplesPerSymbol;
+        if (total > Integer.MAX_VALUE) {
+            return 0;
+        }
+        return (int) total;
     }
 
     /** Encode an a91 payload into 79 FT8 tones (native ft8_encode). */

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/GenerateFT8WaveformSizeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/GenerateFT8WaveformSizeTest.java
@@ -101,4 +101,18 @@ public class GenerateFT8WaveformSizeTest {
         assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, 0f, 12000)).isEqualTo(0);
         assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, -0.16f, 12000)).isEqualTo(0);
     }
+
+    /**
+     * A corrupted/hand-edited backup rate large enough that {@code numTones * samplesPerSymbol}
+     * overflows a 32-bit int must return 0, not a wrapped negative/too-small length (which
+     * would drive a {@code new float[negative]} NegativeArraySizeException or, worse, an
+     * under-sized buffer handed to native). At 20 MHz FT8, {@code round(0.160*20e6) = 3_200_000}
+     * per symbol, {@code * 79 ≈ 2.53e8} still fits; push the rate high enough to overflow.
+     */
+    @Test
+    public void overflowingRate_returnsZero_ratherThanWrappedLength() {
+        // samplesPerSymbol ≈ round(0.160 * 200_000_000) = 32_000_000; * 79 ≈ 2.53e9 > INT_MAX.
+        int result = GenerateFT8.waveformSampleCount(FT8_TONES, FT8_PERIOD, 200_000_000);
+        assertThat(result).isEqualTo(0);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/GenerateFT8WaveformSizeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/GenerateFT8WaveformSizeTest.java
@@ -1,0 +1,104 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link GenerateFT8#waveformSampleCount(int, float, int)} — the TX audio
+ * buffer sizing that MUST equal the number of samples the native GFSK synthesiser
+ * ({@code synth_gfsk}, gfsk.c) writes.
+ *
+ * <p>Native writes {@code numTones * n_spsym} with {@code n_spsym = (int)(0.5f +
+ * signal_rate * symbol_period)} (rounded per symbol). The old Java code sized the buffer
+ * as {@code (int)(0.5f + numTones * symbolPeriod * sampleRate)} (rounded once over the
+ * total). Those agree only when {@code sampleRate * symbolPeriod} is integral — true for
+ * every UI-selectable rate (12/24/48 kHz) but NOT for an arbitrary rate restored from a
+ * settings backup (e.g. 44100 Hz), where the total-rounded count can be smaller than what
+ * native writes → a heap out-of-bounds write on the TX thread.
+ *
+ * <p>Plain JUnit: {@code waveformSampleCount} is a pure static helper with no JNI/global
+ * state (GenerateFT8's static initialiser swallows the {@code loadLibrary} error, so the
+ * class loads on the bare JVM).
+ */
+public class GenerateFT8WaveformSizeTest {
+
+    // Mode parameters from ModeProfile (kept literal here so the test pins the exact
+    // sample counts rather than re-deriving them from the same source under test).
+    private static final int FT8_TONES = 79;
+    private static final float FT8_PERIOD = 0.160f;
+    private static final int FT4_TONES = 105;
+    private static final float FT4_PERIOD = 0.048f;
+    private static final int FT2_TONES = 105;
+    private static final float FT2_PERIOD = 0.024f;
+
+    /** The previous (total-rounded) sizing, reproduced to demonstrate the divergence. */
+    private static int legacySize(int numTones, float symbolPeriod, int sampleRate) {
+        return (int) (0.5f + numTones * symbolPeriod * sampleRate);
+    }
+
+    @Test
+    public void supportedRates_ft8_matchExpectedSampleCounts() {
+        assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, FT8_PERIOD, 12000)).isEqualTo(151680);
+        assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, FT8_PERIOD, 24000)).isEqualTo(303360);
+        assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, FT8_PERIOD, 48000)).isEqualTo(606720);
+    }
+
+    @Test
+    public void supportedRates_ft4_matchExpectedSampleCounts() {
+        assertThat(GenerateFT8.waveformSampleCount(FT4_TONES, FT4_PERIOD, 12000)).isEqualTo(60480);
+        assertThat(GenerateFT8.waveformSampleCount(FT4_TONES, FT4_PERIOD, 24000)).isEqualTo(120960);
+        assertThat(GenerateFT8.waveformSampleCount(FT4_TONES, FT4_PERIOD, 48000)).isEqualTo(241920);
+    }
+
+    @Test
+    public void supportedRates_ft2_matchExpectedSampleCounts() {
+        assertThat(GenerateFT8.waveformSampleCount(FT2_TONES, FT2_PERIOD, 12000)).isEqualTo(30240);
+        assertThat(GenerateFT8.waveformSampleCount(FT2_TONES, FT2_PERIOD, 48000)).isEqualTo(120960);
+    }
+
+    /**
+     * At every UI-selectable rate the new per-symbol sizing is byte-identical to the old
+     * total-rounded sizing, so this change cannot alter TX for any supported configuration.
+     */
+    @Test
+    public void supportedRates_areByteIdenticalToLegacySizing() {
+        int[] rates = {12000, 24000, 48000};
+        for (int r : rates) {
+            assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, FT8_PERIOD, r))
+                    .isEqualTo(legacySize(FT8_TONES, FT8_PERIOD, r));
+            assertThat(GenerateFT8.waveformSampleCount(FT4_TONES, FT4_PERIOD, r))
+                    .isEqualTo(legacySize(FT4_TONES, FT4_PERIOD, r));
+            assertThat(GenerateFT8.waveformSampleCount(FT2_TONES, FT2_PERIOD, r))
+                    .isEqualTo(legacySize(FT2_TONES, FT2_PERIOD, r));
+        }
+    }
+
+    /**
+     * The bug: at a non-integral rate (44100 Hz FT4, a plausible backup-restored audioRate)
+     * the native writer emits {@code 105 * round(0.048*44100) = 105 * 2117 = 222285}
+     * samples, but the old sizing allocated only 222264 — 21 samples short, so native ran
+     * past the end of the buffer. The new sizing returns exactly what native writes.
+     */
+    @Test
+    public void nonStandardRate_matchesNativeWriteCount_notLegacyUnderAllocation() {
+        int nativeWrites = FT4_TONES * Math.round(FT4_PERIOD * 44100); // 105 * 2117
+        assertThat(nativeWrites).isEqualTo(222285);
+
+        int fixed = GenerateFT8.waveformSampleCount(FT4_TONES, FT4_PERIOD, 44100);
+        assertThat(fixed).isEqualTo(nativeWrites);
+
+        // The old total-rounded sizing under-allocated, which is the OOB source.
+        assertThat(legacySize(FT4_TONES, FT4_PERIOD, 44100)).isLessThan(nativeWrites);
+        assertThat(fixed).isGreaterThan(legacySize(FT4_TONES, FT4_PERIOD, 44100));
+    }
+
+    @Test
+    public void degenerateInput_returnsZero_ratherThanNegativeOrThrowing() {
+        assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, FT8_PERIOD, 0)).isEqualTo(0);
+        assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, FT8_PERIOD, -12000)).isEqualTo(0);
+        assertThat(GenerateFT8.waveformSampleCount(0, FT8_PERIOD, 12000)).isEqualTo(0);
+        assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, 0f, 12000)).isEqualTo(0);
+        assertThat(GenerateFT8.waveformSampleCount(FT8_TONES, -0.16f, 12000)).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Summary

The Java TX audio path and the native GFSK synthesiser size the output buffer with **different rounding**, so a non-standard `audioRate` (restored from a settings backup) makes the native encoder write **past the end of the Java `float[]`** — a heap out-of-bounds write on the transmit thread (uncatchable native memory corruption).

## Root cause

- `GenerateFT8.generateFt8ByA91` sized the buffer as `round(numTones · symbolPeriod · sampleRate)` — the **total** rounded once.
- `synth_gfsk` (`gfsk.c`) writes `numTones · (int)(0.5f + sampleRate · symbolPeriod)` — the **samples-per-symbol** rounded, then multiplied.

These are equal **only when `sampleRate · symbolPeriod` is an integer**. That holds for every UI-selectable rate (12/24/48 kHz), so the two are **byte-identical for all supported configurations**.

But `audioRate` is round-tripped **verbatim** through `SettingsBackup` and hydrated with `parseConfigInt` (no value validation — the same unvalidated-config-import vector hardened in #513/#517). A backup imported from another device/version, or hand-edited, can carry e.g. **44100 Hz**. At 44100 in FT4:

| | samples |
|---|---|
| native writes (`105 · round(0.048·44100)`) | **222285** |
| Java allocated (`round(105·0.048·44100)`) | 222264 |

→ `synth_gfsk` writes **21 floats (84 bytes) past the end of the buffer**. FT8 (e.g. 11035 Hz, +32) and FT2 (+17) are affected identically.

## Fix (same root cause, two layers)

1. **Java (root cause):** size the buffer with a new `waveformSampleCount()` that rounds **per symbol**, exactly like the native code — so the buffer always matches the native write count for any rate. Byte-identical at 12/24/48 kHz; also returns `0` (empty buffer, no synthesis) for a degenerate/negative rate that the old code turned into an OOB or a `NegativeArraySizeException`.
2. **Native (defence in depth):** add a bounds guard at the `synth_gfsk` JNI trust boundary (`synth_gfsk_output_len`) so a too-small output array can never drive an out-of-bounds write regardless of caller (also protects the desktop FFI). Mirrors the existing `GetArrayLength(tones) >= FT8_NN` guards in the same file.

## Risk assessment

Low. The waveform length and content are **unchanged for every UI-selectable rate** (proven byte-identical in the tests), so no supported TX configuration changes. The only behavioural change is at non-integral rates, which previously corrupted memory and now either produce a correctly-sized (complete) waveform or, for a degenerate rate, a silent buffer. No DSP/protocol change.

## Testing performed

- **`GenerateFT8WaveformSizeTest`** (pure JVM): pins sample counts for FT8/FT4/FT2 at 12/24/48 kHz, proves byte-identity with the legacy sizing at those rates, shows 44100 Hz FT4 now matches the native write count instead of under-allocating, and covers degenerate input.
- **`test_gfsk_len.c`** (host C, wired into `run_host_tests.sh`/`.ps1`): pins `synth_gfsk_output_len` and verifies via a trailing canary that `synth_gfsk_offset` writes **exactly** that many samples with no overrun.
- Verified locally: `:app:testDebugUnitTest`, `:app:externalNativeBuildDebug` (all 4 ABIs), `:app:assembleDebug`, and the full native host test suite (`run_host_tests.sh`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)