### PR TITLE
Desktop WSJT-X UDP: reject a truncated Halt Tx datagram

### DIFF
--- a/desktop/src-tauri/src/udp/codec.rs
+++ b/desktop/src-tauri/src/udp/codec.rs
@@ -364,7 +364,12 @@ pub fn parse_inbound(buf: &[u8]) -> Option<Inbound> {
         }
         T_REPLAY => Some(Inbound::Replay),
         T_HALT_TX => {
-            let auto_only = r.bool().unwrap_or(false);
+            // Reject a truncated packet rather than defaulting the auto-only flag: a
+            // malformed datagram must never trigger an unintended halt of an in-progress
+            // transmission when "Accept UDP requests" is enabled. A well-formed WSJT-X Halt
+            // always carries the bool; this mirrors the FreeText guard below and the
+            // Android/iOS codec ports, which reject the same truncation.
+            let auto_only = r.bool()?;
             Some(Inbound::HaltTx { auto_only })
         }
         T_FREE_TEXT => {
@@ -737,6 +742,16 @@ mod tests {
         );
 
         assert_eq!(parse_inbound(&begin(T_REPLAY).buf), Some(Inbound::Replay));
+    }
+
+    #[test]
+    fn parse_halt_missing_auto_only_flag_is_rejected() {
+        // A truncated Halt datagram (the trailing auto-only bool missing) must be rejected
+        // rather than defaulting to auto_only=false (a global halt) — otherwise a malformed
+        // or stray packet could stop an in-progress transmission when "Accept UDP requests"
+        // is on. A well-formed Halt still parses (see parse_halt_and_freetext_and_replay).
+        let w = begin(T_HALT_TX); // header only, no auto-only bool appended
+        assert_eq!(parse_inbound(&w.buf), None);
     }
 
     #[test]

--- a/desktop/src-tauri/src/udp/mod.rs
+++ b/desktop/src-tauri/src/udp/mod.rs
@@ -303,6 +303,31 @@ mod tests {
         assert!(to_command(&[0xDE, 0xAD, 0xBE, 0xEF]).is_none());
     }
 
+    // A datagram header for `msg_type` with no type-specific payload.
+    fn header_only(msg_type: u32) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&codec::MAGIC.to_be_bytes());
+        b.extend_from_slice(&codec::SCHEMA.to_be_bytes());
+        b.extend_from_slice(&msg_type.to_be_bytes());
+        b.extend_from_slice(&(codec::CLIENT_ID.len() as u32).to_be_bytes());
+        b.extend_from_slice(codec::CLIENT_ID.as_bytes());
+        b
+    }
+
+    #[test]
+    fn well_formed_halt_stops_tx() {
+        let mut b = header_only(codec::T_HALT_TX);
+        b.push(0); // auto_only = false
+        assert!(matches!(to_command(&b), Some(EngineCommand::StopTx)));
+    }
+
+    #[test]
+    fn truncated_halt_does_not_stop_tx() {
+        // A Halt with the trailing auto-only bool missing must NOT map to StopTx: a
+        // malformed/stray datagram must never halt an in-progress transmission.
+        assert!(to_command(&header_only(codec::T_HALT_TX)).is_none());
+    }
+
     #[test]
     fn disabled_service_send_is_noop() {
         let (tx, _rx) = std::sync::mpsc::channel();


### PR DESCRIPTION
## Summary

The desktop WSJT-X UDP inbound codec accepted a **truncated Halt Tx (type 8)** request as valid, letting a malformed or stray datagram halt an in-progress transmission when *Accept UDP requests* is enabled.

`parse_inbound` read the trailing auto-only flag with `r.bool().unwrap_or(false)`, so a packet missing that byte still produced `Inbound::HaltTx { auto_only: false }`. `udp::to_command` maps **any** `HaltTx` to `EngineCommand::StopTx`, so the truncated packet stopped TX.

## Root cause

`r.bool().unwrap_or(false)` defaults a short read instead of rejecting it — unlike every sibling path:

- The **same codec's Free Text branch** already rejects a missing trailing bool (`r.bool()?`) with a comment that a malformed datagram must never trigger an unintended transmit.
- Both the **Android (Kotlin)** and **iOS (Swift)** codec ports reject a truncated Halt for exactly this reason (with explicit comments).
- The feature's own docs state: *"malformed or truncated datagrams are dropped without effect"* (`docs/wsjtx-udp.md`).

Desktop was the lone outlier, both internally and cross-port.

## Fix

Read the auto-only bool with `?` so a short buffer yields `None` and the datagram is dropped. One-line change; well-formed Halt requests are byte-for-byte unaffected.

## Tests

- `codec::parse_halt_missing_auto_only_flag_is_rejected` — a header-only Halt parses to `None` (fails pre-fix: returned `Some(HaltTx { auto_only: false })`).
- `udp::truncated_halt_does_not_stop_tx` / `udp::well_formed_halt_stops_tx` — the end-to-end `to_command` mapping: no `StopTx` from a truncated packet, `StopTx` from a well-formed one.

## Testing performed

`cargo test` on the real `udp` module, **27/27 green**, run in-sandbox via a host-linked harness (zig cc, since the full Tauri crate can't link webkit2gtk/dbus here). Confirmed the new codec test **fails on the pre-fix source** (`Some(HaltTx…)` vs `None`) and passes after.

## Risk

Minimal. Only behavior change is that a Halt datagram missing its trailing bool is now ignored instead of stopping TX — matching the documented contract and the other two platform ports. Happy-path Halt parsing and every other message type are unchanged.

## Scope

One logical fix, desktop only. No protocol/DSP behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)