### PR TITLE
Fix XieGu X6100 CAT freq decode undercounting the 1 GHz digit (un-ported twin of the Icom fix)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Command.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Command.java
@@ -229,7 +229,7 @@ public class XieGu6100Command {
                 + (int) (data[3] & 0x0f) * 1000000//millions 1MHz
                 + ((int) (data[3] >> 4) & 0xf) * 10000000//ten-millions 10MHz
                 + (int) (data[4] & 0x0f) * 100000000//hundred-millions 100MHz
-                + ((int) (data[4] >> 4) & 0xf) * 100000000;//billions 1GHz
+                + ((int) (data[4] >> 4) & 0xf) * 1000000000L;//billions 1GHz
     }
 
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/XieGu6100CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/XieGu6100CommandTest.java
@@ -65,6 +65,38 @@ public class XieGu6100CommandTest {
     }
 
     @Test
+    public void getFrequency_decodesGigahertzDigit() {
+        // 23cm band: 1296.000 MHz = 1_296_000_000 Hz. The 1 GHz digit lives in the
+        // high nibble of the top BCD byte (data[4]). Little-endian byte order:
+        //   data[0]=00 data[1]=00 data[2]=00 data[3]=0x96 (1MHz=6,10MHz=9)
+        //   data[4]=0x12 (100MHz=2, 1GHz=1)
+        // Mirrors IcomCommandTest.getFrequency_decodesGigahertzDigit — the same
+        // decoder bug lived in this XieGu twin (see the class comment).
+        byte[] frame = {(byte) 0xFE, (byte) 0xFE, (byte) CTRL, (byte) RIG,
+                (byte) 0x03,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x96, (byte) 0x12,
+                (byte) 0xFD};
+        XieGu6100Command c = XieGu6100Command.getCommand(CTRL, RIG, frame);
+        assertThat(c).isNotNull();
+        assertThat(c.getFrequency(false)).isEqualTo(1_296_000_000L);
+    }
+
+    @Test
+    public void getFrequency_gigahertzDigitDoesNotOverflowInt() {
+        // A 1 GHz digit of 9 contributes 9_000_000_000 Hz, which overflows a 32-bit
+        // int. The decode must accumulate in long arithmetic so the value is exact
+        // (int overflow would wrap to a negative/garbage frequency).
+        //   data[4]=0x90 (100MHz=0, 1GHz=9), all lower digits 0.
+        byte[] frame = {(byte) 0xFE, (byte) 0xFE, (byte) CTRL, (byte) RIG,
+                (byte) 0x03,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x90,
+                (byte) 0xFD};
+        XieGu6100Command c = XieGu6100Command.getCommand(CTRL, RIG, frame);
+        assertThat(c).isNotNull();
+        assertThat(c.getFrequency(false)).isEqualTo(9_000_000_000L);
+    }
+
+    @Test
     public void readShortData_bigEndianAssembly() {
         assertThat(XieGu6100Command.readShortData(new byte[]{(byte) 0x12, (byte) 0x34}, 0))
                 .isEqualTo((short) 0x1234);


### PR DESCRIPTION
## Root cause

`XieGu6100Command.getFrequency` weighted the **1 GHz** BCD digit (high nibble of `data[4]`) at `*100000000` (100 MHz) — identical to the 100 MHz digit weight on the line directly above — instead of `*1000000000` (1 GHz):

```java
+ (int) (data[4] & 0x0f) * 100000000   // 100 MHz digit  (correct)
+ ((int) (data[4] >> 4) & 0xf) * 100000000;  // "1GHz" digit — WRONG, should be *1000000000L
```

This is the **exact** defect already fixed in the sibling `IcomCommand.getFrequency` by commit `d90a67ff` — *"Fix Icom/Xiegu CAT freq decode undercounting 1 GHz band by 900 MHz."* That commit's title and rationale explicitly covered **Xiegu**, but its diff only patched `IcomCommand` (which backs `IcomRig` and `XieGuRig`). The parallel `XieGu6100Command` class — used by `XieGu6100Rig.analysisCommand → setFreq` — was overlooked and kept the bug.

## Impact

A 1.2 GHz / 23 cm VFO decodes ~900 MHz low (e.g. `1296.000 MHz → 396.000 MHz`). Latent on HF/6 m, where the top BCD digit is always `0` — consistent with how the maintainers characterised and still accepted the identical Icom fix.

## The fix

One line, mirroring `IcomCommand.java:172` exactly:

```java
+ ((int) (data[4] >> 4) & 0xf) * 1000000000L;//billions 1GHz
```

Using the `long` literal both corrects the weight and widens the accumulation to `long` before the 1 GHz digit is added, avoiding 32-bit `int` overflow for values > 2.147 GHz (the lower digits still sum within `int` range).

## Testing

- Added `XieGu6100CommandTest.getFrequency_decodesGigahertzDigit` (23 cm, 1296.000 MHz) and `getFrequency_gigahertzDigitDoesNotOverflowInt` (1 GHz digit of 9 → 9 000 000 000 Hz), mirroring the `IcomCommandTest` cases from `d90a67ff`. Both **fail** on the old `*100000000` weight and **pass** after the fix.
- Full `:app:testDebugUnitTest` suite passes (no regressions).

## Risk

Minimal. Single-term weight change in one rig's BCD decoder, byte-for-byte identical to the already-merged Icom fix. No behavioural change for HF/6 m XieGu operation (top digit is 0); it only corrects decoding above 1 GHz and hardens against int overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)