### PR TITLE
WSJT-X UDP interface — Android (broadcast + accept requests)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -43,6 +43,12 @@ public class GeneralVariables {
     public static boolean enableQRZ = false;//Whether QRZ auto-sync is enabled
     public static boolean enablePskReporter = true;//Whether PSKReporter spot upload is enabled
     public static boolean enableAdifExport = true;//Append each logged QSO to a running ft8af_log.adi (real-time ADIF mirror for backup + desktop-logger import)
+    // WSJT-X UDP interface (issue: interop with GridTracker/JTAlert/N1MM/Log4OM).
+    // Off by default; persisted as config keys udp_enabled/udp_host/udp_port/udp_accept_requests.
+    public static boolean udpEnabled = false;//Whether the WSJT-X UDP broadcast is enabled
+    public static String udpHost = "127.0.0.1";//WSJT-X UDP server address (unicast/broadcast/multicast)
+    public static int udpPort = 2237;//WSJT-X UDP server port (WSJT-X default 2237)
+    public static boolean udpAcceptRequests = false;//Act on inbound Reply/Halt/Free-Text/Replay requests
     // Dark feature flag for issue #437 (auto per-location Wavelog station profiles).
     // Default false and NOT branched into any live upload path yet — this increment
     // only lands the pure LocationSignature/resolver/create_station/cache foundation.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -79,6 +79,8 @@ import com.k1af.ft8af.ft8transmit.OnTransmitSuccess;
 import com.k1af.ft8af.ft8transmit.TuneMethod;
 import com.k1af.ft8af.html.LogHttpServer;
 import com.k1af.ft8af.icom.WifiRig;
+import com.k1af.ft8af.log.AdifFormat;
+import com.k1af.ft8af.log.AdifLogFile;
 import com.k1af.ft8af.log.QSLCallsignRecord;
 import com.k1af.ft8af.log.QSLRecord;
 import com.k1af.ft8af.log.SWLQsoList;
@@ -122,6 +124,8 @@ import com.k1af.ft8af.x6100.X6100Radio;
 
 import radio.ks3ckc.ft8af.UsbPermissionIntentsKt;
 import radio.ks3ckc.ft8af.pskreporter.PskReporterSender;
+import radio.ks3ckc.ft8af.wsjtx.WsjtxCodec;
+import radio.ks3ckc.ft8af.wsjtx.WsjtxUdpService;
 
 import java.io.File;
 import java.io.IOException;
@@ -325,6 +329,10 @@ public class MainViewModel extends ViewModel {
             // the recorded offsets belong to the old band's activity (issue #418).
             if (ft8TransmitSignal != null && !newWaveLength.equals(oldWaveLength)) {
                 ft8TransmitSignal.clearBandActivity();
+                // New band = new decode context: tell companion apps to wipe their
+                // band + forget our replay history.
+                WsjtxUdpService.INSTANCE.sendClear();
+                WsjtxUdpService.INSTANCE.clearReplayCache();
             }
 
             // The rig reported a band change (e.g. the operator turned the dial) —
@@ -744,6 +752,9 @@ public class MainViewModel extends ViewModel {
 
                 //upload decoded spots to PSKReporter
                 PskReporterSender.INSTANCE.enqueue(messages);
+
+                //broadcast decodes over the WSJT-X UDP interface
+                broadcastWsjtxDecodes(messages);
             }
         });
 
