### PR TITLE
Fix DX/watchlist alerts permanently lost when first heard before notification permission granted

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/alert/AlertDecisions.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/alert/AlertDecisions.java
@@ -1,5 +1,7 @@
 package com.k1af.ft8af.alert;
 
+import java.util.Set;
+
 /**
  * Pure, Android-free decision + dedup logic for {@link DxAlertNotifier}, extracted so the
  * branching can be unit-tested without a device (the notifier itself touches
@@ -18,6 +20,28 @@ package com.k1af.ft8af.alert;
  */
 public final class AlertDecisions {
     private AlertDecisions() {}
+
+    /**
+     * Claim the right to post an alert for {@code dedupKey}, returning {@code true} only when
+     * the caller should proceed to post.
+     *
+     * <p>The permission gate ({@code canPost}) is evaluated <b>before</b> the dedup set is
+     * touched. Consuming the key while notifications are denied would permanently suppress the
+     * station: {@code alerted} lives for the whole process and is never cleared, so once the
+     * key is burned the same station never fires again this session — even after the user
+     * grants POST_NOTIFICATIONS. Gate first, then dedup, so a station first heard during the
+     * permission-denied window still alerts on its next decode once permission is granted.
+     *
+     * @param alerted  per-session set of already-claimed dedup keys; mutated only when this
+     *                 returns {@code true}
+     * @param dedupKey namespaced key for this alert
+     * @param canPost  whether a notification can actually be posted right now (permission
+     *                 present / pre-Android-13)
+     */
+    public static boolean claimAlert(Set<String> alerted, String dedupKey, boolean canPost) {
+        if (!canPost) return false;          // gate FIRST — do not burn the key while denied
+        return alerted.add(dedupKey);        // consume the key only when we can post
+    }
 
     /**
      * @param enabled       the {@code alertOnCqReply} user setting

--- a/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
@@ -191,15 +191,16 @@ public class DxAlertNotifier {
      */
     private void fire(String dedupKey, String channelId, String title, String body,
                       String callsignExtra, long bandExtra) {
-        if (!alerted.add(dedupKey)) return;                         // already alerted this session
+        // Gate on notification permission BEFORE consuming the dedup key. If we burned the
+        // key here while notifications are denied, the per-session `alerted` set (never
+        // cleared) would suppress this station forever — even after the user later grants
+        // POST_NOTIFICATIONS. claimAlert() checks `canPost` first, then dedups.
+        boolean canPost = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+                || ContextCompat.checkSelfPermission(appContext,
+                        Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED;
+        if (!AlertDecisions.claimAlert(alerted, dedupKey, canPost)) return;
 
         GeneralVariables.fileLog("ALERT fire key=[" + dedupKey + "] " + title);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-                && ContextCompat.checkSelfPermission(appContext,
-                        Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-            return;                                                 // no permission → skip silently
-        }
 
         int id = dedupKey.hashCode();
 
@@ -228,7 +229,10 @@ public class DxAlertNotifier {
         try {
             NotificationManagerCompat.from(appContext).notify(id, builder.build());
         } catch (SecurityException ignored) {
-            // Permission revoked between the check and notify(); ignore.
+            // Permission revoked between the check and notify(): nothing was posted, so
+            // release the key to let a later decode of the same station retry rather than
+            // stay suppressed for the session.
+            alerted.remove(dedupKey);
         }
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/alert/AlertDecisionsTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/alert/AlertDecisionsTest.java
@@ -4,8 +4,48 @@ import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 /** Pure-JVM tests for {@link AlertDecisions} (no Android runtime needed). */
 public class AlertDecisionsTest {
+
+    private static Set<String> newAlertedSet() {
+        return Collections.newSetFromMap(new ConcurrentHashMap<>());
+    }
+
+    @Test
+    public void claimAlert_firesAndConsumesKeyWhenPostable() {
+        Set<String> alerted = newAlertedSet();
+        assertThat(AlertDecisions.claimAlert(alerted, "DXCC:Japan", true)).isTrue();
+        assertThat(alerted).contains("DXCC:Japan");
+    }
+
+    @Test
+    public void claimAlert_dedupesRepeatKeyWhenPostable() {
+        Set<String> alerted = newAlertedSet();
+        assertThat(AlertDecisions.claimAlert(alerted, "DXCC:Japan", true)).isTrue();
+        assertThat(AlertDecisions.claimAlert(alerted, "DXCC:Japan", true)).isFalse();
+    }
+
+    @Test
+    public void claimAlert_doesNotBurnKeyWhenNotPostable() {
+        Set<String> alerted = newAlertedSet();
+        assertThat(AlertDecisions.claimAlert(alerted, "DXCC:Japan", false)).isFalse();
+        // The permission gate must run BEFORE the dedup set is touched, so the key is
+        // untouched and the station can still alert once permission is granted.
+        assertThat(alerted).isEmpty();
+    }
+
+    @Test
+    public void claimAlert_firesAfterPermissionGrantedForStationHeardWhileDenied() {
+        Set<String> alerted = newAlertedSet();
+        // Station first heard while notifications are denied — must not be suppressed.
+        assertThat(AlertDecisions.claimAlert(alerted, "WATCH:3Y0J", false)).isFalse();
+        // User grants permission; the same station decodes again and now alerts.
+        assertThat(AlertDecisions.claimAlert(alerted, "WATCH:3Y0J", true)).isTrue();
+    }
 
     @Test
     public void cqReply_firesOnlyWhenEnabledAddressedAndNotBlocked() {


### PR DESCRIPTION
## Summary

Fixes a defect where **needed-DXCC / needed-state / watchlist / CQ-reply alerts are permanently suppressed for the rest of the session** for any station first decoded while the Android-13+ `POST_NOTIFICATIONS` permission is not yet granted — even after the user later grants it.

## Root cause

`DxAlertNotifier.fire()` consumed the per-session dedup key **before** the permission gate:

```java
if (!alerted.add(dedupKey)) return;   // key burned here...
...
if (SDK_INT >= TIRAMISU && !granted) return;   // ...then bailed if denied
```

`alerted` is a process-lifetime `Set` that is never cleared. So when notifications aren't granted, the key is added and the method returns without posting. When the user later grants permission and the same station keeps decoding every cycle, `alerted.add()` returns `false` → the alert never fires. A misleading `fileLog("ALERT fire …")` was also written even though nothing posted.

This hits the freshly-added watchlist (#676) and needed-DX alert paths hardest: the most-wanted stations (a rare DXpedition heard right after install, before the permission prompt is answered) are exactly the ones silently dropped.

## Fix

- Evaluate the permission gate **before** touching the dedup set. The ordering is extracted into a pure, Android-free, unit-testable helper `AlertDecisions.claimAlert(alerted, dedupKey, canPost)` (matching the existing `AlertDecisions` extraction pattern used for the rest of `DxAlertNotifier`): it checks `canPost` first and only consumes the key when a notification can actually be posted.
- Release the key on the `SecurityException` (permission revoked between check and `notify()`) path so a later decode of the same station can retry instead of staying suppressed.
- The `fileLog("ALERT fire …")` line now only runs when a notification is actually posted.

Behaviour when permission **is** granted is unchanged (still one alert per key per session).

## Testing

- New `AlertDecisionsTest` cases: postable-fires-and-consumes, dedup-on-repeat, **not-burned-when-denied**, and **fires-after-permission-granted-for-a-station-heard-while-denied**.
- Verified fail-before-fix: the two bug-capturing cases fail against the old (burn-then-gate) ordering and pass with the fix.
- Full `:app:testDebugUnitTest` suite green.

## Risk

Low. Change is localized to alert gating; no protocol, DSP, decoder, or native code touched. No UI change (no screenshots applicable).