### PR TITLE
Fix bogus "-1" I/O error on every clean Bluetooth SPP disconnect

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocket.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocket.java
@@ -94,6 +94,22 @@ public class BluetoothSerialSocket implements Runnable {
         socket.getOutputStream().write(data);
     }
 
+    /**
+     * Turn one {@link java.io.InputStream#read(byte[])} result into the frame to hand the
+     * listener. A negative length means the remote closed the RFCOMM stream (radio powered
+     * off, link dropped) — a normal end-of-stream, not corrupt data. Report it as a plain
+     * disconnect instead of letting {@code Arrays.copyOf(buffer, -1)} throw a
+     * NegativeArraySizeException whose "-1" message then surfaces to the operator as a bogus
+     * I/O error (every other transport checks {@code read() < 0} for EOF). For {@code len >= 0}
+     * the returned frame is byte-for-byte identical to the previous behaviour.
+     */
+    static byte[] frameFromRead(byte[] buffer, int len) throws IOException {
+        if (len < 0) {
+            throw new IOException("connection closed by remote device");
+        }
+        return Arrays.copyOf(buffer, len);
+    }
+
     @SuppressLint("MissingPermission")
     @Override
     public void run() { // connect & read
@@ -122,7 +138,7 @@ public class BluetoothSerialSocket implements Runnable {
             //noinspection InfiniteLoopStatement
             while (true) {
                 len = socket.getInputStream().read(buffer);
-                byte[] data = Arrays.copyOf(buffer, len);
+                byte[] data = frameFromRead(buffer, len);
                 if(listener != null)
                     listener.onSerialRead(data);
             }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocketFrameTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocketFrameTest.java
@@ -1,0 +1,53 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link BluetoothSerialSocket#frameFromRead(byte[], int)}, the read-loop
+ * seam that decides what to do with an {@link java.io.InputStream#read(byte[])} result.
+ *
+ * The bug this covers: a clean remote EOF (radio powered off / RFCOMM link dropped) makes
+ * {@code read()} return -1. The old loop did {@code Arrays.copyOf(buffer, -1)}, throwing a
+ * NegativeArraySizeException whose "-1" message was then surfaced to the operator as a bogus
+ * I/O error on every normal Bluetooth disconnect.
+ */
+public class BluetoothSerialSocketFrameTest {
+
+    @Test
+    public void frameFromRead_positiveLength_returnsPrefixBytes() throws IOException {
+        byte[] buffer = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+        byte[] frame = BluetoothSerialSocket.frameFromRead(buffer, 3);
+        assertThat(frame).isEqualTo(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    public void frameFromRead_positiveLength_copiesFullBufferWhenLenEqualsLength() throws IOException {
+        byte[] buffer = new byte[]{10, 20, 30};
+        byte[] frame = BluetoothSerialSocket.frameFromRead(buffer, 3);
+        assertThat(frame).isEqualTo(new byte[]{10, 20, 30});
+        // must be a copy, not the same array the read loop reuses
+        assertThat(frame).isNotSameInstanceAs(buffer);
+    }
+
+    @Test
+    public void frameFromRead_zeroLength_returnsEmptyFrame() throws IOException {
+        byte[] buffer = new byte[]{1, 2, 3};
+        byte[] frame = BluetoothSerialSocket.frameFromRead(buffer, 0);
+        assertThat(frame).hasLength(0);
+    }
+
+    @Test
+    public void frameFromRead_endOfStream_throwsIoErrorNotNegativeArraySize() {
+        byte[] buffer = new byte[1024];
+        // Pre-fix this line threw NegativeArraySizeException("-1"); it must now be a clean IOException.
+        IOException e = assertThrows(IOException.class,
+                () -> BluetoothSerialSocket.frameFromRead(buffer, -1));
+        assertThat(e).isNotInstanceOf(NegativeArraySizeException.class);
+        assertThat(e).hasMessageThat().contains("closed");
+    }
+}


### PR DESCRIPTION
## Root cause

`BluetoothSerialSocket.run()`'s read loop copied the read result unconditionally:

```java
len = socket.getInputStream().read(buffer);
byte[] data = Arrays.copyOf(buffer, len);
```

When the remote closes the RFCOMM stream cleanly — the **normal** case when the operator powers the radio off, moves out of range, or the BT link drops — `InputStream.read()` returns `-1`. `Arrays.copyOf(buffer, -1)` then throws `NegativeArraySizeException`, which is caught by the loop's `catch (Exception e)` and routed to `listener.onSerialIoError(e)`.

`NegativeArraySizeException.getMessage()` is `"-1"`, so every routine Bluetooth disconnect is mislabeled an I/O error and the operator sees a bogus **"-1"** error (via `BluetoothRigConnector.onSerialIoError` → `onRunError(e.getMessage())`), with the same string written to `debug.log`.

Every other transport in the app already checks `read() < 0` for end-of-stream — e.g. the USB `SerialInputOutputManager.step()` guards with `if (len > 0)`. The Bluetooth SPP path (untouched since 2023) was the outlier.

## Fix

Extract a small pure seam `frameFromRead(byte[] buffer, int len)` that treats a negative length as a clean end-of-stream, throwing a descriptive `IOException("connection closed by remote device")` instead of the `-1` `NegativeArraySizeException`. The read loop still tears down through the existing `catch`/`onSerialIoError` → `socketDisconnect()` path (there is no separate clean-disconnect callback on `BluetoothSerialListener`), but now with a meaningful message instead of `"-1"`.

For `len >= 0` the returned frame is **byte-for-byte identical** to the previous behaviour, so normal RX is unchanged.

## Testing performed

- New `BluetoothSerialSocketFrameTest` (pure JVM, no Robolectric): positive-length copies the prefix bytes, zero-length returns an empty frame, and the end-of-stream (`len == -1`) case throws a clean `IOException` rather than `NegativeArraySizeException`. Verified the EOF test **fails pre-fix** (throws `NegativeArraySizeException`) by reverting only the guard, and passes after.
- `./gradlew :app:testDebugUnitTest` — full unit-test suite green.
- `./gradlew :app:assembleDebug` — full APK build (4 ABIs, hamlib) green.

## Risk assessment

Very low. Java-only, single file, no protocol/DSP/timing impact. Behaviour is unchanged for all `len >= 0` reads; only the previously-crashing `len < 0` path changes, and it now produces a clearer disconnect message on the same teardown path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)