### PR TITLE
Fix web-logger hash-table page racing the shared callsign hashList (CME / HashMap corruption)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MessageHashMap.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MessageHashMap.java
@@ -7,7 +7,11 @@ package com.k1af.ft8af;
 
 import android.util.Log;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MessageHashMap extends HashMap<Long,String> {
     private static final String TAG = "MessageHashMap";
@@ -54,6 +58,32 @@ public class MessageHashMap extends HashMap<Long,String> {
 //            }
 //        }
 //        return false;
+    }
+
+    /**
+     * Return an independent, point-in-time copy of the (hash&nbsp;&rarr;&nbsp;callsign)
+     * entries, taken while holding this map's monitor.
+     *
+     * <p>{@link #addHash} and {@link #getCallsign} are {@code synchronized} on this
+     * instance, so every writer mutates the backing {@code HashMap} under the
+     * monitor: the decode thread, the DB-load thread, and the TX/Fox thread all
+     * add hashes several times per 15&nbsp;s cycle. A reader that iterates the
+     * <em>live</em> map from another thread races those writers. The web-logger's
+     * hash-table page ({@code LogHttpServer.showCallsignHash}) is built on a
+     * NanoHTTPD worker thread and used to iterate {@code entrySet()} directly, so a
+     * concurrent {@code put} could throw {@link java.util.ConcurrentModificationException}
+     * mid-render, and a {@code put}-driven resize racing the iteration can corrupt
+     * the very map the decoder relies on for hash resolution. Copying under the
+     * lock lets callers iterate a private snapshot without holding the monitor.
+     *
+     * @return a new list of the current entries, safe to iterate without locking
+     */
+    public synchronized List<Map.Entry<Long, String>> snapshotEntries() {
+        List<Map.Entry<Long, String>> copy = new ArrayList<>(size());
+        for (Map.Entry<Long, String> entry : entrySet()) {
+            copy.add(new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue()));
+        }
+        return copy;
     }
 
     //Look up callsign by hash code

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -968,7 +968,12 @@ public class LogHttpServer extends NanoHTTPD {
 
 
         int order = 0;
-        for (Map.Entry<Long, String> entry : Ft8Message.hashList.entrySet()) {
+        // Iterate a snapshot taken under hashList's monitor: this page is served
+        // on a NanoHTTPD worker thread and auto-refreshes every 5 s, while the
+        // decode/DB/TX threads add hashes throughout a cycle. Iterating the live
+        // map here raced those synchronized writers (ConcurrentModificationException,
+        // or a resize corrupting the shared hash table).
+        for (Map.Entry<Long, String> entry : Ft8Message.hashList.snapshotEntries()) {
             HtmlContext.tableRowBegin(result, false, (order / 3) % 2 != 0);
 
             HtmlContext.tableCell(result, entry.getValue());

--- a/ft8af/app/src/test/java/com/k1af/ft8af/MessageHashMapTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/MessageHashMapTest.java
@@ -1,8 +1,15 @@
 package com.k1af.ft8af;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
+
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Exercise {@link MessageHashMap}'s callsign-hash bookkeeping. The class
@@ -95,5 +102,106 @@ public class MessageHashMapTest {
         map.addHash(0x1234L, null);
         assertThat(map.checkHash(0x1234L)).isFalse();
         assertThat(map).isEmpty();
+    }
+
+    @Test
+    public void snapshotEntries_returnsAllCurrentEntries() {
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(0x10L, "K1ABC");
+        map.addHash(0x20L, "VE3XYZ");
+        map.addHash(0x30L, "JA1AA");
+
+        List<Map.Entry<Long, String>> snap = map.snapshotEntries();
+        assertThat(snap).hasSize(3);
+        // Every stored (hash, callsign) pair is present in the snapshot.
+        for (Map.Entry<Long, String> e : snap) {
+            assertThat(map.get(e.getKey())).isEqualTo(e.getValue());
+        }
+    }
+
+    @Test
+    public void snapshotEntries_isDecoupledFromLaterMutation() {
+        // The snapshot is a point-in-time copy: mutating the live map afterwards
+        // must neither change the snapshot's contents nor throw while it is
+        // iterated. This is the property the web-logger's hash-table page relies
+        // on to render safely off the decode thread.
+        MessageHashMap map = new MessageHashMap();
+        map.addHash(1L, "K1ABC");
+        map.addHash(2L, "W1AW");
+
+        List<Map.Entry<Long, String>> snap = map.snapshotEntries();
+        assertThat(snap).hasSize(2);
+
+        // Structurally modify the live map while iterating the snapshot; a live
+        // entrySet() would throw ConcurrentModificationException here.
+        for (Map.Entry<Long, String> ignored : snap) {
+            map.addHash(3L, "N0CALL");
+            map.clear();
+        }
+        assertThat(snap).hasSize(2);
+    }
+
+    @Test
+    public void liveEntrySetIteration_throwsOnConcurrentStructuralModification() {
+        // Documents the hazard snapshotEntries() exists to remove: iterating the
+        // live map while another writer put()s (as addHash does on the decode/DB/
+        // TX threads) is a fail-fast ConcurrentModificationException. Reproduced
+        // deterministically single-threaded via a structural modification during
+        // iteration.
+        MessageHashMap map = new MessageHashMap();
+        for (long h = 1; h <= 50; h++) {
+            map.addHash(h, "K" + h);
+        }
+        try {
+            for (Map.Entry<Long, String> e : map.entrySet()) {
+                map.put(1000L + e.getKey(), "X");
+            }
+            fail("expected ConcurrentModificationException from live entrySet iteration");
+        } catch (ConcurrentModificationException expected) {
+            // exactly the failure mode the web logger hit off-thread
+        }
+    }
+
+    @Test
+    public void snapshotEntries_survivesConcurrentWrites() throws Exception {
+        // Stress the real cross-thread scenario: a writer thread hammers addHash
+        // (the sole production writer path — decode/DB/TX side) while this thread
+        // repeatedly snapshots and iterates (web-logger side). addHash and
+        // snapshotEntries both hold the map's monitor, so the reader must never
+        // observe a ConcurrentModificationException or a corrupted iteration.
+        // Iterating the live entrySet() here instead would throw within a handful
+        // of rounds as the writer's put()s resize the table.
+        MessageHashMap map = new MessageHashMap();
+        AtomicBoolean writerDone = new AtomicBoolean(false);
+        AtomicReference<Throwable> writerError = new AtomicReference<>();
+
+        Thread writer = new Thread(() -> {
+            try {
+                // Fresh keys keep the table growing/resizing (the structural
+                // change that trips a live iterator). Bounded so the map size and
+                // runtime stay modest.
+                for (long h = 1; h <= 20000; h++) {
+                    map.addHash(h, "K" + h);
+                }
+            } catch (Throwable t) {
+                writerError.set(t);
+            } finally {
+                writerDone.set(true);
+            }
+        });
+        writer.start();
+
+        try {
+            while (!writerDone.get()) {
+                for (Map.Entry<Long, String> entry : map.snapshotEntries()) {
+                    // touch both accessors exactly like showCallsignHash() does
+                    entry.getKey();
+                    entry.getValue();
+                }
+            }
+        } finally {
+            writer.join();
+        }
+        assertThat(writerError.get()).isNull();
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/MessageHashMapTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/MessageHashMapTest.java
@@ -132,12 +132,15 @@ public class MessageHashMapTest {
         List<Map.Entry<Long, String>> snap = map.snapshotEntries();
         assertThat(snap).hasSize(2);
 
-        // Structurally modify the live map while iterating the snapshot; a live
+        // Structurally modify the live map via the production writer path
+        // (addHash with fresh keys) while iterating the snapshot; a live
         // entrySet() would throw ConcurrentModificationException here.
+        long freshKey = 100L;
         for (Map.Entry<Long, String> ignored : snap) {
-            map.addHash(3L, "N0CALL");
-            map.clear();
+            map.addHash(freshKey, "N0CALL" + freshKey);
+            freshKey++;
         }
+        // The live map grew, but the point-in-time snapshot is unchanged.
         assertThat(snap).hasSize(2);
     }
 


### PR DESCRIPTION
## Summary

`Ft8Message.hashList` is a process-wide `MessageHashMap` (extends `HashMap<Long,String>`) used to resolve hashed/compound callsigns during decode. Its writers — the **decode** thread, the **DB-load** thread, and the **TX/Fox** thread — all mutate it through the `synchronized addHash()`, several times per 15 s cycle.

`LogHttpServer.showCallsignHash()` (the web-logger's *callsign hash table* page) iterated `Ft8Message.hashList.entrySet()` **directly on a NanoHTTPD worker thread**, holding no lock — and that page auto-refreshes every 5 s while it is open (`setTimeout('myrefresh()',5000)`).

## Root cause

A reader that bypasses the writers' monitor. Iterating the live `HashMap` off-thread races the `synchronized` writers:

- a concurrent `put()` throws **`ConcurrentModificationException`** mid-render (fail-fast iterator), and
- more seriously, a `put()`-driven **resize** concurrent with the iteration can **corrupt the shared hash table** the decoder relies on for callsign-hash resolution — `HashMap` is not safe for concurrent structural modification.

The writers taking the monitor (`addHash`/`getCallsign` are both `synchronized`) gave false safety, because the reader never acquired it.

## Fix

Add a `synchronized snapshotEntries()` to `MessageHashMap` that copies the entries into an independent list **under the map's monitor**, and iterate that private snapshot in `showCallsignHash()`. Minimal and localized:

- `MessageHashMap.snapshotEntries()` — new synchronized accessor (immutable-entry copy).
- `LogHttpServer.showCallsignHash()` — iterate `hashList.snapshotEntries()` instead of `hashList.entrySet()`.

This is the **only** off-thread structural iteration of `hashList`. The other reader, `FT8TransmitSignal.comboFromOurFox()`, already goes through the `synchronized getCallsign()`, and no production code mutates `hashList` outside `addHash()` (verified: no direct `put`/`clear`/`remove`/reassignment anywhere).

## Testing performed

`MessageHashMapTest` (pure JVM, no Robolectric):

- `snapshotEntries_returnsAllCurrentEntries` / `snapshotEntries_isDecoupledFromLaterMutation` — the snapshot is a complete, independent point-in-time copy; mutating the live map afterwards neither changes nor throws while the snapshot is iterated.
- `liveEntrySetIteration_throwsOnConcurrentStructuralModification` — deterministically reproduces the fail-fast `ConcurrentModificationException` the snapshot removes (documents the hazard class).
- `snapshotEntries_survivesConcurrentWrites` — a writer thread hammers `addHash()` (the real writer path) while the test repeatedly snapshots and iterates; asserts no CME/corruption. This would throw against the old live-`entrySet()` path. **Stable across 3+ repeated runs** (the earlier flaky version had the *test* call the unsynchronized `map.clear()`, which no production code does; removed).

Full `:app:testDebugUnitTest` suite passes.

## Risk assessment

Low. No protocol/DSP/encoder change; no behavior change to the rendered page other than that it is now built from a consistent snapshot. `snapshotEntries()` is O(n) in the (small) hash-table size and is only invoked when the web-logger's hash page is served. No new locks in any hot path — the copy uses the same monitor the writers already hold.

## Scope

One logical bug. The parallel web-logger read races on `GeneralVariables.followCallsign` and `QSL_Callsign_list` (also read off-thread on NanoHTTPD workers) are separate collections with a different fix shape and are left for a focused follow-up.