### PR TITLE
Fix iOS ADIF import crash on a huge field-length prefix (Int overflow trap)

### DIFF
--- a/ios/FT8AFKit/Sources/FT8Engine/Adif.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/Adif.swift
@@ -82,7 +82,13 @@ public enum Adif {
 
             // name:len[:type]
             let parts = tag.split(separator: ":", omittingEmptySubsequences: false)
-            guard parts.count >= 2, let len = Int(parts[1]), len >= 0, i + len <= n else {
+            // `len` comes from an untrusted length prefix, so compare against the
+            // remaining byte count as `len <= n - i` rather than `i + len <= n`:
+            // the latter traps on 64-bit signed overflow for a length near Int.max
+            // (crashing the whole app on import of a corrupt/hostile .adi) before
+            // the bound is even checked. `i <= n` always holds here (i = close + 1,
+            // close < n), so `n - i` never underflows.
+            guard parts.count >= 2, let len = Int(parts[1]), len >= 0, len <= n - i else {
                 continue // skip a malformed/over-long field rather than mis-read
             }
             let name = parts[0].lowercased()

--- a/ios/FT8AFKit/Tests/FT8EngineTests/AdifTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/AdifTests.swift
@@ -144,4 +144,18 @@ final class AdifTests: XCTestCase {
         XCTAssertEqual(parsed[0].call, "K1ABC")
         XCTAssertEqual(parsed[0].comment, "")
     }
+
+    func testParseSkipsHugeFieldLengthWithoutOverflowTrap() {
+        // A field length near Int.max fits in Int (so it parses) but is far longer
+        // than the remaining bytes. The over-long guard must reject it WITHOUT
+        // evaluating `i + len` (which would trap on 64-bit signed overflow and
+        // crash the whole app on import of a corrupt/hostile .adi). The record's
+        // valid CALL is still parsed; the huge field is skipped like any other
+        // over-long field.
+        let huge = String(Int.max) // 9223372036854775807
+        let parsed = Adif.parse("<eoh>\n<call:5>K1ABC <comment:\(huge)>x <eor>")
+        XCTAssertEqual(parsed.count, 1)
+        XCTAssertEqual(parsed[0].call, "K1ABC")
+        XCTAssertEqual(parsed[0].comment, "")
+    }
 }


### PR DESCRIPTION
## Root cause

`Adif.parse` (`ios/FT8AFKit/Sources/FT8Engine/Adif.swift`) tokenizes an ADIF
document as length-prefixed `<name:len>value` fields. It validates each field's
declared length with the bound:

```swift
guard parts.count >= 2, let len = Int(parts[1]), len >= 0, i + len <= n else {
    continue // skip a malformed/over-long field rather than mis-read
}
```

`len` is parsed straight from the **untrusted** length prefix as a 64-bit `Int`.
Swift's `+` **traps on signed overflow before** the `<= n` comparison runs, so a
field whose declared length is near `Int.max` — e.g. `<comment:9223372036854775807>` —
overflows `i + len` and crashes the whole app with an arithmetic-overflow trap.

This is on the logbook **ADIF-import** path (`LogbookScreen.importAdif`), which
parses the raw text of any user-picked `.adi` file, so a corrupt, truncated, or
hostile log crashes the app on import.

Note a value like `"99999999999999999999"` (20 digits) is *safe* — `Int(...)`
returns nil and the field is skipped. The crash specifically needs a length that
fits in `Int64` but overflows `i + len`.

## Fix

Compare against the remaining byte count as `len <= n - i` instead of
`i + len <= n`. At that point `i <= n` always holds (`i = close + 1`, `close < n`),
so `n - i` never underflows, and the over-long field is skipped exactly as before
— just without the overflow trap. Happy-path parsing is **byte-identical**.

`parse` is iOS-only (the desktop Rust port only *exports* ADIF), so there is no
divergent port to mirror; the change keeps the lenient "skip a malformed/over-long
field" contract the guard already documents.

## Testing

- Added `AdifTests.testParseSkipsHugeFieldLengthWithoutOverflowTrap`: parses a
  record carrying `<comment:9223372036854775807>` and asserts the CALL still parses
  while the huge field is skipped.
  - **Pre-fix:** hard-crashes the test runner (SIGILL overflow trap; `rsi = 0x7fffffffffffffff`).
  - **Post-fix:** passes.
- Full `FT8AFKit` suite: **88/88 green** via `swift test` (built/tested on Linux;
  the Foundation-only Kit is Linux-buildable).

## Risk assessment

Very low. One-line guard change in a single parser; no protocol/DSP/encoder
behavior is affected, and well-formed ADIF parses identically. No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)