### PR TITLE
Fix dropped DXpedition Fox decodes: guard MessageHashMap.addHash against empty/null callsign

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MessageHashMap.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MessageHashMap.java
@@ -20,8 +20,17 @@ public class MessageHashMap extends HashMap<Long,String> {
      * @return false means it already exists
      */
     public synchronized void addHash(long hashCode, String callsign) {
-        //if (callsign.length()<2){return;}
-        //if (){return;}
+        // A null or empty callsign is never a real call to hash. It reaches here
+        // from the Ft8Message copy-constructor for a DXpedition (Fox/Hound)
+        // decode, which sets callsignFrom="" while still carrying a non-zero
+        // call-from hash (derived from the invited callsign) — so the hashCode==0
+        // short-circuit below does NOT catch it, and callsign.charAt(0) would
+        // throw StringIndexOutOfBoundsException (empty) or callsign.equals(...)
+        // an NPE (null). That exception fired inside the decode loop's try/catch
+        // and silently dropped the whole Fox message.
+        if (callsign == null || callsign.isEmpty()) {
+            return;
+        }
         if (callsign.equals("CQ")||callsign.equals("QRZ")||callsign.equals("DE")){
             return;
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MessageHashMap.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MessageHashMap.java
@@ -13,11 +13,15 @@ public class MessageHashMap extends HashMap<Long,String> {
     private static final String TAG = "MessageHashMap";
 
     /**
-     * Add a callsign and its hash code to the list
+     * Add a callsign and its hash code to the list.
+     *
+     * <p>Silently ignores anything that is not a real call to hash: a null/empty
+     * callsign, the CQ/QRZ/DE tokens, an already-stored hash, a zero hash, or a
+     * still-unresolved {@code <...>} placeholder. There is no return value —
+     * callers cannot distinguish "added" from "skipped".
      *
      * @param hashCode hash code
      * @param callsign callsign
-     * @return false means it already exists
      */
     public synchronized void addHash(long hashCode, String callsign) {
         // A null or empty callsign is never a real call to hash. It reaches here

--- a/ft8af/app/src/test/java/com/k1af/ft8af/MessageHashMapTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/MessageHashMapTest.java
@@ -72,4 +72,28 @@ public class MessageHashMapTest {
         map.addHash(0x10L, "K1ABC");
         assertThat(map.getCallsign(new long[]{1L, 2L, 3L})).isEqualTo("<...>");
     }
+
+    @Test
+    public void addHash_emptyCallsignWithNonZeroHash_isIgnoredNotCrash() {
+        // Regression: a DXpedition (Fox/Hound) decode leaves callsignFrom = ""
+        // yet carries a non-zero call-from hash (derived from the invited call),
+        // so the zero-hash short-circuit does NOT fire and addHash reached
+        // "".charAt(0) -> StringIndexOutOfBoundsException. That threw inside the
+        // decode loop's try/catch, silently dropping the whole Fox message.
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(0xABCDL, "");
+        // No crash, and an empty callsign is never stored.
+        assertThat(map.checkHash(0xABCDL)).isFalse();
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    public void addHash_nullCallsign_isIgnoredNotCrash() {
+        // Ft8Message.extraInfo/callsign defaults are null; a null callsign must
+        // not NPE at the reserved-callsign equals() check either.
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(0x1234L, null);
+        assertThat(map.checkHash(0x1234L)).isFalse();
+        assertThat(map).isEmpty();
+    }
 }


### PR DESCRIPTION
## Root cause

A DXpedition (Fox/Hound) FT8 decode is the one message type that leaves a callsign field **empty while its hash is non-zero**. In `ft8_decode_jni.cpp` (`FTX_MESSAGE_TYPE_DXPEDITION`) the native decoder sets:

```cpp
ft8_set_string(env, ft8Message, FF8.callsignFrom, "");                 // empty
ft8_set_call_hashes(env, ft8Message, call_de, FF8.callFromHash10,      // non-zero
                    FF8.callFromHash12, FF8.callFromHash22);           // (from the invited call)
```

Every decoded frame is copied via the `Ft8Message` copy-constructor (`Ft8Message.java:196-201`), which feeds each callsign+hash pair into `MessageHashMap.addHash`:

```java
hashList.addHash(callFromHash22, callsignFrom); // addHash(<non-zero>, "")
```

Because the hash is non-zero, the `hashCode == 0` short-circuit in `addHash` does **not** fire, so execution reaches:

```java
if (hashCode == 0 || checkHash(hashCode) || callsign.charAt(0) == '<') // "".charAt(0)
```

`"".charAt(0)` throws `StringIndexOutOfBoundsException` (and a null callsign would NPE one line earlier at `callsign.equals("CQ")`). The copy-constructor runs inside `FT8SignalListener`'s per-candidate `try/catch` (`:396-419`), so the exception is swallowed and the **entire Fox message is dropped before it is added to the decode list** — Hound operators working a DXpedition never see the Fox's transmissions.

The `length()`-guard that would have prevented this was present but commented out.

## Fix

Guard null/empty at the top of `addHash` (restoring the intent of the commented-out check):

```java
if (callsign == null || callsign.isEmpty()) {
    return;
}
```

An empty or null string is never a real callsign to hash, so nothing of value is lost, and behaviour is **byte-for-byte unchanged for every valid callsign** (the reserved-callsign / zero-hash / placeholder guards below are untouched).

## Testing

- Added two regression tests to `MessageHashMapTest` — `addHash_emptyCallsignWithNonZeroHash_isIgnoredNotCrash` (the exact DXpedition trigger) and `addHash_nullCallsign_isIgnoredNotCrash`. Both **fail before the fix** (SIOOBE / NPE) and pass after.
- Full `:app:testDebugUnitTest` suite passes (no regressions).
- Pure-JVM test (no Robolectric needed — the guarded paths return before any `android.util.Log` call).

## Risk

Minimal. One localized null/empty guard on a single method; no protocol, DSP, native, or threading change. Only previously-crashing inputs (empty/null callsign) change behaviour, from "throw + drop the message" to "skip storing the hash".

## Affected platforms

Android (all). No native changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)