### PR TITLE
Add callsign/grid/band search to the Logbook Recent tab

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -57,7 +58,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -1185,6 +1189,35 @@ internal fun sortQsosByDateTimeDesc(
     records: List<QSLCallsignRecord>,
 ): List<QSLCallsignRecord> = records.sortedByDescending { qsoSortKey(it) }
 
+/**
+ * Filter the recent-QSO list by a free-text [query] typed into the logbook search
+ * box. A blank/whitespace query returns the list unchanged (no filtering).
+ *
+ * Otherwise the trimmed query is matched case-insensitively as a *substring*
+ * against the fields an operator actually searches a log by — callsign (the
+ * primary target), grid, band, DXCC entity, and the stored "where" location — so
+ * typing a partial call ("K1A"), a grid ("FN42"), a band ("40M"), or a country
+ * narrows the log to the matching contacts. Matching a substring (rather than a
+ * prefix) means "PA" finds both "PA3XYZ" and "W1PA". Extracted as a pure function
+ * so the search behavior is unit-tested without Compose.
+ */
+internal fun filterQsoRecords(
+    records: List<QSLCallsignRecord>,
+    query: String,
+): List<QSLCallsignRecord> {
+    val q = query.trim().uppercase()
+    if (q.isEmpty()) return records
+    return records.filter { record ->
+        sequenceOf(
+            record.callsign,
+            record.grid,
+            record.band,
+            record.dxccStr,
+            record.where,
+        ).any { it != null && it.uppercase().contains(q) }
+    }
+}
+
 internal fun qsoSortKey(record: QSLCallsignRecord): String {
     val date = (record.lastTime ?: "").padEnd(8, '0')
     return date + normalizeTimeOn(record.timeOn)
@@ -1235,28 +1268,126 @@ private fun RecentTab(
         return
     }
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 18.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        items(
-            items = sortQsosByDateTimeDesc(records),
-            // Include id so an edit that changes other fields still maps to a stable key,
-            // and so two grouped rows with otherwise identical display fields don't collide.
-            key = { "${it.id}_${it.callsign}_${it.lastTime}_${it.band}" },
-        ) { record ->
-            QsoRow(
-                record = record,
-                onEdit = { onEdit(record) },
-                onDelete = { onDelete(record) },
-            )
-        }
+    // Free-text search over the log (callsign / grid / band / DXCC). Kept in a
+    // rememberSaveable so the query survives recomposition and rotation; it resets
+    // when the operator leaves the Logbook, which matches the expectation that
+    // search is a transient "find this contact" action, not a persisted filter.
+    var query by rememberSaveable { mutableStateOf("") }
+    val filtered = remember(records, query) { filterQsoRecords(records, query) }
 
-        // Bottom spacer for safe area
-        item { Spacer(modifier = Modifier.height(16.dp)) }
+    Column(modifier = Modifier.fillMaxSize()) {
+        LogSearchBar(
+            query = query,
+            onQueryChange = { query = it },
+            modifier = Modifier
+                .padding(horizontal = 18.dp)
+                .padding(bottom = 6.dp),
+        )
+
+        if (filtered.isEmpty()) {
+            // Records exist but none match — keep the search bar above so the
+            // operator can refine or clear the query.
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 32.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                EmptyStateWaves(size = 140.dp)
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.log_search_no_results_title),
+                    color = TextMuted,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.log_search_no_results_body, query.trim()),
+                    color = TextFaint,
+                    fontSize = 12.sp,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 18.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                items(
+                    items = sortQsosByDateTimeDesc(filtered),
+                    // Include id so an edit that changes other fields still maps to a stable key,
+                    // and so two grouped rows with otherwise identical display fields don't collide.
+                    key = { "${it.id}_${it.callsign}_${it.lastTime}_${it.band}" },
+                ) { record ->
+                    QsoRow(
+                        record = record,
+                        onEdit = { onEdit(record) },
+                        onDelete = { onDelete(record) },
+                    )
+                }
+
+                // Bottom spacer for safe area
+                item { Spacer(modifier = Modifier.height(16.dp)) }
+            }
+        }
     }
