### PR TITLE
Add a "New Grid" decode filter for grid chasers

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
@@ -339,6 +339,21 @@ private fun MetaText(text: String) {
 }
 
 /**
+ * Whether [message] carries a Maidenhead grid field the operator hasn't logged
+ * yet — i.e. a "new grid" for grid-chasing (VUCC). Requires a full 4-character
+ * field (the two-letter field + two-digit square that `checkQSLGrid` keys on);
+ * bare-callsign or sub-square-only frames don't count. Shared by the row's
+ * NEW_GRID highlight and the Decode screen's "New Grid" filter so the pill and
+ * the chip always agree on what counts as new.
+ */
+internal fun isNewGridStation(message: Ft8Message): Boolean {
+    val grid = message.maidenGrid
+    return !grid.isNullOrEmpty() &&
+        grid.length >= 4 &&
+        !GeneralVariables.checkQSLGrid(grid)
+}
+
+/**
  * Resolve the [QsoStatus] for a given [Ft8Message] based on its state.
  *
  * Returns null when there is no useful state to surface (e.g. a station
@@ -357,11 +372,8 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
         GeneralVariables.checkQSLCallsign(message.getCallsignFrom())
     val isToMe = GeneralVariables.checkIsMyCallsign(message.callsignTo ?: "")
     val modifier = message.modifier
-    val grid = message.maidenGrid
 
-    val newGrid = !grid.isNullOrEmpty() &&
-        grid.length >= 4 &&
-        !GeneralVariables.checkQSLGrid(grid)
+    val newGrid = isNewGridStation(message)
     val newBand = !isWorked &&
         GeneralVariables.checkQSLCallsign_OtherBand(message.callsignFrom ?: "")
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -67,7 +67,7 @@ fun DecodeScreen(
     // Filter state. Backed by the ViewModel so the chosen filter survives
     // navigation away from Decode and back (the screen is recreated by the
     // tab switch, which would otherwise reset a local rememberSaveable).
-    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "Needed", "For Me")
+    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "New Grid", "Needed", "For Me")
     val selectedFilter by mainViewModel.decodeFilter.observeAsState("All")
 
     // Couple the "CQ POTA" display filter to Hunt: while it's selected, the auto-call
@@ -522,6 +522,7 @@ private fun filterLabel(key: String): String = when (key) {
     "CQ Calls" -> stringResource(R.string.decode_filter_cq_calls)
     "CQ POTA" -> stringResource(R.string.decode_filter_cq_pota)
     "New DXCC" -> stringResource(R.string.decode_filter_new_dxcc)
+    "New Grid" -> stringResource(R.string.decode_filter_new_grid)
     "Needed" -> stringResource(R.string.decode_filter_needed)
     "For Me" -> stringResource(R.string.decode_filter_for_me)
     else -> stringResource(R.string.decode_filter_all)
@@ -538,6 +539,7 @@ private fun filterLabel(key: String): String = when (key) {
  *  - All: no filtering
  *  - CQ Calls: only CQ messages
  *  - New DXCC: CQ from a DXCC entity not yet in the operator's worked list
+ *  - New Grid: CQ from a Maidenhead grid field not yet in the operator's worked list
  *  - Needed: need QSL confirmation (not in QSL callsign list)
  *  - For Me: callsignTo matches operator's callsign
  */
