### PR TITLE
Fix NTP time-sync applying only a partial (sub-cycle) clock correction

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
@@ -69,7 +69,7 @@ public class GpsClockUpdater extends LocationSubscriber {
     // The interval chosen by prepareStart() for the in-flight start(); consumed by
     // subscribeProviders() and onSubscribed(). Only touched under the monitor.
     private long pendingIntervalMs = -1;
-    // The offset UtcTimer.delay held *before* GPS discipline took it over (NTP's %-15000
+    // The offset UtcTimer.delay held *before* GPS discipline took it over (an NTP
     // sync, a manual correction, or 0). Captured on the first start() and restored by stop()
     // so disabling GPS returns the clock to its pre-GPS state instead of clobbering it with
     // manualTimeCorrectionMs, which NTP never writes. NO_SAVED_DELAY means "not disciplining".

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/UtcTimer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/UtcTimer.java
@@ -318,6 +318,41 @@ public class UtcTimer {
     }
 
     /**
+     * The clock offset (ms) to add to {@link System#currentTimeMillis()} so the app
+     * clock matches an authoritative UTC source — an NTP server's transmit timestamp.
+     * A positive result means the device clock is behind the reference and must be
+     * shifted forward. Written to {@link #delay} by {@link #syncTime}.
+     *
+     * <p><b>The full offset is returned</b>, not just its remainder within one FT8
+     * cycle. Storing only {@code offset % 15000} (as {@code syncTime} did before)
+     * keeps decode/TX cycle alignment intact — every slot length (15000, 7500, 3750)
+     * divides 15000, so the firing instants of {@link #isCycleBoundary} are unchanged
+     * — but it discards the whole-cycle part of the correction. A device clock more
+     * than one cycle out of sync would then leave {@link #getSystemTime()}, and every
+     * UTC value derived from it (the on-screen clock, QSO log start/end times, ADIF
+     * export times, and PSKReporter {@code flowStartSeconds}), wrong by a whole
+     * multiple of 15 s — silently, because RX/TX still work. This mirrors the GPS
+     * clock-discipline path ({@code GpsClockUpdater.gpsClockOffsetMs}) and the manual
+     * correction, both of which write the full offset.
+     *
+     * <p>Clamped to the {@code int} range so an absurdly wrong device clock (more than
+     * ~24.8 days off) can't overflow the {@code int} field into a bogus small value.
+     *
+     * <p>Package-visible via {@code public static} for pure-JVM testing.
+     *
+     * @param referenceUtcMs authoritative UTC "now" in ms (e.g. NTP transmit time)
+     * @param deviceNowMs    the device wall clock at the same instant
+     *                       ({@code System.currentTimeMillis()})
+     * @return the full offset in ms, clamped to {@code int} range
+     */
+    public static int ntpClockOffsetMs(long referenceUtcMs, long deviceNowMs) {
+        long offset = referenceUtcMs - deviceNowMs;
+        if (offset > Integer.MAX_VALUE) offset = Integer.MAX_VALUE;
+        if (offset < Integer.MIN_VALUE) offset = Integer.MIN_VALUE;
+        return (int) offset;
+    }
+
+    /**
      * Synchronize time using Microsoft's time server
      */
     public static void syncTime(AfterSyncTime afterSyncTime) {
@@ -330,8 +365,13 @@ public class UtcTimer {
                     InetAddress inetAddress = InetAddress.getByName("time.windows.com");
                     TimeInfo timeInfo = timeClient.getTime(inetAddress);
                     long serverTime = timeInfo.getMessage().getTransmitTimeStamp().getTime();
-                    int trueDelay = (int) ((serverTime - System.currentTimeMillis()));
-                    UtcTimer.delay = trueDelay % 15000;//delay per cycle
+                    // Apply the FULL correction, not just its remainder within one cycle.
+                    // Truncating to (offset % 15000) kept RX/TX cycle alignment but left the
+                    // app clock — and every UTC timestamp derived from it — off by a whole
+                    // multiple of 15s whenever the device clock was more than a cycle out.
+                    // See ntpClockOffsetMs.
+                    int trueDelay = ntpClockOffsetMs(serverTime, System.currentTimeMillis());
+                    UtcTimer.delay = trueDelay;
                     if (afterSyncTime != null) {
                         afterSyncTime.doAfterSyncTimer(trueDelay);
                     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/UtcTimer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/UtcTimer.java
@@ -338,7 +338,9 @@ public class UtcTimer {
      * <p>Clamped to the {@code int} range so an absurdly wrong device clock (more than
      * ~24.8 days off) can't overflow the {@code int} field into a bogus small value.
      *
-     * <p>Package-visible via {@code public static} for pure-JVM testing.
+     * <p>Exposed as {@code public static} for pure-JVM testing, consistent with the sibling
+     * {@link #sequential(long, int)} / {@link #isCycleBoundary(long, int, int)} helpers in this
+     * file (also {@code public static} and tested from the same package).
      *
      * @param referenceUtcMs authoritative UTC "now" in ms (e.g. NTP transmit time)
      * @param deviceNowMs    the device wall clock at the same instant

--- a/ft8af/app/src/test/java/com/k1af/ft8af/timer/UtcTimerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/timer/UtcTimerTest.java
@@ -242,4 +242,70 @@ public class UtcTimerTest {
             UtcTimer.delay = saved;
         }
     }
+
+    // ------------------------------------------------------------------
+    // ntpClockOffsetMs: the clock correction written to UtcTimer.delay by
+    // an NTP "Sync now" / startup auto-sync. Must be the FULL offset, not
+    // just its remainder within one FT8 cycle.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void ntpClockOffsetMs_zeroWhenClockMatchesReference() {
+        assertThat(UtcTimer.ntpClockOffsetMs(1_700_000_000_000L, 1_700_000_000_000L))
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void ntpClockOffsetMs_subCycleErrorReturnedVerbatim() {
+        // Device 5s behind the reference -> shift forward 5000ms.
+        assertThat(UtcTimer.ntpClockOffsetMs(1_700_000_005_000L, 1_700_000_000_000L))
+                .isEqualTo(5000);
+        // Device 3s ahead -> shift back 3000ms.
+        assertThat(UtcTimer.ntpClockOffsetMs(1_700_000_000_000L, 1_700_000_003_000L))
+                .isEqualTo(-3000);
+    }
+
+    @Test
+    public void ntpClockOffsetMs_multiCycleErrorKeepsWholeCyclePart() {
+        // Device 20s slow: the correction is the FULL 20000ms. The previous
+        // implementation stored (offset % 15000) = 5000, leaving the app clock a
+        // whole cycle (15s) behind true UTC and every logged/reported/displayed
+        // timestamp wrong by that much. Guard against that regression.
+        long device = 1_700_000_000_000L;
+        long reference = device + 20_000L;
+        int offset = UtcTimer.ntpClockOffsetMs(reference, device);
+        assertThat(offset).isEqualTo(20_000);
+        assertThat(offset).isNotEqualTo(20_000 % 15_000); // != the old truncated 5000
+
+        // Device 4 minutes fast -> full -240000ms correction (the old code, with
+        // 240000 an exact multiple of 15000, produced 0 -> "sync did nothing").
+        int fast = UtcTimer.ntpClockOffsetMs(device, device + 240_000L);
+        assertThat(fast).isEqualTo(-240_000);
+    }
+
+    @Test
+    public void ntpClockOffsetMs_preservesCycleAlignmentLikeTheOldTruncation() {
+        // Applying the full offset must keep decode/TX cycle timing identical: for
+        // every FT8/FT4/FT2 slot length, (fullOffset mod slot) == (truncatedOffset
+        // mod slot), because each slot length divides 15000. Only the whole-cycle
+        // part — the timestamp error — differs.
+        long device = 1_700_000_000_000L;
+        long reference = device + 47_321L; // arbitrary >1-cycle skew
+        int full = UtcTimer.ntpClockOffsetMs(reference, device);
+        int truncated = full % 15_000;
+        for (int slot : new int[]{15_000, 7_500, 3_750, 1_000}) {
+            assertThat(Math.floorMod(full, slot)).isEqualTo(Math.floorMod(truncated, slot));
+        }
+    }
+
+    @Test
+    public void ntpClockOffsetMs_clampsAbsurdErrorsToIntRange() {
+        // A wildly wrong device clock (> ~24.8 days off) must not overflow the int
+        // field. Clamp instead of wrapping to a bogus small value.
+        long device = 1_700_000_000_000L;
+        assertThat(UtcTimer.ntpClockOffsetMs(device + 5_000_000_000L, device))
+                .isEqualTo(Integer.MAX_VALUE);
+        assertThat(UtcTimer.ntpClockOffsetMs(device, device + 5_000_000_000L))
+                .isEqualTo(Integer.MIN_VALUE);
+    }
 }


### PR DESCRIPTION
## Summary

`UtcTimer.syncTime()` — the NTP clock sync that runs at startup on **every launch** (`MainViewModel.syncTime(null)`) and behind the settings "Sync now" button — only applied a **partial** correction. It stored `(serverTime - now) % 15000` into the app-wide clock offset `UtcTimer.delay`, throwing away the whole-cycle part of the correction.

## Root cause

`getSystemTime()` is `delay + System.currentTimeMillis()` and feeds slot-boundary detection **and** every UTC timestamp in the app. Because every slot length (FT8 15000 / FT4 7500 / FT2 3750 ms) divides 15000, truncating `delay` to `offset % 15000` kept RX/TX **cycle alignment** intact — which is exactly why this stayed silent — but it left the app clock (and everything derived from it) wrong by a whole multiple of 15 s whenever the device clock was more than one cycle out:

- on-screen UTC clock
- QSO log start/end times (`QSLRecord` via `getSystemTime()`)
- ADIF export times
- PSKReporter `flowStartSeconds`

Worst case: a device exactly N cycles off (e.g. 4 minutes = `240000 % 15000 == 0`) got **zero** correction — "Sync UTC time" did nothing. This hit precisely the users who most need the sync to rescue a drifted clock.

The sibling clock paths already do this correctly: the GPS discipline path (`GpsClockUpdater.gpsClockOffsetMs`, issue #373) and the manual correction both write the **full** offset to `UtcTimer.delay`. The NTP path was the odd one out — a source comment in `GpsClockUpdater` even called out "NTP's %-15000 sync".

## Fix

Apply the full offset. Extracted the arithmetic into a pure static helper `UtcTimer.ntpClockOffsetMs(referenceUtcMs, deviceNowMs)` (clamped to `int` range so an absurdly wrong device clock can't overflow the field), mirroring this file's existing testable `sequential()` / `isCycleBoundary()` helpers. Refreshed the now-stale `GpsClockUpdater` comment.

## Risk assessment

- **Cycle timing unchanged.** A test proves `full-offset mod slot == truncated mod slot` for every slot length (15000/7500/3750/1000), so `isCycleBoundary` fires on identical instants → RX/TX behavior is byte-identical. Only the absolute timestamps change (they become correct).
- **UI already handles a full offset.** The Compose `TimeSyncSettings` screen reads `UtcTimer.delay` and already copes with the large offsets the GPS path writes, so no display regression.
- Localized to two files + a comment; preserves backwards compatibility and cross-platform behavior.

## Testing

- `UtcTimerTest` gains 5 pure-JVM `ntpClockOffsetMs` cases: zero, sub-cycle verbatim, multi-cycle full-correction regression (the old truncation would have returned `5000`/`0`), cycle-alignment preservation, and int-range clamping. Confirmed the new test fails to compile before the helper exists, passes after.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — builds all 4 ABIs successfully.

No DSP/decoder code changed; encoder output and decoder sensitivity are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)