### PR TITLE
Add short/long-path beam heading for directional-antenna operators

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -58,6 +58,12 @@ public class GeneralVariables {
 
     public static boolean distanceInMiles = true;//Display distances in miles (true) or kilometers (false)
 
+    // Show the great-circle beam heading (bearing to the station) next to the
+    // distance on each decode row, for operators pointing a directional antenna.
+    // Off by default — only useful with a beam, and it adds a column most ops
+    // (verticals/wires) don't need.
+    public static boolean showBeamHeading = false;
+
     // Deep decode (subtract-and-redecode + extra LDPC iterations) is on by default so the app
     // pulls weak signals out from under strong ones the way WSJT-X does at its default depth.
     // A persisted "deepMode" config row still overrides this; only installs that never touched

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -3163,6 +3163,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("distanceInMiles")) {
                     GeneralVariables.distanceInMiles = !result.equals("0");
                 }
+                if (name.equalsIgnoreCase("showBeamHeading")) {
+                    GeneralVariables.showBeamHeading = result.equals("1");
+                }
 
             }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeading.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeading.kt
@@ -21,8 +21,9 @@ import kotlin.math.sin
 internal data class BeamHeadings(val shortPathDeg: Int, val longPathDeg: Int)
 
 /**
- * Initial great-circle bearing (degrees, `0..360`) from point 1 to point 2 using
- * the standard forward-azimuth formula. Pure math — no Android types.
+ * Initial great-circle bearing (degrees, `[0, 360)`) from point 1 to point 2
+ * using the standard forward-azimuth formula. The final `% 360.0` means 360 is
+ * never returned (a due-north bearing is 0). Pure math — no Android types.
  */
 internal fun greatCircleBearing(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
     val phi1 = Math.toRadians(lat1)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeading.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeading.kt
@@ -1,0 +1,66 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.k1af.ft8af.maidenhead.MaidenheadGrid
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Great-circle beam heading from the operator's grid to a remote station.
+ *
+ * [shortPathDeg] is the initial great-circle bearing the operator would point a
+ * directional antenna to take the short way round; [longPathDeg] is its
+ * reciprocal (the long way, over the antipode) — a genuinely different heading
+ * DX chasers use when the short path is closed. Both are integer degrees in
+ * `0..359`.
+ *
+ * The trig lives in [greatCircleBearing]/[longPathBearing] as pure functions (no
+ * Android types) so they unit-test without Robolectric; [computeBeamHeadings]
+ * decodes the grids through [MaidenheadGrid] and therefore needs it.
+ */
+internal data class BeamHeadings(val shortPathDeg: Int, val longPathDeg: Int)
+
+/**
+ * Initial great-circle bearing (degrees, `0..360`) from point 1 to point 2 using
+ * the standard forward-azimuth formula. Pure math — no Android types.
+ */
+internal fun greatCircleBearing(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+    val phi1 = Math.toRadians(lat1)
+    val phi2 = Math.toRadians(lat2)
+    val dLon = Math.toRadians(lon2 - lon1)
+    val y = sin(dLon) * cos(phi2)
+    val x = cos(phi1) * sin(phi2) - sin(phi1) * cos(phi2) * cos(dLon)
+    return (Math.toDegrees(atan2(y, x)) + 360.0) % 360.0
+}
+
+/** Long-path heading is the reciprocal of the short-path initial bearing. */
+internal fun longPathBearing(shortPathDeg: Double): Double = (shortPathDeg + 180.0) % 360.0
+
+/** Round a bearing to whole degrees in `0..359` (360 wraps back to 0). */
+internal fun normalizeHeadingDeg(deg: Double): Int = (Math.round(deg).toInt() % 360 + 360) % 360
+
+/**
+ * Short- and long-path beam headings from the operator's grid to the remote
+ * grid, or null when either grid is missing/unparseable or the two points are
+ * identical (a bearing to yourself is undefined). Delegates to
+ * [MaidenheadGrid.gridToLatLng] (Play-Services `LatLng`), so callers and tests
+ * that reach this need Robolectric.
+ */
+internal fun computeBeamHeadings(myGrid: String?, theirGrid: String?): BeamHeadings? {
+    if (myGrid.isNullOrEmpty() || theirGrid.isNullOrEmpty()) return null
+    return try {
+        val me = MaidenheadGrid.gridToLatLng(myGrid) ?: return null
+        val them = MaidenheadGrid.gridToLatLng(theirGrid) ?: return null
+        if (me.latitude == them.latitude && me.longitude == them.longitude) return null
+        val sp = greatCircleBearing(me.latitude, me.longitude, them.latitude, them.longitude)
+        BeamHeadings(
+            shortPathDeg = normalizeHeadingDeg(sp),
+            longPathDeg = normalizeHeadingDeg(longPathBearing(sp)),
+        )
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/** Format a whole-degree heading as e.g. `47°`. */
+internal fun formatHeading(deg: Int): String = "$deg°"

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
@@ -227,6 +227,16 @@ fun DecodeRow(
                     MetaText(distanceText)
                 }
 
+                // Beam heading (short-path bearing) — opt-in, for beam operators
+                // who want to know which way to turn the antenna without opening
+                // the QSO sheet first.
+                if (GeneralVariables.showBeamHeading) {
+                    val headingText = computeBeamHeadingText(message)
+                    if (headingText.isNotEmpty()) {
+                        MetaText(headingText)
+                    }
+                }
+
                 Spacer(modifier = Modifier.weight(1f))
 
                 // Relative "ago" time
@@ -423,4 +433,15 @@ private fun computeDistanceText(message: Ft8Message): String {
     } catch (_: Exception) {
         ""
     }
+}
+
+/**
+ * Short-path beam heading (e.g. "47°") from the operator's grid to the message
+ * sender's grid, or "" when either grid is unknown. Shared with the QSO sheet
+ * via [computeBeamHeadings] so the row and the sheet never disagree.
+ */
+internal fun computeBeamHeadingText(message: Ft8Message): String {
+    val headings = computeBeamHeadings(GeneralVariables.getMyMaidenheadGrid(), message.maidenGrid)
+        ?: return ""
+    return formatHeading(headings.shortPathDeg)
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/QsoSheet.kt
@@ -373,8 +373,15 @@ private fun StatCardsRow(message: Ft8Message) {
     val myGrid = GeneralVariables.getMyMaidenheadGrid()
     val theirGrid = message.maidenGrid ?: ""
 
-    // Compute azimuth + distance from the operator's grid to the remote station.
-    val azimuthText = computeAzimuthText(myGrid, theirGrid)
+    // Compute beam heading + distance from the operator's grid to the remote
+    // station. The azimuth card leads with the short-path heading and carries the
+    // long-path (reciprocal) heading as a subtitle, so DXers with a beam can see
+    // both ways to point the antenna.
+    val headings = computeBeamHeadings(myGrid, theirGrid)
+    val azimuthText = headings?.let { formatHeading(it.shortPathDeg) } ?: "--"
+    val longPathText = headings?.let {
+        stringResource(R.string.qso_stat_azimuth_long_path, formatHeading(it.longPathDeg))
+    }
     val distanceText = computeDistanceText(myGrid, theirGrid)
 
     // Derive band label from message carrier frequency
@@ -401,6 +408,7 @@ private fun StatCardsRow(message: Ft8Message) {
         StatCard(
             label = stringResource(R.string.qso_stat_azimuth),
             value = azimuthText,
+            subtitle = longPathText,
             modifier = Modifier.weight(1f),
         )
         StatCard(
@@ -416,6 +424,7 @@ private fun StatCard(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
+    subtitle: String? = null,
 ) {
     GlassCard(
         modifier = modifier,
@@ -445,6 +454,18 @@ private fun StatCard(
                 maxLines = 1,
                 softWrap = false,
             )
+            if (subtitle != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = subtitle,
+                    color = TextFaint,
+                    fontFamily = GeistMonoFamily,
+                    fontSize = 10.sp,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            }
         }
     }
 }
@@ -919,29 +940,6 @@ private fun LastHeardRow(utcTimeMillis: Long, mainViewModel: MainViewModel) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Compute the bearing/azimuth (in degrees) from the operator's grid to the
- * remote station's grid. Returns "--" if either grid is unavailable.
- */
-private fun computeAzimuthText(myGrid: String?, theirGrid: String?): String {
-    if (myGrid.isNullOrEmpty() || theirGrid.isNullOrEmpty()) return "--"
-    return try {
-        val myLatLng = MaidenheadGrid.gridToLatLng(myGrid) ?: return "--"
-        val theirLatLng = MaidenheadGrid.gridToLatLng(theirGrid) ?: return "--"
-
-        val lat1 = Math.toRadians(myLatLng.latitude)
-        val lat2 = Math.toRadians(theirLatLng.latitude)
-        val dLon = Math.toRadians(theirLatLng.longitude - myLatLng.longitude)
-
-        val y = Math.sin(dLon) * Math.cos(lat2)
-        val x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLon)
-        val bearing = (Math.toDegrees(Math.atan2(y, x)) + 360) % 360
-        "${String.format("%.0f", bearing)}\u00B0"
-    } catch (_: Exception) {
-        "--"
-    }
-}
 
 /**
  * Distance from the operator's grid to the remote station's grid, formatted in

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
@@ -36,6 +36,7 @@ fun DecodeFilterSettings(
     var workedStationList by remember { mutableStateOf(GeneralVariables.getWorkedStationList()) }
     var highlightPota by remember { mutableStateOf(GeneralVariables.highlightPota) }
     var distanceInMiles by remember { mutableStateOf(GeneralVariables.distanceInMiles) }
+    var showBeamHeading by remember { mutableStateOf(GeneralVariables.showBeamHeading) }
 
     // Callsign blocklist (comma-separated entries) + decode display filters
     var blockedExact by remember { mutableStateOf(GeneralVariables.getBlockedExactCallsigns()) }
@@ -358,6 +359,19 @@ fun DecodeFilterSettings(
                             GeneralVariables.distanceInMiles = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "distanceInMiles", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_show_beam_heading),
+                        description = stringResource(R.string.settings_show_beam_heading_desc),
+                        toggle = showBeamHeading,
+                        onToggleChange = { checked ->
+                            showBeamHeading = checked
+                            GeneralVariables.showBeamHeading = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "showBeamHeading", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -202,6 +202,7 @@
     <string name="qso_stat_signal">Signal</string>
     <string name="qso_stat_distance">Distance</string>
     <string name="qso_stat_azimuth">Azimuth</string>
+    <string name="qso_stat_azimuth_long_path">LP %1$s</string>
     <string name="qso_stat_band">Band</string>
     <string name="qso_sequence_header">QSO SEQUENCE</string>
     <string name="qso_step_send_call">Send call</string>
@@ -596,6 +597,8 @@
     <string name="settings_worked_same_mode_desc">Only count QSOs made on the current mode</string>
     <string name="settings_distance_unit">Distance in Miles</string>
     <string name="settings_distance_unit_desc">Show distances in miles instead of kilometers</string>
+    <string name="settings_show_beam_heading">Show beam heading</string>
+    <string name="settings_show_beam_heading_desc">Add the great-circle bearing to each decode row, for pointing a directional antenna</string>
 
     <!-- ===== Settings: callsign blocklist ===== -->
     <string name="settings_exact_callsigns">Exact Callsigns</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeadingGridTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeadingGridTest.kt
@@ -1,0 +1,94 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for [computeBeamHeadings], which decodes both grids through
+ * [com.k1af.ft8af.maidenhead.MaidenheadGrid] (Play-Services `LatLng`) and so
+ * needs Robolectric.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BeamHeadingGridTest {
+
+    @Test
+    fun `returns null when either grid is missing`() {
+        assertThat(computeBeamHeadings(null, "FN42")).isNull()
+        assertThat(computeBeamHeadings("FN42", null)).isNull()
+        assertThat(computeBeamHeadings("", "FN42")).isNull()
+        assertThat(computeBeamHeadings("FN42", "")).isNull()
+    }
+
+    @Test
+    fun `returns null when a grid cannot be parsed`() {
+        // "ABC" is an unsupported length -> gridToLatLng returns null.
+        assertThat(computeBeamHeadings("FN42", "ABC")).isNull()
+    }
+
+    @Test
+    fun `returns null for identical grids (bearing to yourself is undefined)`() {
+        assertThat(computeBeamHeadings("FN42", "FN42")).isNull()
+    }
+
+    @Test
+    fun `long path is always the reciprocal of the short path`() {
+        val h = computeBeamHeadings("FN42", "IO91")
+        assertThat(h).isNotNull()
+        val expectedLp = (h!!.shortPathDeg + 180) % 360
+        assertThat(h.longPathDeg).isEqualTo(expectedLp)
+    }
+
+    @Test
+    fun `headings stay within 0 to 359`() {
+        val h = computeBeamHeadings("FN42", "JO65")
+        assertThat(h).isNotNull()
+        assertThat(h!!.shortPathDeg).isIn(0..359)
+        assertThat(h.longPathDeg).isIn(0..359)
+    }
+
+    @Test
+    fun `Boston to London beams roughly north-east`() {
+        // Boston FN42 -> London IO91 is a classic north-easterly great-circle
+        // heading (~50 deg); allow slack for grid-centre quantisation.
+        val h = computeBeamHeadings("FN42", "IO91")
+        assertThat(h).isNotNull()
+        assertThat(h!!.shortPathDeg).isIn(30..70)
+    }
+
+    @Test
+    fun `a station due east reads near 90 degrees`() {
+        // Two equatorial grids on the same field row: JJ00 (~0N,20E) ->
+        // KJ00 (~0N,40E) is due east.
+        val h = computeBeamHeadings("JJ00", "KJ00")
+        assertThat(h).isNotNull()
+        assertThat(h!!.shortPathDeg).isIn(80..100)
+    }
+
+    // ---------- computeBeamHeadingText (decode-row wrapper) ----------
+
+    @Test
+    fun `row heading text is blank when the operator grid is unset`() {
+        GeneralVariables.setMyMaidenheadGrid("")
+        val msg = Ft8Message(0).apply { maidenGrid = "IO91" }
+        assertThat(computeBeamHeadingText(msg)).isEmpty()
+    }
+
+    @Test
+    fun `row heading text is blank when the message has no grid`() {
+        GeneralVariables.setMyMaidenheadGrid("FN42")
+        val msg = Ft8Message(0).apply { maidenGrid = null }
+        assertThat(computeBeamHeadingText(msg)).isEmpty()
+    }
+
+    @Test
+    fun `row heading text is the formatted short-path bearing`() {
+        GeneralVariables.setMyMaidenheadGrid("FN42")
+        val msg = Ft8Message(0).apply { maidenGrid = "IO91" }
+        val expected = formatHeading(computeBeamHeadings("FN42", "IO91")!!.shortPathDeg)
+        assertThat(computeBeamHeadingText(msg)).isEqualTo(expected)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeadingTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/BeamHeadingTest.kt
@@ -1,0 +1,83 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for the pure beam-heading math ([greatCircleBearing],
+ * [longPathBearing], [normalizeHeadingDeg], [formatHeading]). No Android types
+ * are touched, so these run as plain JUnit (no Robolectric). Grid-decoding
+ * ([computeBeamHeadings]) is covered separately in [BeamHeadingGridTest].
+ */
+class BeamHeadingTest {
+
+    private val tol = 1e-6
+
+    // ---------- greatCircleBearing ----------
+
+    @Test
+    fun `due east along the equator is 90 degrees`() {
+        assertThat(greatCircleBearing(0.0, 0.0, 0.0, 10.0)).isWithin(tol).of(90.0)
+    }
+
+    @Test
+    fun `due west along the equator is 270 degrees`() {
+        assertThat(greatCircleBearing(0.0, 0.0, 0.0, -10.0)).isWithin(tol).of(270.0)
+    }
+
+    @Test
+    fun `heading due north along a meridian is 0 degrees`() {
+        assertThat(greatCircleBearing(10.0, 5.0, 40.0, 5.0)).isWithin(tol).of(0.0)
+    }
+
+    @Test
+    fun `heading due south along a meridian is 180 degrees`() {
+        assertThat(greatCircleBearing(40.0, 5.0, 10.0, 5.0)).isWithin(tol).of(180.0)
+    }
+
+    @Test
+    fun `bearing is always normalized into 0 to 360`() {
+        // A south-west leg would produce a negative raw atan2 result; it must be
+        // wrapped up into the [0,360) range rather than returned negative.
+        val b = greatCircleBearing(40.0, 5.0, 10.0, -20.0)
+        assertThat(b).isAtLeast(0.0)
+        assertThat(b).isLessThan(360.0)
+        assertThat(b).isGreaterThan(180.0) // south-and-west => third quadrant
+    }
+
+    // ---------- longPathBearing ----------
+
+    @Test
+    fun `long path is the reciprocal of the short path`() {
+        assertThat(longPathBearing(47.0)).isWithin(tol).of(227.0)
+        assertThat(longPathBearing(0.0)).isWithin(tol).of(180.0)
+    }
+
+    @Test
+    fun `long path wraps past 360 back into range`() {
+        // 270 + 180 = 450 -> 90
+        assertThat(longPathBearing(270.0)).isWithin(tol).of(90.0)
+    }
+
+    // ---------- normalizeHeadingDeg ----------
+
+    @Test
+    fun `rounding 359 point 7 wraps to 0 rather than 360`() {
+        assertThat(normalizeHeadingDeg(359.7)).isEqualTo(0)
+    }
+
+    @Test
+    fun `rounding stays within 0 to 359`() {
+        assertThat(normalizeHeadingDeg(0.4)).isEqualTo(0)
+        assertThat(normalizeHeadingDeg(46.6)).isEqualTo(47)
+        assertThat(normalizeHeadingDeg(359.4)).isEqualTo(359)
+    }
+
+    // ---------- formatHeading ----------
+
+    @Test
+    fun `format appends a degree sign`() {
+        assertThat(formatHeading(47)).isEqualTo("47°")
+        assertThat(formatHeading(0)).isEqualTo("0°")
+    }
+}


### PR DESCRIPTION
## What & why

Operators running a beam — or any directional antenna — need to know **which way to point it** to work a station. The QSO sheet already showed a single short-path azimuth, but nothing surfaced the **long-path** heading (the reciprocal, used when the short path is closed), and you had to open a station's sheet to see a heading at all.

This PR makes beam heading first-class:

- **QSO sheet** — the *Azimuth* stat card now leads with the short-path heading and shows the long-path heading as a subtitle (`LP 227°`), so DXers can see both ways to aim the antenna at a glance.
- **Decode list (opt-in)** — a compact heading column next to distance, so you can aim before you even tap a station. Gated by a new **Show beam heading** toggle (Settings → Decode filters), **off by default** so vertical/wire operators don't get a column they don't need.

## How

New pure helper `ui/decode/BeamHeading.kt`:

- `greatCircleBearing` — standard forward-azimuth (initial great-circle bearing).
- `longPathBearing` — reciprocal (`short + 180`, wrapped).
- `normalizeHeadingDeg` — round to whole degrees in `0..359` (360 → 0).
- `computeBeamHeadings(myGrid, theirGrid)` — decodes both grids via `MaidenheadGrid`; returns `null` for missing / unparseable / identical grids (a bearing to yourself is undefined).

The trig is Android-free so it unit-tests without Robolectric. The QSO sheet and the decode row both go through `computeBeamHeadings`, so the two surfaces can never disagree. The old private, short-path-only azimuth helper in `QsoSheet.kt` is replaced.

Config: new `GeneralVariables.showBeamHeading` (persisted as `showBeamHeading`, loaded in `DatabaseOpr` next to `distanceInMiles`).

## Tests

- `BeamHeadingTest` — pure math: cardinal bearings (E/W/N/S), `0..360` normalisation, long-path reciprocal + wrap, rounding edge cases (`359.7 → 0`), formatting.
- `BeamHeadingGridTest` (Robolectric) — grid decoding: null cases, long-path = reciprocal, range bounds, Boston→London reads NE (~50°), due-east reads ~90°, plus the decode-row wrapper `computeBeamHeadingText`.

## Verification

- `./gradlew :app:testDebugUnitTest --tests 'radio.ks3ckc.ft8af.ui.decode.*'` — green.
- `./gradlew :app:assembleDebug` — builds successfully (all 4 ABIs).

## Compatibility

Display-only; no change to the FT8/WSJT-X protocol, decoder, or TX path. The decode-row addition is opt-in and default-off, so existing users see no change until they enable it.