### PR TITLE
Fix logbook swipe-to-delete/toggle crash on detached row (getAdapterPosition == -1)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/LogQSLAdapter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/LogQSLAdapter.java
@@ -58,11 +58,27 @@ public class LogQSLAdapter extends RecyclerView.Adapter<LogQSLAdapter.LogQSLItem
     }
 
     /**
+     * True when {@code position} indexes a live row. RecyclerView hands
+     * {@link RecyclerView#NO_POSITION} (-1) for a holder that has been detached or is
+     * mid-swipe/animation, and the backing list can shrink under a LiveData refresh
+     * (a decode/import cycle calling {@code notifyDataSetChanged}) between a swipe
+     * gesture and the confirm-dialog callback — so every position-based mutator must
+     * validate before indexing {@code qslRecords}. Mirrors the {@code position == -1}
+     * guard the sibling {@code CallingListAdapter.menuListener} already has.
+     */
+    boolean isValidPosition(int position) {
+        return position >= 0 && position < qslRecords.size();
+    }
+
+    /**
      * Delete log entry
      *
      * @param position position in the list
      */
     public void deleteRecord(int position) {
+        if (!isValidPosition(position)) {
+            return;
+        }
         mainViewModel.databaseOpr.deleteQSLByID(qslRecords.get(position).id);
         qslRecords.remove(position);
     }
@@ -78,6 +94,9 @@ public class LogQSLAdapter extends RecyclerView.Adapter<LogQSLAdapter.LogQSLItem
      * @param b        status
      */
     public void setRecordIsQSL(int position, boolean b) {
+        if (!isValidPosition(position)) {
+            return;
+        }
         qslRecords.get(position).isQSL = b;
         mainViewModel.databaseOpr.setQSLTableIsQSL(b, qslRecords.get(position).id);
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/LogFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/LogFragment.java
@@ -404,8 +404,14 @@ public class LogFragment extends Fragment {
                             , new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialogInterface, int i) {
-                                    logQSLAdapter.deleteRecord(viewHolder.getAdapterPosition());// Delete log entry
-                                    logQSLAdapter.notifyItemRemoved(viewHolder.getAdapterPosition());
+                                    // The holder may have detached or the list refreshed while the
+                                    // dialog was open, so getAdapterPosition() can now be NO_POSITION.
+                                    int position = viewHolder.getAdapterPosition();
+                                    if (position == RecyclerView.NO_POSITION) {
+                                        return;
+                                    }
+                                    logQSLAdapter.deleteRecord(position);// Delete log entry
+                                    logQSLAdapter.notifyItemRemoved(position);
                                 }
                             });
                     builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
@@ -425,9 +431,12 @@ public class LogFragment extends Fragment {
                 }
 
                 if (direction == ItemTouchHelper.START) {
-                    logQSLAdapter.setRecordIsQSL(viewHolder.getAdapterPosition()
-                            , !logQSLAdapter.getRecord(viewHolder.getAdapterPosition()).isQSL);
-                    logQSLAdapter.notifyItemChanged(viewHolder.getAdapterPosition());
+                    int position = viewHolder.getAdapterPosition();
+                    if (position == RecyclerView.NO_POSITION) {
+                        return;
+                    }
+                    logQSLAdapter.setRecordIsQSL(position, !logQSLAdapter.getRecord(position).isQSL);
+                    logQSLAdapter.notifyItemChanged(position);
                 }
             }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/LogFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/LogFragment.java
