### PR TITLE
Fix Bluetooth CAT-write crash when the link drops mid-QSO (disconnect race)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialService.java
@@ -38,7 +38,10 @@ public class BluetoothSerialService extends Service implements BluetoothSerialLi
     private final IBinder binder;
     private final Queue<QueueItem> queue1, queue2;
 
-    private BluetoothSerialSocket socket;
+    // volatile: assigned on the connect thread, cleared to null on the disconnect
+    // thread, read on the CAT/TX thread (write()). Readers snapshot it into a
+    // local before check-and-use — see write().
+    private volatile BluetoothSerialSocket socket;
     private BluetoothSerialListener listener;
     private boolean connected;
 
@@ -84,9 +87,14 @@ public class BluetoothSerialService extends Service implements BluetoothSerialLi
     }
 
     public void write(byte[] data) throws IOException {
-        if(!connected)
-            throw new IOException("not connected");
-        socket.write(data);
+        // Snapshot the volatile socket ONCE — disconnect() may null it on another
+        // thread between the connected check and the write (check-then-act race).
+        // writeIfConnected converts a torn-down link into the "not connected"
+        // IOException BluetoothRigConnector.sendCommand already handles, never an
+        // uncaught NPE that would crash the CAT/TX worker. See
+        // BluetoothSerialSocket.writeIfConnected.
+        final BluetoothSerialSocket s = socket;
+        BluetoothSerialSocket.writeIfConnected(connected, s == null ? null : s::write, data);
     }
 
     public void attach(BluetoothSerialListener listener) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialService.java
@@ -43,7 +43,10 @@ public class BluetoothSerialService extends Service implements BluetoothSerialLi
     // local before check-and-use — see write().
     private volatile BluetoothSerialSocket socket;
     private BluetoothSerialListener listener;
