### PR TITLE
Add a "Best DX" card to the logbook Stats tab (furthest station worked)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
@@ -80,6 +80,7 @@ import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.count.CountDbOpr
 import com.k1af.ft8af.log.QSLCallsignRecord
 import com.k1af.ft8af.log.ThirdPartyService
+import com.k1af.ft8af.maidenhead.MaidenheadGrid
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.Dispatchers
@@ -631,6 +632,24 @@ private fun StatsTab(stats: LogbookStats, records: List<QSLCallsignRecord>) {
             )
         }
 
+        // Best DX highlight — the furthest station worked, great-circle from the
+        // operator's grid. Only shown once there's a measurable contact (operator
+        // grid configured and at least one logged grid that parses).
+        val myGrid = GeneralVariables.getMyMaidenheadGrid()
+        val bestDx = remember(records, myGrid) {
+            computeBestDx(records) { grid ->
+                if (myGrid.isNullOrEmpty()) {
+                    null
+                } else {
+                    MaidenheadGrid.getDist(myGrid, grid)
+                }
+            }
+        }
+        if (bestDx != null) {
+            SectionHeader(stringResource(R.string.log_section_best_dx))
+            BestDxCard(bestDx = bestDx, modifier = Modifier.fillMaxWidth())
+        }
+
         // Band donut chart
         if (stats.bandCounts.isNotEmpty()) {
             SectionHeader(stringResource(R.string.log_section_band_distribution))
@@ -714,6 +733,52 @@ private fun BigStatCard(
                 fontSize = 11.sp,
                 fontWeight = FontWeight.Medium,
                 letterSpacing = 0.04.sp,
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Best DX card
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun BestDxCard(bestDx: BestDx, modifier: Modifier = Modifier) {
+    // MaidenheadGrid.formatDist already renders in the operator's preferred unit
+    // (mi/km) with its abbreviated label, so this stays unit-agnostic here.
+    val distanceText = MaidenheadGrid.formatDist(bestDx.distanceKm)
+    GlassCard(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = bestDx.callsign,
+                    color = Signal,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = GeistMonoFamily,
+                )
+                if (bestDx.grid.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = bestDx.grid,
+                        color = TextMuted,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 0.04.sp,
+                    )
+                }
+            }
+            Text(
+                text = distanceText,
+                color = Accent,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
             )
         }
     }
@@ -1065,6 +1130,40 @@ private fun gridSquaresWorked(records: List<QSLCallsignRecord>): Int =
         val grid = record.grid
         if (!grid.isNullOrBlank() && grid.length >= 4) grid.substring(0, 4).uppercase() else null
     }.distinct().size
+
+// ---------------------------------------------------------------------------
+// Helper: furthest station worked ("Best DX")
+// ---------------------------------------------------------------------------
+
+/** The furthest logged station and its great-circle distance from the operator. */
+internal data class BestDx(val callsign: String, val grid: String, val distanceKm: Double)
+
+/**
+ * The furthest-worked station across [records], measured great-circle from the
+ * operator's grid. [distanceKm] maps a remote grid to its distance in km, or
+ * null when it can't be measured (unparseable grid, or the operator's own grid
+ * isn't configured). Records with a blank callsign/grid, an un-measurable grid,
+ * or a non-positive / NaN distance are skipped — the last mirrors
+ * MaidenheadGrid's 0-km result for two stations sharing a grid, which is a
+ * distance floor, never a "best DX". Returns null when nothing is measurable.
+ *
+ * The distance function is injected so this reducer stays a pure, JVM-only unit
+ * (the real card passes a MaidenheadGrid-backed lambda).
+ */
+internal fun computeBestDx(
+    records: List<QSLCallsignRecord>,
+    distanceKm: (String) -> Double?,
+): BestDx? =
+    records.asSequence()
+        .mapNotNull { record ->
+            val callsign = record.callsign?.trim().orEmpty()
+            val grid = record.grid?.trim().orEmpty()
+            if (callsign.isEmpty() || grid.isEmpty()) return@mapNotNull null
+            val dist = distanceKm(grid) ?: return@mapNotNull null
+            if (dist.isNaN() || dist <= 0.0) return@mapNotNull null
+            BestDx(callsign, grid, dist)
+        }
+        .maxByOrNull { it.distanceKm }
 
 // ===========================================================================
 // RECENT TAB

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -240,6 +240,7 @@
     <string name="log_award_dxcc_mixed">DXCC Mixed</string>
     <string name="log_award_vucc_grid_squares">VUCC Grid Squares</string>
     <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_best_dx">Best DX</string>
     <string name="log_section_grid_coverage">Grid Coverage</string>
     <string name="log_section_signal_trend">Signal Trend</string>
     <string name="log_no_qsos_yet">No QSOs yet</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/BestDxTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/BestDxTest.kt
