### PR TITLE
Add "same mode only" refinement to worked-station scopes

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -534,6 +534,11 @@ public class GeneralVariables {
     //         3=FROM_LIST (present in the user-maintained worked-station list).
     public static int workedStationMode = 0;   // HIGHLIGHT — preserves legacy behavior
     public static int workedStationScope = 0;   // ON_BAND — preserves legacy behavior
+    // Orthogonal "same mode only" refinement (config "workedSameMode", default off):
+    // when on, the worked lists loaded by DatabaseOpr.GetAllQSLCallsign only count
+    // QSOs made on the current operating mode, giving the "…on this band and mode"
+    // variants of the scopes above. FROM_LIST is user-maintained and unaffected.
+    public static boolean workedSameMode = false;
     // User-maintained "worked" callsign list backing the FROM_LIST scope. Upper-cased
     // whole-call tokens, same parse/join convention as the callsign blocklist.
     private static final java.util.LinkedHashSet<String> workedStationList = new java.util.LinkedHashSet<>();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -68,6 +68,7 @@ import com.k1af.ft8af.database.DatabaseOpr;
 import com.k1af.ft8af.database.OnAfterQueryFollowCallsigns;
 import com.k1af.ft8af.database.OperationBand;
 import com.k1af.ft8af.database.RigNameList;
+import com.k1af.ft8af.database.WorkedModeFilter;
 import com.k1af.ft8af.flex.FlexRadio;
 import com.k1af.ft8af.flex.RadioTcpClient;
 import com.k1af.ft8af.ft8listener.FT8SignalListener;
@@ -1533,13 +1534,24 @@ public class MainViewModel extends ViewModel {
         // Retune within the SAME band to the new mode's dial (see safety note above).
         String waveLength = BaseRigOperation.getMeterFromFreq(GeneralVariables.band);
         long newFreq = OperationBand.getModeBandFreq(waveLength, normId);
+        boolean retuned = false;
         if (newFreq > 0 && newFreq != GeneralVariables.band) {
             GeneralVariables.band = newFreq;
             GeneralVariables.bandListIndex = OperationBand.getIndexByFreq(newFreq);
             databaseOpr.writeConfig("bandFreq", String.valueOf(newFreq), null);
-            databaseOpr.getAllQSLCallsigns();
+            retuned = true;
             GeneralVariables.mutableBandChange.postValue(GeneralVariables.bandListIndex);
             setOperationBand();//push the new dial to the rig over CAT (no-op if not connected)
+        }
+
+        // Reload the worked lists when this switch invalidated them. A retune always
+        // does (they are built per band), but with "same mode only" on they are also
+        // built per operating mode — so a mode switch that does NOT move the dial
+        // (no band entry for the new mode, or the dial is already on target) would
+        // otherwise leave the previous mode's worked stations highlighted/hidden
+        // until some unrelated reload happened to run. See WorkedModeFilter.
+        if (WorkedModeFilter.reloadNeededOnModeChange(retuned, GeneralVariables.workedSameMode)) {
+            databaseOpr.getAllQSLCallsigns();
         }
 
         // Mode changed (and possibly retuned within the band) — optionally wipe the

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2344,11 +2344,18 @@ public class DatabaseOpr extends SQLiteOpenHelper {
     static class GetAllQSLCallsign {
         public static void get(SQLiteDatabase db) {
 
+            // "Same mode only" refinement (Settings → Decode Highlights): when on,
+            // restrict every worked list to QSOs made on the current operating mode,
+            // so the "and mode" variants of the worked-station scopes work. FROM_LIST
+            // is user-maintained and unaffected. See WorkedModeFilter.
+            String meter = BaseRigOperation.getMeterFromFreq(GeneralVariables.band);
+            String mode = com.k1af.ft8af.ModeProfile.fromId(GeneralVariables.operatingMode).displayName;
+            WorkedModeFilter modeFilter = WorkedModeFilter.build(GeneralVariables.workedSameMode, mode);
+
             //String querySQL = "select distinct [call] from QSLTable where freq=?";
             //Changed to get contacted callsigns by band wavelength
-            String querySQL = "select distinct [call] from QSLTable where band=?";
-            Cursor cursor = db.rawQuery(querySQL, new String[]{
-                    BaseRigOperation.getMeterFromFreq(GeneralVariables.band)});
+            String querySQL = "select distinct [call] from QSLTable where band=?" + modeFilter.sqlSuffix;
+            Cursor cursor = db.rawQuery(querySQL, modeFilter.withArgs(meter));
             ArrayList<String> callsigns = new ArrayList<>();
             try {
                 while (cursor.moveToNext()) {
@@ -2363,9 +2370,8 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             }
             GeneralVariables.QSL_Callsign_list = callsigns;
 
-            querySQL = "select distinct [call] from QSLTable where band<>?";
-            cursor = db.rawQuery(querySQL, new String[]{
-                    BaseRigOperation.getMeterFromFreq(GeneralVariables.band)});
+            querySQL = "select distinct [call] from QSLTable where band<>?" + modeFilter.sqlSuffix;
+            cursor = db.rawQuery(querySQL, modeFilter.withArgs(meter));
 
             ArrayList<String> other_callsigns = new ArrayList<>();
             try {
@@ -2386,8 +2392,8 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             // string >= yesterday comparison selects the last two UTC days.
             long nowUtc = com.k1af.ft8af.timer.UtcTimer.getSystemTime();
             String yesterday = com.k1af.ft8af.timer.UtcTimer.getYYYYMMDD(nowUtc - 86400000L);
-            querySQL = "select distinct [call] from QSLTable where qso_date>=?";
-            cursor = db.rawQuery(querySQL, new String[]{yesterday});
+            querySQL = "select distinct [call] from QSLTable where qso_date>=?" + modeFilter.sqlSuffix;
+            cursor = db.rawQuery(querySQL, modeFilter.withArgs(yesterday));
             java.util.HashSet<String> today_callsigns = new java.util.HashSet<>();
             try {
                 while (cursor.moveToNext()) {
@@ -3079,6 +3085,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 if (name.equalsIgnoreCase("workedStationList")) {
                     GeneralVariables.addWorkedStationList(result);
+                }
+                if (name.equalsIgnoreCase("workedSameMode")) {//Restrict worked scopes to the current mode
+                    GeneralVariables.workedSameMode = result.equals("1");
                 }
 
                 if (name.equalsIgnoreCase("distanceInMiles")) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/WorkedModeFilter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/WorkedModeFilter.java
@@ -47,6 +47,23 @@ public final class WorkedModeFilter {
     }
 
     /**
+     * Whether an operating-mode switch has invalidated the cached worked lists.
+     *
+     * <p>{@link DatabaseOpr.GetAllQSLCallsign} builds those lists per band and — when the
+     * "same mode only" refinement is on — per operating mode. {@code MainViewModel.setOperatingMode}
+     * historically reloaded them only when the switch also retuned the dial, which is not
+     * guaranteed: the new mode may have no band entry, or the dial may already sit on the target
+     * frequency. In that case the lists kept the previous mode's stations and the highlighting
+     * (or hiding) stayed wrong until an unrelated reload ran.
+     *
+     * @param retuned  whether the mode switch also moved the dial (band-keyed lists are stale)
+     * @param sameMode whether the "same mode only" refinement is on (mode-keyed lists are stale)
+     */
+    public static boolean reloadNeededOnModeChange(boolean retuned, boolean sameMode) {
+        return retuned || sameMode;
+    }
+
+    /**
      * Combine a base set of query arguments with this filter's extra args.
      *
      * @param baseArgs the arguments already required by the query (e.g. band)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/WorkedModeFilter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/WorkedModeFilter.java
@@ -1,0 +1,64 @@
+package com.k1af.ft8af.database;
+
+import java.util.Locale;
+
+/**
+ * "Same mode only" refinement for the worked-station scopes.
+ *
+ * <p>The worked-before handling (Settings → Decode Highlights) lets the operator
+ * pick which stations count as worked — on this band, worked before anywhere,
+ * worked today, or from a list. This adds the orthogonal "and mode" axis the
+ * feature request asked for ("worked before/today <b>on this band and mode</b>"):
+ * when {@link com.k1af.ft8af.GeneralVariables#workedSameMode} is on, the worked
+ * lists loaded by {@link DatabaseOpr.GetAllQSLCallsign} are additionally
+ * restricted to QSOs made on the current operating mode, so a station worked
+ * only on a different mode (e.g. FT4 while you're on FT8) still counts as new.
+ *
+ * <p>Kept as a plain, side-effect-free helper (no DB/Android types) so the
+ * predicate is unit-testable without Robolectric.
+ */
+public final class WorkedModeFilter {
+
+    /** SQL fragment appended after an existing {@code WHERE} clause (empty when disabled). */
+    public final String sqlSuffix;
+    /** Positional bind arguments for {@link #sqlSuffix}, in order (never null). */
+    public final String[] args;
+
+    private WorkedModeFilter(String sqlSuffix, String[] args) {
+        this.sqlSuffix = sqlSuffix;
+        this.args = args;
+    }
+
+    /**
+     * Build the mode predicate.
+     *
+     * @param sameMode whether the "same mode only" refinement is enabled
+     * @param mode     current operating-mode name ("FT8"/"FT4"…); a null/blank
+     *                 mode disables the predicate even when {@code sameMode} is on
+     */
+    public static WorkedModeFilter build(boolean sameMode, String mode) {
+        if (!sameMode || mode == null || mode.trim().isEmpty()) {
+            return new WorkedModeFilter("", new String[0]);
+        }
+        // Case-insensitive compare so a hand-imported "ft8" still matches "FT8".
+        return new WorkedModeFilter(
+                " and upper(mode) = ?",
+                new String[]{mode.trim().toUpperCase(Locale.US)});
+    }
+
+    /**
+     * Combine a base set of query arguments with this filter's extra args.
+     *
+     * @param baseArgs the arguments already required by the query (e.g. band)
+     * @return {@code baseArgs} followed by {@link #args} (the input array when no extras)
+     */
+    public String[] withArgs(String... baseArgs) {
+        if (args.length == 0) {
+            return baseArgs;
+        }
+        String[] combined = new String[baseArgs.length + args.length];
+        System.arraycopy(baseArgs, 0, combined, 0, baseArgs.length);
+        System.arraycopy(args, 0, combined, baseArgs.length, args.length);
+        return combined;
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
@@ -32,6 +32,7 @@ fun DecodeFilterSettings(
     var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
     var workedStationMode by remember { mutableStateOf(GeneralVariables.workedStationMode) }
     var workedStationScope by remember { mutableStateOf(GeneralVariables.workedStationScope) }
+    var workedSameMode by remember { mutableStateOf(GeneralVariables.workedSameMode) }
     var workedStationList by remember { mutableStateOf(GeneralVariables.getWorkedStationList()) }
     var highlightPota by remember { mutableStateOf(GeneralVariables.highlightPota) }
     var distanceInMiles by remember { mutableStateOf(GeneralVariables.distanceInMiles) }
@@ -297,6 +298,25 @@ fun DecodeFilterSettings(
                             showChevron = true,
                             onClick = { showWorkedScopePicker = true },
                         )
+                        // "and mode" refinement — meaningless for the user list, so
+                        // only offer it for the band/before/today scopes.
+                        if (workedStationScope != workedScopeFromList) {
+                            SectionDivider()
+                            SettingsRow(
+                                label = stringResource(R.string.settings_worked_same_mode),
+                                description = stringResource(R.string.settings_worked_same_mode_desc),
+                                toggle = workedSameMode,
+                                onToggleChange = { checked ->
+                                    workedSameMode = checked
+                                    GeneralVariables.workedSameMode = checked
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "workedSameMode", if (checked) "1" else "0", null,
+                                    )
+                                    // Reload the worked lists so the new filter applies now.
+                                    mainViewModel.databaseOpr.getAllQSLCallsigns()
+                                },
+                            )
+                        }
                         if (workedStationScope == workedScopeFromList) {
                             SectionDivider()
                             SettingsRow(

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -564,6 +564,8 @@
     <string name="settings_worked_scope_from_list">In worked list</string>
     <string name="settings_worked_list_title">Worked List</string>
     <string name="settings_worked_list_desc">Callsigns to treat as worked (comma-separated)</string>
+    <string name="settings_worked_same_mode">Same mode only</string>
+    <string name="settings_worked_same_mode_desc">Only count QSOs made on the current mode</string>
     <string name="settings_distance_unit">Distance in Miles</string>
     <string name="settings_distance_unit_desc">Show distances in miles instead of kilometers</string>
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
@@ -25,9 +25,13 @@ import org.robolectric.RobolectricTestRunner;
 public class GetAllQSLCallsignModeTest {
 
     private SQLiteDatabase db;
+    private long savedBand;
+    private int savedMode;
 
     @Before
     public void setUp() {
+        savedBand = GeneralVariables.band;
+        savedMode = GeneralVariables.operatingMode;
         db = SQLiteDatabase.create(null);
         db.execSQL("CREATE TABLE QSLTable (id INTEGER PRIMARY KEY, [call] TEXT, band TEXT, "
                 + "mode TEXT, qso_date TEXT, gridsquare TEXT, sig TEXT, sig_info TEXT)");
@@ -52,7 +56,15 @@ public class GetAllQSLCallsignModeTest {
         if (db != null) {
             db.close();
         }
+        // GetAllQSLCallsign.get() populates process-global lists, and band/mode/toggle are
+        // global too. Restore every one of them so this class is self-contained and can't
+        // leak worked stations (or an FT8-only filter) into whatever test runs next.
         GeneralVariables.workedSameMode = false;
+        GeneralVariables.QSL_Callsign_list.clear();
+        GeneralVariables.QSL_Callsign_list_other_band.clear();
+        GeneralVariables.QSL_Callsign_list_today.clear();
+        GeneralVariables.band = savedBand;
+        GeneralVariables.operatingMode = savedMode;
     }
 
     private void insert(String call, String band, String mode, String date) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
@@ -1,0 +1,87 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import com.k1af.ft8af.FT8Common;
+import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.timer.UtcTimer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * End-to-end coverage for the "same mode only" refinement wired into
+ * {@link DatabaseOpr.GetAllQSLCallsign}: with an in-memory QSLTable we verify
+ * that {@link GeneralVariables#workedSameMode} restricts the WORKED (current
+ * band), NEW_BAND (other band) and TODAY worked lists to the current operating
+ * mode. Robolectric because it drives real SQLite.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GetAllQSLCallsignModeTest {
+
+    private SQLiteDatabase db;
+
+    @Before
+    public void setUp() {
+        db = SQLiteDatabase.create(null);
+        db.execSQL("CREATE TABLE QSLTable (id INTEGER PRIMARY KEY, [call] TEXT, band TEXT, "
+                + "mode TEXT, qso_date TEXT, gridsquare TEXT, sig TEXT, sig_info TEXT)");
+
+        // Operating on 20m / FT8.
+        GeneralVariables.band = 14074000L;
+        GeneralVariables.operatingMode = FT8Common.FT8_MODE;
+        GeneralVariables.workedSameMode = false;
+
+        String today = UtcTimer.getYYYYMMDD(UtcTimer.getSystemTime());
+
+        insert("ONBAND_FT8", "20m", "FT8", "20200101");
+        insert("ONBAND_FT4", "20m", "FT4", "20200101");
+        insert("OTHER_FT8", "40m", "FT8", "20200101");
+        insert("OTHER_FT4", "40m", "FT4", "20200101");
+        insert("TODAY_FT8", "15m", "FT8", today);
+        insert("TODAY_FT4", "15m", "FT4", today);
+    }
+
+    @After
+    public void tearDown() {
+        if (db != null) {
+            db.close();
+        }
+        GeneralVariables.workedSameMode = false;
+    }
+
+    private void insert(String call, String band, String mode, String date) {
+        db.execSQL("INSERT INTO QSLTable ([call], band, mode, qso_date, gridsquare) VALUES "
+                + "(?, ?, ?, ?, ?)", new Object[]{call, band, mode, date, "EM48"});
+    }
+
+    @Test
+    public void sameModeOffLoadsAllModes() {
+        DatabaseOpr.GetAllQSLCallsign.get(db);
+
+        assertThat(GeneralVariables.QSL_Callsign_list)
+                .containsExactly("ONBAND_FT8", "ONBAND_FT4");
+        assertThat(GeneralVariables.QSL_Callsign_list_other_band)
+                .containsExactly("OTHER_FT8", "OTHER_FT4", "TODAY_FT8", "TODAY_FT4");
+        assertThat(GeneralVariables.QSL_Callsign_list_today)
+                .containsExactly("TODAY_FT8", "TODAY_FT4");
+    }
+
+    @Test
+    public void sameModeOnDropsOtherModeAcrossAllLists() {
+        GeneralVariables.workedSameMode = true;
+
+        DatabaseOpr.GetAllQSLCallsign.get(db);
+
+        // Only FT8 contacts survive while operating FT8.
+        assertThat(GeneralVariables.QSL_Callsign_list).containsExactly("ONBAND_FT8");
+        assertThat(GeneralVariables.QSL_Callsign_list_other_band)
+                .containsExactly("OTHER_FT8", "TODAY_FT8");
+        assertThat(GeneralVariables.QSL_Callsign_list_today).containsExactly("TODAY_FT8");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/WorkedModeFilterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/WorkedModeFilterTest.java
@@ -42,4 +42,30 @@ public class WorkedModeFilterTest {
         WorkedModeFilter f = WorkedModeFilter.build(false, "FT8");
         assertThat(f.withArgs("40m")).asList().containsExactly("40m");
     }
+
+    // ---- reloadNeededOnModeChange -------------------------------------------
+    // setOperatingMode used to reload the worked lists only when the switch also
+    // retuned the dial. With "same mode only" on, the lists are keyed by mode too,
+    // so a mode switch that leaves the dial where it is (no band entry for the new
+    // mode, or already on target) must still reload — otherwise the previous mode's
+    // worked stations stay highlighted/hidden.
+
+    @Test
+    public void reloadNeeded_whenRetuned_regardlessOfSameMode() {
+        assertThat(WorkedModeFilter.reloadNeededOnModeChange(true, false)).isTrue();
+        assertThat(WorkedModeFilter.reloadNeededOnModeChange(true, true)).isTrue();
+    }
+
+    @Test
+    public void reloadNeeded_whenSameModeOn_evenWithoutARetune() {
+        // The regression this guards: no dial change + "same mode only" on.
+        assertThat(WorkedModeFilter.reloadNeededOnModeChange(false, true)).isTrue();
+    }
+
+    @Test
+    public void reloadNotNeeded_whenNeitherDialNorModeFilterApplies() {
+        // Same-mode off and no retune: the band-keyed lists are still valid, so
+        // skip the DB work.
+        assertThat(WorkedModeFilter.reloadNeededOnModeChange(false, false)).isFalse();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/WorkedModeFilterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/WorkedModeFilterTest.java
@@ -1,0 +1,45 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic tests for {@link WorkedModeFilter} — the "same mode only"
+ * refinement behind the worked-station scopes. No Android/DB types, so no
+ * Robolectric runner is needed.
+ */
+public class WorkedModeFilterTest {
+
+    @Test
+    public void disabledAddsNoPredicate() {
+        WorkedModeFilter f = WorkedModeFilter.build(false, "FT8");
+        assertThat(f.sqlSuffix).isEmpty();
+        assertThat(f.args).isEmpty();
+    }
+
+    @Test
+    public void enabledAddsUpperCaseModePredicate() {
+        WorkedModeFilter f = WorkedModeFilter.build(true, "ft4");
+        assertThat(f.sqlSuffix).isEqualTo(" and upper(mode) = ?");
+        assertThat(f.args).asList().containsExactly("FT4");
+    }
+
+    @Test
+    public void enabledWithBlankOrNullModeIsInert() {
+        assertThat(WorkedModeFilter.build(true, null).sqlSuffix).isEmpty();
+        assertThat(WorkedModeFilter.build(true, "   ").args).isEmpty();
+    }
+
+    @Test
+    public void withArgsAppendsExtras() {
+        WorkedModeFilter f = WorkedModeFilter.build(true, "FT8");
+        assertThat(f.withArgs("40m")).asList().containsExactly("40m", "FT8").inOrder();
+    }
+
+    @Test
+    public void withArgsReturnsBaseUnchangedWhenDisabled() {
+        WorkedModeFilter f = WorkedModeFilter.build(false, "FT8");
+        assertThat(f.withArgs("40m")).asList().containsExactly("40m");
+    }
+}


### PR DESCRIPTION
## What & why

Feature request (Optio task e92b348d): *make an option in settings for how long it will count callsigns as worked*. In the thread @lordiu asked for the worked-before options to also come in **"…on this band and mode"** variants (so a station worked earlier on a *different* mode still shows as workable), and @patrickrb noted the app already has the scope system "but not all of the options you've request. I can add those asap."

`dev` already ships the worked-station system — behavior (**Highlight / Ignore / Hide**) × scope (**On band / Before / Today / From list**). The one axis missing from lordiu's list was **mode**. This PR adds it.

## Changes

**Settings → Decode Highlights** — new **Same mode only** toggle (shown when *Worked Stations* is enabled and the scope isn't *From list*). When on, a station only counts as worked if the earlier QSO was on the mode you're currently operating (FT8/FT4/…).

**Implementation**
- `WorkedModeFilter` — pure, side-effect-free helper that turns the toggle + current mode into an `and upper(mode) = ?` SQL predicate (+ bind arg), so it's unit-testable without Robolectric.
- `DatabaseOpr.GetAllQSLCallsign` appends the predicate to the three worked-callsign queries it loads — current-band (`QSL_Callsign_list`), other-band (`QSL_Callsign_list_other_band`), and today (`QSL_Callsign_list_today`) — using `ModeProfile.fromId(operatingMode).displayName`. Because the refinement is applied at list-load time, **every scope that reads those lists honours it automatically** (no change to `isWorkedForScope`). The user-maintained `FROM_LIST` scope is intentionally unaffected.
- `GeneralVariables.workedSameMode` (default off) persisted via `writeConfig("workedSameMode", …)` and hydrated in the config loader. Changing the toggle reloads the worked lists immediately (`getAllQSLCallsigns()`), so highlights update without a band change or restart.

## Tests
- `WorkedModeFilterTest` — pure logic: predicate/arg building, disabled/blank-mode inertness, case-folding, arg ordering.
- `GetAllQSLCallsignModeTest` — Robolectric, drives real SQLite over a seeded `QSLTable` (mixed bands/modes/dates) to confirm the refinement filters the current-band, other-band **and** today lists, and is a no-op when off.

Full `./gradlew :app:testDebugUnitTest` passes.

## Notes / assumptions
- Built on top of `dev`'s existing worked-station scopes; this is a focused, orthogonal addition rather than a reimplementation.
- New user-facing strings added to the default `values/strings_compose.xml` only; other locales fall back to English pending translation, matching the repo's practice for new strings.
- lordiu also mentioned *worked today* resetting strictly at 00:00 UTC — `dev`'s TODAY scope deliberately spans today-or-yesterday (two UTC days) to be forgiving of late-night/timezone edges, so that behaviour is intentionally left unchanged here to avoid regressing a deliberate design choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)