### PR TITLE
Add a "New Zone" decode highlight + filter for Worked All Zones chasers

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -576,6 +576,7 @@ public class GeneralVariables {
     // Decode-list highlight toggles (Settings → Decode Highlights). Gate the
     // status pill shown for each worked-before category in resolveQsoStatus().
     public static boolean highlightNewDxcc = true;//Highlight stations from an unworked DXCC entity
+    public static boolean highlightNewZone = true;//Highlight stations from an unworked CQ zone (Worked All Zones)
     public static boolean highlightNewGrid = false;//Off by default — most grids are "new", so it's noisy
     public static boolean highlightNewBand = true;//Highlight stations worked only on other bands
     public static boolean highlightWorked = true;//Master enable for worked-station handling (see workedStationMode)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -3135,6 +3135,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("highlightNewDxcc")) {
                     GeneralVariables.highlightNewDxcc = result.equals("1");
                 }
+                if (name.equalsIgnoreCase("highlightNewZone")) {
+                    GeneralVariables.highlightNewZone = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("highlightNewGrid")) {
                     GeneralVariables.highlightNewGrid = result.equals("1");
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
@@ -157,6 +157,9 @@ val StatusWorked = Color(0xFF5CD6E8)
 val StatusConfirmed = Color(0xFF4ADE80)
 val StatusCq = Color(0xFFFFAF5E)
 val StatusWarn = Color(0xFFFACC15)
+// Sky-blue, distinct from the purple NEW-DXCC and cyan NEW-BAND pills, for the
+// NEW-ZONE (Worked All Zones) badge.
+val StatusZone = Color(0xFF60A5FA)
 val StatusBad = Color(0xFFEF4444)
 
 // Band colors (for donut chart / logbook)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/StatusPill.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/StatusPill.kt
@@ -36,6 +36,12 @@ enum class QsoStatus(
         Color(0x1FC084FC),  // rgba(192,132,252,0.12)
         Color(0x47C084FC),  // rgba(192,132,252,0.28)
     ),
+    NEW_ZONE(
+        R.string.status_new_zone,
+        StatusZone,
+        Color(0x1F60A5FA),  // rgba(96,165,250,0.12)
+        Color(0x4760A5FA),  // rgba(96,165,250,0.28)
+    ),
     NEW_GRID(
         R.string.status_new_grid,
         StatusWarn,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
@@ -400,6 +400,11 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
             if (newPota) QsoStatus.NEW_POTA else QsoStatus.POTA
         isCQ && modifier == "SOTA" -> QsoStatus.SOTA
         GeneralVariables.highlightNewDxcc && message.fromDxcc -> QsoStatus.NEW
+        // A new CQ zone (Worked All Zones) outranks a new grid: only 40 zones
+        // exist, so an unworked one is a rarer, more prized catch. message.fromCq
+        // is set at decode time in CallsignDatabase (unworked-zone lookup) and
+        // only ever true once the zone map is ready — same gating as fromDxcc.
+        GeneralVariables.highlightNewZone && message.fromCq -> QsoStatus.NEW_ZONE
         GeneralVariables.highlightNewGrid && newGrid -> QsoStatus.NEW_GRID
         GeneralVariables.highlightNewBand && newBand -> QsoStatus.NEW_BAND
         effectiveWorkedMode() == WorkedStationMode.HIGHLIGHT &&

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -67,7 +67,7 @@ fun DecodeScreen(
     // Filter state. Backed by the ViewModel so the chosen filter survives
     // navigation away from Decode and back (the screen is recreated by the
     // tab switch, which would otherwise reset a local rememberSaveable).
-    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "New Grid", "Needed", "For Me")
+    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "New Zone", "New Grid", "Needed", "For Me")
     val selectedFilter by mainViewModel.decodeFilter.observeAsState("All")
 
     // Couple the "CQ POTA" display filter to Hunt: while it's selected, the auto-call
@@ -522,6 +522,7 @@ private fun filterLabel(key: String): String = when (key) {
     "CQ Calls" -> stringResource(R.string.decode_filter_cq_calls)
     "CQ POTA" -> stringResource(R.string.decode_filter_cq_pota)
     "New DXCC" -> stringResource(R.string.decode_filter_new_dxcc)
+    "New Zone" -> stringResource(R.string.decode_filter_new_zone)
     "New Grid" -> stringResource(R.string.decode_filter_new_grid)
     "Needed" -> stringResource(R.string.decode_filter_needed)
     "For Me" -> stringResource(R.string.decode_filter_for_me)
@@ -539,6 +540,7 @@ private fun filterLabel(key: String): String = when (key) {
  *  - All: no filtering
  *  - CQ Calls: only CQ messages
  *  - New DXCC: CQ from a DXCC entity not yet in the operator's worked list
+ *  - New Zone: CQ from a CQ zone not yet in the operator's worked list (WAZ)
  *  - New Grid: CQ from a Maidenhead grid field not yet in the operator's worked list
  *  - Needed: need QSL confirmation (not in QSL callsign list)
  *  - For Me: callsignTo matches operator's callsign
@@ -588,6 +590,10 @@ internal fun filterMessages(
         // this filter and hunting agree on who counts as a POTA station — see issue #333.
         "CQ POTA" -> base.filter { radio.ks3ckc.ft8af.pota.PotaCqClassifier.isPotaCq(it) }
         "New DXCC" -> base.filter { it.checkIsCQ() && it.fromDxcc }
+        // Mirror of "New DXCC" for zone chasers (Worked All Zones): only CQ
+        // stations from a CQ zone the operator hasn't logged yet. fromCq is the
+        // decode-time unworked-zone flag, computed alongside fromDxcc.
+        "New Zone" -> base.filter { it.checkIsCQ() && it.fromCq }
         // Mirror of "New DXCC" for grid chasers (VUCC / grid hunting): only CQ
         // stations whose grid field the operator hasn't logged yet, so the list
         // becomes a one-tap "who's calling from a grid I still need" view.
@@ -616,6 +622,7 @@ internal fun EmptyState(
         "CQ Calls" -> stringResource(R.string.decode_empty_cq_title) to stringResource(R.string.decode_empty_cq_body)
         "CQ POTA" -> stringResource(R.string.decode_empty_pota_title) to stringResource(R.string.decode_empty_pota_body)
         "New DXCC" -> stringResource(R.string.decode_empty_dxcc_title) to stringResource(R.string.decode_empty_dxcc_body)
+        "New Zone" -> stringResource(R.string.decode_empty_zone_title) to stringResource(R.string.decode_empty_zone_body)
         "New Grid" -> stringResource(R.string.decode_empty_grid_title) to stringResource(R.string.decode_empty_grid_body)
         "Needed" -> stringResource(R.string.decode_empty_needed_title) to stringResource(R.string.decode_empty_needed_body)
         "For Me" -> stringResource(R.string.decode_empty_forme_title) to stringResource(R.string.decode_empty_forme_body)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
@@ -27,6 +27,7 @@ fun DecodeFilterSettings(
 ) {
     // Decode-list highlight toggles
     var highlightNewDxcc by remember { mutableStateOf(GeneralVariables.highlightNewDxcc) }
+    var highlightNewZone by remember { mutableStateOf(GeneralVariables.highlightNewZone) }
     var highlightNewGrid by remember { mutableStateOf(GeneralVariables.highlightNewGrid) }
     var highlightNewBand by remember { mutableStateOf(GeneralVariables.highlightNewBand) }
     var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
@@ -240,6 +241,19 @@ fun DecodeFilterSettings(
                             GeneralVariables.highlightNewDxcc = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "highlightNewDxcc", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_highlight_new_zone),
+                        description = stringResource(R.string.settings_highlight_new_zone_desc),
+                        toggle = highlightNewZone,
+                        onToggleChange = { checked ->
+                            highlightNewZone = checked
+                            GeneralVariables.highlightNewZone = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "highlightNewZone", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -46,6 +46,7 @@
 
     <!-- ===== Status pills (decode list badges) ===== -->
     <string name="status_new_dxcc">NEW DXCC</string>
+    <string name="status_new_zone">NEW ZONE</string>
     <string name="status_new_grid">NEW GRID</string>
     <string name="status_new_band">NEW BAND</string>
     <string name="status_pota">POTA</string>
@@ -174,6 +175,7 @@
     <string name="decode_filter_cq_calls">CQ Calls</string>
     <string name="decode_filter_cq_pota">CQ POTA</string>
     <string name="decode_filter_new_dxcc">New DXCC</string>
+    <string name="decode_filter_new_zone">New Zone</string>
     <string name="decode_filter_new_grid">New Grid</string>
     <string name="decode_filter_needed">Needed</string>
     <string name="decode_filter_for_me">For Me</string>
@@ -183,6 +185,8 @@
     <string name="decode_empty_pota_body">No park activations decoded on this band yet — open POTA → Hunt for the spot list.</string>
     <string name="decode_empty_dxcc_title">No new DXCC</string>
     <string name="decode_empty_dxcc_body">No unworked DXCC entities have been decoded yet.</string>
+    <string name="decode_empty_zone_title">No new zones</string>
+    <string name="decode_empty_zone_body">No stations calling from an unworked CQ zone have been decoded yet.</string>
     <string name="decode_empty_grid_title">No new grids</string>
     <string name="decode_empty_grid_body">No stations calling from an unworked grid square have been decoded yet.</string>
     <string name="decode_empty_needed_title">Nothing needed</string>
@@ -571,6 +575,8 @@
     <!-- ===== Settings: decode highlights ===== -->
     <string name="settings_highlight_new_dxcc">New DXCC</string>
     <string name="settings_highlight_new_dxcc_desc">Highlight stations from an unworked DXCC entity</string>
+    <string name="settings_highlight_new_zone">New Zone</string>
+    <string name="settings_highlight_new_zone_desc">Highlight not-yet-worked CQ zones (Worked All Zones)</string>
     <string name="settings_highlight_new_grid">New Grid</string>
     <string name="settings_highlight_new_grid_desc">Highlight not-yet-worked Maidenhead grids</string>
     <string name="settings_highlight_new_band">New Band</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeFilterTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeFilterTest.kt
@@ -79,6 +79,28 @@ class DecodeFilterTest {
     }
 
     @Test
+    fun newZone_keepsCqFromUnworkedZone() {
+        // fromCq is the decode-time "unworked CQ zone" flag; the filter keeps
+        // only CQ stations that carry it.
+        val fresh = cq("K1ABC").apply { fromCq = true }
+        val worked = cq("K2DEF").apply { fromCq = false }
+
+        val result = filterMessages(listOf(fresh, worked), "New Zone")
+
+        assertThat(result).containsExactly(fresh)
+    }
+
+    @Test
+    fun newZone_dropsDirectedMessages() {
+        // A directed reply isn't a callable CQ even if it's from a new zone.
+        val directedNewZone = directed("W1AW", "K2DEF").apply { fromCq = true }
+
+        val result = filterMessages(listOf(directedNewZone), "New Zone")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
     fun newGrid_dropsDirectedAndGridlessMessages() {
         val directedNewGrid = directed("W1AW", "K2DEF").apply { maidenGrid = "EN37" }
         val cqNoGrid = cq("K3GHI").apply { maidenGrid = null }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
@@ -56,6 +56,17 @@ class DecodeScreenTest {
     }
 
     @Test
+    fun newZoneFilter_showsZoneEmptyCopy() {
+        val title = context.getString(R.string.decode_empty_zone_title)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            EmptyState(selectedFilter = "New Zone")
+        }
+
+        composeRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
     fun newGridFilter_showsGridEmptyCopy() {
         val title = context.getString(R.string.decode_empty_grid_title)
         composeRule.mainClock.autoAdvance = false

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewZoneTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewZoneTest.kt
@@ -1,0 +1,110 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import radio.ks3ckc.ft8af.ui.components.QsoStatus
+
+/**
+ * Unit-tests the NEW_ZONE (Worked All Zones) decode-row pill wired off the
+ * decode-time [Ft8Message.fromCq] flag, plus its priority relative to the
+ * neighbouring NEW (DXCC) and NEW_GRID badges. The filter side is covered in
+ * [DecodeFilterTest]; this keeps the two in agreement on what counts as an
+ * unworked CQ zone.
+ *
+ * Robolectric is needed only because [Ft8Message] reaches android.util.Log on
+ * construction; the logic under test is pure.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NewZoneTest {
+
+    private var savedHighlightPota = false
+    private var savedHighlightNewDxcc = false
+    private var savedHighlightNewZone = false
+    private var savedHighlightNewGrid = false
+    private var savedHighlightNewBand = false
+    private var savedHighlightWorked = false
+
+    @Before
+    fun setUp() {
+        savedHighlightPota = GeneralVariables.highlightPota
+        savedHighlightNewDxcc = GeneralVariables.highlightNewDxcc
+        savedHighlightNewZone = GeneralVariables.highlightNewZone
+        savedHighlightNewGrid = GeneralVariables.highlightNewGrid
+        savedHighlightNewBand = GeneralVariables.highlightNewBand
+        savedHighlightWorked = GeneralVariables.highlightWorked
+        GeneralVariables.QSL_Grid_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+        // Isolate the branch under test: only the zone highlight is on unless a
+        // test opts another in.
+        GeneralVariables.highlightPota = false
+        GeneralVariables.highlightNewDxcc = false
+        GeneralVariables.highlightNewZone = true
+        GeneralVariables.highlightNewGrid = false
+        GeneralVariables.highlightNewBand = false
+        GeneralVariables.highlightWorked = false
+    }
+
+    @After
+    fun tearDown() {
+        GeneralVariables.highlightPota = savedHighlightPota
+        GeneralVariables.highlightNewDxcc = savedHighlightNewDxcc
+        GeneralVariables.highlightNewZone = savedHighlightNewZone
+        GeneralVariables.highlightNewGrid = savedHighlightNewGrid
+        GeneralVariables.highlightNewBand = savedHighlightNewBand
+        GeneralVariables.highlightWorked = savedHighlightWorked
+        GeneralVariables.QSL_Grid_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+    }
+
+    private fun cq(from: String): Ft8Message = Ft8Message("CQ", from, "TEST")
+
+    @Test
+    fun newZonePill_surfacesWhenHighlightEnabledAndFromCq() {
+        val msg = cq("K1ABC").apply { fromCq = true }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.NEW_ZONE)
+    }
+
+    @Test
+    fun newZonePill_hiddenWhenHighlightDisabled() {
+        GeneralVariables.highlightNewZone = false
+        val msg = cq("K1ABC").apply { fromCq = true }
+        // Falls through to the plain CQ badge instead of NEW_ZONE.
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.CQ)
+    }
+
+    @Test
+    fun newZonePill_hiddenWhenZoneAlreadyWorked() {
+        val msg = cq("K1ABC").apply { fromCq = false }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.CQ)
+    }
+
+    @Test
+    fun newDxcc_outranksNewZone() {
+        // A station that is both a new DXCC and a new zone shows the DXCC badge —
+        // DXCC is the headline award and NEW is higher priority.
+        GeneralVariables.highlightNewDxcc = true
+        val msg = cq("K1ABC").apply {
+            fromDxcc = true
+            fromCq = true
+        }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.NEW)
+    }
+
+    @Test
+    fun newZone_outranksNewGrid() {
+        // Only 40 CQ zones exist, so an unworked one is rarer than an unworked
+        // grid — NEW_ZONE wins when both apply.
+        GeneralVariables.highlightNewGrid = true
+        val msg = cq("K1ABC").apply {
+            fromCq = true
+            maidenGrid = "FN42" // unworked grid (QSL_Grid_list is empty)
+        }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.NEW_ZONE)
+    }
+}


### PR DESCRIPTION
## What & why

**Worked All Zones (WAZ)** — working all 40 CQ zones — is one of the most prestigious awards in DXing, yet the modern FT8AF decode list gave zone chasers nothing to work with. This adds first-class support so a zone hunter can spot and filter unworked-zone stations at a glance.

The interesting part: the app **already computes** the "this station is from a CQ zone you haven't logged" flag at decode time (`Ft8Message.fromCq`, set in `CallsignDatabase` right next to `fromDxcc`). But that flag was only ever read by the retired legacy `CallingListAdapter` — the Compose decode UI that ships today ignored it entirely. This PR wires that existing signal into the modern UI.

## Changes

- **"New Zone" filter chip** on the decode list — a one-tap "who's calling from a CQ zone I still need" view. Predicate `checkIsCQ() && fromCq`, mirroring the existing "New DXCC" chip.
- **`NEW ZONE` status pill** (sky-blue, distinct from the purple NEW DXCC and cyan NEW BAND badges). Shown when the highlight is enabled. Its priority sits **between** NEW DXCC and NEW GRID: only 40 CQ zones exist, so an unworked one is a rarer catch than a grid square, but it still yields to the headline DXCC badge when a station is both.
- **Settings → Decode Highlights → New Zone** toggle (`highlightNewZone`), persisted through `writeConfig` and restored in `DatabaseOpr`. Defaults **on**, matching New DXCC.

## Not touched

No decoder or transmit code paths change — this is purely decode-list presentation and a config flag. WSJT-X / FT8 protocol behaviour is unaffected.

## Tests

- `NewZoneTest` — pill surfaces on `fromCq`, hidden when disabled/already-worked, and correct priority vs `NEW` (DXCC wins) and `NEW_GRID` (zone wins).
- `DecodeFilterTest` — "New Zone" keeps only CQ-from-unworked-zone, drops directed replies.
- `DecodeScreenTest` — filter-specific empty-state copy renders.

Full `:app:testDebugUnitTest` green; `:app:assembleDebug` builds all ABIs.