### PR TITLE
WSJT-X UDP interface — desktop (broadcast + accept requests)

### DIFF
--- a/desktop/src-tauri/src/db.rs
+++ b/desktop/src-tauri/src/db.rs
@@ -415,6 +415,30 @@ fn row_to_qso(r: &rusqlite::Row) -> rusqlite::Result<QsoRecord> {
     })
 }
 
+/// One QSO as a single ADIF record line (ending in `<eor>`), matching the field
+/// set/order of [`Db::export_adif_range`]. Used for the WSJT-X "Logged ADIF" UDP
+/// message so companion loggers (JTAlert, N1MM) can capture the QSO verbatim.
+pub fn adif_record(r: &QsoRecord) -> String {
+    let mut out = String::new();
+    out.push_str(&adif_field("call", &r.call));
+    let qsl = if r.confirmed { "Y" } else { "N" };
+    out.push_str(&format!("<QSL_RCVD:1>{qsl} <QSL_MANUAL:1>N "));
+    adif_opt(&mut out, "gridsquare", &r.gridsquare);
+    adif_opt(&mut out, "mode", &r.mode);
+    adif_opt(&mut out, "rst_sent", &r.rst_sent);
+    adif_opt(&mut out, "rst_rcvd", &r.rst_rcvd);
+    adif_opt(&mut out, "qso_date", &r.qso_date);
+    adif_opt(&mut out, "time_on", &r.time_on);
+    adif_opt(&mut out, "qso_date_off", &r.qso_date_off);
+    adif_opt(&mut out, "time_off", &r.time_off);
+    adif_opt(&mut out, "band", &r.band);
+    adif_opt(&mut out, "freq", &r.freq);
+    adif_opt(&mut out, "station_callsign", &r.station_callsign);
+    adif_opt(&mut out, "my_gridsquare", &r.my_gridsquare);
+    out.push_str(&format!("<comment:{}>{} <eor>", r.comment.len(), r.comment));
+    out
+}
+
 fn adif_field(name: &str, value: &str) -> String {
     format!("<{}:{}>{} ", name, value.len(), value)
 }

--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -77,6 +77,17 @@ fn wf_boundary_row(corrected_now_ms: i64, last_slot: &mut i64) -> bool {
     }
 }
 
+/// The on-air text of a decode: the raw decoded line if we have it, else a
+/// reconstruction from the parsed fields. Shared by the UI publish and the
+/// WSJT-X UDP Decode broadcast so both show identical message text.
+fn decode_text(m: &DecodedMessage) -> String {
+    if m.raw_text.is_empty() {
+        format!("{} {} {}", m.call_to, m.call_from, m.extra)
+    } else {
+        m.raw_text.clone()
+    }
+}
+
 // --- messages crossing the channel boundary --------------------------------
 
 #[derive(Debug, Clone, Deserialize)]
@@ -118,6 +129,11 @@ pub enum EngineCommand {
     ResyncTime,
     /// Apply new live-waterfall FFT parameters (developer knobs, issue #428).
     SetWaterfallConfig(WfConfig),
+    /// Apply new WSJT-X UDP settings (enable/host/port/accept-requests). Rebinds
+    /// the socket + listener live so the Settings screen takes effect at once.
+    SetUdpConfig(crate::udp::UdpConfig),
+    /// Re-broadcast this session's decodes over UDP (inbound WSJT-X Replay).
+    UdpReplay,
     Shutdown,
 }
 
@@ -288,6 +304,10 @@ struct Engine {
     // live waterfall FFT (plan + window table + floor state; rebuilt on config change)
     wf: WfProcessor,
     last_wf_slot: i64, // last cycle slot marked on the live waterfall (rx-corrected)
+    /// WSJT-X UDP interface (outbound broadcast + inbound request listener).
+    udp: crate::udp::UdpService,
+    /// UTC ms of the last UDP Heartbeat sent (rate-limits it to ~15 s).
+    last_udp_heartbeat_ms: i64,
 }
 
 impl Engine {
@@ -381,11 +401,29 @@ impl Engine {
             tx_parity: None,
             clock_offset_ms: saved_offset.unwrap_or(0),
             time_synced: saved_offset.is_some(),
+            udp: crate::udp::UdpService::new(cmd_tx.clone()),
             cmd_tx,
             ptt: false,
             tx_playback: None,
             wf,
             last_wf_slot: -1,
+            last_udp_heartbeat_ms: 0,
+        }
+    }
+
+    /// Load the persisted WSJT-X UDP settings into a config struct. Falls back to
+    /// the WSJT-X-compatible defaults (disabled, 127.0.0.1:2237) for missing keys.
+    fn read_udp_config(&self) -> crate::udp::UdpConfig {
+        let d = crate::udp::UdpConfig::default();
+        crate::udp::UdpConfig {
+            enabled: self.db.get_config("udp_enabled").as_deref() == Some("true"),
+            host: self.db.get_config("udp_host").filter(|s| !s.is_empty()).unwrap_or(d.host),
+            port: self
+                .db
+                .get_config("udp_port")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(d.port),
+            accept_requests: self.db.get_config("udp_accept_requests").as_deref() == Some("true"),
         }
     }
 
@@ -394,6 +432,15 @@ impl Engine {
     }
 
     fn run(&mut self, cmd_rx: Receiver<EngineCommand>) {
+        // Bring up the WSJT-X UDP interface from persisted settings (binds the
+        // socket + inbound listener if enabled). Non-fatal — a bad host/port just
+        // surfaces an error and leaves the feature off.
+        let udp_cfg = self.read_udp_config();
+        match self.udp.apply(udp_cfg) {
+            Ok(msg) => self.emit(EngineEvent::Info(msg)),
+            Err(e) => self.emit(EngineEvent::Error(e)),
+        }
+
         // Reconnect the last-used rig on startup (non-fatal if it can't).
         if let Some(json) = self.db.get_config("rig_config") {
             if let Ok(cfg) = serde_json::from_str::<RigConfig>(&json) {
@@ -425,6 +472,13 @@ impl Engine {
                     sequential: slot_id.rem_euclid(2),
                     ms_into_cycle: ms_into,
                 }));
+                // WSJT-X UDP Status every tick (so companions track dial/TX/decode
+                // state), Heartbeat every ~15 s (how they discover our address).
+                self.broadcast_status();
+                if now - self.last_udp_heartbeat_ms >= 15_000 {
+                    self.last_udp_heartbeat_ms = now;
+                    self.broadcast_heartbeat();
+                }
                 // RX input level + silence warning, once we're capturing. Surfaces
                 // a dead source (e.g. DAX channel not routed) that otherwise looks
                 // like a broken waterfall.
@@ -525,11 +579,15 @@ impl Engine {
     /// what drives CQ/auto-sequence retransmits.
     fn handle_decoded(&mut self, decoded: Vec<DecodedMessage>, slot_id: i64) {
         self.publish_decodes(&decoded);
+        self.broadcast_decodes(&decoded);
         self.calibrate_dt(&decoded);
 
         if let Some(QsoOutcome::Completed(record)) = self.qso.process_rx(&decoded) {
             match self.db.insert_qso(&record) {
-                Ok(_) => self.emit(EngineEvent::QsoCompleted(record)),
+                Ok(_) => {
+                    self.broadcast_qso(&record);
+                    self.emit(EngineEvent::QsoCompleted(record));
+                }
                 Err(e) => self.emit(EngineEvent::Error(format!("log QSO failed: {e}"))),
             }
         }
@@ -673,17 +731,111 @@ impl Engine {
                 snr: m.snr,
                 freq_hz: m.freq_hz,
                 time_sec: m.time_sec,
-                text: if m.raw_text.is_empty() {
-                    format!("{} {} {}", m.call_to, m.call_from, m.extra)
-                } else {
-                    m.raw_text.clone()
-                },
+                text: decode_text(m),
                 is_cq: m.call_to.eq_ignore_ascii_case("CQ"),
                 to_me: !self.qso.my_call.is_empty()
                     && m.call_to.eq_ignore_ascii_case(&self.qso.my_call),
             })
             .collect();
         self.emit(EngineEvent::Decoded(ui));
+    }
+
+    // --- WSJT-X UDP broadcast (outbound) ------------------------------------
+
+    /// Assemble a WSJT-X Status snapshot from current engine state.
+    fn udp_status(&self) -> crate::udp::codec::Status {
+        let st = self.qso.status();
+        crate::udp::codec::Status {
+            dial_freq_hz: self.dial_hz,
+            mode: "FT8".to_string(),
+            dx_call: st.target.clone().unwrap_or_default(),
+            report: st.report_sent.map(|n| format!("{n:+03}")).unwrap_or_default(),
+            tx_mode: "FT8".to_string(),
+            tx_enabled: st.active,
+            transmitting: self.tx_playback.is_some(),
+            decoding: self.decoding,
+            rx_df: self.tx_audio_hz.max(0) as u32,
+            tx_df: self.tx_audio_hz.max(0) as u32,
+            de_call: self.qso.my_call.clone(),
+            de_grid: self.qso.my_grid.clone(),
+            dx_grid: String::new(),
+            tx_watchdog: false,
+            sub_mode: String::new(),
+            fast_mode: false,
+            special_op_mode: 0,
+            freq_tolerance: 0xFFFF_FFFF,
+            tr_period: 15,
+            config_name: "Default".to_string(),
+            tx_message: st.tx_message.clone().unwrap_or_default(),
+        }
+    }
+
+    fn broadcast_status(&self) {
+        if self.udp.is_enabled() {
+            self.udp.send(&crate::udp::codec::status(&self.udp_status()));
+        }
+    }
+
+    fn broadcast_heartbeat(&self) {
+        if self.udp.is_enabled() {
+            self.udp
+                .send(&crate::udp::codec::heartbeat(env!("CARGO_PKG_VERSION"), ""));
+        }
+    }
+
+    /// Broadcast each of a slot's decodes as a WSJT-X Decode message. The `Time`
+    /// field is ms-since-UTC-midnight; `Frequency` is the audio offset in Hz.
+    fn broadcast_decodes(&mut self, decoded: &[DecodedMessage]) {
+        if !self.udp.is_enabled() {
+            return;
+        }
+        let time_ms = self.now().rem_euclid(86_400_000) as u32;
+        for m in decoded {
+            self.udp.send_decode(crate::udp::codec::Decode {
+                is_new: true,
+                time_ms,
+                snr: m.snr,
+                delta_time: m.time_sec as f64,
+                delta_freq: m.freq_hz.max(0.0) as u32,
+                mode: "FT8".to_string(),
+                message: decode_text(m),
+                low_confidence: false,
+                off_air: false,
+            });
+        }
+    }
+
+    /// Broadcast a logged QSO as both the structured QSO-Logged message and the
+    /// Logged-ADIF message (loggers consume one or the other).
+    fn broadcast_qso(&mut self, record: &QsoRecord) {
+        if !self.udp.is_enabled() {
+            return;
+        }
+        use crate::udp::codec::{qso_logged, DateTime, QsoLogged};
+        // Actual TX RF frequency = dial + audio offset (what WSJT-X reports).
+        let tx_freq_hz = self.dial_hz + self.tx_audio_hz.max(0) as u64;
+        let q = QsoLogged {
+            time_off: DateTime::from_adif(&record.qso_date_off, &record.time_off),
+            dx_call: record.call.clone(),
+            dx_grid: record.gridsquare.clone(),
+            tx_freq_hz,
+            mode: record.mode.clone(),
+            report_sent: record.rst_sent.clone(),
+            report_received: record.rst_rcvd.clone(),
+            tx_power: String::new(),
+            comments: record.comment.clone(),
+            name: String::new(),
+            time_on: DateTime::from_adif(&record.qso_date, &record.time_on),
+            operator_call: record.station_callsign.clone(),
+            my_call: record.station_callsign.clone(),
+            my_grid: record.my_gridsquare.clone(),
+            exchange_sent: String::new(),
+            exchange_received: String::new(),
+            prop_mode: String::new(),
+        };
+        self.udp.send(&qso_logged(&q));
+        self.udp
+            .send(&crate::udp::codec::logged_adif(&crate::db::adif_record(record)));
     }
 
     fn publish_tx_state(&self) {
@@ -694,6 +846,9 @@ impl Engine {
             message: self.qso.tx_message().map(|s| s.to_string()),
             status: self.qso.status(),
         }));