@@ -1,0 +1,95 @@
+package radio.ks3ckc.ft8af.ui.logbook
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.log.QSLCallsignRecord
+import org.junit.Test
+
+/**
+ * Unit tests for [computeBestDx] — the pure reducer behind the logbook Stats
+ * "Best DX" card. The real card measures great-circle distance via
+ * [com.k1af.ft8af.maidenhead.MaidenheadGrid]; here the distance is injected as a
+ * fake grid -> km function so the selection/filtering logic is testable on the
+ * plain JVM (no Robolectric, no operator grid).
+ */
+class BestDxTest {
+
+    private fun rec(callsign: String?, grid: String?): QSLCallsignRecord =
+        QSLCallsignRecord().apply {
+            setCallsign(callsign)
+            setGrid(grid)
+        }
+
+    // Maps a (trimmed) grid to a canned distance; unknown grids are "unparseable".
+    private val fakeDist: (String) -> Double? = { grid ->
+        when (grid.uppercase()) {
+            "AA00" -> 100.0
+            "BB11" -> 5000.0
+            "CC22" -> 18000.0
+            else -> null
+        }
+    }
+
+    @Test
+    fun picksTheFurthestStation() {
+        val best = computeBestDx(
+            listOf(rec("A1AA", "AA00"), rec("B2BB", "BB11"), rec("C3CC", "CC22")),
+            fakeDist,
+        )
+        assertThat(best).isNotNull()
+        assertThat(best!!.callsign).isEqualTo("C3CC")
+        assertThat(best.grid).isEqualTo("CC22")
+        assertThat(best.distanceKm).isEqualTo(18000.0)
+    }
+
+    @Test
+    fun returnsNullForEmptyLog() {
+        assertThat(computeBestDx(emptyList(), fakeDist)).isNull()
+    }
+
+    @Test
+    fun skipsRecordsWithUnparseableGrid() {
+        val best = computeBestDx(listOf(rec("A1AA", "ZZ99"), rec("B2BB", "BB11")), fakeDist)
+        assertThat(best!!.callsign).isEqualTo("B2BB")
+    }
+
+    @Test
+    fun skipsBlankCallsignOrGrid() {
+        val best = computeBestDx(
+            listOf(rec("", "CC22"), rec("B2BB", ""), rec("D4DD", "BB11")),
+            fakeDist,
+        )
+        assertThat(best!!.callsign).isEqualTo("D4DD")
+        assertThat(best.distanceKm).isEqualTo(5000.0)
+    }
+
+    @Test
+    fun returnsNullWhenNothingIsMeasurable() {
+        // Distance fn returns null for everything — e.g. operator grid not set.
+        assertThat(computeBestDx(listOf(rec("A1AA", "AA00")), { null })).isNull()
+    }
+
+    @Test
+    fun skipsZeroAndNaNDistances() {
+        // A 0 km hit (same grid as the operator) and a NaN must never win over a
+        // real distance, mirroring MaidenheadGrid's coincident-point behaviour.
+        val best = computeBestDx(
+            listOf(rec("SAME", "AA00"), rec("BADGRID", "CC22"), rec("FAR", "BB11")),
+            { grid ->
+                when (grid) {
+                    "AA00" -> 0.0
+                    "CC22" -> Double.NaN
+                    "BB11" -> 5000.0
+                    else -> null
+                }
+            },
+        )
+        assertThat(best!!.callsign).isEqualTo("FAR")
+    }
+
+    @Test
+    fun trimsCallsignAndGrid() {
+        val best = computeBestDx(listOf(rec(" C3CC ", " CC22 ")), fakeDist)
+        assertThat(best!!.callsign).isEqualTo("C3CC")
+        assertThat(best.grid).isEqualTo("CC22")
+    }
+}


### PR DESCRIPTION
## What & why

Adds a **Best DX** highlight card to **Logbook → Stats**, showing the furthest station the operator has worked — callsign, distance (in their preferred mi/km), and grid — measured great-circle from their configured Maidenhead grid.

Seeing "what's the furthest I've ever worked?" is one of the first things an FT8/DX operator wants from a logbook, and it's a natural brag stat next to Total QSOs / DXCC / Zones. Every logged QSO already stores a grid, so this surfaces information the app already has — no new data, no schema change, no extra DB query (it reduces over the records already loaded for the Stats tab).

## How it looks

The card sits right below the four big stat cards (Total QSOs / DXCC / CQ / ITU), before the band distribution donut:

```
BEST DX
┌───────────────────────────────────────┐
│  VK3ABC                     16,842 km  │
│  QF22                                  │
└───────────────────────────────────────┘
```

It only appears once there's something measurable — i.e. the operator's own grid is configured **and** at least one logged QSO has a parseable grid. No grid set → the section is hidden (no empty header).

## Implementation

- `computeBestDx(records, distanceKm)` — a pure, top-level `internal` reducer that takes an **injected** grid→distance function and returns the furthest `BestDx(callsign, grid, distanceKm)`. It skips records with a blank callsign/grid, an unparseable grid, or a non-positive/`NaN` distance (the last mirrors `MaidenheadGrid`'s 0-km result for two stations sharing a grid — a distance floor, never a "best DX").
- The Composable `BestDxCard` is a thin wrapper; the screen passes a `MaidenheadGrid.getDist(myGrid, …)`-backed lambda and renders the distance with `MaidenheadGrid.formatDist` (unit-aware).
- Follows the existing extract-pure-helper pattern already used for `gridSquaresWorked` / `workedGridFields`, so the decision logic is unit-testable without Robolectric.

## Tests

New `BestDxTest` (7 plain-JVM cases): furthest wins, empty log → null, unparseable/blank grids skipped, blank callsign skipped, nothing-measurable → null, 0 km and `NaN` distances skipped, callsign/grid trimmed.

## Verification

- `./gradlew :app:testDebugUnitTest --tests 'radio.ks3ckc.ft8af.ui.logbook.*'` — green (BestDxTest 7/7, no regressions in the logbook suite).
- `./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL** (full native + APK).

## Scope / compatibility

Display-only addition to the Stats tab. No change to decoding, transmit, CAT, or the FT8 protocol path. One new string (`log_section_best_dx`); other locales fall back to the default, consistent with recent stats additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)