### PR TITLE
Fix GuoHe Q900 frame sync: require four consecutive 0xA5 bytes

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/GuoHeQ900Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/GuoHeQ900Rig.java
@@ -85,8 +85,12 @@ public class GuoHeQ900Rig extends BaseRig {
     /**
      * Locate the frame length byte, i.e. the first byte after the mandatory
      * FOUR CONSECUTIVE 0xA5 sync bytes that begin every GuoHe frame (see
-     * {@link GuoHeRigConstant}). Returns the index of that length byte, or -1 if
-     * no sync run is present.
+     * {@link GuoHeRigConstant}). Returns the index of that length byte, or -1
+     * when this buffer does not contain one — either because no run of four
+     * 0xA5 bytes is present at all, or because the run is present but the byte
+     * that follows it has not arrived yet (a read that ends inside the sync
+     * run). Both cases mean "no complete frame header here"; the caller simply
+     * waits for more data.
      *
      * <p>The 0xA5 bytes must be consecutive: the payload of a status frame
      * carries two big-endian VFO frequencies that are frequently 0xA5, and when

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/GuoHeQ900Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/GuoHeQ900Rig.java
@@ -82,14 +82,30 @@ public class GuoHeQ900Rig extends BaseRig {
     }
 
 
-    private int checkHead(byte[] data) {
+    /**
+     * Locate the frame length byte, i.e. the first byte after the mandatory
+     * FOUR CONSECUTIVE 0xA5 sync bytes that begin every GuoHe frame (see
+     * {@link GuoHeRigConstant}). Returns the index of that length byte, or -1 if
+     * no sync run is present.
+     *
+     * <p>The 0xA5 bytes must be consecutive: the payload of a status frame
+     * carries two big-endian VFO frequencies that are frequently 0xA5, and when
+     * a read splices a prior frame's tail onto the next frame's sync, counting
+     * 0xA5 bytes anywhere would return an index <em>into</em> the sync run. The
+     * caller would then read a 0xA5 as the length byte ((byte)0xA5 + 1 = -90),
+     * allocating {@code new byte[-90]} and throwing NegativeArraySizeException,
+     * which aborts framing and silently drops the frequency update.
+     */
+    static int checkHead(byte[] data) {
         int count = 0;
         for (int i = 0; i < data.length; i++) {
             if (data[i] == (byte) 0xa5) {
                 count++;
-                if (count == 4) {
-                    return i+1;
-                }
+            } else if (count >= 4) {
+                // First non-sync byte after a run of >=4 0xA5 is the length byte.
+                return i;
+            } else {
+                count = 0;
             }
         }
         return -1;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/GuoHeCheckHeadTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/GuoHeCheckHeadTest.java
@@ -1,0 +1,94 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link GuoHeQ900Rig#checkHead(byte[])}, which locates the frame
+ * length byte that follows the mandatory four-consecutive-0xA5 sync header (see
+ * {@link GuoHeRigConstant}).
+ *
+ * <p>The 0xA5 bytes must be counted <em>consecutively</em>. A status frame's
+ * payload carries two big-endian VFO frequencies that are frequently 0xA5, so
+ * counting 0xA5 anywhere (the old behaviour) could return an index into the sync
+ * run. {@code GuoHeQ900Rig.onReceiveData} would then treat a 0xA5 as the length
+ * byte — {@code (byte)0xA5 + 1 == -90} — and allocate {@code new byte[-90]},
+ * throwing NegativeArraySizeException. The exception aborted framing before
+ * {@code clearBuffer()}, leaving stale partial-frame state and silently dropping
+ * the rig's frequency update.
+ */
+public class GuoHeCheckHeadTest {
+
+    @Test
+    public void wellFormedFrame_returnsLengthByteIndex() {
+        // A5 A5 A5 A5 <len=0x0f> 0b ... : length byte is at index 4.
+        byte[] data = {
+                (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, (byte) 0xA5,
+                (byte) 0x0f, (byte) 0x0b, (byte) 0x01, (byte) 0x02};
+        assertThat(GuoHeQ900Rig.checkHead(data)).isEqualTo(4);
+        // The byte at the returned index is the length, never a 0xA5 sync byte.
+        assertThat(data[GuoHeQ900Rig.checkHead(data)] & 0xFF).isEqualTo(0x0f);
+    }
+
+    @Test
+    public void nonConsecutiveA5_isNotMistakenForSync() {
+        // Three scattered 0xA5 payload bytes then a *real* 4-byte sync run.
+        // The old counter reached 4 mid-way and returned an index into a run of
+        // 0xA5 length bytes; the fixed counter resets on every non-0xA5 byte.
+        byte[] data = {
+                (byte) 0xA5, (byte) 0x01, (byte) 0xA5, (byte) 0x02, (byte) 0xA5,
+                (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, // 4-byte sync
+                (byte) 0x0f, (byte) 0x0b};
+        int idx = GuoHeQ900Rig.checkHead(data);
+        assertThat(idx).isEqualTo(9);
+        assertThat(data[idx] & 0xFF).isEqualTo(0x0f);
+    }
+
+    @Test
+    public void statusFrameWithA5FreqBytes_thenNextSync_findsLengthNotA5() {
+        // Realistic stream splice: the tail of a status frame whose VFO
+        // frequency bytes are 0xA5 (14.074 MHz style values land on 0xA5), the
+        // 2-byte CRC, then the next frame's 4-byte sync + length byte. The old
+        // code returned an index landing on a 0xA5 -> len = -90 -> new byte[-90].
+        byte[] data = {
+                // trailing payload of a previous frame with embedded 0xA5s
+                (byte) 0x00, (byte) 0xA5, (byte) 0xC0, (byte) 0xA5, (byte) 0x37,
+                // next frame sync + length
+                (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, (byte) 0xA5,
+                (byte) 0x03, (byte) 0x0b};
+        int idx = GuoHeQ900Rig.checkHead(data);
+        assertThat(idx).isEqualTo(9);
+        // Must be a valid (non-negative) length byte, never a 0xA5 sync byte.
+        int len = data[idx] + 1;
+        assertThat(len).isGreaterThan(0);
+        assertThat(data[idx] & 0xFF).isNotEqualTo(0xA5);
+    }
+
+    @Test
+    public void moreThanFourConsecutiveA5_skipsEntireSyncRun() {
+        // A stray leading 0xA5 (e.g. previous CRC low byte) makes five in a row.
+        // The length byte is the first non-0xA5 after the whole run, not the 5th 0xA5.
+        byte[] data = {
+                (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, (byte) 0xA5,
+                (byte) 0x05, (byte) 0x0b};
+        int idx = GuoHeQ900Rig.checkHead(data);
+        assertThat(idx).isEqualTo(5);
+        assertThat(data[idx] & 0xFF).isEqualTo(0x05);
+    }
+
+    @Test
+    public void noSyncHeader_returnsMinusOne() {
+        byte[] data = {(byte) 0x01, (byte) 0x02, (byte) 0xA5, (byte) 0xA5, (byte) 0x03};
+        assertThat(GuoHeQ900Rig.checkHead(data)).isEqualTo(-1);
+    }
+
+    @Test
+    public void syncRunAtBufferEnd_returnsMinusOne_ratherThanOverrunning() {
+        // The 4-byte sync arrives but the length byte is in the next read. The
+        // fixed code reports "no complete header yet" (-1) instead of returning
+        // an out-of-range index that would throw on data[startIndex].
+        byte[] data = {(byte) 0xA5, (byte) 0xA5, (byte) 0xA5, (byte) 0xA5};
+        assertThat(GuoHeQ900Rig.checkHead(data)).isEqualTo(-1);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/GuoHeCheckHeadTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/GuoHeCheckHeadTest.java
@@ -34,8 +34,9 @@ public class GuoHeCheckHeadTest {
     @Test
     public void nonConsecutiveA5_isNotMistakenForSync() {
         // Three scattered 0xA5 payload bytes then a *real* 4-byte sync run.
-        // The old counter reached 4 mid-way and returned an index into a run of
-        // 0xA5 length bytes; the fixed counter resets on every non-0xA5 byte.
+        // The old counter reached 4 on the scattered bytes and returned an index
+        // pointing *into* the sync run, so the caller read a 0xA5 sync byte as
+        // the length byte; the fixed counter resets on every non-0xA5 byte.
         byte[] data = {
                 (byte) 0xA5, (byte) 0x01, (byte) 0xA5, (byte) 0x02, (byte) 0xA5,
                 (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, (byte) 0xA5, // 4-byte sync


### PR DESCRIPTION
## Summary

`GuoHeQ900Rig.checkHead()` misidentifies the frame sync header, which intermittently corrupts frequency tracking on the GuoHe Q900 (and its Xiegu-family siblings that share this framing).

Every GuoHe frame begins with **four consecutive `0xA5` sync bytes** (see `GuoHeRigConstant` — `PTT_ON`, `USB_MODE`, `READ_FREQ`, etc. all start `A5 A5 A5 A5 <len> …`). The old `checkHead` counted `0xA5` bytes *anywhere* in the read buffer and returned the moment the 4th was seen:

```java
if (data[i] == (byte) 0xa5) {
    count++;
    if (count == 4) return i + 1;   // never resets on a non-0xA5 byte
}
```

## Root cause

A status frame (`cmd 0x0b`) carries two big-endian VFO frequencies at `buffer[5..12]`, and those bytes are frequently `0xA5` (common HF frequencies land on it). USB-serial reads don't respect frame boundaries, so a read routinely delivers **a prior frame's `0xA5`-bearing tail followed by the next frame's sync run**. The old counter reached 4 partway through those scattered/adjacent `0xA5` bytes and returned an index pointing *into* the sync run.

`onReceiveData` then read a `0xA5` as the length byte:

```
int len = data[startIndex] + 1;   // (byte)0xA5 + 1 == -90
buffer = new byte[len];           // new byte[-90] -> NegativeArraySizeException
```

The exception is swallowed by `onReceiveData`'s `try/catch`, so it is **not** an app crash — but it aborts framing *before* `clearBuffer()`, leaving stale partial-frame state and **silently dropping the frequency update**. Symptom: the app's displayed frequency intermittently fails to track the GuoHe rig's VFO.

## Fix

Reset the run counter on every non-`0xA5` byte and return the first byte *after* a run of ≥4 consecutive `0xA5` — the true length byte:

```java
if (data[i] == (byte) 0xa5) {
    count++;
} else if (count >= 4) {
    return i;      // first non-sync byte = length byte
} else {
    count = 0;     // sync must be consecutive
}
```

This also:
- correctly **skips a stray leading `0xA5`** (e.g. a previous frame's CRC low byte) that would otherwise make five in a row and, under the old code, still land on a `0xA5` length byte;
- returns `-1` ("no complete header yet") instead of an out-of-range index when a sync run lands at the very end of a read.

`checkHead` is now package-private `static` (it referenced no instance state), so the framing logic is unit-tested directly without standing up the rig's `Timer`/connector.

## Testing

New `GuoHeCheckHeadTest` (pure logic, no Robolectric needed) — 6 cases:
- well-formed frame → length-byte index
- non-consecutive `0xA5` payload bytes are **not** mistaken for sync
- realistic status-frame tail (`0xA5` freq bytes) + next sync → finds the length byte, never a `0xA5`
- >4 consecutive `0xA5` skips the whole sync run
- no header → `-1`
- sync run at buffer end → `-1` (no overrun)

Four of these return the wrong index against the old implementation, so the suite fails-before / passes-after.

```
./gradlew :app:testDebugUnitTest --tests 'com.k1af.ft8af.rigs.*'
BUILD SUCCESSFUL   # GuoHeCheckHeadTest 6/6, all rigs tests green
```

## Risk assessment

Very low. The change is confined to a single pure `byte[] → int` helper; no protocol/DSP/native code touched, no behavior change for correctly-framed input (the well-formed case returns the identical index as before). Strictly *more* robust for mis-framed input. No performance impact (same single linear pass).

## Affected platforms

Android only — GuoHe Q900 CAT/frequency read path.