### PR TITLE
Fix FT-2000 CAT: SWR meter dead during TX (only first of two coalesced replies parsed)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu38Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu38Rig.java
@@ -10,6 +10,8 @@ import com.k1af.ft8af.R;
 import com.k1af.ft8af.database.ControlMode;
 import com.k1af.ft8af.ui.ToastMessage;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -130,51 +132,85 @@ public class Yaesu38Rig extends BaseRig {
 
     @Override
     public void onReceiveData(byte[] data) {
-        String s = new String(data);
-        if (!s.contains(";")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            return;//data reception not yet complete.
-        } else {
-            if (s.indexOf(";") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf(";")));
-            }
+        buffer.append(new String(data));
 
-            //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf(";") + 1));
+        // Drain EVERY complete ';'-terminated command, keeping only the
+        // unterminated tail. The meter poll sends two reads back-to-back
+        // (RM4; ALC then RM6; SWR), so the transport frequently coalesces both
+        // replies into one chunk ("RM4nnn;RM6nnn;"). The old parser handled only
+        // the first command and re-buffered the rest with its terminator, where
+        // the next poll's clearBufferData() wiped it — permanently losing the
+        // SWR reading. See splitCommands / processCommand.
+        Frames frames = splitCommands(buffer.toString());
+        clearBufferData();
+        buffer.append(frames.remainder);
+        // Guard against unbounded growth if a terminator never arrives.
+        if (buffer.length() > 1000) clearBufferData();
 
-            if (yaesu3Command == null) {
-                return;
-            }
-            //long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-            //if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-            //    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-            //}
-
-
-            if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
-                    || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
-                if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
-                    swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
-                    alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                showAlert();
-                notifyMeterData(alc, swr);
-            }
-
-
+        for (String command : frames.commands) {
+            processCommand(command);
         }
+    }
 
