### PR TITLE
Stop stale deep-pass decodes from rewinding the QSO sequence

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -584,6 +584,16 @@ public class MainViewModel extends ViewModel {
             @Override
             public void afterDecode(long utc, float time_sec, int sequential
                     , ArrayList<Ft8Message> decoded, boolean isDeep) {
+                // Replay decodes stashed during the last transmission at the first
+                // delivery with TX idle. This must run before the early returns
+                // below: the delivery that follows key-up is our own TX slot, which
+                // is silent except for the loopback echo and so filters down to zero
+                // kept messages every single time. Draining below those returns meant
+                // the stash never emptied on our own slot at all — it survived into
+                // the next receive slot and landed on top of that slot's fresh, newer
+                // evidence, rewinding the QSO a step.
+                drainStashedSequencerDecodes();
+
                 if (decoded.size() == 0) {
                     // beforeListen set mutableIsDecoding=true at the start of this cycle;
                     // clear it here so a silent slot doesn't leave the spectrum-display
@@ -690,15 +700,12 @@ public class MainViewModel extends ViewModel {
                         ft8TransmitSignal.parseMessageToFunction(messages, true);
                     }
                 }
-                // First delivery with TX idle (typically the own-slot fast pass
-                // ~1s after key-up): replay anything stashed mid-TX.
-                if (!ft8TransmitSignal.isTransmitting() && !pendingSequencerDecodes.isEmpty()) {
-                    ArrayList<Ft8Message> stashed =
-                            pendingSequencerDecodes.drain(UtcTimer.getSystemTime());
-                    if (!stashed.isEmpty()) {
-                        ft8TransmitSignal.parseMessageToFunction(stashed, true);
-                    }
-                }
+                // Fast path for a delivery that began mid-TX and stashed above, but
+                // whose transmission finished before we got here: replay it now
+                // rather than waiting for the next delivery. drain() empties the
+                // stash, so this can never re-apply what the call at the top of
+                // afterDecode already handled.
+                drainStashedSequencerDecodes();
 
                 decodeCycleState.labelsAfterPass(messages, isDeep);
 
@@ -1251,6 +1258,30 @@ public class MainViewModel extends ViewModel {
                 15,                           // T/R period (s)
                 "Default",                    // config name
                 "");                          // tx message
+    }
+
+    /**
+     * Replay decodes stashed during a transmission into the QSO sequencer, if any
+     * are pending and TX is idle.
+     *
+     * <p>Called at the top of every decode delivery and again after the deep-pass
+     * handling. The first call is the one that matters: the delivery right after
+     * key-up is our own transmit slot, whose only decode is the loopback echo of
+     * our own signal, so it filters down to zero kept messages and returns early.
+     * Draining only after that return left the stash to be replayed a full cycle
+     * later, on top of newer evidence — rewinding the QSO
+     * (see {@link PendingSequencerDecodes}).
+     *
+     * <p>{@link PendingSequencerDecodes#drain} empties the stash and drops entries
+     * past its age cap, so repeat calls are cheap and cannot double-apply.
+     */
+    private void drainStashedSequencerDecodes() {
+        if (ft8TransmitSignal == null || ft8TransmitSignal.isTransmitting()) return;
+        if (pendingSequencerDecodes.isEmpty()) return;
+        ArrayList<Ft8Message> stashed = pendingSequencerDecodes.drain(UtcTimer.getSystemTime());
+        if (!stashed.isEmpty()) {
+            ft8TransmitSignal.parseMessageToFunction(stashed, true);
+        }
     }
 
     /** Broadcast a slot's decodes as WSJT-X Decode messages. */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
@@ -19,9 +19,9 @@ import java.util.List;
  * {@code FT8TransmitSignal.parseMessageToFunction(list, true)}.
  *
  * <p>Entries older than {@link #MAX_AGE_MS} are evicted on every stash/drain:
- * a reply is only evidence for the QSO it belongs to, and after two full
- * cycles the fast pass has since made its own calls — acting on an older
- * stashed report could advance a state it no longer describes. Matching is
+ * a reply is only evidence for the QSO it belongs to, and after one full
+ * cycle (two slots) the fast pass has since made its own calls — acting on an
+ * older stashed report could advance a state it no longer describes. Matching is
  * additionally guarded by the sequencer itself (from/to callsign and slot
  * parity checks), so the age cap is a backstop, not the primary filter.
  *

--- a/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/PendingSequencerDecodes.java
@@ -32,11 +32,20 @@ import java.util.List;
 public final class PendingSequencerDecodes {
     /**
      * Maximum age of a stashed decode, measured from the message's slot time
-     * ({@code Ft8Message.utcTime}). Two full FT8 cycles (4 slots) — long enough
-     * to survive TX plus one silent delivery gap, short enough that a stale
-     * report can't leak into a later QSO.
+     * ({@code Ft8Message.utcTime}). One full FT8 cycle (2 slots) — long enough to
+     * survive the transmission it was stashed behind and be replayed at the next
+     * key-down gap, short enough that it cannot describe a QSO state the fast
+     * pass has already moved past.
+     *
+     * <p>This was two cycles (60s). At that age a decode outlives a whole
+     * exchange: the partner's opening grid, stashed behind our report, was still
+     * "fresh" a cycle later when the fast pass had already advanced us to RR73 on
+     * their R-report. Replaying it rewound the QSO and re-sent the report. The
+     * sequencer refuses to rewind now
+     * ({@link com.k1af.ft8af.ft8transmit.FT8TransmitSignal#isStaleEvidence}); this
+     * cap keeps such decodes from reaching it at all.
      */
-    static final long MAX_AGE_MS = 60_000;
+    static final long MAX_AGE_MS = 30_000;
 
     private final ArrayList<Ft8Message> pending = new ArrayList<>();
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -1679,6 +1679,17 @@ public class FT8TransmitSignal {
 
 
         if (newOrder != -1) {//message received but QSO not yet complete
+            // A deep/late/stashed pass may re-deliver a decode we already acted on
+            // (e.g. the partner's opening grid replayed a cycle after we advanced to
+            // RR73). Applying it would walk the QSO backwards and re-send a message
+            // the partner has already answered. Evidence-only passes advance, never rewind.
+            if (isStaleEvidence(evidenceOnly, functionOrder, newOrder)) {
+                GeneralVariables.fileLog("QSO: ignore stale evidence order " + functionOrder
+                        + " newOrder=" + newOrder
+                        + " with " + (toCallsign != null ? toCallsign.callsign : "?"));
+                return;
+            }
+
             // originally newOrder == 1, but sometimes the other party sends a signal report directly, i.e. message 2
             if (newOrder == 1 || newOrder == 2) {// this is the first reply from the other party
                 resetTargetReport();// reset the signal reports
@@ -2337,6 +2348,35 @@ public class FT8TransmitSignal {
                 && (noReplyLimit > 0))// I am at RR73, no-reply threshold reached, limit enabled
                 || (functionOrder == 4 && (noReplyCount > RR73_GIVEUP_CYCLES)
                 && (noReplyLimit == 0));// no-reply "ignore" at RR73: QSO already logged, don't hold the run frequency for minutes
+    }
+
+    /**
+     * Whether a deep/late-pass decode describes a QSO state we have already moved
+     * past, and must therefore be ignored.
+     *
+     * <p>Deep, subtraction and stashed passes re-deliver decodes out of order: a
+     * pass finishing during our transmission is replayed after key-up, by which
+     * time the fast pass may already have advanced the QSO on newer evidence. The
+     * partner's opening grid (order 1) replayed after we reached RR73 (order 4)
+     * would otherwise set us back to order 2 and re-send a signal report the
+     * partner already answered — the sequencer walking backwards mid-QSO.
+     *
+     * <p>Only evidence-only passes are gated. The fast pass observes the current
+     * cycle and its verdict is authoritative even when it lowers the order (the
+     * partner really did fall back a step). Order 6 is the CQ baseline rather
+     * than the top of the ladder, so a QSO starting from CQ is never "stale".
+     *
+     * <p>Package-visible for testing.
+     *
+     * @param evidenceOnly  this is a deep/late/stashed parse (positive evidence only)
+     * @param functionOrder my current message order (1-6)
+     * @param newOrder      order of the partner's message this pass (never -1 here)
+     * @return true when the pass would move the QSO backwards and should be dropped
+     */
+    static boolean isStaleEvidence(boolean evidenceOnly, int functionOrder, int newOrder) {
+        if (!evidenceOnly) return false;// fast pass is authoritative for its own cycle
+        if (functionOrder == 6) return false;// CQ baseline: any reply legitimately starts a QSO
+        return newOrder + 1 < functionOrder;// would rewind the sequence
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/PendingSequencerDecodesTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/PendingSequencerDecodesTest.java
@@ -94,4 +94,26 @@ public class PendingSequencerDecodesTest {
 
         assertThat(pending.drain(now)).containsExactly(fresh);
     }
+
+    @Test
+    public void maxAgeIsAtMostOneFt8Cycle() {
+        // The cap must not outlive the exchange the decode belongs to. At the
+        // old two-cycle (60s) setting, a partner's opening grid stashed behind
+        // our report was still "fresh" a cycle later, when the fast pass had
+        // already advanced us to RR73 on their R-report -- replaying it rewound
+        // the QSO (POTA field report 2026-07-23). One 15s slot must survive so
+        // a decode stashed mid-TX still replays after key-up.
+        assertThat(PendingSequencerDecodes.MAX_AGE_MS).isAtLeast(15_000L);
+        assertThat(PendingSequencerDecodes.MAX_AGE_MS).isAtMost(30_000L);
+    }
+
+    @Test
+    public void decodeFromTwoCyclesAgoIsEvicted() {
+        PendingSequencerDecodes pending = new PendingSequencerDecodes();
+        Ft8Message twoCyclesOld = msgAt(0);
+        pending.stash(list(twoCyclesOld), 0);
+
+        // 30s later == two FT8 slots == the exchange has moved on.
+        assertThat(pending.drain(30_001)).isEmpty();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/PendingSequencerDecodesTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/PendingSequencerDecodesTest.java
@@ -108,12 +108,13 @@ public class PendingSequencerDecodesTest {
     }
 
     @Test
-    public void decodeFromTwoCyclesAgoIsEvicted() {
+    public void decodeOlderThanOneCycleIsEvicted() {
         PendingSequencerDecodes pending = new PendingSequencerDecodes();
-        Ft8Message twoCyclesOld = msgAt(0);
-        pending.stash(list(twoCyclesOld), 0);
+        Ft8Message oldDecode = msgAt(0);
+        pending.stash(list(oldDecode), 0);
 
-        // 30s later == two FT8 slots == the exchange has moved on.
+        // 30_001 ms == one full FT8 cycle (two 15s slots) past MAX_AGE_MS, so the
+        // decode is evicted: the exchange it belonged to has moved on.
         assertThat(pending.drain(30_001)).isEmpty();
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/EvidenceOnlyParseTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/EvidenceOnlyParseTest.java
@@ -201,4 +201,56 @@ public class EvidenceOnlyParseTest {
         signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "R-18")), true);
         assertThat(signal.getFunctionOrder()).isEqualTo(2);
     }
+
+    // ---- stale evidence must not rewind the QSO -----------------------------
+    // Field report (POTA 2026-07-23): three QSOs logged "advance order 4->2".
+    // The fast pass correctly advanced us to RR73 on the partner's R-report,
+    // then ~20ms later a replayed decode of that partner's *opening grid* --
+    // stashed behind our previous transmission and drained a cycle late --
+    // knocked the sequence back to order 2. We re-sent the signal report the
+    // partner had already answered, costing a full 30s exchange each time.
+
+    @Test
+    public void deepStaleGridAfterRR73_doesNotRewindToReport() {
+        startQsoAtOrder(4);// we are sending RR73
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "FN20")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(4);// still RR73, not 2
+    }
+
+    @Test
+    public void deepStaleReportAfter73_doesNotRewind() {
+        startQsoAtOrder(5);// we are sending 73
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "R-18")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(5);
+    }
+
+    @Test
+    public void fastPassMayStillLowerTheOrder() {
+        // Only deep/replayed evidence is gated. The fast pass sees the current
+        // cycle, so if the partner genuinely fell back to calling us with a
+        // grid, it still re-seeds the report step.
+        startQsoAtOrder(4);
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "FN20")), false);
+        assertThat(signal.getFunctionOrder()).isEqualTo(2);
+    }
+
+    @Test
+    public void deepStaleEvidence_stillClearsNoReplyCount() {
+        // The decode is too old to move the sequence, but it is still proof the
+        // partner was transmitting: don't let it count towards giving up.
+        startQsoAtOrder(4);
+        GeneralVariables.noReplyCount = 2;
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "FN20")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(4);
+        assertThat(GeneralVariables.noReplyCount).isEqualTo(0);
+    }
+
+    @Test
+    public void deepEvidenceRepeatingCurrentStep_stillAccepted() {
+        // newOrder+1 == functionOrder is not a rewind: at RR73 the partner
+        // re-sending R-report keeps us at RR73 and is normal QSO behaviour.
+        startQsoAtOrder(4);
+        signal.parseMessageToFunction(list(rxMsg("K1AF", "N2JFD", "R-18")), true);
+        assertThat(signal.getFunctionOrder()).isEqualTo(4);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalTest.java
@@ -699,4 +699,52 @@ public class FT8TransmitSignalTest {
             old.delete();
         }
     }
