### PR TITLE
Fix FT-891 CAT: only the first of two coalesced replies parsed (SWR reading lost, next parse poisoned)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CatLineSplitter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CatLineSplitter.java
@@ -1,0 +1,75 @@
+package com.k1af.ft8af.rigs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reassembles a text-framed CAT stream (Yaesu / Kenwood / Elecraft / Flex-6000
+ * class rigs) into whole commands.
+ *
+ * <p>These rigs frame every reply as {@code <ID><data><terminator>} — e.g.
+ * {@code FA014074000;} or {@code RM6020;} — and the serial / USB / Bluetooth
+ * transport delivers bytes in arbitrary chunks: a single read may carry only
+ * part of a command, several whole commands (the rig commonly answers two
+ * back-to-back polls — the meter poll deliberately sends the ALC and SWR
+ * requests one after the other — so both replies arrive in one read), or a whole
+ * command followed by the start of the next. Callers feed each received chunk
+ * together with the bytes left over from the previous chunk; this groups them
+ * into complete commands (each up to, but excluding, a {@code terminator}) plus a
+ * trailing remainder to carry into the next call.
+ *
+ * <p>Pure logic — no rig or Android state — so it is unit-testable, and it is the
+ * text-terminator sibling of {@link CivFrameSplitter} (which does the same job
+ * for the binary CI-V protocol). Each string-terminator rig previously carried
+ * its own reassembly that parsed only the <em>first</em> command in a read and
+ * pushed the untouched remainder — <em>including</em> its retained terminator and
+ * any further complete commands — back into the buffer. That dropped the second
+ * (and later) command of a coalesced read, and the retained terminator then
+ * poisoned the parse of the next read (the stale {@code ID} was parsed as the
+ * command and the real command landed inside the data field and was discarded).
+ */
+final class CatLineSplitter {
+    private CatLineSplitter() {
+    }
+
+    /** Result of {@link #split}: the complete commands and the trailing remainder. */
+    static final class Result {
+        /** Complete commands, terminator stripped, in arrival order. */
+        final List<String> frames;
+        /** Bytes after the last terminator — an incomplete command to buffer. */
+        final String remainder;
+
+        Result(List<String> frames, String remainder) {
+            this.frames = frames;
+            this.remainder = remainder;
+        }
+    }
+
+    /**
+     * Append {@code incoming} to {@code buffered} and split the result into whole
+     * commands plus a trailing remainder.
+     *
+     * <p>Every complete command is returned, so a read that coalesces several
+     * replies yields several frames rather than one; the terminator is stripped
+     * from each frame (matching the pre-existing parse, which fed the command
+     * without its terminator). An empty frame (two adjacent terminators, or a
+     * leading terminator) is preserved so callers see it and treat it as an
+     * unknown/no-op command exactly as before.
+     *
+     * @param buffered   bytes left over from the previous call (never null; may be empty)
+     * @param incoming   newly received bytes (never null; may be empty)
+     * @param terminator the end-of-command character (e.g. {@code ';'})
+     * @return the complete commands and the bytes to carry into the next call
+     */
+    static Result split(String buffered, String incoming, char terminator) {
+        String combined = buffered + incoming;
+        List<String> frames = new ArrayList<>();
+        int start = 0;
+        int idx;
+        while ((idx = combined.indexOf(terminator, start)) >= 0) {
+            frames.add(combined.substring(start, idx));
+            start = idx + 1;
+        }
+        return new Result(frames, combined.substring(start));
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu39Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu39Rig.java
@@ -179,50 +179,54 @@ public class Yaesu39Rig extends BaseRig {
             fileLog("rig.recv[" + data.length + "]: " + preview);
         }
 
-        if (!s.contains(";")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            // return;//data reception not yet complete.
-        } else {
-            if (s.indexOf(";") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf(";")));
-            }
+        // Drain every complete ';'-terminated command in this read (the rig
+        // answers back-to-back polls -- the meter poll sends the ALC and SWR
+        // requests one after the other -- so two replies routinely coalesce into
+        // one read). The old code parsed only the first command and re-buffered
+        // the rest with its terminator retained, dropping the second reply and
+        // poisoning the next parse. Only the trailing, unterminated fragment is
+        // carried into the next call.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), s, ';');
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-            //begin parsing data
-            String bufStr = buffer.toString();
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(bufStr);
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf(";") + 1));
-
-            if (yaesu3Command == null) {
-                if (bufStr.length() > 0) {
-                    fileLog("rig.parse: unknown command: " + bufStr);
-                }
-                return;
-            }
-            if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
-                    || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
-                if (Yaesu3Command.isSWRMeter39(yaesu3Command)) {
-                    swr = Yaesu3Command.getSWROrALC39(yaesu3Command);
-                }
-                if (Yaesu3Command.isALCMeter39(yaesu3Command)) {
-                    alc = Yaesu3Command.getSWROrALC39(yaesu3Command);
-                }
-                showAlert();
-                notifyMeterData(alc, swr);
-            } else {
-                fileLog("rig.parsed: cmd=" + yaesu3Command.getCommandID()
-                        + " data=" + yaesu3Command.getData());
-            }
-
+        for (String frame : result.frames) {
+            processCommand(frame);
         }
