### PR TITLE
Fix Discovery TX-500 SWR meter crash on garbled RM reply (unguarded parseInt)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu3Command.java
@@ -172,11 +172,17 @@ public class Yaesu3Command {
      * ratio; see {@link DiscoveryTX500Rig#tx500CatToSwrRatio(int)}.
      *
      * @param command RM command in {@code RM1vvvv} form
-     * @return the raw 0-30 meter value, or 0 when the reply is too short
+     * @return the raw 0-30 meter value, or 0 when the reply is too short or the
+     *         value chars are non-numeric (garbled frame)
      */
     public static int getTX500MeterValue(Yaesu3Command command) {
         if (command.data.length() < 5) return 0;
-        return Integer.parseInt(command.data.substring(1, 5));
+        // Route through parseMeterValue like every other meter getter: a garbled
+        // or partial RM frame whose value chars aren't all digits (e.g. a ';'
+        // terminator or noise byte landing in substring(1,5)) must return 0
+        // rather than throw NumberFormatException — onReceiveData runs on the
+        // serial/Bluetooth read thread with no surrounding try/catch.
+        return parseMeterValue(command.data.substring(1, 5));
     }
 
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu3CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu3CommandTest.java
@@ -153,4 +153,20 @@ public class Yaesu3CommandTest {
         assertThat(Yaesu3Command.isTX500MeterSWR(c)).isFalse();
         assertThat(Yaesu3Command.getTX500MeterValue(c)).isEqualTo(0);
     }
+
+    @Test
+    public void tx500_garbledValueReturnsZeroNotThrow() {
+        // isTX500MeterSWR only gates on length>=5 and index0=='1'; it does NOT
+        // verify chars 1..4 are digits. A garbled/partial RM frame (noise byte,
+        // or a ';' terminator sliding into substring(1,5)) reaches
+        // getTX500MeterValue and previously crashed with NumberFormatException on
+        // the read thread. It must now return 0, like every other meter getter.
+        Yaesu3Command noise = Yaesu3Command.getCommand("RM1x023"); // data "1x023"
+        assertThat(Yaesu3Command.isTX500MeterSWR(noise)).isTrue();
+        assertThat(Yaesu3Command.getTX500MeterValue(noise)).isEqualTo(0);
+
+        Yaesu3Command terminator = Yaesu3Command.getCommand("RM1030;"); // data "1030;"
+        assertThat(Yaesu3Command.isTX500MeterSWR(terminator)).isTrue();
+        assertThat(Yaesu3Command.getTX500MeterValue(terminator)).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
## Summary

`Yaesu3Command.getTX500MeterValue` parses the four SWR value characters of a Lab599 Discovery TX-500 `RM` meter reply with a **raw `Integer.parseInt`**, while every other meter getter in the same class routes through `parseMeterValue()`, which catches `NumberFormatException` and returns `0`. A garbled or partial `RM` frame therefore crashes the rig's serial/Bluetooth read thread instead of yielding "no reading".

## Root cause

`isTX500MeterSWR` only gates on `data.length() >= 5` and `data.charAt(0) == '1'` — it never verifies that characters 1–4 are digits. So any reply that leads with `'1'` but carries a non-digit in the value window (a noise byte on a Bluetooth SPP link, or a `;` terminator sliding into `substring(1, 5)`, e.g. `RM1030;` → `"030;"`) passes the gate and reaches:

```java
return Integer.parseInt(command.data.substring(1, 5)); // throws NumberFormatException
```

`getTX500MeterValue` is called from `DiscoveryTX500Rig.handleMeterReply`, dispatched by `KenwoodTS2000Rig.onReceiveData` (on `cmd == "RM"`), which is invoked directly from the connector receive callback in `BaseRig` **with no enclosing try/catch**. The exception escapes onto the read thread on every meter poll while transmitting on a TX-500.

The sibling `parseMeterValue()` was written for exactly this hazard — its javadoc states meter replies "are read on the main thread with no surrounding try/catch on the Bluetooth SPP path, so a garbled or non-numeric byte sequence must not be allowed to throw `NumberFormatException` and crash the app." `getTX500MeterValue` was the one meter getter that bypassed it (grep of all `parseInt`/`parseLong` in `rigs/` confirms it was the lone unguarded numeric parse).

## Fix

Route `getTX500MeterValue` through the existing `parseMeterValue` guard — a garbled value now returns `0` (no reading) rather than throwing. One-line change; no behavior change for well-formed `RM1vvvv` replies (the value maps to SWR exactly as before).

## Testing

- Added two fail-before cases to `Yaesu3CommandTest` (`tx500_garbledValueReturnsZeroNotThrow`): a noise byte (`RM1x023`) and an in-window terminator (`RM1030;`). Both pass `isTX500MeterSWR` and previously threw `NumberFormatException` at the parse; they now assert a `0` return.
- Verified fail-before: the new test throws `NumberFormatException` against the unpatched source. Verified pass-after with the fix.
- Full `:app:testDebugUnitTest` suite passes (incl. `DiscoveryTX500RigTest`, `Yaesu3CommandTest`, all other rig tests).

## Risk

Very low. Localized to one getter; identical to the guard every sibling meter parser already uses. No DSP, protocol, or well-formed-reply behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)