### PR TITLE
Clamp spectrumWidth so waterfall/spectrum geometry can't go Infinity/NaN

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -651,13 +651,34 @@ public class GeneralVariables {
         GeneralVariables.baseFrequency = baseFrequency;
     }
 
+    /** Minimum/maximum spectrum display width (Hz), matching the settings UI slider range. */
+    public static final int MIN_SPECTRUM_WIDTH_HZ = 2500;
+    public static final int MAX_SPECTRUM_WIDTH_HZ = 5000;
+
     public static int getSpectrumWidth() {
         return spectrumWidth;
     }
 
+    /**
+     * Set the spectrum display width, clamped to
+     * [{@link #MIN_SPECTRUM_WIDTH_HZ}, {@link #MAX_SPECTRUM_WIDTH_HZ}] Hz.
+     *
+     * <p>This is display-only geometry: the waterfall/spectrum views divide the
+     * view pixel width by it to place the TX marker and message labels
+     * (e.g. {@code WaterfallView.freq_width = w / spectrumWidth}) and it drives
+     * click-to-tune. The settings UI already constrains the value, but config
+     * hydration ({@code DatabaseOpr}'s {@code parseConfigInt(result, 3500)})
+     * reaches this setter with whatever a hand-edited/corrupted settings backup
+     * persisted, unclamped. A stored {@code 0}/negative made {@code freq_width}
+     * {@code Infinity}/negative, so the marker, labels, and click-to-tune drew at
+     * {@code Infinity}/{@code NaN}/mirrored coordinates. Clamping here (mirroring
+     * {@link #setFftWindowType(int)}) keeps every consumer's geometry finite and
+     * is byte-identical for every in-range value.
+     */
     public static void setSpectrumWidth(int width) {
-        mutableSpectrumWidth.postValue(width);
-        GeneralVariables.spectrumWidth = width;
+        int clamped = Math.max(MIN_SPECTRUM_WIDTH_HZ, Math.min(MAX_SPECTRUM_WIDTH_HZ, width));
+        mutableSpectrumWidth.postValue(clamped);
+        GeneralVariables.spectrumWidth = clamped;
     }
 
     public static int getFftWindowType() {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesSpectrumWidthTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesSpectrumWidthTest.java
@@ -1,0 +1,102 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards {@link GeneralVariables#setSpectrumWidth(int)} against storing a
+ * non-positive (or otherwise out-of-range) spectrum display width.
+ *
+ * <p>{@code spectrumWidth} is a display-only value (the RX audio is always
+ * captured/decoded at {@link FT8Common#SAMPLE_RATE}; see {@code SpectrumScale}).
+ * The waterfall/spectrum views divide the view pixel width by it to place the
+ * TX marker and message labels ({@code WaterfallView.freq_width =
+ * (float) w / spectrumWidth}, {@code ColumnarView}), and it drives
+ * click-to-tune. The settings UI constrains it to [{@value
+ * GeneralVariables#MIN_SPECTRUM_WIDTH_HZ}, {@value
+ * GeneralVariables#MAX_SPECTRUM_WIDTH_HZ}] Hz, but config hydration
+ * ({@code DatabaseOpr}: {@code parseConfigInt(result, 3500)}) reaches this
+ * setter with whatever a hand-edited/corrupted settings backup persisted — with
+ * no range check. A stored {@code 0} made {@code freq_width} {@code Infinity}
+ * (and a negative value flipped the axis), so the TX marker, message labels, and
+ * click-to-tune produced {@code Infinity}/{@code NaN}/mirrored coordinates until
+ * the config was fixed. {@code SpectrumScale}'s own javadoc says the range check
+ * is "left to setters" — this makes the setter honour that contract, mirroring
+ * the sibling {@link GeneralVariables#setFftWindowType(int)} clamp.
+ *
+ * <p>Robolectric because {@link GeneralVariables} carries Android LiveData
+ * statics that must initialize before the static setter can be exercised.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesSpectrumWidthTest {
+
+    private int original;
+
+    @Before
+    public void saveOriginal() {
+        original = GeneralVariables.getSpectrumWidth();
+    }
+
+    @After
+    public void restoreOriginal() {
+        GeneralVariables.setSpectrumWidth(original);
+    }
+
+    @Test
+    public void inRangeValue_isStoredUnchanged() {
+        // Byte-identical for every value the settings UI can produce.
+        GeneralVariables.setSpectrumWidth(3000);
+        assertThat(GeneralVariables.getSpectrumWidth()).isEqualTo(3000);
+
+        GeneralVariables.setSpectrumWidth(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ);
+        assertThat(GeneralVariables.getSpectrumWidth())
+                .isEqualTo(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ);
+
+        GeneralVariables.setSpectrumWidth(GeneralVariables.MAX_SPECTRUM_WIDTH_HZ);
+        assertThat(GeneralVariables.getSpectrumWidth())
+                .isEqualTo(GeneralVariables.MAX_SPECTRUM_WIDTH_HZ);
+    }
+
+    @Test
+    public void zero_isClampedToMin_soFreqWidthIsFinite() {
+        // Regression: a persisted "0" used to be stored verbatim, making
+        // WaterfallView.freq_width = w / 0 == +Infinity.
+        GeneralVariables.setSpectrumWidth(0);
+        assertThat(GeneralVariables.getSpectrumWidth())
+                .isEqualTo(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ);
+        assertThat(GeneralVariables.getSpectrumWidth()).isGreaterThan(0);
+    }
+
+    @Test
+    public void negative_isClampedToMin() {
+        GeneralVariables.setSpectrumWidth(-100);
+        assertThat(GeneralVariables.getSpectrumWidth())
+                .isEqualTo(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ);
+    }
+
+    @Test
+    public void belowMin_isClampedToMin() {
+        GeneralVariables.setSpectrumWidth(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ - 1);
+        assertThat(GeneralVariables.getSpectrumWidth())
+                .isEqualTo(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ);
+    }
+
+    @Test
+    public void absurdlyLargeValue_isClampedToMax() {
+        GeneralVariables.setSpectrumWidth(999_999_999);
+        assertThat(GeneralVariables.getSpectrumWidth())
+                .isEqualTo(GeneralVariables.MAX_SPECTRUM_WIDTH_HZ);
+    }
+
+    @Test
+    public void bounds_arePositiveAndOrdered() {
+        assertThat(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ).isGreaterThan(0);
+        assertThat(GeneralVariables.MAX_SPECTRUM_WIDTH_HZ)
+                .isGreaterThan(GeneralVariables.MIN_SPECTRUM_WIDTH_HZ);
+    }
+}


### PR DESCRIPTION
## Root cause
`GeneralVariables.setSpectrumWidth(int)` stored its argument verbatim, with no range check. `spectrumWidth` is **display-only** (RX audio is always captured/decoded at `FT8Common.SAMPLE_RATE` — see `SpectrumScale`), but the spectrum views divide the view's pixel width by it to place the TX marker and message labels:

- `WaterfallView.java`: `freq_width = (float) w / spectrumWidth;` (used for the TX marker at `:220-221` and every message label at `:368/:381`)
- `ColumnarView.java:199`: `freqWidth = (float) getWidth() / spectrumWidth;`
- click-to-tune in both views: `freq_hz = round(spectrumWidth * touch_x / getWidth())`

The settings UI constrains the value to **2500–5000 Hz** (`RadioAudioSettings` `NumberInputDialog min=2500 max=5000`), but **config hydration does not**: `DatabaseOpr:3022` does `GeneralVariables.setSpectrumWidth(parseConfigInt(result, 3500))`, and `parseConfigInt` only defends against *non-numeric* values (it returns the numeric value as-is for any in-`int` number). A hand-edited or corrupted settings backup — the same unclamped-import vector already hardened in #513/#514/#517 — can therefore persist `spectrumWidth = 0` or a negative/absurd value.

With a stored `0`, `freq_width = w / 0 == +Infinity`; a negative value flips the axis. The TX marker, message labels, and click-to-tune then compute at `Infinity`/`NaN`/mirrored coordinates and silently break until the config is fixed.

`SpectrumScale.gradientScale()` / `binsToShow()` (added in #526) already guard `spectrumWidth <= 0` defensively, and `SpectrumScale`'s javadoc explicitly says the range check is *"left to setters"* — but the setter did none. This PR closes that gap.

## Fix
Clamp `setSpectrumWidth()` to `[MIN_SPECTRUM_WIDTH_HZ, MAX_SPECTRUM_WIDTH_HZ]` (2500..5000, the UI range), mirroring the adjacent `setFftWindowType()` clamp. The clamp is applied before both the LiveData `postValue` and the field write, so every consumer (Compose observers, the two views, click-to-tune, `SpectrumScale`) sees a finite, in-range value.

- **Byte-identical** for every value the UI or a sane config produces (2500–5000 unchanged).
- Single point of truth: the only writer of `GeneralVariables.spectrumWidth`.
- Display-only value; no effect on RX capture/decode, TX, or the FFT itself.

## Testing
- New `GeneralVariablesSpectrumWidthTest` (Robolectric, matching the existing `GeneralVariables*Test` classes): in-range values preserved; `0`, negative, below-min, and absurdly-large values clamped. The four out-of-range cases **fail without the clamp** (verified by reverting the fix — 4 red), pass with it.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — clean (4 ABIs).

## Risk
Very low. One-line clamp in a display-only setter; no protocol/DSP/interop impact; happy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)