### PR TITLE
Fix iOS FT8 TX buffer sizing that traps at non-integral sample rates

### DIFF
--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Encoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Encoder.swift
@@ -49,12 +49,27 @@ public enum FT8Encoder {
         return a91
     }
 
+    /// Number of audio samples the GFSK synthesis writes for `nTones` tones at
+    /// `sampleRate`: the *per-symbol*-rounded count the C `synth_gfsk` actually
+    /// produces — `nTones * round(sampleRate * symbolPeriod)` — NOT the
+    /// *total*-rounded `round(nTones * symbolPeriod * sampleRate)`. The two agree
+    /// only when `sampleRate * symbolPeriod` is integral (true for the 12 kHz
+    /// default: `12000 * 0.16 = 1920`) and diverge otherwise, so this is the
+    /// single source of truth shared by both the TX buffer allocation in
+    /// `generateFT8` and the length guard in `synthGFSK`. Keeping them in lockstep
+    /// prevents the allocation from underrunning the write count — which tripped
+    /// `synthGFSK`'s `precondition` at non-integral rates (the iOS twin of the
+    /// Android GenerateFT8 fix and desktop `encode.rs::waveform_len`).
+    public static func waveformSampleCount(nTones: Int, sampleRate: Int32) -> Int {
+        let nSpsym = Int(0.5 + Double(sampleRate) * Double(FT8.symbolPeriod))
+        return nTones * nSpsym
+    }
+
     /// Render `tones` as a GFSK waveform into `signal[offset...]`.
     /// Traps (precondition) if `signal` is too short — mirrors the encode.rs assert.
     public static func synthGFSK(tones: [UInt8], f0: Float, sampleRate: Int32,
                                  into signal: inout [Float], offset: Int) {
-        let nSpsym = Int(0.5 + Double(sampleRate) * Double(FT8.symbolPeriod))
-        let nWave = tones.count * nSpsym
+        let nWave = waveformSampleCount(nTones: tones.count, sampleRate: sampleRate)
         // A negative offset would still satisfy the upper-bound check below yet
         // make the C write before signal[0] (OOB); and offset is handed to C as
         // an `int`, so it must fit Int32. The desktop encode.rs sidesteps both by
@@ -80,7 +95,11 @@ public enum FT8Encoder {
                                    sampleRate: Int32 = FT8.sampleRate) -> [Float]? {
         guard let payload = pack77(text) else { return nil }
         let tones = encodeTones(payload)
-        let numSamples = Int(0.5 + Float(FT8.nn) * FT8.symbolPeriod * Float(sampleRate))
+        // Size the buffer with the SAME per-symbol rounding synthGFSK writes, so
+        // it can never underrun the write count (and trip synthGFSK's length
+        // precondition) at a non-integral sample rate. Byte-identical to the old
+        // total-rounded size at the 12 kHz default.
+        let numSamples = waveformSampleCount(nTones: tones.count, sampleRate: sampleRate)
         var signal = [Float](repeating: 0, count: numSamples)
         synthGFSK(tones: tones, f0: baseFreqHz, sampleRate: sampleRate, into: &signal, offset: 0)
         return signal

--- a/ios/FT8AFKit/Tests/FT8DSPTests/FT8EncodeGoldenTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/FT8EncodeGoldenTests.swift
@@ -56,6 +56,40 @@ final class FT8EncodeGoldenTests: XCTestCase {
         XCTAssertTrue(sig.allSatisfy { abs($0) <= 1.0001 }, "amplitude within [-1, 1]")
     }
 
+    /// Regression: the TX buffer must be sized by the SAME per-symbol rounding
+    /// synthGFSK writes, at EVERY sample rate — not the total-rounded
+    /// `round(nn * symbolPeriod * rate)`, which underruns the write count at a
+    /// non-integral rate (e.g. 12004 Hz) and tripped synthGFSK's length
+    /// precondition. iOS twin of the Android GenerateFT8 fix (#521) and desktop
+    /// `encode.rs::waveform_len` (#551).
+    func testGenerateFT8BufferMatchesSynthWriteCountAcrossRates() {
+        // Multiples of 25 (rate*0.16 integral) stay byte-identical; the rest
+        // diverge — 12004/12005 are the cases where the OLD total-rounded size was
+        // SMALLER than the write count (the trap), 12001 where it was larger.
+        for rate: Int32 in [12_000, 48_000, 44_100, 12_001, 12_004, 12_005, 16_003] {
+            let nSpsym = Int(0.5 + Double(rate) * Double(FT8.symbolPeriod))
+            let nWave = FT8.nn * nSpsym
+            XCTAssertEqual(FT8Encoder.waveformSampleCount(nTones: FT8.nn, sampleRate: rate), nWave,
+                           "rate \(rate): helper must equal per-symbol write count")
+            guard let sig = FT8Encoder.generateFT8("CQ K1ABC FN42", baseFreqHz: 1000, sampleRate: rate) else {
+                return XCTFail("generateFT8 nil at rate \(rate)")
+            }
+            // Buffer is exactly the write count → synthGFSK's precondition can't trap.
+            XCTAssertEqual(sig.count, nWave,
+                           "rate \(rate): buffer must equal synthGFSK write count")
+        }
+        // Default (12 kHz) path is unchanged from the historical total-rounded size.
+        let legacy12k = Int(0.5 + Float(FT8.nn) * FT8.symbolPeriod * Float(FT8.sampleRate))
+        XCTAssertEqual(FT8Encoder.waveformSampleCount(nTones: FT8.nn, sampleRate: FT8.sampleRate),
+                       legacy12k, "12 kHz size must match the legacy formula (byte-identical)")
+        // Document the defect the fix removes: at 12004 Hz the OLD total-rounded
+        // size was strictly smaller than what synthGFSK writes.
+        let oldTotalRounded12004 = Int(0.5 + Float(FT8.nn) * FT8.symbolPeriod * Float(12_004))
+        XCTAssertLessThan(oldTotalRounded12004,
+                          FT8Encoder.waveformSampleCount(nTones: FT8.nn, sampleRate: 12_004),
+                          "old total-rounded size underran the write count at 12004 Hz")
+    }
+
     /// synthGFSK honors a non-zero offset: it writes the waveform into
     /// signal[offset...] and leaves the leading region untouched (the offset
     /// code path the engine uses to place a frame later in a buffer).


### PR DESCRIPTION
## Root cause

`FT8Encoder.generateFT8` (iOS `FT8AFKit/Sources/FT8DSP/FT8Encoder.swift`) sized its output buffer with the **total-rounded** count

```swift
let numSamples = Int(0.5 + Float(FT8.nn) * FT8.symbolPeriod * Float(sampleRate))
```

while `synthGFSK` — mirroring the C `synth_gfsk` — writes the **per-symbol** count

```swift
let nSpsym = Int(0.5 + Double(sampleRate) * Double(FT8.symbolPeriod))
let nWave  = tones.count * nSpsym   // NN * round(sampleRate * symbolPeriod)
```

These two roundings are equal **only** when `sampleRate * symbolPeriod` is integral. That holds for the 12 kHz default (`12000 * 0.16 = 1920` exactly), which is why it never fired in the shipped path — but at any rate whose product isn't integral (e.g. **12004 / 12005 Hz**) the allocation is *smaller* than the write count. `synthGFSK`'s own guard then trips:

```
Precondition failed: synthGFSK: signal buffer too short (need 151759 from offset 0, have 151731)
```

→ a hard trap (crash). Under `-Ounchecked` the C `synth_gfsk_offset` would instead write past the end of the Swift array (heap OOB).

This is the **iOS twin** of the exact same Java/native (and Rust/native) sizing divergence already fixed on:
- **Android** — `GenerateFT8` per-symbol `waveformSampleCount` (PR #521)
- **Desktop** — `dsp/encode.rs::waveform_len` single source of truth (PR #551)

iOS was the last un-fixed frontend of this bug family.

## Fix

Mirror the other two ports: extract a single source of truth `waveformSampleCount(nTones:sampleRate:)` returning the per-symbol write count, and use it for **both** the `generateFT8` allocation and the `synthGFSK` length guard, so they can never diverge. **Byte-identical** to the previous size at the 12 kHz default (and every multiple-of-25 rate).

## Reachability / risk

Latent in the shipped app today — both production callers (`LiveEngine.scheduleTx`, demo `RoundTripViewModel`) use the default `sampleRate: Int32 = FT8.sampleRate = 12_000`. This is a correctness/robustness fix (and consistency across the three frontends), not a currently-firing crash — same posture as the accepted desktop #551. Low risk: no behavior change at 12 kHz.

## Testing performed

- Added `FT8EncodeGoldenTests.testGenerateFT8BufferMatchesSynthWriteCountAcrossRates`: asserts the `generateFT8` buffer equals the per-symbol write count at 12000/48000/44100/12001/12004/12005/16003 Hz, that the 12 kHz size matches the legacy formula (byte-identical), and documents that the old total-rounded size underran at 12004.
- Verified the new test **fails on the pre-fix source**: `XCTAssertEqual` mismatch at 12001 (151693 ≠ 151680) and a `synthGFSK` precondition trap (SIGILL) at 12004.
- Full `FT8AFKit` suite green with the fix: **88 tests, 0 failures** (encode golden vectors unchanged → 12 kHz output byte-identical).
- Built + ran `swift test` for the whole package (CFT8/ft8_lib C compiled from source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)