### PR TITLE
Desktop: clear QSO context on stop() so a manual stage button can't re-key a stopped QSO

### DIFF
--- a/desktop/src-tauri/src/qso.rs
+++ b/desktop/src-tauri/src/qso.rs
@@ -172,6 +172,10 @@ impl QsoEngine {
         self.active = false;
         self.tx_message = None;
         self.stage = TxStage::Idle;
+        // Clear the QSO context too, so a later manual set_stage() can't
+        // re-activate and transmit to a stale target/report from the QSO we
+        // just stopped (mirrors the iOS QsoEngine.stop()).
+        self.reset_qso();
     }
 
     fn reset_qso(&mut self) {
@@ -425,6 +429,29 @@ mod tests {
         }
         // auto-returned to CQ
         assert_eq!(e.tx_message(), Some("CQ K0XYZ EN37"));
+    }
+
+    #[test]
+    fn stop_clears_target_so_set_stage_cannot_rekey_a_stopped_qso() {
+        let mut e = QsoEngine::new("K0XYZ", "EN37");
+        // Answering a CQ arms a target + report context.
+        e.answer(&msg("CQ", "K1ABC", "FN42", "FN42", -5));
+        assert_eq!(e.status().target.as_deref(), Some("K1ABC"));
+        assert_eq!(e.status().report_sent, Some(-5));
+
+        // Operator halts TX: the QSO context must be cleared, not just idled.
+        e.stop();
+        assert!(!e.status().active);
+        assert_eq!(e.status().stage, TxStage::Idle);
+        assert_eq!(e.status().target, None);
+        assert_eq!(e.status().report_sent, None);
+        assert_eq!(e.status().report_rcvd, None);
+
+        // A later manual stage button (WSJT-X Tx1–Tx5) must NOT re-key the
+        // just-stopped station — with no target, set_stage is a no-op.
+        e.set_stage(TxStage::Report);
+        assert!(!e.status().active);
+        assert_eq!(e.tx_message(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a reachable functional bug in the desktop (Tauri/Rust) auto-sequencer: after **Halt Tx**, pressing any WSJT-X-style stage button (Tx1–Tx5) re-keys the QSO the operator just stopped, transmitting to the stale target on air.

## Root cause

`QsoEngine::stop()` (`desktop/src-tauri/src/qso.rs`) cleared `active`, `tx_message`, and `stage`, but **left the QSO context** (`target`, `grid_rcvd`, `report_sent`, `report_rcvd`) intact:

```rust
pub fn stop(&mut self) {
    self.active = false;
    self.tx_message = None;
    self.stage = TxStage::Idle;
}
```

`set_stage()` addresses `self.target` and sets `active = true`, and the engine's `EngineCommand::SetStage` handler (`engine.rs:1017`) calls `maybe_transmit(self.cur_slot())` right after. So the flow **StopTx → (any) stage button** was:

1. `StopTx` → `qso.stop()` — idles but keeps `target = Some("K1ABC")`, stale reports.
2. `SetStage(Report)` → `set_stage()` reads the stale `target`, rebuilds `"K1ABC K0XYZ +NN"`, sets `active = true`.
3. `maybe_transmit(...)` keys up immediately — re-transmitting to the just-stopped station.

## Cross-port evidence

The iOS reference port already guards this — `QsoEngine.stop()` calls `resetQso()` with a comment describing exactly this hazard:

```swift
public func stop() {
    active = false; pendingTx = nil; stage = .idle
    // Clear the QSO context too, so a later manual setStage() can't re-activate
    // and transmit to a stale target/report from the QSO we just stopped.
    resetQso()
}
```

The desktop Rust port dropped that safeguard. This is the same class of cross-port divergence as the recent desktop qso fixes.

## Fix

`stop()` now calls the existing `reset_qso()` helper (clears `target`/`grid_rcvd`/`report_*`), mirroring iOS. With no target, a subsequent `set_stage()` is a no-op — the operator must select a station again before transmitting.

## Risk assessment

Minimal. Happy paths are byte-identical — every existing `stop()` caller already tears the QSO down and reads no persisted context afterward:
- `EngineCommand::StopTx` / `EngineCommand::DisconnectRig` — halt and drop PTT/rig.
- `set_stage(TxStage::Idle)` — going idle.
- `complete()`'s non-auto-return branch — the `QsoRecord` is fully built before `stop()` is called, so clearing context after is correct (it matches the auto-return branch, which already calls `reset_qso()`).

No protocol/DSP/interop impact.

## Testing

- Added `stop_clears_target_so_set_stage_cannot_rekey_a_stopped_qso` (pure Rust `#[cfg(test)]` in `qso.rs`). It **fails pre-fix** (`target` survives `stop()` → `Some("K1ABC")` instead of `None`, and the stage button re-arms `active`) and **passes after**.
- Verified in-sandbox by compiling the real `qso.rs` + `util.rs` against field-faithful `db`/`dsp` stand-ins (zig-cc harness; the full crate needs webkit2gtk/dbus). Full module suite: 8/8 green; confirmed the new test fails when the one-line fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)