### PR TITLE
iOS: fix TX slot-parity off-by-one (transmit on the operator's selected slot)

### DIFF
--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -303,11 +303,12 @@ final class LiveEngine {
         // Sync QSO status back to UI.
         syncQsoStatusToUI()
 
-        // TX scheduling: if QSO engine has a message and slot parity matches, transmit.
+        // TX scheduling: if the QSO engine has a message and this slot matches the
+        // operator's selected TX parity, transmit. The audio keys up immediately,
+        // so it plays in `slotID` itself — gate on that slot's parity (mirrors the
+        // desktop engine's `maybe_transmit`), not the next slot's.
         if let txMsg = qso.txMessage {
-            let nextSlotParity = Int(SlotClock.parity(slotID: slotID + 1))
-            let desiredParity = appState.tx.slotParity
-            if nextSlotParity == desiredParity {
+            if SlotClock.shouldTransmit(slotID: slotID, desiredParity: appState.tx.slotParity) {
                 scheduleTx(message: txMsg, freqHz: appState.waterfall.txFreqHz)
             }
         }

--- a/ios/FT8AFKit/Sources/FT8Audio/SlotClock.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/SlotClock.swift
@@ -33,6 +33,16 @@ public enum SlotClock {
         floorMod(slotID, 2)
     }
 
+    /// Whether we should key up in `slotID` for the operator's selected TX slot.
+    ///
+    /// TX audio is scheduled to start immediately, so it physically occupies
+    /// `slotID` itself — eligibility is therefore the parity of that very slot,
+    /// not the next one. This mirrors the desktop engine's `maybe_transmit`,
+    /// which gates on `slot_id.rem_euclid(2)` for the slot it keys up in.
+    public static func shouldTransmit(slotID: Int64, desiredParity: Int) -> Bool {
+        Int(parity(slotID: slotID)) == desiredParity
+    }
+
     // Euclidean division/modulo: quotient floored toward -inf so the remainder is
     // always in [0, |b|). For non-negative inputs these equal `/` and `%`.
     static func floorDiv(_ a: Int64, _ b: Int64) -> Int64 {

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SlotClockTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SlotClockTests.swift
@@ -32,6 +32,30 @@ final class SlotClockTests: XCTestCase {
         XCTAssertEqual(SlotClock.parity(slotID: 3), 1)
     }
 
+    func testShouldTransmitGatesOnTheSlotWeKeyUpIn() {
+        // We transmit in the slot itself (audio starts immediately), so eligibility
+        // is the parity of that very slot.
+        // Even slot (parity 0):
+        XCTAssertTrue(SlotClock.shouldTransmit(slotID: 4, desiredParity: 0))
+        XCTAssertFalse(SlotClock.shouldTransmit(slotID: 4, desiredParity: 1))
+        // Odd slot (parity 1):
+        XCTAssertTrue(SlotClock.shouldTransmit(slotID: 5, desiredParity: 1))
+        XCTAssertFalse(SlotClock.shouldTransmit(slotID: 5, desiredParity: 0))
+    }
+
+    func testShouldTransmitUsesCurrentSlotNotNextSlotRegression() {
+        // Regression for the off-by-one that gated on `parity(slotID + 1)`: that
+        // inverted the operator's TX1/TX2 selection, keying up on the opposite
+        // slot and colliding with the station being answered. For every slot the
+        // decision must match the slot's own parity, never the next slot's.
+        for slot in Int64(0)..<8 {
+            let ownParity = Int(SlotClock.parity(slotID: slot))
+            let nextParity = Int(SlotClock.parity(slotID: slot + 1))
+            XCTAssertTrue(SlotClock.shouldTransmit(slotID: slot, desiredParity: ownParity))
+            XCTAssertFalse(SlotClock.shouldTransmit(slotID: slot, desiredParity: nextParity))
+        }
+    }
+
     func testEuclideanWithNegativeTimes() {
         // A clock correction can push the effective time slightly negative; the
         // remainder must stay non-negative (Euclidean), not go to -something.


### PR DESCRIPTION
## Root cause

The iOS live auto-sequencer (`LiveEngine.processQsoRx`) decided whether to key up by comparing the operator's selected TX slot (`appState.tx.slotParity`, the TX1/TX2 toggle) against the parity of the **next** slot:

```swift
let nextSlotParity = Int(SlotClock.parity(slotID: slotID + 1))   // ← wrong slot
if nextSlotParity == desiredParity { scheduleTx(...) }
```

But TX audio is scheduled with `scheduleBuffer(at: nil, options: .interrupts)` + `playerNode.play()` (`TxPlayerService.play`), i.e. it starts **immediately** and physically occupies `slotID` — the very slot the decode loop has just entered (`processQsoRx(decoded, slotID: currentSlot)`). `parity(slotID + 1)` is the *opposite* parity of `slotID`, so the gate was inverted: selecting **TX1** made the app transmit on the **TX2** slot and vice-versa.

## Impact

When answering a station you must transmit on the slot opposite to theirs. With the inversion, the operator's TX1/TX2 selection was flipped, so the app keyed up on the *same* slot as the DX it was answering — colliding with it and breaking the standard FT8 alternating handshake. Reachable in normal live operation any time the QSO engine has a queued TX message (Call CQ, answering, hunt mode, free text).

## Cross-check against the reference implementation

The desktop Rust engine — the port the iOS `SlotClock` is explicitly derived from — gates on the **current** slot's parity with no `+1`:

```rust
// engine.rs:602-627  maybe_transmit(slot_id)
let parity = slot_id.rem_euclid(2);           // current slot
if matches!(self.tx_parity, Some(p) if p != parity) { return; }
...
self.start_transmit(&msg);                     // keys up in THIS slot
```

## Fix

- Add `SlotClock.shouldTransmit(slotID:desiredParity:)` — a pure function in the Foundation-only `FT8Audio` module that compares against the parity of the slot we actually key up in.
- Call it from `LiveEngine.processQsoRx`, dropping the `+ 1`.

Keeping the decision in `SlotClock` (rather than a one-off inline expression in the `@MainActor` `LiveEngine`) makes it unit-testable, per the project's "extract the decision logic" testing guidance.

## Testing

- Added `SlotClockTests.testShouldTransmitGatesOnTheSlotWeKeyUpIn` and `testShouldTransmitUsesCurrentSlotNotNextSlotRegression` (the latter asserts the decision follows the current slot's parity and never the next slot's — it fails against the old `slotID + 1`).
- Verified locally on Linux (no Xcode) by compiling the real `SlotClock.swift` against a driver replicating the XCTest assertions (all pass) and a clean `swift build --target FT8Audio`. The full `swift test` builds only on macOS CI because `FT8Engine` imports Apple's `Network`; this change touches only the Foundation-only `FT8Audio` module.

## Risk

Low and localized. No protocol/DSP change — only the slot on which an already-generated waveform is played. Behavior now matches the desktop engine and the operator's explicit TX-slot selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)