### PR TITLE
Fix waterfall UTC gridline hard-coding a 15s cycle (wrong boundaries in FT4/FT2)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallTimestampGate.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallTimestampGate.java
@@ -24,6 +24,8 @@ public final class WaterfallTimestampGate {
     private static final long DEFAULT_SLOT_MILLIS = 15_000L;
 
     private long lastPeriod = -1;
+    /** Slot length the {@link #lastPeriod} above was computed under; -1 = none yet. */
+    private long lastSlotMillis = -1;
 
     /**
      * The slot index {@code utcMs} falls in for a mode of slot length {@code slotMillis}. A
@@ -39,9 +41,25 @@ public final class WaterfallTimestampGate {
      * Whether the gridline should be drawn now: true the first frame {@code utcMs} crosses
      * into a new slot for a mode of slot length {@code slotMillis}, false while it stays
      * within the same slot (so the line and label are stamped exactly once per slot).
+     *
+     * <p>The slot <em>index</em> is only comparable within one mode — period 1 spans 7.5–15s
+     * in FT4 but 15–30s in FT8. So when {@code slotMillis} changes mid-stream (the operator
+     * switched modes), the previous index can't be compared to the new one; doing so would
+     * emit a spurious gridline in the middle of a slot (e.g. FT4→FT8 at t=8s, where the next
+     * true FT8 boundary is 15s). On a mode change we re-baseline to the new mode's grid
+     * silently, drawing only if {@code utcMs} happens to land exactly on a new-mode boundary,
+     * so the next line falls on the next true boundary of the mode now in effect.
      */
     public boolean shouldDraw(long utcMs, long slotMillis) {
-        long period = slotPeriod(utcMs, slotMillis);
+        long slot = slotMillis > 0 ? slotMillis : DEFAULT_SLOT_MILLIS;
+        long period = utcMs / slot;
+        if (lastSlotMillis > 0 && slot != lastSlotMillis) {
+            // Mode change: adopt the new grid without comparing across incompatible indices.
+            lastSlotMillis = slot;
+            lastPeriod = period;
+            return utcMs % slot == 0;
+        }
+        lastSlotMillis = slot;
         if (period == lastPeriod) {
             return false;
         }
@@ -49,8 +67,9 @@ public final class WaterfallTimestampGate {
         return true;
     }
 
-    /** Forget the last drawn slot (e.g. when the bitmap is recreated). */
+    /** Forget the last drawn slot and mode (e.g. when the bitmap is recreated). */
     public void reset() {
         lastPeriod = -1;
+        lastSlotMillis = -1;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallTimestampGate.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallTimestampGate.java
@@ -1,0 +1,56 @@
+package com.k1af.ft8af.ui;
+
+/**
+ * Gates the waterfall's UTC-timestamp gridline (the horizontal boundary line plus the time
+ * label) to one draw per transmit/decode slot, keyed on the <em>current</em> mode's slot
+ * length rather than a fixed 15 seconds.
+ *
+ * <p>FT8 runs a 15s slot, FT4 7.5s, FT2 3.75s (see {@code ModeProfile#slotMillis}). The line
+ * marks where one cycle ends and the next begins on the scrolling waterfall so an operator
+ * can line signals up against the slot grid. Drawing it every 15s in a faster mode misses
+ * every intermediate boundary — FT4 marks only every other slot, FT2 only every fourth —
+ * exactly the kind of hard-coded-15s assumption {@code ModeProfile} exists to remove.
+ *
+ * <p>For a 15000ms slot {@link #slotPeriod(long, long)} reproduces the previous
+ * {@code (utcMs / 1000) / 15} exactly (floor identity {@code floor(floor(x/1000)/15) ==
+ * floor(x/15000)}), so FT8 rendering is unchanged; faster modes simply get their finer grid.
+ *
+ * <p>Makes no Android framework calls, so the once-per-slot rule is unit-tested directly (see
+ * {@code WaterfallTimestampGateTest}); {@link WaterfallView} keeps only a thin call into it.
+ */
+public final class WaterfallTimestampGate {
+
+    /** Fallback slot length (FT8, ms) used if the caller has no valid mode slot. */
+    private static final long DEFAULT_SLOT_MILLIS = 15_000L;
+
+    private long lastPeriod = -1;
+
+    /**
+     * The slot index {@code utcMs} falls in for a mode of slot length {@code slotMillis}. A
+     * non-positive {@code slotMillis} falls back to the 15s FT8 grid so a mid-init caller can
+     * never divide by zero.
+     */
+    public static long slotPeriod(long utcMs, long slotMillis) {
+        long slot = slotMillis > 0 ? slotMillis : DEFAULT_SLOT_MILLIS;
+        return utcMs / slot;
+    }
+
+    /**
+     * Whether the gridline should be drawn now: true the first frame {@code utcMs} crosses
+     * into a new slot for a mode of slot length {@code slotMillis}, false while it stays
+     * within the same slot (so the line and label are stamped exactly once per slot).
+     */
+    public boolean shouldDraw(long utcMs, long slotMillis) {
+        long period = slotPeriod(utcMs, slotMillis);
+        if (period == lastPeriod) {
+            return false;
+        }
+        lastPeriod = period;
+        return true;
+    }
+
+    /** Forget the last drawn slot (e.g. when the bitmap is recreated). */
+    public void reset() {
+        lastPeriod = -1;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
@@ -128,8 +128,10 @@ public class WaterfallView extends View {
         Log.d(TAG, String.format("Bitmap created: %dx%d, blockHeight=%d, freq_width=%.2f, spectrumWidth=%d",
                 w, h, blockHeight, freq_width, spectrumWidth));
         lastBitMap = Bitmap.createBitmap(w, h, ARGB_8888);
-        // Fresh bitmap wiped the stamped labels, so allow the current cycle to re-stamp.
+        // Fresh bitmap wiped the stamped labels and the UTC gridline, so allow the current
+        // slot to re-stamp both instead of waiting for the next slot boundary.
         messageGate.reset();
+        timestampGate.reset();
         _canvas = new Canvas(lastBitMap);
         Paint blackPaint = new Paint();
         blackPaint.setColor(0xFF000000);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
@@ -73,8 +73,9 @@ public class WaterfallView extends View {
     private boolean txActive = false;
     private final Paint txMarkerPaint = new Paint();
 
-    // FT8 period timestamp tracking
-    private long lastTimestampPeriod = -1;
+    // Draws the UTC timestamp line once per slot boundary of the current mode (15s FT8,
+    // 7.5s FT4, 3.75s FT2), not a fixed 15s that would skip the faster modes' boundaries.
+    private final WaterfallTimestampGate timestampGate = new WaterfallTimestampGate();
     // Gates the decoded-label stamp to once per decode slot (the current mode's slot
     // length, not a fixed 15s), so a slot's labels are painted exactly once even though the
     // decode-done flag re-arms on every decode pass.
@@ -302,11 +303,13 @@ public class WaterfallView extends View {
         bitmap.recycle();
         _canvas.drawRect(0, 0, drawWidth, blockHeight, linearPaint);
 
-        // Draw FT8 period timestamp at 15-second boundaries
+        // Draw the UTC timestamp line at each slot boundary of the CURRENT mode (15s FT8,
+        // 7.5s FT4, 3.75s FT2). Using the mode's slotMillis instead of a hard-coded 15s keeps
+        // FT8 byte-identical (floor(utcMs/15000) == the old (utcMs/1000)/15) while marking the
+        // intermediate boundaries the faster modes would otherwise skip.
         long utcMs = UtcTimer.getSystemTime();
-        long period = (utcMs / 1000) / 15;
-        if (period != lastTimestampPeriod) {
-            lastTimestampPeriod = period;
+        long slotMillis = GeneralVariables.currentMode().slotMillis;
+        if (timestampGate.shouldDraw(utcMs, slotMillis)) {
             // Draw horizontal line at the boundary between new row and scrolled content
             _canvas.drawLine(0, blockHeight, drawWidth, blockHeight, timestampLinePaint);
             // Format UTC time label
@@ -321,8 +324,9 @@ public class WaterfallView extends View {
             // Draw outline then fill for readability over any spectrum color
             _canvas.drawText(timeLabel, textX, textY, utcPainBack);
             _canvas.drawText(timeLabel, textX, textY, utcPaint);
-            Log.d(TAG, String.format("Timestamp drawn: %s (period=%d, utcMs=%d, blockHeight=%d, textY=%.1f, drawWidth=%d)",
-                    timeLabel, period, utcMs, blockHeight, textY, drawWidth));
+            long period = WaterfallTimestampGate.slotPeriod(utcMs, slotMillis);
+            Log.d(TAG, String.format("Timestamp drawn: %s (period=%d, utcMs=%d, slotMillis=%d, blockHeight=%d, textY=%.1f, drawWidth=%d)",
+                    timeLabel, period, utcMs, slotMillis, blockHeight, textY, drawWidth));
         }
 
         //Messages have 3 types: normal, CQ, and involving me
@@ -339,8 +343,8 @@ public class WaterfallView extends View {
             // in a fresh slot index and restamp every label a few scrolled rows lower,
             // doubling/garbling all of them. slotMillis stays part of the key so a mode
             // change (FT8/FT4/FT2 divide utc differently) can't collide with a slot already
-            // stamped under the previous mode.
-            long slotMillis = GeneralVariables.currentMode().slotMillis;
+            // stamped under the previous mode. (slotMillis is read once at the top of this
+            // method for the timestamp gridline and reused here.)
             if (messageGate.shouldStamp(slotMillis, messages)) {
                 Log.d(TAG, String.format("Drawing %d messages on waterfall", messages.size()));
                 for (Ft8Message msg : messages) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallTimestampGateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallTimestampGateTest.java
@@ -77,4 +77,27 @@ public class WaterfallTimestampGateTest {
         gate.reset();
         assertThat(gate.shouldDraw(15_000, 15_000)).isTrue();   // after a bitmap recreate
     }
+
+    @Test
+    public void modeSwitchMidSlotDoesNotDrawASpuriousGridline() {
+        // FT4→FT8 at t=8000: FT4 last drew slot index 1 (7.5s boundary); switching to FT8
+        // re-bases to the 15s grid. t=8000 is mid-FT8-slot-0, so no line — the next true FT8
+        // boundary is 15000, where it must draw. The old code compared 0 (FT8) against the
+        // stale 1 (FT4) and drew mid-slot.
+        WaterfallTimestampGate gate = new WaterfallTimestampGate();
+        assertThat(gate.shouldDraw(0, 7_500)).isTrue();         // FT4 slot 0
+        assertThat(gate.shouldDraw(7_500, 7_500)).isTrue();     // FT4 slot 1
+        assertThat(gate.shouldDraw(8_000, 15_000)).isFalse();   // switched to FT8, mid-slot
+        assertThat(gate.shouldDraw(15_000, 15_000)).isTrue();   // first true FT8 boundary
+    }
+
+    @Test
+    public void modeSwitchLandingExactlyOnANewModeBoundaryStillDraws() {
+        // FT8→FT4 exactly at 15000: 15000 is a boundary in both modes, so the switch should
+        // still stamp the line rather than swallow a real boundary.
+        WaterfallTimestampGate gate = new WaterfallTimestampGate();
+        assertThat(gate.shouldDraw(0, 15_000)).isTrue();        // FT8 slot 0
+        assertThat(gate.shouldDraw(15_000, 7_500)).isTrue();    // switched to FT4, on a boundary
+        assertThat(gate.shouldDraw(15_000, 7_500)).isFalse();   // same FT4 slot, no repeat
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallTimestampGateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallTimestampGateTest.java
@@ -1,0 +1,80 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link WaterfallTimestampGate}: the waterfall's UTC gridline is drawn once
+ * per transmit/decode slot of the <em>current</em> mode (15s FT8, 7.5s FT4, 3.75s FT2), not
+ * on a hard-coded 15s grid. Pure JUnit, no Android.
+ */
+public class WaterfallTimestampGateTest {
+
+    /** The exact expression WaterfallView used before the fix (a fixed 15s grid). */
+    private static long legacyFt8Period(long utcMs) {
+        return (utcMs / 1000) / 15;
+    }
+
+    @Test
+    public void ft8SlotReproducesTheLegacyFifteenSecondGrid() {
+        // floor(floor(x/1000)/15) == floor(x/15000): a 15000ms slot must be byte-identical to
+        // the old (utcMs/1000)/15, so FT8 rendering is unchanged by the fix.
+        long[] samples = {0, 1, 999, 1000, 14_999, 15_000, 15_001, 22_500, 1_700_000_123_456L};
+        for (long utcMs : samples) {
+            assertThat(WaterfallTimestampGate.slotPeriod(utcMs, 15_000))
+                    .isEqualTo(legacyFt8Period(utcMs));
+        }
+    }
+
+    @Test
+    public void ft4SlotAdvancesEveryHalfCycleAndSplitsAnFt8Slot() {
+        // Two 7.5s FT4 boundaries fall inside one 15s FT8 slot, so the FT4 gridline must
+        // advance where the fixed-15s code would have skipped it.
+        assertThat(WaterfallTimestampGate.slotPeriod(0, 7_500)).isEqualTo(0);
+        assertThat(WaterfallTimestampGate.slotPeriod(7_499, 7_500)).isEqualTo(0);
+        assertThat(WaterfallTimestampGate.slotPeriod(7_500, 7_500)).isEqualTo(1);
+        assertThat(WaterfallTimestampGate.slotPeriod(15_000, 7_500)).isEqualTo(2);
+    }
+
+    @Test
+    public void ft2SlotAdvancesEveryQuarterCycle() {
+        assertThat(WaterfallTimestampGate.slotPeriod(3_750, 3_750)).isEqualTo(1);
+        assertThat(WaterfallTimestampGate.slotPeriod(15_000, 3_750)).isEqualTo(4);
+    }
+
+    @Test
+    public void nonPositiveSlotMillisFallsBackToFifteenSeconds() {
+        assertThat(WaterfallTimestampGate.slotPeriod(22_500, 0))
+                .isEqualTo(legacyFt8Period(22_500));
+        assertThat(WaterfallTimestampGate.slotPeriod(22_500, -1))
+                .isEqualTo(legacyFt8Period(22_500));
+    }
+
+    @Test
+    public void drawsOnceWhenEnteringANewSlotAndSuppressesRepeatsWithinIt() {
+        WaterfallTimestampGate gate = new WaterfallTimestampGate();
+        assertThat(gate.shouldDraw(15_000, 15_000)).isTrue();   // first frame of the slot
+        assertThat(gate.shouldDraw(15_123, 15_000)).isFalse();  // still same slot
+        assertThat(gate.shouldDraw(29_999, 15_000)).isFalse();  // last frame of the slot
+        assertThat(gate.shouldDraw(30_000, 15_000)).isTrue();   // next slot boundary
+    }
+
+    @Test
+    public void ft4DrawsAtTheHalfCycleBoundaryThatFixedFifteenSecondsWouldMiss() {
+        // The regression under test: in FT4 the intermediate 7.5s boundary must draw a line.
+        WaterfallTimestampGate gate = new WaterfallTimestampGate();
+        assertThat(gate.shouldDraw(0, 7_500)).isTrue();
+        assertThat(gate.shouldDraw(7_500, 7_500)).isTrue();     // fixed-15s code would skip this
+        assertThat(gate.shouldDraw(15_000, 7_500)).isTrue();
+    }
+
+    @Test
+    public void resetAllowsTheSameSlotToDrawAgain() {
+        WaterfallTimestampGate gate = new WaterfallTimestampGate();
+        assertThat(gate.shouldDraw(15_000, 15_000)).isTrue();
+        assertThat(gate.shouldDraw(15_000, 15_000)).isFalse();
+        gate.reset();
+        assertThat(gate.shouldDraw(15_000, 15_000)).isTrue();   // after a bitmap recreate
+    }
+}


### PR DESCRIPTION
## Summary

The waterfall draws a horizontal UTC-timestamp gridline (a boundary line + a `HH:MM:SS` label) once per transmit/decode cycle so an operator can line signals up against the slot grid. `WaterfallView.setWaveData` computed the boundary as:

```java
long period = (utcMs / 1000) / 15;   // fixed 15-second FT8 slot
```

i.e. a hard-coded 15-second FT8 slot, regardless of the operating mode. `ModeProfile` explicitly exists to remove these assumptions and warns against hard-coding 15s/79-tone FT8. This is the same class of bug already fixed for the decoded-**label** stamp (`WaterfallLabelGate` correctly keys on `slotMillis`); the **timestamp gridline** in the same method was overlooked.

## Root cause

The slot length is mode-dependent (`ModeProfile.slotMillis`): **15000 ms FT8, 7500 ms FT4, 3750 ms FT2**. Dividing by a fixed 15 s means:

- **FT4** (7.5 s slots) — the gridline is drawn on only **every other** cycle boundary.
- **FT2** (3.75 s slots) — only **every fourth** boundary.

So in the faster modes the on-screen slot grid no longer lines up with the actual TX/RX cycles, degrading the waterfall's usefulness for timing alignment.

## Fix

Extract the once-per-slot decision into a small, plain (no Android) `WaterfallTimestampGate`, mirroring the existing `WaterfallLabelGate` pattern, and key it on the current mode's slot length:

```java
long slotMillis = GeneralVariables.currentMode().slotMillis;
if (timestampGate.shouldDraw(utcMs, slotMillis)) { ... }
```

`slotPeriod(utcMs, slotMillis)` returns `floor(utcMs / slotMillis)`. For a 15000 ms slot this is **byte-identical** to the old `(utcMs / 1000) / 15` by the floor identity `floor(floor(x/1000)/15) == floor(x/15000)`, so **FT8 rendering is unchanged**; FT4/FT2 simply get their correct finer grid. A non-positive `slotMillis` falls back to the 15 s grid so a mid-init caller can never divide by zero.

`slotMillis` is now read once at the top of the method and reused by both the timestamp gridline and the existing message-label gate (previously it was read a second time).

## Testing

- **New** `WaterfallTimestampGateTest` (pure JUnit, no Android): asserts the FT8 identity against the legacy expression across boundary samples, the FT4 half-cycle / FT2 quarter-cycle boundaries the fixed-15s code skipped, the `<=0` slot fallback, and the once-per-slot gating (draw on entry, suppress within, draw again on the next boundary and after `reset()`).
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — APK builds.

## Risk

Low. Pure UI-timing/rendering change with no DSP, encoder, decoder, or protocol impact. FT8 (the dominant mode) is provably byte-identical; only FT4/FT2 gridline cadence changes, and in the correct direction. No native code touched.

## Notes / follow-up

The same hard-coded-15s pattern still exists in the Grid Tracker cycle-progress bar (`GridTrackerMainActivity` `setProgress((int)((aLong/1000) % 15))`, layout `max="14"`). That one can't stay integer-seconds for a 7.5 s slot and needs a small `max`/millis redesign, so it's intentionally left for a separate focused PR rather than mixed into this rendering fix. (The identical line in `MainActivity` is dead — that activity isn't in `AndroidManifest.xml`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)