### PR TITLE
Fix WaterfallView crash when the view is measured one block tall (h==1)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WaterfallView.java
@@ -107,6 +107,19 @@ public class WaterfallView extends View {
                 , getResources().getDisplayMetrics());
     }
 
+    /**
+     * Height (px) of the existing waterfall region copied and scrolled down by one block on
+     * each new spectrum row. Clamped to be non-negative: when the view is only one block
+     * tall or shorter (e.g. measured at {@code h == 1}, where {@code blockHeight} clamps to
+     * 1 and equals {@code drawHeight}), there is nothing above the new row to scroll, so the
+     * caller must skip the {@code Bitmap.createBitmap} blit — that call throws
+     * {@code IllegalArgumentException} on a non-positive height. Extracted as a pure static
+     * helper so the geometry is unit-testable without a Canvas.
+     */
+    static int scrolledRegionHeight(int drawHeight, int blockHeight) {
+        return Math.max(0, drawHeight - blockHeight);
+    }
+
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         if (w <= 0 || h <= 0) return;
@@ -301,9 +314,18 @@ public class WaterfallView extends View {
         LinearGradient linearGradient = new LinearGradient(0, 0, drawWidth * gradientScale, 0, colors
                 , null, Shader.TileMode.CLAMP);
         linearPaint.setShader(linearGradient);
-        Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, drawHeight - blockHeight);
-        _canvas.drawBitmap(bitmap, 0, blockHeight, null);
-        bitmap.recycle();
+        // Scroll the previously-drawn waterfall down by one block, then paint the new
+        // spectrum row into the freed top strip. When the view is only a block tall (or
+        // shorter) there is nothing above the new row to scroll: scrolledRegionHeight() is
+        // 0 and we skip the blit — Bitmap.createBitmap rejects a non-positive height and
+        // would otherwise throw IllegalArgumentException (seen when the view is measured at
+        // h==1, where blockHeight clamps to 1 == drawHeight). The new-row paint still runs.
+        int scrolledHeight = scrolledRegionHeight(drawHeight, blockHeight);
+        if (scrolledHeight > 0) {
+            Bitmap bitmap = Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, scrolledHeight);
+            _canvas.drawBitmap(bitmap, 0, blockHeight, null);
+            bitmap.recycle();
+        }
         _canvas.drawRect(0, 0, drawWidth, blockHeight, linearPaint);
 
         // Draw the UTC timestamp line at each slot boundary of the CURRENT mode (15s FT8,

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallScrollGuardTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/WaterfallScrollGuardTest.java
@@ -1,0 +1,80 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Guards {@link WaterfallView} against the one-block-tall scroll crash.
+ *
+ * <p>Each new spectrum row scrolls the accumulated waterfall down by {@code blockHeight}
+ * and repaints the freed top strip. The scroll blit copies the region
+ * {@code Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, drawHeight - blockHeight)}. When
+ * the view is measured at {@code h == 1}, {@code onSizeChanged} clamps {@code blockHeight}
+ * to 1 (it would otherwise be {@code 1 / (symbols * cycle) == 0}), so
+ * {@code drawHeight - blockHeight == 0} and {@code createBitmap} throws
+ * {@code IllegalArgumentException} ("height must be > 0"). {@code setWaveData} runs from the
+ * audio LiveData observer with no surrounding try/catch, so this is a whole-app crash.
+ *
+ * <p>{@link WaterfallView#scrolledRegionHeight(int, int)} clamps the region height to a
+ * non-negative value and the caller skips the blit when it is 0. The pure cases below pin
+ * the geometry; the Robolectric case drives the real {@code onSizeChanged}/{@code
+ * setWaveData} path (Robolectric's {@code Bitmap} enforces the same preconditions the device
+ * does) and reproduces the crash before the fix.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class WaterfallScrollGuardTest {
+
+    @Test
+    public void scrolledRegionHeight_oneBlockTall_isZero() {
+        // h == 1 -> blockHeight clamps to 1 -> nothing to scroll.
+        assertThat(WaterfallView.scrolledRegionHeight(1, 1)).isEqualTo(0);
+    }
+
+    @Test
+    public void scrolledRegionHeight_shorterThanBlock_clampsToZero() {
+        // Defensive: never returns negative even if blockHeight somehow exceeds drawHeight.
+        assertThat(WaterfallView.scrolledRegionHeight(1, 2)).isEqualTo(0);
+    }
+
+    @Test
+    public void scrolledRegionHeight_normalHeight_leavesRoomToScroll() {
+        // A normal-sized view: one block scrolls, the rest of the column is copied.
+        assertThat(WaterfallView.scrolledRegionHeight(400, 2)).isEqualTo(398);
+    }
+
+    @Test
+    public void setWaveData_oneRowTallView_doesNotThrow() {
+        // Pre-fix: onSizeChanged(w, 1) leaves drawHeight == blockHeight == 1, and the first
+        // setWaveData scroll blit calls createBitmap(..., height=0) -> IllegalArgumentException.
+        Context context = ApplicationProvider.getApplicationContext();
+        WaterfallView view = new WaterfallView(context);
+        view.onSizeChanged(200, 1, 0, 0);
+
+        int[] data = new int[200];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = i % 256;
+        }
+        view.setWaveData(data, null);
+    }
+
+    @Test
+    public void setWaveData_normalView_stillScrollsWithoutThrowing() {
+        // Happy path is unchanged: a real size still copies the scrolled region.
+        Context context = ApplicationProvider.getApplicationContext();
+        WaterfallView view = new WaterfallView(context);
+        view.onSizeChanged(200, 400, 0, 0);
+
+        int[] data = new int[200];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = i % 256;
+        }
+        view.setWaveData(data, null);
+    }
+}


