### PR TITLE
Fix iOS map/distance mislocating 6-character Maidenhead grids

### DIFF
--- a/ios/FT8AF/FT8AF/Components/QsoPathMap.swift
+++ b/ios/FT8AF/FT8AF/Components/QsoPathMap.swift
@@ -1,3 +1,4 @@
+import FT8Engine
 import SwiftUI
 
 /// Mini equirectangular map showing the great circle path between two grids.

--- a/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/QsoSheet.swift
@@ -1,3 +1,4 @@
+import FT8Engine
 import SwiftUI
 
 /// Bottom sheet showing station detail when a decode row is tapped.

--- a/ios/FT8AF/FT8AF/Screens/Map/AzimuthalMapCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/AzimuthalMapCanvas.swift
@@ -1,3 +1,4 @@
+import FT8Engine
 import SwiftUI
 
 /// Canvas-drawn azimuthal equidistant projection centered on the operator's grid.

--- a/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/MapScreen.swift
@@ -1,3 +1,4 @@
+import FT8Engine
 import SwiftUI
 
 enum MapProjection: String, CaseIterable {
@@ -273,15 +274,5 @@ struct MapMarker: Identifiable, Equatable {
     }
 }
 
-/// Convert 4-char Maidenhead grid to lat/lon center.
-func gridToLatLon(_ grid: String) -> (Double, Double)? {
-    let chars = Array(grid.uppercased().utf8)
-    guard chars.count >= 4,
-          chars[0] >= 65, chars[0] <= 82,
-          chars[1] >= 65, chars[1] <= 82,
-          chars[2] >= 48, chars[2] <= 57,
-          chars[3] >= 48, chars[3] <= 57 else { return nil }
-    let lon = Double(chars[0] - 65) * 20 + Double(chars[2] - 48) * 2 + 1 - 180
-    let lat = Double(chars[1] - 65) * 10 + Double(chars[3] - 48) * 1 + 0.5 - 90
-    return (lat, lon)
-}
+// `gridToLatLon` now lives in FT8Engine (see FT8AFKit/Sources/FT8Engine/Util.swift)
+// so it decodes 6-character subsquares and is unit-tested; imported above.

--- a/ios/FT8AF/FT8AF/Screens/Map/WorldMapCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Map/WorldMapCanvas.swift
@@ -1,3 +1,4 @@
+import FT8Engine
 import SwiftUI
 
 /// Canvas-drawn equirectangular world map with station markers.

