### PR TITLE
Fix map range rings so they align with station markers (drop stray PI/2 factor)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -183,6 +183,18 @@ internal fun azProject(opLat: Double, opLon: Double, lat: Double, lon: Double): 
     )
 }
 
+// Great-circle distance (km) to the map disc edge. The antipode sits at angular
+// distance PI, so it is PI * 6371 km away; [azProject] projects it to a normalized
+// radius of 1 (c / PI), i.e. exactly the disc radius `r`. Range rings must be scaled
+// against this same maximum so they line up with the station markers.
+internal val MAP_EDGE_KM = PI * 6371.0
+
+// Screen radius (px) for a range ring at great-circle distance [km], using the SAME
+// factor [azProject] applies to markers (normalized radius = distKm / MAP_EDGE_KM),
+// so rings align with the marks instead of ballooning past them.
+internal fun rangeRingRadiusPx(km: Double, r: Float, scale: Float): Float =
+    (km / MAP_EDGE_KM).toFloat() * r * scale
+
 // ---------------------------------------------------------------------------
 // Map Screen
 // ---------------------------------------------------------------------------
@@ -1395,13 +1407,12 @@ private fun DrawScope.drawAzimuthalLand(
 }
 
 private fun DrawScope.drawRangeRings(cx: Float, cy: Float, r: Float, scale: Float = 1f) {
-    val maxKm = 20015.0
     val rings = listOf(2500, 5000, 10000, 15000, 20000)
     val ringColor = Color(0x1894A3B8)
     val dashEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 6f))
 
     for (km in rings) {
-        val ringR = (km.toFloat() / maxKm.toFloat()) * r * (PI.toFloat() / 2f) * scale
+        val ringR = rangeRingRadiusPx(km.toDouble(), r, scale)
         drawCircle(
             color = ringColor,
             radius = ringR,

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapProjectionTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapProjectionTest.kt
@@ -2,6 +2,7 @@ package radio.ks3ckc.ft8af.ui.map
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import kotlin.math.sqrt
 
 /**
  * Pure unit tests for the map's coordinate math: great-circle distance, the two
@@ -50,6 +51,46 @@ class MapProjectionTest {
     fun azProject_distanceMatchesGreatCircle() {
         val p = azProject(0.0, 0.0, 0.0, 90.0)
         assertThat(p.distKm).isWithin(1.0).of(quarterArcKm)
+    }
+
+    @Test
+    fun rangeRingRadius_edgeDistanceFillsTheDisc() {
+        // A ring at the antipode distance (MAP_EDGE_KM) must sit exactly on the disc
+        // edge, i.e. its pixel radius equals r * scale.
+        val r = 500f
+        assertThat(rangeRingRadiusPx(MAP_EDGE_KM, r, 1f)).isWithin(1e-3f).of(r)
+        assertThat(rangeRingRadiusPx(MAP_EDGE_KM, r, 2f)).isWithin(1e-3f).of(1000f)
+    }
+
+    @Test
+    fun rangeRingRadius_isLinearInDistanceAndScale() {
+        val r = 400f
+        // Half the edge distance -> half the radius; doubling scale doubles it.
+        assertThat(rangeRingRadiusPx(MAP_EDGE_KM / 2.0, r, 1f)).isWithin(1e-3f).of(r / 2f)
+        assertThat(rangeRingRadiusPx(MAP_EDGE_KM / 2.0, r, 2f)).isWithin(1e-3f).of(r)
+    }
+
+    @Test
+    fun rangeRingRadius_alignsWithProjectedMarker() {
+        // A station at great-circle distance d is drawn at screen radius
+        // sqrt(x^2 + y^2) * r * scale after azProject. The range ring for that same
+        // distance must land on top of the marker, not (as the old PI/2 factor did)
+        // ~57% further out. This is the regression guard for the range-ring bug.
+        val r = 640f
+        val scale = 1.5f
+        val opLat = 40.0
+        val opLon = -75.0
+        for (target in listOf(
+            Pair(0.0, 0.0),
+            Pair(51.5, -0.13),
+            Pair(-33.9, 151.2),
+            Pair(35.7, 139.7),
+        )) {
+            val p = azProject(opLat, opLon, target.first, target.second)
+            val markerRadiusPx = sqrt(p.x * p.x + p.y * p.y) * r * scale
+            val ringRadiusPx = rangeRingRadiusPx(p.distKm, r, scale)
+            assertThat(ringRadiusPx).isWithin(1e-2f).of(markerRadiusPx)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

The distance-ring overlay on the azimuthal-equidistant map scaled every ring by an extra `PI/2` factor, so the rings did **not** line up with the station markers they are meant to annotate.

## Root cause

Markers and land outlines are placed via `azProject()`, which maps a point at angular distance `c` to a normalized radius `c / PI`. The disc edge (screen radius `r`) therefore corresponds to the antipode — `PI * 6371 ≈ 20015 km` away. `drawRangeRings`, however, computed:

```kotlin
val ringR = (km / maxKm) * r * (PI / 2f) * scale   // maxKm = 20015
```

That stray `PI / 2 ≈ 1.571` factor makes each ring ~57% larger than the great-circle distance it claims to represent.

## Impact (functional / UI bug, not a crash)

- The 2500 / 5000 / 10000 km rings sit well outside where a station at that distance actually plots, so an operator can't read a marker's range off the rings.
- The 15000 and 20000 km rings land at ~1.5× the disc radius — entirely outside the clipped disc — so they never render at all.

## Fix

Extract the ring radius into a pure, testable helper that mirrors the marker projection exactly, and drop the `PI/2` factor:

```kotlin
internal val MAP_EDGE_KM = PI * 6371.0
internal fun rangeRingRadiusPx(km: Double, r: Float, scale: Float): Float =
    (km / MAP_EDGE_KM).toFloat() * r * scale
```

`drawRangeRings` now calls it. `MAP_EDGE_KM` is derived from the same Earth radius `azProject`/`greatCircleKm` already use, replacing the hand-rounded `maxKm = 20015` literal.

## Testing

Per the project convention (DrawScope code isn't unit-testable, so the geometry is extracted), three pure-JVM cases were added to `MapProjectionTest`:

- `rangeRingRadius_edgeDistanceFillsTheDisc` — a ring at `MAP_EDGE_KM` has pixel radius exactly `r * scale`.
- `rangeRingRadius_isLinearInDistanceAndScale` — linear in both distance and zoom.
- `rangeRingRadius_alignsWithProjectedMarker` — **regression guard**: for four operator/target pairs, a ring lands exactly on top of the `azProject`-projected marker at the same great-circle distance.

All three fail against the old `PI/2` code and pass after the fix. Full `:app:testDebugUnitTest` is green (JDK 17 / SDK 35 / NDK 27).

## Risk

Very low. Change is confined to the range-ring overlay geometry; no protocol, DSP, encoder/decoder, or marker-placement code is touched. No behavior change for markers, land, connection lines, or compass bearings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)