### PR TITLE
Fix web-logbook crash racing the shared QSL_Callsign_list off-thread

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -509,7 +509,11 @@ public class GeneralVariables {
     //Posted each time a GPS fix disciplines the clock, so the Time Sync screen can recompose
     //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.
     public static MutableLiveData<Long> mutableGpsClockSync = new MutableLiveData<>();
-    public static ArrayList<String> QSL_Callsign_list = new ArrayList<>();//Successfully QSL'd callsigns
+    // Successfully QSL'd callsigns. Read on the NanoHTTPD worker thread (web logbook),
+    // appended to on the decode thread (addQSLCallsign) and reassigned wholesale on the DB
+    // thread (GetAllQSLCallsign). CopyOnWriteArrayList so those readers/writers never race,
+    // and volatile so a reassignment is published safely to the other threads.
+    public static volatile List<String> QSL_Callsign_list = new CopyOnWriteArrayList<>();
     public static ArrayList<String> QSL_Callsign_list_other_band = new ArrayList<>();//Successfully QSL'd callsigns on other bands
     public static HashSet<String> QSL_Callsign_list_today = new HashSet<>();//Callsigns worked today or yesterday (any band); a set for O(1) membership checks
     public static HashSet<String> QSL_Grid_list = new HashSet<>();//Distinct worked 4-char Maidenhead grids (any band)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2370,7 +2370,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             } finally {
                 cursor.close();
             }
-            GeneralVariables.QSL_Callsign_list = callsigns;
+            GeneralVariables.QSL_Callsign_list = new java.util.concurrent.CopyOnWriteArrayList<>(callsigns);
 
             querySQL = "select distinct [call] from QSLTable where band<>?" + modeFilter.sqlSuffix;
             cursor = db.rawQuery(querySQL, modeFilter.withArgs(meter));

