### PR TITLE
Fix RX spectrum/waterfall axis scaled by TX sample rate (wrong at 24/48 kHz)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ColumnarView.java
@@ -89,11 +89,11 @@ public class ColumnarView extends View {
         if (data.length <= 0) {
             return;
         }
-        // Calculate how many FFT bins correspond to spectrumWidth Hz.
-        // The full data array covers 0 to Nyquist (sampleRate/2).
-        float nyquist = GeneralVariables.audioSampleRate / 2f;
-        int binsToShow = Math.min(data.length, Math.round((float) spectrumWidth / nyquist * data.length));
-        if (binsToShow <= 0) binsToShow = data.length / 2;
+        // Calculate how many FFT bins correspond to spectrumWidth Hz. The full
+        // data array covers 0 to the RX Nyquist (FT8Common.SAMPLE_RATE/2 = 6 kHz):
+        // RX audio is always captured/decoded at 12 kHz, independent of the
+        // user-selectable transmit audio rate (see SpectrumScale).
+        int binsToShow = SpectrumScale.binsToShow(data.length, spectrumWidth);
 
         width = getWidth() / binsToShow;
         if (drawblock) {// Whether to show the peak block

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumScale.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumScale.java
@@ -54,8 +54,19 @@ public final class SpectrumScale {
      * Horizontal gradient scale for the waterfall strip: the full bin array
      * (0..{@link #RX_NYQUIST_HZ}) is stretched so that {@code spectrumWidthHz}
      * fills the visible view width.
+     *
+     * <p>A non-positive {@code spectrumWidthHz} (never produced by the settings UI, which
+     * constrains the value, but reachable because config hydration parses the persisted
+     * {@code spectrumWidth} without clamping — {@code DatabaseOpr.parseConfigInt} leaves range
+     * checks to setters) would divide by zero and yield {@code Infinity}/negative, breaking
+     * {@code LinearGradient}. Fall back to a scale of {@code 1.0} (the full 0..Nyquist band
+     * drawn undistorted across the view) instead, mirroring {@link #binsToShow}'s own
+     * collapse-to-zero fallback.
      */
     public static float gradientScale(int spectrumWidthHz) {
+        if (spectrumWidthHz <= 0) {
+            return 1f;
+        }
         return RX_NYQUIST_HZ / spectrumWidthHz;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumScale.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/SpectrumScale.java
@@ -1,0 +1,61 @@
+package com.k1af.ft8af.ui;
+
+import com.k1af.ft8af.FT8Common;
+
+/**
+ * Frequency-axis geometry for the two RX spectrum views (ColumnarView and
+ * WaterfallView).
+ *
+ * <p>The receive audio is always captured, resampled and decoded at
+ * {@link FT8Common#SAMPLE_RATE} (12 kHz) — see {@code MicRecorder.sampleRateInHz},
+ * the USB {@code startCapture(sampleRateInHz)} path, and
+ * {@code FT8SignalListener.InitDecoder(..., FT8Common.SAMPLE_RATE, ...)}. The FFT
+ * both views render is computed over that RX audio, so its bins always span
+ * 0..{@link #RX_NYQUIST_HZ} (0..6 kHz) regardless of anything the user selects.
+ *
+ * <p>The views previously scaled the axis by {@code GeneralVariables.audioSampleRate},
+ * which is the <em>transmit</em> audio rate (user-selectable 12/24/48 kHz for
+ * USB sound-card rigs) and has nothing to do with the RX FFT. Picking 24 kHz or
+ * 48 kHz doubled/quadrupled the assumed Nyquist, so every FFT bin was mapped to
+ * 2x/4x its true frequency: signals no longer lined up with the frequency ruler,
+ * the TX marker, or click-to-tune (which are derived from {@code spectrumWidth}
+ * alone). The default 12 kHz masked the bug. Keying the axis off the fixed RX
+ * rate here fixes it; at 12 kHz the result is bit-for-bit identical to the old
+ * code.
+ *
+ * <p>Extracted as a pure helper so the geometry is JVM-testable, mirroring
+ * {@link BinAggregation} and {@code PeakBlocks}.
+ */
+public final class SpectrumScale {
+
+    /** Nyquist frequency (Hz) of the RX FFT data both spectrum views render. */
+    public static final float RX_NYQUIST_HZ = FT8Common.SAMPLE_RATE / 2f;
+
+    private SpectrumScale() {
+    }
+
+    /**
+     * Number of leading FFT bins that cover {@code spectrumWidthHz} of the
+     * displayed band, i.e. how many of the {@code fftLength} bins (which span
+     * 0..{@link #RX_NYQUIST_HZ}) fall inside the visible width. Clamped to at
+     * most {@code fftLength}; falls back to half the array if the rounded value
+     * collapses to zero, preserving the pre-fix ColumnarView behavior.
+     */
+    public static int binsToShow(int fftLength, int spectrumWidthHz) {
+        int bins = Math.min(fftLength,
+                Math.round((float) spectrumWidthHz / RX_NYQUIST_HZ * fftLength));
+        if (bins <= 0) {
+            bins = fftLength / 2;
+        }
+        return bins;
+    }
+
+    /**
+     * Horizontal gradient scale for the waterfall strip: the full bin array
+     * (0..{@link #RX_NYQUIST_HZ}) is stretched so that {@code spectrumWidthHz}
+     * fills the visible view width.
+     */
+    public static float gradientScale(int spectrumWidthHz) {
+        return RX_NYQUIST_HZ / spectrumWidthHz;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
@@ -290,10 +290,11 @@ public class WaterfallView extends View {
             }
         }
         // Scale gradient so the visible portion (0..drawWidth) maps to 0..spectrumWidth Hz.
-        // The FFT data covers 0 to Nyquist (sampleRate/2). We want spectrumWidth Hz
-        // to fill the view, so the full gradient length = drawWidth * (Nyquist / spectrumWidth).
-        float nyquist = GeneralVariables.audioSampleRate / 2f;
-        float gradientScale = nyquist / spectrumWidth;
+        // The FFT data covers 0 to the RX Nyquist (FT8Common.SAMPLE_RATE/2 = 6 kHz): RX
+        // audio is always captured/decoded at 12 kHz, independent of the user-selectable
+        // transmit audio rate (see SpectrumScale). We want spectrumWidth Hz to fill the
+        // view, so the full gradient length = drawWidth * (Nyquist / spectrumWidth).
+        float gradientScale = SpectrumScale.gradientScale(spectrumWidth);
         LinearGradient linearGradient = new LinearGradient(0, 0, drawWidth * gradientScale, 0, colors
                 , null, Shader.TileMode.CLAMP);
         linearPaint.setShader(linearGradient);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/SpectrumScaleTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/SpectrumScaleTest.java
@@ -1,0 +1,107 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.FT8Common;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link SpectrumScale}: the RX spectrum/waterfall frequency-axis
+ * geometry extracted from ColumnarView and WaterfallView.
+ *
+ * <p>The bug fixed here: both views used {@code GeneralVariables.audioSampleRate}
+ * (the user-selectable <em>transmit</em> rate, 12/24/48 kHz) as the FFT Nyquist,
+ * but the RX FFT is always computed over 12 kHz audio ({@link FT8Common#SAMPLE_RATE}).
+ * Selecting 24/48 kHz therefore mis-scaled the whole display by 2x/4x. These
+ * tests pin the axis to the fixed RX Nyquist and prove it no longer depends on
+ * the transmit rate, while staying bit-for-bit identical at the 12 kHz default.
+ *
+ * <p>Pure math — no Robolectric.
+ */
+public class SpectrumScaleTest {
+
+    /** The pre-fix ColumnarView expression, parameterized by the (wrong) rate. */
+    private static int legacyBinsToShow(int fftLength, int spectrumWidthHz, int assumedRateHz) {
+        float nyquist = assumedRateHz / 2f;
+        int bins = Math.min(fftLength,
+                Math.round((float) spectrumWidthHz / nyquist * fftLength));
+        if (bins <= 0) {
+            bins = fftLength / 2;
+        }
+        return bins;
+    }
+
+    @Test
+    public void rxNyquistIsFixedTwelveKilohertzHalf() {
+        assertThat(SpectrumScale.RX_NYQUIST_HZ).isEqualTo(FT8Common.SAMPLE_RATE / 2f);
+        assertThat(SpectrumScale.RX_NYQUIST_HZ).isEqualTo(6000f);
+    }
+
+    @Test
+    public void binsToShowMatchesLegacyAtTwelveKilohertz() {
+        // At the 12 kHz default the fix must be a no-op (assumed rate == RX rate).
+        int[] widths = {2500, 3000, 3500, 4000, 5000};
+        int[] lengths = {480, 960, 1024};
+        for (int len : lengths) {
+            for (int w : widths) {
+                assertThat(SpectrumScale.binsToShow(len, w))
+                        .isEqualTo(legacyBinsToShow(len, w, 12000));
+            }
+        }
+    }
+
+    @Test
+    public void binsToShowIsIndependentOfTransmitRate() {
+        // The core regression: 24 kHz and 48 kHz TX selections must NOT change
+        // the RX spectrum geometry — the old code shrank it to 1/2 and 1/4.
+        int fftLen = 960;
+        int spectrumWidth = 3500;
+        int fixed = SpectrumScale.binsToShow(fftLen, spectrumWidth);
+
+        assertThat(fixed).isEqualTo(560); // round(3500/6000 * 960)
+        assertThat(legacyBinsToShow(fftLen, spectrumWidth, 24000)).isEqualTo(280); // old, wrong
+        assertThat(legacyBinsToShow(fftLen, spectrumWidth, 48000)).isEqualTo(140); // old, wrong
+        // Fixed value equals the correct 12 kHz value regardless of TX rate.
+        assertThat(fixed).isEqualTo(legacyBinsToShow(fftLen, spectrumWidth, 12000));
+    }
+
+    @Test
+    public void signalWithinSpectrumWidthStaysOnStrip() {
+        // A 1500 Hz signal (bin 240 of a 960-bin 0..6000 Hz FFT) sits well inside
+        // a 3500 Hz display window and must be among the drawn bins. Under the old
+        // 48 kHz scaling only 140 bins (0..875 Hz) were drawn, so it fell off.
+        int fftLen = 960;
+        int spectrumWidth = 3500;
+        int binForFifteenHundredHz = Math.round(1500f / SpectrumScale.RX_NYQUIST_HZ * fftLen);
+
+        assertThat(binForFifteenHundredHz).isEqualTo(240);
+        assertThat(SpectrumScale.binsToShow(fftLen, spectrumWidth)).isGreaterThan(binForFifteenHundredHz);
+        assertThat(legacyBinsToShow(fftLen, spectrumWidth, 48000)).isLessThan(binForFifteenHundredHz);
+    }
+
+    @Test
+    public void binsToShowClampsToFftLength() {
+        // spectrumWidth above the RX Nyquist can't show more bins than exist.
+        assertThat(SpectrumScale.binsToShow(512, 9000)).isEqualTo(512);
+        assertThat(SpectrumScale.binsToShow(512, 6000)).isEqualTo(512);
+    }
+
+    @Test
+    public void binsToShowFallsBackToHalfWhenRoundsToZero() {
+        // Degenerate width rounds to zero bins → fall back to half the array,
+        // preserving the pre-fix ColumnarView guard (never draw zero bars).
+        assertThat(SpectrumScale.binsToShow(960, 0)).isEqualTo(480);
+    }
+
+    @Test
+    public void gradientScaleMatchesLegacyAtTwelveKilohertzAndIsRateIndependent() {
+        int spectrumWidth = 3500;
+        float fixed = SpectrumScale.gradientScale(spectrumWidth);
+
+        assertThat(fixed).isEqualTo(6000f / spectrumWidth);          // RX Nyquist / width
+        assertThat(fixed).isEqualTo(12000 / 2f / spectrumWidth);     // == old 12 kHz value
+        // Old code at 48 kHz produced 24000/3500, ~4x too large (over-compressed).
+        assertThat(24000f / spectrumWidth).isGreaterThan(fixed);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/SpectrumScaleTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/SpectrumScaleTest.java
@@ -104,4 +104,14 @@ public class SpectrumScaleTest {
         // Old code at 48 kHz produced 24000/3500, ~4x too large (over-compressed).
         assertThat(24000f / spectrumWidth).isGreaterThan(fixed);
     }
+
+    @Test
+    public void gradientScaleGuardsNonPositiveWidth() {
+        // An out-of-range persisted spectrumWidth (config hydration doesn't clamp) must not
+        // divide by zero / go negative and break LinearGradient. Falls back to scale 1.0.
+        assertThat(SpectrumScale.gradientScale(0)).isEqualTo(1f);
+        assertThat(SpectrumScale.gradientScale(-100)).isEqualTo(1f);
+        // A positive width is unaffected.
+        assertThat(SpectrumScale.gradientScale(3500)).isEqualTo(6000f / 3500);
+    }
 }


### PR DESCRIPTION
## Root cause

`ColumnarView.setWaveData` (`ColumnarView.java:94`) and `WaterfallView` (`WaterfallView.java:295`) derived the FFT Nyquist from `GeneralVariables.audioSampleRate` — the user-selectable **transmit** audio rate (12/24/48 kHz, set in Settings → Audio, persisted as `audioRate`) — when computing how many FFT bins map to the displayed `spectrumWidth` Hz.

But the RX audio the FFT is computed over is **always** captured, resampled and decoded at a fixed 12 kHz:
- `MicRecorder.sampleRateInHz = 12000` (private static final)
- the USB direct-capture path `usbAudioDevice.startCapture(sampleRateInHz=12000, …)`
- `FT8SignalListener.InitDecoder(…, FT8Common.SAMPLE_RATE=12000, …)`

So the FFT bins always span 0–6 kHz, independent of the TX setting. The frequency ruler, TX-frequency marker, and click-to-tune in the same two views are all derived from `spectrumWidth` alone, so the moment `audioSampleRate != 12000` the **data layer and axis layer disagree**.

## Symptom / failure scenario

Pick 48 kHz TX audio (normal for USB sound-card rigs like DigiRig), `spectrumWidth = 3500`, 960-bin FFT:
- `nyquist` becomes 24000 instead of 6000 → `binsToShow = round(3500/24000 × 960) = 140`.
- Only bins 0…140 (0…875 Hz) are drawn stretched across a width the ruler labels 0…3500 Hz. A real signal at 1500 Hz (bin 240) falls **off the strip entirely**, while its TX marker sits at 0.43·width.
- WaterfallView's `gradientScale = 24000/3500 ≈ 6.86` compresses every trace ~4×.
- Tapping a visible signal writes a TX offset that doesn't match its true audio frequency.

The 12 kHz default masks the bug, which is why it survived.

## Fix

Key the axis off the fixed RX rate. Extracted the bin/gradient geometry into a pure, JVM-testable `SpectrumScale` helper (mirroring the existing `BinAggregation` / `PeakBlocks` extractions) using `FT8Common.SAMPLE_RATE/2`. Both views now call it. **At 12 kHz the output is bit-for-bit identical to the old code** (only 24/48 kHz behavior changes — from wrong to correct).

## Testing

- `SpectrumScaleTest` (pure JVM, 7 cases): bit-identical to the legacy expression at 12 kHz; `binsToShow` invariant to the TX rate (explicitly contrasted with the old 24 kHz → 280 / 48 kHz → 140 values); a 1500 Hz signal stays on-strip; clamp-to-`fftLength` and zero-round fallback preserved; `RX_NYQUIST_HZ == 6000`.
- `./gradlew :app:testDebugUnitTest --tests com.k1af.ft8af.ui.*` — all green.

## Risk

Low. Pure display-geometry change; no DSP, decoder, encoder, or protocol impact. Default 12 kHz path unchanged (byte-identical). Only the previously-broken 24/48 kHz display is corrected.

## Notes / assumptions

- No UI screenshots: the defect only manifests on a physical device with a non-12k TX rate selected; the geometry is fully covered by the pure unit test.
- `GeneralVariables.audioSampleRate` remains correct for all TX paths (`FT8TransmitSignal`, `AudioTrack`), which are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)