+    /**
+     * Parse and act on a single ';'-terminated command (terminator stripped).
+     * Extracted so {@link #onReceiveData} stays a thin drain loop.
+     */
+    private void processCommand(String command) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(command);
+        if (yaesu3Command == null) {
+            return;
+        }
+        if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
+                || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
+            if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
+                swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
+                alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            showAlert();
+            notifyMeterData(alc, swr);
+        }
+    }
+
+    /** Complete commands (terminator stripped) plus the trailing unterminated tail. */
+    static final class Frames {
+        /** Every ';'-terminated command in arrival order, terminator removed. */
+        final List<String> commands;
+        /** Text after the last ';' — an incomplete command to carry over. */
+        final String remainder;
+
+        Frames(List<String> commands, String remainder) {
+            this.commands = commands;
+            this.remainder = remainder;
+        }
+    }
+
+    /**
+     * Split accumulated CAT text into complete {@code ';'}-terminated commands
+     * and the trailing unterminated remainder.
+     *
+     * <p>Pure logic — no rig or Android state — so it is unit-testable without
+     * the Timer-scheduling constructor.
+     *
+     * @param accumulated buffered text so far (never null; may be empty)
+     * @return the complete commands and the bytes to carry into the next read
+     */
+    static Frames splitCommands(String accumulated) {
+        List<String> commands = new ArrayList<>();
+        int start = 0;
+        int semi;
+        while ((semi = accumulated.indexOf(';', start)) >= 0) {
+            commands.add(accumulated.substring(start, semi));
+            start = semi + 1;
+        }
+        return new Frames(commands, accumulated.substring(start));
     }
 
     @Override

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu38RigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Yaesu38RigTest.java
@@ -1,0 +1,100 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for {@link Yaesu38Rig#splitCommands}, the framing helper
+ * that drains a Yaesu gen-3 ({@code ';'}-terminated) CAT text stream into whole
+ * commands plus a trailing remainder.
+ *
+ * <p>The FT-2000 meter poll sends two reads back-to-back — {@code RM4;} (ALC)
+ * then {@code RM6;} (SWR) — so the transport very often delivers both replies
+ * coalesced in a single {@code onReceiveData} chunk ({@code "RM4nnn;RM6nnn;"}).
+ * The old parser consumed only the first {@code ';'}-terminated command and
+ * re-buffered the rest <em>with</em> its terminator, where the next poll's
+ * {@code clearBufferData()} wiped it — so the SWR (second) reply was
+ * permanently lost and the SWR meter never moved. These tests pin the drain
+ * contract: every complete command is returned, and only the unterminated tail
+ * is carried into the next read.
+ *
+ * <p>No Android types are touched, so no Robolectric runner is needed.
+ */
+public class Yaesu38RigTest {
+
+    @Test
+    public void singleCompleteCommand_oneCommandNoRemainder() {
+        Yaesu38Rig.Frames f = Yaesu38Rig.splitCommands("FA007074000;");
+
+        assertThat(f.commands).containsExactly("FA007074000");
+        assertThat(f.remainder).isEmpty();
+    }
+
+    @Test
+    public void twoCoalescedMeterReplies_bothCommandsReturned() {
+        // The regression: ALC then SWR arrive coalesced in one read. The old
+        // parser returned only the first (ALC); SWR was dropped. Both must be
+        // drained so the SWR meter updates.
+        Yaesu38Rig.Frames f = Yaesu38Rig.splitCommands("RM4001;RM6002;");
+
+        assertThat(f.commands).containsExactly("RM4001", "RM6002").inOrder();
+        assertThat(f.remainder).isEmpty();
+    }
+
+    @Test
+    public void completeCommandPlusPartialTail_tailBecomesRemainder() {
+        Yaesu38Rig.Frames f = Yaesu38Rig.splitCommands("RM4001;RM6");
+
+        assertThat(f.commands).containsExactly("RM4001");
+        assertThat(f.remainder).isEqualTo("RM6");
+    }
+
+    @Test
+    public void noTerminator_wholeInputIsRemainder() {
+        Yaesu38Rig.Frames f = Yaesu38Rig.splitCommands("FA0070");
+
+        assertThat(f.commands).isEmpty();
+        assertThat(f.remainder).isEqualTo("FA0070");
+    }
+
+    @Test
+    public void emptyInput_noCommandsNoRemainder() {
+        Yaesu38Rig.Frames f = Yaesu38Rig.splitCommands("");
+
+        assertThat(f.commands).isEmpty();
+        assertThat(f.remainder).isEmpty();
+    }
+
+    @Test
+    public void leadingTerminator_yieldsEmptyLeadingCommand() {
+        // A stray leading ';' (e.g. the tail terminator of a prior frame) must
+        // not swallow the command that follows it.
+        Yaesu38Rig.Frames f = Yaesu38Rig.splitCommands(";RM6002;");
+
+        assertThat(f.commands).containsExactly("", "RM6002").inOrder();
+        assertThat(f.remainder).isEmpty();
+    }
+
+    @Test
+    public void splitAcrossReads_reassemblesViaRemainderCarry() {
+        // A command split over two reads: the first read has no terminator, so
+        // its bytes become the remainder that the caller re-feeds with the next
+        // read. Draining the concatenation recovers the whole command.
+        Yaesu38Rig.Frames first = Yaesu38Rig.splitCommands("FA0070");
+        assertThat(first.commands).isEmpty();
+
+        Yaesu38Rig.Frames second = Yaesu38Rig.splitCommands(first.remainder + "74000;");
+        assertThat(second.commands).containsExactly("FA007074000");
+        assertThat(second.remainder).isEmpty();
+    }
+
+    @Test
+    public void threeCommandsPlusTail_allDrainedTailCarried() {
+        Yaesu38Rig.Frames f = Yaesu38Rig.splitCommands("RM4001;RM6002;FA007074000;RM4");
+
+        assertThat(f.commands)
+                .containsExactly("RM4001", "RM6002", "FA007074000").inOrder();
+        assertThat(f.remainder).isEqualTo("RM4");
+    }
+}


### PR DESCRIPTION
## Summary

`Yaesu38Rig` ("YAESU FT-2000 series") loses its SWR meter reading during TX. On every meter poll the rig is asked for two meters back-to-back — `RM4;` (ALC) then `RM6;` (SWR) — and the transport routinely delivers **both replies coalesced in a single `onReceiveData` chunk** (`"RM4nnn;RM6nnn;"`). The old parser handled only the **first** `;`-terminated command and re-buffered the remainder *with* its terminator; the next poll's `clearBufferData()` then wiped that carry-over, so the second (SWR) reply was **permanently dropped**.

Net effect for FT-2000 users: the SWR bar never moves during transmit, and the high-SWR safety alert never fires.

This is the **same root cause** already fixed for the FT-891 in #665, on a **distinct, still-affected rig**.

## Root cause

`onReceiveData` was a one-command-per-read parser:

```java
Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
clearBufferData();
buffer.append(s.substring(s.indexOf(";") + 1)); // rest kept WITH terminator, parsed never
```

Any second complete command in the same chunk was left in the buffer with its trailing `;` and then destroyed by the next `readMeters()`/`readFreqFromRig()` `clearBufferData()`. Because the SWR read is always the *second* of the two, it is the one consistently lost.

## Fix

`onReceiveData` now **drains every complete `;`-terminated command** from the accumulated buffer and carries only the **unterminated tail** into the next read. The framing decision is extracted into a pure, package-private static helper so it can be unit-tested without the rig's `Timer`-scheduling constructor:

- `splitCommands(String) -> Frames` — pure `String → {List<String> commands, String remainder}`.
- `processCommand(String)` — the existing per-command FA/FB/RM handling, unchanged in behavior.
- Collapsed a latent double `Yaesu3Command.getFrequency()` call.

The `> 1000`-char no-terminator overflow guard is preserved.

Kept **self-contained** (no new shared class) deliberately: #665 introduces a shared `CatLineSplitter` but is still open, so adding my own copy would collide. Once #665 merges, the remaining identical Yaesu gen-3 siblings (FTDX-450 / DX10 / Wolf-SDR) can adopt the shared helper as follow-ups.

## Testing

- New `Yaesu38RigTest` — 8 pure-JVM cases (no Robolectric; the helper is Android-free): single command, **two coalesced meter replies both drained** (the regression), complete + partial tail, no terminator, empty input, leading terminator, split-across-reads reassembly via remainder carry, three-commands-plus-tail.
- `./gradlew :app:testDebugUnitTest` — full suite green; `Yaesu38RigTest` 8/8.

## Risk

Low and localized to one rig's read path. No protocol/DSP change; frame semantics are unchanged for the common single-command case, and the fix only *adds* recovery of previously-dropped coalesced commands. No hardware was available, so validation is via the unit tests and the identical-to-#665 root cause.

## Related

- Same root cause as #665 (FT-891); this covers the FT-2000. Identical siblings `Yaesu38_450Rig`, `YaesuDX10Rig`, `Wolf_sdr_450Rig` remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)