### PR TITLE
CI: clamp Discord merge-notify embed to API limits

### DIFF
--- a/.github/workflows/discord-merge-notify.yml
+++ b/.github/workflows/discord-merge-notify.yml
@@ -39,6 +39,9 @@ jobs:
           sha_short="${SHA:0:7}"
           first_line=$(printf '%s' "$COMMIT_MSG" | head -n1)
           body=$(printf '%s' "$COMMIT_MSG" | tail -n +2 | sed -E '/^[[:space:]]*$/d' || true)
+          # Discord embed limits: title <= 256 chars, description <= 4096 chars.
+          # A large squash-merge commit body overruns description -> HTTP 400, so
+          # clamp both fields (with an ellipsis) before building the payload.
           payload=$(jq -nc \
             --arg branch  "$BRANCH" \
             --arg sha     "$sha_short" \
@@ -50,11 +53,12 @@ jobs:
             --arg repo    "$REPO" \
             --arg emoji   "$emoji" \
             --argjson color "$color" \
-            '{embeds:[{
-               title: ($emoji + " " + $repo + " — merged into " + $branch + ": " + $first),
+            'def clamp(max): if (.|length) > max then (.[0:max-1] + "…") else . end;
+             {embeds:[{
+               title: (($emoji + " " + $repo + " — merged into " + $branch + ": " + $first) | clamp(256)),
                url: $url,
                color: $color,
-               description: (if $body == "" then null else $body end),
+               description: (if $body == "" then null else ($body | clamp(4096)) end),
                fields: [
                  {name:"Commit",  value:("[`"+$sha+"`]("+$url+")"), inline:true},
                  {name:"Author",  value:$author, inline:true},


### PR DESCRIPTION
## Problem
The `notify` job (`.github/workflows/discord-merge-notify.yml`) failed on the push of the #591 squash-merge into `dev`:

```
curl: (22) The requested URL returned error: 400
```

The `DISCORD_WEBHOOK_URL` secret is set and the webhook is valid — the 400 came from the **payload**. The step put the entire commit body into the embed `description` with no length bound. Discord caps an embed `description` at **4096 chars** (and `title` at 256); the large squash-merge commit body overran the limit, so Discord rejected it and `curl -f` failed the job. Ironically it breaks on exactly the biggest merges most worth announcing.

The build was unaffected — only the notification failed.

## Fix
Add a jq `clamp(max)` helper and apply it to both `title` and `description` (slice to `max-1` codepoints + `…`). Oversized commits now post a truncated embed instead of erroring; at/under-limit messages are untouched (no spurious ellipsis).

## Verification
Boundary math validated: oversized → exactly the limit with a trailing ellipsis; a message exactly at the limit is left as-is; empty body still yields `null`. (No jq/YAML test harness exists in-repo; this is a workflow shell change.)