@@ -876,6 +887,9 @@ public class MainViewModel extends ViewModel {
                 // QSO-complete alert (opt-in). Fires once per logged contact.
                 dxAlertNotifier.notifyQsoComplete(qslRecord);
 
+                // broadcast the logged QSO over the WSJT-X UDP interface
+                broadcastWsjtxQso(qslRecord);
+
                 // record to third-party service; may take some time
                 new Thread(new Runnable() {
                     @Override
@@ -914,6 +928,9 @@ public class MainViewModel extends ViewModel {
         meterProtectionController = new MeterProtectionController();
         meterProtectionController.setTransmitSignal(ft8TransmitSignal);
         ft8TransmitSignal.setMeterProtectionController(meterProtectionController);
+
+        //bring up the WSJT-X UDP interface (status provider + inbound request handlers)
+        setupWsjtxUdp();
 
         //open HTTP SERVER
         httpServer = new LogHttpServer(this, LogHttpServer.DEFAULT_PORT);
@@ -1140,6 +1157,149 @@ public class MainViewModel extends ViewModel {
                 order,
                 message.extraInfo);
         ft8TransmitSignal.transmitNow();
+    }
+
+    // --- WSJT-X UDP interface -------------------------------------------------
+
+    /**
+     * Wire the WSJT-X UDP service to this ViewModel's state + transmit path, then
+     * (re)bind from the persisted settings. Called once after the transmit signal
+     * is created; the Settings screen calls {@link WsjtxUdpService#reload()}
+     * directly when the operator changes the options.
+     */
+    private void setupWsjtxUdp() {
+        WsjtxUdpService svc = WsjtxUdpService.INSTANCE;
+        svc.statusProvider = this::buildWsjtxStatus;
+        svc.onReply = this::handleWsjtxReply;
+        svc.onHaltTx = (autoOnly) -> {
+            if (ft8TransmitSignal != null) {
+                ft8TransmitSignal.setTransmitting(false);
+                ft8TransmitSignal.setActivated(false);
+            }
+        };
+        svc.onFreeText = this::handleWsjtxFreeText;
+        svc.onReplay = () -> { /* decodes are re-sent inside the service */ };
+        svc.reload();
+    }
+
+    /** Build a WSJT-X Status snapshot from current state (called ~1 Hz). */
+    private WsjtxCodec.Status buildWsjtxStatus() {
+        boolean transmitting = ft8TransmitSignal != null && ft8TransmitSignal.isTransmitting();
+        boolean txEnabled = ft8TransmitSignal != null && ft8TransmitSignal.isActivated();
+        boolean decoding = Boolean.TRUE.equals(mutableIsDecoding.getValue());
+        String myGrid = GeneralVariables.getMyMaidenheadGrid();
+        if (myGrid == null) myGrid = "";
+        String mode = ModeProfile.fromId(GeneralVariables.operatingMode).displayName;
+        int baseFreq = Math.max(0, (int) GeneralVariables.getBaseFrequency());
+        return new WsjtxCodec.Status(
+                GeneralVariables.band,       // dial frequency (Hz)
+                mode,
+                "",                           // dx call
+                "",                           // report
+                mode,                         // tx mode
+                txEnabled,
+                transmitting,
+                decoding,
+                baseFreq,                     // rx df
+                baseFreq,                     // tx df
+                GeneralVariables.myCallsign,  // de call
+                myGrid,                       // de grid
+                "",                           // dx grid
+                false,                        // tx watchdog
+                "",                           // sub mode
+                false,                        // fast mode
+                0,                            // special op mode
+                0xFFFFFFFF,                   // freq tolerance (u32 max)
+                15,                           // T/R period (s)
+                "Default",                    // config name
+                "");                          // tx message
+    }
+
+    /** Broadcast a slot's decodes as WSJT-X Decode messages. */
+    private void broadcastWsjtxDecodes(ArrayList<Ft8Message> messages) {
+        WsjtxUdpService svc = WsjtxUdpService.INSTANCE;
+        if (!svc.getEnabled()) {
+            return;
+        }
+        for (Ft8Message m : messages) {
+            String text = m.getMessageText();
+            if (text == null) {
+                text = "";
+            }
+            int timeMs = (int) (m.utcTime % 86_400_000L);
+            int snr = m.hasSnr() ? m.snr : 0;
+            int df = Math.max(0, (int) m.freq_hz);
+            String mode = ModeProfile.fromId(m.signalFormat).displayName;
+            svc.sendDecode(new WsjtxCodec.Decode(
+                    true, timeMs, snr, (double) m.time_sec, df, mode, text, false, false));
+        }
+    }
+
+    /** Broadcast a logged QSO as WSJT-X QSO-Logged + Logged-ADIF messages. */
+    private void broadcastWsjtxQso(QSLRecord r) {
+        WsjtxUdpService svc = WsjtxUdpService.INSTANCE;
+        if (!svc.getEnabled()) {
+            return;
+        }
+        long txFreq = r.getBandFreq() + Math.max(0, r.getWavFrequency());
+        WsjtxCodec.QsoLogged q = new WsjtxCodec.QsoLogged(
+                WsjtxCodec.DateTime.fromAdif(r.getQso_date_off(), r.getTime_off()),
+                nz(r.getToCallsign()),
+                nz(r.getToMaidenGrid()),
+                txFreq,
+                r.getMode() == null ? "FT8" : r.getMode(),
+                AdifFormat.formatReport(r.getSendReport()),
+                AdifFormat.formatReport(r.getReceivedReport()),
+                "",                            // tx power
+                nz(r.getComment()),
+                "",                            // name
+                WsjtxCodec.DateTime.fromAdif(r.getQso_date(), r.getTime_on()),
+                nz(r.getMyCallsign()),         // operator call
+                nz(r.getMyCallsign()),         // my call
+                nz(r.getMyMaidenGrid()),
+                "", "", "");                   // exch sent/recv, prop mode
+        String adif = AdifLogFile.fromQslRecord(r).build();
+        svc.sendQsoLogged(q, adif);
+    }
+
+    /** Inbound Reply: call the referenced station, preferring the real decode. */
+    private void handleWsjtxReply(String call, String grid, int snr) {
+        if (ft8TransmitSignal == null || call == null || call.isEmpty()) {
+            return;
+        }
+        Ft8Message target = findRecentDecode(call);
+        if (target == null) {
+            target = new Ft8Message("", call, grid == null ? "" : grid);
+        }
+        callStation(target);
+    }
+
+    /** Inbound Free Text: send the given text (only when the request asks to send). */
+    private void handleWsjtxFreeText(String text, boolean send) {
+        if (ft8TransmitSignal == null || !send || text == null) {
+            return;
+        }
+        ft8TransmitSignal.setFreeText(text);
+        ft8TransmitSignal.setTransmitFreeText(true);
+        ft8TransmitSignal.setActivated(true);
+        ft8TransmitSignal.transmitNow();
+    }
+
+    /** Most recent decode from {@code call} in the master list, or null. */
+    private Ft8Message findRecentDecode(String call) {
+        synchronized (ft8Messages) {
+            for (int i = ft8Messages.size() - 1; i >= 0; i--) {
+                Ft8Message m = ft8Messages.get(i);
+                if (m.callsignFrom != null && m.callsignFrom.equalsIgnoreCase(call)) {
+                    return m;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String nz(String s) {
+        return s == null ? "" : s;
     }
 
     /**
@@ -1925,6 +2085,7 @@ public class MainViewModel extends ViewModel {
         // the rig indefinitely. Tear it down here too.
         stopCatLivenessWatchdog();
         PskReporterSender.INSTANCE.stop();
+        WsjtxUdpService.INSTANCE.stop();
         getQTHThreadPool.shutdown();
         sendWaveDataThreadPool.shutdown();
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2986,6 +2986,23 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("enableAdifExport")) {//Running ft8af_log.adi export
                     GeneralVariables.enableAdifExport = result.equals("1");
                 }
+                // WSJT-X UDP interface
+                if (name.equalsIgnoreCase("udp_enabled")) {
+                    GeneralVariables.udpEnabled = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("udp_host")) {
+                    if (result != null && !result.isEmpty()) GeneralVariables.udpHost = result;
+                }
+                if (name.equalsIgnoreCase("udp_port")) {
+                    try {
+                        int p = Integer.parseInt(result.trim());
+                        if (p > 0 && p <= 65535) GeneralVariables.udpPort = p;
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+                if (name.equalsIgnoreCase("udp_accept_requests")) {
+                    GeneralVariables.udpAcceptRequests = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("qrzXmlUsername")) {
                     GeneralVariables.qrzXmlUsername = result;
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2994,10 +2994,14 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     if (result != null && !result.isEmpty()) GeneralVariables.udpHost = result;
                 }
                 if (name.equalsIgnoreCase("udp_port")) {
-                    try {
-                        int p = Integer.parseInt(result.trim());
-                        if (p > 0 && p <= 65535) GeneralVariables.udpPort = p;
-                    } catch (NumberFormatException ignored) {
+                    // result (cursor.getString) can be null; the other udp_* keys already
+                    // null-check, and Integer.parseInt(null.trim()) would NPE config hydration.
+                    if (result != null) {
+                        try {
+                            int p = Integer.parseInt(result.trim());
+                            if (p > 0 && p <= 65535) GeneralVariables.udpPort = p;
+                        } catch (NumberFormatException ignored) {
+                        }
                     }
                 }
                 if (name.equalsIgnoreCase("udp_accept_requests")) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
@@ -69,10 +69,35 @@ fun LoggingSettings(
     var qrzXmlPass by remember { mutableStateOf(GeneralVariables.qrzXmlPassword.orEmpty()) }
     var qrzApiKey by remember { mutableStateOf(GeneralVariables.qrzApiKey.orEmpty()) }
     var cloudlogAddress by remember { mutableStateOf(GeneralVariables.cloudlogServerAddress.orEmpty()) }
+    // WSJT-X UDP interface (GridTracker / JTAlert / N1MM / Log4OM interop).
+    var udpEnabled by remember { mutableStateOf(GeneralVariables.udpEnabled) }
+    var udpAccept by remember { mutableStateOf(GeneralVariables.udpAcceptRequests) }
+    var udpHost by remember { mutableStateOf(GeneralVariables.udpHost) }
+    var udpPort by remember { mutableStateOf(GeneralVariables.udpPort) }
 
     var showQrzLogbook by remember { mutableStateOf(false) }
     var showQrzCreds by remember { mutableStateOf(false) }
     var showCloudlog by remember { mutableStateOf(false) }
+    var showUdp by remember { mutableStateOf(false) }
+
+    // -- WSJT-X UDP server address dialog --
+    if (showUdp) {
+        WsjtxUdpDialog(
+            initialHost = udpHost,
+            initialPort = udpPort,
+            onDismiss = { showUdp = false },
+            onSave = { host, port ->
+                udpHost = host
+                udpPort = port
+                GeneralVariables.udpHost = host
+                GeneralVariables.udpPort = port
+                mainViewModel.databaseOpr.writeConfig("udp_host", host, null)
+                mainViewModel.databaseOpr.writeConfig("udp_port", port.toString(), null)
+                radio.ks3ckc.ft8af.wsjtx.WsjtxUdpService.reload()
+                showUdp = false
+            },
+        )
+    }
 
     // -- QRZ Logbook API Key Dialog (upload credential) --
     if (showQrzLogbook) {
@@ -236,6 +261,106 @@ fun LoggingSettings(
                         showChevron = true,
                         onClick = { showCloudlog = true },
                     )
+                }
+            }
+        }
+
+        SettingsSection(title = "WSJT-X UDP") {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    SettingsRow(
+                        label = "Enable UDP broadcast",
+                        description = "Broadcast decodes, status and logged QSOs to companion apps " +
+                            "(GridTracker, JTAlert, N1MM, Log4OM).",
+                        toggle = udpEnabled,
+                        onToggleChange = { checked ->
+                            udpEnabled = checked
+                            GeneralVariables.udpEnabled = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "udp_enabled", if (checked) "1" else "0", null,
+                            )
+                            radio.ks3ckc.ft8af.wsjtx.WsjtxUdpService.reload()
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = "Server address",
+                        description = "Destination host and port for outgoing datagrams.",
+                        value = "$udpHost:$udpPort",
+                        showChevron = true,
+                        onClick = { showUdp = true },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = "Accept UDP requests",
+                        description = "Let companion apps reply to a call, halt TX, or send free text.",
+                        toggle = udpAccept,
+                        onToggleChange = { checked ->
+                            udpAccept = checked
+                            GeneralVariables.udpAcceptRequests = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "udp_accept_requests", if (checked) "1" else "0", null,
+                            )
+                            radio.ks3ckc.ft8af.wsjtx.WsjtxUdpService.reload()
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for the WSJT-X UDP server address (host + port). Mirrors the other
+ * connection dialogs in this screen; validation keeps the port in 1..65535.
+ */
+@Composable
+private fun WsjtxUdpDialog(
+    initialHost: String,
+    initialPort: Int,
+    onDismiss: () -> Unit,
+    onSave: (host: String, port: Int) -> Unit,
+) {
+    var host by remember { mutableStateOf(initialHost) }
+    var portText by remember { mutableStateOf(initialPort.toString()) }
+    val port = portText.toIntOrNull()
+    val valid = host.isNotBlank() && port != null && port in 1..65535
+
+    Dialog(onDismissRequest = onDismiss) {
+        GlassCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "WSJT-X UDP server",
+                    style = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Bold),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = host,
+                    onValueChange = { host = it.trim() },
+                    label = { Text("Host") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = portText,
+                    onValueChange = { portText = it.filter { c -> c.isDigit() }.take(5) },
+                    label = { Text("Port") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    TextButton(
+                        onClick = { if (valid) onSave(host.trim(), port!!) },
+                        enabled = valid,
+                    ) { Text("Save") }
                 }
             }
         }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodec.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodec.kt
@@ -1,0 +1,358 @@
+package radio.ks3ckc.ft8af.wsjtx
+
+import androidx.annotation.VisibleForTesting
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+
+/**
+ * Byte-exact (de)serialization of the WSJT-X UDP message protocol.
+ *
+ * WSJT-X broadcasts a documented binary protocol over UDP that GridTracker,
+ * JTAlert, N1MM+, Log4OM etc. consume, and accepts a few request messages so
+ * those apps can drive it. This object speaks that exact wire format so FT8AF is
+ * a drop-in source/sink.
+ *
+ * The framing is a bespoke big-endian Qt-`QDataStream` layout (NOT JSON), so
+ * byte-for-byte correctness is the whole game — every encoder here is pinned by
+ * the same golden vectors as the desktop (Rust) codec (see `docs/wsjtx-udp.md`
+ * and `WsjtxCodecTest`). Pure, no I/O — [WsjtxUdpService] owns the socket.
+ *
+ * Wire primitives (all big-endian): u32/u64/i32/i64/f64, bool(1 byte); string =
+ * u32 byte-length (0xFFFFFFFF = null) then UTF-8 bytes (empty = length 0);
+ * datetime (UTC) = i64 Julian day, u32 ms-since-midnight, u8=1. Every datagram:
+ * u32 magic 0xADBCCBDA, u32 schema, u32 type, string id, then type fields.
+ */
+object WsjtxCodec {
+    @VisibleForTesting internal val MAGIC: Int = 0xADBCCBDA.toInt()
+    const val SCHEMA: Int = 3
+    const val CLIENT_ID: String = "FT8AF"
+
+    // Message type numbers.
+    const val T_HEARTBEAT = 0
+    const val T_STATUS = 1
+    const val T_DECODE = 2
+    const val T_CLEAR = 3
+    const val T_REPLY = 4
+    const val T_QSO_LOGGED = 5
+    const val T_REPLAY = 7
+    const val T_HALT_TX = 8
+    const val T_FREE_TEXT = 9
+    const val T_LOGGED_ADIF = 12
+
+    // --- outbound field carriers --------------------------------------------
+
+    data class Status(
+        val dialFreqHz: Long,
+        val mode: String,
+        val dxCall: String,
+        val report: String,
+        val txMode: String,
+        val txEnabled: Boolean,
+        val transmitting: Boolean,
+        val decoding: Boolean,
+        val rxDf: Int,
+        val txDf: Int,
+        val deCall: String,
+        val deGrid: String,
+        val dxGrid: String,
+        val txWatchdog: Boolean,
+        val subMode: String,
+        val fastMode: Boolean,
+        val specialOpMode: Int,
+        val freqTolerance: Int,
+        val trPeriod: Int,
+        val configName: String,
+        val txMessage: String,
+    )
+
+    data class Decode(
+        val isNew: Boolean,
+        val timeMs: Int,
+        val snr: Int,
+        val deltaTime: Double,
+        val deltaFreq: Int,
+        val mode: String,
+        val message: String,
+        val lowConfidence: Boolean,
+        val offAir: Boolean,
+    )
+
+    /** A UTC instant as WSJT-X serializes it. */
+    data class DateTime(val julianDay: Long, val msOfDay: Int) {
+        companion object {
+            /** Build from ADIF `YYYYMMDD` + `HHMMSS` (UTC); zeroed on bad input. */
+            @JvmStatic
+            fun fromAdif(dateYyyymmdd: String?, timeHhmmss: String?): DateTime =
+                DateTime(
+                    julianDayFromYyyymmdd(dateYyyymmdd) ?: 0L,
+                    msOfDayFromHhmmss(timeHhmmss) ?: 0,
+                )
+        }
+    }
+
+    data class QsoLogged(
+        val timeOff: DateTime,
+        val dxCall: String,
+        val dxGrid: String,
+        val txFreqHz: Long,
+        val mode: String,
+        val reportSent: String,
+        val reportReceived: String,
+        val txPower: String,
+        val comments: String,
+        val name: String,
+        val timeOn: DateTime,
+        val operatorCall: String,
+        val myCall: String,
+        val myGrid: String,
+        val exchangeSent: String,
+        val exchangeReceived: String,
+        val propMode: String,
+    )
+
+    // --- writer -------------------------------------------------------------
+
+    private class Writer {
+        val bytes = ByteArrayOutputStream(64)
+        private val out = DataOutputStream(bytes)
+        fun u8(v: Int) = out.writeByte(v)
+        fun bool(v: Boolean) = out.writeByte(if (v) 1 else 0)
+        fun i32(v: Int) = out.writeInt(v)
+        fun i64(v: Long) = out.writeLong(v)
+        fun f64(v: Double) = out.writeDouble(v)
+        fun string(s: String) {
+            val b = s.toByteArray(Charsets.UTF_8)
+            out.writeInt(b.size)
+            out.write(b)
+        }
+        fun datetime(dt: DateTime) {
+            out.writeLong(dt.julianDay)
+            out.writeInt(dt.msOfDay)
+            out.writeByte(1) // Qt::UTC
+        }
+        fun toByteArray(): ByteArray { out.flush(); return bytes.toByteArray() }
+    }
+
+    private fun begin(type: Int): Writer {
+        val w = Writer()
+        w.i32(MAGIC)
+        w.i32(SCHEMA)
+        w.i32(type)
+        w.string(CLIENT_ID)
+        return w
+    }
+
+    // --- outbound builders --------------------------------------------------
+
+    fun heartbeat(version: String, revision: String): ByteArray {
+        val w = begin(T_HEARTBEAT)
+        w.i32(SCHEMA) // max schema
+        w.string(version)
+        w.string(revision)
+        return w.toByteArray()
+    }
+
+    fun status(s: Status): ByteArray {
+        val w = begin(T_STATUS)
+        w.i64(s.dialFreqHz)
+        w.string(s.mode)
+        w.string(s.dxCall)
+        w.string(s.report)
+        w.string(s.txMode)
+        w.bool(s.txEnabled)
+        w.bool(s.transmitting)
+        w.bool(s.decoding)
+        w.i32(s.rxDf)
+        w.i32(s.txDf)
+        w.string(s.deCall)
+        w.string(s.deGrid)
+        w.string(s.dxGrid)
+        w.bool(s.txWatchdog)
+        w.string(s.subMode)
+        w.bool(s.fastMode)
+        w.u8(s.specialOpMode)
+        w.i32(s.freqTolerance)
+        w.i32(s.trPeriod)
+        w.string(s.configName)
+        w.string(s.txMessage)
+        return w.toByteArray()
+    }
+
+    fun decode(d: Decode): ByteArray {
+        val w = begin(T_DECODE)
+        w.bool(d.isNew)
+        w.i32(d.timeMs)
+        w.i32(d.snr)
+        w.f64(d.deltaTime)
+        w.i32(d.deltaFreq)
+        w.string(d.mode)
+        w.string(d.message)
+        w.bool(d.lowConfidence)
+        w.bool(d.offAir)
+        return w.toByteArray()
+    }
+
+    fun clear(): ByteArray = begin(T_CLEAR).toByteArray()
+
+    fun qsoLogged(q: QsoLogged): ByteArray {
+        val w = begin(T_QSO_LOGGED)
+        w.datetime(q.timeOff)
+        w.string(q.dxCall)
+        w.string(q.dxGrid)
+        w.i64(q.txFreqHz)
+        w.string(q.mode)
+        w.string(q.reportSent)
+        w.string(q.reportReceived)
+        w.string(q.txPower)
+        w.string(q.comments)
+        w.string(q.name)
+        w.datetime(q.timeOn)
+        w.string(q.operatorCall)
+        w.string(q.myCall)
+        w.string(q.myGrid)
+        w.string(q.exchangeSent)
+        w.string(q.exchangeReceived)
+        w.string(q.propMode)
+        return w.toByteArray()
+    }
+
+    fun loggedAdif(adif: String): ByteArray {
+        val w = begin(T_LOGGED_ADIF)
+        w.string(adif)
+        return w.toByteArray()
+    }
+
+    // --- inbound ------------------------------------------------------------
+
+    sealed class Inbound {
+        data class Reply(val call: String, val grid: String, val snr: Int) : Inbound()
+        object Replay : Inbound()
+        data class HaltTx(val autoOnly: Boolean) : Inbound()
+        data class FreeText(val text: String, val send: Boolean) : Inbound()
+    }
+
+    /** Bounds-checked big-endian reader; every read returns null past the end. */
+    private class Reader(private val b: ByteArray) {
+        var pos = 0
+        private fun take(n: Int): Int? {
+            if (pos + n > b.size) return null
+            val start = pos; pos += n; return start
+        }
+        fun u8(): Int? { val i = take(1) ?: return null; return b[i].toInt() and 0xFF }
+        fun bool(): Boolean? { val v = u8() ?: return null; return v != 0 }
+        fun i32(): Int? {
+            val i = take(4) ?: return null
+            return ((b[i].toInt() and 0xFF) shl 24) or ((b[i + 1].toInt() and 0xFF) shl 16) or
+                ((b[i + 2].toInt() and 0xFF) shl 8) or (b[i + 3].toInt() and 0xFF)
+        }
+        fun f64(): Double? {
+            val i = take(8) ?: return null
+            var bits = 0L
+            for (k in 0 until 8) bits = (bits shl 8) or (b[i + k].toLong() and 0xFF)
+            return Double.fromBits(bits)
+        }
+        fun string(): String? {
+            val len = i32() ?: return null
+            if (len == -1) return "" // 0xFFFFFFFF null
+            val i = take(len) ?: return null
+            return String(b, i, len, Charsets.UTF_8)
+        }
+    }
+
+    /**
+     * Parse an inbound datagram into intent. Returns null for anything we don't
+     * act on (bad magic, unknown/outbound-only type, truncated buffer).
+     */
+    fun parseInbound(buf: ByteArray): Inbound? {
+        val r = Reader(buf)
+        if (r.i32() != MAGIC) return null
+        r.i32() ?: return null // schema
+        val type = r.i32() ?: return null
+        r.string() ?: return null // id
+        return when (type) {
+            T_REPLY -> {
+                r.i32() ?: return null // time
+                val snr = r.i32() ?: return null
+                r.f64() ?: return null // dt
+                r.i32() ?: return null // df
+                r.string() ?: return null // mode
+                val message = r.string() ?: return null
+                val target = parseReplyTarget(message) ?: return null
+                Inbound.Reply(target.first, target.second, snr)
+            }
+            T_REPLAY -> Inbound.Replay
+            T_HALT_TX -> Inbound.HaltTx(r.bool() ?: false)
+            T_FREE_TEXT -> {
+                val text = r.string() ?: return null
+                Inbound.FreeText(text, r.bool() ?: true)
+            }
+            else -> null
+        }
+    }
+
+    /**
+     * From a decoded message line, work out which station a Reply should call and
+     * their grid. Handles `TO FROM ...` and CQ lines with an optional directive
+     * (`CQ FROM GRID`, `CQ DX FROM GRID`, `CQ POTA FROM GRID`).
+     */
+    @VisibleForTesting
+    internal fun parseReplyTarget(message: String): Pair<String, String>? {
+        val tokens = message.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }
+        if (tokens.isEmpty()) return null
+        val callIdx = if (tokens[0].equals("CQ", ignoreCase = true)) {
+            when {
+                tokens.size < 2 -> return null
+                isCallsign(tokens[1]) -> 1
+                else -> 2
+            }
+        } else {
+            1
+        }
+        val call = tokens.getOrNull(callIdx) ?: return null
+        if (!isCallsign(call)) return null
+        val grid = tokens.drop(callIdx + 1).firstOrNull { isGrid4(it) }?.uppercase() ?: ""
+        return Pair(call.uppercase(), grid)
+    }
+
+    private fun isCallsign(t: String): Boolean {
+        val core = t.substringBefore('/')
+        val hasAlpha = core.any { it in 'A'..'Z' || it in 'a'..'z' }
+        val hasDigit = core.any { it.isDigit() }
+        val okChars = t.all { it.isLetterOrDigit() || it == '/' }
+        return hasAlpha && hasDigit && okChars && !isGrid4(t)
+    }
+
+    private fun isGrid4(t: String): Boolean {
+        if (t.length != 4) return false
+        val a = t[0].uppercaseChar(); val b = t[1].uppercaseChar()
+        return a in 'A'..'R' && b in 'A'..'R' && t[2].isDigit() && t[3].isDigit()
+    }
+
+    // --- date/time helpers --------------------------------------------------
+
+    /** Julian Day Number for a UTC `YYYYMMDD` date (matches Qt's toJulianDay). */
+    @VisibleForTesting
+    internal fun julianDayFromYyyymmdd(s: String?): Long? {
+        if (s == null || s.length != 8 || !s.all { it.isDigit() }) return null
+        return try {
+            val year = s.substring(0, 4).toInt()
+            val month = s.substring(4, 6).toInt()
+            val day = s.substring(6, 8).toInt()
+            // epochDay 0 = 1970-01-01 = JDN 2440588.
+            java.time.LocalDate.of(year, month, day).toEpochDay() + 2_440_588L
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** Milliseconds since midnight for a UTC `HHMMSS` string. */
+    @VisibleForTesting
+    internal fun msOfDayFromHhmmss(s: String?): Int? {
+        if (s == null || s.length != 6 || !s.all { it.isDigit() }) return null
+        val h = s.substring(0, 2).toInt()
+        val m = s.substring(2, 4).toInt()
+        val sec = s.substring(4, 6).toInt()
+        if (h > 23 || m > 59 || sec > 60) return null
+        return ((h * 3600) + (m * 60) + sec) * 1000
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodec.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodec.kt
@@ -235,7 +235,11 @@ object WsjtxCodec {
     private class Reader(private val b: ByteArray) {
         var pos = 0
         private fun take(n: Int): Int? {
-            if (pos + n > b.size) return null
+            // Reject a negative length (e.g. a hostile/garbled 32-bit string length) and any
+            // n that overruns the buffer. Comparing against the remaining bytes (b.size - pos,
+            // always >= 0 since pos only advances through validated takes) avoids the
+            // pos + n integer overflow a huge n would cause with a naive `pos + n > b.size`.
+            if (n < 0 || n > b.size - pos) return null
             val start = pos; pos += n; return start
         }
         fun u8(): Int? { val i = take(1) ?: return null; return b[i].toInt() and 0xFF }
@@ -281,10 +285,12 @@ object WsjtxCodec {
                 Inbound.Reply(target.first, target.second, snr)
             }
             T_REPLAY -> Inbound.Replay
-            T_HALT_TX -> Inbound.HaltTx(r.bool() ?: false)
+            // Reject a truncated packet rather than defaulting the trailing bool: a malformed
+            // datagram must not trigger an unintended halt or transmit when accepting requests.
+            T_HALT_TX -> Inbound.HaltTx(r.bool() ?: return null)
             T_FREE_TEXT -> {
                 val text = r.string() ?: return null
-                Inbound.FreeText(text, r.bool() ?: true)
+                Inbound.FreeText(text, r.bool() ?: return null)
             }
             else -> null
         }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxUdpService.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxUdpService.kt
@@ -1,0 +1,223 @@
+package radio.ks3ckc.ft8af.wsjtx
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.k1af.ft8af.GeneralVariables
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileWriter
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * WSJT-X UDP transport for Android: owns the socket, broadcasts outbound
+ * datagrams built by [WsjtxCodec], and (when "accept requests" is on) runs a
+ * background listener that turns inbound requests into callbacks the ViewModel
+ * wires to the transmit path.
+ *
+ * Modelled on [radio.ks3ckc.ft8af.pskreporter.PskReporterSender] (an `object`
+ * with an IO coroutine scope + `DatagramSocket`). Settings live in
+ * [GeneralVariables] (`udpEnabled`/`udpHost`/`udpPort`/`udpAcceptRequests`);
+ * [reload] (re)binds from them, so both startup and a Settings change route
+ * through one place.
+ *
+ * Inbound callbacks are posted to the main thread, since they drive the same
+ * transmit entry points as UI taps.
+ */
+object WsjtxUdpService {
+    private const val TAG = "WsjtxUdpService"
+    private const val REPLAY_CACHE_CAP = 1000
+    private const val STATUS_INTERVAL_MS = 1000L
+    private const val HEARTBEAT_INTERVAL_MS = 15_000L
+    private const val RECV_TIMEOUT_MS = 500
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var scope: CoroutineScope? = null
+    private var socket: DatagramSocket? = null
+    private var target: InetAddress? = null
+    private var targetPort = 0
+    private var listenerThread: Thread? = null
+    @Volatile private var listening = false
+    private val replayCache = ArrayDeque<WsjtxCodec.Decode>()
+
+    // Java-friendly SAM interfaces so the (Java) ViewModel can wire these with
+    // plain lambdas.
+    fun interface StatusProvider { fun get(): WsjtxCodec.Status? }
+    fun interface ReplyHandler { fun onReply(call: String, grid: String, snr: Int) }
+    fun interface HaltHandler { fun onHalt(autoOnly: Boolean) }
+    fun interface FreeTextHandler { fun onFreeText(text: String, send: Boolean) }
+    fun interface ReplayHandler { fun onReplay() }
+
+    /** Supplies the current [WsjtxCodec.Status] snapshot for the periodic push. */
+    @JvmField var statusProvider: StatusProvider? = null
+
+    // Inbound request handlers (set by the ViewModel; invoked on the main thread).
+    @JvmField var onReply: ReplyHandler? = null
+    @JvmField var onReplay: ReplayHandler? = null
+    @JvmField var onHaltTx: HaltHandler? = null
+    @JvmField var onFreeText: FreeTextHandler? = null
+
+    val enabled: Boolean get() = socket != null
+
+    /** (Re)bind from the persisted [GeneralVariables] settings. Idempotent. */
+    fun reload() {
+        teardown()
+        if (!GeneralVariables.udpEnabled) {
+            log("disabled")
+            return
+        }
+        try {
+            target = InetAddress.getByName(GeneralVariables.udpHost)
+            targetPort = GeneralVariables.udpPort
+            val sock = DatagramSocket(null as java.net.SocketAddress?).apply {
+                reuseAddress = true
+                bind(InetSocketAddress(0)) // ephemeral local port
+                broadcast = true
+            }
+            socket = sock
+
+            val s = CoroutineScope(Dispatchers.IO + SupervisorJob())
+            scope = s
+            s.launch { periodicLoop() }
+
+            if (GeneralVariables.udpAcceptRequests) startListener(sock)
+            log("bound → ${GeneralVariables.udpHost}:${targetPort}" +
+                if (GeneralVariables.udpAcceptRequests) " (accepting requests)" else "")
+        } catch (e: Exception) {
+            log("bind failed: ${e.javaClass.simpleName}: ${e.message}")
+            teardown()
+        }
+    }
+
+    /** Tear down socket + loops. Safe to call when already stopped. */
+    fun stop() = teardown()
+
+    private fun teardown() {
+        listening = false
+        scope?.cancel()
+        scope = null
+        socket?.close()
+        socket = null
+        target = null
+        // The listener's blocking receive unblocks via SO_TIMEOUT + the closed
+        // socket; give it a moment to exit but don't hang teardown on it.
+        listenerThread?.let { t -> t.join(1000) }
+        listenerThread = null
+    }
+
+    private fun send(datagram: ByteArray) {
+        val sock = socket ?: return
+        val addr = target ?: return
+        try {
+            sock.send(DatagramPacket(datagram, datagram.size, addr, targetPort))
+        } catch (e: Exception) {
+            log("send error: ${e.javaClass.simpleName}: ${e.message}")
+        }
+    }
+
+    // --- outbound -----------------------------------------------------------
+
+    fun sendClear() {
+        if (enabled) send(WsjtxCodec.clear())
+    }
+
+    fun sendDecode(d: WsjtxCodec.Decode) {
+        if (!enabled) return
+        send(WsjtxCodec.decode(d))
+        if (replayCache.size >= REPLAY_CACHE_CAP) replayCache.removeFirst()
+        replayCache.addLast(d)
+    }
+
+    fun sendQsoLogged(q: WsjtxCodec.QsoLogged, adif: String) {
+        if (!enabled) return
+        send(WsjtxCodec.qsoLogged(q))
+        send(WsjtxCodec.loggedAdif(adif))
+    }
+
+    fun clearReplayCache() = replayCache.clear()
+
+    /** Re-broadcast this session's decodes (marked not-new) for a Replay request. */
+    private fun replay() {
+        if (!enabled) return
+        for (d in replayCache.toList()) send(WsjtxCodec.decode(d.copy(isNew = false)))
+    }
+
+    private suspend fun periodicLoop() {
+        val s = scope ?: return
+        var sinceHeartbeatMs = HEARTBEAT_INTERVAL_MS // send one immediately
+        while (s.isActive) {
+            statusProvider?.get()?.let { send(WsjtxCodec.status(it)) }
+            if (sinceHeartbeatMs >= HEARTBEAT_INTERVAL_MS) {
+                send(WsjtxCodec.heartbeat(GeneralVariables.VERSION, ""))
+                sinceHeartbeatMs = 0
+            }
+            delay(STATUS_INTERVAL_MS)
+            sinceHeartbeatMs += STATUS_INTERVAL_MS
+        }
+    }
+
+    // --- inbound listener ---------------------------------------------------
+
+    private fun startListener(sock: DatagramSocket) {
+        sock.soTimeout = RECV_TIMEOUT_MS
+        listening = true
+        val t = Thread({
+            val buf = ByteArray(2048)
+            while (listening) {
+                try {
+                    val packet = DatagramPacket(buf, buf.size)
+                    sock.receive(packet)
+                    dispatch(packet.data.copyOf(packet.length))
+                } catch (e: java.net.SocketTimeoutException) {
+                    // loop to re-check `listening`
+                } catch (e: Exception) {
+                    if (listening) log("recv error: ${e.javaClass.simpleName}: ${e.message}")
+                    if (sock.isClosed) break
+                }
+            }
+        }, "ft8af-wsjtx-rx")
+        t.isDaemon = true
+        t.start()
+        listenerThread = t
+    }
+
+    private fun dispatch(buf: ByteArray) {
+        when (val msg = WsjtxCodec.parseInbound(buf)) {
+            is WsjtxCodec.Inbound.Reply ->
+                mainHandler.post { onReply?.onReply(msg.call, msg.grid, msg.snr) }
+            is WsjtxCodec.Inbound.HaltTx ->
+                mainHandler.post { onHaltTx?.onHalt(msg.autoOnly) }
+            is WsjtxCodec.Inbound.FreeText ->
+                mainHandler.post { onFreeText?.onFreeText(msg.text, msg.send) }
+            WsjtxCodec.Inbound.Replay -> {
+                replay()
+                mainHandler.post { onReplay?.onReplay() }
+            }
+            null -> {} // ignored/unparseable
+        }
+    }
+
+    private fun log(msg: String) {
+        Log.d(TAG, msg)
+        try {
+            val ctx = GeneralVariables.getMainContext() ?: return
+            val dir = ctx.getExternalFilesDir(null) ?: return
+            val ts = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            FileWriter(File(dir, "debug.log"), true).use { it.append("$ts WsjtxUdpService: $msg\n") }
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxUdpService.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxUdpService.kt
@@ -51,7 +51,11 @@ object WsjtxUdpService {
     private var targetPort = 0
     private var listenerThread: Thread? = null
     @Volatile private var listening = false
+    // Guarded by [replayLock]: mutated from decode/band-change callers and read from the
+    // listener thread handling a Replay request, so all access must be synchronized —
+    // ArrayDeque is not thread-safe.
     private val replayCache = ArrayDeque<WsjtxCodec.Decode>()
+    private val replayLock = Any()
 
     // Java-friendly SAM interfaces so the (Java) ViewModel can wire these with
     // plain lambdas.
@@ -82,9 +86,14 @@ object WsjtxUdpService {
         try {
             target = InetAddress.getByName(GeneralVariables.udpHost)
             targetPort = GeneralVariables.udpPort
+            // When accepting requests, bind the configured UDP port (default 2237) so
+            // companion apps that send Reply/Halt/FreeText/Replay to that port actually
+            // reach us. An ephemeral local port would only work for outbound broadcasts —
+            // no companion could discover it. Send-only mode keeps the ephemeral port.
+            val localPort = if (GeneralVariables.udpAcceptRequests) targetPort else 0
             val sock = DatagramSocket(null as java.net.SocketAddress?).apply {
                 reuseAddress = true
-                bind(InetSocketAddress(0)) // ephemeral local port
+                bind(InetSocketAddress(localPort))
                 broadcast = true
             }
             socket = sock
@@ -137,8 +146,10 @@ object WsjtxUdpService {
     fun sendDecode(d: WsjtxCodec.Decode) {
         if (!enabled) return
         send(WsjtxCodec.decode(d))
-        if (replayCache.size >= REPLAY_CACHE_CAP) replayCache.removeFirst()
-        replayCache.addLast(d)
+        synchronized(replayLock) {
+            if (replayCache.size >= REPLAY_CACHE_CAP) replayCache.removeFirst()
+            replayCache.addLast(d)
+        }
     }
 
     fun sendQsoLogged(q: WsjtxCodec.QsoLogged, adif: String) {
@@ -147,12 +158,14 @@ object WsjtxUdpService {
         send(WsjtxCodec.loggedAdif(adif))
     }
 
-    fun clearReplayCache() = replayCache.clear()
+    fun clearReplayCache() = synchronized(replayLock) { replayCache.clear() }
 
     /** Re-broadcast this session's decodes (marked not-new) for a Replay request. */
     private fun replay() {
         if (!enabled) return
-        for (d in replayCache.toList()) send(WsjtxCodec.decode(d.copy(isNew = false)))
+        // Snapshot under the lock, then send outside it (send() must not hold replayLock).
+        val snapshot = synchronized(replayLock) { replayCache.toList() }
+        for (d in snapshot) send(WsjtxCodec.decode(d.copy(isNew = false)))
     }
 
     private suspend fun periodicLoop() {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -200,4 +200,28 @@ public class DatabaseOprConfigHydrationTest {
         assertThat(GeneralVariables.volumePercent).isEqualTo(0.5f);
         assertThat(GeneralVariables.alcTargetLow).isEqualTo(70);
     }
+
+    /**
+     * A raw SQL NULL for {@code udp_port} makes {@code cursor.getString(...)} return null.
+     * Its sibling {@code udp_host} already null-checks, but {@code udp_port} used to call
+     * {@code result.trim()} unguarded — an NPE that bricked config hydration for any backup
+     * carrying a null value. The guard leaves the current value untouched instead.
+     */
+    @Test
+    public void nullUdpPort_doesNotCrashHydration() {
+        int orig = GeneralVariables.udpPort;
+        try {
+            GeneralVariables.udpPort = 2237;
+            // writeConfigSync coerces null -> "", so insert a genuine SQL NULL directly.
+            opr.getWritableDatabase().execSQL("DELETE FROM config WHERE KeyName='udp_port'");
+            opr.getWritableDatabase()
+                    .execSQL("INSERT INTO config (KeyName,Value) VALUES ('udp_port', NULL)");
+
+            hydrate(); // pre-fix: NullPointerException on result.trim()
+
+            assertThat(GeneralVariables.udpPort).isEqualTo(2237); // unchanged, no crash
+        } finally {
+            GeneralVariables.udpPort = orig;
+        }
+    }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodecTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodecTest.kt
@@ -1,0 +1,254 @@
+package radio.ks3ckc.ft8af.wsjtx
+
+import com.google.common.truth.Truth.assertThat
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Test
+
+/**
+ * Byte-exact tests for the WSJT-X UDP codec. The golden hex here matches the
+ * desktop (Rust) codec's vectors in `desktop/src-tauri/src/udp/codec.rs` and
+ * `docs/wsjtx-udp.md`, so the two encoders are provably identical.
+ */
+class WsjtxCodecTest {
+
+    /** Minimal big-endian reader mirroring the (private) codec reader. */
+    private class R(bytes: ByteArray) {
+        val bb: ByteBuffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+        fun i32() = bb.int
+        fun i64() = bb.long
+        fun f64() = bb.double
+        fun u8() = bb.get().toInt() and 0xFF
+        fun bool() = bb.get().toInt() != 0
+        fun str(): String {
+            val len = bb.int
+            val b = ByteArray(len)
+            bb.get(b)
+            return String(b, Charsets.UTF_8)
+        }
+        fun remaining() = bb.remaining()
+    }
+
+    // Read a header, asserting magic/schema/id and returning the type; the reader
+    // is left positioned at the first payload field.
+    private fun readHeader(r: R): Int {
+        assertThat(r.i32()).isEqualTo(WsjtxCodec.MAGIC)
+        assertThat(r.i32()).isEqualTo(WsjtxCodec.SCHEMA)
+        val type = r.i32()
+        assertThat(r.str()).isEqualTo(WsjtxCodec.CLIENT_ID)
+        return type
+    }
+
+    private fun hex(b: ByteArray) = b.joinToString(" ") { "%02x".format(it) }
+
+    @Test
+    fun clearHeaderBytesAreExact() {
+        assertThat(hex(WsjtxCodec.clear()))
+            .isEqualTo("ad bc cb da 00 00 00 03 00 00 00 03 00 00 00 05 46 54 38 41 46")
+    }
+
+    @Test
+    fun heartbeatBytesMatchGolden() {
+        assertThat(hex(WsjtxCodec.heartbeat("0.1.0", "")))
+            .isEqualTo(
+                "ad bc cb da 00 00 00 03 00 00 00 00 00 00 00 05 46 54 38 41 46 " +
+                    "00 00 00 03 00 00 00 05 30 2e 31 2e 30 00 00 00 00",
+            )
+    }
+
+    @Test
+    fun decodeBytesMatchGolden() {
+        val d = WsjtxCodec.Decode(
+            isNew = true, timeMs = 47_493_000, snr = -7, deltaTime = 0.2,
+            deltaFreq = 1500, mode = "FT8", message = "CQ K1ABC FN42",
+            lowConfidence = false, offAir = false,
+        )
+        assertThat(hex(WsjtxCodec.decode(d))).isEqualTo(
+            "ad bc cb da 00 00 00 03 00 00 00 02 00 00 00 05 46 54 38 41 46 " +
+                "01 02 d4 af 88 ff ff ff f9 3f c9 99 99 99 99 99 9a 00 00 05 dc " +
+                "00 00 00 03 46 54 38 00 00 00 0d 43 51 20 4b 31 41 42 43 20 46 4e 34 32 00 00",
+        )
+    }
+
+    @Test
+    fun statusRoundtripsAllFields() {
+        val s = WsjtxCodec.Status(
+            dialFreqHz = 14_074_000, mode = "FT8", dxCall = "K1ABC", report = "-07",
+            txMode = "FT8", txEnabled = true, transmitting = false, decoding = true,
+            rxDf = 1500, txDf = 1500, deCall = "K0XYZ", deGrid = "EN37", dxGrid = "FN42",
+            txWatchdog = false, subMode = "", fastMode = false, specialOpMode = 0,
+            freqTolerance = -1, trPeriod = 15, configName = "Default",
+            txMessage = "K1ABC K0XYZ EN37",
+        )
+        val r = R(WsjtxCodec.status(s))
+        assertThat(readHeader(r)).isEqualTo(WsjtxCodec.T_STATUS)
+        assertThat(r.i64()).isEqualTo(14_074_000L)
+        assertThat(r.str()).isEqualTo("FT8")
+        assertThat(r.str()).isEqualTo("K1ABC")
+        assertThat(r.str()).isEqualTo("-07")
+        assertThat(r.str()).isEqualTo("FT8")
+        assertThat(r.bool()).isTrue()
+        assertThat(r.bool()).isFalse()
+        assertThat(r.bool()).isTrue()
+        assertThat(r.i32()).isEqualTo(1500)
+        assertThat(r.i32()).isEqualTo(1500)
+        assertThat(r.str()).isEqualTo("K0XYZ")
+        assertThat(r.str()).isEqualTo("EN37")
+        assertThat(r.str()).isEqualTo("FN42")
+        assertThat(r.bool()).isFalse()
+        assertThat(r.str()).isEqualTo("")
+        assertThat(r.bool()).isFalse()
+        assertThat(r.u8()).isEqualTo(0)
+        assertThat(r.i32()).isEqualTo(-1) // 0xFFFFFFFF freq tolerance
+        assertThat(r.i32()).isEqualTo(15)
+        assertThat(r.str()).isEqualTo("Default")
+        assertThat(r.str()).isEqualTo("K1ABC K0XYZ EN37")
+        assertThat(r.remaining()).isEqualTo(0)
+    }
+
+    @Test
+    fun qsoLoggedRoundtripsWithDatetime() {
+        val on = WsjtxCodec.DateTime.fromAdif("20260712", "134500")
+        val off = WsjtxCodec.DateTime.fromAdif("20260712", "134615")
+        val q = WsjtxCodec.QsoLogged(
+            timeOff = off, dxCall = "K1ABC", dxGrid = "FN42", txFreqHz = 14_075_500,
+            mode = "FT8", reportSent = "-07", reportReceived = "-12", txPower = "",
+            comments = "", name = "", timeOn = on, operatorCall = "K0XYZ",
+            myCall = "K0XYZ", myGrid = "EN37", exchangeSent = "", exchangeReceived = "",
+            propMode = "",
+        )
+        val r = R(WsjtxCodec.qsoLogged(q))
+        assertThat(readHeader(r)).isEqualTo(WsjtxCodec.T_QSO_LOGGED)
+        assertThat(r.i64()).isEqualTo(off.julianDay)
+        assertThat(r.i32()).isEqualTo(off.msOfDay)
+        assertThat(r.u8()).isEqualTo(1) // UTC spec
+        assertThat(r.str()).isEqualTo("K1ABC")
+        assertThat(r.str()).isEqualTo("FN42")
+        assertThat(r.i64()).isEqualTo(14_075_500L)
+        assertThat(r.str()).isEqualTo("FT8")
+        assertThat(r.str()).isEqualTo("-07")
+        assertThat(r.str()).isEqualTo("-12")
+        assertThat(r.str()).isEqualTo("") // tx power
+        assertThat(r.str()).isEqualTo("") // comments
+        assertThat(r.str()).isEqualTo("") // name
+        assertThat(r.i64()).isEqualTo(on.julianDay)
+        assertThat(r.i32()).isEqualTo(on.msOfDay)
+        assertThat(r.u8()).isEqualTo(1)
+        assertThat(r.str()).isEqualTo("K0XYZ") // operator
+        assertThat(r.str()).isEqualTo("K0XYZ") // my call
+        assertThat(r.str()).isEqualTo("EN37")  // my grid
+        assertThat(r.str()).isEqualTo("")
+        assertThat(r.str()).isEqualTo("")
+        assertThat(r.str()).isEqualTo("")
+        assertThat(r.remaining()).isEqualTo(0)
+    }
+
+    @Test
+    fun loggedAdifWrapsString() {
+        val r = R(WsjtxCodec.loggedAdif("<call:5>K1ABC <eor>"))
+        assertThat(readHeader(r)).isEqualTo(WsjtxCodec.T_LOGGED_ADIF)
+        assertThat(r.str()).isEqualTo("<call:5>K1ABC <eor>")
+        assertThat(r.remaining()).isEqualTo(0)
+    }
+
+    // --- date/time goldens ---------------------------------------------------
+
+    @Test
+    fun julianDayMatchesKnownValues() {
+        assertThat(WsjtxCodec.julianDayFromYyyymmdd("20000101")).isEqualTo(2_451_545L)
+        assertThat(WsjtxCodec.julianDayFromYyyymmdd("19700101")).isEqualTo(2_440_588L)
+        assertThat(WsjtxCodec.julianDayFromYyyymmdd("bad")).isNull()
+        assertThat(WsjtxCodec.julianDayFromYyyymmdd("20261301")).isNull()
+    }
+
+    @Test
+    fun msOfDayFromTime() {
+        assertThat(WsjtxCodec.msOfDayFromHhmmss("000000")).isEqualTo(0)
+        assertThat(WsjtxCodec.msOfDayFromHhmmss("134615")).isEqualTo(49_575_000)
+        assertThat(WsjtxCodec.msOfDayFromHhmmss("235959")).isEqualTo(86_399_000)
+        assertThat(WsjtxCodec.msOfDayFromHhmmss("240000")).isNull()
+        assertThat(WsjtxCodec.msOfDayFromHhmmss("12345")).isNull()
+    }
+
+    // --- inbound parsing -----------------------------------------------------
+
+    private fun beginInbound(type: Int): ByteBuffer {
+        val bb = ByteBuffer.allocate(2048).order(ByteOrder.BIG_ENDIAN)
+        bb.putInt(WsjtxCodec.MAGIC)
+        bb.putInt(WsjtxCodec.SCHEMA)
+        bb.putInt(type)
+        val id = WsjtxCodec.CLIENT_ID.toByteArray()
+        bb.putInt(id.size); bb.put(id)
+        return bb
+    }
+
+    private fun putStr(bb: ByteBuffer, s: String) {
+        val b = s.toByteArray(); bb.putInt(b.size); bb.put(b)
+    }
+
+    private fun sized(bb: ByteBuffer): ByteArray {
+        val out = ByteArray(bb.position()); bb.flip(); bb.get(out); return out
+    }
+
+    private fun makeReply(message: String, snr: Int): ByteArray {
+        val bb = beginInbound(WsjtxCodec.T_REPLY)
+        bb.putInt(47_000_000) // time
+        bb.putInt(snr)
+        bb.putDouble(0.1)     // dt
+        bb.putInt(1500)       // df
+        putStr(bb, "FT8")
+        putStr(bb, message)
+        bb.put(0)             // low confidence
+        bb.put(0)             // modifiers
+        return sized(bb)
+    }
+
+    @Test
+    fun parseReplyPlainCq() {
+        assertThat(WsjtxCodec.parseInbound(makeReply("CQ K1ABC FN42", -3)))
+            .isEqualTo(WsjtxCodec.Inbound.Reply("K1ABC", "FN42", -3))
+    }
+
+    @Test
+    fun parseReplyCqWithDirective() {
+        assertThat(WsjtxCodec.parseInbound(makeReply("CQ DX K1ABC FN42", -3)))
+            .isEqualTo(WsjtxCodec.Inbound.Reply("K1ABC", "FN42", -3))
+        assertThat(WsjtxCodec.parseInbound(makeReply("CQ POTA W1AW/4 EM70", 5)))
+            .isEqualTo(WsjtxCodec.Inbound.Reply("W1AW/4", "EM70", 5))
+    }
+
+    @Test
+    fun parseReplyNonCqCallsSender() {
+        assertThat(WsjtxCodec.parseInbound(makeReply("K0XYZ K1ABC -12", -12)))
+            .isEqualTo(WsjtxCodec.Inbound.Reply("K1ABC", "", -12))
+    }
+
+    @Test
+    fun parseHaltFreeTextReplay() {
+        val halt = beginInbound(WsjtxCodec.T_HALT_TX).also { it.put(1) }
+        assertThat(WsjtxCodec.parseInbound(sized(halt)))
+            .isEqualTo(WsjtxCodec.Inbound.HaltTx(true))
+
+        val free = beginInbound(WsjtxCodec.T_FREE_TEXT)
+        putStr(free, "TEST DE FT8AF"); free.put(1)
+        assertThat(WsjtxCodec.parseInbound(sized(free)))
+            .isEqualTo(WsjtxCodec.Inbound.FreeText("TEST DE FT8AF", true))
+
+        assertThat(WsjtxCodec.parseInbound(sized(beginInbound(WsjtxCodec.T_REPLAY))))
+            .isEqualTo(WsjtxCodec.Inbound.Replay)
+    }
+
+    @Test
+    fun parseRejectsBadAndOutboundOnly() {
+        assertThat(WsjtxCodec.parseInbound(byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7))).isNull()
+        // A Status message is outbound-only; not acted on.
+        assertThat(WsjtxCodec.parseInbound(sized(beginInbound(WsjtxCodec.T_STATUS)))).isNull()
+    }
+
+    @Test
+    fun parseReplyShortBufferIsNull() {
+        val bb = beginInbound(WsjtxCodec.T_REPLY)
+        bb.putInt(1) // time only, truncated
+        assertThat(WsjtxCodec.parseInbound(sized(bb))).isNull()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodecTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/wsjtx/WsjtxCodecTest.kt
@@ -251,4 +251,38 @@ class WsjtxCodecTest {
         bb.putInt(1) // time only, truncated
         assertThat(WsjtxCodec.parseInbound(sized(bb))).isNull()
     }
+
+    @Test
+    fun parseHaltTxMissingBoolIsRejected() {
+        // Truncated HaltTx (no autoOnly byte) must be rejected, not defaulted to false —
+        // a malformed packet must never trigger an unintended halt.
+        assertThat(WsjtxCodec.parseInbound(sized(beginInbound(WsjtxCodec.T_HALT_TX)))).isNull()
+    }
+
+    @Test
+    fun parseFreeTextMissingSendFlagIsRejected() {
+        // Truncated Free-Text (text present, send byte missing) must be rejected, not
+        // defaulted to send=true — a malformed packet must never trigger a transmit.
+        val free = beginInbound(WsjtxCodec.T_FREE_TEXT)
+        putStr(free, "HELLO") // no trailing send bool
+        assertThat(WsjtxCodec.parseInbound(sized(free))).isNull()
+    }
+
+    @Test
+    fun parseRejectsNegativeStringLength() {
+        // A hostile 32-bit string length that is negative (and not the 0xFFFFFFFF null
+        // sentinel) must not move the reader backwards / throw — the reader rejects it.
+        val bb = beginInbound(WsjtxCodec.T_FREE_TEXT)
+        bb.putInt(-2) // negative "text" length (not -1)
+        assertThat(WsjtxCodec.parseInbound(sized(bb))).isNull()
+    }
+
+    @Test
+    fun parseRejectsOverflowStringLength() {
+        // A huge positive length must be rejected via the remaining-bytes check, not wrap
+        // past the buffer end through pos + n integer overflow.
+        val bb = beginInbound(WsjtxCodec.T_FREE_TEXT)
+        bb.putInt(Int.MAX_VALUE) // enormous "text" length
+        assertThat(WsjtxCodec.parseInbound(sized(bb))).isNull()
+    }
 }


### PR DESCRIPTION
## What

Adds the **WSJT-X UDP interface** to the Android build — the second of three per-platform PRs (desktop landed in #553; iOS to follow). Makes the app interoperate with GridTracker, JTAlert, N1MM+, Log4OM. Off by default; configured under **Settings → Logging → WSJT-X UDP** (enable, server address/port, "Accept UDP requests"), defaulting to `127.0.0.1:2237`.

### Outbound
Heartbeat (~15 s), Status (~1 Hz), Decode (per decode), Clear (on band change), QSO Logged + Logged ADIF (per logged QSO).

### Inbound ("Accept UDP requests")
A listener thread maps **Reply** → call the station (`MainViewModel.callStation`), **Halt Tx** → stop, **Free Text** → send, **Replay** → re-broadcast the session's decodes. Inbound callbacks are posted to the main thread and reuse the existing transmit entry points (same paths as UI taps).

## How
- New `wsjtx` package:
  - `WsjtxCodec` — pure, byte-exact encoder/decoder pinned by **golden vectors identical to the desktop Rust codec** (`docs/wsjtx-udp.md`).
  - `WsjtxUdpService` — an `object` modelled on `PskReporterSender` (IO coroutine scope + `DatagramSocket`), with a status/heartbeat loop and an inbound `receive()` loop modelled on `icom/ControlUdp`. Java-friendly SAM callbacks so the Java `MainViewModel` wires it with plain lambdas.
- `MainViewModel` taps existing choke points (`afterDecode` next to `PskReporterSender.enqueue`, `doAfterTransmit`, band change, `onCleared`) and supplies the Status snapshot + inbound handlers.
- Config: 4 keys (`udp_enabled`/`udp_host`/`udp_port`/`udp_accept_requests`) parsed in `DatabaseOpr.GetAllConfigParameter` + statics in `GeneralVariables`; UI in `ui/settings/LoggingSettings.kt`. `INTERNET` permission already present.
- Reuses `AdifLogFile.fromQslRecord(...).build()` for the Logged-ADIF message.

## Testing
- **14 `WsjtxCodec` unit tests**: byte-exact golden vectors (matching the desktop codec byte-for-byte), inbound Reply/Halt/FreeText/Replay round-trips, malformed rejection, Julian-day / time-of-day goldens.
- Full module compiles; `testDebugUnitTest` green (14/14).
- Manual acceptance (not automated here): point GridTracker at the phone's IP:2237 → decodes plot and logged QSOs appear; double-click a spot → the app answers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)