--- a/ios/FT8AFKit/Sources/FT8Engine/Util.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/Util.swift
@@ -34,3 +34,43 @@ enum FT8Time {
 
 /// Truncate a Maidenhead locator to its 4-char field/square (port of util::grid4).
 func grid4(_ s: String) -> String { String(s.prefix(4)) }
+
+/// Decode a Maidenhead locator to a `(latitude, longitude)` centre in degrees, or
+/// `nil` when the field/square characters are malformed.
+///
+/// Handles both 4-character (`FN42`) and 6-character (`IO91wm`) grids. A 4-character
+/// grid resolves to the centre of its 2° × 1° square; a 6-character grid adds the
+/// subsquare offset — each subsquare letter (`a`–`x`, 24 per axis) spans 2°/24 of
+/// longitude and 1°/24 of latitude, and the `+ 0.5` lands on the subsquare centre.
+///
+/// This mirrors the Android decoder (`MaidenheadGrid.gridToLatLng`, whose
+/// `SUBSQUARES = 24` was fixed in the app; a wrong divisor / dropping the subsquare
+/// entirely misplaces a 6-character grid by up to ~55 km — e.g. `IO91wm` (London,
+/// true −0.125° lon) would otherwise resolve to the `IO91` square centre at −1.0°,
+/// the wrong side of the prime meridian). The 4-character result is unchanged from
+/// the previous app-local implementation.
+public func gridToLatLon(_ grid: String) -> (Double, Double)? {
+    let chars = Array(grid.uppercased().utf8)
+    guard chars.count >= 4,
+          chars[0] >= 65, chars[0] <= 82,   // field:  A–R
+          chars[1] >= 65, chars[1] <= 82,
+          chars[2] >= 48, chars[2] <= 57,   // square: 0–9
+          chars[3] >= 48, chars[3] <= 57 else { return nil }
+
+    var lon = Double(chars[0] - 65) * 20 + Double(chars[2] - 48) * 2 - 180
+    var lat = Double(chars[1] - 65) * 10 + Double(chars[3] - 48) - 90
+
+    // Subsquare (chars 4–5, letters a–x → A–X once upper-cased). Only apply it when
+    // both subsquare characters are valid; otherwise fall back to the 4-char square
+    // centre so a malformed 6th/5th character can never mislocate the grid.
+    if chars.count >= 6,
+       chars[4] >= 65, chars[4] <= 88,      // subsquare: A–X (24 letters)
+       chars[5] >= 65, chars[5] <= 88 {
+        lon += (Double(chars[4] - 65) + 0.5) * (2.0 / 24.0)
+        lat += (Double(chars[5] - 65) + 0.5) * (1.0 / 24.0)
+    } else {
+        lon += 1.0   // centre of the 2° longitude square
+        lat += 0.5   // centre of the 1° latitude square
+    }
+    return (lat, lon)
+}

--- a/ios/FT8AFKit/Tests/FT8EngineTests/GridToLatLonTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/GridToLatLonTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import FT8Engine
+
+final class GridToLatLonTests: XCTestCase {
+
+    private func assertClose(
+        _ actual: (Double, Double)?,
+        _ lat: Double,
+        _ lon: Double,
+        accuracy: Double = 1e-9,
+        _ message: String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual else {
+            XCTFail("expected (\(lat), \(lon)) but got nil \(message)", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(actual.0, lat, accuracy: accuracy, "lat \(message)", file: file, line: line)
+        XCTAssertEqual(actual.1, lon, accuracy: accuracy, "lon \(message)", file: file, line: line)
+    }
+
+    // MARK: 4-char (unchanged from the previous app-local implementation)
+
+    func testFourCharResolvesToSquareCentre() {
+        // FN42 (Boston area): field F/N, square 4/2 → centre of the 2°×1° square.
+        // lon = (5*20) + (4*2) + 1 - 180 = -71 ; lat = (13*10) + 2 + 0.5 - 90 = 42.5
+        assertClose(gridToLatLon("FN42"), 42.5, -71.0)
+    }
+
+    func testSixCharPrefixMatchesFourCharCentreForSubsquareAtOrigin() {
+        // "aa" is the first subsquare; its centre sits half a cell in from the
+        // square's SW corner, so a 6-char "..aa" is NOT the 4-char square centre.
+        // Regression guard that the two code paths stay distinct.
+        let four = gridToLatLon("FN42")!
+        let six = gridToLatLon("FN42aa")!
+        XCTAssertNotEqual(four.0, six.0, accuracy: 1e-12)
+        XCTAssertNotEqual(four.1, six.1, accuracy: 1e-12)
+    }
+
+    // MARK: 6-char subsquare precision (the fix)
+
+    func testSixCharHighSubsquareMatchesRealLocation() {
+        // IO91wm = London (true ≈ 51.52°N, -0.125°E). Dropping the subsquare (the old
+        // behaviour) resolved IO91's centre at (51.5, -1.0) — ~45 km west, wrong side
+        // of the prime meridian. With SUBSQUARES = 24 it lands within the subsquare.
+        // lon = (8*20)+(9*2)-180 + (22+0.5)*(2/24) = -2 + 1.875 = -0.125
+        // lat = (14*10)+1-90     + (12+0.5)*(1/24) = 51 + 0.520833… = 51.520833…
+        assertClose(gridToLatLon("IO91wm"), 51.0 + 12.5 / 24.0, -0.125)
+    }
+
+    func testSixCharSubsquareCentreOffsets() {
+        // JN58td (Munich-ish): verify both axes independently.
+        // lon field J=9,square 5 → (9*20)+(5*2)-180 = 10 ; subsquare t = 't'-'a' = 19
+        //   → 10 + (19+0.5)*(2/24) = 10 + 1.625 = 11.625
+        // lat field N=13,square 8 → (13*10)+8-90 = 48 ; subsquare d = 3
+        //   → 48 + (3+0.5)*(1/24) = 48 + 0.145833… = 48.145833…
+        assertClose(gridToLatLon("JN58td"), 48.0 + 3.5 / 24.0, 11.625)
+    }
+
+    func testSubsquareIsCaseInsensitive() {
+        assertClose(gridToLatLon("io91WM"), gridToLatLon("IO91wm")!.0, gridToLatLon("IO91wm")!.1)
+    }
+
+    // MARK: robustness — malformed subsquare falls back to the 4-char centre, never mislocates
+
+    func testMalformedSubsquareFallsBackToSquareCentre() {
+        // 'z' (> 'x') is not a valid subsquare letter → keep the 4-char square centre
+        // rather than indexing an out-of-range cell.
+        assertClose(gridToLatLon("FN42zz"), gridToLatLon("FN42")!.0, gridToLatLon("FN42")!.1)
+    }
+
+    func testFiveCharGridUsesSquareCentre() {
+        assertClose(gridToLatLon("FN42a"), gridToLatLon("FN42")!.0, gridToLatLon("FN42")!.1)
+    }
+
+    // MARK: invalid input → nil
+
+    func testTooShortReturnsNil() {
+        XCTAssertNil(gridToLatLon("FN"))
+        XCTAssertNil(gridToLatLon(""))
+    }
+
+    func testNonGridCharsReturnNil() {
+        XCTAssertNil(gridToLatLon("ZZ99"))   // field letters must be A–R
+        XCTAssertNil(gridToLatLon("FNXY"))   // square must be digits
+    }
+}


### PR DESCRIPTION
## Root cause
iOS `gridToLatLon` (private to `MapScreen.swift`) only decoded the 4-character **field + square** of a Maidenhead locator and returned that square's centre (`+1°` lon / `+0.5°` lat). It **ignored the 6-character subsquare entirely** — for a 6-character input it returned the same point as the 4-character prefix.

The app already stores and displays 6-character grids:
- the operator's **own grid** (the OS-location path keeps subsquare precision),
- imported ADIF `GRIDSQUARE` values,
- PSKReporter / decoded grids.

So every 6-character grid was anchored at the wrong location — up to ~55 km off. Example: **IO91wm** (London, true `-0.125°` lon) resolved to the `IO91` square centre at `-1.0°` — the *wrong side of the prime meridian*. This skewed every map marker, QSO-path line, distance and bearing derived from a 6-character grid (`MapScreen`, `WorldMapCanvas`, `AzimuthalMapCanvas`, `QsoPathMap`, `QsoSheet`, `LogbookAwards`).

Android already decodes 6-character grids correctly — `MaidenheadGrid.gridToLatLng` with `SUBSQUARES = 24` (fixed earlier in the Android app). **iOS was the divergent port.**

## Fix
- Moved `gridToLatLon` into **FT8AFKit → FT8Engine** (`Util.swift`, next to `grid4`). The Kit imports only Foundation, so the function is **unit-testable on the host**.
- Added the subsquare offset: each subsquare letter (`a`–`x`, 24 per axis) spans `2/24°` longitude and `1/24°` latitude, `+0.5` for the cell centre — mirroring the Android decoder.
- A malformed or truncated 5th/6th character **falls back to the 4-char square centre**, so bad input can never mislocate a grid.
- The **4-character result is byte-identical** to the previous implementation.
- The five app views that used the (previously app-local) helper now `import FT8Engine`.

## Testing
- New `FT8EngineTests/GridToLatLonTests` — 9 cases: 4-char unchanged, 6-char precision (incl. **IO91wm/London** and **JN58td**), case-insensitivity, malformed-subsquare fallback, `nil` on invalid input.
- `swift build` + `swift test` on the FT8AFKit package (host/Linux): **96/96 pass**.
- Confirmed the test catches the bug: reverting only the subsquare branch makes **6 of the 9** assertions fail (IO91wm → square centre, JN58td lon/lat wrong); the 4-char and nil cases still pass.

## Risk
Low. Behaviour is unchanged for 4-character grids and for malformed input; only 6-character grids move (to their correct location). No DSP/decoder/protocol impact.

> ⚠️ The **FT8AF app target** compiles only under Xcode (imports SwiftUI/AVFoundation) and was **not** built in this Linux CI environment. The app-side change is limited to deleting the shared helper from `MapScreen.swift` and adding `import FT8Engine` to the files that call it; the tested logic lives entirely in FT8AFKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)