--- a/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/html/LogHttpServer.java
@@ -32,6 +32,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -125,6 +126,35 @@ public class LogHttpServer extends NanoHTTPD {
      */
     static int normalizePageSize(int pageSize) {
         return pageSize > 0 ? pageSize : 100;
+    }
+
+    /**
+     * Render the successful-callsign table body: every worked callsign, comma-separated,
+     * ten per table row.
+     *
+     * <p>Takes the list as a parameter (rather than re-reading the shared
+     * {@link GeneralVariables#QSL_Callsign_list} field on each loop step) so the render
+     * works off a single stable snapshot. The field is reassigned wholesale on the DB
+     * thread ({@code DatabaseOpr.GetAllQSLCallsign}) and appended to on the decode thread;
+     * the old inline {@code size()}/{@code get(i)} loop re-dereferenced the field every
+     * iteration, so a mid-render reassignment to a shorter list made {@code get(i)} run off
+     * the end. The field is now a {@link java.util.concurrent.CopyOnWriteArrayList}, so the
+     * for-each below also never races a concurrent append.
+     */
+    static String qslCallsignBlock(List<String> callsigns) {
+        StringBuilder result = new StringBuilder();
+        result.append("<tr><td class=\"default\" >");
+        int i = 0;
+        for (String callsign : callsigns) {
+            result.append(callsign);
+            result.append(",&nbsp;");
+            if (((i + 1) % 10) == 0) {
+                result.append("</td></tr><tr><td class=\"default\" >\n");
+            }
+            i++;
+        }
+        result.append("</td></tr>\n");
+        return result.toString();
     }
 
     /**
@@ -907,15 +937,7 @@ public class LogHttpServer extends NanoHTTPD {
                 , String.format(GeneralVariables.getStringFromResource(R.string.html_successful_callsign)
                         , GeneralVariables.getBandString())));
 
-        result.append("<tr><td class=\"default\" >");
-        for (int i = 0; i < GeneralVariables.QSL_Callsign_list.size(); i++) {
-            result.append(GeneralVariables.QSL_Callsign_list.get(i));
-            result.append(",&nbsp;");
-            if (((i + 1) % 10) == 0) {
-                result.append("</td></tr><tr><td class=\"default\" >\n");
-            }
-        }
-        result.append("</td></tr>\n");
+        result.append(qslCallsignBlock(GeneralVariables.QSL_Callsign_list));
         HtmlContext.tableEnd(result).append("<br>\n");
 
         HtmlContext.tableBegin(result, false, 0, true).append("\n");

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesQslCallsignListTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesQslCallsignListTest.java
@@ -1,0 +1,89 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Guards the shared worked-callsign list {@link GeneralVariables#QSL_Callsign_list}
+ * against the web-logbook / decode / DB-reload data race.
+ *
+ * <p>The list is reassigned wholesale on the database thread
+ * ({@code DatabaseOpr.GetAllQSLCallsign}) and appended to on the decode thread
+ * ({@link GeneralVariables#addQSLCallsign(String)}), while the NanoHTTPD worker
+ * index-scans it to render the web status page. As a plain {@code ArrayList} that is a
+ * lock-free data race: a for-each on the HTTP thread throws
+ * {@link java.util.ConcurrentModificationException} when a decode adds mid-render.
+ * Backing it with a {@link CopyOnWriteArrayList} makes every reader see a stable snapshot.
+ *
+ * <p>The field is reset to a {@code CopyOnWriteArrayList} in {@code setUp} because
+ * {@code GeneralVariables} statics are process-global and a neighbouring test may leave a
+ * plain list behind; the "production always uses a COW" invariant is proven separately by
+ * {@code GetAllQSLCallsignModeTest} (reload) plus {@code addQSLCallsign} here.
+ *
+ * <p>Robolectric because {@link GeneralVariables} carries Android LiveData statics that
+ * must initialize before the field can be touched.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesQslCallsignListTest {
+
+    @Before
+    public void setUp() {
+        GeneralVariables.QSL_Callsign_list = new CopyOnWriteArrayList<>();
+    }
+
+    @Test
+    public void addQSLCallsignAddsEachCallsignOnce() {
+        GeneralVariables.addQSLCallsign("K1AF");
+        GeneralVariables.addQSLCallsign("K1AF");
+        GeneralVariables.addQSLCallsign("W1AW");
+        assertThat(GeneralVariables.QSL_Callsign_list).containsExactly("K1AF", "W1AW");
+        assertThat(GeneralVariables.checkQSLCallsign("K1AF")).isTrue();
+        assertThat(GeneralVariables.checkQSLCallsign("N0CALL")).isFalse();
+    }
+
+    @Test
+    public void forEachSurvivesConcurrentAppend() throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            GeneralVariables.addQSLCallsign("SEED" + i);
+        }
+
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch writerDone = new CountDownLatch(1);
+
+        Thread writer = new Thread(() -> {
+            for (int i = 0; i < 5000; i++) {
+                GeneralVariables.addQSLCallsign("ADD" + i);
+            }
+            writerDone.countDown();
+        });
+        writer.start();
+
+        // Iterate exactly the way LogHttpServer renders the page: a for-each over the
+        // shared field. On a plain ArrayList this races the writer and throws; on the
+        // CopyOnWriteArrayList each iterator walks a stable snapshot.
+        try {
+            while (writerDone.getCount() > 0) {
+                int count = 0;
+                for (String call : GeneralVariables.QSL_Callsign_list) {
+                    if (call != null) {
+                        count++;
+                    }
+                }
+                assertThat(count).isAtLeast(50);
+            }
+        } catch (Throwable t) {
+            failure.set(t);
+        }
+
+        writer.join();
+        assertThat(failure.get()).isNull();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/GetAllQSLCallsignModeTest.java
@@ -73,6 +73,17 @@ public class GetAllQSLCallsignModeTest {
     }
 
     @Test
+    public void reloadPublishesThreadSafeCopyOnWriteList() {
+        // The list is read on the NanoHTTPD worker while it is reassigned here on the DB
+        // thread and appended to on the decode thread, so the reload must publish a
+        // thread-safe CopyOnWriteArrayList (not a plain ArrayList that races those readers).
+        DatabaseOpr.GetAllQSLCallsign.get(db);
+
+        assertThat(GeneralVariables.QSL_Callsign_list)
+                .isInstanceOf(java.util.concurrent.CopyOnWriteArrayList.class);
+    }
+
+    @Test
     public void sameModeOffLoadsAllModes() {
         DatabaseOpr.GetAllQSLCallsign.get(db);
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerQslBlockTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/html/LogHttpServerQslBlockTest.java
@@ -1,0 +1,109 @@
+package com.k1af.ft8af.html;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Pure-logic coverage for {@link LogHttpServer#qslCallsignBlock(List)}, the
+ * successful-callsign table body rendered on the web-logbook status page.
+ *
+ * <p>The helper was extracted from an inline loop that re-dereferenced the shared
+ * {@link com.k1af.ft8af.GeneralVariables#QSL_Callsign_list} field on every
+ * {@code size()}/{@code get(i)} step. Taking the list as a parameter lets a caller
+ * read one stable snapshot (so a mid-render reassignment on the DB thread can no
+ * longer make {@code get(i)} run off the end of a shorter list), and makes the exact
+ * HTML layout unit-testable. No Android types are touched, so no Robolectric runner is
+ * needed.
+ */
+public class LogHttpServerQslBlockTest {
+
+    private static final String ROW_OPEN = "<tr><td class=\"default\" >";
+    private static final String ROW_BREAK = "</td></tr><tr><td class=\"default\" >\n";
+    private static final String ROW_CLOSE = "</td></tr>\n";
+
+    @Test
+    public void emptyList_rendersEmptyCell() {
+        // Still opens and closes the row so the surrounding table stays well-formed.
+        assertThat(LogHttpServer.qslCallsignBlock(new ArrayList<>()))
+                .isEqualTo(ROW_OPEN + ROW_CLOSE);
+    }
+
+    @Test
+    public void singleCallsign_isCommaSpaced() {
+        assertThat(LogHttpServer.qslCallsignBlock(List.of("K1AF")))
+                .isEqualTo(ROW_OPEN + "K1AF,&nbsp;" + ROW_CLOSE);
+    }
+
+    @Test
+    public void tenthEntry_startsANewRow() {
+        // A row break is emitted after every tenth entry (matching the original layout).
+        List<String> calls = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            calls.add("C" + i);
+        }
+        StringBuilder expected = new StringBuilder(ROW_OPEN);
+        for (int i = 1; i <= 10; i++) {
+            expected.append("C").append(i).append(",&nbsp;");
+        }
+        // The tenth entry triggers exactly one break; nothing follows it before the close.
+        expected.append(ROW_BREAK);
+        expected.append(ROW_CLOSE);
+        assertThat(LogHttpServer.qslCallsignBlock(calls)).isEqualTo(expected.toString());
+    }
+
+    @Test
+    public void elevenEntries_haveOneBreakThenTheEleventh() {
+        List<String> calls = new ArrayList<>();
+        for (int i = 1; i <= 11; i++) {
+            calls.add("C" + i);
+        }
+        String html = LogHttpServer.qslCallsignBlock(calls);
+        // Exactly one row break (after the tenth), and the eleventh entry appears after it.
+        int breaks = html.split(java.util.regex.Pattern.quote(ROW_BREAK), -1).length - 1;
+        assertThat(breaks).isEqualTo(1);
+        assertThat(html).endsWith("C11,&nbsp;" + ROW_CLOSE);
+    }
+
+    @Test
+    public void renderSurvivesConcurrentAppend() throws InterruptedException {
+        // Production scenario: the NanoHTTPD worker renders the block from the shared
+        // CopyOnWriteArrayList while the decode thread appends to it. The render must never
+        // throw and must always see at least the seeded entries. (A plain ArrayList here
+        // would race the writer inside the helper's for-each.)
+        final CopyOnWriteArrayList<String> shared = new CopyOnWriteArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            shared.add("SEED" + i);
+        }
+
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch writerDone = new CountDownLatch(1);
+        Thread writer = new Thread(() -> {
+            for (int i = 0; i < 5000; i++) {
+                shared.add("ADD" + i);
+            }
+            writerDone.countDown();
+        });
+        writer.start();
+
+        try {
+            while (writerDone.getCount() > 0) {
+                String html = LogHttpServer.qslCallsignBlock(shared);
+                assertThat(html).contains("SEED99,&nbsp;");
+                assertThat(html).startsWith(ROW_OPEN);
+                assertThat(html).endsWith(ROW_CLOSE);
+            }
+        } catch (Throwable t) {
+            failure.set(t);
+        }
+
+        writer.join();
+        assertThat(failure.get()).isNull();
+    }
+}