+
+    // ---- isStaleEvidence -----------------------------------------------------
+    // Deep/late/stashed passes re-deliver decodes out of order: a pass finishing
+    // during our transmission is replayed after key-up, by which time the fast
+    // pass may already have advanced the QSO on newer evidence. Such a pass may
+    // move the sequence forward but never back — a partner's opening grid
+    // replayed after we reached RR73 must not rewind us to sending a report.
+    // Field case (POTA 2026-07-23, K0OBX/N8GK/K0OTC): "advance order 4->2".
+
+    @Test
+    public void stale_fastPassIsNeverStale() {
+        // The fast pass observes the current cycle; its verdict stands even when
+        // it lowers the order (the partner really did fall back a step).
+        assertThat(FT8TransmitSignal.isStaleEvidence(
+                /*evidenceOnly*/ false, /*order*/ 4, /*newOrder*/ 1)).isFalse();
+        assertThat(FT8TransmitSignal.isStaleEvidence(false, 5, 1)).isFalse();
+    }
+
+    @Test
+    public void stale_deepGridAfterRR73_isStale() {
+        // The exact field failure: at RR73 (4), a replayed opening grid (1)
+        // would set order back to 2 and re-send the signal report.
+        assertThat(FT8TransmitSignal.isStaleEvidence(true, 4, 1)).isTrue();
+    }
+
+    @Test
+    public void stale_deepEvidenceThatAdvances_isNotStale() {
+        // At order 2 the partner's R-report (3) advances to RR73 (4).
+        assertThat(FT8TransmitSignal.isStaleEvidence(true, 2, 3)).isFalse();
+        // At RR73 (4) their 73 (5) completes.
+        assertThat(FT8TransmitSignal.isStaleEvidence(true, 4, 5)).isFalse();
+    }
+
+    @Test
+    public void stale_deepEvidenceHoldingSameOrder_isNotStale() {
+        // Partner repeats the message we already acted on: newOrder+1 == order.
+        // Not a rewind, and re-affirming resets the no-reply count, so allow it.
+        assertThat(FT8TransmitSignal.isStaleEvidence(true, 4, 3)).isFalse();
+        assertThat(FT8TransmitSignal.isStaleEvidence(true, 2, 1)).isFalse();
+    }
+
+    @Test
+    public void stale_cqBaselineIsNeverStale() {
+        // Order 6 is the CQ baseline, not the top of the ladder: a reply
+        // arriving there legitimately starts a QSO at a lower order.
+        assertThat(FT8TransmitSignal.isStaleEvidence(true, 6, 1)).isFalse();
+        assertThat(FT8TransmitSignal.isStaleEvidence(true, 6, 2)).isFalse();
+    }
 }


