### PR TITLE
Add a day/night gray-line overlay to the world map

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -451,6 +451,7 @@ public class GeneralVariables {
     public static String qrzXmlUsername = ""; //QRZ XML API username (for callsign lookups)
     public static String qrzXmlPassword = ""; //QRZ XML API password
     public static boolean pskOverlayEnabled = false; //PSK Reporter map overlay (issue #33)
+    public static boolean grayLineEnabled = true; //Day/night terminator (gray line) map overlay — on by default
     public static boolean synFrequency = false;//Same-frequency transmit
     // Hold TX freq: don't move the TX offset to a station you answer (WSJT-X
     // "Hold Tx Freq"). Enabled by default (issue #498) to keep the TX frequency

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -3049,6 +3049,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("pskOverlayEnabled")) {
                     GeneralVariables.pskOverlayEnabled = result.equals("1");
                 }
+                if (name.equalsIgnoreCase("grayLineEnabled")) {
+                    GeneralVariables.grayLineEnabled = result.equals("1");
+                }
 
                 if (name.equalsIgnoreCase("swrSwitch")) {
                     GeneralVariables.swr_switch_on = result.equals("1");

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -53,6 +53,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -116,6 +118,12 @@ internal enum class MapViewMode { STANDARD, AZIMUTHAL }
 private const val MAP_MIN_ZOOM = 1f
 private const val MAP_MAX_ZOOM = 8f
 private const val MAP_ZOOM_STEP = 2f
+
+// Gray-line overlay colors. The night side is a translucent navy wash so land
+// and markers stay legible beneath it; the terminator itself is a soft amber
+// stroke — the "gray line" HF operators chase for enhanced propagation.
+private val GrayLineNightFill = Color(0x4A0B1220)
+private val GrayLineTerminator = Color(0xB3F5B44A)
 
 // Persists the PSK filter across config changes / process death. band == "" means all.
 private val PskFilterSaver = listSaver<PskFilter, Any>(
@@ -222,6 +230,24 @@ fun MapScreen(mainViewModel: MainViewModel) {
     // changes via PskFilterSaver. Changing it re-runs the fetch (force-once below).
     var pskFilter by rememberSaveable(stateSaver = PskFilterSaver) { mutableStateOf(PskFilter()) }
     var filterSheetOpen by rememberSaveable { mutableStateOf(false) }
+
+    // Gray-line (day/night terminator) overlay. On by default — it's a passive,
+    // translucent shade that HF operators use to spot enhanced-propagation paths.
+    // `nowMillis` ticks once a minute so the terminator creeps across the map in
+    // real time; the Sun moves ~0.25°/min, far slower than the tick.
+    var grayLineEnabled by rememberSaveable { mutableStateOf(GeneralVariables.grayLineEnabled) }
+    var nowMillis by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(grayLineEnabled) {
+        while (grayLineEnabled) {
+            nowMillis = System.currentTimeMillis()
+            delay(60_000L)
+        }
+    }
+    // The night region as a lat/lon ring, recomputed only when the minute ticks
+    // (not every animation frame). The canvas just projects + fills it.
+    val nightRing = remember(grayLineEnabled, nowMillis) {
+        if (grayLineEnabled) nightPolygonLatLon(subsolarPoint(nowMillis)) else null
+    }
 
     // Zoom + pan (issue #51). Scale is clamped to [1, MAX_ZOOM]; pan is clamped so the
     // scaled map can't be dragged entirely off-screen. Both reset whenever the projection
@@ -412,6 +438,7 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 stations = stations,
                 pskSpots = pskSpots,
                 connectionLines = connectionLines,
+                nightRing = nightRing,
                 selectedCallsign = selectedCallsign,
                 onStationSelected = { selectedCallsign = it },
                 scale = mapScale,
@@ -487,6 +514,22 @@ fun MapScreen(mainViewModel: MainViewModel) {
         ) {
             if (pskOverlayEnabled) {
                 FilterPill(active = filterSheetOpen, onClick = { filterSheetOpen = !filterSheetOpen })
+                Spacer(modifier = Modifier.width(6.dp))
+            }
+            // Gray-line toggle — only the equirectangular map draws the terminator.
+            if (viewMode == MapViewMode.STANDARD) {
+                GrayLineToggle(
+                    enabled = grayLineEnabled,
+                    onToggle = { newVal ->
+                        grayLineEnabled = newVal
+                        GeneralVariables.grayLineEnabled = newVal
+                        mainViewModel.databaseOpr.writeConfig(
+                            "grayLineEnabled",
+                            if (newVal) "1" else "0",
+                            null,
+                        )
+                    },
+                )
                 Spacer(modifier = Modifier.width(6.dp))
             }
             PskOverlayToggle(
@@ -763,6 +806,28 @@ internal fun PskOverlayToggle(enabled: Boolean, onToggle: (Boolean) -> Unit) {
     ) {
         Text(
             text = stringResource(R.string.map_overlay_psk),
+            color = if (enabled) BgApp else TextMuted,
+            fontFamily = GeistMonoFamily,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+internal fun GrayLineToggle(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    val cd = stringResource(R.string.map_overlay_grayline_cd)
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (enabled) GrayLineTerminator else BgSurface3)
+            .clickable { onToggle(!enabled) }
+            .semantics { contentDescription = cd }
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.map_overlay_grayline),
             color = if (enabled) BgApp else TextMuted,
             fontFamily = GeistMonoFamily,
             fontSize = 11.sp,
@@ -1059,6 +1124,7 @@ private fun StandardMapCanvas(
     stations: List<StationMarker>,
     pskSpots: List<PskSpotMarker>,
     connectionLines: List<ConnectionLine>,
+    nightRing: FloatArray?,
     selectedCallsign: String?,
     onStationSelected: (String?) -> Unit,
     scale: Float,
@@ -1093,6 +1159,10 @@ private fun StandardMapCanvas(
 
         // Lat/lon grid (over land so it stays visible across continents)
         drawEquirectGrid(vp)
+
+        // Gray-line (day/night terminator) — translucent night wash + amber
+        // terminator stroke, drawn over land/grid but under the markers.
+        nightRing?.let { ring -> drawGrayLine(ring, vp) }
 
         // Operator marker (at projected lat/lon, scaled + panned with map)
         val opPos = vp.projectLatLon(opLat, opLon)
@@ -1366,6 +1436,47 @@ private fun DrawScope.drawWorldLand(rings: List<FloatArray>, vp: EquirectViewpor
     }
     drawPath(path, color = Color(0x4094A3B8))                                  // fill
     drawPath(path, color = Color(0x9094A3B8), style = Stroke(width = 0.75f))   // outline
+}
+
+/**
+ * Draw the gray-line overlay on the equirectangular map: fill the night side
+ * with a translucent wash and stroke the terminator itself. [ring] is the flat
+ * `[lon, lat, …]` night polygon from [nightPolygonLatLon] — its last two
+ * vertices close the ring along the dark pole, so the terminator stroke uses
+ * everything but those two.
+ */
+private fun DrawScope.drawGrayLine(ring: FloatArray, vp: EquirectViewport) {
+    if (ring.size < 8) return
+    val cx = vp.canvasW / 2f
+    val cy = vp.canvasH / 2f
+    val sxUnit = vp.worldPxW / 2f
+    val syUnit = vp.worldPxH / 2f
+    fun px(lon: Float) = cx + (lon / 180f) * sxUnit + vp.panX
+    fun py(lat: Float) = cy + (-lat / 90f) * syUnit + vp.panY
+
+    // Filled night region (the whole closed ring).
+    val fill = Path()
+    var i = 0
+    while (i + 1 < ring.size) {
+        val x = px(ring[i])
+        val y = py(ring[i + 1])
+        if (i == 0) fill.moveTo(x, y) else fill.lineTo(x, y)
+        i += 2
+    }
+    fill.close()
+    drawPath(fill, color = GrayLineNightFill)
+
+    // Terminator stroke — the curve only, dropping the two pole-closing vertices.
+    val curveFloats = ring.size - 4
+    val stroke = Path()
+    var j = 0
+    while (j < curveFloats) {
+        val x = px(ring[j])
+        val y = py(ring[j + 1])
+        if (j == 0) stroke.moveTo(x, y) else stroke.lineTo(x, y)
+        j += 2
+    }
+    drawPath(stroke, color = GrayLineTerminator, style = Stroke(width = 1.5f))
 }
 
 // ---------------------------------------------------------------------------

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/Terminator.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/Terminator.kt
@@ -1,0 +1,151 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import java.util.Calendar
+import java.util.TimeZone
+import kotlin.math.abs
+import kotlin.math.asin
+import kotlin.math.atan
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.tan
+
+/**
+ * Day/night terminator ("gray line") geometry for the world map.
+ *
+ * The gray line — the moving band of sunrise/sunset sweeping across the Earth —
+ * is where HF propagation is briefly enhanced, so operators deliberately hunt
+ * along it. This file computes where the Sun is and where the terminator falls
+ * as pure functions (no Android/Compose types), so the map Composable stays a
+ * thin wrapper and the math is unit-tested directly.
+ *
+ * All angles are degrees unless noted; longitudes are east-positive in
+ * [-180, 180]; times are UTC epoch milliseconds.
+ */
+
+/** The point on Earth directly beneath the Sun (Sun at the zenith). */
+internal data class SubsolarPoint(val lat: Double, val lon: Double)
+
+/**
+ * Sub-solar point for a UTC instant, via the NOAA low-precision solar-position
+ * algorithm. Accurate to a few tenths of a degree — far finer than the map's
+ * grid, and plenty for a gray-line overlay that only has to look right.
+ */
+internal fun subsolarPoint(utcMillis: Long): SubsolarPoint {
+    val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    cal.timeInMillis = utcMillis
+    val dayOfYear = cal.get(Calendar.DAY_OF_YEAR)
+    val hoursUtc = cal.get(Calendar.HOUR_OF_DAY) +
+        cal.get(Calendar.MINUTE) / 60.0 +
+        cal.get(Calendar.SECOND) / 3600.0
+
+    // Fractional-year angle γ (radians): NOAA uses (day - 1) + (hour - 12) / 24.
+    val gamma = 2.0 * Math.PI / 365.0 * (dayOfYear - 1 + (hoursUtc - 12.0) / 24.0)
+
+    // Equation of time (minutes) — the Sun's longitude wobble vs. clock time.
+    val eqTime = 229.18 * (
+        0.000075 +
+            0.001868 * cos(gamma) -
+            0.032077 * sin(gamma) -
+            0.014615 * cos(2 * gamma) -
+            0.040849 * sin(2 * gamma)
+    )
+    // Solar declination (radians) = sub-solar latitude.
+    val declRad = 0.006918 -
+        0.399912 * cos(gamma) + 0.070257 * sin(gamma) -
+        0.006758 * cos(2 * gamma) + 0.000907 * sin(2 * gamma) -
+        0.002697 * cos(3 * gamma) + 0.00148 * sin(3 * gamma)
+
+    val subsolarLat = Math.toDegrees(declRad)
+    // The Sun is overhead at true solar noon; each UTC hour past noon moves that
+    // meridian 15° west. The equation of time nudges it off clock noon.
+    val subsolarLon = normalizeLon(-15.0 * (hoursUtc + eqTime / 60.0 - 12.0))
+    return SubsolarPoint(subsolarLat, subsolarLon)
+}
+
+/** Wrap a longitude into [-180, 180]. */
+internal fun normalizeLon(lon: Double): Double {
+    var l = lon % 360.0
+    if (l > 180.0) l -= 360.0
+    if (l < -180.0) l += 360.0
+    return l
+}
+
+/**
+ * Solar elevation (degrees) at [lat]/[lon] given the [subsolar] point: the Sun's
+ * angle above the horizon. Positive = daytime, negative = night, ≈0 = on the
+ * terminator (the gray line itself).
+ */
+internal fun solarElevationDeg(lat: Double, lon: Double, subsolar: SubsolarPoint): Double {
+    val phi = Math.toRadians(lat)
+    val decl = Math.toRadians(subsolar.lat)
+    val hourAngle = Math.toRadians(lon - subsolar.lon)
+    val sinElev = sin(phi) * sin(decl) + cos(phi) * cos(decl) * cos(hourAngle)
+    return Math.toDegrees(asin(sinElev.coerceIn(-1.0, 1.0)))
+}
+
+/** Whether [lat]/[lon] is on the night side (Sun below the horizon). */
+internal fun isNight(lat: Double, lon: Double, subsolar: SubsolarPoint): Boolean =
+    solarElevationDeg(lat, lon, subsolar) < 0.0
+
+/**
+ * The terminator latitude at a given [lon] — the latitude where the Sun sits on
+ * the horizon. From sin φ·sin δ + cos φ·cos δ·cos H = 0 → tan φ = −cos H / tan δ.
+ *
+ * Near the equinoxes δ → 0 makes the true terminator two vertical meridians with
+ * no single latitude per longitude; |δ| is floored to [MIN_DECL_DEG] so the
+ * curve stays steep-but-finite (a good visual stand-in for the ~2 days a year
+ * this matters) instead of blowing up.
+ */
+internal fun terminatorLatitude(lon: Double, subsolar: SubsolarPoint): Double {
+    val declDeg = subsolar.lat.let {
+        when {
+            it >= 0.0 && it < MIN_DECL_DEG -> MIN_DECL_DEG
+            it < 0.0 && it > -MIN_DECL_DEG -> -MIN_DECL_DEG
+            else -> it
+        }
+    }
+    val decl = Math.toRadians(declDeg)
+    val hourAngle = Math.toRadians(lon - subsolar.lon)
+    return Math.toDegrees(atan(-cos(hourAngle) / tan(decl)))
+}
+
+/** Floor on |declination| used by [terminatorLatitude] to survive the equinox. */
+private const val MIN_DECL_DEG = 0.3
+
+/**
+ * The terminator as a flat `[lon0, lat0, lon1, lat1, …]` polyline sampled every
+ * [stepDeg] degrees of longitude from −180 to +180. Suitable for drawing the
+ * gray-line stroke; see [nightPolygonLatLon] for the filled night region.
+ */
+internal fun terminatorCurveLatLon(subsolar: SubsolarPoint, stepDeg: Double = 3.0): FloatArray {
+    val step = if (stepDeg <= 0.0) 3.0 else stepDeg
+    val out = ArrayList<Float>()
+    var lon = -180.0
+    while (lon <= 180.0 + 1e-9) {
+        out.add(lon.toFloat())
+        out.add(terminatorLatitude(lon, subsolar).toFloat())
+        lon += step
+    }
+    return out.toFloatArray()
+}
+
+/**
+ * The night region as a flat `[lon0, lat0, …]` closed ring: the terminator curve
+ * plus two vertices along whichever pole is in darkness (the south pole when the
+ * Sun is north of the equator, the north pole otherwise). Fill this ring to
+ * shade the dark side of the map.
+ */
+internal fun nightPolygonLatLon(subsolar: SubsolarPoint, stepDeg: Double = 3.0): FloatArray {
+    val curve = terminatorCurveLatLon(subsolar, stepDeg)
+    // Sun north of the equator ⇒ the south pole is dark; close the ring there.
+    val poleLat = if (subsolar.lat >= 0.0) -90f else 90f
+    val out = FloatArray(curve.size + 4)
+    System.arraycopy(curve, 0, out, 0, curve.size)
+    // Curve ends at lon +180; drop to the dark pole, run back to lon −180, and
+    // let the fill auto-close to the curve's first vertex.
+    out[curve.size] = 180f
+    out[curve.size + 1] = poleLat
+    out[curve.size + 2] = -180f
+    out[curve.size + 3] = poleLat
+    return out
+}

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -363,6 +363,8 @@
     <string name="map_mode_standard">STD</string>
     <string name="map_mode_azimuthal">AZ</string>
     <string name="map_overlay_psk">PSK</string>
+    <string name="map_overlay_grayline">GRAY</string>
+    <string name="map_overlay_grayline_cd">Gray line (day/night terminator) overlay</string>
     <string name="map_filter">Filter</string>
     <string name="map_filter_title">PSK filters</string>
     <string name="map_filter_done">Done</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapOverlayToggleTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/MapOverlayToggleTest.kt
@@ -44,6 +44,21 @@ class MapOverlayToggleTest {
     }
 
     @Test
+    fun grayLineToggle_clickEmitsToggledValue() {
+        val label = context.getString(R.string.map_overlay_grayline)
+        var toggledTo: Boolean? = null
+        composeRule.setContent {
+            GrayLineToggle(enabled = true, onToggle = { toggledTo = it })
+        }
+
+        composeRule.onNodeWithText(label).assertIsDisplayed()
+        composeRule.onNodeWithText(label).performClick()
+
+        // Starts enabled, so a tap turns it off.
+        assertThat(toggledTo).isFalse()
+    }
+
+    @Test
     fun mapViewToggle_selectingAzimuthalEmitsThatMode() {
         val azimuthalLabel = context.getString(R.string.map_mode_azimuthal)
         var selected: MapViewMode? = null

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/TerminatorTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/TerminatorTest.kt
@@ -1,0 +1,138 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.TimeZone
+import kotlin.math.abs
+
+/**
+ * Pure unit tests for the day/night terminator (gray-line) math. No Android or
+ * Compose runtime is touched, so these run as plain JVM tests.
+ */
+class TerminatorTest {
+
+    private fun utc(year: Int, month: Int, day: Int, hour: Int, minute: Int = 0): Long =
+        GregorianCalendar(TimeZone.getTimeZone("UTC")).apply {
+            clear()
+            set(year, month, day, hour, minute, 0)
+        }.timeInMillis
+
+    // -----------------------------------------------------------------------
+    // Sub-solar point
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun subsolar_summerSolstice_isNearMaxNorthernDeclination() {
+        // ~June 21: the Sun is overhead near the Tropic of Cancer (+23.44°).
+        val p = subsolarPoint(utc(2024, Calendar.JUNE, 21, 12))
+        assertThat(p.lat).isWithin(0.6).of(23.44)
+    }
+
+    @Test
+    fun subsolar_winterSolstice_isNearMaxSouthernDeclination() {
+        // ~Dec 21: the Sun is overhead near the Tropic of Capricorn (−23.44°).
+        val p = subsolarPoint(utc(2024, Calendar.DECEMBER, 21, 12))
+        assertThat(p.lat).isWithin(0.6).of(-23.44)
+    }
+
+    @Test
+    fun subsolar_equinox_isNearEquator() {
+        val p = subsolarPoint(utc(2024, Calendar.MARCH, 20, 12))
+        assertThat(abs(p.lat)).isLessThan(1.0)
+    }
+
+    @Test
+    fun subsolar_longitudeTracksUtcHour() {
+        // At 12:00 UTC the Sun is near the prime meridian (± the equation of time).
+        assertThat(abs(subsolarPoint(utc(2024, Calendar.MARCH, 20, 12)).lon)).isLessThan(2.0)
+        // Each hour before/after noon shifts the sub-solar meridian 15° east/west.
+        assertThat(subsolarPoint(utc(2024, Calendar.MARCH, 20, 6)).lon).isWithin(2.0).of(90.0)
+        assertThat(subsolarPoint(utc(2024, Calendar.MARCH, 20, 18)).lon).isWithin(2.0).of(-90.0)
+    }
+
+    @Test
+    fun normalizeLon_wrapsIntoRange() {
+        assertThat(normalizeLon(190.0)).isWithin(1e-9).of(-170.0)
+        assertThat(normalizeLon(-190.0)).isWithin(1e-9).of(170.0)
+        assertThat(normalizeLon(45.0)).isWithin(1e-9).of(45.0)
+        assertThat(normalizeLon(540.0)).isWithin(1e-9).of(180.0)
+    }
+
+    // -----------------------------------------------------------------------
+    // Solar elevation / night test
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun solarElevation_isMaxAtSubsolarPoint_andMinAtAntipode() {
+        val sub = SubsolarPoint(lat = 10.0, lon = 40.0)
+        assertThat(solarElevationDeg(10.0, 40.0, sub)).isWithin(1e-6).of(90.0)
+        assertThat(solarElevationDeg(-10.0, normalizeLon(40.0 + 180.0), sub)).isWithin(1e-6).of(-90.0)
+    }
+
+    @Test
+    fun isNight_subsolarIsDay_antipodeIsNight() {
+        val sub = SubsolarPoint(lat = 0.0, lon = 0.0)
+        assertThat(isNight(0.0, 0.0, sub)).isFalse()
+        assertThat(isNight(0.0, 180.0, sub)).isTrue()
+    }
+
+    // -----------------------------------------------------------------------
+    // Terminator latitude
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun terminatorLatitude_liesOnTheZeroElevationBoundary() {
+        // Well away from the equinox so |δ| isn't floored: the returned latitude
+        // is exactly where the Sun grazes the horizon (elevation ≈ 0).
+        val sub = subsolarPoint(utc(2024, Calendar.JUNE, 21, 9))
+        for (lon in -180..180 step 30) {
+            val lat = terminatorLatitude(lon.toDouble(), sub)
+            assertThat(solarElevationDeg(lat, lon.toDouble(), sub)).isWithin(1e-6).of(0.0)
+        }
+    }
+
+    @Test
+    fun terminatorLatitude_survivesEquinoxWithoutBlowingUp() {
+        // δ ≈ 0: without the floor this divides by ~0. Assert it stays finite and
+        // in-range instead of producing NaN/∞.
+        val sub = SubsolarPoint(lat = 0.0, lon = 0.0)
+        val lat = terminatorLatitude(45.0, sub)
+        assertThat(lat.isFinite()).isTrue()
+        assertThat(abs(lat)).isAtMost(90.0)
+    }
+
+    // -----------------------------------------------------------------------
+    // Night polygon
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun terminatorCurve_spansFullLongitudeRange() {
+        val curve = terminatorCurveLatLon(SubsolarPoint(20.0, 0.0), stepDeg = 3.0)
+        assertThat(curve.size % 2).isEqualTo(0)
+        assertThat(curve.first()).isWithin(1e-3f).of(-180f) // first lon
+        assertThat(curve[curve.size - 2]).isWithin(1e-3f).of(180f) // last lon
+    }
+
+    @Test
+    fun nightPolygon_closesToTheDarkPole() {
+        // Sun in the north ⇒ the south pole is dark: the ring closes at lat −90.
+        val north = nightPolygonLatLon(SubsolarPoint(20.0, 0.0), stepDeg = 3.0)
+        assertThat(north[north.size - 1]).isWithin(1e-3f).of(-90f)
+        assertThat(north[north.size - 3]).isWithin(1e-3f).of(-90f)
+
+        // Sun in the south ⇒ the north pole is dark: the ring closes at lat +90.
+        val south = nightPolygonLatLon(SubsolarPoint(-20.0, 0.0), stepDeg = 3.0)
+        assertThat(south[south.size - 1]).isWithin(1e-3f).of(90f)
+        assertThat(south[south.size - 3]).isWithin(1e-3f).of(90f)
+    }
+
+    @Test
+    fun nightPolygon_hasFourMoreCoordsThanTheCurve() {
+        val sub = SubsolarPoint(15.0, -30.0)
+        val curve = terminatorCurveLatLon(sub, stepDeg = 5.0)
+        val ring = nightPolygonLatLon(sub, stepDeg = 5.0)
+        assertThat(ring.size).isEqualTo(curve.size + 4)
+    }
+}


### PR DESCRIPTION
## What & why

Serious HF operators chase the **gray line** — the moving band of sunrise/sunset sweeping across the Earth, where ionospheric propagation is briefly enhanced and long-haul DX opens up. WSJT-X companions, DX Atlas, and most serious logging maps show it; FT8AF's world map didn't. This adds a real day/night terminator overlay.

**"Wow, I wish every FT8 app did this."** — you glance at the map and instantly see which paths are lit by the gray line right now.

## What it looks like

On the standard (equirectangular) map:
- The **night side** is shaded with a translucent navy wash — land and station/PSK markers stay legible beneath it.
- The **terminator** itself is drawn as a soft amber line (the gray line operators aim for).
- It **creeps across the map in real time**, recomputed once a minute (the Sun moves ~0.25°/min, so a minute cadence is smooth and cheap — no per-frame trig, no battery cost).

A **`GRAY` toggle** sits next to the existing PSK overlay toggle (shown on the standard view only, since that's the map that draws it). Its state persists via a new `grayLineEnabled` config key, loaded the same way as `pskOverlayEnabled`. It defaults **on** so users notice the feature immediately; one tap turns it off.

## How it's built

Following the project's "extract pure logic, keep the Composable thin" convention:

- **New `Terminator.kt`** holds all the solar geometry as pure functions, free of Android/Compose types:
  - `subsolarPoint(utcMillis)` — the point beneath the Sun, via the NOAA low-precision solar-position algorithm (declination + equation of time), accurate to a few tenths of a degree.
  - `solarElevationDeg` / `isNight` — day/night test at any lat/lon.
  - `terminatorLatitude` — where the Sun grazes the horizon for a given longitude, with |declination| floored so the equinox (δ→0) stays finite instead of blowing up.
  - `terminatorCurveLatLon` / `nightPolygonLatLon` — the drawable geometry (curve + a closing edge along whichever pole is dark).
- `MapScreen`'s `StandardMapCanvas` gets a thin `drawGrayLine` DrawScope helper that projects the polygon through the existing viewport and fills/strokes it, layered over land/grid but under the markers.

## Tests

- **`TerminatorTest`** (plain JVM): solstice/equinox sub-solar latitudes, the sub-solar meridian tracking UTC hour, longitude wrap, elevation max/min at sub-solar/antipode, the terminator lying on the zero-elevation boundary, equinox stability, and the night-polygon closing at the correct pole.
- **`MapOverlayToggleTest`** gains a Robolectric case for the new toggle control.

## Scope / notes

- Overlay is on the **standard** map only; the azimuthal projection is left as a natural follow-up (its clip-to-disc terminator is more involved).
- Uses wall-clock time for the Sun position, which is more than accurate enough.

Full `assembleDebug` and the complete `testDebugUnitTest` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)