### PR TITLE
iOS: don't upload the RR73 sign-off as a locator to PSKReporter

### DIFF
--- a/ios/FT8AFKit/Sources/FT8Engine/PskReporter.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PskReporter.swift
@@ -41,11 +41,30 @@ public enum PskReporter {
         return base
     }
 
+    /// A decoded `grid` token is reportable as a PSKReporter `senderLocator`
+    /// only when it is a real Maidenhead locator: at least the 4-char
+    /// field/square, and not the "RR73" QSO sign-off. The decoder copies the
+    /// end-of-QSO roger-73 report into `grid` because it matches the Maidenhead
+    /// field/square shape (`looksLikeGrid("RR73")` is true — R,R are valid A–R
+    /// field letters and 7,3 valid digits), but no protocol-compliant
+    /// transmitter ever means grid RR73: FT8 always packs "RR73" as the report,
+    /// never as a grid. The rest of the app already excludes it (`gridToLatLon`
+    /// returns nil, `QsoEngine` classifies it as the `.rr73` stage) — PSKReporter
+    /// is the one consumer that would otherwise upload a phantom Arctic locator
+    /// (83.5°N, 175°E) to the shared spot database, breaking WSJT-X interop.
+    /// Mirrors the Android fix in `PskReporterSender.reportableLocator`.
+    static func reportableLocator(_ grid: String) -> String? {
+        guard grid.count >= 4 else { return nil }
+        if grid.uppercased() == "RR73" { return nil }
+        return grid
+    }
+
     /// Convert one decode into a spot, applying the Android sender's policy:
     /// drop empty/unresolved-hash calls and free text (i3=0, n3=0), strip
     /// angle brackets from hashed callsigns, never report our own callsign,
-    /// require a >= 4-char locator (else omit it), and report the RF frequency
-    /// as dial + audio offset. Returns nil when the decode must not be spotted.
+    /// require a real >= 4-char Maidenhead locator (else omit it), and report
+    /// the RF frequency as dial + audio offset. Returns nil when the decode
+    /// must not be spotted.
     public static func makeSpot(
         callFrom: String, i3: UInt8, n3: UInt8, grid: String, snr: Int,
         audioFreqHz: Float, dialFreqHz: Int64, myCall: String, utcSeconds: Int64
@@ -62,7 +81,7 @@ public enum PskReporter {
             frequencyHz: dialFreqHz + Int64(audioFreqHz),
             snr: snr,
             mode: "FT8",
-            senderLocator: grid.count >= 4 ? grid : nil,
+            senderLocator: reportableLocator(grid),
             flowStartSeconds: utcSeconds
         )
     }

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PskReporterTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PskReporterTests.swift
@@ -300,6 +300,39 @@ final class PskReporterTests: XCTestCase {
             audioFreqHz: 0, dialFreqHz: 0, myCall: "KD2OGR", utcSeconds: 0))
     }
 
+    // MARK: reportableLocator / RR73 policy
+
+    func testReportableLocatorAcceptsRealGrids() {
+        XCTAssertEqual(PskReporter.reportableLocator("FN42"), "FN42")
+        XCTAssertEqual(PskReporter.reportableLocator("IO91wm"), "IO91wm")
+    }
+
+    func testReportableLocatorRejectsShortTokens() {
+        XCTAssertNil(PskReporter.reportableLocator(""))
+        XCTAssertNil(PskReporter.reportableLocator("FN"))
+        XCTAssertNil(PskReporter.reportableLocator("RR")) // bare sign-off, < 4 chars
+    }
+
+    func testReportableLocatorRejectsRR73SignOff() {
+        // "RR73" is the FT8 roger-73 report, never a grid — even though it is a
+        // 4-char Maidenhead look-alike. Case-insensitive.
+        XCTAssertNil(PskReporter.reportableLocator("RR73"))
+        XCTAssertNil(PskReporter.reportableLocator("rr73"))
+        XCTAssertNil(PskReporter.reportableLocator("Rr73"))
+    }
+
+    func testMakeSpotDropsRR73Locator() {
+        // A decode whose grid field carries the RR73 sign-off must still be
+        // spotted (the call is real), but never with RR73 as the locator.
+        let s = PskReporter.makeSpot(
+            callFrom: "K1ABC", i3: 1, n3: 0, grid: "RR73", snr: -3,
+            audioFreqHz: 1200, dialFreqHz: 14_074_000, myCall: "KD2OGR",
+            utcSeconds: 1_700_000_000)
+        XCTAssertEqual(s?.senderCallsign, "K1ABC")
+        XCTAssertEqual(s?.frequencyHz, 14_075_200)
+        XCTAssertNil(s?.senderLocator)
+    }
+
     // MARK: software string
 
     func testBuildSoftwareString() {


### PR DESCRIPTION
## Summary

The iOS `PskReporter.makeSpot` reported a decode's `senderLocator` whenever the decoded `grid` field was `>= 4` characters. The FT8 end-of-QSO roger-73 report **"RR73"** is a 4-char Maidenhead look-alike (`R`,`R` are valid A–R field letters; `7`,`3` valid digits), so the decoder copies it into `grid` via `looksLikeGrid` — and every decoded RR73 was then spotted to the **global PSKReporter database** as locator "RR73", a phantom Arctic coordinate (83.5°N, 175°E).

This is the iOS side of the same defect fixed on Android in **PR #612** (`PskReporterSender.reportableLocator`).

## Root cause

Per the FT8 protocol, "RR73" is packed as the roger-73 report, never as a grid — no compliant transmitter means grid RR73. The rest of the Kit already recognizes this:

- `gridToLatLon` (`Util.swift:63`) returns `nil` for "RR73"/"RR" to avoid a phantom map pin.
- `QsoEngine` classifies an incoming "RR73" as the `.rr73` sequencer stage (`QsoEngine.swift:348-358`).

`PskReporter.makeSpot` (`PskReporter.swift:65`) was the one consumer that used a naive length check instead, so it leaked RR73 into the shared spot DB — polluting an ecosystem resource and breaking WSJT-X interop.

## Fix

Extracted a pure `reportableLocator(_:)` helper that requires a `>= 4` char locator **and** rejects the "RR73" sign-off (case-insensitive), and gated `makeSpot`'s `senderLocator` on it. Well-formed grids (`FN42`, `IO91wm`, …) are unaffected — byte-identical spots.

## Testing performed

- Added `PskReporterTests` cases: `reportableLocator` accepts real grids, rejects short tokens (`""`, `"FN"`, `"RR"`) and the RR73 sign-off (`RR73`/`rr73`/`Rr73`); and a `makeSpot` case asserting an RR73-grid decode is **still spotted** (the call is real) but with a **nil locator**.
- Ran the real XCTest suite for `PskReporter.swift` in isolation on Linux via SwiftPM: **24 tests pass**. Verified **red→green** — reverting the helper to the old length-only check fails 4 cases.
- Note: a whole-module `swift test` on Linux is currently blocked by an unrelated Apple-only `import Network` in `WsjtxUdpService.swift`; the Foundation-only `PskReporter` source + its tests were exercised standalone.

## Risk assessment

Very low. Single, focused policy change on a pure function; the only behavioral difference is that a locator equal to "RR73" is now omitted (as it already is everywhere else in the app). No protocol/encoder/DSP changes; well-formed decodes produce identical spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)