### PR TITLE
Guarantee TX teardown when the AudioTrack sound-card path throws

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -755,6 +755,24 @@ public class FT8TransmitSignal {
         GeneralVariables.fileLog(
                 "playFT8Signal: using AudioTrack output (Android default sink)");
 
+        // Own the whole sound-card branch under a guaranteed single teardown.
+        // Everything below claims audio focus and keeps PTT keyed, then builds
+        // and drives an AudioTrack — any of which can throw on a bad route/rate,
+        // a DEAD_OBJECT, or an uninitialized track. DoTransmitRunnable (the TX
+        // worker) has no top-level try/catch, so an escaping exception would
+        // crash the app AND strand PTT keyed + audio focus held. Mirrors
+        // playTuneTone's try/catch/finally.
+        runPlaybackWithTeardown(() -> playViaAudioTrack(buffer), this::afterPlayAudio);
+    }
+
+    /**
+     * Sound-card (Android default sink) FT8 TX playback: claim exclusive audio
+     * focus, build and drive the streaming AudioTrack, and drain the tail. Must
+     * run under {@link #runPlaybackWithTeardown} so PTT/focus/track teardown
+     * ({@link #afterPlayAudio}) always happens, even if an AudioTrack call
+     * throws. Sibling of {@link #playViaUsbAudio}.
+     */
+    private void playViaAudioTrack(float[] buffer) {
         // This branch shares Android's mixer with every other app, so claim
         // exclusive focus for the transmission. Denial is log-only: TX must
         // still go out.
@@ -871,10 +889,33 @@ public class FT8TransmitSignal {
             }
         }
 
