### PR TITLE
iOS: bound a WSJT-X reply's requested audio frequency to the TX passband

### DIFF
--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -438,8 +438,13 @@ final class LiveEngine {
         udp.onReply = { [weak self] call, grid, snr, deltaFreq in
             guard let self, let appState = self.appState else { return }
             // Honor the requested audio frequency: answer on the tone the companion asked
-            // for, not whatever the current TX frequency happens to be.
-            if deltaFreq > 0 { appState.waterfall.txFreqHz = Float(deltaFreq) }
+            // for, not whatever the current TX frequency happens to be. `deltaFreq` is a
+            // raw value off an untrusted UDP socket, so only adopt it when it lands inside
+            // the transmittable passband; an unspecified (0) or out-of-band request keeps
+            // the current offset (mirrors the desktop/Android reply-df guards).
+            if let txHz = WaterfallAxis.boundedReplyTxHz(Float(deltaFreq)) {
+                appState.waterfall.txFreqHz = txHz
+            }
             let msg = DecodeMessage(
                 utcTime: Self.utcTimeString(from: Int64(Date().timeIntervalSince1970 * 1000)),
                 callFrom: call, callTo: "", snr: Int(snr),

--- a/ios/FT8AFKit/Sources/FT8Audio/WaterfallAxis.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/WaterfallAxis.swift
@@ -57,4 +57,18 @@ public enum WaterfallAxis {
     public static func tunedTxHz(forFraction fraction: Float) -> Float {
         return min(max(hz(forFraction: fraction), minTxHz), maxTxHz)
     }
+
+    /// The audio offset (Hz) to answer a WSJT-X `Reply` on, given the companion's
+    /// requested `deltaFreq`, or `nil` to keep the current TX offset. The `df`
+    /// arrives on an untrusted UDP socket, so a value of 0 (unspecified — the
+    /// app's own click-to-answer sends 0) or one outside the transmittable
+    /// passband `minTxHz ... maxTxHz` must NOT be adopted: keying up outside the
+    /// SSB passband sends the reply attenuated/off-air, and (because the TX
+    /// marker is separately pinned to the band edge by `clampedFraction`) leaves
+    /// the marker pointing where the tone isn't. Mirrors the desktop
+    /// `reply_tx_audio_hz` and Android `replyTxFrequencyHz` guards, which the iOS
+    /// port previously omitted (it honored any `deltaFreq > 0` unbounded).
+    public static func boundedReplyTxHz(_ hz: Float) -> Float? {
+        return (minTxHz...maxTxHz).contains(hz) ? hz : nil
+    }
 }

--- a/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallAxisTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/WaterfallAxisTests.swift
@@ -77,4 +77,26 @@ final class WaterfallAxisTests: XCTestCase {
         let fraction = WaterfallAxis.fraction(forHz: 2000)
         XCTAssertEqual(WaterfallAxis.tunedTxHz(forFraction: fraction), 2000, accuracy: 1e-3)
     }
+
+    /// A WSJT-X UDP reply's requested `deltaFreq` is honored only when it lands
+    /// inside the transmittable passband — mirrors the desktop/Android guards the
+    /// iOS reply path previously omitted (it adopted any deltaFreq > 0).
+    func testBoundedReplyTxHzHonorsInBandRequests() {
+        XCTAssertEqual(WaterfallAxis.boundedReplyTxHz(200), 200) // lower edge, inclusive
+        XCTAssertEqual(WaterfallAxis.boundedReplyTxHz(1500), 1500)
+        XCTAssertEqual(WaterfallAxis.boundedReplyTxHz(3000), 3000) // upper edge, inclusive
+        XCTAssertEqual(WaterfallAxis.boundedReplyTxHz(WaterfallAxis.minTxHz), WaterfallAxis.minTxHz)
+        XCTAssertEqual(WaterfallAxis.boundedReplyTxHz(WaterfallAxis.maxTxHz), WaterfallAxis.maxTxHz)
+    }
+
+    /// Unspecified (0) or out-of-band requests are dropped (nil) so the caller
+    /// keeps the operator's current offset rather than keying up off-air.
+    func testBoundedReplyTxHzDropsUnspecifiedAndOutOfBand() {
+        XCTAssertNil(WaterfallAxis.boundedReplyTxHz(0))    // the app's own click-to-answer sends 0
+        XCTAssertNil(WaterfallAxis.boundedReplyTxHz(199))  // just below the passband
+        XCTAssertNil(WaterfallAxis.boundedReplyTxHz(3001)) // just above the passband
+        XCTAssertNil(WaterfallAxis.boundedReplyTxHz(3400)) // in the display band but not transmittable
+        // A garbage UInt32 df (huge, would overdrive far outside the passband).
+        XCTAssertNil(WaterfallAxis.boundedReplyTxHz(Float(UInt32.max)))
+    }
 }


### PR DESCRIPTION
## Summary

An inbound WSJT-X **Reply** request — sent by companion apps (GridTracker, JTAlert, N1MM) when the **Accept UDP requests** setting is on — carries a `df` field: the audio-offset (Hz) the companion wants us to answer on. The iOS `LiveEngine.onReply` handler adopted **any** `deltaFreq > 0` straight into `appState.waterfall.txFreqHz` with no range check:

```swift
if deltaFreq > 0 { appState.waterfall.txFreqHz = Float(deltaFreq) }
```

The decoder's display band runs to 3500 Hz (`FT8Decoder`/`WaterfallAxis.displayMaxHz`), so double-clicking a routine 3000–3500 Hz spot in a companion sends a `df` **above** the SSB TX passband; a stray or garbled datagram can send anything up to `UInt32.max`.

## Root cause

`WaterfallAxis` already documents (on `clampedFraction`, lines 38-45) that `txFreqHz` "can be set externally without any range check — a WSJT-X UDP reply carries a raw `deltaFreq`" and defensively clamps the **TX marker** to the band edge. But the actual **TX tone** was still set to the raw out-of-band value. Net effect: the reply keys up outside the passband (attenuated / effectively off-air) while the red TX marker points to the band edge — marker and tone disagree.

Both sibling ports already guard this exact untrusted value:
- **desktop** `reply_tx_audio_hz` → honors `df` only in `[200, 3000]` (`MIN/MAX_TX_AUDIO_HZ`), else keeps the current offset (#564)
- **Android** `replyTxFrequencyHz` → bounds the reply `df` (#563)

The iOS port dropped that guard. This is the same cross-port "one port omitted a safeguard the others have" class as #519 / #554 / #559 / #561 / #573 / #576.

## Fix

Add a pure, Foundation-only, Kit-testable helper mirroring the desktop guard, using iOS's own passband constants (the same range `tunedTxHz` clamps tap-to-tune to):

```swift
public static func boundedReplyTxHz(_ hz: Float) -> Float? {
    return (minTxHz...maxTxHz).contains(hz) ? hz : nil   // [200, 3000]
}
```

`onReply` now adopts the requested tone only when it's in-band; a `df` of 0 (unspecified — the app's own click-to-answer sends 0) or out-of-band keeps the operator's current offset.

- In-band replies behave **exactly as before**.
- No DSP/decoder/protocol change; happy path is byte-identical.
- `Float(deltaFreq)` for a `UInt32` never traps (unlike an integer cast), so a garbage huge `df` is simply rejected.

## Testing

- `WaterfallAxisTests` gains `testBoundedReplyTxHzHonorsInBandRequests` and `testBoundedReplyTxHzDropsUnspecifiedAndOutOfBand`; **4 assertions fail** against the old unbounded behavior, pass with the fix (verified by reverting only the helper).
- Full **FT8AFKit suite: 131/131** green via `swift test` on Linux.
- The `onReply` wiring is in the Xcode-only app target (`ios/FT8AF/**`, imports `Network`/`AVFoundation`), which is not Linux-buildable; the extracted helper and its tests are, and were run.

## Risk

Low. Input-validation-only on untrusted UDP data; the sole behavioral change is that an out-of-band/garbage reply `df` is ignored (current offset kept) instead of keying TX off-air. In-band replies and the desktop-UI click-to-answer path are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)