### PR TITLE
Fix FlexRadio TX-audio crash on a partial final packet (FT2 over network Flex)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
@@ -489,6 +489,40 @@ public class FlexRadio {
      * FlexRadio transmits at 24000 sample rate; also converts mono to stereo
      * @param data audio
      */
+    /**
+     * Fill one stereo TX packet from {@code stereo} starting at sample index
+     * {@code from}, and return the index one past the last sample copied.
+     *
+     * <p>Copies at most {@code packet.length} samples; when fewer remain in
+     * {@code stereo} the tail of {@code packet} is zero-filled (silence padding
+     * for the final, partial packet). It never reads past the end of
+     * {@code stereo}.
+     *
+     * <p>The historic inline loop read {@code stereo[from]} and only tested the
+     * bound <em>after</em> the read, so a {@code stereo} length that was not a
+     * whole multiple of {@code packet.length} ran one element past the array and
+     * threw {@link ArrayIndexOutOfBoundsException} on the TX send thread
+     * (uncaught → whole-app crash). That happens for any waveform whose sample
+     * count is not a multiple of {@code packet.length / 2}; e.g. FT2 at 24 kHz
+     * generates 60480 samples → 120960 interleaved stereo values, which is not a
+     * multiple of 256, so the last packet overran.
+     *
+     * @param stereo interleaved L/R sample buffer
+     * @param from   index of the first sample to copy ({@code 0 <= from <= stereo.length})
+     * @param packet destination packet buffer, fully (over)written
+     * @return {@code min(from + packet.length, stereo.length)}
+     */
+    static int fillVoicePacket(float[] stereo, int from, float[] packet) {
+        int i = 0;
+        for (; i < packet.length && from < stereo.length; i++, from++) {
+            packet[i] = stereo[from];
+        }
+        for (; i < packet.length; i++) {
+            packet[i] = 0f;
+        }
+        return from;
+    }
+
     public void sendWaveData(float[] data) {
 
         float[] temp = new float[data.length * 2];
@@ -521,11 +555,7 @@ public class FlexRadio {
 
 
                     //for (int j = 0; j <3 ; j++) {
-                        for (int i = 0; i < voice.length; i++) {
-                            voice[i] = temp[count];
-                            count++;
-                            if (count > temp.length) break;
-                        }
+                        count = fillVoicePacket(temp, count, voice);
 
                         //byte[] send = vita.audioDataToVita(packetCount, streamTxId,0x534c2d, voice);
                         //daxTxAudioStreamId=0x0084000001&0x00000000ffffffff;
@@ -542,7 +572,7 @@ public class FlexRadio {
                         } catch (UnknownHostException e) {
                             throw new RuntimeException(e);
                         }
-                        if (count>temp.length) break;
+                        if (count>=temp.length) break;
                     //}
                     while (isPttOn) {
                         if (System.currentTimeMillis() - now >= 5) {//5ms per cycle, 256 floats per cycle

--- a/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/flex/FlexRadio.java
@@ -486,10 +486,6 @@ public class FlexRadio {
     }
 
     /**
-     * FlexRadio transmits at 24000 sample rate; also converts mono to stereo
-     * @param data audio
-     */
-    /**
      * Fill one stereo TX packet from {@code stereo} starting at sample index
      * {@code from}, and return the index one past the last sample copied.
      *
@@ -523,6 +519,10 @@ public class FlexRadio {
         return from;
     }
 
+    /**
+     * FlexRadio transmits at 24000 sample rate; also converts mono to stereo
+     * @param data audio
+     */
     public void sendWaveData(float[] data) {
 
         float[] temp = new float[data.length * 2];
@@ -551,7 +551,7 @@ public class FlexRadio {
 
 
 
-                    float[] voice=new float[256];//Because it's stereo, 240*2
+                    float[] voice=new float[256];//256 interleaved stereo floats (128 L/R frames) per packet
 
 
                     //for (int j = 0; j <3 ; j++) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioVoicePacketTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioVoicePacketTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
  */
 public class FlexRadioVoicePacketTest {
 
-    /** Packet size used by {@code sendWaveData} (240 samples, stereo). */
+    /** Packet size used by {@code sendWaveData} (256 interleaved stereo floats — 128 L/R frames). */
     private static final int PACKET = 256;
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioVoicePacketTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/flex/FlexRadioVoicePacketTest.java
@@ -1,0 +1,107 @@
+package com.k1af.ft8af.flex;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link FlexRadio#fillVoicePacket(float[], int, float[])},
+ * the packetiser step of the Flex DAX TX-audio stream.
+ *
+ * <p>{@code sendWaveData} walks the interleaved-stereo waveform in fixed 256-value
+ * packets. The historic inline loop read {@code temp[count]} and only checked the
+ * bound <em>after</em> the read, so when the total number of stereo values was not
+ * a whole multiple of 256 the final packet read one element past the array and
+ * threw an uncaught {@link ArrayIndexOutOfBoundsException} on the TX send thread —
+ * crashing the whole app. FT2 at 24 kHz produces 60480 samples (120960 interleaved
+ * values, {@code 120960 % 256 == 128}), so every FT2 transmit over a network Flex
+ * rig hit it. These tests pin the bounded, zero-padded behaviour.
+ */
+public class FlexRadioVoicePacketTest {
+
+    /** Packet size used by {@code sendWaveData} (240 samples, stereo). */
+    private static final int PACKET = 256;
+
+    @Test
+    public void fillsFullPacketAndAdvancesByPacketSize() {
+        float[] stereo = new float[PACKET * 2];
+        for (int i = 0; i < stereo.length; i++) {
+            stereo[i] = i;
+        }
+        float[] packet = new float[PACKET];
+
+        int next = FlexRadio.fillVoicePacket(stereo, 0, packet);
+
+        assertThat(next).isEqualTo(PACKET);
+        assertThat(packet[0]).isEqualTo(0f);
+        assertThat(packet[PACKET - 1]).isEqualTo(PACKET - 1);
+    }
+
+    @Test
+    public void partialFinalPacketIsZeroPadded_notOutOfBounds() {
+        // 120960 = FT2 @ 24 kHz stereo value count; not a multiple of 256.
+        float[] stereo = new float[120960];
+        for (int i = 0; i < stereo.length; i++) {
+            stereo[i] = 1f;
+        }
+        float[] packet = new float[PACKET];
+
+        // The final packet starts here with only 128 values left (120960 - 120832).
+        int from = 120832;
+        int next = FlexRadio.fillVoicePacket(stereo, from, packet); // must not throw
+
+        assertThat(next).isEqualTo(120960);
+        // First 128 slots are real samples, the remaining 128 are silence padding.
+        assertThat(packet[127]).isEqualTo(1f);
+        assertThat(packet[128]).isEqualTo(0f);
+        assertThat(packet[PACKET - 1]).isEqualTo(0f);
+    }
+
+    @Test
+    public void reusedPacketBufferIsFullyOverwritten() {
+        // A caller reusing a dirty buffer must still see the tail zeroed.
+        float[] stereo = {5f, 6f, 7f};
+        float[] packet = new float[PACKET];
+        for (int i = 0; i < packet.length; i++) {
+            packet[i] = 99f;
+        }
+
+        int next = FlexRadio.fillVoicePacket(stereo, 0, packet);
+
+        assertThat(next).isEqualTo(3);
+        assertThat(packet[0]).isEqualTo(5f);
+        assertThat(packet[2]).isEqualTo(7f);
+        assertThat(packet[3]).isEqualTo(0f);
+        assertThat(packet[PACKET - 1]).isEqualTo(0f);
+    }
+
+    @Test
+    public void fromAtEndProducesSilentPacketAndDoesNotAdvance() {
+        float[] stereo = new float[512];
+        float[] packet = new float[PACKET];
+
+        int next = FlexRadio.fillVoicePacket(stereo, stereo.length, packet);
+
+        assertThat(next).isEqualTo(stereo.length);
+        assertThat(packet[0]).isEqualTo(0f);
+        assertThat(packet[PACKET - 1]).isEqualTo(0f);
+    }
+
+    @Test
+    public void walksExactMultipleToCompletionWithoutOverrun() {
+        // 512 stereo values = exactly two packets; the loop must terminate cleanly.
+        float[] stereo = new float[PACKET * 2];
+        float[] packet = new float[PACKET];
+
+        int count = 0;
+        int packets = 0;
+        while (count < stereo.length) {
+            count = FlexRadio.fillVoicePacket(stereo, count, packet);
+            packets++;
+            if (count >= stereo.length) break;
+        }
+
+        assertThat(packets).isEqualTo(2);
+        assertThat(count).isEqualTo(stereo.length);
+    }
+}


### PR DESCRIPTION
## Summary

`FlexRadio.sendWaveData` streams the TX waveform to the radio in fixed 256-value stereo packets. The inner packetiser loop read `temp[count]` and only tested the bound **after** the read:

```java
for (int i = 0; i < voice.length; i++) {
    voice[i] = temp[count];   // reads before checking
    count++;
    if (count > temp.length) break;
}
```

When the total number of interleaved stereo values is not a whole multiple of 256, the final packet reads one element past the end of `temp` and throws an uncaught `ArrayIndexOutOfBoundsException` on the TX send `Thread` (whose only `catch` is for `UnknownHostException`) — crashing the whole app.

## Root cause

`temp.length == 2 * waveformSamples`.

| Mode | samples @ 24 kHz | stereo values | `% 256` |
|------|------------------|---------------|---------|
| FT8  | 79 × 3840 = 303360 | 606720 | 0 ✓ |
| FT4  | 105 × 1152 = 120960 | 241920 | 0 ✓ |
| **FT2** | **105 × 576 = 60480** | **120960** | **128 ✗** |

FT8 and FT4 buffers are multiples of 256, so the off-by-one stayed dormant. FT2 generates 60480 samples → 120960 stereo values, and `120960 % 256 == 128`, so the last packet reads `temp[120960]` and crashes on **every** FT2 transmit over a network Flex rig (`FlexNetworkRig.sendWaveData` → `GenerateFT8.generateFt8(msg, freq, 24000)`, whose output length is exactly `num_samples` with no padding).

Verified the pre-fix inline logic throws `Index 120960 out of bounds for length 120960` on the FT2 buffer.

## Fix

Extract the packetiser into a pure, unit-tested helper:

```java
static int fillVoicePacket(float[] stereo, int from, float[] packet) {
    int i = 0;
    for (; i < packet.length && from < stereo.length; i++, from++) {
        packet[i] = stereo[from];
    }
    for (; i < packet.length; i++) {
        packet[i] = 0f;   // silence-pad the final partial packet
    }
    return from;
}
```

It copies at most `packet.length` samples, zero-pads the tail of the final partial packet, and never reads past the buffer. Behaviour is **byte-identical** for the already-aligned FT8/FT4 buffers; the only change is that the previously crashing partial-packet case now sends one final silence-padded packet. The post-send `if (count > temp.length)` (dead once the read is bounded) becomes `if (count >= temp.length)` to keep breaking after the last packet.

## Testing

`./gradlew :app:testDebugUnitTest --tests com.k1af.ft8af.flex.FlexRadioVoicePacketTest --tests com.k1af.ft8af.flex.FlexRadioAudioWriteTest` — **BUILD SUCCESSFUL**, 5 new tests pass, existing Flex-audio tests still green.

New `FlexRadioVoicePacketTest` (pure JVM, mirrors the existing `FlexRadioAudioWriteTest` conventions) covers:
- a full 256-value packet advancing by exactly the packet size,
- the FT2 partial-final-packet case (`from = 120832`, 128 values left) that used to overrun — now zero-padded, no exception,
- a reused/dirty packet buffer being fully overwritten (tail zeroed),
- `from == stereo.length` producing a silent no-op packet,
- a clean exact-multiple walk terminating in the right packet count.

## Risk

Low and localized to `FlexRadio.sendWaveData`. No DSP/encoder/decoder math changes — the waveform is unchanged; only the packet-boundary bookkeeping is made bounds-safe. Aligned modes (FT8/FT4) emit identical packets.