### PR TITLE
Fix desktop FT8 encoder buffer size that could panic at non-integral sample rates

### DIFF
--- a/desktop/src-tauri/src/dsp/encode.rs
+++ b/desktop/src-tauri/src/dsp/encode.rs
@@ -43,13 +43,29 @@ pub fn add_crc(payload: &[u8; 10]) -> [u8; 12] {
     a91
 }
 
+/// Number of `f32` samples a GFSK waveform of `n_tones` channel symbols occupies
+/// at `sample_rate`. This is the single source of truth for the buffer size:
+/// [`synth_gfsk`] writes exactly this many samples and [`generate_ft8`] allocates
+/// exactly this many, so the allocation and the write count can never diverge.
+///
+/// The count is *per-symbol* rounded — `n_tones * round(sample_rate * symbol_period)`
+/// — matching the native `synth_gfsk` in `ft8_lib`. Sizing the buffer with a single
+/// *total*-rounded `round(n_tones * symbol_period * sample_rate)` instead comes up a
+/// few samples short at a non-integral sample rate (the two roundings agree only
+/// when `sample_rate * symbol_period` is integral, as at the shipped 12 kHz), which
+/// tripped `synth_gfsk`'s length assert below. This is the desktop sibling of the
+/// Android heap-OOB write fixed in PR #521.
+pub(crate) fn waveform_len(n_tones: usize, sample_rate: i32) -> usize {
+    let n_spsym = (0.5 + sample_rate as f64 * FT8_SYMBOL_PERIOD as f64) as usize;
+    n_tones * n_spsym
+}
+
 /// Render `tones` as a GFSK waveform into `signal[offset..]`.
 ///
 /// # Panics
 /// Panics if `signal` is too short for the waveform starting at `offset`.
 pub fn synth_gfsk(tones: &[u8], f0: f32, sample_rate: i32, signal: &mut [f32], offset: usize) {
-    let n_spsym = (0.5 + sample_rate as f64 * FT8_SYMBOL_PERIOD as f64) as usize;
-    let n_wave = tones.len() * n_spsym;
+    let n_wave = waveform_len(tones.len(), sample_rate);
     assert!(
         offset + n_wave <= signal.len(),
         "synth_gfsk: signal buffer too short (need {} samples from offset {}, have {})",
@@ -75,8 +91,64 @@ pub fn synth_gfsk(tones: &[u8], f0: f32, sample_rate: i32, signal: &mut [f32], o
 pub fn generate_ft8(text: &str, base_freq_hz: f32, sample_rate: i32) -> Option<Vec<f32>> {
     let payload = pack77(text)?;
     let tones = encode_tones(&payload);
-    let num_samples = (0.5 + FT8_NN as f32 * FT8_SYMBOL_PERIOD * sample_rate as f32) as usize;
+    // Size the buffer with the same per-symbol rounding `synth_gfsk` uses for its
+    // write count, so it always fits exactly (see [`waveform_len`]). The previous
+    // total-rounded size could be short of the write count at a non-integral rate.
+    let num_samples = waveform_len(tones.len(), sample_rate);
     let mut signal = vec![0.0f32; num_samples];
     synth_gfsk(&tones, base_freq_hz, sample_rate, &mut signal, 0);
     Some(signal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Independently replicates the write count `synth_gfsk` computes (per-symbol
+    /// rounding), so this test fails if `waveform_len` ever drifts from it.
+    fn synth_write_count(n_tones: usize, sample_rate: i32) -> usize {
+        let n_spsym = (0.5 + sample_rate as f64 * FT8_SYMBOL_PERIOD as f64) as usize;
+        n_tones * n_spsym
+    }
+
+    /// The old buffer size `generate_ft8` used to allocate (total-rounded). Kept
+    /// here only to document the pre-fix behaviour the tests below contrast with.
+    fn old_total_rounded_len(n_tones: usize, sample_rate: i32) -> usize {
+        (0.5 + n_tones as f32 * FT8_SYMBOL_PERIOD * sample_rate as f32) as usize
+    }
+
+    #[test]
+    fn allocation_always_covers_synth_write_count() {
+        // Across integral and non-integral sample rates the allocated buffer must
+        // exactly match synth_gfsk's write count — never short (would panic on the
+        // `offset + n_wave <= signal.len()` assert), never wastefully over-sized.
+        for &rate in &[8000, 11025, 12000, 12001, 12004, 12005, 16000, 22050, 24000, 44100, 48000] {
+            let alloc = waveform_len(FT8_NN, rate);
+            let need = synth_write_count(FT8_NN, rate);
+            assert_eq!(alloc, need, "rate {rate}: buffer {alloc} must match write count {need}");
+        }
+    }
+
+    #[test]
+    fn byte_identical_at_shipped_rate() {
+        // At the app's fixed 12 kHz rate the new per-symbol size equals the old
+        // total-rounded size (12.64 s * 12000 = 151680), so shipped output is
+        // unchanged — this is a pure robustness fix for other rates.
+        assert_eq!(waveform_len(FT8_NN, 12000), 151680);
+        assert_eq!(waveform_len(FT8_NN, 12000), old_total_rounded_len(FT8_NN, 12000));
+    }
+
+    #[test]
+    fn old_total_rounded_size_underran_at_nonintegral_rate() {
+        // Regression guard documenting the bug: at 12004 Hz the old total-rounded
+        // buffer was shorter than synth_gfsk's per-symbol write count, so the assert
+        // fired (the desktop sibling of PR #521). The new size covers it.
+        let rate = 12004;
+        let need = synth_write_count(FT8_NN, rate);
+        assert!(
+            old_total_rounded_len(FT8_NN, rate) < need,
+            "expected the old size to underrun the write count at {rate} Hz",
+        );
+        assert!(waveform_len(FT8_NN, rate) >= need);
+    }
 }


### PR DESCRIPTION
## Root cause

`generate_ft8` in `desktop/src-tauri/src/dsp/encode.rs` sized its output buffer with a single **total-rounded** sample count:

```rust
let num_samples = (0.5 + FT8_NN as f32 * FT8_SYMBOL_PERIOD * sample_rate as f32) as usize;
```

while `synth_gfsk` (wrapping the native `ft8_lib` `synth_gfsk`) writes a **per-symbol-rounded** count:

```rust
let n_spsym = (0.5 + sample_rate as f64 * FT8_SYMBOL_PERIOD as f64) as usize;
let n_wave  = tones.len() * n_spsym;   // asserts offset + n_wave <= signal.len()
```

The two roundings are equal **only when `sample_rate * symbol_period` is integral**. At the shipped fixed **12 kHz** rate they match exactly (12.64 s × 12000 = 151680 samples), so the divergence was latent. But at any non-integral rate (e.g. **12004 Hz**) the total-rounded allocation is a few samples short of what `synth_gfsk` writes, so its `offset + n_wave <= signal.len()` assert fires and the Tauri transmit command panics.

This is the desktop sibling of the Android heap-OOB write fixed in **PR #521**, which had the identical Java/native sample-count rounding divergence (there it was an out-of-bounds heap write; here Rust's bounds-checked `assert!` turns it into a controlled panic instead).

## Fix

Extract `waveform_len(n_tones, sample_rate)` as the **single source of truth** for the buffer size, computed with the same per-symbol rounding `synth_gfsk` uses. Both `synth_gfsk` (its `n_wave`/assert) and `generate_ft8` (its allocation) now call it, so the allocation and the write count can never diverge again.

- **Byte-identical at the shipped 12 kHz rate** (both formulas give 151680) — no change to any real output; this is pure robustness for other/future sample rates.
- Localized: one small helper + two call sites, no behavioural change to the DSP.

## Testing

New pure `#[cfg(test)]` module in `encode.rs` (no FFI needed):

- `allocation_always_covers_synth_write_count` — the allocated size equals `synth_gfsk`'s independently-recomputed write count across integral and non-integral rates (8000…48000 Hz incl. 12001/12004/12005).
- `byte_identical_at_shipped_rate` — new size == old total-rounded size == 151680 at 12 kHz.
- `old_total_rounded_size_underran_at_nonintegral_rate` — regression guard: the old size was `< need` at 12004 Hz (reproduces the panic), the new size covers it.

Verified in-sandbox (no C toolchain / system libs): the real `encode.rs` + `ffi.rs` **typecheck clean** via `cargo check --tests` in an isolated harness, and the real test module **runs green** (3/3 passed) linked against C stubs — using a portable `zig cc`/`ar` toolchain since the full crate can't link webkit2gtk/dbus here. `encode.rs` has no platform `cfg`, so the Windows/macOS CI targets compile identically.

## Risk

Very low. No change at the shipped 12 kHz rate; the only behavioural difference is that buffers at non-integral rates are now sized correctly instead of one-or-more samples short.