### PR TITLE
Collapse decode list to one row per station, update in place, with sort options

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -407,6 +407,8 @@ public class GeneralVariables {
 
     public static boolean clearDecodesEveryCycle = false;//Clear the decode list at the start of each cycle
 
+    public static int decodeSortMode = 0;//Collapsed decode list sort: 0=last heard,1=callsign,2=SNR (DecodeSortMode.configValue)
+
     public static boolean clearOnBandModeChange = true;//Clear the decode list + reset TX target to CQ when the band or mode changes (default on)
 
     public static boolean swr_switch_on = true;//SWR alarm switch

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2705,7 +2705,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
 
                 if (name.equalsIgnoreCase("decodeSortMode")) {
-                    GeneralVariables.decodeSortMode = result.equals("") ? 0 : Integer.parseInt(result);
+                    // parseConfigInt, not Integer.parseInt: a whitespace/non-numeric value in
+                    // the config table would otherwise throw during startup hydration.
+                    GeneralVariables.decodeSortMode = parseConfigInt(result, 0);
                 }
 
                 if (name.equalsIgnoreCase("clearOnBandModeChange")) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2704,6 +2704,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.clearDecodesEveryCycle = result.equals("1");
                 }
 
+                if (name.equalsIgnoreCase("decodeSortMode")) {
+                    GeneralVariables.decodeSortMode = result.equals("") ? 0 : Integer.parseInt(result);
+                }
+
                 if (name.equalsIgnoreCase("clearOnBandModeChange")) {
                     GeneralVariables.clearOnBandModeChange = result.equals("1");
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapse.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapse.kt
@@ -58,7 +58,7 @@ internal fun collapseByStation(
     // tiebreak. Overwrite with the newer decode (>= keeps later-on-tie).
     val latest = LinkedHashMap<String, Ft8Message>()
     for (m in messages) {
-        val cs = m.callsignFrom?.trim()?.uppercase()
+        val cs = stationKey(m)
         if (cs.isNullOrEmpty()) continue
         val existing = latest[cs]
         if (existing == null || m.utcTime >= existing.utcTime) {
@@ -75,6 +75,56 @@ internal fun collapseByStation(
         }
     }
 }
+
+/**
+ * The station identity a decode collapses onto: [Ft8Message.callsignFrom] trimmed
+ * and upper-cased, or null when there is nothing to coalesce on.
+ *
+ * [collapseByStation] returns the original [Ft8Message] objects, whose
+ * `callsignFrom` field is *not* rewritten to this normalized form — the decode
+ * objects are shared with the rest of the app and must not be mutated here. Only
+ * one constructor of `Ft8Message` upper-cases the callsign; the others (and the
+ * hashed-callsign resolution path) can leave mixed case or padding in place. Any
+ * caller that keys UI state off a station must therefore route through this same
+ * function, or a station arriving as "k1abc" one cycle and "K1ABC" the next would
+ * collapse to one row while its row key churned — recreating the row and
+ * defeating the update-in-place behaviour this file exists to provide.
+ */
+internal fun stationKey(message: Ft8Message): String? =
+    message.callsignFrom?.trim()?.uppercase()
+
+/**
+ * The per-render bookkeeping behind the "row is new or just updated" entry
+ * animation: [seen] is what to retain for the next render, [new] is what to
+ * animate now.
+ */
+internal data class RowAnimationState(
+    val seen: Set<String>,
+    val new: Set<String>,
+)
+
+/**
+ * Advance the entry-animation state for a render whose visible rows are [current].
+ *
+ * Retains exactly [current] rather than accumulating every key ever seen. The
+ * keys embed a timestamp (see [rowAnimationKey]), so a union would add one entry
+ * per station per cycle and grow without bound over a long session even though
+ * the visible list stays small — a slow leak in a screen that is left running for
+ * hours. Anything absent from [current] can no longer be on screen, so dropping
+ * it is safe; if that station returns later it animates again, which is the
+ * intended "just updated" cue.
+ */
+internal fun advanceRowAnimation(
+    previousSeen: Set<String>,
+    current: Set<String>,
+): RowAnimationState = RowAnimationState(seen = current, new = current - previousSeen)
+
+/**
+ * Entry-animation key for one collapsed row: normalized station plus the decode's
+ * timestamp, so re-decoding a station in a later cycle re-triggers the highlight.
+ */
+internal fun rowAnimationKey(message: Ft8Message): String =
+    "${stationKey(message).orEmpty()}_${message.utcTime}"
 
 /**
  * Whether the per-cycle time-group dividers make sense for [sortMode]. They only

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapse.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapse.kt
@@ -1,0 +1,101 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.k1af.ft8af.Ft8Message
+
+/**
+ * How the collapsed (one-row-per-station) decode list is ordered.
+ *
+ * The [configValue] is the stable integer persisted via
+ * `GeneralVariables.decodeSortMode` / DB key `"decodeSortMode"` (same pattern as
+ * `msgMode` / `clearDecodesEveryCycle`). Persist by [configValue], never by
+ * ordinal, so reordering the enum can't silently repoint a saved choice.
+ */
+internal enum class DecodeSortMode(val configValue: Int) {
+    /** Most recently decoded station first (default). */
+    LAST_HEARD(0),
+
+    /** Alphabetical by callsign. */
+    CALLSIGN(1),
+
+    /** Strongest signal (highest SNR) first. */
+    SNR(2),
+    ;
+
+    companion object {
+        /** Resolve a persisted [configValue] back to a mode, defaulting to [LAST_HEARD]. */
+        fun fromConfig(value: Int): DecodeSortMode =
+            entries.firstOrNull { it.configValue == value } ?: LAST_HEARD
+    }
+}
+
+/** The mode selected when the operator taps the sort control while on [current]. */
+internal fun nextSortMode(current: DecodeSortMode): DecodeSortMode = when (current) {
+    DecodeSortMode.LAST_HEARD -> DecodeSortMode.CALLSIGN
+    DecodeSortMode.CALLSIGN -> DecodeSortMode.SNR
+    DecodeSortMode.SNR -> DecodeSortMode.LAST_HEARD
+}
+
+/**
+ * Collapse an append-only decode stream to one row per station, keeping the
+ * latest decode for each callsign, then order the result per [sortMode].
+ *
+ * "Latest" is the decode with the greatest [Ft8Message.utcTime]; on a tie the
+ * one that appears later in [messages] wins (it's the newer decode in the raw
+ * append-order stream). Messages with a null/blank callsign have nothing to
+ * coalesce on and are dropped — the row UI keys entirely off the callsign.
+ *
+ * Sorting is stable: ties keep first-appearance order in [messages], so the
+ * list doesn't jitter as identical-key decodes stream in.
+ *
+ * Callers should collapse **after** filtering so the visible-station count
+ * agrees with the active chip filter (see `filterMessages`).
+ */
+internal fun collapseByStation(
+    messages: List<Ft8Message>,
+    sortMode: DecodeSortMode,
+): List<Ft8Message> {
+    // LinkedHashMap preserves first-appearance order, which is our stable
+    // tiebreak. Overwrite with the newer decode (>= keeps later-on-tie).
+    val latest = LinkedHashMap<String, Ft8Message>()
+    for (m in messages) {
+        val cs = m.callsignFrom?.trim()?.uppercase()
+        if (cs.isNullOrEmpty()) continue
+        val existing = latest[cs]
+        if (existing == null || m.utcTime >= existing.utcTime) {
+            latest[cs] = m
+        }
+    }
+    val collapsed = latest.values.toList()
+    return when (sortMode) {
+        DecodeSortMode.LAST_HEARD -> collapsed.sortedByDescending { it.utcTime }
+        DecodeSortMode.CALLSIGN -> collapsed.sortedBy { it.callsignFrom?.uppercase().orEmpty() }
+        // Unknown SNR sinks to the bottom rather than pretending to be very weak.
+        DecodeSortMode.SNR -> collapsed.sortedByDescending {
+            if (it.hasSnr()) it.snr else Int.MIN_VALUE
+        }
+    }
+}
+
+/**
+ * Whether the per-cycle time-group dividers make sense for [sortMode]. They only
+ * do in [DecodeSortMode.LAST_HEARD], where rows stay time-ordered; once sorted by
+ * callsign or SNR the rows interleave cycles and the dividers would be noise.
+ */
+internal fun showTimeGroupDividers(sortMode: DecodeSortMode): Boolean =
+    sortMode == DecodeSortMode.LAST_HEARD
+
+/**
+ * Index to auto-scroll to when the collapsed list grows, or null to leave the
+ * scroll position alone. Only [DecodeSortMode.LAST_HEARD] auto-scrolls, and to
+ * the top (index 0) because that mode puts the newest station first. In the
+ * other modes a new station can land anywhere, so yanking the viewport would
+ * fight the operator.
+ */
+internal fun autoScrollTargetIndex(
+    sortMode: DecodeSortMode,
+    size: Int,
+    previousSize: Int,
+): Int? {
+    if (size <= previousSize || size == 0) return null
+    return if (sortMode == DecodeSortMode.LAST_HEARD) 0 else null
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -153,39 +155,54 @@ fun DecodeScreen(
         ArrayList(messageList ?: arrayListOf())
     }
 
-    // Apply filter
+    // Sort mode for the collapsed list — persisted via GeneralVariables.decodeSortMode
+    // / DB key "decodeSortMode" (same pattern as msgMode / clearDecodesEveryCycle).
+    var sortMode by rememberSaveable { mutableStateOf(DecodeSortMode.fromConfig(GeneralVariables.decodeSortMode)) }
+
+    // Apply filter, THEN collapse to one row per station. Filtering first keeps
+    // the visible-station count consistent with the active chip (a station whose
+    // latest decode is directed but earlier one was a CQ still shows under
+    // "CQ Calls"). See collapseByStation / filterMessages.
     val filteredMessages = remember(messages, selectedFilter) {
         filterMessages(messages, selectedFilter)
     }
-
-    // Precompute, once per list change, where the mode-aware time-group dividers
-    // fall so each row looks its flag up by index instead of recomputing a
-    // hard-coded 15s slot boundary inline (which collapsed 2-4 FT4/FT2 cycles
-    // under one divider).
-    val timeGroupDividers = remember(filteredMessages) {
-        computeTimeGroupDividers(filteredMessages)
+    val collapsedMessages = remember(filteredMessages, sortMode) {
+        collapseByStation(filteredMessages, sortMode)
     }
 
-    // Track which keys are new since the previous render (animated on entry only once).
+    // Precompute, once per list change, where the mode-aware time-group dividers
+    // fall (FT8 15s, FT4 7.5s, FT2 3.75s) so each row looks its flag up by index
+    // instead of recomputing a slot boundary inline. Computed over the collapsed
+    // list this LazyColumn iterates, so index is always in bounds. The dividers
+    // only render in last-heard order (see showTimeGroupDividers) — that gate is
+    // applied at draw time below.
+    val timeGroupDividers = remember(collapsedMessages) {
+        computeTimeGroupDividers(collapsedMessages)
+    }
+
+    // Track which station rows are new-or-just-updated since the previous render
+    // (animated once). Keyed by callsign + utcTime so a station re-decoded in a
+    // later cycle (new utcTime, same callsign) re-triggers the highlight — that's
+    // the "row just updated in place" cue.
     var seenKeys by remember { mutableStateOf(emptySet<String>()) }
-    val currentKeys = remember(filteredMessages) {
-        filteredMessages.mapIndexed { i, m ->
-            "${m.utcTime}_${m.callsignFrom}_${m.freq_hz}_$i"
-        }.toSet()
+    val currentKeys = remember(collapsedMessages) {
+        collapsedMessages.map { "${it.callsignFrom}_${it.utcTime}" }.toSet()
     }
     val newKeys = remember(currentKeys) { currentKeys - seenKeys }
     LaunchedEffect(currentKeys) {
         seenKeys = seenKeys + currentKeys
     }
 
-    // Auto-scroll state
+    // Auto-scroll state. Only "last heard" ordering auto-scrolls (to the top,
+    // where the newest station sits); the other sorts would yank the viewport.
     val listState = rememberLazyListState()
     var previousCount by remember { mutableIntStateOf(0) }
-    LaunchedEffect(filteredMessages.size) {
-        if (filteredMessages.size > previousCount && filteredMessages.isNotEmpty()) {
-            listState.animateScrollToItem(filteredMessages.size - 1)
+    LaunchedEffect(collapsedMessages.size, sortMode) {
+        val target = autoScrollTargetIndex(sortMode, collapsedMessages.size, previousCount)
+        if (target != null) {
+            listState.animateScrollToItem(target)
         }
-        previousCount = filteredMessages.size
+        previousCount = collapsedMessages.size
     }
 
     // A tapped Needed-DX notification asks us to pre-select that station: reset to the
@@ -234,6 +251,17 @@ fun DecodeScreen(
                     )
                 },
                 actions = {
+                    IconButton(
+                        onClick = {
+                            sortMode = nextSortMode(sortMode)
+                            GeneralVariables.decodeSortMode = sortMode.configValue
+                            mainViewModel.databaseOpr.writeConfig(
+                                "decodeSortMode", sortMode.configValue.toString(), null,
+                            )
+                        },
+                    ) {
+                        SortModeLabel(sortMode)
+                    }
                     IconButton(
                         onClick = {
                             clearEachCycle = !clearEachCycle
@@ -288,7 +316,7 @@ fun DecodeScreen(
             )
 
             // Message list or empty state
-            if (filteredMessages.isEmpty()) {
+            if (collapsedMessages.isEmpty()) {
                 EmptyState(
                     selectedFilter = selectedFilter,
                     modifier = Modifier
@@ -304,19 +332,21 @@ fun DecodeScreen(
                     verticalArrangement = Arrangement.spacedBy(0.dp),
                 ) {
                     itemsIndexed(
-                        items = filteredMessages,
-                        key = { index, msg -> "${msg.utcTime}_${msg.callsignFrom}_${msg.freq_hz}_$index" },
+                        items = collapsedMessages,
+                        // Key on the station callsign (stable across cycles) so
+                        // Compose reuses the same row and updates it in place when
+                        // a station is re-decoded, rather than adding a new row.
+                        key = { index, msg -> msg.callsignFrom ?: "row_$index" },
                     ) { index, message ->
-                        val rowKey = "${message.utcTime}_${message.callsignFrom}_${message.freq_hz}_$index"
+                        val rowKey = "${message.callsignFrom}_${message.utcTime}"
 
-                        // Group messages by receive slot (mode-aware: 15s FT8,
-                        // 7.5s FT4, 3.75s FT2). Draw a labeled divider at the first
-                        // row of each new slot; the boundaries were precomputed in
-                        // timeGroupDividers above. It is keyed on the same
-                        // filteredMessages this list iterates, so index is always
-                        // in bounds — index directly rather than masking a
-                        // size mismatch with a getOrElse default.
-                        if (timeGroupDividers[index]) {
+                        // Group rows by receive slot (mode-aware: 15s FT8, 7.5s
+                        // FT4, 3.75s FT2), but only in "last heard" ordering where
+                        // rows stay time-ordered — the other sorts would scatter
+                        // the dividers. Boundaries were precomputed in
+                        // timeGroupDividers above over this same collapsed list, so
+                        // index is always in bounds.
+                        if (showTimeGroupDividers(sortMode) && timeGroupDividers[index]) {
                             TimeGroupDivider(utcTime = message.utcTime, compact = compactMode)
                         }
 
@@ -433,6 +463,42 @@ private fun TimeGroupDivider(utcTime: Long, compact: Boolean = false) {
                 .background(Border),
         )
     }
+}
+
+// ---------------------------------------------------------------------------
+// Sort control
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact label rendered inside the top-bar sort button, showing the active
+ * [DecodeSortMode] (TIME / CALL / SNR). The button cycles modes on tap; the
+ * accessibility content description announces the current mode.
+ */
+@Composable
+internal fun SortModeLabel(sortMode: DecodeSortMode) {
+    val label = stringResource(
+        when (sortMode) {
+            DecodeSortMode.LAST_HEARD -> R.string.decode_sort_label_last_heard
+            DecodeSortMode.CALLSIGN -> R.string.decode_sort_label_callsign
+            DecodeSortMode.SNR -> R.string.decode_sort_label_snr
+        },
+    )
+    val cd = stringResource(
+        when (sortMode) {
+            DecodeSortMode.LAST_HEARD -> R.string.decode_sort_cd_last_heard
+            DecodeSortMode.CALLSIGN -> R.string.decode_sort_cd_callsign
+            DecodeSortMode.SNR -> R.string.decode_sort_cd_snr
+        },
+    )
+    Text(
+        text = label,
+        modifier = Modifier.semantics { contentDescription = cd },
+        color = Accent,
+        fontFamily = GeistMonoFamily,
+        fontWeight = FontWeight.Bold,
+        fontSize = 11.sp,
+        letterSpacing = 0.04.sp,
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -181,16 +181,18 @@ fun DecodeScreen(
     }
 
     // Track which station rows are new-or-just-updated since the previous render
-    // (animated once). Keyed by callsign + utcTime so a station re-decoded in a
-    // later cycle (new utcTime, same callsign) re-triggers the highlight — that's
-    // the "row just updated in place" cue.
+    // (animated once). Keyed by normalized station + utcTime so a station
+    // re-decoded in a later cycle (new utcTime, same station) re-triggers the
+    // highlight — that's the "row just updated in place" cue. Only the visible
+    // keys are retained: accumulating them would grow one entry per station per
+    // cycle for as long as the screen is open. See advanceRowAnimation.
     var seenKeys by remember { mutableStateOf(emptySet<String>()) }
     val currentKeys = remember(collapsedMessages) {
-        collapsedMessages.map { "${it.callsignFrom}_${it.utcTime}" }.toSet()
+        collapsedMessages.map { rowAnimationKey(it) }.toSet()
     }
-    val newKeys = remember(currentKeys) { currentKeys - seenKeys }
+    val newKeys = remember(currentKeys) { advanceRowAnimation(seenKeys, currentKeys).new }
     LaunchedEffect(currentKeys) {
-        seenKeys = seenKeys + currentKeys
+        seenKeys = advanceRowAnimation(seenKeys, currentKeys).seen
     }
 
     // Auto-scroll state. Only "last heard" ordering auto-scrolls (to the top,
@@ -336,9 +338,12 @@ fun DecodeScreen(
                         // Key on the station callsign (stable across cycles) so
                         // Compose reuses the same row and updates it in place when
                         // a station is re-decoded, rather than adding a new row.
-                        key = { index, msg -> msg.callsignFrom ?: "row_$index" },
+                        // Normalized via stationKey so a station whose callsign
+                        // arrives with different case/padding across cycles keeps
+                        // the same key (and so the same row) — see stationKey.
+                        key = { index, msg -> stationKey(msg) ?: "row_$index" },
                     ) { index, message ->
-                        val rowKey = "${message.callsignFrom}_${message.utcTime}"
+                        val rowKey = rowAnimationKey(message)
 
                         // Group rows by receive slot (mode-aware: 15s FT8, 7.5s
                         // FT4, 3.75s FT2), but only in "last heard" ordering where

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -159,6 +159,15 @@
     <string name="decode_clear_list">Clear decode list</string>
     <string name="decode_utc_placeholder">UTC : --:--:--</string>
     <string name="decode_time_group_utc">%1$s UTC</string>
+    <!-- Sort control: cycles the collapsed one-row-per-station decode list. The
+         short _label_ strings render inside the top-bar button; the _cd_ strings
+         are the accessibility content descriptions announcing the active mode. -->
+    <string name="decode_sort_label_last_heard">TIME</string>
+    <string name="decode_sort_label_callsign">CALL</string>
+    <string name="decode_sort_label_snr">SNR</string>
+    <string name="decode_sort_cd_last_heard">Sort: last heard</string>
+    <string name="decode_sort_cd_callsign">Sort: callsign</string>
+    <string name="decode_sort_cd_snr">Sort: SNR</string>
     <string name="decode_filter_all">All</string>
     <string name="decode_filter_cq_calls">CQ Calls</string>
     <string name="decode_filter_cq_pota">CQ POTA</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapseTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapseTest.kt
@@ -1,0 +1,213 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.Ft8Message
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit-tests for the pure [collapseByStation] coalescing/sort logic and its
+ * small helper functions. Robolectric is needed only because [Ft8Message]
+ * reaches android.util.Log on construction (same reason as [DecodeFilterTest]).
+ */
+@RunWith(RobolectricTestRunner::class)
+class DecodeCollapseTest {
+
+    private fun msg(
+        from: String,
+        utc: Long,
+        snr: Int = 0,
+        freq: Float = 1000f,
+    ): Ft8Message = Ft8Message("CQ", from, "FN42").apply {
+        utcTime = utc
+        this.snr = snr
+        freq_hz = freq
+    }
+
+    // ---- duplicate collapse --------------------------------------------------
+
+    @Test
+    fun collapse_keepsOneRowPerStation_withLatestDecode() {
+        val messages = listOf(
+            msg("K1ABC", utc = 1000, snr = -5, freq = 1000f),
+            msg("K2DEF", utc = 1100, snr = 3),
+            msg("K1ABC", utc = 2000, snr = 12, freq = 1500f),
+        )
+
+        val result = collapseByStation(messages, DecodeSortMode.LAST_HEARD)
+
+        assertThat(result.map { it.callsignFrom }).containsExactly("K1ABC", "K2DEF")
+        val k1 = result.first { it.callsignFrom == "K1ABC" }
+        // Fields come from the *latest* K1ABC decode (utc 2000), not the first.
+        assertThat(k1.utcTime).isEqualTo(2000)
+        assertThat(k1.snr).isEqualTo(12)
+        assertThat(k1.getFreq_hz()).isEqualTo("1500")
+    }
+
+    @Test
+    fun collapse_isCaseInsensitiveByCallsign() {
+        // callsignFrom is uppercased on construction, but guard against callers
+        // handing us mixed case anyway.
+        val a = msg("k1abc", utc = 1000)
+        val b = msg("K1ABC", utc = 2000)
+
+        val result = collapseByStation(listOf(a, b), DecodeSortMode.LAST_HEARD)
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first().utcTime).isEqualTo(2000)
+    }
+
+    @Test
+    fun collapse_laterDecodeWinsOnTiedUtcTime() {
+        val first = msg("K1ABC", utc = 5000, snr = -1)
+        val later = msg("K1ABC", utc = 5000, snr = 20)
+
+        val result = collapseByStation(listOf(first, later), DecodeSortMode.LAST_HEARD)
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first().snr).isEqualTo(20)
+    }
+
+    @Test
+    fun collapse_ignoresOutOfOrderOlderDecode() {
+        val newer = msg("K1ABC", utc = 5000, snr = 20)
+        val stale = msg("K1ABC", utc = 1000, snr = -30)
+
+        val result = collapseByStation(listOf(newer, stale), DecodeSortMode.LAST_HEARD)
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first().utcTime).isEqualTo(5000)
+        assertThat(result.first().snr).isEqualTo(20)
+    }
+
+    // ---- sort modes ----------------------------------------------------------
+
+    @Test
+    fun sort_lastHeard_mostRecentFirst() {
+        val messages = listOf(
+            msg("AA", utc = 1000),
+            msg("BB", utc = 3000),
+            msg("CC", utc = 2000),
+        )
+
+        val result = collapseByStation(messages, DecodeSortMode.LAST_HEARD)
+
+        assertThat(result.map { it.callsignFrom }).containsExactly("BB", "CC", "AA").inOrder()
+    }
+
+    @Test
+    fun sort_callsign_alphabetical() {
+        val messages = listOf(
+            msg("W9XYZ", utc = 3000),
+            msg("K1ABC", utc = 1000),
+            msg("N0RC", utc = 2000),
+        )
+
+        val result = collapseByStation(messages, DecodeSortMode.CALLSIGN)
+
+        assertThat(result.map { it.callsignFrom }).containsExactly("K1ABC", "N0RC", "W9XYZ").inOrder()
+    }
+
+    @Test
+    fun sort_snr_strongestFirst_unknownSinks() {
+        val messages = listOf(
+            msg("AA", utc = 1000, snr = -10),
+            msg("BB", utc = 1000, snr = 15),
+            msg("CC", utc = 1000).apply { snr = Ft8Message.SNR_UNKNOWN },
+            msg("DD", utc = 1000, snr = 0),
+        )
+
+        val result = collapseByStation(messages, DecodeSortMode.SNR)
+
+        // 15, 0, -10, then unknown last.
+        assertThat(result.map { it.callsignFrom }).containsExactly("BB", "DD", "AA", "CC").inOrder()
+    }
+
+    // ---- stable ordering on ties ---------------------------------------------
+
+    @Test
+    fun sort_lastHeard_stableOnTiedTime() {
+        val messages = listOf(
+            msg("AA", utc = 1000),
+            msg("BB", utc = 1000),
+            msg("CC", utc = 1000),
+        )
+
+        val result = collapseByStation(messages, DecodeSortMode.LAST_HEARD)
+
+        // Equal times keep first-appearance order.
+        assertThat(result.map { it.callsignFrom }).containsExactly("AA", "BB", "CC").inOrder()
+    }
+
+    @Test
+    fun sort_snr_stableOnTiedSnr() {
+        val messages = listOf(
+            msg("AA", utc = 1000, snr = 5),
+            msg("BB", utc = 2000, snr = 5),
+            msg("CC", utc = 3000, snr = 5),
+        )
+
+        val result = collapseByStation(messages, DecodeSortMode.SNR)
+
+        assertThat(result.map { it.callsignFrom }).containsExactly("AA", "BB", "CC").inOrder()
+    }
+
+    @Test
+    fun collapse_dropsBlankCallsigns() {
+        val messages = listOf(
+            msg("K1ABC", utc = 1000),
+            Ft8Message(1).apply { callsignFrom = null; utcTime = 2000 },
+        )
+
+        val result = collapseByStation(messages, DecodeSortMode.LAST_HEARD)
+
+        assertThat(result.map { it.callsignFrom }).containsExactly("K1ABC")
+    }
+
+    @Test
+    fun collapse_emptyInputYieldsEmpty() {
+        assertThat(collapseByStation(emptyList(), DecodeSortMode.SNR)).isEmpty()
+    }
+
+    // ---- helper functions ----------------------------------------------------
+
+    @Test
+    fun sortMode_configRoundTrips() {
+        for (mode in DecodeSortMode.entries) {
+            assertThat(DecodeSortMode.fromConfig(mode.configValue)).isEqualTo(mode)
+        }
+    }
+
+    @Test
+    fun sortMode_fromConfig_defaultsToLastHeard() {
+        assertThat(DecodeSortMode.fromConfig(-1)).isEqualTo(DecodeSortMode.LAST_HEARD)
+        assertThat(DecodeSortMode.fromConfig(99)).isEqualTo(DecodeSortMode.LAST_HEARD)
+    }
+
+    @Test
+    fun nextSortMode_cyclesThroughAllThenWraps() {
+        assertThat(nextSortMode(DecodeSortMode.LAST_HEARD)).isEqualTo(DecodeSortMode.CALLSIGN)
+        assertThat(nextSortMode(DecodeSortMode.CALLSIGN)).isEqualTo(DecodeSortMode.SNR)
+        assertThat(nextSortMode(DecodeSortMode.SNR)).isEqualTo(DecodeSortMode.LAST_HEARD)
+    }
+
+    @Test
+    fun showTimeGroupDividers_onlyInLastHeard() {
+        assertThat(showTimeGroupDividers(DecodeSortMode.LAST_HEARD)).isTrue()
+        assertThat(showTimeGroupDividers(DecodeSortMode.CALLSIGN)).isFalse()
+        assertThat(showTimeGroupDividers(DecodeSortMode.SNR)).isFalse()
+    }
+
+    @Test
+    fun autoScrollTarget_onlyLastHeardScrollsToTopWhenGrown() {
+        assertThat(autoScrollTargetIndex(DecodeSortMode.LAST_HEARD, size = 3, previousSize = 2)).isEqualTo(0)
+        // No growth -> no scroll.
+        assertThat(autoScrollTargetIndex(DecodeSortMode.LAST_HEARD, size = 2, previousSize = 2)).isNull()
+        // Other modes never auto-scroll.
+        assertThat(autoScrollTargetIndex(DecodeSortMode.CALLSIGN, size = 3, previousSize = 2)).isNull()
+        assertThat(autoScrollTargetIndex(DecodeSortMode.SNR, size = 3, previousSize = 2)).isNull()
+        // Empty list -> no scroll.
+        assertThat(autoScrollTargetIndex(DecodeSortMode.LAST_HEARD, size = 0, previousSize = 0)).isNull()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapseTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeCollapseTest.kt
@@ -47,15 +47,68 @@ class DecodeCollapseTest {
 
     @Test
     fun collapse_isCaseInsensitiveByCallsign() {
-        // callsignFrom is uppercased on construction, but guard against callers
-        // handing us mixed case anyway.
-        val a = msg("k1abc", utc = 1000)
+        // The 3-arg Ft8Message constructor upper-cases callFrom, so passing "k1abc"
+        // through msg() would NOT exercise mixed case — the field has to be set
+        // directly. It genuinely can be mixed case in production: the 5-arg
+        // constructor assigns callFrom verbatim, and the hashed-callsign resolution
+        // path fills callsignFrom from the hash table.
+        val a = msg("K1ABC", utc = 1000).apply { callsignFrom = " k1abc " }
         val b = msg("K1ABC", utc = 2000)
 
         val result = collapseByStation(listOf(a, b), DecodeSortMode.LAST_HEARD)
 
         assertThat(result).hasSize(1)
         assertThat(result.first().utcTime).isEqualTo(2000)
+    }
+
+    @Test
+    fun stationKey_normalisesCaseAndPadding() {
+        assertThat(stationKey(msg("K1ABC", utc = 1).apply { callsignFrom = " k1abc " }))
+            .isEqualTo("K1ABC")
+        assertThat(stationKey(msg("K1ABC", utc = 1).apply { callsignFrom = null })).isNull()
+    }
+
+    @Test
+    fun rowAnimationKey_isStableAcrossCallsignCasing() {
+        // The bug this guards: a row key built from the raw callsignFrom churns when
+        // the same station arrives as "k1abc" then "K1ABC", recreating the row
+        // instead of updating it in place.
+        val lower = msg("K1ABC", utc = 2000).apply { callsignFrom = "k1abc" }
+        val upper = msg("K1ABC", utc = 2000)
+        assertThat(rowAnimationKey(lower)).isEqualTo(rowAnimationKey(upper))
+    }
+
+    // ---- entry-animation bookkeeping ----------------------------------------
+
+    @Test
+    fun advanceRowAnimation_reportsOnlyKeysNotSeenBefore() {
+        val state = advanceRowAnimation(
+            previousSeen = setOf("K1ABC_1000"),
+            current = setOf("K1ABC_1000", "K2DEF_1100"),
+        )
+        assertThat(state.new).containsExactly("K2DEF_1100")
+    }
+
+    @Test
+    fun advanceRowAnimation_retainsOnlyTheVisibleKeys() {
+        // Regression: the previous union grew one entry per station per cycle and
+        // never shrank, so a screen left open for hours leaked. Retention must be
+        // bounded by what's actually on screen.
+        var seen = emptySet<String>()
+        repeat(1000) { cycle ->
+            val current = setOf("K1ABC_$cycle", "K2DEF_$cycle")
+            seen = advanceRowAnimation(seen, current).seen
+        }
+        assertThat(seen).hasSize(2)
+        assertThat(seen).containsExactly("K1ABC_999", "K2DEF_999")
+    }
+
+    @Test
+    fun advanceRowAnimation_reAnimatesAStationThatComesBack() {
+        val first = advanceRowAnimation(emptySet(), setOf("K1ABC_1000"))
+        val gone = advanceRowAnimation(first.seen, setOf("K2DEF_1100"))
+        val back = advanceRowAnimation(gone.seen, setOf("K1ABC_2000"))
+        assertThat(back.new).containsExactly("K1ABC_2000")
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
@@ -3,6 +3,7 @@ package radio.ks3ckc.ft8af.ui.decode
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -52,5 +53,27 @@ class DecodeScreenTest {
         }
 
         composeRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
+    fun sortLabel_showsActiveModeTextAndDescription() {
+        composeRule.setContent {
+            SortModeLabel(sortMode = DecodeSortMode.SNR)
+        }
+
+        composeRule.onNodeWithText(context.getString(R.string.decode_sort_label_snr))
+            .assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(context.getString(R.string.decode_sort_cd_snr))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun sortLabel_lastHeardShowsTimeLabel() {
+        composeRule.setContent {
+            SortModeLabel(sortMode = DecodeSortMode.LAST_HEARD)
+        }
+
+        composeRule.onNodeWithText(context.getString(R.string.decode_sort_label_last_heard))
+            .assertIsDisplayed()
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
@@ -68,12 +68,28 @@ class DecodeScreenTest {
     }
 
     @Test
-    fun sortLabel_lastHeardShowsTimeLabel() {
+    fun sortLabel_lastHeardShowsTimeLabelAndDescription() {
         composeRule.setContent {
             SortModeLabel(sortMode = DecodeSortMode.LAST_HEARD)
         }
 
         composeRule.onNodeWithText(context.getString(R.string.decode_sort_label_last_heard))
+            .assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(context.getString(R.string.decode_sort_cd_last_heard))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun sortLabel_callsignShowsTextAndDescription() {
+        // The third mode: without this, CALLSIGN was the one option whose label and
+        // accessibility description nothing verified.
+        composeRule.setContent {
+            SortModeLabel(sortMode = DecodeSortMode.CALLSIGN)
+        }
+
+        composeRule.onNodeWithText(context.getString(R.string.decode_sort_label_callsign))
+            .assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(context.getString(R.string.decode_sort_cd_callsign))
             .assertIsDisplayed()
     }
 }


### PR DESCRIPTION
## Summary

The decode list was **append-only** — every decode of a station added a new row, so a station heard across several cycles filled the screen with duplicate lines. This change keeps **one row per station** and updates it in place as new decodes arrive, and adds a sort control.

### What changed

- **Collapse by callsign.** New pure, unit-tested `collapseByStation(messages, sortMode)` groups the stream by `callsignFrom` and keeps the *latest* decode per station (greatest `utcTime`; later-on-tie wins). Filtering happens first, then collapse, so per-chip counts stay correct.
- **Update in place.** `LazyColumn` rows are now keyed on the callsign (stable across cycles), so Compose reuses the same row and updates its content rather than appending. The existing entry animation re-fires when a station's `utcTime` changes — that's the "row just updated" highlight cue.
- **Sort control.** A top-bar button cycles **Last heard → Callsign → SNR** (labels `TIME` / `CALL` / `SNR`, with accessibility descriptions). Persisted via `GeneralVariables.decodeSortMode` / DB key `decodeSortMode`, mirroring the existing `msgMode` / `clearDecodesEveryCycle` toggles.
- **Dividers & auto-scroll revisited.** Per-cycle time-group dividers and auto-scroll only apply in **Last heard** ordering (newest first → scroll to top). In callsign/SNR order a new station can land anywhere, so the viewport is left alone and dividers are suppressed (`showTimeGroupDividers` / `autoScrollTargetIndex` helpers).

### Design decisions / assumptions

- **Filter, then collapse** (not the reverse): a station whose *latest* decode is directed but had an earlier CQ still appears under the "CQ Calls" chip, matching operator intent and keeping counts sensible.
- **Last-heard is descending** (most recent first, per the task), so the newest station sits at the top and auto-scroll targets index 0 — a reversal from the old append-to-bottom behavior.
- Rows with a null/blank callsign are dropped (the row UI keys entirely off the callsign); in practice every decode has one.
- **"Clear every cycle"** needs no change — it wipes the source stream in `MainViewModel`, and the collapsed view derives from that.

### Tests

- `DecodeCollapseTest` — duplicate collapse (latest fields win), case-insensitive keying, later/older tie handling, each sort mode, unknown-SNR sinks last, stable ordering on ties, blank-callsign drop, empty input, config round-trip, `nextSortMode`, `showTimeGroupDividers`, `autoScrollTargetIndex`.
- `DecodeScreenTest` — renders `SortModeLabel` for each mode (text + content description).

All `:app:testDebugUnitTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)