### PR TITLE
Fix: TX Delay not applied until value is changed

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -261,8 +261,7 @@ public class FT8TransmitSignal {
      * timer is always restarted; callers should ensure we are not mid-transmit first.
      */
     public void rebuildTimer(ModeProfile mode) {
-        utcTimer.delete();
-        utcTimer = new UtcTimer(mode.slotMillis, false, makeTimerCallback());
+        utcTimer = rebuildTimerPreservingOffset(utcTimer, mode, makeTimerCallback());
         utcTimer.start();
     }
 
@@ -323,6 +322,32 @@ public class FT8TransmitSignal {
         boolean transmit = clip <= tolerance;
         if (clip > slotMillis - 1) clip = slotMillis - 1;
         return new ManualTxGate(transmit, (int) clip);
+    }
+
+    /**
+     * Build the replacement cycle timer for a new operating mode, carrying the manual
+     * TX-delay offset ({@link UtcTimer#getTime_sec()}) from the outgoing timer onto the
+     * fresh one. A new {@link UtcTimer} starts with {@code time_sec = 0}, so without this
+     * carry-over the saved TX Delay loaded at startup (or set before a mode switch) is
+     * silently discarded — the running signal falls back to a 0 ms offset until the value
+     * is edited again. Preserving it here fixes both the startup case and FT8/FT4/FT2
+     * runtime mode switches.
+     *
+     * <p>Package-visible and static so the offset carry-over is unit-testable via
+     * {@code getTime_sec()} without constructing a full {@link FT8TransmitSignal}.
+     *
+     * @param oldTimer the timer being retired (its offset is read, then it is deleted)
+     * @param mode     the mode whose {@link ModeProfile#slotMillis} sets the new period
+     * @param callback the cycle-trigger callback for the new timer
+     * @return the new, not-yet-started timer with the carried-over offset applied
+     */
+    static UtcTimer rebuildTimerPreservingOffset(UtcTimer oldTimer, ModeProfile mode,
+            OnUtcTimer callback) {
+        int prevDelay = oldTimer.getTime_sec();
+        oldTimer.delete();
+        UtcTimer next = new UtcTimer(mode.slotMillis, false, callback);
+        next.setTime_sec(prevDelay);
+        return next;
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -2,6 +2,10 @@ package com.k1af.ft8af.ft8transmit;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.k1af.ft8af.ModeProfile;
+import com.k1af.ft8af.timer.OnUtcTimer;
+import com.k1af.ft8af.timer.UtcTimer;
+
 import org.junit.Test;
 
 /**
@@ -642,5 +646,57 @@ public class FT8TransmitSignalTest {
                 FT8TransmitSignal.decideManualTx(FT8_SLOT + 5000, FT8_SLACK, FT8_SLOT, 4000);
         assertThat(g.transmit).isFalse();
         assertThat(g.clipMs).isEqualTo(FT8_SLOT - 1);
+    }
+
+    // ---- rebuildTimerPreservingOffset ---------------------------------------
+    // A mode change (or the applyLoadedOperatingMode() call at startup) rebuilds
+    // the cycle timer. A fresh UtcTimer starts with time_sec = 0, so before this
+    // fix the saved TX Delay loaded into the running signal was silently wiped
+    // and the offset fell back to 0 ms until the operator re-edited the value —
+    // the reported "TX Delay is not applied until I change its value" bug. The
+    // rebuild must carry the outgoing timer's offset onto the new one.
+    //
+    // UtcTimer construction only schedules java.util.Timer tasks (no JNI / no
+    // Android framework), so this runs on the bare JVM; delete() the timers to
+    // avoid leaking their heartbeat threads between tests.
+
+    private static final OnUtcTimer NOOP_CALLBACK = new OnUtcTimer() {
+        @Override public void doHeartBeatTimer(long utc) { }
+        @Override public void doOnSecTimer(long utc) { }
+    };
+
+    @Test
+    public void rebuildTimer_carriesOffsetOntoNewTimer() {
+        UtcTimer old = new UtcTimer(ModeProfile.FT8.slotMillis, false, NOOP_CALLBACK);
+        try {
+            old.setTime_sec(1800); // saved TX Delay, in ms
+            UtcTimer rebuilt = FT8TransmitSignal.rebuildTimerPreservingOffset(
+                    old, ModeProfile.FT4, NOOP_CALLBACK);
+            try {
+                // The core fix: the offset survives the rebuild instead of resetting to 0.
+                assertThat(rebuilt.getTime_sec()).isEqualTo(1800);
+            } finally {
+                rebuilt.delete();
+            }
+        } finally {
+            old.delete();
+        }
+    }
+
+    @Test
+    public void rebuildTimer_zeroOffsetStaysZero() {
+        // No TX Delay set: the rebuild must not invent one.
+        UtcTimer old = new UtcTimer(ModeProfile.FT8.slotMillis, false, NOOP_CALLBACK);
+        try {
+            UtcTimer rebuilt = FT8TransmitSignal.rebuildTimerPreservingOffset(
+                    old, ModeProfile.FT8, NOOP_CALLBACK);
+            try {
+                assertThat(rebuilt.getTime_sec()).isEqualTo(0);
+            } finally {
+                rebuilt.delete();
+            }
+        } finally {
+            old.delete();
+        }
     }
 }


### PR DESCRIPTION
## Problem

TX Delay isn't applied after startup — the saved value only takes effect once the operator edits it, and it reverts on app exit. It also silently resets on FT8⇄FT4⇄FT2 mode switches.

## Root cause

`ComposeMainActivity.initData()` loads the saved delay into `GeneralVariables.transmitDelay` and applies it to the current `UtcTimer` via `setTimer_sec(...)`, but the immediately-following `applyLoadedOperatingMode()` → `FT8TransmitSignal.rebuildTimer()` **throws that timer away** and builds a fresh `UtcTimer`, which starts with `time_sec = 0`. The delay is discarded until the value is edited again (which calls `setTimer_sec()` on the now-stable timer). The runtime mode-switch path calls the same `rebuildTimer()`, so switching mode resets TX Delay to 0 too.

## Fix

Carry the outgoing timer's offset (`UtcTimer.getTime_sec()`) onto the rebuilt timer. The logic is extracted into a package-visible static helper `rebuildTimerPreservingOffset(oldTimer, mode, callback)` so it covers **both** startup and mode switches, and — per CLAUDE.md — is unit-testable via `getTime_sec()` without constructing a full `FT8TransmitSignal` or touching JNI/Android framework.

## Tests

Added to `FT8TransmitSignalTest`:
- `rebuildTimer_carriesOffsetOntoNewTimer` — a set offset survives the rebuild (fails on the pre-fix code for the expected reason: offset resets to 0).
- `rebuildTimer_zeroOffsetStaysZero` — no offset set → rebuild doesn't invent one.

`./gradlew :app:testDebugUnitTest --tests com.k1af.ft8af.ft8transmit.FT8TransmitSignalTest` passes (54 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)