### PR TITLE
Fix iOS map/distance: reject the RR73 QSO sign-off in gridToLatLon

### DIFF
--- a/ios/FT8AFKit/Sources/FT8Engine/Util.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/Util.swift
@@ -52,9 +52,9 @@ func grid4(_ s: String) -> String { String(s.prefix(4)) }
 public func gridToLatLon(_ grid: String) -> (Double, Double)? {
     let upper = grid.uppercased()
 
-    // "RR73" (and the bare "RR") is an FT8 QSO sign-off, not a locator — but it
-    // matches the Maidenhead field/square pattern (R,R are valid A–R field
-    // letters and 7,3 are valid digits), so it would otherwise decode to a bogus
+    // "RR73" and the bare "RR" are FT8 QSO sign-offs, not locators — but they
+    // match the Maidenhead field/square pattern (R,R are valid A–R field
+    // letters and 7,3 are valid digits), so they would otherwise decode to a bogus
     // point in the Arctic Ocean (83.5°N, 175°E). The decoder places "RR73" in a
     // message's `grid` field via `looksLikeGrid`, and the map/distance/awards
     // screens feed that straight in, so it must be rejected here — mirroring the

--- a/ios/FT8AFKit/Sources/FT8Engine/Util.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/Util.swift
@@ -50,7 +50,19 @@ func grid4(_ s: String) -> String { String(s.prefix(4)) }
 /// the wrong side of the prime meridian). The 4-character result is unchanged from
 /// the previous app-local implementation.
 public func gridToLatLon(_ grid: String) -> (Double, Double)? {
-    let chars = Array(grid.uppercased().utf8)
+    let upper = grid.uppercased()
+
+    // "RR73" (and the bare "RR") is an FT8 QSO sign-off, not a locator — but it
+    // matches the Maidenhead field/square pattern (R,R are valid A–R field
+    // letters and 7,3 are valid digits), so it would otherwise decode to a bogus
+    // point in the Arctic Ocean (83.5°N, 175°E). The decoder places "RR73" in a
+    // message's `grid` field via `looksLikeGrid`, and the map/distance/awards
+    // screens feed that straight in, so it must be rejected here — mirroring the
+    // Android decoder (`MaidenheadGrid.gridToLatLng`, which rejects both tokens)
+    // — to avoid a phantom map pin and a nonsense great-circle distance.
+    if upper == "RR73" || upper == "RR" { return nil }
+
+    let chars = Array(upper.utf8)
     guard chars.count >= 4,
           chars[0] >= 65, chars[0] <= 82,   // field:  A–R
           chars[1] >= 65, chars[1] <= 82,

--- a/ios/FT8AFKit/Tests/FT8EngineTests/GridToLatLonTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/GridToLatLonTests.swift
@@ -85,4 +85,21 @@ final class GridToLatLonTests: XCTestCase {
         XCTAssertNil(gridToLatLon("ZZ99"))   // field letters must be A–R
         XCTAssertNil(gridToLatLon("FNXY"))   // square must be digits
     }
+
+    // MARK: FT8 sign-off tokens that collide with the grid pattern → nil
+
+    func testRr73SignOffIsRejected() {
+        // "RR73" is the FT8 QSO sign-off (roger, best regards), placed in a
+        // message's grid field by the decoder's looksLikeGrid. R,R are valid
+        // A–R field letters and 7,3 are valid digits, so without an explicit
+        // guard it decodes to a phantom point in the Arctic Ocean (83.5°N,
+        // 175°E). The Android decoder rejects it; this port must too.
+        XCTAssertNil(gridToLatLon("RR73"))
+        XCTAssertNil(gridToLatLon("rr73"))   // case-insensitive
+    }
+
+    func testRrSignOffIsRejected() {
+        XCTAssertNil(gridToLatLon("RR"))
+        XCTAssertNil(gridToLatLon("rr"))
+    }
 }


### PR DESCRIPTION
## Root cause

`gridToLatLon` (`ios/FT8AFKit/Sources/FT8Engine/Util.swift`) validated a locator only against the Maidenhead field/square character pattern. `"RR73"` passes that pattern — `R,R` are valid `A–R` field letters and `7,3` are valid `0–9` square digits — so it decoded to a **bogus point in the Arctic Ocean, (83.5°N, 175°E)**.

But `RR73` is the **FT8 QSO sign-off** ("roger, best regards"), not a grid. The decoder puts it into a message's `grid` field via `looksLikeGrid` (`FT8DSP/FT8Decoder.swift:204`, which returns true for any 2-letter+2-digit token). The map/distance/awards screens then feed `message.grid` / `record.gridsquare` straight into `gridToLatLon`:

- `Screens/Map/MapScreen.swift:208` — station marker
- `Screens/Decode/QsoSheet.swift:160` — QSO path
- `Components/QsoPathMap.swift:23-24` — path map
- `Screens/Logbook/LogbookAwards.swift:93` — award zone
- plus the great-circle distance derived from those coordinates

So essentially **every completed QSO** (which ends in `RR73`) drew a phantom map pin in the Arctic and produced a nonsense distance.

## Why this is a regression from the intended behavior

`gridToLatLon`'s own docstring states it "mirrors the Android decoder (`MaidenheadGrid.gridToLatLng`)". The Android reference explicitly rejects both sign-off tokens:

```java
if (grid.equalsIgnoreCase("RR73")) return null;
if (grid.equalsIgnoreCase("RR"))   return null;
```

The iOS port dropped that guard. This is the same class of cross-port divergence fixed in the 6-char subsquare work (#561/#519): a safeguard the Android reference has but the port omitted.

## Fix

Reject `"RR73"` and the bare `"RR"` up front in `gridToLatLon`, returning `nil` (no pin, no distance) — exactly as Android does. The 4- and 6-character happy paths are byte-identical (the guard fires only on the two sign-off tokens).

## Testing

- `GridToLatLonTests.testRr73SignOffIsRejected` — **fails pre-fix**, decoding `"RR73"` to the `(83.5, 175.0)` phantom point; passes after. Also asserts case-insensitivity (`"rr73"`).
- `GridToLatLonTests.testRrSignOffIsRejected` — parity with the Android `"RR"` guard.
- Full `FT8AFKit` suite **117/117 green** via `swift test` (built on Linux; the guard file is Foundation-only).

## Risk

Minimal. One early-return guard on two exact string constants; no change to any valid-grid coordinate. No DSP/decoder/interop impact — purely the map/distance/awards display layer. iOS-only; Android already behaves this way.