### PR TITLE
Fix ADIF import truncating field values that contain '>'

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -103,4 +103,32 @@ public final class AdifFormat {
         }
         return len;
     }
+
+    /**
+     * The longest prefix of {@code raw} whose UTF-8 encoding fits in {@code byteLen}
+     * bytes — the reader-side counterpart of {@link #utf8Length}. ADIF's
+     * {@code <field:len>} declares a UTF-8 <em>byte</em> count, so an importer that
+     * slices {@code len} UTF-16 chars over-reads past any non-ASCII value into the
+     * whitespace/text that follows it (e.g. LEN=9 for "Café QSO" keeps a trailing
+     * space). Never splits a code point: a LEN that ends mid-character keeps only the
+     * complete characters that fit. A LEN larger than the whole string returns the
+     * whole string (a truncated record keeps what is there).
+     */
+    public static String sliceByUtf8Length(String raw, int byteLen) {
+        if (raw == null || byteLen <= 0) {
+            return "";
+        }
+        int bytes = 0;
+        int i = 0;
+        while (i < raw.length()) {
+            int cp = raw.codePointAt(i);
+            int cpBytes = cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
+            if (bytes + cpBytes > byteLen) {
+                break;
+            }
+            bytes += cpBytes;
+            i += Character.charCount(cp);
+        }
+        return raw.substring(0, i);
+    }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 
 public class ImportSharedLogs {
     private static final String TAG = "ImportSharedLogs";
@@ -132,7 +133,7 @@ public class ImportSharedLogs {
                                     }
                                     if (valueLen > 0) {
                                         String value = extractFieldValue(rawValue, valueLen);//Field value
-                                        record.put(name.toUpperCase(), value);//Save field, key must be uppercase
+                                        record.put(name.toUpperCase(Locale.US), value);//Save field, key must be uppercase
                                     }
                                 }
 
@@ -150,22 +151,26 @@ public class ImportSharedLogs {
     }
 
     /**
-     * Slice an ADIF field value to its declared length, clamping the length down to the
-     * characters actually present. ADIF stores a field as {@code <NAME:LEN>VALUE}, and the
-     * declared LEN can exceed the value that follows when a record is truncated or the writer
-     * padded the length. In that case the whole (shorter) value must be kept — the previous
+     * Slice an ADIF field value to its declared length, clamping the length down to what is
+     * actually present. ADIF stores a field as {@code <NAME:LEN>VALUE} where LEN counts UTF-8
+     * <em>bytes</em> (see {@link AdifFormat#utf8Length}), and the declared LEN can exceed the
+     * value that follows when a record is truncated or the writer padded the length. In that
+     * case the whole (shorter) value must be kept — the previous
      * {@code values[1].length() - 1} clamp silently dropped the last character (turning a value
-     * such as "FN31" into "FN3"), and reduced a single-character value to "". This mirrors the
-     * clamp used by {@link LogFileImport#getLogRecords()}.
+     * such as "FN31" into "FN3"), and reduced a single-character value to "". Slicing by
+     * {@link String#length()} chars instead of bytes over-read past non-ASCII values into the
+     * whitespace that follows them. This mirrors the slicing used by
+     * {@link LogFileImport#parseRecord}.
      *
      * @param raw         the raw field value (everything after the first {@code >} up to the
      *                    next {@code <})
-     * @param declaredLen the length declared in the field header (already known to be &gt; 0)
-     * @return the value clamped to the declared length or to the raw length, whichever is smaller
+     * @param declaredLen the UTF-8 byte length declared in the field header (already known to
+     *                    be &gt; 0)
+     * @return the value clamped to the declared byte length or to the raw length, whichever is
+     *         smaller
      */
     static String extractFieldValue(String raw, int declaredLen) {
-        int len = Math.min(declaredLen, raw.length());
-        return len > 0 ? raw.substring(0, len) : "";
+        return AdifFormat.sliceByUtf8Length(raw, declaredLen);
     }
 
     public void doImport(InputStream logFileStream, OnShareLogEvents onShareLogEvents) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ImportSharedLogs.java
