### PR TITLE
Bound CI-V reassembly buffer to prevent OOM on a terminator-less stream

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivFrameSplitter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivFrameSplitter.java
@@ -107,11 +107,14 @@ final class CivFrameSplitter {
         }
         for (int i = remainder.length - 2; i >= 0; i--) {
             if (remainder[i] == PREAMBLE && remainder[i + 1] == PREAMBLE) {
-                byte[] resynced = Arrays.copyOfRange(remainder, i, remainder.length);
-                if (resynced.length <= MAX_BUFFERED_BYTES) {
-                    return resynced;
-                }
-                return Arrays.copyOfRange(resynced, resynced.length - MAX_BUFFERED_BYTES, resynced.length);
+                // Resynchronise to this preamble. If the tail from here still
+                // exceeds the cap (a lone preamble ahead of a huge terminator-less
+                // run) keep only its trailing window. Compute the copy start first
+                // so we allocate at most MAX_BUFFERED_BYTES bytes rather than the
+                // full oversized remainder — this guard fires precisely in the
+                // malformed-stream case, where the extra copy would hurt most.
+                int from = Math.max(i, remainder.length - MAX_BUFFERED_BYTES);
+                return Arrays.copyOfRange(remainder, from, remainder.length);
             }
         }
         if (remainder[remainder.length - 1] == PREAMBLE) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivFrameSplitter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivFrameSplitter.java
@@ -23,10 +23,28 @@ import java.util.List;
  * every earlier fragment of a split command, and (b) appended two stray
  * {@code 0x00} bytes to the carried-over remainder after every frame, corrupting
  * the next command when it was reassembled from more than one chunk.