-        // Worker-thread-owned teardown (drops PTT + releases the track). The UI
-        // thread never releases the streaming track — it only flips txAudioCancelled
-        // and pauses/flushes — so there's no release race against this write loop.
-        afterPlayAudio();
+        // Teardown (drops PTT + releases the track + audio focus) is run by
+        // runPlaybackWithTeardown's finally, so it happens on both the normal
+        // exit here and any thrown AudioTrack failure above. The UI thread never
+        // releases the streaming track — it only flips txAudioCancelled and
+        // pauses/flushes — so there's no release race against this write loop.
+    }
+
+    /**
+     * Runs a sound-card playback {@code body}, then {@code teardown} exactly
+     * once — whether the body returns normally or throws. The AudioTrack
+     * setup/play/write in the body can throw (device route change, DEAD_OBJECT,
+     * an uninitialized track) and the TX worker ({@link DoTransmitRunnable}) has
+     * no top-level try/catch, so an escaping exception would crash the app and
+     * leave PTT keyed + audio focus held + the track leaked — a stuck carrier is
+     * never acceptable. Swallow-and-log the failure and always tear down,
+     * mirroring {@link #playTuneTone}.
+     *
+     * <p>Package-visible and free of Android types for testing.
+     */
+    static void runPlaybackWithTeardown(Runnable body, Runnable teardown) {
+        try {
+            body.run();
+        } catch (Exception e) {
+            Log.e(TAG, "FT8 AudioTrack playback failed: " + e);
+        } finally {
+            teardown.run();
+        }
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -906,13 +906,16 @@ public class FT8TransmitSignal {
      * never acceptable. Swallow-and-log the failure and always tear down,
      * mirroring {@link #playTuneTone}.
      *
-     * <p>Package-visible and free of Android types for testing.
+     * <p>Package-visible for testing. Its parameters are plain {@link Runnable}s,
+     * so a test can drive it with no Android dependency beyond the
+     * {@link Log} call below — which is a no-op stub under the module's
+     * {@code unitTests.returnDefaultValues} setting.
      */
     static void runPlaybackWithTeardown(Runnable body, Runnable teardown) {
         try {
             body.run();
         } catch (Exception e) {
-            Log.e(TAG, "FT8 AudioTrack playback failed: " + e);
+            Log.e(TAG, "FT8 AudioTrack playback failed", e);
         } finally {
             teardown.run();
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/RunPlaybackWithTeardownTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/RunPlaybackWithTeardownTest.java
@@ -1,0 +1,75 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests for {@link FT8TransmitSignal#runPlaybackWithTeardown} — the guard
+ * that keeps a thrown AudioTrack failure from (a) escaping the top-level-catch-less
+ * TX worker (whole-app crash) and (b) stranding PTT keyed + audio focus held +
+ * the track leaked. The contract: teardown runs exactly once whether the body
+ * returns normally or throws, and a body exception never propagates.
+ *
+ * <p>Pure JVM (no Robolectric): the method takes plain {@link Runnable}s and its
+ * only Android touch is {@code Log.e}, which {@code returnDefaultValues} stubs.
+ */
+public class RunPlaybackWithTeardownTest {
+
+    @Test
+    public void bodyCompletes_runsBodyThenTeardownExactlyOnce() {
+        AtomicInteger bodyRuns = new AtomicInteger();
+        AtomicInteger teardownRuns = new AtomicInteger();
+
+        FT8TransmitSignal.runPlaybackWithTeardown(
+                bodyRuns::incrementAndGet, teardownRuns::incrementAndGet);
+
+        assertThat(bodyRuns.get()).isEqualTo(1);
+        assertThat(teardownRuns.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void bodyThrows_runsTeardownAndSwallowsTheException() {
+        AtomicInteger teardownRuns = new AtomicInteger();
+
+        // A throwing body must NOT propagate: the real body runs on the
+        // doTransmitThreadPool worker, whose DoTransmitRunnable has no
+        // top-level try/catch, so an escaping exception crashes the app.
+        FT8TransmitSignal.runPlaybackWithTeardown(() -> {
+            throw new IllegalStateException("AudioTrack died mid-write");
+        }, teardownRuns::incrementAndGet);
+
+        // If the exception were not swallowed this test method would fail with
+        // that IllegalStateException instead of reaching the assertion.
+        assertThat(teardownRuns.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void bodyThrows_stillTearsDownEvenWhenBodyDidPartialWork() {
+        AtomicInteger teardownRuns = new AtomicInteger();
+        AtomicInteger bodyProgress = new AtomicInteger();
+
+        FT8TransmitSignal.runPlaybackWithTeardown(() -> {
+            bodyProgress.incrementAndGet(); // e.g. focus acquired / PTT keyed
+            throw new IllegalArgumentException("bad audio route");
+        }, teardownRuns::incrementAndGet);
+
+        assertThat(bodyProgress.get()).isEqualTo(1);
+        assertThat(teardownRuns.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void teardownRunsOncePerCall_notCumulatively() {
+        AtomicInteger teardownRuns = new AtomicInteger();
+
+        FT8TransmitSignal.runPlaybackWithTeardown(() -> { }, teardownRuns::incrementAndGet);
+        FT8TransmitSignal.runPlaybackWithTeardown(() -> {
+            throw new RuntimeException("second call throws");
+        }, teardownRuns::incrementAndGet);
+
+        // One teardown per invocation regardless of body outcome.
+        assertThat(teardownRuns.get()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Root cause

The FT8 **sound-card** TX branch of `FT8TransmitSignal.playFT8Signal` (the AudioTrack / Android-default-sink path) does, in straight-line order:

1. `txAudioFocus.acquire(...)` — claims exclusive audio focus (PTT is already keyed by `onBeforeTransmit`),
2. `new AudioTrack(...)`, `.play()`, and a blocking `.write()` loop,
3. `afterPlayAudio()` at the very end — which drops PTT (`onAfterTransmit`), releases the track, and abandons audio focus.

Steps in (2) can all throw: `new AudioTrack()`/`play()`/`write()` raise `IllegalArgumentException`/`IllegalStateException`/`UnsupportedOperationException` on a bad route or rate, a `DEAD_OBJECT` (route change mid-TX), or an uninitialized track. Because `afterPlayAudio()` was only reached on the normal straight-line exit, a throw in (2) skipped it entirely.

`DoTransmitRunnable` — the TX worker submitted to `doTransmitThreadPool` — has **no top-level try/catch**, so the escaping exception:

- **crashed the whole app** (uncaught exception on a pooled worker thread), and
- left **PTT keyed** into the RX window, **audio focus held** (other apps stay ducked until the process dies), and the **AudioTrack leaked**.

A stuck keyed carrier is exactly the failure mode the sibling **Tune** path (`playTuneTone`) already guards against with `try/catch/finally`. The FT8 branch introduced in #597 (`Hold exclusive audio focus during AudioTrack TX and Tune`) did not get the same guard — this closes that asymmetry.

## Fix

- Extract the sound-card body into `private void playViaAudioTrack(float[] buffer)` (sibling of the existing `playViaUsbAudio`).
- Run it under a new package-private `runPlaybackWithTeardown(Runnable body, Runnable teardown)` that swallow-and-logs a body failure and always runs `teardown` **exactly once** — mirroring `playTuneTone`'s structure. Teardown is the existing `afterPlayAudio()`.

Happy path is byte-identical: the same single `afterPlayAudio()` call runs at the same point. Only the failure path changes — from *crash + stranded PTT/focus/track* to *logged + full teardown*.

## Testing

- **New:** `RunPlaybackWithTeardownTest` (pure JVM, no Robolectric — the helper takes plain `Runnable`s and its only Android touch is `Log.e`, stubbed by `returnDefaultValues`): teardown runs exactly once on normal completion, runs exactly once when the body throws, and a body exception never propagates.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — 4-ABI native + APK build green.

## Risk assessment

Low. Localized to the sound-card TX branch. No DSP/protocol/interop change (no encoder, decoder, waveform, or timing touched). The only behavioral change is that an AudioTrack failure now tears down cleanly instead of crashing. `catch (Exception)` (not `Throwable`) matches the sibling `playTuneTone`; it does not swallow `Error`s, and the swallowed condition is an environmental audio-device failure that is logged.

No UI changes. No performance impact.