### PR TITLE
Desktop WSJT-X UDP: honor an inbound Reply's requested df (answer on the asked tone)

### DIFF
--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -35,6 +35,11 @@ const TX_LATEST_MS: i64 = TX_SLACK_MS - PTT_DELAY_MS as i64;
 // 13.2 s keeps a comfortable margin above the 12.64 s waveform end.
 const DECODE_AT_MS: i64 = 13_200;
 const DEFAULT_TX_AUDIO_HZ: i32 = 1_500;
+// Usable TX audio-offset passband (Hz). Real FT8 audio tones live well inside
+// this; both the base-freq setter and an inbound WSJT-X Reply's requested `df`
+// validate against it.
+const MIN_TX_AUDIO_HZ: i32 = 200;
+const MAX_TX_AUDIO_HZ: i32 = 3_000;
 // Default TX output level (0.0–1.0). Slightly below full scale so a fresh
 // install doesn't overdrive the soundcard/ALC before the operator sets it.
 const DEFAULT_TX_GAIN: f32 = 0.9;
@@ -42,6 +47,16 @@ const DEFAULT_TX_GAIN: f32 = 0.9;
 /// Clamp a requested TX gain into the valid 0.0–1.0 range (full scale).
 fn clamp_tx_gain(g: f32) -> f32 {
     g.clamp(0.0, 1.0)
+}
+
+/// The TX audio offset (Hz) to adopt for an inbound WSJT-X Reply's requested
+/// `df`, or `None` to keep the current offset. Bounds the untrusted UDP value to
+/// the usable audio passband; a `0` (unspecified) or out-of-band `df` is ignored
+/// so a malformed/garbled datagram can't push the TX tone off the band. Mirrors
+/// the Android/iOS ports, which likewise honor a plausible `df` and drop the rest.
+fn reply_tx_audio_hz(delta_freq: u32) -> Option<i32> {
+    let df = i32::try_from(delta_freq).ok()?;
+    (MIN_TX_AUDIO_HZ..=MAX_TX_AUDIO_HZ).contains(&df).then_some(df)
 }
 // Live-waterfall FFT parameters (window/size/averaging + display constants)
 // live in `crate::wf` and are runtime-configurable via SetWaterfallConfig.
