### PR TITLE
Show a station's gray-line / sun status when you tap it

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
@@ -974,8 +974,14 @@ private fun grayLineStatusText(display: GrayLineDisplay): String {
         GrayLinePhase.NIGHT -> stringResource(R.string.qso_grayline_night)
     }
     val detailText = when (display.detail) {
-        GrayLineDetail.SUNRISE -> stringResource(R.string.qso_grayline_sunrise_in, display.countdown)
-        GrayLineDetail.SUNSET -> stringResource(R.string.qso_grayline_sunset_in, display.countdown)
+        // An empty countdown flags the "happening now" case: use a grammatical,
+        // localized "at sunrise/sunset" string instead of "sunrise in now".
+        GrayLineDetail.SUNRISE ->
+            if (display.countdown.isEmpty()) stringResource(R.string.qso_grayline_sunrise_now)
+            else stringResource(R.string.qso_grayline_sunrise_in, display.countdown)
+        GrayLineDetail.SUNSET ->
+            if (display.countdown.isEmpty()) stringResource(R.string.qso_grayline_sunset_now)
+            else stringResource(R.string.qso_grayline_sunset_in, display.countdown)
         GrayLineDetail.MIDNIGHT_SUN -> stringResource(R.string.qso_grayline_midnight_sun)
         GrayLineDetail.POLAR_NIGHT -> stringResource(R.string.qso_grayline_polar_night)
     }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
@@ -63,9 +63,14 @@ import radio.ks3ckc.ft8af.ui.components.FT8AFIcons
 import radio.ks3ckc.ft8af.ui.components.GlassCard
 import radio.ks3ckc.ft8af.ui.components.QsoStatus
 import radio.ks3ckc.ft8af.ui.components.StatusPill
+import radio.ks3ckc.ft8af.ui.map.GrayLineDetail
+import radio.ks3ckc.ft8af.ui.map.GrayLineDisplay
+import radio.ks3ckc.ft8af.ui.map.GrayLinePhase
 import radio.ks3ckc.ft8af.ui.map.UsStateOutlines
 import radio.ks3ckc.ft8af.ui.map.WorldOutlines
 import radio.ks3ckc.ft8af.ui.map.forEachRingVertex
+import radio.ks3ckc.ft8af.ui.map.grayLineDisplay
+import radio.ks3ckc.ft8af.ui.map.solarSnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -149,6 +154,10 @@ private fun QsoSheetContent(
 
         // -- Last heard: relative recency of this decode, above the map --
         LastHeardRow(utcTimeMillis = message.utcTime, mainViewModel = mainViewModel)
+
+        // -- Gray line: is the DX at their sunrise/sunset right now, and how long
+        // until they are? A propagation timing aid; renders nothing without a grid.
+        GrayLineRow(grid = message.maidenGrid)
 
         Spacer(modifier = Modifier.height(12.dp))
 
@@ -914,6 +923,63 @@ private fun LastHeardRow(utcTimeMillis: Long, mainViewModel: MainViewModel) {
             fontSize = 13.sp,
         )
     }
