### PR TITLE
Desktop: send the answerer's courtesy 73 (fix dead-write in QSO complete())

### DIFF
--- a/desktop/src-tauri/src/engine.rs
+++ b/desktop/src-tauri/src/engine.rs
@@ -622,7 +622,13 @@ impl Engine {
         self.tx_parity = Some(parity);
         self.txed_slot = slot_id;
         if let Some(msg) = self.qso.tx_message().map(|s| s.to_string()) {
-            self.start_transmit(&msg);
+            if self.start_transmit(&msg) {
+                // Tell the sequencer the message actually went out. This is what
+                // lets a courtesy "73" wrap the QSO up only after it's on the air;
+                // if start_transmit bailed (busy/encode error) the QSO stays armed
+                // and retransmits next slot instead of clobbering the 73.
+                self.qso.notify_transmitted();
+            }
         }
     }
 
@@ -640,16 +646,21 @@ impl Engine {
     /// loop (in `tx_playback`) so the engine keeps draining commands — that's what
     /// makes Stop TX able to interrupt mid-transmission. PTT is dropped later, when
     /// the run loop sees the playback finish (or on Stop TX).
-    fn start_transmit(&mut self, message: &str) {
+    ///
+    /// Returns `true` if a transmission was actually started (PTT keyed, playback
+    /// armed), `false` if it bailed out (already transmitting, or an encode /
+    /// device / playback error). The caller uses this to tell the sequencer the
+    /// message really went out.
+    fn start_transmit(&mut self, message: &str) -> bool {
         // Never key a second transmission over a live one.
         if self.tx_playback.is_some() {
-            return;
+            return false;
         }
         let signal = match crate::dsp::encode::generate_ft8(message, self.tx_audio_hz as f32, SAMPLE_RATE) {
             Some(s) => s,
             None => {
                 self.emit(EngineEvent::Error(format!("cannot encode '{message}'")));
-                return;
+                return false;
             }
         };
 
@@ -661,7 +672,7 @@ impl Engine {
             Ok(p) => p,
             Err(e) => {
                 self.emit(EngineEvent::Error(format!("playback failed: {e}")));
-                return;
+                return false;
             }
         };
 
@@ -679,10 +690,11 @@ impl Engine {
         if let Err(e) = prepared.start(ms_late) {
             self.emit(EngineEvent::Error(format!("playback failed: {e}")));
             self.set_ptt(false);
-            return;
+            return false;
         }
         self.tx_playback = Some(prepared);
         self.publish_tx_state();
+        true
     }
 
     /// Stop the in-flight transmission (if any): dropping the handle halts the

--- a/desktop/src-tauri/src/qso.rs
+++ b/desktop/src-tauri/src/qso.rs
@@ -189,6 +189,14 @@ impl QsoEngine {
             return None;
         }
 
+        // The courtesy "73" queued on the previous slot (RReport -> RR73, or a
+        // manual Tx5) has now had its TX slot; wrap up (return to CQ / stop)
+        // regardless of incoming traffic this slot.
+        if self.stage == TxStage::Bye73 {
+            self.finish_qso();
+            return None;
+        }
+
         // Find a message addressed to us, from our target if we have one.
         let mine = messages.iter().find(|m| {
             m.call_to.eq_ignore_ascii_case(&self.my_call)
@@ -305,7 +313,17 @@ impl QsoEngine {
             confirmed: false,
         };
 
-        // Return to CQ or go idle.
+        // If a courtesy "73" is queued (the RReport arm set stage = Bye73), leave
+        // tx_message/stage so the scheduler transmits it; the next slot's Bye73
+        // handler in process_rx then wraps up. Otherwise finish now.
+        if self.stage != TxStage::Bye73 {
+            self.finish_qso();
+        }
+        Some(QsoOutcome::Completed(record))
+    }
+
+    /// Return to calling CQ, or stop, per `auto_return_to_cq`.
+    fn finish_qso(&mut self) {
         if self.auto_return_to_cq {
             self.reset_qso();
             self.stage = TxStage::Cq;
@@ -313,7 +331,6 @@ impl QsoEngine {
         } else {
             self.stop();
         }
-        Some(QsoOutcome::Completed(record))
     }
 }
 
@@ -384,7 +401,7 @@ mod tests {
         assert_eq!(e.tx_message(), Some("K1ABC K0XYZ R-08"));
         assert_eq!(e.status().report_rcvd, Some(-12));
 
-        // DX sends RR73 -> we send 73 and log.
+        // DX sends RR73 -> we log AND queue the courtesy 73 to transmit.
         let out = e.process_rx(&[msg("K0XYZ", "K1ABC", "RR73", "", -8)]);
         match out {
             Some(QsoOutcome::Completed(rec)) => {
@@ -395,6 +412,13 @@ mod tests {
             }
             _ => panic!("expected completed QSO"),
         }
+        // The final 73 is queued (not clobbered by the auto-return to CQ)...
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ 73"));
+        assert_eq!(e.status().stage, TxStage::Bye73);
+        // ...and once its TX slot has passed, the next slot returns to CQ.
+        assert!(e.process_rx(&[]).is_none());
+        assert_eq!(e.tx_message(), Some("CQ K0XYZ EN37"));
+        assert_eq!(e.status().stage, TxStage::Cq);
     }
 
     #[test]

--- a/desktop/src-tauri/src/qso.rs
+++ b/desktop/src-tauri/src/qso.rs
@@ -68,6 +68,11 @@ pub struct QsoEngine {
     report_rcvd: Option<i32>,
     tx_message: Option<String>,
     started_ms: i64,
+    /// True once the courtesy "73" queued in `TxStage::Bye73` has actually been
+    /// handed to the transmitter (via `notify_transmitted`). Guards `finish_qso`
+    /// so a Bye73 that missed its slot (late TX window, rig busy, encode failure)
+    /// is retransmitted next slot instead of being clobbered by the wrap-up.
+    bye73_sent: bool,
 }
 
 impl QsoEngine {
@@ -86,6 +91,7 @@ impl QsoEngine {
             report_rcvd: None,
             tx_message: None,
             started_ms: 0,
+            bye73_sent: false,
         }
     }
 
@@ -102,6 +108,16 @@ impl QsoEngine {
 
     pub fn tx_message(&self) -> Option<&str> {
         self.tx_message.as_deref()
+    }
+
+    /// The scheduler calls this after the current `tx_message` has actually been
+    /// handed to the transmitter. It only matters for the courtesy "73": it marks
+    /// the Bye73 as sent so the next `process_rx` may wrap the QSO up. For every
+    /// other stage the sequencer advances on received replies, so this is a no-op.
+    pub fn notify_transmitted(&mut self) {
+        if self.stage == TxStage::Bye73 {
+            self.bye73_sent = true;
+        }
     }
 
     /// Begin calling CQ.
@@ -157,6 +173,7 @@ impl QsoEngine {
             TxStage::Bye73 => {
                 self.tx_message = Some(format!("{} {} 73", dx, self.my_call));
                 self.stage = TxStage::Bye73;
+                self.bye73_sent = false;
             }
             TxStage::Cq | TxStage::Idle => unreachable!("handled above"),
         }
@@ -180,6 +197,7 @@ impl QsoEngine {
         self.report_sent = None;
         self.report_rcvd = None;
         self.started_ms = util::now_unix_ms();
+        self.bye73_sent = false;
     }
 
     /// Process the decoded messages of a finished RX slot. Updates `tx_message`
@@ -189,11 +207,16 @@ impl QsoEngine {
             return None;
         }
 
-        // The courtesy "73" queued on the previous slot (RReport -> RR73, or a
-        // manual Tx5) has now had its TX slot; wrap up (return to CQ / stop)
-        // regardless of incoming traffic this slot.
+        // A courtesy "73" is queued (RReport -> RR73, or a manual Tx5). Only wrap
+        // up (return to CQ / stop) once it has *actually* been transmitted — the
+        // scheduler signals that via `notify_transmitted`. If it hasn't gone out
+        // yet (missed TX window, rig busy, encode failure), leave the message
+        // queued so the scheduler retransmits it next slot instead of clobbering
+        // it. Either way we don't act on incoming traffic while a 73 is pending.
         if self.stage == TxStage::Bye73 {
-            self.finish_qso();
+            if self.bye73_sent {
+                self.finish_qso();
+            }
             return None;
         }
 
@@ -261,6 +284,7 @@ impl QsoEngine {
                     // Acknowledge with 73, then log.
                     self.tx_message = Some(format!("{} {} 73", dx, self.my_call));
                     self.stage = TxStage::Bye73;
+                    self.bye73_sent = false;
                     return self.complete(&dx);
                 }
                 _ => {}
@@ -415,10 +439,65 @@ mod tests {
         // The final 73 is queued (not clobbered by the auto-return to CQ)...
         assert_eq!(e.tx_message(), Some("K1ABC K0XYZ 73"));
         assert_eq!(e.status().stage, TxStage::Bye73);
+        // ...the scheduler actually transmits it (signalled here)...
+        e.notify_transmitted();
         // ...and once its TX slot has passed, the next slot returns to CQ.
         assert!(e.process_rx(&[]).is_none());
         assert_eq!(e.tx_message(), Some("CQ K0XYZ EN37"));
         assert_eq!(e.status().stage, TxStage::Cq);
+    }
+
+    #[test]
+    fn bye73_not_finished_until_actually_transmitted() {
+        // Regression: process_rx must not wrap up on stage==Bye73 alone. If the
+        // courtesy 73 couldn't be transmitted this slot (late TX window, rig busy,
+        // encode failure) the QSO must stay armed and retransmit it, not clobber
+        // it by returning to CQ.
+        let mut e = QsoEngine::new("K0XYZ", "EN37");
+        e.answer(&msg("CQ", "K1ABC", "FN42", "FN42", -5));
+        e.process_rx(&[msg("K0XYZ", "K1ABC", "-12", "", -8)]);
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ R-08"));
+
+        // DX sends RR73 -> QSO logs and the courtesy 73 is queued.
+        let out = e.process_rx(&[msg("K0XYZ", "K1ABC", "RR73", "", -8)]);
+        assert!(matches!(out, Some(QsoOutcome::Completed(_))));
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ 73"));
+        assert_eq!(e.status().stage, TxStage::Bye73);
+
+        // The 73 did NOT go out this slot (no notify_transmitted). The next slot
+        // must keep the 73 queued rather than returning to CQ, and must not log
+        // the QSO a second time.
+        assert!(e.process_rx(&[]).is_none());
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ 73"));
+        assert_eq!(e.status().stage, TxStage::Bye73);
+        // Still pending after another silent slot.
+        assert!(e.process_rx(&[]).is_none());
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ 73"));
+        assert_eq!(e.status().stage, TxStage::Bye73);
+
+        // Once the scheduler reports the 73 actually transmitted, the next slot
+        // wraps the QSO up and returns to CQ.
+        e.notify_transmitted();
+        assert!(e.process_rx(&[]).is_none());
+        assert_eq!(e.tx_message(), Some("CQ K0XYZ EN37"));
+        assert_eq!(e.status().stage, TxStage::Cq);
+    }
+
+    #[test]
+    fn notify_transmitted_is_noop_off_bye73() {
+        // notify_transmitted only latches the courtesy 73; it must not disturb an
+        // in-progress sequence (e.g. after answering, stage == Grid).
+        let mut e = QsoEngine::new("K0XYZ", "EN37");
+        e.answer(&msg("CQ", "K1ABC", "FN42", "FN42", -5));
+        assert_eq!(e.status().stage, TxStage::Grid);
+        e.notify_transmitted();
+        // Still awaiting the DX report; nothing changed.
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ EN37"));
+        assert_eq!(e.status().stage, TxStage::Grid);
+        // The DX report still advances us normally.
+        e.process_rx(&[msg("K0XYZ", "K1ABC", "-12", "", -8)]);
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ R-08"));
+        assert_eq!(e.status().stage, TxStage::RReport);
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

The desktop QSO auto-sequencer's **answerer** flow (we reply to a CQ → send our grid → send R+report) is supposed to send a final courtesy **"73"** (WSJT-X Tx5) once the DX sends `RR73`. The `RReport` arm of `process_rx` did exactly that:

```rust
TxStage::RReport => match content {
    Content::Rr73 | Content::Rrr | Content::Bye73 => {
        self.tx_message = Some(format!("{} {} 73", dx, self.my_call)); // <- queue 73
        self.stage = TxStage::Bye73;
        return self.complete(&dx);
    }
    ...
```

…but `complete()` then **unconditionally** ran the return-to-CQ / stop cleanup, overwriting both `tx_message` and `stage`. So the queued "73" was a **dead write**: the answerer never transmitted it and instead jumped straight back to calling CQ, and `TxStage::Bye73` was unreachable.

This diverged from:
- **iOS** (`ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift`) — its `complete()` guards the cleanup with `if stage != .bye73`, and `processRx` wraps up on the *next* slot via an early `Bye73` handler. Its unit test explicitly asserts the "73" is sent then CQ resumes.
- **WSJT-X**, which sends the courtesy 73.

The desktop `qso.rs` was the reference port; iOS mirrored it and fixed this, but desktop still shipped the bug.

## Fix

A faithful port of the iOS structure (no protocol/DSP change, pure state-machine sequencing):

- Extract the return-to-CQ / stop cleanup into `finish_qso()`.
- `complete()` now calls `finish_qso()` only when `stage != Bye73`, so a queued courtesy 73 survives to be transmitted on the answerer's next TX slot.
- `process_rx` wraps the QSO up (via `finish_qso()`) on the following slot, once the `Bye73` message has had its TX slot.

**Scope:** only the answerer's `RReport → RR73` path changes. The CQ-initiator path (`Rr73 → 73`) still completes immediately with no courtesy 73, and every other `complete()` caller is unaffected (their stage is never `Bye73`). The QSO is still logged exactly once, on the same slot as before — no change to the emitted `QsoRecord`. `engine.rs` keeps `qso.active` true through the 73 (stage `Bye73`), so `maybe_transmit` sends it, then the next cycle returns to CQ.

## Testing

- Extended `answerer_full_sequence_logs_qso` (which was a partial port of the iOS test that had dropped the `tx_message`/`stage`/next-slot assertions) to assert the courtesy 73 is queued (`"K1ABC K0XYZ 73"`, stage `Bye73`) and that the next slot returns to CQ (`"CQ K0XYZ EN37"`, stage `Cq`).
- Built + ran the real `qso.rs` `#[cfg(test)]` suite in-sandbox via a `#[path]`-include harness (the full Tauri crate can't link webkit/dbus headless). **7/7 pass** with the fix; the extended test **fails on the pre-fix source** (`left: Some("CQ K0XYZ EN37")`, `right: Some("K1ABC K0XYZ 73")`), confirming it catches the regression.

## Risk

Low. Pure Rust logic, no platform `cfg`, no DSP/interop/encoder change — it makes the answerer emit the standard FT8 courtesy 73 that WSJT-X and the iOS port already send. Behavior is unchanged for the CQ-initiator role and for a non-`auto_return_to_cq` operator (the 73 is still sent, then the engine stops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)