### PR TITLE
Fix unsynchronized dedup map race in PskReporterSender (decode-thread corruption)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
@@ -184,9 +184,7 @@ object PskReporterSender {
         // Dedup: skip if same callsign+band reported within window
         val bandMhz = msg.band / 1_000_000
         val dedupKey = "$cleanCall|$bandMhz"
-        val lastSeen = dedup[dedupKey]
-        if (lastSeen != null && nowMs - lastSeen < DEDUP_WINDOW_MS) return null
-        dedup[dedupKey] = nowMs
+        if (!markIfFresh(dedupKey, nowMs)) return null
 
         return SpotRecord(
             senderCallsign = cleanCall,
@@ -196,6 +194,33 @@ object PskReporterSender {
             senderLocator = msg.maidenGrid?.takeIf { it.length >= 4 },
             flowStartSeconds = msg.utcTime / 1000,
         )
+    }
+
+    /**
+     * Atomically test the per-band dedup window for [dedupKey] ("CALL|BAND") and,
+     * when it has not been reported within [DEDUP_WINDOW_MS], record [nowMs] as its
+     * last-seen time.
+     *
+     * enqueue() runs on the decode worker thread, and overlapping decode passes
+     * (slot N's late/deep pass vs slot N+1's early pass, #398) can invoke it
+     * concurrently — the same reason the surrounding afterDecode() state is
+     * synchronized in MainViewModel. Two threads mutating a plain HashMap corrupt
+     * its buckets (dropped spots, wrong size, or a CPU-pinned wedged decode
+     * thread), and the get-then-put must be atomic or the same spot slips through
+     * twice. spotQueue is already a ConcurrentLinkedQueue; this map was the one
+     * shared structure left unguarded.
+     *
+     * @return true if the spot should be reported (and was just marked), false if
+     *         it is a duplicate inside the window.
+     */
+    @VisibleForTesting
+    internal fun markIfFresh(dedupKey: String, nowMs: Long): Boolean {
+        synchronized(dedup) {
+            val lastSeen = dedup[dedupKey]
+            if (lastSeen != null && nowMs - lastSeen < DEDUP_WINDOW_MS) return false
+            dedup[dedupKey] = nowMs
+            return true
+        }
     }
 
     @VisibleForTesting
@@ -536,7 +561,7 @@ object PskReporterSender {
     @VisibleForTesting
     internal fun resetForTests() {
         spotQueue.clear()
-        dedup.clear()
+        synchronized(dedup) { dedup.clear() }
         sendJob?.cancel()
         sendJob = null
         scope?.cancel()

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
@@ -17,6 +17,11 @@ import java.nio.ByteOrder
 @RunWith(RobolectricTestRunner::class)
 class PskReporterSenderTest {
 
+    // Upper bound on how long a worker thread may run before a bounded join() gives up and
+    // the test fails deterministically instead of hanging the whole run. Generous vs. the
+    // sub-millisecond work so it never flakes on a slow/loaded CI box.
+    private val JOIN_TIMEOUT_MS = 30_000L
+
     private val captured = mutableListOf<ByteArray>()
 
     @Before
@@ -553,7 +558,11 @@ class PskReporterSenderTest {
                 }
             }
             threads.forEach { it.start() }
-            threads.forEach { it.join() }
+            // Bounded join: a regression could wedge/spin a thread (one of the failure modes
+            // this test guards against); without a timeout that would hang the whole run
+            // instead of failing. Assert every thread actually finished.
+            threads.forEach { it.join(JOIN_TIMEOUT_MS) }
+            assertThat(threads.none { it.isAlive }).isTrue()
             assertThat(admitted.get()).isEqualTo(1)
         }
     }
@@ -581,7 +590,10 @@ class PskReporterSenderTest {
             }
         }
         threads.forEach { it.start() }