+}
+
+/**
+ * Gray-line / sun status for the tapped station. Shows whether the DX is in
+ * daylight, night, or on the gray line right now, plus a countdown to their next
+ * sunrise/sunset — the moments HF propagation to them is briefly enhanced.
+ *
+ * Renders nothing when the station's grid is unknown (nothing to place on the
+ * globe). The snapshot is computed once when the sheet opens: the state changes
+ * over minutes, and rescanning a 26-hour window every second would be wasteful,
+ * so we deliberately do not observe the ticking clock here.
+ */
+@Composable
+private fun GrayLineRow(grid: String?) {
+    val latLon = remember(grid) { gridToLatLon(grid) } ?: return
+    val display = remember(grid) {
+        grayLineDisplay(solarSnapshot(latLon.first, latLon.second, UtcTimer.getSystemTime()))
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.qso_grayline_label),
+            color = TextFaint,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.06.sp,
+        )
+        val onGrayLine = display.phase == GrayLinePhase.GRAY_LINE
+        Text(
+            text = grayLineStatusText(display),
+            color = if (onGrayLine) Accent else TextPrimary,
+            fontFamily = GeistMonoFamily,
+            fontWeight = if (onGrayLine) FontWeight.Bold else FontWeight.SemiBold,
+            fontSize = 13.sp,
+        )
+    }
+}
+
+/** Map [GrayLineDisplay] tokens to a localized "Daylight · sunset in 1h 20m" line. */
+@Composable
+private fun grayLineStatusText(display: GrayLineDisplay): String {
+    val phaseText = when (display.phase) {
+        GrayLinePhase.GRAY_LINE -> stringResource(R.string.qso_grayline_now)
+        GrayLinePhase.DAYLIGHT -> stringResource(R.string.qso_grayline_daylight)
+        GrayLinePhase.NIGHT -> stringResource(R.string.qso_grayline_night)
+    }
+    val detailText = when (display.detail) {
+        GrayLineDetail.SUNRISE -> stringResource(R.string.qso_grayline_sunrise_in, display.countdown)
+        GrayLineDetail.SUNSET -> stringResource(R.string.qso_grayline_sunset_in, display.countdown)
+        GrayLineDetail.MIDNIGHT_SUN -> stringResource(R.string.qso_grayline_midnight_sun)
+        GrayLineDetail.POLAR_NIGHT -> stringResource(R.string.qso_grayline_polar_night)
+    }
+    return "$phaseText · $detailText"
 }
 
 // ---------------------------------------------------------------------------

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatus.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatus.kt
@@ -147,14 +147,16 @@ internal fun grayLineDisplay(s: SolarSnapshot): GrayLineDisplay {
 }
 
 /**
- * Format a whole-minute countdown as a compact "1h 20m" / "45m" / "now" string.
- * Used for the "sunset in …" / "sunrise in …" gray-line hint. Kept pure (no
- * Android resources) so it is unit-tested directly; the surrounding "sunset
- * in {x}" wording is supplied by the caller via string resources.
+ * Format a whole-minute countdown as a compact "1h 20m" / "45m" string, or the
+ * empty string when the event is happening now (< 1 minute away). Used for the
+ * "sunset in …" / "sunrise in …" gray-line hint; the empty return flags the
+ * "now" case so the caller can pick a grammatical, localized "at sunrise" /
+ * "at sunset" resource instead of interpolating a hardcoded "now" into
+ * "sunrise in …". Kept pure (no Android resources) so it is unit-tested directly.
  */
 internal fun formatSolarCountdown(minutes: Int): String {
     val m = minutes.coerceAtLeast(0)
-    if (m < 1) return "now"
+    if (m < 1) return ""
     val hours = m / 60
     val mins = m % 60
     return when {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatus.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatus.kt
@@ -1,0 +1,165 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import kotlin.math.abs
+import kotlin.math.roundToLong
+
+/**
+ * Per-station solar / gray-line status.
+ *
+ * HF propagation is briefly enhanced along the "gray line" — the moving band of
+ * sunrise/sunset — so a DX operator who knows a distant station is *at* their
+ * sunrise/sunset (or how long until they are) can time a call for the best shot.
+ * The map already draws the terminator; this file answers the same question for
+ * a single point (the station's grid): are they in daylight, night, or on the
+ * gray line right now, and when is their next sunrise/sunset?
+ *
+ * Everything here is a pure function of (lat, lon, UTC) built on the same
+ * [subsolarPoint] / [solarElevationDeg] math as the map overlay, so the QSO
+ * sheet stays a thin wrapper and the logic is unit-tested directly.
+ */
+
+/** Which way the Sun is about to cross the horizon at a point. */
+internal enum class SolarEventKind { SUNRISE, SUNSET }
+
+/**
+ * A point's solar situation at an instant.
+ *
+ * @param elevationDeg the Sun's angle above the horizon (negative = below).
+ * @param isDay whether the Sun is above the horizon.
+ * @param onGrayLine whether the Sun is within the gray-line band of the horizon.
+ * @param nextKind the next horizon crossing, or null in polar day/night where no
+ *   crossing occurs within the scan window.
+ * @param minutesToNext whole minutes until [nextKind]; 0 when [nextKind] is null.
+ */
+internal data class SolarSnapshot(
+    val elevationDeg: Double,
+    val isDay: Boolean,
+    val onGrayLine: Boolean,
+    val nextKind: SolarEventKind?,
+    val minutesToNext: Int,
+)
+
+/** Half-width (degrees) of the gray-line band on either side of the horizon. */
+internal const val GRAY_LINE_HALF_WIDTH_DEG: Double = 6.0
+
+/** Step used when scanning forward for the next sunrise/sunset. */
+private const val EVENT_SCAN_STEP_MS: Long = 2L * 60L * 1000L
+
+/** How far ahead to scan; a little over a day guarantees at least one crossing
+ *  outside the polar regions. */
+private const val EVENT_SCAN_SPAN_MS: Long = 26L * 60L * 60L * 1000L
+
+/**
+ * The solar situation at [lat]/[lon] for the UTC instant [utcMillis].
+ *
+ * "Day" is elevation ≥ 0; the gray line is |elevation| ≤ [grayLineHalfWidthDeg].
+ * The next crossing is found by scanning forward in [EVENT_SCAN_STEP_MS] steps
+ * and linearly interpolating the exact horizon crossing between the two
+ * bracketing samples — accurate to well under a minute, which is plenty for an
+ * operating aid. Near the poles a full day can pass with the Sun never crossing
+ * the horizon (midnight sun / polar night); there [nextKind] is null.
+ */
+internal fun solarSnapshot(
+    lat: Double,
+    lon: Double,
+    utcMillis: Long,
+    grayLineHalfWidthDeg: Double = GRAY_LINE_HALF_WIDTH_DEG,
+): SolarSnapshot {
+    val elevNow = solarElevationDeg(lat, lon, subsolarPoint(utcMillis))
+
+    var prevElev = elevNow
+    var t = utcMillis + EVENT_SCAN_STEP_MS
+    val end = utcMillis + EVENT_SCAN_SPAN_MS
+    var nextKind: SolarEventKind? = null
+    var crossingMs = 0L
+    while (t <= end) {
+        val elev = solarElevationDeg(lat, lon, subsolarPoint(t))
+        // A crossing happens when consecutive samples straddle the horizon.
+        if (prevElev < 0.0 && elev >= 0.0) {
+            nextKind = SolarEventKind.SUNRISE
+        } else if (prevElev >= 0.0 && elev < 0.0) {
+            nextKind = SolarEventKind.SUNSET
+        }
+        if (nextKind != null) {
+            // Linear interpolation of the exact zero crossing within this step.
+            val span = elev - prevElev
+            val frac = if (span == 0.0) 0.0 else (0.0 - prevElev) / span
+            val prevT = t - EVENT_SCAN_STEP_MS
+            crossingMs = prevT + (frac * EVENT_SCAN_STEP_MS).roundToLong()
+            break
+        }
+        prevElev = elev
+        t += EVENT_SCAN_STEP_MS
+    }
+
+    val minutesToNext = if (nextKind == null) {
+        0
+    } else {
+        ((crossingMs - utcMillis).coerceAtLeast(0L) / 60000L).toInt()
+    }
+
+    return SolarSnapshot(
+        elevationDeg = elevNow,
+        isDay = elevNow >= 0.0,
+        onGrayLine = abs(elevNow) <= grayLineHalfWidthDeg,
+        nextKind = nextKind,
+        minutesToNext = minutesToNext,
+    )
+}
+
+/** The three visual phases of the gray-line hint. */
+internal enum class GrayLinePhase { GRAY_LINE, DAYLIGHT, NIGHT }
+
+/** The secondary detail: the next event, or a polar no-event state. */
+internal enum class GrayLineDetail { SUNRISE, SUNSET, MIDNIGHT_SUN, POLAR_NIGHT }
+
+/**
+ * What the gray-line hint should say, as resource-free tokens plus a preformatted
+ * [countdown]. The QSO-sheet Composable maps [phase]/[detail] to localized strings
+ * (so wording stays translatable) while this decision stays pure and unit-tested.
+ * [countdown] is empty for the polar no-event details.
+ */
+internal data class GrayLineDisplay(
+    val phase: GrayLinePhase,
+    val detail: GrayLineDetail,
+    val countdown: String,
+)
+
+/** Resolve a [SolarSnapshot] into the tokens the gray-line hint should display. */
+internal fun grayLineDisplay(s: SolarSnapshot): GrayLineDisplay {
+    val phase = when {
+        s.onGrayLine -> GrayLinePhase.GRAY_LINE
+        s.isDay -> GrayLinePhase.DAYLIGHT
+        else -> GrayLinePhase.NIGHT
+    }
+    return when (s.nextKind) {
+        SolarEventKind.SUNRISE ->
+            GrayLineDisplay(phase, GrayLineDetail.SUNRISE, formatSolarCountdown(s.minutesToNext))
+        SolarEventKind.SUNSET ->
+            GrayLineDisplay(phase, GrayLineDetail.SUNSET, formatSolarCountdown(s.minutesToNext))
+        null ->
+            GrayLineDisplay(
+                phase,
+                if (s.isDay) GrayLineDetail.MIDNIGHT_SUN else GrayLineDetail.POLAR_NIGHT,
+                "",
+            )
+    }
+}
+
+/**
+ * Format a whole-minute countdown as a compact "1h 20m" / "45m" / "now" string.
+ * Used for the "sunset in …" / "sunrise in …" gray-line hint. Kept pure (no
+ * Android resources) so it is unit-tested directly; the surrounding "sunset
+ * in {x}" wording is supplied by the caller via string resources.
+ */
+internal fun formatSolarCountdown(minutes: Int): String {
+    val m = minutes.coerceAtLeast(0)
+    if (m < 1) return "now"
+    val hours = m / 60
+    val mins = m % 60
+    return when {
+        hours <= 0 -> "${mins}m"
+        mins == 0 -> "${hours}h"
+        else -> "${hours}h ${mins}m"
+    }
+}

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -229,6 +229,15 @@
     <string name="qso_last_heard_minutes">%1$dm ago</string>
     <string name="qso_last_heard_hours">%1$dh ago</string>
     <string name="qso_last_heard_days">%1$dd ago</string>
+    <!-- Gray-line / sun status for a tapped station -->
+    <string name="qso_grayline_label">Gray line</string>
+    <string name="qso_grayline_now">On the gray line now</string>
+    <string name="qso_grayline_daylight">Daylight</string>
+    <string name="qso_grayline_night">Night</string>
+    <string name="qso_grayline_sunrise_in">sunrise in %1$s</string>
+    <string name="qso_grayline_sunset_in">sunset in %1$s</string>
+    <string name="qso_grayline_midnight_sun">midnight sun</string>
+    <string name="qso_grayline_polar_night">polar night</string>
 
     <!-- ===== Logbook ===== -->
     <string name="log_tab_stats">Stats</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -236,6 +236,8 @@
     <string name="qso_grayline_night">Night</string>
     <string name="qso_grayline_sunrise_in">sunrise in %1$s</string>
     <string name="qso_grayline_sunset_in">sunset in %1$s</string>
+    <string name="qso_grayline_sunrise_now">at sunrise</string>
+    <string name="qso_grayline_sunset_now">at sunset</string>
     <string name="qso_grayline_midnight_sun">midnight sun</string>
     <string name="qso_grayline_polar_night">polar night</string>
 

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatusTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatusTest.kt
@@ -151,9 +151,11 @@ class SolarStatusTest {
     }
 
     @Test
-    fun countdown_zeroOrNegative_isNow() {
-        assertThat(formatSolarCountdown(0)).isEqualTo("now")
-        assertThat(formatSolarCountdown(-5)).isEqualTo("now")
+    fun countdown_zeroOrNegative_isEmptyNowFlag() {
+        // < 1 minute away returns "" so the caller can render a grammatical,
+        // localized "at sunrise/sunset" instead of "sunrise in now".
+        assertThat(formatSolarCountdown(0)).isEmpty()
+        assertThat(formatSolarCountdown(-5)).isEmpty()
     }
 
     // -----------------------------------------------------------------------
@@ -184,6 +186,20 @@ class SolarStatusTest {
         assertThat(d.phase).isEqualTo(GrayLinePhase.NIGHT)
         assertThat(d.detail).isEqualTo(GrayLineDetail.SUNRISE)
         assertThat(d.countdown).isEqualTo("45m")
+    }
+
+    @Test
+    fun display_eventImminent_hasEmptyCountdownForNowRendering() {
+        // Sunset < 1 minute away: detail is still SUNSET, but the countdown is
+        // empty so the QSO sheet renders the localized "at sunset" now-string.
+        val d = grayLineDisplay(
+            SolarSnapshot(
+                elevationDeg = 0.5, isDay = true, onGrayLine = true,
+                nextKind = SolarEventKind.SUNSET, minutesToNext = 0,
+            ),
+        )
+        assertThat(d.detail).isEqualTo(GrayLineDetail.SUNSET)
+        assertThat(d.countdown).isEmpty()
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatusTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/SolarStatusTest.kt
@@ -1,0 +1,226 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.TimeZone
+
+/**
+ * Pure unit tests for the per-station gray-line / sun-status helper. No Android
+ * or Compose runtime is touched, so these run as plain JVM tests.
+ */
+class SolarStatusTest {
+
+    private fun utc(year: Int, month: Int, day: Int, hour: Int, minute: Int = 0): Long =
+        GregorianCalendar(TimeZone.getTimeZone("UTC")).apply {
+            clear()
+            set(year, month, day, hour, minute, 0)
+        }.timeInMillis
+
+    // -----------------------------------------------------------------------
+    // Day / night classification
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun localSolarNoon_isDaytime() {
+        // Prime meridian at 12:00 UTC near an equinox: the Sun is high overhead.
+        val s = solarSnapshot(lat = 0.0, lon = 0.0, utcMillis = utc(2024, Calendar.MARCH, 20, 12))
+        assertThat(s.isDay).isTrue()
+        assertThat(s.elevationDeg).isGreaterThan(60.0)
+        assertThat(s.onGrayLine).isFalse()
+    }
+
+    @Test
+    fun localMidnight_isNight() {
+        // Prime meridian at 00:00 UTC: the Sun is on the far side of the Earth.
+        val s = solarSnapshot(lat = 0.0, lon = 0.0, utcMillis = utc(2024, Calendar.MARCH, 20, 0))
+        assertThat(s.isDay).isFalse()
+        assertThat(s.elevationDeg).isLessThan(-60.0)
+        assertThat(s.onGrayLine).isFalse()
+    }
+
+    // -----------------------------------------------------------------------
+    // Next sunrise / sunset
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun daytime_nextEventIsSunset() {
+        val s = solarSnapshot(lat = 0.0, lon = 0.0, utcMillis = utc(2024, Calendar.MARCH, 20, 12))
+        assertThat(s.nextKind).isEqualTo(SolarEventKind.SUNSET)
+        // At the equator on an equinox, sunset is ~6 h after local noon.
+        assertThat(s.minutesToNext).isWithin(30).of(6 * 60)
+    }
+
+    @Test
+    fun night_nextEventIsSunrise() {
+        val s = solarSnapshot(lat = 0.0, lon = 0.0, utcMillis = utc(2024, Calendar.MARCH, 20, 3))
+        assertThat(s.nextKind).isEqualTo(SolarEventKind.SUNRISE)
+        // 03:00 UTC on the prime meridian is a few hours before ~06:00 sunrise.
+        assertThat(s.minutesToNext).isWithin(30).of(3 * 60)
+    }
+
+    @Test
+    fun sunriseCrossing_flipsToDaytime() {
+        // Just before sunrise it is night; the very next event is a sunrise, and
+        // an hour later the same point reads as daytime.
+        val beforeDawn = solarSnapshot(lat = 0.0, lon = 0.0, utcMillis = utc(2024, Calendar.MARCH, 20, 5))
+        assertThat(beforeDawn.isDay).isFalse()
+        assertThat(beforeDawn.nextKind).isEqualTo(SolarEventKind.SUNRISE)
+
+        val afterDawn = solarSnapshot(lat = 0.0, lon = 0.0, utcMillis = utc(2024, Calendar.MARCH, 20, 7))
+        assertThat(afterDawn.isDay).isTrue()
+    }
+
+    // -----------------------------------------------------------------------
+    // Gray line
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun nearSunrise_isOnGrayLine() {
+        // Sweep the dawn hour and confirm the point passes through the gray-line
+        // band (|elevation| within the half-width) as the Sun crosses the horizon.
+        var sawGrayLine = false
+        for (minute in 0 until 120 step 4) {
+            val s = solarSnapshot(
+                lat = 0.0,
+                lon = 0.0,
+                utcMillis = utc(2024, Calendar.MARCH, 20, 5, minute % 60) +
+                    (minute / 60) * 3600_000L,
+            )
+            if (s.onGrayLine) sawGrayLine = true
+        }
+        assertThat(sawGrayLine).isTrue()
+    }
+
+    @Test
+    fun grayLineWidth_isConfigurable() {
+        // A point 4° below the horizon is on the gray line at the default 6°
+        // half-width but not at a tight 2° one.
+        // Find an instant where the equatorial Sun sits a few degrees down.
+        var base = utc(2024, Calendar.MARCH, 20, 5, 30)
+        // Nudge forward until elevation lands in (-5, -3).
+        var chosen = -1L
+        var m = 0
+        while (m < 120) {
+            val t = base + m * 60_000L
+            val elev = solarSnapshot(0.0, 0.0, t).elevationDeg
+            if (elev in -5.0..-3.0) {
+                chosen = t
+                break
+            }
+            m++
+        }
+        assertThat(chosen).isGreaterThan(0L)
+        assertThat(solarSnapshot(0.0, 0.0, chosen, grayLineHalfWidthDeg = 6.0).onGrayLine).isTrue()
+        assertThat(solarSnapshot(0.0, 0.0, chosen, grayLineHalfWidthDeg = 2.0).onGrayLine).isFalse()
+    }
+
+    // -----------------------------------------------------------------------
+    // Polar day / night
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun arcticSummer_hasNoSunsetWithinScan() {
+        // North Pole at the June solstice: midnight sun — the Sun never sets, so
+        // there is no next crossing.
+        val s = solarSnapshot(lat = 89.0, lon = 0.0, utcMillis = utc(2024, Calendar.JUNE, 21, 12))
+        assertThat(s.isDay).isTrue()
+        assertThat(s.nextKind).isNull()
+        assertThat(s.minutesToNext).isEqualTo(0)
+    }
+
+    @Test
+    fun arcticWinter_hasNoSunriseWithinScan() {
+        // North Pole at the December solstice: polar night — the Sun never rises.
+        val s = solarSnapshot(lat = 89.0, lon = 0.0, utcMillis = utc(2024, Calendar.DECEMBER, 21, 12))
+        assertThat(s.isDay).isFalse()
+        assertThat(s.nextKind).isNull()
+    }
+
+    // -----------------------------------------------------------------------
+    // Countdown formatting
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun countdown_formatsHoursAndMinutes() {
+        assertThat(formatSolarCountdown(80)).isEqualTo("1h 20m")
+        assertThat(formatSolarCountdown(45)).isEqualTo("45m")
+        assertThat(formatSolarCountdown(120)).isEqualTo("2h")
+        assertThat(formatSolarCountdown(60)).isEqualTo("1h")
+    }
+
+    @Test
+    fun countdown_zeroOrNegative_isNow() {
+        assertThat(formatSolarCountdown(0)).isEqualTo("now")
+        assertThat(formatSolarCountdown(-5)).isEqualTo("now")
+    }
+
+    // -----------------------------------------------------------------------
+    // Display tokens
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun display_daytime_showsDaylightAndSunset() {
+        val d = grayLineDisplay(
+            SolarSnapshot(
+                elevationDeg = 40.0, isDay = true, onGrayLine = false,
+                nextKind = SolarEventKind.SUNSET, minutesToNext = 80,
+            ),
+        )
+        assertThat(d.phase).isEqualTo(GrayLinePhase.DAYLIGHT)
+        assertThat(d.detail).isEqualTo(GrayLineDetail.SUNSET)
+        assertThat(d.countdown).isEqualTo("1h 20m")
+    }
+
+    @Test
+    fun display_night_showsNightAndSunrise() {
+        val d = grayLineDisplay(
+            SolarSnapshot(
+                elevationDeg = -30.0, isDay = false, onGrayLine = false,
+                nextKind = SolarEventKind.SUNRISE, minutesToNext = 45,
+            ),
+        )
+        assertThat(d.phase).isEqualTo(GrayLinePhase.NIGHT)
+        assertThat(d.detail).isEqualTo(GrayLineDetail.SUNRISE)
+        assertThat(d.countdown).isEqualTo("45m")
+    }
+
+    @Test
+    fun display_onGrayLine_overridesDayNightPhase() {
+        val d = grayLineDisplay(
+            SolarSnapshot(
+                elevationDeg = 2.0, isDay = true, onGrayLine = true,
+                nextKind = SolarEventKind.SUNSET, minutesToNext = 12,
+            ),
+        )
+        assertThat(d.phase).isEqualTo(GrayLinePhase.GRAY_LINE)
+        assertThat(d.detail).isEqualTo(GrayLineDetail.SUNSET)
+    }
+
+    @Test
+    fun display_polarDay_showsMidnightSunWithNoCountdown() {
+        val d = grayLineDisplay(
+            SolarSnapshot(
+                elevationDeg = 15.0, isDay = true, onGrayLine = false,
+                nextKind = null, minutesToNext = 0,
+            ),
+        )
+        assertThat(d.phase).isEqualTo(GrayLinePhase.DAYLIGHT)
+        assertThat(d.detail).isEqualTo(GrayLineDetail.MIDNIGHT_SUN)
+        assertThat(d.countdown).isEmpty()
+    }
+
+    @Test
+    fun display_polarNight_showsPolarNightWithNoCountdown() {
+        val d = grayLineDisplay(
+            SolarSnapshot(
+                elevationDeg = -10.0, isDay = false, onGrayLine = false,
+                nextKind = null, minutesToNext = 0,
+            ),
+        )
+        assertThat(d.phase).isEqualTo(GrayLinePhase.NIGHT)
+        assertThat(d.detail).isEqualTo(GrayLineDetail.POLAR_NIGHT)
+        assertThat(d.countdown).isEmpty()
+    }
+}


### PR DESCRIPTION
## What & why

Tapping a decoded station now shows a **Gray line** line in the QSO detail sheet: whether that station is in **daylight**, **night**, or **on the gray line right now**, plus a countdown to their **next sunrise/sunset** (e.g. `Daylight · sunset in 1h 20m`, `Night · sunrise in 40m`, or a highlighted `On the gray line now · sunset in 12m`).

The **gray line** — the moving band of sunrise/sunset sweeping across the Earth — is where HF propagation is briefly enhanced, so DXers deliberately time their calls to a station's sunrise/sunset. FT8AF already draws the terminator across the world map (#675); this answers the same question for the *one station you're about to work*, right at the moment you decide whether to call.

> "Wow, I wish every FT8 app did this" — knowing a distant station is sliding into their sunset (best-propagation window) *before* you tap Call is exactly the edge grey-line chasers want.

## How it works

Reuses the map overlay's NOAA solar math (`subsolarPoint` / `solarElevationDeg`), so no new astronomy and no risk to the decoder/TX path. New **pure, unit-tested** helpers in `ui/map/SolarStatus.kt`:

- `solarSnapshot(lat, lon, utc)` — current solar elevation, day/night, on-gray-line flag, and the next horizon crossing (found by scanning forward and linearly interpolating the exact zero crossing). Returns no event in polar day/night, where the Sun never crosses the horizon (midnight sun / polar night).
- `grayLineDisplay(snapshot)` — maps a snapshot to resource-free display tokens (phase + detail + preformatted countdown).
- `formatSolarCountdown(minutes)` — compact `1h 20m` / `45m` / `now`.

The QSO sheet stays a thin Composable wrapper (`GrayLineRow`) that maps the tokens to localized strings. It computes **once when the sheet opens** (the state changes over minutes; a per-second rescan of a 26-hour window would be wasteful — no battery/perf regression) and **renders nothing** when the station's grid is unknown.

## Scope

- No change to decoding, transmitting, CAT, or audio — display-only, gated on a known grid.
- WSJT-X / FT8 protocol compatibility untouched.

## Tests

`SolarStatusTest` (new): day/night classification, next sunrise vs. sunset with timing, the gray-line band (incl. configurable half-width), polar midnight-sun / polar-night (no crossing), countdown formatting, and the display-token decisions. Full `:app:testDebugUnitTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)