### PR DESCRIPTION
## What happened

During a POTA activation of US-12398 on 2026-07-23, three QSOs jumped backwards mid-sequence — the app sent `RR73`, then went back to sending a signal report the partner had already answered. Each one cost a full 30-second exchange.

Pulled from `debug.log`, the K0OBX case:

```
08:47:45.139 QSO: cycle       order=2 newOrder=3 to=K0OBX   <- they sent R-18
08:47:45.141 QSO: advance order 2->4 with K0OBX             <- correct: go to RR73
08:47:45.162 QSO: cycle(deep) order=4 newOrder=1 to=K0OBX   <- a 30s-old grid re-delivered
08:47:45.172 QSO: advance order 4->2 with K0OBX             <- REGRESSION
08:47:46.155 QSO: TX order=2 msg=[K0OBX K1AF -18]           <- report again, not RR73
```

Identical signature on K0OTC (08:14:45) and N8GK (08:50:15). 23 ms after correctly advancing, a replayed decode of the partner's *opening grid* drags the sequence back down.

## Root cause

Three things had to line up.

**1. The sequencer had no monotonicity guard.** `parseMessageToFunction` ended with

```java
functionOrder = newOrder + 1;   // unconditional
```

Deep/late/stashed passes are fed in with `evidenceOnly=true` and are documented as contributing *positive evidence only* — advance, RR73→73, complete, enqueue. Nothing enforced that. `newOrder=1` sets `functionOrder=2` even from RR73. Every existing guard passes, because the stale decode really is from that partner, really is addressed to us, and really is in the opposite slot parity — it is just 30 seconds old.

