### PR TITLE
Debug: clean 'debug inject' caption off demo POTA card

### DIFF
--- a/ft8af/app/src/debug/kotlin/radio/ks3ckc/ft8af/car/DebugInject.kt
+++ b/ft8af/app/src/debug/kotlin/radio/ks3ckc/ft8af/car/DebugInject.kt
@@ -137,7 +137,9 @@ internal fun applyDebugInject(spec: DebugInjectSpec, vm: MainViewModel) {
         }
     }
 
-    spec.parkRef?.let { PotaSessionManager.start(listOf(it), "debug inject") }
+    // notes=null matches a real no-notes activation (PotaScreen passes
+    // notes.ifBlank { null }); keeps the demo POTA card clean for screenshots.
+    spec.parkRef?.let { PotaSessionManager.start(listOf(it), null) }
 
     // Demo logbook QSOs — written straight into QSLTable through the app's own
     // insert path, so the Logbook tab (which re-queries the DB on load, not the


### PR DESCRIPTION
Follow-up to #605. The demo POTA activation was started with `notes="debug inject"`, which renders as a caption on the POTA activation card — harmless for the emulator harness, but it leaks into Play Store screenshots.

Pass `notes=null` instead, matching a real no-notes activation (`PotaScreen` calls `start(..., notes.ifBlank { null })`). The demo POTA card now shows just park / QSO count / elapsed, no caption.

Debug-only (`src/debug`); no behavior change to the shipping app. One-line change to an existing glue call, so no new test path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)