-        threads.forEach { it.join() }
+        // Bounded join (see the same-key test): a wedged/spinning thread must fail the run,
+        // not hang it. Assert every thread finished within the timeout.
+        threads.forEach { it.join(JOIN_TIMEOUT_MS) }
+        assertThat(threads.none { it.isAlive }).isTrue()
         // Every distinct key is fresh exactly once — no lost or double inserts.
         assertThat(admitted.get()).isEqualTo(threadCount * perThread)
     }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
@@ -496,6 +496,96 @@ class PskReporterSenderTest {
             .isEqualTo("FT8AF 1.0.2")
     }
 
+    // ---------------------------------------------------------------
+    // Dedup window bookkeeping (markIfFresh) + thread-safety
+    // ---------------------------------------------------------------
+
+    // Mirrors PskReporterSender.DEDUP_WINDOW_MS (private const): 5 minutes.
+    private val dedupWindowMs = 5 * 60 * 1000L
+
+    @Test
+    fun `markIfFresh reports first sighting then dedups within the window`() {
+        val key = "W1AW|14"
+        // First sighting → reportable, and now marked.
+        assertThat(PskReporterSender.markIfFresh(key, 1_000L)).isTrue()
+        // Same key well inside the window → duplicate.
+        assertThat(PskReporterSender.markIfFresh(key, 1_000L + 1_000L)).isFalse()
+        assertThat(PskReporterSender.markIfFresh(key, 1_000L + dedupWindowMs - 1)).isFalse()
+        // Once the window has fully elapsed → reportable again.
+        assertThat(PskReporterSender.markIfFresh(key, 1_000L + dedupWindowMs)).isTrue()
+    }
+
+    @Test
+    fun `markIfFresh dedups per callsign-band key independently`() {
+        assertThat(PskReporterSender.markIfFresh("W1AW|14", 1_000L)).isTrue()
+        // Different band for the same call is a separate spot.
+        assertThat(PskReporterSender.markIfFresh("W1AW|7", 1_000L)).isTrue()
+        // Different call, same band is a separate spot.
+        assertThat(PskReporterSender.markIfFresh("K2ABC|14", 1_000L)).isTrue()
+        // Repeats of each are suppressed.
+        assertThat(PskReporterSender.markIfFresh("W1AW|14", 1_000L)).isFalse()
+        assertThat(PskReporterSender.markIfFresh("W1AW|7", 1_000L)).isFalse()
+        assertThat(PskReporterSender.markIfFresh("K2ABC|14", 1_000L)).isFalse()
+    }
+
+    /**
+     * Overlapping decode passes (#398) call enqueue()/toSpotRecord()/markIfFresh()
+     * on two decode threads at once. When many threads race on the SAME key, the
+     * get-then-put must be atomic so exactly one spot is reported — a non-atomic
+     * check (or a plain HashMap) lets several threads see "absent" and each report
+     * the same spot. Barrier-synchronized rounds maximize overlap so a
+     * non-atomic implementation would let more than one through.
+     */
+    @Test
+    fun `markIfFresh admits exactly one thread per key under concurrent access`() {
+        val threadCount = 8
+        repeat(30) { round ->
+            PskReporterSender.resetForTests()
+            PskReporterSender.sendDatagram = { data -> captured.add(data.copyOf()) }
+            val key = "RACE|14"
+            val now = 1_000L + round
+            val admitted = java.util.concurrent.atomic.AtomicInteger(0)
+            val barrier = java.util.concurrent.CyclicBarrier(threadCount)
+            val threads = (0 until threadCount).map {
+                Thread {
+                    barrier.await()
+                    if (PskReporterSender.markIfFresh(key, now)) admitted.incrementAndGet()
+                }
+            }
+            threads.forEach { it.start() }
+            threads.forEach { it.join() }
+            assertThat(admitted.get()).isEqualTo(1)
+        }
+    }
+
+    /**
+     * Concurrent inserts of many DISTINCT keys hammer the shared map's resize path.
+     * A plain HashMap mutated from multiple threads can corrupt its buckets, lose
+     * entries, or spin — the guarded map must simply complete, admitting every key
+     * exactly once.
+     */
+    @Test
+    fun `markIfFresh handles concurrent distinct keys without corruption`() {
+        val threadCount = 8
+        val perThread = 500
+        val admitted = java.util.concurrent.atomic.AtomicInteger(0)
+        val barrier = java.util.concurrent.CyclicBarrier(threadCount)
+        val threads = (0 until threadCount).map { t ->
+            Thread {
+                barrier.await()
+                for (i in 0 until perThread) {
+                    if (PskReporterSender.markIfFresh("CALL_${t}_$i|14", 1_000L)) {
+                        admitted.incrementAndGet()
+                    }
+                }
+            }
+        }
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+        // Every distinct key is fresh exactly once — no lost or double inserts.
+        assertThat(admitted.get()).isEqualTo(threadCount * perThread)
+    }
+
     /** Decode a hex string (all whitespace ignored) into bytes for golden-vector comparison. */
     private fun hex(s: String): ByteArray {
         val clean = s.filterNot { it.isWhitespace() }


### PR DESCRIPTION
## Root cause

`PskReporterSender.enqueue()` → `toSpotRecord()` read and wrote the shared plain `HashMap` `dedup` (`"CALL|BAND" -> last-seen ms`) with **no synchronization**:

```kotlin
val lastSeen = dedup[dedupKey]
if (lastSeen != null && nowMs - lastSeen < DEDUP_WINDOW_MS) return null
dedup[dedupKey] = nowMs
```

`enqueue()` is called from `MainViewModel.afterDecode()` (`MainViewModel.java:746`), which runs on the **decode worker thread**. The codebase explicitly documents that overlapping decode passes — slot N's late/deep pass vs slot N+1's early pass (#398) — call `afterDecode()` **concurrently**, which is exactly why the surrounding `ft8Messages` and decode-cycle state are wrapped in `synchronized(...)` blocks there. `spotQueue` was already a `ConcurrentLinkedQueue`, but the `dedup` map was the one shared structure left unguarded.

Two decode threads mutating one `HashMap` concurrently can:
- corrupt the internal buckets (`HashMap.resize()` on concurrent `put`) → dropped spots, wrong `size`, or a **CPU-pinned wedged decode thread**;
- and, because the get-then-put is non-atomic, let the **same spot slip through twice** (both threads see "absent").

Trigger: PSKReporter enabled (default on) + any overlapping decode pass (especially fast FT4/FT2 slots with deep decode).

## Fix

Extract the dedup check-and-mark into a synchronized, unit-testable `markIfFresh(dedupKey, nowMs)` and call it from `toSpotRecord()`; also guard the `resetForTests()` clear on the same monitor. The `synchronized(dedup)` block makes the compound check-and-set atomic and all map access thread-safe.

Single-threaded behavior is **byte-identical** — same dedup window, same per-`CALL|BAND` semantics. Only concurrent access changes (now correct instead of corrupting).

## Testing

`PskReporterSenderTest` (Robolectric, already present) gains:
- `markIfFresh reports first sighting then dedups within the window` — window bookkeeping.
- `markIfFresh dedups per callsign-band key independently` — per-key isolation.
- `markIfFresh admits exactly one thread per key under concurrent access` — 8 threads, barrier-synchronized, 30 rounds; asserts exactly one admit per key. **Fails on the pre-fix unsynchronized logic**, passes with the lock (verified by temporarily reverting).
- `markIfFresh handles concurrent distinct keys without corruption` — 8 threads × 500 distinct keys hammer the resize path; asserts every key admitted exactly once and no hang/throw.

Full `:app:testDebugUnitTest` passes (23 tests in the class, 0 failures; whole module green).

## Risk

Low. Localized to `PskReporterSender`; no protocol/DSP change; no wire-format change (IPFIX encoding untouched). Adds a per-message monitor acquisition on the decode thread — negligible (the map lookup already dominated, and the lock is uncontended in the common single-pass case).