### PR TITLE
Fix manual time-correction silently truncated to ±2 s on every relaunch

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -712,11 +712,12 @@ public class GeneralVariables {
 
     /**
      * Inclusive bounds (ms) for the manual clock correction ({@link #manualTimeCorrectionMs}
-     * / {@code UtcTimer.delay}). Must stay in sync with the live settings UI's own
-     * {@code TIME_CORRECTION_MIN_MS}/{@code TIME_CORRECTION_MAX_MS} in
-     * {@code TimeCorrection.kt}: that is the authoritative range (±5 s, widened from
-     * ±2 s so an offline phone that has drifted several seconds — a field-reported
-     * Samsung A50 needed over 3 s — can be pulled back).
+     * / {@code UtcTimer.delay}). This is the single source of truth for the range:
+     * the live settings UI's {@code TIME_CORRECTION_MIN_MS}/{@code TIME_CORRECTION_MAX_MS}
+     * in {@code TimeCorrection.kt} now reference these constants, so the UI slider and
+     * the reload-time clamp ({@link #clampManualTimeCorrectionMs}) can't drift apart.
+     * The range is ±5 s (widened from ±2 s so an offline phone that has drifted several
+     * seconds — a field-reported Samsung A50 needed over 3 s — can be pulled back).
      */
     public static final int MANUAL_TIME_CORRECTION_MIN_MS = -5000;
     public static final int MANUAL_TIME_CORRECTION_MAX_MS = 5000;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -449,7 +449,7 @@ public class GeneralVariables {
     public static int transmitDelay = 500;//Transmit delay; also allows decoding time for the previous cycle
     public static int pttDelay = 100;//PTT response time; radios typically need some response time after PTT command, default 100ms
     public static int lateStartTolerance = 2000;//Max ms of leading audio a late manual TX may clip past the per-mode audio slack (ModeProfile.audioSlackMillis) and still go out this cycle. Effective start budget is slack+tolerance. 0-4000. See issue #467.
-    public static int manualTimeCorrectionMs = 0;//Manual clock correction (ms) applied to UtcTimer.delay; for field use without internet NTP. Range -2000..2000. See TimeSyncSettings.
+    public static int manualTimeCorrectionMs = 0;//Manual clock correction (ms) applied to UtcTimer.delay; for field use without internet NTP. Range [MANUAL_TIME_CORRECTION_MIN_MS, MANUAL_TIME_CORRECTION_MAX_MS]. See TimeSyncSettings.
     public static boolean earlyDecode = true;//Fast turnaround: decode a shorter RX window so CQ decodes appear ~1s before the cycle boundary, enabling a next-slot reply.
     public static int operatingMode = FT8Common.FT8_MODE;//Current operating mode (FT8Common.FT8_MODE / FT4_MODE); persisted as config "operatingMode".
     public static int iaruRegion = 2;//Operator's IARU region (1/2/3), used to gate Message-Creator QSY frequency options to legal band edges. Default 2 (the Americas). See com.k1af.ft8af.message.SpecialMessage.
@@ -708,6 +708,36 @@ public class GeneralVariables {
         int clamped = Math.max(MIN_SPECTRUM_WIDTH_HZ, Math.min(MAX_SPECTRUM_WIDTH_HZ, width));
         mutableSpectrumWidth.postValue(clamped);
         GeneralVariables.spectrumWidth = clamped;
+    }
+
+    /**
+     * Inclusive bounds (ms) for the manual clock correction ({@link #manualTimeCorrectionMs}
+     * / {@code UtcTimer.delay}). Must stay in sync with the live settings UI's own
+     * {@code TIME_CORRECTION_MIN_MS}/{@code TIME_CORRECTION_MAX_MS} in
+     * {@code TimeCorrection.kt}: that is the authoritative range (±5 s, widened from
+     * ±2 s so an offline phone that has drifted several seconds — a field-reported
+     * Samsung A50 needed over 3 s — can be pulled back).
+     */
+    public static final int MANUAL_TIME_CORRECTION_MIN_MS = -5000;
+    public static final int MANUAL_TIME_CORRECTION_MAX_MS = 5000;
+
+    /**
+     * Clamp a manual clock correction to
+     * [{@link #MANUAL_TIME_CORRECTION_MIN_MS}, {@link #MANUAL_TIME_CORRECTION_MAX_MS}] ms.
+     *
+     * <p>The live settings UI already clamps to this range before persisting
+     * ({@code TimeSyncSettings.apply} → {@code clampCorrectionMs}), but config
+     * hydration on every launch ({@code DatabaseOpr}'s {@code timeCorrectionMs}
+     * branch) re-applies the persisted value to {@code UtcTimer.delay} and must
+     * clamp with the <em>same</em> bounds. The reload path used to clamp to ±2000
+     * while the UI allowed ±5000, so any correction beyond ±2 s was silently
+     * truncated back to 2 s at startup — leaving the operator's carefully-set
+     * offline clock offset wrong by up to 3 s and degrading decodes. Byte-identical
+     * for every in-range value.
+     */
+    public static int clampManualTimeCorrectionMs(int ms) {
+        return Math.max(MANUAL_TIME_CORRECTION_MIN_MS,
+                Math.min(MANUAL_TIME_CORRECTION_MAX_MS, ms));
     }
 
     public static int getFftWindowType() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2677,7 +2677,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     } catch (NumberFormatException e) {
                         ms = 0;
                     }
-                    ms = Math.max(-2000, Math.min(2000, ms));
+                    // Clamp with the SAME bounds the live settings UI uses when it
+                    // persists this value (±5 s). The reload clamp used to be ±2 s,
+                    // silently truncating any correction beyond ±2 s on every launch.
+                    ms = GeneralVariables.clampManualTimeCorrectionMs(ms);
                     GeneralVariables.manualTimeCorrectionMs = ms;
                     UtcTimer.delay = ms;
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeCorrection.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeCorrection.kt
@@ -1,5 +1,6 @@
 package radio.ks3ckc.ft8af.ui.settings
 
+import com.k1af.ft8af.GeneralVariables
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -17,9 +18,18 @@ import kotlin.math.roundToInt
  * a Samsung A50 needing over 3 s while offline is why this is ±5 s, not ±2 s.
  */
 
-/** Inclusive bounds for the manual correction, in milliseconds. */
-internal const val TIME_CORRECTION_MIN_MS = -5000
-internal const val TIME_CORRECTION_MAX_MS = 5000
+/**
+ * Inclusive bounds for the manual correction, in milliseconds.
+ *
+ * Single source of truth is [GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS] /
+ * [GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS], which the config-hydration
+ * reload path clamps against ([GeneralVariables.clampManualTimeCorrectionMs]).
+ * These reference those so a range change can't drift the UI out of sync with
+ * reload. (Java `static final int` constant expressions inline at compile time,
+ * so this doesn't drag GeneralVariables' class init into this pure-logic file.)
+ */
+internal val TIME_CORRECTION_MIN_MS = GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS
+internal val TIME_CORRECTION_MAX_MS = GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS
 
 /** Coerce an arbitrary correction into the allowed range. */
 internal fun clampCorrectionMs(ms: Int): Int =

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesTimeCorrectionClampTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesTimeCorrectionClampTest.java
@@ -1,0 +1,75 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards {@link GeneralVariables#clampManualTimeCorrectionMs(int)} — the shared
+ * clamp for the manual clock correction (ms) applied to {@code UtcTimer.delay}.
+ *
+ * <p>Regression: the live settings UI ({@code TimeSyncSettings.apply} →
+ * {@code clampCorrectionMs}) clamps and persists this value to ±5000 ms, but the
+ * config-hydration reload path ({@code DatabaseOpr}'s {@code timeCorrectionMs}
+ * branch, run at every launch) used to clamp with a stale ±2000 ms bound. Any
+ * correction the operator set beyond ±2 s was therefore silently truncated back
+ * to 2 s on the next relaunch, leaving an offline (no-NTP) phone's clock offset
+ * wrong by up to 3 s — and incorrect PC/phone time is the single most common
+ * cause of FT8 decode failures. Centralizing the bound here and reusing it on the
+ * reload path keeps the two paths in lock-step.
+ *
+ * <p>Robolectric because {@link GeneralVariables} carries Android LiveData statics
+ * that must initialize before the static helper can be exercised.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesTimeCorrectionClampTest {
+
+    @Test
+    public void inRangeValues_areReturnedUnchanged() {
+        // Byte-identical for every value the settings UI can produce.
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(0)).isEqualTo(0);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(500)).isEqualTo(500);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(-1500)).isEqualTo(-1500);
+    }
+
+    @Test
+    public void correctionBeyondTwoSeconds_survivesTheReloadClamp() {
+        // The load-bearing regression: these all used to be truncated to ±2000.
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(3000)).isEqualTo(3000);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(-3000)).isEqualTo(-3000);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(4500)).isEqualTo(4500);
+    }
+
+    @Test
+    public void boundaryValues_areKept() {
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(
+                GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS))
+                .isEqualTo(GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(
+                GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS))
+                .isEqualTo(GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS);
+    }
+
+    @Test
+    public void outOfRangeValues_areClampedToTheBounds() {
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(6000))
+                .isEqualTo(GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(-6000))
+                .isEqualTo(GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(Integer.MAX_VALUE))
+                .isEqualTo(GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS);
+        assertThat(GeneralVariables.clampManualTimeCorrectionMs(Integer.MIN_VALUE))
+                .isEqualTo(GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS);
+    }
+
+    @Test
+    public void bounds_matchTheLiveUiRangeAndAreSymmetric() {
+        // Must equal TimeCorrection.kt's authoritative ±5 s range (kept in sync by
+        // documentation). If a future edit narrows the reload bound again, this and
+        // the truncation test above fail.
+        assertThat(GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS).isEqualTo(5000);
+        assertThat(GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS).isEqualTo(-5000);
+    }
+}


