### PR TITLE
Make Worked All States (WAS) award real, with the states still needed

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/UsStateLookup.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/UsStateLookup.kt
@@ -2,6 +2,7 @@ package radio.ks3ckc.ft8af.ui.decode
 
 import android.content.Context
 import org.json.JSONObject
+import java.util.Locale
 
 internal object UsStateLookup {
     @Volatile private var map: Map<String, String>? = null
@@ -11,7 +12,7 @@ internal object UsStateLookup {
         val m = map ?: synchronized(this) {
             map ?: load(context).also { map = it }
         }
-        return m[grid.take(4).uppercase()]
+        return m[grid.take(4).uppercase(Locale.ROOT)]
     }
 
     private fun load(context: Context): Map<String, String> {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
@@ -134,6 +134,11 @@ private data class LogbookStats(
     val cqZones: Int = 0,
     val ituZones: Int = 0,
     val bandCounts: List<Pair<String, Int>> = emptyList(),
+    // Worked All States (WAS): distinct US states worked (0..50) and the
+    // canonically-ordered list of states still needed. Derived from each QSO's
+    // grid via UsStateLookup — see WorkedAllStates.kt.
+    val statesWorked: Int = 0,
+    val neededStates: List<String> = emptyList(),
 )
 
 private data class AwardProgress(
@@ -142,6 +147,10 @@ private data class AwardProgress(
     val current: Int,
     val total: Int,
     val color: Color,
+    // When non-empty and the award is incomplete, the remaining targets are
+    // surfaced as chips under the progress bar (used by WAS to show the states
+    // still needed). Empty for awards without an enumerable "needed" list.
+    val remaining: List<String> = emptyList(),
 )
 
 // ---------------------------------------------------------------------------
@@ -169,6 +178,9 @@ fun LogbookScreen(mainViewModel: MainViewModel) {
     var syncDialogState by remember { mutableStateOf<SyncDialogState?>(null) }
 
     val scope = rememberCoroutineScope()
+    // Captured for off-thread grid->state resolution (WAS). UsStateLookup caches
+    // the asset table, so calling it from the IO loader below is cheap.
+    val appContext = LocalContext.current.applicationContext
 
     // Load records and stats from the database. Re-runs when refreshKey changes
     // (e.g. after the user edits or deletes a QSO).
@@ -241,12 +253,20 @@ fun LogbookScreen(mainViewModel: MainViewModel) {
                 val bandCounts = bandInfo?.values?.map { (it.name ?: "") to it.value }
                     ?: emptyList()
 
+                // Worked All States: resolve each QSO's grid to a US state and
+                // collapse to the distinct set (see WorkedAllStates.kt).
+                val worked = workedStates(loaded.map { it.grid }) {
+                    UsStateLookup.stateFromGrid(appContext, it)
+                }
+
                 stats = LogbookStats(
                     totalQsos = totalQsos,
                     dxccEntities = dxccCount,
                     cqZones = cqCount,
                     ituZones = ituCount,
                     bandCounts = bandCounts,
+                    statesWorked = worked.size,
+                    neededStates = neededStates(worked),
                 )
             } catch (_: Exception) {
                 // Leave records/stats at defaults on error
@@ -648,6 +668,13 @@ private fun StatsTab(stats: LogbookStats, records: List<QSLCallsignRecord>) {
             current = stats.dxccEntities,
             total = 340,
             gradientColors = listOf(Signal, StatusConfirmed),
+            progress = chartProgress,
+        )
+        AwardProgressBar(
+            label = stringResource(R.string.log_award_was_states),
+            current = stats.statesWorked,
+            total = 50,
+            gradientColors = listOf(Accent, StatusConfirmed),
             progress = chartProgress,
         )
         AwardProgressBar(
@@ -1481,9 +1508,10 @@ private fun AwardsTab(stats: LogbookStats) {
             AwardProgress(
                 name = wasName,
                 description = wasDesc,
-                current = (stats.dxccEntities * 50 / 340.coerceAtLeast(1)).coerceAtMost(50),
+                current = stats.statesWorked,
                 total = 50,
                 color = Accent,
+                remaining = stats.neededStates,
             ),
             AwardProgress(
                 name = wazName,
@@ -1614,10 +1642,73 @@ private fun AwardCard(award: AwardProgress) {
                             ),
                     )
                 }
+
+                // States still needed (WAS): a capped preview of remaining
+                // targets so a chaser can see at a glance what's left to work.
+                if (award.remaining.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(10.dp))
+                    NeededStatesRow(remaining = award.remaining, accent = award.color)
+                }
             }
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Needed-states chip row (WAS award card)
+// ---------------------------------------------------------------------------
+
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+@Composable
+private fun NeededStatesRow(remaining: List<String>, accent: Color) {
+    // Cap the visible chips so a fresh log (up to 50 remaining) never floods the
+    // card; the rest collapse into a trailing "+N" chip.
+    val (shown, overflow) = neededStatesPreview(remaining, NEEDED_STATES_PREVIEW_MAX)
+    Text(
+        text = stringResource(R.string.log_award_states_needed),
+        color = TextFaint,
+        fontSize = 9.5.sp,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 0.06.sp,
+    )
+    Spacer(modifier = Modifier.height(5.dp))
+    androidx.compose.foundation.layout.FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        for (state in shown) {
+            StateChip(text = state, accent = accent)
+        }
+        if (overflow > 0) {
+            StateChip(text = "+$overflow", accent = accent)
+        }
+    }
+}
+
+@Composable
+private fun StateChip(text: String, accent: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(accent.copy(alpha = 0.12f))
+            .border(1.dp, accent.copy(alpha = 0.26f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 5.dp, vertical = 2.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            color = accent,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = GeistMonoFamily,
+            maxLines = 1,
+        )
+    }
+}
+
+/** Max needed-state chips shown before collapsing the rest into a "+N" chip. */
+private const val NEEDED_STATES_PREVIEW_MAX = 16
 
 // ===========================================================================
 // Per-row QSO edit / delete dialogs (Recent tab)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllStates.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllStates.kt
@@ -1,0 +1,72 @@
+package radio.ks3ckc.ft8af.ui.logbook
+
+import java.util.Locale
+
+/**
+ * Worked All States (WAS) award logic.
+ *
+ * ARRL's WAS award is earned by making contact with all 50 US states. FT8AF
+ * already derives a QSO's state from its Maidenhead grid (see
+ * [radio.ks3ckc.ft8af.ui.decode.UsStateLookup]), so both the count of distinct
+ * worked states and the list of states still needed can be computed directly
+ * from the logbook — no separate tracking table required.
+ *
+ * The functions here are pure (grid->state resolution is injected as a lambda)
+ * so they unit-test without an Android context, mirroring [workedGridFields] /
+ * [buildGridHeatmapCells] in the same package.
+ *
+ * Washington DC is intentionally excluded: it is not one of the 50 WAS states,
+ * even though the grid->state table can resolve a grid to "DC".
+ */
+
+/** The 50 US states (two-letter USPS abbreviations), the ARRL WAS award basis. */
+internal val WAS_STATES: List<String> = listOf(
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+    "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+    "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+    "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+    "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+)
+
+private val WAS_STATE_SET: Set<String> = WAS_STATES.toSet()
+
+/**
+ * The distinct WAS states worked, derived from each grid via [gridToState].
+ *
+ * A grid that resolves to no state (or to DC, or to any non-WAS designator) is
+ * ignored. Resolved abbreviations are trimmed and upper-cased with
+ * [Locale.ROOT] — the state table's designators are ASCII, so upper-casing must
+ * be locale-insensitive (a Turkish-locale `uppercase()` would map "il" to "İL"
+ * and never match the ASCII "IL" state).
+ */
+internal fun workedStates(
+    grids: List<String?>,
+    gridToState: (String) -> String?,
+): Set<String> =
+    grids.asSequence()
+        .filterNotNull()
+        .mapNotNull { grid -> gridToState(grid)?.trim()?.uppercase(Locale.ROOT) }
+        .filter { it in WAS_STATE_SET }
+        .toSet()
+
+/**
+ * The WAS states still needed, in the canonical [WAS_STATES] order, given the
+ * set already [worked]. Comparison is case-insensitive; anything in [worked]
+ * that is not a WAS state (e.g. "DC") is ignored.
+ */
+internal fun neededStates(worked: Set<String>): List<String> {
+    val have = worked.mapTo(HashSet()) { it.trim().uppercase(Locale.ROOT) }
+    return WAS_STATES.filter { it !in have }
+}
+
+/**
+ * Split a [remaining] states list into the chips to display (at most [max]) and
+ * the count hidden behind a trailing "+N" overflow chip, so the WAS card can
+ * preview the states still needed without ever rendering all 50. [max] <= 0
+ * shows nothing and reports the whole list as overflow.
+ */
+internal fun neededStatesPreview(remaining: List<String>, max: Int): Pair<List<String>, Int> = when {
+    max <= 0 -> emptyList<String>() to remaining.size
+    remaining.size <= max -> remaining to 0
+    else -> remaining.take(max) to (remaining.size - max)
+}

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -235,6 +235,8 @@
     <string name="log_award_dxcc_mixed">DXCC Mixed</string>
     <string name="log_award_vucc_grid_squares">VUCC Grid Squares</string>
     <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_award_was_states">Worked All States</string>
+    <string name="log_award_states_needed">STATES NEEDED</string>
     <string name="log_section_grid_coverage">Grid Coverage</string>
     <string name="log_section_signal_trend">Signal Trend</string>
     <string name="log_no_qsos_yet">No QSOs yet</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/UsStateLookupTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/UsStateLookupTest.kt
@@ -1,6 +1,7 @@
 package radio.ks3ckc.ft8af.ui.decode
 
 import com.google.common.truth.Truth.assertThat
+import java.util.Locale
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -64,5 +65,20 @@ class UsStateLookupTest {
     fun stateFromGrid_unknownGrid_returnsNull() {
         // A syntactically valid grid that is not in the US table.
         assertThat(UsStateLookup.stateFromGrid(context, "ZZ99")).isNull()
+    }
+
+    @Test
+    fun stateFromGrid_isLocaleIndependent_underTurkishDefault() {
+        // The grid is uppercased before lookup. Under the Turkish locale a
+        // lower-case 'i' uppercases to the dotted 'İ' (U+0130), which would miss
+        // the ASCII keys — so the lookup must normalize with Locale.ROOT. Guard
+        // that a lower-case grid still resolves regardless of the default locale.
+        val previous = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale("tr", "TR"))
+            assertThat(UsStateLookup.stateFromGrid(context, "bk08")).isEqualTo("HI")
+        } finally {
+            Locale.setDefault(previous)
+        }
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllStatesTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllStatesTest.kt
@@ -1,0 +1,149 @@
+package radio.ks3ckc.ft8af.ui.logbook
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * Unit tests for the Worked All States (WAS) award logic: [workedStates]
+ * (grids -> distinct worked-state set, resolved through an injected grid->state
+ * lambda) and [neededStates] (the 50 WAS states minus those already worked).
+ *
+ * All plain-JVM (no Robolectric) — the helpers take Strings/collections and a
+ * plain lambda, so no Android context is needed. The production caller injects
+ * `UsStateLookup.stateFromGrid(context, grid)` as the resolver.
+ */
+class WorkedAllStatesTest {
+
+    // A tiny fake grid->state resolver for the tests, independent of the app's
+    // real (asset-backed) UsStateLookup.
+    private val fakeGridStates = mapOf(
+        "FN31" to "CT",
+        "FN42" to "MA",
+        "DM79" to "CO",
+        "CM87" to "CA",
+        "BL11" to "HI",
+        "BP51" to "AK",
+        "FM18" to "DC", // District of Columbia — NOT a WAS state
+        "IO91" to null, // resolves to no US state (a DX grid)
+    )
+
+    private fun resolver(grid: String): String? = fakeGridStates[grid.take(4).uppercase(Locale.ROOT)]
+
+    @Test
+    fun thereAreExactly50WasStatesAndTheyAreDistinct() {
+        assertThat(WAS_STATES).hasSize(50)
+        assertThat(WAS_STATES.toSet()).hasSize(50)
+        // DC is deliberately not a WAS state.
+        assertThat(WAS_STATES).doesNotContain("DC")
+        // Spot-check a few corners.
+        assertThat(WAS_STATES).containsAtLeast("AK", "HI", "CA", "ME", "FL")
+    }
+
+    @Test
+    fun workedStatesCollectsDistinctResolvedStates() {
+        val grids = listOf("FN31pr", "FN42", "DM79", "CM87", "BL11", "BP51")
+        val worked = workedStates(grids) { resolver(it) }
+        assertThat(worked).containsExactly("CT", "MA", "CO", "CA", "HI", "AK")
+    }
+
+    @Test
+    fun workedStatesDedupesSameStateFromDifferentGrids() {
+        // Two different CT/MA grids collapse to one entry each.
+        val grids = listOf("FN31", "FN31aa", "FN42", "FN42zz")
+        assertThat(workedStates(grids) { resolver(it) }).containsExactly("CT", "MA")
+    }
+
+    @Test
+    fun workedStatesExcludesDcAndUnresolvedGrids() {
+        val grids = listOf("FM18", "IO91", "FN31")
+        // FM18 -> DC (excluded), IO91 -> null, FN31 -> CT (kept).
+        assertThat(workedStates(grids) { resolver(it) }).containsExactly("CT")
+    }
+
+    @Test
+    fun workedStatesIgnoresNullGrids() {
+        val grids = listOf(null, "FN31", null)
+        assertThat(workedStates(grids) { resolver(it) }).containsExactly("CT")
+    }
+
+    @Test
+    fun workedStatesIsEmptyWhenNothingResolves() {
+        assertThat(workedStates(listOf("IO91", "FM18")) { resolver(it) }).isEmpty()
+        assertThat(workedStates(emptyList()) { resolver(it) }).isEmpty()
+    }
+
+    @Test
+    fun workedStatesUpperCasesLocaleInsensitively() {
+        // A resolver returning a lower-case "il" under a Turkish locale must still
+        // match the ASCII "IL" WAS state — Locale.ROOT keeps the dot off the I.
+        val previous = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale("tr", "TR"))
+            val worked = workedStates(listOf("EN50")) { "il" }
+            assertThat(worked).containsExactly("IL")
+        } finally {
+            Locale.setDefault(previous)
+        }
+    }
+
+    @Test
+    fun neededStatesIsAll50WhenNothingWorked() {
+        val needed = neededStates(emptySet())
+        assertThat(needed).hasSize(50)
+        assertThat(needed).containsExactlyElementsIn(WAS_STATES).inOrder()
+    }
+
+    @Test
+    fun neededStatesRemovesWorkedStatesKeepingCanonicalOrder() {
+        val needed = neededStates(setOf("CA", "NY", "TX"))
+        assertThat(needed).hasSize(47)
+        assertThat(needed).containsNoneOf("CA", "NY", "TX")
+        // Order still follows WAS_STATES (ME precedes MD precedes MA ...).
+        assertThat(needed).containsAtLeast("ME", "MD", "MA").inOrder()
+    }
+
+    @Test
+    fun neededStatesIsEmptyWhenAll50Worked() {
+        assertThat(neededStates(WAS_STATES.toSet())).isEmpty()
+    }
+
+    @Test
+    fun neededStatesPreviewReturnsWholeListWhenUnderCap() {
+        val (shown, overflow) = neededStatesPreview(listOf("MT", "ND", "WY"), 16)
+        assertThat(shown).containsExactly("MT", "ND", "WY").inOrder()
+        assertThat(overflow).isEqualTo(0)
+    }
+
+    @Test
+    fun neededStatesPreviewCapsAndReportsOverflow() {
+        val remaining = WAS_STATES // 50 states
+        val (shown, overflow) = neededStatesPreview(remaining, 16)
+        assertThat(shown).hasSize(16)
+        assertThat(shown).containsExactlyElementsIn(remaining.take(16)).inOrder()
+        assertThat(overflow).isEqualTo(34)
+    }
+
+    @Test
+    fun neededStatesPreviewWithZeroCapShowsNothing() {
+        val (shown, overflow) = neededStatesPreview(listOf("MT", "ND"), 0)
+        assertThat(shown).isEmpty()
+        assertThat(overflow).isEqualTo(2)
+    }
+
+    @Test
+    fun neededStatesPreviewOfEmptyListIsEmpty() {
+        val (shown, overflow) = neededStatesPreview(emptyList(), 16)
+        assertThat(shown).isEmpty()
+        assertThat(overflow).isEqualTo(0)
+    }
+
+    @Test
+    fun neededStatesIgnoresNonWasEntriesLikeDc() {
+        // A stray "DC" in the worked set must not remove a real state nor error.
+        val needed = neededStates(setOf("DC", "ca"))
+        assertThat(needed).hasSize(49)
+        assertThat(needed).doesNotContain("CA")
+        assertThat(needed).contains("NY")
+    }
+}


### PR DESCRIPTION
## What & why

Working all 50 US states (**WAS**) is one of the most popular pursuits in FT8, especially for the large US operator base. FT8AF's Logbook already had a WAS award card — but it was **fake**: `AwardsTab` computed the "worked" count from DXCC entities:

```kotlin
current = (stats.dxccEntities * 50 / 340.coerceAtLeast(1)).coerceAtMost(50)
```

So the number a user saw had nothing to do with which states they'd actually contacted. This PR makes WAS **real** and, more importantly, shows the operator **which states they still need**.

## How

FT8AF already resolves a QSO's US state from its Maidenhead grid (`UsStateLookup`, backed by the `us_grid_states.json` asset). This PR adds a small, pure helper next to the existing logbook heatmap logic:

- `WorkedAllStates.kt`
  - `WAS_STATES` — the 50 states (DC deliberately excluded; it isn't a WAS state).
  - `workedStates(grids, gridToState)` — distinct worked states, grid→state resolution injected as a lambda so it unit-tests without an Android context.
  - `neededStates(worked)` — the states still needed, in canonical order.
  - `neededStatesPreview(remaining, max)` — caps the on-card chip list so a fresh log never renders all 50.

Wiring:
- **Stats tab** gains a real *Worked All States* progress bar (`x / 50`).
- **Awards tab** WAS card now shows the true worked count and, below the bar, a **capped preview of the states still needed** — the at-a-glance list a WAS chaser actually wants (with a trailing `+N` chip when there are more).

The count is derived from worked QSOs, consistent with how the existing DXCC / CQ-zone / ITU-zone stats already work.

## User benefit

Open the Logbook → Awards and you can immediately see *"37/50, still need MT ND WY SD…"* instead of a meaningless placeholder number. That's a genuine, everyday tool for the huge base of US FT8 operators chasing WAS.

## Tests

New `WorkedAllStatesTest` (15 cases, plain-JVM — no Robolectric needed): the 50-state list, distinct collection, DC/unresolved-grid exclusion, dedup, locale-insensitive upper-casing, needed-set ordering, and the preview cap/overflow split. Full `radio.ks3ckc.ft8af.ui.logbook.*` suite passes; `compileDebugKotlin` / `processDebugResources` succeed with the new Compose UI and string resources.

## Assumptions

- WAS counts *worked* states (not LoTW-confirmed), matching the existing DXCC/zone stats in this screen. The card's "confirmed" wording is unchanged for continuity with the other awards.
- Only states resolvable from a logged grid are counted, which is how every other geographic stat in FT8AF already behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
