### PR TITLE
Fix ADIF import losing FT4/FT2 mode (imported as "MFSK", breaks round-trip)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -58,6 +58,35 @@ public final class AdifFormat {
         return null;
     }
 
+    /**
+     * The effective stored mode for an imported ADIF record, resolving ADIF's
+     * MODE/SUBMODE split back to the single mode string FT8AF stores. This is the
+     * reader-side inverse of {@link #mfskSubmode}.
+     *
+     * <p>ADIF models FT4 and FT2 as SUBMODEs of the generic {@code MFSK} MODE, not as
+     * standalone modes. FT8AF — and WSJT-X, JTDX and pota.app — therefore export those
+     * QSOs as {@code MODE=MFSK} with {@code SUBMODE=FT4} (or {@code FT2}). Reading only
+     * MODE on import stored {@code "MFSK"}, silently losing the FT4/FT2 distinction:
+     * that corrupts mode-keyed dedup and band/mode filtering and breaks FT8AF's own
+     * export→import round-trip. When MODE is the generic {@code MFSK} and a non-empty
+     * SUBMODE is present, the SUBMODE is the more specific mode and is used (trimmed and
+     * upper-cased, mirroring {@link #mfskSubmode}); otherwise MODE is returned verbatim,
+     * so every other value (FT8, SSB, CW, a bare {@code <mode>FT4}, …) is unaffected.
+     *
+     * @param mode    the ADIF MODE field value (may be null)
+     * @param submode the ADIF SUBMODE field value, or {@code null} when absent
+     * @return the mode string to store
+     */
+    public static String resolveImportMode(String mode, String submode) {
+        if (mode != null && "MFSK".equalsIgnoreCase(mode.trim()) && submode != null) {
+            String s = submode.trim();
+            if (!s.isEmpty()) {
+                return s.toUpperCase(Locale.US);
+            }
+        }
+        return mode;
+    }
+
     /** "No report" sentinels stored in the SNR int fields; left unformatted so the logbook's
      * empty-report check still recognises them. */
     private static final int NO_REPORT = -100;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
@@ -155,7 +155,10 @@ public class QSLRecord {
             }
         }
         if (map.containsKey("MODE")) {//Mode
-            mode = map.get("MODE");
+            // FT4/FT2 are ADIF SUBMODEs of the generic MFSK MODE (see AdifFormat.mfskSubmode),
+            // so they arrive as MODE=MFSK + SUBMODE=FT4. Resolve that back to the specific
+            // mode; reading MODE alone would store "MFSK" and lose the FT4/FT2 distinction.
+            mode = AdifFormat.resolveImportMode(map.get("MODE"), map.get("SUBMODE"));
         } else {
             mode = "";
         }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
@@ -76,6 +76,55 @@ public class AdifFormatTest {
         assertThat(AdifFormat.mfskSubmode(null)).isNull();
     }
 
