### PR TITLE
Fix ALC target-slider crash on an out-of-order restored config

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -37,6 +37,41 @@ import radio.ks3ckc.ft8af.ui.components.IntSlider
 import radio.ks3ckc.ft8af.ui.components.GlassCard
 import radio.ks3ckc.ft8af.ui.components.SettingsRow
 
+// ALC target window bounds (0-255 normalized ALC scale). The low/high sliders
+// keep a [ALC_GAP]-unit gap between the two values; clampAlcLow/clampAlcHigh use
+// these both to bound each slider and to keep the coerceIn range non-empty when a
+// restored/corrupted config persists an out-of-order pair.
+private const val ALC_LOW_MIN = 10
+private const val ALC_LOW_MAX = 200
+private const val ALC_HIGH_MAX = 250
+private const val ALC_GAP = 10
+
+/**
+ * Clamp a desired ALC-target *low* value into [ALC_LOW_MIN]..[ALC_LOW_MAX], keeping
+ * it at least [ALC_GAP] below the current [high]. The upper bound is floored at
+ * [ALC_LOW_MIN] so the range never inverts: a corrupted/restored config with `high`
+ * below `ALC_LOW_MIN + ALC_GAP` would otherwise make `high - ALC_GAP` fall under
+ * [ALC_LOW_MIN] and crash `coerceIn` with an empty range. Byte-identical to the
+ * previous inline `coerceIn(ALC_LOW_MIN, minOf(ALC_LOW_MAX, high - ALC_GAP))`
+ * whenever that range is already valid (i.e. `high >= ALC_LOW_MIN + ALC_GAP`).
+ */
+internal fun clampAlcLow(desired: Int, high: Int): Int {
+    val upper = minOf(ALC_LOW_MAX, high - ALC_GAP).coerceAtLeast(ALC_LOW_MIN)
+    return desired.coerceIn(ALC_LOW_MIN, upper)
+}
+
+/**
+ * Clamp a desired ALC-target *high* value into (`low + ALC_GAP`)..[ALC_HIGH_MAX].
+ * The lower bound is capped at [ALC_HIGH_MAX] so the range never inverts when a
+ * corrupted/restored config persists a `low` above `ALC_HIGH_MAX - ALC_GAP`.
+ * Byte-identical to the previous inline `coerceIn(low + ALC_GAP, ALC_HIGH_MAX)`
+ * whenever that range is already valid (i.e. `low <= ALC_HIGH_MAX - ALC_GAP`).
+ */
+internal fun clampAlcHigh(desired: Int, low: Int): Int {
+    val lower = (low + ALC_GAP).coerceAtMost(ALC_HIGH_MAX)
+    return desired.coerceIn(lower, ALC_HIGH_MAX)
+}
+
 /**
  * Transmission settings: TX/RX split, watchdog, stop-after, TX protection
  * (auto-volume ALC + SWR halt), and auto-sequencing.
@@ -270,7 +305,7 @@ fun TransmissionSettings(
                             )
                             FT8AFIconButton(
                                 onClick = {
-                                    val clamped = (alcTargetLow - 5).coerceIn(10, minOf(200, alcTargetHigh - 10))
+                                    val clamped = clampAlcLow(alcTargetLow - 5, alcTargetHigh)
                                     alcTargetLow = clamped
                                     GeneralVariables.alcTargetLow = clamped
                                     mainViewModel.databaseOpr.writeConfig(
@@ -284,7 +319,7 @@ fun TransmissionSettings(
                             IntSlider(
                                 value = alcTargetLow,
                                 onValueChange = { v ->
-                                    val clamped = v.coerceIn(10, minOf(200, alcTargetHigh - 10))
+                                    val clamped = clampAlcLow(v, alcTargetHigh)
                                     alcTargetLow = clamped
                                     GeneralVariables.alcTargetLow = clamped
                                 },
@@ -300,7 +335,7 @@ fun TransmissionSettings(
                             )
                             FT8AFIconButton(
                                 onClick = {
-                                    val clamped = (alcTargetLow + 5).coerceIn(10, minOf(200, alcTargetHigh - 10))
+                                    val clamped = clampAlcLow(alcTargetLow + 5, alcTargetHigh)
                                     alcTargetLow = clamped
                                     GeneralVariables.alcTargetLow = clamped
                                     mainViewModel.databaseOpr.writeConfig(
@@ -327,7 +362,7 @@ fun TransmissionSettings(
                             )
                             FT8AFIconButton(
                                 onClick = {
-                                    val clamped = (alcTargetHigh - 5).coerceIn(alcTargetLow + 10, 250)
+                                    val clamped = clampAlcHigh(alcTargetHigh - 5, alcTargetLow)
                                     alcTargetHigh = clamped
                                     GeneralVariables.alcTargetHigh = clamped
                                     mainViewModel.databaseOpr.writeConfig(
@@ -341,7 +376,7 @@ fun TransmissionSettings(
                             IntSlider(
                                 value = alcTargetHigh,
                                 onValueChange = { v ->
-                                    val clamped = v.coerceIn(alcTargetLow + 10, 250)
+                                    val clamped = clampAlcHigh(v, alcTargetLow)
                                     alcTargetHigh = clamped
                                     GeneralVariables.alcTargetHigh = clamped
                                 },
@@ -357,7 +392,7 @@ fun TransmissionSettings(
                             )
                             FT8AFIconButton(
                                 onClick = {
-                                    val clamped = (alcTargetHigh + 5).coerceIn(alcTargetLow + 10, 250)
+                                    val clamped = clampAlcHigh(alcTargetHigh + 5, alcTargetLow)
                                     alcTargetHigh = clamped
                                     GeneralVariables.alcTargetHigh = clamped
                                     mainViewModel.databaseOpr.writeConfig(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -47,11 +47,14 @@ private const val ALC_HIGH_MAX = 250
 private const val ALC_GAP = 10
 
 /**
- * Clamp a desired ALC-target *low* value into [ALC_LOW_MIN]..[ALC_LOW_MAX], keeping
- * it at least [ALC_GAP] below the current [high]. The upper bound is floored at
+ * Clamp a desired ALC-target *low* value into [ALC_LOW_MIN]..[ALC_LOW_MAX]. The
+ * [ALC_GAP]-unit gap below the current [high] is enforced only when [high] leaves
+ * room for it (i.e. `high >= ALC_LOW_MIN + ALC_GAP`); otherwise the value is simply
+ * clamped to [ALC_LOW_MIN]. This is because the upper bound is floored at
  * [ALC_LOW_MIN] so the range never inverts: a corrupted/restored config with `high`
  * below `ALC_LOW_MIN + ALC_GAP` would otherwise make `high - ALC_GAP` fall under
- * [ALC_LOW_MIN] and crash `coerceIn` with an empty range. Byte-identical to the
+ * [ALC_LOW_MIN] and crash `coerceIn` with an empty range (in that degenerate case
+ * the only non-crashing result is [ALC_LOW_MIN] itself). Byte-identical to the
  * previous inline `coerceIn(ALC_LOW_MIN, minOf(ALC_LOW_MAX, high - ALC_GAP))`
  * whenever that range is already valid (i.e. `high >= ALC_LOW_MIN + ALC_GAP`).
  */