**2. The mid-TX stash could not drain when it was supposed to.** `MainViewModel.afterDecode` drained `pendingSequencerDecodes` *below* the `messages.size() == 0` early return. The delivery immediately after key-up is our own transmit slot, which is silent except for the loopback echo of our own signal — so it filters down to zero kept messages **every single time** (213 of 213 own-slot deliveries in the field log). The drain was unreachable at exactly the moment it was designed to fire, so the stash survived into the next receive slot and landed on top of that slot's fresher evidence.

**3. The stash age cap was too generous.** `MAX_AGE_MS = 60_000` — two full FT8 cycles. At that age a decode outlives the whole exchange it belongs to.

## The fix

- **`FT8TransmitSignal.isStaleEvidence()`** — new package-private helper. On an evidence-only pass, a decode may advance or hold the sequence but never lower it. The fast pass stays authoritative for its own cycle (if the partner genuinely fell back a step, that still counts). Order 6 is the CQ baseline rather than the top of the ladder, so it is exempt. A gated decode **still clears the no-reply count** — it is stale, not absent, and it is proof the partner was transmitting.
- **`MainViewModel.drainStashedSequencerDecodes()`** — extracted and hoisted to the top of `afterDecode`, above the early returns. `drain()` empties the stash, so the existing call further down is now just a same-delivery fast path and cannot double-apply.
- **`PendingSequencerDecodes.MAX_AGE_MS`** — 60s → 30s. Still leaves a decode stashed mid-TX room to replay after key-up, but it can no longer describe a state the fast pass has moved past.

