### PR TITLE
Show "Worked before" QSO history when you tap a decoded station

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -576,6 +576,43 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         return out;
     }
 
+    /**
+     * Every prior logged QSO with {@code callsign}, oldest first, as lightweight
+     * {@link com.k1af.ft8af.log.PriorQso} rows (date/time/band/mode only). Powers
+     * the decode sheet's "Worked before" card. Returns an empty list when the
+     * station has never been worked, on a blank callsign, or on any read error.
+     *
+     * <p>The exact-match on {@code "call"} is served by the {@code QSLTable_call_IDX}
+     * index, so this stays cheap even on a large log. Decoded callsigns are already
+     * upper-cased (as are stored ones), so no case-folding is needed — folding here
+     * would only defeat the index.
+     */
+    public java.util.List<com.k1af.ft8af.log.PriorQso> getPriorQsos(String callsign) {
+        java.util.List<com.k1af.ft8af.log.PriorQso> out = new ArrayList<>();
+        if (db == null || callsign == null) {
+            return out;
+        }
+        String c = callsign.trim();
+        if (c.isEmpty()) {
+            return out;
+        }
+        try (Cursor cursor = db.rawQuery(
+                "SELECT qso_date, time_on, band, mode FROM QSLTable "
+                        + "WHERE \"call\" = ? ORDER BY qso_date, time_on",
+                new String[]{c})) {
+            while (cursor.moveToNext()) {
+                out.add(new com.k1af.ft8af.log.PriorQso(
+                        cursor.getString(0),
+                        cursor.getString(1),
+                        cursor.getString(2),
+                        cursor.getString(3)));
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "getPriorQsos failed: " + e.getClass().getSimpleName());
+        }
+        return out;
+    }
+
     /** Drop every cached signature mapping (e.g. on server/logbook switch). */
     public void clearLocationStationCache() {
         if (db == null) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/PriorQso.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/PriorQso.java
@@ -1,0 +1,41 @@
+package com.k1af.ft8af.log;
+
+/**
+ * A minimal previously-logged QSO record used by the decode sheet's
+ * "Worked before" history card. Holds only the columns that card needs
+ * (date/time/band/mode) so it stays cheap to read out of {@code QSLTable}
+ * in bulk. All fields may be null/empty for a sparse log row.
+ */
+public class PriorQso {
+    private final String qsoDate;
+    private final String timeOn;
+    private final String band;
+    private final String mode;
+
+    public PriorQso(String qsoDate, String timeOn, String band, String mode) {
+        this.qsoDate = qsoDate;
+        this.timeOn = timeOn;
+        this.band = band;
+        this.mode = mode;
+    }
+
+    /** ADIF {@code qso_date}, typically {@code YYYYMMDD}; may be null/empty. */
+    public String getQsoDate() {
+        return qsoDate;
+    }
+
+    /** ADIF {@code time_on}, typically {@code HHMMSS} or {@code HHMM}; may be null. */
+    public String getTimeOn() {
+        return timeOn;
+    }
+
+    /** Band label such as {@code 20m}; may be null/empty. */
+    public String getBand() {
+        return band;
+    }
+
+    /** Mode such as {@code FT8}; may be null/empty. */
+    public String getMode() {
+        return mode;
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
@@ -152,6 +152,10 @@ private fun QsoSheetContent(
 
         Spacer(modifier = Modifier.height(12.dp))
 
+        // -- Worked before: prior-QSO history with this station (renders nothing
+        // for a never-worked station, so first contacts stay uncluttered) --
+        WorkedBeforeCard(callsign = callsign)
+
         // -- Path map: operator grid -> remote grid, with a connecting line.
         // Renders nothing (and no trailing spacer) when either grid is unknown.
         QsoPathMap(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/WorkedBeforeHistory.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/WorkedBeforeHistory.kt
@@ -1,0 +1,198 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.R
+import com.k1af.ft8af.database.DatabaseOpr
+import com.k1af.ft8af.log.PriorQso
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import radio.ks3ckc.ft8af.theme.GeistMonoFamily
+import radio.ks3ckc.ft8af.theme.StatusConfirmed
+import radio.ks3ckc.ft8af.theme.TextFaint
+import radio.ks3ckc.ft8af.theme.TextMuted
+import radio.ks3ckc.ft8af.theme.TextPrimary
+import radio.ks3ckc.ft8af.ui.components.FT8AFIcons
+import radio.ks3ckc.ft8af.ui.components.GlassCard
+
+/**
+ * Structured summary of the operator's prior QSOs with one station, ready to
+ * render in the decode sheet's "Worked before" card.
+ *
+ * `lastLine` is a pre-joined "date · band · mode" recap of the most recent
+ * contact (blank parts skipped); `bands` is the distinct set of bands ever
+ * worked, in first-worked order, so band-fill hunters can see at a glance what
+ * they still need. Both are derived by [summarizeWorkedBefore].
+ */
+internal data class WorkedBeforeSummary(
+    val count: Int,
+    val lastLine: String,
+    val bands: List<String>,
+)
+
+/** Separator used to join the recap parts and the band list. */
+private const val PART_SEP = " · " // " · "
+
+/**
+ * Collapse a list of prior [PriorQso] rows into a [WorkedBeforeSummary], or null
+ * when there is no prior contact (so the caller renders nothing).
+ *
+ * The most recent QSO is chosen by (qso_date, time_on) ascending, independent of
+ * the input order, so callers don't have to pre-sort. Distinct bands are kept in
+ * the order they were first worked (input order after the stable sort).
+ */
+internal fun summarizeWorkedBefore(qsos: List<PriorQso>): WorkedBeforeSummary? {
+    if (qsos.isEmpty()) return null
+
+    val sorted = qsos.sortedWith(
+        compareBy({ it.qsoDate.orEmpty() }, { it.timeOn.orEmpty() }),
+    )
+    val last = sorted.last()
+
+    val lastLine = listOf(
+        formatQsoDate(last.qsoDate),
+        last.band?.trim().orEmpty(),
+        last.mode?.trim().orEmpty(),
+    ).filter { it.isNotEmpty() }.joinToString(PART_SEP)
+
+    val bands = sorted
+        .mapNotNull { it.band?.trim()?.takeIf { b -> b.isNotEmpty() } }
+        .distinct()
+
+    return WorkedBeforeSummary(
+        count = qsos.size,
+        lastLine = lastLine,
+        bands = bands,
+    )
+}
+
+/**
+ * Format an ADIF `qso_date` (`YYYYMMDD`) as `YYYY-MM-DD`. Anything that isn't
+ * exactly 8 digits is returned trimmed and unchanged (e.g. already-formatted or
+ * malformed values), and null becomes "".
+ */
+internal fun formatQsoDate(raw: String?): String {
+    val d = raw?.trim().orEmpty()
+    return if (d.length == 8 && d.all { it.isDigit() }) {
+        "${d.substring(0, 4)}-${d.substring(4, 6)}-${d.substring(6, 8)}"
+    } else {
+        d
+    }
+}
+
+/**
+ * "Worked before" card: shows how many times — and most recently when/where —
+ * the operator has logged the given [callsign], plus the distinct bands worked.
+ *
+ * Reads [DatabaseOpr.getPriorQsos] off the main thread and renders nothing until
+ * the query resolves, or if the station has never been worked (keeps the sheet
+ * clean for the common first-contact case). The heavy lifting is in the pure
+ * [summarizeWorkedBefore]; this composable is a thin renderer.
+ */
+@Composable
+internal fun WorkedBeforeCard(callsign: String) {
+    val context = LocalContext.current
+    val summary by produceState<WorkedBeforeSummary?>(initialValue = null, callsign) {
+        value = if (callsign.isBlank()) {
+            null
+        } else {
+            withContext(Dispatchers.IO) {
+                val rows = try {
+                    DatabaseOpr.getInstance(context, null).getPriorQsos(callsign.trim())
+                } catch (_: Exception) {
+                    emptyList<PriorQso>()
+                }
+                summarizeWorkedBefore(rows)
+            }
+        }
+    }
+
+    val s = summary ?: return
+
+    // Own the trailing gap so a never-worked station (early return above) leaves
+    // no empty space between the last-heard row and the path map.
+    Column(modifier = Modifier.fillMaxWidth()) {
+        GlassCard(
+            modifier = Modifier.fillMaxWidth(),
+            cornerRadius = 12.dp,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    FT8AFIcons.Check(color = StatusConfirmed, size = 16.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.qso_worked_before_title),
+                        color = TextFaint,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 0.06.sp,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.qso_worked_before_count,
+                            s.count,
+                            s.count,
+                        ),
+                        color = StatusConfirmed,
+                        fontFamily = GeistMonoFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 13.sp,
+                    )
+                }
+
+                if (s.lastLine.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = stringResource(R.string.qso_worked_before_last, s.lastLine),
+                        color = TextPrimary,
+                        fontFamily = GeistMonoFamily,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 13.sp,
+                    )
+                }
+
+                // Only surface the band list when there's more than one — a single
+                // band is already implied by the recap line above.
+                if (s.bands.size > 1) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(
+                            R.string.qso_worked_before_bands,
+                            s.bands.joinToString(PART_SEP),
+                        ),
+                        color = TextMuted,
+                        fontFamily = GeistMonoFamily,
+                        fontSize = 12.sp,
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+    }
+}

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -215,6 +215,13 @@
     <string name="qso_live_step_fallback">message</string>
     <string name="qso_tx_now">TX NOW</string>
     <string name="qso_tx_next">TX NEXT</string>
+    <string name="qso_worked_before_title">Worked before</string>
+    <plurals name="qso_worked_before_count">
+        <item quantity="one">%1$d QSO</item>
+        <item quantity="other">%1$d QSOs</item>
+    </plurals>
+    <string name="qso_worked_before_last">last %1$s</string>
+    <string name="qso_worked_before_bands">Bands: %1$s</string>
     <string name="qso_last_heard">Last heard</string>
     <string name="qso_last_heard_unknown">--</string>
     <string name="qso_last_heard_just_now">just now</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/WorkedBeforeHistoryTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/WorkedBeforeHistoryTest.kt
@@ -1,0 +1,102 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.log.PriorQso
+import org.junit.Test
+
+/**
+ * Unit tests for the pure "Worked before" summariser logic. [PriorQso] is a
+ * plain POJO and [summarizeWorkedBefore]/[formatQsoDate] touch no Android types,
+ * so no Robolectric runner is needed.
+ */
+class WorkedBeforeHistoryTest {
+
+    private fun qso(
+        date: String,
+        time: String = "120000",
+        band: String? = "20m",
+        mode: String? = "FT8",
+    ) = PriorQso(date, time, band, mode)
+
+    // ---- summarizeWorkedBefore ----
+
+    @Test
+    fun `empty log yields null so nothing renders`() {
+        assertThat(summarizeWorkedBefore(emptyList())).isNull()
+    }
+
+    @Test
+    fun `single QSO reports count 1 and a formatted recap line`() {
+        val s = summarizeWorkedBefore(listOf(qso("20250612", "143000", "20m", "FT8")))!!
+        assertThat(s.count).isEqualTo(1)
+        assertThat(s.lastLine).isEqualTo("2025-06-12 · 20m · FT8")
+        assertThat(s.bands).containsExactly("20m")
+    }
+
+    @Test
+    fun `most recent QSO is chosen regardless of input order`() {
+        val s = summarizeWorkedBefore(
+            listOf(
+                qso("20240101", "090000", "40m", "FT8"),
+                qso("20260724", "010000", "15m", "FT4"),
+                qso("20250612", "143000", "20m", "FT8"),
+            ),
+        )!!
+        assertThat(s.count).isEqualTo(3)
+        // 2026-07-24 is the newest, so its band/mode drive the recap line.
+        assertThat(s.lastLine).isEqualTo("2026-07-24 · 15m · FT4")
+    }
+
+    @Test
+    fun `same-day QSOs break the tie on time_on`() {
+        val s = summarizeWorkedBefore(
+            listOf(
+                qso("20250612", "235900", "20m", "FT8"),
+                qso("20250612", "000100", "40m", "FT8"),
+            ),
+        )!!
+        assertThat(s.lastLine).isEqualTo("2025-06-12 · 20m · FT8")
+    }
+
+    @Test
+    fun `distinct bands are kept in first-worked order`() {
+        val s = summarizeWorkedBefore(
+            listOf(
+                qso("20240101", "090000", "40m"),
+                qso("20250101", "090000", "20m"),
+                qso("20250601", "090000", "40m"), // repeat 40m — deduped
+                qso("20260101", "090000", "15m"),
+            ),
+        )!!
+        assertThat(s.bands).containsExactly("40m", "20m", "15m").inOrder()
+    }
+
+    @Test
+    fun `blank band and mode parts are skipped in the recap line`() {
+        val s = summarizeWorkedBefore(listOf(qso("20250612", "120000", "  ", null)))!!
+        assertThat(s.lastLine).isEqualTo("2025-06-12")
+        assertThat(s.bands).isEmpty()
+    }
+
+    @Test
+    fun `unparseable date is passed through so the recap is never empty`() {
+        val s = summarizeWorkedBefore(listOf(qso("2025-06-12", "120000", "20m", "FT8")))!!
+        assertThat(s.lastLine).isEqualTo("2025-06-12 · 20m · FT8")
+    }
+
+    // ---- formatQsoDate ----
+
+    @Test
+    fun `formatQsoDate turns YYYYMMDD into YYYY-MM-DD`() {
+        assertThat(formatQsoDate("20250612")).isEqualTo("2025-06-12")
+    }
+
+    @Test
+    fun `formatQsoDate leaves non-8-digit values untouched and trims`() {
+        assertThat(formatQsoDate(" 2025 ")).isEqualTo("2025")
+        assertThat(formatQsoDate("2025-06-12")).isEqualTo("2025-06-12")
+        assertThat(formatQsoDate("abcdefgh")).isEqualTo("abcdefgh")
+        assertThat(formatQsoDate(null)).isEqualTo("")
+        assertThat(formatQsoDate("")).isEqualTo("")
+    }
+}


### PR DESCRIPTION
## What & why

Tapping a station in the decode list now shows a **"Worked before"** card right in the QSO sheet — so before you commit to a call you can instantly see:

- **How many times** you've logged that callsign
- **When you last worked them** — `date · band · mode`
- **Which bands** you've already got them on (distinct, in first-worked order)

It answers the two questions every operator asks before calling — *"have I worked them?"* and *"do I need this band?"* — without leaving the decode screen to dig through the logbook. For a station you've **never** worked, the card renders nothing, so first contacts stay uncluttered.

This helps everyone: dupe-avoidance in contests/activations, and band-fill hunting (see at a glance that you have someone on 40m/20m but still need 15m).

## How it works

- **`DatabaseOpr.getPriorQsos(call)`** — an indexed exact-match read of `QSLTable` (served by the existing `QSLTable_call_IDX`), returning lightweight `PriorQso` rows (date/time/band/mode only). Cheap even on a large log; runs off the main thread.
- **`summarizeWorkedBefore()` / `formatQsoDate()`** — pure, fully unit-tested logic that picks the most-recent QSO (by `qso_date`, then `time_on`, independent of input order) and computes the distinct-band list.
- **`WorkedBeforeCard`** — a thin Compose renderer following the existing `QsoPathMap` async-load pattern (`produceState` + `Dispatchers.IO`); wired into `QsoSheet` under the last-heard row.

## Tests

New `WorkedBeforeHistoryTest` covers the pure summariser: empty→null, single/multi QSO recap, most-recent selection regardless of order, same-day tie-break on `time_on`, distinct first-worked band ordering, blank-part skipping, and date formatting edge cases. Full `testDebugUnitTest` suite and a full `assembleDebug` both pass.

## Notes / assumptions

- Callsigns are stored and decoded upper-cased, so the query is an exact match (case-folding would only defeat the index).
- The card reads the operator's own logged QSOs (`QSLTable`), i.e. genuine worked contacts — not spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)