### PR TITLE
Fix XieGu X6100 CI-V frequency decode: GHz digit mis-weighted (×10⁸ instead of ×10⁹)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Command.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/XieGu6100Command.java
@@ -229,7 +229,7 @@ public class XieGu6100Command {
                 + (int) (data[3] & 0x0f) * 1000000//millions 1MHz
                 + ((int) (data[3] >> 4) & 0xf) * 10000000//ten-millions 10MHz
                 + (int) (data[4] & 0x0f) * 100000000//hundred-millions 100MHz
-                + ((int) (data[4] >> 4) & 0xf) * 100000000;//billions 1GHz
+                + ((int) (data[4] >> 4) & 0xf) * 1000000000L;//billions 1GHz (long: keeps the sum from overflowing int, matches IcomCommand.getFrequency)
     }
 
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/XieGu6100CommandTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/XieGu6100CommandTest.java
@@ -64,6 +64,45 @@ public class XieGu6100CommandTest {
         assertThat(c.getFrequency(false)).isEqualTo(14_074_000L);
     }
 
+    /** Build a read-frequency reply carrying the 5 little-endian BCD frequency bytes. */
+    private static byte[] freqFrame(int b0, int b1, int b2, int b3, int b4) {
+        return new byte[]{
+                (byte) 0xFE, (byte) 0xFE, (byte) CTRL, (byte) RIG,
+                (byte) 0x03,
+                (byte) b0, (byte) b1, (byte) b2, (byte) b3, (byte) b4,
+                (byte) 0xFD};
+    }
+
+    /**
+     * The most-significant BCD digit is the 1 GHz place and must be weighted 10^9,
+     * matching {@link IcomCommand#getFrequency}. Weighting it 10^8 (a copy/paste of
+     * the 100 MHz multiplier) drops that digit by an order of magnitude — e.g.
+     * 1.296 GHz would decode as 0.396 GHz.
+     */
+    @Test
+    public void getFrequency_weightsGigahertzDigitCorrectly() {
+        // 1,296,074,000 Hz -> BCD 00 40 07 96 12 (GHz digit = 1)
+        XieGu6100Command c = XieGu6100Command.getCommand(CTRL, RIG,
+                freqFrame(0x00, 0x40, 0x07, 0x96, 0x12));
+        assertThat(c).isNotNull();
+        assertThat(c.getFrequency(false)).isEqualTo(1_296_074_000L);
+    }
+
+    /**
+     * A frequency above {@link Integer#MAX_VALUE} must survive the BCD assembly: the
+     * decoder returns {@code long}, so the arithmetic has to stay in {@code long}
+     * rather than overflowing an {@code int} partway through (again mirroring
+     * {@link IcomCommand#getFrequency}, whose top term is a {@code long} literal).
+     */
+    @Test
+    public void getFrequency_doesNotOverflowIntAboveTwoGigahertz() {
+        // 2,400,000,000 Hz -> BCD 00 00 00 00 24 (> Integer.MAX_VALUE)
+        XieGu6100Command c = XieGu6100Command.getCommand(CTRL, RIG,
+                freqFrame(0x00, 0x00, 0x00, 0x00, 0x24));
+        assertThat(c).isNotNull();
+        assertThat(c.getFrequency(false)).isEqualTo(2_400_000_000L);
+    }
+
     @Test
     public void readShortData_bigEndianAssembly() {
         assertThat(XieGu6100Command.readShortData(new byte[]{(byte) 0x12, (byte) 0x34}, 0))


### PR DESCRIPTION
## Root cause

`XieGu6100Command.getFrequency()` and `IcomCommand.getFrequency()` are twins — both decode a 5-byte little-endian BCD Icom CI-V frequency, digit by digit. The `IcomCommand` version is the audited-correct reference; the XieGu copy diverged in its most-significant term:

```java
// XieGu6100Command (before)
+ ((int) (data[4] >> 4) & 0xf) * 100000000;   // "billions 1GHz"  <-- 10^8, and int math

// IcomCommand (correct)
+ ((int) (data[4] >> 4) & 0xf) * 1000000000L;  // billions 1GHz    <-- 10^9, long
```

The `1 GHz` BCD digit was multiplied by `100000000` (10⁸) — a copy/paste of the adjacent `100 MHz` multiplier — instead of `1000000000` (10⁹), and the whole sum was computed in `int`. `IcomCommand` uses a `1000000000L` **long** literal precisely to get the magnitude right and keep the assembly out of `int` overflow.

## Effect

- The top BCD digit is dropped by an order of magnitude (e.g. 1.296 GHz → 0.396 GHz).
- A decoded value above `Integer.MAX_VALUE` overflows partway through the `int` sum.

For the X6100's HF/6m operating range the GHz digit is always `0`, and `XieGu6100Rig` additionally range-gates the result to `[500 kHz, 250 MHz]`, so **the live on-air decode is unaffected today**. This is a latent correctness defect: the shared CI-V BCD decoder is simply wrong for any frequency ≥ 1 GHz and silently diverges from its audited `IcomCommand` twin.

## Fix

One-line change: weight the GHz digit by `1000000000L`, matching `IcomCommand.getFrequency()`. The `long` literal both corrects the magnitude and keeps the accumulation in `long`.

## Testing

- Added two unit tests to `XieGu6100CommandTest` — `getFrequency_weightsGigahertzDigitCorrectly` (1.296 GHz) and `getFrequency_doesNotOverflowIntAboveTwoGigahertz` (2.4 GHz, > int max). Both **fail before** the fix (return 0.396 GHz and 0.6 GHz respectively) and pass after.
- Existing `XieGu6100CommandTest` cases (incl. the 14.074 MHz HF decode) and `IcomCommandTest` unchanged and green.
- Full `:app:testDebugUnitTest` suite passes.

## Risk

Minimal. Single arithmetic-literal change in a leaf decoder; no protocol/DSP behavior change; the HF/6m path is byte-for-byte identical to before (GHz digit = 0). Brings the XieGu decoder into line with the already-audited `IcomCommand`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)