### PR TITLE
Desktop: complete the QSO when a partner signs off with RR73

### DIFF
--- a/desktop/src-tauri/src/qso.rs
+++ b/desktop/src-tauri/src/qso.rs
@@ -373,15 +373,23 @@ fn fmt_report(n: i32) -> String {
 }
 
 fn classify(msg: &DecodedMessage) -> Content {
-    if !msg.grid.is_empty() {
-        return Content::Grid(msg.grid.clone());
-    }
+    // Recognize the QSO sign-offs before treating the message as a grid report.
+    // "RR73" is a valid 4-char Maidenhead-shaped token (R,R in A..R + two
+    // digits), so the decoder copies it into `grid` (looks_like_grid("RR73") is
+    // true). Checking grid first would classify a partner's standard RR73
+    // sign-off as Content::Grid, stranding the auto-sequencer at the RReport
+    // stage — it would retransmit our R-report forever and never complete/log
+    // the QSO. Matching the sign-offs first fixes that without touching
+    // looks_like_grid (the map/distance code relies on its shape test).
     let extra = msg.extra.trim();
     match extra {
         "RR73" => return Content::Rr73,
         "RRR" => return Content::Rrr,
         "73" => return Content::Bye73,
         _ => {}
+    }
+    if !msg.grid.is_empty() {
+        return Content::Grid(msg.grid.clone());
     }
     if let Some(rest) = extra.strip_prefix('R') {
         if let Ok(n) = rest.parse::<i32>() {
@@ -429,8 +437,10 @@ mod tests {
         assert_eq!(e.tx_message(), Some("K1ABC K0XYZ R-08"));
         assert_eq!(e.status().report_rcvd, Some(-12));
 
-        // DX sends RR73 -> we log AND queue the courtesy 73 to transmit.
-        let out = e.process_rx(&[msg("K0XYZ", "K1ABC", "RR73", "", -8)]);
+        // DX sends RR73 -> we log AND queue the courtesy 73 to transmit. The
+        // decoder copies the grid-shaped "RR73" into the grid field, so pass it
+        // here as it actually arrives live (grid == "RR73"), not grid == "".
+        let out = e.process_rx(&[msg("K0XYZ", "K1ABC", "RR73", "RR73", -8)]);
         match out {
             Some(QsoOutcome::Completed(rec)) => {
                 assert_eq!(rec.call, "K1ABC");
@@ -462,8 +472,9 @@ mod tests {
         e.process_rx(&[msg("K0XYZ", "K1ABC", "-12", "", -8)]);
         assert_eq!(e.tx_message(), Some("K1ABC K0XYZ R-08"));
 
-        // DX sends RR73 -> QSO logs and the courtesy 73 is queued.
-        let out = e.process_rx(&[msg("K0XYZ", "K1ABC", "RR73", "", -8)]);
+        // DX sends RR73 -> QSO logs and the courtesy 73 is queued. As live, the
+        // grid-shaped "RR73" also lands in the decoder's grid field.
+        let out = e.process_rx(&[msg("K0XYZ", "K1ABC", "RR73", "RR73", -8)]);
         assert!(matches!(out, Some(QsoOutcome::Completed(_))));
         assert_eq!(e.tx_message(), Some("K1ABC K0XYZ 73"));
         assert_eq!(e.status().stage, TxStage::Bye73);
@@ -564,5 +575,44 @@ mod tests {
         // traffic between two other stations
         assert!(e.process_rx(&[msg("W1AW", "K1ABC", "FN42", "FN42", -3)]).is_none());
         assert_eq!(e.tx_message(), Some("CQ K0XYZ EN37"));
+    }
+
+    #[test]
+    fn rr73_signoff_is_not_classified_as_a_grid() {
+        // "RR73" passes looks_like_grid, so the decoder copies it into the grid
+        // field. classify must still treat it as the RR73 sign-off, not a grid
+        // report — otherwise the auto-sequencer never completes the QSO.
+        let signoff = msg("K0XYZ", "K1ABC", "RR73", "RR73", -8);
+        assert!(matches!(classify(&signoff), Content::Rr73));
+        // A genuine grid report is unaffected.
+        let grid = msg("K0XYZ", "K1ABC", "FN42", "FN42", -8);
+        assert!(matches!(classify(&grid), Content::Grid(g) if g == "FN42"));
+    }
+
+    #[test]
+    fn rr73_with_decoder_grid_still_completes_qso() {
+        // Regression for the sign-off-vs-grid classification bug. Live, the DX's
+        // RR73 arrives with grid == "RR73" (looks_like_grid is true). Before the
+        // fix classify returned Content::Grid, the RReport arm hit `_ => {}`, and
+        // the QSO hung retransmitting our R-report forever instead of logging.
+        let mut e = QsoEngine::new("K0XYZ", "EN37");
+        e.answer(&msg("CQ", "K1ABC", "FN42", "FN42", -5));
+        e.process_rx(&[msg("K0XYZ", "K1ABC", "-12", "", -8)]);
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ R-08"));
+        assert_eq!(e.status().stage, TxStage::RReport);
+
+        // DX signs off with RR73 exactly as the decoder emits it live.
+        let out = e.process_rx(&[msg("K0XYZ", "K1ABC", "RR73", "RR73", -8)]);
+        match out {
+            Some(QsoOutcome::Completed(rec)) => {
+                assert_eq!(rec.call, "K1ABC");
+                assert_eq!(rec.gridsquare, "FN42");
+                assert_eq!(rec.rst_sent, "-08");
+                assert_eq!(rec.rst_rcvd, "-12");
+            }
+            _ => panic!("RR73 sign-off must complete the QSO"),
+        }
+        assert_eq!(e.tx_message(), Some("K1ABC K0XYZ 73"));
+        assert_eq!(e.status().stage, TxStage::Bye73);
     }
 }


### PR DESCRIPTION
## Summary

The desktop auto-sequencer never completed (or logged) a QSO when the partner signed off with the standard WSJT-X **RR73** — it hung retransmitting our R-report indefinitely. Only the non-grid-shaped `73`/`RRR` sign-offs closed a QSO. This is a functional bug affecting normal FT8 QSO flow (Category 2).

## Root cause

`classify()` in `desktop/src-tauri/src/qso.rs` checked the message's `grid` field **before** matching the `RR73`/`RRR`/`73` sign-offs:

```rust
if !msg.grid.is_empty() { return Content::Grid(msg.grid.clone()); }
// ...sign-off match came after...
```

`"RR73"` is a valid 4-char Maidenhead-shaped token (`R,R` in `A..R` + two digits), so `looks_like_grid("RR73")` is `true` and the decoder copies it into the `grid` field (`dsp/decoder.rs:285`). `classify()` therefore returned `Content::Grid("RR73")` for a standard sign-off. In `process_rx`, the `TxStage::RReport` arm only handles `Content::Rr73 | Content::Rrr | Content::Bye73`; a `Grid` fell through to `_ => {}`, so the engine kept resending our R-report and the QSO never advanced to `complete()`.

## Fix

Match the `RR73`/`RRR`/`73` sign-offs on the trimmed `extra` text **before** the grid check in `classify()`. Minimal reorder, no behavior change for genuine grid reports (a real locator like `FN42` still classifies as `Content::Grid`). `looks_like_grid` is intentionally left untouched — the map/distance code relies on its shape test and rejects `RR73` separately.

## Testing

Verified by compiling `qso.rs` standalone (the full Tauri crate needs webkit/dbus system libs unavailable here) via `rustc --test` with a zig linker, stubbing only serde and the two dependency structs:

- **With the fix:** all 8 `qso` tests pass.
- **Against the pre-fix `classify`:** the 2 new tests **and** the 2 de-masked fixtures fail — confirming they capture the bug.

New tests:
- `rr73_signoff_is_not_classified_as_a_grid` — direct `classify()` unit test (RR73→`Rr73`, FN42→`Grid`).
- `rr73_with_decoder_grid_still_completes_qso` — full RReport→complete flow with the realistic `grid == "RR73"` the live decoder emits.

Also corrected the two existing RR73 fixtures, which passed `grid == ""` (never happens live) and so masked the bug, to `grid == "RR73"`.

## Risk

Low. Single-function reorder in a pure state machine; genuine grid reports and the R-report/report paths are unchanged. Preserves WSJT-X interoperability (RR73 is the standard sign-off).

## Notes / follow-up

The **same root bug exists on iOS** (`ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift` `classify`, decoder `FT8Decoder.swift`), where its tests likewise pass RR73 fixtures with an empty grid. Left for a separate focused PR (one platform per PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)