### PR DESCRIPTION
## Summary

The manual clock correction (**Settings → Time Sync**) is silently truncated from its configured value back to ±2 s on **every app relaunch**, because the config-reload path clamps it with a stale bound that no longer matches the live UI. Since incorrect device time is the single most common cause of FT8 decode failures, an operator who deliberately dialed in a >2 s offset (typical on an offline phone with no NTP) has their decoding quietly degraded after the next restart.

## Root cause

A range mismatch between the **write/live** path and the **reload** path:

- The live UI allows **±5000 ms**: `TimeCorrection.kt` defines `TIME_CORRECTION_MIN/MAX_MS = ∓5000` and `clampCorrectionMs()`; `TimeSyncSettings.apply()` persists `clampCorrectionMs(newMs)` to config key `timeCorrectionMs`. The range was deliberately widened from ±2 s to ±5 s (docstring cites a field-reported Samsung A50 needing over 3 s while offline).
- The reload path was **never updated**: `DatabaseOpr` hydrates `timeCorrectionMs` at every launch and re-applied it to `UtcTimer.delay` with `Math.max(-2000, Math.min(2000, ms))`. The stale `GeneralVariables.manualTimeCorrectionMs` comment also still said `Range -2000..2000`.

So a persisted `3000` was read back, clamped to `2000`, and applied to the running timers — the clock offset is now wrong by up to 3 s. (The DB row itself is not rewritten during hydration, so no persisted data is corrupted; only the in-memory applied value is truncated. It can become permanent if the user later re-opens Time Sync, whose state seeds from the truncated `UtcTimer.delay`.)

