### PR TITLE
CI: fix Play internal publish (changesNotSentForReview)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -616,6 +616,15 @@ jobs:
           track: ${{ steps.tag.outputs.play_track }}
           status: completed
           releaseName: ${{ steps.tag.outputs.release_tag }}
+          # The app has pending Play Console changes that require review (e.g. the
+          # Android Auto removal / store-listing edits), so Google refuses to
+          # auto-send the edit for review from the API and the upload fails with
+          # "Changes cannot be sent for review automatically. Please set the query
+          # parameter changesNotSentForReview to true." Committing the edit WITHOUT
+          # auto-review lets the AAB land on the track; the release is then sent for
+          # review manually from the Play Console UI (Publishing overview -> Send
+          # for review). Harmless once no review-gated changes are pending.
+          changesNotSentForReview: true
 
       # Make a swallowed publish failure visible (annotation on the run) without
       # failing the job — the artifact + GitHub Release already succeeded.


### PR DESCRIPTION
## Problem

The staging push (`android-dev.659`) built and signed the AAB and cut the GitHub Release, but **nothing reached the Play internal track**. The `Publish AAB to Play` step is `continue-on-error`, so the run stayed green and only left a warning annotation.

The upload actually failed with:

> Changes cannot be sent for review automatically. Please set the query parameter `changesNotSentForReview` to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.

This happens because the app has **pending Play Console changes that require review** (the recent Android Auto removal / store-listing edits from the Play production rejection). The default `r0adkll/upload-google-play` behavior commits the edit *and* auto-sends for review, which Google refuses in that state.

## Fix

Set `changesNotSentForReview: true` on the upload step. The edit now commits (the AAB lands on the track) without auto-review; the release is sent for review manually from the Play Console UI. Harmless once no review-gated changes are pending.

## After merge

Once this reaches `staging` (dev → staging), the next staging push publishes `android-dev.<run#>` to internal successfully. Then in Play Console: **Publishing overview → Send changes for review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)