### PR TITLE
Fix iOS waterfall painting black for the first seconds at startup (noise-floor seed 0 → -60 dB)

### DIFF
--- a/ios/FT8AFKit/Sources/FT8Audio/WaterfallRowBuilder.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/WaterfallRowBuilder.swift
@@ -30,6 +30,7 @@ public struct WaterfallRowBuilder {
     public static let spanDb: Float = 26          // dB above black that maps to full brightness
     public static let blackOffsetDb: Float = 4    // push black above the noise floor
     public static let noiseFloorPercentile: Float = 0.30
+    public static let floorSeedDb: Float = -60    // WfProcessor::new seeds the floor here
     private static let floorEmaUp: Float = 0.9    // previous-floor weight
     private static let floorEmaNew: Float = 0.1   // new-sample weight
 
@@ -46,11 +47,14 @@ public struct WaterfallRowBuilder {
         return min(fftSize / 2, max(1, Int(maxHz / bh)))
     }
 
-    /// EMA state of the noise floor (dB). Seeded at 0 like the engine; it settles
-    /// onto the real floor within a few rows.
+    /// EMA state of the noise floor (dB). Seeded at -60 dB like the engine
+    /// (desktop `wf.rs` `WfProcessor::new`), then reconverges onto the real floor
+    /// within a couple of seconds. Seeding at 0 dB instead pins the black point ~4
+    /// dB — far above a real -40…-80 dB floor — so every signal renders black until
+    /// the EMA crawls down, painting the first seconds of each waterfall dark.
     public private(set) var floorDb: Float
 
-    public init(floorDb: Float = 0) { self.floorDb = floorDb }
+    public init(floorDb: Float = WaterfallRowBuilder.floorSeedDb) { self.floorDb = floorDb }
 
     /// Build one brightness row from the summed power spectrum. `summedPower[i]`
     /// is Σ over `segments` of |FFT bin i|² (length == displayed columns). Updates

--- a/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallRowBuilderTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallRowBuilderTests.swift
@@ -52,6 +52,28 @@ final class WaterfallRowBuilderTests: XCTestCase {
         XCTAssertEqual(row.hzPerCol, 12_000.0 / 2_048.0, accuracy: 1e-4)
     }
 
+    func testDefaultFloorSeedMatchesEngine() {
+        // Regression: the noise-floor EMA must seed at the engine's -60 dB
+        // (desktop wf.rs `WfProcessor::new` -> `floor_db: -60.0`), NOT 0 dB. A 0 dB
+        // seed puts the black point ~4 dB, far above the real floor, so the first
+        // seconds of every waterfall (and every rebuild) render black until the EMA
+        // crawls down to the true floor.
+        XCTAssertEqual(WaterfallRowBuilder().floorDb, -60, accuracy: 0.001)
+    }
+
+    func testStrongSignalIsVisibleOnTheVeryFirstRow() {
+        // With the correct -60 dB seed, a real signal above the noise floor is
+        // bright immediately at startup instead of being swallowed by a too-high
+        // black point. Pre-fix (0 dB seed) bins[10] came back 0 (black).
+        var b = WaterfallRowBuilder()
+        let cols = 100
+        var spec = [Float](repeating: summedPower(forDb: -60), count: cols) // noise floor
+        spec[10] = summedPower(forDb: -25) // strong signal, well above the floor
+        let row = b.buildRow(summedPower: spec, sampleRate: 12_000) // the FIRST row
+        XCTAssertEqual(row.bins[10], 255, "strong signal is bright on the first row, not black")
+        XCTAssertEqual(row.bins[0], 0, "noise floor still renders dark")
+    }
+
     func testColumnsClampToNyquistHalfAtHighRates() {
         // A very high rate would put maxHz within the first few bins; columns must
         // still be >= 1 and never exceed fftSize/2.


### PR DESCRIPTION
## Summary

The iOS live waterfall opens **black for the first ~4–5 seconds** on startup (and after every rebuild), hiding signals until it slowly self-corrects. Root cause is a one-line cross-port divergence in the noise-floor seed.

## Root cause

`WaterfallRowBuilder` colorizes each FFT row relative to a smoothed noise-floor estimate (`floorDb`), with the black point at `floorDb + blackOffsetDb` (4 dB). It seeded that EMA at **0 dB**, whereas the reference engine — desktop `wf.rs` `WfProcessor::new` — seeds it at **-60 dB** (its comment: *"Restarts at -60 dB on rebuild and reconverges within a couple of seconds"*).

With a 0 dB seed the black point starts at ~4 dB — far above a real -40…-80 dB noise floor — so every bin maps below the black point and renders black. The EMA (`0.9·prev + 0.1·sample`) needs ~15–20 rows (~4–5 s at 4 rows/s) to crawl down to the true floor, so the waterfall opens dark instead of showing decodable signals.

The doc comment even claimed *"Seeded at 0 like the engine"* — factually wrong; the engine seeds at -60. This is iOS-only; Android and desktop are unaffected.

## Fix

Seed the default at -60 dB via a new named `floorSeedDb` constant (mirroring the file's other `WF_*` tunables), matching the desktop reference exactly. The first row now has a correct black point.

- **Display-only.** No change to DSP, decoder sensitivity, encoder output, or WSJT-X interop.
- Conservative — restores parity with the benchmark-justified reference, not an algorithm "improvement."
- Explicit `floorDb:` callers (the EMA-mechanism test) are unchanged.

## Testing

Built and `swift test`-ed on Linux against `FT8AFKit` (the Kit imports only Foundation + CFT8, so it's host-testable without Xcode):

- `testDefaultFloorSeedMatchesEngine` — default seed is -60, not 0.
- `testStrongSignalIsVisibleOnTheVeryFirstRow` — a -25 dB signal over a -60 dB floor renders `255` (bright) on the **first** row; came back `0` (black) pre-fix, while the noise floor still renders dark.

Both fail pre-fix and pass after. Full Kit suite: **117/117 green** (115 prior + 2 new).

## Risk

Minimal. Single default-value change to a pure, host-tested display helper; the only shipped caller is `LiveEngine.runWaterfallLoop` which uses the default seed. No effect once the EMA has converged (identical steady-state behavior); only the first ~seconds change, from black → correctly scaled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)