### PR TITLE
Remove Android Auto support to clear Play production rejection

### DIFF
--- a/ft8af/app/src/main/AndroidManifest.xml
+++ b/ft8af/app/src/main/AndroidManifest.xml
@@ -30,11 +30,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
 
-    <!-- Android Auto: NAVIGATION-category car app that draws its QSO map on the
-         car Surface (see QsoStatusScreen/CarMapSurfaceRenderer). -->
-    <uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES" />
-    <uses-permission android:name="androidx.car.app.ACCESS_SURFACE" />
-
     <application
         android:name="radio.ks3ckc.ft8af.FT8AFApplication"
         android:allowBackup="false"
@@ -117,30 +112,6 @@
             <meta-data
                 android:name="autoStoreLocales"
                 android:value="true" />
-        </service>
-
-        <!-- Android Auto (phone projection): read-only QSO status screens rendered
-             with car-app-library templates. Exported so the Android Auto host can
-             bind; access is gated by FT8AFCarAppService's HostValidator. -->
-        <meta-data
-            android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc" />
-        <!-- Level 1 = backward-compat floor. The surface map (NavigationTemplate)
-             needs API level 5+; older hosts fall back to a text PaneTemplate. -->
-        <meta-data
-            android:name="androidx.car.app.minCarApiLevel"
-            android:value="1" />
-
-        <service
-            android:name="radio.ks3ckc.ft8af.car.FT8AFCarAppService"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="androidx.car.app.CarAppService" />
-                <!-- NAVIGATION (not IOT/POI) so the full-bleed QSO map surface stays
-                     visible while the vehicle is moving — the point of mobile FT8.
-                     POI/IOT map surfaces are blanked or disallowed while driving. -->
-                <category android:name="androidx.car.app.category.NAVIGATION" />
-            </intent-filter>
         </service>
 
         <provider

--- a/ft8af/app/src/main/res/xml/automotive_app_desc.xml
+++ b/ft8af/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-    Declares to the Android Auto host that this app renders car-app-library
-    templates (see FT8AFCarAppService). Referenced from the manifest via the
-    com.google.android.gms.car.application meta-data entry.
--->
-<automotiveApp>
-    <uses name="template" />
-</automotiveApp>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarAppManifestWiringTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarAppManifestWiringTest.kt
@@ -3,6 +3,7 @@ package radio.ks3ckc.ft8af.car
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Bundle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -42,10 +43,12 @@ class CarAppManifestWiringTest {
             context.packageName,
             PackageManager.GET_META_DATA,
         )
-        // Other application-level meta-data (e.g. io.sentry.auto-init) keeps this
-        // bundle non-null; what must be gone is the Android Auto descriptor and the
-        // car-app API-level floor that together mark the app as an AA app.
-        val meta = appInfo.metaData
+        // ApplicationInfo.metaData is null when the manifest carries no
+        // application-level meta-data at all; treat that as an empty Bundle so the
+        // test asserts on absence of the AA keys rather than NPE-ing. (Today
+        // io.sentry.auto-init keeps it non-null, but the guard must not depend on
+        // that unrelated entry surviving.)
+        val meta = appInfo.metaData ?: Bundle()
         assertThat(meta.containsKey("com.google.android.gms.car.application")).isFalse()
         assertThat(meta.containsKey("androidx.car.app.minCarApiLevel")).isFalse()
     }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarAppManifestWiringTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarAppManifestWiringTest.kt
