### PR TITLE
Fix web-logbook crash from racing the shared followCallsign list off-thread

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -632,7 +632,19 @@ public class GeneralVariables {
     }
 
 
-    public static final ArrayList<String> followCallsign = new ArrayList<>();//Followed callsigns
+    // The followed-callsigns list. Mutated concurrently with no external lock:
+    // the decode/DB threads add (MainViewModel.addFollowCallsign,
+    // getFollowCallsignsFromDataBase) and the UI thread clears it
+    // (ClearCacheDataDialog), while the web logbook renders it on a NanoHTTPD
+    // worker thread (LogHttpServer). A plain ArrayList corrupts its backing
+    // array / throws IndexOutOfBounds under that contention, so this is a
+    // CopyOnWriteArrayList: every add/clear is atomic. Readers must iterate the
+    // list itself (for-each snapshots the array) rather than size()+get(i),
+    // which can still race a concurrent clear.
+    // final: the thread-safety invariant depends on this always being the
+    // CopyOnWriteArrayList — never reassign it to a plain List. Mutate in place
+    // (add/clear) only.
+    public static final List<String> followCallsign = new CopyOnWriteArrayList<>();//Followed callsigns
 
     // The calling-UI "followed entries" list. Mutated concurrently from three
     // threads with no external lock: the decode thread (findIncludedCallsigns

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -923,13 +923,7 @@ public class LogHttpServer extends NanoHTTPD {
                 , GeneralVariables.getStringFromResource(R.string.html_tracking_callsign)));
 
         result.append("<tr><td class=\"default\" >");
-        for (int i = 0; i < GeneralVariables.followCallsign.size(); i++) {
-            result.append(GeneralVariables.followCallsign.get(i));
-            result.append(",&nbsp;");
-            if (((i + 1) % 10) == 0) {
-                result.append("</td></tr><tr><td class=\"default\" >\n");
-            }
-        }
+        result.append(followCallsignBlock(GeneralVariables.followCallsign));
         result.append("</td></tr>\n");
         HtmlContext.tableEnd(result).append("\n");
 
