### PR TITLE
Fix web-logbook crash from racing the shared QSL callsign list off-thread

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -509,7 +509,14 @@ public class GeneralVariables {
     //Posted each time a GPS fix disciplines the clock, so the Time Sync screen can recompose
     //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.
     public static MutableLiveData<Long> mutableGpsClockSync = new MutableLiveData<>();
-    public static ArrayList<String> QSL_Callsign_list = new ArrayList<>();//Successfully QSL'd callsigns
+    // Successfully QSL'd callsigns (current band). Rebuilt wholesale on the DB thread
+    // (DatabaseOpr.GetAllQSLCallsign), appended to on the TX thread (addQSLCallsign), and
+    // read concurrently from decode/UI threads and the NanoHTTPD web-logbook worker. It is
+    // therefore a CopyOnWriteArrayList behind a volatile reference: the volatile makes the
+    // wholesale ref-swap publish safely, and copy-on-write keeps every concurrent reader on a
+    // stable snapshot so an in-place add() can't tear an iteration. Always assign a
+    // CopyOnWriteArrayList in production; see LogHttpServer.successfulCallsignBlock.
+    public static volatile List<String> QSL_Callsign_list = new CopyOnWriteArrayList<>();
     public static ArrayList<String> QSL_Callsign_list_other_band = new ArrayList<>();//Successfully QSL'd callsigns on other bands
     public static HashSet<String> QSL_Callsign_list_today = new HashSet<>();//Callsigns worked today or yesterday (any band); a set for O(1) membership checks
     public static HashSet<String> QSL_Grid_list = new HashSet<>();//Distinct worked 4-char Maidenhead grids (any band)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2370,7 +2370,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             } finally {
                 cursor.close();
             }
