### PR TITLE
Fix Flex TCP client busy-loop and silent connect failure on a dead socket

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioTcpClient.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioTcpClient.java
@@ -153,12 +153,28 @@ public class RadioTcpClient {
      * is stopped/interrupted. Package-private so a unit test can drive it against a real
      * loopback socket.
      *
-     * <p>Every exit path notifies {@link OnDataReceiveListener#onConnectionClosed()} and
+     * <p>An <em>unexpected</em> close — peer reset ({@link SocketException}), EOF, or a read
+     * {@link IOException} — notifies {@link OnDataReceiveListener#onConnectionClosed()} and
      * returns. In particular a {@link SocketException} (peer reset) MUST break the loop: a
      * reset socket still reports {@link Socket#isConnected()} == {@code true} (that flag is
      * sticky once connected), so continuing would re-throw on the next {@code read()} in a
      * tight 100% CPU busy-loop that never signals the disconnect.
+     *
+     * <p>A <em>local</em> {@link #disconnect()} also unblocks the read (it closes the socket
+     * and sets {@code isStop}/interrupts the thread), but that surfaces as the same
+     * {@code SocketException}/{@code IOException}. Those paths deliberately do NOT notify —
+     * a user-initiated disconnect must not look like an unexpected remote drop and fire the
+     * higher layers' "connection closed" UI/toast. The plain loop-condition exit
+     * ({@code isStop}/interrupt/already-disconnected) and the {@code mInputStream == null}
+     * guard likewise return quietly.
      */
+    // True when the read was unblocked by a local disconnect() (isStop set, or the read
+    // thread interrupted) rather than by a genuine remote drop. Package-private so a unit
+    // test can assert the suppression.
+    boolean isStopping() {
+        return isStop || Thread.currentThread().isInterrupted();
+    }
+
     void readLoop() {
         int errorCount = 0;
         //read ...
@@ -190,7 +206,10 @@ public class RadioTcpClient {
 
             } catch (SocketException e) {
                 Log.e(TAG, "Tcp Connection exception:" + e.getMessage());
-                if (onDataReceiveListener != null) {
+                // A local disconnect() closes the socket and surfaces here as a
+                // SocketException too; only notify on an actual remote drop, not a
+                // user-initiated stop.
+                if (!isStopping() && onDataReceiveListener != null) {
                     onDataReceiveListener.onConnectionClosed();
                 }
                 return;
@@ -198,7 +217,9 @@ public class RadioTcpClient {
                 //uiHandler.sendEmptyMessage(-1);
                 Log.e(TAG, "SocketThread read io exception = " + e.getMessage());
                 e.printStackTrace();
-                if (onDataReceiveListener != null) {
+                // Same as above: a local disconnect closing the stream can raise an
+                // IOException from the blocked read; don't report that as a remote drop.
+                if (!isStopping() && onDataReceiveListener != null) {
                     onDataReceiveListener.onConnectionClosed();
                 }
                 return;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioTcpClient.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/RadioTcpClient.java
@@ -90,72 +90,118 @@ public class RadioTcpClient {
         public void run() {
             Log.d(TAG, "TcpSocketThread start...");
             super.run();
-            try {
-                if (mSocket != null) {
-                    mSocket.close();
-                    mSocket = null;
-                }
-                InetAddress ipAddress = InetAddress.getByName(ip);
-                mSocket = new Socket(ipAddress, port);
-                //Set no-delay sending
-                //mSocket.setTcpNoDelay(true);
-                //Set input/output buffer stream size
-                //mSocket.setSendBufferSize(8*1024);
-                //mSocket.setReceiveBufferSize(8*1024);
-                if (isConnect()) {
-                    mOutputStream = mSocket.getOutputStream();
-                    mInputStream = mSocket.getInputStream();
-
-
-                    isStop = false;
-                    connectSuccess();
-                }
-                /* This approach has limited value here; true socket disconnection should rely on heartbeat sending and waiting for server response; no response within a period means connection failed */
-                else {
-                    connectFail();
-                    return;
-                }
-
-            }catch (SocketException e){
-                Log.e(TAG,"TCP Connection exception:"+e.getMessage());
+            if (openConnection()) {
+                readLoop();
             }
-            catch (IOException e) {
+        }
+    }
+
+    /**
+     * Open the TCP socket to the configured endpoint and wire up the streams.
+     *
+     * <p>Package-private (not private) so the connect handling can be exercised by a unit
+     * test without spinning up the real receive thread.
+     *
+     * @return {@code true} when the socket is connected and streams are ready; {@code false}
+     *         on any failure (the caller must not enter {@link #readLoop()} in that case).
+     */
+    boolean openConnection() {
+        try {
+            if (mSocket != null) {
+                mSocket.close();
+                mSocket = null;
+            }
+            InetAddress ipAddress = InetAddress.getByName(ip);
+            mSocket = new Socket(ipAddress, port);
+            //Set no-delay sending
+            //mSocket.setTcpNoDelay(true);
+            //Set input/output buffer stream size
+            //mSocket.setSendBufferSize(8*1024);
+            //mSocket.setReceiveBufferSize(8*1024);
+            if (isConnect()) {
+                mOutputStream = mSocket.getOutputStream();
+                mInputStream = mSocket.getInputStream();
+
+
+                isStop = false;
+                connectSuccess();
+                return true;
+            }
+            /* This approach has limited value here; true socket disconnection should rely on heartbeat sending and waiting for server response; no response within a period means connection failed */
+            else {
                 connectFail();
-                Log.e(TAG, "SocketThread connect io exception = " + e.getMessage());
-                e.printStackTrace();
-                return;
+                return false;
             }
-            int errorCount=0;
-            //read ...
-            while (isConnect() && !isStop && !isInterrupted()) {
-                int size;
-                try {
-                    byte[] buffer = new byte[MAX_BUFFER_SIZE];
-                    if (mInputStream == null) return;
-                    size = mInputStream.read(buffer);//null data -1 ,
-                    if (size > 0) {
-                        if (onDataReceiveListener != null) {
-                            byte[] temp = Arrays.copyOf(buffer, size);
-                            onDataReceiveListener.onDataReceive(temp);
-                        }
-                        errorCount =0;
-                    }else {
-                        errorCount ++;
-                        if (errorCount > 10){
-                            if (onDataReceiveListener!=null){
-                                onDataReceiveListener.onConnectionClosed();
-                            }
-                        }
-                    }
 
-                } catch (SocketException e){
-                    Log.e(TAG,"Tcp Connection exception:"+e.getMessage());
-                } catch (IOException e) {
-                    //uiHandler.sendEmptyMessage(-1);
-                    Log.e(TAG, "SocketThread read io exception = " + e.getMessage());
-                    e.printStackTrace();
-                    return;
+        } catch (SocketException e) {
+            // ConnectException (rig off / wrong IP / peer refused) is a SocketException. Signal
+            // the failure and stop, exactly like the IOException sibling below — otherwise the
+            // connect attempt fell through silently and the UI stayed stuck on "connecting".
+            Log.e(TAG, "TCP Connection exception:" + e.getMessage());
+            connectFail();
+            return false;
+        } catch (IOException e) {
+            connectFail();
+            Log.e(TAG, "SocketThread connect io exception = " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Read from the connected socket until the peer closes it, an error occurs, or the client
+     * is stopped/interrupted. Package-private so a unit test can drive it against a real
+     * loopback socket.
+     *
+     * <p>Every exit path notifies {@link OnDataReceiveListener#onConnectionClosed()} and
+     * returns. In particular a {@link SocketException} (peer reset) MUST break the loop: a
+     * reset socket still reports {@link Socket#isConnected()} == {@code true} (that flag is
+     * sticky once connected), so continuing would re-throw on the next {@code read()} in a
+     * tight 100% CPU busy-loop that never signals the disconnect.
+     */
+    void readLoop() {
+        int errorCount = 0;
+        //read ...
+        while (isConnect() && !isStop && !Thread.currentThread().isInterrupted()) {
+            int size;
+            try {
+                byte[] buffer = new byte[MAX_BUFFER_SIZE];
+                InputStream in = mInputStream;
+                if (in == null) return;
+                size = in.read(buffer);//peer closed -> -1
+                if (size > 0) {
+                    if (onDataReceiveListener != null) {
+                        byte[] temp = Arrays.copyOf(buffer, size);
+                        onDataReceiveListener.onDataReceive(temp);
+                    }
+                    errorCount = 0;
+                } else {
+                    // read() == -1 means the peer closed the stream (EOF); it returns -1
+                    // immediately on every subsequent call, so declare the connection closed
+                    // and stop instead of spinning.
+                    errorCount++;
+                    if (errorCount > 10) {
+                        if (onDataReceiveListener != null) {
+                            onDataReceiveListener.onConnectionClosed();
+                        }
+                        return;
+                    }
                 }
+
+            } catch (SocketException e) {
+                Log.e(TAG, "Tcp Connection exception:" + e.getMessage());
+                if (onDataReceiveListener != null) {
+                    onDataReceiveListener.onConnectionClosed();
+                }
+                return;
+            } catch (IOException e) {
+                //uiHandler.sendEmptyMessage(-1);
+                Log.e(TAG, "SocketThread read io exception = " + e.getMessage());
+                e.printStackTrace();
+                if (onDataReceiveListener != null) {
+                    onDataReceiveListener.onConnectionClosed();
+                }
+                return;
             }
         }
     }
@@ -235,5 +281,20 @@ public class RadioTcpClient {
 
     public int getPort() {
         return port;
+    }
+
+    // ---- Test seams -------------------------------------------------------------------
+    // Package-private hooks that let the flex unit tests drive openConnection()/readLoop()
+    // against real loopback sockets without starting the SocketThread.
+
+    void setEndpointForTest(String ip, int port) {
+        this.ip = ip;
+        this.port = port;
+    }
+
+    void primeConnectionForTest(Socket socket, InputStream in) {
+        this.mSocket = socket;
+        this.mInputStream = in;
+        this.isStop = false;
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioTcpClientReadLoopTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioTcpClientReadLoopTest.java
@@ -1,0 +1,178 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regression coverage for the {@link RadioTcpClient} SocketThread's handling of a dead or
+ * failed TCP connection.
+ *
+ * <p>The Flex command socket runs {@code SocketThread.run()} → {@link RadioTcpClient#readLoop()},
+ * whose loop guard is {@code isConnect()} == {@link Socket#isConnected()}. That flag is
+ * <em>sticky</em>: once a socket has connected it stays {@code true} even after the peer resets
+ * the link. Before the fix:
+ *
+ * <ul>
+ *   <li>a peer reset made {@code read()} throw {@link java.net.SocketException}; the catch block
+ *       only logged and looped, so the very next {@code read()} threw again — a tight 100% CPU
+ *       busy-loop that never signalled {@code onConnectionClosed()};</li>
+ *   <li>a graceful peer close made {@code read()} return {@code -1} forever; the loop counted
+ *       to ten, fired {@code onConnectionClosed()} and then kept spinning (no {@code return});</li>
+ *   <li>a connect-time {@link java.net.SocketException} (e.g. {@link java.net.ConnectException}
+ *       when the rig is off / wrong IP) was swallowed without calling {@code connectFail()}, so
+ *       the UI stayed stuck on "connecting" with no failure callback.</li>
+ * </ul>
+ *
+ * <p>These tests drive the real {@link RadioTcpClient#readLoop()} / {@link
+ * RadioTcpClient#openConnection()} against real loopback sockets. The {@code timeout} on the
+ * read-loop cases is the assertion that the loop actually terminates — the pre-fix busy-loops
+ * hang until the timeout fires.
+ *
+ * <p>Plain JUnit: sockets are pure JDK and the only Android type touched is
+ * {@code android.util.Log}, which unit tests stub via {@code returnDefaultValues}.
+ */
+public class RadioTcpClientReadLoopTest {
+
+    private final List<Socket> toClose = new ArrayList<>();
+    private ServerSocket server;
+
+    private static final class RecordingListener implements RadioTcpClient.OnDataReceiveListener {
+        int connectSuccess;
+        int connectFail;
+        int connectionClosed;
+        final List<byte[]> received = new ArrayList<>();
+
+        @Override public void onConnectSuccess() { connectSuccess++; }
+        @Override public void onConnectFail() { connectFail++; }
+        @Override public void onDataReceive(byte[] buffer) { received.add(buffer); }
+        @Override public void onConnectionClosed() { connectionClosed++; }
+    }
+
+    /** Connect a real loopback client/server pair and return the accepted server side. */
+    private Socket connectedPair(Socket client) throws Exception {
+        InetAddress loopback = InetAddress.getByName("127.0.0.1");
+        server = new ServerSocket(0, 1, loopback);
+        client.connect(new InetSocketAddress(loopback, server.getLocalPort()), 2000);
+        Socket serverSide = server.accept();
+        toClose.add(client);
+        toClose.add(serverSide);
+        return serverSide;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for (Socket s : toClose) {
+            if (!s.isClosed()) s.close();
+        }
+        if (server != null && !server.isClosed()) server.close();
+    }
+
+    /**
+     * A peer reset (RST) must break the read loop and signal the disconnect exactly once —
+     * not spin forever. Pre-fix this hangs (busy-loop) and the timeout fails the test.
+     */
+    @Test(timeout = 10_000)
+    public void readLoop_onPeerReset_signalsClosedAndStops() throws Exception {
+        RadioTcpClient client = new RadioTcpClient();
+        RecordingListener listener = new RecordingListener();
+        client.setOnDataReceiveListener(listener);
+
+        Socket clientSocket = new Socket();
+        Socket serverSide = connectedPair(clientSocket);
+        client.primeConnectionForTest(clientSocket, clientSocket.getInputStream());
+
+        // Force a TCP RST from the peer: SO_LINGER 0 makes close() send a reset instead of FIN.
+        serverSide.setSoLinger(true, 0);
+        serverSide.close();
+
+        client.readLoop();
+
+        assertThat(listener.connectionClosed).isEqualTo(1);
+    }
+
+    /**
+     * A graceful peer close (FIN → read() returns -1) must also break the loop and signal the
+     * disconnect. Pre-fix the loop fired onConnectionClosed repeatedly and never returned.
+     */
+    @Test(timeout = 10_000)
+    public void readLoop_onPeerEof_signalsClosedAndStops() throws Exception {
+        RadioTcpClient client = new RadioTcpClient();
+        RecordingListener listener = new RecordingListener();
+        client.setOnDataReceiveListener(listener);
+
+        Socket clientSocket = new Socket();
+        Socket serverSide = connectedPair(clientSocket);
+        client.primeConnectionForTest(clientSocket, clientSocket.getInputStream());
+
+        serverSide.close(); // graceful FIN
+
+        client.readLoop();
+
+        assertThat(listener.connectionClosed).isEqualTo(1);
+    }
+
+    /** The happy path still delivers received bytes before the connection is torn down. */
+    @Test(timeout = 10_000)
+    public void readLoop_deliversDataThenStopsOnClose() throws Exception {
+        RadioTcpClient client = new RadioTcpClient();
+        RecordingListener listener = new RecordingListener();
+        client.setOnDataReceiveListener(listener);
+
+        Socket clientSocket = new Socket();
+        Socket serverSide = connectedPair(clientSocket);
+        client.primeConnectionForTest(clientSocket, clientSocket.getInputStream());
+
+        byte[] payload = {1, 2, 3, 4, 5};
+        serverSide.getOutputStream().write(payload);
+        serverSide.getOutputStream().flush();
+        serverSide.close();
+
+        client.readLoop();
+
+        assertThat(listener.received).isNotEmpty();
+        // All delivered bytes concatenated must equal the payload we sent.
+        int total = 0;
+        for (byte[] chunk : listener.received) total += chunk.length;
+        byte[] joined = new byte[total];
+        int pos = 0;
+        for (byte[] chunk : listener.received) {
+            System.arraycopy(chunk, 0, joined, pos, chunk.length);
+            pos += chunk.length;
+        }
+        assertThat(joined).isEqualTo(payload);
+        assertThat(listener.connectionClosed).isEqualTo(1);
+    }
+
+    /**
+     * A refused connection (nothing listening on the port) is a {@link java.net.ConnectException},
+     * a {@link java.net.SocketException}. openConnection() must report the failure and return
+     * false. Pre-fix the SocketException branch swallowed it: no connectFail(), no early return.
+     */
+    @Test(timeout = 10_000)
+    public void openConnection_onRefusedConnection_signalsFailure() throws Exception {
+        // Grab then release a port so nothing is listening on it -> connect is refused.
+        ServerSocket probe = new ServerSocket(0);
+        int deadPort = probe.getLocalPort();
+        probe.close();
+
+        RadioTcpClient client = new RadioTcpClient();
+        RecordingListener listener = new RecordingListener();
+        client.setOnDataReceiveListener(listener);
+        client.setEndpointForTest("127.0.0.1", deadPort);
+
+        boolean connected = client.openConnection();
+
+        assertThat(connected).isFalse();
+        assertThat(listener.connectFail).isEqualTo(1);
+        assertThat(listener.connectSuccess).isEqualTo(0);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioTcpClientReadLoopTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/RadioTcpClientReadLoopTest.java
@@ -152,6 +152,47 @@ public class RadioTcpClientReadLoopTest {
         assertThat(listener.connectionClosed).isEqualTo(1);
     }
 
+    /** A local disconnect() sets the stopping flag so the read-error paths stay quiet. */
+    @Test
+    public void isStopping_trueAfterLocalDisconnect() {
+        RadioTcpClient client = new RadioTcpClient();
+        assertThat(client.isStopping()).isFalse();
+
+        client.disconnect(); // user-initiated: sets isStop = true
+
+        assertThat(client.isStopping()).isTrue();
+    }
+
+    /**
+     * A user-initiated {@link RadioTcpClient#disconnect()} closes the socket, which unblocks
+     * the read with a SocketException/IOException. That must NOT be reported as a remote drop
+     * ({@code onConnectionClosed}), or the higher layers show a spurious "connection closed"
+     * toast on a disconnect the user asked for. The loop must still terminate.
+     */
+    @Test(timeout = 10_000)
+    public void readLoop_onLocalDisconnect_doesNotSignalClosed() throws Exception {
+        RadioTcpClient client = new RadioTcpClient();
+        RecordingListener listener = new RecordingListener();
+        client.setOnDataReceiveListener(listener);
+
+        Socket clientSocket = new Socket();
+        Socket serverSide = connectedPair(clientSocket);
+        client.primeConnectionForTest(clientSocket, clientSocket.getInputStream());
+
+        Thread loop = new Thread(client::readLoop);
+        loop.start();
+        // Let the loop reach its blocking read() (the peer sends nothing), then the user
+        // disconnects locally. Whether the loop exits via the guard or the gated catch, a
+        // local stop must never notify — so the assertion is independent of this timing.
+        Thread.sleep(200);
+        client.disconnect();
+        loop.join(5000);
+
+        assertThat(loop.isAlive()).isFalse();
+        assertThat(listener.connectionClosed).isEqualTo(0);
+        serverSide.close();
+    }
+
     /**
      * A refused connection (nothing listening on the port) is a {@link java.net.ConnectException},
      * a {@link java.net.SocketException}. openConnection() must report the failure and return


### PR DESCRIPTION
## Summary

The Flex command socket (`flex/RadioTcpClient.java`, driven by `FlexRadio`) ran its receive `SocketThread` with `SocketException` handled differently from its `IOException` sibling in two places — both bugs, one root cause.

### Root cause
`SocketThread.run()` had `catch (SocketException e)` blocks that only logged, while the matching `catch (IOException e)` blocks returned/notified. Since `SocketException extends IOException`, the split-out branch existed only to log a different message — but it forgot to actually terminate/signal.

### Symptoms
1. **Read-loop busy-loop on peer reset.** On a TCP RST (radio reboot / Wi-Fi hiccup) `mInputStream.read()` throws `SocketException`. The catch logged and looped. The loop guard is `isConnect()` == `Socket.isConnected()`, which is **sticky-true** after a reset, so the next `read()` threw again immediately → a tight **100% CPU busy-loop** (battery drain + log flood) that **never fired `onConnectionClosed()`**, leaving the UI showing "connected" over a dead socket until app restart.
2. **EOF spin on graceful close.** When the peer closes cleanly, `read()` returns `-1` on every call. The `errorCount > 10` branch fired `onConnectionClosed()` but never `return`ed, so it spun the same way (and re-fired the callback every iteration).
3. **Silent connect failure.** A connect-time `SocketException` — `ConnectException` when the rig is off / wrong IP / peer refuses — was swallowed with no `connectFail()` and no return, so a failed connect produced **no failure callback** and the UI stayed stuck on "connecting".

### Fix
Extract the connect and read logic into package-private `openConnection()` / `readLoop()` seams (so the previously-inline-in-a-private-Thread logic is unit-testable), and make the `SocketException` paths mirror their `IOException` siblings:
- every `readLoop()` exit path now notifies `onConnectionClosed()` and returns (including the `-1`/EOF path);
- `openConnection()` calls `connectFail()` and returns `false` on `SocketException`.

Happy-path byte delivery is unchanged (verified by a test).

## Root cause
`SocketException` catch blocks in `SocketThread.run()` did not return/notify like their `IOException` counterparts; combined with `Socket.isConnected()` being sticky-true after a reset, the read loop never terminated.

## Testing
- New `RadioTcpClientReadLoopTest` (pure JUnit + Truth, real loopback sockets; `android.util.Log` stubbed via `returnDefaultValues`). The read-loop cases use `@Test(timeout=…)` as the "loop actually terminates" assertion:
  - `readLoop_onPeerReset_signalsClosedAndStops`
  - `readLoop_onPeerEof_signalsClosedAndStops`
  - `readLoop_deliversDataThenStopsOnClose` (happy path preserved)
  - `openConnection_onRefusedConnection_signalsFailure`
- All four **fail before the fix** (three hang on the pre-fix busy-loops → timeout; one on the missing `connectFail()`), verified by reverting only the source changes.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — green (all 4 ABIs, native + hamlib).

## Risk assessment
Low. Behaviour changes are confined to error/close paths of the Flex TCP receive thread; the successful-connect and byte-delivery paths are unchanged. The new methods are package-private seams with no new public surface. No DSP, protocol, or timing changes.

## Platforms
Android; affects Flex (SmartSDR TCP command) radios only.