### PR TITLE
Don't upload the RR73 sign-off as a locator to PSKReporter

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
@@ -191,10 +191,37 @@ object PskReporterSender {
             frequencyHz = freqHz,
             snr = if (msg.hasSnr()) msg.snr else 0,
             mode = mode,
-            senderLocator = msg.maidenGrid?.takeIf { it.length >= 4 },
+            senderLocator = reportableLocator(msg.maidenGrid),
             flowStartSeconds = msg.utcTime / 1000,
         )
     }
+
+    /**
+     * Decide whether a decoded message's grid slot is a genuine Maidenhead
+     * locator worth reporting to PSKReporter, or a value that must be dropped.
+     *
+     * A standard/non-standard FT8 message ends a QSO with the sign-off token
+     * "RR73", which the JNI decoder stores into [Ft8Message.maidenGrid] because
+     * it is a syntactic 4-char grid look-alike (R,R in field range A–R; 7,3 in
+     * square range 0–9). It is NOT a location: the FT8 encoder always packs
+     * "RR73" as the roger-73 report, never as a grid (see ft8_lib `packgrid`),
+     * so no compliant transmitter ever means grid RR73 (a phantom cell in the
+     * Arctic Ocean). Reporting it would inject bogus locators into the global
+     * PSKReporter spot database and break interoperability with WSJT-X, which
+     * never treats RR73 as a grid.
+     *
+     * This mirrors the RR73 exclusion the rest of the app already applies when
+     * classifying a grid — [GeneralVariables.checkFun1],
+     * `MaidenheadGrid.gridToLatLng`, and `CountDbOpr` — which the naive
+     * `length >= 4` check here previously missed. Pure function — testable
+     * without Android.
+     *
+     * @return the locator to report, or null when the grid is absent, too short
+     *         to be a locator, or the RR73 sign-off token.
+     */
+    @VisibleForTesting
+    internal fun reportableLocator(maidenGrid: String?): String? =
+        maidenGrid?.takeIf { it.length >= 4 && !it.equals("RR73", ignoreCase = true) }
 
     /**
      * Atomically test the per-band dedup window for [dedupKey] ("CALL|BAND") and,

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
@@ -502,6 +502,36 @@ class PskReporterSenderTest {
     }
 
     // ---------------------------------------------------------------
+    // Sender locator sanitation (reportableLocator)
+    // ---------------------------------------------------------------
+
+    @Test
+    fun `reportableLocator keeps a genuine 4-char grid`() {
+        assertThat(PskReporterSender.reportableLocator("FN31")).isEqualTo("FN31")
+    }
+
+    @Test
+    fun `reportableLocator keeps a 6-char grid`() {
+        assertThat(PskReporterSender.reportableLocator("IO91wm")).isEqualTo("IO91wm")
+    }
+
+    @Test
+    fun `reportableLocator drops the RR73 signoff token`() {
+        // "RR73" is a syntactic grid look-alike (R,R + 7,3) but is the roger-73
+        // sign-off, never a Maidenhead locator. It must not be uploaded to the
+        // global PSKReporter database. The old `length >= 4` check let it through.
+        assertThat(PskReporterSender.reportableLocator("RR73")).isNull()
+        assertThat(PskReporterSender.reportableLocator("rr73")).isNull()
+    }
+
+    @Test
+    fun `reportableLocator drops absent or too-short grids`() {
+        assertThat(PskReporterSender.reportableLocator(null)).isNull()
+        assertThat(PskReporterSender.reportableLocator("")).isNull()
+        assertThat(PskReporterSender.reportableLocator("FN")).isNull()
+    }
+
+    // ---------------------------------------------------------------
     // Dedup window bookkeeping (markIfFresh) + thread-safety
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

`PskReporterSender.toSpotRecord` decided the reported **senderLocator** with a naive length check:

```kotlin
senderLocator = msg.maidenGrid?.takeIf { it.length >= 4 },
```

The JNI decoder stores the end-of-QSO sign-off token **"RR73"** into `Ft8Message.maidenGrid`, because `ft8_looks_like_grid()` classifies it as a grid — it is a syntactic 4-char grid look-alike (`R,R` in the `A–R` field range; `7,3` in the `0–9` square range).

But "RR73" is **not a location**. The FT8 encoder always packs "RR73" as the roger-73 report, never as a grid:

```c
// ft8_lib/ft8/message.c — packgrid()
if (equals(grid4, "RR73"))
    return MAXGRID4 + 3;   // report token, NOT a grid
```

So no compliant FT8 transmitter ever means grid RR73 (a phantom cell in the Arctic Ocean), and WSJT-X never treats it as one.

## Impact

Every QSO-ending **RR73** the app decoded (standard `i3=1/2` and non-standard `i3=4` messages) was uploaded to the **global PSKReporter spot database** as the sender's Maidenhead locator `"RR73"` — injecting phantom Arctic coordinates into a shared ecosystem resource and breaking interoperability with established FT8 implementations.

## Why this is the one place that leaked

The rest of the app already excludes this token wherever it classifies a grid:

- `GeneralVariables.checkFun1` — `... && !extraInfo.equals("RR73")`
- `MaidenheadGrid.gridToLatLng` — `if (grid.equalsIgnoreCase("RR73")) return null;`
- `CountDbOpr.computeDistanceStats` — skips grids that don't parse (its javadoc explicitly calls out `"RR73"` as a token "operators commonly leak into the GRIDSQUARE field")

The PSKReporter upload path was the single consumer that used a bare `length >= 4` check instead.

## Fix

Extract the decision into a pure, testable `reportableLocator()` helper (mirroring the codebase's convention of pulling decision logic out of hard-to-test wrappers). It keeps genuine grids and drops the RR73 sign-off — plus the absent/too-short grids the old check already dropped:

```kotlin
maidenGrid?.takeIf { it.length >= 4 && !it.equals("RR73", ignoreCase = true) }
```

Behaviour is unchanged for every real locator.

## Testing performed

- Added `reportableLocator` cases to `PskReporterSenderTest`: keeps `FN31` / `IO91wm`, drops `RR73` / `rr73` / `null` / `""` / `"FN"`.
- Verified the RR73 case is meaningful: it **fails** against the old length-only logic and **passes** after the fix (temporarily reverted the helper body to confirm red→green).
- `:app:testDebugUnitTest` — full unit suite green (JDK 17 / AGP 8.7.3, all 34 tasks).

## Risk

Minimal. One localized change in the PSKReporter consumer; no protocol, DSP, decoder, threading, or native change. No effect on any message that carries a real grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)