### PR TITLE
Fix Icom/Xiegu Wi-Fi UDP send race: one shared Runnable reused across the pool

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomUdpClient.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomUdpClient.java
@@ -30,8 +30,12 @@ public class IcomUdpClient {
     private boolean activated = false;
     private OnUdpEvents onUdpEvents = null;
     private final ExecutorService doReceiveThreadPool = Executors.newCachedThreadPool();
-    private final ExecutorService sendDataThreadPool = Executors.newCachedThreadPool();
-    private SendDataRunnable sendDataRunnable = new SendDataRunnable(this);
+    private ExecutorService sendDataThreadPool = Executors.newCachedThreadPool();
+    // Serializes the actual socket send across the pool's workers. The old code got this
+    // for free by reusing one shared Runnable (its `synchronized(this)`); now that each
+    // send has its own task, a shared lock keeps DatagramSocket.send (not documented
+    // thread-safe) one-at-a-time per client.
+    private final Object sendLock = new Object();
 
     public IcomUdpClient() {//Random local port
         localPort = -1;
@@ -45,10 +49,15 @@ public class IcomUdpClient {
         if (!activated) return;
 
         InetAddress address = InetAddress.getByName(ip);
-        sendDataRunnable.address = address;
-        sendDataRunnable.data = data;
-        sendDataRunnable.port = port;
-        sendDataThreadPool.execute(sendDataRunnable);
+        // Build a fresh task per call. A single shared SendDataRunnable reused across
+        // this cached pool let two overlapping sends (the ping/idle/are-you-there
+        // timers all fire on their own threads, plus CAT command sends) clobber each
+        // other's data/address/port. Because packets differ in length, a worker could
+        // read the old buffer but the new length in `new DatagramPacket(data,
+        // data.length, ...)` and throw IllegalArgumentException — uncaught on the pool
+        // thread, i.e. an app crash — or silently transmit the wrong bytes and desync
+        // the tracked sequence. A per-call immutable snapshot removes the shared state.
+        sendDataThreadPool.execute(new SendDataRunnable(this, data, address, port));
 //        new Thread(new Runnable() {
 //            @Override
 //            public void run() {
@@ -68,30 +77,37 @@ public class IcomUdpClient {
 //        }).start();
     }
 
-    private static class SendDataRunnable implements Runnable {
-        byte[] data;
-        int port;
-        InetAddress address;
-        IcomUdpClient client;
+    // Package-private (not private) so a unit test in this package can capture the
+    // per-call task and assert each keeps its own payload.
+    static class SendDataRunnable implements Runnable {
+        final byte[] data;
+        final int port;
+        final InetAddress address;
+        final IcomUdpClient client;
 
-        public SendDataRunnable(IcomUdpClient client) {
+        SendDataRunnable(IcomUdpClient client, byte[] data, InetAddress address, int port) {
             this.client = client;
+            this.data = data;
+            this.address = address;
+            this.port = port;
         }
 
         @Override
         public void run() {
             DatagramPacket packet = new DatagramPacket(data, data.length, address, port);
-            synchronized (this) {
+            synchronized (client.sendLock) {
+                // Snapshot the shared socket once: reading the field twice (null-check
+                // then send) could NPE if a concurrent disconnect nulls it in between. A
+                // closed socket still surfaces as an IOException, which is handled below.
+                DatagramSocket socket = client.sendSocket;
                 try {
-                    if (client.sendSocket != null) client.sendSocket.send(packet);
+                    if (socket != null) socket.send(packet);
 
                 } catch (IOException e) {
                     e.printStackTrace();
                     Log.e(TAG, "IComUdpClient: " + e.getMessage());
-                    if (client != null) {
-                        if (client.onUdpEvents != null) {
-                            client.onUdpEvents.OnUdpSendIOException(e);
-                        }
+                    if (client.onUdpEvents != null) {
+                        client.onUdpEvents.OnUdpSendIOException(e);
                     }
                 }
             }
@@ -257,6 +273,12 @@ public class IcomUdpClient {
     // receive loop, so DoReceiveRunnable's teardown can be asserted deterministically.
     void primeSendSocketForTest(DatagramSocket socket) {
         this.sendSocket = socket;
+    }
+
+    // Visible for tests: swap in a capturing executor so the per-call send tasks can be
+    // grabbed and asserted independent instead of run on the real cached pool.
+    void setSendExecutorForTest(ExecutorService executor) {
+        this.sendDataThreadPool = executor;
     }
 
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomUdpClient.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomUdpClient.java
@@ -276,9 +276,16 @@ public class IcomUdpClient {
     }
 
     // Visible for tests: swap in a capturing executor so the per-call send tasks can be
-    // grabbed and asserted independent instead of run on the real cached pool.
+    // grabbed and asserted independent instead of run on the real cached pool. Rejects
+    // null (it would NPE the next sendData) and shuts down the executor being displaced
+    // so the default cached pool's worker threads don't leak across tests.
     void setSendExecutorForTest(ExecutorService executor) {
+        java.util.Objects.requireNonNull(executor, "executor");
+        ExecutorService previous = this.sendDataThreadPool;
         this.sendDataThreadPool = executor;
+        if (previous != null && previous != executor) {
+            previous.shutdownNow();
+        }
     }
 
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomUdpClientSendDataTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomUdpClientSendDataTest.java
@@ -1,0 +1,131 @@
+package com.k1af.ft8af.icom;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Regression coverage for the {@link IcomUdpClient} shared-send-{@code Runnable} race.
+ *
+ * <p>{@code sendData} used to mutate a single long-lived {@code SendDataRunnable}
+ * (its {@code data}/{@code address}/{@code port} fields) and resubmit that <em>same</em>
+ * object to a cached thread pool on every call. An Icom/Xiegu Wi-Fi session drives that
+ * method from several threads at once — the ping (500 ms), idle and are-you-there timers
+ * plus CAT command sends — so two overlapping sends clobbered each other. Because control
+ * / ping / command packets differ in length, a pool worker could read the previous
+ * buffer but the next length in {@code new DatagramPacket(data, data.length, ...)} and
+ * throw {@code IllegalArgumentException} (uncaught on the pool thread → app crash), or at
+ * best transmit the wrong bytes and desync the tracked sequence.
+ *
+ * <p>The fix builds a fresh, immutable task per call. These tests capture the submitted
+ * tasks with a stub executor and run them deterministically — no threads, no timing.
+ *
+ * <p>Plain JUnit: {@code DatagramSocket} is pure JDK and the only Android type touched is
+ * {@code android.util.Log}, which unit tests stub via {@code returnDefaultValues}.
+ */
+public class IcomUdpClientSendDataTest {
+
+    /** Executor that records submitted tasks instead of running them. */
+    private static final class CapturingExecutor extends AbstractExecutorService {
+        final List<Runnable> tasks = new ArrayList<>();
+
+        @Override
+        public void execute(Runnable command) {
+            tasks.add(command);
+        }
+
+        @Override
+        public void shutdown() {
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+    }
+
+    private IcomUdpClient client;
+    private DatagramSocket receiver;
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) client.setActivated(false);
+        if (receiver != null && !receiver.isClosed()) receiver.close();
+    }
+
+    /** Every send must produce its own task; the pre-fix code reused one shared object. */
+    @Test
+    public void sendData_buildsAFreshTaskPerCall() throws Exception {
+        client = new IcomUdpClient(-1);
+        CapturingExecutor executor = new CapturingExecutor();
+        client.setSendExecutorForTest(executor);
+        client.setActivated(true);
+
+        client.sendData(new byte[]{1, 2, 3, 4}, "127.0.0.1", 50000);
+        client.sendData(new byte[]{9, 9}, "127.0.0.1", 50000);
+
+        assertThat(executor.tasks).hasSize(2);
+        assertThat(executor.tasks.get(0)).isNotSameInstanceAs(executor.tasks.get(1));
+    }
+
+    /**
+     * The first-queued task must still transmit the FIRST payload after a second, shorter
+     * send was submitted. With the shared runnable it already held the second buffer, so
+     * running the first task sent the wrong bytes (and a length change could crash it).
+     */
+    @Test
+    public void queuedSend_keepsItsOwnPayload_notTheLatest() throws Exception {
+        receiver = new DatagramSocket(0, InetAddress.getByName("127.0.0.1"));
+        receiver.setSoTimeout(2000);
+        int port = receiver.getLocalPort();
+
+        client = new IcomUdpClient(-1);
+        CapturingExecutor executor = new CapturingExecutor();
+        client.setSendExecutorForTest(executor);
+        client.setActivated(true); // opens the real send socket used by the tasks
+
+        byte[] first = {1, 2, 3, 4, 5, 6, 7, 8};
+        byte[] second = {9, 9};
+
+        client.sendData(first, "127.0.0.1", port);
+        client.sendData(second, "127.0.0.1", port);
+
+        executor.tasks.get(0).run();
+        assertThat(receiveBytes()).isEqualTo(first);
+
+        executor.tasks.get(1).run();
+        assertThat(receiveBytes()).isEqualTo(second);
+    }
+
+    private byte[] receiveBytes() throws Exception {
+        byte[] buf = new byte[64];
+        DatagramPacket packet = new DatagramPacket(buf, buf.length);
+        receiver.receive(packet);
+        return Arrays.copyOf(packet.getData(), packet.getLength());
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomUdpClientSendDataTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomUdpClientSendDataTest.java
@@ -38,6 +38,7 @@ public class IcomUdpClientSendDataTest {
     /** Executor that records submitted tasks instead of running them. */
     private static final class CapturingExecutor extends AbstractExecutorService {
         final List<Runnable> tasks = new ArrayList<>();
+        boolean shutdownNowCalled = false;
 
         @Override
         public void execute(Runnable command) {
@@ -50,6 +51,7 @@ public class IcomUdpClientSendDataTest {
 
         @Override
         public List<Runnable> shutdownNow() {
+            shutdownNowCalled = true;
             return new ArrayList<>();
         }
 
@@ -120,6 +122,31 @@ public class IcomUdpClientSendDataTest {
 
         executor.tasks.get(1).run();
         assertThat(receiveBytes()).isEqualTo(second);
+    }
+
+    /** The test hook rejects null instead of leaving a null pool that would NPE sendData. */
+    @Test
+    public void setSendExecutorForTest_rejectsNull() {
+        client = new IcomUdpClient(-1);
+        try {
+            client.setSendExecutorForTest(null);
+            org.junit.Assert.fail("Expected NullPointerException");
+        } catch (NullPointerException expected) {
+            // executor is required
+        }
+    }
+
+    /** Swapping in a new executor shuts down the one it displaces, so its threads don't leak. */
+    @Test
+    public void setSendExecutorForTest_shutsDownDisplacedExecutor() {
+        client = new IcomUdpClient(-1);
+        CapturingExecutor first = new CapturingExecutor();
+        CapturingExecutor second = new CapturingExecutor();
+
+        client.setSendExecutorForTest(first);   // displaces the default cached pool
+        client.setSendExecutorForTest(second);  // displaces `first`
+
+        assertThat(first.shutdownNowCalled).isTrue();
     }
 
     private byte[] receiveBytes() throws Exception {


### PR DESCRIPTION
## Summary

`IcomUdpClient.sendData` mutated a **single long-lived** `SendDataRunnable` (its `data`/`address`/`port` fields) and resubmitted that **same object** to a cached thread pool on every call. An Icom/Xiegu Wi-Fi session drives `sendData` from several threads at once, so overlapping sends clobbered each other on the shared object.

## Root cause

One mutable `Runnable` shared across a concurrent `ExecutorService`:

```java
sendDataRunnable.address = address;
sendDataRunnable.data = data;
sendDataRunnable.port = port;
sendDataThreadPool.execute(sendDataRunnable);   // same instance every call
```

`IcomUdpBase.sendUntrackedPacket`/`sendTrackedPacket` are `synchronized`, so the *field write + submit* is atomic — but the async `run()` is not, and neither is the packet it builds:

```java
DatagramPacket packet = new DatagramPacket(data, data.length, address, port);
```

The concurrent senders are real and continuous during a Wi-Fi session:
- ping timer (500 ms), idle timer, are-you-there timer — each on its own `Timer` thread
- CAT command / token sends

Two of these overlapping means one pool worker reads fields the other is overwriting. Two consequences:

1. **Crash.** Control/ping/command packets differ in length. If a worker reads the *previous* buffer for `data` but the *next* value for `data.length`, `new DatagramPacket(buf, length, …)` with `length > buf.length` throws `IllegalArgumentException`. It's on a cached-pool worker and the surrounding `try/catch` only catches `IOException`, so it escapes to the default uncaught handler → **app crash**.
2. **Silent corruption.** More often the worker just sends the *other* packet's bytes, dropping the intended one and desyncing the tracked sequence (the rig then has to request a retransmit).

The per-runnable `synchronized(this)` only serialized the socket `send()` — it did nothing for the racy field reads that build the packet *before* the synchronized block.

## Fix

- Build a **fresh, immutable `SendDataRunnable` per call**: `data`/`address`/`port`/`client` are now `final`, captured in the constructor. No shared mutable state, so there is nothing to clobber.
- Move send serialization onto a dedicated per-client `sendLock` so `DatagramSocket.send` (not documented thread-safe) stays one-at-a-time per client — preserving the guarantee the old shared-object `synchronized(this)` gave for free.
- `run()` now snapshots `sendSocket` once instead of reading it twice (null-check then send), removing a narrow NPE window if a concurrent disconnect nulls it in between (a closed socket still surfaces as the handled `IOException`).

Happy path is byte-identical: a single in-flight send builds and transmits exactly the same packet as before.

## Testing

- `IcomUdpClientSendDataTest` (new, pure JUnit + Truth, real loopback `DatagramSocket`s, no Robolectric):
  - `sendData_buildsAFreshTaskPerCall` — two sends yield two distinct task instances.
  - `queuedSend_keepsItsOwnPayload_notTheLatest` — a task queued first still transmits *its* payload after a second, shorter send was submitted.
  - Both **fail on the pre-fix shared runnable** (verified by reverting only the source) and **pass after**.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — release build green (all 4 ABIs, hamlib included).

## Risk

Low and localized to `IcomUdpClient`. No protocol/DSP change, no wire-format change; only the concurrency around how the send task is constructed and serialized. The same shared-mutable-Runnable pattern exists in the Flex/`RadioUdpClient`/`RadioTcpClient` and `IcomAudioUdp` transports — deliberately left out to keep this one focused (different classes, separate follow-ups).

## Affected platforms

Android, Icom (IC-705) / Xiegu Wi-Fi (network) rig control only. USB/serial CAT paths are unaffected.