### PR TITLE
Show real VUCC grid-square progress on the Awards tab (was hardcoded 0)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
@@ -138,6 +138,7 @@ private data class LogbookStats(
     val dxccEntities: Int = 0,
     val cqZones: Int = 0,
     val ituZones: Int = 0,
+    val gridSquares: Int = 0,
     val bandCounts: List<Pair<String, Int>> = emptyList(),
     // Raw continent codes worked (e.g. "NA", "EU"), for the WAC award. Reduced
     // to award progress by [workedAllContinents]; empty when nothing resolves.
@@ -278,11 +279,16 @@ fun LogbookScreen(mainViewModel: MainViewModel) {
                     UsStateLookup.stateFromGrid(appContext, it)
                 }
 
+                // VUCC grid squares — unique 4-char Maidenhead squares across all
+                // logged QSOs (computed from the already-loaded records).
+                val gridSquareCount = gridSquaresWorked(loaded.map { it.grid })
+
                 stats = LogbookStats(
                     totalQsos = totalQsos,
                     dxccEntities = dxccCount,
                     cqZones = cqCount,
                     ituZones = ituCount,
+                    gridSquares = gridSquareCount,
                     bandCounts = bandCounts,
                     continentCodes = continentCodes,
                     statesWorked = worked.size,
@@ -724,7 +730,7 @@ private fun StatsTab(stats: LogbookStats, records: List<QSLCallsignRecord>) {
         )
         AwardProgressBar(
             label = stringResource(R.string.log_award_vucc_grid_squares),
-            current = gridSquaresWorked(records),
+            current = gridSquaresWorked(records.map { it.grid }),
             total = 100,
             gradientColors = listOf(StatusNew, Band12m),
             progress = chartProgress,
@@ -1263,13 +1269,26 @@ private fun DrawScope.drawSparkline(
 }
 
 // ---------------------------------------------------------------------------
-// Helper: count unique grid squares worked
+// Helper: count unique grid squares worked (VUCC)
 // ---------------------------------------------------------------------------
 
-private fun gridSquaresWorked(records: List<QSLCallsignRecord>): Int =
-    records.mapNotNull { record ->
-        val grid = record.grid
-        if (!grid.isNullOrBlank() && grid.length >= 4) grid.substring(0, 4).uppercase() else null
+/**
+ * The number of distinct Maidenhead grid squares worked — the VUCC metric shown
+ * on both the Stats-tab progress bar and the Awards-tab card. A square is the
+ * first four grid characters (e.g. "FN31"); longer grids are truncated to their
+ * square and blank/partial grids are ignored.
+ *
+ * Locale.ROOT: grid letters are ASCII A..R, so upper-casing must be
+ * locale-insensitive — a default-locale uppercase() would map "i" to "İ" under a
+ * Turkish locale, counting "io91" and "IO91" as two squares instead of one.
+ */
+internal fun gridSquaresWorked(grids: List<String?>): Int =
+    grids.mapNotNull { grid ->
+        if (!grid.isNullOrBlank() && grid.length >= 4) {
+            grid.substring(0, 4).uppercase(Locale.ROOT)
+        } else {
+            null
+        }
     }.distinct().size
 
 // ---------------------------------------------------------------------------
@@ -1873,7 +1892,7 @@ private fun AwardsTab(stats: LogbookStats) {
             AwardProgress(
                 name = vuccName,
                 description = vuccDesc,
-                current = 0, // Would need per-band grid counting
+                current = stats.gridSquares,
                 total = 100,
                 color = Band12m,
             ),

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
@@ -730,7 +730,7 @@ private fun StatsTab(stats: LogbookStats, records: List<QSLCallsignRecord>) {
         )
         AwardProgressBar(
             label = stringResource(R.string.log_award_vucc_grid_squares),
-            current = gridSquaresWorked(records.map { it.grid }),
+            current = stats.gridSquares,
             total = 100,
             gradientColors = listOf(StatusNew, Band12m),
             progress = chartProgress,

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/GridSquaresWorkedTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/GridSquaresWorkedTest.kt
@@ -11,8 +11,9 @@ import java.util.Locale
  * VUCC counts *unique* squares worked, so the helper de-dupes and ignores
  * partial/blank grids. All plain-JVM (the helper takes Strings).
  *
- * The regression these guard: the Awards-tab VUCC card used to be hardcoded to
- * 0, so grid chasers saw "0 / 100" no matter how many squares they had worked.
+ * The regression these tests guard against: the Awards-tab VUCC card used to be
+ * hardcoded to 0, so grid chasers saw "0 / 100" no matter how many squares they
+ * had worked.
  */
 class GridSquaresWorkedTest {
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/GridSquaresWorkedTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/GridSquaresWorkedTest.kt
@@ -1,0 +1,60 @@
+package radio.ks3ckc.ft8af.ui.logbook
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * Unit tests for [gridSquaresWorked], the VUCC (grid-square) counter that backs
+ * both the Stats-tab "VUCC Grid Squares" progress bar and the Awards-tab VUCC
+ * card. A grid square is the first four Maidenhead characters (e.g. "FN31");
+ * VUCC counts *unique* squares worked, so the helper de-dupes and ignores
+ * partial/blank grids. All plain-JVM (the helper takes Strings).
+ *
+ * The regression these guard: the Awards-tab VUCC card used to be hardcoded to
+ * 0, so grid chasers saw "0 / 100" no matter how many squares they had worked.
+ */
+class GridSquaresWorkedTest {
+
+    @Test
+    fun countsUniqueFourCharSquares() {
+        // FN31 and FN42 are different squares within the same field; both count.
+        assertThat(gridSquaresWorked(listOf("FN31", "FN42", "JO22"))).isEqualTo(3)
+    }
+
+    @Test
+    fun dedupesRepeatedSquares() {
+        // Same square worked three times (extra chars truncated to 4) counts once.
+        assertThat(gridSquaresWorked(listOf("FN31", "FN31pr", "fn31"))).isEqualTo(1)
+    }
+
+    @Test
+    fun skipsNullBlankAndTooShortGrids() {
+        assertThat(gridSquaresWorked(listOf(null, "", "  ", "FN", "FN3"))).isEqualTo(0)
+    }
+
+    @Test
+    fun truncatesSixCharGridToItsSquare() {
+        // FN31pr and FN31aa share the FN31 square.
+        assertThat(gridSquaresWorked(listOf("FN31pr", "FN31aa"))).isEqualTo(1)
+    }
+
+    @Test
+    fun mixedValidAndInvalidGrids() {
+        assertThat(gridSquaresWorked(listOf("FN31", null, "bad", "JO22", "JO22"))).isEqualTo(2)
+    }
+
+    @Test
+    fun upperCasesLocaleInsensitively() {
+        // Under a Turkish locale a default-locale uppercase() maps "i" to the
+        // dotted capital "İ", so "io91" and "IO91" would count as two squares.
+        // Locale.ROOT keeps both "IO91", so they de-dupe to one.
+        val previous = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale("tr", "TR"))
+            assertThat(gridSquaresWorked(listOf("io91wm", "IO91WM"))).isEqualTo(1)
+        } finally {
+            Locale.setDefault(previous)
+        }
+    }
+}


### PR DESCRIPTION
## User benefit

Operators chasing the **VUCC grid-square award** now see their **real progress** on the Logbook → Awards tab. Previously the VUCC card was hardcoded to `current = 0`, so no matter how many unique Maidenhead squares you had logged, it always showed **"0 / 100"** — useless for anyone tracking the award. FT8 is a grid-centric mode, so this is a stat operators actually care about.

## What changed

- The Stats tab already computed the real grid-square count; the Awards tab simply never received it. This wires the two together so both views agree.
- Extracted the counter into a pure, testable `internal fun gridSquaresWorked(grids: List<String?>): Int` (mirrors the existing `workedGridFields` pattern). A grid square is the first four Maidenhead characters (e.g. `FN31`); longer grids are truncated to their square, blank/partial grids are ignored, and duplicates are de-duped (VUCC counts *unique* squares).
- Upper-cases with `Locale.ROOT` — a default-locale `uppercase()` maps `i` → `İ` under a Turkish locale, which would count `io91` and `IO91` as two different squares. This also fixes that latent locale bug in the old Stats-tab counter.
- Surfaced the count through `LogbookStats.gridSquares` so the Awards-tab card (which only receives `stats`) can display it.

The IOTA card is left as a placeholder (island references aren't in the DB — out of scope), and WAS is untouched.

## Tests

New `GridSquaresWorkedTest` (plain-JVM, 6 cases): unique-square counting, de-duplication, truncation of 6-char grids, skipping null/blank/too-short grids, and locale-insensitive upper-casing. Full `:app:testDebugUnitTest` for the logbook package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)