### PR TITLE
Clamp Maidenhead grid indices so a pole/antimeridian GPS fix can't emit an invalid locator

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
@@ -210,11 +210,15 @@ public class MaidenheadGrid {
     }
 
     /**
-     * This function calculates a 6-character Maidenhead grid from latitude/longitude.
-     * Latitude/longitude use NMEA format. In other words, west longitude and south latitude are negative. They are specified as double type.
+     * Calculates the 4-character Maidenhead grid (field pair + square pair, e.g. {@code "EM48"})
+     * containing the given position. Latitude/longitude are decimal degrees, signed: west
+     * longitude and south latitude are negative.
      *
-     * @param location latitude/longitude
-     * @return String Maidenhead grid string
+     * <p>Boundary coordinates are clamped to a legal locator — see {@link #gridSquareFor} for
+     * the math and why the clamp matters.
+     *
+     * @param location latitude/longitude in decimal degrees
+     * @return 4-character Maidenhead grid string
      */
     public static String getGridSquare(LatLng location) {
         return gridSquareFor(location.latitude, location.longitude);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
@@ -217,10 +217,34 @@ public class MaidenheadGrid {
      * @return String Maidenhead grid string
      */
     public static String getGridSquare(LatLng location) {
+        return gridSquareFor(location.latitude, location.longitude);
+    }
+
+    /**
+     * Latitude/longitude (decimal degrees) -> 4-character Maidenhead grid. Extracted from
+     * {@link #getGridSquare(LatLng)} so the boundary math is unit-testable without a
+     * Play-Services {@code LatLng} (which additionally clamps latitude to [-90, 90] and
+     * normalizes longitude to [-180, 180)).
+     *
+     * <p>Each field/digit/subsquare index is clamped to its legal Maidenhead range via
+     * {@link #clampIndex}. Without the clamp, a fix on the {@code +180} antimeridian
+     * ({@code lon == 180}) or the North Pole ({@code lat == 90}) drove the first-pair index
+     * to 18 — one past the legal A-R field range — emitting the letter {@code 'S'}, i.e. an
+     * invalid locator such as {@code "JS09"}. That grid is written to config as the
+     * operator's own grid, transmitted in FT8 messages and uploaded to PSKReporter, so a
+     * pole/antimeridian fix polluted the QSO and the shared spot database with a
+     * non-existent locator. Clamping folds the boundary onto the northernmost/easternmost
+     * cell (field {@code R}) — the standard Maidenhead convention — and is a no-op for every
+     * in-range coordinate (which never reaches a clamp ceiling), so ordinary fixes are
+     * byte-identical. This mirrors the defensive clamps already used elsewhere in this class
+     * ({@link #gridToLatLng}'s ±85° map clamp, {@link #greatCircleDistanceKm}'s acos domain
+     * clamp).
+     */
+    static String gridSquareFor(double lat, double lon) {
         double tempNumber;//For intermediate calculation
         int index;//Determines the character to display
-        double _long = location.longitude;
-        double _lat = location.latitude;
+        double _long = lon;
+        double _lat = lat;
         StringBuilder buff = new StringBuilder();
 
         /*
@@ -228,13 +252,13 @@ public class MaidenheadGrid {
          */
         _long += 180;                    // Start from the middle of the Pacific
         tempNumber = _long / 20;            // Each major square is 20 degrees wide
-        index = (int) tempNumber;            // Index for uppercase letter
+        index = clampIndex((int) tempNumber, 17);   // Field letters A-R (0..17)
         buff.append(String.valueOf((char) (index + 'A')));  // Set the first character
         _long = _long - (index * 20);            // Remainder for step 2
 
         _lat += 90;                    // Start from the South Pole, 180 degrees
         tempNumber = _lat / 10;                // Each major square is 10 degrees tall
-        index = (int) tempNumber;            // Index for uppercase letter
+        index = clampIndex((int) tempNumber, 17);   // Field letters A-R (0..17)
         buff.append(String.valueOf((char) (index + 'A')));//Set the second character
         _lat = _lat - (index * 10);            // Remainder for step 2
 
@@ -242,12 +266,12 @@ public class MaidenheadGrid {
          *	Now the second pair of two digits:
          */
         tempNumber = _long / 2;                // Remainder from step 1 divided by 2
-        index = (int) tempNumber;            // Digit index
+        index = clampIndex((int) tempNumber, 9);    // Square digits 0-9
         buff.append(String.valueOf((char) (index + '0')));//Set the third character
         _long = _long - (index * 2);            // Remainder for step 3
 
         tempNumber = _lat;                // Remainder from step 1 divided by 1
-        index = (int) tempNumber;            // Digit index
+        index = clampIndex((int) tempNumber, 9);    // Square digits 0-9
         buff.append(String.valueOf((char) (index + '0')));//Set the fourth character
         _lat = _lat - index;                // Remainder for step 3
 
@@ -255,14 +279,26 @@ public class MaidenheadGrid {
          * Now the third pair of two lowercase characters:
          */
         tempNumber = _long / 0.083333;            // Remainder from step 2 divided by 0.083333
-        index = (int) tempNumber;            // Index for lowercase letter
+        index = clampIndex((int) tempNumber, 23);   // Subsquare letters a-x (0..23)
         buff.append(String.valueOf((char) (index + 'a')));//Set the fifth character
 
         tempNumber = _lat / 0.0416665;            // Remainder from step 2 divided by 0.0416665
-        index = (int) tempNumber;            // Index for lowercase letter
+        index = clampIndex((int) tempNumber, 23);   // Subsquare letters a-x (0..23)
         buff.append(String.valueOf((char) (index + 'a')));//Set the sixth character
 
         return buff.toString().substring(0, 4);
+    }
+
+    /**
+     * Clamp a Maidenhead character index to {@code [0, max]}. A pole/antimeridian fix (or an
+     * out-of-range coordinate) would otherwise index one past the pair's legal range and emit
+     * a character outside it (e.g. {@code 'S'} for the A-R field letters). For every in-range
+     * coordinate the index already lands inside {@code [0, max]}, so this is a no-op there.
+     */
+    private static int clampIndex(int value, int max) {
+        if (value < 0) return 0;
+        if (value > max) return max;
+        return value;
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/maidenhead/MaidenheadGridSquareTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/maidenhead/MaidenheadGridSquareTest.java
@@ -1,0 +1,92 @@
+package com.k1af.ft8af.maidenhead;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM tests for {@link MaidenheadGrid#gridSquareFor(double, double)} — the raw
+ * latitude/longitude -> Maidenhead grid math, extracted from
+ * {@link MaidenheadGrid#getGridSquare} so the boundary clamps can be exercised without a
+ * Play-Services {@code LatLng} (which clamps latitude and normalizes longitude before the
+ * math ever runs, hiding the +180 antimeridian case). No Robolectric runner needed: the
+ * method touches no Android types.
+ */
+public class MaidenheadGridSquareTest {
+
+    // ---------- normal coordinates are byte-identical to the historical output ----------
+
+    @Test
+    public void gridSquareFor_knownLocationsUnchanged() {
+        // Boston ~ FN42, London ~ IO91, Tokyo ~ PM95, Sydney ~ QF56. These reach no clamp
+        // ceiling, so the clamped path must be identical to the pre-fix output.
+        assertThat(MaidenheadGrid.gridSquareFor(42.5, -71.0)).isEqualTo("FN42");
+        assertThat(MaidenheadGrid.gridSquareFor(51.5, -0.1)).isEqualTo("IO91");
+        assertThat(MaidenheadGrid.gridSquareFor(35.68, 139.77)).isEqualTo("PM95");
+        assertThat(MaidenheadGrid.gridSquareFor(-33.87, 151.21)).isEqualTo("QF56");
+    }
+
+    @Test
+    public void gridSquareFor_producesValidLocatorAcrossTheGlobe() {
+        // Sweep a coarse grid of coordinates; every result must be a structurally valid
+        // 4-character Maidenhead locator (fields A-R, digits 0-9). Asserted on the raw
+        // character ranges rather than checkMaidenhead, which additionally rejects the
+        // "RR73" sign-off token even though it is a geometrically valid locator.
+        for (double lat = -89; lat <= 89; lat += 7.5) {
+            for (double lon = -179; lon <= 179; lon += 7.5) {
+                assertValidLocator(MaidenheadGrid.gridSquareFor(lat, lon));
+            }
+        }
+    }
+
+    // ---------- boundary / out-of-range coordinates stay valid (the fix) ----------
+
+    @Test
+    public void gridSquareFor_plus180AntimeridianClampsToFieldR() {
+        // lon == 180 pushed the longitude field index to 18 -> 'S' (one past A-R).
+        // It must fold onto the easternmost field 'R'.
+        String grid = MaidenheadGrid.gridSquareFor(0.0, 180.0);
+        assertThat(MaidenheadGrid.checkMaidenhead(grid)).isTrue();
+        assertThat(grid.charAt(0)).isEqualTo('R');
+        assertThat(grid.charAt(0)).isAtMost('R');
+    }
+
+    @Test
+    public void gridSquareFor_northPoleClampsToFieldR() {
+        // lat == 90 pushed the latitude field index to 18 -> 'S'. It must fold onto the
+        // northernmost field 'R'.
+        String grid = MaidenheadGrid.gridSquareFor(90.0, 0.0);
+        assertThat(MaidenheadGrid.checkMaidenhead(grid)).isTrue();
+        assertThat(grid.charAt(1)).isEqualTo('R');
+        assertThat(grid.charAt(1)).isAtMost('R');
+    }
+
+    @Test
+    public void gridSquareFor_southPoleAndWestAntimeridianAreLowerBound() {
+        // The low edges were already in range (index 0 -> 'A'); guard against a
+        // regression from an over-eager clamp.
+        assertThat(MaidenheadGrid.gridSquareFor(-90.0, -180.0)).isEqualTo("AA00");
+    }
+
+    @Test
+    public void gridSquareFor_outOfRangeCoordinatesStillYieldValidLocator() {
+        // Defensive: even nonsensical coordinates (garbage fix, uncorrected sensor) must
+        // never emit a character outside a legal Maidenhead pair.
+        for (double lat : new double[] {-1000, -90.0001, 90.0001, 1000}) {
+            for (double lon : new double[] {-1000, -180.0001, 180.0001, 1000}) {
+                assertValidLocator(MaidenheadGrid.gridSquareFor(lat, lon));
+            }
+        }
+    }
+
+    /** Assert a 4-char string is a structurally valid Maidenhead locator: fields A-R, digits 0-9. */
+    private static void assertValidLocator(String grid) {
+        assertThat(grid).hasLength(4);
+        assertThat(grid.charAt(0)).isAtLeast('A');
+        assertThat(grid.charAt(0)).isAtMost('R');
+        assertThat(grid.charAt(1)).isAtLeast('A');
+        assertThat(grid.charAt(1)).isAtMost('R');
+        assertThat(Character.isDigit(grid.charAt(2))).isTrue();
+        assertThat(Character.isDigit(grid.charAt(3))).isTrue();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/maidenhead/MaidenheadGridTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/maidenhead/MaidenheadGridTest.java
@@ -127,6 +127,22 @@ public class MaidenheadGridTest {
         assertThat(grid).isEqualTo("FN42");
     }
 
+    @Test
+    public void getGridSquare_northPoleStaysWithinFieldRange() {
+        // A GPS fix at the North Pole (lat == 90) drove the latitude field index
+        // to 18 — one past the legal A-R range — emitting the letter 'S', i.e. an
+        // invalid locator that was then written to config as the operator's grid,
+        // transmitted in FT8 messages, and uploaded to PSKReporter. (Play-Services
+        // LatLng clamps latitude to [-90, 90] so 90 survives; it normalizes
+        // longitude 180 -> -180, so the antimeridian overflow is only reachable in
+        // the raw math — see MaidenheadGridSquareTest.) The field letters must stay
+        // in A-R.
+        String grid = MaidenheadGrid.getGridSquare(new LatLng(90.0, 0.0));
+        assertThat(MaidenheadGrid.checkMaidenhead(grid)).isTrue();
+        assertThat(grid.charAt(0)).isAtMost('R');
+        assertThat(grid.charAt(1)).isAtMost('R');
+    }
+
     // ---------- getDist ----------
 
     @Test


### PR DESCRIPTION
## Summary

`MaidenheadGrid.getGridSquare()` converts a GPS latitude/longitude to the operator's own Maidenhead locator. It truncated each field/digit index with **no upper bound**, so at a boundary coordinate the index ran one past its legal range and emitted an out-of-range character:

- **North Pole (`lat == 90`)** → latitude field index `18` → the letter **`'S'`** (fields are only `A`–`R`), producing an invalid locator like `"JS09"`.
- **`+180°` antimeridian (`lon == 180`)** → the same overflow on the longitude field in the raw math. Google Play-Services `LatLng` normalizes `180 → -180` (and only *clamps* latitude, so `90` survives), so this axis is only reachable through the extracted function — but it is defended too.

This grid is not cosmetic: it is written to config as the station's own grid, **transmitted in FT8 messages**, and **uploaded to PSKReporter** as `senderLocator`. A pole/antimeridian fix therefore polluted the QSO and the shared spot database with a non-existent locator, breaking interop — the same class of problem as the recently-fixed `RR73`-as-locator leaks (#612 / #615).

## Root cause

Each of the six `index = (int) tempNumber` steps floored the coordinate into a cell index but never bounded it, so an at/over-range coordinate indexed past the pair's legal range (`A`–`R` fields, `0`–`9` digits, `a`–`x` subsquares).

## Fix

Clamp every field/digit/subsquare index to its legal Maidenhead range, folding the boundary onto the northernmost/easternmost cell (field `R`) — the standard Maidenhead convention. The clamp is a **no-op for every in-range coordinate** (which never reaches a clamp ceiling), so ordinary fixes are byte-identical. This mirrors the defensive clamps already living in this class (`gridToLatLng`'s ±85° map clamp, `greatCircleDistanceKm`'s `acos` domain clamp).

The `lat/lon → grid` math is extracted into a pure static `gridSquareFor(double lat, double lon)` so the boundary behavior is unit-testable without a Play-Services `LatLng`; `getGridSquare(LatLng)` becomes a thin wrapper.

## Testing performed

- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full APK builds (all 4 ABIs, native lib included).
- New **Robolectric** North-Pole regression test in `MaidenheadGridTest` (fails pre-fix with an `'S'` field, passes after).
- New **pure-JVM** `MaidenheadGridSquareTest`: antimeridian & both poles clamp to field `R`, a global coordinate sweep and out-of-range inputs always yield a structurally valid locator, and known locations (Boston `FN42`, London `IO91`, Tokyo `PM95`, Sydney `QF56`) are byte-identical to the historical output.

## Risk assessment

Very low. Pure-Java change confined to `MaidenheadGrid`; no native/DSP, protocol, or threading changes. Behavior is provably identical for all in-range coordinates and only corrects at/beyond the ±90°/±180° boundaries.

## Definition of Done

- [x] Root cause identified
- [x] Smallest safe fix implemented (localized, defensive, matches existing pattern)
- [x] Builds successfully (unit tests + debug APK)
- [x] New tests added (one fails pre-fix)
- [x] No protocol/interop regression (byte-identical normal path)
