### PR TITLE
Fix Grid Tracker calling-list tap crash on the live decode list (main-thread IndexOutOfBounds)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -1053,6 +1053,41 @@ public class MainViewModel extends ViewModel {
     }
 
     /**
+     * Bounds-checked, lock-guarded read of the live {@link #ft8Messages} decode
+     * list; returns {@code null} when {@code position} is out of range.
+     *
+     * <p>UI item-click handlers (e.g. the Grid Tracker calling list) turn a
+     * RecyclerView row into a position and then index the live list on the main
+     * thread. The decode thread mutates {@code ft8Messages} — {@code addAll} plus
+     * {@link GeneralVariables#deleteArrayListMore} ({@code remove(0)}) and
+     * {@code clear()} — under {@code synchronized (ft8Messages)}. A main-thread
+     * {@code size()}-check-then-{@code get(pos)} is therefore not atomic: a
+     * concurrent {@code remove(0)}/{@code clear()} landing between the two steps
+     * throws {@link IndexOutOfBoundsException} on the UI thread (an uncaught,
+     * whole-app crash), and a {@code remove(0)} that merely shifts indices makes
+     * an in-bounds {@code get} return the wrong station. Reading under the
+     * writers' monitor makes the check-and-get atomic. Package-visible for
+     * testing.
+     */
+    static Ft8Message messageAt(ArrayList<Ft8Message> list, int position) {
+        synchronized (list) {
+            if (position < 0 || position >= list.size()) {
+                return null;
+            }
+            return list.get(position);
+        }
+    }
+
+    /**
+     * Safe accessor for a decoded message by list position for main-thread UI
+     * callers; {@code null} if the position is no longer valid. See
+     * {@link #messageAt(ArrayList, int)} for why the lock is required.
+     */
+    public Ft8Message getFt8MessageAtOrNull(int position) {
+        return messageAt(ft8Messages, position);
+    }
+
+    /**
      * Wipe the now-stale decode list and reset the TX target to CQ after a band or
      * mode change, so the decode screen and TX target reflect the new band/mode
      * instead of leftover spots from the old one (tester request). Callers gate this

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -1069,6 +1069,7 @@ public class MainViewModel extends ViewModel {
      * writers' monitor makes the check-and-get atomic. Package-visible for
      * testing.
      */
