### PR TITLE
Fix decode-list time dividers hard-coding the 15s FT8 cycle (mode-agnostic FT4/FT2)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -312,8 +312,11 @@ fun DecodeScreen(
                         // Group messages by receive slot (mode-aware: 15s FT8,
                         // 7.5s FT4, 3.75s FT2). Draw a labeled divider at the first
                         // row of each new slot; the boundaries were precomputed in
-                        // timeGroupDividers above.
-                        if (timeGroupDividers.getOrElse(index) { true }) {
+                        // timeGroupDividers above. It is keyed on the same
+                        // filteredMessages this list iterates, so index is always
+                        // in bounds — index directly rather than masking a
+                        // size mismatch with a getOrElse default.
+                        if (timeGroupDividers[index]) {
                             TimeGroupDivider(utcTime = message.utcTime, compact = compactMode)
                         }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -38,7 +38,9 @@ import com.k1af.ft8af.Ft8Message
 import com.k1af.ft8af.R
 import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
+import com.k1af.ft8af.ModeProfile
 import com.k1af.ft8af.timer.UtcTimer
+import com.k1af.ft8af.ui.WaterfallTimestampGate
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.EmptyStateWaves
 import radio.ks3ckc.ft8af.ui.components.FilterChips
@@ -154,6 +156,14 @@ fun DecodeScreen(
     // Apply filter
     val filteredMessages = remember(messages, selectedFilter) {
         filterMessages(messages, selectedFilter)
+    }
+
+    // Precompute, once per list change, where the mode-aware time-group dividers
+    // fall so each row looks its flag up by index instead of recomputing a
+    // hard-coded 15s slot boundary inline (which collapsed 2-4 FT4/FT2 cycles
+    // under one divider).
+    val timeGroupDividers = remember(filteredMessages) {
+        computeTimeGroupDividers(filteredMessages)
     }
 
     // Track which keys are new since the previous render (animated on entry only once).
@@ -299,11 +309,11 @@ fun DecodeScreen(
                     ) { index, message ->
                         val rowKey = "${message.utcTime}_${message.callsignFrom}_${message.freq_hz}_$index"
 
-                        // Group messages by FT8 cycle (15s slots). Draw a labeled
-                        // divider whenever we cross into a new slot.
-                        val prevSlot = if (index > 0) filteredMessages[index - 1].utcTime / 15000L else null
-                        val thisSlot = message.utcTime / 15000L
-                        if (prevSlot == null || prevSlot != thisSlot) {
+                        // Group messages by receive slot (mode-aware: 15s FT8,
+                        // 7.5s FT4, 3.75s FT2). Draw a labeled divider at the first
+                        // row of each new slot; the boundaries were precomputed in
+                        // timeGroupDividers above.
+                        if (timeGroupDividers.getOrElse(index) { true }) {
                             TimeGroupDivider(utcTime = message.utcTime, compact = compactMode)
                         }
 
@@ -359,6 +369,35 @@ fun DecodeScreen(
 // ---------------------------------------------------------------------------
 // Time Group Divider
 // ---------------------------------------------------------------------------
+
+/**
+ * For each message in [messages], whether a time-group divider should be drawn
+ * above it. A divider marks the start of a new receive slot (cycle): the first
+ * message always gets one, and every later message gets one when it falls in a
+ * different slot than its predecessor.
+ *
+ * The slot length is per-message and mode-aware — FT8 15s, FT4 7.5s, FT2 3.75s
+ * (see [ModeProfile.slotMillis]) — so a fast-mode list gets its finer grid
+ * instead of collapsing 2-4 real cycles under a single hard-coded 15s divider.
+ * The boundary math is shared with the waterfall gridline via
+ * [WaterfallTimestampGate.slotPeriod] so the two views stay on the same grid;
+ * for FT8's 15000ms slot it reproduces the previous `utcTime / 15000` exactly.
+ * Two messages of different modes never share a group even if their slot indices
+ * happen to coincide, because the (slot length, index) pair differs.
+ */
+internal fun computeTimeGroupDividers(messages: List<Ft8Message>): BooleanArray {
+    val dividers = BooleanArray(messages.size)
+    var prevSlotMillis = -1L
+    var prevSlotIndex = 0L
+    for (i in messages.indices) {
+        val slotMillis = ModeProfile.fromId(messages[i].signalFormat).slotMillis.toLong()
+        val slotIndex = WaterfallTimestampGate.slotPeriod(messages[i].utcTime, slotMillis)
+        dividers[i] = i == 0 || slotMillis != prevSlotMillis || slotIndex != prevSlotIndex
+        prevSlotMillis = slotMillis
+        prevSlotIndex = slotIndex
+    }
+    return dividers
+}
 
 @Composable
 private fun TimeGroupDivider(utcTime: Long, compact: Boolean = false) {

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeTimeGroupTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeTimeGroupTest.kt
@@ -4,20 +4,21 @@ import com.google.common.truth.Truth.assertThat
 import com.k1af.ft8af.FT8Common
 import com.k1af.ft8af.Ft8Message
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /**
  * Unit-tests the pure [computeTimeGroupDividers] decode-list slot grouper.
- * Robolectric is needed only because [Ft8Message] reaches android.util.Log on
- * construction (same reason as [DecodeFilterTest]).
+ *
+ * No Robolectric runner: [computeTimeGroupDividers] only reaches the pure
+ * [com.k1af.ft8af.ModeProfile] and [com.k1af.ft8af.ui.WaterfallTimestampGate],
+ * and the `Ft8Message(int)` constructor just assigns `signalFormat` (no
+ * android.util.Log). Any incidental framework call returns defaults under
+ * `unitTests.returnDefaultValues`.
  *
  * The divider marks the first row of each receive slot. It must key on the
  * per-message mode's slot length (FT8 15s, FT4 7.5s, FT2 3.75s) rather than a
  * hard-coded 15s, which previously collapsed 2-4 fast-mode cycles under one
  * divider.
  */
-@RunWith(RobolectricTestRunner::class)
 class DecodeTimeGroupTest {
 
     private fun msg(mode: Int, utcMs: Long) = Ft8Message(mode).apply { utcTime = utcMs }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeTimeGroupTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeTimeGroupTest.kt
@@ -1,0 +1,115 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.FT8Common
+import com.k1af.ft8af.Ft8Message
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit-tests the pure [computeTimeGroupDividers] decode-list slot grouper.
+ * Robolectric is needed only because [Ft8Message] reaches android.util.Log on
+ * construction (same reason as [DecodeFilterTest]).
+ *
+ * The divider marks the first row of each receive slot. It must key on the
+ * per-message mode's slot length (FT8 15s, FT4 7.5s, FT2 3.75s) rather than a
+ * hard-coded 15s, which previously collapsed 2-4 fast-mode cycles under one
+ * divider.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DecodeTimeGroupTest {
+
+    private fun msg(mode: Int, utcMs: Long) = Ft8Message(mode).apply { utcTime = utcMs }
+
+    @Test
+    fun emptyList_returnsEmptyArray() {
+        assertThat(computeTimeGroupDividers(emptyList()).toList()).isEmpty()
+    }
+
+    @Test
+    fun firstMessage_alwaysGetsDivider() {
+        val result = computeTimeGroupDividers(listOf(msg(FT8Common.FT8_MODE, 15_000L)))
+        assertThat(result.toList()).containsExactly(true)
+    }
+
+    @Test
+    fun ft8_groupsWithinSlotAndBreaksAcrossSlots() {
+        // Two decodes in the same 15s slot, then one in the next slot.
+        val messages = listOf(
+            msg(FT8Common.FT8_MODE, 30_000L),
+            msg(FT8Common.FT8_MODE, 32_000L),
+            msg(FT8Common.FT8_MODE, 45_000L),
+        )
+
+        val result = computeTimeGroupDividers(messages)
+
+        assertThat(result.toList()).containsExactly(true, false, true).inOrder()
+    }
+
+    @Test
+    fun ft8_reproducesLegacyDivide15000() {
+        // Reproduce the previous inline `utcTime / 15000L` grouping exactly.
+        val times = longArrayOf(0L, 14_999L, 15_000L, 29_999L, 30_000L, 30_001L)
+        val messages = times.map { msg(FT8Common.FT8_MODE, it) }
+
+        val result = computeTimeGroupDividers(messages)
+
+        var prevSlot = Long.MIN_VALUE
+        val expected = times.mapIndexed { i, t ->
+            val slot = t / 15_000L
+            val divider = i == 0 || slot != prevSlot
+            prevSlot = slot
+            divider
+        }
+        assertThat(result.toList()).isEqualTo(expected)
+    }
+
+    @Test
+    fun ft4_marksEachHalfCycleThatFifteenSecondGridWouldCollapse() {
+        // Two FT4 decodes in the SAME 15s window (both `utc/15000 == 0`) but
+        // different 7.5s slots (0 and 1). The old /15000 math drew one divider;
+        // the mode-aware grid draws two.
+        val messages = listOf(
+            msg(FT8Common.FT4_MODE, 1_000L),   // 7.5s slot 0
+            msg(FT8Common.FT4_MODE, 8_000L),   // 7.5s slot 1
+        )
+
+        // Precondition: the legacy 15s grid would have grouped these.
+        assertThat(1_000L / 15_000L).isEqualTo(8_000L / 15_000L)
+
+        val result = computeTimeGroupDividers(messages)
+
+        assertThat(result.toList()).containsExactly(true, true).inOrder()
+    }
+
+    @Test
+    fun ft2_marksEachQuarterCycle() {
+        // Four FT2 decodes one 3.75s slot apart each get their own divider,
+        // where a 15s grid would have shown a single group.
+        val messages = listOf(
+            msg(FT8Common.FT2_MODE, 3_750L),
+            msg(FT8Common.FT2_MODE, 7_500L),
+            msg(FT8Common.FT2_MODE, 11_250L),
+            msg(FT8Common.FT2_MODE, 15_000L),
+        )
+
+        val result = computeTimeGroupDividers(messages)
+
+        assertThat(result.toList()).containsExactly(true, true, true, true).inOrder()
+    }
+
+    @Test
+    fun modeChange_forcesDividerEvenWhenSlotIndexCoincides() {
+        // FT8 utc=15000 -> slot index 1; FT4 utc=7500 -> slot index 1 too, but the
+        // slot lengths differ so they must not be grouped together.
+        val messages = listOf(
+            msg(FT8Common.FT8_MODE, 15_000L),
+            msg(FT8Common.FT4_MODE, 7_500L),
+        )
+
+        val result = computeTimeGroupDividers(messages)
+
+        assertThat(result.toList()).containsExactly(true, true).inOrder()
+    }
+}


### PR DESCRIPTION
## Root cause

The Compose decode list (`DecodeScreen.kt`) grouped rows into time-group dividers using a hard-coded FT8 cycle:

```kotlin
val prevSlot = if (index > 0) filteredMessages[index - 1].utcTime / 15000L else null
val thisSlot = message.utcTime / 15000L
```

FT8 runs a 15s slot, but **FT4 is 7.5s and FT2 is 3.75s** (`ModeProfile.slotMillis`). At `/15000`, two adjacent FT4 cycles and up to four adjacent FT2 cycles collapse under a single divider, so the operator can't tell which receive slot a fast-mode decode belongs to. The divider label (the slot's UTC time) is also wrong for every collapsed cycle after the first.

This is the **last survivor of the "hard-coded 15s" bug family** — `SlotProgressBar` (#524), `WaterfallTimestampGate` (#523), `UtcTimer`, and `Ft8Message.slotIndex` (#205) were already made mode-aware.

## Fix

Extracted a pure, unit-testable helper next to the existing `filterMessages`:

```kotlin
internal fun computeTimeGroupDividers(messages: List<Ft8Message>): BooleanArray
```

- Keys each divider on **the message's own** mode slot length via `ModeProfile.fromId(message.signalFormat).slotMillis` — mixed-mode lists (after a mode switch mid-session) are handled correctly.
- Shares the boundary math with the waterfall gridline through the existing `WaterfallTimestampGate.slotPeriod(utcMs, slotMillis)` so the two views stay on the same grid.
- Compares the composite `(slotMillis, slotIndex)` so two decodes of different modes never share a group even if their slot indices coincide.

The Composable now precomputes the flags once per list change (`remember(filteredMessages)`) and each row looks up its flag by index — no per-row recomputation.

## Compatibility / risk

- **FT8 is byte-identical.** For a 15000ms slot, `slotPeriod` reduces to `utcTime / 15000`, exactly the old expression. Verified by `ft8_reproducesLegacyDivide15000` and by reverting the helper to the hard-coded grid (the FT8 tests still pass; only the FT4/FT2 tests fail).
- Pure display/grouping change in one Compose screen — no DSP, protocol, timing, or native code touched.
- Low risk, localized.

## Testing

New `DecodeTimeGroupTest` (Robolectric, mirrors `DecodeFilterTest` — Robolectric only because `Ft8Message` construction reaches `android.util.Log`):

- `emptyList_returnsEmptyArray`, `firstMessage_alwaysGetsDivider`
- `ft8_groupsWithinSlotAndBreaksAcrossSlots`, `ft8_reproducesLegacyDivide15000`
- `ft4_marksEachHalfCycleThatFifteenSecondGridWouldCollapse` (asserts the two rows share a 15s window, so the legacy grid grouped them)
- `ft2_marksEachQuarterCycle`
- `modeChange_forcesDividerEvenWhenSlotIndexCoincides`

Verified the FT4/FT2 tests **fail** against the pre-fix `/15000` logic and pass after. Full `:app:testDebugUnitTest` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)