+}
+
+/**
+ * Search field for the Logbook Recent tab. A thin Compose wrapper around an
+ * [OutlinedTextField]; all match logic lives in the pure [filterQsoRecords].
+ */
+@Composable
+private fun LogSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = modifier.fillMaxWidth(),
+        singleLine = true,
+        placeholder = {
+            Text(
+                text = stringResource(R.string.log_search_hint),
+                color = TextFaint,
+                fontSize = 13.sp,
+                fontFamily = GeistMonoFamily,
+            )
+        },
+        leadingIcon = {
+            radio.ks3ckc.ft8af.ui.components.FT8AFIcons.Search(color = TextMuted, size = 18.dp)
+        },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                val clearLabel = stringResource(R.string.log_search_clear)
+                IconButton(onClick = { onQueryChange("") }) {
+                    radio.ks3ckc.ft8af.ui.components.FT8AFIcons.Close(
+                        modifier = Modifier.semantics { contentDescription = clearLabel },
+                        color = TextMuted,
+                        size = 18.dp,
+                    )
+                }
+            }
+        },
+        textStyle = TextStyle(
+            color = TextPrimary,
+            fontSize = 14.sp,
+            fontFamily = GeistMonoFamily,
+        ),
+        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedTextColor = TextPrimary,
+            unfocusedTextColor = TextPrimary,
+            cursorColor = Accent,
+            focusedBorderColor = Accent,
+            unfocusedBorderColor = Border,
+        ),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -245,6 +245,10 @@
     <string name="log_section_signal_trend">Signal Trend</string>
     <string name="log_no_qsos_yet">No QSOs yet</string>
     <string name="log_no_qsos_recorded_yet">No QSOs recorded yet</string>
+    <string name="log_search_hint">Search callsign, grid, band…</string>
+    <string name="log_search_clear">Clear search</string>
+    <string name="log_search_no_results_title">No matching QSOs</string>
+    <string name="log_search_no_results_body">Nothing in your log matches “%1$s”</string>
     <string name="log_state_usa">%1$s, USA</string>
     <string name="log_cd_qso_actions">QSO actions</string>
     <string name="log_action_edit">Edit</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookSearchTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookSearchTest.kt
@@ -1,0 +1,122 @@
+package radio.ks3ckc.ft8af.ui.logbook
+
+import com.k1af.ft8af.log.QSLCallsignRecord
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [filterQsoRecords], the pure search extracted from the Logbook
+ * Recent tab so an operator can find a contact by callsign, grid, band, or DXCC.
+ *
+ * QSLCallsignRecord is a plain POJO, so these run on the bare JVM with no
+ * Robolectric.
+ */
+class LogbookSearchTest {
+
+    private fun record(
+        callsign: String,
+        grid: String = "",
+        band: String = "",
+        dxcc: String = "",
+        where: String? = null,
+    ): QSLCallsignRecord {
+        val r = QSLCallsignRecord()
+        r.setCallsign(callsign)
+        r.setGrid(grid)
+        r.setBand(band)
+        r.dxccStr = dxcc
+        r.where = where
+        return r
+    }
+
+    private fun calls(records: List<QSLCallsignRecord>): List<String?> =
+        records.map { it.callsign }
+
+    private val log = listOf(
+        record("K1ABC", grid = "FN42", band = "20M", dxcc = "United States"),
+        record("PA3XYZ", grid = "JO22", band = "40M", dxcc = "Netherlands"),
+        record("VK2DEF", grid = "QF56", band = "20M", dxcc = "Australia"),
+        record("JA1QRP", grid = "PM95", band = "15M", dxcc = "Japan"),
+    )
+
+    @Test
+    fun blankQueryReturnsEverythingUnchanged() {
+        assertThat(filterQsoRecords(log, "")).isEqualTo(log)
+        assertThat(filterQsoRecords(log, "   ")).isEqualTo(log)
+    }
+
+    @Test
+    fun matchesByCallsignPrefix() {
+        val result = filterQsoRecords(log, "K1")
+        assertThat(calls(result)).containsExactly("K1ABC")
+    }
+
+    @Test
+    fun matchesCallsignSubstringNotJustPrefix() {
+        // "XYZ" appears at the end of a callsign — a substring match (not a prefix
+        // match) must still find it so the search is forgiving.
+        val busier = listOf(
+            record("PA3XYZ", grid = "JO22", band = "40M"),
+            record("W1ABC", grid = "FN31", band = "20M"),
+            record("K9XYZ", grid = "EN52", band = "15M"),
+        )
+        val result = filterQsoRecords(busier, "XYZ")
+        assertThat(calls(result)).containsExactly("PA3XYZ", "K9XYZ").inOrder()
+    }
+
+    @Test
+    fun isCaseInsensitive() {
+        val result = filterQsoRecords(log, "ja1qrp")
+        assertThat(calls(result)).containsExactly("JA1QRP")
+    }
+
+    @Test
+    fun matchesByGrid() {
+        val result = filterQsoRecords(log, "JO22")
+        assertThat(calls(result)).containsExactly("PA3XYZ")
+    }
+
+    @Test
+    fun matchesByBand() {
+        val result = filterQsoRecords(log, "20M")
+        assertThat(calls(result)).containsExactly("K1ABC", "VK2DEF").inOrder()
+    }
+
+    @Test
+    fun matchesByDxccEntity() {
+        val result = filterQsoRecords(log, "japan")
+        assertThat(calls(result)).containsExactly("JA1QRP")
+    }
+
+    @Test
+    fun matchesByWhereLocation() {
+        val withWhere = listOf(record("EA8ABC", where = "Canary Islands"))
+        val result = filterQsoRecords(withWhere, "canary")
+        assertThat(calls(result)).containsExactly("EA8ABC")
+    }
+
+    @Test
+    fun trimsSurroundingWhitespaceInQuery() {
+        val result = filterQsoRecords(log, "  K1ABC  ")
+        assertThat(calls(result)).containsExactly("K1ABC")
+    }
+
+    @Test
+    fun noMatchReturnsEmpty() {
+        assertThat(filterQsoRecords(log, "ZZ9ZZZ")).isEmpty()
+    }
+
+    @Test
+    fun emptyLogReturnsEmpty() {
+        assertThat(filterQsoRecords(emptyList(), "K1ABC")).isEmpty()
+    }
+
+    @Test
+    fun toleratesNullOptionalFields() {
+        // where is null and dxcc empty on many rows; the match must not NPE and
+        // should still find the callsign.
+        val sparse = listOf(record("N0CALL"))
+        val result = filterQsoRecords(sparse, "N0")
+        assertThat(calls(result)).containsExactly("N0CALL")
+    }
+}