### PR DESCRIPTION
## Root cause

Each new spectrum row in `WaterfallView` scrolls the accumulated waterfall down by one `blockHeight` and repaints the freed top strip. The scroll copies the old region with:

```java
Bitmap.createBitmap(lastBitMap, 0, 0, drawWidth, drawHeight - blockHeight);
```

`onSizeChanged` computes `blockHeight = h / (symbols * cycle)` and clamps it to a minimum of 1. When the view is measured at **h == 1** (a transient Compose layout pass), `1 / (93 * 2)` is 0 → clamps to 1, so `bitmapHeight` and `blockHeight` are both 1 and `drawHeight - blockHeight == 0`. `Bitmap.createBitmap` rejects a non-positive height and throws `IllegalArgumentException: height must be > 0`.

`setWaveData` is called from the audio `LiveData` observer with **no surrounding try/catch**, so this surfaces as a whole-app crash. `onSizeChanged` already guards `w <= 0 || h <= 0`, but not this h==1 degenerate case.

## Fix

Extract `scrolledRegionHeight(drawHeight, blockHeight)` — a pure static helper that clamps the copied region height to a non-negative value — and skip the scroll blit when it is 0. When the view is only one block tall there is nothing above the new row to scroll; the new-row paint (`drawRect`) still runs, so the strip keeps updating. This is in-pattern with the existing zero-dimension guards in `WaterfallView.onSizeChanged` and `ColumnarView` (see `ColumnarViewSizeGuardTest`).

## Technical details

- `Math.max(0, drawHeight - blockHeight)` also defends against any future case where `blockHeight` could exceed `drawHeight`.
- No behavior change for normally-sized views: `drawHeight - blockHeight > 0` there, so the blit runs exactly as before.

## Testing

- New `WaterfallScrollGuardTest`:
  - Pure geometry cases pinning `scrolledRegionHeight` (h==1 → 0, shorter-than-block → 0, normal → room to scroll).
  - A Robolectric case that drives the real `onSizeChanged(w, 1)` / `setWaveData` path. Robolectric's `Bitmap` enforces the same preconditions the device does, so it **reproduces the crash before the fix** (verified: reverting the guard fails this case with the field `IllegalArgumentException`) and passes after.
- Full `:app:testDebugUnitTest` suite passes.

## Risk assessment

Very low. Localized to `WaterfallView`'s scroll blit; guards a degenerate zero-height copy and is a no-op for all normal view sizes. No DSP, encoder, decoder, or protocol change.