### PR TITLE
Fix native SIGSEGV when a decoder audio pin fails (float feed paths)

### DIFF
--- a/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
@@ -35,6 +35,7 @@ int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
 
 #include "ft8_call_hash.h"
 #include "ftx_hash_store.h"
+#include "ftx_feed.h"
 
 // ---------------------------------------------------------------------------
 // 22-bit WSJT-X callsign hash (copy of jni_ft8af.cpp's compute_n22, kept local so
@@ -237,11 +238,10 @@ static void ft2_feed(ft2_decoder_state* d, const float* data, int n)
 {
     if (!d || !d->mon_ready)
         return;
-    if (d->samples && n <= d->num_samples)
-        memcpy(d->samples, data, sizeof(float) * n);
-    monitor_reset(&d->mon);
-    for (int pos = 0; pos + d->mon.block_size <= n; pos += d->mon.block_size)
-        monitor_process(&d->mon, data + pos);
+    // Null-safe copy + monitor feed (shared with ft8_feed via ftx_feed.h). A
+    // NULL `data` (a failed JNI array pin under memory pressure) is a no-op,
+    // not a native SIGSEGV.
+    ftx_feed_monitor(&d->mon, d->samples, d->num_samples, data, n);
 }
 
 FT2JNI(void, DecoderFt2MonitorPressFloat)(JNIEnv* env, jobject, jfloatArray buffer, jlong handle)

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft2_decode_jni.cpp
@@ -251,6 +251,12 @@ FT2JNI(void, DecoderFt2MonitorPressFloat)(JNIEnv* env, jobject, jfloatArray buff
         return;
     jsize n = env->GetArrayLength(buffer);
     jfloat* data = env->GetFloatArrayElements(buffer, nullptr);
+    // GetFloatArrayElements may return NULL if the JVM can't pin the array (OOM/heap
+    // pressure), leaving a pending exception. Bail out before feeding or releasing —
+    // ReleaseFloatArrayElements with a NULL pointer is undefined. Mirrors the int16
+    // DecoderMonitorPress guard in ft8_decode_jni.cpp.
+    if (!data)
+        return;
     ft2_feed(d, data, n);
     env->ReleaseFloatArrayElements(buffer, data, JNI_ABORT);
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -316,6 +316,12 @@ Java_com_k1af_ft8af_ft8listener_FT8SignalListener_DecoderMonitorPressFloat(
         return;
     jsize n = env->GetArrayLength(buffer);
     jfloat* data = env->GetFloatArrayElements(buffer, nullptr);
+    // GetFloatArrayElements may return NULL if the JVM can't pin the array (OOM/heap
+    // pressure), leaving a pending exception. Bail out before feeding or releasing —
+    // ReleaseFloatArrayElements with a NULL pointer is undefined. Mirrors the int16
+    // DecoderMonitorPress guard above.
+    if (!data)
+        return;
     ft8_feed(d, data, n);
     env->ReleaseFloatArrayElements(buffer, data, JNI_ABORT);
 }

--- a/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ft8_decode_jni.cpp
@@ -32,6 +32,7 @@ int ft8_snr(const waterfall_t* wf, const candidate_t* candidate);
 #include "ft8_xslot.h"
 #include "ft8_call_hash.h"
 #include "ftx_hash_store.h"
+#include "ftx_feed.h"
 
 // ---------------------------------------------------------------------------
 // 22-bit WSJT-X callsign hash (same as ft2_decode_jni.cpp / test_golden_encode.c).
@@ -261,17 +262,12 @@ static void ft8_feed(ft8_decoder_state* d, const float* data, int n)
 {
     if (!d || !d->mon_ready)
         return;
-    d->num_fed = 0;
     d->wf_dirty = false;
     d->sub_done_count = 0;
-    if (d->samples && n <= d->num_samples)
-    {
-        memcpy(d->samples, data, sizeof(float) * n);
-        d->num_fed = n;
-    }
-    monitor_reset(&d->mon);
-    for (int pos = 0; pos + d->mon.block_size <= n; pos += d->mon.block_size)
-        monitor_process(&d->mon, data + pos);
+    // Null-safe copy + monitor feed (shared with ft2_feed via ftx_feed.h). A
+    // NULL `data` (a failed JNI array pin under memory pressure) is a no-op,
+    // not a native SIGSEGV.
+    d->num_fed = ftx_feed_monitor(&d->mon, d->samples, d->num_samples, data, n);
 
     // Invalidate only: the context is rebuilt lazily when a deep pass
     // actually needs it (see DecoderFt8Analysis).

--- a/ft8af/app/src/main/cpp/ft8af_glue/ftx_feed.h
+++ b/ft8af/app/src/main/cpp/ft8af_glue/ftx_feed.h
@@ -1,0 +1,62 @@
+// ftx_feed.h — the per-slot audio-feed step shared by the FT8 and FT4/FT2
+// decoders.
+//
+// WHY THIS EXISTS
+// ------------------------------------------------------------------
+// Each decoder pushes one slot of PCM audio through its monitor (building the
+// waterfall) and keeps a copy of the samples for the deep-decode subtraction
+// pass. ft8_decode_jni.cpp (ft8_feed) and ft2_decode_jni.cpp (ft2_feed) kept a
+// byte-for-byte identical copy of that inner step: an optional bounded memcpy
+// into the retained buffer, then monitor_reset() and a monitor_process() loop
+// over the buffer.
+//
+// Both copies dereferenced the incoming `data` pointer WITHOUT a null check.
+// The float feed entry points (DecoderMonitorPressFloat / DecoderFt2Monitor-
+// PressFloat) hand this the raw result of JNIEnv::GetFloatArrayElements, which
+// is allowed to return NULL when the JVM cannot pin the array (out-of-memory /
+// heap pressure). The int16 sibling DecoderMonitorPress already guards its pin
+// with `if (!data) return;`, but the float paths did not — so a failed pin fed
+// a NULL pointer straight into memcpy()/monitor_process(), an uncatchable
+// native SIGSEGV on the decode thread.
+//
+// This header collapses the two copies into one null-safe, host-tested
+// implementation (test_feed.c). The behaviour is identical to the old inline
+// copies for every valid buffer; the only change is that a NULL `data` (or a
+// negative length) is now a no-op instead of a crash.
+
+#ifndef FT8AF_FTX_FEED_H
+#define FT8AF_FTX_FEED_H
+
+#include <stddef.h>
+#include <string.h>
+
+#include "common/monitor.h"
+
+// Feed one slot of `n` audio samples through `mon`, first keeping a copy of up
+// to `num_samples` of them in `samples` (when `samples` is non-NULL and the
+// slot fits) for the later subtraction pass.
+//
+// Returns the number of samples copied into `samples` (0 when nothing was kept,
+// including the null-guarded no-op case). A NULL `mon` or `data`, or a negative
+// `n`, is a no-op that returns 0 — never a dereference.
+static inline int ftx_feed_monitor(monitor_t* mon, float* samples,
+                                   int num_samples, const float* data, int n)
+{
+    if (mon == NULL || data == NULL || n < 0)
+        return 0;
+
+    int copied = 0;
+    if (samples != NULL && n <= num_samples)
+    {
+        memcpy(samples, data, sizeof(float) * (size_t)n);
+        copied = n;
+    }
+
+    monitor_reset(mon);
+    for (int pos = 0; pos + mon->block_size <= n; pos += mon->block_size)
+        monitor_process(mon, data + pos);
+
+    return copied;
+}
+
+#endif // FT8AF_FTX_FEED_H

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.ps1
@@ -337,6 +337,28 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_gfsk_len)." }
 & $outGfskLen
 $gfskLenExit = $LASTEXITCODE
 
+# ---------------------------------------------------------------------------
+# Audio-feed tests: the per-slot monitor feed shared by ft8_decode_jni.cpp and
+# ft2_decode_jni.cpp (ftx_feed.h). Guards the bounded copy into the retained
+# samples buffer and, crucially, that a NULL `data` pointer (a failed JNI array
+# pin) is a no-op instead of the native SIGSEGV the two float feed paths used to
+# take. Links the monitor + FFT + decode path monitor_process exercises.
+# ---------------------------------------------------------------------------
+$feedSrcs = @(
+    "common\monitor.c","ft8\decode.c","ft8\constants.c","ft8\crc.c",
+    "ft8\text.c","ft8\message.c","ft8\pack.c","ft8\encode.c",
+    "ft8\ldpc.c","ft8\osd.c","ft8\unpack.c","fft\kiss_fft.c","fft\kiss_fftr.c"
+) | ForEach-Object { Join-Path $ft8 $_ }
+
+$srcFeed = Join-Path $here "test_feed.c"
+$outFeed = Join-Path $env:TEMP "ft8_feed_test.exe"
+
+& $Clang @common $srcFeed @feedSrcs -o $outFeed
+if ($LASTEXITCODE -ne 0) { Write-Error "Compile failed (test_feed)." }
+
+& $outFeed
+$feedExit = $LASTEXITCODE
+
 if ($goldenExit -ne 0) { exit $goldenExit }
 if ($dev625Exit -ne 0) { exit $dev625Exit }
 if ($fftWinExit -ne 0) { exit $fftWinExit }
@@ -351,4 +373,5 @@ if ($subExit -ne 0) { exit $subExit }
 if ($osdExit -ne 0) { exit $osdExit }
 if ($fineExit -ne 0) { exit $fineExit }
 if ($xslotExit -ne 0) { exit $xslotExit }
-exit $gfskLenExit
+if ($gfskLenExit -ne 0) { exit $gfskLenExit }
+exit $feedExit

--- a/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
+++ b/ft8af/app/src/main/cpp/ft8af_glue/run_host_tests.sh
@@ -307,3 +307,30 @@ gfsk_len_out="$tmp/ft8_gfsk_len_test"
     -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
     -I "$ft8" "${gfsk_len_srcs[@]}" -lm -o "$gfsk_len_out"
 "$gfsk_len_out"
+
+# Audio-feed tests: the per-slot monitor feed shared by ft8_decode_jni.cpp and
+# ft2_decode_jni.cpp (ftx_feed.h). Guards the bounded copy into the retained
+# samples buffer and, crucially, that a NULL `data` pointer (a failed JNI array
+# pin) is a no-op instead of the native SIGSEGV the two float feed paths used to
+# take. Links the monitor + FFT + decode path monitor_process exercises.
+feed_srcs=(
+    "$here/test_feed.c"
+    "$ft8/common/monitor.c"
+    "$ft8/ft8/decode.c"
+    "$ft8/ft8/constants.c"
+    "$ft8/ft8/crc.c"
+    "$ft8/ft8/text.c"
+    "$ft8/ft8/message.c"
+    "$ft8/ft8/pack.c"
+    "$ft8/ft8/encode.c"
+    "$ft8/ft8/ldpc.c"
+    "$ft8/ft8/osd.c"
+    "$ft8/ft8/unpack.c"
+    "$ft8/fft/kiss_fft.c"
+    "$ft8/fft/kiss_fftr.c"
+)
+feed_out="$tmp/ft8_feed_test"
+"$CC" -std=c11 -O2 -D_GNU_SOURCE \
+    -Wall -Wno-deprecated-non-prototype -Wno-unused-function \
+    -I "$ft8" -I "$here" "${feed_srcs[@]}" -lm -o "$feed_out"
+"$feed_out"

--- a/ft8af/app/src/main/cpp/ft8af_glue/test_feed.c
+++ b/ft8af/app/src/main/cpp/ft8af_glue/test_feed.c
@@ -1,0 +1,122 @@
+// Host unit tests for ftx_feed.h — the per-slot audio-feed step shared by the
+// FT8 and FT4/FT2 decoders. Run by run_host_tests.sh / .ps1.
+//
+// Covered:
+//   1. A valid buffer that fits is copied bit-exact into the retained samples
+//      buffer and the copied count is returned (the deep-decode subtraction
+//      pass reads this copy).
+//   2. A buffer larger than the retained capacity is NOT copied (copied==0) but
+//      is still fed through the monitor without overrunning `samples`.
+//   3. A NULL retained buffer (samples==NULL) still feeds the monitor and
+//      returns 0 — the int16 path used to feed with no kept copy.
+//   4. REGRESSION (the reason this file exists): a NULL `data` pointer — the
+//      value JNIEnv::GetFloatArrayElements returns when the JVM cannot pin the
+//      array under memory pressure — must be a no-op that returns 0, NOT a
+//      native SIGSEGV. The previous inline copies in ft8_decode_jni.cpp /
+//      ft2_decode_jni.cpp dereferenced `data` in memcpy()/monitor_process()
+//      with no null check; the int16 sibling DecoderMonitorPress guarded its
+//      pin but the two float paths did not. This test feeds NULL and can only
+//      pass if the dereference is guarded.
+//   5. A negative length is likewise a no-op returning 0.
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common/monitor.h"
+#include "decode_params.h"
+#include "ftx_feed.h"
+
+#define RATE 12000
+#define NSAMPLES (RATE * 15)
+
+static int g_failures = 0;
+
+static void check(bool ok, const char* what)
+{
+    printf("  %s %s\n", ok ? "ok:  " : "FAIL:", what);
+    if (!ok)
+        g_failures++;
+}
+
+static void init_monitor(monitor_t* mon)
+{
+    monitor_config_t cfg;
+    cfg.f_min = 100;
+    cfg.f_max = 3500;
+    cfg.sample_rate = RATE;
+    cfg.time_osr = FT8AF_TIME_OSR;
+    cfg.freq_osr = FT8AF_FREQ_OSR;
+    cfg.protocol = FTX_PROTOCOL_FT8;
+    monitor_init(mon, &cfg);
+}
+
+int main(void)
+{
+    monitor_t mon;
+    init_monitor(&mon);
+
+    // A deterministic ramp of audio; a fraction of a slot is plenty to exercise
+    // several monitor blocks.
+    const int n = RATE * 2;
+    float* data = (float*)malloc(sizeof(float) * (size_t)NSAMPLES);
+    for (int i = 0; i < NSAMPLES; ++i)
+        data[i] = (float)((i % 4096) - 2048) / 2048.0f;
+
+    // Retained buffer, sized like the decoder's `samples` (one full slot).
+    const int cap = NSAMPLES;
+    float* samples = (float*)malloc(sizeof(float) * (size_t)cap);
+    for (int i = 0; i < cap; ++i)
+        samples[i] = -999.0f; // sentinel
+
+    // 1. Valid buffer that fits: copied bit-exact, count returned.
+    int copied = ftx_feed_monitor(&mon, samples, cap, data, n);
+    check(copied == n, "valid feed returns the copied sample count");
+    bool exact = true;
+    for (int i = 0; i < n; ++i)
+        if (samples[i] != data[i])
+        {
+            exact = false;
+            break;
+        }
+    check(exact, "valid feed copies the samples bit-exact");
+    check(samples[n] == -999.0f, "valid feed copies exactly n samples (no overrun)");
+
+    // 2. Buffer larger than the retained capacity: not copied, but still fed.
+    monitor_t mon2;
+    init_monitor(&mon2);
+    int copied_big = ftx_feed_monitor(&mon2, samples, /*num_samples=*/n - 1, data, n);
+    check(copied_big == 0, "over-capacity slot is not copied (copied==0)");
+
+    // 3. NULL retained buffer: monitor still fed, nothing kept.
+    monitor_t mon3;
+    init_monitor(&mon3);
+    int copied_null_samples = ftx_feed_monitor(&mon3, NULL, cap, data, n);
+    check(copied_null_samples == 0, "NULL samples buffer keeps nothing");
+
+    // 4. REGRESSION: NULL data must be a guarded no-op, not a SIGSEGV.
+    monitor_t mon4;
+    init_monitor(&mon4);
+    int copied_null_data = ftx_feed_monitor(&mon4, samples, cap, NULL, n);
+    check(copied_null_data == 0, "NULL data is a no-op (no crash)");
+
+    // 5. Negative length: guarded no-op.
+    int copied_neg = ftx_feed_monitor(&mon, samples, cap, data, -1);
+    check(copied_neg == 0, "negative length is a no-op");
+
+    monitor_free(&mon);
+    monitor_free(&mon2);
+    monitor_free(&mon3);
+    monitor_free(&mon4);
+    free(data);
+    free(samples);
+
+    if (g_failures == 0)
+    {
+        printf("test_feed: ALL PASS\n");
+        return 0;
+    }
+    printf("test_feed: %d FAILURE(S)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Root cause

The FT8 and FT4/FT2 decoders each fed one slot of PCM audio through their monitor with a **byte-for-byte identical inline copy loop** — `ft8_feed` (`ft8_decode_jni.cpp`) and `ft2_feed` (`ft2_decode_jni.cpp`). Both dereferenced the incoming `data` pointer with **no null check**:

```c
if (d->samples && n <= d->num_samples)
    memcpy(d->samples, data, sizeof(float) * n);   // deref data
monitor_reset(&d->mon);
for (int pos = 0; pos + d->mon.block_size <= n; pos += d->mon.block_size)
    monitor_process(&d->mon, data + pos);          // deref data
```

The float feed entry points — `DecoderMonitorPressFloat` and `DecoderFt2MonitorPressFloat` — pass the raw result of `JNIEnv::GetFloatArrayElements(buffer, nullptr)` straight into this loop:

```c
jfloat* data = env->GetFloatArrayElements(buffer, nullptr);
ft8_feed(d, data, n);   // no null check
```

`GetFloatArrayElements` is permitted to return `NULL` when the JVM cannot pin the array (out-of-memory / heap pressure). The **int16 sibling** `DecoderMonitorPress` already guards its pin (`if (!data) return;`), but the two **float** paths — the ones actually used on the live decode path (`FT8SignalListener.pressFloatDecode` → `DecoderMonitorPressFloat` / `DecoderFt2MonitorPressFloat`) — did not. A failed pin therefore fed `NULL` into `memcpy()` / `monitor_process()`: an **uncatchable native SIGSEGV on the decode thread** (Java `try/catch` cannot intercept it).

## Fix

Collapse the two identical feed loops into a single null-safe, host-tested helper `ftx_feed_monitor()` in a new **`ftx_feed.h`**, mirroring the existing `ftx_hash_store.h` extraction (PR #504) that de-duplicated the decoders' shared hash table for the same reason. The helper null-guards `data` (and a negative length) at the root, so **all three** feed entry points — both float paths and the int16 path, which routes through `ft8_feed` — are protected.

Behaviour is **identical for every valid buffer**: the same bounded copy into the retained `samples` buffer, the same `monitor_reset` + `monitor_process` loop. The only change is that a `NULL` `data` is now a no-op instead of a crash.

## Testing

- **New host test `test_feed.c`** (wired into `run_host_tests.sh` and `run_host_tests.ps1`) covering the bounded copy (bit-exact, no overrun), the over-capacity and null-`samples` cases, the **NULL-`data` regression**, and a negative length. Verified it **SIGSEGVs (exit 139) against the pre-fix inline logic** and passes after the fix — a genuine regression test.
- Full native host suite (`run_host_tests.sh`) passes.
- `:app:externalNativeBuildDebug` builds clean across all four ABIs (arm64-v8a, armeabi-v7a, x86, x86_64); no new warnings.

## Risk

Very low. Pure native change, no Java/Kotlin touched, no protocol/DSP behaviour change — byte-identical output for all valid audio. The guard only alters the previously-crashing NULL path. De-duplicating the two copies also removes a latent maintenance hazard (a fix to one feed loop no longer needs to be mirrored by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)