### PR DESCRIPTION
## What & why

The Logbook **Recent** tab listed *every* logged QSO with no way to search. Answering the everyday operator question — *"have I worked this station before, and on what band?"* — meant scrolling the entire log. This PR adds a search box above the recent list that filters the log as you type.

**Users notice this immediately:** tap Logbook → Recent, type a partial call, and the list narrows to matching contacts.

## Behavior

- Case-insensitive **substring** match (so "PA" finds both `PA3XYZ` and `W1PA`) across the fields an operator actually searches a log by:
  - **callsign** (primary)
  - **grid** (e.g. `FN42`)
  - **band** (e.g. `40M`)
  - **DXCC entity** (e.g. `Japan`)
  - stored **location** / "where"
- A blank query shows the full list (no filtering).
- A clear (✕) button resets the query.
- When records exist but nothing matches, a distinct *"No matching QSOs"* state is shown **with the search box still in place**, so the query can be refined or cleared.
- The query lives in a `rememberSaveable`, so it survives rotation/recomposition but resets when you leave the Logbook — matching the expectation that search is a transient "find this contact" action, not a persisted filter.

## Design

Per the project convention (Composables can't be unit-tested directly), all match logic is extracted into a pure top-level `internal fun filterQsoRecords(records, query)`; the search bar (`LogSearchBar`) is a thin Compose wrapper that just calls it. Sorting is unchanged — the filtered list still flows through the existing `sortQsosByDateTimeDesc`.

## Tests

New `LogbookSearchTest` (pure JVM, no Robolectric) covering: blank/whitespace query passthrough, callsign prefix + mid-string substring, case-insensitivity, match by grid/band/DXCC/where, query trimming, no-match empty result, empty log, and null optional fields.

```
./gradlew :app:testDebugUnitTest --tests "radio.ks3ckc.ft8af.ui.logbook.*"  → BUILD SUCCESSFUL
```

`:app:compileDebugKotlin` also passes. No decoder/TX/protocol code touched.

## Scope

Focused, additive, UI-only. Nothing outside the Recent tab changes.