### PR TITLE
Fix Kenwood TS-570/590/2000 + TX-500 CAT: replies never parsed (';'-framed but split on '\r')

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CatLineSplitter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CatLineSplitter.java
@@ -62,13 +62,36 @@ final class CatLineSplitter {
      * @return the complete commands and the bytes to carry into the next call
      */
     static Result split(String buffered, String incoming, char terminator) {
+        return split(buffered, incoming, String.valueOf(terminator));
+    }
+
+    /**
+     * Multi-terminator variant: any character in {@code terminators} ends a
+     * command.
+     *
+     * <p>Some rigs' framing terminator is uncertain or historically inconsistent.
+     * The Kenwood family (TS-570/590/2000, Lab599 TX-500) sends {@code ';'}-framed
+     * commands and replies (per the Kenwood/Lab599 CAT protocol — e.g. the meter
+     * reply {@code RM10023;} documented in issue #599), yet the old per-rig
+     * reassembly split replies on {@code '\r'}, so no reply ever parsed:
+     * frequency read-back and — critically — SWR/ALC over-power protection were
+     * dead. Accepting {@code ";\r"} parses the real {@code ';'}-framed stream
+     * without regressing any transport that might interleave a {@code '\r'}.
+     *
+     * @param buffered    bytes left over from the previous call (never null; may be empty)
+     * @param incoming    newly received bytes (never null; may be empty)
+     * @param terminators the set of end-of-command characters (e.g. {@code ";\r"})
+     * @return the complete commands and the bytes to carry into the next call
+     */
+    static Result split(String buffered, String incoming, String terminators) {
         String combined = buffered + incoming;
         List<String> frames = new ArrayList<>();
         int start = 0;
-        int idx;
-        while ((idx = combined.indexOf(terminator, start)) >= 0) {
-            frames.add(combined.substring(start, idx));
-            start = idx + 1;
+        for (int i = 0; i < combined.length(); i++) {
+            if (terminators.indexOf(combined.charAt(i)) >= 0) {
+                frames.add(combined.substring(start, i));
+                start = i + 1;
+            }
         }
         return new Result(frames, combined.substring(start));
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS2000Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS2000Rig.java
@@ -136,35 +136,39 @@ public class KenwoodTS2000Rig extends BaseRig {
     public void onReceiveData(byte[] data) {
         String s = new String(data);
 
-        if (!s.contains("\r")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            //return;//data reception not yet complete.
-        } else {
-            if (s.indexOf("\r") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf("\r")));
-            }
-            //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf("\r") + 1));
+        // Kenwood frames every command and reply with ';' (e.g. the freq reply
+        // FA...; and the meter reply RM...;). The old code split on '\r', which
+        // Kenwood never sends, so no reply ever parsed -- frequency read-back and
+        // SWR/ALC protection were dead (issues #599/#589 on the TX-500 subclass).
+        // Drain every complete ';'/CR-terminated command in this read (the RM
+        // poll answers SWR then ALC back-to-back, so both replies routinely
+        // coalesce into one read) and carry only the trailing, unterminated
+        // fragment into the next call.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), s, ";\r");
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-            if (yaesu3Command == null) {
-                return;
-            }
-            String cmd = yaesu3Command.getCommandID();
-            if (cmd.equalsIgnoreCase("FA")) {//frequency
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (cmd.equalsIgnoreCase("RM")) {//meter
-                handleMeterReply(yaesu3Command);
-            }
-
+        for (String frame : result.frames) {
+            processCommand(frame);
         }
+    }
 
+    private void processCommand(String frame) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(frame);
+        if (yaesu3Command == null) {
+            return;
+        }
+        String cmd = yaesu3Command.getCommandID();
+        if (cmd.equalsIgnoreCase("FA")) {//frequency
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (cmd.equalsIgnoreCase("RM")) {//meter
+            handleMeterReply(yaesu3Command);
+        }
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS570Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS570Rig.java
@@ -114,42 +114,45 @@ public class KenwoodTS570Rig extends BaseRig {
     public void onReceiveData(byte[] data) {
         String s = new String(data);
 
-        if (!s.contains("\r")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            //return;//data reception not yet complete.
-        } else {
-            if (s.indexOf("\r") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf("\r")));
-            }
-            //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf("\r") + 1));
+        // Kenwood frames every command and reply with ';' (e.g. the freq reply
+        // FA...; and the meter reply RM...;). The old code split on '\r', which
+        // Kenwood never sends, so no reply ever parsed -- frequency read-back and
+        // SWR/ALC protection were dead. Drain every complete ';'/CR-terminated
+        // command in this read (the RM poll answers SWR then ALC back-to-back, so
+        // both replies routinely coalesce into one read) and carry only the
+        // trailing, unterminated fragment into the next call.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), s, ";\r");
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-            if (yaesu3Command == null) {
-                return;
-            }
-            String cmd = yaesu3Command.getCommandID();
-            if (cmd.equalsIgnoreCase("FA")) {//frequency
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (cmd.equalsIgnoreCase("RM")) {//meter
-                if (Yaesu3Command.is590MeterSWR(yaesu3Command)) {
-                    swr = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
-                }
-                if (Yaesu3Command.is590MeterALC(yaesu3Command)) {
-                    alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
-                }
-                showAlert();
-                notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
-            }
-
+        for (String frame : result.frames) {
+            processCommand(frame);
         }
+    }
 
+    private void processCommand(String frame) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(frame);
+        if (yaesu3Command == null) {
+            return;
+        }
+        String cmd = yaesu3Command.getCommandID();
+        if (cmd.equalsIgnoreCase("FA")) {//frequency
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (cmd.equalsIgnoreCase("RM")) {//meter
+            if (Yaesu3Command.is590MeterSWR(yaesu3Command)) {
+                swr = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
+            }
+            if (Yaesu3Command.is590MeterALC(yaesu3Command)) {
+                alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
+            }
+            showAlert();
+            notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
+        }
     }
 
     private void showAlert() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS590Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/KenwoodTS590Rig.java
@@ -126,42 +126,45 @@ public class KenwoodTS590Rig extends BaseRig {
     public void onReceiveData(byte[] data) {
         String s = new String(data);
 
-        if (!s.contains("\r")) {
-            buffer.append(s);
-            if (buffer.length() > 1000) clearBufferData();
-            //return;//data reception not yet complete.
-        } else {
-            if (s.indexOf("\r") > 0) {//received end-of-data, and delimiter is not the first character
-                buffer.append(s.substring(0, s.indexOf("\r")));
-            }
-            //begin parsing data
-            Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf("\r") + 1));
+        // Kenwood frames every command and reply with ';' (e.g. the freq reply
+        // FA...; and the meter reply RM...;). The old code split on '\r', which
+        // Kenwood never sends, so no reply ever parsed -- frequency read-back and
+        // SWR/ALC protection were dead. Drain every complete ';'/CR-terminated
+        // command in this read (the RM poll answers SWR then ALC back-to-back, so
+        // both replies routinely coalesce into one read) and carry only the
+        // trailing, unterminated fragment into the next call.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), s, ";\r");
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-            if (yaesu3Command == null) {
-                return;
-            }
-            String cmd = yaesu3Command.getCommandID();
-            if (cmd.equalsIgnoreCase("FA")) {//frequency
-                long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
-                if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Yaesu3Command.getFrequency(yaesu3Command));
-                }
-            } else if (cmd.equalsIgnoreCase("RM")) {//meter
-                if (Yaesu3Command.is590MeterSWR(yaesu3Command)) {
-                    swr = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
-                }
-                if (Yaesu3Command.is590MeterALC(yaesu3Command)) {
-                    alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
-                }
-                showAlert();
-                notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
-            }
-
+        for (String frame : result.frames) {
+            processCommand(frame);
         }
+    }
 
+    private void processCommand(String frame) {
+        Yaesu3Command yaesu3Command = Yaesu3Command.getCommand(frame);
+        if (yaesu3Command == null) {
+            return;
+        }
+        String cmd = yaesu3Command.getCommandID();
+        if (cmd.equalsIgnoreCase("FA")) {//frequency
+            long tempFreq = Yaesu3Command.getFrequency(yaesu3Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                setFreq(tempFreq);
+            }
+        } else if (cmd.equalsIgnoreCase("RM")) {//meter
+            if (Yaesu3Command.is590MeterSWR(yaesu3Command)) {
+                swr = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
+            }
+            if (Yaesu3Command.is590MeterALC(yaesu3Command)) {
+                alc = Yaesu3Command.get590ALCOrSWR(yaesu3Command);
+            }
+            showAlert();
+            notifyMeterData(Math.min(alc * 8, 255), Math.min(swr * 8, 255));
+        }
     }
 
     private void showAlert() {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CatLineSplitterTest.java
@@ -137,4 +137,68 @@ public class CatLineSplitterTest {
         assertThat(r.frames).containsExactly("IF00014074000", "FA1").inOrder();
         assertThat(r.remainder).isEmpty();
     }
+
+    // --- Multi-terminator overload: the Kenwood family (TS-570/590/2000, TX-500)
+    // frames replies with ';' but the old per-rig handlers split on '\r', so no
+    // reply ever parsed (freq read-back + SWR/ALC protection dead, issues
+    // #599/#589). These rigs adopt split(..., ";\r") to parse the real ';' stream
+    // while still tolerating a stray '\r'.
+
+    @Test
+    public void kenwoodSemicolonReply_parsedByMultiTerminatorSplit() {
+        // The exact reply the TX-500 reporter documented in #599: RM10023; -- a
+        // ';'-terminated meter frame with no '\r'. The old '\r' split never saw a
+        // terminator and buffered it forever, so SWR stayed 0 and protection never
+        // tripped. The ";\r" split yields the frame.
+        CatLineSplitter.Result r = CatLineSplitter.split("", "RM10023;", ";\r");
+        assertThat(r.frames).containsExactly("RM10023");
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void kenwoodMeterPoll_swrAndAlcCoalesced_bothSurvive() {
+        // A single RM; poll on the TS-590 answers the SWR (RM1) and ALC (RM3)
+        // meters back-to-back; both must be delivered so neither reading is stale.
+        CatLineSplitter.Result r = CatLineSplitter.split("", "RM10023;RM30150;", ";\r");
+        assertThat(r.frames).containsExactly("RM10023", "RM30150").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void kenwoodFreqThenMeterCoalesced_bothParsedInOrder() {
+        CatLineSplitter.Result r = CatLineSplitter.split("", "FA00014074000;RM10023;", ";\r");
+        assertThat(r.frames).containsExactly("FA00014074000", "RM10023").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void multiTerminator_semicolonSplitAcrossReads_reassembled() {
+        CatLineSplitter.Result first = CatLineSplitter.split("", "FA000140", ";\r");
+        assertThat(first.frames).isEmpty();
+        assertThat(first.remainder).isEqualTo("FA000140");
+
+        CatLineSplitter.Result second = CatLineSplitter.split(first.remainder, "74000;", ";\r");
+        assertThat(second.frames).containsExactly("FA00014074000");
+        assertThat(second.remainder).isEmpty();
+    }
+
+    @Test
+    public void multiTerminator_toleratesStrayCarriageReturnAroundSemicolon() {
+        // If a transport ever interleaves a '\r' (CR/LF-style framing), the empty
+        // span between ';' and '\r' is an empty frame the rig treats as a no-op
+        // (Yaesu3Command.getCommand returns null for <2 chars), and the real
+        // command is still delivered intact -- so accepting both cannot regress a
+        // '\r'-influenced stream.
+        CatLineSplitter.Result r = CatLineSplitter.split("", "RM10023;\r", ";\r");
+        assertThat(r.frames).containsExactly("RM10023", "").inOrder();
+        assertThat(r.remainder).isEmpty();
+    }
+
+    @Test
+    public void charAndStringOverloadsAgree_forSingleTerminator() {
+        CatLineSplitter.Result viaChar = CatLineSplitter.split("", "FA1;FB2;", ';');
+        CatLineSplitter.Result viaString = CatLineSplitter.split("", "FA1;FB2;", ";");
+        assertThat(viaString.frames).containsExactlyElementsIn(viaChar.frames).inOrder();
+        assertThat(viaString.remainder).isEqualTo(viaChar.remainder);
+    }
 }


### PR DESCRIPTION
## Root cause

The Kenwood-family rigs — `KenwoodTS570Rig`, `KenwoodTS590Rig`, `KenwoodTS2000Rig`, and `DiscoveryTX500Rig` (which inherits `onReceiveData` from TS-2000) — send every CAT command **and reply** terminated with `;` (`FA;`, `RM;`, `FR0;`, per `KenwoodTK90RigConstant`). But their `onReceiveData` split incoming bytes on `\r`, which these rigs never send. So `s.contains("\r")` was never true: every reply was appended to the buffer until it exceeded 1000 chars and got wiped — **no reply was ever parsed.**

This was a half-migration: the command constants were changed to `;`-terminated but the reply parser was left splitting on `\r`. The same-repo Kenwood-family rigs `TrUSDXRig` (TS-480 emulation) and `Flex6000Rig` already split on `;`.

### Consequences
- **Frequency read-back dead** — `FA` replies never applied (the CAT status chip goes red within seconds because reads never complete).
- **SWR/ALC over-power protection dead** — the safety feature that halts TX on high SWR never received a reading. This is why the TX-500's SWR fix (#599 / PR #626) never actually worked: #626 corrected the meter *layout*, but the reply reached parsing through the inherited `\r` split and was dropped first.

### Evidence it's `;`, not `\r` (resolved without hardware)
1. **#599** reporter documented the exact meter reply `RM10023;` — `;`-terminated, no `\r`.
2. **#589** same TX-500 user: band/PTT control (writes) "working normally **except swr protection is not working at all**", and the CAT chip turns red within seconds — the classic signature of *reads never parsing*.
3. `TrUSDXRig` and `Flex6000Rig` (both Kenwood-family in this repo) already split on `;`.
4. All the `TS590`/`TS2000`/`TS570` command constants are `;`-terminated.

## Fix

Add a multi-terminator overload `CatLineSplitter.split(buffered, incoming, String terminators)` — any character in the set ends a command (the existing `char` overload delegates to it). The three Kenwood rigs adopt `split(buffer, s, ";\r")` and extract a `processCommand(String)`, draining **every** complete command in a read.

Accepting both `;` **and** `\r`:
- Fixes the confirmed-broken `;` stream.
- Cannot regress any transport that might interleave a `\r` — Kenwood data never contains `;`, and an empty span between `;` and `\r` becomes an empty frame that `Yaesu3Command.getCommand` treats as a no-op (returns null for <2 chars).
- Draining all frames per read also fixes the coalesced `RM` SWR+ALC reply drop, matching the `CatLineSplitter` adoption already done for the Yaesu/Elecraft rigs.

`DiscoveryTX500Rig` is fixed via inheritance (no change needed there).

## Testing
- 6 new `CatLineSplitterTest` cases: `;`-framed Kenwood reply (`RM10023;`), coalesced SWR+ALC meter poll, freq+meter coalescing, cross-read reassembly, stray-`\r` tolerance, and `char`/`String` overload agreement. **19 tests, all green.**
- Full `:app:testDebugUnitTest` rig package green; main sources compile (`compileDebugJavaWithJavac`).
- The rig `onReceiveData` itself is not unit-tested (it touches Android LiveData/`ToastMessage`), matching the existing convention — the reassembly/terminator logic is fully covered by the pure `CatLineSplitter` tests.

## Risk
Low. Localized to three rigs' reply parsing plus a purely-additive splitter overload. Accepting both terminators is strictly more permissive than the old `\r`-only path, so it cannot break a setup that somehow worked before, and it repairs the ones that never did.

Refs #599, #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)