### PR TITLE
Fix HamlibRig crash from CAT calls after disconnect (RejectedExecutionException)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibRig.java
@@ -61,6 +61,13 @@ public class HamlibRig extends BaseRig {
      * call repeatedly.
      */
     private synchronized boolean ensureOpen() {
+        if (closed) {
+            // Torn down (or being torn down): never re-open. A task that was
+            // queued just before onDisconnecting() could otherwise open a fresh
+            // handle here that the close task (which captured the old handle)
+            // never releases — leaking the rig and leaving it open post-disconnect.
+            return false;
+        }
         if (handle != 0) {
             return true;
         }
@@ -101,13 +108,30 @@ public class HamlibRig extends BaseRig {
      * crash the app; here the request is simply dropped instead.
      */
     private void submitToWorker(Runnable task) {
-        if (closed) return;
+        if (closed) return; // fast path: don't even enqueue after disconnect
         try {
-            worker.submit(task);
+            worker.submit(() -> {
+                // Re-check at execution time: a task enqueued a moment before
+                // onDisconnecting() set closed can still be sitting in the queue
+                // when the rig is torn down. Running its CAT body then would call
+                // ensureOpen() and could re-open the handle after disconnect.
+                if (closed) return;
+                task.run();
+            });
         } catch (RejectedExecutionException e) {
             // Raced onDisconnecting()'s shutdown; the rig is gone — drop the task.
             Log.w(TAG, "worker rejected task after disconnect");
         }
+    }
+
+    /** Visible for tests: submit a raw task through the same closed-gate. */
+    void submitForTest(Runnable task) {
+        submitToWorker(task);
+    }
+
+    /** Visible for tests: block until the worker has fully drained/terminated. */
+    void awaitWorkerForTest() throws InterruptedException {
+        worker.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
     }
 
     @Override
@@ -176,8 +200,13 @@ public class HamlibRig extends BaseRig {
                 }
             });
         } catch (RejectedExecutionException e) {
-            // Worker already terminated; the native handle (if any) is unreachable.
-            Log.w(TAG, "worker rejected close task");
+            // Worker already terminated, so it can't run the close for us. The
+            // handle is still reachable via the local h — close it inline rather
+            // than leaking the native rig/pump resources.
+            Log.w(TAG, "worker rejected close task; closing handle inline");
+            if (h != 0) {
+                HamlibNative.nativeClose(h);
+            }
         }
         worker.shutdown();
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/HamlibRig.java
@@ -7,6 +7,7 @@ import com.k1af.ft8af.wave.HamlibNative;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * A {@link BaseRig} backed by hamlib instead of a hand-rolled per-manufacturer
@@ -32,6 +33,14 @@ public class HamlibRig extends BaseRig {
     private final int modelId;
     private final ExecutorService worker = Executors.newSingleThreadExecutor();
     private volatile long handle = 0;
+    /**
+     * Set once in {@link #onDisconnecting()}. After that the {@link #worker}
+     * executor has been shut down, so any further {@code worker.submit(...)}
+     * would throw {@link RejectedExecutionException}. Guarding on this flag (and
+     * catching the race with the shutdown) keeps a post-disconnect CAT call — or
+     * a second {@code onDisconnecting()} — from crashing the app.
+     */
+    private volatile boolean closed = false;
 
     /** Receives CAT bytes hamlib wants sent to the radio; forwards to connector. */
     private final HamlibNative.HamlibSink sink = data -> {
@@ -84,9 +93,26 @@ public class HamlibRig extends BaseRig {
         }
     }
 
+    /**
+     * Submit a CAT task to the worker, tolerating a rig that is (or is being)
+     * torn down. Once {@link #onDisconnecting()} has shut the executor down,
+     * {@code worker.submit(...)} would throw {@link RejectedExecutionException}
+     * on the caller's thread (the UI thread, or the TX sequencer for PTT) and
+     * crash the app; here the request is simply dropped instead.
+     */
+    private void submitToWorker(Runnable task) {
+        if (closed) return;
+        try {
+            worker.submit(task);
+        } catch (RejectedExecutionException e) {
+            // Raced onDisconnecting()'s shutdown; the rig is gone — drop the task.
+            Log.w(TAG, "worker rejected task after disconnect");
+        }
+    }
+
     @Override
     public void setUsbModeToRig() {
-        worker.submit(() -> {
+        submitToWorker(() -> {
             if (!ensureOpen()) return;
             int rc = HamlibNative.nativeSetMode(handle, FT_MODE);
             if (rc != 0) Log.w(TAG, "set_mode(" + FT_MODE + ") rc=" + rc);
@@ -99,7 +125,7 @@ public class HamlibRig extends BaseRig {
         // The app already picks an in-band FT8 frequency, so this never QSYs to
         // an untuned band — hamlib just sets exactly what the app asked for.
         final long hz = getFreq();
-        worker.submit(() -> {
+        submitToWorker(() -> {
             if (!ensureOpen()) return;
             int rc = HamlibNative.nativeSetFreq(handle, hz);
             if (rc != 0) Log.w(TAG, "set_freq(" + hz + ") rc=" + rc);
@@ -108,7 +134,7 @@ public class HamlibRig extends BaseRig {
 
     @Override
     public void readFreqFromRig() {
-        worker.submit(() -> {
+        submitToWorker(() -> {
             if (!ensureOpen()) return;
             long f = HamlibNative.nativeGetFreq(handle);
             if (f > 0) {
@@ -120,7 +146,7 @@ public class HamlibRig extends BaseRig {
     @Override
     public void setPTT(boolean on) {
         super.setPTT(on); // notify listeners / meter state
-        worker.submit(() -> {
+        submitToWorker(() -> {
             if (!ensureOpen()) return;
             int rc = HamlibNative.nativeSetPtt(handle, on);
             if (rc != 0) Log.w(TAG, "set_ptt(" + on + ") rc=" + rc);
@@ -134,13 +160,25 @@ public class HamlibRig extends BaseRig {
 
     @Override
     public void onDisconnecting() {
+        // Idempotent: this can be called more than once on the same instance
+        // (e.g. a user disconnect via CableConnector.disconnect() followed by a
+        // reconnect through connectRig(), which does not null the old rig).
+        // Shutting the worker down twice — or submitting to it after the first
+        // shutdown — would throw RejectedExecutionException and crash the app.
+        if (closed) return;
+        closed = true;
         final long h = handle;
         handle = 0;
-        worker.submit(() -> {
-            if (h != 0) {
-                HamlibNative.nativeClose(h);
-            }
-        });
+        try {
+            worker.submit(() -> {
+                if (h != 0) {
+                    HamlibNative.nativeClose(h);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // Worker already terminated; the native handle (if any) is unreachable.
+            Log.w(TAG, "worker rejected close task");
+        }
         worker.shutdown();
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibRigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibRigTest.java
@@ -36,4 +36,36 @@ public class HamlibRigTest {
         // reaching here without an exception is the assertion
         assertThat(rig.getName()).isEqualTo("Hamlib");
     }
+
+    @Test
+    public void onDisconnecting_isIdempotent_doesNotThrow() {
+        // onDisconnecting() shuts down the internal worker executor. It can be
+        // invoked more than once on the same instance (a user disconnect via
+        // CableConnector.disconnect() leaves baseRig set, then a reconnect runs
+        // connectRig() -> onDisconnecting() again). A second call must not
+        // re-submit to the now-terminated executor (RejectedExecutionException).
+        HamlibRig rig = new HamlibRig(1036);
+        rig.onDisconnecting();
+        rig.onDisconnecting(); // second call previously threw
+        rig.onDisconnecting(); // still safe on repeat
+        assertThat(rig.getName()).isEqualTo("Hamlib");
+    }
+
+    @Test
+    public void catControlAfterDisconnecting_doesNotThrow() {
+        // After the rig is torn down, any residual CAT call (e.g. the CAT
+        // liveness probe, a queued band change, or the TX sequencer releasing
+        // PTT) must be dropped rather than crashing the caller thread with a
+        // RejectedExecutionException from the shut-down worker.
+        HamlibRig rig = new HamlibRig(1036);
+        rig.onDisconnecting();
+
+        rig.setFreqToRig();
+        rig.readFreqFromRig();
+        rig.setUsbModeToRig();
+        rig.setPTT(true);
+        rig.setPTT(false);
+        // reaching here without an exception is the assertion
+        assertThat(rig.getName()).isEqualTo("Hamlib");
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibRigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/HamlibRigTest.java
@@ -2,6 +2,10 @@ package com.k1af.ft8af.rigs;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Test;
 
 /**
@@ -67,5 +71,41 @@ public class HamlibRigTest {
         rig.setPTT(false);
         // reaching here without an exception is the assertion
         assertThat(rig.getName()).isEqualTo("Hamlib");
+    }
+
+    @Test
+    public void taskQueuedBeforeDisconnect_doesNotRunBodyAfterClose() throws Exception {
+        // A CAT task can be sitting in the worker queue at the moment
+        // onDisconnecting() flips `closed`. Its body must NOT run afterward —
+        // otherwise it would call ensureOpen() and re-open a handle that the
+        // close task (which captured the pre-disconnect handle) never releases.
+        HamlibRig rig = new HamlibRig(1036);
+        CountDownLatch aStarted = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicBoolean bBodyRan = new AtomicBoolean(false);
+
+        // Task A occupies the single worker thread until released.
+        rig.submitForTest(() -> {
+            aStarted.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertThat(aStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Task B is enqueued behind A while the rig is still live (closed==false),
+        // so it passes the submit-time fast path and gets wrapped + queued.
+        rig.submitForTest(() -> bBodyRan.set(true));
+
+        // Tear down: sets closed=true, then shutdown() lets A and B drain.
+        rig.onDisconnecting();
+
+        release.countDown();
+        rig.awaitWorkerForTest();
+
+        // The execution-time re-check dropped B's body after disconnect.
+        assertThat(bBodyRan.get()).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
`HamlibRig` (the hamlib CAT backend added in #516) crashes the app with an uncaught `RejectedExecutionException` when a CAT operation — or a second `onDisconnecting()` — runs after the rig has been disconnected. This is a stability bug in freshly-merged code.

## Root cause
`HamlibRig` runs hamlib's synchronous `rig_*` round-trips on a private single-thread `ExecutorService worker`. `onDisconnecting()` calls `worker.shutdown()`, but every other method still submits to it with no guard:

- `setUsbModeToRig()`, `setFreqToRig()`, `readFreqFromRig()`, `setPTT()` — all `worker.submit(...)`
- `onDisconnecting()` itself re-submits (the `nativeClose` task) and re-shuts-down

Once the executor is terminated, `worker.submit(...)` throws `RejectedExecutionException` (unchecked, default `AbortPolicy`) **on the caller's thread**, crashing the process.

## Reachability (confirmed)
`onDisconnecting()` is not always the terminal call on an instance:

- `CableConnector.disconnect()` calls `cableConnectedRig.onDisconnecting()` but does **not** null `MainViewModel.baseRig`.
- Only `connectRig()` nulls `baseRig` (right after its own `onDisconnecting()` call).

So switching from a USB hamlib rig to a network rig runs `baseRig.getConnector().disconnect()` → `onDisconnecting()` (#1, worker shut down), then `connectRig()` → `onDisconnecting()` (#2) on the same instance → `submit` on a terminated executor → **crash**. A residual CAT call after disconnect (the CAT-liveness probe at `MainViewModel.catLivenessTick`, a queued band change via `setFreqToRig`, or the TX sequencer releasing PTT via `setPTT(false)`) hits the same throw.

`HamlibRig` is the only rig whose `onDisconnecting()` shuts down an executor and re-submits — the other rigs' overrides just emit bytes and are inherently idempotent, so this is specific to the hamlib backend.

## Fix
Smallest safe change; happy path is byte-identical:
- `onDisconnecting()` is now **idempotent** via a `volatile boolean closed` flag (this also prevents a double `nativeClose`, i.e. a native double-free/`delete b`).
- All worker submissions route through a `submitToWorker()` helper that drops the task when `closed`, and defensively catches `RejectedExecutionException` to cover the set-flag/shutdown race between threads.

## Testing
`ft8af/app/src/test/java/.../rigs/HamlibRigTest.java` (pure JUnit, no device):
- `onDisconnecting_isIdempotent_doesNotThrow`
- `catControlAfterDisconnecting_doesNotThrow`

Both **fail on the pre-fix code** with `RejectedExecutionException` (verified by reverting only the source) and **pass** after the fix. Full `:app:testDebugUnitTest --tests "com.k1af.ft8af.rigs.*"` is green (JDK 17 / NDK 27 / cmake 3.22).

## Risk
Very low. No protocol/DSP behavior changes; no native changes. Only adds a guard around existing background-task submission so teardown/reconnect can't crash the caller thread. Byte-identical while connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)