### PR TITLE
Fix distorted USB-direct TX audio: band-limit the 12k->48k upsampler

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/TxUpsampler.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/TxUpsampler.java
@@ -5,7 +5,8 @@ package com.k1af.ft8af.wave;
  * {@link UsbAudioDevice#writeAudio}.
  *
  * <p>Why it exists (distorted TX audio with the Yaesu FT-710): the FT8 waveform is generated at
- * 12 kHz and the USB audio device streams at 48 kHz, so writeAudio() must upsample 4x. The old
+ * 12 kHz and the USB audio device streams at a higher rate — commonly 48 kHz, so writeAudio()
+ * upsamples 4x, though 44.1 kHz devices (a 147/40 ratio) go through the same path. The old
  * path did this with naive linear interpolation. A linear interpolator is a convolution with a
  * triangular kernel, whose frequency response ({@code sinc^2}) only lightly attenuates the
  * spectral images of the 12 kHz-sampled tone. For a ~1500 Hz FT8 tone the first images land at
@@ -16,9 +17,11 @@ package com.k1af.ft8af.wave;
  *
  * <p>The fix reuses the same Blackman-windowed-sinc polyphase kernel already used (and
  * host-tested) on the capture side ({@link RationalResampler}): interpolate by L, low-pass,
- * decimate by M for the exact reduced ratio {@code toRate/fromRate}. The stopband sits well below
- * FT8's ~3 kHz top, so the images are rejected by > 40 dB and the transmitted tone is clean.
- * Covered by {@code TxUpsamplerTest}.
+ * decimate by M for the exact reduced ratio {@code toRate/fromRate}. The low-pass cutoff is
+ * {@code 0.45 / max(L, M)} of the interpolated rate — about 5.4 kHz for a 12 kHz source — so the
+ * passband clears FT8's ~3 kHz top with room to spare while the images at 10.5/13.5 kHz sit deep
+ * in the stopband and are rejected by > 40 dB, leaving the transmitted tone clean. Covered by
+ * {@code TxUpsamplerTest}.
  */
 public final class TxUpsampler {
 
@@ -29,8 +32,11 @@ public final class TxUpsampler {
      * band-limited polyphase filter. Returns a buffer of exactly {@code input.length * L / M}
      * samples, where {@code L/M} is the reduced {@code toRate/fromRate} ratio, group-delay
      * compensated so output sample 0 lines up with input sample 0 (the FT8 leading Costas sync
-     * array must not be shifted or clipped). Returns the input array unchanged when the rates
-     * match or either rate is non-positive.
+     * array must not be shifted or clipped). The compensation is a whole number of output
+     * samples, so for a non-integer ratio (e.g. 12 kHz -> 44.1 kHz, L/M = 147/40) the residual
+     * FIR group delay is fractional and the alignment holds to within one output sample rather
+     * than exactly — far below what the decoder's sync search cares about. Returns the input
+     * array unchanged when the rates match or either rate is non-positive.
      */
     public static float[] resample(float[] input, int fromRate, int toRate) {
         if (fromRate <= 0 || toRate <= 0 || fromRate == toRate || input.length == 0) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/TxUpsampler.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/TxUpsampler.java
@@ -1,0 +1,75 @@
+package com.k1af.ft8af.wave;
+
+/**
+ * Band-limited one-shot resampler for the USB-direct (libusb) TX output path in
+ * {@link UsbAudioDevice#writeAudio}.
+ *
+ * <p>Why it exists (distorted TX audio with the Yaesu FT-710): the FT8 waveform is generated at
+ * 12 kHz and the USB audio device streams at 48 kHz, so writeAudio() must upsample 4x. The old
+ * path did this with naive linear interpolation. A linear interpolator is a convolution with a
+ * triangular kernel, whose frequency response ({@code sinc^2}) only lightly attenuates the
+ * spectral images of the 12 kHz-sampled tone. For a ~1500 Hz FT8 tone the first images land at
+ * {@code 12000 - 1500 = 10500} Hz and {@code 12000 + 1500 = 13500} Hz — inside the 48 kHz output
+ * band — and ride into the radio's modulator as harmonic distortion. The phone-speaker path
+ * stays clean because Android/the OS USB driver resamples it with a proper band-limited filter;
+ * only the app's own direct-libusb path used the crude interpolator.
+ *
+ * <p>The fix reuses the same Blackman-windowed-sinc polyphase kernel already used (and
+ * host-tested) on the capture side ({@link RationalResampler}): interpolate by L, low-pass,
+ * decimate by M for the exact reduced ratio {@code toRate/fromRate}. The stopband sits well below
+ * FT8's ~3 kHz top, so the images are rejected by > 40 dB and the transmitted tone is clean.
+ * Covered by {@code TxUpsamplerTest}.
+ */
+public final class TxUpsampler {
+
+    private TxUpsampler() {}
+
+    /**
+     * Resample mono full-scale float PCM from {@code fromRate} to {@code toRate} with a
+     * band-limited polyphase filter. Returns a buffer of exactly {@code input.length * L / M}
+     * samples, where {@code L/M} is the reduced {@code toRate/fromRate} ratio, group-delay
+     * compensated so output sample 0 lines up with input sample 0 (the FT8 leading Costas sync
+     * array must not be shifted or clipped). Returns the input array unchanged when the rates
+     * match or either rate is non-positive.
+     */
+    public static float[] resample(float[] input, int fromRate, int toRate) {
+        if (fromRate <= 0 || toRate <= 0 || fromRate == toRate || input.length == 0) {
+            return input;
+        }
+
+        final int g = gcd(toRate, fromRate);
+        final int l = toRate / g;   // interpolation factor
+        final int m = fromRate / g; // decimation factor
+
+        final RationalResampler rs = new RationalResampler(l, m);
+        final int targetLen = (int) ((long) input.length * l / m);
+
+        // The FIR is symmetric, so the output lags the input by (numTaps - 1) / 2 upsampled
+        // samples, i.e. (numTaps - 1) / (2 * M) output samples. Push that many extra output
+        // samples out by feeding trailing zeros, then drop them off the front so output[0]
+        // corresponds to input[0] rather than to the filter's ramp-up.
+        final int groupDelayOut = (rs.numTaps() - 1) / (2 * m);
+        final int flushInputs = (int) Math.ceil((double) groupDelayOut * m / l) + 2;
+        final int fedLen = input.length + flushInputs;
+
+        final float[] fed = java.util.Arrays.copyOf(input, fedLen); // pads with trailing zeros
+        final float[] tmp = new float[rs.maxOutputFor(fedLen)];
+        final int produced = rs.process(fed, fedLen, tmp);
+
+        final float[] out = new float[targetLen];
+        final int copy = Math.min(targetLen, produced - groupDelayOut);
+        if (copy > 0) {
+            System.arraycopy(tmp, groupDelayOut, out, 0, copy);
+        }
+        return out;
+    }
+
+    private static int gcd(int a, int b) {
+        while (b != 0) {
+            int t = a % b;
+            a = b;
+            b = t;
+        }
+        return a;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -917,28 +917,16 @@ public class UsbAudioDevice {
     }
 
     /**
-     * Linear interpolation resampler.
+     * Band-limited TX resampler (12 kHz FT8 generator rate -> the device's 48 kHz output rate).
+     *
+     * <p>Delegates to {@link TxUpsampler}, which uses the same polyphase windowed-sinc kernel as
+     * the capture path. The previous naive linear interpolator left the 12 kHz sampling images
+     * (e.g. 10.5/13.5 kHz for a 1500 Hz tone) only lightly attenuated, which the radio's
+     * modulator turned into audible harmonic distortion on TX even though the OS-resampled phone
+     * speaker stayed clean.
      */
     private float[] resample(float[] input, int fromRate, int toRate) {
-        if (fromRate == toRate) return input;
-
-        double ratio = (double) toRate / fromRate;
-        int outputLen = (int) (input.length * ratio);
-        float[] output = new float[outputLen];
-
-        for (int i = 0; i < outputLen; i++) {
-            double srcIndex = i / ratio;
-            int idx = (int) srcIndex;
-            double frac = srcIndex - idx;
-
-            if (idx + 1 < input.length) {
-                output[i] = (float) (input[idx] * (1 - frac) + input[idx + 1] * frac);
-            } else if (idx < input.length) {
-                output[i] = input[idx];
-            }
-        }
-
-        return output;
+        return TxUpsampler.resample(input, fromRate, toRate);
     }
 
     public void close() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -917,7 +917,8 @@ public class UsbAudioDevice {
     }
 
     /**
-     * Band-limited TX resampler (12 kHz FT8 generator rate -> the device's 48 kHz output rate).
+     * Band-limited TX resampler (12 kHz FT8 generator rate -> whatever rate the USB device
+     * streams at — commonly 48 kHz, but 44.1 kHz and other rates take the same path).
      *
      * <p>Delegates to {@link TxUpsampler}, which uses the same polyphase windowed-sinc kernel as
      * the capture path. The previous naive linear interpolator left the 12 kHz sampling images

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/TxUpsamplerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/TxUpsamplerTest.java
@@ -1,0 +1,144 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Guards the band-limited TX upsampler used by the USB-direct (libusb) output path in
+ * {@link UsbAudioDevice#writeAudio}. The FT8 waveform is generated at 12 kHz and the USB audio
+ * device streams at 48 kHz, so writeAudio() must upsample 4x.
+ *
+ * <p>The bug this covers (distorted TX audio with the Yaesu FT-710): the old path used naive
+ * linear interpolation, whose triangular kernel leaves the spectral images of the 12 kHz-sampled
+ * tone only lightly attenuated. For a ~1500 Hz FT8 tone those images land at 12000 - 1500 =
+ * 10500 Hz and 12000 + 1500 = 13500 Hz — inside the 48 kHz output band — and ride into the
+ * radio's modulator as harmonic distortion, even though the OS-resampled phone-speaker path stays
+ * clean. {@link TxUpsampler} replaces the linear interpolator with the same Blackman-windowed-sinc
+ * polyphase kernel already used on the capture side, which rejects those images.
+ */
+public class TxUpsamplerTest {
+
+    private static final int SRC_RATE = 12000;   // FT8 generator rate
+    private static final int DST_RATE = 48000;   // USB audio device rate
+
+    private static float[] tone(int rate, double freqHz, double seconds) {
+        int n = (int) (rate * seconds);
+        float[] in = new float[n];
+        for (int i = 0; i < n; i++) {
+            in[i] = (float) Math.sin(2.0 * Math.PI * freqHz * i / rate);
+        }
+        return in;
+    }
+
+    /** Naive linear-interpolation upsampler — the code being replaced, kept here as a control. */
+    private static float[] linearResample(float[] input, int fromRate, int toRate) {
+        if (fromRate == toRate) return input;
+        double ratio = (double) toRate / fromRate;
+        int outputLen = (int) (input.length * ratio);
+        float[] output = new float[outputLen];
+        for (int i = 0; i < outputLen; i++) {
+            double srcIndex = i / ratio;
+            int idx = (int) srcIndex;
+            double frac = srcIndex - idx;
+            if (idx + 1 < input.length) {
+                output[i] = (float) (input[idx] * (1 - frac) + input[idx + 1] * frac);
+            } else if (idx < input.length) {
+                output[i] = input[idx];
+            }
+        }
+        return output;
+    }
+
+    /** Single-bin magnitude via Goertzel, normalized so a unit-amplitude tone reads ~1.0. */
+    private static double toneMag(float[] x, double freqHz, int rate) {
+        double w = 2.0 * Math.PI * freqHz / rate;
+        double cw = Math.cos(w);
+        double sw = Math.sin(w);
+        double coeff = 2.0 * cw;
+        double s1 = 0.0;
+        double s2 = 0.0;
+        for (float v : x) {
+            double s0 = v + coeff * s1 - s2;
+            s2 = s1;
+            s1 = s0;
+        }
+        double re = s1 - s2 * cw;
+        double im = s2 * sw;
+        return Math.sqrt(re * re + im * im) / (x.length / 2.0);
+    }
+
+    /** Dominant frequency of the back half via zero-crossing count (clean single tone). */
+    private static double zeroCrossFreq(float[] out, int outRate) {
+        int start = out.length / 2;
+        int crossings = 0;
+        for (int i = start + 1; i < out.length; i++) {
+            if ((out[i - 1] < 0f) != (out[i] < 0f)) crossings++;
+        }
+        double seconds = (double) (out.length - start) / outRate;
+        return crossings / (2.0 * seconds);
+    }
+
+    private static float steadyPeak(float[] out) {
+        float peak = 0f;
+        for (int i = out.length / 2; i < out.length; i++) {
+            peak = Math.max(peak, Math.abs(out[i]));
+        }
+        return peak;
+    }
+
+    @Test
+    public void passesThroughWhenRatesEqual() {
+        float[] in = tone(SRC_RATE, 1000.0, 0.1);
+        assertThat(TxUpsampler.resample(in, SRC_RATE, SRC_RATE)).isSameInstanceAs(in);
+    }
+
+    @Test
+    public void quadruplesLengthFor12kTo48k() {
+        float[] in = tone(SRC_RATE, 1500.0, 1.0);
+        float[] out = TxUpsampler.resample(in, SRC_RATE, DST_RATE);
+        assertThat(out.length).isEqualTo(in.length * 4);
+    }
+
+    @Test
+    public void preservesToneFrequencyAndAmplitude() {
+        float[] out = TxUpsampler.resample(tone(SRC_RATE, 1500.0, 1.0), SRC_RATE, DST_RATE);
+        assertThat(zeroCrossFreq(out, DST_RATE)).isWithin(5.0).of(1500.0);
+        assertThat((double) steadyPeak(out)).isWithin(0.05).of(1.0);
+    }
+
+    @Test
+    public void rejectsSpectralImagesThatLinearInterpolationLeaves() {
+        float[] in = tone(SRC_RATE, 1500.0, 1.0);
+
+        // Control: naive linear interpolation leaves a clearly audible image at 12000 - 1500 Hz.
+        float[] linear = linearResample(in, SRC_RATE, DST_RATE);
+        double linearFund = toneMag(linear, 1500.0, DST_RATE);
+        double linearImage = toneMag(linear, 10500.0, DST_RATE);
+        // The image the field bug is about is real and non-trivial on the old path.
+        assertThat(linearImage / linearFund).isGreaterThan(0.02);
+
+        // Band-limited polyphase upsampler: same fundamental, image rejected by > 40 dB.
+        float[] out = TxUpsampler.resample(in, SRC_RATE, DST_RATE);
+        double fund = toneMag(out, 1500.0, DST_RATE);
+        double image = toneMag(out, 10500.0, DST_RATE);
+        assertThat((double) fund).isWithin(0.05).of(1.0);
+        assertThat(image / fund).isLessThan(0.01);
+    }
+
+    @Test
+    public void handlesNonIntegerRatio44100() {
+        // A device that only streams 44.1 kHz reduces to L/M = 147/40; the tone must survive.
+        float[] in = tone(SRC_RATE, 1500.0, 1.0);
+        float[] out = TxUpsampler.resample(in, SRC_RATE, 44100);
+        assertThat(out.length).isEqualTo((int) ((long) in.length * 147 / 40));
+        assertThat(zeroCrossFreq(out, 44100)).isWithin(5.0).of(1500.0);
+    }
+
+    @Test
+    public void guardsDegenerateRates() {
+        float[] in = tone(SRC_RATE, 1000.0, 0.05);
+        assertThat(TxUpsampler.resample(in, 0, DST_RATE)).isSameInstanceAs(in);
+        assertThat(TxUpsampler.resample(in, SRC_RATE, 0)).isSameInstanceAs(in);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/TxUpsamplerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/TxUpsamplerTest.java
@@ -7,7 +7,9 @@ import org.junit.Test;
 /**
  * Guards the band-limited TX upsampler used by the USB-direct (libusb) output path in
  * {@link UsbAudioDevice#writeAudio}. The FT8 waveform is generated at 12 kHz and the USB audio
- * device streams at 48 kHz, so writeAudio() must upsample 4x.
+ * device streams at a higher rate — commonly 48 kHz (a 4x upsample), which is what most of the
+ * cases below use; {@code handlesNonIntegerRatio44100} covers a 44.1 kHz device, where the ratio
+ * reduces to 147/40.
  *
  * <p>The bug this covers (distorted TX audio with the Yaesu FT-710): the old path used naive
  * linear interpolation, whose triangular kernel leaves the spectral images of the 12 kHz-sampled


### PR DESCRIPTION
## Problem

Reported as *"Distorted TX audio with YAESU FT710"*: when the FT-710 is connected over USB the transmitted tone is no longer a pure sine — it picks up harmonics — even though monitoring the same audio from the phone speaker sounds clean. The reporter confirmed it happens on both USB audio sinks and is not fixed by TX/USB gain changes.

## Root cause

The **USB-direct (libusb) TX path** in `UsbAudioDevice.writeAudio()` upsamples the 12 kHz FT8 waveform to the device's 48 kHz output rate using **naive linear interpolation** (`resample()`).

A linear interpolator is a convolution with a triangular kernel, whose frequency response (`sinc²`) only lightly attenuates the **spectral images** of the 12 kHz-sampled signal. For a ~1500 Hz FT8 tone the first images land at `12000 − 1500 = 10500` Hz and `12000 + 1500 = 13500` Hz — **inside the 48 kHz output band** — and get sent to the radio, where the modulator renders them as audible harmonic distortion on air.

The phone-speaker path stays clean because Android's OS USB-audio driver does the 12 k→48 k conversion with a proper band-limited filter; only the app's own direct-libusb path used the crude interpolator. This matches the maintainer's earlier diagnosis in the issue thread ("a simple linear-interpolation upsampler that can add harmonics").

## Fix

New `TxUpsampler` helper that reuses the **same Blackman-windowed-sinc polyphase kernel** already used (and host-tested) on the capture side (`RationalResampler`):

- Exact `L/M` rational resampling for the reduced `toRate/fromRate` (12 k→48 k = 4/1; a 44.1 kHz device = 147/40).
- Stopband well below FT8's ~3 kHz top → the 12 kHz images are rejected by **> 40 dB**.
- **Group-delay compensated** (flush + front-trim) so `output[0]` aligns with `input[0]` and the FT8 leading Costas sync array is neither shifted nor clipped, and output length stays exactly `input.length × L/M` (TX duration unchanged, no cycle overrun).

`UsbAudioDevice.resample()` now delegates to `TxUpsampler`; both the native (`nativeWrite`) and the `UsbRequest` fallback write paths consume the improved audio since resampling happens once before either is chosen. No native/C++ changes needed.

## Tests

`TxUpsamplerTest` (6 tests, all passing) covers:
- pass-through / degenerate-rate guards,
- 4× length for 12 k→48 k,
- tone frequency + amplitude preservation,
- **image rejection vs. the old linear path** — the test includes the old linear interpolator as a control, asserts it *does* leave the 10.5 kHz image, and asserts `TxUpsampler` rejects it by > 40 dB,
- the 44.1 kHz non-integer ratio.

`./gradlew :app:testDebugUnitTest` passes in full.

## Assumptions / scope
- Limited to the app-side USB-direct upsampler, which is the only in-app resampling on the TX path. The Android `AudioTrack` path and the on-device speaker are untouched (the OS already band-limits those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)