+ *
+ * <p>The carried-over remainder is also bounded: a stream that never delivers the
+ * {@code 0xFD} terminator (a rig on the wrong baud, line noise, a misbehaving
+ * network peer) would otherwise grow it without limit and eventually exhaust
+ * memory. See {@link #boundRemainder}.
  */
 final class CivFrameSplitter {
     /** CI-V end-of-message terminator. */
     private static final byte END_MARKER = (byte) 0xFD;
+    /** CI-V preamble byte; a command opens with two of these ({@code FE FE}). */
+    private static final byte PREAMBLE = (byte) 0xFE;
+
+    /**
+     * Hard cap on the carried-over remainder. A well-formed CI-V command this app
+     * exchanges is a few to a few dozen bytes, so the reassembly buffer should
+     * never approach this. It only matters when the terminator {@code 0xFD} never
+     * arrives — a rig on the wrong baud, line noise, or a misbehaving network peer
+     * streaming garbage — which would otherwise grow {@code dataBuffer} without
+     * bound and eventually OOM the app. 1 KiB is orders of magnitude above any
+     * real frame yet keeps memory firmly bounded.
+     */
+    private static final int MAX_BUFFERED_BYTES = 1024;
 
     private CivFrameSplitter() {
     }
@@ -65,6 +83,40 @@ final class CivFrameSplitter {
                 start = i + 1;
             }
         }
-        return new Result(commands, Arrays.copyOfRange(combined, start, combined.length));
+        return new Result(commands, boundRemainder(Arrays.copyOfRange(combined, start, combined.length)));
+    }
+
+    /**
+     * Keep the trailing remainder from growing without bound when the terminator
+     * never arrives. A remainder holds a command still in progress (it contains no
+     * {@code 0xFD}, or it would have been split off already), so under normal
+     * operation it stays tiny. Only a malformed stream lets it exceed
+     * {@link #MAX_BUFFERED_BYTES}; when it does, resynchronise to the most recent
+     * {@code FE FE} preamble — the earliest point a valid command could still begin
+     * — discarding the unparseable bytes before it. Bytes preceding that preamble
+     * can never complete a frame (a valid one would have ended in {@code 0xFD} and
+     * been emitted), so dropping them is lossless for well-formed traffic and only
+     * ever trims garbage. If no preamble is present the buffer is pure noise: keep
+     * at most a trailing {@code 0xFE} in case a preamble is split across the read
+     * boundary. A final trailing-window clamp guarantees boundedness even in the
+     * pathological case of a lone preamble followed by a huge terminator-less run.
+     */
+    private static byte[] boundRemainder(byte[] remainder) {
+        if (remainder.length <= MAX_BUFFERED_BYTES) {
+            return remainder;
+        }
+        for (int i = remainder.length - 2; i >= 0; i--) {
+            if (remainder[i] == PREAMBLE && remainder[i + 1] == PREAMBLE) {
+                byte[] resynced = Arrays.copyOfRange(remainder, i, remainder.length);
+                if (resynced.length <= MAX_BUFFERED_BYTES) {
+                    return resynced;
+                }
+                return Arrays.copyOfRange(resynced, resynced.length - MAX_BUFFERED_BYTES, resynced.length);
+            }
+        }
+        if (remainder[remainder.length - 1] == PREAMBLE) {
+            return new byte[]{PREAMBLE};
+        }
+        return new byte[0];
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivFrameSplitterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivFrameSplitterTest.java
@@ -148,6 +148,110 @@ public class CivFrameSplitterTest {
         assertThat(r.remainder).hasLength(0);
     }
 
+    // The reassembly buffer must not grow without bound. The remainder holds a
+    // command still in progress (no terminator yet), so under normal operation it
+    // stays tiny; but a stream that never sends 0xFD — a rig on the wrong baud,
+    // line noise, or a misbehaving network peer — would otherwise accumulate every
+    // byte forever and eventually OOM the app. The cap below (1 KiB) is orders of
+    // magnitude above any real CI-V command, so these tests only exercise the
+    // malformed-stream guard and never affect well-formed traffic.
+    private static final int MAX_BUFFERED_BYTES = 1024;
+
+    @Test
+    public void terminatorlessStream_remainderStaysBounded() {
+        // Simulate a rig streaming garbage that never contains a terminator across
+        // many callbacks. Without the cap the carried buffer would grow to megabytes.
+        byte[] buffered = new byte[0];
+        byte[] noise = new byte[512]; // no 0xFD, no FE FE
+        for (int i = 0; i < noise.length; i++) {
+            noise[i] = (byte) (i & 0x7F); // 0x00..0x7F, never 0xFD or 0xFE
+        }
+        for (int call = 0; call < 100; call++) {
+            CivFrameSplitter.Result r = CivFrameSplitter.split(buffered, noise);
+            assertThat(r.commands).isEmpty();
+            assertThat(r.remainder.length).isAtMost(MAX_BUFFERED_BYTES);
+            buffered = r.remainder;
+        }
+    }
+
+    @Test
+    public void overflow_resyncsToMostRecentPreamble() {
+        // Garbage with no terminator, then a fresh command's preamble and start.
+        byte[] garbage = new byte[1100]; // all 0x00: no FD, no FE
+        byte[] partialNext = {(byte) 0xFE, (byte) 0xFE, (byte) 0xE0, (byte) 0xA4, (byte) 0x03};
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], concat(garbage, partialNext));
+
+        assertThat(r.commands).isEmpty();
+        // Everything before the last FE FE is unparseable and is dropped; the live
+        // command-in-progress is preserved so the next chunk completes it.
+        assertThat(r.remainder).isEqualTo(partialNext);
+    }
+
+    @Test
+    public void overflow_resyncedFrameStillCompletesOnNextChunk() {
+        byte[] garbage = new byte[1100];
+        byte[] frame = freqFrame();
+        byte[] frameFirst = java.util.Arrays.copyOfRange(frame, 0, 5);
+        byte[] frameRest = java.util.Arrays.copyOfRange(frame, 5, frame.length);
+
+        CivFrameSplitter.Result r1 = CivFrameSplitter.split(new byte[0], concat(garbage, frameFirst));
+        assertThat(r1.commands).isEmpty();
+        assertThat(r1.remainder).isEqualTo(frameFirst);
+
+        CivFrameSplitter.Result r2 = CivFrameSplitter.split(r1.remainder, frameRest);
+        assertThat(r2.commands).hasSize(1);
+        assertThat(r2.commands.get(0)).isEqualTo(frame);
+        assertThat(r2.remainder).hasLength(0);
+    }
+
+    @Test
+    public void overflow_noPreambleDropsNoiseButKeepsTrailingPreambleByte() {
+        byte[] noiseEndingInFe = new byte[1100];
+        noiseEndingInFe[noiseEndingInFe.length - 1] = (byte) 0xFE; // possible split preamble
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], noiseEndingInFe);
+
+        assertThat(r.commands).isEmpty();
+        // Keep the lone trailing 0xFE so a preamble split across the read boundary
+        // still reassembles; everything else was pure noise.
+        assertThat(r.remainder).isEqualTo(new byte[]{(byte) 0xFE});
+    }
+
+    @Test
+    public void overflow_pureNoiseDropsEverything() {
+        byte[] noise = new byte[1100]; // all 0x00: no FD, no FE
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], noise);
+
+        assertThat(r.commands).isEmpty();
+        assertThat(r.remainder).hasLength(0);
+    }
+
+    @Test
+    public void overflow_lonePreambleWithHugeTail_isHardCapped() {
+        // Pathological: a preamble at the very start followed by a terminator-less
+        // run longer than the cap. Resync alone can't shrink it, so the trailing
+        // window clamp guarantees boundedness.
+        byte[] buf = new byte[2200];
+        buf[0] = (byte) 0xFE;
+        buf[1] = (byte) 0xFE; // FE FE at index 0, nothing else notable, no FD
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], buf);
+
+        assertThat(r.commands).isEmpty();
+        assertThat(r.remainder.length).isEqualTo(MAX_BUFFERED_BYTES);
+    }
+
+    @Test
+    public void largeButUnderCapPartial_isCarriedUnchanged() {
+        // A big-but-legitimate partial command (still under the cap) must pass
+        // through untouched — the guard only trims genuinely oversized buffers.
+        byte[] partial = new byte[MAX_BUFFERED_BYTES];
+        partial[0] = (byte) 0xFE;
+        partial[1] = (byte) 0xFE; // valid-looking start, no terminator yet
+        CivFrameSplitter.Result r = CivFrameSplitter.split(new byte[0], partial);
+
+        assertThat(r.commands).isEmpty();
+        assertThat(r.remainder).isEqualTo(partial);
+    }
+
     private static byte[] concat(byte[] a, byte[] b) {
         byte[] out = new byte[a.length + b.length];
         System.arraycopy(a, 0, out, 0, a.length);


### PR DESCRIPTION
## Summary

The shared CI-V (Icom / Xiegu) stream reassembler, `CivFrameSplitter`, buffered
the trailing bytes after the last frame terminator (`0xFD`) and carried them into
the next read via each rig's `dataBuffer`. Nothing bounded that buffer: a CI-V
stream that never delivers a terminator — a rig connected at the wrong baud rate,
line noise on a serial link, or a misbehaving network peer streaming garbage —
made `dataBuffer` grow by every received byte, without limit, until the app
eventually ran out of memory.

This affects every CI-V rig, since `IcomRig`, `XieGuRig`, and `XieGu6100Rig` all
feed their bytes through `CivFrameSplitter.split(...)` and store `result.remainder`
back into `dataBuffer`.

## Root cause

`CivFrameSplitter.split` returned everything after the last `0xFD` as the
remainder with no upper bound. Under well-formed traffic the remainder is a
command still in progress and stays tiny (a CI-V command this app exchanges is a
few to a few dozen bytes), so the growth only manifests when the terminator never
arrives — i.e. exactly the malformed-stream case a robust reassembler must
tolerate without falling over.

## Fix

Bound the carried-over remainder in the one shared place it is produced
(`CivFrameSplitter.boundRemainder`). When the remainder exceeds a hard cap
(`MAX_BUFFERED_BYTES = 1024`, orders of magnitude above any real CI-V command):

- **Resynchronise to the most recent `FE FE` preamble** — the earliest point a
  valid command could still begin — and drop the unparseable bytes before it.
  Those bytes can never complete a frame (a valid one would have ended in `0xFD`
  and already been split off), so this is lossless for well-formed traffic and
  only ever trims garbage.
- If no preamble is present, the buffer is pure noise: keep at most a single
  trailing `0xFE`, in case a preamble is split across the read boundary.
- A final trailing-window clamp guarantees boundedness even in the pathological
  case of a lone preamble followed by a huge terminator-less run.

Behaviour is unchanged for all well-formed and normally-fragmented traffic (the
remainder never approaches the cap there), so decode/CAT interoperability is
untouched.

## Testing

`./gradlew :app:testDebugUnitTest --tests com.k1af.ft8af.rigs.CivFrameSplitterTest`

Added pure-JVM cases to the existing `CivFrameSplitterTest`:

- a terminator-less stream fed across 100 callbacks keeps the remainder `<= 1024`
  bytes (fails before the fix — the remainder grows unbounded);
- an overflow resynchronises to the last `FE FE` preamble and the resynced
  command still completes on the next chunk;
- overflow with no preamble drops the noise but keeps a trailing `0xFE`;
- overflow of pure noise drops everything;
- a lone preamble followed by a huge terminator-less tail is hard-capped to 1024;
- a large-but-under-cap partial command is carried through unchanged.

All existing reassembly tests continue to pass (single/multi-frame,
split-across-callbacks, no stray bytes).

## Risk

Low. The change is confined to the shared pure-logic helper and only alters
behaviour once the buffer exceeds a cap far above any legitimate CI-V frame;
normal and normally-fragmented traffic is byte-for-byte identical. No native, DSP,
encoder/decoder, or protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
