### PR TITLE
Fix Elecraft CAT: coalesced SWR/freq replies dropped (SWR alert can miss a spike; next parse poisoned)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/ElecraftRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/ElecraftRig.java
@@ -122,42 +122,49 @@ public class ElecraftRig extends BaseRig {
     public void onReceiveData(byte[] data) {
         String s = new String(data);
 
-        if (!s.contains(";")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            // return;//data reception not yet complete.
-        } else {
-            if (s.indexOf(";") > 0) {//received end-of-data, and ';' is not the first character
-                buffer.append(s.substring(0, s.indexOf(";")));
-            }
+        // Drain every complete ';'-terminated command in this read. The transport
+        // delivers bytes in arbitrary chunks, so a single read routinely coalesces
+        // two back-to-back replies (e.g. successive SWR meter polls during TX, or a
+        // freq reply followed by a meter reply). The old parser handled only the
+        // first command and re-buffered the rest WITH its retained terminator, so
+        // the second reply was dropped (then wiped by the next poll's
+        // clearBufferData()) and the retained ';' poisoned the next parse (the
+        // stale ID was read as the command and the real command landed in the data
+        // field). Only the trailing, unterminated fragment is carried over.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), s, ';');
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-            //begin parsing data
-            ElecraftCommand elecraftCommand = ElecraftCommand.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf(";") + 1));
-
-            if (elecraftCommand == null) {
-                return;
-            }
-            if (elecraftCommand.getCommandID().equalsIgnoreCase("FA")
-                    || elecraftCommand.getCommandID().equalsIgnoreCase("FB")) {
-                long tempFreq = ElecraftCommand.getFrequency(elecraftCommand);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(ElecraftCommand.getFrequency(elecraftCommand));
-                }
-            } else if (elecraftCommand.getCommandID().equalsIgnoreCase("SW")) {//METER
-                if (ElecraftCommand.isSWRMeter(elecraftCommand)) {
-                    swr = ElecraftCommand.getSWRMeter(elecraftCommand);
-                }
-
-                showAlert();
-                notifyMeterData(-1, Math.min(swr * 4, 255));
-            }
-
-
+        for (String command : result.frames) {
+            processCommand(command);
         }
+    }
 
+    /**
+     * Parse and act on one complete CAT command (terminator already stripped).
+     * Extracted so {@link #onReceiveData} stays a thin drain loop.
+     */
+    private void processCommand(String command) {
+        ElecraftCommand elecraftCommand = ElecraftCommand.getCommand(command);
+        if (elecraftCommand == null) {
+            return;
+        }
+        if (elecraftCommand.getCommandID().equalsIgnoreCase("FA")
+                || elecraftCommand.getCommandID().equalsIgnoreCase("FB")) {
+            long tempFreq = ElecraftCommand.getFrequency(elecraftCommand);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (elecraftCommand.getCommandID().equalsIgnoreCase("SW")) {//METER
+            if (ElecraftCommand.isSWRMeter(elecraftCommand)) {
+                swr = ElecraftCommand.getSWRMeter(elecraftCommand);
+            }
+
+            showAlert();
+            notifyMeterData(-1, Math.min(swr * 4, 255));
+        }
     }
 
     @Override

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
@@ -108,6 +108,28 @@ public class CatLineSplitterTest {
     }
 
     @Test
+    public void elecraftCoalescedSwrMeterPolls_bothReadingsSurvive() {
+        // During TX the Elecraft SWR meter is polled repeatedly and two "SW"
+        // replies routinely coalesce into one read. The old per-rig reassembly
+        // kept only the first and dropped the second (higher, i.e. worse) reading,
+        // so the SWR alert could miss a spike. Both must now be delivered.
+        CatLineSplitter.Result r = CatLineSplitter.split("", "SW030;SW045;", ';');
+        assertThat(r.frames).containsExactly("SW030", "SW045").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void elecraftFreqThenMeter_retainedTerminatorCannotPoisonNextParse() {
+        // A freq reply coalesced with a meter reply: the old code parsed FA, then
+        // re-buffered "SW045;" WITH its ';'. If a further read arrived before the
+        // buffer was cleared, "SW045;" + next command concatenated into a single
+        // poisoned parse. The splitter yields both as clean, separate frames.
+        CatLineSplitter.Result r = CatLineSplitter.split("", "FA00014074000;SW045;", ';');
+        assertThat(r.frames).containsExactly("FA00014074000", "SW045").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
     public void carriageReturnTerminator_supportedForSiblingRigs() {
         // The splitter is terminator-parameterised so the Kenwood/Elecraft '\r'
         // handlers can adopt it too.


### PR DESCRIPTION
## Root cause

`ElecraftRig.onReceiveData()` reassembled its `;`-terminated CAT stream **one command at a time**: it parsed only the *first* command in a read and pushed the remainder back into the buffer **with its retained terminator**.

The serial / USB / Bluetooth transport delivers bytes in arbitrary chunks, so a single read routinely coalesces two back-to-back replies — successive SWR meter polls during TX, or a frequency reply followed by a meter reply. With the old parser that produced two failures:

1. **Dropped reply.** The second coalesced command was never parsed; it sat in the buffer until the next poll's `clearBufferData()` wiped it. So the higher (worse) of two coalesced SWR readings could be lost and the high-SWR alert miss a spike during transmit.
2. **Poisoned next parse.** The remainder was re-buffered *including* its `;`. If a further chunk arrived before the buffer was cleared, the stale trailing command concatenated with the next one: the stale ID was read as the command ID and the real command landed inside the data field and was discarded.

This is the same class of defect already fixed for the Yaesu FT-891 (#665, which introduced the shared `CatLineSplitter`) and the FT-2000 (#667) — the text-framed rigs never got the multi-frame drain that the binary CI-V rigs already have via `CivFrameSplitter`.

## Fix

Drain **every** complete `;`-terminated command per read via the shared `CatLineSplitter`, carrying only the trailing *unterminated* fragment into the next read (with the existing 1000-char runaway guard). The per-command logic is extracted verbatim into `processCommand()` so `onReceiveData()` stays a thin drain loop. A latent double `getFrequency()` call is collapsed while there.

No protocol/DSP behavior changes; the terminator (`;`) and every parse path are unchanged — the read loop now simply processes all commands in a read instead of one.

## Testing

- Added two `CatLineSplitterTest` cases pinning the Elecraft scenarios: two coalesced `SW` meter replies both survive, and a coalesced `FA…;SW…;` cannot poison the next parse.
- `./gradlew :app:testDebugUnitTest` — full unit-test suite green (`BUILD SUCCESSFUL`).
- No hardware available; the rig's `onReceiveData` itself touches Android/LiveData and is not unit-tested, matching the convention established by #665/#667.

## Risk

Low and localized to `ElecraftRig`. The reassembler is the same one already shipping for the FT-891. Only the Elecraft rig class is affected; other rigs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)