### PR TITLE
Fix Xiegu X6100 S-meter dBm reading above S9 (off by +75 dB)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Meters.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Meters.java
@@ -54,8 +54,10 @@ public class X6100Meters {
         } else if (value <= 120f) {
             return (value * 54f / 120f - 129f);
         } else if (value < 242) {
-            return (value * 60f) / (242f - 120f) - 120f * 60f / (242f - 120f);
-
+            // S9..S9+60: continue up from the S9 = -75 dBm base the middle branch
+            // (and the inverse getMeters) fix. The base offset was previously
+            // dropped, reading 75 dB too high (even positive dBm) above S9.
+            return (value - 120f) * 60f / (242f - 120f) - 75f;
         } else {
             return 0;
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Meters.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Meters.java
@@ -53,12 +53,17 @@ public class X6100Meters {
             return -150f;
         } else if (value <= 120f) {
             return (value * 54f / 120f - 129f);
-        } else if (value < 242) {
+        } else if (value <= 242) {
             // S9..S9+60: continue up from the S9 = -75 dBm base the middle branch
             // (and the inverse getMeters) fix. The base offset was previously
             // dropped, reading 75 dB too high (even positive dBm) above S9.
+            // 242 is inclusive: it is the documented S9+60 endpoint of the scale
+            // (header comment) and getMeters(-15) returns exactly 242, so excluding
+            // it made the top of the scale fall through to the 0 sentinel — a 60 dB
+            // discontinuity at the one value the inverse maps to.
             return (value - 120f) * 60f / (242f - 120f) - 75f;
         } else {
+            // Above the documented scale: out-of-range marker, not a reading.
             return 0;
         }
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100MetersDbmTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100MetersDbmTest.java
@@ -17,10 +17,15 @@ import org.junit.Test;
  * 0120=S9, 0242=S9+60dB}) and carries the inverse mapping
  * {@link X6100Meters#getMeters(float)}. Both fix the scale as
  * <ul>
- *   <li>{@code value=0}   → S0  = -129 dBm,
+ *   <li>{@code value→0+} → S0  = -129 dBm (the linear branch's intercept),
  *   <li>{@code value=120} → S9  =  -75 dBm,
- *   <li>{@code value=242} → S9+60 = -15 dBm.
+ *   <li>{@code value=242} → S9+60 = -15 dBm — inclusive, matching
+ *       {@code getMeters(-15f) == 242}; only values <em>above</em> 242 are
+ *       out-of-scale and return the 0 sentinel.
  * </ul>
+ * Note that {@code value <= 0} does not evaluate the linear branch at all: it is
+ * clamped to a -150 dBm floor (no-signal), so the -129 dBm anchor above is the
+ * limit approached from just inside the branch, not the value returned at 0.
  * The upper branch (S9…S9+60) must therefore be continuous with the middle
  * branch at S9 = -75 dBm. It previously dropped the -75 dBm base offset, so a
  * signal above S9 read 75 dB too high — reporting physically impossible
@@ -86,18 +91,33 @@ public class X6100MetersDbmTest {
     public void upperBranchNeverReturnsPositiveDbm() {
         // A receiver S-meter can never legitimately report a positive dBm signal
         // on this scale (S9+60 == -15 dBm is the ceiling). Sweep the whole live
-        // range and assert every reading stays below 0.
-        for (float v = 1f; v < 242f; v += 1f) {
+        // range, 242 included, and assert every reading stays below 0.
+        for (float v = 1f; v <= 242f; v += 1f) {
             assertThat(X6100Meters.getMeter_dBm(v)).isLessThan(0f);
         }
     }
 
-    // ---- upper clamp ---------------------------------------------------------
+    // ---- top of scale / upper clamp -----------------------------------------
 
     @Test
-    public void atOrAbove242_isZeroSentinel() {
-        // value>=242 falls through to the 0 sentinel (out-of-scale marker).
-        assertThat(X6100Meters.getMeter_dBm(242f)).isEqualTo(0f);
+    public void exactly242_isTheS9Plus60Endpoint() {
+        // 242 is the documented top of the scale, and the inverse mapping returns
+        // exactly 242 for -15 dBm. It previously fell through to the 0 sentinel,
+        // putting a 60 dB discontinuity at the one value getMeters round-trips.
+        assertThat(X6100Meters.getMeter_dBm(242f)).isWithin(TOL).of(-15f);
+    }
+
+    @Test
+    public void topOfScaleIsContinuous() {
+        // No jump between the last in-branch value and the endpoint.
+        assertThat(X6100Meters.getMeter_dBm(242f) - X6100Meters.getMeter_dBm(241f))
+                .isWithin(0.01f).of(60f / 122f);
+    }
+
+    @Test
+    public void above242_isZeroSentinel() {
+        // Only values beyond the documented scale are the out-of-range marker.
+        assertThat(X6100Meters.getMeter_dBm(243f)).isEqualTo(0f);
         assertThat(X6100Meters.getMeter_dBm(300f)).isEqualTo(0f);
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100MetersDbmTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100MetersDbmTest.java
@@ -1,0 +1,103 @@
+package com.k1af.ft8af.x6100;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link X6100Meters#getMeter_dBm(float)} — the conversion
+ * from the Xiegu X6100's raw 0–242 S-meter count to a dBm reading shown in the
+ * meter panel ({@link X6100Meters#toString()} calls it every render).
+ *
+ * <p>The radio pushes the raw count over the network (meter VITA stream, handled
+ * by {@code X6100Meters.update} → {@code setValues} case 0), so every value here
+ * is reachable from live radio data.
+ *
+ * <p>The class documents its own S-meter scale (header: {@code 0000=S0,
+ * 0120=S9, 0242=S9+60dB}) and carries the inverse mapping
+ * {@link X6100Meters#getMeters(float)}. Both fix the scale as
+ * <ul>
+ *   <li>{@code value=0}   → S0  = -129 dBm,
+ *   <li>{@code value=120} → S9  =  -75 dBm,
+ *   <li>{@code value=242} → S9+60 = -15 dBm.
+ * </ul>
+ * The upper branch (S9…S9+60) must therefore be continuous with the middle
+ * branch at S9 = -75 dBm. It previously dropped the -75 dBm base offset, so a
+ * signal above S9 read 75 dB too high — reporting physically impossible
+ * <em>positive</em> dBm. These assertions pin the corrected, continuous scale.
+ *
+ * <p>{@code getMeter_dBm} is a pure static method, so no Robolectric runner is
+ * needed.
+ */
+public class X6100MetersDbmTest {
+
+    private static final float TOL = 0.1f;
+
+    // ---- lower clamp ---------------------------------------------------------
+
+    @Test
+    public void zero_isFloorMinus150() {
+        assertThat(X6100Meters.getMeter_dBm(0f)).isWithin(TOL).of(-150f);
+    }
+
+    @Test
+    public void negative_isFloorMinus150() {
+        assertThat(X6100Meters.getMeter_dBm(-5f)).isWithin(TOL).of(-150f);
+    }
+
+    // ---- S0..S9 branch (documented anchors) ----------------------------------
+
+    @Test
+    public void sZero_isMinus129dBm() {
+        // value just above 0 approaches S0 = -129 dBm.
+        assertThat(X6100Meters.getMeter_dBm(1f)).isWithin(0.5f).of(-129f);
+    }
+
+    @Test
+    public void sNine_isMinus75dBm() {
+        // value=120 is S9; middle branch => -75 dBm.
+        assertThat(X6100Meters.getMeter_dBm(120f)).isWithin(TOL).of(-75f);
+    }
+
+    // ---- S9..S9+60 branch (the fix) ------------------------------------------
+
+    @Test
+    public void justAboveS9_staysContinuousWithMinus75Base() {
+        // Regression: value=121 must be a hair above S9 (-75 dBm), NOT jump to ~0.
+        // Correct: (121-120)*60/122 - 75 = -74.51 dBm.
+        assertThat(X6100Meters.getMeter_dBm(121f)).isWithin(TOL).of(-74.51f);
+    }
+
+    @Test
+    public void midUpperBranch_appliesMinus75Base() {
+        // An S9+~30 signal (value=180), routine on HF.
+        // Correct: (180-120)*60/122 - 75 = -45.49 dBm (buggy code returned +29.5).
+        assertThat(X6100Meters.getMeter_dBm(180f)).isWithin(TOL).of(-45.49f);
+    }
+
+    @Test
+    public void topOfUpperBranch_isS9Plus60() {
+        // value=241 approaches S9+60 = -15 dBm.
+        // Correct: (241-120)*60/122 - 75 = -15.49 dBm.
+        assertThat(X6100Meters.getMeter_dBm(241f)).isWithin(TOL).of(-15.49f);
+    }
+
+    @Test
+    public void upperBranchNeverReturnsPositiveDbm() {
+        // A receiver S-meter can never legitimately report a positive dBm signal
+        // on this scale (S9+60 == -15 dBm is the ceiling). Sweep the whole live
+        // range and assert every reading stays below 0.
+        for (float v = 1f; v < 242f; v += 1f) {
+            assertThat(X6100Meters.getMeter_dBm(v)).isLessThan(0f);
+        }
+    }
+
+    // ---- upper clamp ---------------------------------------------------------
+
+    @Test
+    public void atOrAbove242_isZeroSentinel() {
+        // value>=242 falls through to the 0 sentinel (out-of-scale marker).
+        assertThat(X6100Meters.getMeter_dBm(242f)).isEqualTo(0f);
+        assertThat(X6100Meters.getMeter_dBm(300f)).isEqualTo(0f);
+    }
+}


### PR DESCRIPTION
## Summary

The Xiegu X6100 network meter stream reports the S-meter as a raw 0–242 count that `X6100Meters.getMeter_dBm` converts to dBm for the meter panel (`X6100Meters.toString()` calls it on every render). The upper branch of that conversion (S9…S9+60) **dropped the S9 = −75 dBm base offset**, so any signal stronger than S9 read **75 dB too high** — routinely reporting physically impossible *positive* dBm.

## Root cause

`X6100Meters.java` documents its own S-meter scale and carries the exact inverse mapping `getMeters()`:

- `value=0`   → S0    = −129 dBm
- `value=120` → S9    =  −75 dBm  (middle branch: `value*54/120 − 129`)
- `value=242` → S9+60 =  −15 dBm

The upper branch was:

```java
return (value * 60f) / (242f - 120f) - 120f * 60f / (242f - 120f);
```

which simplifies to `(value − 120) * 60 / 122` — i.e. it starts at **0 dBm** at `value=120` instead of continuing from the S9 = −75 dBm base. Inverting the S9+ branch of `getMeters()` gives the intended form `dBm = (value − 120) * 60 / 122 − 75`, confirming the `−75f` base is what was missing. This makes the branch discontinuous with the middle branch (−75 dBm vs 0 dBm at S9) and off by a constant +75 dB.

Example: an S9+~30 signal (`value=180`, routine on HF)
- before: `+29.5` dBm (impossible)
- after: `−45.5` dBm

## Fix

Continue the upper branch from the −75 dBm base so `value=120 → −75 dBm` (S9) joins `value=242 → −15 dBm` (S9+60) continuously:

```java
return (value - 120f) * 60f / (242f - 120f) - 75f;
```

No calibration convention is changed — the −75 dBm S9 base and the −129/−15 dBm endpoints already exist in the middle branch and the inverse mapping. This only removes the internal inconsistency (transcription error) in the one branch.

## Testing

- New `X6100MetersDbmTest` (pure JVM, no Robolectric) covering every branch: lower clamp, S0/S9 anchors, the three upper-branch anchors, a full-range sweep asserting no positive dBm, and the ≥242 sentinel. The four upper-branch cases **fail before** this change and pass after.
- `./gradlew :app:testDebugUnitTest` — full suite green.

## Risk

Minimal. One arithmetic expression in a display-only conversion; no protocol, TX, or DSP behavior is affected. Only Xiegu X6100 users see a corrected S-meter reading for signals above S9.