### PR TITLE
Fix USB CAT write/read NPE when port I/O races an in-progress (re)open

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/serialport/CommonUsbSerialPort.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/serialport/CommonUsbSerialPort.java
@@ -193,10 +193,15 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
     }
 
     protected int read(final byte[] dest, final int timeout, boolean testConnection) throws IOException {
-        // mReadEndpoint (like mWriteEndpoint) is null until openInt() runs, which
-        // open() calls only after publishing mConnection — guard both so a read
-        // racing an in-progress (re)open throws instead of NPEing. See ioEndpointReady.
-        if (!ioEndpointReady(mConnection, mReadEndpoint)) {
+        // Snapshot the connection and endpoint into locals so a concurrent close()
+        // (cable yanked on another thread) nulling the fields mid-read can't NPE
+        // here — it stays a recoverable IOException. mReadEndpoint (like
+        // mWriteEndpoint) is also null until openInt() runs, which open() calls
+        // only after publishing mConnection, so the guard covers the (re)open race
+        // too. See ioEndpointReady.
+        final UsbDeviceConnection connection = mConnection;
+        final UsbEndpoint readEndpoint = mReadEndpoint;
+        if (!ioEndpointReady(connection, readEndpoint)) {
             throw new IOException("Connection closed");
         }
         if(dest.length <= 0) {
@@ -214,7 +219,7 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
             // data loss / crashes were observed with timeout up to 200 msec
             long endTime = testConnection ? MonotonicClock.millis() + timeout : 0;
             int readMax = Math.min(dest.length, MAX_READ_SIZE);
-            nread = mConnection.bulkTransfer(mReadEndpoint, dest, readMax, timeout);
+            nread = connection.bulkTransfer(readEndpoint, dest, readMax, timeout);
             // Android error propagation is improvable:
             //  nread == -1 can be: timeout, connection lost, buffer to small, ???
             if(nread == -1 && testConnection && MonotonicClock.millis() < endTime)
@@ -225,7 +230,7 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
             if (!mUsbRequest.queue(buf, dest.length)) {
                 throw new IOException("Queueing USB request failed");
             }
-            final UsbRequest response = mConnection.requestWait();
+            final UsbRequest response = connection.requestWait();
             if (response == null) {
                 throw new IOException("Waiting for USB request failed");
             }
@@ -244,11 +249,17 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
         int offset = 0;
         final long endTime = (timeout == 0) ? 0 : (MonotonicClock.millis() + timeout);
 
-        // Guard the endpoint, not just the connection: open() publishes
-        // mConnection before openInt() assigns mWriteEndpoint, so a write racing
-        // an in-progress (re)open would otherwise NPE on mWriteEndpoint below.
-        // See ioEndpointReady.
-        if (!ioEndpointReady(mConnection, mWriteEndpoint)) {
+        // Snapshot the connection and endpoint into locals: close() (called from
+        // another thread when the cable is yanked) nulls the mConnection /
+        // mWriteEndpoint fields, so reading them once here — rather than
+        // dereferencing the live fields through the loop below — means a
+        // concurrent close can't turn an in-flight write into an NPE. It stays a
+        // recoverable IOException instead. The guard also covers the (re)open
+        // window where open() publishes mConnection before openInt() assigns
+        // mWriteEndpoint. See ioEndpointReady.
+        final UsbDeviceConnection connection = mConnection;
+        final UsbEndpoint writeEndpoint = mWriteEndpoint;
+        if (!ioEndpointReady(connection, writeEndpoint)) {
             throw new IOException("Connection closed");
         }
         while (offset < src.length) {
@@ -260,7 +271,7 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
                 final byte[] writeBuffer;
 
                 if (mWriteBuffer == null) {
-                    mWriteBuffer = new byte[mWriteEndpoint.getMaxPacketSize()];
+                    mWriteBuffer = new byte[writeEndpoint.getMaxPacketSize()];
                 }
                 requestLength = Math.min(src.length - offset, mWriteBuffer.length);
                 if (offset == 0) {
@@ -280,7 +291,7 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
                 if (requestTimeout < 0) {
                     actualLength = -2;
                 } else {
-                    actualLength = mConnection.bulkTransfer(mWriteEndpoint, writeBuffer, requestLength, requestTimeout);
+                    actualLength = connection.bulkTransfer(writeEndpoint, writeBuffer, requestLength, requestTimeout);
                 }
             }
             if (DEBUG) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/serialport/CommonUsbSerialPort.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/serialport/CommonUsbSerialPort.java
@@ -134,6 +134,29 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
 
     protected abstract void openInt(UsbDeviceConnection connection) throws IOException;
 
+    /**
+     * Whether the port is ready for I/O on the given endpoint.
+     *
+     * <p>A port is usable only once {@link #open} has BOTH published the
+     * connection and {@code openInt()} has assigned the endpoint. {@code open()}
+     * deliberately sets {@link #mConnection} (line "mConnection = connection")
+     * <em>before</em> calling {@code openInt()} — {@code openInt}/{@code close}
+     * need the connection during setup — so there is a window where
+     * {@code mConnection != null} but the endpoint is still {@code null}. A
+     * {@code read()}/{@code write()} from another thread during that window
+     * (e.g. a TX PTT firing while CAT auto-reconnect is re-opening a freshly
+     * allocated port) would pass a bare {@code mConnection == null} check and
+     * then NPE dereferencing the endpoint. Treating a missing connection OR
+     * endpoint as "not open" turns that crash into a recoverable
+     * {@link IOException} the CAT/TX layer already handles.
+     *
+     * <p>Extracted as a package-private static so the readiness decision is
+     * unit-testable without a live {@link UsbDeviceConnection}/{@link UsbEndpoint}.
+     */
+    static boolean ioEndpointReady(Object connection, Object endpoint) {
+        return connection != null && endpoint != null;
+    }
+
     @Override
     public void close() throws IOException {
         if (mConnection == null) {
@@ -170,7 +193,10 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
     }
 
     protected int read(final byte[] dest, final int timeout, boolean testConnection) throws IOException {
-        if(mConnection == null) {
+        // mReadEndpoint (like mWriteEndpoint) is null until openInt() runs, which
+        // open() calls only after publishing mConnection — guard both so a read
+        // racing an in-progress (re)open throws instead of NPEing. See ioEndpointReady.
+        if (!ioEndpointReady(mConnection, mReadEndpoint)) {
             throw new IOException("Connection closed");
         }
         if(dest.length <= 0) {
@@ -218,7 +244,11 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
         int offset = 0;
         final long endTime = (timeout == 0) ? 0 : (MonotonicClock.millis() + timeout);
 
-        if(mConnection == null) {
+        // Guard the endpoint, not just the connection: open() publishes
+        // mConnection before openInt() assigns mWriteEndpoint, so a write racing
+        // an in-progress (re)open would otherwise NPE on mWriteEndpoint below.
+        // See ioEndpointReady.
+        if (!ioEndpointReady(mConnection, mWriteEndpoint)) {
             throw new IOException("Connection closed");
         }
         while (offset < src.length) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/serialport/CommonUsbSerialPortEndpointReadyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/serialport/CommonUsbSerialPortEndpointReadyTest.java
@@ -1,0 +1,43 @@
+package com.k1af.ft8af.serialport;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM coverage for {@link CommonUsbSerialPort#ioEndpointReady}, the
+ * readiness decision behind {@code read()}/{@code write()} throwing a
+ * recoverable {@link java.io.IOException} instead of crashing.
+ *
+ * <p>Root cause reproduced by {@link #connectionPublishedButEndpointNotYetAssigned_notReady}:
+ * {@code open()} sets {@code mConnection} <em>before</em> {@code openInt()}
+ * assigns the read/write endpoint, so a concurrent I/O call (a TX PTT firing
+ * during CAT auto-reconnect on a freshly allocated port) can observe a non-null
+ * connection with a still-null endpoint. That case previously passed the bare
+ * {@code mConnection == null} check and then NPEd dereferencing the endpoint
+ * ({@code mWriteEndpoint.getMaxPacketSize()}); it must now read as "not open".
+ */
+public class CommonUsbSerialPortEndpointReadyTest {
+
+    @Test
+    public void bothPresent_ready() {
+        assertThat(CommonUsbSerialPort.ioEndpointReady(new Object(), new Object())).isTrue();
+    }
+
+    @Test
+    public void connectionPublishedButEndpointNotYetAssigned_notReady() {
+        // The crash window: open() published the connection, openInt() has not
+        // yet assigned the endpoint.
+        assertThat(CommonUsbSerialPort.ioEndpointReady(new Object(), null)).isFalse();
+    }
+
+    @Test
+    public void nullConnection_notReady() {
+        assertThat(CommonUsbSerialPort.ioEndpointReady(null, new Object())).isFalse();
+    }
+
+    @Test
+    public void bothNull_notReady() {
+        assertThat(CommonUsbSerialPort.ioEndpointReady(null, null)).isFalse();
+    }
+}


### PR DESCRIPTION
## Root cause

`CommonUsbSerialPort.open()` publishes `mConnection` **before** `openInt()` assigns `mReadEndpoint`/`mWriteEndpoint`:

```java
mConnection = connection;          // (1) connection is now visible
try {
    openInt(connection);           // (2) endpoints assigned here
    ...
```

`openInt()` and the catch-path `close()` both need the connection during setup, so the ordering is deliberate — but it leaves a window where `mConnection != null` while `mWriteEndpoint`/`mReadEndpoint` are still `null`.

`read()`/`write()` only guarded `mConnection == null`. A call landing in that window passed the guard and then dereferenced a null endpoint:

```java
if (mWriteBuffer == null) {
    mWriteBuffer = new byte[mWriteEndpoint.getMaxPacketSize()]; // NPE
}
```

`CableSerialPort.sendData()` catches `IOException` but not the `RuntimeException` NPE, so it escaped to the TX worker thread and crashed the app.

## Evidence

Sentry fatal (Pixel 8 / Android 16, `radio.ks3ckc.ft8af@1.1.0-dev+5`):

```
NullPointerException: 'int android.hardware.usb.UsbEndpoint.getMaxPacketSize()' on a null object reference
  at CommonUsbSerialPort.write(CommonUsbSerialPort.java:233)
  at CableSerialPort.writeIfOpen / sendData
  at CableConnector.setPttOn
  at Yaesu39Rig.setPTT
  at MainViewModel$6.beginKeying / onBeforeTransmit
  at FT8TransmitSignal$DoTransmitRunnable.run   (ThreadPoolExecutor worker)
```

The window is hit in practice during **CAT auto-reconnect**: `CableSerialPort.prepare()` allocates a fresh port (`driver.getPorts().get(portNum)`, endpoints null) and `connect()` calls `open()`; a TX PTT firing from the transmit thread during that `open()` keys the crash. This is the endpoint-side twin of the earlier disconnect-race guards (`writeIfOpen`, PR #647).

## Fix

Guard the endpoint as well as the connection, via a small unit-testable helper applied symmetrically to `read()` and `write()`:

```java
static boolean ioEndpointReady(Object connection, Object endpoint) {
    return connection != null && endpoint != null;
}
```

A missing connection **or** endpoint now throws the same recoverable `IOException("Connection closed")` that the CAT/TX layer already handles, instead of crashing. This is a strict superset of the previous `mConnection == null` check — no behavior change once the port is fully open.

## Testing

- New `CommonUsbSerialPortEndpointReadyTest` (pure JVM) covers the readiness decision, including the exact crash case `ioEndpointReady(connection, null) == false`.
- `./gradlew :app:testDebugUnitTest` — full suite green.

## Risk

Very low. Localized to two guard checks in `CommonUsbSerialPort`; only adds an earlier, already-handled `IOException` on a previously-crashing path. No protocol, DSP, or performance impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)