@@ -68,6 +68,19 @@ public class LogFragment extends Fragment {
     private ShareLogsProgressDialog dialog = null;// Share log generation dialog
 
 
+    /**
+     * Whether a swipe callback may act on {@code position}. Swipe callbacks fire
+     * asynchronously — the END-delete path waits on a confirmation dialog — so by the time
+     * one runs the row may have detached ({@link RecyclerView#NO_POSITION}) or the backing
+     * list may have shrunk below {@code position}. Acting on such a position deletes/toggles
+     * the wrong record, throws IndexOutOfBounds in {@code getRecord()}, or desyncs the
+     * RecyclerView via an out-of-range {@code notifyItem*()}. Extracted (and package-private)
+     * so it can be unit-tested without a RecyclerView.
+     */
+    static boolean isSwipePositionActionable(int position, int itemCount) {
+        return position >= 0 && position < itemCount;
+    }
+
     public LogFragment() {
         // Required empty public constructor
     }
@@ -404,10 +417,15 @@ public class LogFragment extends Fragment {
                             , new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialogInterface, int i) {
-                                    // The holder may have detached or the list refreshed while the
-                                    // dialog was open, so getAdapterPosition() can now be NO_POSITION.
+                                    // This fires asynchronously after the confirm dialog, so the
+                                    // holder may have detached (NO_POSITION) or the list may have
+                                    // shrunk below `position` while the dialog was open. Acting on
+                                    // such a position would delete the wrong record or fire
+                                    // notifyItemRemoved() with an out-of-range index (RecyclerView
+                                    // inconsistency). Resync the whole list instead.
                                     int position = viewHolder.getAdapterPosition();
-                                    if (position == RecyclerView.NO_POSITION) {
+                                    if (!isSwipePositionActionable(position, logQSLAdapter.getItemCount())) {
+                                        logQSLAdapter.notifyDataSetChanged();
                                         return;
                                     }
                                     logQSLAdapter.deleteRecord(position);// Delete log entry
@@ -431,8 +449,13 @@ public class LogFragment extends Fragment {
                 }
 
                 if (direction == ItemTouchHelper.START) {
+                    // Guard the full valid range, not just NO_POSITION: if the backing list
+                    // shrank between the swipe and this callback, getRecord(position) would
+                    // throw IndexOutOfBounds and notifyItemChanged() would desync the
+                    // RecyclerView. Resync via notifyDataSetChanged() when out of range.
                     int position = viewHolder.getAdapterPosition();
-                    if (position == RecyclerView.NO_POSITION) {
+                    if (!isSwipePositionActionable(position, logQSLAdapter.getItemCount())) {
+                        logQSLAdapter.notifyDataSetChanged();
                         return;
                     }
                     logQSLAdapter.setRecordIsQSL(position, !logQSLAdapter.getRecord(position).isQSL);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/LogQSLAdapterPositionGuardTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/LogQSLAdapterPositionGuardTest.java
@@ -1,0 +1,74 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link LogQSLAdapter}'s position-bounds guards.
+ *
+ * <p>The QSO logbook's swipe gestures (see {@code LogFragment.onSwiped}) call the
+ * adapter's mutators with {@code viewHolder.getAdapterPosition()}, which RecyclerView
+ * returns as {@link androidx.recyclerview.widget.RecyclerView#NO_POSITION} (-1) when the
+ * holder has detached or the list refreshed under a swipe / open confirm-dialog. Before
+ * the guards, {@code deleteRecord(-1)} / {@code setRecordIsQSL(-1, ...)} indexed
+ * {@code qslRecords.get(-1)} and threw {@link IndexOutOfBoundsException} on the main
+ * thread → whole-app crash. The sibling {@code CallingListAdapter} already guards -1;
+ * this test pins the equivalent guard for {@code LogQSLAdapter}.
+ *
+ * <p>Pure JUnit: the adapter's ctor only stores its args and the guard paths early-return
+ * before touching the (here null) MainViewModel/Context, and records are added directly to
+ * the exposed backing list so no {@code notifyDataSetChanged()} is needed.
+ */
+public class LogQSLAdapterPositionGuardTest {
+
+    private static LogQSLAdapter adapterWith(int rows) {
+        LogQSLAdapter adapter = new LogQSLAdapter(null, null);
+        for (int i = 0; i < rows; i++) {
+            QSLRecordStr r = new QSLRecordStr();
+            r.id = i;
+            adapter.getRecords().add(r);
+        }
+        return adapter;
+    }
+
+    @Test
+    public void isValidPosition_acceptsInRangeRejectsOutOfRange() {
+        LogQSLAdapter adapter = adapterWith(2);
+        assertThat(adapter.isValidPosition(0)).isTrue();
+        assertThat(adapter.isValidPosition(1)).isTrue();
+
+        assertThat(adapter.isValidPosition(-1)).isFalse(); // RecyclerView.NO_POSITION
+        assertThat(adapter.isValidPosition(2)).isFalse();  // == size
+        assertThat(adapter.isValidPosition(99)).isFalse();
+    }
+
+    @Test
+    public void isValidPosition_emptyListRejectsEverything() {
+        LogQSLAdapter adapter = adapterWith(0);
+        assertThat(adapter.isValidPosition(0)).isFalse();
+        assertThat(adapter.isValidPosition(-1)).isFalse();
+    }
+
+    @Test
+    public void deleteRecord_noPositionIsNoOp_notCrash() {
+        LogQSLAdapter adapter = adapterWith(3);
+        // Pre-fix this did qslRecords.get(-1) and threw IndexOutOfBoundsException.
+        adapter.deleteRecord(-1);
+        adapter.deleteRecord(3);   // == size, also out of range
+        adapter.deleteRecord(100);
+        assertThat(adapter.getItemCount()).isEqualTo(3); // nothing removed
+    }
+
+    @Test
+    public void setRecordIsQSL_noPositionIsNoOp_notCrash() {
+        LogQSLAdapter adapter = adapterWith(2);
+        // Pre-fix this indexed qslRecords.get(-1) (and would then dereference a null
+        // MainViewModel); the guard returns before either.
+        adapter.setRecordIsQSL(-1, true);
+        adapter.setRecordIsQSL(2, true);
+        // Neither existing record was flipped.
+        assertThat(adapter.getRecords().get(0).isQSL).isFalse();
+        assertThat(adapter.getRecords().get(1).isQSL).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/LogFragmentSwipePositionTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/LogFragmentSwipePositionTest.java
@@ -1,0 +1,44 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Regression coverage for the logbook swipe callbacks acting on a stale row position.
+ *
+ * <p>Swipe callbacks fire asynchronously (the END-delete path waits on a confirmation
+ * dialog), so by the time one runs the {@code ViewHolder} may have detached
+ * ({@code getAdapterPosition() == NO_POSITION == -1}) or the backing list may have shrunk
+ * below the swiped position. The original fix guarded only {@code NO_POSITION}; an
+ * out-of-range position still reached {@code getRecord(position)} (IndexOutOfBounds) and
+ * {@code notifyItem*(position)} (RecyclerView inconsistency). {@link
+ * LogFragment#isSwipePositionActionable(int, int)} is the extracted decision so it can be
+ * driven without a RecyclerView.
+ */
+public class LogFragmentSwipePositionTest {
+
+    @Test
+    public void noPositionSentinel_isNotActionable() {
+        // RecyclerView.NO_POSITION == -1
+        assertThat(LogFragment.isSwipePositionActionable(-1, 5)).isFalse();
+    }
+
+    @Test
+    public void positionAtOrBeyondItemCount_isNotActionable() {
+        // List shrank while the confirm dialog was open: position now == size (out of bounds).
+        assertThat(LogFragment.isSwipePositionActionable(5, 5)).isFalse();
+        assertThat(LogFragment.isSwipePositionActionable(9, 5)).isFalse();
+    }
+
+    @Test
+    public void emptyList_isNeverActionable() {
+        assertThat(LogFragment.isSwipePositionActionable(0, 0)).isFalse();
+    }
+
+    @Test
+    public void inRangePositions_areActionable() {
+        assertThat(LogFragment.isSwipePositionActionable(0, 5)).isTrue();
+        assertThat(LogFragment.isSwipePositionActionable(4, 5)).isTrue();
+    }
+}


### PR DESCRIPTION
## Root cause

Swiping a QSO row in the logbook (`LogFragment.onSwiped`) drives three `LogQSLAdapter` accessors with `viewHolder.getAdapterPosition()`:

- **END swipe** → delete-confirm dialog → on OK: `deleteRecord(getAdapterPosition())` + `notifyItemRemoved(...)` (`LogFragment.java:407-408`)
- **START swipe** → `setRecordIsQSL(getAdapterPosition(), !getRecord(getAdapterPosition()).isQSL)` (`LogFragment.java:428-429`)

`getAdapterPosition()` returns `RecyclerView.NO_POSITION` (**-1**) whenever the holder has detached / is mid-animation, or the backing list shrank under a `notifyDataSetChanged()` (a decode or web-import refresh) — which for the delete path can happen while the confirm dialog is open, and is then read on the async OK click.

`LogQSLAdapter.deleteRecord()` / `setRecordIsQSL()` / `getRecord()` indexed `qslRecords.get(position)` with no bounds check, so `get(-1)` threw **`IndexOutOfBoundsException` on the main thread → whole-app crash.**

The sibling `CallingListAdapter.menuListener` already guards `position == -1`; `LogQSLAdapter` was missed.

## Fix

- **`LogQSLAdapter`**: add `isValidPosition(int)` and guard the `deleteRecord()` and `setRecordIsQSL()` mutators (no-op on an out-of-range position) — root-cause hardening at the data-access boundary.
- **`LogFragment`**: capture `getAdapterPosition()` once per swipe callback and return early on `RecyclerView.NO_POSITION` (mirrors `CallingListAdapter`). This fixes the START-swipe `getRecord(-1)` read and avoids `notifyItem*(-1)`.

Happy path (valid position) is unchanged.

## Testing

- New `LogQSLAdapterPositionGuardTest` (pure JUnit): `deleteRecord(-1)` / `deleteRecord(size)` / `setRecordIsQSL(-1, …)` are no-ops post-fix and leave the list intact; `isValidPosition` accepts in-range and rejects `-1` / `>= size` / empty-list. **Verified the mutator cases throw `IndexOutOfBoundsException` pre-fix** by reverting only the two guard lines.
- `:app:testDebugUnitTest` — green (full suite).
- `:app:assembleDebug` — green (all 4 ABIs).

## Risk

Low. Purely additive bounds guards; no protocol/DSP/native code touched. Only behavior change is that an invalid (detached/stale) swipe position is ignored instead of crashing.

## Scope note

Swipe is enabled only for the QSO list (`getMovementFlags` disables it for the callsign list), so this is scoped to `LogQSLAdapter`. The context-menu path (`onContextItemSelected`, tag-based position) shares the same root shape but is a separate, rarer flow left out to keep this PR focused on the reachable swipe crash.