@@ -942,6 +936,33 @@ public class LogHttpServer extends NanoHTTPD {
         result.append("</td></tr>\n");
         HtmlContext.tableEnd(result).append("\n");
 
+        return result.toString();
+    }
+
+    /**
+     * Render the followed-callsign block as comma-separated cells, ten per row.
+     *
+     * <p>This runs on a NanoHTTPD worker thread while the decode/DB threads add
+     * to and the UI thread clears {@link GeneralVariables#followCallsign}. It
+     * iterates the list with a for-each so a {@link java.util.concurrent.CopyOnWriteArrayList}
+     * hands back a stable array snapshot — never a {@code size()}/{@code get(i)}
+     * scan, which can race a concurrent clear into an
+     * {@link IndexOutOfBoundsException}.
+     *
+     * @param callsigns the followed callsigns (never mutated here)
+     * @return the inner HTML for the tracking-callsign table cell
+     */
+    static String followCallsignBlock(java.util.List<String> callsigns) {
+        StringBuilder result = new StringBuilder();
+        int index = 0;
+        for (String callsign : callsigns) {
+            result.append(callsign);
+            result.append(",&nbsp;");
+            if (((index + 1) % 10) == 0) {
+                result.append("</td></tr><tr><td class=\"default\" >\n");
+            }
+            index++;
+        }
         return result.toString();
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ClearCacheDataDialog.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ClearCacheDataDialog.java
@@ -105,8 +105,10 @@ public class ClearCacheDataDialog extends Dialog {
         StringBuilder msg = new StringBuilder();
         if (cache_mode == CACHE_MODE.FOLLOW_DATA) {
             msg.append(GeneralVariables.getStringFromResource(R.string.html_tracking_callsign));
-            for (int i = 0; i < GeneralVariables.followCallsign.size(); i++) {
-                msg.append("\n" + GeneralVariables.followCallsign.get(i));
+            // for-each snapshots the CopyOnWriteArrayList; a size()+get(i) scan
+            // could race a concurrent add/clear into IndexOutOfBounds.
+            for (String callsign : GeneralVariables.followCallsign) {
+                msg.append("\n" + callsign);
             }
             cacheHelpMessage.setText(msg.toString());
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesFollowCallsignTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesFollowCallsignTest.java
@@ -54,11 +54,17 @@ public class GeneralVariablesFollowCallsignTest {
         final int rounds = 5000;
 
         Thread writer = new Thread(() -> {
-            for (int r = 0; r < rounds; r++) {
-                GeneralVariables.followCallsign.add("W" + (r % 64));
-                if ((r % 25) == 0) {
-                    GeneralVariables.followCallsign.clear();
+            try {
+                for (int r = 0; r < rounds; r++) {
+                    GeneralVariables.followCallsign.add("W" + (r % 64));
+                    if ((r % 25) == 0) {
+                        GeneralVariables.followCallsign.clear();
+                    }
                 }
+            } catch (Throwable t) {
+                // Record writer-side failures too; a bare thread throw would be
+                // swallowed by the JVM and let this test pass despite a crash.
+                failure.compareAndSet(null, t);
             }
         });
         writer.start();
@@ -74,7 +80,7 @@ public class GeneralVariablesFollowCallsignTest {
                 }
             }
         } catch (Throwable t) {
-            failure.set(t);
+            failure.compareAndSet(null, t);
         }
         writer.join();
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesFollowCallsignTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesFollowCallsignTest.java
@@ -1,0 +1,83 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Pins the thread-safety of {@link GeneralVariables#followCallsign}.
+ *
+ * <p>The list is mutated with no external lock from several threads: the
+ * decode/DB threads add to it ({@code MainViewModel.addFollowCallsign},
+ * {@code getFollowCallsignsFromDataBase}) and the UI thread clears it
+ * ({@code ClearCacheDataDialog}), while the web logbook renders it on a
+ * NanoHTTPD worker thread ({@code LogHttpServer}). As a plain {@code ArrayList}
+ * that contention corrupts the backing array and a {@code size()}+{@code get(i)}
+ * scan on the HTTP thread races a concurrent clear into an
+ * {@link IndexOutOfBoundsException}. It must be a {@link CopyOnWriteArrayList}
+ * (mirroring its sibling {@code transmitMessages}) so every add/clear is atomic
+ * and for-each readers get a stable snapshot.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesFollowCallsignTest {
+
+    @Before
+    public void setUp() {
+        GeneralVariables.followCallsign.clear();
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.followCallsign.clear();
+    }
+
+    @Test
+    public void followCallsign_isCopyOnWriteArrayList() {
+        // Regression lock: a plain ArrayList reintroduces the cross-thread
+        // web-logbook crash this guards against.
+        assertThat(GeneralVariables.followCallsign).isInstanceOf(CopyOnWriteArrayList.class);
+    }
+
+    @Test
+    public void concurrentAddClear_duringForEach_neverThrows() throws Exception {
+        for (int i = 0; i < 32; i++) {
+            GeneralVariables.followCallsign.add("SEED" + i);
+        }
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final int rounds = 5000;
+
+        Thread writer = new Thread(() -> {
+            for (int r = 0; r < rounds; r++) {
+                GeneralVariables.followCallsign.add("W" + (r % 64));
+                if ((r % 25) == 0) {
+                    GeneralVariables.followCallsign.clear();
+                }
+            }
+        });
+        writer.start();
+
+        try {
+            for (int r = 0; r < rounds; r++) {
+                // The read pattern LogHttpServer/ClearCacheDataDialog now use:
+                // a for-each over the shared list must never throw while the
+                // writer thread adds/clears it.
+                StringBuilder sink = new StringBuilder();
+                for (String callsign : GeneralVariables.followCallsign) {
+                    sink.append(callsign);
+                }
+            }
+        } catch (Throwable t) {
+            failure.set(t);
+        }
+        writer.join();
+
+        assertThat(failure.get()).isNull();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerFollowBlockTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerFollowBlockTest.java
@@ -100,11 +100,17 @@ public class LogHttpServerFollowBlockTest {
         final int rounds = 5000;
 
         Thread writer = new Thread(() -> {
-            for (int r = 0; r < rounds; r++) {
-                shared.add("X" + (r % 64));
-                if ((r % 32) == 0) {
-                    shared.clear();
+            try {
+                for (int r = 0; r < rounds; r++) {
+                    shared.add("X" + (r % 64));
+                    if ((r % 32) == 0) {
+                        shared.clear();
+                    }
                 }
+            } catch (Throwable t) {
+                // Record writer-side failures too; a bare thread throw would be
+                // swallowed by the JVM and let this test pass despite a crash.
+                failure.compareAndSet(null, t);
             }
         });
         writer.start();
@@ -115,7 +121,7 @@ public class LogHttpServerFollowBlockTest {
                 LogHttpServer.followCallsignBlock(shared);
             }
         } catch (Throwable t) {
-            failure.set(t);
+            failure.compareAndSet(null, t);
         }
         writer.join();
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerFollowBlockTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerFollowBlockTest.java
@@ -1,0 +1,138 @@
+package com.k1af.ft8af.html;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for {@link LogHttpServer#followCallsignBlock(List)}, the
+ * followed-callsign cell renderer on the web-logbook config page.
+ *
+ * <p>The block used to be an inline {@code for (i < followCallsign.size())
+ * followCallsign.get(i)} index scan run on a NanoHTTPD worker thread, while the
+ * decode/DB threads add to and the UI thread clears the shared
+ * {@code GeneralVariables.followCallsign} list. That {@code size()}-then-{@code
+ * get(i)} pattern races a concurrent clear straight into an
+ * {@link IndexOutOfBoundsException}, and a plain {@code ArrayList} has no
+ * happens-before against the writers at all. Extracting the loop and iterating
+ * with a for-each lets a {@link CopyOnWriteArrayList} hand back a stable
+ * snapshot. These tests pin the exact HTML (including the ten-per-row break) and
+ * lock in that a concurrent add/clear during rendering never throws. No Android
+ * types are touched, so no Robolectric runner is needed.
+ */
+public class LogHttpServerFollowBlockTest {
+
+    @Test
+    public void emptyList_rendersNothing() {
+        assertThat(LogHttpServer.followCallsignBlock(new ArrayList<>())).isEmpty();
+    }
+
+    @Test
+    public void singleCallsign_rendersOneCell() {
+        List<String> calls = new ArrayList<>();
+        calls.add("K1ABC");
+        assertThat(LogHttpServer.followCallsignBlock(calls)).isEqualTo("K1ABC,&nbsp;");
+    }
+
+    @Test
+    public void tenCallsigns_breakRowAfterTheTenth() {
+        List<String> calls = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            calls.add("C" + i);
+        }
+        String html = LogHttpServer.followCallsignBlock(calls);
+        // The row break fires once, immediately after the tenth cell.
+        assertThat(html).endsWith(",&nbsp;</td></tr><tr><td class=\"default\" >\n");
+        assertThat(countOccurrences(html, "</td></tr><tr><td class=\"default\" >\n")).isEqualTo(1);
+    }
+
+    @Test
+    public void elevenCallsigns_startNewRowForTheEleventh() {
+        List<String> calls = new ArrayList<>();
+        for (int i = 0; i < 11; i++) {
+            calls.add("C" + i);
+        }
+        String html = LogHttpServer.followCallsignBlock(calls);
+        // Exactly one break (after ten), and the eleventh trails it.
+        assertThat(countOccurrences(html, "</td></tr><tr><td class=\"default\" >\n")).isEqualTo(1);
+        assertThat(html).endsWith("C10,&nbsp;");
+    }
+
+    @Test
+    public void twentyCallsigns_breakTwice() {
+        List<String> calls = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            calls.add("C" + i);
+        }
+        String html = LogHttpServer.followCallsignBlock(calls);
+        assertThat(countOccurrences(html, "</td></tr><tr><td class=\"default\" >\n")).isEqualTo(2);
+    }
+
+    @Test
+    public void preservesInsertionOrder() {
+        List<String> calls = new ArrayList<>();
+        calls.add("W1AW");
+        calls.add("VE3XYZ");
+        calls.add("G0ABC");
+        assertThat(LogHttpServer.followCallsignBlock(calls))
+                .isEqualTo("W1AW,&nbsp;VE3XYZ,&nbsp;G0ABC,&nbsp;");
+    }
+
+    /**
+     * The reason the field is a CopyOnWriteArrayList: a writer thread adding and
+     * clearing it while the renderer iterates must never throw. A plain
+     * ArrayList would surface a ConcurrentModificationException / a torn read;
+     * the COW snapshot iterator is immune. Run enough rounds that a plain-list
+     * implementation would reliably trip.
+     */
+    @Test
+    public void concurrentAddClear_duringRender_neverThrows() throws Exception {
+        final List<String> shared = new CopyOnWriteArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            shared.add("SEED" + i);
+        }
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final int rounds = 5000;
+
+        Thread writer = new Thread(() -> {
+            for (int r = 0; r < rounds; r++) {
+                shared.add("X" + (r % 64));
+                if ((r % 32) == 0) {
+                    shared.clear();
+                }
+            }
+        });
+        writer.start();
+
+        try {
+            for (int r = 0; r < rounds; r++) {
+                // Must not throw even as the list is mutated underneath us.
+                LogHttpServer.followCallsignBlock(shared);
+            }
+        } catch (Throwable t) {
+            failure.set(t);
+        }
+        writer.join();
+
+        assertThat(failure.get()).isNull();
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int from = 0;
+        while (true) {
+            int idx = haystack.indexOf(needle, from);
+            if (idx < 0) {
+                break;
+            }
+            count++;
+            from = idx + needle.length();
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Root cause

`GeneralVariables.followCallsign` was a plain `ArrayList` mutated with **no external lock** from several threads:

- **decode / DB threads** add to it — `MainViewModel.addFollowCallsign`, `getFollowCallsignsFromDataBase`
- **UI thread** clears it — `ClearCacheDataDialog`
- **NanoHTTPD worker thread** renders it — `LogHttpServer` (the web-logbook config page)

The web page auto-refreshes every ~5 s, so its render runs concurrently with the writers on essentially every cycle.

Both readers walked the list with an index scan:

```java
for (int i = 0; i < GeneralVariables.followCallsign.size(); i++) {
    result.append(GeneralVariables.followCallsign.get(i));
    ...
}
```

`size()`-then-`get(i)` is a TOCTOU. A concurrent `clear()` (or an `add()`-driven resize) landing between the two calls throws **`IndexOutOfBoundsException`**, and reading a plain `ArrayList` with no happens-before against the writers can additionally tear the backing array. Symptom: the web-logbook page 500s / renders broken and keeps re-failing on every refresh, and in the worst case the shared list the decode path reads via `callsignInFollow()` is left corrupt.

This is the un-hardened twin of `GeneralVariables.transmitMessages`, whose own comment already documents this exact hazard ("Index scans must still snapshot the list first — `size()` then `get(i)` can otherwise race a concurrent remove") and is already a `CopyOnWriteArrayList`. It is also the sibling race called out while fixing the `hashList` CME in #656.

## Fix

- Make `followCallsign` a `CopyOnWriteArrayList` (mirroring `transmitMessages`) so every `add`/`clear` is atomic. All call sites already use only `List`-interface methods (`add`/`contains`/`clear`/`size`/`get`).
- Have the readers iterate with a **for-each**, which on a COW list hands back a stable array snapshot — no `IndexOutOfBoundsException`, no `ConcurrentModificationException`, even if the list is cleared mid-iteration.
- Extract the `LogHttpServer` render loop into a pure, package-private `followCallsignBlock(List)` helper so the formatting (including the ten-per-row break) is unit-testable.

## Testing

- `LogHttpServerFollowBlockTest` (pure JVM): exact HTML for empty / single / 10 / 11 / 20 callsigns, insertion order, and a concurrent add/clear-during-render stress that must never throw.
- `GeneralVariablesFollowCallsignTest` (Robolectric): regression-locks the field type as `CopyOnWriteArrayList` (fails before the fix) and stresses concurrent add/clear during for-each iteration.
- Full `:app:testDebugUnitTest` passes.

## Risk

Low and localized. No protocol/DSP/encoder behavior changes. `CopyOnWriteArrayList` is the right structure here — the list is tiny (a handful of followed callsigns) and read far more often than written, so copy-on-write is cheap. The rendered HTML is byte-for-byte identical to the previous loop.

Out of scope (kept as a separate, higher-blast-radius change): the neighboring `QSL_Callsign_list` in the same page is wholesale-reassigned on the DB thread rather than mutated in place, so it needs a different fix (volatility + snapshot) and is not addressed here.