## Fix

Centralize the bound as `GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS` / `MAX_MS` (±5000, matching the authoritative `TimeCorrection.kt` range) behind a pure `clampManualTimeCorrectionMs()` helper, and have the `DatabaseOpr` reload path reuse it so the two paths can no longer drift. This mirrors the existing `GeneralVariables.setSpectrumWidth` / `MIN/MAX_SPECTRUM_WIDTH_HZ` precedent for the same class of "UI clamps, reload doesn't" hydration bug. Byte-identical for every in-range value.

## Testing performed

- **New:** `GeneralVariablesTimeCorrectionClampTest` (Robolectric, 5 cases): in-range values unchanged; ±3 s / ±4.5 s corrections survive the clamp; boundary values kept; out-of-range values clamp to ±5 s; bounds equal the live UI's ±5 s.
- **Fail-before-fix verified:** with the old ±2000 bound the `correctionBeyondTwoSeconds_survivesTheReloadClamp` and `bounds_matchTheLiveUiRange` cases fail.
- `./gradlew :app:testDebugUnitTest` for the new test plus the existing `GeneralVariables*` and `TimeCorrectionTest` suites — all green.

## Risk assessment

Very low. Change is localized to one clamp bound + a shared helper; no protocol/DSP behavior, no persisted-data migration, byte-identical for every value already within ±2 s. Widening the reload clamp only lets legitimately-configured corrections in [2 s, 5 s] survive a relaunch, exactly matching what the live UI already permits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)