### PR TITLE
Fix distance stats collapsing to 0 km on unparseable log grids

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/count/CountDbOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/count/CountDbOpr.java
@@ -12,6 +12,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.AsyncTask;
 
+import com.google.android.gms.maps.model.LatLng;
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
 import com.k1af.ft8af.callsign.CallsignInfo;
@@ -51,6 +52,79 @@ public class CountDbOpr {
         new DistanceCount(db,afterCount).execute();
     }
 
+    /**
+     * Accumulated maximum/minimum great-circle distance (in km) from the
+     * operator's own grid to a set of log gridsquares. {@link #hasData()}
+     * distinguishes "no valid contacts were found" from a genuine 0 km
+     * (same-grid) contact.
+     */
+    static class DistanceStats {
+        /** Sentinel matching the legacy "unset minimum" value. */
+        static final double NO_MIN = 6553500d;
+
+        double maxKm = -1;
+        double minKm = NO_MIN;
+        String maxGrid = "";
+        String minGrid = "";
+
+        boolean hasData() {
+            return maxKm > -1 && minKm < NO_MIN;
+        }
+
+        /** Fold another band's extremes into this (global) accumulator. */
+        void merge(DistanceStats other) {
+            if (other.maxKm > maxKm) {
+                maxKm = other.maxKm;
+                maxGrid = other.maxGrid;
+            }
+            if (other.minKm < minKm) {
+                minKm = other.minKm;
+                minGrid = other.minGrid;
+            }
+        }
+    }
+
+    /**
+     * Compute the maximum and minimum great-circle distance from {@code myGrid}
+     * to each gridsquare in {@code grids}.
+     *
+     * <p>Gridsquares that do not parse as a Maidenhead locator are SKIPPED
+     * rather than being treated as 0 km. {@link MaidenheadGrid#getDist(String, String)}
+     * returns 0 when either grid fails to parse (wrong length, or an end-of-QSO
+     * token such as {@code "RR73"} that operators commonly leak into the
+     * GRIDSQUARE field), so counting those as 0 km would collapse the "Nearest
+     * distance" statistic to 0 with a junk grid whenever the log holds even one
+     * contaminated row. A genuine same-grid (0 km) contact still parses and is
+     * retained. If {@code myGrid} itself is not a valid locator no distance can
+     * be computed and empty stats are returned.
+     */
+    static DistanceStats computeDistanceStats(java.util.List<String> grids, String myGrid) {
+        DistanceStats stats = new DistanceStats();
+        if (grids == null) {
+            return stats;
+        }
+        LatLng myLatLng = MaidenheadGrid.gridToLatLng(myGrid);
+        if (myLatLng == null) {
+            return stats;
+        }
+        for (String grid : grids) {
+            LatLng gridLatLng = MaidenheadGrid.gridToLatLng(grid);
+            if (gridLatLng == null) {
+                continue;
+            }
+            double distance = MaidenheadGrid.getDist(gridLatLng, myLatLng);
+            if (distance > stats.maxKm) {
+                stats.maxKm = distance;
+                stats.maxGrid = grid;
+            }
+            if (distance < stats.minKm) {
+                stats.minKm = distance;
+                stats.minGrid = grid;
+            }
+        }
+        return stats;
+    }
+
 
     static class DistanceCount extends AsyncTask<Void,Void,Void>{
         private final SQLiteDatabase db;
@@ -66,10 +140,9 @@ public class CountDbOpr {
         protected Void doInBackground(Void... voids) {
             String querySQL;
             Cursor cursor;
-            double maxDistance=-1;
-            String maxDistanceGrid="";
-            double minDistance=6553500f;
-            String minDistanceGrid="";
+            String myGrid = GeneralVariables.getMyMaidenheadGrid();
+
+            DistanceStats global = new DistanceStats();
 
             ArrayList<CountValue> values=new ArrayList<>();
 
@@ -86,50 +159,30 @@ public class CountDbOpr {
 
                 querySQL = "SELECT DISTINCT SUBSTR(gridsquare,1,4) as g FROM QSLTable q where (gridsquare <>\"\")and(band=?)";
                 cursor = db.rawQuery(querySQL, new String[]{band});
-                double max=-1;
-                String maxGrid="";
-                double min=6553500f;
-                String minGrid="";
-
+                ArrayList<String> grids = new ArrayList<>();
                 while (cursor.moveToNext()) {
-                    String grid = cursor.getString(cursor.getColumnIndex("g"));
-                    double distance = MaidenheadGrid.getDist(grid, GeneralVariables.getMyMaidenheadGrid());
-                    if (distance > maxDistance) {
-                        maxDistance = distance;
-                        maxDistanceGrid = grid;
-                    }
-                    if (distance < minDistance) {
-                        minDistance = distance;
-                        minDistanceGrid = grid;
-                    }
-
-                    if (distance > max) {
-                        max = distance;
-                        maxGrid = grid;
-                    }
-                    if (distance < min) {
-                        min = distance;
-                        minGrid = grid;
-                    }
-
+                    grids.add(cursor.getString(cursor.getColumnIndex("g")));
                 }
                 cursor.close();
 
-                if ((max>-1)&&(min<6553500f)){
-                    values.add(new CountValue((int) Math.round(MaidenheadGrid.convertDist(max)),String.format(
+                DistanceStats bandStats = computeDistanceStats(grids, myGrid);
+                global.merge(bandStats);
+
+                if (bandStats.hasData()){
+                    values.add(new CountValue((int) Math.round(MaidenheadGrid.convertDist(bandStats.maxKm)),String.format(
                             GeneralVariables.getStringFromResource(R.string.maximum_distance)
-                            ,getQSLInfo(maxGrid))));
-                    values.add(new CountValue((int) Math.round(MaidenheadGrid.convertDist(min)),String.format(
+                            ,getQSLInfo(bandStats.maxGrid))));
+                    values.add(new CountValue((int) Math.round(MaidenheadGrid.convertDist(bandStats.minKm)),String.format(
                             GeneralVariables.getStringFromResource(R.string.minimum_distance)
-                            ,getQSLInfo(minGrid))));
+                            ,getQSLInfo(bandStats.minGrid))));
                 }
             }
 
            String info=String.format(GeneralVariables.getStringFromResource(R.string.count_distance_info)
-                   ,MaidenheadGrid.convertDist(maxDistance),MaidenheadGrid.getDistUnitLabel(),maxDistanceGrid
-                   ,MaidenheadGrid.convertDist(minDistance),MaidenheadGrid.getDistUnitLabel(),minDistanceGrid);
+                   ,MaidenheadGrid.convertDist(global.maxKm),MaidenheadGrid.getDistUnitLabel(),global.maxGrid
+                   ,MaidenheadGrid.convertDist(global.minKm),MaidenheadGrid.getDistUnitLabel(),global.minGrid);
 
-            if (afterCount!=null &&(maxDistance>0)&&(minDistance<6553500f)){
+            if (afterCount!=null &&(global.maxKm>0)&&global.hasData()){
                 afterCount.countInformation(new CountInfo(info
                         ,ChartType.None
                         ,GeneralVariables.getStringFromResource(R.string.distance_statistics)

--- a/ft8af/app/src/test/java/com/k1af/ft8af/count/CountDbOprDistanceStatsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/count/CountDbOprDistanceStatsTest.java
@@ -1,0 +1,115 @@
+package com.k1af.ft8af.count;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.maidenhead.MaidenheadGrid;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Exercise {@link CountDbOpr#computeDistanceStats} — the distance-statistics
+ * min/max scan behind the "Distance statistics" report.
+ *
+ * The regression under test: {@link MaidenheadGrid#getDist(String, String)}
+ * returns 0 for any gridsquare that does not parse as a Maidenhead locator
+ * (wrong length, or an end-of-QSO token such as "RR73" that operators commonly
+ * leak into the GRIDSQUARE field of an imported log). The old scan compared
+ * that spurious 0 with {@code <}, so a single contaminated log row collapsed the
+ * "Nearest distance" statistic to 0 km attributed to the junk grid. The fix
+ * skips unparseable grids while still retaining a genuine same-grid 0 km contact.
+ *
+ * Robolectric is required because the production math builds Play Services
+ * {@code LatLng} objects.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CountDbOprDistanceStatsTest {
+
+    private static final String MY_GRID = "IO91"; // London-ish
+    private static final double TOL = 1e-6;
+
+    @Test
+    public void invalidGrid_isSkipped_notCountedAsZeroKm() {
+        double fn42 = MaidenheadGrid.getDist("FN42", MY_GRID);
+        double jn47 = MaidenheadGrid.getDist("JN47", MY_GRID);
+        double expectedMin = Math.min(fn42, jn47);
+        double expectedMax = Math.max(fn42, jn47);
+
+        // "RR73" is a valid-length string that gridToLatLng rejects -> getDist == 0.
+        CountDbOpr.DistanceStats stats =
+                CountDbOpr.computeDistanceStats(Arrays.asList("FN42", "RR73", "JN47"), MY_GRID);
+
+        assertThat(stats.hasData()).isTrue();
+        // The nearest distance must be a real contact, never the spurious 0 from RR73.
+        assertThat(stats.minKm).isGreaterThan(0.0);
+        assertThat(stats.minKm).isWithin(TOL).of(expectedMin);
+        assertThat(stats.maxKm).isWithin(TOL).of(expectedMax);
+        assertThat(stats.minGrid).isNotEqualTo("RR73");
+        assertThat(stats.maxGrid).isNotEqualTo("RR73");
+    }
+
+    @Test
+    public void wrongLengthGrid_isSkipped() {
+        double fn42 = MaidenheadGrid.getDist("FN42", MY_GRID);
+
+        // "ABC" (length 3) is not a valid locator length -> skipped.
+        CountDbOpr.DistanceStats stats =
+                CountDbOpr.computeDistanceStats(Arrays.asList("ABC", "FN42"), MY_GRID);
+
+        assertThat(stats.hasData()).isTrue();
+        assertThat(stats.minGrid).isEqualTo("FN42");
+        assertThat(stats.maxGrid).isEqualTo("FN42");
+        assertThat(stats.minKm).isWithin(TOL).of(fn42);
+    }
+
+    @Test
+    public void sameGridContact_isRetainedAsZeroKm() {
+        // A genuine same-grid contact is 0 km and must remain the minimum, not
+        // be over-eagerly discarded along with the invalid grids.
+        CountDbOpr.DistanceStats stats =
+                CountDbOpr.computeDistanceStats(Collections.singletonList(MY_GRID), MY_GRID);
+
+        assertThat(stats.hasData()).isTrue();
+        assertThat(stats.minKm).isWithin(TOL).of(0.0);
+        assertThat(stats.minGrid).isEqualTo(MY_GRID);
+    }
+
+    @Test
+    public void myGridInvalid_returnsEmptyStats() {
+        CountDbOpr.DistanceStats stats =
+                CountDbOpr.computeDistanceStats(Arrays.asList("FN42", "JN47"), "");
+
+        assertThat(stats.hasData()).isFalse();
+        assertThat(stats.minGrid).isEmpty();
+        assertThat(stats.maxGrid).isEmpty();
+    }
+
+    @Test
+    public void allGridsInvalid_returnsEmptyStats() {
+        CountDbOpr.DistanceStats stats =
+                CountDbOpr.computeDistanceStats(Arrays.asList("RR73", "RR", "ABCDE"), MY_GRID);
+
+        assertThat(stats.hasData()).isFalse();
+    }
+
+    @Test
+    public void merge_keepsGlobalExtremesAcrossBands() {
+        CountDbOpr.DistanceStats bandA =
+                CountDbOpr.computeDistanceStats(Collections.singletonList("FN42"), MY_GRID);
+        CountDbOpr.DistanceStats bandB =
+                CountDbOpr.computeDistanceStats(Collections.singletonList("JN47"), MY_GRID);
+
+        CountDbOpr.DistanceStats global = new CountDbOpr.DistanceStats();
+        global.merge(bandA);
+        global.merge(bandB);
+
+        double fn42 = MaidenheadGrid.getDist("FN42", MY_GRID);
+        double jn47 = MaidenheadGrid.getDist("JN47", MY_GRID);
+        assertThat(global.maxKm).isWithin(TOL).of(Math.max(fn42, jn47));
+        assertThat(global.minKm).isWithin(TOL).of(Math.min(fn42, jn47));
+    }
+}


### PR DESCRIPTION
## Root cause

`CountDbOpr.DistanceCount.doInBackground` builds the **Distance statistics** report (Maximum / Nearest distance, globally and per band) by scanning every distinct 4‑char gridsquare in the QSO log through `MaidenheadGrid.getDist(String, String)`.

`getDist(String, String)` returns **0** whenever *either* grid fails to parse as a Maidenhead locator (`gridToLatLng` returns `null`): a length other than 2/4/6, or an end‑of‑QSO token such as `RR73`/`RR` — which operators very commonly leak into the ADIF `GRIDSQUARE` field of an imported log. The min‑tracking then did `if (distance < minDistance)`, so a **single contaminated log row** collapsed the "Nearest distance" figure (both the global value and every per‑band row) to `0 km`, attributed to the junk grid. The `SUBSTR(gridsquare,1,4)` and `gridsquare <> ""` query filters do not exclude these.

The sibling display helpers `getDistStr`/`getDistStrEN` return `""` for a 0 result, so the statistics screen was the unique place this "invalid grid → 0 km" conflation leaked to the user.

This is distinct from the earlier `getDist` work (PR #512), which clamped `acos` for *coincident* points and deliberately keeps returning 0 for a genuine same‑grid contact — it never addressed unparseable grids in the stats consumer.

## Fix

Extract the min/max scan into a testable `computeDistanceStats(List<String> grids, String myGrid)` helper (with a small `DistanceStats` holder) that:

- **skips** gridsquares which don't parse (`gridToLatLng == null`) instead of counting them as 0 km;
- returns empty stats when the operator's own grid isn't a valid locator (so no bogus 0 km report when the home grid is unset);
- **retains** a genuine same‑grid (0 km) contact as a legitimate minimum, since that grid still parses.

`DistanceCount` becomes a thin wrapper that collects each band's grids, calls the helper, and folds per‑band extremes into the global accumulator via `merge`. Per‑band and global reporting paths and their guards are otherwise unchanged, so **valid‑grid output is byte‑identical**.

## Testing

- New `CountDbOprDistanceStatsTest` (Robolectric — the math builds Play Services `LatLng`) covering: `RR73` and wrong‑length grids skipped, same‑grid 0 km retained, invalid/empty home grid → empty, all‑invalid input → empty, and cross‑band `merge`. The three skip cases were verified to **fail** against the pre‑fix behavior.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full APK build green (all 4 ABIs).

## Risk

Low. Change is confined to `CountDbOpr` (a stats/reporting `AsyncTask`); no DSP, decoder, encoder, native, CAT, or protocol path is touched. No behavior change for logs with only valid grids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)