### PR TITLE
Fix web-logbook ADIF export using UTF-16 char length instead of UTF-8 byte length

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -1224,7 +1224,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
             if (cursor.getString(cursor.getColumnIndex("gridsquare")) != null) {
                 logStr.append(String.format("<gridsquare:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("gridsquare")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("gridsquare")))
                         , cursor.getString(cursor.getColumnIndex("gridsquare"))));
             }
 
@@ -1235,77 +1235,77 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 String submode = AdifFormat.mfskSubmode(mode);
                 if (submode != null) {
                     logStr.append(String.format("<mode:4>MFSK <submode:%d>%s "
-                            , submode.length(), submode));
+                            , AdifFormat.utf8Length(submode), submode));
                 } else {
                     logStr.append(String.format("<mode:%d>%s "
-                            , mode.length(), mode));
+                            , AdifFormat.utf8Length(mode), mode));
                 }
             }
 
             if (cursor.getString(cursor.getColumnIndex("rst_sent")) != null) {
                 logStr.append(String.format("<rst_sent:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("rst_sent")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("rst_sent")))
                         , cursor.getString(cursor.getColumnIndex("rst_sent"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("rst_rcvd")) != null) {
                 logStr.append(String.format("<rst_rcvd:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("rst_rcvd")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("rst_rcvd")))
                         , cursor.getString(cursor.getColumnIndex("rst_rcvd"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("qso_date")) != null) {
                 logStr.append(String.format("<qso_date:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("qso_date")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("qso_date")))
                         , cursor.getString(cursor.getColumnIndex("qso_date"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("time_on")) != null) {
                 logStr.append(String.format("<time_on:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("time_on")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("time_on")))
                         , cursor.getString(cursor.getColumnIndex("time_on"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("qso_date_off")) != null) {
                 logStr.append(String.format("<qso_date_off:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("qso_date_off")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("qso_date_off")))
                         , cursor.getString(cursor.getColumnIndex("qso_date_off"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("time_off")) != null) {
                 logStr.append(String.format("<time_off:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("time_off")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("time_off")))
                         , cursor.getString(cursor.getColumnIndex("time_off"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("band")) != null) {
                 logStr.append(String.format("<band:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("band")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("band")))
                         , cursor.getString(cursor.getColumnIndex("band"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("freq")) != null) {
                 logStr.append(String.format("<freq:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("freq")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("freq")))
                         , cursor.getString(cursor.getColumnIndex("freq"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("station_callsign")) != null) {
                 logStr.append(String.format("<station_callsign:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("station_callsign")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("station_callsign")))
                         , cursor.getString(cursor.getColumnIndex("station_callsign"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("my_gridsquare")) != null) {
                 logStr.append(String.format("<my_gridsquare:%d>%s "
-                        , cursor.getString(cursor.getColumnIndex("my_gridsquare")).length()
+                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("my_gridsquare")))
                         , cursor.getString(cursor.getColumnIndex("my_gridsquare"))));
             }
 
             if (cursor.getColumnIndex("operator") != -1) {
                 if (cursor.getString(cursor.getColumnIndex("operator")) != null) {
                     logStr.append(String.format("<operator:%d>%s "
-                            , cursor.getString(cursor.getColumnIndex("operator")).length()
+                            , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("operator")))
                             , cursor.getString(cursor.getColumnIndex("operator"))));
                 }
             }
@@ -1318,11 +1318,14 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             appendPotaField(logStr, cursor, "sig_info", "SIG_INFO");
 
             String comment = cursor.getString(cursor.getColumnIndex("comment"));
+            if (comment == null) {
+                comment = "";
+            }
 
             //<comment:15>Distance: 99 km <eor>
             //When writing to db, must append " km"
             logStr.append(String.format("<comment:%d>%s <eor>\n"
-                    , comment.length()
+                    , AdifFormat.utf8Length(comment)
                     , comment));
         }
 
@@ -1336,7 +1339,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         if (idx < 0) return;
         String value = cursor.getString(idx);
         if (value == null || value.isEmpty()) return;
-        sb.append(String.format("<%s:%d>%s ", adifName, value.length(), value));
+        sb.append(String.format("<%s:%d>%s ", adifName, AdifFormat.utf8Length(value), value));
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 
 public class DatabaseOpr extends SQLiteOpenHelper {
     private static final String TAG = "DatabaseOpr";
@@ -1198,7 +1199,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
      * @param isSWL whether in SWL mode
      * @return ADIF text content
      */
-    @SuppressLint({"Range", "DefaultLocale"})
+    @SuppressLint("Range")
     public String downQSLTable(Cursor cursor, boolean isSWL) {
         StringBuilder logStr = new StringBuilder();
 
@@ -1223,7 +1224,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             }
 
             if (cursor.getString(cursor.getColumnIndex("gridsquare")) != null) {
-                logStr.append(String.format("<gridsquare:%d>%s "
+                logStr.append(String.format(Locale.US, "<gridsquare:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("gridsquare")))
                         , cursor.getString(cursor.getColumnIndex("gridsquare"))));
             }
@@ -1234,77 +1235,77 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 String mode = cursor.getString(cursor.getColumnIndex("mode"));
                 String submode = AdifFormat.mfskSubmode(mode);
                 if (submode != null) {
-                    logStr.append(String.format("<mode:4>MFSK <submode:%d>%s "
+                    logStr.append(String.format(Locale.US, "<mode:4>MFSK <submode:%d>%s "
                             , AdifFormat.utf8Length(submode), submode));
                 } else {
-                    logStr.append(String.format("<mode:%d>%s "
+                    logStr.append(String.format(Locale.US, "<mode:%d>%s "
                             , AdifFormat.utf8Length(mode), mode));
                 }
             }
 
             if (cursor.getString(cursor.getColumnIndex("rst_sent")) != null) {
-                logStr.append(String.format("<rst_sent:%d>%s "
+                logStr.append(String.format(Locale.US, "<rst_sent:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("rst_sent")))
                         , cursor.getString(cursor.getColumnIndex("rst_sent"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("rst_rcvd")) != null) {
-                logStr.append(String.format("<rst_rcvd:%d>%s "
+                logStr.append(String.format(Locale.US, "<rst_rcvd:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("rst_rcvd")))
                         , cursor.getString(cursor.getColumnIndex("rst_rcvd"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("qso_date")) != null) {
-                logStr.append(String.format("<qso_date:%d>%s "
+                logStr.append(String.format(Locale.US, "<qso_date:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("qso_date")))
                         , cursor.getString(cursor.getColumnIndex("qso_date"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("time_on")) != null) {
-                logStr.append(String.format("<time_on:%d>%s "
+                logStr.append(String.format(Locale.US, "<time_on:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("time_on")))
                         , cursor.getString(cursor.getColumnIndex("time_on"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("qso_date_off")) != null) {
-                logStr.append(String.format("<qso_date_off:%d>%s "
+                logStr.append(String.format(Locale.US, "<qso_date_off:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("qso_date_off")))
                         , cursor.getString(cursor.getColumnIndex("qso_date_off"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("time_off")) != null) {
-                logStr.append(String.format("<time_off:%d>%s "
+                logStr.append(String.format(Locale.US, "<time_off:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("time_off")))
                         , cursor.getString(cursor.getColumnIndex("time_off"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("band")) != null) {
-                logStr.append(String.format("<band:%d>%s "
+                logStr.append(String.format(Locale.US, "<band:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("band")))
                         , cursor.getString(cursor.getColumnIndex("band"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("freq")) != null) {
-                logStr.append(String.format("<freq:%d>%s "
+                logStr.append(String.format(Locale.US, "<freq:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("freq")))
                         , cursor.getString(cursor.getColumnIndex("freq"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("station_callsign")) != null) {
-                logStr.append(String.format("<station_callsign:%d>%s "
+                logStr.append(String.format(Locale.US, "<station_callsign:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("station_callsign")))
                         , cursor.getString(cursor.getColumnIndex("station_callsign"))));
             }
 
             if (cursor.getString(cursor.getColumnIndex("my_gridsquare")) != null) {
-                logStr.append(String.format("<my_gridsquare:%d>%s "
+                logStr.append(String.format(Locale.US, "<my_gridsquare:%d>%s "
                         , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("my_gridsquare")))
                         , cursor.getString(cursor.getColumnIndex("my_gridsquare"))));
             }
 
             if (cursor.getColumnIndex("operator") != -1) {
                 if (cursor.getString(cursor.getColumnIndex("operator")) != null) {
-                    logStr.append(String.format("<operator:%d>%s "
+                    logStr.append(String.format(Locale.US, "<operator:%d>%s "
                             , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("operator")))
                             , cursor.getString(cursor.getColumnIndex("operator"))));
                 }
@@ -1324,7 +1325,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
             //<comment:15>Distance: 99 km <eor>
             //When writing to db, must append " km"
-            logStr.append(String.format("<comment:%d>%s <eor>\n"
+            logStr.append(String.format(Locale.US, "<comment:%d>%s <eor>\n"
                     , AdifFormat.utf8Length(comment)
                     , comment));
         }
@@ -1339,7 +1340,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         if (idx < 0) return;
         String value = cursor.getString(idx);
         if (value == null || value.isEmpty()) return;
-        sb.append(String.format("<%s:%d>%s ", adifName, AdifFormat.utf8Length(value), value));
+        sb.append(String.format(Locale.US, "<%s:%d>%s ", adifName, AdifFormat.utf8Length(value), value));
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifLengthTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifLengthTest.java
@@ -7,6 +7,7 @@ import android.database.MatrixCursor;
 import androidx.test.core.app.ApplicationProvider;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -106,5 +107,23 @@ public class DatabaseOprAdifLengthTest {
         // Previously comment.length() NPE'd on a NULL comment, aborting the whole download.
         String adif = export(null, null, null);
         assertThat(adif).contains("<comment:0> <eor>");
+    }
+
+    @Test
+    public void arabicDefaultLocale_stillEmitsAsciiDigitLengths() {
+        // %d under a default locale whose numbering system is Arabic-Indic (e.g. "ar")
+        // emits ٠١٢٣… digits, making every <field:len> header unparseable to ADIF
+        // consumers. The export must format with Locale.US regardless of device locale.
+        Locale saved = Locale.getDefault();
+        Locale.setDefault(new Locale("ar"));
+        try {
+            String adif = export("Café QSO", "JÜRGEN", null);
+            assertThat(adif).contains("<comment:9>Café QSO <eor>");
+            assertDeclaredLenIsUtf8ByteLen(adif, "operator", "JÜRGEN");
+            // No non-ASCII digits anywhere in the export.
+            assertThat(adif.matches("(?s).*[\\u0660-\\u0669].*")).isFalse();
+        } finally {
+            Locale.setDefault(saved);
+        }
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifLengthTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifLengthTest.java
@@ -1,0 +1,110 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.database.MatrixCursor;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Verifies that the web-logbook ADIF export in {@link DatabaseOpr#downQSLTable} declares every
+ * field length as the UTF-8 <em>byte</em> count (what the ADIF {@code <field:len>} grammar
+ * requires), not the UTF-16 {@link String#length()} char count. The two differ for any non-ASCII
+ * content (an accented comment, an international POTA park name): declaring the shorter char count
+ * makes a byte-correct consumer (LoTW/QRZ/Cloudlog) read fewer bytes than were written, truncating
+ * the field and mis-aligning the record boundary. The canonical writer {@link
+ * com.k1af.ft8af.log.AdifRecord} already uses {@code AdifFormat.utf8Length}; this covers the
+ * un-migrated {@code downQSLTable} twin used by the built-in web logbook download.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseOprAdifLengthTest {
+
+    /** Columns downQSLTable reads, including the optional operator/POTA columns. */
+    private static final String[] COLUMNS = {
+            "call", "isLotW_QSL", "isQSL", "gridsquare", "mode", "rst_sent", "rst_rcvd",
+            "qso_date", "time_on", "qso_date_off", "time_off", "band", "freq",
+            "station_callsign", "my_gridsquare", "operator",
+            "my_sig", "my_sig_info", "sig", "sig_info", "comment"
+    };
+
+    private DatabaseOpr opr;
+
+    @Before
+    public void setUp() {
+        opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 19);
+    }
+
+    @After
+    public void tearDown() {
+        opr.close();
+    }
+
+    /** Export one row with the given comment / operator / sig_info values (nulls allowed). */
+    private String export(String comment, String operator, String sigInfo) {
+        MatrixCursor cursor = new MatrixCursor(COLUMNS);
+        cursor.addRow(new Object[]{
+                "W1AW", 0, 0, null, "FT8", "+00", "-05",
+                "20260101", "1200", null, null, "20m", "14074000",
+                null, null, operator,
+                null, null, null, sigInfo, comment
+        });
+        return opr.downQSLTable(cursor, false);
+    }
+
+    /** Assert the declared length of {@code <name:LEN>value} equals value's UTF-8 byte length. */
+    private static void assertDeclaredLenIsUtf8ByteLen(String adif, String name, String value) {
+        Matcher m = Pattern.compile("<" + name + ":(\\d+)>").matcher(adif);
+        assertThat(m.find()).isTrue();
+        int declared = Integer.parseInt(m.group(1));
+        assertThat(declared).isEqualTo(value.getBytes(StandardCharsets.UTF_8).length);
+    }
+
+    @Test
+    public void comment_nonAscii_declaresUtf8ByteLength() {
+        // "Café QSO": 8 UTF-16 chars, 9 UTF-8 bytes (é = 2 bytes). Old code emitted <comment:8>,
+        // truncating the trailing 'O' and corrupting the <eor> boundary.
+        String comment = "Café QSO";
+        String adif = export(comment, null, null);
+        assertDeclaredLenIsUtf8ByteLen(adif, "comment", comment);
+        assertThat(adif).contains("<comment:9>Café QSO <eor>");
+    }
+
+    @Test
+    public void operator_nonAscii_declaresUtf8ByteLength() {
+        String op = "JÜRGEN"; // Ü = 2 UTF-8 bytes -> 6 chars, 7 bytes
+        String adif = export("QSO by FT8AF", op, null);
+        assertDeclaredLenIsUtf8ByteLen(adif, "operator", op);
+    }
+
+    @Test
+    public void potaSigInfo_nonAscii_declaresUtf8ByteLength() {
+        String park = "Åland-01"; // Å = 2 UTF-8 bytes
+        String adif = export("QSO by FT8AF", null, park);
+        assertDeclaredLenIsUtf8ByteLen(adif, "SIG_INFO", park);
+    }
+
+    @Test
+    public void asciiComment_unchanged_declaresCharLength() {
+        // Pure-ASCII path must stay byte-identical to the prior format.
+        String comment = "QSO by FT8AF";
+        String adif = export(comment, null, null);
+        assertThat(adif).contains("<comment:" + comment.length() + ">" + comment + " <eor>");
+    }
+
+    @Test
+    public void nullComment_doesNotThrow_emitsEmptyField() {
+        // Previously comment.length() NPE'd on a NULL comment, aborting the whole download.
+        String adif = export(null, null, null);
+        assertThat(adif).contains("<comment:0> <eor>");
+    }
+}


### PR DESCRIPTION
## Summary

`DatabaseOpr.downQSLTable` — the ADIF generator behind the **built-in web-logbook ADIF download** (`LogHttpServer`, 4 call sites) — declared every `<field:len>` length using Java `String.length()` (a **UTF-16 char count**) instead of the **UTF-8 byte count** the ADIF grammar requires.

For any non-ASCII field value the declared length is too short, so a byte-correct ADIF consumer (LoTW, QRZ, Cloudlog, WSJT-X) reads fewer bytes than were actually written — truncating the field and mis-aligning everything after it, including the `<eor>` record boundary. The record is rejected or silently mangled.

## Root cause

This method is the **un-migrated twin** of the canonical ADIF writer. The repo already diagnosed and fixed this exact class of bug: `AdifRecord.build()` and the `ThirdPartyService` upload paths route every field length through `AdifFormat.utf8Length()`, whose javadoc spells out the failure mode ("declaring the shorter char count makes the receiving parser read fewer bytes than were written, truncating the field and mis-aligning everything after it, so LoTW/QRZ/Cloudlog reject or mangle the record"). `downQSLTable` was never converted, so the web-logbook download regressed the very bug fixed elsewhere.

The file-export UI path (`ExportLogSheet` → `ShareLogs` → `AdifRecord`) is already correct; only this web-download path was affected.

## Fix

- Route `downQSLTable` and its `appendPotaField` helper through the shared `AdifFormat.utf8Length()`. It has an ASCII fast-path, so **pure-ASCII rows stay byte-identical** and there is no measurable cost.
- **Null-guard the `comment` field** (mirroring `AdifRecord.build()`'s `comment == null ? ""`). The old `comment.length()` dereference threw an NPE on a NULL comment, aborting the entire web-logbook download and leaking the cursor.

## Reachability

A foreign ADIF containing a non-ASCII `COMMENT` (e.g. `Café QSO`) uploaded to the built-in web logbook is stored verbatim (`LogHttpServer.doImportADI` → `LogFileImport` → `QSLRecord` → `doInsertQSLData`). Downloading the logbook as ADIF then emits `<comment:8>Café QSO <eor>` (should be `:9`), truncating the trailing `O` and corrupting the record boundary.

## Concrete example

`comment = "Café QSO"` → 8 UTF-16 chars, 9 UTF-8 bytes (`é` = 2 bytes).
- Before: `<comment:8>Café QSO <eor>` → consumer reads `Café QS`, drops `O`, `<eor>` desynced.
- After: `<comment:9>Café QSO <eor>` → correct.

## Testing

- New `DatabaseOprAdifLengthTest` (Robolectric + `MatrixCursor`, mirroring the existing `DatabaseOprAdifModeTest`): non-ASCII `comment` / `operator` / POTA `SIG_INFO` each declare the UTF-8 byte length; ASCII stays char-length (byte-identical); a NULL `comment` no longer throws. **4 of 5 cases fail before the fix** (3 assertion failures + 1 NPE), all pass after.
- Full `:app:testDebugUnitTest` suite green.

## Risk

Low. The change only affects declared field lengths and is byte-identical for ASCII content (the common case); it aligns this path with the already-shipped `AdifFormat.utf8Length` convention used by every other ADIF writer. No protocol/DSP behavior changes.