### PR TITLE
Harden web-logbook server against malformed pagination query params

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -74,6 +74,47 @@ public class LogHttpServer extends NanoHTTPD {
     }
 
     /**
+     * Parse an integer query-parameter value, falling back to {@code fallback} when the
+     * value is {@code null} or not a valid integer.
+     *
+     * <p>The web-logbook handlers read {@code ?page=}, {@code ?pageSize=} and
+     * {@code ?session=} straight off the request. NanoHTTPD's {@code ClientHandler}
+     * swallows any exception thrown out of {@link #serve} — it logs it and closes the
+     * socket — so a raw {@code Integer.parseInt} of a malformed value (a hand-edited URL,
+     * a stale bookmark, or a truncated link) surfaced to the browser as an aborted/empty
+     * response instead of the requested view. Routing every parse through here keeps a bad
+     * value from throwing: the handler just uses its default (page 1, the default page
+     * size, or an id that matches no import task).
+     */
+    static int parseQueryInt(String value, int fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /**
+     * Clamp a 1-based page index to {@code [1, pageCount]}.
+     *
+     * <p>The three list handlers clamped only the high side
+     * ({@code if (pageIndex > pageCount) pageIndex = pageCount}), so {@code ?page=0} or a
+     * negative page left {@code pageIndex < 1} and the paged query's
+     * {@code LIMIT (pageIndex - 1) * pageSize, pageSize} offset went negative — a wrong or
+     * empty result set numbered from a negative "No." column. {@link #pageCount(int, int)}
+     * always returns at least 1, so the clamped index is always a page that exists.
+     */
+    static int clampPageIndex(int pageIndex, int pageCount) {
+        if (pageIndex < 1) {
+            return 1;
+        }
+        return Math.min(pageIndex, pageCount);
+    }
+
+    /**
      * Clamp a page size parsed from a {@code ?pageSize=} query value to a safe positive size.
      *
      * <p>{@link #pageCount(int, int)} tolerates a non-positive size, but the raw value also
@@ -241,8 +282,7 @@ public class LogHttpServer extends NanoHTTPD {
                 " </script>\n";
         Map<String, String> pars = session.getParms();
         if (pars.get("session") != null) {
-            String s = Objects.requireNonNull(pars.get("session"));
-            int id = Integer.parseInt(s);
+            int id = parseQueryInt(pars.get("session"), -1);
             if (!importTaskList.checkTaskIsRunning(id)) {//If the task has stopped, no need to refresh
                 script = "";
             }
@@ -257,8 +297,7 @@ public class LogHttpServer extends NanoHTTPD {
         Map<String, String> pars = session.getParms();
         Log.e(TAG, "doCancelImport: " + pars.toString());
         if (pars.get("session") != null) {
-            String s = Objects.requireNonNull(pars.get("session"));
-            int id = Integer.parseInt(s);
+            int id = parseQueryInt(pars.get("session"), -1);
             importTaskList.cancelTask(id);
             return String.format("<head>\n<meta http-equiv=\"Refresh\" content=\"0; URL=getImportTask?session=%d\" /></head><body></body>"
                     , id);
@@ -973,12 +1012,8 @@ public class LogHttpServer extends NanoHTTPD {
         //Read query parameters
         Map<String, String> pars = session.getParms();
         int pageIndex = 1;
-        if (pars.get("page") != null) {
-            pageIndex = Integer.parseInt(Objects.requireNonNull(pars.get("page")));
-        }
-        if (pars.get("pageSize") != null) {
-            pageSize = Integer.parseInt(Objects.requireNonNull(pars.get("pageSize")));
-        }
+        pageIndex = parseQueryInt(pars.get("page"), pageIndex);
+        pageSize = parseQueryInt(pars.get("pageSize"), pageSize);
         // Normalize before it feeds pageCount(), the SQL LIMIT, and the nav links, so a
         // malformed 0/negative ?pageSize= can't force an empty page or an undefined limit.
         pageSize = normalizePageSize(pageSize);
@@ -1029,7 +1064,7 @@ public class LogHttpServer extends NanoHTTPD {
                 , new String[]{whereStr, whereStr});
         cursor.moveToFirst();
         int pageCount = pageCount(cursor.getInt(cursor.getColumnIndex("rc")), pageSize);
-        if (pageIndex > pageCount) pageIndex = pageCount;
+        pageIndex = clampPageIndex(pageIndex, pageCount);
         cursor.close();
 
         //Query and per-page message count settings
@@ -1220,12 +1255,8 @@ public class LogHttpServer extends NanoHTTPD {
         //Read query parameters
         Map<String, String> pars = session.getParms();
         int pageIndex = 1;
-        if (pars.get("page") != null) {
-            pageIndex = Integer.parseInt(Objects.requireNonNull(pars.get("page")));
-        }
-        if (pars.get("pageSize") != null) {
-            pageSize = Integer.parseInt(Objects.requireNonNull(pars.get("pageSize")));
-        }
+        pageIndex = parseQueryInt(pars.get("page"), pageIndex);
+        pageSize = parseQueryInt(pars.get("pageSize"), pageSize);
         // Normalize before it feeds pageCount(), the SQL LIMIT, and the nav links, so a
         // malformed 0/negative ?pageSize= can't force an empty page or an undefined limit.
         pageSize = normalizePageSize(pageSize);
@@ -1273,7 +1304,7 @@ public class LogHttpServer extends NanoHTTPD {
                 , new String[]{whereStr, whereStr});
         cursor.moveToFirst();
         int pageCount = pageCount(cursor.getInt(cursor.getColumnIndex("rc")), pageSize);
-        if (pageIndex > pageCount) pageIndex = pageCount;
+        pageIndex = clampPageIndex(pageIndex, pageCount);
         cursor.close();
 
         //Query and per-page message count settings
@@ -1468,12 +1499,8 @@ public class LogHttpServer extends NanoHTTPD {
         //Read query parameters
         Map<String, String> pars = session.getParms();
         int pageIndex = 1;
-        if (pars.get("page") != null) {
-            pageIndex = Integer.parseInt(Objects.requireNonNull(pars.get("page")));
-        }
-        if (pars.get("pageSize") != null) {
-            pageSize = Integer.parseInt(Objects.requireNonNull(pars.get("pageSize")));
-        }
+        pageIndex = parseQueryInt(pars.get("page"), pageIndex);
+        pageSize = parseQueryInt(pars.get("pageSize"), pageSize);
         // Normalize before it feeds pageCount(), the SQL LIMIT, and the nav links, so a
         // malformed 0/negative ?pageSize= can't force an empty page or an undefined limit.
         pageSize = normalizePageSize(pageSize);
@@ -1536,7 +1563,7 @@ public class LogHttpServer extends NanoHTTPD {
                 , new String[]{whereStr, whereStr});
         cursor.moveToFirst();
         int pageCount = pageCount(cursor.getInt(cursor.getColumnIndex("rc")), pageSize);
-        if (pageIndex > pageCount) pageIndex = pageCount;
+        pageIndex = clampPageIndex(pageIndex, pageCount);
         cursor.close();
 
         //Query and per-page message count settings

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerQueryParamTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerQueryParamTest.java
@@ -1,0 +1,84 @@
+package com.k1af.ft8af.html;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for the web-logbook query-parameter guards
+ * {@link LogHttpServer#parseQueryInt(String, int)} and
+ * {@link LogHttpServer#clampPageIndex(int, int)}.
+ *
+ * <p>The always-on {@code LogHttpServer} reads {@code ?page=}, {@code ?pageSize=} and
+ * {@code ?session=} straight off the request. The handlers used to
+ * {@code Integer.parseInt} those raw values and clamped {@code pageIndex} only on the
+ * high side, so a malformed value threw (NanoHTTPD swallows it into an aborted response)
+ * and {@code ?page=0} drove the paged query's {@code LIMIT (pageIndex - 1) * pageSize}
+ * offset negative. These tests pin the guarded behaviour. No Android types are touched,
+ * so no Robolectric runner is needed (mirrors {@link LogHttpServerPageCountTest}).
+ */
+public class LogHttpServerQueryParamTest {
+
+    @Test
+    public void parseQueryInt_parsesValidValue() {
+        assertThat(LogHttpServer.parseQueryInt("5", 1)).isEqualTo(5);
+        assertThat(LogHttpServer.parseQueryInt("100", 1)).isEqualTo(100);
+        assertThat(LogHttpServer.parseQueryInt("-3", 1)).isEqualTo(-3);
+    }
+
+    @Test
+    public void parseQueryInt_fallsBackForNull() {
+        // A parameter that was never supplied keeps the handler's default.
+        assertThat(LogHttpServer.parseQueryInt(null, 1)).isEqualTo(1);
+        assertThat(LogHttpServer.parseQueryInt(null, 100)).isEqualTo(100);
+    }
+
+    @Test
+    public void parseQueryInt_fallsBackForNonNumeric() {
+        // The regression: a raw parseInt of these threw NumberFormatException out of
+        // serve(), which NanoHTTPD swallows into an aborted/empty response.
+        assertThat(LogHttpServer.parseQueryInt("abc", 1)).isEqualTo(1);
+        assertThat(LogHttpServer.parseQueryInt("", 7)).isEqualTo(7);
+        assertThat(LogHttpServer.parseQueryInt("12x", 7)).isEqualTo(7);
+        assertThat(LogHttpServer.parseQueryInt("99999999999999999999", 7)).isEqualTo(7);
+    }
+
+    @Test
+    public void parseQueryInt_trimsSurroundingWhitespace() {
+        assertThat(LogHttpServer.parseQueryInt("  5  ", 1)).isEqualTo(5);
+    }
+
+    @Test
+    public void clampPageIndex_floorsZeroAndNegativeToOne() {
+        // The core fix: ?page=0 / ?page=-5 must not leave pageIndex < 1, or the
+        // LIMIT (pageIndex - 1) * pageSize offset goes negative.
+        assertThat(LogHttpServer.clampPageIndex(0, 5)).isEqualTo(1);
+        assertThat(LogHttpServer.clampPageIndex(-5, 5)).isEqualTo(1);
+    }
+
+    @Test
+    public void clampPageIndex_keepsInRangeValue() {
+        assertThat(LogHttpServer.clampPageIndex(1, 5)).isEqualTo(1);
+        assertThat(LogHttpServer.clampPageIndex(3, 5)).isEqualTo(3);
+        assertThat(LogHttpServer.clampPageIndex(5, 5)).isEqualTo(5);
+    }
+
+    @Test
+    public void clampPageIndex_capsToPageCount() {
+        assertThat(LogHttpServer.clampPageIndex(6, 5)).isEqualTo(5);
+        assertThat(LogHttpServer.clampPageIndex(999, 5)).isEqualTo(5);
+        // pageCount is always >= 1 (see LogHttpServer#pageCount), so an empty log with a
+        // stale high page still lands on the single real page.
+        assertThat(LogHttpServer.clampPageIndex(6, 1)).isEqualTo(1);
+    }
+
+    @Test
+    public void clampPageIndex_neverProducesNegativeSqlOffset() {
+        // Guards the actual downstream use: LIMIT (pageIndex - 1) * pageSize.
+        int pageSize = 100;
+        for (int requested : new int[] {-10, -1, 0, 1, 2, 50}) {
+            int clamped = LogHttpServer.clampPageIndex(requested, 5);
+            assertThat((clamped - 1) * pageSize).isAtLeast(0);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

The always-on `LogHttpServer` (started at app launch in `MainViewModel`, listening on `DEFAULT_PORT` for the whole session — LAN-reachable) parsed its pagination query parameters with raw `Integer.parseInt` and clamped the page index only on the high side. Two defects on untrusted input:

1. **Uncaught `NumberFormatException` on non-numeric params.** `?page=abc` / `?pageSize=abc` / `?session=abc` (a hand-edited URL, a stale bookmark, a truncated nav link) threw out of `serve()`. NanoHTTPD's `ClientHandler.run()` catches `Exception` broadly — it logs and closes the socket — so the browser got an **aborted/empty response** instead of the requested logbook view. (Reliability, not an app crash.)

2. **Negative SQL offset from an un-floored page index.** Each list handler did `if (pageIndex > pageCount) pageIndex = pageCount;` with no `< 1` floor. So `?page=0` (or a negative page) left `pageIndex < 1`, and the paged query's `LIMIT (pageIndex - 1) * pageSize, pageSize` offset went **negative** — a wrong/empty result set numbered from a negative "No." column. (Functional bug affecting existing web-logbook behaviour.)

Both stem from the same root: unvalidated pagination query parameters.

## Fix

Two pure static helpers, mirroring the file's existing `pageCount` / `normalizePageSize` pattern:

- `parseQueryInt(String value, int fallback)` — returns `fallback` when the value is null or not a valid integer (also trims whitespace).
- `clampPageIndex(int pageIndex, int pageCount)` — floors to `1` and caps at `pageCount` (which is always `>= 1`).

Applied at all three paged views (`getMessages`, `getSWLQsoMessages`, `getQsoLogs`) and both import-session handlers (`makeGetImportTaskHTML`, `doCancelImport`, fallback `-1` = an id matching no task). Behaviour is **byte-identical for well-formed requests**; malformed ones now fall back to a sane default (page 1 / default page size) instead of breaking the response.

## Testing

- New `LogHttpServerQueryParamTest` (pure JVM, JUnit4 + Truth, no Robolectric — mirrors `LogHttpServerPageCountTest`), 8 cases covering valid/null/non-numeric/whitespace parse and the page-index floor/cap plus the "offset never negative" invariant.
- Verified the guard cases **fail against the pre-fix behaviour** (raw parse throws NFE; old high-side-only clamp leaves `page=0` → offset `-pageSize`), pass after.
- `./gradlew :app:testDebugUnitTest` green (full suite).
- `./gradlew :app:assembleDebug` green (4 ABIs, hamlib/NDK).

## Risk

Low. Change is confined to `LogHttpServer` query-param parsing; no DSP/decoder/protocol/interop surface touched. Well-formed requests are unchanged.