### PR TITLE
Fix garbled Icom Wi-Fi TX from a shared, concurrently-run audio Runnable

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomAudioUdp.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomAudioUdp.java
@@ -42,11 +42,10 @@ public class IcomAudioUdp extends AudioUdp {
     public void sendTxAudioData(float[] audioData) {
         if (audioData==null) return;
 
-        //Incoming audio is LPCM, 32-bit float, 12000Hz
-        //iCOM audio format is LPCM 16-bit Int, 12000Hz
-        //Need to convert from float to 16-bit int
-        short[] temp = floatToPcm16(audioData);
-
+        // Claim the transmit slot BEFORE converting. The conversion allocates a
+        // short[] the length of a full ~12.6 s FT8 buffer and walks every sample;
+        // doing it first meant an overlapping TX — the exact case this guard exists
+        // for — paid that cost only to throw the result away.
         if (!transmitting.compareAndSet(false, true)) {
             // A transmission is already running on the pool. Starting another here
             // would run a concurrent DoTXAudioRunnable that interleaves PCM on the
@@ -54,7 +53,32 @@ public class IcomAudioUdp extends AudioUdp {
             Log.w(TAG, "sendTxAudioData: transmit already in progress, dropping overlapping request");
             return;
         }
+
+        //Incoming audio is LPCM, 32-bit float, 12000Hz
+        //iCOM audio format is LPCM 16-bit Int, 12000Hz
+        //Need to convert from float to 16-bit int
+        short[] temp;
+        try {
+            temp = convertForTransmit(audioData);
+        } catch (RuntimeException | Error e) {
+            // We hold the guard and never submitted, so release it here — a latched
+            // guard would block every future transmission for the process lifetime.
+            // (Deliberately not a finally around submitTransmit: that already
+            // releases on a pool rejection, and re-clearing afterwards could clear a
+            // guard a different thread had since claimed.)
+            transmitting.set(false);
+            throw e;
+        }
         submitTransmit(temp);
+    }
+
+    /**
+     * Instance seam over {@link #floatToPcm16} so tests can observe whether the
+     * conversion ran at all (an overlapping request must be dropped before paying
+     * for it) — same pattern as {@link #submitTransmit}.
+     */
+    short[] convertForTransmit(float[] audioData) {
+        return floatToPcm16(audioData);
     }
 
     /**
@@ -105,7 +129,10 @@ public class IcomAudioUdp extends AudioUdp {
                 if (audioData == null) return;
 
                 final int partialLen = IComPacketTypes.TX_BUFFER_SIZE * 2;//Packet data length
-                //Convert to BYTE, little-endian
+                // Samples go out little-endian (low byte first), which is what the
+                // helper below emits despite being named shortToBigEndian — see its
+                // Javadoc in IComPacketTypes. Don't "fix" the byte order to match the
+                // name; the wire format is little-endian.
 
                 //byte[] data = new byte[audioData.length * 2 + partialLen * 4];//Extra silence padding: 20ms*2 = 80ms total before and after
                 //Play silence first before audio; the for-i loop handles leading silence, the for-j loop handles trailing silence

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomAudioUdp.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomAudioUdp.java
@@ -8,85 +8,140 @@ package com.k1af.ft8af.icom;
 import android.util.Log;
 
 import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.concurrent.SafeExecutor;
 
 import java.net.DatagramPacket;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class IcomAudioUdp extends AudioUdp {
     private static final String TAG = "IcomAudioUdp";
 
 
     private final ExecutorService doTXThreadPool =Executors.newCachedThreadPool();
-    private final DoTXAudioRunnable doTXAudioRunnable=new DoTXAudioRunnable(this);
+
+    /**
+     * Guards against overlapping transmissions. Each {@link #sendTxAudioData} call
+     * used to mutate the {@code audioData} field of a single shared
+     * {@link DoTXAudioRunnable} and re-{@code execute()} that same instance on the
+     * cached pool. A second TX (or Tune) firing before the first ~12.6&nbsp;s run
+     * finished then ran the <em>same</em> Runnable on two pool threads at once —
+     * stomping the shared PCM buffer mid-transmission and racing the unsynchronised
+     * {@code innerSeq} increment, producing duplicated/garbled Icom-over-Wi-Fi audio
+     * and a desynced packet sequence. We now snapshot the PCM per call and refuse a
+     * new submission while one is in flight.
+     *
+     * <p>Package-private so unit tests can observe/reset the guard.
+     */
+    final AtomicBoolean transmitting = new AtomicBoolean(false);
 
 
     @Override
     public void sendTxAudioData(float[] audioData) {
         if (audioData==null) return;
 
-        short[] temp=new short[audioData.length];
         //Incoming audio is LPCM, 32-bit float, 12000Hz
         //iCOM audio format is LPCM 16-bit Int, 12000Hz
         //Need to convert from float to 16-bit int
+        short[] temp = floatToPcm16(audioData);
+
+        if (!transmitting.compareAndSet(false, true)) {
+            // A transmission is already running on the pool. Starting another here
+            // would run a concurrent DoTXAudioRunnable that interleaves PCM on the
+            // shared socket and races innerSeq. Drop the overlapping request.
+            Log.w(TAG, "sendTxAudioData: transmit already in progress, dropping overlapping request");
+            return;
+        }
+        submitTransmit(temp);
+    }
+
+    /**
+     * Convert incoming LPCM 32-bit float samples ([-1.0, 1.0]) to LPCM 16-bit int.
+     * Out-of-range samples are clamped before scaling, matching the original
+     * inline conversion exactly.
+     */
+    static short[] floatToPcm16(float[] audioData) {
+        short[] temp = new short[audioData.length];
         for (int i = 0; i < audioData.length; i++) {
             float x = audioData[i];
             if (x > 1.0)
                 x = 1.0f;
             else if (x < -1.0)
                 x = -1.0f;
-            temp[i] = (short)  (x * 32767.0);
+            temp[i] = (short) (x * 32767.0);
         }
-        doTXAudioRunnable.audioData=temp;
-        doTXThreadPool.execute(doTXAudioRunnable);
+        return temp;
     }
-    private static class DoTXAudioRunnable implements Runnable{
-        IcomAudioUdp icomAudioUdp;
-        short[] audioData;//Incoming audio is LPCM 16-bit Int, 12000Hz
 
-        public DoTXAudioRunnable(IcomAudioUdp icomAudioUdp) {
+    /**
+     * Submit a fresh {@link DoTXAudioRunnable} for {@code pcm}. Each call gets its
+     * own runnable holding an immutable snapshot, so there is no shared mutable
+     * state between transmissions. If the pool rejects the task (shutdown race) the
+     * transmit guard is released so a later TX can still start.
+     *
+     * <p>Package-private and overridable so unit tests can observe submissions
+     * without a live socket.
+     */
+    void submitTransmit(short[] pcm) {
+        if (!SafeExecutor.tryExecute(doTXThreadPool, new DoTXAudioRunnable(this, pcm))) {
+            transmitting.set(false);
+        }
+    }
+
+    private static class DoTXAudioRunnable implements Runnable{
+        final IcomAudioUdp icomAudioUdp;
+        final short[] audioData;//Incoming audio is LPCM 16-bit Int, 12000Hz
+
+        public DoTXAudioRunnable(IcomAudioUdp icomAudioUdp, short[] audioData) {
             this.icomAudioUdp = icomAudioUdp;
+            this.audioData = audioData;
         }
 
         @Override
         public void run() {
-            if (audioData==null) return;
+            try {
+                if (audioData == null) return;
 
-            final int partialLen = IComPacketTypes.TX_BUFFER_SIZE * 2;//Packet data length
-            //Convert to BYTE, little-endian
+                final int partialLen = IComPacketTypes.TX_BUFFER_SIZE * 2;//Packet data length
+                //Convert to BYTE, little-endian
 
-            //byte[] data = new byte[audioData.length * 2 + partialLen * 4];//Extra silence padding: 20ms*2 = 80ms total before and after
-            //Play silence first before audio; the for-i loop handles leading silence, the for-j loop handles trailing silence
-            byte[] audioPacket = new byte[partialLen];
-            for (int i = 0; i < (audioData.length / IComPacketTypes.TX_BUFFER_SIZE) + 8; i++) {//6 extra cycles: 3 before, 3 after
-                if (!icomAudioUdp.isPttOn) break;
-                long now = System.currentTimeMillis() - 1;//Get current time
+                //byte[] data = new byte[audioData.length * 2 + partialLen * 4];//Extra silence padding: 20ms*2 = 80ms total before and after
+                //Play silence first before audio; the for-i loop handles leading silence, the for-j loop handles trailing silence
+                byte[] audioPacket = new byte[partialLen];
+                for (int i = 0; i < (audioData.length / IComPacketTypes.TX_BUFFER_SIZE) + 8; i++) {//6 extra cycles: 3 before, 3 after
+                    if (!icomAudioUdp.isPttOn) break;
+                    long now = System.currentTimeMillis() - 1;//Get current time
 
-                icomAudioUdp.sendTrackedPacket(IComPacketTypes.AudioPacket.getTxAudioPacket(audioPacket
-                        , (short) 0, icomAudioUdp.localId, icomAudioUdp.remoteId, icomAudioUdp.innerSeq));
-                icomAudioUdp.innerSeq++;
+                    icomAudioUdp.sendTrackedPacket(IComPacketTypes.AudioPacket.getTxAudioPacket(audioPacket
+                            , (short) 0, icomAudioUdp.localId, icomAudioUdp.remoteId, icomAudioUdp.innerSeq));
+                    icomAudioUdp.innerSeq++;
 
-                Arrays.fill(audioPacket,(byte)0x00);
-                if (i>=3) {//Let the first two empty packets be sent out
-                    for (int j = 0; j < IComPacketTypes.TX_BUFFER_SIZE; j++) {
-                        if ((i-3) * IComPacketTypes.TX_BUFFER_SIZE + j < audioData.length) {
-                            System.arraycopy(IComPacketTypes.shortToBigEndian((short)
-                                            (audioData[(i-3) * IComPacketTypes.TX_BUFFER_SIZE + j]
-                                                    * GeneralVariables.volumePercent))//Multiply by volume ratio
-                                    , 0, audioPacket, j * 2, 2);
+                    Arrays.fill(audioPacket, (byte) 0x00);
+                    if (i >= 3) {//Let the first two empty packets be sent out
+                        for (int j = 0; j < IComPacketTypes.TX_BUFFER_SIZE; j++) {
+                            if ((i - 3) * IComPacketTypes.TX_BUFFER_SIZE + j < audioData.length) {
+                                System.arraycopy(IComPacketTypes.shortToBigEndian((short)
+                                                (audioData[(i - 3) * IComPacketTypes.TX_BUFFER_SIZE + j]
+                                                        * GeneralVariables.volumePercent))//Multiply by volume ratio
+                                        , 0, audioPacket, j * 2, 2);
+                            }
+                        }
+                    }
+                    while (icomAudioUdp.isPttOn) {
+                        if (System.currentTimeMillis() - now >= 21) {//20ms per cycle
+                            break;
                         }
                     }
                 }
-                while (icomAudioUdp.isPttOn) {
-                    if (System.currentTimeMillis() - now >= 21) {//20ms per cycle
-                        break;
-                    }
-                }
+                Log.d(TAG, "run: Audio transmission complete!!");
+            } finally {
+                // Always release the guard, even if PTT dropped early or a send threw,
+                // so the next TX cycle can start. (Previously the shared runnable also
+                // wrongly left the pooled worker's interrupt flag set here.)
+                icomAudioUdp.transmitting.set(false);
             }
-            Log.d(TAG, "run: Audio transmission complete!!" );
-            Thread.currentThread().interrupt();
         }
 
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomAudioUdpTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomAudioUdpTest.java
@@ -36,6 +36,25 @@ public class IcomAudioUdpTest {
         }
     }
 
+    /**
+     * Adds a count of how many times the PCM conversion actually ran, so the tests
+     * can pin that an overlapping (dropped) request never pays for it, and can force
+     * the conversion to fail.
+     */
+    private static class CountingIcomAudioUdp extends RecordingIcomAudioUdp {
+        int conversions = 0;
+        Error conversionFailure = null;
+
+        @Override
+        short[] convertForTransmit(float[] audioData) {
+            conversions++;
+            if (conversionFailure != null) {
+                throw conversionFailure;
+            }
+            return super.convertForTransmit(audioData);
+        }
+    }
+
     // ---- floatToPcm16 conversion ----
 
     @Test
@@ -77,6 +96,51 @@ public class IcomAudioUdpTest {
         rig.transmitting.set(false);
         rig.sendTxAudioData(new float[10]);
         assertThat(rig.submitted).hasSize(2);
+    }
+
+    @Test
+    public void sendTxAudioData_droppedRequestSkipsTheConversionEntirely() {
+        // The guard is claimed before the PCM conversion, so an overlapping request
+        // costs nothing: no full-buffer short[] allocation and no per-sample loop for
+        // audio that is about to be thrown away.
+        CountingIcomAudioUdp rig = new CountingIcomAudioUdp();
+
+        rig.sendTxAudioData(new float[10]);   // claims the guard, converts once
+        assertThat(rig.conversions).isEqualTo(1);
+        assertThat(rig.transmitting.get()).isTrue();
+
+        rig.sendTxAudioData(new float[10]);   // overlapping: dropped before converting
+        assertThat(rig.submitted).hasSize(1);
+        assertThat(rig.conversions).isEqualTo(1);
+
+        // ...and once the slot frees up, the next TX converts again as normal.
+        rig.transmitting.set(false);
+        rig.sendTxAudioData(new float[10]);
+        assertThat(rig.conversions).isEqualTo(2);
+    }
+
+    @Test
+    public void sendTxAudioData_conversionFailureReleasesTheGuard() {
+        // If the conversion blows up (OOM on the ~12.6 s buffer is the realistic
+        // case) we still hold the guard and never submitted. Leaving it latched
+        // would block every future transmission for the life of the process.
+        CountingIcomAudioUdp rig = new CountingIcomAudioUdp();
+        rig.conversionFailure = new OutOfMemoryError("simulated");
+
+        try {
+            rig.sendTxAudioData(new float[10]);
+            throw new AssertionError("expected the conversion failure to propagate");
+        } catch (OutOfMemoryError expected) {
+            // propagated to the caller, as before
+        }
+
+        assertThat(rig.submitted).isEmpty();
+        assertThat(rig.transmitting.get()).isFalse();
+
+        // A later TX still works.
+        rig.conversionFailure = null;
+        rig.sendTxAudioData(new float[10]);
+        assertThat(rig.submitted).hasSize(1);
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomAudioUdpTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/IcomAudioUdpTest.java
@@ -1,0 +1,122 @@
+package com.k1af.ft8af.icom;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regression coverage for {@link IcomAudioUdp}'s TX-audio path.
+ *
+ * <p>The old code held a single shared {@code DoTXAudioRunnable}, mutated its
+ * {@code audioData} field on every {@link IcomAudioUdp#sendTxAudioData} call, and
+ * re-{@code execute()}d that same instance on a cached thread pool. A second TX (or
+ * Tune) firing before the first ~12.6&nbsp;s run finished ran the <em>same</em>
+ * Runnable on two pool threads concurrently — stomping the shared PCM buffer and
+ * racing the unsynchronised {@code innerSeq}, garbling Icom-over-Wi-Fi audio. It also
+ * left the pooled worker's interrupt flag set on exit.
+ *
+ * <p>The fix snapshots PCM per call into a fresh runnable and guards with an
+ * {@code AtomicBoolean} so an overlapping submission is dropped instead of racing.
+ * These tests drive the {@code submitTransmit} seam and the guard directly — no
+ * socket, plain JUnit + Truth (the only Android type touched is {@code Log}, stubbed
+ * via {@code returnDefaultValues}).
+ */
+public class IcomAudioUdpTest {
+
+    /** Captures submissions instead of running them, so the guard stays "in flight". */
+    private static class RecordingIcomAudioUdp extends IcomAudioUdp {
+        final List<short[]> submitted = new ArrayList<>();
+
+        @Override
+        void submitTransmit(short[] pcm) {
+            submitted.add(pcm);
+        }
+    }
+
+    // ---- floatToPcm16 conversion ----
+
+    @Test
+    public void floatToPcm16_clampsAndScales() {
+        short[] out = IcomAudioUdp.floatToPcm16(new float[] {0f, 1.0f, -1.0f, 0.5f, 2.0f, -3.0f});
+
+        assertThat(out.length).isEqualTo(6);
+        assertThat(out[0]).isEqualTo((short) 0);
+        assertThat(out[1]).isEqualTo((short) 32767);     // +full scale
+        assertThat(out[2]).isEqualTo((short) -32767);    // -full scale (clamped to -1.0)
+        assertThat(out[3]).isEqualTo((short) 16383);     // 0.5 * 32767 truncated
+        assertThat(out[4]).isEqualTo((short) 32767);     // >1.0 clamped, not overflowed
+        assertThat(out[5]).isEqualTo((short) -32767);    // <-1.0 clamped, not overflowed
+    }
+
+    @Test
+    public void floatToPcm16_emptyInput_returnsEmpty() {
+        assertThat(IcomAudioUdp.floatToPcm16(new float[0])).hasLength(0);
+    }
+
+    // ---- overlap guard ----
+
+    @Test
+    public void sendTxAudioData_dropsOverlappingRequestWhileTransmitting() {
+        RecordingIcomAudioUdp rig = new RecordingIcomAudioUdp();
+
+        rig.sendTxAudioData(new float[10]);
+        // First call acquired the guard and submitted exactly one transmission.
+        assertThat(rig.submitted).hasSize(1);
+        assertThat(rig.transmitting.get()).isTrue();
+        assertThat(rig.submitted.get(0)).hasLength(10);
+
+        // A second call while the first is still "in flight" must be dropped — not
+        // submitted as a concurrent runnable that would garble the shared stream.
+        rig.sendTxAudioData(new float[10]);
+        assertThat(rig.submitted).hasSize(1);
+
+        // Once the running transmission releases the guard, the next TX starts again.
+        rig.transmitting.set(false);
+        rig.sendTxAudioData(new float[10]);
+        assertThat(rig.submitted).hasSize(2);
+    }
+
+    @Test
+    public void sendTxAudioData_nullAudio_isNoOpAndLeavesGuardFree() {
+        RecordingIcomAudioUdp rig = new RecordingIcomAudioUdp();
+
+        rig.sendTxAudioData(null);
+
+        assertThat(rig.submitted).isEmpty();
+        assertThat(rig.transmitting.get()).isFalse();
+    }
+
+    @Test
+    public void sendTxAudioData_dropDoesNotAdvanceSequence() {
+        RecordingIcomAudioUdp rig = new RecordingIcomAudioUdp();
+        short seqBefore = rig.innerSeq;
+
+        rig.sendTxAudioData(new float[10]);   // acquires guard, no packets sent by the stub
+        rig.sendTxAudioData(new float[10]);   // dropped
+
+        // Neither the acquired-but-stubbed submit nor the dropped call touches innerSeq.
+        assertThat(rig.innerSeq).isEqualTo(seqBefore);
+    }
+
+    // ---- guard is released when the real transmission finishes ----
+
+    @Test
+    public void realRun_releasesGuardWhenPttOff() throws Exception {
+        // Use the real submitTransmit + cached pool. With PTT off, the runnable's
+        // for-loop breaks before any sendTrackedPacket (so no socket is needed) and
+        // the finally block must clear the guard so a later TX can start.
+        IcomAudioUdp rig = new IcomAudioUdp();
+        rig.isPttOn = false;
+
+        rig.sendTxAudioData(new float[240]);
+
+        long deadline = System.currentTimeMillis() + 2000;
+        while (rig.transmitting.get() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(5);
+        }
+        assertThat(rig.transmitting.get()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`IcomAudioUdp` transmits FT8 audio to a Wi-Fi Icom rig by reusing **one**
`DoTXAudioRunnable` instance: `sendTxAudioData()` overwrites its `audioData`
field and re-`execute()`s that same object on a cached thread pool. Each `run()`
loops the full ~12.6&nbsp;s transmission while reading the shared `audioData` and
mutating the unsynchronised `innerSeq`.

If a second TX (or a Tune) fires before the first run finishes, the **same
Runnable runs on two pool threads at once** — the PCM buffer is stomped
mid-transmission and the packet sequence number races. The rig keys and audio is
audible, but it's duplicated/garbled and never decodes. `run()` also ended with
`Thread.currentThread().interrupt()`, leaving the pooled worker's interrupt flag
set for whatever task borrowed that thread next.

## Root cause

Mutable state — the audio buffer and `innerSeq` — shared across overlapping
executions of a single reused `Runnable`, with no guard against concurrent
starts. The sibling `XieGuAudioUdp` had already been reworked away from this
shared-mutable-Runnable pattern; the Icom path was left behind.

## Fix

Smallest safe change that keeps the existing per-TX one-shot model:

- **Snapshot PCM per call** into a fresh `DoTXAudioRunnable` (immutable
  per-transmission buffer), via an extracted `floatToPcm16()` helper. The
  conversion is byte-for-byte identical to the old inline code, so TX output /
  WSJT-X interop is unchanged.
- **Guard concurrent starts** with an `AtomicBoolean`: while a transmission is in
  flight an overlapping `sendTxAudioData()` is dropped rather than racing. The
  guard is released in `run()`'s `finally` (so the next cycle always starts) and
  also if the pool rejects the submission during a shutdown race
  (`SafeExecutor.tryExecute`).
- **Remove** the erroneous `Thread.currentThread().interrupt()` on the pooled
  worker.

## Testing

New pure-JVM `IcomAudioUdpTest`:
- `floatToPcm16` clamping/scaling (incl. out-of-range and empty input)
- overlap-drop guard — **fails against the un-guarded code, passes with the fix**
- null-audio no-op leaves the guard free
- a dropped overlapping call does not advance `innerSeq`
- the real runnable releases the guard when PTT is off (deterministic, no socket)

`./gradlew :app:testDebugUnitTest` — full suite green.

## Risk assessment

Low. No protocol/DSP change (PCM conversion is identical). Behaviour differs only
in the previously-broken overlapping-TX case, which is now dropped instead of
garbling the stream. Icom-Wi-Fi TX path only; RX and other rigs untouched. No
device was available to verify on real hardware — validated via unit tests and
by mirroring the already-proven `XieGuAudioUdp` ownership model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)