+    // ---- resolveImportMode: the reader-side inverse of mfskSubmode ----
+
+    @Test
+    public void resolveImportMode_mfskSubmodeBecomesTheSubmode() {
+        // The bug: an FT4/FT2 QSO is written as MODE=MFSK + SUBMODE=FT4; reading only
+        // MODE stored "MFSK", losing FT4/FT2 and breaking export->import round-trip.
+        assertThat(AdifFormat.resolveImportMode("MFSK", "FT4")).isEqualTo("FT4");
+        assertThat(AdifFormat.resolveImportMode("MFSK", "FT2")).isEqualTo("FT2");
+    }
+
+    @Test
+    public void resolveImportMode_isCaseInsensitiveAndTrimmedAndUpperCased() {
+        assertThat(AdifFormat.resolveImportMode(" mfsk ", " ft4 ")).isEqualTo("FT4");
+        assertThat(AdifFormat.resolveImportMode("Mfsk", "Ft2")).isEqualTo("FT2");
+    }
+
+    @Test
+    public void resolveImportMode_mfskWithoutSubmodeStaysMfsk() {
+        // Plain MFSK (no SUBMODE) is a real mode on its own; leave it untouched.
+        assertThat(AdifFormat.resolveImportMode("MFSK", null)).isEqualTo("MFSK");
+        assertThat(AdifFormat.resolveImportMode("MFSK", "")).isEqualTo("MFSK");
+        assertThat(AdifFormat.resolveImportMode("MFSK", "   ")).isEqualTo("MFSK");
+    }
+
+    @Test
+    public void resolveImportMode_standaloneModesPassThroughVerbatim() {
+        // Non-MFSK modes are returned exactly as stored (no case change, no trim) so
+        // existing imports are byte-for-byte unchanged, even with a stray SUBMODE.
+        assertThat(AdifFormat.resolveImportMode("FT8", null)).isEqualTo("FT8");
+        assertThat(AdifFormat.resolveImportMode("FT4", null)).isEqualTo("FT4"); // bare FT4
+        assertThat(AdifFormat.resolveImportMode("SSB", "USB")).isEqualTo("SSB");
+        assertThat(AdifFormat.resolveImportMode("CW", null)).isEqualTo("CW");
+    }
+
+    @Test
+    public void resolveImportMode_nullModeReturnedVerbatim() {
+        assertThat(AdifFormat.resolveImportMode(null, "FT4")).isNull();
+    }
+
+    @Test
+    public void resolveImportMode_isTheInverseOfMfskSubmode() {
+        // Every mode that exports as MODE=MFSK + SUBMODE must import back to itself.
+        for (String mode : new String[] { "FT4", "FT2" }) {
+            String submode = AdifFormat.mfskSubmode(mode);
+            assertThat(submode).isNotNull();
+            assertThat(AdifFormat.resolveImportMode("MFSK", submode)).isEqualTo(mode);
+        }
+    }
+
     @Test
     public void formatReport_alwaysSignedAndTwoDigits() {
         // The bug: bare String.valueOf(int) gave "5"/"-5"/"0" — no sign on positives, no padding.

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/QSLRecordTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/QSLRecordTest.java
@@ -96,6 +96,60 @@ public class QSLRecordTest {
     }
 
     @Test
+    public void mapConstructor_mfskSubmodeResolvesToFt4() {
+        // The bug: FT4/FT2 are exported as MODE=MFSK + SUBMODE=FT4 (both by FT8AF and
+        // by WSJT-X/JTDX/pota.app). Reading only MODE stored "MFSK", losing the FT4
+        // distinction and breaking mode-keyed dedup, band/mode filtering and re-export.
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put("MODE", "MFSK");
+        map.put("SUBMODE", "FT4");
+
+        QSLRecord r = new QSLRecord(map);
+
+        assertThat(r.getMode()).isEqualTo("FT4");
+    }
+
+    @Test
+    public void mapConstructor_mfskSubmodeResolvesToFt2() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put("MODE", "MFSK");
+        map.put("SUBMODE", "FT2");
+
+        QSLRecord r = new QSLRecord(map);
+
+        assertThat(r.getMode()).isEqualTo("FT2");
+    }
+
+    @Test
+    public void mapConstructor_plainMfskWithoutSubmodeStaysMfsk() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put("MODE", "MFSK");
+
+        QSLRecord r = new QSLRecord(map);
+
+        assertThat(r.getMode()).isEqualTo("MFSK");
+    }
+
+    @Test
+    public void mapConstructor_ft8ModeUnaffectedBySubmodeResolution() {
+        // Regression guard: a first-class MODE (FT8) is stored verbatim.
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put("MODE", "FT8");
+
+        QSLRecord r = new QSLRecord(map);
+
+        assertThat(r.getMode()).isEqualTo("FT8");
+    }
+
+    @Test
     public void mapConstructor_qslAndPotaFields() {
         HashMap<String, String> map = new HashMap<>();
         map.put("CALL", "W1AW");


### PR DESCRIPTION
## Summary

ADIF import silently dropped the FT4/FT2 mode: every imported FT4/FT2 QSO was stored as mode **`MFSK`**.

FT4 and FT2 are ADIF **SUBMODEs** of the generic **MFSK** mode — they are not standalone modes. FT8AF itself (and WSJT-X / JTDX / pota.app) therefore *exports* those QSOs as `MODE=MFSK` + `SUBMODE=FT4` (via the existing `AdifFormat.mfskSubmode()`, used by `AdifRecord`, `DatabaseOpr.downQSLTable` and `ThirdPartyService`). But the import constructor `QSLRecord(HashMap)` read only the `MODE` field and ignored `SUBMODE`, so the specific mode was lost.

## Root cause

`QSLRecord(HashMap<String,String>)` (`ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java`) did:

```java
if (map.containsKey("MODE")) { mode = map.get("MODE"); } else { mode = ""; }
```

`SUBMODE` never appeared on any read/import path (confirmed by grepping the tree — it existed only on the write side). The ADIF field parser (`LogFileImport.parseRecord`) *does* capture `SUBMODE` into the record map, so the value was available and simply discarded.

Both import entry points — the share/VIEW-intent importer (`ImportSharedLogs`) and the built-in web-logger upload (`LogHttpServer`) — funnel through this single constructor, so the fix is localized.

## Impact

- Imported FT4/FT2 QSOs recorded as `MFSK`.
- Corrupts mode-keyed dedup (`checkIsQSL` / `checkQSLCallsign` match on `mode`) and band/mode filtering.
- Breaks FT8AF's own **export → import round-trip**: an exported FT4 log re-imports as MFSK, and re-exporting then emits `MODE=MFSK` with no submode.

## Fix

Add `AdifFormat.resolveImportMode(mode, submode)` — the reader-side inverse of `mfskSubmode()`. When `MODE` is the generic `MFSK` and a non-empty `SUBMODE` is present, use the `SUBMODE` (trimmed, upper-cased, mirroring `mfskSubmode`); otherwise return `MODE` verbatim so every other value (FT8, SSB, CW, a bare `<mode>FT4`, …) is byte-for-byte unaffected. The import constructor now calls it.

After the fix, an imported `MODE=MFSK`+`SUBMODE=FT4` QSO stores `FT4`, and re-export via the unchanged `mfskSubmode()` writers reproduces `MODE=MFSK`+`SUBMODE=FT4` — a clean round-trip.

## Testing

- `AdifFormatTest`: new coverage for `resolveImportMode` — FT4/FT2 resolution, case-insensitive/trim/upper-case, plain `MFSK` (no submode) unchanged, standalone modes returned verbatim, null MODE, and that it is the exact inverse of `mfskSubmode`.
- `QSLRecordTest`: import constructor — `MFSK`+`FT4` → `FT4`, `MFSK`+`FT2` → `FT2`, plain `MFSK` stays `MFSK`, and an `FT8` regression guard. Both FT4/FT2 constructor cases **fail before the fix** (verified — they asserted the old `MFSK` value).
- Full `:app:testDebugUnitTest` suite green.

## Risk assessment

Low. Behavior changes only for records with `MODE=MFSK` **and** a non-empty `SUBMODE`; all other imports are unchanged. No DSP, protocol, or on-air behavior is touched — this is logbook metadata only, and it restores interoperability with WSJT-X/JTDX/pota.app ADIF as well as FT8AF's own exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)