### PR TITLE
Fix grid-tracker map leak: decoded-line direction animator never cancelled

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/DirectionLineAnimator.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/DirectionLineAnimator.java
@@ -1,0 +1,65 @@
+package com.k1af.ft8af.grid_tracker;
+
+import android.animation.ValueAnimator;
+
+/**
+ * Owns the infinite "marching ants" {@link ValueAnimator} that animates the
+ * direction highlight sweeping along a decoded {@code GridPolyLine}.
+ *
+ * <p>Extracted from {@code GridOsmMapView.GridPolyLine} so its lifecycle — in
+ * particular that {@link #stop()} cancels the infinite animator when the line is
+ * removed from the map — is unit-testable without an osmdroid {@code MapView}. The
+ * per-frame drawing math (which slice of the line to paint) stays in the line via
+ * the {@link OnProgress} callback; this class only owns the animator.
+ *
+ * <p><b>Why it exists.</b> The animator was previously a bare local: it was created
+ * with {@link ValueAnimator#INFINITE} repeat, started, and then never referenced
+ * again — so nothing ever cancelled it. The platform {@code AnimationHandler} keeps
+ * a strong reference to every running animator, so each orphaned animator (a) could
+ * never be garbage-collected, dragging its captured line and the whole
+ * {@code MapView} with it, and (b) kept firing its update callback — which calls
+ * {@code MapView.invalidate()} — roughly 60 times a second forever. The grid-tracker
+ * map rebuilds its lines every decode cycle ({@code clearLines()} then
+ * {@code drawLine()} per decode), so on a busy band the orphaned animators piled up
+ * without bound: steadily rising CPU/redraw load and a monotonic memory leak that
+ * ends in jank/ANR/OOM. Storing the animator here and cancelling it when the line
+ * leaves the map fixes that.
+ */
+final class DirectionLineAnimator {
+
+    /** Per-frame callback; {@code fraction} sweeps {@code 0f..1f} and repeats. */
+    interface OnProgress {
+        void onProgress(float fraction);
+    }
+
+    private final ValueAnimator animator;
+
+    DirectionLineAnimator(long durationMs, final OnProgress onProgress) {
+        animator = ValueAnimator.ofFloat(0f, 1f);
+        animator.setRepeatCount(ValueAnimator.INFINITE);
+        animator.setDuration(durationMs);
+        animator.setStartDelay(0);
+        animator.addUpdateListener(a -> onProgress.onProgress((float) a.getAnimatedValue()));
+    }
+
+    /** Begin (or restart) the repeating animation. */
+    void start() {
+        animator.start();
+    }
+
+    /**
+     * Cancel the animation and detach its update listener so the platform
+     * {@code AnimationHandler} releases the animator (and everything the update
+     * callback captured). Idempotent — safe to call more than once, and safe to
+     * call on a line that never started.
+     */
+    void stop() {
+        animator.cancel();
+        animator.removeAllUpdateListeners();
+    }
+
+    /** Whether {@link #start()} has run and {@link #stop()} has not since. */
+    boolean isRunning() {
+        return animator.isStarted();
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridOsmMapView.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/grid_tracker/GridOsmMapView.java
@@ -14,7 +14,6 @@ import static java.lang.Math.floor;
 import static java.lang.Math.sin;
 import static java.lang.Math.tan;
 
-import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
@@ -223,6 +222,7 @@ public class GridOsmMapView {
     public void clearSelectedLines() {
         if (selectedLine != null) {
             selectedLine.closeInfoWindow();
+            selectedLine.stopAnimation();// removed from the map for good: cancel its animator
             gridMapView.getOverlays().remove(selectedLine);
             selectedLine = null;
 
@@ -244,12 +244,25 @@ public class GridOsmMapView {
         }
         for (GridPolyLine line : gridLines) {
             line.closeInfoWindow();
+            // Cancel each discarded line's infinite direction animator before dropping it;
+            // otherwise every decode cycle's lines pile up as orphaned animators that pin
+            // the MapView and repaint ~60x/s forever (see DirectionLineAnimator). Skip the
+            // retained selectedLine (re-added just below and still visible) so it keeps
+            // animating.
+            if (line != selectedLine) {
+                line.stopAnimation();
+            }
             gridMapView.getOverlays().remove(line);
         }
         gridLines.clear();
         if (selectedLine != null && selectLineTimeOut > 0) {
             gridMapView.getOverlays().add(selectedLine);
             if (isOpening) selectedLine.showInfoWindow();
+        } else if (selectedLine != null) {
+            // Its retention window has elapsed and it was not re-added above: it is gone
+            // from the map for good, so cancel its animator too rather than leak it.
+            selectedLine.stopAnimation();
+            selectedLine = null;
         }
         gridMapView.invalidate();
     }
@@ -568,6 +581,13 @@ public class GridOsmMapView {
         public QSLRecordStr recorder;
         //public boolean marked = false;
 
+        // The infinite direction-highlight animator for a decoded line (null for a
+        // QSL-history line, which has none). Retained so it can be cancelled when the
+        // line is removed from the map — see stopAnimation() and clearLines(). Without
+        // this the animator was a bare local that ran forever and leaked. Package-private
+        // for GridOsmMapView's line-cleanup paths.
+        private DirectionLineAnimator pathAnimator;
+
         @SuppressLint("DefaultLocale")
         public GridPolyLine(MapView mapView, LatLng fromLatLng, LatLng toLatLng, QSLRecordStr recordStr) {
             super(mapView);
@@ -648,24 +668,31 @@ public class GridOsmMapView {
             setMilestoneManagers(managers);
 
 
-            //Set up directional animation
-            final ValueAnimator percentageCompletion = ValueAnimator.ofFloat(0, 1); // 10 kilometers
-
-            percentageCompletion.setRepeatCount(ValueAnimator.INFINITE);
-            percentageCompletion.setDuration(1000); // 1 seconds
-            percentageCompletion.setStartDelay(0); // 1 second
-
-            percentageCompletion.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-                @Override
-                public void onAnimationUpdate(ValueAnimator animation) {
-                    double dist = ((float) animation.getAnimatedValue()) * lineLen;
-                    double distStart = dist - pointLen;
-                    if (distStart < 0) distStart = 0;
-                    slicerForPath.setMeterDistanceSlice(distStart, dist);
-                    mapView.invalidate();
-                }
+            //Set up directional animation. Retained in pathAnimator (not a bare local as
+            //before) so clearLines() can cancel it when the line leaves the map; an
+            //un-cancelled INFINITE animator leaks the line + MapView and repaints ~60x/s
+            //forever (see DirectionLineAnimator).
+            this.pathAnimator = new DirectionLineAnimator(1000, fraction -> {
+                double dist = fraction * lineLen;
+                double distStart = dist - pointLen;
+                if (distStart < 0) distStart = 0;
+                slicerForPath.setMeterDistanceSlice(distStart, dist);
+                mapView.invalidate();
             });
-            percentageCompletion.start();
+            this.pathAnimator.start();
+        }
+
+        /**
+         * Stop and release this line's direction animation, if it has one. Called when
+         * the line is removed from the map (see {@link GridOsmMapView#clearLines()} and
+         * {@link GridOsmMapView#clearSelectedLines()}) so its infinite animator does not
+         * outlive the line. Idempotent; a QSL-history line has no animator, making this a
+         * no-op there.
+         */
+        public void stopAnimation() {
+            if (pathAnimator != null) {
+                pathAnimator.stop();
+            }
         }
 
         /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/grid_tracker/DirectionLineAnimatorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/grid_tracker/DirectionLineAnimatorTest.java
@@ -1,0 +1,61 @@
+package com.k1af.ft8af.grid_tracker;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Lifecycle tests for {@link DirectionLineAnimator}, the animator extracted from
+ * {@code GridOsmMapView.GridPolyLine} so its cancellation can be verified without an
+ * osmdroid MapView.
+ *
+ * <p>The bug these pin: the direction animator used to be started and never
+ * cancelled, so every removed line left a running INFINITE animator behind (a leak +
+ * a ~60 Hz repaint that never stops). {@link DirectionLineAnimator#stop()} must turn
+ * a running animator off — that is what {@code clearLines()} now calls for each line
+ * it drops. {@code android.animation.ValueAnimator} is an Android type, hence
+ * Robolectric.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DirectionLineAnimatorTest {
+
+    @Test
+    public void newAnimator_isNotRunningUntilStarted() {
+        DirectionLineAnimator anim = new DirectionLineAnimator(1000, fraction -> { });
+        // Construction alone must not start the animation.
+        assertThat(anim.isRunning()).isFalse();
+    }
+
+    @Test
+    public void start_thenStop_leavesAnimatorNotRunning() {
+        DirectionLineAnimator anim = new DirectionLineAnimator(1000, fraction -> { });
+        anim.start();
+        assertThat(anim.isRunning()).isTrue();
+        // The fix: stopping the line's animator must actually cancel the infinite
+        // animation (before this it ran forever after the line was removed).
+        anim.stop();
+        assertThat(anim.isRunning()).isFalse();
+    }
+
+    @Test
+    public void stop_isIdempotent() {
+        DirectionLineAnimator anim = new DirectionLineAnimator(1000, fraction -> { });
+        anim.start();
+        anim.stop();
+        // clearLines() may reach a line whose animation is already stopped; a second
+        // stop() must be a harmless no-op, never an exception.
+        anim.stop();
+        assertThat(anim.isRunning()).isFalse();
+    }
+
+    @Test
+    public void stop_beforeStart_isSafe() {
+        DirectionLineAnimator anim = new DirectionLineAnimator(1000, fraction -> { });
+        // A line removed before its animation ever ran (or a QSL line routed here in
+        // future) must tolerate stop() without starting.
+        anim.stop();
+        assertThat(anim.isRunning()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

The grid-tracker map leaks an **infinite `ValueAnimator` per decoded line** — never cancelled — which pins the `MapView` in memory and forces a full map redraw ~60×/second forever. On a long-running session over a busy band these accumulate without bound: rising CPU/redraw load and a monotonic memory leak that ends in jank / ANR / OOM.

## Root cause

`GridOsmMapView.GridPolyLine`'s decoded-line constructor sets up the "marching ants" direction highlight like this:

```java
final ValueAnimator percentageCompletion = ValueAnimator.ofFloat(0, 1);
percentageCompletion.setRepeatCount(ValueAnimator.INFINITE);
...
percentageCompletion.addUpdateListener(a -> { ...; mapView.invalidate(); });
percentageCompletion.start();
```

`percentageCompletion` is a **bare local**: it is started and then never referenced again — there is no field, no `cancel()`, nowhere. The platform `AnimationHandler` holds a strong reference to every running animator, so each one:

1. can never be garbage-collected — it drags its captured line and the whole `MapView` with it, and
2. keeps firing its update listener, which calls `MapView.invalidate()`, ~60×/second **forever**.

The tracker map rebuilds its lines every decode cycle: the LiveData observers call `clearLines()` and then `drawLine()` per decoded station. `clearLines()` removed each line from the overlay list but **never cancelled its animator**, so every cycle's discarded lines were left behind as orphaned, still-running animators. Only the `Ft8Message` constructor animates; the QSL-history line has no animator.

## Fix

- Extract the animator into a small, focused **`DirectionLineAnimator`** (`start()` / `stop()` / `isRunning()`) so its lifecycle can be unit-tested without an osmdroid `MapView`. `GridPolyLine` holds it in a field and exposes `stopAnimation()`. The animation config (infinite, 1 s, the same per-frame slice math) is unchanged — animating lines look and behave exactly as before.
- Cancel the animator at **every point a line leaves the map**:
  - each discarded `gridLines` member in `clearLines()` — skipping the retained `selectedLine`, which is re-added and still visible, so it keeps animating;
  - the `selectedLine` when its highlight retention window elapses (and it is not re-added);
  - `clearSelectedLines()`.
- `stop()` is idempotent and safe before `start()`; `stopAnimation()` is a no-op on a QSL-history line (no animator).

`clearLines()` / `clearSelectedLines()` are the only sites that remove a `GridPolyLine` from the map — the other `gridLines` loops just open/close info windows.

## Testing

- New **`DirectionLineAnimatorTest`** (Robolectric — `ValueAnimator` is an Android type): not-running until started; `stop()` cancels a running infinite animator; `stop()` is idempotent; `stop()` before `start()` is safe.
- `./gradlew :app:testDebugUnitTest` — full suite passes, no regressions.

## Risk

Low. Localized to the grid-tracker overlay teardown. No protocol, DSP, decoder, or CAT behaviour is touched; interoperability and decode sensitivity are unaffected. Animation appearance for live lines is unchanged — the only difference is that an animator now stops when its line disappears from the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)