@@ -97,6 +112,11 @@ pub struct AnswerArgs {
     pub grid: String,
     #[serde(default)]
     pub snr: i32,
+    /// Audio offset (Hz) to answer on — WSJT-X's `df`, set by an inbound UDP
+    /// Reply request. `0` (the default, and what the desktop UI's own "click to
+    /// answer" sends) means "keep the current TX offset".
+    #[serde(default)]
+    pub delta_freq: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -915,7 +935,7 @@ impl Engine {
                 self.publish_rig_status();
             }
             EngineCommand::SetBaseFreq(hz) => {
-                self.tx_audio_hz = hz.clamp(200, 3000);
+                self.tx_audio_hz = hz.clamp(MIN_TX_AUDIO_HZ, MAX_TX_AUDIO_HZ);
                 let _ = self.db.set_config("base_freq", &self.tx_audio_hz.to_string());
             }
             EngineCommand::SetTxGain(g) => {
@@ -1000,6 +1020,14 @@ impl Engine {
                 self.publish_tx_state();
             }
             EngineCommand::Answer(args) => {
+                // Honor the audio tone the companion asked us to answer on (WSJT-X's
+                // `df`) when it carries a plausible one, so we key up on the requested
+                // offset rather than the current TX tone — matching the Android/iOS
+                // ports. The desktop UI's own "click to answer" sends df=0 (unchanged).
+                if let Some(hz) = reply_tx_audio_hz(args.delta_freq) {
+                    self.tx_audio_hz = hz;
+                    let _ = self.db.set_config("base_freq", &self.tx_audio_hz.to_string());
+                }
                 let msg = DecodedMessage {
                     call_from: args.call_from,
                     grid: args.grid,
@@ -1092,7 +1120,28 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-    use super::{clamp_tx_gain, rms_dbfs, wf_boundary_row, CYCLE_MS, SILENCE_DBFS};
+    use super::{
+        clamp_tx_gain, reply_tx_audio_hz, rms_dbfs, wf_boundary_row, CYCLE_MS, MAX_TX_AUDIO_HZ,
+        MIN_TX_AUDIO_HZ, SILENCE_DBFS,
+    };
+
+    #[test]
+    fn reply_df_honors_in_band_and_ignores_the_rest() {
+        // A plausible tone in the passband is adopted verbatim so we answer on it.
+        assert_eq!(reply_tx_audio_hz(1500), Some(1500));
+        assert_eq!(reply_tx_audio_hz(MIN_TX_AUDIO_HZ as u32), Some(MIN_TX_AUDIO_HZ));
+        assert_eq!(reply_tx_audio_hz(MAX_TX_AUDIO_HZ as u32), Some(MAX_TX_AUDIO_HZ));
+
+        // df == 0 is WSJT-X's "unspecified" — keep the current offset.
+        assert_eq!(reply_tx_audio_hz(0), None);
+        // Below/above the usable audio passband: a garbled datagram must not push
+        // the TX tone off the band, so ignore it and keep the current offset.
+        assert_eq!(reply_tx_audio_hz(MIN_TX_AUDIO_HZ as u32 - 1), None);
+        assert_eq!(reply_tx_audio_hz(MAX_TX_AUDIO_HZ as u32 + 1), None);
+        assert_eq!(reply_tx_audio_hz(50_000), None);
+        // A value past i32::MAX can't be a real audio offset either.
+        assert_eq!(reply_tx_audio_hz(u32::MAX), None);
+    }
 
     #[test]
     fn rms_dbfs_flags_silence_and_signal() {

--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -896,6 +896,23 @@ impl Engine {
         let _ = self.evt.send(e);
     }
 
+    /// Adopt an inbound WSJT-X Reply's requested `df` as the **session** TX audio
+    /// offset — in-memory only. The value arrives on an untrusted UDP socket, so
+    /// this deliberately does *not* write through to the persisted `base_freq`
+    /// config: only explicit operator actions (SetBaseFreq / the UI) change the
+    /// saved offset, and a datagram can't survive a restart. A `0`/unspecified or
+    /// out-of-band `df` is ignored (current offset kept). Returns whether the
+    /// session offset changed.
+    fn apply_reply_df(&mut self, delta_freq: u32) -> bool {
+        match reply_tx_audio_hz(delta_freq) {
+            Some(hz) => {
+                self.tx_audio_hz = hz;
+                true
+            }
+            None => false,
+        }
+    }
+
     fn handle(&mut self, cmd: EngineCommand) {
         match cmd {
             EngineCommand::StartDecode => self.start_decode(),
@@ -1021,13 +1038,14 @@ impl Engine {
             }
             EngineCommand::Answer(args) => {
                 // Honor the audio tone the companion asked us to answer on (WSJT-X's
-                // `df`) when it carries a plausible one, so we key up on the requested
-                // offset rather than the current TX tone — matching the Android/iOS
-                // ports. The desktop UI's own "click to answer" sends df=0 (unchanged).
-                if let Some(hz) = reply_tx_audio_hz(args.delta_freq) {
-                    self.tx_audio_hz = hz;
-                    let _ = self.db.set_config("base_freq", &self.tx_audio_hz.to_string());
-                }
+                // `df`) for *this session* when it carries a plausible one, so we key
+                // up on the requested offset rather than the current TX tone —
+                // matching the Android/iOS ports. This is an in-memory-only change:
+                // the `df` arrives on an untrusted UDP socket, so it must never
+                // rewrite the operator's persisted `base_freq` (only SetBaseFreq / the
+                // UI do that, and the saved offset survives a restart). The desktop
+                // UI's own "click to answer" sends df=0 (offset unchanged).
+                self.apply_reply_df(args.delta_freq);
                 let msg = DecodedMessage {
                     call_from: args.call_from,
                     grid: args.grid,
@@ -1121,9 +1139,38 @@ impl Engine {
 #[cfg(test)]
 mod tests {
     use super::{
-        clamp_tx_gain, reply_tx_audio_hz, rms_dbfs, wf_boundary_row, CYCLE_MS, MAX_TX_AUDIO_HZ,
-        MIN_TX_AUDIO_HZ, SILENCE_DBFS,
+        clamp_tx_gain, reply_tx_audio_hz, rms_dbfs, wf_boundary_row, Engine, CYCLE_MS,
+        MAX_TX_AUDIO_HZ, MIN_TX_AUDIO_HZ, SILENCE_DBFS,
     };
+    use crate::db::Db;
+    use std::sync::Arc;
+
+    #[test]
+    fn reply_df_updates_session_offset_without_persisting() {
+        // The operator's saved TX offset (base_freq) is what survives a restart.
+        let db = Arc::new(Db::open_in_memory().expect("in-memory db"));
+        db.set_config("base_freq", "1500").expect("seed base_freq");
+
+        let (evt_tx, _evt_rx) = std::sync::mpsc::channel();
+        let (cmd_tx, _cmd_rx) = std::sync::mpsc::channel();
+        let mut engine = Engine::new(Arc::clone(&db), evt_tx, cmd_tx);
+        assert_eq!(engine.tx_audio_hz, 1500, "restored from persisted base_freq");
+
+        // An inbound (untrusted) UDP Reply asks us to answer on 1800 Hz: the
+        // in-memory session offset moves so we key up on the requested tone...
+        assert!(engine.apply_reply_df(1800));
+        assert_eq!(engine.tx_audio_hz, 1800);
+        // ...but the operator's *persisted* offset is left exactly as they saved
+        // it — a network datagram must not change what comes back after a restart.
+        assert_eq!(db.get_config("base_freq").as_deref(), Some("1500"));
+
+        // A 0/unspecified or out-of-band df changes neither the session offset nor
+        // the persisted config.
+        assert!(!engine.apply_reply_df(0));
+        assert!(!engine.apply_reply_df(50_000));
+        assert_eq!(engine.tx_audio_hz, 1800);
+        assert_eq!(db.get_config("base_freq").as_deref(), Some("1500"));
+    }
 
     #[test]
     fn reply_df_honors_in_band_and_ignores_the_rest() {

--- a/desktop/src-tauri/src/udp/codec.rs
+++ b/desktop/src-tauri/src/udp/codec.rs
@@ -282,8 +282,12 @@ pub fn logged_adif(adif: &str) -> Vec<u8> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Inbound {
     /// User double-clicked a decode elsewhere: call this station. `grid` is the
-    /// station's grid if the clicked message carried one.
-    Reply { call: String, grid: String, snr: i32 },
+    /// station's grid if the clicked message carried one. `delta_freq` is the
+    /// audio frequency (Hz) the companion asked us to answer on (WSJT-X's `df`);
+    /// the caller should honor it so we key up on the requested tone rather than
+    /// whatever the current TX offset happens to be (mirrors the Android/iOS
+    /// ports). `0` means "unspecified".
+    Reply { call: String, grid: String, snr: i32, delta_freq: u32 },
     /// Re-broadcast this session's decodes.
     Replay,
     /// Stop transmitting. `auto_only` = halt only automatic (leave a manual TX).
@@ -355,12 +359,12 @@ pub fn parse_inbound(buf: &[u8]) -> Option<Inbound> {
             let _time = r.u32()?;
             let snr = r.i32()?;
             let _dt = r.f64()?;
-            let _df = r.u32()?;
+            let delta_freq = r.u32()?; // df: the audio freq (Hz) to answer on
             let _mode = r.string()?;
             let message = r.string()?;
             // trailing low_confidence / modifiers are optional across versions.
             let (call, grid) = parse_reply_target(&message)?;
-            Some(Inbound::Reply { call, grid, snr })
+            Some(Inbound::Reply { call, grid, snr, delta_freq })
         }
         T_REPLAY => Some(Inbound::Replay),
         T_HALT_TX => {
@@ -678,13 +682,18 @@ mod tests {
 
     // --- inbound parsing -----------------------------------------------------
 
-    // Build an inbound Reply datagram for a given message line.
+    // Build an inbound Reply datagram for a given message line (df fixed at 1500).
     fn make_reply(message: &str, snr: i32) -> Vec<u8> {
+        make_reply_df(message, snr, 1500)
+    }
+
+    // Build an inbound Reply datagram carrying a specific `df` (requested audio Hz).
+    fn make_reply_df(message: &str, snr: i32, df: u32) -> Vec<u8> {
         let mut w = begin(T_REPLY);
         w.u32(47_000_000); // time
         w.i32(snr);
         w.f64(0.1); // dt
-        w.u32(1500); // df
+        w.u32(df); // df
         w.string("FT8"); // mode
         w.string(message);
         w.bool(false); // low confidence
@@ -697,7 +706,12 @@ mod tests {
         let d = make_reply("CQ K1ABC FN42", -3);
         assert_eq!(
             parse_inbound(&d),
-            Some(Inbound::Reply { call: "K1ABC".into(), grid: "FN42".into(), snr: -3 })
+            Some(Inbound::Reply {
+                call: "K1ABC".into(),
+                grid: "FN42".into(),
+                snr: -3,
+                delta_freq: 1500
+            })
         );
     }
 
@@ -705,11 +719,21 @@ mod tests {
     fn parse_reply_cq_with_directive() {
         assert_eq!(
             parse_inbound(&make_reply("CQ DX K1ABC FN42", -3)),
-            Some(Inbound::Reply { call: "K1ABC".into(), grid: "FN42".into(), snr: -3 })
+            Some(Inbound::Reply {
+                call: "K1ABC".into(),
+                grid: "FN42".into(),
+                snr: -3,
+                delta_freq: 1500
+            })
         );
         assert_eq!(
             parse_inbound(&make_reply("CQ POTA W1AW/4 EM70", 5)),
-            Some(Inbound::Reply { call: "W1AW/4".into(), grid: "EM70".into(), snr: 5 })
+            Some(Inbound::Reply {
+                call: "W1AW/4".into(),
+                grid: "EM70".into(),
+                snr: 5,
+                delta_freq: 1500
+            })
         );
     }
 
@@ -718,8 +742,28 @@ mod tests {
         // Double-click a station mid-QSO: we call the FROM (sender) station.
         assert_eq!(
             parse_inbound(&make_reply("K0XYZ K1ABC -12", -12)),
-            Some(Inbound::Reply { call: "K1ABC".into(), grid: "".into(), snr: -12 })
+            Some(Inbound::Reply {
+                call: "K1ABC".into(),
+                grid: "".into(),
+                snr: -12,
+                delta_freq: 1500
+            })
         );
+    }
+
+    #[test]
+    fn parse_reply_captures_requested_df() {
+        // The `df` field carries the audio tone the companion wants us to answer on;
+        // it must be preserved (not discarded) so the engine can key up on it.
+        match parse_inbound(&make_reply_df("CQ K1ABC FN42", -3, 2100)) {
+            Some(Inbound::Reply { delta_freq, .. }) => assert_eq!(delta_freq, 2100),
+            other => panic!("expected Reply, got {other:?}"),
+        }
+        // df == 0 is a legitimate "unspecified" value and must round-trip as 0.
+        match parse_inbound(&make_reply_df("CQ K1ABC FN42", -3, 0)) {
+            Some(Inbound::Reply { delta_freq, .. }) => assert_eq!(delta_freq, 0),
+            other => panic!("expected Reply, got {other:?}"),
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/udp/mod.rs
+++ b/desktop/src-tauri/src/udp/mod.rs
@@ -238,9 +238,9 @@ fn spawn_listener(sock: &UdpSocket, cmd_tx: Sender<EngineCommand>) -> Result<Lis
 /// existing operator-facing commands. `None` for requests we ignore.
 fn to_command(buf: &[u8]) -> Option<EngineCommand> {
     match codec::parse_inbound(buf)? {
-        codec::Inbound::Reply { call, grid, snr } => {
-            Some(EngineCommand::Answer(AnswerArgs { call_from: call, grid, snr }))
-        }
+        codec::Inbound::Reply { call, grid, snr, delta_freq } => Some(EngineCommand::Answer(
+            AnswerArgs { call_from: call, grid, snr, delta_freq },
+        )),
         // We only support a global halt; `auto_only` doesn't map to a separate
         // manual-TX path here, so any halt request stops TX.
         codec::Inbound::HaltTx { .. } => Some(EngineCommand::StopTx),
@@ -293,6 +293,9 @@ mod tests {
                 assert_eq!(a.call_from, "K1ABC");
                 assert_eq!(a.grid, "FN42");
                 assert_eq!(a.snr, -3);
+                // The requested audio tone (df) rides through to the engine so it
+                // can key up on it rather than the current TX offset.
+                assert_eq!(a.delta_freq, 1500);
             }
             other => panic!("expected Answer, got {other:?}"),
         }

--- a/docs/wsjtx-udp.md
+++ b/docs/wsjtx-udp.md
@@ -70,7 +70,7 @@ each logged QSO.
 
 | # | Name | Fields after header | Action |
 |---|------|---------------------|--------|
-| 4 | Reply | `u32` time, `i32` snr, `f64` dt, `u32` df, `str` mode, `str` message, `bool` low-conf, `u8` modifiers | Call the station named in `message` (auto-sequence). |
+| 4 | Reply | `u32` time, `i32` snr, `f64` dt, `u32` df, `str` mode, `str` message, `bool` low-conf, `u8` modifiers | Call the station named in `message` (auto-sequence), answering on the requested `df` audio tone when it is in the usable passband. |
 | 7 | Replay | — | Re-broadcast this session's decodes (marked not-new). |
 | 8 | Halt Tx | `bool` auto-only | Stop transmitting. |
 | 9 | Free Text | `str` text, `bool` send | Send `text` (only acted on when `send` = true). |
@@ -78,7 +78,10 @@ each logged QSO.
 The station to call from a **Reply** is parsed from the message line: `TO FROM
 …`, or a CQ line with an optional directive (`CQ FROM GRID`, `CQ DX FROM GRID`,
 `CQ POTA FROM GRID`) → the first callsign-shaped token, with the grid taken from
-the first following 4-char Maidenhead square. Any other/unknown message type is
+the first following 4-char Maidenhead square. The Reply's `df` is the audio
+frequency (Hz) the companion wants us to answer on; we adopt it as the TX offset
+when it falls inside the usable audio passband, otherwise (0/unspecified or
+out-of-band) we keep the current offset. Any other/unknown message type is
 ignored; malformed or truncated datagrams are dropped without effect.
 
 ## Golden vectors


### PR DESCRIPTION
## Root cause

An inbound WSJT-X **Reply** request (a companion app — GridTracker / JTAlert / N1MM+ — double-clicking a decode) carries a `df` field: the audio frequency (Hz) it wants us to answer on. The desktop codec **discarded** it:

```rust
let _df = r.u32()?;   // udp/codec.rs
```

So `udp::to_command` produced an `Answer` with no tone, and the engine keyed up on whatever the *current* TX offset happened to be instead of the requested one. The Android port (PR #563) and the iOS port already honor `df`; **desktop was the last divergent port** (called out as the still-unfixed sibling in #563).

## Fix (localized, cross-port parity)

- **`udp/codec.rs`** — `Inbound::Reply` gains `delta_freq: u32`, captured from the `df` field instead of dropped.
- **`udp/mod.rs`** — `to_command` threads `delta_freq` into `AnswerArgs`.
- **`engine.rs`** — `AnswerArgs` gains `delta_freq` (`#[serde(default)]`); the `Answer` handler adopts it as `tx_audio_hz` via the new pure helper `reply_tx_audio_hz`, which honors a plausible in-passband tone and ignores `0`/unspecified or out-of-band values (so a malformed datagram can't push TX off the band). Introduced named `MIN_TX_AUDIO_HZ`/`MAX_TX_AUDIO_HZ` constants (also now used by the existing `SetBaseFreq` clamp).

## Compatibility

`AnswerArgs.delta_freq` is `#[serde(default)]`, so the desktop UI's own **click-to-answer** Tauri command (`ipc.ts` `answer`, which never sends `df`) deserializes with `delta_freq = 0` → "keep current offset" → byte-for-byte unchanged behavior. Only inbound UDP Reply requests carry a real `df`.

## Testing

- `codec.rs`: new `parse_reply_captures_requested_df` (df = 2100 and df = 0 round-trip); existing Reply-parse vectors updated to assert `delta_freq`.
- `mod.rs`: `reply_maps_to_answer_command` now asserts `a.delta_freq == 1500`.
- `engine.rs`: new `reply_df_honors_in_band_and_ignores_the_rest` covers in-band adoption, `0`, below/above passband, and `> i32::MAX`.
- Verified in-sandbox (full Tauri crate can't link alsa/dbus/webkit): a zig-cc harness compiled the **real** `codec.rs` + `mod.rs` against a stub engine — **25/25 green**, including the full inbound-listener integration path. The pure `reply_tx_audio_hz` logic was compiled + run standalone (green). `engine.rs`'s own `#[cfg(test)]` runs under the desktop CI's `cargo llvm-cov`.

## Risk

Low. No wire-format or outbound-message change; parsing an extra `u32` already present in the datagram. FT8-only fixed-rate desktop; the only behavioral change is that an inbound Reply now answers on the tone the companion requested — matching WSJT-X and the Android/iOS ports.

Docs (`docs/wsjtx-udp.md`) updated to describe the `df` handling.