### PR TITLE
Add a Worked All Continents (WAC) award to the logbook

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/count/CountDbOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/count/CountDbOpr.java
@@ -78,16 +78,15 @@ public class CountDbOpr {
     @SuppressLint("Range")
     public static java.util.List<String> queryWorkedContinents(SQLiteDatabase db){
         java.util.ArrayList<String> continents=new java.util.ArrayList<>();
-        String querySQL="SELECT dl.continent AS cont FROM dxcc_grid dg\n" +
+        String querySQL="SELECT DISTINCT dl.continent AS cont FROM dxcc_grid dg\n" +
                 "inner join QSLTable q on dg.grid = UPPER(SUBSTR(q.gridsquare,1,4))\n" +
                 "left join dxccList dl on dg.dxcc = dl.dxcc\n" +
-                "WHERE dl.continent IS NOT NULL AND TRIM(dl.continent) <> ''\n" +
-                "GROUP BY dl.continent";
-        Cursor cursor=db.rawQuery(querySQL,null);
-        while (cursor.moveToNext()){
-            continents.add(cursor.getString(cursor.getColumnIndex("cont")));
+                "WHERE dl.continent IS NOT NULL AND TRIM(dl.continent) <> ''";
+        try (Cursor cursor=db.rawQuery(querySQL,null)){
+            while (cursor.moveToNext()){
+                continents.add(cursor.getString(cursor.getColumnIndex("cont")));
+            }
         }
-        cursor.close();
         return continents;
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/count/CountDbOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/count/CountDbOpr.java
@@ -53,6 +53,45 @@ public class CountDbOpr {
     }
 
     /**
+     * Count the continents worked, for the "Worked All Continents" (WAC) award.
+     * Fires the callback once with one {@link CountValue} per worked continent
+     * (its {@code name} is the continent code, e.g. "EU"); the presentation logic
+     * lives in the pure Kotlin {@code workedAllContinents} reducer.
+     */
+    public static void getContinentCount(SQLiteDatabase db,AfterCount afterCount){
+        new GetContinentCount(db,afterCount).execute();
+    }
+
+    /**
+     * The distinct continent codes worked, derived from each log gridsquare via
+     * the DXCC lookup tables ({@code dxcc_grid} grid -> DXCC entity, then
+     * {@code dxccList} DXCC -> continent) exactly like the DXCC / CQ-zone stats.
+     *
+     * <p>Extracted as a synchronous static method (separate from the AsyncTask)
+     * so the grid -> continent join is unit-testable against an in-memory
+     * database without touching the UI thread. Blank / null continents are
+     * filtered in SQL, so the returned list holds only usable codes (which may
+     * still include the non-WAC "AN"/"-" — the Kotlin reducer drops those).
+     *
+     * @return one continent code per group; empty when no logged grid resolves.
+     */
+    @SuppressLint("Range")
+    public static java.util.List<String> queryWorkedContinents(SQLiteDatabase db){
+        java.util.ArrayList<String> continents=new java.util.ArrayList<>();
+        String querySQL="SELECT dl.continent AS cont FROM dxcc_grid dg\n" +
+                "inner join QSLTable q on dg.grid = UPPER(SUBSTR(q.gridsquare,1,4))\n" +
+                "left join dxccList dl on dg.dxcc = dl.dxcc\n" +
+                "WHERE dl.continent IS NOT NULL AND TRIM(dl.continent) <> ''\n" +
+                "GROUP BY dl.continent";
+        Cursor cursor=db.rawQuery(querySQL,null);
+        while (cursor.moveToNext()){
+            continents.add(cursor.getString(cursor.getColumnIndex("cont")));
+        }
+        cursor.close();
+        return continents;
+    }
+
+    /**
      * Accumulated maximum/minimum great-circle distance (in km) from the
      * operator's own grid to a set of log gridsquares. {@link #hasData()}
      * distinguishes "no valid contacts were found" from a genuine 0 km
@@ -564,6 +603,37 @@ public class CountDbOpr {
 
 
 
+
+    /**
+     * Gather the worked continents for the WAC award off the UI thread. The
+     * heavy lifting (the grid -> continent join) is in {@link #queryWorkedContinents}
+     * so this task is just the async wrapper + callback marshalling.
+     */
+    static class GetContinentCount extends AsyncTask<Void, Void, Void>{
+        private final SQLiteDatabase db;
+        private final AfterCount afterCount;
+
+        public GetContinentCount(SQLiteDatabase db, AfterCount afterCount) {
+            this.db = db;
+            this.afterCount = afterCount;
+        }
+
+        @Override
+        protected Void doInBackground(Void... voids) {
+            java.util.List<String> continents = queryWorkedContinents(db);
+            ArrayList<CountValue> values = new ArrayList<>();
+            for (String c : continents) {
+                values.add(new CountValue(1, c));
+            }
+            if (afterCount != null) {
+                afterCount.countInformation(new CountInfo(""
+                        , ChartType.Bar
+                        , GeneralVariables.getStringFromResource(R.string.continent_completion_statistics)
+                        , values));
+            }
+            return null;
+        }
+    }
 
     public interface  AfterCount{
         void countInformation(CountInfo countInfo);

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/LogbookScreen.kt
@@ -139,6 +139,9 @@ private data class LogbookStats(
     val cqZones: Int = 0,
     val ituZones: Int = 0,
     val bandCounts: List<Pair<String, Int>> = emptyList(),
+    // Raw continent codes worked (e.g. "NA", "EU"), for the WAC award. Reduced
+    // to award progress by [workedAllContinents]; empty when nothing resolves.
+    val continentCodes: List<String> = emptyList(),
 )
 
 private data class AwardProgress(
@@ -246,12 +249,24 @@ fun LogbookScreen(mainViewModel: MainViewModel) {
                 val bandCounts = bandInfo?.values?.map { (it.name ?: "") to it.value }
                     ?: emptyList()
 
+                // Worked continents for the WAC award (single-fire callback).
+                val continentInfo = suspendCancellableCoroutine { cont ->
+                    val resumed = AtomicBoolean(false)
+                    CountDbOpr.getContinentCount(db) { info ->
+                        if (resumed.compareAndSet(false, true)) cont.resume(info)
+                    }
+                }
+                val continentCodes = continentInfo?.values
+                    ?.mapNotNull { it.name }
+                    ?: emptyList()
+
                 stats = LogbookStats(
                     totalQsos = totalQsos,
                     dxccEntities = dxccCount,
                     cqZones = cqCount,
                     ituZones = ituCount,
                     bandCounts = bandCounts,
+                    continentCodes = continentCodes,
                 )
             } catch (_: Exception) {
                 // Leave records/stats at defaults on error
@@ -654,6 +669,13 @@ private fun StatsTab(stats: LogbookStats, records: List<QSLCallsignRecord>) {
             BestDxCard(bestDx = bestDx, modifier = Modifier.fillMaxWidth())
         }
 
+        // Worked All Continents — the six-continent award, one chip per continent.
+        SectionHeader(stringResource(R.string.log_section_wac))
+        WorkedAllContinentsCard(
+            wac = remember(stats.continentCodes) { workedAllContinents(stats.continentCodes) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
         // Band donut chart
         if (stats.bandCounts.isNotEmpty()) {
             SectionHeader(stringResource(R.string.log_section_band_distribution))
@@ -785,6 +807,94 @@ private fun BestDxCard(bestDx: BestDx, modifier: Modifier = Modifier) {
                 fontFamily = GeistMonoFamily,
             )
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worked All Continents (WAC) card
+// ---------------------------------------------------------------------------
+
+/** Localized full name for a continent code, for chip accessibility labels. */
+@Composable
+private fun continentName(code: String): String = when (code) {
+    "NA" -> stringResource(R.string.continent_na)
+    "SA" -> stringResource(R.string.continent_sa)
+    "EU" -> stringResource(R.string.continent_eu)
+    "AF" -> stringResource(R.string.continent_af)
+    "AS" -> stringResource(R.string.continent_as)
+    "OC" -> stringResource(R.string.continent_oc)
+    else -> code
+}
+
+@Composable
+private fun WorkedAllContinentsCard(wac: WacProgress, modifier: Modifier = Modifier) {
+    GlassCard(modifier = modifier) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = if (wac.isComplete) {
+                        stringResource(R.string.log_wac_complete)
+                    } else {
+                        stringResource(R.string.log_wac_progress, wac.workedCount, wac.total)
+                    },
+                    color = if (wac.isComplete) StatusConfirmed else TextPrimary,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = "${wac.workedCount} / ${wac.total}",
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    fontFamily = GeistMonoFamily,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                for (chip in wac.chips) {
+                    ContinentChipView(chip = chip, modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContinentChipView(chip: ContinentChip, modifier: Modifier = Modifier) {
+    val name = continentName(chip.code)
+    val label = if (chip.worked) {
+        stringResource(R.string.log_wac_continent_worked, name)
+    } else {
+        stringResource(R.string.log_wac_continent_needed, name)
+    }
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (chip.worked) StatusNew.copy(alpha = 0.16f) else BgSurface3)
+            .border(
+                1.dp,
+                if (chip.worked) StatusNew.copy(alpha = 0.5f) else Border,
+                RoundedCornerShape(8.dp),
+            )
+            .padding(vertical = 8.dp)
+            .semantics { contentDescription = label },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = chip.code,
+            color = if (chip.worked) StatusNew else TextDim,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = GeistMonoFamily,
+        )
     }
 }
 
@@ -1697,9 +1807,12 @@ private fun AwardsTab(stats: LogbookStats) {
     val wazDesc = stringResource(R.string.log_award_waz_desc)
     val vuccName = stringResource(R.string.log_award_vucc)
     val vuccDesc = stringResource(R.string.log_award_vucc_desc)
+    val wacName = stringResource(R.string.log_award_wac)
+    val wacDesc = stringResource(R.string.log_award_wac_desc)
     val iotaName = stringResource(R.string.log_award_iota)
     val iotaDesc = stringResource(R.string.log_award_iota_desc)
     val awards = remember(stats) {
+        val wac = workedAllContinents(stats.continentCodes)
         listOf(
             AwardProgress(
                 name = dxccMixedName,
@@ -1721,6 +1834,13 @@ private fun AwardsTab(stats: LogbookStats) {
                 current = stats.cqZones,
                 total = 40,
                 color = StatusNew,
+            ),
+            AwardProgress(
+                name = wacName,
+                description = wacDesc,
+                current = wac.workedCount,
+                total = wac.total,
+                color = Band10m,
             ),
             AwardProgress(
                 name = vuccName,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllContinents.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllContinents.kt
@@ -1,0 +1,56 @@
+package radio.ks3ckc.ft8af.ui.logbook
+
+/**
+ * Pure presentation logic for the "Worked All Continents" (WAC) award shown on
+ * the logbook Stats tab. Kept as plain top-level functions/data (no Compose) so
+ * the award reducer is unit-testable on the JVM without Robolectric — the
+ * Composable card is a thin wrapper that just renders [workedAllContinents].
+ *
+ * WAC is one of the oldest and most recognisable amateur-radio awards: confirm a
+ * two-way contact with each of the six populated continents. Antarctica ("AN")
+ * is an optional endorsement, not one of the six required, so it never counts
+ * toward the award total here.
+ *
+ * The raw continent codes come from the DXCC lookup tables via
+ * [com.k1af.ft8af.count.CountDbOpr.queryWorkedContinents] (grid -> DXCC entity ->
+ * continent), matching how the DXCC / CQ-zone stats are already derived.
+ */
+
+/** The six WAC continents, in a conventional display order. */
+internal val WAC_CONTINENTS: List<String> = listOf("NA", "SA", "EU", "AF", "AS", "OC")
+
+/** One continent's award state: its code (e.g. "EU") and whether it's worked. */
+internal data class ContinentChip(val code: String, val worked: Boolean)
+
+/** Reduced WAC award progress: a chip per required continent plus a worked tally. */
+internal data class WacProgress(
+    val chips: List<ContinentChip>,
+    val workedCount: Int,
+) {
+    /** Number of continents required for the award (always 6). */
+    val total: Int get() = WAC_CONTINENTS.size
+
+    /** True once every required continent has been worked. */
+    val isComplete: Boolean get() = workedCount >= WAC_CONTINENTS.size
+}
+
+/**
+ * Reduce a collection of raw continent codes (as stored in `dxccList.continent`,
+ * e.g. "NA", "EU", or the stray "AN"/"-") into [WacProgress].
+ *
+ * Codes are trimmed and upper-cased before matching, duplicates collapse, and
+ * anything outside the six standard continents (Antarctica, blanks, unknown "-",
+ * junk) is ignored so it can never inflate the award total. The returned chip
+ * list is always the six [WAC_CONTINENTS] in canonical order, so the UI renders a
+ * stable row regardless of which continents happen to be present in the input.
+ */
+internal fun workedAllContinents(rawCodes: Collection<String?>): WacProgress {
+    val worked = rawCodes
+        .asSequence()
+        .filterNotNull()
+        .map { it.trim().uppercase() }
+        .filter { it in WAC_CONTINENTS }
+        .toSet()
+    val chips = WAC_CONTINENTS.map { ContinentChip(code = it, worked = it in worked) }
+    return WacProgress(chips = chips, workedCount = worked.size)
+}

--- a/ft8af/app/src/main/res/values/strings.xml
+++ b/ft8af/app/src/main/res/values/strings.xml
@@ -318,6 +318,7 @@
     <string name="count_total_cqzone">Total CQ Zone : %d \n Completed : %d(%.1f%%)</string>
     <string name="count_cqzone_proportion">CQ Zone Statistics</string>
     <string name="dxcc_completion_statistics">DXCC statistics</string>
+    <string name="continent_completion_statistics">Continent statistics</string>
     <string name="count_total_dxcc">Total DXCC : %d \nCompleted : %d(%.1f%%)</string>
     <string name="count_dxcc_proportion">DXCC statistics</string>
     <string name="callsign_info">Callsign:%s\nLocation:%s\nCQ zone:%d\nITU zone:%d\nContinent:%s\nLongitude and latitude:%.2f,%.2f\nTime zone:%.0f\nDxcc prefix:%s</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -248,6 +248,11 @@
     <string name="log_award_vucc_grid_squares">VUCC Grid Squares</string>
     <string name="log_award_dxcc_challenge">DXCC Challenge</string>
     <string name="log_section_best_dx">Best DX</string>
+    <string name="log_section_wac">Worked All Continents</string>
+    <string name="log_wac_progress">%1$d / %2$d continents</string>
+    <string name="log_wac_complete">All six continents worked 🌍</string>
+    <string name="log_wac_continent_worked">%1$s worked</string>
+    <string name="log_wac_continent_needed">%1$s not yet worked</string>
     <string name="log_section_grid_coverage">Grid Coverage</string>
     <string name="log_section_signal_trend">Signal Trend</string>
     <string name="log_no_qsos_yet">No QSOs yet</string>
@@ -267,6 +272,8 @@
     <string name="log_award_waz_desc">Work all 40 CQ zones confirmed</string>
     <string name="log_award_vucc">VUCC</string>
     <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 grid squares on a single band</string>
+    <string name="log_award_wac">WAC</string>
+    <string name="log_award_wac_desc">Worked All Continents -- contact all six continents</string>
     <string name="log_award_iota">IOTA</string>
     <string name="log_award_iota_desc">Islands on the Air -- work stations on designated islands</string>
     <string name="log_edit_qso">Edit QSO</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/count/CountDbOprContinentTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/count/CountDbOprContinentTest.java
@@ -1,0 +1,115 @@
+package com.k1af.ft8af.count;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.List;
+
+/**
+ * Exercises {@link CountDbOpr#queryWorkedContinents} — the grid -> DXCC entity ->
+ * continent join behind the "Worked All Continents" (WAC) award. Uses an
+ * in-memory SQLite database mirroring the three tables the query touches
+ * ({@code dxcc_grid}, {@code dxccList}, {@code QSLTable}); Robolectric provides
+ * real SQLite.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CountDbOprContinentTest {
+
+    private SQLiteDatabase db;
+
+    @Before
+    public void setUp() {
+        db = SQLiteDatabase.create(null);
+        db.execSQL("CREATE TABLE QSLTable (id INTEGER PRIMARY KEY, gridsquare TEXT)");
+        db.execSQL("CREATE TABLE dxcc_grid (dxcc INTEGER, grid TEXT)");
+        db.execSQL("CREATE TABLE dxccList (dxcc INTEGER, continent TEXT)");
+
+        // DXCC entities -> continent (one blank + Antarctica to exercise filtering).
+        insertDxcc(1, "EU");
+        insertDxcc(2, "NA");
+        insertDxcc(3, "AN");   // Antarctica: returned raw, dropped later by the reducer
+        insertDxcc(4, "");     // blank continent: filtered out in SQL
+
+        // 4-char grid -> DXCC entity.
+        insertGrid(1, "IO91");
+        insertGrid(2, "FN20");
+        insertGrid(3, "AA00");
+        insertGrid(4, "BB11");
+    }
+
+    @After
+    public void tearDown() {
+        if (db != null) {
+            db.close();
+        }
+    }
+
+    private void insertDxcc(int dxcc, String continent) {
+        db.execSQL("INSERT INTO dxccList (dxcc, continent) VALUES (?, ?)",
+                new Object[]{dxcc, continent});
+    }
+
+    private void insertGrid(int dxcc, String grid) {
+        db.execSQL("INSERT INTO dxcc_grid (dxcc, grid) VALUES (?, ?)",
+                new Object[]{dxcc, grid});
+    }
+
+    private void logQso(String gridsquare) {
+        db.execSQL("INSERT INTO QSLTable (gridsquare) VALUES (?)", new Object[]{gridsquare});
+    }
+
+    @Test
+    public void resolvesWorkedContinents_fromSixCharGrids() {
+        logQso("IO91np"); // EU
+        logQso("FN20xr"); // NA
+
+        List<String> continents = CountDbOpr.queryWorkedContinents(db);
+
+        assertThat(continents).containsExactly("EU", "NA");
+    }
+
+    @Test
+    public void matchIsCaseInsensitive_onTheGridPrefix() {
+        // Operators frequently log the locator lower-cased; the query upper-cases
+        // the 4-char prefix before joining dxcc_grid.
+        logQso("aa00"); // -> AA00 -> AN
+
+        List<String> continents = CountDbOpr.queryWorkedContinents(db);
+
+        assertThat(continents).containsExactly("AN");
+    }
+
+    @Test
+    public void blankContinentAndUnmatchedGrids_areExcluded() {
+        logQso("BB11aa"); // maps to a DXCC whose continent is blank -> excluded
+        logQso("ZZ99zz"); // no dxcc_grid row -> dropped by the inner join
+
+        List<String> continents = CountDbOpr.queryWorkedContinents(db);
+
+        assertThat(continents).isEmpty();
+    }
+
+    @Test
+    public void deduplicatesContinents_acrossManyContacts() {
+        logQso("IO91aa"); // EU
+        logQso("IO91bb"); // EU (same continent, different sub-square)
+        logQso("FN20cc"); // NA
+
+        List<String> continents = CountDbOpr.queryWorkedContinents(db);
+
+        // GROUP BY continent collapses the duplicate EU contacts to one row.
+        assertThat(continents).containsExactly("EU", "NA");
+    }
+
+    @Test
+    public void emptyLog_returnsEmptyList() {
+        assertThat(CountDbOpr.queryWorkedContinents(db)).isEmpty();
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllContinentsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/logbook/WorkedAllContinentsTest.kt
@@ -1,0 +1,65 @@
+package radio.ks3ckc.ft8af.ui.logbook
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [workedAllContinents] — the pure reducer behind the logbook
+ * "Worked All Continents" (WAC) award card and Awards-tab progress bar. Runs on
+ * the plain JVM: the reducer takes raw continent codes (as produced by
+ * [com.k1af.ft8af.count.CountDbOpr.queryWorkedContinents]) and never touches
+ * Android/DB types.
+ */
+class WorkedAllContinentsTest {
+
+    @Test
+    fun emptyInput_isZeroOfSix_notComplete() {
+        val wac = workedAllContinents(emptyList())
+        assertThat(wac.workedCount).isEqualTo(0)
+        assertThat(wac.total).isEqualTo(6)
+        assertThat(wac.isComplete).isFalse()
+        // Always renders all six chips, in canonical order, none worked.
+        assertThat(wac.chips.map { it.code }).containsExactlyElementsIn(WAC_CONTINENTS).inOrder()
+        assertThat(wac.chips.none { it.worked }).isTrue()
+    }
+
+    @Test
+    fun marksOnlyTheWorkedContinents() {
+        val wac = workedAllContinents(listOf("NA", "EU", "AS"))
+        assertThat(wac.workedCount).isEqualTo(3)
+        assertThat(wac.isComplete).isFalse()
+        val worked = wac.chips.filter { it.worked }.map { it.code }.toSet()
+        assertThat(worked).containsExactly("NA", "EU", "AS")
+    }
+
+    @Test
+    fun allSixWorked_isComplete() {
+        val wac = workedAllContinents(listOf("NA", "SA", "EU", "AF", "AS", "OC"))
+        assertThat(wac.workedCount).isEqualTo(6)
+        assertThat(wac.isComplete).isTrue()
+        assertThat(wac.chips.all { it.worked }).isTrue()
+    }
+
+    @Test
+    fun duplicatesCollapse_countIsDistinct() {
+        val wac = workedAllContinents(listOf("EU", "EU", "EU", "NA"))
+        assertThat(wac.workedCount).isEqualTo(2)
+    }
+
+    @Test
+    fun normalizesCaseAndWhitespace() {
+        val wac = workedAllContinents(listOf(" na ", "eu", "As"))
+        assertThat(wac.chips.filter { it.worked }.map { it.code }.toSet())
+            .containsExactly("NA", "EU", "AS")
+    }
+
+    @Test
+    fun antarcticaBlanksAndJunk_areIgnored() {
+        // "AN" (Antarctica) is an endorsement, not one of the six required; "-",
+        // blanks, nulls and unrelated tokens must never inflate the award.
+        val wac = workedAllContinents(listOf("AN", "-", "", "  ", null, "ZZ", "NA"))
+        assertThat(wac.workedCount).isEqualTo(1)
+        assertThat(wac.chips.single { it.worked }.code).isEqualTo("NA")
+        assertThat(wac.chips.map { it.code }).doesNotContain("AN")
+    }
+}


### PR DESCRIPTION
## What & why

**Worked All Continents (WAC)** — a two-way contact with each of the six populated continents — is one of the oldest and most recognisable amateur-radio awards. The logbook already tracks DXCC entities, CQ/ITU zones, grid coverage and Best DX, but it never tracked continents. Chasing all six is a milestone almost every active operator reaches early and enjoys watching fill in, so surfacing it is an immediately-noticeable win.

## What operators see

- **Stats tab** — a new **Worked All Continents** card: the six continents as chips (worked ones highlighted, the rest dimmed), a `N / 6` counter, and an "All six continents worked 🌍" banner once complete.
- **Awards tab** — a real **WAC** progress bar, alongside the existing DXCC/WAS/WAZ entries (previously WAC wasn't listed at all).

## How it works

Continents are derived exactly like the existing DXCC / zone statistics — each logged gridsquare is resolved through the DXCC lookup tables (`dxcc_grid`: grid → DXCC entity, then `dxccList`: entity → continent). No new data source, no per-callsign prefix lookup, no network.

- `CountDbOpr.queryWorkedContinents()` — the synchronous grid→continent join, **extracted** from the AsyncTask so it's unit-testable against an in-memory DB (mirrors the `computeDistanceStats` pattern). Wrapped by a new `getContinentCount()` task modelled on `getDxcc()`.
- `workedAllContinents()` — a pure Kotlin reducer that turns the raw continent codes into award progress: normalises case, dedupes, and drops Antarctica / blanks / unknown `"-"` / junk so they can never inflate the six-continent total. The Composable card is a thin wrapper over it.

## Tests

- `WorkedAllContinentsTest` (pure JVM) — reducer: empty, partial, all-six-complete, dedup, case/whitespace normalisation, Antarctica/blank/junk filtering.
- `CountDbOprContinentTest` (Robolectric + in-memory SQLite) — the grid→continent join: 6-char grids, case-insensitive grid-prefix match, blank-continent & unmatched-grid exclusion, cross-contact dedup, empty log.

## Verification

- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — APK builds.

No decoder/TX path touched; WSJT-X / FT8 protocol compatibility unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)