### PR TITLE
Add a callsign watchlist that alerts the instant a wanted station is decoded

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -220,6 +220,15 @@ public class GeneralVariables {
     private static final java.util.LinkedHashSet<String> blockedExactCallsigns = new java.util.LinkedHashSet<>();
     private static final java.util.LinkedHashSet<String> blockedKeywords = new java.util.LinkedHashSet<>();
 
+    // Callsign watchlist (Settings → Needed-DX Alerts → Watchlist). When non-empty,
+    // a decoded message from a matching station fires a high-priority alert (sound +
+    // vibrate + notification) via DxAlertNotifier — the "tell me the instant this
+    // station is on the air" hunt tool for a rare DXpedition, a needed prefix, or a
+    // friend. Entries match by callsign PREFIX (so "3Y0" catches 3Y0J and 3Y0J/MM,
+    // and a full call like "W1AW" also matches "W1AW/P"), mirroring the excluded-
+    // callsign prefix semantics. Unlike the needed-DX alerts it is not CQ-gated.
+    private static final java.util.LinkedHashSet<String> watchCallsigns = new java.util.LinkedHashSet<>();
+
     /**
      * Split a user-entered list on comma / space / pipe / Chinese comma and
      * collect the non-empty, upper-cased tokens into {@code target}.
@@ -295,6 +304,37 @@ public class GeneralVariables {
 
     public static synchronized String getBlockedKeywords() {
         return joinBlockTokens(blockedKeywords);
+    }
+
+    /** Replace the callsign watchlist from a user-entered comma/space/pipe list. */
+    public static synchronized void addWatchCallsigns(String callsigns) {
+        parseBlockTokens(callsigns, watchCallsigns);
+    }
+
+    /** The watchlist in canonical comma-separated form (for persistence + display). */
+    public static synchronized String getWatchCallsigns() {
+        return joinBlockTokens(watchCallsigns);
+    }
+
+    /** Whether the user has any watchlist entries (gates the watchlist alert). */
+    public static synchronized boolean hasWatchCallsigns() {
+        return !watchCallsigns.isEmpty();
+    }
+
+    /**
+     * Whether {@code callsign} matches the watchlist by PREFIX (case-insensitive):
+     * "3Y0" matches 3Y0J / 3Y0J/MM, "W1AW" matches W1AW / W1AW/P. Anchored at the
+     * start, so "W1AW" does not match "KW1AW". Empty list matches nothing.
+     */
+    public static synchronized boolean checkIsWatchedCallsign(String callsign) {
+        if (callsign == null || watchCallsigns.isEmpty()) return false;
+        String up = callsign.toUpperCase();
+        for (String prefix : watchCallsigns) {
+            if (up.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/alert/AlertDecisions.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/alert/AlertDecisions.java
@@ -42,6 +42,27 @@ public final class AlertDecisions {
         return "QSO:" + norm(toCallsign) + "|" + norm(endTime);
     }
 
+    /**
+     * Watchlist alert — fire when a decoded station matches the user's callsign
+     * watchlist (a rare DXpedition prefix, a needed call, a friend). Unlike the
+     * needed-DX alerts this is not CQ-gated: the point is to know the instant the
+     * station is on the air, whatever it's transmitting.
+     *
+     * @param hasWatchlist whether the user has any watchlist entries (the feature is
+     *                     active purely by having a non-empty list — no separate toggle)
+     * @param matched      whether the decoded sender matches a watchlist entry
+     *                     (resolved by the caller via {@code checkIsWatchedCallsign})
+     * @param blocked      whether the message is filtered by the user's block list
+     */
+    public static boolean shouldAlertWatch(boolean hasWatchlist, boolean matched, boolean blocked) {
+        return hasWatchlist && matched && !blocked;
+    }
+
+    /** Dedup key for a watchlist alert: alert once per session per watched station. */
+    public static String watchDedupKey(String fromCallsign) {
+        return "WATCH:" + norm(fromCallsign);
+    }
+
     private static String norm(String s) {
         return s == null ? "" : s.trim().toUpperCase();
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
@@ -30,7 +30,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * <ul>
  *   <li>{@code dx_alerts} — a station calling CQ that is a NEW (unworked) entity in a
  *       user-enabled category: a new DXCC ({@link GeneralVariables#alertNewDxcc}) or US
- *       state ({@link GeneralVariables#alertNewState}). Driven from
+ *       state ({@link GeneralVariables#alertNewState}); and any decode from a station on
+ *       the user's callsign watchlist ({@link GeneralVariables#checkIsWatchedCallsign},
+ *       not CQ-gated). Driven from
  *       {@code MainViewModel.GetQTHRunnable.run()} once the {@code from*} flags are set.</li>
  *   <li>{@code qso_alerts} — someone calling YOU
  *       ({@link GeneralVariables#alertOnCqReply}, also driven from {@code processDecodes})
@@ -65,7 +67,7 @@ public class DxAlertNotifier {
                 appContext.getSystemService(Context.NOTIFICATION_SERVICE);
         if (nm == null) return;
         createHighChannel(nm, CHANNEL_ID, "Needed-DX alerts",
-                "New DXCC / US state stations calling CQ");
+                "New DXCC / US state stations calling CQ, and watchlist callsigns");
         createHighChannel(nm, QSO_CHANNEL_ID, "QSO & CQ alerts",
                 "Someone calling you, and completed-QSO alerts");
     }
@@ -95,13 +97,26 @@ public class DxAlertNotifier {
     public void processDecodes(List<Ft8Message> messages) {
         if (appContext == null || messages == null) return;
         if (!GeneralVariables.alertNewDxcc && !GeneralVariables.alertNewState
-                && !GeneralVariables.alertOnCqReply) {
+                && !GeneralVariables.alertOnCqReply && !GeneralVariables.hasWatchCallsigns()) {
             return;
         }
 
         for (Ft8Message msg : messages) {
             if (msg == null) continue;
             if (GeneralVariables.checkIsBlockedMessage(msg)) continue;
+
+            // Watchlist: any decode from a station on the user's watchlist — a rare
+            // DXpedition, a needed prefix, a friend. NOT CQ-gated (checked before the
+            // CQ-only continue below) so an in-QSO watched station still alerts the
+            // instant it's on the air. Blocked messages already `continue`d above.
+            boolean watched = GeneralVariables.checkIsWatchedCallsign(msg.getCallsignFrom());
+            if (AlertDecisions.shouldAlertWatch(
+                    GeneralVariables.hasWatchCallsigns(), watched, false)) {
+                fire(AlertDecisions.watchDedupKey(msg.getCallsignFrom()),
+                        CHANNEL_ID,
+                        appContext.getString(R.string.alert_watch_title, msg.getCallsignFrom()),
+                        defaultBody(msg), msg.getCallsignFrom(), msg.band);
+            }
 
             // CQ reply: any decoded message addressed to my callsign. The batch is already
             // own-TX-echo filtered upstream, so a message to my call is another station

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2891,6 +2891,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("blockedKeywords")) {//Blocklist: keyword substrings
                     GeneralVariables.addBlockedKeywords(result);
                 }
+                if (name.equalsIgnoreCase("watchCallsigns")) {//Watchlist: alert on these call(prefix)es
+                    GeneralVariables.addWatchCallsigns(result);
+                }
                 if (name.equalsIgnoreCase("filterShowOnlyCQ")) {//Decode filter: CQ only
                     GeneralVariables.filterShowOnlyCQ = result.equals("1");
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
@@ -52,6 +52,7 @@ fun DecodeFilterSettings(
     var alertNewState by remember { mutableStateOf(GeneralVariables.alertNewState) }
     var alertOnCqReply by remember { mutableStateOf(GeneralVariables.alertOnCqReply) }
     var alertOnQsoComplete by remember { mutableStateOf(GeneralVariables.alertOnQsoComplete) }
+    var watchCallsigns by remember { mutableStateOf(GeneralVariables.getWatchCallsigns()) }
 
     // Continent codes (stored on the message) and their display names, parallel lists.
     val continentCodes = listOf("NA", "SA", "EU", "AF", "AS", "OC", "AN")
@@ -88,6 +89,7 @@ fun DecodeFilterSettings(
     var showWorkedModePicker by remember { mutableStateOf(false) }
     var showWorkedScopePicker by remember { mutableStateOf(false) }
     var showWorkedListDialog by remember { mutableStateOf(false) }
+    var showWatchDialog by remember { mutableStateOf(false) }
 
     // -- Blocklist: exact whole-call dialog --
     if (showBlockExactDialog) {
@@ -199,6 +201,22 @@ fun DecodeFilterSettings(
                 workedStationList = GeneralVariables.getWorkedStationList()
                 mainViewModel.databaseOpr.writeConfig("workedStationList", workedStationList, null)
                 showWorkedListDialog = false
+            },
+        )
+    }
+
+    // -- Needed-DX alerts: callsign watchlist editor --
+    if (showWatchDialog) {
+        TextListDialog(
+            title = stringResource(R.string.settings_watch_dialog_title),
+            description = stringResource(R.string.settings_watch_dialog_desc),
+            initialValue = watchCallsigns,
+            onDismiss = { showWatchDialog = false },
+            onSave = { text ->
+                GeneralVariables.addWatchCallsigns(text)
+                watchCallsigns = GeneralVariables.getWatchCallsigns()
+                mainViewModel.databaseOpr.writeConfig("watchCallsigns", watchCallsigns, null)
+                showWatchDialog = false
             },
         )
     }
@@ -484,6 +502,14 @@ fun DecodeFilterSettings(
         SettingsSection(title = stringResource(R.string.settings_section_needed_dx_alerts)) {
             GlassCard(modifier = Modifier.fillMaxWidth()) {
                 Column {
+                    SettingsRow(
+                        label = stringResource(R.string.settings_alert_watchlist),
+                        description = stringResource(R.string.settings_alert_watchlist_desc),
+                        value = watchCallsigns.ifBlank { stringResource(R.string.common_none) },
+                        showChevron = true,
+                        onClick = { showWatchDialog = true },
+                    )
+                    SectionDivider()
                     SettingsRow(
                         label = stringResource(R.string.settings_alert_new_dxcc),
                         description = stringResource(R.string.settings_alert_new_dxcc_desc),

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -618,6 +618,11 @@
     <string name="settings_alert_qso_complete_desc">Sound + vibrate + notify when a QSO is logged</string>
     <string name="alert_cq_reply_title">Calling you: %1$s</string>
     <string name="alert_qso_complete_title">QSO complete</string>
+    <string name="settings_alert_watchlist">Callsign watchlist</string>
+    <string name="settings_alert_watchlist_desc">Sound + vibrate + notify the moment a watched callsign or prefix is decoded, on any band</string>
+    <string name="settings_watch_dialog_title">Callsign watchlist</string>
+    <string name="settings_watch_dialog_desc">Comma-separated calls or prefixes (e.g. 3Y0, W1AW, TX7). An alert fires the instant a match is decoded — matched by prefix, so a DXpedition prefix catches every variant.</string>
+    <string name="alert_watch_title">Watchlist: %1$s</string>
     <string name="rx_service_channel_name">Background receiving</string>
     <string name="rx_service_channel_desc">Keeps FT8 decoding running while the app is in the background or the screen is off</string>
     <string name="rx_service_title">FT8AF is receiving</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesWatchCallsignTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesWatchCallsignTest.java
@@ -1,0 +1,75 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Pins the callsign watchlist matcher used by the "Watchlist" alert
+ * ({@link com.k1af.ft8af.alert.DxAlertNotifier}). Entries match by callsign
+ * PREFIX so a DXpedition prefix (e.g. "3Y0") catches every variant it decodes
+ * and a full call ("W1AW") still matches a portable suffix ("W1AW/P").
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesWatchCallsignTest {
+
+    @Before
+    public void setUp() {
+        GeneralVariables.addWatchCallsigns("");
+    }
+
+    @After
+    public void tearDown() {
+        GeneralVariables.addWatchCallsigns("");
+    }
+
+    @Test
+    public void emptyWatchlist_matchesNothing_andReportsEmpty() {
+        assertThat(GeneralVariables.hasWatchCallsigns()).isFalse();
+        assertThat(GeneralVariables.checkIsWatchedCallsign("3Y0J")).isFalse();
+    }
+
+    @Test
+    public void addAndGet_roundTripsCanonicalCsv() {
+        GeneralVariables.addWatchCallsigns("3y0, w1aw");
+        assertThat(GeneralVariables.hasWatchCallsigns()).isTrue();
+        assertThat(GeneralVariables.getWatchCallsigns()).isEqualTo("3Y0,W1AW");
+    }
+
+    @Test
+    public void prefixMatch_catchesDxpeditionVariants() {
+        GeneralVariables.addWatchCallsigns("3Y0");
+        assertThat(GeneralVariables.checkIsWatchedCallsign("3Y0J")).isTrue();
+        assertThat(GeneralVariables.checkIsWatchedCallsign("3Y0J/MM")).isTrue();
+        // Same prefix, different station still counts — that's the point of a prefix watch.
+        assertThat(GeneralVariables.checkIsWatchedCallsign("3Y0K")).isTrue();
+        // A different entity must not match.
+        assertThat(GeneralVariables.checkIsWatchedCallsign("W1AW")).isFalse();
+    }
+
+    @Test
+    public void fullCall_stillMatchesPortableSuffix() {
+        GeneralVariables.addWatchCallsigns("W1AW");
+        assertThat(GeneralVariables.checkIsWatchedCallsign("W1AW")).isTrue();
+        assertThat(GeneralVariables.checkIsWatchedCallsign("W1AW/P")).isTrue();
+        // Must not match a different call that merely shares a leading substring in
+        // the middle — the match is anchored at the start.
+        assertThat(GeneralVariables.checkIsWatchedCallsign("KW1AW")).isFalse();
+    }
+
+    @Test
+    public void matcher_isCaseInsensitive() {
+        GeneralVariables.addWatchCallsigns("tx7");
+        assertThat(GeneralVariables.checkIsWatchedCallsign("TX7L")).isTrue();
+    }
+
+    @Test
+    public void nullCallsign_isSafe() {
+        GeneralVariables.addWatchCallsigns("W1AW");
+        assertThat(GeneralVariables.checkIsWatchedCallsign(null)).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/alert/AlertDecisionsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/alert/AlertDecisionsTest.java
@@ -53,4 +53,39 @@ public class AlertDecisionsTest {
         assertThat(k).isEqualTo("QSO:W5XYZ|20231114-123456");
         assertThat(k).isNotEqualTo(AlertDecisions.qsoCompleteDedupKey("W5XYZ", "20231114-123457"));
     }
+
+    @Test
+    public void watch_firesOnlyWhenListNonEmptyMatchedAndNotBlocked() {
+        assertThat(AlertDecisions.shouldAlertWatch(true, true, false)).isTrue();
+    }
+
+    @Test
+    public void watch_suppressedWhenListEmpty() {
+        assertThat(AlertDecisions.shouldAlertWatch(false, true, false)).isFalse();
+    }
+
+    @Test
+    public void watch_suppressedWhenNotMatched() {
+        assertThat(AlertDecisions.shouldAlertWatch(true, false, false)).isFalse();
+    }
+
+    @Test
+    public void watch_suppressedWhenBlocked() {
+        assertThat(AlertDecisions.shouldAlertWatch(true, true, true)).isFalse();
+    }
+
+    @Test
+    public void watchDedupKey_isStableAndCaseInsensitive() {
+        String a = AlertDecisions.watchDedupKey(" 3y0j ");
+        String b = AlertDecisions.watchDedupKey("3Y0J");
+        assertThat(a).isEqualTo(b);
+        assertThat(a).isEqualTo("WATCH:3Y0J");
+    }
+
+    @Test
+    public void watchDedupKey_differsPerCallAndHandlesNull() {
+        assertThat(AlertDecisions.watchDedupKey("W1AW"))
+                .isNotEqualTo(AlertDecisions.watchDedupKey("W2AW"));
+        assertThat(AlertDecisions.watchDedupKey(null)).isEqualTo("WATCH:");
+    }
 }


### PR DESCRIPTION
## What & why

DXers and friend-hunters constantly want to know **the moment a specific station shows up** — a rare DXpedition (`3Y0J`), a needed prefix, or a friend — without having to watch the decode list every cycle. FT8AF already fires sound/vibrate/notification alerts for **new DXCC**, **new US state**, **someone calling you**, and **QSO complete**, but there was no way to watch a *chosen* callsign.

This adds a **Callsign watchlist** to **Settings → Decode Filters → Needed-DX Alerts**.

- Enter comma-separated calls or prefixes, e.g. `3Y0, W1AW, TX7`.
- The instant any decoded station whose callsign **starts with** a watchlist entry is heard — **on any band**, and whether it's calling CQ or mid-QSO — a high-priority **sound + vibrate + notification** fires.
- Tapping the notification pre-selects that station on the Decode screen (existing `EXTRA_CALLSIGN` intent path).
- **Prefix matching** is what makes this a hunt tool: a DXpedition prefix catches every variant it puts out (`3Y0J`, `3Y0J/MM`), and a full call still matches its portable suffix (`W1AW/P`). Anchored at the start, so `W1AW` never matches `KW1AW`.
- Deduped once per station per session (reusing the existing `dx_alerts` notification channel), so a watched station calling every cycle only buzzes once.

If you released this today, a DX chaser would immediately appreciate never missing a rare one again.

## Implementation

Reuses the existing alert plumbing end to end:

- `GeneralVariables`: `watchCallsigns` set + `addWatchCallsigns` / `getWatchCallsigns` / `hasWatchCallsigns` / `checkIsWatchedCallsign`, mirroring the blocklist's token parsing and prefix-match semantics.
- `AlertDecisions`: pure `shouldAlertWatch(...)` gate + `watchDedupKey(...)` (namespaced `WATCH:`), matching the existing CQ-reply/QSO-complete decision helpers.
- `DxAlertNotifier.processDecodes`: fires the watch alert **before** the CQ-only gate (so an in-QSO watched station still alerts). The early-return guard now also stays active when only the watchlist is set. Blocked messages already `continue` upstream.
- `DatabaseOpr`: loads the `watchCallsigns` config key on startup.
- `DecodeFilterSettings`: a "Callsign watchlist" editor row (reusing `TextListDialog`) at the top of the Needed-DX Alerts section, persisted via `writeConfig("watchCallsigns", …)`.

No new notification channel, no schema change, no impact on the decode/TX path — the feature is inert unless the user adds a watchlist entry.

## Testing

- `AlertDecisionsTest`: new cases for `shouldAlertWatch` (list-empty / not-matched / blocked suppression) and `watchDedupKey` (stable, case-insensitive, null-safe).
- `GeneralVariablesWatchCallsignTest` (new, Robolectric): prefix match catches DXpedition variants, full call matches portable suffix but not a leading-substring collision, case-insensitivity, null safety, CSV round-trip.
- `./gradlew :app:testDebugUnitTest --tests …` green; full `:app:assembleDebug` builds (native + Kotlin) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)