### PR TITLE
Fix CI-V (Icom/Xiegu) stream reassembly dropping fragments and injecting stray bytes

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivFrameSplitter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivFrameSplitter.java
@@ -1,0 +1,70 @@
+package com.k1af.ft8af.rigs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Reassembles a CI-V byte stream (Icom / Xiegu rigs) into whole commands.
+ *
+ * <p>CI-V commands are framed as {@code FE FE <to> <from> <cmd> [data...] FD}
+ * and delivered by the serial/network transport in arbitrary chunks: a single
+ * read may carry only part of a command, several whole commands (a rig commonly
+ * echoes the request and then sends its reply back-to-back in one read), or a
+ * whole command followed by the start of the next. Callers feed each received
+ * chunk together with the bytes left over from the previous chunk; this groups
+ * them into complete commands (each terminated by {@code 0xFD}) plus a trailing
+ * remainder to carry into the next call.
+ *
+ * <p>Pure logic — no rig or Android state — so it is unit-testable and shared by
+ * every CI-V rig ({@link IcomRig}, {@link XieGuRig}, {@link XieGu6100Rig}). Each
+ * of those previously carried its own copy of this reassembly that (a) discarded
+ * the accumulated buffer whenever a chunk arrived without a terminator, losing
+ * every earlier fragment of a split command, and (b) appended two stray
+ * {@code 0x00} bytes to the carried-over remainder after every frame, corrupting
+ * the next command when it was reassembled from more than one chunk.
+ */
+final class CivFrameSplitter {
+    /** CI-V end-of-message terminator. */
+    private static final byte END_MARKER = (byte) 0xFD;
+
+    private CivFrameSplitter() {
+    }
+
+    /** Result of {@link #split}: the complete commands and the trailing remainder. */
+    static final class Result {
+        /** Complete commands, each ending in {@code 0xFD}, in arrival order. */
+        final List<byte[]> commands;
+        /** Bytes after the last terminator — an incomplete command to buffer. */
+        final byte[] remainder;
+
+        Result(List<byte[]> commands, byte[] remainder) {
+            this.commands = commands;
+            this.remainder = remainder;
+        }
+    }
+
+    /**
+     * Append {@code incoming} to {@code buffered} and split the result into whole
+     * CI-V commands plus a trailing remainder.
+     *
+     * @param buffered bytes left over from the previous call (never null; may be empty)
+     * @param incoming newly received bytes (never null; may be empty)
+     * @return the complete commands and the bytes to carry into the next call
+     */
+    static Result split(byte[] buffered, byte[] incoming) {
+        byte[] combined = new byte[buffered.length + incoming.length];
+        System.arraycopy(buffered, 0, combined, 0, buffered.length);
+        System.arraycopy(incoming, 0, combined, buffered.length, incoming.length);
+
+        List<byte[]> commands = new ArrayList<>();
+        int start = 0;
+        for (int i = 0; i < combined.length; i++) {
+            if (combined[i] == END_MARKER) {
+                commands.add(Arrays.copyOfRange(combined, start, i + 1));
+                start = i + 1;
+            }
+        }
+        return new Result(commands, Arrays.copyOfRange(combined, start, combined.length));
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -116,21 +116,6 @@ public class IcomRig extends BaseRig {
     }
 
     /**
-     * Find the position of the command end marker. Returns -1 if not found.
-     *
-     * @param data data
-     * @return position
-     */
-    private int getCommandEnd(byte[] data) {
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] == (byte) 0xFD) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    /**
      * Find command header. Returns -1 if not found, otherwise returns position of first FE FE.
      *
      * @param data data
@@ -228,31 +213,15 @@ public class IcomRig extends BaseRig {
     public void onReceiveData(byte[] data) {
         //ToastMessage.show(byteToStr(data));
 
-        int commandEnd = getCommandEnd(data);
-        if (commandEnd <= -1) {//no command end marker
-            byte[] temp = new byte[dataBuffer.length + data.length];
-            System.arraycopy(dataBuffer, 0, temp, 0, dataBuffer.length);
-            System.arraycopy(data, 0, temp, dataBuffer.length, data.length);
-            dataBuffer = temp;
-        } else {
-            byte[] temp = new byte[dataBuffer.length + commandEnd + 1];
-            System.arraycopy(dataBuffer, 0, temp, 0, dataBuffer.length);
-            dataBuffer = temp;
-            System.arraycopy(data, 0, dataBuffer, dataBuffer.length - commandEnd - 1, commandEnd + 1);
+        // Append to any partial command buffered from a previous callback, then
+        // process every complete command (each ending in 0xFD) and keep only the
+        // trailing incomplete bytes for next time. See CivFrameSplitter for why the
+        // previous hand-rolled reassembly dropped fragments and injected stray bytes.
+        CivFrameSplitter.Result result = CivFrameSplitter.split(dataBuffer, data);
+        for (byte[] command : result.commands) {
+            analysisCommand(command);
         }
-        if (commandEnd != -1) {
-            analysisCommand(dataBuffer);
-        }
-        dataBuffer = new byte[0];//clear buffer
-        if (commandEnd <= -1 || commandEnd < data.length) {
-            byte[] temp = new byte[data.length - commandEnd + 1];
-            for (int i = 0; i < data.length - commandEnd - 1; i++) {
-                temp[i] = data[commandEnd + i + 1];
-            }
-            dataBuffer = temp;
-        }
-
-
+        dataBuffer = result.remainder;
     }
 
     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Rig.java
@@ -122,21 +122,6 @@ public class XieGu6100Rig extends BaseRig {
     }
 
     /**
-     * Find the position of the command end marker. Returns -1 if not found.
-     *
-     * @param data data
-     * @return position
-     */
-    private int getCommandEnd(byte[] data) {
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] == (byte) 0xFD) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    /**
      * Find command header. Returns -1 if not found, otherwise returns position of first FE FE.
      *
      * @param data data
@@ -244,31 +229,15 @@ public class XieGu6100Rig extends BaseRig {
 
     @Override
     public void onReceiveData(byte[] data) {
-        int commandEnd = getCommandEnd(data);
-        if (commandEnd <= -1) {//no command end marker
-            byte[] temp = new byte[dataBuffer.length + data.length];
-            System.arraycopy(dataBuffer, 0, temp, 0, dataBuffer.length);
-            System.arraycopy(data, 0, temp, dataBuffer.length, data.length);
-            dataBuffer = temp;
-        } else {
-            byte[] temp = new byte[dataBuffer.length + commandEnd + 1];
-            System.arraycopy(dataBuffer, 0, temp, 0, dataBuffer.length);
-            dataBuffer = temp;
-            System.arraycopy(data, 0, dataBuffer, dataBuffer.length - commandEnd - 1, commandEnd + 1);
+        // Append to any partial command buffered from a previous callback, then
+        // process every complete command (each ending in 0xFD) and keep only the
+        // trailing incomplete bytes for next time. See CivFrameSplitter for why the
+        // previous hand-rolled reassembly dropped fragments and injected stray bytes.
+        CivFrameSplitter.Result result = CivFrameSplitter.split(dataBuffer, data);
+        for (byte[] command : result.commands) {
+            analysisCommand(command);
         }
-        if (commandEnd != -1) {
-            analysisCommand(dataBuffer);
-        }
-        dataBuffer = new byte[0];//clear buffer
-        if (commandEnd <= -1 || commandEnd < data.length) {
-            byte[] temp = new byte[data.length - commandEnd + 1];
-            for (int i = 0; i < data.length - commandEnd - 1; i++) {
-                temp[i] = data[commandEnd + i + 1];
-            }
-            dataBuffer = temp;
-        }
-
-
+        dataBuffer = result.remainder;
     }
 
     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGuRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGuRig.java
@@ -113,21 +113,6 @@ public class XieGuRig extends BaseRig {
     }
 
     /**
-     * Find the position of the command end marker. Returns -1 if not found.
-     *
-     * @param data data
-     * @return position
-     */
-    private int getCommandEnd(byte[] data) {
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] == (byte) 0xFD) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    /**
      * Find command header. Returns -1 if not found, otherwise returns position of first FE FE.
      *
      * @param data data
@@ -233,31 +218,15 @@ public class XieGuRig extends BaseRig {
 
     @Override
     public void onReceiveData(byte[] data) {
-        int commandEnd = getCommandEnd(data);
-        if (commandEnd <= -1) {//no command end marker
-            byte[] temp = new byte[dataBuffer.length + data.length];
-            System.arraycopy(dataBuffer, 0, temp, 0, dataBuffer.length);
-            System.arraycopy(data, 0, temp, dataBuffer.length, data.length);
-            dataBuffer = temp;
-        } else {
-            byte[] temp = new byte[dataBuffer.length + commandEnd + 1];
-            System.arraycopy(dataBuffer, 0, temp, 0, dataBuffer.length);
-            dataBuffer = temp;
-            System.arraycopy(data, 0, dataBuffer, dataBuffer.length - commandEnd - 1, commandEnd + 1);
+        // Append to any partial command buffered from a previous callback, then
+        // process every complete command (each ending in 0xFD) and keep only the
+        // trailing incomplete bytes for next time. See CivFrameSplitter for why the
+        // previous hand-rolled reassembly dropped fragments and injected stray bytes.
+        CivFrameSplitter.Result result = CivFrameSplitter.split(dataBuffer, data);
+        for (byte[] command : result.commands) {
+            analysisCommand(command);
         }
-        if (commandEnd != -1) {
-            analysisCommand(dataBuffer);
-        }
-        dataBuffer = new byte[0];//clear buffer
-        if (commandEnd <= -1 || commandEnd < data.length) {
-            byte[] temp = new byte[data.length - commandEnd + 1];
-            for (int i = 0; i < data.length - commandEnd - 1; i++) {
-                temp[i] = data[commandEnd + i + 1];
-            }
-            dataBuffer = temp;
-        }
-
-
+        dataBuffer = result.remainder;
     }
 
     @Override

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivFrameSplitterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivFrameSplitterTest.java
@@ -1,0 +1,157 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for {@link CivFrameSplitter}, the shared CI-V (Icom /
+ * Xiegu) stream reassembler.
+ *
+ * <p>CI-V frames are {@code FE FE <to> <from> <cmd> [data...] FD}. The transport
+ * delivers bytes in arbitrary chunks, so a command can span several callbacks or
+ * several commands can arrive in one. These tests pin the reassembly contract and
+ * lock in the two regressions the old per-rig reassembly had:
+ * <ul>
+ *   <li>a chunk with no terminator dropped everything buffered so far, so a
+ *       command split across callbacks lost its leading fragments; and</li>
+ *   <li>every processed frame left two stray {@code 0x00} bytes in the carry-over
+ *       buffer, corrupting the next command reassembled from more than one chunk.</li>
+ * </ul>
+ *
+ * <p>No Android types are touched, so no Robolectric runner is needed.
+ */
+public class CivFrameSplitterTest {
+
+    private static final byte FD = (byte) 0xFD;
+
+    /** A read-frequency reply (14.074 MHz), the reference frame from IcomCommandTest. */
+    private static byte[] freqFrame() {
+        return new byte[]{
+                (byte) 0xFE, (byte) 0xFE, (byte) 0xE0, (byte) 0xA4,
+                (byte) 0x03,
+                (byte) 0x00, (byte) 0x40, (byte) 0x07, (byte) 0x14, (byte) 0x00,
+                FD};
+    }
+
+    @Test
+    public void singleCompleteFrame_oneCommandNoRemainder() {
+        byte[] frame = freqFrame();
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], frame);
+
+        assertThat(r.commands).hasSize(1);
+        assertThat(r.commands.get(0)).isEqualTo(frame);
+        // Regression: a fully-consumed frame must leave an EMPTY remainder, not the
+        // two stray 0x00 bytes the old reassembly appended after every frame.
+        assertThat(r.remainder).hasLength(0);
+    }
+
+    @Test
+    public void twoFramesInOneChunk_bothCommandsNoRemainder() {
+        // A rig commonly echoes the request then sends its reply back-to-back in a
+        // single read. The old code processed only the first and mangled the rest.
+        byte[] echo = {(byte) 0xFE, (byte) 0xFE, (byte) 0xA4, (byte) 0xE0, (byte) 0x03, FD};
+        byte[] reply = freqFrame();
+        byte[] chunk = concat(echo, reply);
+
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], chunk);
+
+        assertThat(r.commands).hasSize(2);
+        assertThat(r.commands.get(0)).isEqualTo(echo);
+        assertThat(r.commands.get(1)).isEqualTo(reply);
+        assertThat(r.remainder).hasLength(0);
+    }
+
+    @Test
+    public void completeFramePlusPartialNext_carriesOnlyThePartial() {
+        byte[] frame = freqFrame();
+        byte[] partial = {(byte) 0xFE, (byte) 0xFE, (byte) 0xE0}; // start of next, no FD
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], concat(frame, partial));
+
+        assertThat(r.commands).hasSize(1);
+        assertThat(r.commands.get(0)).isEqualTo(frame);
+        assertThat(r.remainder).isEqualTo(partial);
+    }
+
+    @Test
+    public void chunkWithoutTerminator_bufferedWholeAndNoCommands() {
+        byte[] partial = {(byte) 0xFE, (byte) 0xFE, (byte) 0xE0, (byte) 0xA4, (byte) 0x03};
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], partial);
+
+        assertThat(r.commands).isEmpty();
+        assertThat(r.remainder).isEqualTo(partial);
+    }
+
+    @Test
+    public void splitAcrossTwoCallbacks_reassemblesWithoutLosingLeadingBytes() {
+        // The core regression: split one frame at an arbitrary point across two
+        // callbacks. The old reassembly discarded the first fragment when the
+        // second chunk (also without a terminator until its end) arrived.
+        byte[] frame = freqFrame();
+        byte[] first = java.util.Arrays.copyOfRange(frame, 0, 4);
+        byte[] second = java.util.Arrays.copyOfRange(frame, 4, frame.length);
+
+        CivFrameSplitter.Result r1 = CivFrameSplitter.split(new byte[0], first);
+        assertThat(r1.commands).isEmpty();
+        assertThat(r1.remainder).isEqualTo(first);
+
+        CivFrameSplitter.Result r2 = CivFrameSplitter.split(r1.remainder, second);
+        assertThat(r2.commands).hasSize(1);
+        assertThat(r2.commands.get(0)).isEqualTo(frame);
+        assertThat(r2.remainder).hasLength(0);
+    }
+
+    @Test
+    public void splitAcrossThreeCallbacks_reassemblesExactBytes() {
+        byte[] frame = freqFrame();
+        byte[] a = java.util.Arrays.copyOfRange(frame, 0, 3);
+        byte[] b = java.util.Arrays.copyOfRange(frame, 3, 7);
+        byte[] c = java.util.Arrays.copyOfRange(frame, 7, frame.length);
+
+        byte[] buffered = new byte[0];
+        for (byte[] chunk : new byte[][]{a, b}) {
+            CivFrameSplitter.Result r = CivFrameSplitter.split(buffered, chunk);
+            assertThat(r.commands).isEmpty(); // no FD until the last chunk
+            buffered = r.remainder;
+        }
+        CivFrameSplitter.Result last = CivFrameSplitter.split(buffered, c);
+        assertThat(last.commands).hasSize(1);
+        assertThat(last.commands.get(0)).isEqualTo(frame);
+        assertThat(last.remainder).hasLength(0);
+    }
+
+    @Test
+    public void frameThenSplitNextFrame_noStrayBytesCorruptTheReassembly() {
+        // End-to-end proof of both fixes together: process a complete frame, then
+        // reassemble the NEXT frame across two chunks through the carried buffer.
+        // The old code would have seeded that buffer with 0x00 0x00, corrupting it.
+        byte[] frame1 = freqFrame();
+        byte[] frame2 = freqFrame();
+        byte[] f2first = java.util.Arrays.copyOfRange(frame2, 0, 5);
+        byte[] f2second = java.util.Arrays.copyOfRange(frame2, 5, frame2.length);
+
+        CivFrameSplitter.Result r1 = CivFrameSplitter.split(new byte[0], concat(frame1, f2first));
+        assertThat(r1.commands).hasSize(1);
+        assertThat(r1.commands.get(0)).isEqualTo(frame1);
+        assertThat(r1.remainder).isEqualTo(f2first); // exactly the partial, no stray bytes
+
+        CivFrameSplitter.Result r2 = CivFrameSplitter.split(r1.remainder, f2second);
+        assertThat(r2.commands).hasSize(1);
+        assertThat(r2.commands.get(0)).isEqualTo(frame2);
+        assertThat(r2.remainder).hasLength(0);
+    }
+
+    @Test
+    public void emptyInputs_yieldNoCommandsAndEmptyRemainder() {
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], new byte[0]);
+        assertThat(r.commands).isEmpty();
+        assertThat(r.remainder).hasLength(0);
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+}


