### PR TITLE
Fix Icom/Xiegu Wi-Fi reconnect race that clobbered the fresh UDP socket

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomUdpClient.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomUdpClient.java
@@ -30,7 +30,6 @@ public class IcomUdpClient {
     private boolean activated = false;
     private OnUdpEvents onUdpEvents = null;
     private final ExecutorService doReceiveThreadPool = Executors.newCachedThreadPool();
-    private DoReceiveRunnable doReceiveRunnable = new DoReceiveRunnable(this);
     private final ExecutorService sendDataThreadPool = Executors.newCachedThreadPool();
     private SendDataRunnable sendDataRunnable = new SendDataRunnable(this);
 
@@ -123,6 +122,11 @@ public class IcomUdpClient {
         } else {
             if (sendSocket != null) {
                 sendSocket.close();
+                // Owner-nulls the shared slot after closing it. The receive worker
+                // used to do this on its way out, but a slow worker could run that
+                // teardown *after* a reconnect had already installed a fresh socket
+                // here, closing/nulling the new socket and leaving the rig dead.
+                sendSocket = null;
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
@@ -133,7 +137,11 @@ public class IcomUdpClient {
     }
 
     private void receiveData() {
-        doReceiveThreadPool.execute(doReceiveRunnable);
+        // Hand the worker the exact socket it should own, captured under this
+        // synchronized method. It never reads the shared sendSocket field again, so a
+        // later reconnect that swaps sendSocket can't make it receive on (or tear down)
+        // the wrong socket.
+        doReceiveThreadPool.execute(new DoReceiveRunnable(this, sendSocket));
 //        new Thread(new Runnable() {
 //            @Override
 //            public void run() {
@@ -200,23 +208,35 @@ public class IcomUdpClient {
         return s.toString();
     }
 
-    private static class DoReceiveRunnable implements Runnable {
-        IcomUdpClient icomUdpClient;
+    // Package-private (not private) so a unit test in this package can drive its
+    // teardown deterministically.
+    static class DoReceiveRunnable implements Runnable {
+        final IcomUdpClient icomUdpClient;
+        // The socket this worker owns. Captured at construction so the loop and the
+        // teardown never touch the shared sendSocket field, which a reconnect may
+        // have swapped for a different socket.
+        final DatagramSocket socket;
 
-        public DoReceiveRunnable(IcomUdpClient icomUdpClient) {
+        public DoReceiveRunnable(IcomUdpClient icomUdpClient, DatagramSocket socket) {
             this.icomUdpClient = icomUdpClient;
+            this.socket = socket;
         }
 
         @Override
         public void run() {
-            while (icomUdpClient.activated) {
+            // Exit when deactivated OR when our own socket is closed. Keying on the
+            // socket (not just the shared activated flag) means a reconnect that flips
+            // activated false->true again still stops this old worker instead of
+            // leaving it to double-receive on the new socket or tight-spin on a closed
+            // one.
+            while (icomUdpClient.activated && !socket.isClosed()) {
                 byte[] data = new byte[icomUdpClient.MAX_BUFFER_SIZE];
                 DatagramPacket packet = new DatagramPacket(data, data.length);
                 try {
-                    icomUdpClient.sendSocket.receive(packet);
+                    socket.receive(packet);
                     if (icomUdpClient.onUdpEvents != null) {
                         byte[] temp = Arrays.copyOf(packet.getData(), packet.getLength());
-                        icomUdpClient.onUdpEvents.OnReceiveData(icomUdpClient.sendSocket, packet, temp);
+                        icomUdpClient.onUdpEvents.OnReceiveData(socket, packet, temp);
                     }
                     //Log.d(TAG, "receiveData:host ip: " + packet.getAddress().getHostName());
                 } catch (IOException e) {
@@ -226,9 +246,17 @@ public class IcomUdpClient {
 
             }
             Log.e(TAG, "udpClient: is exit!");
-            icomUdpClient.sendSocket.close();
-            icomUdpClient.sendSocket = null;
+            // Close only the socket we own; never touch the shared sendSocket field
+            // (setActivated owns its lifecycle). Closing our own socket is idempotent
+            // if setActivated already closed it during teardown.
+            socket.close();
         }
+    }
+
+    // Visible for tests: install a socket into the shared slot without opening the
+    // receive loop, so DoReceiveRunnable's teardown can be asserted deterministically.
+    void primeSendSocketForTest(DatagramSocket socket) {
+        this.sendSocket = socket;
     }
 
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomUdpClientReceiveTeardownTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomUdpClientReceiveTeardownTest.java
@@ -1,0 +1,70 @@
+package com.k1af.ft8af.icom;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.net.DatagramSocket;
+
+/**
+ * Regression coverage for the {@link IcomUdpClient} receive-thread teardown race.
+ *
+ * <p>An Icom/Xiegu Wi-Fi rig reconnect re-opens the UDP stream in place
+ * ({@code IcomUdpBase.openStream()} does {@code setActivated(false)} then
+ * {@code setActivated(true)}). The previous receive worker used to close and null the
+ * <em>shared</em> {@code sendSocket} field on its way out; when that worker was slow to
+ * exit, it ran that teardown after the reconnect had already installed a brand-new
+ * socket, closing/nulling the new socket and leaving the rig dead until an app restart.
+ *
+ * <p>The fix gives each worker the socket it owns and forbids it from touching the
+ * shared field. These tests drive {@link IcomUdpClient.DoReceiveRunnable} directly (the
+ * client starts deactivated, so {@code run()} skips the receive loop and executes only
+ * the teardown) — no threads, no timing, fully deterministic.
+ *
+ * <p>Plain JUnit: {@code DatagramSocket} is pure JDK and the only Android type touched
+ * is {@code android.util.Log}, which unit tests stub via {@code returnDefaultValues}.
+ */
+public class IcomUdpClientReceiveTeardownTest {
+
+    private final DatagramSocket owned;
+    private final DatagramSocket replacement;
+
+    public IcomUdpClientReceiveTeardownTest() throws Exception {
+        owned = new DatagramSocket();
+        replacement = new DatagramSocket();
+    }
+
+    @After
+    public void tearDown() {
+        if (!owned.isClosed()) owned.close();
+        if (!replacement.isClosed()) replacement.close();
+    }
+
+    /** The worker closes the socket it owns when its loop ends. */
+    @Test
+    public void teardown_closesOwnedSocket() {
+        IcomUdpClient client = new IcomUdpClient(-1);
+
+        new IcomUdpClient.DoReceiveRunnable(client, owned).run();
+
+        assertThat(owned.isClosed()).isTrue();
+    }
+
+    /**
+     * The worker must NOT clobber a replacement socket a reconnect installed into the
+     * shared slot — the exact failure that left the rig dead after a reconnect.
+     */
+    @Test
+    public void teardown_leavesReplacementSocketAndSharedSlotIntact() {
+        IcomUdpClient client = new IcomUdpClient(-1);
+        // Simulate a reconnect having installed a fresh socket while the old worker is
+        // still winding down.
+        client.primeSendSocketForTest(replacement);
+
+        new IcomUdpClient.DoReceiveRunnable(client, owned).run();
+
+        assertThat(replacement.isClosed()).isFalse();
+        assertThat(client.getSendSocket()).isSameInstanceAs(replacement);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a reconnect-teardown race in `IcomUdpClient` (the UDP transport shared by every Icom and Xiegu **Wi-Fi** rig) that could leave the rig connection dead until the app was restarted.

## Root cause

`IcomUdpBase.openStream()` reopens the stream **in place** on a reconnect:

```java
if (udpClient.isActivated()) udpClient.setActivated(false); // close old socket
udpClient.setActivated(true);                               // open a fresh socket + new receive thread
```

The receive worker (`DoReceiveRunnable`) used to close **and null the shared `sendSocket` field** on its way out:

```java
icomUdpClient.sendSocket.close();
icomUdpClient.sendSocket = null;
```

That teardown ran on the *old* worker thread, off-lock. When the old worker was slow to exit (a loaded device), it executed those two lines **after** `setActivated(true)` had already installed a brand-new socket into `sendSocket` — closing and nulling the new socket. Every subsequent `sendData()` then silently no-ops (it is guarded by `if (client.sendSocket != null)`), so the rig comes up dead. The `Thread.sleep(100)` band-aid in `setActivated(false)` only narrowed the window; it didn't close it.

Two related hazards from the same design: the worker's loop keyed only on the shared `activated` flag, so a reconnect that flips `activated` `false`→`true` could leave the old worker **double-receiving** on the new socket, or **tight-spinning** on a closed one.

## Fix

Each receive worker now **owns the socket it was given** at construction:
- receives on and closes **only** that socket;
- exits when **that socket** is closed (not merely on the shared `activated` flag), so a reconnect reliably stops the old worker;
- never touches the shared `sendSocket` field.

`setActivated(false)` now owns nulling the shared slot after closing it — a single, lock-held owner for that field's lifecycle. This mirrors the earlier **USB-capture teardown race** (#533) and **Hamlib post-disconnect** (#531) fixes.

## Testing

- New `IcomUdpClientReceiveTeardownTest` (pure JUnit + Truth, no Android runtime): drives the worker's teardown directly and asserts it (1) closes the socket it owns and (2) leaves a reconnect-installed replacement socket and the shared slot intact. **Verified it fails against the old teardown and passes with the fix.**
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — all 4 ABIs + native/hamlib build green.

## Risk

Low and localized to `IcomUdpClient`. Happy-path behavior (single connect → disconnect) is byte-for-byte equivalent: the worker still closes its socket on exit; the shared field still ends up `null` after `setActivated(false)`. No protocol, DSP, encoder, or decoder behavior is touched. Hardware-gated (Icom/Xiegu Wi-Fi rig reconnect), so validated by unit test + build rather than on-device.