### PR TITLE
Fix Icom/Xiegu Wi-Fi RX-audio use-after-release crash on disconnect

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
@@ -5,8 +5,6 @@ package com.k1af.ft8af.icom;
  * @date 2023-03-20
  */
 
-import android.media.AudioTrack;
-
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
 import com.k1af.ft8af.icom.IcomUdpBase.IcomUdpStyle;
@@ -45,12 +43,8 @@ public class IComWifiRig extends WifiRig{
                 if (onDataEvents!=null){
                     onDataEvents.onReceivedWaveData(audioData);
                 }
-                if (audioTrack!=null){
-                   // if (!isPttOn) {//If PTT is not pressed
-                        audioTrack.write(audioData, 0, audioData.length
-                                , AudioTrack.WRITE_NON_BLOCKING);
-                 //   }
-                }
+                // (Historically gated on !isPttOn; left ungated as before.)
+                writeAudio(audioData);//Guards against a concurrent closeAudio() release
             }
 
             @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
@@ -102,8 +102,12 @@ public abstract class WifiRig {
             writeAudioToTrack(audioData);
         } catch (IllegalStateException e) {
             // closeAudio() released the track on another thread between the null-check
-            // and the write (disconnect while RX audio was still streaming).
-            Log.w(TAG, "Dropped RX audio chunk: AudioTrack released mid-write");
+            // and the write (disconnect while RX audio was still streaming). Log the
+            // throwable for diagnosability. We deliberately do NOT null audioTrack here:
+            // closeAudio() already nulls it on the disconnect thread, and clearing it
+            // from the RX worker would race a reconnect's fresh AudioTrack and silently
+            // clobber it.
+            Log.w(TAG, "Dropped RX audio chunk: AudioTrack released mid-write", e);
         }
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
@@ -9,6 +9,7 @@ package com.k1af.ft8af.icom;
 import android.media.AudioAttributes;
 import android.media.AudioFormat;
 import android.media.AudioTrack;
