### PR TITLE
Fix ArrayIndexOutOfBoundsException in FT8Package.getStdCall for all-slash callsigns

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8signal/FT8Package.java
@@ -109,6 +109,12 @@ public class FT8Package {
     public static String getStdCall(String compoundCallsign) {
         if (!compoundCallsign.contains("/")) return compoundCallsign;
         String[] callsigns = compoundCallsign.split("/");
+        // An all-slash string ("/", "//", ...) splits to a zero-length array
+        // because Java strips trailing empty tokens; there is no segment to
+        // extract, so fall back to the input rather than indexing callsigns[0]
+        // below and throwing ArrayIndexOutOfBoundsException. Mirrors the same
+        // guard in GeneralVariables.getShortCallsign.
+        if (callsigns.length == 0) return compoundCallsign;
         for (String callsign : callsigns) {// extract standard callsign using regex
             // FT8 definition: a standard amateur callsign consists of a one or two character prefix (at least one must be a letter), followed by a decimal digit and up to three letter suffix.
             if (callsign.matches("[A-Z0-9]?[A-Z0-9][0-9][A-Z][A-Z0-9]?[A-Z]?")) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8signal/FT8PackageTest.java
@@ -38,4 +38,26 @@ public class FT8PackageTest {
         // Neither side matches the standard shape -> return the longest segment.
         assertThat(FT8Package.getStdCall("PY1/ZZ")).isEqualTo("PY1");
     }
+
+    @Test
+    public void allSlashCallsign_returnsInputInsteadOfCrashing() {
+        // A string of only slashes splits to a zero-length array (Java strips
+        // trailing empty tokens), so there is no segment to fall back to.
+        // Must not throw ArrayIndexOutOfBoundsException; return the input as-is.
+        assertThat(FT8Package.getStdCall("/")).isEqualTo("/");
+        assertThat(FT8Package.getStdCall("//")).isEqualTo("//");
+        assertThat(FT8Package.getStdCall("///")).isEqualTo("///");
+    }
+
+    @Test
+    public void trailingSlash_stillReturnsSegment() {
+        // Trailing slash is dropped by split but a real segment remains.
+        assertThat(FT8Package.getStdCall("W1AW/")).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void leadingSlash_stillReturnsSegment() {
+        // Leading empty token is preserved by split; the callsign segment wins.
+        assertThat(FT8Package.getStdCall("/K1ABC")).isEqualTo("K1ABC");
+    }
 }


### PR DESCRIPTION
## Summary

`FT8Package.getStdCall("/")` — or any all-slash callsign (`"//"`, `"///"`, …) — throws `ArrayIndexOutOfBoundsException`.

`String.split("/")` strips **trailing** empty tokens, so an all-slash input splits to a **zero-length** array. `getStdCall` then skips both its scan loops (there are no elements) and unconditionally evaluates `callsigns[index]` (`index == 0`) at the end, indexing into the empty array.

## Root cause

```java
String[] callsigns = compoundCallsign.split("/");  // "/" -> []  (length 0)
for (String callsign : callsigns) { ... }          // skipped
int len = 0, index = 0;
for (int i = 0; i < callsigns.length; i++) { ... } // skipped
return callsigns[index];                            // callsigns[0] -> AIOOBE
```

This is the identical defect that **PR #509** fixed in `GeneralVariables.getShortCallsign` (which added a `temp.length == 0` guard). That guard was never mirrored into this sibling method.

## Reachability

`getStdCall` is called from `generatePack77_i1` during TX packing, when both the to- and from-callsigns are compound (contain `/`). A misconfigured all-slash own-callsign therefore turns every transmit attempt into an unhandled exception. Low-to-moderate reachability (own callsign, not RF input), but a hard crash on the TX path.

## Fix

Fall back to the original input when the split yields no segments — exactly the shape of the existing `getShortCallsign` guard:

```java
if (callsigns.length == 0) return compoundCallsign;
```

Localized, no behavior change for any valid or already-handled input.

## Testing

Added to `FT8PackageTest`:
- `allSlashCallsign_returnsInputInsteadOfCrashing` — `"/"`, `"//"`, `"///"` (fails with AIOOBE before the fix)
- `trailingSlash_stillReturnsSegment` — `"W1AW/"` → `"W1AW"`
- `leadingSlash_stillReturnsSegment` — `"/K1ABC"` → `"K1ABC"`

Verified the new all-slash test throws `ArrayIndexOutOfBoundsException` **before** the fix and the full `FT8PackageTest` class (7 tests) passes **after** it:

```
./gradlew :app:testDebugUnitTest --tests com.k1af.ft8af.ft8signal.FT8PackageTest
BUILD SUCCESSFUL
```

## Risk

Minimal. Pure-Java guard on an edge case; identical to the established `getShortCallsign` pattern. No DSP, protocol, or native changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)