+    @Nullable
     static Ft8Message messageAt(ArrayList<Ft8Message> list, int position) {
         synchronized (list) {
             if (position < 0 || position >= list.size()) {
@@ -1083,6 +1084,7 @@ public class MainViewModel extends ViewModel {
      * callers; {@code null} if the position is no longer valid. See
      * {@link #messageAt(ArrayList, int)} for why the lock is required.
      */
+    @Nullable
     public Ft8Message getFt8MessageAtOrNull(int position) {
         return messageAt(ft8Messages, position);
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridTrackerMainActivity.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridTrackerMainActivity.java
@@ -156,10 +156,13 @@ public class GridTrackerMainActivity extends AppCompatActivity {
                 if (position == -1) {
                     return;
                 }
-                if (position > mainViewModel.ft8Messages.size() - 1) {
+                // Read under the decode-list monitor: an unguarded size()-then-get() on
+                // the main thread races the decode thread's remove(0)/clear() and throws
+                // IndexOutOfBoundsException (whole-app crash) — see getFt8MessageAtOrNull.
+                Ft8Message msg = mainViewModel.getFt8MessageAtOrNull(position);
+                if (msg == null) {
                     return;
                 }
-                Ft8Message msg = mainViewModel.ft8Messages.get(position);
 
                 if (msg.checkIsCQ()) {
                     GridOsmMapView.GridMarker marker = gridOsmMapView.getMarker(msg);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelMessageAtTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelMessageAtTest.java
@@ -1,0 +1,74 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+/**
+ * Tests {@link MainViewModel#messageAt} — the bounds-checked, lock-guarded read
+ * behind {@link MainViewModel#getFt8MessageAtOrNull}.
+ *
+ * <p>The Grid Tracker calling-list item click used to do an unguarded
+ * {@code size()}-check-then-{@code get(pos)} on the main thread against the live
+ * {@code ft8Messages} list, which the decode thread mutates under
+ * {@code synchronized (ft8Messages)} — appending decodes and trimming the front
+ * with {@link GeneralVariables#deleteArrayListMore} ({@code remove(0)}), or
+ * {@code clear()}ing it. A concurrent trim/clear between the check and the get
+ * throws {@link IndexOutOfBoundsException} on the UI thread (whole-app crash).
+ * {@code messageAt} makes the check-and-get atomic and returns {@code null} for a
+ * position that is no longer valid.
+ */
+public class MainViewModelMessageAtTest {
+
+    private static ArrayList<Ft8Message> listOf(int n) {
+        ArrayList<Ft8Message> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(new Ft8Message("CQ", "K1AB" + i, "FN42"));
+        }
+        return list;
+    }
+
+    @Test
+    public void inRange_returnsElement() {
+        ArrayList<Ft8Message> list = listOf(3);
+        assertThat(MainViewModel.messageAt(list, 0)).isSameInstanceAs(list.get(0));
+        assertThat(MainViewModel.messageAt(list, 2)).isSameInstanceAs(list.get(2));
+    }
+
+    @Test
+    public void negativePosition_returnsNull() {
+        assertThat(MainViewModel.messageAt(listOf(3), -1)).isNull();
+    }
+
+    @Test
+    public void positionEqualToSize_returnsNull() {
+        assertThat(MainViewModel.messageAt(listOf(3), 3)).isNull();
+    }
+
+    @Test
+    public void positionBeyondSize_returnsNull() {
+        // Would have thrown IndexOutOfBoundsException with a raw get(position).
+        assertThat(MainViewModel.messageAt(listOf(3), 9)).isNull();
+    }
+
+    @Test
+    public void emptyList_returnsNull() {
+        assertThat(MainViewModel.messageAt(new ArrayList<>(), 0)).isNull();
+    }
+
+    @Test
+    public void stalePositionAfterFrontTrim_returnsNullInsteadOfThrowing() {
+        // Reproduces the race outcome: the click handler captured position 4 while
+        // the list held 5 messages; the decode thread then trimmed the front
+        // (deleteArrayListMore -> remove(0)) down to 3. The old code's
+        // ft8Messages.get(4) would throw; messageAt returns null.
+        ArrayList<Ft8Message> list = listOf(5);
+        int stalePosition = 4;
+        while (list.size() > 3) {
+            list.remove(0);
+        }
+        assertThat(MainViewModel.messageAt(list, stalePosition)).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

The **Grid Tracker** screen (`GridTrackerMainActivity`, registered and live in the manifest) shows a calling-list `RecyclerView`. Its item-click handler read the **live** `MainViewModel.ft8Messages` `ArrayList` with an unguarded, non-atomic `size()`-check-then-`get(position)` **on the main thread**:

```java
if (position > mainViewModel.ft8Messages.size() - 1) return;
Ft8Message msg = mainViewModel.ft8Messages.get(position);
```

That same list is structurally mutated on the **decode thread** under `synchronized (ft8Messages)`:

- `ft8Messages.addAll(...)` (append decodes)
- `GeneralVariables.deleteArrayListMore(ft8Messages)` → `remove(0)` (trim the front over the display cap)
- `ft8Messages.clear()` (clear-every-cycle / Clear button / band-mode change)

The size-check and the get are two separate operations with no lock held between them. If a decode-thread `remove(0)`/`clear()` lands in that window, `get(position)` throws **`IndexOutOfBoundsException` on the main thread → uncaught whole-app crash**. Even when the index stays in bounds, a `remove(0)` that merely shifts elements makes the tap open the **wrong station's** marker/line. Decodes arrive every ~15 s, so any tap while decoding is exposed.

## Root cause

Unsynchronized, non-atomic indexed access to a list that another thread mutates. The Compose decode path already renders immutable snapshots (`publishFt8MessageList()` / `uiSeedSnapshot`); this legacy activity click handler still indexed the live instance directly.

## Fix (localized)

- New `MainViewModel.messageAt(list, position)` — lock-guarded (`synchronized (list)`), bounds-checked, returns `null` when the position is no longer valid — and a thin public `getFt8MessageAtOrNull(position)` accessor over the live list.
- `GridTrackerMainActivity` click handler now calls `getFt8MessageAtOrNull(position)` and bails on `null`, so the check-and-get is atomic.

This is a **different site** from the still-open **PR #567** (which guards `CallingListAdapter`'s own internal indexing); both share the same root cause — unsynchronized reads of the concurrently-mutated live decode list — but are in separate files.

## Testing

- New `MainViewModelMessageAtTest` (pure JVM): in-range returns the element; negative / `==size` / `>size` / empty-list return `null`; and the stale-position-after-front-trim case (position 4 while the decode thread trims 5→3) returns `null` instead of throwing (the exact race outcome).
- `./gradlew :app:testDebugUnitTest` — new test + existing `UiSeedSnapshotTest` and `grid_tracker` tests pass; full debug Java/Kotlin compiles.

## Risk

Low. Additive helper + a one-site swap that preserves the handler's intent (bail when there's no valid message) while making it crash-safe. No protocol, DSP, or threading-model changes; no behavior change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)