### PR TITLE
Enable Hold Tx freq by default (issue #498)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -431,7 +431,7 @@ public class GeneralVariables {
     public static String qrzXmlPassword = ""; //QRZ XML API password
     public static boolean pskOverlayEnabled = false; //PSK Reporter map overlay (issue #33)
     public static boolean synFrequency = false;//Same-frequency transmit
-    public static boolean holdTxFreq = false;//Hold TX freq: don't move the TX offset to a station you answer (WSJT-X "Hold Tx Freq")
+    public static boolean holdTxFreq = true;//Hold TX freq: don't move the TX offset to a station you answer (WSJT-X "Hold Tx Freq"). Enabled by default (issue #498) for frequency stability.
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms into a cycle that a manual TX may start; leading audio is clipped so TX still ends on the cycle boundary. 0-4000.

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesHoldTxFreqDefaultTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesHoldTxFreqDefaultTest.java
@@ -1,0 +1,25 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards the default for the "Hold Tx freq" transmission setting (issue #498):
+ * it must default to enabled so a fresh install (no stored {@code holdTxFreq}
+ * config row) keeps the operator's TX offset instead of following the answered
+ * station. The Settings > Transmission toggle and {@link
+ * com.k1af.ft8af.ft8transmit.FT8TransmitSignal#shouldFollowTargetFreq} both read
+ * this static, so its initial value is what "enabled by default" means.
+ * Robolectric because {@link GeneralVariables} carries Android LiveData statics.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesHoldTxFreqDefaultTest {
+
+    @Test
+    public void holdTxFreq_defaultsTrue() {
+        assertThat(GeneralVariables.holdTxFreq).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
The **Settings > Transmission > "Hold Tx freq"** option now defaults to **enabled**, so a fresh install keeps the operator's TX offset rather than moving it onto a station being answered in TX=RX (split) mode — the WSJT-X "Hold Tx Freq" behavior. Resolves [#498](https://github.com/patrickrb/FT8AF/issues/498).

## Change
- `GeneralVariables.holdTxFreq` static default flipped `false → true`.

Both the Compose Settings toggle (`TransmissionSettings.kt`) and the TX decision logic (`FT8TransmitSignal.shouldFollowTargetFreq`) read this static, so the UI shows the option on by default and TX honors it immediately.

## Behavior / migration notes
- **Fresh install:** no `holdTxFreq` config row exists, so the static default applies → enabled.
- **Existing users who never touched the setting:** no stored row → they also pick up the new default (this is the intended change per the issue).
- **Explicit user choice is preserved:** a persisted `holdTxFreq="0"` row still disables it — the config loader in `DatabaseOpr` (`!(result.equals("") || result.equals("0"))`) overrides the static default when a row exists. No first-run seeding writes this key, so the static default is authoritative.

## Testing
- Added `GeneralVariablesHoldTxFreqDefaultTest` asserting the new default, mirroring the existing `GeneralVariablesPerLocationFlagTest` pattern (Robolectric, since `GeneralVariables` carries Android LiveData statics).
- Verified TDD: the new test fails on the old `false` default and passes on `true`.
- Full `:app:testDebugUnitTest` suite passes — no regressions (including the existing `FT8TransmitSignalTest.shouldFollowTargetFreq` cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)