### PR TITLE
Fix SWR protection on Lab599 Discovery TX-500 (#599)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/DiscoveryTX500Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/DiscoveryTX500Rig.java
@@ -1,16 +1,106 @@
 package com.k1af.ft8af.rigs;
 
+import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.R;
+import com.k1af.ft8af.ft8transmit.MeterProtectionController;
+import com.k1af.ft8af.ui.ToastMessage;
+
 /**
  * Lab599 Discovery TX-500. CAT-identical to KENWOOD TS-2000, except it is placed in
  * DATA mode (MD6;) instead of USB (MD2;) so the rig takes audio from the USB line
  * input rather than the microphone. Issue #108.
+ *
+ * <p>Its SWR meter, however, does not follow the TS-2000/TS-590 RM layout, so meter
+ * reading is handled here rather than inherited (issue #599):
+ * <ul>
+ *   <li>The rig must be switched to the SWR meter with {@code RM1;} before {@code RM;}
+ *       returns a reading — the inherited path only ever sends {@code RM;}.</li>
+ *   <li>The reply is {@code RM1vvvv}: the selector digit is at index 0 ({@code '1'} =
+ *       SWR), not index 2, and the value is the four digits {@code substring(1,5)}
+ *       (a raw 0000-0030 field), not the TS-590's layout.</li>
+ *   <li>The 0-30 field maps to an SWR ratio via Lab599's published chart
+ *       ({@link #tx500CatToSwrRatio(int)}); only that ratio, normalized the same way
+ *       the SWR-halt threshold is stored, makes {@link MeterProtectionController} fire.</li>
+ * </ul>
  */
 public class DiscoveryTX500Rig extends KenwoodTS2000Rig {
+
+    /**
+     * Actual SWR the toast warning fires at (mirrors the TS-590's ~3.0:1 alert point).
+     */
+    private static final float TX500_SWR_ALERT_RATIO = 3.0f;
+
+    private boolean swrAlert = false;
+
     @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
             getConnector().sendData(KenwoodTK90RigConstant.setTS2000OperationDataMode());
         }
+    }
+
+    /**
+     * The TX-500 needs the meter switched to SWR ({@code RM1;}) before {@code RM;}
+     * returns an SWR reading; the inherited path only sends {@code RM;}.
+     */
+    @Override
+    protected void sendMeterReadCommand() {
+        getConnector().sendData(KenwoodTK90RigConstant.setTX500SelectSwrMeter());
+        getConnector().sendData(KenwoodTK90RigConstant.setRead590Meters());
+    }
+
+    /**
+     * Parse the TX-500's {@code RM1vvvv} SWR reply and feed the protection controller.
+     * The TX-500 reports no ALC meter here, so ALC is passed as {@code -1} ("not
+     * reported").
+     */
+    @Override
+    protected void handleMeterReply(Yaesu3Command yaesu3Command) {
+        if (!Yaesu3Command.isTX500MeterSWR(yaesu3Command)) {
+            return; // not the SWR meter — ignore rather than mis-parse as TS-590
+        }
+        int normalizedSwr = tx500CatToNormalizedSwr(Yaesu3Command.getTX500MeterValue(yaesu3Command));
+        showSwrAlert(normalizedSwr);
+        notifyMeterData(-1, normalizedSwr);
+    }
+
+    private void showSwrAlert(int normalizedSwr) {
+        boolean high = normalizedSwr >= MeterProtectionController.swrRatioToNormalized(TX500_SWR_ALERT_RATIO)
+                && GeneralVariables.swr_switch_on;
+        if (high) {
+            if (!swrAlert) {
+                swrAlert = true;
+                ToastMessage.show(GeneralVariables.getStringFromResource(R.string.swr_high_alert));
+            }
+        } else {
+            swrAlert = false;
+        }
+    }
+
+    /**
+     * Map the TX-500's raw 0000-0030 SWR meter field to an actual SWR ratio.
+     * Per Lab599's published value→SWR chart the relationship is linear:
+     * {@code cat = 3 * (swr - 1)} (cat 6 → 3.0:1, cat 27 → 10:1), i.e.
+     * {@code swr = 1 + cat / 3}.
+     *
+     * @param catValue raw 0-30 meter value
+     * @return the corresponding SWR ratio (never below 1.0)
+     */
+    static float tx500CatToSwrRatio(int catValue) {
+        if (catValue <= 0) return 1.0f;
+        return 1.0f + catValue / 3.0f;
+    }
+
+    /**
+     * Map the raw 0000-0030 field to a 0-255 SWR value on the same scale the SWR-halt
+     * threshold is stored on ({@link MeterProtectionController#swrRatioToNormalized}),
+     * so the configured halt ratio is meaningful for this rig.
+     *
+     * @param catValue raw 0-30 meter value
+     * @return normalized 0-255 SWR value
+     */
+    static int tx500CatToNormalizedSwr(int catValue) {
+        return MeterProtectionController.swrRatioToNormalized(tx500CatToSwrRatio(catValue));
     }
 
     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTK90RigConstant.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTK90RigConstant.java