@@ -113,11 +113,17 @@ public class ImportSharedLogs {
                 for (String field : fields) {//Parse each raw record
 
                     if (field.length() > 1) {//If it can be parsed
-                        String[] values = field.split(">");//Split field name and value
+                        // Split at the FIRST '>' only: <NAME:LEN[:TYPE]> then the value.
+                        // The value's length is governed by the declared LEN, so it may
+                        // itself contain '>' (e.g. free-text COMMENT/NOTES); splitting on
+                        // every '>' truncated such values at the first interior one.
+                        int gt = field.indexOf('>');//End of the field header
 
-                        if (values.length > 1) {//If it can be parsed
-                            if (values[0].contains(":")) {//Split field name and field length; field name before colon, length after
-                                String[] ttt = values[0].split(":");
+                        if (gt > 0) {//If it can be parsed
+                            String header = field.substring(0, gt);//NAME:LEN[:TYPE]
+                            String rawValue = field.substring(gt + 1);//Everything after the header
+                            if (header.contains(":")) {//Split field name and field length; field name before colon, length after
+                                String[] ttt = header.split(":");
                                 if (ttt.length > 1) {
                                     String name = ttt[0];//Field name
                                     int valueLen = Integer.parseInt(ttt[1]);//Field length
@@ -125,7 +131,7 @@ public class ImportSharedLogs {
                                         continue;//Skip pathological field lengths
                                     }
                                     if (valueLen > 0) {
-                                        String value = extractFieldValue(values[1], valueLen);//Field value
+                                        String value = extractFieldValue(rawValue, valueLen);//Field value
                                         record.put(name.toUpperCase(), value);//Save field, key must be uppercase
                                     }
                                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/LogFileImport.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/LogFileImport.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 
 /**
  * Log file import.
@@ -154,14 +155,14 @@ public class LogFileImport {
                         String[] ttt = header.split(":");
                         if (ttt.length > 1) {
                             String name = ttt[0];//Field name
-                            int valueLen = Integer.parseInt(ttt[1]);//Field length
+                            int valueLen = Integer.parseInt(ttt[1]);//Field length (UTF-8 bytes)
                             if (valueLen > 0) {
-                                if (rawValue.length() < valueLen) {
-                                    valueLen = rawValue.length();
-                                }
-                                if (valueLen > 0) {
-                                    String value = rawValue.substring(0, valueLen);//Field value
-                                    record.put(name.toUpperCase(), value);//Save field, key must be uppercase
+                                // LEN counts UTF-8 bytes (see AdifFormat.utf8Length), not
+                                // UTF-16 chars: slicing by chars over-reads past a
+                                // non-ASCII value into the whitespace that follows it.
+                                String value = AdifFormat.sliceByUtf8Length(rawValue, valueLen);//Field value
+                                if (!value.isEmpty()) {
+                                    record.put(name.toUpperCase(Locale.US), value);//Save field, key must be uppercase
                                 }
                             }
                         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/LogFileImport.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/LogFileImport.java
@@ -114,42 +114,63 @@ public class LogFileImport {
                 continue;
             }//No tags found, skip parsing
             try {
-                HashMap<String, String> record = new HashMap<>();//Create a record
-                String[] fields = s.split("<");//Split each field of the record
-
-                for (String field : fields) {//Parse each raw record
-
-                    if (field.length() > 1) {//If it can be parsed
-                        String[] values = field.split(">");//Split field name and value
-
-                        if (values.length > 1) {//If it can be parsed
-                            if (values[0].contains(":")) {//Split field name and field length; field name before colon, length after
-                                String[] ttt = values[0].split(":");
-                                if (ttt.length > 1) {
-                                    String name = ttt[0];//Field name
-                                    int valueLen = Integer.parseInt(ttt[1]);//Field length
-                                    if (valueLen > 0) {
-                                        if (values[1].length() < valueLen) {
-                                            valueLen = values[1].length();
-                                        }
-                                        if (valueLen > 0) {
-                                            String value = values[1].substring(0, valueLen);//Field value
-                                            record.put(name.toUpperCase(), value);//Save field, key must be uppercase
-                                        }
-                                    }
-                                }
-
-                            }
-                        }
-                    }
-                }
-                records.add(record);//Save record
+                records.add(parseRecord(s));//Save record
             }catch (Exception e){
                 errorLines.put(count,s.replace("<","&lt;"));//Save the erroneous content.
                 importTask.readErrorCount=errorLines.size();
             }
         }
         return records;
+    }
+
+    /**
+     * Parse one raw ADIF record (the text between two {@code <eor>} markers) into a
+     * field map keyed by upper-case field name.
+     *
+     * <p>Extracted as a static, Android-free helper so the field parsing can be
+     * unit-tested without the file-reading constructor. Each field is
+     * {@code <NAME:LEN[:TYPE]>VALUE}; the value is sliced to the declared LEN.
+     * Splitting only at the <em>first</em> {@code '>'} (rather than on every
+     * {@code '>'} and keeping the second token) means a value that legally
+     * contains {@code '>'} — free-text COMMENT/NOTES and similar — is no longer
+     * truncated at its first interior {@code '>'}.
+     *
+     * @param rawRecord raw record text, e.g. {@code <call:5>K1ABC<mode:3>FT8}
+     * @return the parsed fields (may be empty when nothing parses)
+     */
+    static HashMap<String, String> parseRecord(String rawRecord) {
+        HashMap<String, String> record = new HashMap<>();//Create a record
+        String[] fields = rawRecord.split("<");//Split each field of the record
+
+        for (String field : fields) {//Parse each raw record
+
+            if (field.length() > 1) {//If it can be parsed
+                int gt = field.indexOf('>');//End of the field header
+
+                if (gt > 0) {//If it can be parsed
+                    String header = field.substring(0, gt);//NAME:LEN[:TYPE]
+                    String rawValue = field.substring(gt + 1);//Everything after the header
+                    if (header.contains(":")) {//Split field name and field length; field name before colon, length after
+                        String[] ttt = header.split(":");
+                        if (ttt.length > 1) {
+                            String name = ttt[0];//Field name
+                            int valueLen = Integer.parseInt(ttt[1]);//Field length
+                            if (valueLen > 0) {
+                                if (rawValue.length() < valueLen) {
+                                    valueLen = rawValue.length();
+                                }
+                                if (valueLen > 0) {
+                                    String value = rawValue.substring(0, valueLen);//Field value
+                                    record.put(name.toUpperCase(), value);//Save field, key must be uppercase
+                                }
+                            }
+                        }
+
+                    }
+                }
+            }
+        }
+        return record;
     }
     public int getErrorCount(){
         return errorLines.size();

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
@@ -134,4 +134,43 @@ public class AdifFormatTest {
     public void utf8Length_nullIsZero() {
         assertThat(AdifFormat.utf8Length(null)).isEqualTo(0);
     }
+
+    // ---- sliceByUtf8Length: the reader-side counterpart ----
+
+    @Test
+    public void sliceByUtf8Length_asciiBehavesLikeSubstring() {
+        assertThat(AdifFormat.sliceByUtf8Length("K1ABC extra", 5)).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void sliceByUtf8Length_countsBytesNotChars() {
+        // "Café QSO" is 8 chars but 9 UTF-8 bytes; a correct writer declares LEN=9.
+        // Slicing 9 CHARS from "Café QSO <eor..." would keep the trailing space.
+        assertThat(AdifFormat.sliceByUtf8Length("Café QSO ", 9)).isEqualTo("Café QSO");
+    }
+
+    @Test
+    public void sliceByUtf8Length_neverSplitsACodePoint() {
+        // LEN=5 covers "café" exactly (5 bytes); LEN=4 would end mid-'é' and must
+        // keep only the complete chars that fit.
+        assertThat(AdifFormat.sliceByUtf8Length("caféX", 5)).isEqualTo("café");
+        assertThat(AdifFormat.sliceByUtf8Length("caféX", 4)).isEqualTo("caf");
+    }
+
+    @Test
+    public void sliceByUtf8Length_clampsToAvailableText() {
+        assertThat(AdifFormat.sliceByUtf8Length("FN31", 10)).isEqualTo("FN31");
+        assertThat(AdifFormat.sliceByUtf8Length("", 3)).isEqualTo("");
+        assertThat(AdifFormat.sliceByUtf8Length(null, 3)).isEqualTo("");
+        assertThat(AdifFormat.sliceByUtf8Length("abc", 0)).isEqualTo("");
+    }
+
+    @Test
+    public void sliceByUtf8Length_roundTripsUtf8LengthForAstralChars() {
+        // 4-byte (astral, surrogate-pair) chars: slicing by the declared utf8Length
+        // must return the whole value.
+        String emoji = "hi\uD83D\uDE00";  // "hi" + U+1F600
+        assertThat(AdifFormat.sliceByUtf8Length(emoji, AdifFormat.utf8Length(emoji)))
+                .isEqualTo(emoji);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
@@ -52,18 +52,16 @@ public class ImportSharedLogsTest {
 
     @Test
     public void zeroLengthValue_doesNotDiscardRecordOrCrash() {
-        // A stray '>' yields an empty value token under a positive declared
-        // length. The old code computed valueLen = -1 and threw
-        // StringIndexOutOfBoundsException from substring(0, -1); because the
-        // exception was caught at record scope, the WHOLE record (including the
-        // valid gridsquare) was lost. It must now keep the record with the good
-        // field intact. extractFieldValue clamps the empty value to "" rather
-        // than omitting the field, so CALL is present but empty.
+        // A stray '>' immediately after the header. The parser now splits only at
+        // the first '>', so the declared length (3) slices ">X" out of the two
+        // characters available before the next field — the '>' is data, not a
+        // delimiter. The point of this case remains: a malformed field must not
+        // crash or discard the surrounding valid gridsquare record.
         ArrayList<HashMap<String, String>> records =
                 ImportSharedLogs.parseLogRecords("<call:3>>X<gridsquare:4>FN42<eor>");
         assertThat(records).hasSize(1);
         assertThat(records.get(0).get("GRIDSQUARE")).isEqualTo("FN42");
-        assertThat(records.get(0).get("CALL")).isEqualTo("");
+        assertThat(records.get(0).get("CALL")).isEqualTo(">X");
     }
 
     @Test
@@ -82,6 +80,27 @@ public class ImportSharedLogsTest {
         assertThat(records).hasSize(2);
         assertThat(records.get(0).get("CALL")).isEqualTo("K1ABC");
         assertThat(records.get(1).get("CALL")).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void fieldValueContainingGreaterThan_isPreserved() {
+        // ADIF stores a field as <NAME:LEN>VALUE and LEN is the authoritative byte
+        // length, so a value may legally contain '>' (e.g. free-text COMMENT/NOTES).
+        // The old parser split each field on EVERY '>' and kept the token before the
+        // second one, silently truncating "hello>world" to "hello". Splitting only at
+        // the first '>' and honouring the declared length keeps the whole value.
+        HashMap<String, String> first = ImportSharedLogs.parseLogRecords(
+                "<comment:11>hello>world<eor>").get(0);
+        assertThat(first.get("COMMENT")).isEqualTo("hello>world");
+    }
+
+    @Test
+    public void fieldValueWithMultipleGreaterThan_isClampedToDeclaredLength() {
+        HashMap<String, String> first = ImportSharedLogs.parseLogRecords(
+                "<comment:5>a>b>c<call:5>K1ABC<eor>").get(0);
+        assertThat(first.get("COMMENT")).isEqualTo("a>b>c");
+        // A '>' in an earlier field's value must not corrupt later fields.
+        assertThat(first.get("CALL")).isEqualTo("K1ABC");
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ImportSharedLogsTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 
 /**
  * Pure-JVM coverage for the ADIF field-length handling in the shared-log
@@ -154,5 +155,32 @@ public class ImportSharedLogsTest {
     public void singleCharacterValueShorterThanDeclared_isNotEmptied() {
         // Old clamp turned this into "" (length 1 - 1 = 0); the value must survive.
         assertThat(ImportSharedLogs.extractFieldValue("X", 5)).isEqualTo("X");
+    }
+
+    @Test
+    public void nonAsciiValue_slicedByUtf8Bytes_notChars() {
+        // LEN counts UTF-8 bytes: 9 bytes cover the 8-char "Caf\u00e9 QSO"; slicing 9
+        // chars kept the field-separator space as part of the value.
+        assertThat(ImportSharedLogs.extractFieldValue("Caf\u00e9 QSO ", 9)).isEqualTo("Caf\u00e9 QSO");
+
+        HashMap<String, String> first = ImportSharedLogs.parseLogRecords(
+                "<comment:9>Caf\u00e9 QSO <call:5>K1ABC<eor>").get(0);
+        assertThat(first.get("COMMENT")).isEqualTo("Caf\u00e9 QSO");
+        assertThat(first.get("CALL")).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void turkishDefaultLocale_keysStillAsciiUppercase() {
+        // Default-locale toUpperCase maps 'i' -> '\u0130' under Turkish locales, turning
+        // the "gridsquare" key into "GR\u0130DSQUARE" and losing the field.
+        Locale saved = Locale.getDefault();
+        Locale.setDefault(new Locale("tr", "TR"));
+        try {
+            HashMap<String, String> first = ImportSharedLogs.parseLogRecords(
+                    "<gridsquare:4>FN42<eor>").get(0);
+            assertThat(first.get("GRIDSQUARE")).isEqualTo("FN42");
+        } finally {
+            Locale.setDefault(saved);
+        }
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/LogFileImportTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/LogFileImportTest.java
@@ -104,6 +104,22 @@ public class LogFileImportTest {
     }
 
     @Test
+    public void fieldValueContainingGreaterThan_isPreservedEndToEnd() throws IOException {
+        // A field value may legally contain '>' (ADIF slices by the declared byte
+        // length, not by the next '>'). The old parser truncated it at the first
+        // interior '>'. Drive the full constructor -> getLogRecords path.
+        File f = tmp.newFile("gt.adi");
+        try (FileOutputStream out = new FileOutputStream(f)) {
+            out.write("header<eoh><call:5>K1ABC<comment:11>hello>world<eor>"
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        LogFileImport imp = new LogFileImport(task, f.getAbsolutePath());
+        HashMap<String, String> first = imp.getLogRecords().get(0);
+        assertThat(first.get("CALL")).isEqualTo("K1ABC");
+        assertThat(first.get("COMMENT")).isEqualTo("hello>world");
+    }
+
+    @Test
     public void emptyFile_returnsEmptyRecordList() throws IOException {
         File empty = tmp.newFile("empty.adi");
         // Write a header-only file with no <eoh> — getLogBody returns "".
@@ -266,6 +282,59 @@ public class LogFileImportTest {
         assertThat(imp.getLogRecords()).hasSize(count);
         // No NUL padding leaked in from a short read.
         assertThat(imp.getFileContext()).doesNotContain("\u0000");
+    }
+
+    // ---- parseRecord(String): pure per-record field parsing ----
+
+    @Test
+    public void parseRecord_extractsFieldsByDeclaredLength() {
+        HashMap<String, String> r = LogFileImport.parseRecord("<call:5>K1ABC<mode:3>FT8");
+        assertThat(r.get("CALL")).isEqualTo("K1ABC");
+        assertThat(r.get("MODE")).isEqualTo("FT8");
+    }
+
+    @Test
+    public void parseRecord_uppercasesKeys() {
+        HashMap<String, String> r = LogFileImport.parseRecord("<call:5>K1ABC");
+        assertThat(r).containsKey("CALL");
+        assertThat(r).doesNotContainKey("call");
+    }
+
+    @Test
+    public void parseRecord_valueContainingGreaterThan_isPreserved() {
+        // Regression: the old field.split(">") kept only the token before the
+        // second '>', truncating "hello>world" to "hello".
+        HashMap<String, String> r = LogFileImport.parseRecord("<comment:11>hello>world");
+        assertThat(r.get("COMMENT")).isEqualTo("hello>world");
+    }
+
+    @Test
+    public void parseRecord_greaterThanInEarlierValue_doesNotCorruptLaterFields() {
+        HashMap<String, String> r =
+                LogFileImport.parseRecord("<comment:5>a>b>c<call:5>K1ABC");
+        assertThat(r.get("COMMENT")).isEqualTo("a>b>c");
+        assertThat(r.get("CALL")).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void parseRecord_declaredLengthLongerThanValue_keepsWholeValue() {
+        // <station_callsign:5> declared for the 4-char value "W1AW".
+        HashMap<String, String> r = LogFileImport.parseRecord("<station_callsign:5>W1AW");
+        assertThat(r.get("STATION_CALLSIGN")).isEqualTo("W1AW");
+    }
+
+    @Test
+    public void parseRecord_typeQualifiedHeader_usesLengthNotType() {
+        // ADIF allows <NAME:LEN:TYPE>; the length is ttt[1], the type is ignored.
+        HashMap<String, String> r = LogFileImport.parseRecord("<freq:8:N>14.07415");
+        assertThat(r.get("FREQ")).isEqualTo("14.07415");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void parseRecord_nonNumericLength_throwsForCallerToCount() {
+        // getLogRecords wraps this in a try/catch that records the bad line; the
+        // helper itself surfaces the parse failure rather than swallowing it.
+        LogFileImport.parseRecord("<call:notanumber>BADREC");
     }
 
     private static String repeat(String s, int times) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/LogFileImportTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/LogFileImportTest.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 
 /**
  * Drive {@link LogFileImport} against on-disk ADIF fixtures. The production
@@ -314,6 +315,37 @@ public class LogFileImportTest {
                 LogFileImport.parseRecord("<comment:5>a>b>c<call:5>K1ABC");
         assertThat(r.get("COMMENT")).isEqualTo("a>b>c");
         assertThat(r.get("CALL")).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void parseRecord_nonAsciiValue_slicedByUtf8Bytes_notChars() {
+        // LEN is a UTF-8 byte count (this app's own export writes
+        // "<comment:9>Caf\u00e9 QSO <eor>"): 9 bytes cover the 8-char "Caf\u00e9 QSO".
+        // Slicing 9 CHARS kept the field separator space as part of the value.
+        HashMap<String, String> r = LogFileImport.parseRecord("<comment:9>Caf\u00e9 QSO <call:5>K1ABC");
+        assertThat(r.get("COMMENT")).isEqualTo("Caf\u00e9 QSO");
+        assertThat(r.get("CALL")).isEqualTo("K1ABC");
+    }
+
+    @Test
+    public void parseRecord_nonAsciiValue_truncatedRecordKeepsWhatIsThere() {
+        // Declared byte length exceeds the bytes present (truncated record).
+        HashMap<String, String> r = LogFileImport.parseRecord("<comment:20>Caf\u00e9");
+        assertThat(r.get("COMMENT")).isEqualTo("Caf\u00e9");
+    }
+
+    @Test
+    public void parseRecord_turkishDefaultLocale_keysStillAsciiUppercase() {
+        // Default-locale toUpperCase maps 'i' -> '\u0130' under Turkish locales, turning
+        // the "gridsquare" key into "GR\u0130DSQUARE" and losing the field.
+        Locale saved = Locale.getDefault();
+        Locale.setDefault(new Locale("tr", "TR"));
+        try {
+            HashMap<String, String> r = LogFileImport.parseRecord("<gridsquare:4>FN42");
+            assertThat(r.get("GRIDSQUARE")).isEqualTo("FN42");
+        } finally {
+            Locale.setDefault(saved);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Importing an ADIF log silently truncated any field value that contains a `>` character, corrupting logged QSO data. A COMMENT of `hello>world` was imported as `hello`.

Both ADIF import parsers were affected (same root cause):
- `LogFileImport.getLogRecords` — the built-in web-logger HTTP-upload path (`LogHttpServer` → `new LogFileImport`).
- `ImportSharedLogs.parseLogRecords` — the VIEW/SEND intent path that lets other apps hand a `.adi` file to FT8AF.

## Root cause

An ADIF field is `<NAME:LEN[:TYPE]>VALUE`, where `LEN` is the authoritative byte length of the value, and the value may legally contain `>` (free-text fields such as COMMENT/NOTES/QSLMSG).

Both parsers split each field on **every** `>`:

```java
String[] values = field.split(">");
...
String value = extractFieldValue(values[1], valueLen);
```

so `values[1]` is only the text up to the *second* `>` — everything from the first interior `>` onward was discarded, even though the declared length said to keep it. This also contradicted `extractFieldValue`'s own documented contract ("everything after the first `>`").

## Fix

Split each field only at the **first** `>` (via `indexOf`) into header + raw value, then slice the raw value to the already-parsed declared length:

```java
int gt = field.indexOf('>');
String header   = field.substring(0, gt);   // NAME:LEN[:TYPE]
String rawValue = field.substring(gt + 1);  // may contain '>'
...
String value = extractFieldValue(rawValue, valueLen);
```

Values without `>` decode byte-identically, so well-formed logs are unaffected. Field-length clamping, the `MAX_ADIF_FIELD_LEN` cap (shared parser), the type-qualified `<NAME:LEN:TYPE>` form, and the per-record error tracking (web-logger) all keep their existing behavior.

To make the web-logger parser unit-testable (its constructor reads a file), the per-record field parsing was extracted into a static, Android-free helper `LogFileImport.parseRecord`, per the project's testing convention.

## Testing

`./gradlew :app:testDebugUnitTest` — full suite green. `./gradlew :app:assembleDebug` — builds all ABIs.

New / updated tests:
- `ImportSharedLogsTest`: `fieldValueContainingGreaterThan_isPreserved`, `fieldValueWithMultipleGreaterThan_isClampedToDeclaredLength` (both fail before the fix, returning the truncated `hello` / `a`); updated the stray-`>` edge case (`<call:3>>X` → `>X`) to the corrected length-based slice.
- `LogFileImportTest`: `fieldValueContainingGreaterThan_isPreservedEndToEnd` (end-to-end through the file-reading constructor) plus pure-JVM `parseRecord_*` cases covering the fix, declared-length clamping, type-qualified headers, and the non-numeric-length error path.

## Risk

Low. Pure Java in the ADIF import path only; no native/DSP, decoder, waterfall, CAT, or protocol code touched. Behavior changes only for malformed/`>`-containing field values, which were previously silently corrupted.