### PR TITLE
Fix Flex DAX RX-audio use-after-release crash on disconnect

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
@@ -282,7 +282,7 @@ public class FlexRadio {
     /**
      * Write one DAX audio frame to the playback track, tolerating the
      * disconnect-while-streaming race. Audio frames arrive on the UDP stream
-     * read thread ({@link RadioUdpClient.ReceiveRunnable#run()}, whose loop
+     * read thread (the {@link RadioUdpClient} receive worker, whose loop
      * catches only {@code IOException}), while {@link #closeAudio()} releases
      * and nulls {@link #audioTrack} from the disconnect thread — and
      * {@code FlexConnector.disconnect()} calls {@code closeAudio()} <em>before</em>
@@ -297,9 +297,12 @@ public class FlexRadio {
         try {
             writeAudioToTrack(data);
         } catch (IllegalStateException e) {
-            // audioTrack was released concurrently (disconnect during
-            // streaming); drop this frame rather than crash the receive thread.
-            Log.e(TAG, "writeAudio: track released mid-stream: " + e.getMessage());
+            // audioTrack was released concurrently (disconnect during streaming);
+            // drop this frame rather than crash the receive thread. This is an
+            // expected, handled race and multiple frames can arrive between
+            // release() and audioTrack=null, so log at DEBUG to avoid ERROR-level
+            // per-frame spam on every disconnect.
+            Log.d(TAG, "writeAudio: track released mid-stream: " + e.getMessage());
         }
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
@@ -108,7 +108,9 @@ public class FlexRadio {
     private OnMessageListener onMessageListener;//Message event trigger
     private OnStatusListener onStatusListener;//Status event trigger
     //*****************************************************************
-    private AudioTrack audioTrack = null;
+    // volatile: written by openAudio/closeAudio on the connect/disconnect thread,
+    // read by the UDP stream thread in writeAudioToTrack.
+    private volatile AudioTrack audioTrack = null;
 
     public FlexRadio() {
         updateLastSeen();
@@ -274,10 +276,43 @@ public class FlexRadio {
         if (onReceiveStreamData != null) {
             onReceiveStreamData.onReceiveAudio(data);
         }
-        if (audioTrack != null) {//If audio playback is already open, write audio stream data
-            float[] sound = getFloatFromBytes(data);//Length is 256 floats
-            audioTrack.write(sound, 0, sound.length, AudioTrack.WRITE_NON_BLOCKING);
+        writeAudio(data);
+    }
+
+    /**
+     * Write one DAX audio frame to the playback track, tolerating the
+     * disconnect-while-streaming race. Audio frames arrive on the UDP stream
+     * read thread ({@link RadioUdpClient.ReceiveRunnable#run()}, whose loop
+     * catches only {@code IOException}), while {@link #closeAudio()} releases
+     * and nulls {@link #audioTrack} from the disconnect thread — and
+     * {@code FlexConnector.disconnect()} calls {@code closeAudio()} <em>before</em>
+     * it stops the stream port, so the receive thread is still live when the
+     * track is torn down. Between the null-check and the write the track can be
+     * released, making {@link AudioTrack#write} throw an
+     * {@link IllegalStateException}; swallow it here rather than let it escape
+     * and crash the whole app. Package-private so a unit test can drive it
+     * without constructing a real {@link AudioTrack}.
+     */
+    void writeAudio(byte[] data) {
+        try {
+            writeAudioToTrack(data);
+        } catch (IllegalStateException e) {
+            // audioTrack was released concurrently (disconnect during
+            // streaming); drop this frame rather than crash the receive thread.
+            Log.e(TAG, "writeAudio: track released mid-stream: " + e.getMessage());
         }
+    }
+
+    /**
+     * Seam performing the actual conversion + write on a single volatile
+     * snapshot of {@link #audioTrack}. A no-op when audio is closed (snapshot is
+     * null). Overridden in tests to simulate a track released mid-write.
+     */
+    void writeAudioToTrack(byte[] data) {
+        AudioTrack track = audioTrack;// snapshot the volatile field once
+        if (track == null) return;// audio not open (or already closed)
+        float[] sound = getFloatFromBytes(data);//Length is 256 floats
+        track.write(sound, 0, sound.length, AudioTrack.WRITE_NON_BLOCKING);
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioAudioWriteTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioAudioWriteTest.java
@@ -1,0 +1,87 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link FlexRadio#writeAudio(byte[])} — the crash fix for
+ * the Flex DAX RX-audio use-after-release race on disconnect.
+ *
+ * <p>Audio frames arrive on the UDP stream read thread
+ * ({@link RadioUdpClient.ReceiveRunnable#run()}), whose loop catches only
+ * {@code IOException}. {@link FlexRadio#closeAudio()} releases and nulls the
+ * playback track from the disconnect thread, and
+ * {@code FlexConnector.disconnect()} calls {@code closeAudio()} <em>before</em>
+ * stopping the stream port — so the receive thread is still delivering frames
+ * while the track is torn down. The old inline {@code doReceiveAudio} did an
+ * unguarded {@code audioTrack.write(...)} after a plain null-check, so a track
+ * released between the check and the write threw an uncaught
+ * {@link IllegalStateException} on the receive thread and crashed the whole app.
+ *
+ * <p>{@link FlexRadio}'s no-arg constructor touches no Android framework beyond
+ * {@code System.currentTimeMillis()}, and the {@code writeAudioToTrack} seam is
+ * overridden here so no real {@link android.media.AudioTrack} is constructed —
+ * hence no Robolectric runner is needed ({@code returnDefaultValues} covers the
+ * {@code Log} call in {@code writeAudio}).
+ */
+public class FlexRadioAudioWriteTest {
+
+    /** Records whether the seam ran, so we can assert the happy path still writes. */
+    private static class RecordingFlexRadio extends FlexRadio {
+        int writes = 0;
+
+        @Override
+        void writeAudioToTrack(byte[] data) {
+            writes++;
+        }
+    }
+
+    /** Simulates a track released between the null-check and the write. */
+    private static class ReleasedTrackFlexRadio extends FlexRadio {
+        @Override
+        void writeAudioToTrack(byte[] data) {
+            throw new IllegalStateException("play() called on uninitialized AudioTrack");
+        }
+    }
+
+    /** Simulates any other unchecked failure that must NOT be swallowed. */
+    private static class BadArgFlexRadio extends FlexRadio {
+        @Override
+        void writeAudioToTrack(byte[] data) {
+            throw new IllegalArgumentException("bad audio buffer");
+        }
+    }
+
+    @Test
+    public void writeAudio_swallowsIllegalStateFromReleasedTrack() {
+        // The disconnect-while-streaming crash: pre-fix this IllegalStateException
+        // escaped doReceiveAudio and killed the UDP receive thread / app.
+        FlexRadio radio = new ReleasedTrackFlexRadio();
+        radio.writeAudio(new byte[16]); // must not throw
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void writeAudio_doesNotSwallowOtherRuntimeExceptions() {
+        // The catch must be narrow: only the release race is tolerated, so a
+        // genuine programming error still surfaces.
+        FlexRadio radio = new BadArgFlexRadio();
+        radio.writeAudio(new byte[16]);
+    }
+
+    @Test
+    public void writeAudio_deliversFrameOnHappyPath() {
+        // When the track is healthy the frame is still written exactly once.
+        RecordingFlexRadio radio = new RecordingFlexRadio();
+        radio.writeAudio(new byte[16]);
+        assertThat(radio.writes).isEqualTo(1);
+    }
+
+    @Test
+    public void writeAudioToTrack_isNoOpWhenAudioClosed() {
+        // Real seam with no track open (audioTrack == null): must not throw and
+        // must not attempt a write. Exercises the null-guard directly.
+        FlexRadio radio = new FlexRadio();
+        radio.writeAudioToTrack(new byte[16]); // audio never opened -> no-op
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a **whole-app crash** on the Flex/SmartSDR network rig path when the radio is disconnected while DAX RX audio is streaming.

Flex DAX audio frames are delivered on the UDP stream read thread (`RadioUdpClient.ReceiveRunnable.run()`), whose loop **catches only `IOException`**. `FlexRadio.doReceiveAudio()` performed an unguarded `audioTrack.write(...)` after a plain null-check on the (non-`volatile`) `audioTrack` field:

```java
if (audioTrack != null) {
    float[] sound = getFloatFromBytes(data);
    audioTrack.write(sound, 0, sound.length, AudioTrack.WRITE_NON_BLOCKING);
}
```

## Root cause

A **check-then-use race** across two threads plus a **cross-thread visibility gap** on a non-volatile field:

- `closeAudio()` runs `stop()` / `release()` / `audioTrack = null` on the **disconnect thread**.
- `FlexConnector.disconnect()` calls `closeAudio()` **before** `closeStreamPort()`, so the UDP receive thread is still delivering frames when the track is torn down.
- If the track is released between the null-check and the `write`, `AudioTrack.write` throws `IllegalStateException` — a `RuntimeException`, **not** `IOException` — which escapes the receive loop uncaught and crashes the whole app.

This is the direct Flex twin of the Icom/Xiegu Wi-Fi RX-audio use-after-release hardening (same class of bug, different rig/file).

## Fix

Localized, conservative, happy-path byte-identical:

- Make `audioTrack` `volatile` so the receive thread reliably observes `openAudio`/`closeAudio` writes.
- Route the write through `writeAudio()`, which delegates to a `writeAudioToTrack()` seam that snapshots the `volatile` field **once**, null-guards, and writes. `writeAudio()` swallows **only** `IllegalStateException` (the release race) and lets any other unchecked exception surface, so genuine bugs still crash/report.

## Testing performed

- **New `FlexRadioAudioWriteTest`** (pure JVM, no `AudioTrack` constructed — the seam is overridden per test):
  - swallows the released-track `IllegalStateException` (no throw);
  - does **not** swallow other `RuntimeException`s (narrow catch);
  - delivers the frame exactly once on the happy path;
  - no-ops when audio is closed (`audioTrack == null`).
  - The swallow test **fails pre-fix** with an uncaught `IllegalStateException`, verified by reverting only the catch.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — green (all 4 ABIs).

## Risk assessment

Low. No DSP/protocol change; audio decode and the write itself are unchanged on the healthy path. The only behavioral change is that a frame arriving during teardown is dropped (already the intended outcome — audio is closing) instead of crashing the process. Visibility of `audioTrack` is strengthened, not weakened.

## Notes

No linked issue — found during an autonomous maintenance sweep of the un-hardened `flex/` network transport layer.