### PR TITLE
Fix iOS waterfall frequency axis (overlays assumed 3000 Hz while data spans 3500 Hz)

### DIFF
--- a/ios/FT8AF/FT8AF/Screens/Waterfall/FrequencyRuler.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/FrequencyRuler.swift
@@ -1,14 +1,16 @@
 import SwiftUI
+import FT8Audio
 
-/// Horizontal ruler showing Hz tick marks from 0 to 3000.
+/// Horizontal ruler showing Hz tick marks across the displayed audio band.
+/// Ticks span the same range the waterfall/spectrum data covers
+/// (`WaterfallAxis.displayMaxHz`) so the labels line up with the trace.
 struct FrequencyRuler: View {
-    private let ticks = stride(from: 0, through: 3000, by: 500).map { $0 }
+    private let ticks = stride(from: 0, through: Int(WaterfallAxis.displayMaxHz), by: 500).map { $0 }
 
     var body: some View {
         Canvas { context, size in
-            let hzRange: CGFloat = 3000
             for hz in ticks {
-                let x = CGFloat(hz) / hzRange * size.width
+                let x = CGFloat(WaterfallAxis.fraction(forHz: Float(hz))) * size.width
                 // Tick mark
                 let tickPath = Path { p in
                     p.move(to: CGPoint(x: x, y: 0))

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FT8Audio
 
 /// Vertical bar chart of live FFT magnitudes with a TX frequency marker.
 /// Reads normalized magnitudes (0...1) from `appState.waterfall.spectrum`.
@@ -6,8 +7,6 @@ import SwiftUI
 struct SpectrumStrip: View {
     @Environment(AppState.self) private var appState
     @State private var touchFreq: Float?
-
-    private let maxFreqHz: Float = 3000
 
     var body: some View {
         GeometryReader { geo in
@@ -29,13 +28,13 @@ struct SpectrumStrip: View {
                 }
 
                 // TX frequency marker line
-                let txX = CGFloat(appState.waterfall.txFreqHz / maxFreqHz) * size.width
+                let txX = CGFloat(WaterfallAxis.fraction(forHz: appState.waterfall.txFreqHz)) * size.width
                 let markerRect = CGRect(x: txX - 0.5, y: 0, width: 1, height: size.height)
                 context.fill(Path(markerRect), with: .color(accent))
 
                 // Touch frequency indicator
                 if let tf = touchFreq {
-                    let touchX = CGFloat(tf / maxFreqHz) * size.width
+                    let touchX = CGFloat(WaterfallAxis.fraction(forHz: tf)) * size.width
                     let touchRect = CGRect(x: touchX - 0.5, y: 0, width: 1, height: size.height)
                     context.fill(Path(touchRect), with: .color(target.opacity(0.7)))
 
@@ -57,12 +56,12 @@ struct SpectrumStrip: View {
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        let freq = Float(value.location.x / geo.size.width) * maxFreqHz
-                        touchFreq = max(100, min(freq, maxFreqHz))
+                        let fraction = Float(value.location.x / geo.size.width)
+                        touchFreq = WaterfallAxis.tunedTxHz(forFraction: fraction)
                     }
                     .onEnded { value in
-                        let freq = Float(value.location.x / geo.size.width) * maxFreqHz
-                        let clamped = max(100, min(freq, maxFreqHz))
+                        let fraction = Float(value.location.x / geo.size.width)
+                        let clamped = WaterfallAxis.tunedTxHz(forFraction: fraction)
                         appState.waterfall.txFreqHz = clamped
                         // Clear touch indicator after short delay
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/SpectrumStrip.swift
@@ -28,7 +28,7 @@ struct SpectrumStrip: View {
                 }
 
                 // TX frequency marker line
-                let txX = CGFloat(WaterfallAxis.fraction(forHz: appState.waterfall.txFreqHz)) * size.width
+                let txX = CGFloat(WaterfallAxis.clampedFraction(forHz: appState.waterfall.txFreqHz)) * size.width
                 let markerRect = CGRect(x: txX - 0.5, y: 0, width: 1, height: size.height)
                 context.fill(Path(markerRect), with: .color(accent))
 

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
@@ -43,7 +43,7 @@ struct WaterfallCanvas: View {
             // Draw TX frequency marker. Map with the same span the waterfall
             // columns cover (WaterfallAxis) so the marker sits on the trace.
             let txFreq = appState.waterfall.txFreqHz
-            let txX = CGFloat(WaterfallAxis.fraction(forHz: txFreq)) * size.width
+            let txX = CGFloat(WaterfallAxis.clampedFraction(forHz: txFreq)) * size.width
             let txPath = Path { p in
                 p.move(to: CGPoint(x: txX, y: 0))
                 p.addLine(to: CGPoint(x: txX, y: size.height))

--- a/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
+++ b/ios/FT8AF/FT8AF/Screens/Waterfall/WaterfallCanvas.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FT8Audio
 
 /// Live scrolling waterfall heatmap, driven by `appState.waterfall.rows`.
 /// Each row is a `[UInt8]` of brightness values (0...255) produced by
@@ -39,10 +40,10 @@ struct WaterfallCanvas: View {
                 drawMessageLabels(context: context, size: size, numCols: numCols)
             }
 
-            // Draw TX frequency marker
+            // Draw TX frequency marker. Map with the same span the waterfall
+            // columns cover (WaterfallAxis) so the marker sits on the trace.
             let txFreq = appState.waterfall.txFreqHz
-            let maxFreq: Float = 3000 // FT8 audio bandwidth
-            let txX = CGFloat(txFreq / maxFreq) * size.width
+            let txX = CGFloat(WaterfallAxis.fraction(forHz: txFreq)) * size.width
             let txPath = Path { p in
                 p.move(to: CGPoint(x: txX, y: 0))
                 p.addLine(to: CGPoint(x: txX, y: size.height))
@@ -58,7 +59,6 @@ struct WaterfallCanvas: View {
         let messages = appState.decode.messages
         guard !messages.isEmpty else { return }
 
-        let maxFreq: Float = 3000
         // Only show unique callsigns at unique frequencies (latest per callsign)
         var seen = Set<String>()
         let uniqueMessages = messages.prefix(20).filter { msg in
@@ -69,7 +69,7 @@ struct WaterfallCanvas: View {
         }
 
         for msg in uniqueMessages {
-            let x = CGFloat(msg.freqHz / maxFreq) * size.width
+            let x = CGFloat(WaterfallAxis.fraction(forHz: msg.freqHz)) * size.width
             guard x > 0, x < size.width else { continue }
 
             let label = context.resolve(Text(msg.callFrom)

--- a/ios/FT8AFKit/Sources/FT8Audio/WaterfallAxis.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/WaterfallAxis.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Horizontal-axis geometry shared by the waterfall heatmap, the spectrum
 /// strip, the frequency ruler and tap-to-tune.
 ///
@@ -27,7 +25,7 @@ public enum WaterfallAxis {
     /// bound keeps TX inside the SSB passband and mirrors the desktop engine's
     /// `tx_audio_hz.clamp(200, 3000)`; the display band (`displayMaxHz`) extends
     /// above it so higher signals remain visible even though they can't be tuned.
-    public static let minTxHz: Float = 100
+    public static let minTxHz: Float = 200
     public static let maxTxHz: Float = 3000
 
     /// Horizontal position (0...1 of the view width) for a frequency.
@@ -35,6 +33,15 @@ public enum WaterfallAxis {
         let span = displayMaxHz
         guard span > 0 else { return 0 }
         return hz / span
+    }
+
+    /// Horizontal position for a TX-marker overlay, clamped to the drawable
+    /// width (0...1). `txFreqHz` can be set externally without any range check
+    /// — a WSJT-X UDP reply carries a raw `deltaFreq` — so an out-of-band value
+    /// would otherwise push the marker line off-canvas. Clamping keeps it pinned
+    /// to the nearest edge instead of vanishing.
+    public static func clampedFraction(forHz hz: Float) -> Float {
+        return min(max(fraction(forHz: hz), 0), 1)
     }
 
     /// Frequency (Hz) at a horizontal position given as a 0...1 fraction of the

--- a/ios/FT8AFKit/Sources/FT8Audio/WaterfallAxis.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/WaterfallAxis.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Horizontal-axis geometry shared by the waterfall heatmap, the spectrum
+/// strip, the frequency ruler and tap-to-tune.
+///
+/// The waterfall and spectrum columns produced by `WaterfallRowBuilder` are
+/// drawn edge-to-edge across the full view width and cover the audio band
+/// `0 ... WaterfallRowBuilder.maxHz` (`columns(...) * binHz(...)`, i.e. the top
+/// of the displayed band — 3500 Hz, matching the desktop engine's `WF_MAX_HZ`).
+/// Any overlay that positions a frequency on that view — the TX marker, decoded
+/// message labels, the ruler ticks, tap-to-tune — must map with the **same**
+/// span, or it drifts off the trace it annotates. Previously the overlays used a
+/// hard-coded 3000 Hz while the data spanned 3500 Hz, so every marker sat ~17%
+/// away from its signal and tapping a visible trace keyed up on the wrong audio
+/// frequency.
+///
+/// This is the single source of truth for that mapping, extracted off the
+/// SwiftUI `Canvas` views so it can be unit-tested (per the project rule of
+/// putting geometry in a plain, testable type).
+public enum WaterfallAxis {
+    /// Top of the displayed audio band, in Hz. Kept equal to the span the
+    /// waterfall/spectrum data is actually built to so overlays line up with the
+    /// columns.
+    public static var displayMaxHz: Float { WaterfallRowBuilder.maxHz }
+
+    /// Lowest / highest audio offset the operator may transmit on. The upper
+    /// bound keeps TX inside the SSB passband and mirrors the desktop engine's
+    /// `tx_audio_hz.clamp(200, 3000)`; the display band (`displayMaxHz`) extends
+    /// above it so higher signals remain visible even though they can't be tuned.
+    public static let minTxHz: Float = 100
+    public static let maxTxHz: Float = 3000
+
+    /// Horizontal position (0...1 of the view width) for a frequency.
+    public static func fraction(forHz hz: Float) -> Float {
+        let span = displayMaxHz
+        guard span > 0 else { return 0 }
+        return hz / span
+    }
+
+    /// Frequency (Hz) at a horizontal position given as a 0...1 fraction of the
+    /// view width. Inverse of `fraction(forHz:)`.
+    public static func hz(forFraction fraction: Float) -> Float {
+        return fraction * displayMaxHz
+    }
+
+    /// Tap-to-tune: the frequency under a horizontal fraction of the view,
+    /// clamped to the valid TX offset range. The fraction is read against the
+    /// display span so the tap lands on the trace under the finger; the result
+    /// is then clamped so it never exceeds the SSB passband.
+    public static func tunedTxHz(forFraction fraction: Float) -> Float {
+        return min(max(hz(forFraction: fraction), minTxHz), maxTxHz)
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallAxisTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallAxisTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Foundation
 import FT8Audio
 
 final class WaterfallAxisTests: XCTestCase {
@@ -52,6 +51,24 @@ final class WaterfallAxisTests: XCTestCase {
         // Far right (3500 Hz) clamps down to the SSB passband ceiling, not 3500.
         XCTAssertEqual(WaterfallAxis.tunedTxHz(forFraction: 1.0), WaterfallAxis.maxTxHz, accuracy: 1e-4)
         XCTAssertEqual(WaterfallAxis.maxTxHz, 3000, accuracy: 1e-6)
+    }
+
+    /// A TX marker's x-fraction must stay on-canvas even when `txFreqHz` is set
+    /// externally without clamping (e.g. a WSJT-X UDP reply's raw deltaFreq).
+    func testClampedFractionStaysWithinUnitInterval() {
+        // Below the band clamps to the left edge.
+        XCTAssertEqual(WaterfallAxis.clampedFraction(forHz: -500), 0, accuracy: 1e-6)
+        // Above the display span clamps to the right edge.
+        XCTAssertEqual(WaterfallAxis.clampedFraction(forHz: 9999), 1, accuracy: 1e-6)
+        // In-band values pass through unchanged.
+        XCTAssertEqual(WaterfallAxis.clampedFraction(forHz: 1750),
+                       WaterfallAxis.fraction(forHz: 1750), accuracy: 1e-6)
+        // Sweep a range spanning outside the band; result never leaves [0, 1].
+        for hz: Float in [-10_000, -1, 0, 1750, 3500, 4000, 100_000] {
+            let f = WaterfallAxis.clampedFraction(forHz: hz)
+            XCTAssertGreaterThanOrEqual(f, 0)
+            XCTAssertLessThanOrEqual(f, 1)
+        }
     }
 
     /// Tapping a visible signal keys up on that signal, not ~17% low as before.

--- a/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallAxisTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallAxisTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import Foundation
+import FT8Audio
+
+final class WaterfallAxisTests: XCTestCase {
+
+    func testDisplaySpanMatchesDataTop() {
+        // The overlay axis must span the same range as the waterfall data, i.e.
+        // the top of the displayed band the builder is configured for.
+        XCTAssertEqual(WaterfallAxis.displayMaxHz, WaterfallRowBuilder.maxHz, accuracy: 1e-6)
+        XCTAssertEqual(WaterfallAxis.displayMaxHz, 3500, accuracy: 1e-6)
+    }
+
+    func testFractionMapsAcrossFullDataSpan() {
+        XCTAssertEqual(WaterfallAxis.fraction(forHz: 0), 0, accuracy: 1e-6)
+        XCTAssertEqual(WaterfallAxis.fraction(forHz: 1750), 0.5, accuracy: 1e-6)
+        XCTAssertEqual(WaterfallAxis.fraction(forHz: 3500), 1.0, accuracy: 1e-6)
+    }
+
+    func testFractionAndHzAreInverse() {
+        for hz: Float in [0, 100, 733, 1500, 2400, 3200, 3500] {
+            let round = WaterfallAxis.hz(forFraction: WaterfallAxis.fraction(forHz: hz))
+            XCTAssertEqual(round, hz, accuracy: 1e-3)
+        }
+    }
+
+    /// Regression: the overlays used to place a 1500 Hz signal at fraction 0.5
+    /// (a 3000 Hz span) while the data draws it at 1500/3500 ≈ 0.4286. The marker
+    /// now lands on the trace, not ~17% to its right.
+    func testSignalNoLongerMisplacedByOldThreeThousandConstant() {
+        let f = WaterfallAxis.fraction(forHz: 1500)
+        XCTAssertEqual(f, 1500.0 / 3500.0, accuracy: 1e-6)
+        XCTAssertNotEqual(f, 1500.0 / 3000.0, accuracy: 1e-3) // the old, wrong mapping
+    }
+
+    /// The overlay axis lines up with the actual columns the builder emits:
+    /// x == width corresponds to `columns * binHz`, which is within one bin of
+    /// `displayMaxHz`.
+    func testAxisAgreesWithActualColumnSpan() {
+        for sr in [12_000, 24_000, 48_000] {
+            let bin = WaterfallRowBuilder.binHz(sampleRate: sr)
+            let dataTop = Float(WaterfallRowBuilder.columns(sampleRate: sr)) * bin
+            XCTAssertEqual(dataTop, WaterfallAxis.displayMaxHz, accuracy: bin)
+        }
+    }
+
+    func testTapToTuneClampsToTxPassband() {
+        // Middle of the strip tunes to the frequency under the finger.
+        XCTAssertEqual(WaterfallAxis.tunedTxHz(forFraction: 0.5), 1750, accuracy: 1e-4)
+        // Far left clamps up to the minimum TX offset.
+        XCTAssertEqual(WaterfallAxis.tunedTxHz(forFraction: 0.0), WaterfallAxis.minTxHz, accuracy: 1e-4)
+        // Far right (3500 Hz) clamps down to the SSB passband ceiling, not 3500.
+        XCTAssertEqual(WaterfallAxis.tunedTxHz(forFraction: 1.0), WaterfallAxis.maxTxHz, accuracy: 1e-4)
+        XCTAssertEqual(WaterfallAxis.maxTxHz, 3000, accuracy: 1e-6)
+    }
+
+    /// Tapping a visible signal keys up on that signal, not ~17% low as before.
+    func testTapOnVisibleSignalTunesToIt() {
+        // A 2000 Hz signal is drawn at fraction 2000/3500.
+        let fraction = WaterfallAxis.fraction(forHz: 2000)
+        XCTAssertEqual(WaterfallAxis.tunedTxHz(forFraction: fraction), 2000, accuracy: 1e-3)
+    }
+}


### PR DESCRIPTION
## Summary

On the iOS Waterfall screen, every overlay that positions a frequency on the display — the **TX marker**, decoded **callsign labels**, the **frequency ruler**, and **tap-to-tune** — mapped frequency → x with a hard-coded **3000 Hz** full scale. But the waterfall heatmap and spectrum strip draw their FFT columns **edge-to-edge across the full width**, covering `0 … WaterfallRowBuilder.maxHz` = **3500 Hz** (the same top-of-band the desktop engine uses via `WF_MAX_HZ = 3500`).

So the overlays were miscalibrated by a factor of 3500/3000 ≈ 1.17:

- A signal drawn at 1500 Hz (fraction `1500/3500` ≈ 0.43 of the width) had its label/marker painted at `1500/3000` = 0.50 of the width — **~17% to the right of the trace it names.**
- **Tapping a visible signal to set the TX audio tone keyed up ~17% low** — e.g. tapping a 2000 Hz trace tuned to ~1714 Hz. On an FT8 QSO that means calling/answering on the wrong frequency, an interoperability failure.
- Signals in the 3000–3500 Hz region were painted by the waterfall but could never be marked or tuned.

## Root cause

The **display span** (3500 Hz, what the data covers) and the **maximum TX audio offset** (3000 Hz, the SSB-passband tuning limit) were conflated into a single `3000` constant, duplicated across the three view files. The display-mapping half of that constant was simply wrong relative to the DSP.

## Fix

Introduce `WaterfallAxis` in the `FT8Audio` package as the single source of truth for the display-axis geometry:

- `fraction(forHz:)` / `hz(forFraction:)` map frequency ↔ horizontal position against the **actual data span** (`WaterfallRowBuilder.maxHz`), so overlays line up with the columns they annotate.
- `tunedTxHz(forFraction:)` reads the tapped frequency against the display span (so the tap lands on the trace under the finger) and then **clamps to the TX passband `[100, 3000] Hz`** — mirroring the desktop engine's `tx_audio_hz.clamp(200, 3000)`. The effective TX ceiling is therefore **unchanged**.

`WaterfallCanvas`, `SpectrumStrip`, and `FrequencyRuler` become thin callers. This also follows the project rule of extracting `Canvas`/geometry logic into a plain, unit-testable type.

## Testing

- Added `WaterfallAxisTests` (FT8Audio, runs under `swift test` on the macOS CI): mapping, round-trip, TX-clamp behavior, a regression asserting 1500 Hz now maps to `1500/3500` (not the old `1500/3000`), and an **invariant test** that the overlay span agrees with `columns × binHz` within one FFT bin at 12/24/48 kHz.
- Verified the real compiled `FT8Audio` sources locally (the full package `swift build`/`swift test` requires macOS because `FT8Engine/WsjtxUdpService.swift` imports Apple's `Network` framework): the `FT8Audio` module compiles clean on Linux, and a standalone driver exercising the real `WaterfallAxis` + `WaterfallRowBuilder` passes all assertions, including `columns×binHz ≈ 3498/3492 Hz` matching the 3500 Hz axis within one bin.

## Risk

Low. Pure display/tuning geometry; no DSP, encoder, or decoder change. Overlays now match the trace and tap-to-tune keys up on the tapped signal. The maximum transmittable audio offset stays at 3000 Hz. Waterfall/spectrum column rendering is untouched.

## Notes / follow-up (out of scope)

The `settings.spectrumWidthHz` picker (2500/3000/4000/5000 Hz in Radio & Audio settings) is persisted but not wired to anything — neither the DSP column count nor the display axis reads it. Wiring it would change the DSP data span and is a separate logical change; left for a follow-up.

*Optio Task ID: c36758f5-b9b1-4691-8e66-3a76f60d76d4*