### PR TITLE
Fix PSKReporter dedup map growing without bound (slow memory leak)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
@@ -250,8 +250,43 @@ object PskReporterSender {
         }
     }
 
+    /**
+     * Evict dedup entries whose last-seen time has aged past [DEDUP_WINDOW_MS].
+     *
+     * The dedup map records a last-seen timestamp per "CALL|BAND" so a station is
+     * uploaded at most once per window. Entries are added on every fresh spot, but
+     * were never removed — so over a long monitoring session (the common
+     * PSKReporter use case: leave the app decoding a busy band for hours or days)
+     * the map grew without bound, one entry per distinct callsign/band ever heard.
+     * Because this is a process-lifetime singleton, that is a slow, unbounded leak.
+     *
+     * An entry older than the window carries no information: [markIfFresh] would
+     * report that key as fresh again regardless, so dropping it is behavior-neutral.
+     * Called from [flush] (once per send interval), which keeps the map bounded to
+     * roughly the distinct stations seen within the last window. Pure w.r.t.
+     * [nowMs] so it is deterministically testable.
+     */
+    @VisibleForTesting
+    internal fun pruneDedup(nowMs: Long) {
+        synchronized(dedup) {
+            val it = dedup.entries.iterator()
+            while (it.hasNext()) {
+                if (nowMs - it.next().value >= DEDUP_WINDOW_MS) it.remove()
+            }
+        }
+    }
+
+    /** For testing: current number of live dedup entries. */
+    @VisibleForTesting
+    internal fun dedupSize(): Int = synchronized(dedup) { dedup.size }
+
     @VisibleForTesting
     internal suspend fun flush() {
+        // Keep the dedup map bounded: drop keys that have aged out of the window
+        // (see pruneDedup). Runs every send interval, before draining the queue, so
+        // it fires even when the band is quiet and no spots are pending.
+        pruneDedup(System.currentTimeMillis())
+
         val spots = mutableListOf<SpotRecord>()
         while (true) {
             val s = spotQueue.poll() ?: break

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSender.kt
@@ -251,7 +251,7 @@ object PskReporterSender {
     }
 
     /**
-     * Evict dedup entries whose last-seen time has aged past [DEDUP_WINDOW_MS].
+     * Evict dedup entries whose age has reached or passed [DEDUP_WINDOW_MS].
      *
      * The dedup map records a last-seen timestamp per "CALL|BAND" so a station is
      * uploaded at most once per window. Entries are added on every fresh spot, but
@@ -260,8 +260,10 @@ object PskReporterSender {
      * the map grew without bound, one entry per distinct callsign/band ever heard.
      * Because this is a process-lifetime singleton, that is a slow, unbounded leak.
      *
-     * An entry older than the window carries no information: [markIfFresh] would
-     * report that key as fresh again regardless, so dropping it is behavior-neutral.
+     * An entry at or past the window boundary carries no information: [markIfFresh]
+     * would report that key as fresh again regardless (it treats age
+     * `>= DEDUP_WINDOW_MS` as no longer a duplicate), so dropping it is
+     * behavior-neutral.
      * Called from [flush] (once per send interval), which keeps the map bounded to
      * roughly the distinct stations seen within the last window. Pure w.r.t.
      * [nowMs] so it is deterministically testable.

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/pskreporter/PskReporterSenderTest.kt
@@ -628,6 +628,59 @@ class PskReporterSenderTest {
         assertThat(admitted.get()).isEqualTo(threadCount * perThread)
     }
 
+    // ---------------------------------------------------------------
+    // Dedup map eviction (pruneDedup) — bounded-memory guarantee
+    // ---------------------------------------------------------------
+
+    @Test
+    fun `pruneDedup evicts entries aged past the window and keeps fresh ones`() {
+        // Two stations marked at t=1000; one refreshed just before pruning.
+        assertThat(PskReporterSender.markIfFresh("OLD|14", 1_000L)).isTrue()
+        assertThat(PskReporterSender.markIfFresh("NEW|14", 1_000L)).isTrue()
+        assertThat(PskReporterSender.dedupSize()).isEqualTo(2)
+
+        // Refresh NEW right at the prune instant so it is still inside the window.
+        val now = 1_000L + dedupWindowMs
+        assertThat(PskReporterSender.markIfFresh("NEW|14", now)).isTrue()
+
+        // OLD is exactly window-old (nowMs - lastSeen == window) → aged out; NEW stays.
+        PskReporterSender.pruneDedup(now)
+        assertThat(PskReporterSender.dedupSize()).isEqualTo(1)
+        // OLD is gone, so it reports fresh again; NEW is still deduped.
+        assertThat(PskReporterSender.markIfFresh("OLD|14", now)).isTrue()
+        assertThat(PskReporterSender.markIfFresh("NEW|14", now)).isFalse()
+    }
+
+    @Test
+    fun `pruneDedup keeps entries still inside the window`() {
+        assertThat(PskReporterSender.markIfFresh("W1AW|14", 1_000L)).isTrue()
+        // One millisecond short of the full window → not yet stale.
+        PskReporterSender.pruneDedup(1_000L + dedupWindowMs - 1)
+        assertThat(PskReporterSender.dedupSize()).isEqualTo(1)
+    }
+
+    @Test
+    fun `pruneDedup on an empty map is a no-op`() {
+        PskReporterSender.pruneDedup(10_000_000L)
+        assertThat(PskReporterSender.dedupSize()).isEqualTo(0)
+    }
+
+    @Test
+    fun `flush prunes stale dedup entries so the map stays bounded`() {
+        // Populate the dedup map with entries that are already stale relative to the
+        // real clock flush() uses, then flush an empty spot queue: without eviction
+        // the map would retain every historical entry forever (the leak).
+        assertThat(PskReporterSender.markIfFresh("STALE1|14", 1_000L)).isTrue()
+        assertThat(PskReporterSender.markIfFresh("STALE2|7", 2_000L)).isTrue()
+        assertThat(PskReporterSender.dedupSize()).isEqualTo(2)
+
+        kotlinx.coroutines.runBlocking { PskReporterSender.flush() }
+
+        // System.currentTimeMillis() is vastly larger than the fixture timestamps, so
+        // every entry has aged past the 5-minute window and flush() evicts them all.
+        assertThat(PskReporterSender.dedupSize()).isEqualTo(0)
+    }
+
     /** Decode a hex string (all whitespace ignored) into bytes for golden-vector comparison. */
     private fun hex(s: String): ByteArray {
         val clean = s.filterNot { it.isWhitespace() }


### PR DESCRIPTION
## Summary

`PskReporterSender` (a process-lifetime `object` singleton) keeps a per-`"CALL|BAND"` last-seen map (`dedup`) so a decoded station is uploaded to PSKReporter at most once per 5-minute window. Entries were **added on every fresh spot but never removed**, so the map grew one entry per distinct callsign/band ever heard for the life of the process.

The common PSKReporter use case is to leave the app decoding a busy band for hours or days. On a busy band that is hundreds of unique stations per hour, accumulating unbounded — a slow but real memory leak with no ceiling.

## Root cause

`markIfFresh()` did `dedup[key] = now` on every first sighting but nothing ever evicted stale keys. Once an entry is older than `DEDUP_WINDOW_MS` (5 min) it carries **no information** — `markIfFresh()` would treat that key as fresh again regardless — so it is pure dead weight.

## Fix

Add `pruneDedup(nowMs)`, which evicts entries whose last-seen time has aged past the window, and call it from `flush()` (once per send interval, before draining the queue, so it fires even when the band is quiet and no spots are pending). This bounds the map to roughly the distinct stations seen within the last window.

The change is **behavior-neutral** for spot reporting: only entries that could never suppress a duplicate again are removed. No protocol/DSP/encoding path is touched.

## Testing

- 4 new `PskReporterSenderTest` cases:
  - `pruneDedup evicts entries aged past the window and keeps fresh ones` — boundary: exactly window-old is evicted, an entry refreshed at the prune instant is kept, and an evicted key reports fresh again.
  - `pruneDedup keeps entries still inside the window` — one ms short of the window is retained.
  - `pruneDedup on an empty map is a no-op`.
  - `flush prunes stale dedup entries so the map stays bounded` — end-to-end via `flush()`.
- Full `:app:testDebugUnitTest` green (31 cases in this class, whole suite passing).

## Risk

Very low. Localized to the dedup-bookkeeping path; no change to IPFIX encoding, the send loop, or dedup semantics within the window. Pure `nowMs` parameterization keeps it deterministically testable.