+    }
 
+    /**
+     * Parse and act on one complete CAT command (terminator already stripped).
+     */
+    private void processCommand(String bufStr) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(bufStr);
+        if (yaesu3Command == null) {
+            if (bufStr.length() > 0) {
+                fileLog("rig.parse: unknown command: " + bufStr);
+            }
+            return;
+        }
+        if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
+                || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
+            if (Yaesu3Command.isSWRMeter39(yaesu3Command)) {
+                swr = Yaesu3Command.getSWROrALC39(yaesu3Command);
+            }
+            if (Yaesu3Command.isALCMeter39(yaesu3Command)) {
+                alc = Yaesu3Command.getSWROrALC39(yaesu3Command);
+            }
+            showAlert();
+            notifyMeterData(alc, swr);
+        } else {
+            fileLog("rig.parsed: cmd=" + yaesu3Command.getCommandID()
+                    + " data=" + yaesu3Command.getData());
+        }
     }
 
     @Override

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
@@ -1,0 +1,101 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for {@link CatLineSplitter}, the shared text-terminator
+ * (Yaesu / Kenwood / Elecraft / Flex-6000) CAT stream reassembler.
+ *
+ * <p>These rigs frame commands as {@code <ID><data>;} and the transport delivers
+ * bytes in arbitrary chunks, so a command can span several callbacks or several
+ * commands can arrive in one read. These tests pin the reassembly contract and
+ * lock in the regression the old per-rig reassembly had: it parsed only the
+ * <em>first</em> command in a read and re-buffered the remainder <em>with</em> its
+ * retained terminator, so a coalesced second reply (routine for the ALC+SWR meter
+ * poll) was dropped and the retained {@code ';'} then poisoned the next parse.
+ *
+ * <p>No Android types are touched, so no Robolectric runner is needed.
+ */
+public class CatLineSplitterTest {
+
+    @Test
+    public void singleCompleteCommand_oneFrameNoRemainder() {
+        CatLineSplitter.Result r = CatLineSplitter.split("", "FA014074000;", ';');
+        assertThat(r.frames).containsExactly("FA014074000");
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void twoCommandsInOneRead_bothReturned() {
+        // The regression: the ALC and SWR meter replies coalesce into one read.
+        CatLineSplitter.Result r = CatLineSplitter.split("", "RM4100;RM6020;", ';');
+        assertThat(r.frames).containsExactly("RM4100", "RM6020").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void terminatorStrippedFromEveryFrame() {
+        CatLineSplitter.Result r = CatLineSplitter.split("", "FA1;FB2;", ';');
+        for (String frame : r.frames) {
+            assertThat(frame).doesNotContain(";");
+        }
+    }
+
+    @Test
+    public void incompleteCommand_noFramesCarriedAsRemainder() {
+        CatLineSplitter.Result r = CatLineSplitter.split("", "FA0140", ';');
+        assertThat(r.frames).isEmpty();
+        assertThat(r.remainder).isEqualTo("FA0140");
+    }
+
+    @Test
+    public void commandSplitAcrossTwoReads_reassembledFromBufferedRemainder() {
+        CatLineSplitter.Result first = CatLineSplitter.split("", "FA0140", ';');
+        assertThat(first.frames).isEmpty();
+
+        CatLineSplitter.Result second = CatLineSplitter.split(first.remainder, "74000;", ';');
+        assertThat(second.frames).containsExactly("FA014074000");
+        assertThat(second.remainder).isEmpty();
+    }
+
+    @Test
+    public void completeCommandFollowedByStartOfNext_remainderCarried() {
+        CatLineSplitter.Result r = CatLineSplitter.split("", "FA014074000;RM6", ';');
+        assertThat(r.frames).containsExactly("FA014074000");
+        assertThat(r.remainder).isEqualTo("RM6");
+    }
+
+    @Test
+    public void bufferedRemainderPrependedBeforeSplitting() {
+        // A whole command sitting in the carry-over buffer plus a fresh terminated
+        // command must yield two frames, never a single poisoned concatenation.
+        CatLineSplitter.Result r = CatLineSplitter.split("RM6020;", "FA014076000;", ';');
+        assertThat(r.frames).containsExactly("RM6020", "FA014076000").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void emptyFrames_preservedForAdjacentAndLeadingTerminators() {
+        CatLineSplitter.Result r = CatLineSplitter.split("", ";FA1;;", ';');
+        assertThat(r.frames).containsExactly("", "FA1", "").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void noInputAtAll_noFramesEmptyRemainder() {
+        CatLineSplitter.Result r = CatLineSplitter.split("", "", ';');
+        assertThat(r.frames).isEmpty();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void carriageReturnTerminator_supportedForSiblingRigs() {
+        // The splitter is terminator-parameterised so the Kenwood/Elecraft '\r'
+        // handlers can adopt it too.
+        CatLineSplitter.Result r = CatLineSplitter.split("", "IF00014074000\rFA1\r", '\r');
+        assertThat(r.frames).containsExactly("IF00014074000", "FA1").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

`Yaesu39Rig.onReceiveData` (Yaesu **FT-891**) parsed only the **first** `;`-terminated command in a serial/USB read, then pushed the remainder — *including its retained `;` and any further complete commands* — back into the buffer. When the rig answers two back-to-back polls in one read, the second reply is silently dropped and the retained `;` poisons the next read's parse.

## Root cause

`onReceiveData` split on the **first** terminator only:

```java
buffer.append(s.substring(0, s.indexOf(";")));      // first command
Yaesu3Command cmd = Yaesu3Command.getCommand(buffer.toString());
clearBufferData();
buffer.append(s.substring(s.indexOf(";") + 1));     // remainder KEEPS its own ';'
```

There is no loop to drain every complete command, and the remainder is re-buffered with its terminator retained. On the next read, that stale, already-terminated command is concatenated with the fresh bytes; `getCommand` parses the stale two-letter ID as the command while the real new command lands inside the data field and is discarded.

## Why it happens in normal operation

`readMeters()` sends the ALC and SWR requests one after the other:

```java
getConnector().sendData(Yaesu3RigConstant.setRead39Meters_ALC());
getConnector().sendData(Yaesu3RigConstant.setRead39Meters_SWR());
```

so the rig replies `RM4nnn;RM6nnn;` and the two frames routinely coalesce into a single read. The first (ALC) is parsed; the second (**SWR**) sits unparsed in the buffer and is then discarded by the next poll's `clearBufferData()` — so the SWR reading goes **stale during TX, exactly when SWR protection matters**. The same happens to coalesced `FA` frequency replies under auto-information, leaving the displayed frequency lagging or stuck on a stale value.

Trace (`onReceiveData("FA014074000;FA014075000;")` then `onReceiveData("FA014076000;")`):
- read 1 → `setFreq(14074000)`; buffer left holding `"FA014075000;"` (second frame unparsed this call)
- read 2 → buffer becomes `"FA014075000;FA014076000"` → `Long.parseLong("014075000;FA014076000")` throws (caught → 0) → **frequency not updated**; `14075000` skipped entirely.

## Fix

The binary CI-V rigs (Icom/Xiegu) were already migrated to a shared reassembler (`CivFrameSplitter`) that fixes exactly this class of bug; the string-terminator rigs never got the equivalent. This PR adds **`CatLineSplitter`** — the text-terminator sibling of `CivFrameSplitter`: a pure, unit-testable helper that appends the incoming bytes to the buffered remainder and splits the result into every complete command (terminator stripped) plus a trailing remainder.

`Yaesu39Rig` now drains **all** commands per read and carries only the unterminated tail into the next call. Per-command handling is unchanged (extracted verbatim into `processCommand`); a latent double `getFrequency()` call is collapsed to reuse the already-computed value.

## Testing

New `CatLineSplitterTest` — 10 pure-JVM cases (no Robolectric, matching `CivFrameSplitterTest`) pinning the reassembly contract and locking the regression:
- two commands in one read → **two** frames (the coalesced ALC+SWR case)
- a whole command in the carry-over buffer + a fresh command → two frames, never a poisoned concatenation
- a command split across two reads reassembles from the buffered remainder
- terminator stripped from every frame; empty / leading-terminator frames preserved as no-ops
- carriage-return terminator supported (for the sibling-rig follow-ups)

`./gradlew :app:testDebugUnitTest` — full suite green (JDK 17 / Android SDK 35 / NDK 27).

## Risk

Low. Behaviour is byte-for-byte identical for single-command and split-across-reads reads; only the previously-broken multi-command-per-read path changes. No DSP/native/encoder/decoder code touched; no protocol or public-API change.

## Scope / follow-up

This PR fixes the **FT-891 (`Yaesu39Rig`) only**. The same one-command-per-read pattern exists in the other string-terminator handlers (`Yaesu38`/`Yaesu38_450`/`YaesuDX10`, `Elecraft`, `Kenwood TS570`/`TS590`/`TS2000`, `Flex6000`, `Wolf_sdr_450`). `CatLineSplitter` is terminator-parameterised (handles `;` and `\r`) so those can adopt it in focused follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)