@@ -5,16 +5,21 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.k1af.ft8af.R
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Pins the Android Auto manifest wiring: the host discovers the app through the
- * CarAppService intent filter plus the automotive_app_desc meta-data, and a
- * silently dropped entry would only show up as "app missing from the car
- * launcher" — a failure mode adb/unit tests can't otherwise see.
+ * Pins Android Auto as *unwired* in the manifest. The car-app screens
+ * (FT8AFCarAppService/QsoStatusScreen) still exist in the tree, but the manifest
+ * entries the Android Auto host discovers them through were removed: Play rejected
+ * the app for not behaving as a NAVIGATION-category car app ("does not load map and
+ * user location in Android Auto Environment"), and re-adding either entry would
+ * re-flag the app as Android-Auto-enabled and re-trigger that review failure.
+ *
+ * This runs against the debug variant's merged manifest, which still overlays the
+ * debug-only CarAppActivity used for on-emulator development — that entry is not a
+ * release Android Auto descriptor and never ships, so it doesn't count here.
  */
 @RunWith(RobolectricTestRunner::class)
 class CarAppManifestWiringTest {
@@ -22,28 +27,26 @@ class CarAppManifestWiringTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
-    fun carAppService_isDeclaredExported_withNavigationCategory() {
+    fun noCarAppService_isDeclared() {
         val intent = Intent("androidx.car.app.CarAppService").setPackage(context.packageName)
         val services = context.packageManager.queryIntentServices(
             intent,
             PackageManager.GET_RESOLVED_FILTER,
         )
-        assertThat(services).hasSize(1)
-        val resolved = services[0]
-        assertThat(resolved.serviceInfo.name).isEqualTo("radio.ks3ckc.ft8af.car.FT8AFCarAppService")
-        assertThat(resolved.serviceInfo.exported).isTrue()
-        // NAVIGATION category = the full-bleed map surface stays visible while driving.
-        assertThat(resolved.filter.hasCategory("androidx.car.app.category.NAVIGATION")).isTrue()
+        assertThat(services).isEmpty()
     }
 
     @Test
-    fun automotiveAppDescriptor_andMinCarApiLevel_areDeclared() {
+    fun androidAutoDescriptorMetaData_isAbsent() {
         val appInfo = context.packageManager.getApplicationInfo(
             context.packageName,
             PackageManager.GET_META_DATA,
         )
-        assertThat(appInfo.metaData.getInt("com.google.android.gms.car.application"))
-            .isEqualTo(R.xml.automotive_app_desc)
-        assertThat(appInfo.metaData.getInt("androidx.car.app.minCarApiLevel")).isEqualTo(1)
+        // Other application-level meta-data (e.g. io.sentry.auto-init) keeps this
+        // bundle non-null; what must be gone is the Android Auto descriptor and the
+        // car-app API-level floor that together mark the app as an AA app.
+        val meta = appInfo.metaData
+        assertThat(meta.containsKey("com.google.android.gms.car.application")).isFalse()
+        assertThat(meta.containsKey("androidx.car.app.minCarApiLevel")).isFalse()
     }
 }


### PR DESCRIPTION
## Why

Play rejected the Production release under **Auto App Quality Guidelines: App doesn't perform as expected** — _"does not load map and user location in Android Auto Environment."_

The app declared itself a **NAVIGATION-category** Android Auto app, but it's a ham-radio QSO monitor, not a navigation app:

- The car map only renders once the phone engine is running (`MainViewModel.peekInstance()`), so a reviewer on a fresh install sees the "open the app on your phone" template.
- Even when it renders, it centers on the operator's Maidenhead grid, not GPS — there's no "user location."

A non-navigation app can't meet NAVIGATION-category quality bars, and no approved Android Auto category fits this app, so a compliance fix would keep bouncing. This takes Play's alternative path: **remove the Android Auto manifest wiring** so the app is no longer flagged as AA-enabled.

## Changes

- **`AndroidManifest.xml`** — remove the two `androidx.car.app.*` permissions, the `com.google.android.gms.car.application` descriptor + `androidx.car.app.minCarApiLevel` meta-data, and the `FT8AFCarAppService` service.
- **Delete `res/xml/automotive_app_desc.xml`** — dead once the descriptor is gone.
- **`CarAppManifestWiringTest`** — flipped from asserting AA is wired to a **regression guard** asserting it's unwired, so the descriptor/CarAppService can't be silently re-added and re-trigger the rejection.

The `car/` Kotlin package and `androidx.car.app:app` dependency stay in-tree (dead but compiling) so the feature can be revived; debug-only AAOS scaffolding (`src/debug` CarAppActivity + `DebugInjectReceiver`) is untouched.

## Testing

- `gradlew testDebugUnitTest --tests radio.ks3ckc.ft8af.car.*` — **passes**, including the new guard, which runs against the merged manifest and confirms no `CarAppService` + no AA descriptor.
- `processReleaseMainManifest` — succeeds; the release manifest is AA-free.
- Full APK link isn't possible in a fresh worktree (hamlib prebuilt isn't in git; needs a one-time WSL build), so this was verified via unit tests + manifest processing rather than a device install.

## Follow-up (Play Console, not in this PR)

Roll the compliant build to 100% across **every** track (Production + Internal/Closed/Open testing), moving the noncompliant APKs to "Not Included."

🤖 Generated with [Claude Code](https://claude.com/claude-code)