### PR TITLE
Fix whole-app crash on garbled Xiegu UDP discovery broadcast

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/x6100/XieguRadioFactory.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/x6100/XieguRadioFactory.java
@@ -109,11 +109,22 @@ public class XieguRadioFactory {
      * @param s data
      * @return MAC address
      */
-    private String getMacAddress(String s){
+    static String getMacAddress(String s){
+        if (s==null){return "";}
         String[] strings=s.split(" ");
         for (int i = 0; i <strings.length ; i++) {
-            if (strings[i].toLowerCase().startsWith("mac")){
-                return strings[i].substring("mac".length()+1);
+            // Require the "mac=" prefix (not just "mac") before reading the value.
+            // The old code matched startsWith("mac") and then did
+            // substring("mac".length() + 1) == substring(4) unconditionally, so a
+            // bare "mac" token (length 3, as in a truncated/garbled discovery
+            // broadcast) threw StringIndexOutOfBoundsException. This runs on the
+            // UDP discovery read thread (RadioUdpClient), whose loop catches only
+            // IOException, so that RuntimeException escaped and crashed the whole
+            // app. Requiring the '=' also matches how X6100Radio.getParameterStr
+            // reads "mac=" and avoids misreading a stray "machine" token as a MAC.
+            // Twin of the FlexRadioFactory.getSerialNum fix (PR #501/#503).
+            if (strings[i].toLowerCase().startsWith("mac=")){
+                return strings[i].substring("mac=".length());
             }
         }
         return "";

--- a/ft8af/app/src/test/java/com/k1af/ft8af/x6100/XieguRadioFactoryTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/x6100/XieguRadioFactoryTest.java
@@ -1,0 +1,100 @@
+package com.k1af.ft8af.x6100;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link XieguRadioFactory#getMacAddress(String)} — the
+ * crash fix for a truncated/garbled Xiegu VITA discovery payload.
+ *
+ * <p>The discovery payload is parsed on the UDP discovery read thread
+ * ({@code RadioUdpClient}). That receive loop catches only {@code IOException},
+ * so any {@link RuntimeException} thrown while parsing escapes the loop, kills
+ * the discovery thread, and crashes the whole app.
+ *
+ * <p>The old code matched {@code startsWith("mac")} and then did
+ * {@code substring("mac".length() + 1)} == {@code substring(4)} unconditionally.
+ * A bare {@code "mac"} token (length 3, case-insensitive) — as in a corrupt or
+ * partial broadcast — made {@code substring(4)} throw
+ * {@link StringIndexOutOfBoundsException}. Requiring the {@code "mac="} prefix
+ * removes the crash and matches how {@code X6100Radio.getParameterStr} reads the
+ * same field. This is the direct twin of the {@code FlexRadioFactory.getSerialNum}
+ * fix (PR #501/#503).
+ *
+ * <p>{@code getMacAddress} touches no Android types, so no Robolectric runner is
+ * needed.
+ */
+public class XieguRadioFactoryTest {
+
+    /** A representative well-formed Xiegu discovery payload. */
+    private static final String DISCOVERY =
+            "ft8cn_server_version=1.0 model=X6100 mac=AA:BB:CC:DD:EE:FF "
+                    + "control_port=50001 stream_port=50002 discovery_port=7001";
+
+    @Test
+    public void wellFormedDiscovery_returnsMac() {
+        assertThat(XieguRadioFactory.getMacAddress(DISCOVERY))
+                .isEqualTo("AA:BB:CC:DD:EE:FF");
+    }
+
+    @Test
+    public void macAsFirstToken_returnsMac() {
+        assertThat(XieguRadioFactory.getMacAddress("mac=11:22:33:44:55:66 model=X6100"))
+                .isEqualTo("11:22:33:44:55:66");
+    }
+
+    @Test
+    public void bareMacToken_doesNotCrash() {
+        // Regression: token "mac" (length 3) -> substring(4) threw
+        // StringIndexOutOfBoundsException on the UDP discovery thread.
+        assertThat(XieguRadioFactory.getMacAddress("model=X6100 mac stream_port=50002"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void bareMacTokenUppercase_doesNotCrash() {
+        // startsWith is applied to toLowerCase(), so "MAC" would also have matched.
+        assertThat(XieguRadioFactory.getMacAddress("MAC")).isEqualTo("");
+    }
+
+    @Test
+    public void machineToken_notMisreadAsMac() {
+        // The old startsWith("mac") matched "machine=..." and returned "ine=...".
+        // Requiring "mac=" makes it a non-match, so no bogus MAC is produced.
+        assertThat(XieguRadioFactory.getMacAddress("machine=router model=X6100"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void macWithEmptyValue_returnsEmpty() {
+        // "mac=" -> substring(4) == "" is valid; not a MAC, treated as absent.
+        assertThat(XieguRadioFactory.getMacAddress("mac= model=X6100")).isEqualTo("");
+    }
+
+    @Test
+    public void noMacToken_returnsEmpty() {
+        assertThat(XieguRadioFactory.getMacAddress("model=X6100 stream_port=50002"))
+                .isEqualTo("");
+    }
+
+    @Test
+    public void emptyPayload_returnsEmpty() {
+        assertThat(XieguRadioFactory.getMacAddress("")).isEqualTo("");
+    }
+
+    @Test
+    public void nullPayload_isEmpty() {
+        // new String(vita.payload) is never null in practice, but guard anyway
+        // so a future caller can't trip a NullPointerException on the thread.
+        assertThat(XieguRadioFactory.getMacAddress(null)).isEqualTo("");
+    }
+
+    @Test
+    public void macTokenIsCaseInsensitive_valuePreserved() {
+        // The prefix match lower-cases the token, but the returned value keeps
+        // its original case.
+        assertThat(XieguRadioFactory.getMacAddress("MAC=Ab:Cd:Ef:01:23:45"))
+                .isEqualTo("Ab:Cd:Ef:01:23:45");
+    }
+}


### PR DESCRIPTION
## Root cause

`XieguRadioFactory.getMacAddress` parses the MAC out of a Xiegu discovery
broadcast:

```java
if (strings[i].toLowerCase().startsWith("mac")){
    return strings[i].substring("mac".length()+1);   // substring(4)
}
```

The guard only checks the `"mac"` prefix but then calls `substring(4)`
**unconditionally**. A bare `"mac"` token (length 3) — as produced by a
truncated or garbled broadcast — makes `substring(4)` throw
`StringIndexOutOfBoundsException`. The loose prefix also misreads any
`"machine=…"`-style token as a MAC (`"hine=…"`).

This parse runs on the UDP **discovery read thread**
(`RadioUdpClient.ReceiveRunnable.run()`), whose receive loop catches only
`IOException`. A `RuntimeException` therefore escapes the loop, kills the
discovery thread, and — via Android's default uncaught-exception handler —
crashes the whole app. The trigger is a single unauthenticated UDP packet on
port 7001 with a valid VITA discovery header and a malformed payload, so any
device on the LAN can crash the app while the user is scanning for Xiegu rigs.

This is the exact twin of the already-fixed `FlexRadioFactory.getSerialNum`
crash (PRs #501 / #503); the Xiegu factory was simply never hardened the same
way.

## Fix

- Require the `"mac="` prefix and read `substring("mac=".length())`, mirroring
  `FlexRadioFactory.getSerialNum` and `X6100Radio.getParameterStr` — the latter
  parses the **same** discovery payload with `startsWith(prefix + "=")`, so
  `"mac="` is the correct, consistent delimiter.
- Add a `null` guard.
- Make `getMacAddress` package-private `static` (it is stateless) so it can be
  unit-tested without the socket-binding constructor.

Happy-path parsing of a well-formed broadcast is byte-identical.

## Testing

- New `XieguRadioFactoryTest` (pure-JVM, no Robolectric — mirrors the existing
  `FlexRadioFactoryTest`). The two bare-`mac` cases (which threw SIOOBE) and the
  `"machine"` misparse case all **fail before the fix** and pass after.
- `./gradlew :app:testDebugUnitTest` — green (full suite).
- `./gradlew :app:assembleDebug` — green (all 4 ABIs).

## Risk

Very low. Localized to one discovery-string parse helper; no protocol, DSP,
audio, or TX/RX behavior changes. Only the crash/misparse edge cases change
behavior; well-formed `mac=` broadcasts parse identically.

## Affected platforms

Android, Xiegu (X6100/G90-class) Wi-Fi rig discovery only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)