### PR TITLE
Add the two thermal controls the shipping UI was missing

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -65,6 +65,16 @@ public class GeneralVariables {
     // time bound.
     public static boolean deepDecodeMode = true;//Whether deep decode mode is enabled
 
+    // Hold the screen awake while the app is in the foreground. On by default —
+    // that was the hard-coded behaviour before this became a setting — but a long
+    // portable session is the case where you want it off: an always-on panel at
+    // outdoor brightness is one of the two biggest heat sources on the phone, and
+    // a hot phone browns out its own OTG accessory rail (see the 2026-07-23 field
+    // log: 48.6C battery, twelve USB re-enumerations). RX keeps running with the
+    // screen off via RxForegroundService, so turning this off costs nothing but
+    // having to wake the phone to look at the waterfall.
+    public static boolean keepScreenOn = true;
+
     public static boolean audioOutput32Bit = true;//Audio output type: true=float, false=int16
     public static int audioSampleRate = 12000;//Transmit audio sample rate
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2958,10 +2958,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.usbAudioOutputProductId = parseConfigInt(result, 0);
                 }
                 if (name.equalsIgnoreCase("deepMode")) {//Deep decode mode
-                    GeneralVariables.deepDecodeMode =result.equals("1");
+                    GeneralVariables.deepDecodeMode = "1".equals(result);
                 }
                 if (name.equalsIgnoreCase("keepScreenOn")) {//Hold the screen awake in foreground
-                    GeneralVariables.keepScreenOn = result.equals("1");
+                    // "1".equals(result), not result.equals("1"): a null config value
+                    // (missing/blank column from an imported backup) must not NPE here.
+                    GeneralVariables.keepScreenOn = "1".equals(result);
                 }
                 if (name.equalsIgnoreCase("debugModeEnabled")) {//Hidden debug screen unlock
                     GeneralVariables.debugModeEnabled = result.equals("1");

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2960,6 +2960,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("deepMode")) {//Deep decode mode
                     GeneralVariables.deepDecodeMode =result.equals("1");
                 }