+import android.util.Log;
 
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
@@ -18,6 +19,8 @@ import com.k1af.ft8af.ui.ToastMessage;
 import java.io.IOException;
 
 public abstract class WifiRig {
+    private static final String TAG = "WifiRig";
+
     public interface OnDataEvents {
         void onReceivedCivData(byte[] data);
 
@@ -25,7 +28,10 @@ public abstract class WifiRig {
     }
 
     public ControlUdp controlUdp;
-    public AudioTrack audioTrack = null;
+    // volatile: the UDP receive worker reads this to play RX audio while another
+    // thread (UI disconnect, or a send-side network error routed through
+    // OnUdpSendIOException -> close()) may release and null it in closeAudio().
+    public volatile AudioTrack audioTrack = null;
     public final String ip;
     public final int port;
     public final String userName;
@@ -77,6 +83,36 @@ public abstract class WifiRig {
                 , IComPacketTypes.AUDIO_SAMPLE_RATE * 4, AudioTrack.MODE_STREAM
                 , mySession);
         audioTrack.play();
+    }
+
+    /**
+     * Play a chunk of received RX audio to the speaker, tolerating a concurrent
+     * {@link #closeAudio()} on another thread.
+     *
+     * <p>The UDP receive worker calls this for every audio packet. A disconnect —
+     * either the user tapping disconnect or a send-side network error routed through
+     * {@code OnUdpSendIOException -> close() -> closeAudio()} — can release the
+     * {@link AudioTrack} while a chunk is in flight. Writing to a released AudioTrack
+     * throws {@link IllegalStateException}; uncaught on the receive worker (its loop
+     * catches only {@code IOException}) that crashed the whole app. Swallow it and
+     * drop the chunk instead.
+     */
+    public void writeAudio(byte[] audioData) {
+        try {
+            writeAudioToTrack(audioData);
+        } catch (IllegalStateException e) {
+            // closeAudio() released the track on another thread between the null-check
+            // and the write (disconnect while RX audio was still streaming).
+            Log.w(TAG, "Dropped RX audio chunk: AudioTrack released mid-write");
+        }
+    }
+
+    // Isolated from writeAudio() so a unit test can drive the released-track path
+    // deterministically without emulating AudioTrack's native lifecycle.
+    void writeAudioToTrack(byte[] audioData) {
+        AudioTrack track = audioTrack; // single volatile read
+        if (track == null) return;
+        track.write(audioData, 0, audioData.length, AudioTrack.WRITE_NON_BLOCKING);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
@@ -5,8 +5,6 @@ package com.k1af.ft8af.icom;
  * @date 2023-08-27
  */
 
-import android.media.AudioTrack;
-
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
 import com.k1af.ft8af.icom.IcomUdpBase.IcomUdpStyle;
@@ -45,10 +43,7 @@ public class XieGuWifiRig extends WifiRig{
                 if (onDataEvents!=null){
                     onDataEvents.onReceivedWaveData(audioData);
                 }
-                if (audioTrack!=null){
-                        audioTrack.write(audioData, 0, audioData.length
-                                , AudioTrack.WRITE_NON_BLOCKING);
-                }
+                writeAudio(audioData);//Guards against a concurrent closeAudio() release
             }
 
             @Override

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/WifiRigWriteAudioTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/WifiRigWriteAudioTest.java
@@ -1,0 +1,130 @@
+package com.k1af.ft8af.icom;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Regression coverage for the {@link WifiRig} RX-audio use-after-release crash.
+ *
+ * <p>For a Wi-Fi Icom/Xiegu rig, the UDP receive worker plays every incoming audio
+ * packet via {@link WifiRig#writeAudio(byte[])}. A disconnect while audio is still
+ * streaming — the user tapping disconnect, or a send-side network error routed through
+ * {@code OnUdpSendIOException -> close() -> closeAudio()} — releases the AudioTrack on a
+ * <em>different</em> thread. The old code did an unguarded {@code audioTrack.write(...)};
+ * writing to a released AudioTrack throws {@link IllegalStateException}, and the receive
+ * worker's loop catches only {@code IOException}, so it escaped and crashed the app.
+ *
+ * <p>The fix wraps the write in {@link WifiRig#writeAudio(byte[])} and snapshots the
+ * (now {@code volatile}) field inside {@link WifiRig#writeAudioToTrack(byte[])}. These
+ * tests drive that seam directly, so the released-track path is deterministic without
+ * emulating AudioTrack's native lifecycle.
+ *
+ * <p>Plain JUnit + Truth: the only Android type touched is {@code android.util.Log},
+ * which unit tests stub via {@code returnDefaultValues}. No AudioTrack is constructed.
+ */
+public class WifiRigWriteAudioTest {
+
+    /**
+     * Minimal concrete {@link WifiRig} whose abstract members are no-ops and whose
+     * {@link #writeAudioToTrack(byte[])} seam is scriptable per test.
+     */
+    private static class TestWifiRig extends WifiRig {
+        RuntimeException toThrow;
+        final AtomicReference<byte[]> lastWritten = new AtomicReference<>();
+        final AtomicInteger writeCount = new AtomicInteger();
+
+        TestWifiRig() {
+            super("192.0.2.1", 50001, "user", "pass");
+        }
+
+        @Override
+        void writeAudioToTrack(byte[] audioData) {
+            writeCount.incrementAndGet();
+            lastWritten.set(audioData);
+            if (toThrow != null) throw toThrow;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void setPttOn(boolean on) {}
+
+        @Override
+        public void sendCivData(byte[] data) {}
+
+        @Override
+        public void sendWaveData(float[] data) {}
+
+        @Override
+        public void close() {}
+    }
+
+    @Test
+    public void writeAudio_releasedTrackThrowsIllegalState_isSwallowed() {
+        TestWifiRig rig = new TestWifiRig();
+        rig.toThrow = new IllegalStateException("play() called on uninitialized AudioTrack");
+
+        // Must not propagate: pre-fix this exact throw escaped the receive worker
+        // (which catches only IOException) and crashed the app.
+        rig.writeAudio(new byte[] {1, 2, 3, 4});
+
+        assertThat(rig.writeCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void writeAudio_delegatesChunkToTrack() {
+        TestWifiRig rig = new TestWifiRig();
+        byte[] chunk = {10, 20, 30};
+
+        rig.writeAudio(chunk);
+
+        assertThat(rig.writeCount.get()).isEqualTo(1);
+        assertThat(rig.lastWritten.get()).isSameInstanceAs(chunk);
+    }
+
+    @Test
+    public void writeAudio_doesNotSwallowUnrelatedRuntimeExceptions() {
+        TestWifiRig rig = new TestWifiRig();
+        rig.toThrow = new IllegalArgumentException("bug we must not mask");
+
+        try {
+            rig.writeAudio(new byte[] {1});
+            org.junit.Assert.fail("Expected IllegalArgumentException to propagate");
+        } catch (IllegalArgumentException expected) {
+            // Only IllegalStateException (released-track race) is swallowed; other
+            // RuntimeExceptions must surface so real bugs aren't hidden.
+        }
+    }
+
+    @Test
+    public void writeAudioToTrack_nullTrack_returnsWithoutWriting() {
+        // Real seam (not overridden) with audioTrack still null: the receive worker
+        // races a disconnect that already nulled the track. Must be a clean no-op,
+        // never an NPE.
+        WifiRig rig = new WifiRig("192.0.2.2", 50001, "user", "pass") {
+            @Override
+            public void start() {}
+
+            @Override
+            public void setPttOn(boolean on) {}
+
+            @Override
+            public void sendCivData(byte[] data) {}
+
+            @Override
+            public void sendWaveData(float[] data) {}
+
+            @Override
+            public void close() {}
+        };
+
+        assertThat(rig.audioTrack).isNull();
+        rig.writeAudioToTrack(new byte[] {1, 2, 3}); // no throw
+        rig.writeAudio(new byte[] {1, 2, 3}); // no throw through the public entry either
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a whole-app crash on Icom/Xiegu **Wi-Fi** rigs when the session ends while RX audio is still streaming.

`WifiRig` plays every incoming audio packet from the UDP receive worker via an inline unguarded write:

```java
// IComWifiRig / XieGuWifiRig, OnReceivedAudioData (receive-worker thread)
if (audioTrack != null) {
    audioTrack.write(audioData, 0, audioData.length, AudioTrack.WRITE_NON_BLOCKING);
}
```

`audioTrack` is torn down by `closeAudio()` (`stop()` / `release()` / `= null`) on a **different** thread whenever the connection closes:
- the user tapping disconnect (UI thread), or
- a send-side network error routed through `OnUdpSendIOException -> close() -> closeAudio()` (send-pool thread) — i.e. exactly when the rig is going away mid-stream.

## Root cause

Two defects on the `audioTrack` field:

1. **Non-volatile** — the receive thread could observe a stale reference.
2. **Check-then-act race** — even with a fresh read, if `closeAudio()` releases the track between the `!= null` check and the `write()`, the worker writes to a **released** `AudioTrack`, which throws `IllegalStateException`. The receive loop (`IcomUdpClient.DoReceiveRunnable.run()`) catches only `IOException`, so the unchecked ISE escaped the pooled worker and crashed the app.

`disconnect-while-streaming` is a normal operation, so this is reachable in ordinary use.

## Fix (root cause, localized)

- Make `WifiRig.audioTrack` `volatile` (visibility across the receive/close threads).
- Add `WifiRig.writeAudio(byte[])`: a `try/catch(IllegalStateException)` around a package-private `writeAudioToTrack(byte[])` that takes a single volatile snapshot, null-guards, and writes.
- Both subclasses' `OnReceivedAudioData` now call `writeAudio(audioData)` instead of the inline write (the now-unused `AudioTrack` import is dropped from each).

Only `IllegalStateException` (the released-track race) is swallowed — other `RuntimeException`s still surface so genuine bugs aren't masked. The happy path (open track) is byte-identical to before.

## Testing

- **`WifiRigWriteAudioTest`** (new, pure JUnit + Truth — no `AudioTrack` constructed; the `writeAudioToTrack` seam is overridden per test):
  - released track throws `IllegalStateException` → swallowed (no propagation);
  - chunk is delegated to the track;
  - an unrelated `RuntimeException` still propagates (catch is narrow);
  - null track → clean no-op (never NPE).
  - The swallow test **fails pre-fix** (ISE propagates), verified by temporarily removing the `catch`.
- `:app:testDebugUnitTest` — full suite green.
- `:app:assembleDebug` — green across all 4 ABIs (native included).

## Risk

Low. Change is confined to `com.k1af.ft8af.icom` Wi-Fi rig audio playback. No protocol/DSP behavior changes; the only semantic change is that a chunk racing a concurrent disconnect is dropped instead of crashing the process.

Related teardown-race fixes in the same un-hardened transport layer: #531 (Hamlib executor), #540 (Icom UDP socket clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)