### PR DESCRIPTION
## Root cause

`GeneralVariables.QSL_Callsign_list` is a `public static`, **non-volatile** `ArrayList` touched by three threads with no shared lock:

- **NanoHTTPD worker** — `LogHttpServer` renders the "successful callsigns" table by index-scanning it (`size()` / `get(i)`), re-dereferencing the field on every loop step. The web page auto-refreshes, so this runs regularly.
- **Decode thread** — `GeneralVariables.addQSLCallsign()` appends in place on QSO completion.
- **DB thread** — `DatabaseOpr.GetAllQSLCallsign` **reassigns the whole field** (`QSL_Callsign_list = callsigns`) on every band/mode reload.

That is a data race:

1. **`IndexOutOfBoundsException` on the HTTP worker** — the reader reads `size()` off one list, the DB thread swaps in a shorter list, then `get(i)` runs off the end of the new list.
2. **Torn read** — an in-place append during the scan can be observed inconsistently.
3. **Unsafe publication** — the non-volatile field published the freshly built `ArrayList` without a happens-before edge.

This is the sibling of the `followCallsign` race (#659) and the `hashList` race (#656); same subsystem, same "web logbook reads shared app state on a NanoHTTPD worker without the writers' lock" root cause.

## Fix

Root-cause and minimal:

- Back `QSL_Callsign_list` with a **`CopyOnWriteArrayList`** and make the field **`volatile`** — every reader now sees a stable, safely published snapshot, and a concurrent append never disturbs an in-flight iteration. `GetAllQSLCallsign` publishes a `CopyOnWriteArrayList` too.
- Extract **`LogHttpServer.qslCallsignBlock(List)`**, which renders from a single snapshot passed by value (no per-step field re-read). The emitted HTML is byte-for-byte identical to the old inline loop; the method is a thin, unit-testable seam.

Field declared as `List<String>` (backed by a COW instance) so existing single-threaded test assignments compile unchanged; production only ever assigns a `CopyOnWriteArrayList`.

## Risk / performance

Low. No protocol, DSP, decoder, or waterfall behavior changes. `contains()` (decode-thread hot path) stays an O(n) scan with no locking; `add()` and the DB reload happen at most once per QSO / per band-change, so copy-on-write's O(n) copy is negligible on a worked-callsign list. Cross-platform behavior unchanged (pure JVM/Android Java).

## Testing performed

`./gradlew :app:testDebugUnitTest` — full suite green. New/updated tests:

- **`LogHttpServerQslBlockTest`** (pure): HTML parity — empty, single, tenth-entry row break, eleven entries — plus render-under-concurrent-append.
- **`GeneralVariablesQslCallsignListTest`** (Robolectric): `addQSLCallsign` de-dup; a page-style for-each survives a concurrent-append writer thread.
- **`GetAllQSLCallsignModeTest`**: added `reloadPublishesThreadSafeCopyOnWriteList` — verified it **fails against the pre-fix plain `ArrayList`** and passes after.

## Acceptance criteria

- [x] Root cause identified
- [x] Smallest safe fix, localized
- [x] Backwards / cross-platform compatible
- [x] New tests (incl. a fail-before-fix regression test)
- [x] Full unit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)