-            GeneralVariables.QSL_Callsign_list = callsigns;
+            // Publish as a CopyOnWriteArrayList so the wholesale swap is atomic for the
+            // decode/UI/web-logbook readers racing this background reload (see the field's note).
+            GeneralVariables.QSL_Callsign_list = new java.util.concurrent.CopyOnWriteArrayList<>(callsigns);
 
             querySQL = "select distinct [call] from QSLTable where band<>?" + modeFilter.sqlSuffix;
             cursor = db.rawQuery(querySQL, modeFilter.withArgs(meter));

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -145,12 +145,17 @@ public class LogHttpServer extends NanoHTTPD {
     static String successfulCallsignBlock(List<String> callsigns) {
         StringBuilder sb = new StringBuilder();
         sb.append("<tr><td class=\"default\" >");
-        for (int i = 0; i < callsigns.size(); i++) {
-            sb.append(callsigns.get(i));
+        // for-each, not size()/get(i): this uses CopyOnWriteArrayList's snapshot
+        // iterator, so a concurrent clear()/remove() (or a different List impl
+        // passed in) can't reintroduce a size/get TOCTOU IndexOutOfBoundsException.
+        int i = 0;
+        for (String callsign : callsigns) {
+            sb.append(callsign);
             sb.append(",&nbsp;");
             if (((i + 1) % 10) == 0) {
                 sb.append("</td></tr><tr><td class=\"default\" >\n");
             }
+            i++;
         }
         sb.append("</td></tr>\n");
         return sb.toString();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -32,6 +32,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -125,6 +126,34 @@ public class LogHttpServer extends NanoHTTPD {
      */
     static int normalizePageSize(int pageSize) {
         return pageSize > 0 ? pageSize : 100;
+    }
+
+    /**
+     * Render the "successfully contacted callsigns" cell block for the debug page, ten
+     * callsigns per table row.
+     *
+     * <p>Extracted so the caller reads the shared
+     * {@link GeneralVariables#QSL_Callsign_list} exactly once — passing the reference in as
+     * {@code callsigns} — and iterates that single snapshot. The old inline loop re-read the
+     * static field on every {@code size()} and {@code get(i)}, so a background DB reload
+     * ({@link com.k1af.ft8af.database.DatabaseOpr.GetAllQSLCallsign}) that swaps the list
+     * wholesale between the two reads could hand {@code get(i)} an index past the end of a
+     * now-shorter list and throw {@link IndexOutOfBoundsException} mid-render (the page
+     * auto-refreshes every 5 s, so the window is hit often). With the list published as a
+     * CopyOnWriteArrayList a concurrent in-place add() can't tear this iteration either.
+     */
+    static String successfulCallsignBlock(List<String> callsigns) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<tr><td class=\"default\" >");
+        for (int i = 0; i < callsigns.size(); i++) {
+            sb.append(callsigns.get(i));
+            sb.append(",&nbsp;");
+            if (((i + 1) % 10) == 0) {
+                sb.append("</td></tr><tr><td class=\"default\" >\n");
+            }
+        }
+        sb.append("</td></tr>\n");
+        return sb.toString();
     }
 
     /**
@@ -907,15 +936,7 @@ public class LogHttpServer extends NanoHTTPD {
                 , String.format(GeneralVariables.getStringFromResource(R.string.html_successful_callsign)
                         , GeneralVariables.getBandString())));
 
-        result.append("<tr><td class=\"default\" >");
-        for (int i = 0; i < GeneralVariables.QSL_Callsign_list.size(); i++) {
-            result.append(GeneralVariables.QSL_Callsign_list.get(i));
-            result.append(",&nbsp;");
-            if (((i + 1) % 10) == 0) {
-                result.append("</td></tr><tr><td class=\"default\" >\n");
-            }
-        }
-        result.append("</td></tr>\n");
+        result.append(successfulCallsignBlock(GeneralVariables.QSL_Callsign_list));
         HtmlContext.tableEnd(result).append("<br>\n");
 
         HtmlContext.tableBegin(result, false, 0, true).append("\n");

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
@@ -85,6 +85,18 @@ public class GetAllQSLCallsignModeTest {
     }
 
     @Test
+    public void loadPublishesCopyOnWriteList() {
+        DatabaseOpr.GetAllQSLCallsign.get(db);
+
+        // The worked list is read from decode/UI threads and the NanoHTTPD web-logbook worker
+        // while this background reload swaps it wholesale; publishing a CopyOnWriteArrayList (not
+        // a plain ArrayList) is what keeps those readers on a stable snapshot. See the field note
+        // in GeneralVariables and LogHttpServer.successfulCallsignBlock.
+        assertThat(GeneralVariables.QSL_Callsign_list)
+                .isInstanceOf(java.util.concurrent.CopyOnWriteArrayList.class);
+    }
+
+    @Test
     public void sameModeOnDropsOtherModeAcrossAllLists() {
         GeneralVariables.workedSameMode = true;
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerSuccessfulCallsignBlockTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerSuccessfulCallsignBlockTest.java
@@ -1,0 +1,120 @@
+package com.k1af.ft8af.html;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Pure-logic coverage for {@link LogHttpServer#successfulCallsignBlock(List)}, the
+ * "successfully contacted callsigns" cell block on the web-logbook debug page.
+ *
+ * <p>The block used to iterate the shared {@link com.k1af.ft8af.GeneralVariables#QSL_Callsign_list}
+ * inline with {@code for (i < list.size()) list.get(i)}, re-reading the static field on every
+ * {@code size()}/{@code get(i)}. A background DB reload swaps that list wholesale, so a swap to a
+ * shorter list between the two reads threw {@link IndexOutOfBoundsException} mid-render. The block
+ * now takes a single snapshot reference, and the field is a CopyOnWriteArrayList, so neither a
+ * ref-swap nor a concurrent in-place add() can tear the iteration. These tests pin the exact HTML
+ * shape and prove the render survives a concurrent writer. No Android types are touched, so no
+ * Robolectric runner is needed.
+ */
+public class LogHttpServerSuccessfulCallsignBlockTest {
+
+    @Test
+    public void emptyList_rendersJustTheWrappingCell() {
+        assertThat(LogHttpServer.successfulCallsignBlock(new ArrayList<>()))
+                .isEqualTo("<tr><td class=\"default\" ></td></tr>\n");
+    }
+
+    @Test
+    public void singleCallsign_appendsSeparator() {
+        assertThat(LogHttpServer.successfulCallsignBlock(List.of("K1ABC")))
+                .isEqualTo("<tr><td class=\"default\" >K1ABC,&nbsp;</td></tr>\n");
+    }
+
+    @Test
+    public void tenthCallsign_startsANewRow() {
+        List<String> calls = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            calls.add("C" + i);
+        }
+        String html = LogHttpServer.successfulCallsignBlock(calls);
+
+        // The row break fires after the 10th entry (i + 1 == 10); since that's the last entry the
+        // block closes with the (pre-existing) trailing empty row. Ten separators, one per call.
+        assertThat(countOccurrences(html, "</td></tr><tr><td class=\"default\" >\n")).isEqualTo(1);
+        assertThat(html).contains("C10,&nbsp;");
+        assertThat(html).endsWith("</td></tr><tr><td class=\"default\" >\n</td></tr>\n");
+        assertThat(countOccurrences(html, "&nbsp;")).isEqualTo(10);
+    }
+
+    @Test
+    public void wrapsEveryTenCallsigns() {
+        List<String> calls = new ArrayList<>();
+        for (int i = 1; i <= 25; i++) {
+            calls.add("C" + i);
+        }
+        // Row breaks after the 10th and 20th entries only (not the 25th, mid-row).
+        assertThat(countOccurrences(
+                LogHttpServer.successfulCallsignBlock(calls),
+                "</td></tr><tr><td class=\"default\" >\n")).isEqualTo(2);
+    }
+
+    /**
+     * The regression: a writer mutating the same CopyOnWriteArrayList while the block renders it
+     * must never throw and must always produce well-formed HTML. Run against a plain ArrayList
+     * this loop reliably throws; against the copy-on-write list production now uses, it can't.
+     */
+    @Test
+    public void concurrentInPlaceAdd_neverThrows() throws InterruptedException {
+        List<String> shared = new CopyOnWriteArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            shared.add("SEED" + i);
+        }
+
+        AtomicBoolean stop = new AtomicBoolean(false);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        Thread writer = new Thread(() -> {
+            int n = 0;
+            while (!stop.get()) {
+                shared.add("NEW" + (n++));
+            }
+        });
+        writer.start();
+
+        try {
+            for (int r = 0; r < 2000; r++) {
+                String html = LogHttpServer.successfulCallsignBlock(shared);
+                // Well-formed: opens and closes the wrapping cell every time.
+                assertThat(html).startsWith("<tr><td class=\"default\" >");
+                assertThat(html).endsWith("</td></tr>\n");
+            }
+        } catch (Throwable t) {
+            failure.set(t);
+        } finally {
+            stop.set(true);
+            writer.join();
+        }
+
+        assertThat(failure.get()).isNull();
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int from = 0;
+        while (true) {
+            int at = haystack.indexOf(needle, from);
+            if (at < 0) {
+                return count;
+            }
+            count++;
+            from = at + needle.length();
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerSuccessfulCallsignBlockTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerSuccessfulCallsignBlockTest.java
@@ -81,9 +81,16 @@ public class LogHttpServerSuccessfulCallsignBlockTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
         Thread writer = new Thread(() -> {
+            // Bound the writes and yield between them: CopyOnWriteArrayList copies
+            // its entire backing array on every add(), so an unbounded tight add
+            // loop balloons memory (and render time, since each render walks the
+            // whole list) and makes the test slow/flaky. A few thousand bounded
+            // adds still overlap the reader's 2000 renders and exercise concurrent
+            // mutation.
             int n = 0;
-            while (!stop.get()) {
+            while (!stop.get() && n < 5000) {
                 shared.add("NEW" + (n++));
+                Thread.yield();
             }
         });
         writer.start();


### PR DESCRIPTION
## Root cause

The web-logbook **debug page** (`LogHttpServer.showDebug`, which auto-refreshes every 5 s) renders the *"successfully contacted callsigns"* block by index-looping the shared static `GeneralVariables.QSL_Callsign_list`:

```java
for (int i = 0; i < GeneralVariables.QSL_Callsign_list.size(); i++) {
    result.append(GeneralVariables.QSL_Callsign_list.get(i));
    ...
}
```

This runs on a **NanoHTTPD worker thread** holding no lock, re-reading the static field on every `size()`/`get(i)`. But `QSL_Callsign_list` is a process-global that other threads write:

- **`DatabaseOpr.GetAllQSLCallsign.get()`** rebuilds it and **ref-swaps the field wholesale** on a background DB thread (band change / log reload).
- **`FT8TransmitSignal.addQSLCallsign()`** appends to it **in place** on the TX thread after a completed QSO.

A wholesale swap to a **shorter** list landing between the reader's `size()` and `get(i)` hands `get(i)` an index past the end of the new list → **`IndexOutOfBoundsException` mid-render**. A concurrent in-place `add()` is likewise an unsynchronized structural mutation of the list being iterated.

This is the same class of off-thread shared-collection race fixed for `Ft8Message.hashList` (#656) and the followed-callsign list (#659).

## Fix

- Publish `QSL_Callsign_list` as a **`volatile List<String>` backed by a `CopyOnWriteArrayList`**. The `volatile` makes the ref-swap publish safely; copy-on-write keeps every concurrent reader — the web worker **and** the decode/UI `checkQSLCallsign()` hot path — on a stable snapshot, so an in-place `add()` can no longer tear an iteration. `DatabaseOpr` publishes a fresh `CopyOnWriteArrayList` so the swap stays atomic.
- Extract the render into a pure, testable **`LogHttpServer.successfulCallsignBlock(List)`** that reads the field **exactly once** (the caller passes the reference in) and iterates that single snapshot, eliminating the `size()`/`get()` double-read of the static field.

## Technical notes / risk

- **HTML output is byte-for-byte unchanged** (pinned by tests, including the pre-existing trailing-empty-row behavior at multiples of 10).
- **Performance:** `add()` runs once per completed QSO, so the copy-on-write allocation is negligible; `checkQSLCallsign()` stays an `O(n)` `contains()` with no added cost. No DSP/decoder/audio paths touched.
- Field type widened to `List<String>` (from `ArrayList<String>`); all production/test usages use only `List` API, so existing tests that assign `arrayListOf(...)` still compile.

## Testing performed

- **`LogHttpServerSuccessfulCallsignBlockTest`** (pure JVM) — pins the exact HTML for empty list / separator / ten-per-row wrap, and stress-renders the block while a writer thread concurrently `add()`s to the same `CopyOnWriteArrayList`, asserting it never throws and always emits well-formed markup.
- **`GetAllQSLCallsignModeTest.loadPublishesCopyOnWriteList`** — drives the real DB reload and asserts the published list is a `CopyOnWriteArrayList` (fail-before-fix: it was a plain `ArrayList`).
- Full `:app:testDebugUnitTest` suite green.

## Follow-ups (out of scope, separate PRs)

The sibling worked-lists (`QSL_Callsign_list_other_band`, `_today`, grids, POTA) are also swapped wholesale on the DB thread and read off-thread, but only via `.contains()` (a single field read, no index tear) — lower risk; noted for a later focused pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)