### PR TITLE
Read bundled data assets fully so a short read can't corrupt the callsign/DXCC/zone databases

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/callsign/CallsignFileOperation.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/callsign/CallsignFileOperation.java
@@ -8,6 +8,8 @@ package com.k1af.ft8af.callsign;
 import android.content.Context;
 import android.content.res.AssetManager;
 
+import com.k1af.ft8af.util.Streams;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -53,8 +55,7 @@ public class CallsignFileOperation {
      */
     public static String[] getLinesFromInputStream(InputStream inputStream, String deLimited) {
         try {
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             return (new String(bytes)).split(deLimited);
         }catch (IOException e){
             return null;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -37,6 +37,7 @@ import com.k1af.ft8af.log.QSLRecord;
 import com.k1af.ft8af.log.QSLRecordStr;
 import com.k1af.ft8af.rigs.BaseRigOperation;
 import com.k1af.ft8af.timer.UtcTimer;
+import com.k1af.ft8af.util.Streams;
 import com.k1af.ft8af.wave.InputAudioLevel;
 
 import org.jetbrains.annotations.Nullable;
@@ -609,8 +610,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 "VALUES(?,?)";
         try {
             inputStream = assetManager.open("ituzone.json");
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             JSONObject jsonObject = new JSONObject(new String(bytes));
             JSONArray array = jsonObject.names();
             for (int i = 0; i < array.length(); i++) {
@@ -635,8 +635,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 "VALUES(?,?)";
         try {
             inputStream = assetManager.open("cqzone.json");
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             JSONObject jsonObject = new JSONObject(new String(bytes));
             JSONArray array = jsonObject.names();
             for (int i = 0; i < array.length(); i++) {
@@ -660,8 +659,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         ArrayList<DxccObject> dxccObjects = new ArrayList<>();
         try {
             inputStream = assetManager.open("dxcc_list.json");
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             JSONObject jsonObject = new JSONObject(new String(bytes));
             JSONArray array = jsonObject.names();
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/OperationBand.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/OperationBand.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import com.k1af.ft8af.FT8Common;
 import com.k1af.ft8af.ModeProfile;
 import com.k1af.ft8af.rigs.BaseRigOperation;
+import com.k1af.ft8af.util.Streams;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -365,8 +366,7 @@ public class OperationBand {
      */
     public static String[] getLinesFromInputStream(InputStream inputStream, String deLimited) {
         try {
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             return (new String(bytes)).split(deLimited);
         }catch (IOException e){
             return null;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/RigNameList.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/RigNameList.java
@@ -11,6 +11,7 @@ import android.util.Log;
 
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
+import com.k1af.ft8af.util.Streams;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -98,8 +99,7 @@ public class RigNameList {
      */
     public static String[] getLinesFromInputStream(InputStream inputStream, String deLimited) {
         try {
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             return (new String(bytes)).split(deLimited);
         }catch (IOException e){
             return null;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ClearCacheDataDialog.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ClearCacheDataDialog.java
@@ -27,6 +27,7 @@ import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
 import com.k1af.ft8af.database.DatabaseOpr;
 import com.k1af.ft8af.database.OnAfterQueryFollowCallsigns;
+import com.k1af.ft8af.util.Streams;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -219,8 +220,7 @@ public class ClearCacheDataDialog extends Dialog {
         AssetManager assetManager = context.getAssets();
         try {
             InputStream inputStream = assetManager.open(fileName);
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             inputStream.close();
 
             return new String(bytes);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ClearCacheDataDialog.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ClearCacheDataDialog.java
@@ -218,12 +218,11 @@ public class ClearCacheDataDialog extends Dialog {
 
     public String getTextFromAssets(String fileName) {
         AssetManager assetManager = context.getAssets();
-        try {
-            InputStream inputStream = assetManager.open(fileName);
-            byte[] bytes = Streams.readAllBytes(inputStream);
-            inputStream.close();
-
-            return new String(bytes);
+        // try-with-resources: readAllBytes can throw part-way through a read, and a
+        // manual close() after it would be skipped on that path, leaking the
+        // AssetInputStream.
+        try (InputStream inputStream = assetManager.open(fileName)) {
+            return new String(Streams.readAllBytes(inputStream));
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/HelpDialog.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/HelpDialog.java
@@ -25,6 +25,7 @@ import androidx.annotation.NonNull;
 import com.k1af.ft8af.BuildConfig;
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
+import com.k1af.ft8af.util.Streams;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -161,8 +162,7 @@ public class HelpDialog extends Dialog {
         AssetManager assetManager = context.getAssets();
         try {
             InputStream inputStream = assetManager.open(fileName);
-            byte[] bytes = new byte[inputStream.available()];
-            inputStream.read(bytes);
+            byte[] bytes = Streams.readAllBytes(inputStream);
             inputStream.close();
 
             return new String(bytes);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/HelpDialog.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/HelpDialog.java
@@ -160,12 +160,11 @@ public class HelpDialog extends Dialog {
 
     public String getTextFromAssets(String fileName) {
         AssetManager assetManager = context.getAssets();
-        try {
-            InputStream inputStream = assetManager.open(fileName);
-            byte[] bytes = Streams.readAllBytes(inputStream);
-            inputStream.close();
-
-            return new String(bytes);
+        // try-with-resources: readAllBytes can throw part-way through a read, and a
+        // manual close() after it would be skipped on that path, leaking the
+        // AssetInputStream.
+        try (InputStream inputStream = assetManager.open(fileName)) {
+            return new String(Streams.readAllBytes(inputStream));
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/util/Streams.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/util/Streams.java
@@ -1,0 +1,48 @@
+package com.k1af.ft8af.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Small stream helpers.
+ */
+public final class Streams {
+
+    private Streams() {
+    }
+
+    /**
+     * Reads an {@link InputStream} to its end into a byte array.
+     *
+     * <p>The bundled data files (cty.dat, the DXCC/CQ/ITU-zone JSON tables,
+     * rigaddress.txt, bands.txt, the help texts) used to be read with
+     * {@code new byte[in.available()]} followed by a single {@code in.read(buf)}
+     * whose return value was ignored. Neither is reliable: {@code available()}
+     * is only a hint, and one {@code read(byte[])} is explicitly permitted to
+     * return fewer bytes than requested. Android's {@code AssetInputStream}
+     * decompresses on the fly, so for a large compressed asset (cty.dat is
+     * ~280&nbsp;KB, the zone tables are 450&nbsp;KB&ndash;740&nbsp;KB) the lone
+     * read returns only the first chunk and the tail of the buffer stays as NUL
+     * bytes. That silently truncated the callsign&rarr;country/zone database and
+     * made the zone/DXCC JSON fail to parse entirely. Draining the stream in a
+     * loop until EOF (the same fix already applied to log import in
+     * {@code LogFileImport.readFully}) reads the whole file regardless of how the
+     * underlying stream chunks it.
+     *
+     * @param in the stream to drain (not closed here &mdash; the caller owns it)
+     * @return the full stream contents
+     * @throws IOException if the underlying read fails
+     */
+    public static byte[] readAllBytes(InputStream in) throws IOException {
+        // available() is only a sizing hint; guard against a 0/negative estimate.
+        int hint = Math.max(32, in.available());
+        ByteArrayOutputStream out = new ByteArrayOutputStream(hint);
+        byte[] chunk = new byte[8192];
+        int n;
+        while ((n = in.read(chunk)) != -1) {
+            out.write(chunk, 0, n);
+        }
+        return out.toByteArray();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/callsign/CallsignFileOperationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/callsign/CallsignFileOperationTest.java
@@ -93,4 +93,63 @@ public class CallsignFileOperationTest {
         String[] lines = CallsignFileOperation.getLinesFromInputStream(in, ";");
         assertThat(lines).asList().containsExactly("only");
     }
+
+    @Test
+    public void getLinesFromInputStream_readsEveryRecordFromAChunkedStream() {
+        // Regression for the truncated-asset-read bug: cty.dat is a ~280 KB
+        // compressed asset, and Android's AssetInputStream delivers it in chunks.
+        // The old code did new byte[available()] + a single read(), so it kept only
+        // the first chunk and dropped the tail — losing whole countries from the
+        // callsign->DXCC/zone map. Feed a stream that yields one byte per read and
+        // assert every semicolon-separated record still comes back. Under the old
+        // single-read this returns just "rec0..." (one byte) and fails.
+        int records = 2000;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < records; i++) {
+            if (i > 0) {
+                sb.append(';');
+            }
+            sb.append("rec").append(i);
+        }
+        byte[] data = sb.toString().getBytes(StandardCharsets.UTF_8);
+        InputStream in = new OneBytePerReadStream(data);
+
+        String[] lines = CallsignFileOperation.getLinesFromInputStream(in, ";");
+
+        assertThat(lines).hasLength(records);
+        assertThat(lines[0]).isEqualTo("rec0");
+        assertThat(lines[records - 1]).isEqualTo("rec" + (records - 1));
+    }
+
+    /** Stream that returns at most one byte per bulk read, like a chunking asset stream. */
+    private static final class OneBytePerReadStream extends InputStream {
+        private final byte[] data;
+        private int pos;
+
+        OneBytePerReadStream(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public int read() {
+            return pos >= data.length ? -1 : (data[pos++] & 0xff);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            if (pos >= data.length) {
+                return -1;
+            }
+            if (len <= 0) {
+                return 0;
+            }
+            b[off] = data[pos++];
+            return 1;
+        }
+
+        @Override
+        public int available() {
+            return data.length - pos;
+        }
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/util/StreamsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/util/StreamsTest.java
@@ -1,0 +1,105 @@
+package com.k1af.ft8af.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Coverage for {@link Streams#readAllBytes(InputStream)}.
+ *
+ * <p>The bug this replaces sized a buffer from {@code available()} and did a
+ * single {@code read(byte[])}. Both are unreliable: a lone read may return fewer
+ * bytes than the buffer length, and {@code available()} is only a hint. Android's
+ * compressed {@code AssetInputStream} exhibits exactly this — a big asset is
+ * delivered in chunks. {@link ShortReadInputStream} reproduces that behaviour so
+ * the fix is exercised without an Android runtime.
+ */
+public class StreamsTest {
+
+    /**
+     * An {@link InputStream} that hands back at most {@code maxPerRead} bytes per
+     * {@code read(byte[], int, int)} call and can report an arbitrary (wrong)
+     * {@code available()}, mirroring a decompressing asset stream.
+     */
+    private static final class ShortReadInputStream extends InputStream {
+        private final byte[] data;
+        private final int maxPerRead;
+        private final int reportedAvailable;
+        private int pos;
+
+        ShortReadInputStream(byte[] data, int maxPerRead, int reportedAvailable) {
+            this.data = data;
+            this.maxPerRead = maxPerRead;
+            this.reportedAvailable = reportedAvailable;
+        }
+
+        @Override
+        public int read() {
+            if (pos >= data.length) {
+                return -1;
+            }
+            return data[pos++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            if (pos >= data.length) {
+                return -1;
+            }
+            int n = Math.min(Math.min(len, maxPerRead), data.length - pos);
+            System.arraycopy(data, pos, b, off, n);
+            pos += n;
+            return n;
+        }
+
+        @Override
+        public int available() {
+            return reportedAvailable;
+        }
+    }
+
+    @Test
+    public void readAllBytes_returnsExactContentOfPlainStream() throws IOException {
+        byte[] src = "hello world".getBytes(StandardCharsets.UTF_8);
+        byte[] out = Streams.readAllBytes(new ByteArrayInputStream(src));
+        assertThat(out).isEqualTo(src);
+    }
+
+    @Test
+    public void readAllBytes_emptyStreamReturnsEmptyArray() throws IOException {
+        byte[] out = Streams.readAllBytes(new ByteArrayInputStream(new byte[0]));
+        assertThat(out).hasLength(0);
+    }
+
+    @Test
+    public void readAllBytes_drainsStreamThatShortReadsOneBytePerCall() throws IOException {
+        // 100 KB is larger than the 8 KB working chunk and, more importantly, the
+        // stream only yields one byte per read — the exact case the old
+        // single-read code truncated. The loop must reassemble every byte.
+        byte[] src = new byte[100_000];
+        for (int i = 0; i < src.length; i++) {
+            src[i] = (byte) (i * 31 + 7);
+        }
+        byte[] out = Streams.readAllBytes(
+                new ShortReadInputStream(src, 1, src.length));
+        assertThat(out).isEqualTo(src);
+    }
+
+    @Test
+    public void readAllBytes_ignoresUnderReportedAvailable() throws IOException {
+        // available() lies (says 4) but the stream holds far more. Because we drain
+        // to EOF rather than trusting available(), the full payload comes back.
+        byte[] src = new byte[20_000];
+        for (int i = 0; i < src.length; i++) {
+            src[i] = (byte) (i & 0x7f);
+        }
+        byte[] out = Streams.readAllBytes(
+                new ShortReadInputStream(src, 4096, 4));
+        assertThat(out).isEqualTo(src);
+    }
+}


### PR DESCRIPTION
## Root cause

The bundled reference-data assets are read with:

```java
byte[] bytes = new byte[inputStream.available()];
inputStream.read(bytes);            // return value ignored
```

Both halves are unsafe:

- `InputStream.available()` is only a hint, not the length.
- A single `read(byte[])` is explicitly permitted to return **fewer** bytes than requested.

Android's `AssetInputStream` decompresses assets on the fly, so a large compressed asset is handed back in chunks. The lone `read` keeps only the first chunk; the tail of the buffer stays as NUL bytes, silently truncating the file.

## Impact

- **`cty.dat` (~280 KB)** — the callsign→country / CQ-zone / ITU-zone map (`CallsignFileOperation`). Truncation drops whole countries, so callsigns past the first chunk resolve to the wrong (or no) country/zone in the decode list, on the map, and in ADIF export.
- **`ituzone.json` / `cqzone.json` / `dxcc_list.json` (450–740 KB)** — loaded in `DatabaseOpr` and parsed as JSON *immediately after the read*. A truncated buffer makes `new JSONObject(new String(bytes))` throw `JSONException`, which is caught and logged — wiping the **entire** zone/DXCC table.
- **`bands.txt` / `rigaddress.txt` / help texts** — smaller, but the same latent defect (`OperationBand`, `RigNameList`, `HelpDialog`, `ClearCacheDataDialog`).

This is the same class of bug the team already fixed for log import in `LogFileImport.readFully` (which carries a detailed comment on exactly this hazard). These eight sites were the remaining copies of the pattern.

## Fix

Added `com.k1af.ft8af.util.Streams.readAllBytes(InputStream)`, which drains the stream to EOF in a loop (8 KB working buffer, `available()` used only as an initial sizing hint). Routed all eight call sites through it. Decoding is otherwise unchanged — still `new String(bytes)` with the platform default charset — so this is strictly a "read the whole file" fix with no behavioral change on inputs that already fit in one read.

Files: `CallsignFileOperation`, `RigNameList`, `OperationBand`, `DatabaseOpr` (×3), `HelpDialog`, `ClearCacheDataDialog`, + new `Streams`.

## Testing

- **`StreamsTest`** (new, pure JVM): `readAllBytes` fully drains a stream that yields one byte per `read`, and one that under-reports `available()`; plus exact-content and empty-stream cases.
- **`CallsignFileOperationTest`** (new case): feeds `getLinesFromInputStream` a chunked (one-byte-per-read) stream of 2000 `;`-separated records and asserts every record survives. **Verified this fails against the old single-read code and passes with the fix.**
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full APK (all 4 ABIs, native + hamlib) builds successfully.

## Risk

Low. No DSP/native/protocol changes. The only behavioral change is that these bundled files are now read in full instead of a truncated prefix; on any input small enough that the old single read already succeeded, output is byte-identical.