### PR TITLE
Fix Kenwood TS-590/570/2000 SWR/ALC meter read at the wrong byte offset

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
@@ -141,11 +141,15 @@ public class Yaesu3Command {
 
     public static boolean is590MeterALC(Yaesu3Command command){
         if (command.data.length() < 5) return false;
-        return command.data.charAt(2) == '3';
+        // Kenwood "RM" reply is "mvvvv": meter-type selector at index 0
+        // (3 = ALC), 4-digit value at indices 1..4. Reading the selector at
+        // index 2 (a value digit) mis-detected the meter type -- see get590ALCOrSWR.
+        return command.data.charAt(0) == '3';
     }
     public static boolean is590MeterSWR(Yaesu3Command command){
         if (command.data.length() < 5) return false;
-        return command.data.charAt(2) == '1';
+        // Meter-type selector is at index 0 (1 = SWR); see is590MeterALC.
+        return command.data.charAt(0) == '1';
     }
 
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatMeterParserTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatMeterParserTest.java
@@ -85,6 +85,56 @@ public class CatMeterParserTest {
         assertThat(Yaesu3Command.get590ALCOrSWR(c)).isEqualTo(0);
     }
 
+    // ---- Yaesu3Command.is590MeterSWR / is590MeterALC (Kenwood TS-590/2000/570) ----
+    //
+    // The Kenwood "RM" (read-meter) reply is "RM P1 P2;": after the "RM" command
+    // id is stripped, data = "mvvvv" where P1 (index 0) is the meter-type selector
+    // (1 = SWR, 3 = ALC) and P2 (indices 1..4) is the 4-digit value. The value
+    // extractor get590ALCOrSWR already reads substring(1,5), so the type selector
+    // is data.charAt(0) -- matching the sibling isSWRMeter38/39 which use charAt(0).
+
+    @Test
+    public void is590MeterSWR_trueForSwrFrame() {
+        // "RM10015;" -> data "10015": P1 = '1' (SWR), value "0015".
+        Yaesu3Command c = new Yaesu3Command("RM", "10015");
+        assertThat(Yaesu3Command.is590MeterSWR(c)).isTrue();
+    }
+
+    @Test
+    public void is590MeterALC_trueForAlcFrame() {
+        // "RM30020;" -> data "30020": P1 = '3' (ALC), value "0020".
+        Yaesu3Command c = new Yaesu3Command("RM", "30020");
+        assertThat(Yaesu3Command.is590MeterALC(c)).isTrue();
+    }
+
+    @Test
+    public void is590MeterSWR_falseForAlcFrame() {
+        Yaesu3Command c = new Yaesu3Command("RM", "30020");
+        assertThat(Yaesu3Command.is590MeterSWR(c)).isFalse();
+    }
+
+    @Test
+    public void is590MeterALC_falseForSwrFrame() {
+        Yaesu3Command c = new Yaesu3Command("RM", "10015");
+        assertThat(Yaesu3Command.is590MeterALC(c)).isFalse();
+    }
+
+    @Test
+    public void is590Meter_selectorNotConfusedWithValueDigits() {
+        // An SWR frame whose value happens to contain a '3' at index 2 must not
+        // be misread as ALC (the pre-fix charAt(2) bug classified this as ALC).
+        Yaesu3Command c = new Yaesu3Command("RM", "10300");
+        assertThat(Yaesu3Command.is590MeterSWR(c)).isTrue();
+        assertThat(Yaesu3Command.is590MeterALC(c)).isFalse();
+    }
+
+    @Test
+    public void is590Meter_returnsFalseOnShortData() {
+        Yaesu3Command c = new Yaesu3Command("RM", "10");
+        assertThat(Yaesu3Command.is590MeterSWR(c)).isFalse();
+        assertThat(Yaesu3Command.is590MeterALC(c)).isFalse();
+    }
+
     // ---- ElecraftCommand.getSWRMeter (substring(0,3)) ----
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu3CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu3CommandTest.java
@@ -10,7 +10,8 @@ import org.junit.Test;
  *
  * Frames are {@code <2-letter ID><data>}; frequency replies are FA/FB with an
  * integer Hz string. Meter replies are RM frames whose first data char selects
- * the meter (6=SWR, 4=ALC for 38/39; index 2 = 3 ALC / 1 SWR for the 590).
+ * the meter (6=SWR, 4=ALC for 38/39; 1=SWR, 3=ALC at index 0 for the 590, with
+ * the 4-digit value in the following chars).
  */
 public class Yaesu3CommandTest {
 
@@ -98,20 +99,20 @@ public class Yaesu3CommandTest {
 
     @Test
     public void ts590_alcSelectorAndValue() {
-        // data "01300": index2 == '3' -> ALC; value = substring(1,5) = "1300".
-        Yaesu3Command alc = Yaesu3Command.getCommand("RM01300");
+        // data "30020": index0 == '3' -> ALC; value = substring(1,5) = "0020".
+        Yaesu3Command alc = Yaesu3Command.getCommand("RM30020");
         assertThat(Yaesu3Command.is590MeterALC(alc)).isTrue();
         assertThat(Yaesu3Command.is590MeterSWR(alc)).isFalse();
-        assertThat(Yaesu3Command.get590ALCOrSWR(alc)).isEqualTo(1300);
+        assertThat(Yaesu3Command.get590ALCOrSWR(alc)).isEqualTo(20);
     }
 
     @Test
     public void ts590_swrSelector() {
-        // data "01100": index2 == '1' -> SWR.
-        Yaesu3Command swr = Yaesu3Command.getCommand("RM01100");
+        // data "10015": index0 == '1' -> SWR; value = substring(1,5) = "0015".
+        Yaesu3Command swr = Yaesu3Command.getCommand("RM10015");
         assertThat(Yaesu3Command.is590MeterSWR(swr)).isTrue();
         assertThat(Yaesu3Command.is590MeterALC(swr)).isFalse();
-        assertThat(Yaesu3Command.get590ALCOrSWR(swr)).isEqualTo(1100);
+        assertThat(Yaesu3Command.get590ALCOrSWR(swr)).isEqualTo(15);
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Kenwood `RM` (read-meter) reply is `RM P1 P2;`. After the two-char `RM` command id is stripped, `data = "mvvvv"` where:
- **P1** (index **0**) is the meter-type selector — `1` = SWR, `3` = ALC
- **P2** (indices **1..4**) is the 4-digit meter value

`Yaesu3Command.get590ALCOrSWR` already reads the value at `substring(1, 5)`, correctly treating index 0 as the selector. But the two type detectors read the selector at the **wrong offset**:

```java
public static boolean is590MeterALC(...) { ... return command.data.charAt(2) == '3'; }
public static boolean is590MeterSWR(...) { ... return command.data.charAt(2) == '1'; }
```

`charAt(2)` is the **2nd digit of the 4-digit value**, not the meter selector.

## Root cause

Latent since the meter feature was first added (commit `ee764862`) — never a regression. The value extractor and the type detectors disagree on the frame layout; the sibling FT-991/FT-891 helpers (`isSWRMeter38`/`isALCMeter38`/`isSWRMeter39`) correctly use `charAt(0)`, confirming the intended layout.

## Impact

`is590MeterSWR`/`is590MeterALC` are used by **`KenwoodTS590Rig`, `KenwoodTS570Rig`, and `KenwoodTS2000Rig`** on every CAT meter poll. With the wrong offset:
- SWR/ALC were captured only in the coincidental frames where the value's 3rd char happened to equal `1`/`3`, so the on-screen meter was erratic; and
- an SWR reading whose value contains a `3` could be misclassified as ALC (and vice-versa).
- Most importantly, `showAlert()` gates the **high-SWR safety warning** on the `swr` field, so the protective alert was unreliable for these three real rigs.

## Fix

Read the meter-type selector at `data.charAt(0)` in both detectors (one character per line). No change to the value extractor or any other rig.

## Testing

- Added realistic-frame coverage to `CatMeterParserTest` (`is590MeterSWR`/`is590MeterALC` true/false cases + a selector-vs-value-digit case + short-data guard). **3 of the new assertions fail before the fix, pass after.**
- Corrected two `Yaesu3CommandTest` cases (`ts590_alcSelectorAndValue`, `ts590_swrSelector`) that had been written against the buggy `charAt(2)` offset using invalid `'0'`-selector frames; they now use real `RM10015`/`RM30020` frames.
- Full suite green: `./gradlew :app:testDebugUnitTest` — **2262 tests pass**.

## Risk

Very low. One-character offset correction in two pure static helpers; behavior is now internally consistent with `get590ALCOrSWR` and the 38/39 siblings. No protocol/DSP/encoder changes; no performance impact.