### PR DESCRIPTION
## Summary

The three CI-V rigs — **IcomRig**, **XieGuRig**, and **XieGu6100Rig** — each carried a byte-for-byte identical, hand-rolled `onReceiveData()` that reassembled the `0xFD`-terminated CI-V command stream incorrectly. This fixes the shared root cause once by extracting a small, pure, unit-tested reassembler and wiring all three rigs to it.

## Root cause

CI-V commands are framed as `FE FE <to> <from> <cmd> [data…] FD`. The serial/USB (and network) transport hands `onReceiveData` arbitrary byte chunks, so a command may span several callbacks, or several commands may arrive in one. The old reassembly had two defects:

1. **Stray bytes.** After processing any frame it left the carry-over buffer set to the frame's bytes **plus two stray `0x00` bytes**. Verified empirically — a complete frame `FE FE E0 A4 03 … FD` left `dataBuffer = {00, 00}`.
2. **Fragment loss.** A chunk arriving with **no `0xFD`** discarded the *entire* accumulated buffer, losing every earlier fragment of a command split across more than two reads.

The consequence: a CI-V frequency/mode/meter reply that arrives split across reads — or the very common case of a rig **echoing the request and then sending its reply back-to-back in one read** — gets the `00 00` injected *before* the command byte:

```
expected:  FE FE E0 A4 03 00 40 07 14 00 FD
old code:  FE FE E0 A4 00 00 03 00 40 07 14 00 FD
                        ^^^^^ stray bytes shift the command byte
```