@@ -586,6 +588,10 @@ internal fun filterMessages(
         // this filter and hunting agree on who counts as a POTA station — see issue #333.
         "CQ POTA" -> base.filter { radio.ks3ckc.ft8af.pota.PotaCqClassifier.isPotaCq(it) }
         "New DXCC" -> base.filter { it.checkIsCQ() && it.fromDxcc }
+        // Mirror of "New DXCC" for grid chasers (VUCC / grid hunting): only CQ
+        // stations whose grid field the operator hasn't logged yet, so the list
+        // becomes a one-tap "who's calling from a grid I still need" view.
+        "New Grid" -> base.filter { it.checkIsCQ() && isNewGridStation(it) }
         "Needed" -> base.filter {
             !it.isQSL_Callsign &&
                 !GeneralVariables.checkQSLCallsign(it.callsignFrom ?: "")
@@ -610,6 +616,7 @@ internal fun EmptyState(
         "CQ Calls" -> stringResource(R.string.decode_empty_cq_title) to stringResource(R.string.decode_empty_cq_body)
         "CQ POTA" -> stringResource(R.string.decode_empty_pota_title) to stringResource(R.string.decode_empty_pota_body)
         "New DXCC" -> stringResource(R.string.decode_empty_dxcc_title) to stringResource(R.string.decode_empty_dxcc_body)
+        "New Grid" -> stringResource(R.string.decode_empty_grid_title) to stringResource(R.string.decode_empty_grid_body)
         "Needed" -> stringResource(R.string.decode_empty_needed_title) to stringResource(R.string.decode_empty_needed_body)
         "For Me" -> stringResource(R.string.decode_empty_forme_title) to stringResource(R.string.decode_empty_forme_body)
         else -> stringResource(R.string.decode_empty_default_title) to stringResource(R.string.decode_empty_default_body, GeneralVariables.currentMode().displayName)

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -174,6 +174,7 @@
     <string name="decode_filter_cq_calls">CQ Calls</string>
     <string name="decode_filter_cq_pota">CQ POTA</string>
     <string name="decode_filter_new_dxcc">New DXCC</string>
+    <string name="decode_filter_new_grid">New Grid</string>
     <string name="decode_filter_needed">Needed</string>
     <string name="decode_filter_for_me">For Me</string>
     <string name="decode_empty_cq_title">No CQ calls</string>
@@ -182,6 +183,8 @@
     <string name="decode_empty_pota_body">No park activations decoded on this band yet — open POTA → Hunt for the spot list.</string>
     <string name="decode_empty_dxcc_title">No new DXCC</string>
     <string name="decode_empty_dxcc_body">No unworked DXCC entities have been decoded yet.</string>
+    <string name="decode_empty_grid_title">No new grids</string>
+    <string name="decode_empty_grid_body">No stations calling from an unworked grid square have been decoded yet.</string>
     <string name="decode_empty_needed_title">Nothing needed</string>
     <string name="decode_empty_needed_body">No stations needing confirmation found.</string>
     <string name="decode_empty_forme_title">No calls for you</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeFilterTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeFilterTest.kt
@@ -1,7 +1,10 @@
 package radio.ks3ckc.ft8af.ui.decode
 
 import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
 import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -10,15 +13,29 @@ import org.robolectric.RobolectricTestRunner
  * Unit-tests the pure [filterMessages] decode-list filter. Robolectric is
  * needed only because [Ft8Message] reaches android.util.Log on construction.
  *
- * These exercise the two chip filters that depend purely on message content
- * (no operator-specific GeneralVariables state, which stays at its defaults
- * here): "All" passes everything through, "CQ Calls" keeps only CQ messages.
+ * These exercise the chip filters that depend on message content plus the
+ * operator's worked-grid list (kept at its defaults except where a test seeds
+ * it explicitly): "All" passes everything through, "CQ Calls" keeps only CQ
+ * messages, and "New Grid" keeps only CQ stations from an unworked grid.
  */
 @RunWith(RobolectricTestRunner::class)
 class DecodeFilterTest {
 
     private fun cq(from: String) = Ft8Message("CQ", from, "FN42")
     private fun directed(to: String, from: String) = Ft8Message(to, from, "FN42")
+
+    /** A CQ message carrying a decoded Maidenhead grid (the field the filter keys on). */
+    private fun cqFromGrid(from: String, grid: String) = cq(from).apply { maidenGrid = grid }
+
+    @Before
+    fun clearWorkedGrids() {
+        GeneralVariables.QSL_Grid_list.clear()
+    }
+
+    @After
+    fun tearDown() {
+        GeneralVariables.QSL_Grid_list.clear()
+    }
 
     @Test
     fun all_returnsEveryMessage() {
@@ -38,5 +55,38 @@ class DecodeFilterTest {
         val result = filterMessages(listOf(cqMsg, directedMsg), "CQ Calls")
 
         assertThat(result).containsExactly(cqMsg)
+    }
+
+    @Test
+    fun newGrid_keepsCqFromUnworkedGrid() {
+        // No grids worked yet, so every 4-char grid counts as new.
+        val cqMsg = cqFromGrid("K1ABC", "FN42")
+
+        val result = filterMessages(listOf(cqMsg), "New Grid")
+
+        assertThat(result).containsExactly(cqMsg)
+    }
+
+    @Test
+    fun newGrid_dropsCqFromAlreadyWorkedGrid() {
+        GeneralVariables.QSL_Grid_list.add("FN42")
+        val worked = cqFromGrid("K1ABC", "FN42")   // grid already logged
+        val fresh = cqFromGrid("K2DEF", "EN37")     // still needed
+
+        val result = filterMessages(listOf(worked, fresh), "New Grid")
+
+        assertThat(result).containsExactly(fresh)
+    }
+
+    @Test
+    fun newGrid_dropsDirectedAndGridlessMessages() {
+        val directedNewGrid = directed("W1AW", "K2DEF").apply { maidenGrid = "EN37" }
+        val cqNoGrid = cq("K3GHI").apply { maidenGrid = null }
+
+        val result = filterMessages(listOf(directedNewGrid, cqNoGrid), "New Grid")
+
+        // Directed messages aren't callable CQs; a CQ without a grid can't be
+        // judged new — both are excluded.
+        assertThat(result).isEmpty()
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
@@ -56,6 +56,17 @@ class DecodeScreenTest {
     }
 
     @Test
+    fun newGridFilter_showsGridEmptyCopy() {
+        val title = context.getString(R.string.decode_empty_grid_title)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            EmptyState(selectedFilter = "New Grid")
+        }
+
+        composeRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
     fun sortLabel_showsActiveModeTextAndDescription() {
         composeRule.setContent {
             SortModeLabel(sortMode = DecodeSortMode.SNR)

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewGridTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewGridTest.kt
@@ -1,0 +1,92 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import radio.ks3ckc.ft8af.ui.components.QsoStatus
+
+/**
+ * Unit-tests the shared [isNewGridStation] predicate that backs both the
+ * decode row's NEW_GRID pill and the "New Grid" decode filter, so the two never
+ * disagree on what counts as an unworked grid.
+ *
+ * Robolectric is needed only because [Ft8Message] reaches android.util.Log on
+ * construction; the logic under test is pure.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NewGridTest {
+
+    private var savedHighlightPota = false
+    private var savedHighlightNewDxcc = false
+    private var savedHighlightNewGrid = false
+    private var savedHighlightNewBand = false
+    private var savedHighlightWorked = false
+
+    @Before
+    fun setUp() {
+        savedHighlightPota = GeneralVariables.highlightPota
+        savedHighlightNewDxcc = GeneralVariables.highlightNewDxcc
+        savedHighlightNewGrid = GeneralVariables.highlightNewGrid
+        savedHighlightNewBand = GeneralVariables.highlightNewBand
+        savedHighlightWorked = GeneralVariables.highlightWorked
+        GeneralVariables.QSL_Grid_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+    }
+
+    @After
+    fun tearDown() {
+        GeneralVariables.highlightPota = savedHighlightPota
+        GeneralVariables.highlightNewDxcc = savedHighlightNewDxcc
+        GeneralVariables.highlightNewGrid = savedHighlightNewGrid
+        GeneralVariables.highlightNewBand = savedHighlightNewBand
+        GeneralVariables.highlightWorked = savedHighlightWorked
+        GeneralVariables.QSL_Grid_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+    }
+
+    private fun cqFromGrid(from: String, grid: String?): Ft8Message =
+        Ft8Message("CQ", from, "TEST").apply { maidenGrid = grid }
+
+    @Test
+    fun unworkedFourCharGrid_isNew() {
+        assertThat(isNewGridStation(cqFromGrid("K1ABC", "FN42"))).isTrue()
+    }
+
+    @Test
+    fun workedGrid_isNotNew() {
+        GeneralVariables.QSL_Grid_list.add("FN42")
+        assertThat(isNewGridStation(cqFromGrid("K1ABC", "FN42"))).isFalse()
+    }
+
+    @Test
+    fun workedGridMatchIsCaseAndSubSquareInsensitive() {
+        // checkQSLGrid keys on the upper-cased 4-char field, so a 6-char decode
+        // from the same square is still "worked".
+        GeneralVariables.QSL_Grid_list.add("FN42")
+        assertThat(isNewGridStation(cqFromGrid("K1ABC", "fn42ab"))).isFalse()
+    }
+
+    @Test
+    fun missingOrTooShortGrid_isNotNew() {
+        assertThat(isNewGridStation(cqFromGrid("K1ABC", null))).isFalse()
+        assertThat(isNewGridStation(cqFromGrid("K1ABC", ""))).isFalse()
+        assertThat(isNewGridStation(cqFromGrid("K1ABC", "FN"))).isFalse()
+    }
+
+    @Test
+    fun newGridPill_surfacesWhenHighlightEnabled() {
+        GeneralVariables.highlightPota = false
+        GeneralVariables.highlightNewDxcc = false
+        GeneralVariables.highlightNewGrid = true
+        GeneralVariables.highlightNewBand = false
+        GeneralVariables.highlightWorked = false
+
+        assertThat(resolveQsoStatus(cqFromGrid("K1ABC", "FN42")))
+            .isEqualTo(QsoStatus.NEW_GRID)
+    }
+}


### PR DESCRIPTION
## What & why

Grid-square hunting — VUCC, the Fred Fish Memorial award, chasing rare grids — is one of the most popular things operators do on FT8. The decode list already flags a station in an unworked grid with a **NEW GRID** pill, but the only award-oriented *filter* chip was **New DXCC**, so there was no one-tap way to focus the list on grids you still need.

This adds a symmetric **New Grid** filter chip. With it selected, the decode list shows only CQ stations whose Maidenhead grid field the operator hasn't logged yet — turning the list into a *"who's calling from a grid I still need"* view. It's the grid-chasing counterpart to the existing "New DXCC" chip and reuses the same worked-grid bookkeeping (`GeneralVariables.checkQSLGrid` over the distinct worked 4-char grid set), so a grid the operator has confirmed drops out automatically.

**User benefit:** grid chasers can spot the calls worth answering at a glance instead of scanning every CQ, with zero setup.

## Changes

- Extract the "is this an unworked grid?" test the decode row already computed inline into a shared `isNewGridStation()` helper, so the NEW GRID pill and the new filter chip can never disagree on what counts as new (requires a full 4-char grid field; case- and sub-square-insensitive).
- Wire the new chip through the filter option list, its localized label, the filter predicate, and a dedicated empty state ("No new grids").
- Untranslated locales fall back to the English strings until translated, matching how new user-facing strings are normally added here.

## Testing

`:app:testDebugUnitTest` — all green. New/updated coverage:

- `DecodeFilterTest`: keeps unworked-grid CQs, drops already-worked grids, drops directed and grid-less frames.
- `NewGridTest` (new): the shared predicate — 4-char requirement, case/sub-square insensitivity, worked vs. new — plus the NEW_GRID pill wiring.
- `DecodeScreenTest`: renders the "No new grids" empty state.

## Notes / assumptions

- Like "New DXCC", the filter is independent of the `highlightNewGrid` decode-highlight toggle: selecting the chip is an explicit request to see only new grids, regardless of whether the passive pill is enabled.
- Scope is intentionally the operator's own worked-grid list (any band), consistent with the existing pill; no protocol, decoder, or TX paths are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)