### PR TITLE
Fix web logbook trailing empty page at exact record-count multiples

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -52,6 +52,27 @@ public class LogHttpServer extends NanoHTTPD {
 
     }
 
+    /**
+     * Number of pages needed to show {@code recordCount} rows at {@code pageSize} rows per page.
+     *
+     * <p>This is a ceiling division: {@code n} pages hold up to {@code n * pageSize} rows. The
+     * old {@code Math.round(rc / pageSize + 0.5f)} form actually evaluated to
+     * {@code floor(rc / pageSize) + 1} (because {@link Math#round(float)} is itself
+     * {@code floor(x + 0.5)}, so the {@code + 0.5f} added a whole extra page), so an exact
+     * multiple — e.g. 100 rows at the default 100 rows/page — reported one page too many and
+     * the web logbook rendered a trailing empty page whose "last page" link led nowhere.
+     *
+     * <p>Always returns at least 1 so the page controls still render over an empty log (matching
+     * the old behaviour for 0 rows), and a non-positive {@code pageSize} (a malformed
+     * {@code ?pageSize=} query value) collapses to a single page instead of dividing by zero.
+     */
+    static int pageCount(int recordCount, int pageSize) {
+        if (pageSize <= 0 || recordCount <= 0) {
+            return 1;
+        }
+        return (recordCount + pageSize - 1) / pageSize;
+    }
+
     @Override
     public Response serve(IHTTPSession session) {
         String[] uriList = session.getUri().split("/");
@@ -991,7 +1012,7 @@ public class LogHttpServer extends NanoHTTPD {
                         "where ((CALL_TO LIKE ?)OR(CALL_FROM LIKE ?))" + dateSql
                 , new String[]{whereStr, whereStr});
         cursor.moveToFirst();
-        int pageCount = Math.round(((float) cursor.getInt(cursor.getColumnIndex("rc")) / pageSize) + 0.5f);
+        int pageCount = pageCount(cursor.getInt(cursor.getColumnIndex("rc")), pageSize);
         if (pageIndex > pageCount) pageIndex = pageCount;
         cursor.close();
 
@@ -1232,7 +1253,7 @@ public class LogHttpServer extends NanoHTTPD {
                         "where (([call] LIKE ?)OR(station_callsign LIKE ?))" + dateSql
                 , new String[]{whereStr, whereStr});
         cursor.moveToFirst();
-        int pageCount = Math.round(((float) cursor.getInt(cursor.getColumnIndex("rc")) / pageSize) + 0.5f);
+        int pageCount = pageCount(cursor.getInt(cursor.getColumnIndex("rc")), pageSize);
         if (pageIndex > pageCount) pageIndex = pageCount;
         cursor.close();
 
@@ -1492,7 +1513,7 @@ public class LogHttpServer extends NanoHTTPD {
                         "where (([call] LIKE ?)OR(station_callsign LIKE ?))" + dateSql
                 , new String[]{whereStr, whereStr});
         cursor.moveToFirst();
-        int pageCount = Math.round(((float) cursor.getInt(cursor.getColumnIndex("rc")) / pageSize) + 0.5f);
+        int pageCount = pageCount(cursor.getInt(cursor.getColumnIndex("rc")), pageSize);
         if (pageIndex > pageCount) pageIndex = pageCount;
         cursor.close();
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -73,6 +73,19 @@ public class LogHttpServer extends NanoHTTPD {
         return (recordCount + pageSize - 1) / pageSize;
     }
 
+    /**
+     * Clamp a page size parsed from a {@code ?pageSize=} query value to a safe positive size.
+     *
+     * <p>{@link #pageCount(int, int)} tolerates a non-positive size, but the raw value also
+     * drives the paged {@code LIMIT (offset),(pageSize)} query and every navigation link. A
+     * {@code pageSize} of 0 forces {@code LIMIT ...,0} (an always-empty table) and a negative
+     * value hands SQLite an undefined/unbounded limit — and either leaks into the links. Fall
+     * back to the default so the count, the query, and the links all agree on one sane size.
+     */
+    static int normalizePageSize(int pageSize) {
+        return pageSize > 0 ? pageSize : 100;
+    }
+
     @Override
     public Response serve(IHTTPSession session) {
         String[] uriList = session.getUri().split("/");
@@ -966,6 +979,9 @@ public class LogHttpServer extends NanoHTTPD {
         if (pars.get("pageSize") != null) {
             pageSize = Integer.parseInt(Objects.requireNonNull(pars.get("pageSize")));
         }
+        // Normalize before it feeds pageCount(), the SQL LIMIT, and the nav links, so a
+        // malformed 0/negative ?pageSize= can't force an empty page or an undefined limit.
+        pageSize = normalizePageSize(pageSize);
         if (pars.get("callsign") != null) {
             callsign = Objects.requireNonNull(pars.get("callsign"));
         }
@@ -1210,6 +1226,9 @@ public class LogHttpServer extends NanoHTTPD {
         if (pars.get("pageSize") != null) {
             pageSize = Integer.parseInt(Objects.requireNonNull(pars.get("pageSize")));
         }
+        // Normalize before it feeds pageCount(), the SQL LIMIT, and the nav links, so a
+        // malformed 0/negative ?pageSize= can't force an empty page or an undefined limit.
+        pageSize = normalizePageSize(pageSize);
         if (pars.get("callsign") != null) {
             callsign = Objects.requireNonNull(pars.get("callsign"));
         }
@@ -1455,6 +1474,9 @@ public class LogHttpServer extends NanoHTTPD {
         if (pars.get("pageSize") != null) {
             pageSize = Integer.parseInt(Objects.requireNonNull(pars.get("pageSize")));
         }
+        // Normalize before it feeds pageCount(), the SQL LIMIT, and the nav links, so a
+        // malformed 0/negative ?pageSize= can't force an empty page or an undefined limit.
+        pageSize = normalizePageSize(pageSize);
         if (pars.get("callsign") != null) {
             callsign = Objects.requireNonNull(pars.get("callsign"));
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerPageCountTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerPageCountTest.java
@@ -1,0 +1,53 @@
+package com.k1af.ft8af.html;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for {@link LogHttpServer#pageCount(int, int)}, the page-count
+ * math shared by the three web-logbook views (SWL messages, SWL QSOs, QSL logbook).
+ *
+ * <p>The old inline form {@code Math.round(rc / pageSize + 0.5f)} evaluated to
+ * {@code floor(rc / pageSize) + 1}, so an exact multiple of the page size reported one
+ * page too many and the web logbook showed a trailing empty page. These tests pin the
+ * correct ceiling division and lock in that regression, plus the empty-log and
+ * malformed-{@code pageSize} guards. No Android types are touched, so no Robolectric
+ * runner is needed.
+ */
+public class LogHttpServerPageCountTest {
+
+    @Test
+    public void exactMultiple_hasNoTrailingEmptyPage() {
+        // The core regression: rows == k * pageSize must be exactly k pages, not k + 1.
+        assertThat(LogHttpServer.pageCount(100, 100)).isEqualTo(1);
+        assertThat(LogHttpServer.pageCount(200, 100)).isEqualTo(2);
+        assertThat(LogHttpServer.pageCount(300, 100)).isEqualTo(3);
+        assertThat(LogHttpServer.pageCount(7, 7)).isEqualTo(1);
+        assertThat(LogHttpServer.pageCount(5, 1)).isEqualTo(5);
+    }
+
+    @Test
+    public void partialLastPage_roundsUp() {
+        assertThat(LogHttpServer.pageCount(1, 100)).isEqualTo(1);
+        assertThat(LogHttpServer.pageCount(99, 100)).isEqualTo(1);
+        assertThat(LogHttpServer.pageCount(101, 100)).isEqualTo(2);
+        assertThat(LogHttpServer.pageCount(150, 100)).isEqualTo(2);
+        assertThat(LogHttpServer.pageCount(250, 100)).isEqualTo(3);
+    }
+
+    @Test
+    public void emptyLog_stillOnePage() {
+        // Preserve the old behaviour (Math.round(0 + 0.5f) == 1): show a single empty
+        // page so the page controls still render.
+        assertThat(LogHttpServer.pageCount(0, 100)).isEqualTo(1);
+    }
+
+    @Test
+    public void nonPositivePageSize_collapsesToOnePage() {
+        // A malformed ?pageSize= query value must not divide by zero (the old float form
+        // produced Integer.MAX_VALUE via rc / 0f == Infinity).
+        assertThat(LogHttpServer.pageCount(50, 0)).isEqualTo(1);
+        assertThat(LogHttpServer.pageCount(50, -5)).isEqualTo(1);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerPageCountTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerPageCountTest.java
@@ -50,4 +50,21 @@ public class LogHttpServerPageCountTest {
         assertThat(LogHttpServer.pageCount(50, 0)).isEqualTo(1);
         assertThat(LogHttpServer.pageCount(50, -5)).isEqualTo(1);
     }
+
+    @Test
+    public void normalizePageSize_fallsBackForNonPositive() {
+        // A 0 pageSize would make the SQL LIMIT ...,0 an always-empty table and a negative
+        // value an undefined/unbounded limit; both must be clamped to the default before they
+        // reach the query and the nav links.
+        assertThat(LogHttpServer.normalizePageSize(0)).isEqualTo(100);
+        assertThat(LogHttpServer.normalizePageSize(-25)).isEqualTo(100);
+    }
+
+    @Test
+    public void normalizePageSize_keepsValidSize() {
+        assertThat(LogHttpServer.normalizePageSize(1)).isEqualTo(1);
+        assertThat(LogHttpServer.normalizePageSize(50)).isEqualTo(50);
+        assertThat(LogHttpServer.normalizePageSize(100)).isEqualTo(100);
+        assertThat(LogHttpServer.normalizePageSize(500)).isEqualTo(500);
+    }
 }


### PR DESCRIPTION
## Summary

The built-in web logbook (`LogHttpServer`, served over HTTP to a browser at the phone's IP) rendered a **trailing empty page** whenever the total matching record count was an exact multiple of the page size — the common case at the default 100 rows/page (100, 200, 300, … contacts). The page-count label was inflated by one and the "last page" (`>|`) link landed on an empty table.

## Root cause

All three paginated views computed the page count as:

```java
int pageCount = Math.round(((float) rc / pageSize) + 0.5f);
```

`Math.round(x)` is itself `floor(x + 0.5)`, so this evaluates to `floor(rc/pageSize + 1.0)` = `floor(rc/pageSize) + 1` — a whole extra page, not a ceiling. For `rc = k * pageSize` it returns `k + 1` instead of `k`. The intended `ceil(rc/pageSize)` only agrees with the buggy form on non-multiples, which is why it went unnoticed.

The identical expression appeared at three call sites — `getMessages` (SWL messages), `getSWLQsoMessages` (SWL QSOs) and the main QSL logbook view — so all three were affected.

## Fix

Extracted a single, pure, testable helper and routed all three sites through it:

```java
static int pageCount(int recordCount, int pageSize) {
    if (pageSize <= 0 || recordCount <= 0) {
        return 1;
    }
    return (recordCount + pageSize - 1) / pageSize;  // integer ceiling
}
```

- Correct ceiling division: `100 rows / 100 → 1` page (was `2`), `200 → 2` (was `3`), `150 → 2` (unchanged).
- Returns at least `1` so the page controls still render over an empty log — matching the old behaviour for 0 rows (`Math.round(0 + 0.5f) == 1`).
- A non-positive `pageSize` (a malformed `?pageSize=` query value) now collapses to a single page instead of `rc / 0f == Infinity → Integer.MAX_VALUE`.

## Testing

- New `LogHttpServerPageCountTest` (pure JVM, JUnit4 + Truth, no Robolectric): exact-multiple (regression), partial last page, empty log, and non-positive page size. Verified the exact-multiple and zero-page-size cases **fail on the old formula** and pass on the fix.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — release build green (all 4 ABIs).

## Risk

Very low. Display-only pagination arithmetic in the optional web logbook; no DSP, decode, encode, audio, or CAT paths touched. Behaviour changes only for exact-multiple and malformed-input cases, both strictly corrections. Happy path (partial last page) is byte-identical.
