### PR TITLE
Fix ADIF upload using UTF-16 char length instead of UTF-8 byte length

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -1,5 +1,6 @@
 package com.k1af.ft8af.log;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 /**
@@ -74,5 +75,22 @@ public final class AdifFormat {
             return String.valueOf(report);
         }
         return String.format(Locale.US, "%+03d", report);
+    }
+
+    /**
+     * The number of UTF-8 <em>bytes</em> in {@code value} — the length an ADIF
+     * {@code <field:len>value } declaration must carry, not the UTF-16
+     * {@link String#length()} (char count). The two differ for any non-ASCII content
+     * (an accented comment, a POTA park name): declaring the shorter char count makes
+     * the receiving parser read fewer bytes than were written, truncating the field
+     * and mis-aligning everything after it, so LoTW/QRZ/Cloudlog reject or mangle the
+     * record. Shared source of truth for every ADIF writer ({@link AdifRecord} and the
+     * {@link ThirdPartyService} upload paths). Null counts as 0.
+     */
+    public static int utf8Length(String value) {
+        if (value == null) {
+            return 0;
+        }
+        return value.getBytes(StandardCharsets.UTF_8).length;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -91,6 +91,16 @@ public final class AdifFormat {
         if (value == null) {
             return 0;
         }
-        return value.getBytes(StandardCharsets.UTF_8).length;
+        // Fast path: pure-ASCII values (callsigns, grids, most English comments — the
+        // overwhelmingly common case, especially in the syncAllQSOs batch loop) have exactly
+        // one UTF-8 byte per char, so the byte count equals String.length() with no
+        // allocation. Only non-ASCII content falls through to encode the array.
+        final int len = value.length();
+        for (int i = 0; i < len; i++) {
+            if (value.charAt(i) >= 0x80) {
+                return value.getBytes(StandardCharsets.UTF_8).length;
+            }
+        }
+        return len;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifRecord.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifRecord.java
@@ -169,6 +169,6 @@ public final class AdifRecord {
     }
 
     private static int utf8Length(String value) {
-        return value.getBytes(StandardCharsets.UTF_8).length;
+        return AdifFormat.utf8Length(value);
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -229,7 +229,7 @@ public class ThirdPartyService {
 
         if (qslRecord.getToMaidenGrid() != null) {
             logStr.append(String.format("<gridsquare:%d>%s "
-                    , qslRecord.getToMaidenGrid().length()
+                    , AdifFormat.utf8Length(qslRecord.getToMaidenGrid())
                     , qslRecord.getToMaidenGrid()));
         }
 
@@ -239,46 +239,46 @@ public class ThirdPartyService {
             String submode = AdifFormat.mfskSubmode(qslRecord.getMode());
             if (submode != null) {
                 logStr.append(String.format("<mode:4>MFSK <submode:%d>%s "
-                        , submode.length(), submode));
+                        , AdifFormat.utf8Length(submode), submode));
             } else {
                 logStr.append(String.format("<mode:%d>%s "
-                        , qslRecord.getMode().length()
+                        , AdifFormat.utf8Length(qslRecord.getMode())
                         , qslRecord.getMode()));
             }
         }
 
         String rstSent = AdifFormat.formatReport(qslRecord.getSendReport());
-        logStr.append(String.format("<rst_sent:%d>%s ", rstSent.length(), rstSent));
+        logStr.append(String.format("<rst_sent:%d>%s ", AdifFormat.utf8Length(rstSent), rstSent));
 
         String rstRcvd = AdifFormat.formatReport(qslRecord.getReceivedReport());
-        logStr.append(String.format("<rst_rcvd:%d>%s ", rstRcvd.length(), rstRcvd));
+        logStr.append(String.format("<rst_rcvd:%d>%s ", AdifFormat.utf8Length(rstRcvd), rstRcvd));
 
         if (qslRecord.getQso_date() != null) {
             logStr.append(String.format("<qso_date:%d>%s "
-                    , qslRecord.getQso_date().length()
+                    , AdifFormat.utf8Length(qslRecord.getQso_date())
                     , qslRecord.getQso_date()));
         }
 
         if (qslRecord.getTime_on() != null) {
             logStr.append(String.format("<time_on:%d>%s "
-                    , qslRecord.getTime_on().length()
+                    , AdifFormat.utf8Length(qslRecord.getTime_on())
                     , qslRecord.getTime_on()));
         }
         if (qslRecord.getBandLength() != null) {
             logStr.append(String.format("<band:%d>%s "
-                    , qslRecord.getBandLength().length()
+                    , AdifFormat.utf8Length(qslRecord.getBandLength())
                     , qslRecord.getBandLength()));
         }
 
         if (qslRecord.getQso_date_off() != null) {
             logStr.append(String.format("<qso_date_off:%d>%s "
-                    , qslRecord.getQso_date_off().length()
+                    , AdifFormat.utf8Length(qslRecord.getQso_date_off())
                     , qslRecord.getQso_date_off()));
         }
 
         if (qslRecord.getTime_off() != null) {
             logStr.append(String.format("<time_off:%d>%s "
-                    , qslRecord.getTime_off().length()
+                    , AdifFormat.utf8Length(qslRecord.getTime_off())
                     , qslRecord.getTime_off()));
         }
 
@@ -291,19 +291,19 @@ public class ThirdPartyService {
             }
 
             logStr.append(String.format("<freq:%d>%s "
-                    , freq.length()
+                    , AdifFormat.utf8Length(freq)
                     , freq));
         }
 
         if (qslRecord.getMyCallsign() != null) {
             logStr.append(String.format("<station_callsign:%d>%s "
-                    , qslRecord.getMyCallsign().length()
+                    , AdifFormat.utf8Length(qslRecord.getMyCallsign())
                     , qslRecord.getMyCallsign()));
         }
 
         if (qslRecord.getMyMaidenGrid() != null) {
             logStr.append(String.format("<my_gridsquare:%d>%s "
-                    , qslRecord.getMyMaidenGrid().length()
+                    , AdifFormat.utf8Length(qslRecord.getMyMaidenGrid())
                     , qslRecord.getMyMaidenGrid()));
         }
 
@@ -312,7 +312,7 @@ public class ThirdPartyService {
         //<comment:15>Distance: 99 km <eor>
         //When writing to the database, be sure to append " km"
         logStr.append(String.format("<comment:%d>%s <eor>\n"
-                , comment.length()
+                , AdifFormat.utf8Length(comment)
                 , comment));
         return logStr.toString();
     }
@@ -595,13 +595,13 @@ public class ThirdPartyService {
 
         String comment = colStr(c, "comment");
         if (comment == null) comment = "";
-        s.append(String.format("<comment:%d>%s <eor>\n", comment.length(), comment));
+        s.append(String.format("<comment:%d>%s <eor>\n", AdifFormat.utf8Length(comment), comment));
         return s.toString();
     }
 
     private static void appendAdif(StringBuilder sb, String tag, String value) {
         if (value == null || value.isEmpty()) return;
-        sb.append(String.format("<%s:%d>%s ", tag, value.length(), value));
+        sb.append(String.format("<%s:%d>%s ", tag, AdifFormat.utf8Length(value), value));
     }
 
     private static String colStr(Cursor c, String name) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -308,6 +308,7 @@ public class ThirdPartyService {
         }
 
         String comment = qslRecord.getComment();
+        if (comment == null) comment = "";
 
         //<comment:15>Distance: 99 km <eor>
         //When writing to the database, be sure to append " km"

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
@@ -105,4 +105,33 @@ public class AdifFormatTest {
         assertThat(AdifFormat.formatReport(-100)).isEqualTo("-100");
         assertThat(AdifFormat.formatReport(-120)).isEqualTo("-120");
     }
+
+    @Test
+    public void utf8Length_asciiEqualsCharCount() {
+        // Pure ASCII: byte length == char length, so existing records are byte-identical.
+        assertThat(AdifFormat.utf8Length("")).isEqualTo(0);
+        assertThat(AdifFormat.utf8Length("K1ABC")).isEqualTo(5);
+        assertThat(AdifFormat.utf8Length("Distance: 99 km, QSO by FT8AF")).isEqualTo(29);
+    }
+
+    @Test
+    public void utf8Length_countsBytesNotChars() {
+        // The bug: an ADIF <field:len> declared String.length() (chars). Non-ASCII
+        // content has more UTF-8 bytes than chars, so the declared length undercounted
+        // and the receiving logger mis-parsed the record.
+        assertThat("Café".length()).isEqualTo(4);        // é is one UTF-16 char
+        assertThat(AdifFormat.utf8Length("Café")).isEqualTo(5); // but two UTF-8 bytes
+
+        assertThat("naïve".length()).isEqualTo(5);
+        assertThat(AdifFormat.utf8Length("naïve")).isEqualTo(6);
+
+        // Three CJK ideographs: 3 chars, 9 bytes (3 bytes each).
+        assertThat("中文注".length()).isEqualTo(3);
+        assertThat(AdifFormat.utf8Length("中文注")).isEqualTo(9);
+    }
+
+    @Test
+    public void utf8Length_nullIsZero() {
+        assertThat(AdifFormat.utf8Length(null)).isEqualTo(0);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceAdifLengthTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceAdifLengthTest.java
@@ -71,6 +71,19 @@ public class ThirdPartyServiceAdifLengthTest {
     }
 
     @Test
+    public void nullComment_emitsEmptyFieldNotLiteralNull() {
+        // A COMMENT key mapped to a null value leaves getComment() null. Without coercion
+        // String.format would emit "<comment:0>null <eor>" (%s renders null as "null"),
+        // declaring length 0 but writing 4 bytes. It must be an empty field instead.
+        String adif = ThirdPartyService.QSLRecordToADIF(recordWithComment(null),
+                ServiceType.QRZ);
+
+        assertThat(declaredCommentLength(adif)).isEqualTo(0);
+        assertThat(adif).contains("<comment:0> <eor>");
+        assertThat(adif).doesNotContain("null <eor>");
+    }
+
+    @Test
     public void asciiComment_lengthUnchanged() {
         // Pure-ASCII values must be byte-identical to before: bytes == chars.
         String comment = "Distance: 99 km, QSO by FT8AF";

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceAdifLengthTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceAdifLengthTest.java
@@ -1,0 +1,83 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+/**
+ * Verifies that {@link ThirdPartyService#QSLRecordToADIF} declares each ADIF
+ * {@code <field:LEN>} length in UTF-8 <em>bytes</em>, not UTF-16 chars — the same
+ * rule {@link AdifRecord} enforces via {@link AdifFormat#utf8Length}.
+ *
+ * <p>The Cloudlog/QRZ upload path hand-built its records with {@code String.length()},
+ * so any non-ASCII value (an accented comment, a POTA park name) declared a length
+ * shorter than the bytes actually written. The receiving logger reads only that many
+ * bytes and mis-aligns everything after the field, so the record is truncated/rejected.
+ *
+ * <p>Runs under Robolectric because {@link QSLRecord} touches Android {@code Log}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ThirdPartyServiceAdifLengthTest {
+
+    private static QSLRecord recordWithComment(String comment) {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("STATION_CALLSIGN", "K1AF");
+        map.put("MODE", "FT8");
+        map.put("COMMENT", comment);
+        return new QSLRecord(map);
+    }
+
+    /** Pull the declared length out of {@code <comment:LEN>...} in the record. */
+    private static int declaredCommentLength(String adif) {
+        int tag = adif.indexOf("<comment:");
+        assertThat(tag).isAtLeast(0);
+        int gt = adif.indexOf('>', tag);
+        return Integer.parseInt(adif.substring(tag + "<comment:".length(), gt));
+    }
+
+    @Test
+    public void comment_lengthIsUtf8ByteCount_notCharCount() {
+        // "Café QSO" — the 'é' is one UTF-16 char but two UTF-8 bytes, so the byte
+        // length (9) exceeds the char length (8). The buggy code declared 8.
+        String comment = "Café QSO";
+        assertThat(comment.length()).isEqualTo(8);
+        assertThat(comment.getBytes(StandardCharsets.UTF_8).length).isEqualTo(9);
+
+        String adif = ThirdPartyService.QSLRecordToADIF(recordWithComment(comment),
+                ServiceType.QRZ);
+
+        assertThat(declaredCommentLength(adif)).isEqualTo(9);
+        assertThat(adif).contains("<comment:9>Café QSO <eor>");
+        assertThat(adif).doesNotContain("<comment:8>");
+    }
+
+    @Test
+    public void comment_multiByteCjk_declaresByteLength() {
+        // Three CJK ideographs: 3 chars, 9 UTF-8 bytes (3 bytes each).
+        String comment = "中文注"; // 中文注
+        assertThat(comment.length()).isEqualTo(3);
+        assertThat(comment.getBytes(StandardCharsets.UTF_8).length).isEqualTo(9);
+
+        String adif = ThirdPartyService.QSLRecordToADIF(recordWithComment(comment),
+                ServiceType.Cloudlog);
+
+        assertThat(declaredCommentLength(adif)).isEqualTo(9);
+    }
+
+    @Test
+    public void asciiComment_lengthUnchanged() {
+        // Pure-ASCII values must be byte-identical to before: bytes == chars.
+        String comment = "Distance: 99 km, QSO by FT8AF";
+        String adif = ThirdPartyService.QSLRecordToADIF(recordWithComment(comment),
+                ServiceType.QRZ);
+
+        assertThat(declaredCommentLength(adif)).isEqualTo(comment.length());
+        assertThat(adif).contains("<comment:" + comment.length() + ">" + comment + " <eor>");
+    }
+}


### PR DESCRIPTION
## Summary

The QRZ / Cloudlog / Wavelog upload path hand-builds each ADIF record and declares every `<field:LEN>` length with `String.length()` — the UTF-16 **char** count — instead of the UTF-8 **byte** count that ADIF requires. For any non-ASCII field value the declared length is too small, so the receiving logbook reads fewer bytes than were actually written, truncating the field and mis-aligning everything after it in the record.

This is the exact bug that `AdifRecord` / `AdifFormat` were created to prevent ("single source of truth … the number of UTF-8 *bytes* of the value, not UTF-16 chars"), but the two upload builders never routed through them and kept using `.length()`.

## Root cause

`ThirdPartyService.QSLRecordToADIF` (immediate post-QSO upload) and `ThirdPartyService.buildAdifFromCursor` (batch re-sync in `syncAllQSOs`) both compute the ADIF field length as `value.length()`. `String.length()` returns UTF-16 code units; ADIF `<field:len>` is defined in bytes. They agree only for ASCII.

**Concrete trigger:** a QSO whose `COMMENT` (or any non-ASCII value — e.g. an accented comment or a POTA park name imported from another logger and re-uploaded via *Sync all QSOs*) contains a multi-byte character. `"Café QSO"` is 8 chars but 9 UTF-8 bytes; the record went out as `<comment:8>Café QSO ` and the receiving parser mis-reads it.

## Fix

- Add a shared `AdifFormat.utf8Length(String)` helper (UTF-8 byte count; `null` → 0) — the natural home, since `ThirdPartyService` already depends on `AdifFormat` for `callField`/`mfskSubmode`/`formatReport`.
- `AdifRecord`'s private `utf8Length` now delegates to it, so there is a single implementation (matching the class's own "single source of truth" intent). No behaviour change — the implementation is identical.
- Replace every `.length()` ADIF field-length in `QSLRecordToADIF`, `buildAdifFromCursor`, and `appendAdif` with `AdifFormat.utf8Length(...)`. Pure-ASCII records (the common case) are byte-identical; only non-ASCII field lengths change, and they become correct.

`AdifFormat.callField` is unchanged — callsigns are ASCII by the ADIF/FT8 alphabet, so char length == byte length there.

## Testing

- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — builds (all ABIs).
- New tests (both fail before the fix):
  - `AdifFormatTest`: `utf8Length` on ASCII (== char count), accented/CJK text (bytes > chars), and null.
  - `ThirdPartyServiceAdifLengthTest` (Robolectric): `QSLRecordToADIF` with an accented and a CJK `COMMENT` declares the UTF-8 byte length; an ASCII comment is unchanged.
- Existing `ThirdPartyServiceAdifModeTest` / `ThirdPartyServiceQrzTest` still pass (all-ASCII assertions unaffected).

## Risk

Low. ASCII records — every field in an in-app QSO except a user/import-supplied comment — are byte-for-byte identical. The only behavioural change is that non-ASCII field lengths are now declared correctly, which is strictly more correct for LoTW/QRZ/Cloudlog. Java-only; no DSP, native, or protocol change.
