### PR TITLE
Fix FT-450/DX10/Wolf-SDR CAT: SWR meter dead during TX (coalesced reply dropped)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Wolf_sdr_450Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Wolf_sdr_450Rig.java
@@ -141,50 +141,50 @@ public class Wolf_sdr_450Rig extends BaseRig {
 
     @Override
     public void onReceiveData(byte[] data) {
-        String s = new String(data);
-        //ToastMessage.showDebug("39 YAESU read data:"+new String(Yaesu3RigConstant.setReadOperationFreq()));
+        // Drain every complete ';'-terminated command in this read. The meter
+        // poll sends the ALC and SWR reads back-to-back, so the transport
+        // routinely coalesces both replies ("RM4nnn;RM6nnn;") into one chunk.
+        // The old parser consumed only the first command and re-buffered the
+        // rest with its terminator retained, where the next poll's
+        // clearBufferData() wiped it -- permanently losing the SWR reading (so
+        // the high-SWR safety alert never fires during TX). Only the trailing,
+        // unterminated fragment is carried into the next call. Shared with the
+        // other Yaesu gen-3 rigs via CatLineSplitter.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), new String(data), ';');
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-        if (!s.contains(";")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            //return;//data reception not yet complete.
-        } else {
-            if (s.indexOf(";") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf(";")));
-            }
-
-            //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf(";") + 1));
-
-            if (yaesu3Command == null) {
-                return;
-            }
-            //long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-            //if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-            //    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-            //}
-
-            if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
-                    || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
-                if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
-                    swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
-                    alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                showAlert();
-            }
-
+        for (String command : result.frames) {
+            processCommand(command);
         }
+    }
 
+    /**
+     * Parse and act on one complete ';'-terminated command (terminator already
+     * stripped). Extracted so {@link #onReceiveData} stays a thin drain loop.
+     */
+    private void processCommand(String command) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(command);
+        if (yaesu3Command == null) {
+            return;
+        }
+        if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
+                || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
+            if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
+                swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
+                alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            showAlert();
+        }
     }
 
     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu38_450Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Yaesu38_450Rig.java
@@ -131,50 +131,50 @@ public class Yaesu38_450Rig extends BaseRig {
 
     @Override
     public void onReceiveData(byte[] data) {
-        String s = new String(data);
-        //ToastMessage.showDebug("39 YAESU read data:"+new String(Yaesu3RigConstant.setReadOperationFreq()));
+        // Drain every complete ';'-terminated command in this read. The meter
+        // poll sends the ALC and SWR reads back-to-back, so the transport
+        // routinely coalesces both replies ("RM4nnn;RM6nnn;") into one chunk.
+        // The old parser consumed only the first command and re-buffered the
+        // rest with its terminator retained, where the next poll's
+        // clearBufferData() wiped it -- permanently losing the SWR reading (so
+        // the high-SWR safety alert never fires during TX). Only the trailing,
+        // unterminated fragment is carried into the next call. Shared with the
+        // other Yaesu gen-3 rigs via CatLineSplitter.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), new String(data), ';');
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-        if (!s.contains(";")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            //return;//data reception not yet complete.
-        } else {
-            if (s.indexOf(";") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf(";")));
-            }
-
-            //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf(";") + 1));
-
-            if (yaesu3Command == null) {
-                return;
-            }
-            //long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-            //if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-            //    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-            //}
-
-            if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
-                    || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
-                if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
-                    swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
-                    alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                showAlert();
-            }
-
+        for (String command : result.frames) {
+            processCommand(command);
         }
+    }
 
+    /**
+     * Parse and act on one complete ';'-terminated command (terminator already
+     * stripped). Extracted so {@link #onReceiveData} stays a thin drain loop.
+     */
+    private void processCommand(String command) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(command);
+        if (yaesu3Command == null) {
+            return;
+        }
+        if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
+                || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
+            if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
+                swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
+                alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            showAlert();
+        }
     }
 
     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/YaesuDX10Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/YaesuDX10Rig.java
@@ -144,49 +144,50 @@ public class YaesuDX10Rig extends BaseRig {
 
     @Override
     public void onReceiveData(byte[] data) {
-        String s = new String(data);
-        if (!s.contains(";")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            return;//data reception not yet complete.
-        } else {
-            if (s.indexOf(";") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf(";")));
-            }
-            //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf(";") + 1));
+        // Drain every complete ';'-terminated command in this read. The meter
+        // poll sends the ALC and SWR reads back-to-back, so the transport
+        // routinely coalesces both replies ("RM4nnn;RM6nnn;") into one chunk.
+        // The old parser consumed only the first command and re-buffered the
+        // rest with its terminator retained, where the next poll's
+        // clearBufferData() wiped it -- permanently losing the SWR reading (so
+        // the high-SWR safety alert never fires during TX). Only the trailing,
+        // unterminated fragment is carried into the next call. Shared with the
+        // other Yaesu gen-3 rigs via CatLineSplitter.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), new String(data), ';');
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-            if (yaesu3Command == null) {
-                return;
-            }
-            //if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
-            //        || yaesu3Command.getCommandID().toLowerCase().equals("FB")) {
-            //    long tempFreq=Yaesu3Command.getFrequency(yaesu3Command);
-            //    if (tempFreq!=0) {//if tempFreq==0, frequency is invalid
-            //        setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-            //   }
-            //}
-            if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
-                    || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
-                if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
-                    swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
-                    alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
-                }
-                showAlert();
-            }
-
+        for (String command : result.frames) {
+            processCommand(command);
         }
