### PR TITLE
Guard web-logger uriList[2] reads so a missing month segment can't crash the handler

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -86,6 +86,33 @@ public class LogHttpServer extends NanoHTTPD {
         return pageSize > 0 ? pageSize : 100;
     }
 
+    /**
+     * The request path segment at {@code index} (from {@code getUri().split("/")}),
+     * or {@code null} when the request has no such segment.
+     *
+     * <p>Every {@code uriList[2]} read in {@link #serve} routes through this so a
+     * request that omits the trailing segment falls back to the default page instead
+     * of throwing {@link ArrayIndexOutOfBoundsException}. {@code GET /SHOWQSL} split to
+     * {@code ["", "SHOWQSL"]} (length 2), so the old bare {@code uriList[2]} threw — and
+     * for SHOWQSL that read sat <em>outside</em> the try/catch, so it escaped
+     * {@code serve} uncaught; for the DOWNQSL / DOWNQSLNOQSL {@code Content-Disposition}
+     * header it threw inside the try and returned an opaque HTTP 500 even though the
+     * body branch had already fallen back correctly. Mirrors the {@code uriList.length
+     * >= 3} guard the DELFOLLOW / DELQSL / DELQSLCALLSIGN branches already use.
+     */
+    static String uriSegment(String[] uriList, int index) {
+        return uriList != null && index >= 0 && index < uriList.length ? uriList[index] : null;
+    }
+
+    /**
+     * {@code Content-Disposition} filename for a per-month QSL download. Falls back to
+     * {@code log.adi} when the month segment is absent (see {@link #uriSegment}), rather
+     * than reading a missing path segment.
+     */
+    static String downloadFileName(String month) {
+        return String.format("log%s.adi", month != null ? month : "");
+    }
+
     @Override
     public Response serve(IHTTPSession session) {
         String[] uriList = session.getUri().split("/");
@@ -146,7 +173,8 @@ public class LogHttpServer extends NanoHTTPD {
         } else if (uri.equalsIgnoreCase("SHOWALLQSL")) {
             msg = HTML_STRING(showAllQSL());
         } else if (uri.equalsIgnoreCase("SHOWQSL")) {
-            msg = HTML_STRING(showQSLByMonth(uriList[2]));
+            String month = uriSegment(uriList, 2);
+            msg = month != null ? HTML_STRING(showQSLByMonth(month)) : HtmlContext.DEFAULT_HTML();
         } else if (uri.equalsIgnoreCase("DELQSLCALLSIGN")) {//Delete a QSO callsign
             if (uriList.length >= 3) {
                 deleteQSLCallSign(uriList[2].replace("_", "/"));
@@ -164,22 +192,24 @@ public class LogHttpServer extends NanoHTTPD {
                 response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", msg);
                 response.addHeader("Content-Disposition", "attachment;filename=All_log.adi");
             } else if (uri.equalsIgnoreCase("DOWNQSL")) {
-                if (uriList.length >= 3) {
-                    msg = downQSLByMonth(uriList[2], true);
+                String month = uriSegment(uriList, 2);
+                if (month != null) {
+                    msg = downQSLByMonth(month, true);
                 } else {
                     msg = HtmlContext.DEFAULT_HTML();
                 }
                 response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", msg);
-                response.addHeader("Content-Disposition", String.format("attachment;filename=log%s.adi", uriList[2]));
+                response.addHeader("Content-Disposition", "attachment;filename=" + downloadFileName(month));
 
             } else if (uri.equalsIgnoreCase("DOWNQSLNOQSL")) {
-                if (uriList.length >= 3) {
-                    msg = downQSLByMonth(uriList[2], false);
+                String month = uriSegment(uriList, 2);
+                if (month != null) {
+                    msg = downQSLByMonth(month, false);
                 } else {
                     msg = HtmlContext.DEFAULT_HTML();
                 }
                 response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", msg);
-                response.addHeader("Content-Disposition", String.format("attachment;filename=log%s.adi", uriList[2]));
+                response.addHeader("Content-Disposition", "attachment;filename=" + downloadFileName(month));
 
             } else {
                 response = newFixedLengthResponse(msg);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -101,7 +101,15 @@ public class LogHttpServer extends NanoHTTPD {
      * >= 3} guard the DELFOLLOW / DELQSL / DELQSLCALLSIGN branches already use.
      */
     static String uriSegment(String[] uriList, int index) {
-        return uriList != null && index >= 0 && index < uriList.length ? uriList[index] : null;
+        if (uriList == null || index < 0 || index >= uriList.length) {
+            return null;
+        }
+        String segment = uriList[index];
+        // Treat a present-but-empty segment (e.g. the "" that a double slash like
+        // "/SHOWQSL//" splits to) as absent, so it falls back to the default page
+        // rather than flowing an empty month into showQSLByMonth/downQSLByMonth
+        // (where month.length() == 0 could match unintended rows).
+        return segment == null || segment.isEmpty() ? null : segment;
     }
 
     /**
@@ -195,21 +203,23 @@ public class LogHttpServer extends NanoHTTPD {
                 String month = uriSegment(uriList, 2);
                 if (month != null) {
                     msg = downQSLByMonth(month, true);
+                    response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", msg);
+                    response.addHeader("Content-Disposition", "attachment;filename=" + downloadFileName(month));
                 } else {
-                    msg = HtmlContext.DEFAULT_HTML();
+                    // No month segment: serve the normal HTML page instead of a
+                    // text/plain .adi attachment whose body is actually HTML.
+                    response = newFixedLengthResponse(HtmlContext.DEFAULT_HTML());
                 }
-                response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", msg);
-                response.addHeader("Content-Disposition", "attachment;filename=" + downloadFileName(month));
 
             } else if (uri.equalsIgnoreCase("DOWNQSLNOQSL")) {
                 String month = uriSegment(uriList, 2);
                 if (month != null) {
                     msg = downQSLByMonth(month, false);
+                    response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", msg);
+                    response.addHeader("Content-Disposition", "attachment;filename=" + downloadFileName(month));
                 } else {
-                    msg = HtmlContext.DEFAULT_HTML();
+                    response = newFixedLengthResponse(HtmlContext.DEFAULT_HTML());
                 }
-                response = newFixedLengthResponse(NanoHTTPD.Response.Status.OK, "text/plain", msg);
-                response.addHeader("Content-Disposition", "attachment;filename=" + downloadFileName(month));
 
             } else {
                 response = newFixedLengthResponse(msg);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerUriSegmentTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerUriSegmentTest.java
@@ -1,0 +1,70 @@
+package com.k1af.ft8af.html;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for {@link LogHttpServer#uriSegment(String[], int)} and
+ * {@link LogHttpServer#downloadFileName(String)}, the guards that keep the
+ * web-logbook {@code serve} dispatch from reading a missing {@code uriList[2]}
+ * path segment.
+ *
+ * <p>Regression: {@code GET /SHOWQSL} (no trailing month) split to
+ * {@code ["", "SHOWQSL"]} and the bare {@code uriList[2]} read threw
+ * {@link ArrayIndexOutOfBoundsException}. For SHOWQSL that read was outside the
+ * {@code serve} try/catch, so it escaped the handler entirely; the
+ * DOWNQSL / DOWNQSLNOQSL {@code Content-Disposition} header read threw inside the
+ * try and returned an opaque HTTP 500 even though the body branch had already
+ * fallen back to the default page. The three guarded sibling branches
+ * (DELFOLLOW / DELQSL / DELQSLCALLSIGN) already used {@code uriList.length >= 3}.
+ *
+ * <p>These tests reproduce the exact {@code getUri().split("/")} shape and pin the
+ * guarded behaviour. No Android types are touched, so no Robolectric runner is
+ * needed.
+ */
+public class LogHttpServerUriSegmentTest {
+
+    @Test
+    public void missingTrailingSegment_isNull() {
+        // "/SHOWQSL".split("/") == ["", "SHOWQSL"] (length 2), so index 2 is absent.
+        String[] uriList = "/SHOWQSL".split("/");
+        assertThat(uriList).hasLength(2);
+        assertThat(LogHttpServer.uriSegment(uriList, 2)).isNull();
+    }
+
+    @Test
+    public void presentTrailingSegment_isReturned() {
+        String[] uriList = "/SHOWQSL/202401".split("/");
+        assertThat(LogHttpServer.uriSegment(uriList, 2)).isEqualTo("202401");
+    }
+
+    @Test
+    public void downloadMissingMonth_isNull() {
+        // The DOWNQSL Content-Disposition header used to dereference this unconditionally.
+        assertThat(LogHttpServer.uriSegment("/DOWNQSL".split("/"), 2)).isNull();
+        assertThat(LogHttpServer.uriSegment("/DOWNQSLNOQSL".split("/"), 2)).isNull();
+    }
+
+    @Test
+    public void outOfRangeAndDegenerateInputs_areNull() {
+        String[] one = {"", "SHOWQSL"};
+        assertThat(LogHttpServer.uriSegment(one, 5)).isNull();
+        assertThat(LogHttpServer.uriSegment(one, -1)).isNull();
+        assertThat(LogHttpServer.uriSegment(new String[0], 0)).isNull();
+        assertThat(LogHttpServer.uriSegment(null, 2)).isNull();
+    }
+
+    @Test
+    public void downloadFileName_usesMonthWhenPresent() {
+        // Identical to the old String.format("log%s.adi", uriList[2]) when the month exists.
+        assertThat(LogHttpServer.downloadFileName("202401")).isEqualTo("log202401.adi");
+        assertThat(LogHttpServer.downloadFileName("")).isEqualTo("log.adi");
+    }
+
+    @Test
+    public void downloadFileName_fallsBackWhenMonthMissing() {
+        // A bare GET /DOWNQSL must produce a sane filename, not crash the header build.
+        assertThat(LogHttpServer.downloadFileName(null)).isEqualTo("log.adi");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerUriSegmentTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerUriSegmentTest.java
@@ -47,6 +47,19 @@ public class LogHttpServerUriSegmentTest {
     }
 
     @Test
+    public void presentButEmptySegment_isTreatedAsAbsent() {
+        // "/SHOWQSL//x".split("/") == ["", "SHOWQSL", "", "x"], so index 2 is a
+        // present-but-empty segment. It must read as null (not "") so an empty
+        // month never reaches showQSLByMonth/downQSLByMonth where
+        // month.length() == 0 could match unintended rows.
+        String[] uriList = "/SHOWQSL//x".split("/");
+        assertThat(uriList[2]).isEmpty();
+        assertThat(LogHttpServer.uriSegment(uriList, 2)).isNull();
+        // Same for a direct empty element.
+        assertThat(LogHttpServer.uriSegment(new String[] {"", "DOWNQSL", ""}, 2)).isNull();
+    }
+
+    @Test
     public void outOfRangeAndDegenerateInputs_areNull() {
         String[] one = {"", "SHOWQSL"};
         assertThat(LogHttpServer.uriSegment(one, 5)).isNull();


### PR DESCRIPTION
## Root cause

`LogHttpServer` is the always-on web-logbook HTTP server; it's constructed and `start()`ed unconditionally during `MainViewModel` init (`MainViewModel.java:936`), so it listens on `DEFAULT_PORT` for the whole app session and any browser on the same LAN (or the phone itself) can reach it.

Its request dispatcher, `serve()`, reads the trailing path segment `uriList[2]` (from `getUri().split("/")`) in three branches **without** the `uriList.length >= 3` guard that its sibling branches — `DELFOLLOW`, `DELQSL`, `DELQSLCALLSIGN` — already have:

- **`SHOWQSL`** — `msg = HTML_STRING(showQSLByMonth(uriList[2]));` sits **outside** the `serve()` `try/catch`. A bare `GET /SHOWQSL` splits to `["", "SHOWQSL"]` (length 2), so `uriList[2]` throws an **uncaught** `ArrayIndexOutOfBoundsException` straight out of `serve()`.
- **`DOWNQSL` / `DOWNQSLNOQSL`** — the body branch correctly falls back to the default page when the segment is missing, but the `Content-Disposition` header line then dereferences `uriList[2]` **unconditionally**. That throws inside the `try`, so the client gets an opaque **HTTP 500** instead of the intended default page.

## Fix

Route every `uriList[2]` read through a new bounds-checked static helper `uriSegment(uriList, index)` (returns `null` when the segment is absent), and build the download filename through `downloadFileName(month)` (falls back to `log.adi`). This mirrors the guard the sibling branches already use.

- **Well-formed requests are unchanged** — `GET /SHOWQSL/202401` and `GET /DOWNQSL/202401` produce byte-identical output/headers (`downloadFileName("202401") == "log202401.adi"`, exactly what `String.format("log%s.adi", uriList[2])` produced).
- **Malformed requests** (missing trailing segment) now return the default page instead of throwing / returning a 500.

## Testing

- New pure-JVM `LogHttpServerUriSegmentTest` (6 cases) pins the guard: reproduces the exact `"/SHOWQSL".split("/")` → length-2 shape, asserts `uriSegment(...) == null` for the missing/out-of-range/negative/empty/null cases, and covers `downloadFileName` present/absent-month behaviour. Matches the existing `LogHttpServerPageCountTest` style (no Robolectric needed).
- `./gradlew :app:testDebugUnitTest` — full unit-test suite green (BUILD SUCCESSFUL).

## Risk

Low. Localized to `LogHttpServer.serve()` dispatch; no protocol/DSP/audio behavior touched, no change for valid requests. Java-only (no Kotlin/ktlint impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)