### PR TITLE
Fix decode-screen NPE crash when a message has a null destination call

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/Ft8Message.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/Ft8Message.java
@@ -502,12 +502,18 @@ t71     Telemetry data, up to 18 hex digits
      * @return boolean Returns true if CQ.
      */
     public boolean checkIsCQ() {
-        String s = callsignTo.trim().split(" ")[0];
-        if (s == null) {
+        // callsignTo defaults to null and stays null for free-text/telemetry
+        // frames and unresolved-hash decodes that still reach the decode list.
+        // The Compose decode screen calls this unconditionally on the main
+        // thread (DecodeRow / resolveQsoStatus / filterMessages), so a missing
+        // destination must be treated as "not a CQ" rather than NPE on trim().
+        // (The previous `s == null` check was dead: String.split()[0] is never
+        // null; the deref that actually throws is callsignTo above.)
+        if (callsignTo == null) {
             return false;
-        } else {
-            return (s.equals("CQ") || s.equals("DE") || s.equals("QRZ"));
         }
+        String s = callsignTo.trim().split(" ")[0];
+        return (s.equals("CQ") || s.equals("DE") || s.equals("QRZ"));
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/Ft8MessageTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/Ft8MessageTest.java
@@ -88,6 +88,20 @@ public class Ft8MessageTest {
     }
 
     @Test
+    public void checkIsCQ_falseWhenCallsignToNull() {
+        // A free-text / telemetry / unresolved-hash decode can reach the decode
+        // list with callsignTo still at its null default (single-arg ctor). The
+        // Compose decode screen calls checkIsCQ() unconditionally on every
+        // rendered row (DecodeRow / resolveQsoStatus / filterMessages) on the
+        // main thread with no try/catch, so a missing destination must return
+        // "not a CQ" rather than NPE. Mirrors the #254 guard already present in
+        // ActiveQsoPanel for the same deref.
+        Ft8Message msg = new Ft8Message(FT8Common.FT8_MODE);
+        assertThat(msg.callsignTo).isNull();
+        assertThat(msg.checkIsCQ()).isFalse();
+    }
+
+    @Test
     public void getMessageText_freeTextPadsToThirteen() {
         // Default i3/n3 == 0 selects the free-text branch, which upper-cases and
         // left-pads the payload to 13 chars.


### PR DESCRIPTION
## Root cause

`Ft8Message.checkIsCQ()` dereferenced `callsignTo` **before** its guard, and the guard checked the wrong variable:

```java
String s = callsignTo.trim().split(" ")[0];   // NPE here when callsignTo == null
if (s == null) { return false; }              // dead: String.split()[0] is never null
```

`callsignTo` defaults to `null` (`public String callsignTo = null`) and stays null for free-text/telemetry frames and unresolved-hash decodes that still reach the published decode list. The `if (s == null)` check is dead — `String.split()[0]` never returns null — so the intended "missing destination → not a CQ" behaviour never actually protected the real deref.

## Impact (live main-thread crash on the primary screen)

The Compose decode screen calls `checkIsCQ()` **unconditionally on the main thread with no try/catch**:

- `DecodeRow.kt:72` — for **every** rendered decode row
- `DecodeRow.kt:352` — inside `resolveQsoStatus(...)`
- `DecodeScreen.kt:479, 511, 515` — inside `filterMessages(...)` ("Show only CQ", "CQ Calls", "New DXCC")

A single decode with a null `callsignTo` therefore crashed the whole app on the app's primary screen.

This is proven reachable by the existing **#254** guard already present in `ActiveQsoPanel.kt:104`:

```kotlin
// Guard: checkIsCQ() calls callsignTo.trim() which NPEs on null. (#254)
if (msg.callsignTo != null && msg.checkIsCQ()) return@forEach
```

`ActiveQsoPanel` is a sibling consumer of the **same** `mainViewModel.mutableFt8MessageList`. That guard was added there but not to the decode-list consumers, which have the identical deref.

## Fix

Null-guard `callsignTo` inside `checkIsCQ()` itself — the single choke point every caller funnels through — so a missing destination returns "not a CQ" instead of throwing. This covers `DecodeRow`, `resolveQsoStatus`, `filterMessages`, and `MapScreen` at once. Behaviour is byte-for-byte unchanged for any message that has a `callsignTo`.

## Testing performed

- Added `Ft8MessageTest.checkIsCQ_falseWhenCallsignToNull` — reproduces the NPE against the unfixed code (`java.lang.NullPointerException`), passes after the fix.
- `:app:testDebugUnitTest` — full unit suite green.
- `:app:assembleDebug` — clean APK build across all 4 ABIs.

## Risk

Minimal. One-line defensive null-guard in a leaf helper; no protocol/DSP/threading behaviour changes; no change for well-formed messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)