### PR TITLE
Make the QRZ avatar cache thread-safe (fix Settings-clear vs lookup race)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/qrz/LruCache.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/qrz/LruCache.kt
@@ -1,0 +1,41 @@
+package radio.ks3ckc.ft8af.qrz
+
+import androidx.annotation.VisibleForTesting
+
+/**
+ * A tiny thread-safe LRU cache backed by an access-ordered [LinkedHashMap].
+ *
+ * The QRZ image clients read this cache from per-decode avatar lookups on
+ * Dispatchers.IO while the Settings screen [clear]s it from the main thread
+ * when credentials change. An access-ordered LinkedHashMap re-links its
+ * internal list on every `get()`, so read and clear MUST be mutually excluded
+ * — an unlocked clear() racing a get() is a structural-modification data race
+ * (ConcurrentModificationException / NPE / silent corruption). Every operation
+ * here is `@Synchronized` on this instance, so the two callers can't collide.
+ *
+ * The map is capped at [maxSize] entries via [LinkedHashMap.removeEldestEntry];
+ * because it is access-ordered, the evicted entry is the least-recently-used.
+ */
+internal class LruCache<K, V>(private val maxSize: Int) {
+    private val map = object : LinkedHashMap<K, V>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>): Boolean =
+            size > maxSize
+    }
+
+    @Synchronized
+    fun get(key: K): V? = map[key]
+
+    @Synchronized
+    fun put(key: K, value: V) {
+        map[key] = value
+    }
+
+    @Synchronized
+    fun clear() {
+        map.clear()
+    }
+
+    @VisibleForTesting
+    @Synchronized
+    fun size(): Int = map.size
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/qrz/QrzWebClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/qrz/QrzWebClient.kt
@@ -3,8 +3,6 @@ package radio.ks3ckc.ft8af.qrz
 import android.util.Log
 import com.k1af.ft8af.GeneralVariables
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileWriter
@@ -34,8 +32,7 @@ object QrzWebClient {
     private const val USER_AGENT = "Mozilla/5.0 (Linux; Android) ft8af/1.0"
     private const val CACHE_MAX = 200
 
-    private val cacheMutex = Mutex()
-    private val cache = LinkedHashMap<String, String?>(16, 0.75f, true)
+    private val cache = LruCache<String, String>(CACHE_MAX)
 
     private val ogImageRegex = Regex(
         """<meta\s+property=["']og:image["']\s+content=["']([^"']+)["']""",
@@ -59,7 +56,7 @@ object QrzWebClient {
         val key = callsign.trim().uppercase()
         if (key.isEmpty()) return@withContext null
 
-        cacheMutex.withLock { cache[key] }?.let { return@withContext it }
+        cache.get(key)?.let { return@withContext it }
 
         val url = "https://www.qrz.com/db/${URLEncoder.encode(key, StandardCharsets.UTF_8.name())}"
         val html = fetch(url) ?: return@withContext null
@@ -84,13 +81,7 @@ object QrzWebClient {
         }
 
         log("$key -> $image")
-        cacheMutex.withLock {
-            cache[key] = image
-            while (cache.size > CACHE_MAX) {
-                val oldest = cache.entries.iterator().next()
-                cache.remove(oldest.key)
-            }
-        }
+        cache.put(key, image)
         image
     }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/qrz/QrzXmlClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/qrz/QrzXmlClient.kt
@@ -45,8 +45,7 @@ object QrzXmlClient {
     private val sessionMutex = Mutex()
     @Volatile private var sessionKey: String? = null
 
-    private val cacheMutex = Mutex()
-    private val cache = LinkedHashMap<String, QrzLookup>(16, 0.75f, true)
+    private val cache = LruCache<String, QrzLookup>(CACHE_MAX)
 
     @Volatile var lastError: String? = null
         private set
@@ -73,9 +72,9 @@ object QrzXmlClient {
      * failed lookups can be retried with the new auth.
      */
     fun clearCache() {
-        // mutex-free read/clear is safe here: only changes the map identity from the
-        // perspective of callers; concurrent puts will just produce a slightly old
-        // view that the next call resolves.
+        // cache.clear() is synchronized inside LruCache, so this is safe to call
+        // from the main thread (Settings save) while avatar lookups read the cache
+        // on Dispatchers.IO.
         cache.clear()
         lastError = null
     }
@@ -84,7 +83,7 @@ object QrzXmlClient {
         val key = callsign.trim().uppercase()
         if (key.isEmpty()) return@withContext null
 
-        cacheMutex.withLock { cache[key] }?.let { return@withContext it }
+        cache.get(key)?.let { return@withContext it }
 
         val user = GeneralVariables.qrzXmlUsername.orEmpty()
         val pass = GeneralVariables.qrzXmlPassword.orEmpty()
@@ -126,13 +125,7 @@ object QrzXmlClient {
 
         log("lookup($key) -> $image")
         val result = QrzLookup(imageUrl = image)
-        cacheMutex.withLock {
-            cache[key] = result
-            while (cache.size > CACHE_MAX) {
-                val oldest = cache.entries.iterator().next()
-                cache.remove(oldest.key)
-            }
-        }
+        cache.put(key, result)
         result
     }
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/qrz/LruCacheTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/qrz/LruCacheTest.kt
@@ -1,6 +1,7 @@
 package radio.ks3ckc.ft8af.qrz
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import org.junit.Test
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
@@ -126,13 +127,33 @@ class LruCacheTest {
                 } catch (th: Throwable) {
                     failures.add(th)
                 }
-            }.also { it.start() }
+            }.also {
+                // Daemon so a genuinely wedged worker can never keep the JVM (and the
+                // Gradle test worker) alive after this test has reported its verdict.
+                it.isDaemon = true
+                it.start()
+            }
         }
 
         start.countDown()
-        workers.forEach { it.join(TimeUnit.SECONDS.toMillis(30)) }
-        stop.set(true)
 
+        // One shared deadline across all joins, not 30s per thread. A worker still alive
+        // when it expires is a failure, not something to shrug off: `stop` is only the
+        // fallback that asks the loops to bail out so the test doesn't leave them running.
+        val deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
+        val stalled = workers.filter { worker ->
+            val remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime())
+            if (remainingMs > 0) worker.join(remainingMs)
+            worker.isAlive
+        }
+        if (stalled.isNotEmpty()) {
+            stop.set(true)
+            stalled.forEach { it.join(TimeUnit.SECONDS.toMillis(5)) }
+        }
+
+        assertWithMessage("workers still running after the join deadline")
+            .that(stalled.map { it.name })
+            .isEmpty()
         assertThat(failures).isEmpty()
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/qrz/LruCacheTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/qrz/LruCacheTest.kt
@@ -1,0 +1,138 @@
+package radio.ks3ckc.ft8af.qrz
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Pure-JVM tests for [LruCache], the small thread-safe LRU the QRZ image
+ * clients share.
+ *
+ * The class exists because the QRZ clients previously cleared an
+ * access-ordered [LinkedHashMap] from the Settings screen (main thread, on
+ * saving credentials) with NO lock, while per-decode avatar lookups read the
+ * same map on Dispatchers.IO under a coroutine mutex. An access-ordered
+ * LinkedHashMap re-links its internal list on every get(), so an unlocked
+ * clear() racing a get() is a structural-modification data race
+ * (ConcurrentModificationException / NPE / corruption). LruCache funnels
+ * every read, write, and clear through a single monitor so the two callers
+ * can never collide. No Android types are touched, so no Robolectric runner.
+ */
+class LruCacheTest {
+
+    @Test
+    fun getReturnsPutValue() {
+        val cache = LruCache<String, String>(4)
+        cache.put("W5XO", "url")
+        assertThat(cache.get("W5XO")).isEqualTo("url")
+    }
+
+    @Test
+    fun getMissReturnsNull() {
+        val cache = LruCache<String, String>(4)
+        assertThat(cache.get("missing")).isNull()
+    }
+
+    @Test
+    fun clearEmptiesTheCache() {
+        val cache = LruCache<String, String>(4)
+        cache.put("a", "1")
+        cache.put("b", "2")
+        cache.clear()
+        assertThat(cache.get("a")).isNull()
+        assertThat(cache.get("b")).isNull()
+        assertThat(cache.size()).isEqualTo(0)
+    }
+
+    @Test
+    fun evictsEldestWhenOverCapacity() {
+        val cache = LruCache<String, Int>(2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("c", 3) // over capacity: "a" is the least-recently-used, evicted
+        assertThat(cache.size()).isEqualTo(2)
+        assertThat(cache.get("a")).isNull()
+        assertThat(cache.get("b")).isEqualTo(2)
+        assertThat(cache.get("c")).isEqualTo(3)
+    }
+
+    @Test
+    fun accessOrderProtectsRecentlyReadEntryFromEviction() {
+        // Access-order (LRU) semantics: reading "a" makes it most-recent, so
+        // the next over-capacity put evicts "b" (now the eldest) instead.
+        val cache = LruCache<String, Int>(2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        assertThat(cache.get("a")).isEqualTo(1) // touch "a"
+        cache.put("c", 3)
+        assertThat(cache.get("b")).isNull()
+        assertThat(cache.get("a")).isEqualTo(1)
+        assertThat(cache.get("c")).isEqualTo(3)
+    }
+
+    /**
+     * Documents *why* the cache must be synchronized: an access-ordered
+     * LinkedHashMap treats get() as a structural modification (it moves the
+     * touched entry to the tail of its list). This is deterministic, single
+     * threaded proof that a concurrent unlocked clear() would race a get().
+     */
+    @Test
+    fun rawAccessOrderMap_getIsAStructuralModification() {
+        val raw = LinkedHashMap<String, Int>(16, 0.75f, true)
+        raw["a"] = 1
+        raw["b"] = 2
+        raw["c"] = 3
+        raw["a"] // touch — reorders in access-order mode
+        assertThat(raw.keys.toList()).containsExactly("b", "c", "a").inOrder()
+    }
+
+    /**
+     * Smoke/stress harness: many reader/writer threads hammer the cache while
+     * another repeatedly clears it — exactly the Settings-save-vs-avatar-lookup
+     * collision from production. With every op synchronized this must complete
+     * with no throwable escaping. (The underlying data race usually manifests as
+     * silent map corruption rather than a deterministic exception, so this is a
+     * best-effort regression guard, not a proof of the bug — the deterministic
+     * proof that get() is a structural modification lives in the test above.)
+     */
+    @Test
+    fun concurrentGetPutAndClear_neverThrows() {
+        val cache = LruCache<Int, Int>(64)
+        val threads = 8
+        val iterations = 20_000
+        val start = CountDownLatch(1)
+        val stop = AtomicBoolean(false)
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        val workers = (0 until threads).map { t ->
+            Thread {
+                start.await()
+                try {
+                    var i = 0
+                    while (!stop.get() && i < iterations) {
+                        val k = i and 0x7f
+                        if (t % 4 == 0) {
+                            cache.clear()
+                        } else if (i and 1 == 0) {
+                            cache.put(k, i)
+                        } else {
+                            cache.get(k)
+                        }
+                        i++
+                    }
+                } catch (th: Throwable) {
+                    failures.add(th)
+                }
+            }.also { it.start() }
+        }
+
+        start.countDown()
+        workers.forEach { it.join(TimeUnit.SECONDS.toMillis(30)) }
+        stop.set(true)
+
+        assertThat(failures).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

Makes the QRZ profile-image cache thread-safe. Both QRZ clients cached lookups in an **access-ordered** `LinkedHashMap` and cleared it from the main thread with no lock, while reads happen on `Dispatchers.IO` — a data race on a non-thread-safe collection.

## Root cause

`QrzWebClient` and `QrzXmlClient` each hold:

```kotlin
private val cacheMutex = Mutex()
private val cache = LinkedHashMap<String, …>(16, 0.75f, true)   // accessOrder = true
```

Reads go through `cacheMutex.withLock { cache[key] }`, but `clearCache()` did:

```kotlin
fun clearCache() {
    // "mutex-free read/clear is safe here"  ← not true
    cache.clear()
}
```

An access-ordered `LinkedHashMap` **re-links its internal list on every `get()`** (the touched entry moves to the tail). So a `clear()` racing a `get()` mutates the same structure from two threads with no mutual exclusion — a data race whose defined behavior is *undefined*: silent map corruption (lost/duplicated entries, broken LRU order) and, in the worst case, a throw from `Map` internals (`ConcurrentModificationException` / `NullPointerException`).

The two callers genuinely collide in production:

- **Reads** — `QrzAvatar` fires a `LaunchedEffect(callsign)` per decode row that calls `fetchProfileImage()` / `lookup()` on `Dispatchers.IO`, with **no try/catch** (`ui/decode/QrzAvatar.kt:45`). An escaping throwable would take down that coroutine.
- **Clear** — the Settings screen calls both `clearCache()` on the **main thread** when the user saves QRZ credentials (`ui/settings/LoggingSettings.kt:131-132`).

## Fix

Extract a small `internal` thread-safe `LruCache<K, V>` backed by the same access-ordered `LinkedHashMap`, with every `get`/`put`/`clear` `@Synchronized` on a single monitor, and use it from both clients. This:

- closes the race — read, write, and clear can no longer run concurrently;
- removes the duplicated manual `while (size > CACHE_MAX)` eviction loop (now handled by `removeEldestEntry`, which respects access order → true LRU);
- drops the now-unused coroutine `Mutex` from `QrzWebClient` (`QrzXmlClient` keeps its separate `sessionMutex`, which is out of scope and untouched).

Behavior for well-formed single-threaded use is unchanged (same 200-entry LRU with access-order eviction).

## Testing

- New pure-JVM `LruCacheTest` (7 cases): `get`/miss/`clear`, over-capacity eviction, access-order protection of a recently-read entry, a **deterministic** proof that `get()` on an access-ordered map is a structural modification (documents *why* `clear` must be synchronized), and a concurrent get/put/clear stress smoke test.
- `./gradlew :app:testDebugUnitTest` — full QRZ package green (LruCache 7 + existing QrzXmlClient 12 + QrzXmlParseTag 5).
- `./gradlew :app:assembleDebug` — clean across all 4 ABIs (arm64-v8a, armeabi-v7a, x86, x86_64).

## Risk

Low. Pure Kotlin, localized to `qrz/`. No protocol/DSP/native change. The concurrency test is a best-effort smoke guard — the underlying race usually manifests as silent corruption rather than a deterministic exception (see the test's comment), so correctness rests on all cache access now sharing one monitor plus the functional + structural-modification tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