+                if (name.equalsIgnoreCase("keepScreenOn")) {//Hold the screen awake in foreground
+                    GeneralVariables.keepScreenOn = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("debugModeEnabled")) {//Hidden debug screen unlock
                     GeneralVariables.debugModeEnabled = result.equals("1");
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -139,6 +139,17 @@ class ComposeMainActivity : AppCompatActivity() {
             if (v != null) UsbAudioNative.setTxVolume(v)
         }
 
+        // Re-apply the screen-awake preference once config hydration finishes.
+        // onCreate/onResume both run before initData()'s async config load
+        // completes, so they apply the default (on); if the stored value is
+        // actually false the screen would stay awake until the next resume or a
+        // manual toggle. Observing mutableConfigLoaded catches the moment the real
+        // value lands. Lifecycle-bound and delivered on the main thread, so the
+        // window flag is set safely.
+        mainViewModel.mutableConfigLoaded.observe(this) { loaded ->
+            if (loaded == true) ScreenWake.apply(window, GeneralVariables.keepScreenOn)
+        }
+
         // Register back press handler. Priority: dismiss the QSO sheet if
         // it's open, otherwise show exit confirm. Without this, back-from-
         // sheet tries to exit the whole app, which surprises users who

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -16,7 +16,6 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
-import android.view.WindowManager
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -99,7 +98,11 @@ class ComposeMainActivity : AppCompatActivity() {
         // hiding the system bars immersively (transient reveal on swipe) instead
         // of the deprecated fullscreen flag. Keep the screen on as before.
         enableEdgeToEdge()
-        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        // Screen-awake is now a setting (default on, matching the previous
+        // hard-coded behaviour). Config has not hydrated yet at this point, so
+        // this applies the default; onResume re-applies once the stored value is
+        // loaded, and the settings toggle applies it live.
+        ScreenWake.apply(window, GeneralVariables.keepScreenOn)
 
         super.onCreate(savedInstanceState)
 
@@ -615,6 +618,14 @@ class ComposeMainActivity : AppCompatActivity() {
             try { unregisterReceiver(it) } catch (_: Exception) {}
             usbDetachReceiver = null
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Re-apply the screen-awake preference. onCreate runs before config
+        // hydration, so the stored value may differ from the default it applied;
+        // this also covers returning from the settings screen.
+        ScreenWake.apply(window, GeneralVariables.keepScreenOn)
     }
 
     override fun onStop() {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ScreenWake.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ScreenWake.kt
@@ -1,0 +1,50 @@
+package radio.ks3ckc.ft8af
+
+import android.view.Window
+import android.view.WindowManager
+
+/**
+ * Applies the "keep the screen awake" preference to a window.
+ *
+ * The flag used to be added unconditionally in [ComposeMainActivity.onCreate], so a
+ * foreground session held the panel on at whatever brightness for its entire
+ * duration. On a long portable run that is one of the two biggest heat sources on
+ * the phone (the other being the deep-decode loop), and a hot phone browns out its
+ * own OTG accessory rail — the 2026-07-23 field log shows the battery at 48.6C and
+ * the USB bus re-enumerating twelve times, twice leaving the rig keyed.
+ *
+ * Receive keeps running with the screen off via `RxForegroundService`, so this is a
+ * safe knob: turning it off costs nothing but having to wake the phone to look at
+ * the waterfall.
+ *
+ * Split out of the activity so the add/clear decision is unit-testable — the
+ * activity itself cannot be instantiated in a plain JVM test.
+ */
+object ScreenWake {
+
+    /**
+     * Add or clear [WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON] on [window].
+     *
+     * Idempotent: setting the same value twice is a no-op, so this can be called
+     * from `onCreate`, again after config hydration (which may flip it), and again
+     * whenever the user toggles the setting.
+     *
+     * @param keepOn the user's preference, i.e. `GeneralVariables.keepScreenOn`
+     */
+    @JvmStatic
+    fun apply(window: Window, keepOn: Boolean) {
+        if (keepOn) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    /**
+     * Whether [flags] currently holds the screen awake. Exposed for the activity's
+     * own re-apply path and for tests.
+     */
+    @JvmStatic
+    fun isHoldingScreenOn(flags: Int): Boolean =
+        (flags and WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) != 0
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
@@ -40,6 +40,7 @@ import com.k1af.ft8af.database.OnAfterQueryConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8af.ScreenWake
 import radio.ks3ckc.ft8af.crash.CrashReporting
 import radio.ks3ckc.ft8af.theme.Accent
 import radio.ks3ckc.ft8af.theme.BgSurface2
@@ -159,6 +160,11 @@ fun AdvancedSettings(
     var txDelay by remember { mutableIntStateOf(GeneralVariables.transmitDelay) }
     var lateStartMs by remember { mutableIntStateOf(GeneralVariables.lateStartTolerance) }
     var currentTheme by remember { mutableStateOf(loadTheme(context)) }
+
+    // Power & heat knobs. Seeded from GeneralVariables, which config hydration
+    // has already populated by the time settings can be opened.
+    var keepScreenOn by remember { mutableStateOf(GeneralVariables.keepScreenOn) }
+    var deepDecode by remember { mutableStateOf(GeneralVariables.deepDecodeMode) }
 
     // Opt-in crash reporting (Sentry). Only surfaced when a DSN was compiled in.
     var crashReportingEnabled by remember { mutableStateOf(CrashReporting.isOptedIn(context)) }
@@ -555,6 +561,54 @@ fun AdvancedSettings(
                         value = stringResource(binAggregationLabelRes(binAggregation)),
                         showChevron = true,
                         onClick = { showBinAggregationPicker = true },
+                    )
+                }
+            }
+        }
+
+        // =====================================================================
+        // POWER & HEAT
+        // =====================================================================
+        // Both knobs exist because a long portable session cooks the phone until
+        // it browns out its own OTG accessory rail and drops the CAT link (field
+        // log 2026-07-23: 48.6C battery, twelve USB re-enumerations). The screen
+        // flag used to be hard-coded on; deep decode was only reachable from the
+        // retired legacy settings fragment, so neither was adjustable in the
+        // shipping UI.
+        SettingsSection(title = stringResource(R.string.settings_section_power)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    SettingsRow(
+                        label = stringResource(R.string.settings_keep_screen_on),
+                        description = stringResource(R.string.settings_keep_screen_on_desc),
+                        toggle = keepScreenOn,
+                        onToggleChange = { on ->
+                            keepScreenOn = on
+                            GeneralVariables.keepScreenOn = on
+                            mainViewModel.databaseOpr.writeConfig(
+                                "keepScreenOn", if (on) "1" else "0", null,
+                            )
+                            // Apply live rather than waiting for the next onResume,
+                            // so the effect is visible from the settings screen.
+                            (context as? android.app.Activity)?.let {
+                                ScreenWake.apply(it.window, on)
+                            }
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_deep_decode),
+                        description = stringResource(R.string.settings_deep_decode_desc),
+                        toggle = deepDecode,
+                        onToggleChange = { on ->
+                            deepDecode = on
+                            GeneralVariables.deepDecodeMode = on
+                            // Same "deepMode" key the retired legacy fragment wrote,
+                            // so an existing preference carries over unchanged.
+                            mainViewModel.databaseOpr.writeConfig(
+                                "deepMode", if (on) "1" else "0", null,
+                            )
+                        },
                     )
                 }
             }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -643,6 +643,13 @@
     <string name="settings_tx_delay_desc">Delay before transmit to allow prior-cycle decode</string>
     <string name="settings_late_start_tolerance">Late-start Tolerance</string>
     <string name="settings_late_start_tolerance_desc">Extra leading audio (ms) a late manual TX may clip so it still goes out this cycle instead of waiting for the next slot</string>
+    <!-- Power / thermal controls. A long portable session heats the phone until it
+         browns out its own OTG accessory rail, taking the CAT link with it. -->
+    <string name="settings_section_power">POWER &amp; HEAT</string>
+    <string name="settings_keep_screen_on">Keep screen on</string>
+    <string name="settings_keep_screen_on_desc">Hold the display awake while the app is open. Turn off for long portable sessions — receive keeps running in the background and the phone runs much cooler</string>
+    <string name="settings_deep_decode">Deep decode</string>
+    <string name="settings_deep_decode_desc">Subtract-and-redecode pass that digs weak signals out from under strong ones. Uses up to 75%% of every slot at full CPU — the biggest single heat source. Turn off to run cooler at the cost of some weak decodes</string>
     <string name="late_start_deferred">Too late this cycle (need %d ms clip) — waiting for next slot</string>
 
     <!-- ===== Settings: about ===== -->

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -649,7 +649,7 @@
     <string name="settings_keep_screen_on">Keep screen on</string>
     <string name="settings_keep_screen_on_desc">Hold the display awake while the app is open. Turn off for long portable sessions — receive keeps running in the background and the phone runs much cooler</string>
     <string name="settings_deep_decode">Deep decode</string>
-    <string name="settings_deep_decode_desc">Subtract-and-redecode pass that digs weak signals out from under strong ones. Uses up to 75%% of every slot at full CPU — the biggest single heat source. Turn off to run cooler at the cost of some weak decodes</string>
+    <string name="settings_deep_decode_desc" formatted="false">Subtract-and-redecode pass that digs weak signals out from under strong ones. Uses up to 75% of every slot at full CPU — the biggest single heat source. Turn off to run cooler at the cost of some weak decodes</string>
     <string name="late_start_deferred">Too late this cycle (need %d ms clip) — waiting for next slot</string>
 
     <!-- ===== Settings: about ===== -->

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -52,6 +52,8 @@ public class DatabaseOprConfigHydrationTest {
     private int origIcomUdpPort;
     private float origVolumePercent;
     private int origAlcTargetLow;
+    private boolean origDeepDecodeMode;
+    private boolean origKeepScreenOn;
 
     @Before
     public void setUp() {
@@ -67,6 +69,8 @@ public class DatabaseOprConfigHydrationTest {
         origIcomUdpPort = GeneralVariables.icomUdpPort;
         origVolumePercent = GeneralVariables.volumePercent;
         origAlcTargetLow = GeneralVariables.alcTargetLow;
+        origDeepDecodeMode = GeneralVariables.deepDecodeMode;
+        origKeepScreenOn = GeneralVariables.keepScreenOn;
 
         opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 18);
     }
@@ -88,6 +92,8 @@ public class DatabaseOprConfigHydrationTest {
             GeneralVariables.icomUdpPort = origIcomUdpPort;
             GeneralVariables.volumePercent = origVolumePercent;
             GeneralVariables.alcTargetLow = origAlcTargetLow;
+            GeneralVariables.deepDecodeMode = origDeepDecodeMode;
+            GeneralVariables.keepScreenOn = origKeepScreenOn;
         }
     }
 
@@ -223,5 +229,76 @@ public class DatabaseOprConfigHydrationTest {
         } finally {
             GeneralVariables.udpPort = orig;
         }
+    }
+
+    // ---- power & heat toggles ------------------------------------------------
+    // Both are surfaced in the Compose settings for the first time. deepMode
+    // reuses the key the retired legacy fragment wrote, so an existing preference
+    // must still hydrate; keepScreenOn is new and must default to the previous
+    // hard-coded behaviour (on) when absent.
+
+    @Test
+    public void powerToggles_hydrateFromStoredValues() {
+        GeneralVariables.deepDecodeMode = true;
+        GeneralVariables.keepScreenOn = true;
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("deepMode", "0");
+        config.put("keepScreenOn", "0");
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.deepDecodeMode).isFalse();
+        assertThat(GeneralVariables.keepScreenOn).isFalse();
+    }
+
+    @Test
+    public void powerToggles_hydrateBackOn() {
+        GeneralVariables.deepDecodeMode = false;
+        GeneralVariables.keepScreenOn = false;
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("deepMode", "1");
+        config.put("keepScreenOn", "1");
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.deepDecodeMode).isTrue();
+        assertThat(GeneralVariables.keepScreenOn).isTrue();
+    }
+
+    @Test
+    public void keepScreenOn_absentFromConfigKeepsThePreviousBehaviour() {
+        // An install that predates the setting has no row; the screen must keep
+        // behaving as it did when the flag was hard-coded on.
+        GeneralVariables.keepScreenOn = true;
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("deepMode", "1");
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.keepScreenOn).isTrue();
+    }
+
+    @Test
+    public void powerToggles_nonBooleanValueReadsAsOff() {
+        // Hydration compares against "1", so anything else is off rather than a
+        // parse crash (the failure mode this test class exists for).
+        GeneralVariables.deepDecodeMode = true;
+        GeneralVariables.keepScreenOn = true;
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("deepMode", "");
+        config.put("keepScreenOn", "yes");
+        opr.writeConfigSync(config);
+
+        hydrate(); // must not throw
+
+        assertThat(GeneralVariables.deepDecodeMode).isFalse();
+        assertThat(GeneralVariables.keepScreenOn).isFalse();
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ScreenWakeTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ScreenWakeTest.kt
@@ -1,0 +1,92 @@
+package radio.ks3ckc.ft8af
+
+import android.app.Activity
+import android.view.WindowManager
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Coverage for [ScreenWake], which applies the "keep screen on" preference.
+ *
+ * The flag used to be added unconditionally in `ComposeMainActivity.onCreate`, so
+ * a foreground session held the panel awake for its whole duration with no way to
+ * turn it off. That is one of the two biggest heat sources on the phone during a
+ * long portable run, and a hot phone browns out its own OTG accessory rail —
+ * field log 2026-07-23 shows 48.6C battery and twelve USB re-enumerations, two of
+ * which left the rig keyed.
+ *
+ * Robolectric: needs a real [android.view.Window] to add and clear flags on.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ScreenWakeTest {
+
+    private fun window() = Robolectric.buildActivity(Activity::class.java).setup().get().window
+
+    private fun holdsScreenOn(activityWindow: android.view.Window) =
+        ScreenWake.isHoldingScreenOn(activityWindow.attributes.flags)
+
+    @Test
+    fun `apply true holds the screen awake`() {
+        val w = window()
+        ScreenWake.apply(w, true)
+        assertThat(holdsScreenOn(w)).isTrue()
+    }
+
+    @Test
+    fun `apply false releases the screen`() {
+        val w = window()
+        ScreenWake.apply(w, true)
+        ScreenWake.apply(w, false)
+        assertThat(holdsScreenOn(w)).isFalse()
+    }
+
+    @Test
+    fun `apply false on a window that never held it is a no-op`() {
+        // onCreate applies the default before config hydration; hydration may then
+        // apply false to a window that never had the flag.
+        val w = window()
+        ScreenWake.apply(w, false)
+        assertThat(holdsScreenOn(w)).isFalse()
+    }
+
+    @Test
+    fun `repeated applies are idempotent`() {
+        // Called from onCreate, again from onResume, and again on every toggle.
+        val w = window()
+        ScreenWake.apply(w, true)
+        ScreenWake.apply(w, true)
+        assertThat(holdsScreenOn(w)).isTrue()
+        ScreenWake.apply(w, false)
+        ScreenWake.apply(w, false)
+        assertThat(holdsScreenOn(w)).isFalse()
+    }
+
+    @Test
+    fun `toggling back on after off re-holds the screen`() {
+        val w = window()
+        ScreenWake.apply(w, false)
+        ScreenWake.apply(w, true)
+        assertThat(holdsScreenOn(w)).isTrue()
+    }
+
+    @Test
+    fun `isHoldingScreenOn reads the flag bit`() {
+        assertThat(ScreenWake.isHoldingScreenOn(0)).isFalse()
+        assertThat(
+            ScreenWake.isHoldingScreenOn(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON),
+        ).isTrue()
+        // Must not be confused by other flags sharing the mask word.
+        assertThat(
+            ScreenWake.isHoldingScreenOn(WindowManager.LayoutParams.FLAG_FULLSCREEN),
+        ).isFalse()
+        assertThat(
+            ScreenWake.isHoldingScreenOn(
+                WindowManager.LayoutParams.FLAG_FULLSCREEN or
+                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON,
+            ),
+        ).isTrue()
+    }
+}


### PR DESCRIPTION
## Why

A long portable session heats the phone until it browns out its own OTG accessory rail and drops the CAT link. From the 2026-07-23 field log:

| time | battery temp | voltage | USB drops |
|---|---|---|---|
| 07:25 (start) | 35.1 °C | 4147 mV | — |
| 08:09 | **48.6 °C** | 3991 mV | — |
| 09:18 | 44.4 °C | **3725 mV** | 12 in the preceding 30 min |

Zero drops in the first 90 minutes while the phone was cool and full; twelve bus re-enumerations once it was hot, two of which left the rig keyed (fixed separately in #652).

The phone's two largest sustained loads during that session were both **unadjustable from the shipping UI**:

- `FLAG_KEEP_SCREEN_ON` was added unconditionally in `onCreate`, so a foreground session held the panel awake at outdoor brightness for its whole duration.
- Deep decode runs the subtract-and-redecode loop for up to **75% of every slot at full CPU** — `ModeProfile.deepDecodeBudgetMillis()` is `max(2500, slot × 0.75)`, i.e. 11.25 s of every 15 s FT8 slot, 301 deep passes that session. `GeneralVariables.deepDecodeMode` has always existed and the decoder honours it, but the fast/deep toggle only ever lived in the retired legacy `assets/ConfigFragment.java`. It was never ported to Compose, so whatever sits in the config DB is what you get, permanently.

## What

Both are now toggles in a new **POWER & HEAT** section of Advanced settings.

**Keep screen on** → new `GeneralVariables.keepScreenOn`, persisted under a new `keepScreenOn` config key, **defaulting to true** so an install that predates the setting behaves exactly as before. Flag application moves into `ScreenWake.apply(window, keepOn)`:

- called from `onCreate` with the default, since config has not hydrated that early;
- re-applied in a new `onResume` once the stored value is loaded;
- applied live from the toggle, so the effect is visible from the settings screen.

RX keeps running with the screen off via `RxForegroundService`, so turning it off costs nothing but having to wake the phone to see the waterfall.

**Deep decode** → writes the same `deepMode` key the legacy fragment used, so an existing preference carries over untouched. The description states the trade-off plainly: in that same session deep passes found the partner's reply in **31 cycles the fast pass missed**, so this is a lever for hot days, not a default to change.

## What this does not do

Neither toggle stops the phone getting hot on its own — the hardware fix is powering the interface externally rather than off the phone's OTG rail. This makes the two biggest *software* contributors adjustable, which they weren't.

## Tests

- `ScreenWakeTest` — apply true/false, no-op clear on a window that never held the flag, idempotent repeats, re-enable after disable, and flag-mask reading that isn't confused by other window flags.
- `DatabaseOprConfigHydrationTest` — both keys hydrate on and off, `keepScreenOn` absent from config keeps the previous hard-coded behaviour, and a non-boolean value reads as off rather than crashing hydration (the failure mode that test class exists for).

Full suite: **2481 tests, 0 failures.** Installed on a Pixel 8 and smoke-launched — process comes up clean with no crash records. The settings section itself was not visually verified; the device was locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