The parser then reads the command id `0x03` as `0x00`, so the reply is dropped or misdispatched — a stuck frequency display and a missed CAT-liveness beat.

## Fix

Extract a shared pure helper `CivFrameSplitter.split(buffered, incoming)` (in the `rigs` package) that returns every complete command plus the true remainder, and reduce each rig's `onReceiveData` to a thin wrapper:

```java
CivFrameSplitter.Result result = CivFrameSplitter.split(dataBuffer, data);
for (byte[] command : result.commands) {
    analysisCommand(command);
}
dataBuffer = result.remainder;
```

- No stray bytes; no fragment loss.
- Processes **all** complete commands in a read instead of only the first — removes the echo+reply latency the old code had (the second frame previously waited for the next read).
- The now-dead per-rig `getCommandEnd()` helper is removed; `getCommandHead()` stays (still used by `analysisCommand`).
- Dispatch is byte-identical for a single whole frame, so the happy path is unchanged.

Per the project's one-bug-per-PR rule, this is a single logical bug whose three occurrences share the same copy-pasted root cause, so they are fixed together.

## Testing

- **New `CivFrameSplitterTest`** — 8 pure-JVM (JUnit4 + Truth, no Robolectric) cases: single whole frame leaves an empty remainder (no stray bytes), two frames in one read (echo+reply) both dispatched, complete-frame-plus-partial carries only the partial, no-terminator accumulation, 2- and 3-chunk split reassembly, empty inputs.
- Confirmed the old algorithm's two defects empirically (scratch JDK program) before writing the fix.
- Full `:app:testDebugUnitTest` suite green.

## Risk

Low. The change is confined to CI-V frame reassembly; command *parsing* (`IcomCommand`, `analysisCommand`) is untouched. Single whole frames dispatch identically to before; the behavioral change is strictly *more* correct (split frames now reassemble, multiple frames per read now all process). No DSP, decoder, or protocol-output code is affected.