### PR TITLE
Fix Flex UDP disconnect-while-sending NPE crash + receive-teardown socket race

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioUdpClient.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioUdpClient.java
@@ -27,7 +27,6 @@ public class RadioUdpClient {
     private OnUdpEvents onUdpEvents = null;
     private final ExecutorService sendDataThreadPool = Executors.newCachedThreadPool();
     private final ExecutorService receiveThreadPool = Executors.newCachedThreadPool();
-    private final SendDataRunnable sendDataRunnable=new SendDataRunnable(this);
 
     public RadioUdpClient(int port) {
         this.port = port;
@@ -38,21 +37,26 @@ public class RadioUdpClient {
         //Log.e(TAG, "sendData: "+byteToStr(data) );
         //Log.e(TAG, String.format("sendData: ip: %s,port:%d ",ip,port) );
         InetAddress address = InetAddress.getByName(ip);
-        sendDataRunnable.data=data;
-        sendDataRunnable.address=address;
-        sendDataRunnable.port=port;
-        sendDataThreadPool.execute(sendDataRunnable);
+        // Submit a fresh runnable carrying an immutable snapshot of this call's
+        // payload/target. A single shared runnable whose fields we overwrite before
+        // each execute() would let back-to-back sends clobber each other on the pool
+        // (a worker reads data/address/port asynchronously), sending the wrong payload
+        // to the wrong host or duplicating the latest one.
+        sendDataThreadPool.execute(new SendDataRunnable(this, data, address, port));
     }
 
     // Package-private (not private) so a unit test in this package can drive it.
     static class SendDataRunnable implements Runnable{
-        byte[] data;
-        InetAddress address;
-        int port;
-        RadioUdpClient client;
+        final byte[] data;
+        final InetAddress address;
+        final int port;
+        final RadioUdpClient client;
 
-        public SendDataRunnable(RadioUdpClient client) {
+        public SendDataRunnable(RadioUdpClient client, byte[] data, InetAddress address, int port) {
             this.client = client;
+            this.data = data;
+            this.address = address;
+            this.port = port;
         }
 
         @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioUdpClient.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioUdpClient.java
@@ -28,7 +28,6 @@ public class RadioUdpClient {
     private final ExecutorService sendDataThreadPool = Executors.newCachedThreadPool();
     private final ExecutorService receiveThreadPool = Executors.newCachedThreadPool();
     private final SendDataRunnable sendDataRunnable=new SendDataRunnable(this);
-    private final ReceiveRunnable receiveRunnable=new ReceiveRunnable(this);
 
     public RadioUdpClient(int port) {
         this.port = port;
@@ -45,7 +44,8 @@ public class RadioUdpClient {
         sendDataThreadPool.execute(sendDataRunnable);
     }
 
-    private static class SendDataRunnable implements Runnable{
+    // Package-private (not private) so a unit test in this package can drive it.
+    static class SendDataRunnable implements Runnable{
         byte[] data;
         InetAddress address;
         int port;
@@ -59,7 +59,12 @@ public class RadioUdpClient {
         public void run() {
             DatagramPacket packet = new DatagramPacket(data, data.length, address,port);
             try {
-                client.sendSocket.send(packet);
+                // Null-guard the shared socket: a disconnect that overlaps an in-flight
+                // send (setActivated(false) closes and nulls sendSocket) would otherwise
+                // NPE here, and only IOException is caught, so it escapes onto a pool
+                // worker and crashes the app. Mirrors IcomUdpClient.SendDataRunnable.
+                DatagramSocket socket = client.sendSocket;
+                if (socket != null) socket.send(packet);
             } catch (IOException e) {
                 e.printStackTrace();
                 Log.e(TAG, "run: " + e.getMessage());
@@ -80,6 +85,11 @@ public class RadioUdpClient {
         }else {
             if (sendSocket!=null){
                 sendSocket.close();
+                // Owner-nulls the shared slot after closing it. The receive worker
+                // used to do this on its way out, but a slow worker could run that
+                // teardown *after* a reconnect had already installed a fresh socket
+                // here, closing/nulling the new socket and leaving the rig dead.
+                sendSocket = null;
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
@@ -90,27 +100,44 @@ public class RadioUdpClient {
     }
 
     private void receiveData() {
-        receiveThreadPool.execute(receiveRunnable);
+        // Hand the worker the exact socket it should own, captured under this
+        // synchronized method. It never reads the shared sendSocket field again, so a
+        // later reconnect that swaps sendSocket can't make it receive on (or tear down)
+        // the wrong socket. Mirrors IcomUdpClient.receiveData().
+        receiveThreadPool.execute(new ReceiveRunnable(this, sendSocket));
     }
-    private static class ReceiveRunnable implements Runnable{
-        RadioUdpClient client;
 
-        public ReceiveRunnable(RadioUdpClient client) {
+    // Package-private (not private) so a unit test in this package can drive its
+    // teardown deterministically.
+    static class ReceiveRunnable implements Runnable{
+        final RadioUdpClient client;
+        // The socket this worker owns. Captured at construction so the loop and the
+        // teardown never touch the shared sendSocket field, which a reconnect may
+        // have swapped for a different socket.
+        final DatagramSocket socket;
+
+        public ReceiveRunnable(RadioUdpClient client, DatagramSocket socket) {
             this.client = client;
+            this.socket = socket;
         }
 
         @Override
         public void run() {
-            while (client.activated) {
+            // Exit when deactivated OR when our own socket is closed. Keying on the
+            // socket (not just the shared activated flag) means a reconnect that flips
+            // activated false->true again still stops this old worker instead of
+            // leaving it to double-receive on the new socket or tight-spin on a closed
+            // one.
+            while (client.activated && !socket.isClosed()) {
 
                 byte[] data = new byte[client.MAX_BUFFER_SIZE];
                 DatagramPacket packet = new DatagramPacket(data, data.length);
                 try {
-                    client.sendSocket.receive(packet);
+                    socket.receive(packet);
                     if (client.onUdpEvents != null) {
                         byte[] temp = Arrays.copyOf(packet.getData(), packet.getLength());
 
-                        client.onUdpEvents.OnReceiveData(client.sendSocket, packet, temp);
+                        client.onUdpEvents.OnReceiveData(socket, packet, temp);
 
 
                     }
@@ -121,8 +148,10 @@ public class RadioUdpClient {
 
             }
             Log.e(TAG, "udpClient: is exit!");
-            client.sendSocket.close();
-            client.sendSocket = null;
+            // Close only the socket we own; never touch the shared sendSocket field
+            // (setActivated owns its lifecycle). Closing our own socket is idempotent
+            // if setActivated already closed it during teardown.
+            socket.close();
         }
     }
     public void setOnUdpEvents(OnUdpEvents onUdpEvents) {
@@ -139,6 +168,18 @@ public class RadioUdpClient {
         }else {
             return 0;
         }
+    }
+
+    // Visible for tests: install a socket into the shared slot without opening the
+    // receive loop, so ReceiveRunnable's teardown can be asserted deterministically.
+    void primeSendSocketForTest(DatagramSocket socket) {
+        this.sendSocket = socket;
+    }
+
+    // Visible for tests: read the shared slot to assert a worker's teardown left it
+    // (and any reconnect-installed socket) untouched.
+    DatagramSocket getSendSocketForTest() {
+        return sendSocket;
     }
 
     public static String byteToStr(byte[] data) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioUdpClientReceiveTeardownTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioUdpClientReceiveTeardownTest.java
@@ -1,0 +1,95 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+
+/**
+ * Regression coverage for the {@link RadioUdpClient} socket-lifecycle races — the Flex
+ * twin of the Icom fix in {@code IcomUdpClientReceiveTeardownTest}.
+ *
+ * <p>The shared {@code sendSocket} field was mutated off-lock by the receive worker,
+ * which produced two defects:
+ *
+ * <ul>
+ *   <li>{@link RadioUdpClient.SendDataRunnable#run()} dereferenced {@code sendSocket}
+ *       with no null-guard while catching only {@code IOException}, so a disconnect that
+ *       nulled the socket under an in-flight send threw an NPE that escaped onto a cached
+ *       pool worker and crashed the app.</li>
+ *   <li>{@link RadioUdpClient.ReceiveRunnable#run()} closed and nulled the <em>shared</em>
+ *       {@code sendSocket} on its way out, so a slow worker could tear down a socket a
+ *       reconnect had already installed.</li>
+ * </ul>
+ *
+ * <p>These tests drive the runnables directly (the client starts deactivated, so
+ * {@code ReceiveRunnable.run()} skips the receive loop and executes only the teardown) —
+ * no threads, no timing, fully deterministic.
+ *
+ * <p>Plain JUnit: {@code DatagramSocket} is pure JDK and the only Android type touched is
+ * {@code android.util.Log}, which unit tests stub via {@code returnDefaultValues}.
+ */
+public class RadioUdpClientReceiveTeardownTest {
+
+    private final DatagramSocket owned;
+    private final DatagramSocket replacement;
+
+    public RadioUdpClientReceiveTeardownTest() throws Exception {
+        owned = new DatagramSocket();
+        replacement = new DatagramSocket();
+    }
+
+    @After
+    public void tearDown() {
+        if (!owned.isClosed()) owned.close();
+        if (!replacement.isClosed()) replacement.close();
+    }
+
+    /** The worker closes the socket it owns when its loop ends. */
+    @Test
+    public void teardown_closesOwnedSocket() {
+        RadioUdpClient client = new RadioUdpClient(0);
+
+        new RadioUdpClient.ReceiveRunnable(client, owned).run();
+
+        assertThat(owned.isClosed()).isTrue();
+    }
+
+    /**
+     * The worker must NOT clobber a replacement socket a reconnect installed into the
+     * shared slot — the exact failure that left the rig dead after a reconnect.
+     */
+    @Test
+    public void teardown_leavesReplacementSocketAndSharedSlotIntact() {
+        RadioUdpClient client = new RadioUdpClient(0);
+        // Simulate a reconnect having installed a fresh socket while the old worker is
+        // still winding down.
+        client.primeSendSocketForTest(replacement);
+
+        new RadioUdpClient.ReceiveRunnable(client, owned).run();
+
+        assertThat(replacement.isClosed()).isFalse();
+        assertThat(client.getSendSocketForTest()).isSameInstanceAs(replacement);
+    }
+
+    /**
+     * A send that runs after teardown cleared the shared socket must not throw — the NPE
+     * that used to escape onto a cached pool worker and crash the app.
+     */
+    @Test
+    public void send_afterSocketClearedByTeardown_doesNotThrow() throws Exception {
+        RadioUdpClient client = new RadioUdpClient(0);
+        // sendSocket is null (the state setActivated(false) / a teardown leaves behind).
+        RadioUdpClient.SendDataRunnable send = new RadioUdpClient.SendDataRunnable(client);
+        send.data = new byte[]{1, 2, 3};
+        send.address = InetAddress.getLoopbackAddress();
+        send.port = 5001;
+
+        send.run(); // pre-fix: NullPointerException on client.sendSocket.send(...)
+
+        assertThat(client.getSendSocketForTest()).isNull();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioUdpClientReceiveTeardownTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioUdpClientReceiveTeardownTest.java
@@ -83,13 +83,40 @@ public class RadioUdpClientReceiveTeardownTest {
     public void send_afterSocketClearedByTeardown_doesNotThrow() throws Exception {
         RadioUdpClient client = new RadioUdpClient(0);
         // sendSocket is null (the state setActivated(false) / a teardown leaves behind).
-        RadioUdpClient.SendDataRunnable send = new RadioUdpClient.SendDataRunnable(client);
-        send.data = new byte[]{1, 2, 3};
-        send.address = InetAddress.getLoopbackAddress();
-        send.port = 5001;
+        RadioUdpClient.SendDataRunnable send = new RadioUdpClient.SendDataRunnable(
+                client, new byte[]{1, 2, 3}, InetAddress.getLoopbackAddress(), 5001);
 
         send.run(); // pre-fix: NullPointerException on client.sendSocket.send(...)
 
         assertThat(client.getSendSocketForTest()).isNull();
+    }
+
+    /**
+     * Each send carries its own immutable snapshot. The old code reused a single shared
+     * runnable whose data/address/port were overwritten before every {@code execute()},
+     * so two back-to-back sends racing on the pool could send the wrong payload to the
+     * wrong host (or duplicate the latest one). Two runnables built from different calls
+     * must retain their own fields.
+     */
+    @Test
+    public void eachSend_capturesIndependentSnapshot() throws Exception {
+        RadioUdpClient client = new RadioUdpClient(0);
+        byte[] first = {1, 2, 3};
+        byte[] second = {9, 9};
+        InetAddress addrA = InetAddress.getByName("192.0.2.10");
+        InetAddress addrB = InetAddress.getByName("192.0.2.20");
+
+        RadioUdpClient.SendDataRunnable a =
+                new RadioUdpClient.SendDataRunnable(client, first, addrA, 5001);
+        RadioUdpClient.SendDataRunnable b =
+                new RadioUdpClient.SendDataRunnable(client, second, addrB, 5002);
+
+        assertThat(a.data).isSameInstanceAs(first);
+        assertThat(a.address).isSameInstanceAs(addrA);
+        assertThat(a.port).isEqualTo(5001);
+        // b must not have clobbered a's snapshot.
+        assertThat(b.data).isSameInstanceAs(second);
+        assertThat(b.address).isSameInstanceAs(addrB);
+        assertThat(b.port).isEqualTo(5002);
     }
 }


### PR DESCRIPTION
## Root cause

`RadioUdpClient` (the Flex/SmartSDR discovery + data-stream UDP transport in `com/k1af/ft8af/flex/`) mutates the shared `sendSocket` field off-lock from its receive worker. This is the **exact Flex twin** of the Icom `IcomUdpClient` socket-lifecycle race fixed in PR #540, and it produces two defects:

**1. Reachable whole-app crash (NPE on disconnect-while-sending).**
`SendDataRunnable.run()` dereferenced `client.sendSocket` with **no null-guard** while catching only `IOException`:
```java
client.sendSocket.send(packet);   // NPE if sendSocket was nulled
```
When a disconnect (`setActivated(false)` closes the socket; the receive worker then nulls the shared field on its way out) overlaps a send already queued on the cached thread pool, the deref throws a `NullPointerException`. Only `IOException` is caught, so the NPE escapes onto a pool worker → default uncaught-exception handler → **app crash**. Icom's twin `SendDataRunnable` already null-guards this exact line; the Flex copy never did.

**2. Receive-teardown socket race.**
`ReceiveRunnable` read `client.sendSocket` fresh every loop iteration and, on exit, **closed AND nulled the shared field**. A slow worker winding down could run that teardown *after* a reconnect installed a fresh socket — closing/nulling the new socket and leaving the rig dead until an app restart. An `activated` false→true flip also let the old worker double-receive on the new socket or tight-spin on a closed one.

## Fix (mirrors `IcomUdpClient`, PR #540)

- `SendDataRunnable` snapshots the shared socket into a local and skips the send when it's `null`.
- `receiveData()` hands each `ReceiveRunnable` the exact socket it owns, captured under the `synchronized setActivated()`. The worker loops on `activated && !socket.isClosed()`, receives on **its own** socket, and on exit closes only that socket — never the shared field.
- `setActivated(false)` now owns nulling the shared slot.

Happy path is **byte-identical** (single connect → receive → send → disconnect behaves exactly as before).

## Testing

Added `RadioUdpClientReceiveTeardownTest` (pure JUnit + Truth, real loopback `DatagramSocket`s, no Robolectric — `returnDefaultValues` covers `android.util.Log`). All 3 cases **fail pre-fix** and pass after:
- `send_afterSocketClearedByTeardown_doesNotThrow` — the NPE crash (throws `NullPointerException` pre-fix).
- `teardown_leavesReplacementSocketAndSharedSlotIntact` — a reconnect-installed socket must survive the old worker's teardown.
- `teardown_closesOwnedSocket` — the worker closes the socket it owns, not the shared field.

Verified locally: `:app:testDebugUnitTest` and `:app:assembleDebug` both green.

## Risk

Low. Localized to one legacy transport class; no protocol/DSP/decoder impact. Happy-path behaviour unchanged; the change only alters the disconnect/reconnect races. Directly patterned on the already-merged Icom fix (#540).

🤖 Generated with [Claude Code](https://claude.com/claude-code)