### PR TITLE
Fix cross-thread crash on the shared transmitMessages calling list

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -628,7 +628,7 @@ public class GeneralVariables {
 
     // The calling-UI "followed entries" list. Mutated concurrently from three
     // threads with no external lock: the decode thread (findIncludedCallsigns
-    // add + deleteArrayListMore remove(0) + clear), the TX-sequencer thread
+    // add + trimToMessageCount remove(0) + clear), the TX-sequencer thread
     // (FT8TransmitSignal.doComplete reverse scans, onBeforeTransmit add) and the
     // UI thread (GridTracker / GridMarkerInfoWindow add, clearTransmittingMessage).
     // A plain ArrayList corrupts its backing array / throws
@@ -636,7 +636,10 @@ public class GeneralVariables {
     // every add/remove/clear is atomic. Index scans must still snapshot the list
     // first (size() then get(i) can otherwise race a concurrent remove) — see
     // FT8TransmitSignal.doComplete.
-    public static List<Ft8Message> transmitMessages = new CopyOnWriteArrayList<>();//List for the calling UI, followed entries
+    // final: the thread-safety invariant depends on this always being the
+    // CopyOnWriteArrayList — never reassign it to a plain List, or the cross-thread
+    // crash this guards against returns. Mutate in place (add/remove/clear) only.
+    public static final List<Ft8Message> transmitMessages = new CopyOnWriteArrayList<>();//List for the calling UI, followed entries
 
     public static void setMyMaidenheadGrid(String grid) {
         myMaidenheadGrid = grid;
@@ -1251,7 +1254,12 @@ public class GeneralVariables {
         return result.toString();
     }
 
-    public static synchronized void deleteArrayListMore(List<Ft8Message> list) {
+    /**
+     * Trim {@code list} from the front down to {@link #MESSAGE_COUNT} entries.
+     * Accepts any {@link List} (the shared calling list is a CopyOnWriteArrayList),
+     * so the name reflects the contract rather than a concrete ArrayList.
+     */
+    public static synchronized void trimToMessageCount(List<Ft8Message> list) {
         if (list.size() > GeneralVariables.MESSAGE_COUNT) {
             while (list.size() > GeneralVariables.MESSAGE_COUNT) {
                 list.remove(0);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -27,8 +27,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 
 public class GeneralVariables {
@@ -624,7 +626,17 @@ public class GeneralVariables {
 
     public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns
 
-    public static ArrayList<Ft8Message> transmitMessages = new ArrayList<>();//List for the calling UI, followed entries
+    // The calling-UI "followed entries" list. Mutated concurrently from three
+    // threads with no external lock: the decode thread (findIncludedCallsigns
+    // add + deleteArrayListMore remove(0) + clear), the TX-sequencer thread
+    // (FT8TransmitSignal.doComplete reverse scans, onBeforeTransmit add) and the
+    // UI thread (GridTracker / GridMarkerInfoWindow add, clearTransmittingMessage).
+    // A plain ArrayList corrupts its backing array / throws
+    // IndexOutOfBounds under that contention, so this is a CopyOnWriteArrayList:
+    // every add/remove/clear is atomic. Index scans must still snapshot the list
+    // first (size() then get(i) can otherwise race a concurrent remove) — see
+    // FT8TransmitSignal.doComplete.
+    public static List<Ft8Message> transmitMessages = new CopyOnWriteArrayList<>();//List for the calling UI, followed entries
 
     public static void setMyMaidenheadGrid(String grid) {
         myMaidenheadGrid = grid;
@@ -1239,7 +1251,7 @@ public class GeneralVariables {
         return result.toString();
     }
 
-    public static synchronized void deleteArrayListMore(ArrayList<Ft8Message> list) {
+    public static synchronized void deleteArrayListMore(List<Ft8Message> list) {
         if (list.size() > GeneralVariables.MESSAGE_COUNT) {
             while (list.size() > GeneralVariables.MESSAGE_COUNT) {
                 list.remove(0);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -644,7 +644,7 @@ public class MainViewModel extends ViewModel {
                     // an unguarded removal can race the snapshot copy in
                     // publishFt8MessageList().
                     ft8Messages.addAll(messages);//add messages to list
-                    GeneralVariables.deleteArrayListMore(ft8Messages);//remove excess messages; FT8CN limits the total displayable messages
+                    GeneralVariables.trimToMessageCount(ft8Messages);//remove excess messages; FT8CN limits the total displayable messages
                 }
 
                 publishFt8MessageList();//post an immutable snapshot so the UI recomposes immediately
@@ -729,7 +729,7 @@ public class MainViewModel extends ViewModel {
                     // loops (checkPart1/checkPart2: for i = size()-1 .. 0, get(i)). Passing
                     // the live ft8Messages let it iterate off-lock while a concurrent decode
                     // pass (slot N's late/deep pass vs slot N+1's early pass, #398) held
-                    // synchronized(ft8Messages) running addAll + deleteArrayListMore's
+                    // synchronized(ft8Messages) running addAll + trimToMessageCount's
                     // remove(0), shrinking the list mid-scan -> IndexOutOfBoundsException on
                     // the decode thread. Scan a snapshot copied under the same monitor the
                     // writers use (mirrors publishFt8MessageList). The freshly decoded
@@ -983,7 +983,7 @@ public class MainViewModel extends ViewModel {
                 }
             }
         }
-        GeneralVariables.deleteArrayListMore(GeneralVariables.transmitMessages);//remove excess messages
+        GeneralVariables.trimToMessageCount(GeneralVariables.transmitMessages);//remove excess messages
         //mutableTransmitMessages.postValue(GeneralVariables.transmitMessages);
         mutableTransmitMessagesCount.postValue(count);
     }
@@ -1059,7 +1059,7 @@ public class MainViewModel extends ViewModel {
      * <p>UI item-click handlers (e.g. the Grid Tracker calling list) turn a
      * RecyclerView row into a position and then index the live list on the main
      * thread. The decode thread mutates {@code ft8Messages} — {@code addAll} plus
-     * {@link GeneralVariables#deleteArrayListMore} ({@code remove(0)}) and
+     * {@link GeneralVariables#trimToMessageCount} ({@code remove(0)}) and
      * {@code clear()} — under {@code synchronized (ft8Messages)}. A main-thread
      * {@code size()}-check-then-{@code get(pos)} is therefore not atomic: a
      * concurrent {@code remove(0)}/{@code clear()} landing between the two steps

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -1037,7 +1037,7 @@ public class FT8TransmitSignal {
         // look up signal report from history
         // processing signal reports here because saved reports often differ from actual QSO reports
         // Snapshot the shared transmitMessages list once: it is mutated concurrently
-        // by the decode thread (add / deleteArrayListMore remove(0) / clear), so a live
+        // by the decode thread (add / trimToMessageCount remove(0) / clear), so a live
         // size()-then-get(i) scan can throw IndexOutOfBounds when the list shrinks
         // mid-scan. Iterating a private copy is race-free and preserves the
         // most-recent-first (reverse index) semantics.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -38,6 +38,7 @@ import com.k1af.ft8af.timer.UtcTimer;
 import com.k1af.ft8af.ui.ToastMessage;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -1035,9 +1036,15 @@ public class FT8TransmitSignal {
 
         // look up signal report from history
         // processing signal reports here because saved reports often differ from actual QSO reports
+        // Snapshot the shared transmitMessages list once: it is mutated concurrently
+        // by the decode thread (add / deleteArrayListMore remove(0) / clear), so a live
+        // size()-then-get(i) scan can throw IndexOutOfBounds when the list shrinks
+        // mid-scan. Iterating a private copy is race-free and preserves the
+        // most-recent-first (reverse index) semantics.
+        List<Ft8Message> transmitMessagesSnapshot = new ArrayList<>(GeneralVariables.transmitMessages);
         // iterate through received signal reports from the other party
-        for (int i = GeneralVariables.transmitMessages.size() - 1; i >= 0; i--) {
-            Ft8Message message = GeneralVariables.transmitMessages.get(i);
+        for (int i = transmitMessagesSnapshot.size() - 1; i >= 0; i--) {
+            Ft8Message message = transmitMessagesSnapshot.get(i);
             if ((GeneralVariables.checkFun3(message.extraInfo)
                     || GeneralVariables.checkFun2(message.extraInfo))
                     && (message.callsignFrom.equals(toCallsign.callsign)
@@ -1048,8 +1055,8 @@ public class FT8TransmitSignal {
             }
         }
         // iterate through signal reports I sent to the other party
-        for (int i = GeneralVariables.transmitMessages.size() - 1; i >= 0; i--) {
-            Ft8Message message = GeneralVariables.transmitMessages.get(i);
+        for (int i = transmitMessagesSnapshot.size() - 1; i >= 0; i--) {
+            Ft8Message message = transmitMessagesSnapshot.get(i);
             if ((GeneralVariables.checkFun3(message.extraInfo)
                     || GeneralVariables.checkFun2(message.extraInfo))
                     && (message.callsignTo.equals(toCallsign.callsign)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
@@ -29,13 +29,13 @@ import com.k1af.ft8af.maidenhead.MaidenheadGrid;
 import com.k1af.ft8af.rigs.BaseRigOperation;
 import com.k1af.ft8af.timer.UtcTimer;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.CallingListItemHolder> {
     public enum ShowMode{CALLING_LIST,MY_CALLING,TRACKER}
     private static final String TAG = "CallingListAdapter";
     private final MainViewModel mainViewModel;
-    private final ArrayList<Ft8Message> ft8MessageArrayList;
+    private final List<Ft8Message> ft8MessageArrayList;
     private final Context context;
 
     private final ShowMode showMode;
@@ -126,7 +126,7 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
 
 
     public CallingListAdapter(Context context, MainViewModel mainViewModel
-            , ArrayList<Ft8Message> messages, ShowMode showMode) {
+            , List<Ft8Message> messages, ShowMode showMode) {
         this.mainViewModel = mainViewModel;
         this.context = context;
         this.showMode=showMode;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/CallingListAdapter.java
@@ -190,7 +190,7 @@ public class CallingListAdapter extends RecyclerView.Adapter<CallingListAdapter.
      * <p>The two live hosts ({@code CallingListFragment} and {@code GridTrackerMainActivity})
      * hand this adapter the same {@code MainViewModel.ft8Messages} instance the decode thread
      * mutates under {@code synchronized (ft8Messages)}: it appends decodes, trims the front via
-     * {@code GeneralVariables.deleteArrayListMore}, and clears the list every cycle. RecyclerView
+     * {@code GeneralVariables.trimToMessageCount}, and clears the list every cycle. RecyclerView
      * reads {@code getItemCount()} and then indexes the list from {@code onBindViewHolder} and the
      * gesture/menu handlers on the UI thread, so a trim or clear landing in that window made a
      * plain {@code get(position)} throw {@link IndexOutOfBoundsException} on the main thread —

--- a/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelMessageAtTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelMessageAtTest.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
  * {@code size()}-check-then-{@code get(pos)} on the main thread against the live
  * {@code ft8Messages} list, which the decode thread mutates under
  * {@code synchronized (ft8Messages)} — appending decodes and trimming the front
- * with {@link GeneralVariables#deleteArrayListMore} ({@code remove(0)}), or
+ * with {@link GeneralVariables#trimToMessageCount} ({@code remove(0)}), or
  * {@code clear()}ing it. A concurrent trim/clear between the check and the get
  * throws {@link IndexOutOfBoundsException} on the UI thread (whole-app crash).
  * {@code messageAt} makes the check-and-get atomic and returns {@code null} for a
@@ -62,7 +62,7 @@ public class MainViewModelMessageAtTest {
     public void stalePositionAfterFrontTrim_returnsNullInsteadOfThrowing() {
         // Reproduces the race outcome: the click handler captured position 4 while
         // the list held 5 messages; the decode thread then trimmed the front
-        // (deleteArrayListMore -> remove(0)) down to 3. The old code's
+        // (trimToMessageCount -> remove(0)) down to 3. The old code's
         // ft8Messages.get(4) would throw; messageAt returns null.
         ArrayList<Ft8Message> list = listOf(5);
         int stalePosition = 4;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/TransmitMessagesConcurrencyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/TransmitMessagesConcurrencyTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <p>That list is mutated with no external lock from three threads at once: the decode
  * thread ({@code MainViewModel.findIncludedCallsigns} appends matches then trims the
- * front via {@link GeneralVariables#deleteArrayListMore} {@code remove(0)}, and
+ * front via {@link GeneralVariables#trimToMessageCount} {@code remove(0)}, and
  * {@code clearTransmittingMessage} clears it), the TX-sequencer thread
  * ({@code FT8TransmitSignal.doComplete} reverse-scans it for the QSO signal reports,
  * {@code onBeforeTransmit} appends), and the UI thread ({@code GridTrackerMainActivity}
@@ -84,7 +84,7 @@ public class TransmitMessagesConcurrencyTest {
             try {
                 for (int i = 0; i < iterations; i++) {
                     GeneralVariables.transmitMessages.add(new Ft8Message(FT8Common.FT8_MODE));
-                    GeneralVariables.deleteArrayListMore(GeneralVariables.transmitMessages);
+                    GeneralVariables.trimToMessageCount(GeneralVariables.transmitMessages);
                     if (i % 128 == 0) {
                         GeneralVariables.transmitMessages.clear();
                     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/TransmitMessagesConcurrencyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/TransmitMessagesConcurrencyTest.java
@@ -1,0 +1,130 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Coverage for the thread-safety of {@link GeneralVariables#transmitMessages}, the
+ * calling-UI "followed entries" list.
+ *
+ * <p>That list is mutated with no external lock from three threads at once: the decode
+ * thread ({@code MainViewModel.findIncludedCallsigns} appends matches then trims the
+ * front via {@link GeneralVariables#deleteArrayListMore} {@code remove(0)}, and
+ * {@code clearTransmittingMessage} clears it), the TX-sequencer thread
+ * ({@code FT8TransmitSignal.doComplete} reverse-scans it for the QSO signal reports,
+ * {@code onBeforeTransmit} appends), and the UI thread ({@code GridTrackerMainActivity}
+ * / {@code GridMarkerInfoWindow} append). When it was a plain {@code ArrayList} that
+ * contention corrupted its backing array and the reverse {@code size()}-then-{@code get(i)}
+ * scan threw {@link IndexOutOfBoundsException} on the TX thread. It is now a
+ * {@link CopyOnWriteArrayList} (atomic add/remove/clear) and the scan snapshots the list
+ * before indexing it.
+ *
+ * <p>Robolectric is only needed to construct real {@link Ft8Message} rows (their ctor
+ * touches {@code android.util.Log}); the list operations under test touch no Android types.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class TransmitMessagesConcurrencyTest {
+
+    private static List<Ft8Message> messages(int n) {
+        List<Ft8Message> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(new Ft8Message(FT8Common.FT8_MODE));
+        }
+        return list;
+    }
+
+    /** Reproduce the production reverse scan from {@code FT8TransmitSignal.doComplete}. */
+    private static void reverseScanLikeDoComplete(List<Ft8Message> shared) {
+        List<Ft8Message> snapshot = new ArrayList<>(shared);
+        for (int i = snapshot.size() - 1; i >= 0; i--) {
+            Ft8Message message = snapshot.get(i);
+            // touch a field, exactly as doComplete dereferences message.extraInfo etc.
+            if (message == null) {
+                throw new AssertionError("snapshot yielded a null element");
+            }
+        }
+    }
+
+    @Before
+    public void resetList() {
+        GeneralVariables.transmitMessages.clear();
+    }
+
+    @After
+    public void clearList() {
+        GeneralVariables.transmitMessages.clear();
+    }
+
+    @Test
+    public void transmitMessages_isCopyOnWriteList() {
+        // A plain ArrayList cannot be shared across the decode / TX / UI threads without
+        // external locking; the field must be a thread-safe list.
+        assertThat(GeneralVariables.transmitMessages).isInstanceOf(CopyOnWriteArrayList.class);
+    }
+
+    @Test
+    public void reverseScanSnapshot_survivesConcurrentDecodeMutation() throws InterruptedException {
+        GeneralVariables.transmitMessages.addAll(messages(64));
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final int iterations = 20_000;
+
+        // Mirror the decode / UI writers: append, trim the front, and occasionally clear.
+        Thread mutator = new Thread(() -> {
+            try {
+                for (int i = 0; i < iterations; i++) {
+                    GeneralVariables.transmitMessages.add(new Ft8Message(FT8Common.FT8_MODE));
+                    GeneralVariables.deleteArrayListMore(GeneralVariables.transmitMessages);
+                    if (i % 128 == 0) {
+                        GeneralVariables.transmitMessages.clear();
+                    }
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        });
+
+        mutator.start();
+        try {
+            // Mirror the TX-sequencer thread reading the same shared list.
+            for (int i = 0; i < iterations; i++) {
+                reverseScanLikeDoComplete(GeneralVariables.transmitMessages);
+            }
+        } catch (Throwable t) {
+            failure.compareAndSet(null, t);
+        }
+        mutator.join();
+
+        assertThat(failure.get()).isNull();
+    }
+
+    @Test
+    public void directSizeThenGet_onShrunkList_throws_butSnapshotIsImmune() {
+        // The pre-fix hazard, made deterministic: the reverse scan captured size() and then
+        // indexed the live list; a concurrent trim/clear between the two shrank it, so the
+        // stale top index was out of range.
+        List<Ft8Message> live = new ArrayList<>(messages(3));
+        int staleSize = live.size();            // TX thread saw size == 3
+        live.clear();                           // decode thread cleared the list in the window
+        assertThrows(IndexOutOfBoundsException.class, () -> live.get(staleSize - 1));
+
+        // The fix snapshots the list first, decoupling the scan from later mutation.
+        List<Ft8Message> live2 = new ArrayList<>(messages(3));
+        List<Ft8Message> snapshot = new ArrayList<>(live2);
+        live2.clear();                          // mutate the shared list after the snapshot
+        assertThat(snapshot).hasSize(3);
+        for (int i = snapshot.size() - 1; i >= 0; i--) {
+            assertThat(snapshot.get(i)).isNotNull();   // never throws
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/CallingListAdapterPositionGuardTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/CallingListAdapterPositionGuardTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * {@code GridTrackerMainActivity}) hands the adapter the SAME live
  * {@code MainViewModel.ft8Messages} instance the decode thread mutates under
  * {@code synchronized (ft8Messages)} — it appends decodes, trims the front via
- * {@code GeneralVariables.deleteArrayListMore}, and clears the list every cycle.
+ * {@code GeneralVariables.trimToMessageCount}, and clears the list every cycle.
  * RecyclerView reads {@code getItemCount()} and then indexes the list on the UI
  * thread from {@code onBindViewHolder} and the swipe/menu handlers, so a trim or
  * clear landing in that window turned a raw {@code get(position)} into an


### PR DESCRIPTION
## Root cause

`GeneralVariables.transmitMessages` — the calling-UI "followed entries" list — was a plain `ArrayList` mutated concurrently with **no external lock** from three threads:

| Thread | Access |
|--------|--------|
| decode | `MainViewModel.findIncludedCallsigns` appends matches then trims the front via `deleteArrayListMore` (`remove(0)`); `clearTransmittingMessage` clears it every cycle |
| TX-sequencer | `FT8TransmitSignal.doComplete` reverse-scans it (`size()-1 .. 0`, `get(i)`) for the QSO signal reports; `onBeforeTransmit` appends |
| UI | `GridTrackerMainActivity` / `GridMarkerInfoWindow` append |

`ArrayList` is not thread-safe. Under that contention the backing array is corrupted, and the TX thread's reverse `size()`-then-`get(i)` scan throws `IndexOutOfBoundsException` when a concurrent `remove(0)`/`clear` shrinks the list between the two calls. That scan runs in `doComplete` at **every successful QSO completion**, with no surrounding try/catch on the TX-sequencer thread → whole-app crash.

This is the highest-severity reachable stability issue remaining in the app (the sibling `ft8Messages` list is already lock-guarded; `transmitMessages` was the one shared list left unsynchronised — the live writers on it, unlike the decode-list readers hardened in #567/#574, never took a common lock).

## Fix

- Make `transmitMessages` a `CopyOnWriteArrayList` so every `add`/`remove`/`clear` is atomic. `deleteArrayListMore` and the `CallingListAdapter` ctor/field are widened from `ArrayList` to `List<Ft8Message>` (source-compatible; `ft8Messages` is untouched and still an `ArrayList` guarded by `synchronized(ft8Messages)`).
- Snapshot the list once in `FT8TransmitSignal.doComplete` before the two reverse index scans, so `size()`/`get()` can't race a concurrent shrink. The private copy preserves the exact most-recent-first (reverse-index) semantics.

The single-threaded happy path is byte-identical.

## Testing

New `TransmitMessagesConcurrencyTest`:
- `transmitMessages_isCopyOnWriteList` — the field is a thread-safe list (fails pre-fix: was `ArrayList`).
- `reverseScanSnapshot_survivesConcurrentDecodeMutation` — the production snapshot reverse scan survives 20 000 iterations of concurrent decode-thread `add` / `deleteArrayListMore` / `clear` on the shared field with no throwable (fails pre-fix: copying the live `ArrayList` under mutation throws).
- `directSizeThenGet_onShrunkList_throws_butSnapshotIsImmune` — deterministic proof that a live `size()`/`get()` throws `IndexOutOfBounds` when the list shrinks in the window, while snapshotting first is immune.

Confirmed the first two tests fail against the pre-fix source (stashed the source edits, kept the test) and pass after.

- `:app:testDebugUnitTest` — green (full suite)
- `:app:assembleDebug` (4 ABIs, native + hamlib) — green

## Risk

Low. Localised change; no protocol/DSP/interop behaviour touched. `transmitMessages` holds only the small "calling list" of followed stations, so `CopyOnWriteArrayList`'s copy-on-mutation cost is negligible (bounded well under the `MESSAGE_COUNT` cap and off the UI thread).