-    private boolean connected;
+    // volatile for the same reason as socket: written by connect()/disconnect() and
+    // the background onSerial* callbacks, read by binder callers (write()) — without
+    // it the writeIfConnected guard can see a stale value under the Java memory model.
+    private volatile boolean connected;
 
     /**
      * Lifecylce

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocket.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocket.java
@@ -32,7 +32,12 @@ public class BluetoothSerialSocket implements Runnable {
     private final Context context;
     private BluetoothSerialListener listener;
     private final BluetoothDevice device;
-    private BluetoothSocket socket;
+    // volatile: assigned on the RFCOMM connect thread (run()), cleared to null on
+    // the disconnect thread (disconnect(), driven by the background
+    // INTENT_ACTION_DISCONNECT receiver or the read loop's error path), and read
+    // on the CAT/TX thread (write()). Readers MUST snapshot it into a local before
+    // check-and-use — see write()/writeIfConnected.
+    private volatile BluetoothSocket socket;
     private boolean connected;
 
     public BluetoothSerialSocket(Context context, BluetoothDevice device) {
@@ -89,9 +94,45 @@ public class BluetoothSerialSocket implements Runnable {
     }
 
     void write(byte[] data) throws IOException {
-        if (!connected)
+        // Snapshot the volatile socket ONCE. disconnect() (the background
+        // INTENT_ACTION_DISCONNECT receiver, or the read loop's error path) may
+        // null `socket` on another thread between the connected check and the
+        // getOutputStream() call. Reading the field twice let that concurrent
+        // disconnect turn a passed null-check into a null dereference — an NPE
+        // that escapes BluetoothRigConnector.sendCommand's IOException-only catch
+        // and crashes the CAT/TX worker mid-QSO. Passing the single snapshot to
+        // writeIfConnected reports a torn-down link as the "not connected"
+        // IOException the caller already handles instead. Mirrors the USB-serial
+        // fix in CableSerialPort.writeIfOpen.
+        final BluetoothSocket s = socket;
+        writeIfConnected(connected, s == null ? null : d -> s.getOutputStream().write(d), data);
+    }
+
+    /**
+     * A sink that writes one frame to the live link — the socket's output stream
+     * in production, a capture in tests.
+     */
+    @FunctionalInterface
+    interface ByteSink {
+        void write(byte[] data) throws IOException;
+    }
+
+    /**
+     * Issue a write only if the link is still up. {@code sink} is the caller's
+     * single snapshot of the (volatile) socket's writer, so a concurrent
+     * {@link #disconnect()} that nulls the field afterwards cannot affect this
+     * call. When the link is down ({@code !connected}) or the snapshot was
+     * already null (disconnect() ran first, before {@code connected} was cleared),
+     * throw the {@code "not connected"} {@link IOException} the CAT connector
+     * already handles ({@code BluetoothRigConnector.sendCommand}) rather than
+     * NPEing on a nulled socket and crashing the CAT/TX worker thread. Mirrors
+     * {@code CableSerialPort.writeIfOpen} on the USB-serial path.
+     */
+    static void writeIfConnected(boolean connected, ByteSink sink, byte[] data) throws IOException {
+        if (!connected || sink == null) {
             throw new IOException("not connected");
-        socket.getOutputStream().write(data);
+        }
+        sink.write(data);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocket.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothSerialSocket.java
@@ -38,7 +38,10 @@ public class BluetoothSerialSocket implements Runnable {
     // on the CAT/TX thread (write()). Readers MUST snapshot it into a local before
     // check-and-use — see write()/writeIfConnected.
     private volatile BluetoothSocket socket;
-    private boolean connected;
+    // volatile for the same reason as socket: set on the connect thread, cleared on
+    // the disconnect thread, read on the CAT/TX thread (write()) — without it those
+    // reads can see a stale value under the Java memory model.
+    private volatile boolean connected;
 
     public BluetoothSerialSocket(Context context, BluetoothDevice device) {
         if(context instanceof Activity)

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/BluetoothSerialWriteTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/BluetoothSerialWriteTest.java
@@ -1,0 +1,69 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Pure-JVM coverage for {@link BluetoothSerialSocket#writeIfConnected}, the
+ * disconnect-race guard behind CAT-over-Bluetooth writes.
+ *
+ * <p>The bug this covers: a background {@code INTENT_ACTION_DISCONNECT} (rig
+ * powered off / RFCOMM link dropped mid-QSO) runs {@code disconnect()} on another
+ * thread, which nulls the socket. A CAT/TX worker already past the
+ * {@code connected} check then dereferenced the now-null socket
+ * ({@code socket.getOutputStream()} / {@code socket.write()}) → a
+ * {@link NullPointerException}. That NPE escaped
+ * {@code BluetoothRigConnector.sendCommand}'s {@code IOException}-only catch and
+ * crashed the app on a background thread. Both {@code write()} layers now
+ * snapshot the socket once and route it through {@code writeIfConnected}, which
+ * reports the torn-down link as the {@code "not connected"} {@link IOException}
+ * the connector already handles instead of NPEing — mirroring the USB-serial
+ * {@code CableSerialPort.writeIfOpen} fix.
+ */
+public class BluetoothSerialWriteTest {
+
+    @Test
+    public void nullSink_afterConcurrentDisconnect_throwsNotConnectedNotNpe() throws IOException {
+        // The crash case: the caller passed the connected==true check, but a
+        // concurrent disconnect() nulled the socket, so the snapshot -> sink is
+        // null. Must be a clean IOException, never an NPE.
+        IOException e = assertThrows(IOException.class,
+                () -> BluetoothSerialSocket.writeIfConnected(true, null, new byte[]{1, 2, 3}));
+        assertThat(e).isNotInstanceOf(NullPointerException.class);
+        assertThat(e).hasMessageThat().contains("not connected");
+    }
+
+    @Test
+    public void notConnected_throwsNotConnectedAndDoesNotWrite() {
+        // Link already down: report "not connected" without touching the sink.
+        IOException e = assertThrows(IOException.class,
+                () -> BluetoothSerialSocket.writeIfConnected(false,
+                        d -> { throw new AssertionError("must not write while disconnected"); },
+                        new byte[]{0}));
+        assertThat(e).hasMessageThat().contains("not connected");
+    }
+
+    @Test
+    public void connectedOpenSink_writesExactBytes() throws IOException {
+        AtomicReference<byte[]> got = new AtomicReference<>();
+        byte[] src = "FA021074000;".getBytes();
+
+        BluetoothSerialSocket.writeIfConnected(true, got::set, src);
+
+        assertThat(got.get()).isSameInstanceAs(src);
+    }
+
+    @Test
+    public void connectedSink_propagatesIoException() {
+        // A real write failure (socket died mid-write) must surface as IOException
+        // for sendCommand's catch to report — not be swallowed or masked.
+        assertThrows(IOException.class,
+                () -> BluetoothSerialSocket.writeIfConnected(true,
+                        d -> { throw new IOException("socket died"); }, new byte[]{0}));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a **currently-reachable crash**: when a Bluetooth-SPP CAT rig drops or powers off mid-QSO, the app can crash with an uncaught `NullPointerException` on a background thread. This is the same check-then-act (TOCTOU) disconnect race the **USB-serial** path was already hardened against (`CableSerialPort.writeIfOpen`); the Bluetooth twin never received the analogous guard.

## Root cause

`BluetoothSerialSocket.disconnect()` (driven by the background `INTENT_ACTION_DISCONNECT` receiver, or the read loop's error path) runs on a different thread and **nulls the socket field**. Meanwhile a CAT/TX worker calls down through `BluetoothRigConnector.sendCommand → BluetoothSerialService.write → BluetoothSerialSocket.write`. Each `write()` did:

```java
if (!connected) throw new IOException("not connected");
socket.getOutputStream().write(data);   // socket read AGAIN — can be null here
```

A writer that passes the `connected` check and is then preempted by `disconnect()` dereferences a **null** `socket` → `NullPointerException`. `sendCommand` only catches `IOException`, so the unchecked NPE escapes and crashes the app on the CAT/TX worker thread.

`CableSerialPort` documents and fixes exactly this on the USB path ("...reading the field twice let a concurrent disconnect null it between the null-check and `usbSerialPort.write()`, NPE-ing a delayed CAT freq write on the FT-891 as the rig dropped") via a `volatile` field, a single snapshot into a local, and the pure `writeIfOpen` helper. The Bluetooth `write()` methods were never converted.

## Fix

Both Bluetooth `write()` layers now:

- mark `socket` **`volatile`** (assigned on connect, nulled on disconnect, read on the CAT/TX thread), and
- **snapshot the field once** into a local and route it through a new pure helper `BluetoothSerialSocket.writeIfConnected(connected, sink, data)`, which reports a torn-down link as the `"not connected"` `IOException` the caller already handles — never an NPE.

Because the snapshot is read once, a concurrent `disconnect()` that nulls the field afterwards cannot turn a passed check into a null dereference. The change is behaviour-preserving on the happy path (identical bytes written) and on the already-disconnected path (still throws `"not connected"`, which `sendCommand` already handles).

## Testing

- New `BluetoothSerialWriteTest` (pure JVM, 4 cases) covering `writeIfConnected`, including **the race case** (`connected == true` but the snapshotted sink is null → clean `IOException`, asserted *not* an NPE), the not-connected path, the happy path (exact bytes), and `IOException` propagation. Mirrors the existing `CableSerialPortControlLineTest` `writeIfOpen` tests.
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full APK (incl. native build) links.

## Risk

Low. Two localized files in the Bluetooth transport; no protocol/DSP/encoder behaviour changes. The only semantic change is that a write racing a disconnect now surfaces as the existing `"not connected"` `IOException` instead of crashing. USB-serial, audio, decode, and CAT parsing paths are untouched.

## Affected platforms

Android, Bluetooth-SPP CAT control only.