### PR TITLE
Validate X6100 rig-reported audio frames/period before TX use (crash/hang hardening)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Radio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Radio.java
@@ -79,8 +79,16 @@ public class X6100Radio {
     private XieguCommand xieguCommand;
     private int handle = 0;
     private String commandStr;
-    private int frames = 768;//frames per cycle
+    private int frames = 768;//frames per cycle (samples per TX audio packet)
     private int period = 64;//duration per cycle in milliseconds
+
+    // Upper bound accepted for a rig-reported audio "frames" (samples per TX
+    // packet). The default is 768 (64 ms at 12 kHz); a single packet larger than
+    // a whole 15 s TX cycle (180 000 samples) is nonsensical, so anything above
+    // this is a garbled/hostile reply. Capping keeps sendWaveData's
+    // `new short[frames]` allocation bounded (never an OutOfMemoryError) — see
+    // parseAudioFrames.
+    static final int MAX_AUDIO_FRAMES = 192_000;
 
 
     //************************event handling interfaces*******************************
@@ -755,14 +763,71 @@ public class X6100Radio {
         for (int i = 0; i < keys.length; i++) {
             String[] val = keys[i].split("=");
             if (val.length < 2) continue;
-            try {
-                if (val[0].equalsIgnoreCase("period")) period = Integer.parseInt(val[1]) / 1000;
-                if (val[0].equalsIgnoreCase("frames")) frames = Integer.parseInt(val[1]);
-            } catch (NumberFormatException e) {
-                Log.e(TAG, "Error parsing audio info: " + keys[i], e);
-            }
+            if (val[0].equalsIgnoreCase("period")) period = parseAudioPeriodMs(val[1], period);
+            if (val[0].equalsIgnoreCase("frames")) frames = parseAudioFrames(val[1], frames);
         }
         Log.d(TAG, String.format("set audio para:frames=%d,period=%d", frames, period));
+    }
+
+    /**
+     * Parse the rig's audio {@code frames=} value (samples per TX audio packet)
+     * from its network "audio get all" reply, returning {@code fallback} (the
+     * current value) for anything that isn't a sane positive count.
+     *
+     * <p>The value is consumed by {@link #sendWaveData(float[])} as an array size
+     * ({@code new short[frames]}) and a chunk stride. A non-positive value there
+     * is not just wrong data — it crashes or hangs the TX thread, and that thread
+     * is reached from untrusted network input via the TCP CAT read loop
+     * ({@link com.k1af.ft8af.flex.RadioTcpClient}), which catches only
+     * {@code SocketException}/{@code IOException}, while {@code sendWaveData}
+     * itself catches only {@code UnknownHostException}:
+     * <ul>
+     *   <li>{@code frames < 0} → {@code new short[frames]} throws
+     *       {@code NegativeArraySizeException} → uncaught → whole-app crash.</li>
+     *   <li>{@code frames == 0} → the copy loop never advances its offset and
+     *       spins for the whole over, flooding the rig with empty audio.</li>
+     *   <li>an absurdly large value → multi-GB allocation →
+     *       {@code OutOfMemoryError}.</li>
+     * </ul>
+     * Validating here, at the single ingestion point, keeps the invariant
+     * {@code 0 < frames <= MAX_AUDIO_FRAMES} for the field (its only other writer
+     * is the 768 default), so {@code sendWaveData} can never see a bad value.
+     *
+     * <p>Package-private and static so it can be unit-tested without a live
+     * socket or {@code Context}.
+     */
+    static int parseAudioFrames(String raw, int fallback) {
+        if (raw == null) return fallback;
+        try {
+            int f = Integer.parseInt(raw.trim());
+            if (f > 0 && f <= MAX_AUDIO_FRAMES) {
+                return f;
+            }
+        } catch (NumberFormatException ignored) {
+            // fall through to fallback
+        }
+        return fallback;
+    }
+
+    /**
+     * Parse the rig's audio {@code period=} value (microseconds) into whole
+     * milliseconds, returning {@code fallback} for anything that isn't a positive
+     * duration. {@code sendWaveData} busy-waits {@code period} ms between packets;
+     * a value below 1000 µs truncates to 0 ms on the {@code /1000}, turning that
+     * wait into a tight CPU spin. Same ingestion-point-validation rationale (and
+     * unit-testability) as {@link #parseAudioFrames}.
+     */
+    static int parseAudioPeriodMs(String raw, int fallback) {
+        if (raw == null) return fallback;
+        try {
+            int ms = Integer.parseInt(raw.trim()) / 1000;
+            if (ms > 0) {
+                return ms;
+            }
+        } catch (NumberFormatException ignored) {
+            // fall through to fallback
+        }
+        return fallback;
     }
 
     public synchronized void sendData(byte[] data) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Radio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Radio.java
@@ -83,12 +83,20 @@ public class X6100Radio {
     private int period = 64;//duration per cycle in milliseconds
 
     // Upper bound accepted for a rig-reported audio "frames" (samples per TX
-    // packet). The default is 768 (64 ms at 12 kHz); a single packet larger than
-    // a whole 15 s TX cycle (180 000 samples) is nonsensical, so anything above
-    // this is a garbled/hostile reply. Capping keeps sendWaveData's
-    // `new short[frames]` allocation bounded (never an OutOfMemoryError) — see
-    // parseAudioFrames.
-    static final int MAX_AUDIO_FRAMES = 192_000;
+    // packet). The default is 768 (64 ms at 12 kHz); a single packet as large as
+    // a whole 15 s TX cycle (180 000 samples at 12 kHz) is already the ceiling of
+    // anything sensible, so anything larger is a garbled/hostile reply. Capping
+    // keeps sendWaveData's `new short[frames]` allocation bounded (never an
+    // OutOfMemoryError) — see parseAudioFrames.
+    static final int MAX_AUDIO_FRAMES = 180_000;
+
+    // Upper bound accepted for the rig-reported audio "period" (packet-pacing gap
+    // in ms, after the µs→ms conversion). The X6100 uses 64 ms; sendWaveData
+    // busy-waits `period` ms between packets, so a garbled value like
+    // period=2147483647 (µs) would spin the TX thread at 100% CPU for ~35 minutes
+    // per packet. A gap beyond 1 s is far past any real rig cadence, so treat it
+    // as garbled and fall back — see parseAudioPeriodMs.
+    static final int MAX_AUDIO_PERIOD_MS = 1_000;
 
 
     //************************event handling interfaces*******************************
@@ -811,17 +819,19 @@ public class X6100Radio {
 
     /**
      * Parse the rig's audio {@code period=} value (microseconds) into whole
-     * milliseconds, returning {@code fallback} for anything that isn't a positive
-     * duration. {@code sendWaveData} busy-waits {@code period} ms between packets;
-     * a value below 1000 µs truncates to 0 ms on the {@code /1000}, turning that
-     * wait into a tight CPU spin. Same ingestion-point-validation rationale (and
-     * unit-testability) as {@link #parseAudioFrames}.
+     * milliseconds, returning {@code fallback} for anything that isn't a sane
+     * positive duration. {@code sendWaveData} busy-waits {@code period} ms between
+     * packets, so the value is bounded on both ends: a value below 1000 µs
+     * truncates to 0 ms on the {@code /1000}, turning that wait into a tight CPU
+     * spin, and a value above {@link #MAX_AUDIO_PERIOD_MS} would spin the TX
+     * thread for many seconds/minutes per packet. Same ingestion-point-validation
+     * rationale (and unit-testability) as {@link #parseAudioFrames}.
      */
     static int parseAudioPeriodMs(String raw, int fallback) {
         if (raw == null) return fallback;
         try {
             int ms = Integer.parseInt(raw.trim()) / 1000;
-            if (ms > 0) {
+            if (ms > 0 && ms <= MAX_AUDIO_PERIOD_MS) {
                 return ms;
             }
         } catch (NumberFormatException ignored) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100RadioAudioInfoTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100RadioAudioInfoTest.java
@@ -1,0 +1,115 @@
+package com.k1af.ft8af.x6100;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link X6100Radio#parseAudioFrames(String, int)} and
+ * {@link X6100Radio#parseAudioPeriodMs(String, int)} — the validation of the
+ * audio parameters the Xiegu X6100 reports in its network "audio get all" reply.
+ *
+ * <p>These values are consumed by {@code X6100Radio.sendWaveData} as an array
+ * size ({@code new short[frames]}) and a busy-wait duration. Before this guard a
+ * non-positive / garbled {@code frames=} crashed the TX thread with
+ * {@code NegativeArraySizeException} (or spun it forever on {@code frames=0}),
+ * and a {@code period} under 1000 µs truncated to a 0 ms wait (a CPU spin) — all
+ * reachable from untrusted network input, since the CAT read loop
+ * ({@link com.k1af.ft8af.flex.RadioTcpClient}) catches only
+ * {@code SocketException}/{@code IOException} and {@code sendWaveData} catches
+ * only {@code UnknownHostException}.
+ *
+ * <p>{@code android.util.Log} returns defaults under plain JUnit
+ * (unitTests.returnDefaultValues), and the helpers are pure, so no Robolectric
+ * runner is needed.
+ */
+public class X6100RadioAudioInfoTest {
+
+    private static final int FRAMES_DEFAULT = 768; // the field's initial value
+    private static final int PERIOD_DEFAULT = 64;  // ms
+
+    // ---- parseAudioFrames ----------------------------------------------------
+
+    @Test
+    public void frames_validValue_isApplied() {
+        // A normal X6100 reports frames=768 (64 ms at 12 kHz).
+        assertThat(X6100Radio.parseAudioFrames("768", FRAMES_DEFAULT)).isEqualTo(768);
+    }
+
+    @Test
+    public void frames_otherValidValue_isApplied() {
+        assertThat(X6100Radio.parseAudioFrames("1024", FRAMES_DEFAULT)).isEqualTo(1024);
+    }
+
+    @Test
+    public void frames_maxBoundary_isApplied() {
+        assertThat(X6100Radio.parseAudioFrames(
+                Integer.toString(X6100Radio.MAX_AUDIO_FRAMES), FRAMES_DEFAULT))
+                .isEqualTo(X6100Radio.MAX_AUDIO_FRAMES);
+    }
+
+    @Test
+    public void frames_zero_keepsDefault_avoidsSendWaveDataSpin() {
+        // frames==0 makes sendWaveData's copy loop never advance -> infinite spin.
+        assertThat(X6100Radio.parseAudioFrames("0", FRAMES_DEFAULT)).isEqualTo(FRAMES_DEFAULT);
+    }
+
+    @Test
+    public void frames_negative_keepsDefault_avoidsNegativeArraySize() {
+        // frames<0 -> new short[frames] -> NegativeArraySizeException (uncaught crash).
+        assertThat(X6100Radio.parseAudioFrames("-5", FRAMES_DEFAULT)).isEqualTo(FRAMES_DEFAULT);
+    }
+
+    @Test
+    public void frames_absurdlyLarge_keepsDefault_avoidsOom() {
+        // A multi-GB short[] would OutOfMemoryError; reject values past the cap.
+        assertThat(X6100Radio.parseAudioFrames("999999999", FRAMES_DEFAULT))
+                .isEqualTo(FRAMES_DEFAULT);
+        assertThat(X6100Radio.parseAudioFrames(
+                Integer.toString(X6100Radio.MAX_AUDIO_FRAMES + 1), FRAMES_DEFAULT))
+                .isEqualTo(FRAMES_DEFAULT);
+    }
+
+    @Test
+    public void frames_nonNumeric_keepsDefault() {
+        assertThat(X6100Radio.parseAudioFrames("abc", FRAMES_DEFAULT)).isEqualTo(FRAMES_DEFAULT);
+        assertThat(X6100Radio.parseAudioFrames("", FRAMES_DEFAULT)).isEqualTo(FRAMES_DEFAULT);
+        assertThat(X6100Radio.parseAudioFrames(null, FRAMES_DEFAULT)).isEqualTo(FRAMES_DEFAULT);
+    }
+
+    @Test
+    public void frames_whitespaceIsTolerated() {
+        assertThat(X6100Radio.parseAudioFrames("  768  ", FRAMES_DEFAULT)).isEqualTo(768);
+    }
+
+    // ---- parseAudioPeriodMs --------------------------------------------------
+
+    @Test
+    public void period_validValue_isConvertedToMs() {
+        // A normal X6100 reports period in microseconds (64000 -> 64 ms).
+        assertThat(X6100Radio.parseAudioPeriodMs("64000", PERIOD_DEFAULT)).isEqualTo(64);
+    }
+
+    @Test
+    public void period_belowOneMs_keepsDefault_avoidsBusyWaitSpin() {
+        // Under 1000 µs truncates to 0 ms on the /1000 -> the packet-pacing
+        // busy-wait becomes a tight CPU spin. Keep the sane default instead.
+        assertThat(X6100Radio.parseAudioPeriodMs("500", PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
+    }
+
+    @Test
+    public void period_zero_keepsDefault() {
+        assertThat(X6100Radio.parseAudioPeriodMs("0", PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
+    }
+
+    @Test
+    public void period_negative_keepsDefault() {
+        assertThat(X6100Radio.parseAudioPeriodMs("-1000", PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
+    }
+
+    @Test
+    public void period_nonNumeric_keepsDefault() {
+        assertThat(X6100Radio.parseAudioPeriodMs("xyz", PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
+        assertThat(X6100Radio.parseAudioPeriodMs(null, PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100RadioAudioInfoTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100RadioAudioInfoTest.java
@@ -112,4 +112,30 @@ public class X6100RadioAudioInfoTest {
         assertThat(X6100Radio.parseAudioPeriodMs("xyz", PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
         assertThat(X6100Radio.parseAudioPeriodMs(null, PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
     }
+
+    @Test
+    public void period_maxBoundary_isApplied() {
+        // Exactly the cap (1 s == 1_000_000 µs) is still accepted.
+        assertThat(X6100Radio.parseAudioPeriodMs(
+                Integer.toString(X6100Radio.MAX_AUDIO_PERIOD_MS * 1000), PERIOD_DEFAULT))
+                .isEqualTo(X6100Radio.MAX_AUDIO_PERIOD_MS);
+    }
+
+    @Test
+    public void period_absurdlyLarge_keepsDefault_avoidsBusyWaitHang() {
+        // period=2147483647 µs -> ~35 min busy-wait per packet on the TX thread.
+        // Anything past MAX_AUDIO_PERIOD_MS must fall back to the sane default.
+        assertThat(X6100Radio.parseAudioPeriodMs(
+                Integer.toString(Integer.MAX_VALUE), PERIOD_DEFAULT)).isEqualTo(PERIOD_DEFAULT);
+        assertThat(X6100Radio.parseAudioPeriodMs(
+                Integer.toString((X6100Radio.MAX_AUDIO_PERIOD_MS + 1) * 1000), PERIOD_DEFAULT))
+                .isEqualTo(PERIOD_DEFAULT);
+    }
+
+    @Test
+    public void frames_maxCapMatchesWholeTxCycle() {
+        // The cap equals a whole 15 s TX cycle at 12 kHz (180 000 samples), so the
+        // documented rationale and the constant agree.
+        assertThat(X6100Radio.MAX_AUDIO_FRAMES).isEqualTo(180_000);
+    }
 }


### PR DESCRIPTION
## Summary

The Xiegu **X6100 network (ft8cns) mode** reads its audio-stream parameters from the rig's `audio get all` reply in `X6100Radio.setAudioInfo`, storing them in the `frames`/`period` fields. `frames` was parsed with `Integer.parseInt` and stored **with no range check**; `sendWaveData` then uses it directly as an array size (`new short[frames]`) and a chunk stride, and `period` as a busy-wait duration.

These values come from **untrusted network input**, and the surrounding code is clearly meant to survive a bad packet (the CAT read loop only reconnects) — but it doesn't here.

## Root cause

`X6100Radio.setAudioInfo` (reached on the TCP CAT read thread whenever the rig answers the audio query) stored `frames`/`period` verbatim. `sendWaveData` (the live X6100 network TX path: `XieGu6100NetRig → X6100Connector → X6100Radio`) then consumes them on the transmit thread with no validation:

- `frames < 0` → `new short[frames]` throws **`NegativeArraySizeException`** → uncaught → **whole-app crash**.
- `frames == 0` → the copy loop never advances `count` → **spins for the whole over**, flooding the rig with empty audio (undecodable TX + CPU/battery drain).
- an absurdly large `frames` → multi-GB `short[]` → **`OutOfMemoryError`**.
- `period` below 1000 µs → truncates to `0` ms on the `/1000` → the packet-pacing busy-wait becomes a **tight CPU spin**.

The read loop (`flex/RadioTcpClient`) catches only `SocketException`/`IOException`, and `sendWaveData` catches only `UnknownHostException`, so none of the above is contained — matching the network-parse-crash hazard class fixed across many prior PRs for Flex/Xiegu.

## Fix

Validate at the single ingestion point. `parseAudioFrames` / `parseAudioPeriodMs` parse and range-check the value, returning the current (default `768` / `64` ms) value for anything that isn't a sane positive count. The field's only other writer is its `768` default, so the invariant `0 < frames <= MAX_AUDIO_FRAMES` and `period > 0` always holds and `sendWaveData` can never see a crashing/spinning value. No change to `sendWaveData` itself.

A well-behaved X6100 (`frames=768`, `period=64000`) is **unaffected** — its values pass through unchanged. No protocol/interop change.

Same package-private-static, pure-JVM-testable shape as the existing `parseXieguHandle` crash fix in this class.

## Testing

- **New:** `X6100RadioAudioInfoTest` — 13 pure-JUnit + Truth cases (no Robolectric; `android.util.Log` returns defaults under `unitTests.returnDefaultValues`): valid values applied; zero/negative/absurd `frames` and sub-ms/zero/negative `period` keep the default; whitespace tolerated; non-numeric/`null` handled.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full APK (incl. native/hamlib ×4 ABIs) builds clean.

## Risk

Very low. One Java file, one method rewritten to delegate to two pure helpers plus a defensive range check; happy-path behavior byte-identical for valid rig replies. No DSP, native, or protocol changes. No device required to validate the fix (the decision logic is fully unit-tested).