### PR TITLE
Fix CallingListAdapter main-thread crash on the live decode list (concurrent IndexOutOfBounds)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
@@ -47,9 +47,11 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
 
             //view.setTag(ft8Message);// Pass the message object to the parent view
             int postion= (int) view.getTag();
-            if (postion==-1) return;
-            if (postion>ft8MessageArrayList.size()-1) return;
-            Ft8Message ft8Message=ft8MessageArrayList.get(postion);
+            // The tag was captured at bind time; the shared decode list can be trimmed or
+            // cleared out from under a long-press, so fetch under the decode-thread lock
+            // with a range check rather than indexing raw. See messageAtOrNull.
+            Ft8Message ft8Message = messageAtOrNull(postion);
+            if (ft8Message == null) return;
 
             // Menu parameters: i1=group, i2=id, i3=display order
             if (!ft8Message.getCallsignTo().contains("...")// Target cannot be self
@@ -150,16 +152,15 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
      * @param position Position in the list
      */
     public void deleteMessage(int position) {
-        if (position >= 0) {
-            ft8MessageArrayList.remove(position);
+        synchronized (ft8MessageArrayList) {
+            if (isValidPosition(position, ft8MessageArrayList.size())) {
+                ft8MessageArrayList.remove(position);
+            }
         }
     }
 
     public Ft8Message getMessageByPosition(int position){
-        if (ft8MessageArrayList==null) return null;
-        if (position<0) return null;
-        if (position>ft8MessageArrayList.size()-1) return null;
-        return ft8MessageArrayList.get(position);
+        return messageAtOrNull(position);
     }
 
     /**
@@ -169,17 +170,56 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
      * @return ft8message
      */
     public Ft8Message getMessageByViewHolder(RecyclerView.ViewHolder holder) {
-        if (holder.getAdapterPosition() == -1) {
-            return null;
+        return messageAtOrNull(holder.getAdapterPosition());
+    }
+
+    /**
+     * True when {@code position} indexes an existing row of a {@code size}-element list.
+     * RecyclerView returns {@link RecyclerView#NO_POSITION} (-1) for a detached holder,
+     * and the live decode list can shrink under the UI thread, so every indexed access
+     * must range-check first. Mirrors {@code LogQSLAdapter.isValidPosition}.
+     */
+    static boolean isValidPosition(int position, int size) {
+        return position >= 0 && position < size;
+    }
+
+    /**
+     * Fetch the row at {@code position} atomically with respect to the decode thread, or
+     * {@code null} if it is out of range.
+     *
+     * <p>The two live hosts ({@code CallingListFragment} and {@code GridTrackerMainActivity})
+     * hand this adapter the same {@code MainViewModel.ft8Messages} instance the decode thread
+     * mutates under {@code synchronized (ft8Messages)}: it appends decodes, trims the front via
+     * {@code GeneralVariables.deleteArrayListMore}, and clears the list every cycle. RecyclerView
+     * reads {@code getItemCount()} and then indexes the list from {@code onBindViewHolder} and the
+     * gesture/menu handlers on the UI thread, so a trim or clear landing in that window made a
+     * plain {@code get(position)} throw {@link IndexOutOfBoundsException} on the main thread —
+     * an uncaught whole-app crash. Locking on the list instance (the decode thread's own monitor)
+     * makes the range-check-and-get a single critical section that cannot observe a half-applied
+     * mutation.
+     */
+    Ft8Message messageAtOrNull(int position) {
+        if (ft8MessageArrayList == null) return null;
+        synchronized (ft8MessageArrayList) {
+            if (!isValidPosition(position, ft8MessageArrayList.size())) return null;
+            return ft8MessageArrayList.get(position);
         }
-        return ft8MessageArrayList.get(holder.getAdapterPosition());
     }
 
     @SuppressLint("ResourceAsColor")
     @Override
     public void onBindViewHolder(@NonNull CallingListItemHolder holder, int position) {
+        Ft8Message message = messageAtOrNull(position);
+        if (message == null) {
+            // The decode thread trimmed/cleared the shared ft8Messages list between
+            // getItemCount() and this bind (both run off-lock on the UI thread while the
+            // decode thread mutates the list under synchronized(ft8Messages)). Skip this
+            // stale bind rather than crashing; the mutableFt8MessageList observer already
+            // has a notifyDataSetChanged queued that rebinds against a consistent list.
+            return;
+        }
         holder.callListHolderConstraintLayout.setTag(position);// Set layout tag to identify message position
-        holder.ft8Message = ft8MessageArrayList.get(position);
+        holder.ft8Message = message;
         holder.showMode = showMode;// Determine if this is the message list or the watched message list
         holder.isSyncFreq = mainViewModel.ft8TransmitSignal.isSynFrequency();// If transmitting on same frequency, don't show call receiver
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
@@ -206,6 +206,19 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
         }
     }
 
+    /**
+     * The layout tag a bound row must carry so its click / long-press handlers act on the
+     * right message. The handlers read this tag back
+     * ({@code messageAtOrNull(tag)} in the context menu, {@code tag == -1} guard in the
+     * grid-tracker click listener), so a row with no backing message — the decode list was
+     * trimmed/cleared between {@link #getItemCount()} and the bind — must carry
+     * {@link RecyclerView#NO_POSITION} rather than the previous bind's index. Otherwise a tap
+     * on a reused-but-stale holder would fire against whatever message now occupies that index.
+     */
+    static int rowTagFor(Ft8Message message, int position) {
+        return message == null ? RecyclerView.NO_POSITION : position;
+    }
+
     @SuppressLint("ResourceAsColor")
     @Override
     public void onBindViewHolder(@NonNull CallingListItemHolder holder, int position) {
@@ -216,9 +229,15 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
             // decode thread mutates the list under synchronized(ft8Messages)). Skip this
             // stale bind rather than crashing; the mutableFt8MessageList observer already
             // has a notifyDataSetChanged queued that rebinds against a consistent list.
+            // RecyclerView recycles holders, so before returning put this one into a safe
+            // "no row" state: leaving the previous bind's tag/message/content in place would
+            // keep a stale row visible and clickable until the queued rebind, letting a tap
+            // or long-press fire against whatever message now sits at that index.
+            resetRowToNoPosition(holder);
             return;
         }
-        holder.callListHolderConstraintLayout.setTag(position);// Set layout tag to identify message position
+        holder.itemView.setVisibility(View.VISIBLE);// Undo any prior no-row hide before rebinding
+        holder.callListHolderConstraintLayout.setTag(rowTagFor(message, position));// Set layout tag to identify message position
         holder.ft8Message = message;
         holder.showMode = showMode;// Determine if this is the message list or the watched message list
         holder.isSyncFreq = mainViewModel.ft8TransmitSignal.isSynFrequency();// If transmitting on same frequency, don't show call receiver
@@ -369,6 +388,33 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
             holder.callingListCallsignToTextView.setVisibility(View.VISIBLE);
             holder.callingListCallsignFromTextView.setVisibility(View.VISIBLE);
         }
+    }
+
+    /**
+     * Put a recycled holder into a safe "no row" state for the null-message early return in
+     * {@link #onBindViewHolder}. Clears the layout tag to {@link RecyclerView#NO_POSITION} (so the
+     * click / long-press handlers treat it as empty instead of acting on a stale index), drops the
+     * cached message, blanks the visible text, and hides the row until the queued rebind restores it.
+     */
+    private void resetRowToNoPosition(@NonNull CallingListItemHolder holder) {
+        holder.callListHolderConstraintLayout.setTag(rowTagFor(null, RecyclerView.NO_POSITION));
+        holder.ft8Message = null;
+        holder.otherBandIsQso = false;
+
+        holder.callingUtcTextView.setText("");
+        holder.callingListSequenceTextView.setText("");
+        holder.callingListIdBTextView.setText("");
+        holder.callListDtTextView.setText("");
+        holder.callingListFreqTextView.setText("");
+        holder.callListMessageTextView.setText("");
+        holder.bandItemTextView.setText("");
+        holder.callingListDistTextView.setText("");
+        holder.callingListCommandIInfoTextView.setText("");
+        holder.callingListCallsignFromTextView.setText("");
+        holder.callingListCallsignToTextView.setText("");
+        holder.isWeakSignalImageView.setVisibility(View.INVISIBLE);
+
+        holder.itemView.setVisibility(View.GONE);// Take no visible space until the rebind
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/CallingListAdapterPositionGuardTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/CallingListAdapterPositionGuardTest.java
@@ -92,6 +92,25 @@ public class CallingListAdapterPositionGuardTest {
     }
 
     @Test
+    public void rowTagFor_boundRowKeepsItsPosition() {
+        Ft8Message message = new Ft8Message(FT8Common.FT8_MODE);
+        // A row backed by a message tags its own index so the click / long-press handlers
+        // resolve the right message.
+        assertThat(CallingListAdapter.rowTagFor(message, 0)).isEqualTo(0);
+        assertThat(CallingListAdapter.rowTagFor(message, 7)).isEqualTo(7);
+    }
+
+    @Test
+    public void rowTagFor_noRowUsesNoPositionSentinel() {
+        // A recycled holder whose position no longer has a message (list trimmed/cleared
+        // between getItemCount() and the bind) must carry NO_POSITION so a tap can't fire
+        // against whatever message now occupies the stale index. The grid-tracker click
+        // listener guards `position == -1` and the context menu fetches messageAtOrNull(-1).
+        assertThat(CallingListAdapter.rowTagFor(null, 5)).isEqualTo(-1);
+        assertThat(CallingListAdapter.rowTagFor(null, -1)).isEqualTo(-1);
+    }
+
+    @Test
     public void deleteMessage_outOfRangeIsNoOp_notCrash() {
         CallingListAdapter adapter = adapterWith(messages(3));
         // Pre-fix deleteMessage only guarded position >= 0, so an END-swipe on a holder

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/CallingListAdapterPositionGuardTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/CallingListAdapterPositionGuardTest.java
@@ -1,0 +1,154 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.FT8Common;
+import com.k1af.ft8af.Ft8Message;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Coverage for {@link CallingListAdapter}'s position-bounds and concurrency guards.
+ *
+ * <p>The legacy decode/call/grid-tracker list ({@code CallingListFragment},
+ * {@code GridTrackerMainActivity}) hands the adapter the SAME live
+ * {@code MainViewModel.ft8Messages} instance the decode thread mutates under
+ * {@code synchronized (ft8Messages)} — it appends decodes, trims the front via
+ * {@code GeneralVariables.deleteArrayListMore}, and clears the list every cycle.
+ * RecyclerView reads {@code getItemCount()} and then indexes the list on the UI
+ * thread from {@code onBindViewHolder} and the swipe/menu handlers, so a trim or
+ * clear landing in that window turned a raw {@code get(position)} into an
+ * {@link IndexOutOfBoundsException} on the main thread (whole-app crash). The
+ * adapter now routes every indexed access through {@link CallingListAdapter#messageAtOrNull}
+ * / {@link CallingListAdapter#isValidPosition}, fetching under the decode-thread lock
+ * with a range check.
+ *
+ * <p>Robolectric is only needed to construct real {@link Ft8Message} rows; the guard
+ * methods themselves touch no Android types (the ctor's Context/MainViewModel are
+ * never dereferenced on these paths, so they are passed as {@code null}).
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CallingListAdapterPositionGuardTest {
+
+    private static CallingListAdapter adapterWith(ArrayList<Ft8Message> list) {
+        return new CallingListAdapter(null, null, list, CallingListAdapter.ShowMode.CALLING_LIST);
+    }
+
+    private static ArrayList<Ft8Message> messages(int n) {
+        ArrayList<Ft8Message> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(new Ft8Message(FT8Common.FT8_MODE));
+        }
+        return list;
+    }
+
+    @Test
+    public void isValidPosition_acceptsInRangeRejectsOutOfRange() {
+        assertThat(CallingListAdapter.isValidPosition(0, 2)).isTrue();
+        assertThat(CallingListAdapter.isValidPosition(1, 2)).isTrue();
+
+        assertThat(CallingListAdapter.isValidPosition(-1, 2)).isFalse(); // RecyclerView.NO_POSITION
+        assertThat(CallingListAdapter.isValidPosition(2, 2)).isFalse();  // == size
+        assertThat(CallingListAdapter.isValidPosition(99, 2)).isFalse();
+        assertThat(CallingListAdapter.isValidPosition(0, 0)).isFalse();  // empty list
+    }
+
+    @Test
+    public void messageAtOrNull_returnsElementInRange() {
+        ArrayList<Ft8Message> list = messages(3);
+        CallingListAdapter adapter = adapterWith(list);
+        assertThat(adapter.messageAtOrNull(0)).isSameInstanceAs(list.get(0));
+        assertThat(adapter.messageAtOrNull(2)).isSameInstanceAs(list.get(2));
+    }
+
+    @Test
+    public void messageAtOrNull_outOfRangeReturnsNull_notCrash() {
+        CallingListAdapter adapter = adapterWith(messages(3));
+        // Pre-fix onBindViewHolder / getMessageByViewHolder did a raw get() here and threw.
+        assertThat(adapter.messageAtOrNull(-1)).isNull(); // NO_POSITION
+        assertThat(adapter.messageAtOrNull(3)).isNull();  // == size, stale after a front trim
+        assertThat(adapter.messageAtOrNull(99)).isNull();
+    }
+
+    @Test
+    public void messageAtOrNull_emptyListReturnsNull() {
+        CallingListAdapter adapter = adapterWith(new ArrayList<>());
+        assertThat(adapter.messageAtOrNull(0)).isNull();
+        assertThat(adapter.messageAtOrNull(-1)).isNull();
+    }
+
+    @Test
+    public void getMessageByPosition_delegatesToSafeFetch() {
+        ArrayList<Ft8Message> list = messages(2);
+        CallingListAdapter adapter = adapterWith(list);
+        assertThat(adapter.getMessageByPosition(1)).isSameInstanceAs(list.get(1));
+        assertThat(adapter.getMessageByPosition(-1)).isNull();
+        assertThat(adapter.getMessageByPosition(2)).isNull();
+    }
+
+    @Test
+    public void deleteMessage_outOfRangeIsNoOp_notCrash() {
+        CallingListAdapter adapter = adapterWith(messages(3));
+        // Pre-fix deleteMessage only guarded position >= 0, so an END-swipe on a holder
+        // whose getAdapterPosition() equals the (since-shrunk) size did remove(size) and
+        // threw IndexOutOfBoundsException on the main thread.
+        adapter.deleteMessage(-1);
+        adapter.deleteMessage(3);   // == size
+        adapter.deleteMessage(100);
+        assertThat(adapter.getItemCount()).isEqualTo(3); // nothing removed
+
+        adapter.deleteMessage(0);   // valid: front removal still works
+        assertThat(adapter.getItemCount()).isEqualTo(2);
+    }
+
+    /**
+     * Hammer {@link CallingListAdapter#messageAtOrNull} from the "UI thread" while a
+     * background thread continuously clears and refills the shared list under the same
+     * monitor the decode thread uses. Pre-fix an unsynchronized range-check-then-get
+     * raced the clear/refill and threw {@link IndexOutOfBoundsException}; the fetch must
+     * now either return a live element or {@code null}, never throw.
+     */
+    @Test
+    public void messageAtOrNull_isThreadSafeAgainstConcurrentClearAndRefill() throws InterruptedException {
+        final ArrayList<Ft8Message> list = messages(64);
+        final CallingListAdapter adapter = adapterWith(list);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final int iterations = 20_000;
+
+        Thread mutator = new Thread(() -> {
+            try {
+                for (int i = 0; i < iterations; i++) {
+                    // Mirror the decode thread: clear + repopulate under the list monitor.
+                    synchronized (list) {
+                        list.clear();
+                        for (int k = 0; k < (i % 64); k++) {
+                            list.add(new Ft8Message(FT8Common.FT8_MODE));
+                        }
+                    }
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        });
+
+        mutator.start();
+        try {
+            for (int i = 0; i < iterations; i++) {
+                // Read across the whole plausible index range, including indices that are
+                // valid one instant and out of range the next.
+                adapter.messageAtOrNull(i % 64);
+                adapter.getItemCount();
+            }
+        } catch (Throwable t) {
+            failure.compareAndSet(null, t);
+        }
+        mutator.join();
+
+        assertThat(failure.get()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

The legacy decode / call / grid-tracker `RecyclerView` — hosted by **`CallingListFragment`** (in the navigation graph) and **`GridTrackerMainActivity`** (in the manifest), both live — is handed the *same* live `MainViewModel.ft8Messages` `ArrayList` that the **decode thread** mutates under `synchronized (ft8Messages)`:

- `ft8Messages.addAll(...)` (append decodes)
- `GeneralVariables.deleteArrayListMore(ft8Messages)` → `remove(0)` (trim the front over the display cap)
- `ft8Messages.clear()` (clear-every-cycle mode / clear button)

`CallingListAdapter` read that list on the **UI thread** with raw, unbounded, unsynchronized indexing in `onBindViewHolder`, `getMessageByViewHolder`, `getMessageByPosition`, and the context-menu listener. RecyclerView reads `getItemCount()` and then binds/handles gestures against those positions; if a decode-thread trim or clear lands in that window, `ft8MessageArrayList.get(position)` throws **`IndexOutOfBoundsException` on the main thread → uncaught whole-app crash**. Decodes arrive every 3.75–15 s, so any user scrolling or swiping the calling list / grid tracker is exposed.

## Root cause

Unsynchronized, unbounded indexed access to a list structurally mutated on another thread. The Compose decode path already renders immutable snapshots (`publishFt8MessageList()`); this legacy adapter was never updated and still binds the live instance.

## Fix (localized to `CallingListAdapter`)

- New `messageAtOrNull(position)` locks on the list instance — **the decode thread's own monitor** — and range-checks before `get()`, so the check-and-fetch is one critical section that cannot observe a half-applied mutation.
- All indexed reads (`onBindViewHolder`, `getMessageByViewHolder`, `getMessageByPosition`, menu listener) and `deleteMessage()` now route through that guard.
- `onBindViewHolder` skips a stale bind rather than crashing; the `mutableFt8MessageList` observer already has a `notifyDataSetChanged` queued that rebinds against a consistent list.
- Extracted pure static `isValidPosition(position, size)`, mirroring the existing `LogQSLAdapter.isValidPosition`.

This also closes the swipe-path twin of #548 / #558: `getMessageByViewHolder` previously guarded only `NO_POSITION` (-1), not a stale positive index left after a front trim.

**Happy path is byte-identical** for valid, non-racing positions.

## Testing

`CallingListAdapterPositionGuardTest` (Robolectric only to construct real `Ft8Message` rows; the guards touch no Android types):

- `isValidPosition` / `messageAtOrNull` bounds cases (in-range returns the element; -1, `== size`, past-end, empty → `null`).
- `getMessageByPosition` delegation.
- `deleteMessage_outOfRangeIsNoOp_notCrash` — **reproduces the pre-fix `IndexOutOfBoundsException`** (`deleteMessage(size)` did `remove(size)`); no-op after the fix.
- `messageAtOrNull_isThreadSafeAgainstConcurrentClearAndRefill` — hammers `messageAtOrNull` from the UI thread while a background thread clears/refills the list under the same monitor (20k iterations); must never throw.

Verified locally:
- `./gradlew :app:testDebugUnitTest` — green (full suite).
- `./gradlew :app:assembleDebug` — green (all 4 ABIs, native build).
- Confirmed the `deleteMessage` regression test throws pre-fix and passes post-fix by reverting only the source guard.

## Risk

Low. Change is confined to one adapter; all call sites already handle a `null` return (`CallingListFragment.onSwiped`/`onChildDraw` null-check `getMessageByViewHolder`). No protocol, DSP, or transport behavior touched; performance unchanged (a short `synchronized` around a range-check-and-get, contended only against the decode thread's own brief critical sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)