### PR TITLE
Fix Xiegu X6100 supply-voltage meter under-reading below 5V

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Meters.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/x6100/X6100Meters.java
@@ -68,8 +68,12 @@ public class X6100Meters {
      * @return voltage
      */
     public static float getMeter_volt(float value) {
+        // Calibration (see class header): 0000=0V, 0075=5V, 0241=16V.
+        // Low segment 0..75 is linear 0V..5V (slope 5/75 = 1/15); the previous
+        // 1/25 divisor under-read the supply (75 -> 3V, not 5V) and left a
+        // discontinuity with the upper segment at value == 75.
         if (value <= 75) {
-            return value / 25f;
+            return value / 15f;
         } else {
             return (value - 75f) * 11 / 166f + 5;
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100MetersVoltTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/x6100/X6100MetersVoltTest.java
@@ -1,0 +1,71 @@
+package com.k1af.ft8af.x6100;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link X6100Meters#getMeter_volt(float)} — the Xiegu
+ * X6100 supply-voltage meter conversion.
+ *
+ * <p>The device sends a raw 0..255 meter value; the class header documents the
+ * calibration as {@code 0000=0V, 0075=5V, 0241=16V}. The low segment (0..75)
+ * must therefore be linear from 0V to 5V (slope 5/75 = 1/15). The previous
+ * implementation divided by 25 instead of 15, so a raw value of 75 read 3.0V
+ * instead of 5.0V and every reading below the 5V knee under-reported the supply
+ * — and the two segments no longer met at the knee.
+ *
+ * <p>No Robolectric runner: {@code getMeter_volt} is pure arithmetic and never
+ * touches Android types.
+ */
+public class X6100MetersVoltTest {
+
+    private static final float TOL = 0.02f;
+
+    @Test
+    public void zero_isZeroVolts() {
+        assertThat(X6100Meters.getMeter_volt(0f)).isWithin(TOL).of(0.0f);
+    }
+
+    @Test
+    public void knee_at75_is5Volts() {
+        // Regression: the old 1/25 divisor returned 3.0V here.
+        assertThat(X6100Meters.getMeter_volt(75f)).isWithin(TOL).of(5.0f);
+    }
+
+    @Test
+    public void lowSegment_midpoint_isHalfOf5Volts() {
+        // 37.5 -> 2.5V on the 0..75 -> 0..5V ramp (old code gave 1.5V).
+        assertThat(X6100Meters.getMeter_volt(37.5f)).isWithin(TOL).of(2.5f);
+    }
+
+    @Test
+    public void lowSegment_isContinuousWithUpperSegmentAtKnee() {
+        // Both branches must agree at the knee (value == 75) so the reading
+        // does not jump. The old low branch (3.0V) broke this.
+        float low = X6100Meters.getMeter_volt(75f);
+        float high = X6100Meters.getMeter_volt(75.0001f);
+        assertThat(low).isWithin(0.01f).of(high);
+    }
+
+    @Test
+    public void upperCalibrationPoint_at241_is16Volts() {
+        assertThat(X6100Meters.getMeter_volt(241f)).isWithin(TOL).of(16.0f);
+    }
+
+    @Test
+    public void upperSegment_midpoint() {
+        // Halfway between the 75 (5V) and 241 (16V) points -> 10.5V.
+        assertThat(X6100Meters.getMeter_volt(158f)).isWithin(TOL).of(10.5f);
+    }
+
+    @Test
+    public void isMonotonicallyIncreasing() {
+        float prev = X6100Meters.getMeter_volt(0f);
+        for (int v = 1; v <= 255; v++) {
+            float cur = X6100Meters.getMeter_volt(v);
+            assertThat(cur).isGreaterThan(prev);
+            prev = cur;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The Xiegu X6100 network meter panel under-reported the radio's supply voltage for any reading on the low segment of the scale.

`X6100Meters.getMeter_volt` converts the raw 0–255 meter value the radio sends into volts. The class header documents the device calibration as:

```
Volt-Meter:
0000=0V, 0075=5V, 0241=16V
```

So the low segment (raw `0..75`) is a straight line from **0 V to 5 V**, slope `5/75 = 1/15`. The code divided by **25** instead of **15**:

```java
if (value <= 75) {
    return value / 25f;   // maps 0..75 -> 0..3V  (should be 0..5V)
}
```

## Root cause
The low-branch divisor (`/25f`) does not match the documented slope. Consequences:
- Every reading below the 5 V knee is under-reported (e.g. raw 37.5 shows **1.5 V** instead of **2.5 V**).
- The two branches are **discontinuous** at the knee: raw 75 gives **3.0 V** on the low branch but **5.0 V** on the upper branch, so the reading jumps as the supply crosses that point.

The upper segment (`(value - 75) * 11 / 166 + 5`) already matches the calibration (raw 241 → 16 V) and is left untouched.

## Fix
Change the low-segment divisor from `25f` to `15f` so the segment is linear `0V..5V` and meets the upper segment continuously at the knee. One-line change plus an explanatory comment; no other behavior changes.

## Testing
- Added pure-JVM `X6100MetersVoltTest` (no Robolectric needed — `getMeter_volt` is pure arithmetic): both calibration knees (0→0V, 75→5V, 241→16V), the low-segment midpoint, segment continuity at the knee, an upper-segment midpoint, and full monotonicity across 0–255.
- Verified fail-before: with the old `/25f` divisor the three low-segment assertions fail; with the fix all 7 pass.
- `./gradlew :app:testDebugUnitTest --tests com.k1af.ft8af.x6100.X6100MetersVoltTest` → BUILD SUCCESSFUL (JDK 17, NDK 27, cmake 3.22.1).

## Risk
Very low. Localized to one arithmetic branch in a display-only conversion for a single rig (Xiegu X6100). No impact on TX/RX, DSP, decoder, protocol, or other rigs. Sibling S-meter/SWR conversions in the same file are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)