### PR TITLE
fix: guard CAT serial writes against a concurrent disconnect (null-port NPE)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
@@ -56,7 +56,13 @@ public class CableSerialPort {
     private int portNum = 0;//Port number
     private int baudRate = 19200;//Baud rate
 
-    private UsbSerialPort usbSerialPort;
+    // volatile: written on the connect thread (open) and cleared to null on the
+    // disconnect thread (disconnect()), read on the CAT/TX threads (sendData,
+    // setRTS/DTR). Readers MUST snapshot it into a local before check-and-use —
+    // reading the field twice let a concurrent disconnect null it between the
+    // null-check and usbSerialPort.write(), NPE-ing a delayed CAT freq write on
+    // the FT-891 (Yaesu39Rig.setFreqToRig) as the rig dropped.
+    private volatile UsbSerialPort usbSerialPort;
     private SerialInputOutputManager usbIoManager;
     public SerialInputOutputManager.Listener ioListener = null;
 
@@ -238,31 +244,58 @@ public class CableSerialPort {
         Log.d(TAG, msg);
     }
 
+    /**
+     * A single raw port write, extracted so the disconnect-race guard is
+     * unit-testable without the full {@link UsbSerialPort} surface (or a live
+     * device).
+     */
+    @FunctionalInterface
+    interface RawWrite {
+        void write(byte[] src, int timeout) throws IOException;
+    }
+
+    /**
+     * Write {@code src} to a port reference the caller has already snapshotted.
+     * A {@code null} writer means the port was disconnected (closed and nulled
+     * by {@link #disconnect()}): no write, returns {@code false} — never NPEs.
+     * The caller passes the snapshot's {@code ::write}, so a concurrent
+     * disconnect that nulls the field afterwards cannot affect this call.
+     *
+     * @return true if the write was issued, false if the port was not open
+     */
+    static boolean writeIfOpen(RawWrite writer, byte[] src, int timeout) throws IOException {
+        if (writer == null) return false;
+        writer.write(src, timeout);
+        return true;
+    }
+
     public boolean sendData(final byte[] src) {
-        if (usbSerialPort != null) {
-            try {
-                String preview = new String(src).replace("\r", "\\r").replace("\n", "\\n");
-                // Only log non-periodic commands (skip FA; reads to avoid log spam)
-                if (!preview.equals("FA;") && !preview.startsWith("RM")) {
-                    StringBuilder hex = new StringBuilder();
-                    for (byte b : src) hex.append(String.format("%02X ", b));
-                    fileLog("serial.send[" + src.length + "]: " + preview + " | hex: " + hex.toString().trim());
-                }
-                usbSerialPort.write(src, SEND_TIMEOUT);
-                if (!preview.equals("FA;") && !preview.startsWith("RM")) {
-                    fileLog("serial.send: write completed OK");
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-                fileLog("serial.send ERROR: " + e.getMessage());
-                return false;
-            }
-            return true;
-        } else {
+        // Snapshot the volatile field ONCE; disconnect() may null it on another
+        // thread at any moment. Using the local for both the check and the write
+        // removes the check-then-act NPE (see the field's comment).
+        final UsbSerialPort port = usbSerialPort;
+        if (port == null) {
             fileLog("serial.send: port not open!");
             return false;
         }
-
+        try {
+            String preview = new String(src).replace("\r", "\\r").replace("\n", "\\n");
+            // Only log non-periodic commands (skip FA; reads to avoid log spam)
+            if (!preview.equals("FA;") && !preview.startsWith("RM")) {
+                StringBuilder hex = new StringBuilder();
+                for (byte b : src) hex.append(String.format("%02X ", b));
+                fileLog("serial.send[" + src.length + "]: " + preview + " | hex: " + hex.toString().trim());
+            }
+            writeIfOpen(port::write, src, SEND_TIMEOUT);
+            if (!preview.equals("FA;") && !preview.startsWith("RM")) {
+                fileLog("serial.send: write completed OK");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            fileLog("serial.send ERROR: " + e.getMessage());
+            return false;
+        }
+        return true;
     }
 
     public void disconnect() {
@@ -324,12 +357,15 @@ public class CableSerialPort {
      * @param rts_on true: on, false: off
      */
     public boolean setRTS_On(boolean rts_on) {
-        if (usbSerialPort == null) {
+        // Snapshot once — disconnect() may null the field on another thread
+        // between the check and the setRTS() call (same race as sendData).
+        final UsbSerialPort port = usbSerialPort;
+        if (port == null) {
             fileLog("serial.setRTS: port not open!");
             return false;
         }
         try {
-            if (!controlLineSupported(usbSerialPort.getSupportedControlLines(),
+            if (!controlLineSupported(port.getSupportedControlLines(),
                     UsbSerialPort.ControlLine.RTS)) {
                 // Report failure rather than a silent no-op: callers use the return
                 // value to decide whether a PTT toggle actually happened, so a port
@@ -337,7 +373,7 @@ public class CableSerialPort {
                 fileLog("serial.setRTS: RTS not supported by this port");
                 return false;
             }
-            usbSerialPort.setRTS(rts_on);
+            port.setRTS(rts_on);
             return true;
         } catch (IOException e) {
             e.printStackTrace();
@@ -347,19 +383,21 @@ public class CableSerialPort {
     }
 
     public boolean setDTR_On(boolean dtr_on) {
-        if (usbSerialPort == null) {
+        // Snapshot once (see setRTS_On) — the field can be nulled concurrently.
+        final UsbSerialPort port = usbSerialPort;
+        if (port == null) {
             fileLog("serial.setDTR: port not open!");
             return false;
         }
         try {
-            if (!controlLineSupported(usbSerialPort.getSupportedControlLines(),
+            if (!controlLineSupported(port.getSupportedControlLines(),
                     UsbSerialPort.ControlLine.DTR)) {
                 // Report failure rather than a silent no-op (see setRTS_On): a port
                 // that can't drive DTR must not read as a successful PTT toggle.
                 fileLog("serial.setDTR: DTR not supported by this port");
                 return false;
             }
-            usbSerialPort.setDTR(dtr_on);
+            port.setDTR(dtr_on);
             return true;
         } catch (IOException e) {
             e.printStackTrace();

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/CableSerialPortControlLineTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/CableSerialPortControlLineTest.java
@@ -1,12 +1,16 @@
 package com.k1af.ft8af.connector;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.k1af.ft8af.serialport.UsbSerialPort;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Pure-JVM coverage for {@link CableSerialPort#controlLineSupported}, the
@@ -38,5 +42,44 @@ public class CableSerialPortControlLineTest {
     @Test
     public void nullSet_isNotSupported() {
         assertThat(CableSerialPort.controlLineSupported(null, UsbSerialPort.ControlLine.RTS)).isFalse();
+    }
+
+    // ---- writeIfOpen: the disconnect-race guard -----------------------------
+    // A concurrent disconnect() nulls the serial port between a caller's
+    // null-check and its write(); reading the field twice NPE-d a delayed CAT
+    // freq write on the FT-891. sendData now snapshots the port and writes
+    // through writeIfOpen, which treats a null (disconnected) port as "not
+    // open" instead of dereferencing it.
+
+    @Test
+    public void writeIfOpen_nullPort_returnsFalseAndDoesNotWrite() throws IOException {
+        // The crash case: the snapshot came back null (port disconnected). Must
+        // report "not open", never NPE.
+        assertThat(CableSerialPort.writeIfOpen(null, new byte[]{1, 2, 3}, 500)).isFalse();
+    }
+
+    @Test
+    public void writeIfOpen_openPort_writesExactBytesAndTimeout() throws IOException {
+        AtomicReference<byte[]> got = new AtomicReference<>();
+        AtomicInteger gotTimeout = new AtomicInteger(-1);
+        byte[] src = "FA021074000;".getBytes();
+
+        boolean wrote = CableSerialPort.writeIfOpen((s, t) -> {
+            got.set(s);
+            gotTimeout.set(t);
+        }, src, 800);
+
+        assertThat(wrote).isTrue();
+        assertThat(got.get()).isSameInstanceAs(src);
+        assertThat(gotTimeout.get()).isEqualTo(800);
+    }
+
+    @Test
+    public void writeIfOpen_propagatesIoException() {
+        // A real write failure (port died mid-write) must surface as IOException
+        // for sendData's catch to log + return false — not be swallowed.
+        assertThrows(IOException.class, () ->
+                CableSerialPort.writeIfOpen((s, t) -> { throw new IOException("port died"); },
+                        new byte[]{0}, 500));
     }
 }


### PR DESCRIPTION
## Problem

Selecting the **FT-891** CAT (native `Yaesu39Rig`, `instructionSet=19`) could crash on launch:

```
java.lang.NullPointerException: Attempt to invoke interface method
  'void com.k1af.ft8af.serialport.UsbSerialPort.write(byte[], int)' on a null object reference
    at com.k1af.ft8af.connector.CableSerialPort.sendData(CableSerialPort.java:251)
    at com.k1af.ft8af.connector.CableConnector.sendData(CableConnector.java:139)
    at com.k1af.ft8af.rigs.Yaesu39Rig.setFreqToRig(Yaesu39Rig.java:156)
    at com.k1af.ft8af.MainViewModel$9.run(MainViewModel.java:1258)
```

## Cause

`sendData()` read `usbSerialPort` twice — a null-check then `usbSerialPort.write(...)`. A delayed 800 ms CAT frequency task (`MainViewModel$9`) fired just as the rig dropped and `disconnect()` set `usbSerialPort = null` **between** the check and the write — a classic check-then-act race across threads. The field `debug.log` shows the window: a burst of `setOperationBand: rig not connected, skipping` (the guarded path) around the one delayed write that raced through and NPE'd.

## Fix

- Make `usbSerialPort` **volatile** and have each reader **snapshot it into a local once**, using the local for both the check and the write — a concurrent disconnect can no longer null it mid-call.
- `sendData` writes through an extracted **`writeIfOpen()`** seam: a null snapshot means "port not open" → returns `false` instead of dereferencing.
- `setRTS_On` / `setDTR_On` snapshot the same way (identical race on the PTT path).

## Tests

`writeIfOpen` null / open / IOException-propagation cases added to `CableSerialPortControlLineTest` (pure JVM, 6 tests green).

## Scope note

This is the **native-Yaesu** CAT crash (`instructionSet=19`). A separate **native `SIGABRT`** ("destroyed mutex") when the **Hamlib** backend (`instructionSet=26`) is selected is a distinct libusb-lifecycle issue and is **not** addressed here — tracked separately (needs a fresh backtrace; tombstones had rotated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)