### PR TITLE
fix: USB capture reliability — stop crash-on-attach and the clean-stop reinit churn

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -310,19 +310,35 @@ public class MicRecorder {
             }
 
             @Override
-            public void onCaptureStopped() {
-                // The libusb-direct capture session ended without an explicit
-                // stop. Decide whether it counts as a failure by how long it
-                // stayed alive: a session that dies before it can carry a
-                // fraction of an FT8 cycle is useless even if a few samples
-                // arrived first (the Pixel 8 + C-Media field mode: ~100ms of
-                // audio, then every iso transfer retires). The old rule only
-                // counted "no data at all", so that mode never tripped the tally
-                // and churned a fresh libusb_init/exit every 2s forever — the
-                // waterfall freeze, and the churn that raced libusb into a
-                // native SIGSEGV.
+            public void onCaptureStopped(int stopCode) {
                 long now = SystemClock.elapsedRealtime();
                 long aliveMs = now - usbCaptureStartMs;
+
+                // A clean stop (code 0) is a nativeStop WE requested — a reinit,
+                // a band change, stopRecord(), or app teardown — not a capture
+                // failure. The initiator restarts capture itself where wanted
+                // (reinitialize() -> start()), so scheduling a retry here would
+                // tear down the capture it just brought back, and that self-kill
+                // then looks like another "failure" and schedules yet another
+                // reinit. That feedback loop pinned the C-Media adapter in a
+                // perpetual fail->backoff->reinit churn (in the field 429 of 434
+                // stops were clean stops misclassified this way), leaving the
+                // decoder deaf for ~87% of receive slots so stations' replies
+                // were never heard — the "QSO sequence broken" report. Only a
+                // genuine failure (non-zero code: transfers retired, NO_DEVICE,
+                // event-loop error) drives the retry below.
+                if (!UsbCaptureRetryPolicy.isRetryableFailure(stopCode)) {
+                    GeneralVariables.fileLog(String.format(
+                            "startUsbCapture: clean stop (code=%d aliveMs=%d) — not a "
+                                    + "failure, no reinit scheduled", stopCode, aliveMs));
+                    return;
+                }
+
+                // Genuine failure. Decide whether it counts against the tally by
+                // how long it stayed alive: a session that dies before it can
+                // carry a fraction of an FT8 cycle is useless even if a few
+                // samples arrived first (the Pixel 8 + C-Media field mode: ~100ms
+                // of audio, then every iso transfer retires).
                 boolean failure = UsbCaptureRetryPolicy.isFailure(usbAudioSawData, aliveMs);
                 UsbCaptureRetryPolicy.ReinitPlan plan = UsbCaptureRetryPolicy.planReinit(
                         usbAudioSawData, aliveMs, consecutiveUsbFailures);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -328,9 +328,18 @@ public class MicRecorder {
                 // genuine failure (non-zero code: transfers retired, NO_DEVICE,
                 // event-loop error) drives the retry below.
                 if (!UsbCaptureRetryPolicy.isRetryableFailure(stopCode)) {
+                    // A clean stop is never a failure, but if this session stayed
+                    // alive and delivering audio long enough to be useful the
+                    // device is healthy — clear any stale failure streak so the
+                    // next genuine failure doesn't inherit an inflated backoff.
+                    int resetTally = UsbCaptureRetryPolicy.tallyAfterCleanStop(
+                            consecutiveUsbFailures, usbAudioSawData, aliveMs);
+                    boolean streakCleared = resetTally != consecutiveUsbFailures;
+                    consecutiveUsbFailures = resetTally;
                     GeneralVariables.fileLog(String.format(
                             "startUsbCapture: clean stop (code=%d aliveMs=%d) — not a "
-                                    + "failure, no reinit scheduled", stopCode, aliveMs));
+                                    + "failure, no reinit scheduled%s", stopCode, aliveMs,
+                            streakCleared ? " (healthy session, failure streak reset)" : ""));
                     return;
                 }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -22,6 +22,10 @@ import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
 import com.k1af.ft8af.ui.ToastMessage;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 public class MicRecorder {
     private static final String TAG = "MicRecorder";
     private int bufferSize = 0;//minimum buffer size
@@ -68,6 +72,50 @@ public class MicRecorder {
     private long lastReinitMs = 0;
     private int consecutiveUsbFailures = 0;
     private volatile boolean usbAudioSawData = false;
+
+    // Runs the backoff + reinitialize() that follows a USB capture-stopped event.
+    // onCaptureStopped() fires on the native libusb event thread; doing the sleep
+    // + reinit there keeps that thread parked inside the native event loop, so an
+    // in-flight nativeStop()'s join() blocks on it while the reinit drives the
+    // next nativeStart() — the new libusb_init() then overlaps the dying
+    // session's libusb_exit() and the process aborts on a destroyed libusb mutex
+    // ("pthread_mutex_lock called on a destroyed mutex", the USB-attach crash
+    // loop). Handing the work to this single dedicated thread lets the event
+    // thread return so nativeStop() completes first; single-threaded so stacked
+    // stops reinit one-at-a-time; daemon so it never holds up process exit.
+    // Built via newUsbReinitExecutor() so a unit test can exercise the exact
+    // same executor (off-caller-thread + serialized) that guards the crash.
+    private final ExecutorService usbReinitExecutor = newUsbReinitExecutor();
+
+    /**
+     * The executor that must run every post-capture-stop reinit. A single
+     * daemon worker named {@code USB-Audio-Reinit}: single-threaded so stacked
+     * stop events reinit one-at-a-time (never two overlapping libusb contexts),
+     * off the caller so the native event thread is never parked in reinit, and
+     * daemon so it never holds up process exit. Extracted so
+     * {@code MicRecorderUsbReinitDispatchTest} verifies these properties on the
+     * real construction.
+     */
+    static ExecutorService newUsbReinitExecutor() {
+        return Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "USB-Audio-Reinit");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    /**
+     * Dispatch the backoff + reinit for a stopped USB capture session. The one
+     * job of this seam: the work ALWAYS goes through {@code executor} and NEVER
+     * runs on the calling thread. onCaptureStopped() runs on the native libusb
+     * event thread; running the reinit inline there is exactly what raced
+     * libusb into the destroyed-mutex SIGABRT (nativeStop()'s join() blocks on
+     * the event thread while it drives the next nativeStart()). A unit test
+     * pins this by passing an executor that records where the work ran.
+     */
+    static void dispatchUsbReinit(Executor executor, Runnable backoffAndReinit) {
+        executor.execute(backoffAndReinit);
+    }
     // When the current USB capture session started, to measure how long it
     // stayed alive. SystemClock.elapsedRealtime() (monotonic) — not wall clock:
     // a duration must be immune to NTP/user time jumps, which would otherwise
@@ -276,46 +324,58 @@ public class MicRecorder {
                 long now = SystemClock.elapsedRealtime();
                 long aliveMs = now - usbCaptureStartMs;
                 boolean failure = UsbCaptureRetryPolicy.isFailure(usbAudioSawData, aliveMs);
-                if (failure) {
-                    consecutiveUsbFailures++;
-                } else {
-                    consecutiveUsbFailures = 0;
-                }
+                UsbCaptureRetryPolicy.ReinitPlan plan = UsbCaptureRetryPolicy.planReinit(
+                        usbAudioSawData, aliveMs, consecutiveUsbFailures);
+                consecutiveUsbFailures = plan.consecutiveFailures;
                 GeneralVariables.fileLog(String.format(
                         "startUsbCapture: capture STOPPED (sawData=%b aliveMs=%d "
                                 + "failure=%b consecFailures=%d)",
                         usbAudioSawData, aliveMs, failure, consecutiveUsbFailures));
 
+                // CRITICAL: this callback runs on the native libusb event thread.
+                // The backoff sleep + reinitialize() (which drives the next
+                // nativeStart()/libusb_init()) MUST NOT run here — an in-flight
+                // nativeStop() is blocked in eventThread.join() waiting on this
+                // very thread, so running the reinit inline overlaps the new
+                // libusb context with the dying one's libusb_exit() and the
+                // process aborts on a destroyed libusb mutex (the USB-attach
+                // crash loop). Hand the sleep + reinit to a dedicated worker so
+                // this thread returns, the event loop exits, and nativeStop()
+                // finishes tearing the old context down first.
+                //
                 // Exponential, capped backoff before the next attempt. We keep
                 // retrying USB and never silently switch to the phone's built-in
                 // mic — an operator wants radio audio or none. A persistently
                 // dead adapter is still retried at the cap in case it recovers,
                 // without spinning the bus or libusb global state.
-                long backoff = UsbCaptureRetryPolicy.backoffMs(consecutiveUsbFailures);
-                if (backoff > 0) {
-                    GeneralVariables.fileLog(
-                            "startUsbCapture: backing off " + backoff
-                                    + "ms before USB reinit (consecFailures="
-                                    + consecutiveUsbFailures + ")");
-                    try {
-                        Thread.sleep(backoff);
-                    } catch (InterruptedException ignored) {
-                        Thread.currentThread().interrupt();
+                final long backoff = plan.backoffMs;
+                final int failuresForLog = plan.consecutiveFailures;
+                dispatchUsbReinit(usbReinitExecutor, () -> {
+                    if (backoff > 0) {
+                        GeneralVariables.fileLog(
+                                "startUsbCapture: backing off " + backoff
+                                        + "ms before USB reinit (consecFailures="
+                                        + failuresForLog + ")");
+                        try {
+                            Thread.sleep(backoff);
+                        } catch (InterruptedException ignored) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                    }
+
+                    // A stop may have landed during the backoff (app teardown, or
+                    // a real unplug already drove reinitialize elsewhere). Don't
+                    // re-arm capture when we are no longer supposed to be running.
+                    if (!isRunning) {
+                        GeneralVariables.fileLog(
+                                "startUsbCapture: not re-arming USB capture "
+                                        + "(isRunning=false)");
                         return;
                     }
-                }
-
-                // A stop may have landed during the backoff (app teardown, or a
-                // real unplug already drove reinitialize elsewhere). Don't
-                // re-arm capture when we are no longer supposed to be running.
-                if (!isRunning) {
-                    GeneralVariables.fileLog(
-                            "startUsbCapture: not re-arming USB capture "
-                                    + "(isRunning=false)");
-                    return;
-                }
-                lastReinitMs = System.currentTimeMillis();
-                self.reinitialize();
+                    lastReinitMs = System.currentTimeMillis();
+                    self.reinitialize();
+                });
             }
         });
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -58,7 +58,17 @@ public class UsbAudioDevice {
     private volatile boolean capturing = false;
     // Non-zero when the libusb-backed capture session is live; in that case
     // captureLoop() is bypassed and stopCapture() routes through native.
-    private volatile long nativeCaptureHandle = 0;
+    // The live native capture session pointer (0 = none). AtomicLong so exactly
+    // one caller can claim it for teardown via getAndSet(0): a natural capture
+    // retire and a concurrent explicit stopCapture() must never both nativeStop
+    // the same session (that would double libusb_exit/free). See stopCapture()
+    // and the onCaptureStopped callback — the callback deliberately does NOT
+    // clear this, so the session's libusb context is freed by the follow-up
+    // stopCapture() (on the reinit worker, off the native event thread) instead
+    // of being leaked; leaking it burned a pthread TLS key per retire and
+    // eventually aborted libusb_init with a destroyed-mutex/key-exhaustion crash.
+    private final java.util.concurrent.atomic.AtomicLong nativeCaptureHandle =
+            new java.util.concurrent.atomic.AtomicLong(0);
 
     // Output (speaker)
     private UsbInterface streamingInterfaceOut;
@@ -545,14 +555,21 @@ public class UsbAudioDevice {
                                     "UsbAudioDevice: libusb capture stopped, "
                                             + "code=" + code + " ("
                                             + describeCaptureStopCode(code) + ")");
-                            nativeCaptureHandle = 0;
+                            // Do NOT clear nativeCaptureHandle here. This runs on
+                            // the native libusb event thread, which cannot free
+                            // its own session (nativeStop would join itself). We
+                            // leave the handle set so the follow-up stopCapture()
+                            // — driven by reinitialize() on the reinit worker,
+                            // off this thread — calls nativeStop() and releases
+                            // the libusb context (and its TLS key). Clearing it
+                            // here is what leaked the context on every retire.
                             capturing = false;
                             if (javaCb != null) javaCb.onCaptureStopped(code);
                         }
                     });
 
             if (handle != 0) {
-                nativeCaptureHandle = handle;
+                nativeCaptureHandle.set(handle);
                 com.k1af.ft8af.GeneralVariables.fileLog(
                         "UsbAudioDevice: libusb capture started OK");
                 return;
@@ -728,11 +745,23 @@ public class UsbAudioDevice {
         }
     }
 
