### PR TITLE
Fix logbook context-menu crash on a stale/detached row position

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/LogFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/LogFragment.java
@@ -286,6 +286,19 @@ public class LogFragment extends Fragment {
     @Override
     public boolean onContextItemSelected(@NonNull MenuItem item) {
         int position = (Integer) item.getActionView().getTag();
+        // The tag holds the row's adapter position captured at long-press time
+        // (LogQSLItemHolder#onCreateContextMenu). By the time the user taps a menu
+        // item that position can be stale: the row may have detached
+        // (getAdapterPosition() == RecyclerView.NO_POSITION == -1) or the backing
+        // list may have shrunk under a refresh (web import / notifyDataSetChanged).
+        // Indexing the adapter with it would throw IndexOutOfBoundsException on the
+        // main thread, so drop the stale action instead of crashing.
+        int itemCount = mainViewModel.logListShowCallsign
+                ? logCallsignAdapter.getItemCount()
+                : logQSLAdapter.getItemCount();
+        if (!isContextPositionInRange(position, itemCount)) {
+            return super.onContextItemSelected(item);
+        }
         if (!mainViewModel.logListShowCallsign) {
             switch (item.getItemId()) {
                 case 0:
@@ -324,6 +337,23 @@ public class LogFragment extends Fragment {
         }
 
         return super.onContextItemSelected(item);
+    }
+
+    /**
+     * A context-menu action carries the row's adapter position captured at
+     * long-press time. That index is only safe to use against the currently
+     * displayed adapter while it remains in range; a detached row yields
+     * {@link RecyclerView#NO_POSITION} (-1) and a list that shrank under a
+     * refresh leaves the captured index past the end. Extracted so the guard
+     * that keeps {@link #onContextItemSelected(MenuItem)} from indexing out of
+     * bounds on the main thread can be unit tested.
+     *
+     * @param position  adapter position captured when the context menu was built
+     * @param itemCount current item count of the visible adapter
+     * @return whether {@code position} can be safely used to index the adapter
+     */
+    static boolean isContextPositionInRange(int position, int itemCount) {
+        return position >= 0 && position < itemCount;
     }
 
 //    private boolean itemIsOnScreen(View view) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/LogFragmentContextPositionTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/LogFragmentContextPositionTest.java
@@ -1,0 +1,52 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit coverage for {@link LogFragment#isContextPositionInRange(int, int)}, the
+ * bounds guard that keeps the QSO-logbook context menu from indexing the adapter
+ * with a stale position.
+ *
+ * <p>The context menu stores the row's adapter position in the menu item's tag
+ * when it is built (long-press). By the time the user taps a menu action the row
+ * may have detached ({@code getAdapterPosition() == RecyclerView.NO_POSITION ==
+ * -1}) or the backing list may have shrunk under a refresh (web import /
+ * {@code notifyDataSetChanged}); using that position unguarded threw
+ * {@code IndexOutOfBoundsException} on the main thread. Pure JVM — the helper is
+ * a plain integer range check with no Android types involved.
+ */
+public class LogFragmentContextPositionTest {
+
+    @Test
+    public void positionWithinRange_isValid() {
+        assertThat(LogFragment.isContextPositionInRange(0, 5)).isTrue();
+        assertThat(LogFragment.isContextPositionInRange(4, 5)).isTrue();
+    }
+
+    @Test
+    public void noPositionSentinel_isRejected() {
+        // RecyclerView.NO_POSITION for a detached / mid-animation holder.
+        assertThat(LogFragment.isContextPositionInRange(-1, 5)).isFalse();
+    }
+
+    @Test
+    public void negativePosition_isRejected() {
+        assertThat(LogFragment.isContextPositionInRange(-7, 5)).isFalse();
+    }
+
+    @Test
+    public void positionPastEndAfterListShrank_isRejected() {
+        // Captured at index 4, list later refreshed down to 3 rows.
+        assertThat(LogFragment.isContextPositionInRange(4, 3)).isFalse();
+        // Exactly one past the end.
+        assertThat(LogFragment.isContextPositionInRange(5, 5)).isFalse();
+    }
+
+    @Test
+    public void anyPositionAgainstEmptyList_isRejected() {
+        assertThat(LogFragment.isContextPositionInRange(0, 0)).isFalse();
+        assertThat(LogFragment.isContextPositionInRange(-1, 0)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Long-pressing a row in the QSO logbook opens a context menu whose actions carry the row's **adapter position**, captured in the menu item's tag when the menu is built:

```java
// LogQSLAdapter.LogQSLItemHolder#onCreateContextMenu
view.setTag(getAdapterPosition());
```

`LogFragment.onContextItemSelected` then indexed the adapter with that position **unguarded** — `logQSLAdapter.setRecordIsQSL(position, …)`, `logQSLAdapter.getRecord(position)`, and `logCallsignAdapter.getRecord(position)`.

## Root cause
`getAdapterPosition()` returns `RecyclerView.NO_POSITION` (`-1`) for a detached or mid-animation holder, and the captured index goes **stale** if the backing list shrinks under a refresh (web import / `notifyDataSetChanged`) while the menu is open. Either way `qslRecords.get(position)` throws **`IndexOutOfBoundsException` on the main thread → whole-app crash**.

This is the context-menu twin of the swipe-handler crash on the same screen (PR #548, swipe path). `CallingListAdapter` already range-guards its equivalent menu listener; `LogFragment`'s context-menu path was missed.

## Fix
Validate the captured position against the **visible adapter's current item count** at the top of `onContextItemSelected` and drop the stale action when it is out of range. The range check is extracted to a package-private static helper `isContextPositionInRange(position, itemCount)` so the decision can be unit tested (the `@Composable`/Fragment wrapper stays thin). Happy path is byte-identical.

## Scope / collision
- Touches only `LogFragment.onContextItemSelected` (lines ~287–326) + a new static helper. **Disjoint** from open PR #548, which only modifies `onSwiped` (~404–437) and `LogQSLAdapter`; no shared hunks, no method-name overlap.

## Testing
- New `LogFragmentContextPositionTest` (pure JVM, JUnit4 + Truth): in-range, `NO_POSITION` (-1), negative, past-end-after-shrink, and empty-list cases.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full APK (4 ABIs) builds green.

## Risk
Very low. Adds a bounds check on a UI event path; no protocol, DSP, timing, or native code touched. Only behavior change is that a context-menu tap on an already-gone row is now ignored instead of crashing.