+        // Mirror the state change out over WSJT-X UDP so companion apps see TX
+        // start/stop and QSO progress without waiting for the next 1 Hz tick.
+        self.broadcast_status();
     }
 
     fn publish_rig_status(&self) {
@@ -727,6 +882,13 @@ impl Engine {
             EngineCommand::StopDecode => {
                 self.decoding = false;
                 self.input = None;
+                // Tell companion apps to wipe their decode band and forget the
+                // replay history — this is a genuine reset, not a per-cycle churn.
+                if self.udp.is_enabled() {
+                    self.udp.send(&crate::udp::codec::clear());
+                }
+                self.udp.clear_replay_cache();
+                self.broadcast_status();
                 self.emit(EngineEvent::Info("decode stopped".into()));
             }
             EngineCommand::SetStation { call, grid } => {
@@ -743,6 +905,13 @@ impl Engine {
                 if let Some(rig) = self.rig.as_mut() {
                     let _ = rig.set_frequency(hz);
                 }
+                // New band = new decode context: clear companions' band + replay
+                // history and push the fresh dial frequency in a Status.
+                if self.udp.is_enabled() {
+                    self.udp.send(&crate::udp::codec::clear());
+                }
+                self.udp.clear_replay_cache();
+                self.broadcast_status();
                 self.publish_rig_status();
             }
             EngineCommand::SetBaseFreq(hz) => {
@@ -768,6 +937,26 @@ impl Engine {
                     cfg.avg
                 )));
             }
+            EngineCommand::SetUdpConfig(cfg) => {
+                // Persist the four settings, then rebind live.
+                let _ = self.db.set_config("udp_enabled", if cfg.enabled { "true" } else { "false" });
+                let _ = self.db.set_config("udp_host", &cfg.host);
+                let _ = self.db.set_config("udp_port", &cfg.port.to_string());
+                let _ = self.db.set_config(
+                    "udp_accept_requests",
+                    if cfg.accept_requests { "true" } else { "false" },
+                );
+                match self.udp.apply(cfg) {
+                    Ok(msg) => {
+                        // Prime companions immediately on enable.
+                        self.broadcast_heartbeat();
+                        self.broadcast_status();
+                        self.emit(EngineEvent::Info(msg));
+                    }
+                    Err(e) => self.emit(EngineEvent::Error(e)),
+                }
+            }
+            EngineCommand::UdpReplay => self.udp.replay(),
             EngineCommand::SetInputDevice(name) => {
                 self.input_device = name.clone();
                 let _ = self.db.set_config("input_device", name.as_deref().unwrap_or(""));

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -18,5 +18,6 @@ pub mod os_location;
 pub mod qso;
 pub mod rig;
 pub mod timesync;
+pub mod udp;
 pub mod util;
 pub mod wf;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -274,6 +274,14 @@ fn set_waterfall_config(state: State<AppState>, config: WfConfig) {
     state.engine.send(EngineCommand::SetWaterfallConfig(config));
 }
 
+/// Apply new WSJT-X UDP settings. The engine persists the `udp_*` config keys
+/// and rebinds the socket + inbound listener live; see
+/// `EngineCommand::SetUdpConfig`.
+#[tauri::command]
+fn set_udp_config(state: State<AppState>, config: ft8af::udp::UdpConfig) {
+    state.engine.send(EngineCommand::SetUdpConfig(config));
+}
+
 fn main() {
     // Debug helper: `ft8af --list-rigs` prints the Hamlib-enumerated rig count
     // and exits — verifies the bundled Hamlib library loads without the GUI.
@@ -355,6 +363,7 @@ fn main() {
             set_config,
             all_config,
             set_waterfall_config,
+            set_udp_config,
             get_os_location,
         ])
         .run(tauri::generate_context!())

--- a/desktop/src-tauri/src/udp/codec.rs
+++ b/desktop/src-tauri/src/udp/codec.rs
@@ -1,0 +1,755 @@
+//! Byte-exact (de)serialization of the WSJT-X UDP message protocol.
+//!
+//! WSJT-X broadcasts a documented binary protocol over UDP that the wider
+//! ecosystem (GridTracker, JTAlert, N1MM+, Log4OM, ...) consumes to plot spots
+//! and auto-log QSOs, and it *accepts* a few request messages so those apps can
+//! drive it. This module speaks that exact wire format so FT8AF is a drop-in
+//! source/sink for those tools.
+//!
+//! The framing is a bespoke big-endian Qt-`QDataStream` layout (NOT JSON), so
+//! byte-for-byte correctness is the whole game — every encoder here is pinned by
+//! golden-vector tests (see the module tests and `docs/wsjtx-udp.md`). No I/O
+//! lives here; `super::UdpService` owns the socket. Keeping the codec pure is
+//! what makes it unit-testable and lets the Android/iOS ports transcribe the
+//! same vectors.
+//!
+//! Wire primitives (all big-endian):
+//!   * u32 / u64 / i32 / i64 / f64 / bool(1 byte)
+//!   * string: u32 byte-length (0xFFFFFFFF = null) then that many UTF-8 bytes;
+//!     an empty string is length 0.
+//!   * datetime (UTC form): i64 Julian day, u32 ms-since-midnight, u8=1 (UTC).
+//!
+//! Every datagram starts with: u32 magic 0xADBCCBDA, u32 schema, u32 type, then
+//! a string `id` (our client id), then type-specific fields.
+
+/// Magic number prefixing every WSJT-X datagram.
+pub const MAGIC: u32 = 0xADBC_CBDA;
+/// Schema version we advertise (current WSJT-X). Receivers we target parse it.
+pub const SCHEMA: u32 = 3;
+/// Client id we stamp on every outbound message. Distinguishes FT8AF from a real
+/// WSJT-X instance in multi-source setups (GridTracker keys stations by id).
+pub const CLIENT_ID: &str = "FT8AF";
+/// Max schema we understand, reported in the Heartbeat.
+pub const MAX_SCHEMA: u32 = SCHEMA;
+
+// WSJT-X message type numbers.
+pub const T_HEARTBEAT: u32 = 0;
+pub const T_STATUS: u32 = 1;
+pub const T_DECODE: u32 = 2;
+pub const T_CLEAR: u32 = 3;
+pub const T_REPLY: u32 = 4;
+pub const T_QSO_LOGGED: u32 = 5;
+pub const T_REPLAY: u32 = 7;
+pub const T_HALT_TX: u32 = 8;
+pub const T_FREE_TEXT: u32 = 9;
+pub const T_LOGGED_ADIF: u32 = 12;
+
+// --- writer -----------------------------------------------------------------
+
+/// Append-only big-endian byte writer for the Qt-DataStream primitives.
+struct Writer {
+    buf: Vec<u8>,
+}
+
+impl Writer {
+    fn new() -> Self {
+        Writer { buf: Vec::with_capacity(64) }
+    }
+    fn u8(&mut self, v: u8) {
+        self.buf.push(v);
+    }
+    fn bool(&mut self, v: bool) {
+        self.buf.push(v as u8);
+    }
+    fn u32(&mut self, v: u32) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn i32(&mut self, v: i32) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn u64(&mut self, v: u64) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn i64(&mut self, v: i64) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    fn f64(&mut self, v: f64) {
+        self.buf.extend_from_slice(&v.to_be_bytes());
+    }
+    /// UTF-8 string: u32 byte length then the bytes. Empty string => length 0.
+    fn string(&mut self, s: &str) {
+        self.u32(s.len() as u32);
+        self.buf.extend_from_slice(s.as_bytes());
+    }
+    /// QDateTime in UTC form: i64 Julian day, u32 ms-since-midnight, u8 spec=1.
+    fn datetime(&mut self, julian_day: i64, ms_of_day: u32) {
+        self.i64(julian_day);
+        self.u32(ms_of_day);
+        self.u8(1); // Qt::UTC
+    }
+}
+
+/// Start a datagram: magic + schema + type + client id.
+fn begin(msg_type: u32) -> Writer {
+    let mut w = Writer::new();
+    w.u32(MAGIC);
+    w.u32(SCHEMA);
+    w.u32(msg_type);
+    w.string(CLIENT_ID);
+    w
+}
+
+// --- outbound: builders returning ready-to-send datagrams --------------------
+
+/// Type 0. Periodic keep-alive; also how companion apps learn our address so
+/// their reply/halt/free-text requests can be routed back to us.
+pub fn heartbeat(version: &str, revision: &str) -> Vec<u8> {
+    let mut w = begin(T_HEARTBEAT);
+    w.u32(MAX_SCHEMA);
+    w.string(version);
+    w.string(revision);
+    w.buf
+}
+
+/// All the fields a WSJT-X Status message carries, gathered from engine state.
+#[derive(Debug, Clone)]
+pub struct Status {
+    pub dial_freq_hz: u64,
+    pub mode: String,
+    pub dx_call: String,
+    pub report: String,
+    pub tx_mode: String,
+    pub tx_enabled: bool,
+    pub transmitting: bool,
+    pub decoding: bool,
+    pub rx_df: u32,
+    pub tx_df: u32,
+    pub de_call: String,
+    pub de_grid: String,
+    pub dx_grid: String,
+    pub tx_watchdog: bool,
+    pub sub_mode: String,
+    pub fast_mode: bool,
+    pub special_op_mode: u8,
+    pub freq_tolerance: u32,
+    pub tr_period: u32,
+    pub config_name: String,
+    pub tx_message: String,
+}
+
+/// Type 1. The big state snapshot: dial freq, mode, who we're working, and the
+/// TX/decode flags that drive companion-app UI.
+pub fn status(s: &Status) -> Vec<u8> {
+    let mut w = begin(T_STATUS);
+    w.u64(s.dial_freq_hz);
+    w.string(&s.mode);
+    w.string(&s.dx_call);
+    w.string(&s.report);
+    w.string(&s.tx_mode);
+    w.bool(s.tx_enabled);
+    w.bool(s.transmitting);
+    w.bool(s.decoding);
+    w.u32(s.rx_df);
+    w.u32(s.tx_df);
+    w.string(&s.de_call);
+    w.string(&s.de_grid);
+    w.string(&s.dx_grid);
+    w.bool(s.tx_watchdog);
+    w.string(&s.sub_mode);
+    w.bool(s.fast_mode);
+    w.u8(s.special_op_mode);
+    w.u32(s.freq_tolerance);
+    w.u32(s.tr_period);
+    w.string(&s.config_name);
+    w.string(&s.tx_message);
+    w.buf
+}
+
+/// One decoded FT8 message.
+#[derive(Debug, Clone)]
+pub struct Decode {
+    /// `true` for a fresh decode (vs. a replay).
+    pub is_new: bool,
+    /// Milliseconds since 00:00:00 UTC of the decode.
+    pub time_ms: u32,
+    pub snr: i32,
+    /// Time offset (DT) in seconds.
+    pub delta_time: f64,
+    /// Audio frequency offset in Hz.
+    pub delta_freq: u32,
+    pub mode: String,
+    pub message: String,
+    pub low_confidence: bool,
+    pub off_air: bool,
+}
+
+/// Type 2. A single decode line — the bread and butter that lights up spot maps.
+pub fn decode(d: &Decode) -> Vec<u8> {
+    let mut w = begin(T_DECODE);
+    w.bool(d.is_new);
+    w.u32(d.time_ms);
+    w.i32(d.snr);
+    w.f64(d.delta_time);
+    w.u32(d.delta_freq);
+    w.string(&d.mode);
+    w.string(&d.message);
+    w.bool(d.low_confidence);
+    w.bool(d.off_air);
+    w.buf
+}
+
+/// Type 3 (outbound form). Tells companion apps to wipe their decode band —
+/// sent at the start of each cycle so their view tracks ours.
+pub fn clear() -> Vec<u8> {
+    begin(T_CLEAR).buf
+}
+
+/// A completed QSO, in WSJT-X "QSO Logged" field order.
+#[derive(Debug, Clone)]
+pub struct QsoLogged {
+    pub time_off: DateTime,
+    pub dx_call: String,
+    pub dx_grid: String,
+    pub tx_freq_hz: u64,
+    pub mode: String,
+    pub report_sent: String,
+    pub report_received: String,
+    pub tx_power: String,
+    pub comments: String,
+    pub name: String,
+    pub time_on: DateTime,
+    pub operator_call: String,
+    pub my_call: String,
+    pub my_grid: String,
+    pub exchange_sent: String,
+    pub exchange_received: String,
+    pub prop_mode: String,
+}
+
+/// A UTC instant as WSJT-X serializes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DateTime {
+    pub julian_day: i64,
+    pub ms_of_day: u32,
+}
+
+impl DateTime {
+    /// Build from ADIF-style `YYYYMMDD` + `HHMMSS` strings (both UTC). Returns a
+    /// zeroed instant if either is malformed — a bad clock string must not abort
+    /// the whole QSO-Logged datagram.
+    pub fn from_adif(date_yyyymmdd: &str, time_hhmmss: &str) -> DateTime {
+        let julian_day = julian_day_from_yyyymmdd(date_yyyymmdd).unwrap_or(0);
+        let ms_of_day = ms_of_day_from_hhmmss(time_hhmmss).unwrap_or(0);
+        DateTime { julian_day, ms_of_day }
+    }
+}
+
+/// Type 5. Emitted when a QSO is logged so companion loggers capture it.
+pub fn qso_logged(q: &QsoLogged) -> Vec<u8> {
+    let mut w = begin(T_QSO_LOGGED);
+    w.datetime(q.time_off.julian_day, q.time_off.ms_of_day);
+    w.string(&q.dx_call);
+    w.string(&q.dx_grid);
+    w.u64(q.tx_freq_hz);
+    w.string(&q.mode);
+    w.string(&q.report_sent);
+    w.string(&q.report_received);
+    w.string(&q.tx_power);
+    w.string(&q.comments);
+    w.string(&q.name);
+    w.datetime(q.time_on.julian_day, q.time_on.ms_of_day);
+    w.string(&q.operator_call);
+    w.string(&q.my_call);
+    w.string(&q.my_grid);
+    w.string(&q.exchange_sent);
+    w.string(&q.exchange_received);
+    w.string(&q.prop_mode);
+    w.buf
+}
+
+/// Type 12. The just-logged QSO as an ADIF record string. Loggers that key off
+/// ADIF (JTAlert, N1MM) prefer this to the field-by-field QSO Logged message.
+pub fn logged_adif(adif: &str) -> Vec<u8> {
+    let mut w = begin(T_LOGGED_ADIF);
+    w.string(adif);
+    w.buf
+}
+
+// --- inbound: parse companion-app requests -----------------------------------
+
+/// A request a companion app sent us, already decoded to intent.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Inbound {
+    /// User double-clicked a decode elsewhere: call this station. `grid` is the
+    /// station's grid if the clicked message carried one.
+    Reply { call: String, grid: String, snr: i32 },
+    /// Re-broadcast this session's decodes.
+    Replay,
+    /// Stop transmitting. `auto_only` = halt only automatic (leave a manual TX).
+    HaltTx { auto_only: bool },
+    /// Set/send an arbitrary free-text message. `send` = transmit immediately.
+    FreeText { text: String, send: bool },
+}
+
+/// Big-endian reader mirroring [`Writer`]. Every read is bounds-checked and
+/// returns `None` on a short/malformed buffer so a stray datagram can't panic
+/// the listener.
+struct Reader<'a> {
+    b: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(b: &'a [u8]) -> Self {
+        Reader { b, pos: 0 }
+    }
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        let s = self.b.get(self.pos..end)?;
+        self.pos = end;
+        Some(s)
+    }
+    fn u8(&mut self) -> Option<u8> {
+        self.take(1).map(|s| s[0])
+    }
+    fn bool(&mut self) -> Option<bool> {
+        self.u8().map(|v| v != 0)
+    }
+    fn u32(&mut self) -> Option<u32> {
+        self.take(4).map(|s| u32::from_be_bytes(s.try_into().unwrap()))
+    }
+    fn i32(&mut self) -> Option<i32> {
+        self.take(4).map(|s| i32::from_be_bytes(s.try_into().unwrap()))
+    }
+    fn f64(&mut self) -> Option<f64> {
+        self.take(8).map(|s| f64::from_be_bytes(s.try_into().unwrap()))
+    }
+    /// String: u32 length then bytes. A null string (0xFFFFFFFF) reads as empty.
+    fn string(&mut self) -> Option<String> {
+        let len = self.u32()?;
+        if len == 0xFFFF_FFFF {
+            return Some(String::new());
+        }
+        let bytes = self.take(len as usize)?;
+        Some(String::from_utf8_lossy(bytes).into_owned())
+    }
+    fn skip_string(&mut self) -> Option<()> {
+        self.string().map(|_| ())
+    }
+}
+
+/// Parse an inbound datagram into intent. Returns `None` for anything we don't
+/// act on (bad magic, unknown/outbound-only type, truncated buffer).
+pub fn parse_inbound(buf: &[u8]) -> Option<Inbound> {
+    let mut r = Reader::new(buf);
+    if r.u32()? != MAGIC {
+        return None;
+    }
+    let _schema = r.u32()?;
+    let msg_type = r.u32()?;
+    r.skip_string()?; // id — we don't filter on it
+
+    match msg_type {
+        T_REPLY => {
+            let _time = r.u32()?;
+            let snr = r.i32()?;
+            let _dt = r.f64()?;
+            let _df = r.u32()?;
+            let _mode = r.string()?;
+            let message = r.string()?;
+            // trailing low_confidence / modifiers are optional across versions.
+            let (call, grid) = parse_reply_target(&message)?;
+            Some(Inbound::Reply { call, grid, snr })
+        }
+        T_REPLAY => Some(Inbound::Replay),
+        T_HALT_TX => {
+            let auto_only = r.bool().unwrap_or(false);
+            Some(Inbound::HaltTx { auto_only })
+        }
+        T_FREE_TEXT => {
+            let text = r.string()?;
+            let send = r.bool().unwrap_or(true);
+            Some(Inbound::FreeText { text, send })
+        }
+        _ => None,
+    }
+}
+
+/// From a decoded message line, work out which station a Reply should call and
+/// their grid (if present). Handles plain `TO FROM ...` and CQ lines with an
+/// optional directive: `CQ FROM GRID`, `CQ DX FROM GRID`, `CQ POTA FROM GRID`.
+///
+/// The caller is the first callsign-shaped token after any `CQ`+directive; the
+/// grid is the first following 4-char Maidenhead square.
+fn parse_reply_target(message: &str) -> Option<(String, String)> {
+    let tokens: Vec<&str> = message.split_whitespace().collect();
+    if tokens.is_empty() {
+        return None;
+    }
+    // Index of the caller's callsign.
+    let call_idx = if tokens[0].eq_ignore_ascii_case("CQ") {
+        // Skip a directive token that isn't itself a callsign (e.g. DX, POTA, a
+        // numeric frequency directive) — the caller is the next real callsign.
+        match tokens.get(1) {
+            Some(t) if is_callsign(t) => 1,
+            Some(_) => 2,
+            None => return None,
+        }
+    } else {
+        // "TO FROM ..." — the sender we'd answer is the second token.
+        1
+    };
+    let call = tokens.get(call_idx)?;
+    if !is_callsign(call) {
+        return None;
+    }
+    let grid = tokens
+        .get(call_idx + 1..)
+        .unwrap_or(&[])
+        .iter()
+        .find(|t| is_grid4(t))
+        .map(|t| t.to_uppercase())
+        .unwrap_or_default();
+    Some((call.to_uppercase(), grid))
+}
+
+/// A token that looks like a callsign: has at least one letter and one digit and
+/// is otherwise alphanumeric or `/`. Deliberately loose (covers portable `/P`,
+/// compound prefixes) while still rejecting directives like `DX`/`POTA` and bare
+/// grids/reports.
+fn is_callsign(t: &str) -> bool {
+    let core = t.split('/').next().unwrap_or(t);
+    let has_alpha = core.chars().any(|c| c.is_ascii_alphabetic());
+    let has_digit = core.chars().any(|c| c.is_ascii_digit());
+    let ok_chars = t.chars().all(|c| c.is_ascii_alphanumeric() || c == '/');
+    has_alpha && has_digit && ok_chars && !is_grid4(t)
+}
+
+/// A 4-character Maidenhead square: two letters A–R then two digits.
+fn is_grid4(t: &str) -> bool {
+    let b = t.as_bytes();
+    b.len() == 4
+        && b[0].to_ascii_uppercase().is_ascii_uppercase()
+        && (b'A'..=b'R').contains(&b[0].to_ascii_uppercase())
+        && (b'A'..=b'R').contains(&b[1].to_ascii_uppercase())
+        && b[2].is_ascii_digit()
+        && b[3].is_ascii_digit()
+}
+
+// --- date/time helpers -------------------------------------------------------
+
+/// Julian Day Number for a UTC `YYYYMMDD` date (proleptic Gregorian), matching
+/// what Qt's `QDate::toJulianDay` produces. `None` if the string is malformed.
+fn julian_day_from_yyyymmdd(s: &str) -> Option<i64> {
+    if s.len() != 8 || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let year: i32 = s[0..4].parse().ok()?;
+    let month: u32 = s[4..6].parse().ok()?;
+    let day: u32 = s[6..8].parse().ok()?;
+    let date = chrono::NaiveDate::from_ymd_opt(year, month, day)?;
+    // chrono day 1 = 0001-01-01 (proleptic Gregorian); JDN of that day = 1721426.
+    use chrono::Datelike;
+    Some(date.num_days_from_ce() as i64 + 1_721_425)
+}
+
+/// Milliseconds since midnight for a UTC `HHMMSS` string. `None` if malformed.
+fn ms_of_day_from_hhmmss(s: &str) -> Option<u32> {
+    if s.len() != 6 || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let h: u32 = s[0..2].parse().ok()?;
+    let m: u32 = s[2..4].parse().ok()?;
+    let sec: u32 = s[4..6].parse().ok()?;
+    if h > 23 || m > 59 || sec > 60 {
+        return None;
+    }
+    Some(((h * 3600) + (m * 60) + sec) * 1000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Re-read a datagram's header, returning the type and leaving the reader
+    // positioned at the first payload field (after the id string).
+    fn read_header(buf: &[u8]) -> (u32, Reader<'_>) {
+        let mut r = Reader::new(buf);
+        assert_eq!(r.u32().unwrap(), MAGIC, "magic");
+        assert_eq!(r.u32().unwrap(), SCHEMA, "schema");
+        let t = r.u32().unwrap();
+        assert_eq!(r.string().unwrap(), CLIENT_ID, "id");
+        (t, r)
+    }
+
+    #[test]
+    fn header_bytes_are_exact() {
+        let d = clear();
+        // magic AD BC CB DA, schema 00 00 00 03, type 00 00 00 03,
+        // id length 00 00 00 05, "FT8AF".
+        assert_eq!(
+            d,
+            vec![
+                0xAD, 0xBC, 0xCB, 0xDA, // magic
+                0x00, 0x00, 0x00, 0x03, // schema 3
+                0x00, 0x00, 0x00, 0x03, // type 3 (clear)
+                0x00, 0x00, 0x00, 0x05, // id len 5
+                b'F', b'T', b'8', b'A', b'F',
+            ]
+        );
+    }
+
+    #[test]
+    fn heartbeat_roundtrips() {
+        let d = heartbeat("1.2.3", "");
+        let (t, mut r) = read_header(&d);
+        assert_eq!(t, T_HEARTBEAT);
+        assert_eq!(r.u32().unwrap(), MAX_SCHEMA);
+        assert_eq!(r.string().unwrap(), "1.2.3");
+        assert_eq!(r.string().unwrap(), "");
+        assert_eq!(r.pos, d.len(), "no trailing bytes");
+    }
+
+    #[test]
+    fn decode_roundtrips_and_string_framing() {
+        let d = decode(&Decode {
+            is_new: true,
+            time_ms: 47_493_000,
+            snr: -7,
+            delta_time: 0.2,
+            delta_freq: 1500,
+            mode: "FT8".into(),
+            message: "CQ K1ABC FN42".into(),
+            low_confidence: false,
+            off_air: false,
+        });
+        let (t, mut r) = read_header(&d);
+        assert_eq!(t, T_DECODE);
+        assert!(r.bool().unwrap());
+        assert_eq!(r.u32().unwrap(), 47_493_000);
+        assert_eq!(r.i32().unwrap(), -7);
+        assert_eq!(r.f64().unwrap(), 0.2);
+        assert_eq!(r.u32().unwrap(), 1500);
+        assert_eq!(r.string().unwrap(), "FT8");
+        assert_eq!(r.string().unwrap(), "CQ K1ABC FN42");
+        assert!(!r.bool().unwrap());
+        assert!(!r.bool().unwrap());
+        assert_eq!(r.pos, d.len());
+    }
+
+    #[test]
+    fn status_roundtrips_all_fields() {
+        let s = Status {
+            dial_freq_hz: 14_074_000,
+            mode: "FT8".into(),
+            dx_call: "K1ABC".into(),
+            report: "-07".into(),
+            tx_mode: "FT8".into(),
+            tx_enabled: true,
+            transmitting: false,
+            decoding: true,
+            rx_df: 1500,
+            tx_df: 1500,
+            de_call: "K0XYZ".into(),
+            de_grid: "EN37".into(),
+            dx_grid: "FN42".into(),
+            tx_watchdog: false,
+            sub_mode: "".into(),
+            fast_mode: false,
+            special_op_mode: 0,
+            freq_tolerance: 0xFFFF_FFFF,
+            tr_period: 15,
+            config_name: "Default".into(),
+            tx_message: "K1ABC K0XYZ EN37".into(),
+        };
+        let d = status(&s);
+        let (t, mut r) = read_header(&d);
+        assert_eq!(t, T_STATUS);
+        assert_eq!(r.take(8).unwrap(), &14_074_000u64.to_be_bytes());
+        assert_eq!(r.string().unwrap(), "FT8"); // mode
+        assert_eq!(r.string().unwrap(), "K1ABC"); // dx_call
+        assert_eq!(r.string().unwrap(), "-07"); // report
+        assert_eq!(r.string().unwrap(), "FT8"); // tx_mode
+        assert!(r.bool().unwrap()); // tx_enabled
+        assert!(!r.bool().unwrap()); // transmitting
+        assert!(r.bool().unwrap()); // decoding
+        assert_eq!(r.u32().unwrap(), 1500); // rx_df
+        assert_eq!(r.u32().unwrap(), 1500); // tx_df
+        assert_eq!(r.string().unwrap(), "K0XYZ"); // de_call
+        assert_eq!(r.string().unwrap(), "EN37"); // de_grid
+        assert_eq!(r.string().unwrap(), "FN42"); // dx_grid
+        assert!(!r.bool().unwrap()); // tx_watchdog
+        assert_eq!(r.string().unwrap(), ""); // sub_mode
+        assert!(!r.bool().unwrap()); // fast_mode
+        assert_eq!(r.u8().unwrap(), 0); // special_op_mode
+        assert_eq!(r.u32().unwrap(), 0xFFFF_FFFF); // freq_tolerance
+        assert_eq!(r.u32().unwrap(), 15); // tr_period
+        assert_eq!(r.string().unwrap(), "Default"); // config_name
+        assert_eq!(r.string().unwrap(), "K1ABC K0XYZ EN37"); // tx_message
+        assert_eq!(r.pos, d.len());
+    }
+
+    #[test]
+    fn qso_logged_roundtrips_with_datetime() {
+        let on = DateTime::from_adif("20260712", "134500");
+        let off = DateTime::from_adif("20260712", "134615");
+        let q = QsoLogged {
+            time_off: off,
+            dx_call: "K1ABC".into(),
+            dx_grid: "FN42".into(),
+            tx_freq_hz: 14_075_500,
+            mode: "FT8".into(),
+            report_sent: "-07".into(),
+            report_received: "-12".into(),
+            tx_power: "".into(),
+            comments: "".into(),
+            name: "".into(),
+            time_on: on,
+            operator_call: "K0XYZ".into(),
+            my_call: "K0XYZ".into(),
+            my_grid: "EN37".into(),
+            exchange_sent: "".into(),
+            exchange_received: "".into(),
+            prop_mode: "".into(),
+        };
+        let d = qso_logged(&q);
+        let (t, mut r) = read_header(&d);
+        assert_eq!(t, T_QSO_LOGGED);
+        // time_off datetime
+        assert_eq!(r.take(8).unwrap(), &off.julian_day.to_be_bytes());
+        assert_eq!(r.u32().unwrap(), off.ms_of_day);
+        assert_eq!(r.u8().unwrap(), 1); // UTC spec
+        assert_eq!(r.string().unwrap(), "K1ABC");
+        assert_eq!(r.string().unwrap(), "FN42");
+        assert_eq!(r.take(8).unwrap(), &14_075_500u64.to_be_bytes());
+        assert_eq!(r.string().unwrap(), "FT8");
+        assert_eq!(r.string().unwrap(), "-07");
+        assert_eq!(r.string().unwrap(), "-12");
+        // tx_power, comments, name
+        assert_eq!(r.string().unwrap(), "");
+        assert_eq!(r.string().unwrap(), "");
+        assert_eq!(r.string().unwrap(), "");
+        // time_on datetime
+        assert_eq!(r.take(8).unwrap(), &on.julian_day.to_be_bytes());
+        assert_eq!(r.u32().unwrap(), on.ms_of_day);
+        assert_eq!(r.u8().unwrap(), 1);
+        assert_eq!(r.string().unwrap(), "K0XYZ"); // operator
+        assert_eq!(r.string().unwrap(), "K0XYZ"); // my_call
+        assert_eq!(r.string().unwrap(), "EN37"); // my_grid
+        assert_eq!(r.string().unwrap(), ""); // exch sent
+        assert_eq!(r.string().unwrap(), ""); // exch recv
+        assert_eq!(r.string().unwrap(), ""); // prop mode
+        assert_eq!(r.pos, d.len());
+    }
+
+    #[test]
+    fn logged_adif_wraps_string() {
+        let d = logged_adif("<call:5>K1ABC <eor>");
+        let (t, mut r) = read_header(&d);
+        assert_eq!(t, T_LOGGED_ADIF);
+        assert_eq!(r.string().unwrap(), "<call:5>K1ABC <eor>");
+        assert_eq!(r.pos, d.len());
+    }
+
+    // --- julian day / time-of-day golden values ------------------------------
+
+    #[test]
+    fn julian_day_matches_known_values() {
+        // 2000-01-01 has Julian Day Number 2451545 (the J2000 epoch date).
+        assert_eq!(julian_day_from_yyyymmdd("20000101"), Some(2_451_545));
+        // 1970-01-01 (Unix epoch) = JDN 2440588.
+        assert_eq!(julian_day_from_yyyymmdd("19700101"), Some(2_440_588));
+        assert_eq!(julian_day_from_yyyymmdd("bad"), None);
+        assert_eq!(julian_day_from_yyyymmdd("20261301"), None); // month 13
+    }
+
+    #[test]
+    fn ms_of_day_from_time() {
+        assert_eq!(ms_of_day_from_hhmmss("000000"), Some(0));
+        assert_eq!(ms_of_day_from_hhmmss("134615"), Some(49_575_000));
+        assert_eq!(ms_of_day_from_hhmmss("235959"), Some(86_399_000));
+        assert_eq!(ms_of_day_from_hhmmss("240000"), None);
+        assert_eq!(ms_of_day_from_hhmmss("12345"), None);
+    }
+
+    // --- inbound parsing -----------------------------------------------------
+
+    // Build an inbound Reply datagram for a given message line.
+    fn make_reply(message: &str, snr: i32) -> Vec<u8> {
+        let mut w = begin(T_REPLY);
+        w.u32(47_000_000); // time
+        w.i32(snr);
+        w.f64(0.1); // dt
+        w.u32(1500); // df
+        w.string("FT8"); // mode
+        w.string(message);
+        w.bool(false); // low confidence
+        w.u8(0); // modifiers
+        w.buf
+    }
+
+    #[test]
+    fn parse_reply_plain_cq() {
+        let d = make_reply("CQ K1ABC FN42", -3);
+        assert_eq!(
+            parse_inbound(&d),
+            Some(Inbound::Reply { call: "K1ABC".into(), grid: "FN42".into(), snr: -3 })
+        );
+    }
+
+    #[test]
+    fn parse_reply_cq_with_directive() {
+        assert_eq!(
+            parse_inbound(&make_reply("CQ DX K1ABC FN42", -3)),
+            Some(Inbound::Reply { call: "K1ABC".into(), grid: "FN42".into(), snr: -3 })
+        );
+        assert_eq!(
+            parse_inbound(&make_reply("CQ POTA W1AW/4 EM70", 5)),
+            Some(Inbound::Reply { call: "W1AW/4".into(), grid: "EM70".into(), snr: 5 })
+        );
+    }
+
+    #[test]
+    fn parse_reply_non_cq_calls_sender() {
+        // Double-click a station mid-QSO: we call the FROM (sender) station.
+        assert_eq!(
+            parse_inbound(&make_reply("K0XYZ K1ABC -12", -12)),
+            Some(Inbound::Reply { call: "K1ABC".into(), grid: "".into(), snr: -12 })
+        );
+    }
+
+    #[test]
+    fn parse_halt_and_freetext_and_replay() {
+        let mut w = begin(T_HALT_TX);
+        w.bool(true);
+        assert_eq!(parse_inbound(&w.buf), Some(Inbound::HaltTx { auto_only: true }));
+
+        let mut w = begin(T_FREE_TEXT);
+        w.string("TEST DE FT8AF");
+        w.bool(true);
+        assert_eq!(
+            parse_inbound(&w.buf),
+            Some(Inbound::FreeText { text: "TEST DE FT8AF".into(), send: true })
+        );
+
+        assert_eq!(parse_inbound(&begin(T_REPLAY).buf), Some(Inbound::Replay));
+    }
+
+    #[test]
+    fn parse_rejects_bad_and_outbound_only() {
+        // Wrong magic.
+        assert_eq!(parse_inbound(&[0, 1, 2, 3, 4, 5, 6, 7]), None);
+        // Truncated (magic only).
+        assert_eq!(parse_inbound(&MAGIC.to_be_bytes()), None);
+        // A Status message is outbound-only; we don't act on it.
+        assert_eq!(parse_inbound(&begin(T_STATUS).buf), None);
+    }
+
+    #[test]
+    fn parse_reply_short_buffer_is_none() {
+        // Reply header but truncated before the message field.
+        let mut w = begin(T_REPLY);
+        w.u32(1); // time only
+        assert_eq!(parse_inbound(&w.buf), None);
+    }
+}

--- a/desktop/src-tauri/src/udp/codec.rs
+++ b/desktop/src-tauri/src/udp/codec.rs
@@ -198,8 +198,9 @@ pub fn decode(d: &Decode) -> Vec<u8> {
     w.buf
 }
 
-/// Type 3 (outbound form). Tells companion apps to wipe their decode band —
-/// sent at the start of each cycle so their view tracks ours.
+/// Type 3 (outbound form). Tells companion apps to wipe their decode band. The
+/// engine sends this on a genuine decode reset — stopping decode and changing
+/// band/context — not once per cycle, to avoid churning companions' views.
 pub fn clear() -> Vec<u8> {
     begin(T_CLEAR).buf
 }
@@ -368,7 +369,10 @@ pub fn parse_inbound(buf: &[u8]) -> Option<Inbound> {
         }
         T_FREE_TEXT => {
             let text = r.string()?;
-            let send = r.bool().unwrap_or(true);
+            // Reject a truncated packet rather than defaulting the send flag to true: a
+            // malformed datagram must never trigger an unintended transmit when "Accept
+            // UDP requests" is enabled.
+            let send = r.bool()?;
             Some(Inbound::FreeText { text, send })
         }
         _ => None,
@@ -733,6 +737,17 @@ mod tests {
         );
 
         assert_eq!(parse_inbound(&begin(T_REPLAY).buf), Some(Inbound::Replay));
+    }
+
+    #[test]
+    fn parse_freetext_missing_send_flag_is_rejected() {
+        // A truncated Free-Text datagram (text present, send bool missing) must be
+        // rejected rather than defaulting send=true — otherwise a malformed packet could
+        // trigger an unintended transmit when "Accept UDP requests" is enabled.
+        let mut w = begin(T_FREE_TEXT);
+        w.string("HELLO");
+        // no w.bool(...) — the trailing send flag is missing
+        assert_eq!(parse_inbound(&w.buf), None);
     }
 
     #[test]