+    }
 
+    /**
+     * Parse and act on one complete ';'-terminated command (terminator already
+     * stripped). Extracted so {@link #onReceiveData} stays a thin drain loop.
+     */
+    private void processCommand(String command) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(command);
+        if (yaesu3Command == null) {
+            return;
+        }
+        if (yaesu3Command.getCommandID().equalsIgnoreCase("FA")
+                || yaesu3Command.getCommandID().equalsIgnoreCase("FB")) {
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (yaesu3Command.getCommandID().equalsIgnoreCase("RM")) {//METER
+            if (Yaesu3Command.isSWRMeter38(yaesu3Command)) {
+                swr = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            if (Yaesu3Command.isALCMeter38(yaesu3Command)) {
+                alc = Yaesu3Command.getALCOrSWR38(yaesu3Command);
+            }
+            showAlert();
+        }
     }
 
     @Override

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
@@ -91,6 +91,23 @@ public class CatLineSplitterTest {
     }
 
     @Test
+    public void yaesuGen3MeterPoll_swrSurvivesCoalescedAndPartialReads() {
+        // Models the FT-450 / DX10 / Wolf-SDR meter poll: setRead39Meters_ALC()
+        // then _SWR() sent back-to-back. The transport first delivers the ALC
+        // reply plus the leading bytes of the SWR reply, then the tail. Draining
+        // must surface the ALC frame on the first read and the SWR frame on the
+        // second -- the old parse would have dropped the coalesced SWR reply and
+        // then poisoned the follow-up read with the retained ';'.
+        CatLineSplitter.Result first = CatLineSplitter.split("", "RM4100;RM6", ';');
+        assertThat(first.frames).containsExactly("RM4100");
+        assertThat(first.remainder).isEqualTo("RM6");
+
+        CatLineSplitter.Result second = CatLineSplitter.split(first.remainder, "020;", ';');
+        assertThat(second.frames).containsExactly("RM6020");
+        assertThat(second.remainder).isEmpty();
+    }
+
+    @Test
     public void carriageReturnTerminator_supportedForSiblingRigs() {
         // The splitter is terminator-parameterised so the Kenwood/Elecraft '\r'
         // handlers can adopt it too.


### PR DESCRIPTION
## Summary

Three more Yaesu gen-3 CAT handlers — **FT-450** (`Yaesu38_450Rig`), **DX10 series** (`YaesuDX10Rig`) and **Wolf SDR** (`Wolf_sdr_450Rig`) — carried the same one-command-per-read reassembly bug already fixed for the **FT-891** (#665) and **FT-2000** (#667). During TX the SWR meter reads stale/zero and the high-SWR safety alert never fires.

These three handlers are byte-identical in the affected code and share a single root cause, so they are fixed together in one PR.

## Root cause

`onReceiveData` parsed only the **first** `;`-terminated command in a read and re-buffered the remainder **with its retained terminator**. The meter poll deliberately sends the ALC and SWR reads back-to-back:

```java
getConnector().sendData(Yaesu3RigConstant.setRead39Meters_ALC());
getConnector().sendData(Yaesu3RigConstant.setRead39Meters_SWR());
```

so the transport routinely coalesces both replies into one read (`RM4nnn;RM6nnn;`). The old parse consumed only the ALC frame and pushed `RM6nnn;` back into the buffer; the **next** poll's `clearBufferData()` then wiped it before it was ever parsed. Net effect: the **SWR reading is permanently lost**, and the retained `;` further poisons the following read's parse (the stale ID is read as the command and the real command lands inside the data field and is discarded). This is exactly the failure #665/#667 describe, on the remaining gen-3 rigs.

## Fix

Drain **every** complete command per read via the shared `CatLineSplitter` (added in #665 — the text-terminator sibling of `CivFrameSplitter`), carrying only the trailing unterminated fragment into the next call. Per-command handling is extracted verbatim into `processCommand`, so `onReceiveData` becomes a thin drain loop. This also:

- consolidates three byte-identical hand-rolled reassemblies onto the already-tested shared splitter, and
- collapses a latent double `Yaesu3Command.getFrequency()` call.

No protocol or decoding behavior changes beyond no longer dropping coalesced replies; the 1000-char runaway-buffer guard is preserved.

## Testing

- Added `CatLineSplitterTest.yaesuGen3MeterPoll_swrSurvivesCoalescedAndPartialReads` modelling the gen-3 meter poll — a coalesced ALC + partial-SWR read followed by the SWR tail — asserting the SWR frame survives and no `;` is retained.
- `./gradlew :app:testDebugUnitTest` — **BUILD SUCCESSFUL**, full suite green (JDK 17, Android SDK 35, NDK 27).

## Risk assessment

Low. Change is confined to three rig handlers' receive path; the reassembly logic is the shared, unit-tested `CatLineSplitter` already shipped with #665/#667. No DSP, encoder/decoder, or waterfall code touched; performance characteristics are unchanged (a single linear scan per read). No hardware was available to bench-verify, so the fix mirrors the verified FT-891/FT-2000 approach exactly.

## Still open (same root cause, different command classes)

`ElecraftRig`, `KenwoodTS570Rig`, `KenwoodTS590Rig`, `KenwoodTS2000Rig`, `Flex6000Rig` each have their own single-command reassembly (some `\r`-terminated) — candidates for follow-up PRs adopting the same shared splitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)