### PR TITLE
Fix off-by-one serial port-index guard that could crash the app on connect

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
@@ -110,6 +110,27 @@ public class CableSerialPort {
                 && GeneralVariables.controlMode == ControlMode.CAT;
     }
 
+    /**
+     * Whether {@code portNum} is a valid 0-based index into a driver port list
+     * of {@code portCount} ports, i.e. in {@code 0 .. portCount-1}.
+     *
+     * <p>{@link #prepare()} calls {@code driver.getPorts().get(portNum)} right
+     * after this check. The previous guard was {@code portCount < portNum},
+     * which is off by one: it let {@code portNum == portCount} (a persisted
+     * multi-port selection replayed against a device that now enumerates fewer
+     * ports, or an empty port list with the default {@code portNum == 0}) pass,
+     * so {@code get(portNum)} threw {@link IndexOutOfBoundsException} out of
+     * {@code prepare()} → {@code connect()}. On the CAT auto-reconnect worker
+     * that exception is uncaught and crashes the app. Requiring
+     * {@code portNum < portCount} (and non-negative) makes the guard actually
+     * cover the index it protects.
+     *
+     * <p>Package-visible for testing.
+     */
+    static boolean isValidPortIndex(int portCount, int portNum) {
+        return portNum >= 0 && portNum < portCount;
+    }
+
     private boolean prepare() {
         registerRigSerialPort(context);
         UsbDevice device = null;
@@ -137,7 +158,7 @@ public class CableSerialPort {
             //Try adding the unknown device to the CDC driver
             driver = new CdcAcmSerialDriver(device);
         }
-        if (driver.getPorts().size() < portNum) {
+        if (!isValidPortIndex(driver.getPorts().size(), portNum)) {
             Log.e(TAG, "Serial port number does not exist, cannot open.");
             return false;
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/CableSerialPortPortIndexTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/CableSerialPortPortIndexTest.java
@@ -1,0 +1,57 @@
+package com.k1af.ft8af.connector;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link CableSerialPort#isValidPortIndex}, the bounds
+ * guard that decides whether {@code prepare()} may call
+ * {@code driver.getPorts().get(portNum)}.
+ *
+ * <p>The old guard tested {@code getPorts().size() < portNum} and then indexed
+ * with {@code get(portNum)}. Port lists are 0-based, so the only safe indices
+ * are {@code 0 .. size-1}: the guard was off by one and let {@code portNum ==
+ * size} (and an empty port list with {@code portNum == 0}) through, so
+ * {@code get(portNum)} threw {@link IndexOutOfBoundsException} out of
+ * {@code prepare()} → {@code connect()}. On the CAT auto-reconnect worker that
+ * exception is uncaught and crashes the app. These cases pin the boundary.
+ */
+public class CableSerialPortPortIndexTest {
+
+    @Test
+    public void firstPortOfSinglePortDriver_isValid() {
+        assertThat(CableSerialPort.isValidPortIndex(1, 0)).isTrue();
+    }
+
+    @Test
+    public void lastPortOfMultiPortDriver_isValid() {
+        assertThat(CableSerialPort.isValidPortIndex(4, 3)).isTrue();
+    }
+
+    @Test
+    public void portNumEqualToCount_isRejected() {
+        // The off-by-one case: a persisted multi-port selection replayed against
+        // a device that now enumerates fewer ports. Old guard (size < portNum)
+        // returned "valid" here, then get(portNum) threw.
+        assertThat(CableSerialPort.isValidPortIndex(2, 2)).isFalse();
+        assertThat(CableSerialPort.isValidPortIndex(1, 1)).isFalse();
+    }
+
+    @Test
+    public void emptyPortList_isRejected() {
+        // A driver that reports zero ports with the default portNum=0: old guard
+        // (0 < 0 == false) let it through and get(0) threw on an empty list.
+        assertThat(CableSerialPort.isValidPortIndex(0, 0)).isFalse();
+    }
+
+    @Test
+    public void portNumBeyondCount_isRejected() {
+        assertThat(CableSerialPort.isValidPortIndex(2, 5)).isFalse();
+    }
+
+    @Test
+    public void negativePortNum_isRejected() {
+        assertThat(CableSerialPort.isValidPortIndex(2, -1)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`CableSerialPort.prepare()` guards the port lookup with
`driver.getPorts().size() < portNum` and then indexes the list with
`driver.getPorts().get(portNum)`. Port lists are **0-based**, so the only safe
indices are `0 .. size-1`. The guard is off by one: it lets `portNum == size`
through (and an empty port list with the default `portNum == 0`), so
`get(portNum)` throws `IndexOutOfBoundsException` out of `prepare()` →
`connect()`.

## Root cause

The guard was written to prevent exactly this out-of-bounds access, but the
comparison is wrong. To safely call `get(portNum)` you need `portNum < size`,
not `portNum <= size`. The condition should reject `portNum == size` as well.

## Why it crashes (not just fails to connect)

`connect()` is driven from the **`CAT-Auto-Reconnect`** worker thread
(`CableConnector`), whose body is a `try { … } finally { reconnecting = false; }`
with **no `catch`**. The `IndexOutOfBoundsException` therefore escapes
`run()` uncaught → the default uncaught-exception handler → app crash, instead
of surfacing the intended "serial port number does not exist" error and letting
the retry logic proceed.

## When it triggers

- A persisted multi-port selection (`portNum` = 1/2/3 from an earlier FTDI/CP210x
  device) replayed against a device that now enumerates fewer ports — including a
  different unit sharing the same `vendorId` (`prepare()` matches by vendorId and
  picks the last matching device).
- A probed driver that reports zero ports with the default `portNum == 0`
  (`0 < 0` is false, so the old guard passed and `get(0)` threw on an empty list).

## Fix

Extract a package-visible pure helper:

```java
static boolean isValidPortIndex(int portCount, int portNum) {
    return portNum >= 0 && portNum < portCount;
}
```

and use it in `prepare()`. This makes the guard actually cover the index it
protects and additionally rejects a negative `portNum`. Behavior is **unchanged
for every valid selection** (`0 .. size-1` still proceeds); only the previously
crashing out-of-range cases now cleanly return `false`.

## Testing

- New pure-JVM `CableSerialPortPortIndexTest` (6 cases): first/last valid index,
  `portNum == count`, empty list, `portNum > count`, negative. The boundary,
  empty-list, and negative cases **fail against the old `size < portNum` guard**
  and pass with the fix.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full native + Java build succeeds.

## Risk

Very low. One-method change to a bounds check plus a new pure helper and tests;
no protocol/DSP/native behavior touched. Preserves all valid-port behavior and
only converts a latent crash into the already-handled "can't open port" path.