--- a/desktop/src-tauri/src/udp/mod.rs
+++ b/desktop/src-tauri/src/udp/mod.rs
@@ -9,7 +9,7 @@
 
 pub mod codec;
 
-use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs, UdpSocket};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
@@ -120,13 +120,26 @@ impl UdpService {
             return Ok("WSJT-X UDP off".into());
         }
 
+        // Reject a zero port: it can never deliver, but would otherwise leave the service
+        // "enabled" (sock bound to an ephemeral port) yet silently dropping every send.
+        if cfg.port == 0 {
+            return Err("WSJT-X UDP port must be non-zero".into());
+        }
+
         let target = (cfg.host.as_str(), cfg.port)
             .to_socket_addrs()
             .map_err(|e| format!("bad UDP host '{}': {e}", cfg.host))?
             .next()
             .ok_or_else(|| format!("could not resolve UDP host '{}'", cfg.host))?;
 
-        let sock = UdpSocket::bind("0.0.0.0:0").map_err(|e| format!("UDP bind failed: {e}"))?;
+        // Bind the same address family as the resolved target. A dual-stack name like
+        // "localhost" can resolve to IPv6 (::1) first, and an IPv4-only 0.0.0.0 socket
+        // can't send to an IPv6 destination — send_to would fail at runtime.
+        let bind_addr: SocketAddr = match target {
+            SocketAddr::V4(_) => (Ipv4Addr::UNSPECIFIED, 0).into(),
+            SocketAddr::V6(_) => (Ipv6Addr::UNSPECIFIED, 0).into(),
+        };
+        let sock = UdpSocket::bind(bind_addr).map_err(|e| format!("UDP bind failed: {e}"))?;
         // Allow a broadcast destination (e.g. x.x.x.255); harmless otherwise.
         let _ = sock.set_broadcast(true);
         // For a multicast target, join the group so replies on it reach us.
