### PR TITLE
Fix WSJT-X inbound Free-Text crash (null TX target) and repeating send

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -1279,10 +1279,14 @@ public class MainViewModel extends ViewModel {
         if (ft8TransmitSignal == null || !send || text == null) {
             return;
         }
-        ft8TransmitSignal.setFreeText(text);
-        ft8TransmitSignal.setTransmitFreeText(true);
-        ft8TransmitSignal.setActivated(true);
-        ft8TransmitSignal.transmitNow();
+        // Route through the purpose-built one-shot entry point instead of open-coding the
+        // arming sequence. An inbound Free-Text request can be the very first TX action of a
+        // session (a companion app sends it before any CQ or decode tap), and transmitNow()
+        // dereferences toCallsign — which stays null until the first setTransmit/resetToCQ —
+        // for its status toast. sendFreeTextOnce() seeds a CQ baseline in that case (issue
+        // #401), validates the callsign, and arms freeTextOneShot so the text goes out once
+        // (WSJT-X Tx5 semantics) rather than repeating every cycle.
+        ft8TransmitSignal.sendFreeTextOnce(text);
     }
 
     /** Most recent decode from {@code call} in the master list, or null. */

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FreeTextTransmitTargetSeedTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FreeTextTransmitTargetSeedTest.java
@@ -1,0 +1,94 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.k1af.ft8af.GeneralVariables;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Field;
+
+/**
+ * Regression coverage for the WSJT-X UDP inbound Free-Text crash.
+ *
+ * <p>An inbound Free-Text request (a companion app driving us with "accept requests"
+ * on) can be the very first TX action of a session — before any CQ or decode tap has
+ * set a target. {@code transmitNow()} unconditionally dereferences {@code toCallsign}
+ * (its "adjust call target" status toast), which stays {@code null} until the first
+ * {@code setTransmit}/{@code resetToCQ}. The Free-Text handler therefore must route
+ * through {@code sendFreeTextOnce}, which seeds a CQ baseline (issue #401), rather than
+ * open-coding {@code setActivated(true) + transmitNow()} and hitting a main-thread NPE.
+ *
+ * <p>The first test reproduces the exact null state the buggy path left; the second
+ * proves the seed the fixed path performs removes that null-deref precondition. Both
+ * are native-free and deterministic (the NPE fires before the slot/doTransmit logic,
+ * and {@code resetToCQ} only builds the message list).
+ */
+@RunWith(RobolectricTestRunner.class)
+public class FreeTextTransmitTargetSeedTest {
+
+    private FT8TransmitSignal signal;
+
+    @Before
+    public void setUp() {
+        // A valid callsign (length >= 3) so transmitNow() passes the readiness gate and
+        // reaches the toCallsign dereference — the crash the buggy Free-Text path hit.
+        GeneralVariables.myCallsign = "K1ABC";
+        signal = new FT8TransmitSignal(null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.myCallsign = "";
+    }
+
+    private Object toCallsign() throws Exception {
+        Field f = FT8TransmitSignal.class.getDeclaredField("toCallsign");
+        f.setAccessible(true);
+        return f.get(signal);
+    }
+
+    private boolean freeTextOneShotFlag() throws Exception {
+        Field f = FT8TransmitSignal.class.getDeclaredField("freeTextOneShot");
+        f.setAccessible(true);
+        return f.getBoolean(signal);
+    }
+
+    @Test
+    public void transmitNow_withNoTargetSeeded_throwsNpe() throws Exception {
+        // Fresh signal: no setTransmit/resetToCQ has run, so there is no TX target.
+        assertThat(toCallsign()).isNull();
+        // Exactly what the open-coded Free-Text path did: fire transmitNow() with no
+        // target. The status-toast argument dereferences the null toCallsign -> NPE.
+        assertThrows(NullPointerException.class, () -> signal.transmitNow());
+    }
+
+    @Test
+    public void resetToCQ_seedsTarget_removingTheNullDeref() throws Exception {
+        // sendFreeTextOnce (the entry point the fixed handler now uses) seeds a CQ
+        // baseline via resetToCQ when no target has been set this session.
+        assertThat(toCallsign()).isNull();
+        signal.resetToCQ();
+        // Target now present, so transmitNow()'s toCallsign deref is safe on a
+        // first-action Free-Text send.
+        assertThat(toCallsign()).isNotNull();
+    }
+
+    @Test
+    public void sendFreeTextOnce_firstActionOfSession_doesNotCrashAndArmsOneShot() throws Exception {
+        // The behavior the fixed handler routes to: an inbound Free-Text send that is the
+        // first TX action of the session (no target set). This must NOT throw (the CQ
+        // baseline is seeded) and must arm the one-shot so the text goes out once rather
+        // than repeating every cycle.
+        assertThat(toCallsign()).isNull();
+        signal.sendFreeTextOnce("TEST DE K1ABC");
+        assertThat(signal.isTransmitFreeText()).isTrue();
+        assertThat(freeTextOneShotFlag()).isTrue();
+        assertThat(toCallsign()).isNotNull();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FreeTextTransmitTargetSeedTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FreeTextTransmitTargetSeedTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.timer.UtcTimer;
 
 import org.junit.After;
 import org.junit.Before;
@@ -45,6 +46,28 @@ public class FreeTextTransmitTargetSeedTest {
     @After
     public void tearDown() {
         GeneralVariables.myCallsign = "";
+        UtcTimer.delay = 0;// undo any clock pinning so other tests see the real clock
+    }
+
+    /**
+     * Pin the wall clock (via {@link UtcTimer#delay}) so {@code getNowSequential()}
+     * lands on {@code targetParity}, in the MIDDLE of that slot. Landing mid-slot keeps
+     * the parity stable across {@code transmitNow()}'s single {@code getNowSequential()}
+     * read (no slot-boundary race), which lets a test force a deterministic slot
+     * mismatch: with the signal's post-seed sequential != {@code targetParity},
+     * {@code transmitNow()} returns after the toast/flag updates instead of entering
+     * {@code doTransmit()} — so the native encoder never runs on a background thread.
+     */
+    private static void pinNowSequential(int targetParity) {
+        int slot = GeneralVariables.currentMode().slotMillis;
+        long now = System.currentTimeMillis();
+        // Shift so we sit at slot/2 (far from both slot boundaries).
+        long adjust = (slot / 2L) - (now % slot);
+        // If that lands on the wrong parity, shift one whole slot; still mid-slot.
+        if (((now + adjust) / slot) % 2 != targetParity) {
+            adjust += slot;
+        }
+        UtcTimer.delay = (int) adjust;
     }
 
     private Object toCallsign() throws Exception {
@@ -85,6 +108,14 @@ public class FreeTextTransmitTargetSeedTest {
         // first TX action of the session (no target set). This must NOT throw (the CQ
         // baseline is seeded) and must arm the one-shot so the text goes out once rather
         // than repeating every cycle.
+        // Force a deterministic slot mismatch. sendFreeTextOnce seeds a CQ baseline
+        // (resetToCQ), which sets the signal's sequential to (0 + 1) % 2 == 1 on a fresh
+        // signal. Pinning getNowSequential() to 0 makes transmitNow()'s slot check
+        // (getNowSequential() == sequential) fail, so it returns right after updating the
+        // toast/flags — it never enters doTransmit()/the native encoder. Without this the
+        // test is time-dependent: ~half of runs the live slot matches and, if early in the
+        // cycle, a background native encode fires (flaky, UnsatisfiedLinkError noise).
+        pinNowSequential(0);
         assertThat(toCallsign()).isNull();
         signal.sendFreeTextOnce("TEST DE K1ABC");
         assertThat(signal.isTransmitFreeText()).isTrue();


### PR DESCRIPTION
## Summary
An inbound WSJT-X **Free-Text** request (a companion app such as GridTracker/JTAlert driving FT8AF with *Accept UDP requests* enabled) can be the **very first TX action of a session** — before any CQ or decode tap has set a TX target. `MainViewModel.handleWsjtxFreeText` open-coded the free-text arming sequence and called `FT8TransmitSignal.transmitNow()` directly:

```java
ft8TransmitSignal.setFreeText(text);
ft8TransmitSignal.setTransmitFreeText(true);
ft8TransmitSignal.setActivated(true);
ft8TransmitSignal.transmitNow();   // <-- NPE
```

`transmitNow()` unconditionally dereferences `toCallsign` for its "adjust call target" status toast, and `toCallsign` stays `null` until the first `setTransmit`/`resetToCQ`. So the request crashed the app with a **NullPointerException on the main thread** — the listener's dispatch callback is posted to the main `Looper` (`WsjtxUdpService.dispatch`) with no try/catch, so the exception is uncaught.

## Root cause
The codebase already has a purpose-built free-text entry point, `FT8TransmitSignal.sendFreeTextOnce()`, whose own comment documents this exact null (issue #401): it **seeds a CQ baseline** when no target is set, validates the callsign, and arms `freeTextOneShot` so the text is sent **once** (WSJT-X Tx5 semantics). `handleWsjtxFreeText` bypassed all of that. Besides the NPE it also omitted `freeTextOneShot`, so a UDP-triggered free text **repeated every cycle** instead of going out once.

The fix routes the handler through `sendFreeTextOnce()` — the same method the in-app UI free-text button uses — which resolves both the crash and the repeating-send behavior.

## Reproduction
1. Enable UDP + *Accept requests* (Logging settings); `WsjtxUdpService` binds and runs the listener.
2. Configure a callsign (normal) — passes `transmitNow()`'s readiness gate, so control reaches the `toCallsign` deref.
3. Do **not** transmit yet this session (`toCallsign == null`).
4. A companion app sends a Free-Text message (`send = true`) → `handleWsjtxFreeText` runs on the main thread → `transmitNow()` → **NPE, app crash**.

## Testing
- New `FreeTextTransmitTargetSeedTest` (Robolectric):
  - `transmitNow_withNoTargetSeeded_throwsNpe` — reproduces the null-target crash the buggy path hit.
  - `resetToCQ_seedsTarget_removingTheNullDeref` — proves the CQ seed makes the target non-null.
  - `sendFreeTextOnce_firstActionOfSession_doesNotCrashAndArmsOneShot` — the entry point the fix uses is crash-safe on a first-action send and arms the one-shot.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — APK builds (all 4 ABIs).

## Risk
Low and localized. One-line behavioral change in `handleWsjtxFreeText`; the happy path (a Free-Text send after a target already exists) is unchanged — `sendFreeTextOnce` leaves an existing `toCallsign` in place. No DSP/protocol/native changes. Disjoint from the in-flight WSJT-X Reply-df work (that touches `handleWsjtxReply`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)