+    /**
+     * Atomically take ownership of the native capture handle for teardown:
+     * returns the handle to stop (and clears the field), or {@code 0} if it was
+     * already claimed/absent. Pulling the two racing teardown drivers — a
+     * natural capture retire and an explicit stopCapture() — through one atomic
+     * getAndSet guarantees exactly one nativeStop() per session, so libusb_exit
+     * (and the free) runs once. Package-visible so the single-claim guarantee is
+     * unit-testable.
+     */
+    static long claimCaptureHandleForStop(java.util.concurrent.atomic.AtomicLong handleRef) {
+        return handleRef.getAndSet(0);
+    }
+
     public void stopCapture() {
         capturing = false;
-        long h = nativeCaptureHandle;
+        long h = claimCaptureHandleForStop(nativeCaptureHandle);
         if (h != 0) {
-            nativeCaptureHandle = 0;
             try {
                 UsbAudioNative.nativeStop(h);
             } catch (Throwable t) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -73,12 +73,19 @@ public class UsbAudioDevice {
     public interface AudioInputCallback {
         void onAudioData(float[] data, int length);
         /**
-         * Fired on a worker thread when the capture loop exits without
-         * stopCapture() being called — e.g. the USB device was disconnected
-         * or the kernel returned a null URB. Default is a no-op so existing
-         * callers compile unchanged.
+         * Fired on a worker thread when the capture session ends.
+         *
+         * @param stopCode the native stop reason (see
+         *     {@link #describeCaptureStopCode}): {@code 0} means a clean stop we
+         *     requested via {@code nativeStop()} (a reinit, band change,
+         *     {@code stopRecord()}, or teardown) — NOT a failure; any non-zero
+         *     value is a genuine capture failure (transfers retired, NO_DEVICE,
+         *     event-loop error). Callers must not treat a clean stop as a failure:
+         *     doing so pinned the adapter in a reinit loop that starved the
+         *     decoder (429 of 434 field stops were clean stops). Default is a
+         *     no-op so existing callers compile unchanged.
          */
-        default void onCaptureStopped() {}
+        default void onCaptureStopped(int stopCode) {}
     }
 
     /**
@@ -540,7 +547,7 @@ public class UsbAudioDevice {
                                             + describeCaptureStopCode(code) + ")");
                             nativeCaptureHandle = 0;
                             capturing = false;
-                            if (javaCb != null) javaCb.onCaptureStopped();
+                            if (javaCb != null) javaCb.onCaptureStopped(code);
                         }
                     });
 
@@ -711,8 +718,11 @@ public class UsbAudioDevice {
             capturing = false;
             if (abnormalExit && callback != null) {
                 final AudioInputCallback cb = callback;
+                // Non-zero stop code: this is a genuine failure (device died),
+                // not a clean stop, so the recorder's retry path must run.
                 new Thread(() -> {
-                    try { cb.onCaptureStopped(); } catch (Exception ignored) {}
+                    try { cb.onCaptureStopped(CAPTURE_STOP_FALLBACK_FAILURE); }
+                    catch (Exception ignored) {}
                 }, "USB-Audio-Capture-Stopped").start();
             }
         }
@@ -1022,6 +1032,7 @@ public class UsbAudioDevice {
      * <p>Package-visible for testing.
      */
     static String describeCaptureStopCode(int code) {
+        if (code == CAPTURE_STOP_FALLBACK_FAILURE) return "UsbRequest fallback capture died";
         if (code == 0) return "clean stop (nativeStop)";
         if (code == 1) return "all transfers retired (no terminal cause)";
         if (code >= 1000 && code < 2000) {
@@ -1128,6 +1139,14 @@ public class UsbAudioDevice {
      * any immediate setup failure.
      */
     static final long MAX_FALLBACK_ELAPSED_MS = 1_000;
+
+    /**
+     * Stop code reported when the {@code UsbRequest} fallback capture loop exits
+     * abnormally (device died). Distinct negative sentinel so it can't collide
+     * with a native libusb stop reason ({@code 0}, {@code 1}, {@code 1000+});
+     * any non-zero code drives the recorder's failure-retry path.
+     */
+    static final int CAPTURE_STOP_FALLBACK_FAILURE = -1;
 
     public boolean hasInput() { return endpointIn != null; }
     public boolean hasOutput() { return endpointOut != null; }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -83,17 +83,30 @@ public class UsbAudioDevice {
     public interface AudioInputCallback {
         void onAudioData(float[] data, int length);
         /**
-         * Fired on a worker thread when the capture session ends.
+         * Fired on a worker thread when a capture session ends. The exact
+         * contract differs by capture path:
+         *
+         * <ul>
+         *   <li><b>Native (libusb) path</b> — invoked on <em>every</em> session
+         *       end. {@code stopCode == 0} is a clean stop we requested via
+         *       {@code nativeStop()} (a reinit, band change, {@code stopRecord()},
+         *       or teardown); any non-zero value is a genuine capture failure
+         *       (transfers retired, NO_DEVICE, event-loop error).</li>
+         *   <li><b>{@code UsbRequest} fallback path</b> — invoked <em>only</em> on
+         *       an abnormal exit (the device died mid-capture), always with
+         *       {@link #CAPTURE_STOP_FALLBACK_FAILURE}. A clean stop on this path
+         *       does not fire the callback at all, so {@code stopCode == 0} is
+         *       never delivered here.</li>
+         * </ul>
+         *
+         * <p>In both paths a non-zero code is a genuine failure and a
+         * {@code 0}/absent callback is a clean stop. Callers must not treat a
+         * clean stop as a failure: doing so pinned the adapter in a reinit loop
+         * that starved the decoder (429 of 434 field stops were clean stops).
+         * Default is a no-op so existing callers compile unchanged.
          *
          * @param stopCode the native stop reason (see
-         *     {@link #describeCaptureStopCode}): {@code 0} means a clean stop we
-         *     requested via {@code nativeStop()} (a reinit, band change,
-         *     {@code stopRecord()}, or teardown) — NOT a failure; any non-zero
-         *     value is a genuine capture failure (transfers retired, NO_DEVICE,
-         *     event-loop error). Callers must not treat a clean stop as a failure:
-         *     doing so pinned the adapter in a reinit loop that starved the
-         *     decoder (429 of 434 field stops were clean stops). Default is a
-         *     no-op so existing callers compile unchanged.
+         *     {@link #describeCaptureStopCode})
          */
         default void onCaptureStopped(int stopCode) {}
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicy.java
@@ -46,6 +46,28 @@ public final class UsbCaptureRetryPolicy {
     static final long MAX_BACKOFF_MS = 60_000;
 
     /**
+     * Whether a finished capture session warrants the failure-retry path at all,
+     * based on the native stop reason (see
+     * {@code UsbAudioDevice.describeCaptureStopCode}).
+     *
+     * <p>A clean stop ({@code stopCode == 0}) is a {@code nativeStop} <em>we</em>
+     * requested — a reinit, a band change, {@code stopRecord()}, or teardown —
+     * and the initiator restarts capture itself where appropriate. Treating it
+     * as a failure and scheduling a retry tears down the capture the initiator
+     * just brought back; doing that on every clean stop is what pinned the
+     * C-Media adapter in a fail&rarr;backoff&rarr;reinit loop (429 of 434 field
+     * stops were clean stops misclassified as failures), starving the FT8
+     * decoder of ~87% of receive slots so QSO replies were never heard. Only a
+     * non-zero stop reason (transfers retired, NO_DEVICE, event-loop error, or
+     * the {@code UsbRequest}-fallback death sentinel) is a real failure.
+     *
+     * @param stopCode native stop reason; {@code 0} == clean stop
+     */
+    static boolean isRetryableFailure(int stopCode) {
+        return stopCode != 0;
+    }
+
+    /**
      * Whether a finished capture session should count against the
      * consecutive-failure tally.
      *

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicy.java
@@ -109,6 +109,24 @@ public final class UsbCaptureRetryPolicy {
     }
 
     /**
+     * The failure tally after a <em>clean</em> stop (a {@code nativeStop} we
+     * requested: reinit, band change, {@code stopRecord()}, teardown). A clean
+     * stop is never itself a failure, so it never increments the tally — but if
+     * the session that just ended had been alive and delivering audio long enough
+     * to be useful (see {@link #isFailure}), the device has proven healthy, so any
+     * stale streak from earlier genuine failures is cleared to {@code 0}. Without
+     * this a healthy session that ends via a band change leaves an old streak in
+     * place, and the next genuine failure inherits an inflated backoff.
+     *
+     * @param prevFailures the tally before this session ended (never negative)
+     * @param sawData      whether any audio arrived during the session
+     * @param aliveMs      how long the session ran before the clean stop
+     */
+    static int tallyAfterCleanStop(int prevFailures, boolean sawData, long aliveMs) {
+        return isFailure(sawData, aliveMs) ? prevFailures : 0;
+    }
+
+    /**
      * The complete plan for reacting to a finished USB capture session: the
      * updated failure tally and how long to wait before the next reinit attempt.
      * Computed up front (on the native capture event thread) so the actual

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicy.java
@@ -71,4 +71,53 @@ public final class UsbCaptureRetryPolicy {
         if (delay <= 0 || delay > MAX_BACKOFF_MS) return MAX_BACKOFF_MS;
         return delay;
     }
+
+    /**
+     * The failure tally after a session ends: incremented when the session was a
+     * failure (see {@link #isFailure}), reset to {@code 0} when it stayed alive
+     * long enough to be useful. Kept separate from the raw {@code ++} at the call
+     * site so the state transition is unit-testable without a live capture.
+     *
+     * @param prevFailures the tally before this session ended (never negative)
+     * @param sawData      whether any audio arrived during the session
+     * @param aliveMs      how long the session ran before it stopped
+     */
+    static int failureTallyAfter(int prevFailures, boolean sawData, long aliveMs) {
+        return isFailure(sawData, aliveMs) ? prevFailures + 1 : 0;
+    }
+
+    /**
+     * The complete plan for reacting to a finished USB capture session: the
+     * updated failure tally and how long to wait before the next reinit attempt.
+     * Computed up front (on the native capture event thread) so the actual
+     * backoff sleep + {@code reinitialize()} can be handed to a separate worker
+     * thread — running them on the event thread is what raced libusb into the
+     * destroyed-mutex SIGABRT (nativeStop()'s join() blocks on the event thread
+     * while it drives the next nativeStart(), overlapping the two libusb
+     * contexts). See {@code MicRecorder}'s onCaptureStopped handoff.
+     */
+    static final class ReinitPlan {
+        /** Consecutive-failure tally after this session (see {@link #failureTallyAfter}). */
+        final int consecutiveFailures;
+        /** Delay before the reinit, in ms ({@code 0} = reinit immediately). */
+        final long backoffMs;
+
+        ReinitPlan(int consecutiveFailures, long backoffMs) {
+            this.consecutiveFailures = consecutiveFailures;
+            this.backoffMs = backoffMs;
+        }
+    }
+
+    /**
+     * Fold {@link #failureTallyAfter} and {@link #backoffMs} into the single
+     * decision {@code MicRecorder} needs when a capture session stops.
+     *
+     * @param sawData      whether any audio arrived during the session
+     * @param aliveMs      how long the session ran before it stopped
+     * @param prevFailures the tally before this session ended
+     */
+    static ReinitPlan planReinit(boolean sawData, long aliveMs, int prevFailures) {
+        int tally = failureTallyAfter(prevFailures, sawData, aliveMs);
+        return new ReinitPlan(tally, backoffMs(tally));
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/MicRecorderUsbReinitDispatchTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/MicRecorderUsbReinitDispatchTest.java
@@ -1,0 +1,116 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Locks the concurrency invariant behind the USB-attach crash fix so it can
+ * never regress: a USB capture-stopped event must hand its backoff +
+ * {@code reinitialize()} to a dedicated serialized worker, never run it on the
+ * calling thread.
+ *
+ * <p>onCaptureStopped() fires on the native libusb event thread. Running the
+ * reinit inline there parked that thread inside the native event loop while an
+ * in-flight {@code nativeStop()}'s {@code join()} waited on it, so the next
+ * {@code nativeStart()}/{@code libusb_init()} overlapped the dying context's
+ * {@code libusb_exit()} and the process aborted on a destroyed libusb mutex
+ * ("pthread_mutex_lock called on a destroyed mutex") — the crash-on-USB-attach
+ * loop. These tests exercise the exact executor and dispatch seam the fix uses.
+ */
+public class MicRecorderUsbReinitDispatchTest {
+
+    @Test
+    public void dispatch_runsWorkOffTheCallingThread() throws Exception {
+        ExecutorService ex = MicRecorder.newUsbReinitExecutor();
+        try {
+            Thread caller = Thread.currentThread();
+            AtomicReference<Thread> ranOn = new AtomicReference<>();
+            CountDownLatch done = new CountDownLatch(1);
+
+            MicRecorder.dispatchUsbReinit(ex, () -> {
+                ranOn.set(Thread.currentThread());
+                done.countDown();
+            });
+
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(ranOn.get()).isNotNull();
+            // The whole point: the reinit ran somewhere other than the caller
+            // (the native event thread), so nativeStop()'s join() can complete.
+            assertThat(ranOn.get()).isNotSameInstanceAs(caller);
+        } finally {
+            ex.shutdownNow();
+        }
+    }
+
+    @Test
+    public void dispatch_neverRunsInlineBeforeReturning() {
+        // A busy worker is modelled by an executor that queues but never runs.
+        // dispatch must return without having executed the reinit on the caller;
+        // if it ran inline (the bug), this flag would already be set.
+        final boolean[] ranInline = { false };
+        Executor busyWorker = command -> { /* queued, not run — worker is busy */ };
+        MicRecorder.dispatchUsbReinit(busyWorker, () -> ranInline[0] = true);
+        assertThat(ranInline[0]).isFalse();
+    }
+
+    @Test
+    public void executor_usesADedicatedDaemonThread() throws Exception {
+        ExecutorService ex = MicRecorder.newUsbReinitExecutor();
+        try {
+            AtomicReference<Thread> ranOn = new AtomicReference<>();
+            CountDownLatch done = new CountDownLatch(1);
+            ex.execute(() -> {
+                ranOn.set(Thread.currentThread());
+                done.countDown();
+            });
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+            // Daemon so a stuck reinit never holds up process exit; named so it
+            // is identifiable in a tombstone if it ever does misbehave.
+            assertThat(ranOn.get().isDaemon()).isTrue();
+            assertThat(ranOn.get().getName()).isEqualTo("USB-Audio-Reinit");
+        } finally {
+            ex.shutdownNow();
+        }
+    }
+
+    @Test
+    public void executor_serializesStackedReinits() throws Exception {
+        // Two capture-stopped events in quick succession (a composite adapter
+        // fires several around one cable event) must reinit one-at-a-time —
+        // never two concurrent reinitialize()s driving two overlapping libusb
+        // contexts. A single-thread executor guarantees it; prove no overlap.
+        ExecutorService ex = MicRecorder.newUsbReinitExecutor();
+        try {
+            AtomicInteger concurrent = new AtomicInteger(0);
+            AtomicInteger maxConcurrent = new AtomicInteger(0);
+            CountDownLatch both = new CountDownLatch(2);
+            Runnable task = () -> {
+                int now = concurrent.incrementAndGet();
+                maxConcurrent.accumulateAndGet(now, Math::max);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+                concurrent.decrementAndGet();
+                both.countDown();
+            };
+
+            MicRecorder.dispatchUsbReinit(ex, task);
+            MicRecorder.dispatchUsbReinit(ex, task);
+
+            assertThat(both.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(maxConcurrent.get()).isEqualTo(1);
+        } finally {
+            ex.shutdownNow();
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioCaptureHandleTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioCaptureHandleTest.java
@@ -1,0 +1,72 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tests {@link UsbAudioDevice#claimCaptureHandleForStop(AtomicLong)} — the
+ * atomic handoff that guarantees a native capture session is stopped (and its
+ * libusb context freed) exactly once.
+ *
+ * <p>Two teardown drivers race for the same session: a natural capture retire
+ * (the event thread's onCaptureStopped, which now leaves the handle set) and an
+ * explicit {@code stopCapture()} on the reinit worker. If both called
+ * {@code nativeStop} on the same pointer it would double {@code libusb_exit}/
+ * free; if neither did, the context (and a pthread TLS key) leaked until
+ * {@code libusb_init} aborted. Exactly one claimant must win.
+ */
+public class UsbAudioCaptureHandleTest {
+
+    @Test
+    public void firstClaimGetsHandle_secondGetsZero() {
+        AtomicLong handle = new AtomicLong(0xCAFEBABEL);
+
+        assertThat(UsbAudioDevice.claimCaptureHandleForStop(handle)).isEqualTo(0xCAFEBABEL);
+        // Field cleared, so a second teardown driver stops nothing.
+        assertThat(UsbAudioDevice.claimCaptureHandleForStop(handle)).isEqualTo(0);
+        assertThat(handle.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void noHandle_claimsZero() {
+        assertThat(UsbAudioDevice.claimCaptureHandleForStop(new AtomicLong(0))).isEqualTo(0);
+    }
+
+    @Test
+    public void concurrentClaims_exactlyOneWinner() throws InterruptedException {
+        // Model the retire/stopCapture race directly: many threads claim the same
+        // handle at once; exactly one must get the non-zero pointer to nativeStop.
+        for (int trial = 0; trial < 200; trial++) {
+            final AtomicLong handle = new AtomicLong(0x1234L);
+            final int threads = 8;
+            final CountDownLatch start = new CountDownLatch(1);
+            final CountDownLatch done = new CountDownLatch(threads);
+            final AtomicInteger winners = new AtomicInteger(0);
+
+            for (int i = 0; i < threads; i++) {
+                new Thread(() -> {
+                    try {
+                        start.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    if (UsbAudioDevice.claimCaptureHandleForStop(handle) != 0) {
+                        winners.incrementAndGet();
+                    }
+                    done.countDown();
+                }).start();
+            }
+
+            start.countDown();
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(winners.get()).isEqualTo(1);
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicyTest.java
@@ -59,6 +59,27 @@ public class UsbCaptureRetryPolicyTest {
         assertThat(UsbCaptureRetryPolicy.backoffMs(-5)).isEqualTo(0);
     }
 
+    // ---- isRetryableFailure ------------------------------------------------
+
+    @Test
+    public void cleanStop_isNotRetryable() {
+        // code 0 = a nativeStop WE requested (reinit / band change / stopRecord /
+        // teardown). Must NOT drive a retry — that self-kill loop starved the
+        // decoder in the field (429 of 434 stops were clean stops).
+        assertThat(UsbCaptureRetryPolicy.isRetryableFailure(0)).isFalse();
+    }
+
+    @Test
+    public void genuineFailures_areRetryable() {
+        // Every non-zero native stop reason is a real capture death and must retry.
+        assertThat(UsbCaptureRetryPolicy.isRetryableFailure(1)).isTrue();       // transfers retired
+        assertThat(UsbCaptureRetryPolicy.isRetryableFailure(2004)).isTrue();    // resubmit NO_DEVICE
+        assertThat(UsbCaptureRetryPolicy.isRetryableFailure(1005)).isTrue();    // transfer NO_DEVICE
+        assertThat(UsbCaptureRetryPolicy.isRetryableFailure(3110)).isTrue();    // handle_events failed
+        assertThat(UsbCaptureRetryPolicy.isRetryableFailure(
+                UsbAudioDevice.CAPTURE_STOP_FALLBACK_FAILURE)).isTrue();        // UsbRequest fallback died
+    }
+
     // ---- failureTallyAfter -------------------------------------------------
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicyTest.java
@@ -131,4 +131,26 @@ public class UsbCaptureRetryPolicyTest {
         assertThat(plan.consecutiveFailures).isEqualTo(0);
         assertThat(plan.backoffMs).isEqualTo(0);
     }
+
+    // ---- tallyAfterCleanStop -----------------------------------------------
+
+    @Test
+    public void cleanStop_afterHealthySession_clearsStaleStreak() {
+        // A long, healthy session ended by a band change / teardown proves the
+        // device works, so a stale failure streak from earlier is cleared.
+        assertThat(UsbCaptureRetryPolicy.tallyAfterCleanStop(
+                4, true, UsbCaptureRetryPolicy.MIN_USEFUL_SESSION_MS)).isEqualTo(0);
+        assertThat(UsbCaptureRetryPolicy.tallyAfterCleanStop(9, true, 60_000)).isEqualTo(0);
+    }
+
+    @Test
+    public void cleanStop_afterShortOrSilentSession_leavesStreakUnchanged() {
+        // A clean stop is never a failure (no increment), but a session that was
+        // too short or delivered no audio hasn't proven the device healthy, so an
+        // existing streak must be preserved rather than reset.
+        assertThat(UsbCaptureRetryPolicy.tallyAfterCleanStop(3, true, 100)).isEqualTo(3);
+        assertThat(UsbCaptureRetryPolicy.tallyAfterCleanStop(3, false, 60_000)).isEqualTo(3);
+        // Never increments, even from a short session.
+        assertThat(UsbCaptureRetryPolicy.tallyAfterCleanStop(0, true, 100)).isEqualTo(0);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbCaptureRetryPolicyTest.java
@@ -58,4 +58,56 @@ public class UsbCaptureRetryPolicyTest {
         assertThat(UsbCaptureRetryPolicy.backoffMs(0)).isEqualTo(0);
         assertThat(UsbCaptureRetryPolicy.backoffMs(-5)).isEqualTo(0);
     }
+
+    // ---- failureTallyAfter -------------------------------------------------
+
+    @Test
+    public void tally_incrementsOnFailure() {
+        // A too-short session bumps the running count.
+        assertThat(UsbCaptureRetryPolicy.failureTallyAfter(0, true, 100)).isEqualTo(1);
+        assertThat(UsbCaptureRetryPolicy.failureTallyAfter(3, false, 0)).isEqualTo(4);
+    }
+
+    @Test
+    public void tally_resetsOnHealthySession() {
+        // A session that stayed alive long enough clears the streak, no matter
+        // how high it had climbed.
+        assertThat(UsbCaptureRetryPolicy.failureTallyAfter(
+                7, true, UsbCaptureRetryPolicy.MIN_USEFUL_SESSION_MS)).isEqualTo(0);
+        assertThat(UsbCaptureRetryPolicy.failureTallyAfter(1, true, 60_000)).isEqualTo(0);
+    }
+
+    // ---- planReinit --------------------------------------------------------
+
+    @Test
+    public void plan_firstFailure_backsOffBaseDelay() {
+        UsbCaptureRetryPolicy.ReinitPlan plan =
+                UsbCaptureRetryPolicy.planReinit(true, 100, 0);
+        assertThat(plan.consecutiveFailures).isEqualTo(1);
+        assertThat(plan.backoffMs).isEqualTo(UsbCaptureRetryPolicy.BASE_BACKOFF_MS);
+    }
+
+    @Test
+    public void plan_repeatedFailures_growExponentiallyUpToCap() {
+        // The Pixel 8 + C-Media field mode: session after session dies ~100ms in.
+        UsbCaptureRetryPolicy.ReinitPlan second =
+                UsbCaptureRetryPolicy.planReinit(true, 100, 1);
+        assertThat(second.consecutiveFailures).isEqualTo(2);
+        assertThat(second.backoffMs).isEqualTo(UsbCaptureRetryPolicy.BASE_BACKOFF_MS * 2);
+
+        UsbCaptureRetryPolicy.ReinitPlan many =
+                UsbCaptureRetryPolicy.planReinit(false, 0, 99);
+        assertThat(many.consecutiveFailures).isEqualTo(100);
+        assertThat(many.backoffMs).isEqualTo(UsbCaptureRetryPolicy.MAX_BACKOFF_MS);
+    }
+
+    @Test
+    public void plan_healthySession_resetsTallyAndReinitsImmediately() {
+        // A session that carried real audio clears the streak and re-arms with
+        // no backoff, so a genuine transient stop doesn't stall capture.
+        UsbCaptureRetryPolicy.ReinitPlan plan =
+                UsbCaptureRetryPolicy.planReinit(true, 30_000, 5);
+        assertThat(plan.consecutiveFailures).isEqualTo(0);
+        assertThat(plan.backoffMs).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
Three related USB-audio-capture reliability fixes for the C-Media `0D8C:0012` adapter (same subsystem / `MicRecorder.onCaptureStopped` + `UsbAudioDevice` capture lifecycle).

## 1. Crash-on-USB-attach (`SIGABRT`) — verified on device ✅
`onCaptureStopped()` ran the backoff + `reinitialize()` (→ next `nativeStart()`/`libusb_init()`) inline on the native libusb event thread, overlapping a concurrent `nativeStop()`'s `libusb_exit()` and destroying the global libusb mutex under the live context. **Fix:** hand the backoff + reinit to a single-threaded daemon executor so the event thread returns and the two libusb contexts never overlap.

## 2. Clean-stop reinit churn (deaf receiver) — root cause proven from field log
A POTA field log showed the app **deaf ~87% of receive slots** (327 reinit-backoff events / 30 min). Of 434 capture stops, **429 were `code=0` clean stops** we requested — but `onCaptureStopped()` ignored the native stop code and guessed "failure" from `aliveMs`, so every intentional stop scheduled a reinit that tore down the healthy capture. **Fix:** propagate the native stop `code`; only retry on a genuine failure (`code != 0`). This is what improved auto-callback/QSO sequencing in the field.

## 3. libusb context leak on natural retire (native crash class) — new
`libusb_exit` only ran in `nativeStop`, which was never called when a session retired on its own (the handle was cleared first). Each retire leaked the context + a **pthread TLS key**; after enough, `libusb_init` aborts (`pthread_key_create ... failed` / destroyed-mutex) — the launch-crash class. **Fix (Java lifecycle, reuses `nativeStop`, no native changes):** `onCaptureStopped` no longer clears the handle (it's on the event thread and can't self-`nativeStop`); the follow-up `stopCapture()` on the reinit worker frees it. Handle is now an `AtomicLong` claimed via `getAndSet(0)` so retire + explicit stop can't double-free.

## Tests
- `MicRecorderUsbReinitDispatchTest` — reinit runs off the calling thread, serialized daemon worker.
- `UsbCaptureRetryPolicyTest` — clean-stop vs every genuine failure code (`isRetryableFailure`), tally/backoff plan (13 tests).
- `UsbAudioCaptureHandleTest` — single-claim teardown invariant incl. a concurrent-race trial.
- Full `testDebugUnitTest` green, incl. `R8KeepRulesTest`.

## Verification
- #1 confirmed on device (no crash-loop). #2 root cause proven from field `debug.log`; the churn-fixed build improved callback pickup in the field. #3 closes the slow TLS-key leak that was the remaining trigger for the launch `SIGABRT` (which stopped reproducing after #2). Full on-device confirmation of #2/#3 needs a session with the radio attached (single USB-C port ⇒ can't run the radio and Mac-tether at once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)