### PR TITLE
Add a live clock-sync (DT) indicator to the operating screen

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -229,6 +229,10 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
     val operatingMode by mainViewModel.mutableOperatingMode.observeAsState(GeneralVariables.operatingMode)
     val modeName = ModeProfile.fromId(operatingMode).displayName
 
+    // Mean decode DT (seconds) for the slot-timer bar's live clock-sync pill; null until
+    // the first decode cycle reports one, so the bar renders unchanged before then.
+    val avgDtSec by mainViewModel.mutableTimerOffset.observeAsState()
+
     // Observe SWR lockout state
     val swrLocked by mainViewModel.meterProtectionController.swrLockout.observeAsState(false)
     val lockoutSwrRatio by mainViewModel.meterProtectionController.lockoutSwrRatio.observeAsState("")
@@ -352,9 +356,12 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 qsoPanel(Modifier)
             }
 
-            // Slot timer bar — fills 0→100% across each slot (15s FT8 / 7.5s FT4)
+            // Slot timer bar — fills 0→100% across each slot (15s FT8 / 7.5s FT4).
+            // The mean decode DT rides on the bar as a live clock-sync pill so the
+            // operator can spot a drifting clock without opening Settings → Time Sync.
             SlotTimerBar(
                 slotMillis = ModeProfile.fromId(operatingMode).slotMillis.toLong(),
+                offsetSec = avgDtSec,
             )
 
             // TX status strip — always visible above tab bar

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSync.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSync.kt
@@ -1,0 +1,141 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.R
+import radio.ks3ckc.ft8af.theme.GeistMonoFamily
+import radio.ks3ckc.ft8af.theme.StatusBad
+import radio.ks3ckc.ft8af.theme.StatusConfirmed
+import radio.ks3ckc.ft8af.theme.StatusWarn
+import radio.ks3ckc.ft8af.theme.TextMuted
+import java.util.Locale
+import kotlin.math.abs
+
+/**
+ * Clock-sync health derived from the mean decode DT (time offset, in seconds).
+ *
+ * FT8 tolerates only ~2 s of clock error before decoding collapses — both ways: a
+ * mis-set clock stops you decoding others *and* pushes your transmissions to the edge
+ * of everyone else's receive window so they can't decode you either. Yet the app never
+ * surfaced this on the operating screen; the operator had to open Settings → Time Sync
+ * to notice. The mean DT of the stations you decode is a good proxy for your own clock
+ * offset: most stations are themselves synced, so a consistent bias across all of them
+ * is almost certainly yours.
+ */
+internal enum class ClockSyncLevel { GOOD, FAIR, POOR, UNKNOWN }
+
+/** |DT| at/below this (seconds) is a healthy, in-the-sweet-spot clock. */
+internal const val CLOCK_SYNC_GOOD_SEC = 0.3f
+
+/** |DT| at/below this (seconds) still decodes but is worth a resync; above it is POOR. */
+internal const val CLOCK_SYNC_FAIR_SEC = 1.0f
+
+/**
+ * Classify the mean decode DT into a sync-health level. A `null` value means no decode
+ * cycle has reported yet this session; a non-finite value is treated the same way so a bad
+ * reading can never mis-color the pill.
+ */
+internal fun clockSyncLevel(offsetSec: Float?): ClockSyncLevel {
+    if (offsetSec == null || offsetSec.isNaN() || offsetSec.isInfinite()) return ClockSyncLevel.UNKNOWN
+    val mag = abs(offsetSec)
+    return when {
+        mag <= CLOCK_SYNC_GOOD_SEC -> ClockSyncLevel.GOOD
+        mag <= CLOCK_SYNC_FAIR_SEC -> ClockSyncLevel.FAIR
+        else -> ClockSyncLevel.POOR
+    }
+}
+
+/**
+ * Signed, one-decimal-second DT label (WSJT-X style), e.g. "+0.1 s", "-1.3 s", "0.0 s",
+ * or an em dash when unknown. A value that rounds to zero renders unsigned (never "-0.0 s").
+ */
+internal fun clockSyncOffsetLabel(offsetSec: Float?): String {
+    if (offsetSec == null || offsetSec.isNaN() || offsetSec.isInfinite()) return "—"
+    val mag = String.format(Locale.US, "%.1f", abs(offsetSec))
+    val sign = when {
+        mag == "0.0" -> ""
+        offsetSec < 0f -> "-"
+        else -> "+"
+    }
+    return "$sign$mag s"
+}
+
+/** Green in-sync, amber worth-a-resync, red clock-off, grey unknown. */
+internal fun clockSyncColor(level: ClockSyncLevel): Color = when (level) {
+    ClockSyncLevel.GOOD -> StatusConfirmed
+    ClockSyncLevel.FAIR -> StatusWarn
+    ClockSyncLevel.POOR -> StatusBad
+    ClockSyncLevel.UNKNOWN -> TextMuted
+}
+
+/** Short status word resource for accessibility / screen readers. */
+internal fun clockSyncStatusText(level: ClockSyncLevel): Int = when (level) {
+    ClockSyncLevel.GOOD -> R.string.clock_sync_good
+    ClockSyncLevel.FAIR -> R.string.clock_sync_fair
+    ClockSyncLevel.POOR -> R.string.clock_sync_poor
+    ClockSyncLevel.UNKNOWN -> R.string.clock_sync_unknown
+}
+
+/**
+ * Compact clock-sync pill for the slot-timer bar: a color-coded dot, the "DT" label
+ * operators know from WSJT-X, and the signed offset. All decision/format logic lives in
+ * the plain functions above; this composable only draws and wires accessibility.
+ */
+@Composable
+internal fun ClockSyncIndicator(
+    offsetSec: Float?,
+    modifier: Modifier = Modifier,
+) {
+    val level = clockSyncLevel(offsetSec)
+    val color = clockSyncColor(level)
+    val offsetLabel = clockSyncOffsetLabel(offsetSec)
+    val statusWord = stringResource(clockSyncStatusText(level))
+    val label = stringResource(R.string.clock_sync_label)
+    val cd = stringResource(R.string.clock_sync_cd, offsetLabel, statusWord)
+
+    Row(
+        modifier = modifier.semantics { contentDescription = cd },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = label,
+            color = TextMuted,
+            fontFamily = GeistMonoFamily,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.06.sp,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = offsetLabel,
+            color = color,
+            fontFamily = GeistMonoFamily,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SlotTimerBar.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SlotTimerBar.kt
@@ -34,6 +34,9 @@ import radio.ks3ckc.ft8af.theme.TextMuted
 @Composable
 fun SlotTimerBar(
     slotMillis: Long = 15_000L,
+    // Mean decode DT (seconds) for the live clock-sync pill; null until the first decode
+    // cycle reports, in which case no pill is shown (the bar looks exactly as before).
+    offsetSec: Float? = null,
     modifier: Modifier = Modifier,
 ) {
     var nowMs by remember { mutableLongStateOf(UtcTimer.getSystemTime()) }
@@ -56,6 +59,9 @@ fun SlotTimerBar(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        if (offsetSec != null) {
+            ClockSyncIndicator(offsetSec = offsetSec)
+        }
         Box(
             modifier = Modifier
                 .weight(1f)

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -743,6 +743,15 @@
     <string name="input_level_too_high">High</string>
     <string name="input_level_clipping">Clip</string>
 
+    <!-- ===== Clock-sync (DT) indicator on the slot-timer bar ===== -->
+    <string name="clock_sync_label" translatable="false">DT</string>
+    <string name="clock_sync_good">in sync</string>
+    <string name="clock_sync_fair">check clock</string>
+    <string name="clock_sync_poor">clock off</string>
+    <string name="clock_sync_unknown">no decodes</string>
+    <!-- %1$s = signed offset e.g. "+0.1 s"; %2$s = status word e.g. "in sync" -->
+    <string name="clock_sync_cd">Clock sync: average decode offset %1$s, %2$s</string>
+
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Language</string>
     <string name="settings_language_desc">App display language</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSyncTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSyncTest.kt
@@ -1,0 +1,59 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/** Pure-JVM tests for the clock-sync classifier/formatter (no Compose/Android needed). */
+class ClockSyncTest {
+
+    @Test
+    fun level_goodWhenNearZero() {
+        assertThat(clockSyncLevel(0f)).isEqualTo(ClockSyncLevel.GOOD)
+        assertThat(clockSyncLevel(0.1f)).isEqualTo(ClockSyncLevel.GOOD)
+        assertThat(clockSyncLevel(-0.2f)).isEqualTo(ClockSyncLevel.GOOD)
+        // Boundary: exactly the GOOD threshold is still GOOD.
+        assertThat(clockSyncLevel(0.3f)).isEqualTo(ClockSyncLevel.GOOD)
+        assertThat(clockSyncLevel(-0.3f)).isEqualTo(ClockSyncLevel.GOOD)
+    }
+
+    @Test
+    fun level_fairInTheMiddleBand() {
+        assertThat(clockSyncLevel(0.31f)).isEqualTo(ClockSyncLevel.FAIR)
+        assertThat(clockSyncLevel(-0.7f)).isEqualTo(ClockSyncLevel.FAIR)
+        // Boundary: exactly the FAIR threshold is still FAIR.
+        assertThat(clockSyncLevel(1.0f)).isEqualTo(ClockSyncLevel.FAIR)
+        assertThat(clockSyncLevel(-1.0f)).isEqualTo(ClockSyncLevel.FAIR)
+    }
+
+    @Test
+    fun level_poorWhenFarFromZero() {
+        assertThat(clockSyncLevel(1.01f)).isEqualTo(ClockSyncLevel.POOR)
+        assertThat(clockSyncLevel(-2.4f)).isEqualTo(ClockSyncLevel.POOR)
+    }
+
+    @Test
+    fun level_unknownForNullOrNonFinite() {
+        assertThat(clockSyncLevel(null)).isEqualTo(ClockSyncLevel.UNKNOWN)
+        assertThat(clockSyncLevel(Float.NaN)).isEqualTo(ClockSyncLevel.UNKNOWN)
+        assertThat(clockSyncLevel(Float.POSITIVE_INFINITY)).isEqualTo(ClockSyncLevel.UNKNOWN)
+    }
+
+    @Test
+    fun offsetLabel_signedToOneDecimalSecond() {
+        assertThat(clockSyncOffsetLabel(0.14f)).isEqualTo("+0.1 s")
+        assertThat(clockSyncOffsetLabel(-1.25f)).isEqualTo("-1.3 s")
+    }
+
+    @Test
+    fun offsetLabel_zeroHasNoSign() {
+        assertThat(clockSyncOffsetLabel(0f)).isEqualTo("0.0 s")
+        // A value that rounds to zero should also render unsigned, not "-0.0 s".
+        assertThat(clockSyncOffsetLabel(-0.02f)).isEqualTo("0.0 s")
+    }
+
+    @Test
+    fun offsetLabel_dashWhenUnknown() {
+        assertThat(clockSyncOffsetLabel(null)).isEqualTo("—")
+        assertThat(clockSyncOffsetLabel(Float.NaN)).isEqualTo("—")
+    }
+}


### PR DESCRIPTION
## Summary

Adds an always-visible **clock-sync pill** to the slot-timer bar so operators can spot a drifting clock at a glance — without digging into Settings.

FT8 only tolerates roughly **±2 s** of clock error before decoding collapses in *both* directions: a mis-set clock stops you decoding others **and** shoves your own transmissions to the edge of everyone else's receive window, so nobody spots you either. "Why am I not decoding / why is nobody answering me?" is very often a clock problem — and until now the app gave no hint of it on the operating screen.

The data already existed: `FT8SignalListener.averageOffset()` computes the mean decode **DT** each cycle and `MainViewModel` posts it to `mutableTimerOffset` (a `LiveData<Float>`). It was only ever shown inside **Settings → Time Sync**. This PR surfaces it where the operator actually looks.

## What the user sees

A compact pill on the persistent slot-timer bar: a color-coded dot • the `DT` label (WSJT-X's term) • the signed average offset, e.g. `● DT +0.1 s`.

| |DT| | Level | Color | Meaning |
|------|-------|-------|---------|
| ≤ 0.3 s | GOOD | green | in sync |
| 0.3–1.0 s | FAIR | amber | check clock |
| > 1.0 s | POOR | red | clock off |

The mean DT of the stations you decode is a good proxy for *your own* clock offset, because most stations are themselves synced — a consistent bias across all of them is almost certainly yours.

## Design / safety

- **No visual change until there's data.** The pill only renders once the first decode cycle reports a DT (`offsetSec != null`), so an idle/just-launched bar looks exactly as before.
- **Pure, tested logic.** Per this project's testing rules, the decision/format logic is extracted into plain functions — `clockSyncLevel`, `clockSyncOffsetLabel`, `clockSyncColor`, `clockSyncStatusText` — covered by a new `ClockSyncTest` (thresholds, boundaries, sign handling incl. the "-0.0 s" edge, null/NaN → UNKNOWN). The composable `ClockSyncIndicator` is a thin drawing wrapper.
- **Accessibility.** The pill carries a `contentDescription` ("Clock sync: average decode offset +0.1 s, in sync") for screen readers.
- **Backward compatible.** `SlotTimerBar` gains a nullable `offsetSec` parameter (defaulted to `null`); its single caller passes the observed value. No protocol, DSP, decoder, or native code touched.

## Testing

- New `ClockSyncTest` (pure JVM, no Robolectric) — all pass.
- Full `:app:testDebugUnitTest` suite green.
- `:app:assembleDebug` builds the APK cleanly (Compose compiler + resource merge for the new strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)