### PR TITLE
Fix Yaesu FT-817/857/897 set-frequency encoder tens-of-Hz nibble

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu2RigConstant.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu2RigConstant.java
@@ -77,11 +77,15 @@ public class Yaesu2RigConstant {
         return GET_DISCONNECT;
     }
     public static byte[] setOperationFreq(long freq) {
+        // 4 BCD bytes, most-significant nibble first, weights 1e8..1e1 (10 Hz LSB).
+        // The last nibble is the tens-of-Hz digit (freq % 100 / 10), NOT freq % 100:
+        // Yaesu2Command.getFrequency weights it x10, so packing the full 0-99 remainder
+        // there desynced the encoder from its own decoder (e.g. ...050 read back as ...320).
         byte[] data = new byte[]{
                 (byte) (((byte) (freq % 1000000000 / 100000000) << 4) + (byte) (freq % 100000000 / 10000000))
                 , (byte) (((byte) (freq % 10000000 / 1000000) << 4) + (byte) (freq % 1000000 / 100000))
                 , (byte) (((byte) (freq % 100000 / 10000) << 4) + (byte) (freq % 10000 / 1000))
-                , (byte) (((byte) (freq % 1000 / 100) << 4) + (byte) (freq % 100))
+                , (byte) (((byte) (freq % 1000 / 100) << 4) + (byte) (freq % 100 / 10))
                 ,(byte) 0x01
         };
         return data;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2CommandTest.java
@@ -12,9 +12,9 @@ import org.junit.Test;
  * sequence with weights 1e8, 1e7, 1e6, 1e5, 1e4, 1e3, 1e2, 1e1 (10 Hz LSB).
  *
  * This inverts {@link Yaesu2RigConstant#setOperationFreq} exactly for
- * 100 Hz-aligned dials. The encoder packs the last nibble as {@code freq % 100}
- * rather than a clean tens-of-Hz digit, so for frequencies with a non-zero
- * sub-100 Hz remainder the encoder and decoder are not exact inverses.
+ * 10 Hz-aligned dials. The encoder packs the last nibble as the tens-of-Hz digit
+ * ({@code freq % 100 / 10}); only the sub-10 Hz remainder (below the rig's CAT
+ * resolution) is dropped, so the two are exact inverses for any 10 Hz-aligned VFO.
  */
 public class Yaesu2CommandTest {
 
@@ -41,12 +41,20 @@ public class Yaesu2CommandTest {
 
     @Test
     public void getFrequency_roundTripsSetOperationFreqEncoding() {
-        // The decoder must invert the encoder. Use a 100 Hz-aligned dial so the
-        // round trip isolates the decoder weights (the encoder packs the two
-        // sub-100 Hz digits into a single nibble, an unrelated limitation).
-        long dial = 14_074_300L; // 14.074 MHz + 300 Hz, exercises the low nibbles
+        // The decoder must invert the encoder for any 10 Hz-aligned dial. This dial
+        // has non-zero hundreds- and tens-of-Hz digits, exercising both nibbles of
+        // the last byte (which previously desynced: 50 packed raw read back as 320).
+        long dial = 14_074_350L; // 14.074 MHz + 350 Hz
         byte[] encoded = Yaesu2RigConstant.setOperationFreq(dial);
         assertThat(Yaesu2Command.getFrequency(encoded)).isEqualTo(dial);
+    }
+
+    @Test
+    public void getFrequency_dropsOnlySub10HzOnRoundTrip() {
+        // The rig CAT frame has 10 Hz resolution, so the sub-10 Hz remainder is the
+        // only part not preserved; everything at or above 10 Hz round-trips exactly.
+        byte[] encoded = Yaesu2RigConstant.setOperationFreq(14_074_058L);
+        assertThat(Yaesu2Command.getFrequency(encoded)).isEqualTo(14_074_050L);
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2RigConstantTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu2RigConstantTest.java
@@ -33,6 +33,17 @@ public class Yaesu2RigConstantTest {
     }
 
     @Test
+    public void setOperationFreq_packsTensOfHzInLastNibble() {
+        // 14.074050 MHz: the 50 Hz component is the tens-of-Hz digit (5), which must
+        // land in the low nibble of the last byte -> 0x05, not the raw remainder 50
+        // (0x32). Packing 50 there used to desync the encoder from getFrequency, which
+        // weights that nibble x10 (would have read back 14_074_320, +270 Hz).
+        byte[] f = Yaesu2RigConstant.setOperationFreq(14_074_050L);
+        byte[] expected = {(byte) 0x01, (byte) 0x40, (byte) 0x74, (byte) 0x05, (byte) 0x01};
+        assertThat(f).isEqualTo(expected);
+    }
+
+    @Test
     public void setPTTState_toggleByteDiffers() {
         byte[] on = Yaesu2RigConstant.setPTTState(true);
         byte[] off = Yaesu2RigConstant.setPTTState(false);


### PR DESCRIPTION
## Root cause

`Yaesu2RigConstant.setOperationFreq` packs the low nibble of the last BCD frequency byte as `freq % 100` — the entire 0–99 sub-100 Hz remainder crammed into a single 4-bit nibble:

```java
, (byte) (((byte) (freq % 1000 / 100) << 4) + (byte) (freq % 100))   // last byte
```

But the rig's own decoder, `Yaesu2Command.getFrequency`, weights that same nibble **×10** as the tens-of-Hz digit:

```java
+((int) (rawData[3] >> 4) & 0xf) * 100   // hundreds-of-Hz
+(int)  (rawData[3] & 0x0f)      * 10;   // tens-of-Hz
```

So the encoder is **not** the inverse of its own decoder. The 4-byte CAT block is 8 BCD nibbles with weights 1e8…1e1 (10 Hz LSB); the last nibble is the tens-of-Hz digit, i.e. `freq % 100 / 10`, not `freq % 100`.

### Impact
- `setOperationFreq(14_074_050)` (14.074 MHz + 50 Hz) round-trips to **14_074_320** (+270 Hz).
- Remainders > 15 (e.g. ...58) produce a non-BCD nibble (`0x3A`+), corrupting the frequency by **>1 kHz**.
- On live TX this keys the rig on the wrong VFO for any dial that isn't 100 Hz-aligned (10-Hz-resolution reads, custom bands — see issue #470), pushing the FT8 signal off frequency so decodes/spots don't line up.

100 Hz-aligned dials (the common FT8 case, `freq % 100 == 0`) were unaffected, which is why this slipped past.

## Fix

One-line change: pack the last nibble as the tens-of-Hz digit.

```java
- , (byte) (((byte) (freq % 1000 / 100) << 4) + (byte) (freq % 100))
+ , (byte) (((byte) (freq % 1000 / 100) << 4) + (byte) (freq % 100 / 10))
```

The sub-10 Hz digit is below the rig's CAT resolution and is correctly dropped (the decoder has no nibble for it either). The encoder is now an exact inverse of the decoder for any 10 Hz-aligned VFO.

PR #497 fixed the matching **decoder** and explicitly left this encoder quirk untouched; this completes the pair.

## Testing

- Added `setOperationFreq_packsTensOfHzInLastNibble` — asserts 14.074050 MHz encodes the 50 Hz component to low nibble `0x05`, not the raw remainder `0x32`.
- Updated `getFrequency_roundTripsSetOperationFreqEncoding` to a non-100 Hz-aligned dial (14_074_350) so it exercises the tens-of-Hz nibble that previously desynced.
- Added `getFrequency_dropsOnlySub10HzOnRoundTrip` — documents that only the sub-10 Hz remainder is lost.
- Refreshed the now-stale Javadoc in both test files describing the encoder as a known-broken limitation.
- Confirmed **red** against the old encoder (3 failures) and **green** with the fix; full `:app:testDebugUnitTest` suite passes.

## Risk

Very low. Pure integer-arithmetic change in one BCD encoder, no protocol/DSP/threading surface. Behavior for the dominant 100 Hz-aligned case is byte-for-byte unchanged; only non-100 Hz-aligned dials — previously encoded wrong — change, and now round-trip correctly.