### PR TITLE
Fix ADIF FREQ import corrupting UHF/microwave frequencies via float precision

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
@@ -142,8 +142,10 @@ public class QSLRecord {
         }
 
         if (map.containsKey("FREQ")) {//Carrier frequency
-            try {//Convert float to Long
-                float freq = Float.parseFloat(Objects.requireNonNull(map.get("FREQ")));
+            try {//Convert MHz to Hz. Parse as double: a 32-bit float only holds
+                //~7 significant digits, so UHF/microwave dials (e.g. 432.174 or
+                //1296.174 MHz) would drift by tens of Hz once scaled to Hz.
+                double freq = Double.parseDouble(Objects.requireNonNull(map.get("FREQ")));
                 bandFreq = Math.round(freq * 1000000);
             } catch (NumberFormatException e) {
                 isInvalid=true;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/QSLRecordTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/QSLRecordTest.java
@@ -141,6 +141,51 @@ public class QSLRecordTest {
     }
 
     @Test
+    public void mapConstructor_uhfFreq_preservesExactHz() {
+        // 432.174 MHz (70cm). A 24-bit float mantissa cannot hold this many
+        // significant Hz exactly, so the old float-based parse stored 432174016
+        // (+16 Hz). Import must round-trip the exact dial frequency.
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put("FREQ", "432.174000");
+
+        QSLRecord r = new QSLRecord(map);
+
+        assertThat(r.isInvalid).isFalse();
+        assertThat(r.getBandFreq()).isEqualTo(432_174_000L);
+    }
+
+    @Test
+    public void mapConstructor_microwaveFreq_preservesExactHz() {
+        // 1296.174 MHz (23cm). Float precision drifts even further here
+        // (old value 1296173952, -48 Hz).
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put("FREQ", "1296.174000");
+
+        QSLRecord r = new QSLRecord(map);
+
+        assertThat(r.isInvalid).isFalse();
+        assertThat(r.getBandFreq()).isEqualTo(1_296_174_000L);
+    }
+
+    @Test
+    public void mapConstructor_hfFreq_unchanged() {
+        // HF stays within float's exact-integer range; behaviour is preserved.
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put("FREQ", "14.074000");
+
+        QSLRecord r = new QSLRecord(map);
+
+        assertThat(r.isInvalid).isFalse();
+        assertThat(r.getBandFreq()).isEqualTo(14_074_000L);
+    }
+
+    @Test
     public void toStringAndHtml_includeTypeHeader() {
         QSLRecord r = new QSLRecord(EPOCH, PLUS_15S, "K1ABC", "", "W1AW", "",
                 -5, -10, "FT8", 14_074_000L, 1500);


### PR DESCRIPTION
## Root cause

`QSLRecord`'s `HashMap` (ADIF import) constructor parsed the `FREQ` field with `Float.parseFloat` and scaled MHz→Hz:

```java
float freq = Float.parseFloat(Objects.requireNonNull(map.get("FREQ")));
bandFreq = Math.round(freq * 1000000);
```

A 32-bit `float` mantissa (24 bits) holds only ~7 significant decimal digits. Once a UHF/microwave dial frequency is scaled to Hz, the value exceeds float's exact-integer range and drifts. Verified (float32 semantics):

| ADIF `FREQ` | old (float) | correct | error |
|---|---|---|---|
| `432.174000` (70cm) | 432174016 | 432174000 | **+16 Hz** |
| `1296.174000` (23cm) | 1296173952 | 1296174000 | **−48 Hz** |
| `14.074000` (20m) | 14074000 | 14074000 | 0 |

HF (≤30 MHz) stays within float's exact-integer range, which is why the defect was invisible on the common bands.

## Impact

Imported QSL records are persisted to the DB and re-exported by the ADIF log/share paths (`AdifLogFile`/`ShareLogs`), so a corrupted `FREQ` propagates into re-exported logs — a data-fidelity bug for VHF+/UHF/microwave operators importing peer or file `.adi` records.

## Fix

Parse with `Double.parseDouble`. `double` comfortably represents these Hz values exactly. As a bonus, `Math.round(double)` returns `long` (matching the `long bandFreq` field), removing a latent `int` overflow above ~2.147 GHz that the old `Math.round(float)→int` path had. Behaviour is byte-identical for HF/VHF where float was already exact.

## Testing

- `./gradlew :app:testDebugUnitTest` — full suite green.
- Added `QSLRecordTest` cases: `mapConstructor_uhfFreq_preservesExactHz` (432.174 → 432174000), `mapConstructor_microwaveFreq_preservesExactHz` (1296.174 → 1296174000), and `mapConstructor_hfFreq_unchanged` (14.074 → 14074000). The two VHF+ tests fail on the pre-fix `float` code and pass after.

## Risk

Minimal, localized one-line parse change. No protocol/DSP behavior touched; HF import output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)