### PR TITLE
Fix waterfall frequency-ruler labels drifting when spectrumWidth isn't a 500 multiple

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/waterfall/WaterfallScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/waterfall/WaterfallScreen.kt
@@ -421,29 +421,59 @@ private fun WaterfallCanvas(
 // Frequency ruler (pure Compose)
 // ---------------------------------------------------------------------------
 
+/** Hz step between adjacent ruler labels. */
+private const val RulerStepHz = 500
+
+/** A single ruler label: its frequency and where it sits across the strip. */
+internal data class RulerTick(val hz: Int, val fraction: Float)
+
+/**
+ * Ruler labels at [RulerStepHz] intervals from 0 up to [spectrumWidth], each
+ * paired with the horizontal fraction it must sit at.
+ *
+ * The waterfall/columnar views map a signal at `hz` to `hz / spectrumWidth` of
+ * the width ([WaterfallView].freq_width = width / spectrumWidth), so a label's
+ * fraction is `hz / spectrumWidth` too. When [spectrumWidth] is a multiple of
+ * [RulerStepHz] the top tick equals it (fraction 1.0) and the gaps are uniform,
+ * so this reduces to the old even layout; otherwise the top tick sits below the
+ * far edge instead of being stretched to it.
+ */
+internal fun rulerTicks(spectrumWidth: Int): List<RulerTick> {
+    if (spectrumWidth <= 0) return listOf(RulerTick(0, 0f))
+    return buildList {
+        var hz = 0
+        while (hz <= spectrumWidth) {
+            add(RulerTick(hz, hz.toFloat() / spectrumWidth))
+            hz += RulerStepHz
+        }
+    }
+}
+
 @Composable
 internal fun FrequencyRuler(spectrumWidth: Int, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier.background(BgSurface),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        val labels = buildList {
-            var freq = 0
-            while (freq <= spectrumWidth) {
-                add(freq.toString())
-                freq += 500
+        val ticks = rulerTicks(spectrumWidth)
+        ticks.forEachIndexed { index, tick ->
+            // Weight each spacer by the fraction gap to the previous tick so the
+            // labels track their true Hz positions instead of stretching evenly.
+            if (index > 0) {
+                Spacer(modifier = Modifier.weight(tick.fraction - ticks[index - 1].fraction))
             }
-        }
-        labels.forEachIndexed { index, label ->
-            if (index > 0) Spacer(modifier = Modifier.weight(1f))
             Text(
-                text = label,
+                text = tick.hz.toString(),
                 color = TextDim,
                 fontFamily = GeistMonoFamily,
                 fontSize = 8.sp,
                 letterSpacing = 0.02.sp,
             )
         }
+        // Fill the remainder past the top tick so it isn't pushed to the far
+        // edge when spectrumWidth isn't a multiple of the step (no-op otherwise).
+        val trailing = 1f - ticks.last().fraction
+        if (trailing > 0f) Spacer(modifier = Modifier.weight(trailing))
     }
 }
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/waterfall/FrequencyRulerTicksTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/waterfall/FrequencyRulerTicksTest.kt
@@ -1,0 +1,67 @@
+package radio.ks3ckc.ft8af.ui.waterfall
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Guards the frequency-ruler tick geometry. [rulerTicks] is pure Kotlin (no
+ * Android/Compose runtime), so this is a plain JVM test.
+ *
+ * The waterfall/columnar views map a signal at `hz` to the horizontal fraction
+ * `hz / spectrumWidth` (WaterfallView.freq_width = width / spectrumWidth). A
+ * ruler tick must therefore sit at that same fraction, NOT be spread evenly to
+ * the far edge — otherwise the labels drift from the traces, the TX marker and
+ * tap-to-tune whenever `spectrumWidth` is not a multiple of the 500 Hz step.
+ */
+class FrequencyRulerTicksTest {
+
+    @Test
+    fun multipleOf500_lastTickSitsAtFarEdge() {
+        // 3500 is an exact multiple of the 500 Hz step, so the top tick equals
+        // spectrumWidth and lands at fraction 1.0 (the old even-weight layout was
+        // already correct for this case).
+        val ticks = rulerTicks(3500)
+        assertThat(ticks.map { it.hz }).containsExactly(0, 500, 1000, 1500, 2000, 2500, 3000, 3500).inOrder()
+        assertThat(ticks.first().fraction).isEqualTo(0f)
+        assertThat(ticks.last().fraction).isEqualTo(1f)
+    }
+
+    @Test
+    fun multipleOf500_ticksAreEvenlySpaced() {
+        // For a 500-multiple width every gap is identical, so the new
+        // fraction-based layout is byte-identical to the old equal-weight one.
+        val ticks = rulerTicks(3000)
+        val fractions = ticks.map { it.fraction }
+        val gaps = fractions.zipWithNext { a, b -> b - a }
+        gaps.forEach { assertThat(it).isWithin(1e-6f).of(500f / 3000f) }
+    }
+
+    @Test
+    fun nonMultipleOf500_topTickIsBelowFarEdge() {
+        // 2750 is NOT a multiple of 500: the highest tick is 2500, which lives at
+        // 2500/2750 = 0.909 of the width, not jammed against the right edge (1.0)
+        // where the old layout wrongly placed it. 2750 Hz itself has no label.
+        val ticks = rulerTicks(2750)
+        assertThat(ticks.map { it.hz }).containsExactly(0, 500, 1000, 1500, 2000, 2500).inOrder()
+        assertThat(ticks.last().hz).isEqualTo(2500)
+        assertThat(ticks.last().fraction).isWithin(1e-6f).of(2500f / 2750f)
+        assertThat(ticks.last().fraction).isLessThan(1f)
+    }
+
+    @Test
+    fun everyTickFractionEqualsHzOverSpectrumWidth() {
+        val spectrumWidth = 4200
+        rulerTicks(spectrumWidth).forEach { tick ->
+            assertThat(tick.fraction).isWithin(1e-6f).of(tick.hz.toFloat() / spectrumWidth)
+        }
+    }
+
+    @Test
+    fun nonPositiveSpectrumWidth_yieldsSingleZeroTick() {
+        // Defensive: the width picker clamps to 2500..5000, but never divide by a
+        // non-positive width. A degenerate width collapses to just the 0 Hz tick.
+        assertThat(rulerTicks(0).map { it.hz }).containsExactly(0)
+        assertThat(rulerTicks(0).first().fraction).isEqualTo(0f)
+        assertThat(rulerTicks(-100).map { it.hz }).containsExactly(0)
+    }
+}


### PR DESCRIPTION
## Root cause

The live Compose `FrequencyRuler` (`ui/waterfall/WaterfallScreen.kt`) laid its
`0, 500, …, ≤spectrumWidth` labels out in a `Row` with equal `weight(1f)`
spacers between them. That places the first label at `x=0` and the *top* label
flush against the far right edge (fraction `1.0`) — i.e. it silently assumes the
top label equals `spectrumWidth`.

That assumption only holds when `spectrumWidth` is a multiple of the 500 Hz
label step. But:

- The waterfall/columnar renderers map a signal at `hz` to fraction
  `hz / spectrumWidth` (`WaterfallView.freq_width = width / spectrumWidth`, and
  the tap-to-tune inverse `freq = spectrumWidth * touch_x / width`).
- The spectrum-width picker is a **free** `NumberInputDialog(min=2500, max=5000)`
  (`RadioAudioSettings`) with no 500 Hz step — `setSpectrumWidth` only clamps the
  range.

So for e.g. `spectrumWidth = 2750`, the labels run `0…2500` with **"2500"
jammed at the right edge**, where 2750 Hz actually lives. The ruler ticks drift
up to ~9% away from the actual traces, the red TX marker and the tap-to-tune
mapping below them.

## Fix

Extract a pure, unit-testable `rulerTicks(spectrumWidth)` that pairs each label
with its true horizontal fraction `hz / spectrumWidth`, and position the labels
by **fraction-gap** spacer weights, plus a trailing spacer to fill the remainder
past the top tick.

- **Byte-identical for 500-multiple widths** (default 3500, and 2500/3000/…):
  every gap is uniform and the trailing remainder is zero, so the layout matches
  the old even spacing exactly.
- For a non-multiple width the top tick now sits at its real position instead of
  being stretched to the edge.

`Modifier.weight` requires a positive weight: inter-tick gaps are always
`500/spectrumWidth > 0`, and the trailing spacer is guarded by `> 0f`.

## Testing

- New `FrequencyRulerTicksTest` (pure JVM, no Robolectric): covers 500-multiple
  widths (top tick at fraction 1.0, uniform gaps), a non-multiple width
  (`2750` → top tick `2500` at `0.909`, not `1.0`), the fraction invariant, and
  the degenerate non-positive width guard.
- `:app:testDebugUnitTest` — green.
- `:app:assembleDebug` — green (all 4 ABIs).

## Risk

Low. UI-only change to a single display strip; no DSP, protocol, or decode path
touched. Happy-path (500-multiple `spectrumWidth`) layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)