@@ -62,10 +65,14 @@ internal fun clampAlcLow(desired: Int, high: Int): Int {
 
 /**
  * Clamp a desired ALC-target *high* value into (`low + ALC_GAP`)..[ALC_HIGH_MAX].
- * The lower bound is capped at [ALC_HIGH_MAX] so the range never inverts when a
- * corrupted/restored config persists a `low` above `ALC_HIGH_MAX - ALC_GAP`.
- * Byte-identical to the previous inline `coerceIn(low + ALC_GAP, ALC_HIGH_MAX)`
- * whenever that range is already valid (i.e. `low <= ALC_HIGH_MAX - ALC_GAP`).
+ * The [ALC_GAP]-unit gap above the current [low] is enforced only when [low] leaves
+ * room for it (i.e. `low <= ALC_HIGH_MAX - ALC_GAP`); otherwise the lower bound is
+ * capped at [ALC_HIGH_MAX] and the value clamps to [ALC_HIGH_MAX]. This keeps the
+ * range from inverting when a corrupted/restored config persists a `low` above
+ * `ALC_HIGH_MAX - ALC_GAP` (in that degenerate case the only non-crashing result is
+ * [ALC_HIGH_MAX] itself). Byte-identical to the previous inline
+ * `coerceIn(low + ALC_GAP, ALC_HIGH_MAX)` whenever that range is already valid
+ * (i.e. `low <= ALC_HIGH_MAX - ALC_GAP`).
  */
 internal fun clampAlcHigh(desired: Int, low: Int): Int {
     val lower = (low + ALC_GAP).coerceAtMost(ALC_HIGH_MAX)

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/AlcTargetClampTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/AlcTargetClampTest.kt
@@ -1,0 +1,123 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [clampAlcLow] and [clampAlcHigh] — the pure helpers that bound
+ * the ALC auto-volume target sliders in [TransmissionSettings].
+ *
+ * These replace six inline `coerceIn(...)` expressions that could crash with an
+ * empty-range `IllegalArgumentException` on the UI thread when a restored or
+ * hand-edited config persisted an out-of-order ALC pair (e.g. `alcTargetHigh`
+ * below 20, or `alcTargetLow` above 240) — the range's max fell below its min.
+ * The tests assert both the crash-proofing and byte-identical behaviour on the
+ * happy path.
+ */
+class AlcTargetClampTest {
+
+    // =====================================================================
+    // clampAlcLow — byte-identical to coerceIn(10, minOf(200, high - 10))
+    //                when high >= 20
+    // =====================================================================
+
+    @Test
+    fun `low with default high keeps a mid-range value`() {
+        // high = 100 → upper = min(200, 90) = 90
+        assertThat(clampAlcLow(60, 100)).isEqualTo(60)
+    }
+
+    @Test
+    fun `low is floored at 10`() {
+        assertThat(clampAlcLow(0, 100)).isEqualTo(10)
+        assertThat(clampAlcLow(-50, 100)).isEqualTo(10)
+    }
+
+    @Test
+    fun `low is capped 10 below high`() {
+        // high = 100 → upper = 90
+        assertThat(clampAlcLow(200, 100)).isEqualTo(90)
+        assertThat(clampAlcLow(95, 100)).isEqualTo(90)
+    }
+
+    @Test
+    fun `low is capped at 200 when high is very large`() {
+        assertThat(clampAlcLow(999, 500)).isEqualTo(200)
+    }
+
+    // ---- Empty-range crash cases (max < min in the old inline coerceIn) ----
+
+    @Test
+    fun `low does not crash when high is below the gap`() {
+        // Old: coerceIn(10, minOf(200, 15 - 10) = 5) → IllegalArgumentException.
+        assertThat(clampAlcLow(60, 15)).isEqualTo(10)
+    }
+
+    @Test
+    fun `low does not crash when high equals the minimum`() {
+        // high = 20 → upper = minOf(200, 10) = 10 → coerceIn(10, 10) = 10.
+        assertThat(clampAlcLow(60, 20)).isEqualTo(10)
+    }
+
+    @Test
+    fun `low does not crash when high is zero or negative`() {
+        assertThat(clampAlcLow(60, 0)).isEqualTo(10)
+        assertThat(clampAlcLow(60, -100)).isEqualTo(10)
+    }
+
+    // =====================================================================
+    // clampAlcHigh — byte-identical to coerceIn(low + 10, 250) when low <= 240
+    // =====================================================================
+
+    @Test
+    fun `high with default low keeps a mid-range value`() {
+        // low = 60 → lower = 70
+        assertThat(clampAlcHigh(100, 60)).isEqualTo(100)
+    }
+
+    @Test
+    fun `high is capped at 250`() {
+        assertThat(clampAlcHigh(999, 60)).isEqualTo(250)
+    }
+
+    @Test
+    fun `high is floored 10 above low`() {
+        // low = 60 → lower = 70
+        assertThat(clampAlcHigh(50, 60)).isEqualTo(70)
+        assertThat(clampAlcHigh(0, 60)).isEqualTo(70)
+    }
+
+    // ---- Empty-range crash cases (min > max in the old inline coerceIn) ----
+
+    @Test
+    fun `high does not crash when low is above the ceiling minus gap`() {
+        // Old: coerceIn(245 + 10 = 255, 250) → 255 > 250 → IllegalArgumentException.
+        assertThat(clampAlcHigh(100, 245)).isEqualTo(250)
+    }
+
+    @Test
+    fun `high does not crash when low equals the ceiling minus gap`() {
+        // low = 240 → lower = 250 → coerceIn(250, 250) = 250.
+        assertThat(clampAlcHigh(100, 240)).isEqualTo(250)
+    }
+
+    @Test
+    fun `high does not crash when low is far above the ceiling`() {
+        assertThat(clampAlcHigh(100, 1000)).isEqualTo(250)
+    }
+
+    // =====================================================================
+    // Round-trip: the sliders' own clamping keeps the pair ordered so a
+    // second clamp on the sibling value never inverts.
+    // =====================================================================
+
+    @Test
+    fun `clamped pair stays ordered with a 10-unit gap`() {
+        // Start from a corrupted pair and clamp each toward the other.
+        val high = clampAlcHigh(5, 250) // low=250 (corrupt) → high floored to 250
+        val low = clampAlcLow(250, high) // → capped 10 below high
+        assertThat(high - low).isAtLeast(10)
+        assertThat(low).isAtLeast(10)
+        assertThat(high).isAtMost(250)
+    }
+}


### PR DESCRIPTION
## Summary

The auto-volume (ALC) target-range sliders in **TransmissionSettings** crash the whole app on the first slider/button interaction when a restored or hand-edited settings backup persisted an out-of-order ALC pair.

Each slider clamped its value with an inline `coerceIn` whose bounds depend on the *sibling* value:

- **Low** slider/buttons: `v.coerceIn(10, minOf(200, alcTargetHigh - 10))`
- **High** slider/buttons: `v.coerceIn(alcTargetLow + 10, 250)`

`coerceIn(min, max)` throws `IllegalArgumentException` ("Cannot coerce value to an empty range") whenever `max < min`. That happens when:

- `alcTargetHigh < 20` → Low's `minOf(200, high - 10)` falls below `10`, or
- `alcTargetLow > 240` → High's `alcTargetLow + 10` exceeds `250`.

These run in the `onValueChange` / button `onClick` lambdas on the **UI thread with no try/catch**, so the first touch of the slider is a hard crash.

## Root cause

`alcTargetLow` / `alcTargetHigh` are hydrated from config via `parseConfigInt(result, default)` in `DatabaseOpr` with **no range clamp**. The UI keeps the pair ordered (`High >= Low + 10`) during normal use, so an inverted pair is only reachable via a corrupted/hand-edited settings backup — the same restore vector already hardened for `setSpectrumWidth` (#537) and the `DatabaseOpr` numeric hydration keys (#513 / #517). The six `coerceIn` sites were the one consumer that turns an out-of-range persisted value into a crash rather than tolerating it.

## Fix

Extracted the two clamp decisions into pure, testable top-level helpers `clampAlcLow` / `clampAlcHigh` (mirroring the existing `IntSlider` helper extraction) that floor/cap the computed bound so the `coerceIn` range can never invert, and routed all six sites (both sliders' drag handler plus their `+`/`-` buttons) through them.

Behaviour is **byte-identical on the happy path** — whenever the old inline range was already valid (`high >= 20`, `low <= 240`), the helpers return exactly what the inline expression did. Out-of-order inputs now clamp to the nearest valid bound instead of throwing.

Change is localized to `TransmissionSettings.kt`; no protocol, DSP, native, or RX/TX-timing behavior is touched.

## Testing

- New `AlcTargetClampTest` (pure JVM, JUnit4 + Truth — no Robolectric): 14 cases covering the happy path, both floor/cap boundaries, the previously-crashing empty-range inputs, and a round-trip ordering invariant.
- `./gradlew :app:testDebugUnitTest --tests radio.ks3ckc.ft8af.ui.settings.AlcTargetClampTest` → 14 passed, 0 failures.
- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL (all 4 ABIs).

## Risk assessment

Low. Pure UI-thread arithmetic; happy-path output is unchanged, the only behavioral difference is that a corrupted persisted ALC pair now clamps to a valid value instead of crashing. No native/DSP/decoder/encoder impact, so no interoperability or performance considerations.