Fix 1 stops the symptom on its own. Fixes 2 and 3 stop the stale decode being in flight at all.

## Tests

- `FT8TransmitSignalTest` — truth table for `isStaleEvidence`: fast pass never stale, grid-after-RR73 stale, advancing evidence not stale, `newOrder+1 == order` (partner repeating) not stale, CQ baseline exempt.
- `EvidenceOnlyParseTest` — end-to-end through `parseMessageToFunction`: grid-after-RR73 does not rewind, report-after-73 does not rewind, the fast pass may still lower the order, a gated decode still clears the no-reply count, and repeating the current step is still accepted.
- `PendingSequencerDecodesTest` — age cap bounded to one FT8 cycle; a two-cycle-old decode is evicted.

Full suite: **2483 tests, 0 failures.** Built and installed on a Pixel 8.

## Not addressed here

Two other things the same log turned up, both out of scope for this PR:

- The fast decode pass missed the partner's reply in **31 cycles** (~29% of replies), with only a deep pass catching it. It self-heals when the deep pass lands in time, but three landed after the TX was already built. Worth its own investigation.
- The caller queue serves stations 60–90 s after they call, by which time most have moved on — and with the no-reply limit set to 0 (unlimited) the app never gives up, hammering a report 5–7 times (KF4CCG, WC7F, N4IUA, AA4QE, K7YMG). Queue staleness + a sane default cap is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
