### PR TITLE
Guard the web-logbook upload handler against a missing file1 part

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -162,6 +162,26 @@ public class LogHttpServer extends NanoHTTPD {
         return String.format("log%s.adi", month != null ? month : "");
     }
 
+    /**
+     * The temp-file path NanoHTTPD stored for the {@code file1} upload part of a POST/PUT
+     * to {@code /IMPORTLOGDATA}, or {@code null} when the request carried no such part.
+     *
+     * <p>{@link IHTTPSession#parseBody} fills the supplied map with one entry per uploaded
+     * file, keyed by the form field name. A malformed or non-form request — or a bare LAN
+     * probe of the always-on logbook port — leaves the map without {@code file1}. The
+     * handler used to dereference the missing value directly
+     * ({@code files.get("file1").hashCode()}), so a request without the part threw a
+     * {@link NullPointerException}. That throw escaped {@link #serve} <em>before</em> its
+     * try/catch (the {@code IMPORTLOGDATA} branch runs in the leading dispatch chain), so
+     * NanoHTTPD's worker aborted the request with no useful response. Callers must treat
+     * {@code null} as "no upload" and reject the request the way a non-POST method already
+     * does. Mirrors the {@link #uriSegment} / {@link #parseQueryInt} guards that already
+     * harden the sibling handlers in this file.
+     */
+    static String uploadedFilePath(Map<String, String> files) {
+        return files == null ? null : files.get("file1");
+    }
+
     @Override
     public Response serve(IHTTPSession session) {
         String[] uriList = session.getUri().split("/");
@@ -283,7 +303,12 @@ public class LogHttpServer extends NanoHTTPD {
                 session.parseBody(files);
 
                 Log.e(TAG, "doImportLogFile: information:" + files.toString());
-                String param = files.get("file1");//this is the key for the POST or PUT file
+                String param = uploadedFilePath(files);//temp-file path of the file1 upload part (null if absent)
+                if (param == null) {
+                    // No file1 part: reject like an illegal command instead of NPE-ing on
+                    // the missing upload (see uploadedFilePath).
+                    return GeneralVariables.getStringFromResource(R.string.html_illegal_command);
+                }
 
                 ImportTaskList.ImportTask task = importTaskList.addTask(param.hashCode());//create a new task
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerUploadPartTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerUploadPartTest.java
@@ -1,0 +1,66 @@
+package com.k1af.ft8af.html;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Pure-logic coverage for {@link LogHttpServer#uploadedFilePath(Map)}, the guard that keeps
+ * the web-logbook {@code /IMPORTLOGDATA} handler from dereferencing a missing upload part.
+ *
+ * <p>Regression: {@code doImportLogFile} read the multipart upload as
+ * {@code files.get("file1").hashCode()}. A POST/PUT to {@code /IMPORTLOGDATA} that carried
+ * no {@code file1} file field (a malformed or non-form request, or a bare LAN probe of the
+ * always-on logbook port) left {@code files} without the key, so the bare
+ * {@code .hashCode()} threw {@link NullPointerException}. That throw escaped {@code serve}
+ * before its try/catch — the {@code IMPORTLOGDATA} branch runs in the leading dispatch
+ * chain — so NanoHTTPD's worker aborted the request with no useful response. The sibling
+ * handlers in the same file were already hardened
+ * ({@link LogHttpServer#uriSegment(String[], int)} in PR #584,
+ * {@link LogHttpServer#parseQueryInt(String, int)} in PR #585); this pins the matching
+ * guard for the upload part.
+ *
+ * <p>No Android types are touched, so no Robolectric runner is needed (mirrors
+ * {@link LogHttpServerUriSegmentTest} / {@link LogHttpServerQueryParamTest}).
+ */
+public class LogHttpServerUploadPartTest {
+
+    @Test
+    public void presentFilePart_isReturned() {
+        Map<String, String> files = new HashMap<>();
+        files.put("file1", "/data/tmp/NanoHTTPD-123456.tmp");
+        assertThat(LogHttpServer.uploadedFilePath(files))
+                .isEqualTo("/data/tmp/NanoHTTPD-123456.tmp");
+    }
+
+    @Test
+    public void missingFilePart_isNull() {
+        // The regression: no file1 entry (e.g. a POST/PUT with no file field, or a differently
+        // named part). The old files.get("file1").hashCode() NPE'd here.
+        assertThat(LogHttpServer.uploadedFilePath(new HashMap<>())).isNull();
+
+        Map<String, String> wrongName = new HashMap<>();
+        wrongName.put("someOtherField", "/data/tmp/x.tmp");
+        assertThat(LogHttpServer.uploadedFilePath(wrongName)).isNull();
+    }
+
+    @Test
+    public void nullMap_isNull() {
+        // parseBody is only invoked for POST/PUT, but treat a null map defensively so the
+        // guard never becomes the crash it is meant to prevent.
+        assertThat(LogHttpServer.uploadedFilePath(null)).isNull();
+    }
+
+    @Test
+    public void emptyStringPath_isReturnedNotSwallowed() {
+        // An empty path is still "present": the downstream LogFileImport opens it and fails
+        // with a caught FileNotFoundException, so uploadedFilePath must not conflate ""
+        // with "absent" (which would silently change the null-only guard's scope).
+        Map<String, String> files = new HashMap<>();
+        files.put("file1", "");
+        assertThat(LogHttpServer.uploadedFilePath(files)).isEqualTo("");
+    }
+}


### PR DESCRIPTION
## Root cause

The always-on web logbook server (`LogHttpServer`, started unconditionally at app launch and reachable on the LAN) handles ADIF uploads at `/IMPORTLOGDATA`. `doImportLogFile` read the multipart upload as:

```java
String param = files.get("file1");
ImportTaskList.ImportTask task = importTaskList.addTask(param.hashCode()); // NPE if param == null
```

`IHTTPSession.parseBody(files)` only inserts a `"file1"` entry when the POST/PUT actually carries a file field with that name. A malformed or non-form request — or a bare LAN probe of the logbook port — leaves the map without the key, so `param` is `null` and `param.hashCode()` throws `NullPointerException`.

That `NullPointerException` is thrown in the **leading dispatch chain of `serve()`** (line ~221), which runs *before* `serve()`'s own `try/catch` (which starts further down and only catches `IOException | ResponseException` anyway). The throw therefore escapes `serve()` entirely. NanoHTTPD's worker (`ClientHandler.run()`) catches it in its generic `catch (Exception)` and logs *"Communication with the client broken"*, so it is **not an app crash** — the request is aborted with no useful response.

This is the last unguarded external-input deref in a file whose siblings were already hardened:
- missing path segment `uriList[2]` → `uriSegment(...)` (PR #584)
- malformed `?page=`/`?pageSize=`/`?session=` params → `parseQueryInt(...)` / `clampPageIndex(...)` (PR #585)

## Fix

- Extract a bounds-safe static helper `uploadedFilePath(Map<String,String> files)` that returns the `file1` temp-file path, or `null` when the part is absent (also null-safe on a null map). This mirrors the existing `uriSegment` / `parseQueryInt` static guards and keeps the decision logic unit-testable per the project's Compose/JNI-free testing rule.
- Reject a `null` result with the existing `R.string.html_illegal_command` page — the **same fallback a non-POST method already returns** — instead of dereferencing it.

Well-formed uploads are byte-for-byte identical: a present `file1` flows through unchanged.

## Testing performed

- New `LogHttpServerUploadPartTest` — pure-JVM (no Robolectric), mirroring `LogHttpServerUriSegmentTest` / `LogHttpServerQueryParamTest`. Covers present part, missing part, wrong field name, null map, and empty-string path (which must stay "present", since the downstream `LogFileImport` opens it and fails with a *caught* `FileNotFoundException`).
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — green (all 4 ABIs, incl. native/hamlib build).

## Risk assessment

Very low. Pure Java, one added null-guard on an error path plus a thin extracted helper; no protocol, DSP, threading, or native changes; no behavior change for well-formed requests. LAN-facing reliability (category-2) hardening — completes the `LogHttpServer` external-input sweep.

## Affected platforms

Android (the web-logbook server is Android-only).