### PR TITLE
Debug: demo-data mode (waterfall + logbook) for Play Store screenshots

### DIFF
--- a/ft8af/app/src/debug/kotlin/radio/ks3ckc/ft8af/car/DebugInject.kt
+++ b/ft8af/app/src/debug/kotlin/radio/ks3ckc/ft8af/car/DebugInject.kt
@@ -172,8 +172,11 @@ internal fun applyDebugInject(spec: DebugInjectSpec, vm: MainViewModel) {
     if (spec.waterfall > 0) {
         val tones = demoToneFrequencies(spec.waterfall)
         vm.spectrumListener?.let { listener ->
+            val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
             repeat(WF_FRAMES) { frame ->
-                listener.mutableDataBuffer.postValue(buildDemoAudio(tones, seed = frame))
+                val buf = buildDemoAudio(tones, seed = frame)
+                // Use setValue on the main thread so each frame is delivered (no postValue coalescing).
+                mainHandler.post { listener.mutableDataBuffer.value = buf }
                 try {
                     Thread.sleep(WF_FRAME_MS)
                 } catch (_: InterruptedException) {
@@ -209,12 +212,13 @@ internal fun buildDemoAudio(
     sampleRate: Int = 12000,
     seed: Int = 0,
 ): FloatArray {
-    val out = FloatArray(sampleCount)
-    if (tonesHz.isEmpty() || sampleCount <= 0) return out
+    val n = sampleCount.coerceAtLeast(0)
+    val out = FloatArray(n)
+    if (tonesHz.isEmpty() || n == 0 || sampleRate <= 0) return out
     // Keep the summed peak inside [-1, 1] even with several tones.
     val amp = (0.9 / tonesHz.size).coerceAtMost(0.18)
     val noiseAmp = 0.006
-    for (i in 0 until sampleCount) {
+    for (i in 0 until n) {
         var v = 0.0
         for (f in tonesHz) v += amp * sin(2.0 * PI * f * i / sampleRate)
         // Hash-based pseudo-noise: deterministic, phase-varied per frame by seed.

--- a/ft8af/app/src/debug/kotlin/radio/ks3ckc/ft8af/car/DebugInject.kt
+++ b/ft8af/app/src/debug/kotlin/radio/ks3ckc/ft8af/car/DebugInject.kt
@@ -8,29 +8,44 @@ import com.k1af.ft8af.Ft8Message
 import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.ft8transmit.TransmitCallsign
+import com.k1af.ft8af.log.QSLRecord
 import com.k1af.ft8af.maidenhead.MaidenheadGrid
 import radio.ks3ckc.ft8af.pota.PotaSessionManager
 import radio.ks3ckc.ft8af.pskreporter.PskReporterSpot
 import radio.ks3ckc.ft8af.pskreporter.WhoHeardMeCache
+import kotlin.math.PI
+import kotlin.math.floor
+import kotlin.math.sin
 
 /**
- * DEBUG-ONLY test harness for the Android Auto QSO map. Lives in `src/debug`, so
- * it is never compiled into a release build.
+ * DEBUG-ONLY test/demo harness. Lives in `src/debug`, so it is never compiled
+ * into a release build. Originally built to exercise the Android Auto QSO map on
+ * an emulator; it doubles as the "demo data" source for Play Store screenshots —
+ * it forges the live engine state the main phone screens read, so each tab looks
+ * populated without a radio.
  *
- * The car map is a read-out of the live engine: it draws the operator dot from
- * [GeneralVariables.getMyMaidenheadGrid], the partner dot + connecting line from
- * the current QSO target, decode dots from [MainViewModel.mutableFt8MessageList],
- * and "who heard me" rings from [WhoHeardMeCache]. On an emulator there is no
- * radio, so this receiver forges that state.
+ * What it drives:
+ * - **Decode list + map**: operator dot from [GeneralVariables.getMyMaidenheadGrid],
+ *   partner dot + line from the current QSO target, decode dots from
+ *   [MainViewModel.mutableFt8MessageList], "who heard me" rings from [WhoHeardMeCache].
+ * - **Waterfall**: a stream of synthetic 12 kHz audio frames posted to
+ *   `spectrumListener.mutableDataBuffer`; the Waterfall screen FFTs each frame, so
+ *   chosen audio tones render as clean vertical FT8-style traces (`wf` extra).
+ * - **Logbook**: sample completed QSOs written into `QSLTable` via the app's own
+ *   insert path so the Logbook tab, which re-queries the DB, shows a full log
+ *   (`qsos` extra). These use obviously-fictitious demo callsigns; remove them by
+ *   reinstalling the debug build (which wipes the DB).
  *
  * Usage (app must be open so the engine singleton exists):
  * ```
  * adb shell am broadcast -a ft8af.DEBUG_INJECT \
  *   --es call W1ABC --es grid FN42 --es opgrid EM29 --es park K-1234 \
- *   --ei snr -8 --ei decodes 8 --ei psk 6
+ *   --ei snr -8 --ei decodes 8 --ei psk 6 --ei qsos 12 --ei wf 6
  * ```
- * `decodes` adds N sample US decode dots; `psk` adds N sample "who heard me"
- * rings. All extras are optional; [parseDebugInject] fills sensible defaults.
+ * `decodes` adds N sample decode dots; `psk` adds N "who heard me" rings; `qsos`
+ * adds N demo logbook entries; `wf` streams a waterfall with N tone traces (be on
+ * the Waterfall tab to see it fill). All extras are optional; [parseDebugInject]
+ * fills sensible defaults.
  */
 class DebugInjectReceiver : BroadcastReceiver() {
 
@@ -68,6 +83,33 @@ private val SAMPLE_PSK = listOf(
     "K8JKL" to "EN80", "W9MNO" to "EM69", "KH6PQR" to "BL11", "VE7STU" to "CN89",
 )
 
+/** Sample worked stations for the demo logbook — a DX-flavoured mix across continents. */
+private val SAMPLE_QSOS = listOf(
+    "DL1ABC" to "JO31", "G4XYZ" to "IO91", "JA1DEF" to "PM95", "VK3GHI" to "QF22",
+    "EA5JKL" to "IM98", "F5MNO" to "JN18", "PY2PQR" to "GG66", "ZL2STU" to "RE78",
+    "OH2VWX" to "KP20", "I2YZA" to "JN45", "SP5BCD" to "KO02", "VE1EFG" to "FN85",
+    "9A1HIJ" to "JN75", "LU3KLM" to "GF05", "ON4NOP" to "JO20", "SM3QRS" to "JP81",
+)
+
+/** FT8/FT4 dial frequencies (Hz) the demo QSOs are spread across. */
+private data class DemoBand(val mode: String, val dialHz: Long)
+private val DEMO_BANDS = listOf(
+    DemoBand("FT8", 14_074_000L), // 20m
+    DemoBand("FT8", 7_074_000L),  // 40m
+    DemoBand("FT4", 14_080_000L), // 20m FT4
+    DemoBand("FT8", 21_074_000L), // 15m
+    DemoBand("FT8", 28_074_000L), // 10m
+    DemoBand("FT8", 10_136_000L), // 30m
+)
+
+/** Waterfall passband (audio Hz) the demo tone traces are spread across. */
+private const val WF_MIN_HZ = 250.0
+private const val WF_MAX_HZ = 2750.0
+
+/** Waterfall stream length: enough frames to fill the scrolling bitmap (~3s at 22ms). */
+private const val WF_FRAMES = 140
+private const val WF_FRAME_MS = 22L
+
 /**
  * Forges the engine state a [DebugInjectSpec] describes: operator grid, a decode
  * for the QSO partner (+ optional sample decodes), an optional POTA activation,
@@ -97,9 +139,128 @@ internal fun applyDebugInject(spec: DebugInjectSpec, vm: MainViewModel) {
 
     spec.parkRef?.let { PotaSessionManager.start(listOf(it), "debug inject") }
 
+    // Demo logbook QSOs — written straight into QSLTable through the app's own
+    // insert path, so the Logbook tab (which re-queries the DB on load, not the
+    // in-memory list) shows a populated log. Uses the caller's real callsign if
+    // set, else a placeholder; the worked stations are obviously-fictitious demo
+    // calls. addQSL_Callsign runs its own background insert.
+    if (spec.qsos > 0) {
+        val myCall = GeneralVariables.myCallsign.ifEmpty { "W1AW" }
+        val myGrid = GeneralVariables.getMyMaidenheadGrid() ?: spec.opGrid
+        buildDemoQsoLog(spec.qsos, System.currentTimeMillis()).forEach { q ->
+            vm.databaseOpr.addQSL_Callsign(
+                QSLRecord(
+                    q.startMillis, q.endMillis, myCall, myGrid,
+                    q.toCall, q.toGrid, q.sendReport, q.receivedReport,
+                    q.mode, q.bandFreqHz, q.audioHz,
+                ),
+            )
+        }
+    }
+
     // Setting the target triggers the car screen's observer → re-render.
     val target = TransmitCallsign(0, 0, spec.partnerCall, 0f, 0, spec.snr)
     vm.ft8TransmitSignal.mutableToCallsign.postValue(target)
+
+    // Waterfall: post a stream of synthetic 12 kHz audio frames. The Waterfall
+    // screen FFTs each frame (mutableDataBuffer carries raw audio, not a spectrum),
+    // so the chosen tones render as vertical traces and the scrolling bitmap fills.
+    // Done LAST so its ~3s of spaced posts don't delay the other state above; the
+    // observer only runs while the Waterfall tab is on screen. postValue (not
+    // setValue) because this runs on a worker thread; the spacing keeps LiveData's
+    // coalescing from dropping most frames.
+    if (spec.waterfall > 0) {
+        val tones = demoToneFrequencies(spec.waterfall)
+        vm.spectrumListener?.let { listener ->
+            repeat(WF_FRAMES) { frame ->
+                listener.mutableDataBuffer.postValue(buildDemoAudio(tones, seed = frame))
+                try {
+                    Thread.sleep(WF_FRAME_MS)
+                } catch (_: InterruptedException) {
+                    return
+                }
+            }
+        }
+    }
+}
+
+/** Audio tone offsets (Hz) for the demo waterfall, spread evenly across the passband. */
+internal fun demoToneFrequencies(count: Int): List<Double> {
+    val n = count.coerceIn(0, 12)
+    return when {
+        n == 0 -> emptyList()
+        n == 1 -> listOf((WF_MIN_HZ + WF_MAX_HZ) / 2)
+        else -> {
+            val step = (WF_MAX_HZ - WF_MIN_HZ) / (n - 1)
+            (0 until n).map { WF_MIN_HZ + it * step }
+        }
+    }
+}
+
+/**
+ * A frame of synthetic 12 kHz mono audio: the sum of sinusoids at [tonesHz] plus a
+ * small deterministic noise floor, in the float PCM range [-1, 1] the recorder
+ * produces. The waterfall's FFT of this shows a vertical trace per tone. Kept pure
+ * (no Random — [seed] varies frame-to-frame reproducibly) so it is unit-testable.
+ */
+internal fun buildDemoAudio(
+    tonesHz: List<Double>,
+    sampleCount: Int = 1920,
+    sampleRate: Int = 12000,
+    seed: Int = 0,
+): FloatArray {
+    val out = FloatArray(sampleCount)
+    if (tonesHz.isEmpty() || sampleCount <= 0) return out
+    // Keep the summed peak inside [-1, 1] even with several tones.
+    val amp = (0.9 / tonesHz.size).coerceAtMost(0.18)
+    val noiseAmp = 0.006
+    for (i in 0 until sampleCount) {
+        var v = 0.0
+        for (f in tonesHz) v += amp * sin(2.0 * PI * f * i / sampleRate)
+        // Hash-based pseudo-noise: deterministic, phase-varied per frame by seed.
+        val h = sin((i + seed * 7919 + 1) * 12.9898) * 43758.5453
+        val noise = ((h - floor(h)) * 2.0 - 1.0) * noiseAmp
+        out[i] = (v + noise).toFloat().coerceIn(-1f, 1f)
+    }
+    return out
+}
+
+/** A single demo logbook entry; Android-free so [buildDemoQsoLog] stays unit-testable. */
+internal data class DemoQso(
+    val toCall: String,
+    val toGrid: String,
+    val mode: String,
+    val bandFreqHz: Long,
+    val audioHz: Int,
+    val sendReport: Int,
+    val receivedReport: Int,
+    val startMillis: Long,
+    val endMillis: Long,
+)
+
+/**
+ * Builds up to [count] demo QSOs (clamped to the sample-station pool) ending
+ * shortly before [nowMillis], stepping ~7 minutes further into the past per entry
+ * so the log reads as a recent operating run. Deterministic given its inputs.
+ */
+internal fun buildDemoQsoLog(count: Int, nowMillis: Long): List<DemoQso> {
+    val n = count.coerceIn(0, SAMPLE_QSOS.size)
+    return (0 until n).map { i ->
+        val (call, grid) = SAMPLE_QSOS[i]
+        val band = DEMO_BANDS[i % DEMO_BANDS.size]
+        val start = nowMillis - (i + 1) * 7L * 60_000L
+        DemoQso(
+            toCall = call,
+            toGrid = grid,
+            mode = band.mode,
+            bandFreqHz = band.dialHz,
+            audioHz = 400 + (i * 233) % 2200,
+            sendReport = -6 - (i % 12),
+            receivedReport = -3 - (i * 3) % 15,
+            startMillis = start,
+            endMillis = start + 75_000L,
+        )
+    }
 }
 
 /**
@@ -125,6 +286,8 @@ internal data class DebugInjectSpec(
     val parkRef: String?,
     val decodes: Int,
     val psk: Int,
+    val qsos: Int,
+    val waterfall: Int,
 )
 
 /**
@@ -144,6 +307,8 @@ internal fun parseDebugInject(get: (String) -> String?): DebugInjectSpec {
         parkRef = str("park")?.uppercase(),
         decodes = str("decodes")?.toIntOrNull()?.coerceAtLeast(0) ?: 0,
         psk = str("psk")?.toIntOrNull()?.coerceAtLeast(0) ?: 0,
+        qsos = str("qsos")?.toIntOrNull()?.coerceAtLeast(0) ?: 0,
+        waterfall = str("wf")?.toIntOrNull()?.coerceAtLeast(0) ?: 0,
     )
 }
 

--- a/ft8af/app/src/testDebug/kotlin/radio/ks3ckc/ft8af/car/DebugInjectTest.kt
+++ b/ft8af/app/src/testDebug/kotlin/radio/ks3ckc/ft8af/car/DebugInjectTest.kt
@@ -23,6 +23,8 @@ class DebugInjectTest {
                 parkRef = null,
                 decodes = 0,
                 psk = 0,
+                qsos = 0,
+                waterfall = 0,
             ),
         )
     }
@@ -34,6 +36,15 @@ class DebugInjectTest {
         val spec = parseDebugInject { extras[it] }
         assertThat(spec.decodes).isEqualTo(8)
         assertThat(spec.psk).isEqualTo(0)
+    }
+
+    /** qsos/wf counts parse as ints and clamp negatives to zero. */
+    @Test
+    fun qsoAndWaterfallCounts_parseAndClamp() {
+        val extras = mapOf("qsos" to "12", "wf" to "-4")
+        val spec = parseDebugInject { extras[it] }
+        assertThat(spec.qsos).isEqualTo(12)
+        assertThat(spec.waterfall).isEqualTo(0)
     }
 
     /** Supplied values win over defaults and are upper-cased. */
@@ -76,5 +87,131 @@ class DebugInjectTest {
     fun negativeSnr_parses() {
         val spec = parseDebugInject { if (it == "snr") "-8" else null }
         assertThat(spec.snr).isEqualTo(-8)
+    }
+
+    // --- demoToneFrequencies -------------------------------------------------
+
+    /** Zero tones → empty; the caller then posts silence / skips the waterfall. */
+    @Test
+    fun toneFrequencies_zero_isEmpty() {
+        assertThat(demoToneFrequencies(0)).isEmpty()
+    }
+
+    /** Counts above the cap are clamped so a huge `wf` value can't blow up. */
+    @Test
+    fun toneFrequencies_clampAndStayInBand() {
+        val tones = demoToneFrequencies(999)
+        assertThat(tones).hasSize(12)
+        tones.forEach {
+            assertThat(it).isAtLeast(250.0)
+            assertThat(it).isAtMost(2750.0)
+        }
+    }
+
+    /** Multiple tones are distinct and ascending (evenly spread across the band). */
+    @Test
+    fun toneFrequencies_distinctAscending() {
+        val tones = demoToneFrequencies(6)
+        assertThat(tones).hasSize(6)
+        assertThat(tones).isInStrictOrder()
+        assertThat(tones.first()).isWithin(1e-9).of(250.0)
+        assertThat(tones.last()).isWithin(1e-9).of(2750.0)
+    }
+
+    // --- buildDemoAudio ------------------------------------------------------
+
+    /** No tones → a silent buffer of the requested length (no crash). */
+    @Test
+    fun demoAudio_noTones_isSilentAndSized() {
+        val audio = buildDemoAudio(emptyList(), sampleCount = 1920)
+        assertThat(audio).hasLength(1920)
+        assertThat(audio.all { it == 0f }).isTrue()
+    }
+
+    /** Every sample stays inside the [-1, 1] float-PCM range the recorder emits. */
+    @Test
+    fun demoAudio_staysInPcmRange() {
+        val audio = buildDemoAudio(demoToneFrequencies(8))
+        assertThat(audio).hasLength(1920)
+        audio.forEach {
+            assertThat(it).isAtLeast(-1f)
+            assertThat(it).isAtMost(1f)
+        }
+    }
+
+    /**
+     * The FFT the waterfall computes should show energy at the injected tone and
+     * near-nothing in an empty part of the band — otherwise the traces wouldn't
+     * appear. Verified with a direct DFT magnitude at the tone vs. a quiet bin.
+     */
+    @Test
+    fun demoAudio_concentratesEnergyAtTone() {
+        val toneHz = 1500.0
+        val audio = buildDemoAudio(listOf(toneHz), sampleCount = 1920, sampleRate = 12000)
+        val atTone = dftMagnitude(audio, toneHz, 12000)
+        val atQuiet = dftMagnitude(audio, 60.0, 12000) // below the passband → noise floor only
+        assertThat(atTone).isGreaterThan(atQuiet * 20)
+    }
+
+    /** Same seed → identical buffer (deterministic); different seed → it varies. */
+    @Test
+    fun demoAudio_isDeterministicPerSeed() {
+        val tones = demoToneFrequencies(4)
+        assertThat(buildDemoAudio(tones, seed = 3)).isEqualTo(buildDemoAudio(tones, seed = 3))
+        assertThat(buildDemoAudio(tones, seed = 3)).isNotEqualTo(buildDemoAudio(tones, seed = 4))
+    }
+
+    // --- buildDemoQsoLog -----------------------------------------------------
+
+    /** Count is clamped to the sample-station pool; zero yields no entries. */
+    @Test
+    fun qsoLog_countClamps() {
+        assertThat(buildDemoQsoLog(0, NOW)).isEmpty()
+        assertThat(buildDemoQsoLog(5, NOW)).hasSize(5)
+        // Requesting more than the pool returns the whole pool, not a crash.
+        assertThat(buildDemoQsoLog(999, NOW).size).isAtLeast(12)
+    }
+
+    /** Every demo QSO sits in the past, has a positive duration, and cascades back. */
+    @Test
+    fun qsoLog_timestampsAreRecentPast() {
+        val log = buildDemoQsoLog(8, NOW)
+        log.forEach {
+            assertThat(it.startMillis).isLessThan(NOW)
+            assertThat(it.endMillis).isGreaterThan(it.startMillis)
+        }
+        // Newer entries first: each start is strictly earlier than the previous.
+        log.map { it.startMillis }.zipWithNext { a, b -> assertThat(b).isLessThan(a) }
+    }
+
+    /** Fields are realistic: distinct calls, known modes/bands, plausible reports. */
+    @Test
+    fun qsoLog_fieldsAreRealistic() {
+        val log = buildDemoQsoLog(12, NOW)
+        assertThat(log.map { it.toCall }.toSet()).hasSize(log.size) // no duplicate calls
+        log.forEach {
+            assertThat(it.mode).isAnyOf("FT8", "FT4")
+            assertThat(it.bandFreqHz).isGreaterThan(1_000_000L)
+            assertThat(it.audioHz).isIn(200..2700)
+            assertThat(it.sendReport).isIn(-25..5)
+            assertThat(it.receivedReport).isIn(-25..5)
+        }
+    }
+
+    private companion object {
+        // Fixed reference "now" so the timestamp tests are deterministic.
+        const val NOW = 1_700_000_000_000L
+
+        /** Single-bin DFT magnitude at [freqHz] — enough to prove a tone is present. */
+        fun dftMagnitude(samples: FloatArray, freqHz: Double, sampleRate: Int): Double {
+            var re = 0.0
+            var im = 0.0
+            for (i in samples.indices) {
+                val a = 2.0 * Math.PI * freqHz * i / sampleRate
+                re += samples[i] * Math.cos(a)
+                im += samples[i] * Math.sin(a)
+            }
+            return Math.hypot(re, im)
+        }
     }
 }


### PR DESCRIPTION
## Why

We need fresh Play Store screenshots, but the main screens render empty without a radio + live traffic. The debug-only `DebugInject` receiver already forges decode-list / map / "who heard me" state on a radio-less device. This extends it to the **two remaining main screens** so every tab looks populated for screenshots.

## What

Two new broadcast extras (both optional, debug build only):

| Extra | Effect |
|-------|--------|
| `--ei wf N` | Streams synthetic 12 kHz audio to the waterfall → **N clean vertical FT8-style traces**. `mutableDataBuffer` carries raw audio, so the screen's own FFT turns the injected tones into the display. |
| `--ei qsos N` | Inserts **N sample completed QSOs** into `QSLTable` via the app's own `addQSL_Callsign` path → the Logbook tab shows a full recent log (DX-flavoured fictitious calls across 40/30/20/15/10m, FT8+FT4). |

Full demo in one shot (app open; be on the Waterfall tab to watch it fill):

```
adb shell am broadcast -a ft8af.DEBUG_INJECT \
  --es call W1ABC --es grid FN42 --es opgrid EM29 --es park K-1234 \
  --ei snr -8 --ei decodes 8 --ei psk 6 --ei qsos 12 --ei wf 6
```

## Design / testing

Per repo convention, the decision/geometry logic is extracted into pure, Android-free `internal` functions (`demoToneFrequencies`, `buildDemoAudio`, `buildDemoQsoLog`); the receiver stays a thin wrapper. New unit tests (`src/testDebug`) cover:
- the new `qsos`/`wf` parse + clamp,
- tone spread, band-clamping, ascending/distinct,
- synthetic audio stays in the `[-1,1]` float-PCM range **and** concentrates FFT energy at the injected tone (direct DFT) vs. a quiet bin,
- demo log entries are deterministic, in the recent past, non-duplicate, plausible reports/bands.

`testDebugUnitTest` passes. Debug Kotlin/Java compile clean. (Local `assembleDebug` can't finish only because the hamlib native step needs a Linux NDK — unrelated to this change; CI builds it.)

## Notes
- **Never compiled into release** — lives entirely in `src/debug` / `src/testDebug`.
- Demo QSOs use obviously-fictitious calls; clear them by reinstalling the debug build (wipes the DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)