@@ -39,6 +39,7 @@ public class KenwoodTK90RigConstant {
     private static final String TS2000_SET_DATA = "MD6;";//KENWOOD/TX-500 DATA mode (USB line input)
     private static final String TS590_READ_FREQ = "FA;";//KENWOOD read frequency
     private static final String TS590_READ_METERS = "RM;";//KENWOOD read METER
+    private static final String TX500_SELECT_SWR_METER = "RM1;";//Lab599 TX-500: switch meter to SWR before reading (issue #599)
 
     private static final String TS570_PTT_OFF = "RX;";//KENWOOD TS570,PTT
     private static final String TS570_PTT_ON = "TX;";//KENWOOD TS570,PTT
@@ -165,6 +166,10 @@ public class KenwoodTK90RigConstant {
 
     public static byte[] setRead590Meters() {
         return TS590_READ_METERS.getBytes();
+    }
+
+    public static byte[] setTX500SelectSwrMeter() {
+        return TX500_SELECT_SWR_METER.getBytes();
     }
 
     public static byte[] setTS590ReadOperationFreq() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS2000Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS2000Rig.java
@@ -59,17 +59,26 @@ public class KenwoodTS2000Rig extends BaseRig {
     /**
      * Read Meter RM;
      */
-    private void readMeters() {
+    protected void readMeters() {
         if (getConnector() != null) {
             clearBufferData();//clear buffer
-            getConnector().sendData(KenwoodTK90RigConstant.setRead590Meters());
+            sendMeterReadCommand();
         }
+    }
+
+    /**
+     * Send the CAT command(s) that request a meter reading. The TS-2000/TS-590
+     * just polls {@code RM;}; subclasses whose rig needs a meter-select first
+     * (e.g. the TX-500's {@code RM1;} SWR select) override this. Issue #599.
+     */
+    protected void sendMeterReadCommand() {
+        getConnector().sendData(KenwoodTK90RigConstant.setRead590Meters());
     }
 
     /**
      * Clear buffer data
      */
-    private void clearBufferData() {
+    protected void clearBufferData() {
         buffer.setLength(0);
     }
 
@@ -151,18 +160,28 @@ public class KenwoodTS2000Rig extends BaseRig {
                     setFreq(Yaesu3Command.getFrequency(yaesu3Command));
                 }
             } else if (cmd.equalsIgnoreCase("RM")) {//meter
-                if (Yaesu3Command.is590MeterSWR(yaesu3Command)) {
-                    swr = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
-                }
-                if (Yaesu3Command.is590MeterALC(yaesu3Command)) {
-                    alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
-                }
-                showAlert();
-                notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
+                handleMeterReply(yaesu3Command);
             }
 
         }
 
+    }
+
+    /**
+     * Parse an RM meter reply and forward the result to the protection
+     * controller. The TS-2000/TS-590 layout puts the selector at index 2 and the
+     * value at {@code substring(1,5)}; rigs with a different RM layout (e.g. the
+     * TX-500) override this. Issue #599.
+     */
+    protected void handleMeterReply(Yaesu3Command yaesu3Command) {
+        if (Yaesu3Command.is590MeterSWR(yaesu3Command)) {
+            swr = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
+        }
+        if (Yaesu3Command.is590MeterALC(yaesu3Command)) {
+            alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
+        }
+        showAlert();
+        notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
     }
 
     private void showAlert() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
@@ -131,6 +131,32 @@ public class Yaesu3Command {
         return command.data.charAt(2) == '1';
     }
 
+    /**
+     * Lab599 Discovery TX-500 SWR meter reply. Unlike the TS-590 layout (meter
+     * selector at index 2), the TX-500 answers {@code RM;} with {@code RM1vvvv}
+     * where the leading digit is the meter selector ({@code '1'} = SWR) and the
+     * four following digits are the meter value (0000-0030). Issue #599.
+     *
+     * @param command RM command
+     * @return true when the reply carries the SWR meter
+     */
+    public static boolean isTX500MeterSWR(Yaesu3Command command) {
+        if (command.data.length() < 5) return false;
+        return command.data.charAt(0) == '1';
+    }
+
+    /**
+     * Value of the TX-500 SWR meter reply: the four digits after the selector
+     * ({@code substring(1,5)}), a raw 0000-0030 field. Callers map it to an SWR
+     * ratio; see {@link DiscoveryTX500Rig#tx500CatToSwrRatio(int)}.
+     *
+     * @param command RM command in {@code RM1vvvv} form
+     * @return the raw 0-30 meter value, or 0 when the reply is too short
+     */
+    public static int getTX500MeterValue(Yaesu3Command command) {
+        if (command.data.length() < 5) return 0;
+        return Integer.parseInt(command.data.substring(1, 5));
+    }
 
 
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/DiscoveryTX500RigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/DiscoveryTX500RigTest.java
@@ -55,7 +55,7 @@ public class DiscoveryTX500RigTest {
     }
 
     @Test
-    public void catToNormalizedSwr_trippsHaltAboveDefaultThreshold() {
+    public void catToNormalizedSwr_tripsHaltAboveDefaultThreshold() {
         // Default swr-halt threshold is 120 (~3.0:1); a reading of 23 (~8.7:1) must halt.
         int normalized = DiscoveryTX500Rig.tx500CatToNormalizedSwr(23);
         assertThat(MeterProtectionController.shouldHaltForSwr(normalized, true, 120)).isTrue();

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/DiscoveryTX500RigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/DiscoveryTX500RigTest.java
@@ -1,0 +1,67 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.ft8transmit.MeterProtectionController;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for the Lab599 Discovery TX-500 SWR meter mapping (#599).
+ *
+ * The rig reports SWR as a raw 0000-0030 field; per Lab599's published chart the
+ * relationship to actual SWR is linear ({@code cat = 3 * (swr - 1)}), and the value
+ * handed to {@link MeterProtectionController} must sit on the same 0-255 scale the
+ * SWR-halt threshold is stored on, or protection can never trip.
+ */
+public class DiscoveryTX500RigTest {
+
+    @Test
+    public void catToSwrRatio_matchesPublishedChart() {
+        // cat = 3 * (swr - 1): a few anchor points straight from the chart.
+        assertThat(DiscoveryTX500Rig.tx500CatToSwrRatio(0)).isEqualTo(1.0f);
+        assertThat(DiscoveryTX500Rig.tx500CatToSwrRatio(6)).isEqualTo(3.0f);   // 3.0:1
+        assertThat(DiscoveryTX500Rig.tx500CatToSwrRatio(9)).isEqualTo(4.0f);   // 4.0:1
+        assertThat(DiscoveryTX500Rig.tx500CatToSwrRatio(18)).isEqualTo(7.0f);  // 7.0:1
+        assertThat(DiscoveryTX500Rig.tx500CatToSwrRatio(27)).isEqualTo(10.0f); // 10:1
+    }
+
+    @Test
+    public void catToSwrRatio_neverBelowUnity() {
+        assertThat(DiscoveryTX500Rig.tx500CatToSwrRatio(-1)).isEqualTo(1.0f);
+        assertThat(DiscoveryTX500Rig.tx500CatToSwrRatio(0)).isEqualTo(1.0f);
+    }
+
+    @Test
+    public void catToSwrRatio_isMonotonic() {
+        float prev = -1f;
+        for (int cat = 0; cat <= 30; cat++) {
+            float ratio = DiscoveryTX500Rig.tx500CatToSwrRatio(cat);
+            assertThat(ratio).isAtLeast(prev);
+            prev = ratio;
+        }
+    }
+
+    @Test
+    public void catToNormalizedSwr_alignsWithHaltThresholdScale() {
+        // cat 6 == 3.0:1 == the default halt threshold (120) once normalized.
+        assertThat(DiscoveryTX500Rig.tx500CatToNormalizedSwr(6))
+                .isEqualTo(MeterProtectionController.swrRatioToNormalized(3.0f));
+        assertThat(DiscoveryTX500Rig.tx500CatToNormalizedSwr(6)).isEqualTo(120);
+
+        // A clean match (cat 0) and a high reading (cat 30 -> >10:1 -> clamps to 255).
+        assertThat(DiscoveryTX500Rig.tx500CatToNormalizedSwr(0)).isEqualTo(0);
+        assertThat(DiscoveryTX500Rig.tx500CatToNormalizedSwr(30)).isEqualTo(255);
+    }
+
+    @Test
+    public void catToNormalizedSwr_trippsHaltAboveDefaultThreshold() {
+        // Default swr-halt threshold is 120 (~3.0:1); a reading of 23 (~8.7:1) must halt.
+        int normalized = DiscoveryTX500Rig.tx500CatToNormalizedSwr(23);
+        assertThat(MeterProtectionController.shouldHaltForSwr(normalized, true, 120)).isTrue();
+
+        // A low reading (cat 3 ~= 2.0:1) must NOT halt at the default threshold.
+        int low = DiscoveryTX500Rig.tx500CatToNormalizedSwr(3);
+        assertThat(MeterProtectionController.shouldHaltForSwr(low, true, 120)).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu3CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu3CommandTest.java
@@ -120,4 +120,36 @@ public class Yaesu3CommandTest {
         assertThat(Yaesu3Command.is590MeterALC(c)).isFalse();
         assertThat(Yaesu3Command.is590MeterSWR(c)).isFalse();
     }
+
+    // ---------- Lab599 Discovery TX-500 (#599) ----------
+
+    @Test
+    public void tx500_swrSelectorAtIndex0AndValue() {
+        // RM10023 -> data "10023": selector '1' at index 0 = SWR; value substring(1,5) = 23.
+        Yaesu3Command swr = Yaesu3Command.getCommand("RM10023");
+        assertThat(Yaesu3Command.isTX500MeterSWR(swr)).isTrue();
+        assertThat(Yaesu3Command.getTX500MeterValue(swr)).isEqualTo(23);
+    }
+
+    @Test
+    public void tx500_zeroValueParsed() {
+        Yaesu3Command swr = Yaesu3Command.getCommand("RM10000");
+        assertThat(Yaesu3Command.isTX500MeterSWR(swr)).isTrue();
+        assertThat(Yaesu3Command.getTX500MeterValue(swr)).isEqualTo(0);
+    }
+
+    @Test
+    public void tx500_nonSwrSelectorRejected() {
+        // A reply that does not lead with '1' is not the SWR meter (unlike the TS-590,
+        // whose selector sits at index 2 — here index 2 being '1' must NOT match).
+        Yaesu3Command notSwr = Yaesu3Command.getCommand("RM00123");
+        assertThat(Yaesu3Command.isTX500MeterSWR(notSwr)).isFalse();
+    }
+
+    @Test
+    public void tx500_shortDataDefaults() {
+        Yaesu3Command c = Yaesu3Command.getCommand("RM10"); // data "10" len 2
+        assertThat(Yaesu3Command.isTX500MeterSWR(c)).isFalse();
+        assertThat(Yaesu3Command.getTX500MeterValue(c)).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
## Problem

SWR protection never fired on the Lab599 **Discovery TX-500** (issue #599). The rig is handled by `DiscoveryTX500Rig`, which extended `KenwoodTS2000Rig` and inherited its meter read + parse unchanged. Two things there are incompatible with the TX-500's CAT interface, so `swr` stayed `0` and `MeterProtectionController` was never tripped:

1. **The read command never selected the SWR meter.** `readMeters()` only ever sent `RM;`. Per the TX-500 CAT protocol the rig first needs `RM1;` to switch the meter to SWR, *then* `RM;` returns the reading.
2. **The response parse expected the TS-590/2000 layout.** The TX-500 replies `RM10023;` → after stripping `RM`, `data = "10023"`: the selector digit is at **index 0** (`'1'` = SWR), not index 2, and the value is `substring(1,5)` (a raw `0000`–`0030` field). `is590MeterSWR()` checks `charAt(2)`, so it never matched and the reading was dropped.
3. **Scaling was off.** The `0000`–`0030` field is a different curve from the TS-590's, so it needed a TX-500-specific mapping before reaching the halt threshold.

## Fix

Give `DiscoveryTX500Rig` its own meter handling rather than inheriting the TS-2000 path:

- **`sendMeterReadCommand()`** override sends `RM1;` (select SWR) before `RM;`.
- **`handleMeterReply()`** override parses the `RM1vvvv` layout (selector at index 0, value at `substring(1,5)`) via new pure-logic helpers `Yaesu3Command.isTX500MeterSWR()` / `getTX500MeterValue()`.
- **Value → SWR mapping.** Lab599's published value→SWR chart is linear (`cat = 3·(swr−1)`, i.e. `swr = 1 + cat/3`; cat 6 → 3.0:1, cat 27 → 10:1). The mapped ratio is then normalized through the existing `MeterProtectionController.swrRatioToNormalized()` — the *same* scale the user-configured halt threshold is stored on — so the halt decision is meaningful for this rig.

`KenwoodTS2000Rig` gains two `protected` seams (`sendMeterReadCommand()`, `handleMeterReply()`) so the override is a clean hook rather than a copy of the RX/parse path; the inherited TS-2000/TS-590 behavior is unchanged.

## Scope / assumptions

- **SWR only.** ALC protection was raised as a non-blocking open question in the issue; the TX-500 reports no ALC meter here, so ALC is passed as `-1` ("not reported"). This can be a follow-up if the ALC meter id + select command are confirmed.
- Went with the direct `DiscoveryTX500Rig` override rather than routing through hamlib (which currently has no `rig_get_level`/meter binding), per the reporter's own build-vs-hamlib analysis in the issue.

## Tests

Per CLAUDE.md, all new logic is covered by pure-logic unit tests:

- `Yaesu3CommandTest` — TX-500 `RM10023` → SWR selector true + value 23, zero value, non-`'1'` selector rejected (distinct from the TS-590 index-2 layout), and short-data defaults.
- `DiscoveryTX500RigTest` — cat→ratio chart anchor points, monotonicity, unity floor, normalization alignment with the default halt threshold (cat 6 == 120 == 3.0:1), and end-to-end `shouldHaltForSwr` decisions (cat 23 halts, cat 3 does not).

`./gradlew :app:testDebugUnitTest` passes (full suite, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)