@@ -309,6 +322,24 @@ mod tests {
     }
 
     #[test]
+    fn apply_enabled_zero_port_is_rejected_and_disabled() {
+        // Port 0 can never deliver; apply() must error and leave the service disabled
+        // rather than binding an ephemeral port that silently drops every send.
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut svc = UdpService::new(tx);
+        let err = svc
+            .apply(UdpConfig {
+                enabled: true,
+                host: "127.0.0.1".into(),
+                port: 0,
+                accept_requests: false,
+            })
+            .unwrap_err();
+        assert!(err.contains("non-zero"));
+        assert!(!svc.is_enabled());
+    }
+
+    #[test]
     fn apply_enabled_binds_and_sends_to_loopback() {
         // Bind a real receiver on an OS-assigned port, point the service at it,
         // and confirm a datagram arrives — exercises the full bind+send path.
@@ -344,7 +375,9 @@ mod tests {
         svc.apply(UdpConfig {
             enabled: true,
             host: "127.0.0.1".into(),
-            port: 0, // send target unused here; we drive the listener directly
+            // Any valid non-zero target; the socket still binds an ephemeral local port and
+            // we drive the listener directly via local_addr() below, so the target is unused.
+            port: 2237,
             accept_requests: true,
         })
         .unwrap();

--- a/desktop/src-tauri/src/udp/mod.rs
+++ b/desktop/src-tauri/src/udp/mod.rs
@@ -1,0 +1,409 @@
+//! WSJT-X UDP transport: owns the socket, sends outbound datagrams built by
+//! [`codec`], and (when "accept requests" is on) runs a background listener that
+//! turns inbound requests into [`EngineCommand`]s.
+//!
+//! All state changes triggered by inbound datagrams are funnelled back through
+//! the engine's command channel and handled on the engine thread, so the QSO
+//! state machine is never touched from the listener thread — no locking, same
+//! ordering guarantees as an operator clicking in the UI.
+
+pub mod codec;
+
+use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs, UdpSocket};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::{AnswerArgs, EngineCommand};
+
+/// How many recent decodes to retain for an inbound Replay request. Roughly a
+/// few band-sessions of traffic; bounded so a long run can't grow unboundedly.
+const REPLAY_CACHE_CAP: usize = 1000;
+
+/// User-facing UDP settings (persisted as `udp_*` config keys, edited in the
+/// desktop Settings screen). Mirrors WSJT-X's Reporting → UDP options.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UdpConfig {
+    /// Master on/off for the whole feature.
+    pub enabled: bool,
+    /// Destination address for outbound datagrams (unicast, broadcast, or an
+    /// IPv4 multicast group). WSJT-X default is loopback.
+    pub host: String,
+    /// Destination port. WSJT-X default is 2237.
+    pub port: u16,
+    /// Bind a listener and act on inbound Reply/Halt/Free-Text/Replay requests.
+    pub accept_requests: bool,
+}
+
+impl Default for UdpConfig {
+    fn default() -> Self {
+        UdpConfig {
+            enabled: false,
+            host: "127.0.0.1".to_string(),
+            port: 2237,
+            accept_requests: false,
+        }
+    }
+}
+
+/// Owns the send socket + listener lifecycle. Held by the engine on its thread.
+pub struct UdpService {
+    cfg: UdpConfig,
+    /// Sender for outbound datagrams. `None` when disabled or a bind failed.
+    sock: Option<UdpSocket>,
+    target: Option<SocketAddr>,
+    listener: Option<Listener>,
+    /// Cloned to hand each spawned listener so inbound requests reach the engine.
+    cmd_tx: Sender<EngineCommand>,
+    /// This session's decodes, for the Replay request.
+    replay_cache: Vec<codec::Decode>,
+}
+
+struct Listener {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for Listener {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        // The recv loop uses a read timeout, so it observes the flag promptly.
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl UdpService {
+    /// Create in the disabled state. Call [`apply`](Self::apply) with the
+    /// persisted config to actually bind.
+    pub fn new(cmd_tx: Sender<EngineCommand>) -> Self {
+        UdpService {
+            cfg: UdpConfig { enabled: false, ..UdpConfig::default() },
+            sock: None,
+            target: None,
+            listener: None,
+            cmd_tx,
+            replay_cache: Vec::new(),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.cfg.enabled && self.sock.is_some()
+    }
+
+    pub fn config(&self) -> &UdpConfig {
+        &self.cfg
+    }
+
+    /// The local address the send/receive socket is bound to, if enabled. Lets
+    /// callers (and tests) learn the ephemeral port companion apps reply to.
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.sock.as_ref().and_then(|s| s.local_addr().ok())
+    }
+
+    /// Reconfigure to `cfg`: tears down any existing socket/listener and rebinds
+    /// as needed. Returns `Ok(human summary)` for the status line, or `Err` if
+    /// binding failed (the service ends up disabled).
+    pub fn apply(&mut self, cfg: UdpConfig) -> Result<String, String> {
+        // Always drop the old listener + socket first (Listener::drop joins).
+        self.listener = None;
+        self.sock = None;
+        self.target = None;
+        self.cfg = cfg.clone();
+
+        if !cfg.enabled {
+            return Ok("WSJT-X UDP off".into());
+        }
+
+        let target = (cfg.host.as_str(), cfg.port)
+            .to_socket_addrs()
+            .map_err(|e| format!("bad UDP host '{}': {e}", cfg.host))?
+            .next()
+            .ok_or_else(|| format!("could not resolve UDP host '{}'", cfg.host))?;
+
+        let sock = UdpSocket::bind("0.0.0.0:0").map_err(|e| format!("UDP bind failed: {e}"))?;
+        // Allow a broadcast destination (e.g. x.x.x.255); harmless otherwise.
+        let _ = sock.set_broadcast(true);
+        // For a multicast target, join the group so replies on it reach us.
+        if let SocketAddr::V4(v4) = target {
+            if v4.ip().is_multicast() {
+                let _ = sock.join_multicast_v4(v4.ip(), &Ipv4Addr::UNSPECIFIED);
+            }
+        }
+
+        if cfg.accept_requests {
+            self.listener = Some(spawn_listener(&sock, self.cmd_tx.clone())?);
+        }
+
+        self.sock = Some(sock);
+        self.target = Some(target);
+        let listening = if cfg.accept_requests { " (accepting requests)" } else { "" };
+        Ok(format!("WSJT-X UDP → {}:{}{listening}", cfg.host, cfg.port))
+    }
+
+    /// Send a pre-built datagram to the configured target. No-op when disabled;
+    /// send errors are swallowed (UDP is best-effort and a dropped spot must not
+    /// disturb the engine loop).
+    pub fn send(&self, datagram: &[u8]) {
+        if let (Some(sock), Some(target)) = (&self.sock, &self.target) {
+            let _ = sock.send_to(datagram, target);
+        }
+    }
+
+    /// Send a decode (caching it for Replay). Cheap no-op when disabled.
+    pub fn send_decode(&mut self, d: codec::Decode) {
+        if !self.is_enabled() {
+            return;
+        }
+        self.send(&codec::decode(&d));
+        if self.replay_cache.len() >= REPLAY_CACHE_CAP {
+            self.replay_cache.remove(0);
+        }
+        self.replay_cache.push(d);
+    }
+
+    /// Re-broadcast this session's cached decodes (marked not-new), answering an
+    /// inbound Replay request.
+    pub fn replay(&self) {
+        if !self.is_enabled() {
+            return;
+        }
+        for d in &self.replay_cache {
+            let mut d = d.clone();
+            d.is_new = false;
+            self.send(&codec::decode(&d));
+        }
+    }
+
+    /// Clear the replay cache (call at band change / decode clear).
+    pub fn clear_replay_cache(&mut self) {
+        self.replay_cache.clear();
+    }
+}
+
+/// Spawn the inbound listener: a blocking `recv_from` loop (short read timeout so
+/// it notices the stop flag) that parses requests and forwards them as commands.
+fn spawn_listener(sock: &UdpSocket, cmd_tx: Sender<EngineCommand>) -> Result<Listener, String> {
+    let rx = sock
+        .try_clone()
+        .map_err(|e| format!("UDP listener clone failed: {e}"))?;
+    rx.set_read_timeout(Some(Duration::from_millis(500)))
+        .map_err(|e| format!("UDP listener timeout failed: {e}"))?;
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_thread = stop.clone();
+    let handle = std::thread::Builder::new()
+        .name("ft8af-udp-rx".into())
+        .spawn(move || {
+            let mut buf = [0u8; 2048];
+            while !stop_thread.load(Ordering::Relaxed) {
+                match rx.recv_from(&mut buf) {
+                    Ok((n, _src)) => {
+                        if let Some(cmd) = to_command(&buf[..n]) {
+                            if cmd_tx.send(cmd).is_err() {
+                                return; // engine gone
+                            }
+                        }
+                    }
+                    // Timeout (WouldBlock/TimedOut) — loop to re-check the flag.
+                    Err(ref e)
+                        if e.kind() == std::io::ErrorKind::WouldBlock
+                            || e.kind() == std::io::ErrorKind::TimedOut => {}
+                    Err(_) => return, // socket closed / fatal
+                }
+            }
+        })
+        .map_err(|e| format!("spawn UDP listener failed: {e}"))?;
+    Ok(Listener { stop, handle: Some(handle) })
+}
+
+/// Translate a parsed inbound request into an engine command, reusing the
+/// existing operator-facing commands. `None` for requests we ignore.
+fn to_command(buf: &[u8]) -> Option<EngineCommand> {
+    match codec::parse_inbound(buf)? {
+        codec::Inbound::Reply { call, grid, snr } => {
+            Some(EngineCommand::Answer(AnswerArgs { call_from: call, grid, snr }))
+        }
+        // We only support a global halt; `auto_only` doesn't map to a separate
+        // manual-TX path here, so any halt request stops TX.
+        codec::Inbound::HaltTx { .. } => Some(EngineCommand::StopTx),
+        // Load-without-send has no engine path (FreeText transmits), so only act
+        // when the request asks to send.
+        codec::Inbound::FreeText { text, send } if send => Some(EngineCommand::FreeText(text)),
+        codec::Inbound::FreeText { .. } => None,
+        codec::Inbound::Replay => Some(EngineCommand::UdpReplay),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_matches_wsjtx() {
+        let c = UdpConfig::default();
+        assert_eq!(c.host, "127.0.0.1");
+        assert_eq!(c.port, 2237);
+        assert!(!c.enabled);
+        assert!(!c.accept_requests);
+    }
+
+    fn reply_datagram(msg: &str) -> Vec<u8> {
+        // Mirror codec's inbound Reply layout via a tiny hand-built buffer.
+        let mut b = Vec::new();
+        b.extend_from_slice(&codec::MAGIC.to_be_bytes());
+        b.extend_from_slice(&codec::SCHEMA.to_be_bytes());
+        b.extend_from_slice(&codec::T_REPLY.to_be_bytes());
+        b.extend_from_slice(&(codec::CLIENT_ID.len() as u32).to_be_bytes());
+        b.extend_from_slice(codec::CLIENT_ID.as_bytes());
+        b.extend_from_slice(&0u32.to_be_bytes()); // time
+        b.extend_from_slice(&(-3i32).to_be_bytes()); // snr
+        b.extend_from_slice(&0.1f64.to_be_bytes()); // dt
+        b.extend_from_slice(&1500u32.to_be_bytes()); // df
+        b.extend_from_slice(&3u32.to_be_bytes()); // mode len
+        b.extend_from_slice(b"FT8");
+        b.extend_from_slice(&(msg.len() as u32).to_be_bytes());
+        b.extend_from_slice(msg.as_bytes());
+        b.push(0); // low confidence
+        b
+    }
+
+    #[test]
+    fn reply_maps_to_answer_command() {
+        let cmd = to_command(&reply_datagram("CQ K1ABC FN42")).unwrap();
+        match cmd {
+            EngineCommand::Answer(a) => {
+                assert_eq!(a.call_from, "K1ABC");
+                assert_eq!(a.grid, "FN42");
+                assert_eq!(a.snr, -3);
+            }
+            other => panic!("expected Answer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unparseable_datagram_yields_no_command() {
+        assert!(to_command(&[0xDE, 0xAD, 0xBE, 0xEF]).is_none());
+    }
+
+    #[test]
+    fn disabled_service_send_is_noop() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let svc = UdpService::new(tx);
+        // No socket bound: send must not panic.
+        svc.send(b"anything");
+        assert!(!svc.is_enabled());
+    }
+
+    #[test]
+    fn apply_disabled_config_ok() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut svc = UdpService::new(tx);
+        let msg = svc.apply(UdpConfig::default()).unwrap();
+        assert!(msg.contains("off"));
+        assert!(!svc.is_enabled());
+    }
+
+    #[test]
+    fn apply_enabled_binds_and_sends_to_loopback() {
+        // Bind a real receiver on an OS-assigned port, point the service at it,
+        // and confirm a datagram arrives — exercises the full bind+send path.
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        receiver.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+        let port = receiver.local_addr().unwrap().port();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut svc = UdpService::new(tx);
+        svc.apply(UdpConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            port,
+            accept_requests: false,
+        })
+        .unwrap();
+        assert!(svc.is_enabled());
+
+        svc.send(&codec::clear());
+        let mut buf = [0u8; 64];
+        let (n, _src) = receiver.recv_from(&mut buf).expect("datagram should arrive");
+        assert_eq!(&buf[..4], &codec::MAGIC.to_be_bytes());
+        assert!(n >= 16);
+    }
+
+    #[test]
+    fn listener_delivers_inbound_reply_as_command() {
+        // Full inbound path: bind with accept_requests, fire a Reply datagram at
+        // the bound port from a throwaway socket, and confirm the listener thread
+        // turns it into an Answer command on the engine channel.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut svc = UdpService::new(tx);
+        svc.apply(UdpConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            port: 0, // send target unused here; we drive the listener directly
+            accept_requests: true,
+        })
+        .unwrap();
+        // The socket binds 0.0.0.0:<port>; target loopback with that port.
+        let port = svc.local_addr().expect("bound").port();
+        let dest = SocketAddr::from(([127, 0, 0, 1], port));
+
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        sender.send_to(&reply_datagram("CQ K1ABC FN42"), dest).unwrap();
+
+        let cmd = rx.recv_timeout(Duration::from_secs(2)).expect("command should arrive");
+        match cmd {
+            EngineCommand::Answer(a) => {
+                assert_eq!(a.call_from, "K1ABC");
+                assert_eq!(a.grid, "FN42");
+            }
+            other => panic!("expected Answer, got {other:?}"),
+        }
+        // Dropping the service joins the listener thread cleanly.
+        drop(svc);
+    }
+
+    #[test]
+    fn replay_resends_cached_decodes_as_not_new() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        receiver.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+        let port = receiver.local_addr().unwrap().port();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut svc = UdpService::new(tx);
+        svc.apply(UdpConfig { enabled: true, host: "127.0.0.1".into(), port, accept_requests: false })
+            .unwrap();
+
+        let d = codec::Decode {
+            is_new: true,
+            time_ms: 0,
+            snr: -5,
+            delta_time: 0.0,
+            delta_freq: 1500,
+            mode: "FT8".into(),
+            message: "CQ K1ABC FN42".into(),
+            low_confidence: false,
+            off_air: false,
+        };
+        svc.send_decode(d);
+        let mut buf = [0u8; 256];
+        let (n1, _) = receiver.recv_from(&mut buf).unwrap(); // the live decode
+        let live = buf[..n1].to_vec();
+
+        svc.replay();
+        let (n2, _) = receiver.recv_from(&mut buf).unwrap(); // the replayed copy
+        let replayed = &buf[..n2];
+
+        // Same length; only the is_new flag (first payload byte after the id)
+        // differs — true in the live copy, false in the replay.
+        assert_eq!(live.len(), replayed.len());
+        // is_new sits at offset 12 (magic4+schema4+type4) + 4 (id len) + 5 ("FT8AF").
+        let flag_off = 12 + 4 + codec::CLIENT_ID.len();
+        assert_eq!(live[flag_off], 1);
+        assert_eq!(replayed[flag_off], 0);
+    }
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -991,11 +991,19 @@ function SettingsScreen(props: {
 
   // Push UDP settings to the backend (which persists + rebinds live).
   function applyUdp(next: UdpConfig) {
-    setUdp(next);
-    api.setUdpConfig(next);
+    // Normalize before persisting. The port input uses parseInt(...) || 0, so clearing the
+    // field yields 0 (NaN/out-of-range are possible too); fall back to the default 2237 so
+    // we never persist a port the backend rejects or that can't deliver. Default an empty
+    // host to loopback. Write the corrected config back to state so the field reflects it.
+    const port =
+      Number.isFinite(next.port) && next.port > 0 && next.port <= 65535 ? next.port : 2237;
+    const host = next.host.trim().length > 0 ? next.host.trim() : "127.0.0.1";
+    const cfg: UdpConfig = { ...next, host, port };
+    setUdp(cfg);
+    api.setUdpConfig(cfg);
     onStatus(
-      next.enabled
-        ? `WSJT-X UDP → ${next.host}:${next.port}${next.accept_requests ? " (accepting requests)" : ""}`
+      cfg.enabled
+        ? `WSJT-X UDP → ${cfg.host}:${cfg.port}${cfg.accept_requests ? " (accepting requests)" : ""}`
         : "WSJT-X UDP off",
     );
   }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -15,6 +15,7 @@ import {
   type SerialPortInfo,
   type TxStage,
   type TxStateEvent,
+  type UdpConfig,
   type UiMessage,
   type WaterfallConfig,
   type WfWindow,
@@ -898,6 +899,14 @@ function SettingsScreen(props: {
     fft_size: 2048,
     avg: 6,
   });
+  // WSJT-X UDP interface (outbound broadcast + inbound requests). Defaults match
+  // WSJT-X: disabled, 127.0.0.1:2237. Rust persists the udp_* keys.
+  const [udp, setUdp] = useState<UdpConfig>({
+    enabled: false,
+    host: "127.0.0.1",
+    port: 2237,
+    accept_requests: false,
+  });
   const [rigCfg, setRigCfg] = useState<RigConfig>({
     backend: "none",
     port: "",
@@ -959,6 +968,36 @@ function SettingsScreen(props: {
   function applyWfCfg(next: WaterfallConfig) {
     setWfCfg(next);
     api.setWaterfallConfig(next);
+  }
+
+  // Load the persisted WSJT-X UDP settings on mount (only the exact string
+  // "true" enables a flag, so a missing/garbage value stays off).
+  useEffect(() => {
+    Promise.all([
+      api.getConfig("udp_enabled"),
+      api.getConfig("udp_host"),
+      api.getConfig("udp_port"),
+      api.getConfig("udp_accept_requests"),
+    ]).then(([en, host, port, accept]) => {
+      const p = parseInt(port ?? "", 10);
+      setUdp((prev) => ({
+        enabled: en === "true",
+        host: host && host.length > 0 ? host : prev.host,
+        port: Number.isFinite(p) && p > 0 && p <= 65535 ? p : prev.port,
+        accept_requests: accept === "true",
+      }));
+    });
+  }, []);
+
+  // Push UDP settings to the backend (which persists + rebinds live).
+  function applyUdp(next: UdpConfig) {
+    setUdp(next);
+    api.setUdpConfig(next);
+    onStatus(
+      next.enabled
+        ? `WSJT-X UDP → ${next.host}:${next.port}${next.accept_requests ? " (accepting requests)" : ""}`
+        : "WSJT-X UDP off",
+    );
   }
 
   const refreshPorts = () => api.listSerialPorts().then(setPorts);
@@ -1352,6 +1391,64 @@ function SettingsScreen(props: {
                 </option>
               ))}
             </select>
+          </div>
+        </div>
+      </div>
+
+      <div className="panel">
+        <h3>WSJT-X UDP</h3>
+        <div className="col">
+          <div className="muted">
+            Broadcast decodes, status and logged QSOs over UDP in the WSJT-X
+            protocol so companion apps (GridTracker, JTAlert, N1MM+, Log4OM) can
+            plot and log them. Default target 127.0.0.1:2237.
+          </div>
+          <div className="field">
+            <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <input
+                type="checkbox"
+                checked={udp.enabled}
+                onChange={(e) => applyUdp({ ...udp, enabled: e.target.checked })}
+                style={{ width: "auto" }}
+              />
+              Enable UDP broadcast
+            </label>
+          </div>
+          <div className="field">
+            <label>Server address (host)</label>
+            <input
+              type="text"
+              value={udp.host}
+              disabled={!udp.enabled}
+              onChange={(e) => setUdp({ ...udp, host: e.target.value })}
+              onBlur={() => applyUdp(udp)}
+              placeholder="127.0.0.1"
+            />
+          </div>
+          <div className="field">
+            <label>Server port</label>
+            <input
+              type="number"
+              min={1}
+              max={65535}
+              value={udp.port}
+              disabled={!udp.enabled}
+              onChange={(e) => setUdp({ ...udp, port: parseInt(e.target.value, 10) || 0 })}
+              onBlur={() => applyUdp(udp)}
+              placeholder="2237"
+            />
+          </div>
+          <div className="field">
+            <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <input
+                type="checkbox"
+                checked={udp.accept_requests}
+                disabled={!udp.enabled}
+                onChange={(e) => applyUdp({ ...udp, accept_requests: e.target.checked })}
+                style={{ width: "auto" }}
+              />
+              Accept UDP requests (let companion apps reply/halt/free-text)
+            </label>
           </div>
         </div>
       </div>

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -219,4 +219,16 @@ export const api = {
   /** Apply + persist live-waterfall FFT parameters (Rust side persists). */
   setWaterfallConfig: (config: WaterfallConfig) =>
     invoke("set_waterfall_config", { config }),
+
+  /** Apply + persist WSJT-X UDP settings (Rust side persists the udp_* keys and
+   * rebinds the socket/listener live). */
+  setUdpConfig: (config: UdpConfig) => invoke("set_udp_config", { config }),
+};
+
+/** WSJT-X UDP settings. Field names match the Rust `UdpConfig` (snake_case). */
+export type UdpConfig = {
+  enabled: boolean;
+  host: string;
+  port: number;
+  accept_requests: boolean;
 };

--- a/docs/wsjtx-udp.md
+++ b/docs/wsjtx-udp.md
@@ -1,0 +1,123 @@
+# WSJT-X UDP interface
+
+FT8AF speaks the [WSJT-X UDP message
+protocol](https://sourceforge.net/p/wsjt/wsjtx/ci/master/tree/Network/NetworkMessage.hpp)
+so it interoperates with the wider desktop ecosystem — GridTracker, JTAlert,
+N1MM+, Log4OM, PSKReporter proxies, etc. It **broadcasts** decodes, status and
+logged QSOs, and (when enabled) **accepts** a few request messages so those apps
+can drive it.
+
+This document is the shared, language-agnostic spec: the desktop (Rust), Android
+(Kotlin) and iOS (Swift) builds each implement the same wire format and are
+pinned to the same golden vectors below, so all three encoders are byte-for-byte
+identical.
+
+## Settings
+
+Off by default. Configure under **Settings → WSJT-X UDP**:
+
+| Setting | Default | Meaning |
+|---|---|---|
+| Enable UDP broadcast | off | Master on/off. |
+| Server address | `127.0.0.1` | Destination host — unicast, broadcast (`x.x.x.255`), or an IPv4 multicast group. |
+| Server port | `2237` | Destination port (WSJT-X default). |
+| Accept UDP requests | off | Bind a listener and act on inbound Reply/Halt/Free-Text/Replay. |
+
+The app sends from an ephemeral local port; companion apps learn our address
+from the periodic **Heartbeat** and reply to that source, exactly as they do for
+a real WSJT-X instance.
+
+## Wire format
+
+Bespoke big-endian Qt-`QDataStream` framing (not JSON). Primitives, all
+big-endian:
+
+- `u32` / `u64` / `i32` / `i64` / `f64`
+- `bool` — 1 byte (`00`/`01`)
+- **string** — `u32` byte length (`0xFFFFFFFF` = null), then that many UTF-8
+  bytes. Empty string = length `0`.
+- **datetime** (UTC form) — `i64` Julian Day Number, `u32` ms-since-midnight,
+  `u8` = `1` (Qt UTC timespec).
+
+Every datagram starts with a header:
+
+```
+u32  magic   = 0xADBCCBDA
+u32  schema  = 3
+u32  type
+str  id      = "FT8AF"        (client id; distinguishes us from real WSJT-X)
+```
+
+…followed by type-specific fields.
+
+### Outbound (FT8AF → companion apps)
+
+| # | Name | Fields after header |
+|---|------|---------------------|
+| 0 | Heartbeat | `u32` max-schema=3, `str` version, `str` revision |
+| 1 | Status | `u64` dial-Hz, `str` mode, `str` dx-call, `str` report, `str` tx-mode, `bool` tx-enabled, `bool` transmitting, `bool` decoding, `u32` rx-df, `u32` tx-df, `str` de-call, `str` de-grid, `str` dx-grid, `bool` tx-watchdog, `str` sub-mode, `bool` fast-mode, `u8` special-op, `u32` freq-tol, `u32` tr-period, `str` config-name, `str` tx-message |
+| 2 | Decode | `bool` new, `u32` time-ms-of-day, `i32` snr, `f64` dt-sec, `u32` df-Hz (audio offset), `str` mode, `str` message, `bool` low-conf, `bool` off-air |
+| 3 | Clear | (header only) |
+| 5 | QSO Logged | `datetime` time-off, `str` dx-call, `str` dx-grid, `u64` tx-Hz, `str` mode, `str` rpt-sent, `str` rpt-rcvd, `str` tx-power, `str` comments, `str` name, `datetime` time-on, `str` op-call, `str` my-call, `str` my-grid, `str` exch-sent, `str` exch-rcvd, `str` prop-mode |
+| 12 | Logged ADIF | `str` ADIF record |
+
+Cadence: **Status** every ~1 s and on every TX/QSO state change; **Heartbeat**
+every ~15 s; **Decode** per decoded message; **Clear** on decode-stop / band
+change (a genuine reset, *not* every cycle); **QSO Logged** + **Logged ADIF** on
+each logged QSO.
+
+### Inbound (companion apps → FT8AF, when "Accept UDP requests" is on)
+
+| # | Name | Fields after header | Action |
+|---|------|---------------------|--------|
+| 4 | Reply | `u32` time, `i32` snr, `f64` dt, `u32` df, `str` mode, `str` message, `bool` low-conf, `u8` modifiers | Call the station named in `message` (auto-sequence). |
+| 7 | Replay | — | Re-broadcast this session's decodes (marked not-new). |
+| 8 | Halt Tx | `bool` auto-only | Stop transmitting. |
+| 9 | Free Text | `str` text, `bool` send | Send `text` (only acted on when `send` = true). |
+
+The station to call from a **Reply** is parsed from the message line: `TO FROM
+…`, or a CQ line with an optional directive (`CQ FROM GRID`, `CQ DX FROM GRID`,
+`CQ POTA FROM GRID`) → the first callsign-shaped token, with the grid taken from
+the first following 4-char Maidenhead square. Any other/unknown message type is
+ignored; malformed or truncated datagrams are dropped without effect.
+
+## Golden vectors
+
+Byte-exact reference datagrams (hex). The Rust codec's unit tests in
+`desktop/src-tauri/src/udp/codec.rs` are the authoritative fixtures; the Android
+and iOS ports transcribe the same field values and assert the same bytes.
+
+**Header only — Clear (type 3):**
+
+```
+ad bc cb da  00 00 00 03  00 00 00 03  00 00 00 05  46 54 38 41 46
+└─ magic ──┘  └ schema 3┘  └─ type 3 ┘  └ id len 5┘  └── "FT8AF" ──┘
+```
+
+**Heartbeat (type 0)** — version `"0.1.0"`, revision `""`:
+
+```
+ad bc cb da 00 00 00 03 00 00 00 00 00 00 00 05 46 54 38 41 46
+00 00 00 03                      max-schema = 3
+00 00 00 05 30 2e 31 2e 30       version "0.1.0"
+00 00 00 00                      revision ""
+```
+
+**Decode (type 2)** — new=true, time=47493000 ms, snr=-7, dt=0.2, df=1500,
+mode="FT8", message="CQ K1ABC FN42", low-conf=false, off-air=false:
+
+```
+ad bc cb da 00 00 00 03 00 00 00 02 00 00 00 05 46 54 38 41 46
+01                               new = true
+02 d4 af 88                      time = 47493000
+ff ff ff f9                      snr = -7
+3f c9 99 99 99 99 99 9a          dt = 0.2 (f64)
+00 00 05 dc                      df = 1500
+00 00 00 03 46 54 38             mode "FT8"
+00 00 00 0d 43 51 20 4b 31 41 42 43 20 46 4e 34 32   message "CQ K1ABC FN42"
+00 00                            low-conf=false, off-air=false
+```
+
+**datetime** example — `2000-01-01` has Julian Day Number `2451545`; midnight is
+ms-of-day `0`, so a `time_on` of that instant serializes as
+`00 00 00 00 00 25 68 59` (`i64` 2451545) `00 00 00 00` (`u32` 0) `01` (UTC).


### PR DESCRIPTION
## What

Adds a **WSJT-X UDP interface** to the desktop (Tauri) build so FT8AF interoperates with the wider ham-radio desktop ecosystem — GridTracker, JTAlert, N1MM+, Log4OM. Off by default; configured under **Settings → WSJT-X UDP** (enable, host, port, "Accept UDP requests"), defaulting to WSJT-X's `127.0.0.1:2237`.

This is the **first of three per-platform PRs** (desktop → Android → iOS). It also lands the shared, language-agnostic spec + golden vectors (`docs/wsjtx-udp.md`) the Android/iOS ports will transcribe so all three encoders are byte-for-byte identical.

### Outbound (FT8AF → companion apps)
Heartbeat (~15 s), Status (~1 Hz + on every TX/QSO change), Decode (per decode), Clear (on decode-stop / band change — a genuine reset, not per-cycle churn), and QSO Logged + Logged ADIF (per logged QSO).

### Inbound ("Accept UDP requests")
A listener thread maps **Reply** → call the station, **Halt Tx** → stop, **Free Text** → send, **Replay** → re-broadcast this session's decodes. All routed through the existing engine commands, so the QSO state machine is only ever mutated on the engine thread (no locking, same ordering as an operator click).

## How
- New `desktop/src-tauri/src/udp/` module:
  - `codec.rs` — pure, byte-exact encode/decode of the big-endian Qt-DataStream framing, pinned by golden-vector tests.
  - `mod.rs` — `UdpService` owning the send socket + inbound listener, with live reconfigure on settings change (modelled on the existing `timesync` thread + PSKReporter sender pattern).
- Engine taps existing choke points (`handle_decoded`, `publish_tx_state`, the 1 Hz tick, QSO completion); new `SetUdpConfig`/`UdpReplay` engine commands and a `set_udp_config` Tauri command; `udp_*` keys persisted in the SQLite `config` table.
- Reuses `qso::AnswerArgs`/`StopTx`/`FreeText` for inbound and a new `db::adif_record` helper for the Logged-ADIF message.
- Frontend: "WSJT-X UDP" settings section in `App.tsx` + `setUdpConfig` in `ipc.ts`.

## Testing
- **22 new UDP unit tests**: byte-exact encode goldens (header/heartbeat/decode/status/qso-logged/logged-adif), Julian-day/time-of-day goldens, inbound Reply/Halt/FreeText/Replay round-trips, malformed/short-buffer rejection, and **real cross-socket runtime checks** — loopback bind+send and a live inbound-listener thread delivering an `Answer` command.
- Full Rust suite green (77 lib tests + integration/round-trip), frontend `tsc` clean, `cargo build` warning-free.
- Manual acceptance (not automated here): point GridTracker at `127.0.0.1:2237` → decodes plot and logged QSOs appear; double-click a spot → FT8AF starts answering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)