### PR TITLE
Fix dropped Needed-DX alerts: overlapping decode passes raced a shared QTH-lookup Runnable

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -209,8 +209,6 @@ public class MainViewModel extends ViewModel {
 
     private final ExecutorService getQTHThreadPool = Executors.newCachedThreadPool();
     private final ExecutorService sendWaveDataThreadPool = Executors.newCachedThreadPool();
-    private final GetQTHRunnable getQTHRunnable = new GetQTHRunnable(this);
-    private final SendWaveDataRunnable sendWaveDataRunnable = new SendWaveDataRunnable();
 
 
     //variables for displaying shared log generation progress
@@ -728,12 +726,19 @@ public class MainViewModel extends ViewModel {
                 mutableIsDecoding.postValue(decodingMarkerAfterPass(decoded.size(), messages.size()));
 
 
-                getQTHRunnable.messages = messages;
+                // A fresh task per dispatch, bound to *this* pass's messages. slot N's
+                // late/deep pass and slot N+1's early pass enter afterDecode concurrently
+                // (#398, same reason ft8Messages/decodeCycleState are synchronized above):
+                // a single shared Runnable whose `messages` field is overwritten per call
+                // and re-submitted to the pool loses one pass's list — that pass's QTH
+                // lookup (country/grid flags) and Needed-DX alerts are silently dropped,
+                // and two pool workers race on the one non-volatile field.
                 // Guard against the ViewModel-teardown race: a late deep-decode
                 // pass can deliver here after onCleared() shut the pool down,
                 // and a raw execute() on a terminated pool throws
                 // RejectedExecutionException on this decode thread (crash).
-                SafeExecutor.tryExecute(getQTHThreadPool, getQTHRunnable);//query location via thread pool
+                SafeExecutor.tryExecute(getQTHThreadPool,
+                        new GetQTHRunnable(MainViewModel.this, messages));//query location via thread pool
 
                 //this variable also notifies message list changes
                 mutable_Decoded_Counter.postValue(
@@ -873,10 +878,11 @@ public class MainViewModel extends ViewModel {
                 if (GeneralVariables.connectMode == ConnectMode.NETWORK) {
                     if (baseRig != null) {
                         if (baseRig.isConnected()) {
-                            sendWaveDataRunnable.baseRig = baseRig;
-                            sendWaveDataRunnable.message = msg;
-                            //send network data packets via thread pool
-                            SafeExecutor.tryExecute(sendWaveDataThreadPool, sendWaveDataRunnable);
+                            //send network data packets via thread pool. A fresh task per
+                            //dispatch (not a shared, per-call-mutated instance) so a re-entrant
+                            //transmit/tune can't race the baseRig/message fields on the pool.
+                            SafeExecutor.tryExecute(sendWaveDataThreadPool,
+                                    new SendWaveDataRunnable(baseRig, msg));
                         }
                     }
                 }
@@ -902,9 +908,8 @@ public class MainViewModel extends ViewModel {
                 if (!supportTransmitOverCAT()) {
                     return;
                 }
-                sendWaveDataRunnable.baseRig = baseRig;
-                sendWaveDataRunnable.message = msg;
-                SafeExecutor.tryExecute(sendWaveDataThreadPool, sendWaveDataRunnable);
+                SafeExecutor.tryExecute(sendWaveDataThreadPool,
+                        new SendWaveDataRunnable(baseRig, msg));
             }
 
         }, new OnTransmitSuccess() {//when QSO is successful
@@ -2211,14 +2216,22 @@ public class MainViewModel extends ViewModel {
         }
     }
 
-    private static class GetQTHRunnable implements Runnable {
-        MainViewModel mainViewModel;
-        ArrayList<Ft8Message> messages;
+    // Per-dispatch, immutable payload. One instance per afterDecode() call — never shared
+    // and mutated between submissions — so overlapping decode passes (#398) each get their
+    // own message list processed instead of racing/clobbering a single shared field.
+    static final class GetQTHRunnable implements Runnable {
+        private final MainViewModel mainViewModel;
+        private final ArrayList<Ft8Message> messages;
 
-        public GetQTHRunnable(MainViewModel mainViewModel) {
+        GetQTHRunnable(MainViewModel mainViewModel, ArrayList<Ft8Message> messages) {
             this.mainViewModel = mainViewModel;
+            this.messages = messages;
         }
 
+        /** The decode pass this task resolves locations for (bound at construction). */
+        ArrayList<Ft8Message> messages() {
+            return messages;
+        }
 
         @Override
         public void run() {
@@ -2230,10 +2243,22 @@ public class MainViewModel extends ViewModel {
         }
     }
 
-    private static class SendWaveDataRunnable implements Runnable {
-        BaseRig baseRig;
-        //float[] data;
-        Ft8Message message;
+    // Per-dispatch, immutable payload (see GetQTHRunnable): a fresh instance per transmit so
+    // a re-entrant TX/tune can't clobber baseRig/message on a worker still playing the prior
+    // waveform (the same shared-Runnable hazard fixed in IcomAudioUdp).
+    static final class SendWaveDataRunnable implements Runnable {
+        private final BaseRig baseRig;
+        private final Ft8Message message;
+
+        SendWaveDataRunnable(BaseRig baseRig, Ft8Message message) {
+            this.baseRig = baseRig;
+            this.message = message;
+        }
+
+        /** The message whose waveform this task sends (bound at construction). */
+        Ft8Message message() {
+            return message;
+        }
 
         @Override
         public void run() {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelPooledTaskTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelPooledTaskTest.java
@@ -1,0 +1,113 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regression coverage for the shared-mutable pooled-{@link Runnable} race in
+ * {@code MainViewModel.afterDecode()} (and the TX {@code onTransmit*} path).
+ *
+ * <p>{@code afterDecode} is entered <em>concurrently</em> — slot N's late/deep pass and
+ * slot N+1's early pass overlap (#398), which is why {@code ft8Messages} and
+ * {@code decodeCycleState} are synchronized there. The QTH-lookup dispatch, however, used
+ * to reuse one {@code GetQTHRunnable} instance: each call did
+ * {@code getQTHRunnable.messages = messages} on the shared object and re-submitted it to a
+ * cached thread pool. When two passes overlapped, the second field write clobbered the
+ * first, so one pass's list never got its country/grid flags resolved
+ * ({@code getMessagesLocation}) and never fired its Needed-DX alerts
+ * ({@code dxAlertNotifier.processDecodes}) — the alerts were silently dropped, and two pool
+ * workers raced on the one non-volatile field. The fix binds the message list to a fresh
+ * task per dispatch ({@code new GetQTHRunnable(this, messages)}); the TX
+ * {@code SendWaveDataRunnable} got the same treatment.
+ *
+ * <p>Robolectric is only needed to construct real {@link Ft8Message} rows (their ctor
+ * touches {@code android.util.Log}); the binding under test touches no Android types.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class MainViewModelPooledTaskTest {
+
+    @Test
+    public void getQthRunnable_bindsItsOwnMessageList_perDispatch() {
+        // Two overlapping afterDecode passes, each with its own decoded-message list.
+        ArrayList<Ft8Message> passA = new ArrayList<>();
+        ArrayList<Ft8Message> passB = new ArrayList<>();
+
+        MainViewModel.GetQTHRunnable a = new MainViewModel.GetQTHRunnable(null, passA);
+        // Constructing the second dispatch must NOT disturb the first. With the old shared
+        // instance, the second `getQTHRunnable.messages = passB` would have rebound both.
+        MainViewModel.GetQTHRunnable b = new MainViewModel.GetQTHRunnable(null, passB);
+
+        assertThat(a.messages()).isSameInstanceAs(passA);
+        assertThat(b.messages()).isSameInstanceAs(passB);
+        assertThat(a.messages()).isNotSameInstanceAs(b.messages());
+    }
+
+    @Test
+    public void sendWaveDataRunnable_bindsItsOwnMessage_perDispatch() {
+        Ft8Message first = new Ft8Message(FT8Common.FT8_MODE);
+        Ft8Message second = new Ft8Message(FT8Common.FT8_MODE);
+
+        MainViewModel.SendWaveDataRunnable a =
+                new MainViewModel.SendWaveDataRunnable(null, first);
+        MainViewModel.SendWaveDataRunnable b =
+                new MainViewModel.SendWaveDataRunnable(null, second);
+
+        assertThat(a.message()).isSameInstanceAs(first);
+        assertThat(b.message()).isSameInstanceAs(second);
+    }
+
+    @Test
+    public void sendWaveDataRunnable_nullRigOrMessage_isNoOp() {
+        // The guard survives the immutable rewrite: a task with no rig/message just returns.
+        new MainViewModel.SendWaveDataRunnable(null, null).run();
+        new MainViewModel.SendWaveDataRunnable(null, new Ft8Message(FT8Common.FT8_MODE)).run();
+    }
+
+    /**
+     * Makes the dropped-pass hazard deterministic: a single shared payload holder overwritten
+     * before either "worker" runs loses the first pass's list, whereas a fresh task per
+     * dispatch preserves both. This is the exact shape of the production bug the fix removes.
+     */
+    @Test
+    public void sharedInstance_dropsAPass_whilePerDispatchDoesNot() {
+        List<Object> processed = new ArrayList<>();
+
+        Object listA = new Object();
+        Object listB = new Object();
+
+        // OLD wiring: one shared holder whose payload is overwritten by the 2nd dispatch,
+        // then both submitted Runnables read the (now single) shared payload.
+        MutableHolder shared = new MutableHolder();
+        shared.payload = listA;                                   // pass A dispatched
+        Runnable sharedDispatchA = () -> processed.add(shared.payload);
+        shared.payload = listB;                                   // pass B clobbers A
+        Runnable sharedDispatchB = () -> processed.add(shared.payload);
+        sharedDispatchA.run();
+        sharedDispatchB.run();
+        assertThat(processed).containsExactly(listB, listB);      // pass A's list was lost
+
+        // NEW wiring: a fresh task bound to each pass's payload.
+        processed.clear();
+        Object freshA = new Object();
+        Object freshB = new Object();
+        Runnable boundA = boundTask(processed, freshA);
+        Runnable boundB = boundTask(processed, freshB);
+        boundA.run();
+        boundB.run();
+        assertThat(processed).containsExactly(freshA, freshB);    // both passes processed
+    }
+
+    private static Runnable boundTask(List<Object> sink, Object payload) {
+        return () -> sink.add(payload);
+    }
+
+    private static final class MutableHolder {
+        Object payload;
+    }
+}


### PR DESCRIPTION
## Summary

`MainViewModel.afterDecode()` is documented as running **concurrently** — slot N's late/deep decode pass and slot N+1's early pass overlap (#398), which is exactly why `ft8Messages` and `decodeCycleState` are `synchronized` in that method. But the per-cycle QTH lookup reused a **single shared `GetQTHRunnable` instance**: every call did

```java
getQTHRunnable.messages = messages;              // mutate shared object
SafeExecutor.tryExecute(getQTHThreadPool, getQTHRunnable);  // re-submit same instance
```

on a `newCachedThreadPool`. When two passes overlap, the second field write clobbers the first, so both pool workers end up processing the same list.

## Root cause

The runnable carried per-call state on a shared object dispatched to a multi-threaded pool:

- **Lost update / dropped alerts:** whichever `messages =` write lands last wins. The other pass's list — typically the deep/late pass that decoded the DX the fast pass *missed* — never gets its country/grid flags resolved (`CallsignDatabase.getMessagesLocation`) and never reaches `dxAlertNotifier.processDecodes(...)`, so **its Needed-DX alerts are silently dropped** (or the surviving list's fire twice). This directly defeats the purpose of the #363 late pass.
- **Data race:** a non-volatile field written by decode threads and read by two pool worker threads; `run()` re-reads `messages` between `getMessagesLocation` and `processDecodes`, so a mid-run clobber makes those steps operate on different lists.

Not a hard crash (the downstream calls are internally synchronized / snapshot defensively) — the symptom is corruption and lost work.

The TX path had the **identical** shape: `sendWaveDataRunnable` (a single shared instance) is mutated (`baseRig`, `message`) and re-submitted from `onTransmitByWifi` / `onTransmitOverCAT`. A re-entrant transmit/tune can clobber those fields on a worker still playing the prior ~12.6 s waveform — the same shared-Runnable hazard already fixed for `IcomAudioUdp` (PR #637).

## Fix

Remove both shared fields; construct a **fresh, immutable task per dispatch**:

```java
SafeExecutor.tryExecute(getQTHThreadPool, new GetQTHRunnable(MainViewModel.this, messages));
...
SafeExecutor.tryExecute(sendWaveDataThreadPool, new SendWaveDataRunnable(baseRig, msg));
```

Both nested classes now hold `final` fields set at construction. The `SafeExecutor` teardown-race guard is preserved. Behavior is identical for the non-overlapping case; overlapping passes now each get their own list processed. No protocol/DSP/timing behavior changes.

## Testing

- New `MainViewModelPooledTaskTest` (4 cases): asserts each dispatch binds its own message list/message, the null-guard survives the rewrite, and a deterministic model reproducing the dropped-pass hazard (shared holder loses pass A; per-dispatch preserves both).
- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — full APK (incl. native hamlib ×4 ABIs) builds successfully.

## Risk

Low. Localized to the two dispatch sites and their runnable definitions; strictly removes shared mutable state (no new shared state, no lock added). No native, DSP, encoder/decoder, or wire-protocol code touched.