### PR TITLE
Fix Icom/Xiegu CAT freq decode undercounting the 1 GHz band by 900 MHz

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomCommand.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomCommand.java
@@ -169,7 +169,7 @@ public class IcomCommand {
                 + (int) (data[3] & 0x0f) * 1000000//millions 1MHz
                 + ((int) (data[3] >> 4) & 0xf) * 10000000//ten-millions 10MHz
                 + (int) (data[4] & 0x0f) * 100000000//hundred-millions 100MHz
-                + ((int) (data[4] >> 4) & 0xf) * 100000000;//billions 1GHz
+                + ((int) (data[4] >> 4) & 0xf) * 1000000000L;//billions 1GHz
     }
 
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomCommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomCommandTest.java
@@ -81,6 +81,36 @@ public class IcomCommandTest {
     }
 
     @Test
+    public void getFrequency_decodesGigahertzDigit() {
+        // 23cm band: 1296.000 MHz = 1_296_000_000 Hz. The 1 GHz digit lives in the
+        // high nibble of the top BCD byte (data[4]). Little-endian byte order:
+        //   data[0]=00 data[1]=00 data[2]=00 data[3]=0x96 (1MHz=6,10MHz=9)
+        //   data[4]=0x12 (100MHz=2, 1GHz=1)
+        byte[] frame = {(byte) 0xFE, (byte) 0xFE, (byte) CTRL, (byte) RIG,
+                (byte) 0x03,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x96, (byte) 0x12,
+                (byte) 0xFD};
+        IcomCommand cmd = IcomCommand.getCommand(CTRL, RIG, frame);
+        assertThat(cmd).isNotNull();
+        assertThat(cmd.getFrequency(false)).isEqualTo(1_296_000_000L);
+    }
+
+    @Test
+    public void getFrequency_gigahertzDigitDoesNotOverflowInt() {
+        // A 1 GHz digit of 9 contributes 9_000_000_000 Hz, which overflows a 32-bit
+        // int. The decode must accumulate in long arithmetic so the value is exact
+        // (int overflow would wrap to a negative/garbage frequency).
+        //   data[4]=0x90 (100MHz=0, 1GHz=9), all lower digits 0.
+        byte[] frame = {(byte) 0xFE, (byte) 0xFE, (byte) CTRL, (byte) RIG,
+                (byte) 0x03,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x90,
+                (byte) 0xFD};
+        IcomCommand cmd = IcomCommand.getCommand(CTRL, RIG, frame);
+        assertThat(cmd).isNotNull();
+        assertThat(cmd.getFrequency(false)).isEqualTo(9_000_000_000L);
+    }
+
+    @Test
     public void getFrequency_missingDataSectionReturnsMinusOne() {
         // A short/garbled frame that matches the preamble and cmd 03 but carries
         // no data payload: FE FE E0 A4 03 FD. getData(false) has nothing after the


### PR DESCRIPTION
## Summary

`IcomCommand.getFrequency` decodes the rig's 5-byte little-endian BCD frequency from every CI-V frequency-read reply. The most-significant digit — the **1 GHz** digit in the high nibble of `data[4]` — was weighted `* 100000000` (100 MHz), a copy of the 100 MHz digit's weight on the line directly above, instead of `* 1000000000` (1 GHz).

Result: on any band ≥ 1 GHz the reported VFO frequency is undercounted by 900 MHz per unit of the 1 GHz digit. A 23cm contact at **1296.000 MHz decoded as 396.000 MHz**.

## Root cause

```java
+ (int) (data[4] & 0x0f) * 100000000   // hundred-millions 100MHz  ✅
+ ((int) (data[4] >> 4) & 0xf) * 100000000; // billions 1GHz       ❌ should be 1e9
```

Classic copy-paste of the adjacent decade weight — the same defect class as the Yaesu2Command decade-weight fix (PR #497).

## Fix

Change the 1 GHz term to a **long** literal `* 1000000000L`. Making it `long` also widens the accumulation before that digit is added, so frequencies above the 32-bit int ceiling (~2.147 GHz) no longer overflow — the lower nine digits still sum within int range (max 999,999,999), then promote to `long`. One-line change; happy path for HF/VHF is byte-identical (the top digit is 0 there, which is why the bug was latent).

## Reachability

`IcomRig.analysisCommand:171` and `XieGuRig:153` feed `getFrequency(false)` directly into `setFreq()` on every frequency-read reply, so this affects the on-screen VFO/CAT frequency for any Icom (e.g. IC-9700) or Xiegu rig operating on 23cm/1.2 GHz.

## Testing

- Added `IcomCommandTest.getFrequency_decodesGigahertzDigit` — 1296.000 MHz (23cm) frame decodes to `1_296_000_000L`.
- Added `IcomCommandTest.getFrequency_gigahertzDigitDoesNotOverflowInt` — 1 GHz digit of 9 (`9_000_000_000` Hz) proves the `long` accumulation.
- Both **fail** on the old `* 100000000` weight and pass after the fix; verified by temporarily reverting the source.
- `:app:testDebugUnitTest` — full suite green.
- `:app:assembleDebug` (all 4 ABIs, hamlib from source) — green.

## Risk

Very low. Single arithmetic-weight correction on a well-tested pure-logic decoder; existing HF/VHF decode paths are unchanged (byte-identical output where the 1 GHz digit is 0). No protocol/DSP behavior affected.