### PR TITLE
Add a "New State" decode highlight + filter for Worked All States chasers

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -577,6 +577,7 @@ public class GeneralVariables {
     // status pill shown for each worked-before category in resolveQsoStatus().
     public static boolean highlightNewDxcc = true;//Highlight stations from an unworked DXCC entity
     public static boolean highlightNewZone = true;//Highlight stations from an unworked CQ zone (Worked All Zones)
+    public static boolean highlightNewState = false;//Off by default — US-only (Worked All States); noise for non-US ops
     public static boolean highlightNewGrid = false;//Off by default — most grids are "new", so it's noisy
     public static boolean highlightNewBand = true;//Highlight stations worked only on other bands
     public static boolean highlightWorked = true;//Master enable for worked-station handling (see workedStationMode)

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -3138,6 +3138,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("highlightNewZone")) {
                     GeneralVariables.highlightNewZone = result.equals("1");
                 }
+                if (name.equalsIgnoreCase("highlightNewState")) {
+                    GeneralVariables.highlightNewState = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("highlightNewGrid")) {
                     GeneralVariables.highlightNewGrid = result.equals("1");
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
@@ -160,6 +160,9 @@ val StatusWarn = Color(0xFFFACC15)
 // Sky-blue, distinct from the purple NEW-DXCC and cyan NEW-BAND pills, for the
 // NEW-ZONE (Worked All Zones) badge.
 val StatusZone = Color(0xFF60A5FA)
+// Teal, distinct from the blue NEW-ZONE, cyan NEW-BAND and green POTA pills, for
+// the NEW-STATE (Worked All States) badge.
+val StatusState = Color(0xFF2DD4BF)
 val StatusBad = Color(0xFFEF4444)
 
 // Band colors (for donut chart / logbook)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/StatusPill.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/StatusPill.kt
@@ -42,6 +42,12 @@ enum class QsoStatus(
         Color(0x1F60A5FA),  // rgba(96,165,250,0.12)
         Color(0x4760A5FA),  // rgba(96,165,250,0.28)
     ),
+    NEW_STATE(
+        R.string.status_new_state,
+        StatusState,
+        Color(0x1F2DD4BF),  // rgba(45,212,191,0.12)
+        Color(0x472DD4BF),  // rgba(45,212,191,0.28)
+    ),
     NEW_GRID(
         R.string.status_new_grid,
         StatusWarn,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
@@ -405,6 +405,12 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
         // is set at decode time in CallsignDatabase (unworked-zone lookup) and
         // only ever true once the zone map is ready — same gating as fromDxcc.
         GeneralVariables.highlightNewZone && message.fromCq -> QsoStatus.NEW_ZONE
+        // A new US state (Worked All States) outranks a new grid: WAS is one of
+        // the most-chased US awards, so an unworked state is more prized than a
+        // bare new grid field. message.fromNewState is set at decode time in
+        // CallsignDatabase (US-grid → unworked-state lookup); null/non-US grids
+        // leave it false.
+        GeneralVariables.highlightNewState && message.fromNewState -> QsoStatus.NEW_STATE
         GeneralVariables.highlightNewGrid && newGrid -> QsoStatus.NEW_GRID
         GeneralVariables.highlightNewBand && newBand -> QsoStatus.NEW_BAND
         effectiveWorkedMode() == WorkedStationMode.HIGHLIGHT &&

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -67,7 +67,7 @@ fun DecodeScreen(
     // Filter state. Backed by the ViewModel so the chosen filter survives
     // navigation away from Decode and back (the screen is recreated by the
     // tab switch, which would otherwise reset a local rememberSaveable).
-    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "New Zone", "New Grid", "Needed", "For Me")
+    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "New Zone", "New State", "New Grid", "Needed", "For Me")
     val selectedFilter by mainViewModel.decodeFilter.observeAsState("All")
 
     // Couple the "CQ POTA" display filter to Hunt: while it's selected, the auto-call
@@ -523,6 +523,7 @@ private fun filterLabel(key: String): String = when (key) {
     "CQ POTA" -> stringResource(R.string.decode_filter_cq_pota)
     "New DXCC" -> stringResource(R.string.decode_filter_new_dxcc)
     "New Zone" -> stringResource(R.string.decode_filter_new_zone)
+    "New State" -> stringResource(R.string.decode_filter_new_state)
     "New Grid" -> stringResource(R.string.decode_filter_new_grid)
     "Needed" -> stringResource(R.string.decode_filter_needed)
     "For Me" -> stringResource(R.string.decode_filter_for_me)
@@ -541,6 +542,7 @@ private fun filterLabel(key: String): String = when (key) {
  *  - CQ Calls: only CQ messages
  *  - New DXCC: CQ from a DXCC entity not yet in the operator's worked list
  *  - New Zone: CQ from a CQ zone not yet in the operator's worked list (WAZ)
+ *  - New State: CQ from a US state not yet in the operator's worked list (WAS)
  *  - New Grid: CQ from a Maidenhead grid field not yet in the operator's worked list
  *  - Needed: need QSL confirmation (not in QSL callsign list)
  *  - For Me: callsignTo matches operator's callsign
@@ -594,6 +596,10 @@ internal fun filterMessages(
         // stations from a CQ zone the operator hasn't logged yet. fromCq is the
         // decode-time unworked-zone flag, computed alongside fromDxcc.
         "New Zone" -> base.filter { it.checkIsCQ() && it.fromCq }
+        // Mirror of "New DXCC" for state chasers (Worked All States): only CQ
+        // stations from a US state the operator hasn't logged yet. fromNewState is
+        // the decode-time unworked-state flag (US-grid → state, US-only table).
+        "New State" -> base.filter { it.checkIsCQ() && it.fromNewState }
         // Mirror of "New DXCC" for grid chasers (VUCC / grid hunting): only CQ
         // stations whose grid field the operator hasn't logged yet, so the list
         // becomes a one-tap "who's calling from a grid I still need" view.
@@ -623,6 +629,7 @@ internal fun EmptyState(
         "CQ POTA" -> stringResource(R.string.decode_empty_pota_title) to stringResource(R.string.decode_empty_pota_body)
         "New DXCC" -> stringResource(R.string.decode_empty_dxcc_title) to stringResource(R.string.decode_empty_dxcc_body)
         "New Zone" -> stringResource(R.string.decode_empty_zone_title) to stringResource(R.string.decode_empty_zone_body)
+        "New State" -> stringResource(R.string.decode_empty_state_title) to stringResource(R.string.decode_empty_state_body)
         "New Grid" -> stringResource(R.string.decode_empty_grid_title) to stringResource(R.string.decode_empty_grid_body)
         "Needed" -> stringResource(R.string.decode_empty_needed_title) to stringResource(R.string.decode_empty_needed_body)
         "For Me" -> stringResource(R.string.decode_empty_forme_title) to stringResource(R.string.decode_empty_forme_body)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
@@ -28,6 +28,7 @@ fun DecodeFilterSettings(
     // Decode-list highlight toggles
     var highlightNewDxcc by remember { mutableStateOf(GeneralVariables.highlightNewDxcc) }
     var highlightNewZone by remember { mutableStateOf(GeneralVariables.highlightNewZone) }
+    var highlightNewState by remember { mutableStateOf(GeneralVariables.highlightNewState) }
     var highlightNewGrid by remember { mutableStateOf(GeneralVariables.highlightNewGrid) }
     var highlightNewBand by remember { mutableStateOf(GeneralVariables.highlightNewBand) }
     var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
@@ -254,6 +255,19 @@ fun DecodeFilterSettings(
                             GeneralVariables.highlightNewZone = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "highlightNewZone", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_highlight_new_state),
+                        description = stringResource(R.string.settings_highlight_new_state_desc),
+                        toggle = highlightNewState,
+                        onToggleChange = { checked ->
+                            highlightNewState = checked
+                            GeneralVariables.highlightNewState = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "highlightNewState", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -47,6 +47,7 @@
     <!-- ===== Status pills (decode list badges) ===== -->
     <string name="status_new_dxcc">NEW DXCC</string>
     <string name="status_new_zone">NEW ZONE</string>
+    <string name="status_new_state">NEW STATE</string>
     <string name="status_new_grid">NEW GRID</string>
     <string name="status_new_band">NEW BAND</string>
     <string name="status_pota">POTA</string>
@@ -176,6 +177,7 @@
     <string name="decode_filter_cq_pota">CQ POTA</string>
     <string name="decode_filter_new_dxcc">New DXCC</string>
     <string name="decode_filter_new_zone">New Zone</string>
+    <string name="decode_filter_new_state">New State</string>
     <string name="decode_filter_new_grid">New Grid</string>
     <string name="decode_filter_needed">Needed</string>
     <string name="decode_filter_for_me">For Me</string>
@@ -187,6 +189,8 @@
     <string name="decode_empty_dxcc_body">No unworked DXCC entities have been decoded yet.</string>
     <string name="decode_empty_zone_title">No new zones</string>
     <string name="decode_empty_zone_body">No stations calling from an unworked CQ zone have been decoded yet.</string>
+    <string name="decode_empty_state_title">No new states</string>
+    <string name="decode_empty_state_body">No stations calling from an unworked US state have been decoded yet.</string>
     <string name="decode_empty_grid_title">No new grids</string>
     <string name="decode_empty_grid_body">No stations calling from an unworked grid square have been decoded yet.</string>
     <string name="decode_empty_needed_title">Nothing needed</string>
@@ -577,6 +581,8 @@
     <string name="settings_highlight_new_dxcc_desc">Highlight stations from an unworked DXCC entity</string>
     <string name="settings_highlight_new_zone">New Zone</string>
     <string name="settings_highlight_new_zone_desc">Highlight not-yet-worked CQ zones (Worked All Zones)</string>
+    <string name="settings_highlight_new_state">New State</string>
+    <string name="settings_highlight_new_state_desc">Highlight not-yet-worked US states (Worked All States)</string>
     <string name="settings_highlight_new_grid">New Grid</string>
     <string name="settings_highlight_new_grid_desc">Highlight not-yet-worked Maidenhead grids</string>
     <string name="settings_highlight_new_band">New Band</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeFilterTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeFilterTest.kt
@@ -58,6 +58,28 @@ class DecodeFilterTest {
     }
 
     @Test
+    fun newState_keepsCqFromUnworkedState() {
+        // fromNewState is the decode-time "unworked US state" flag; the filter
+        // keeps only CQ stations that carry it.
+        val fresh = cq("K1ABC").apply { fromNewState = true }
+        val worked = cq("K2DEF").apply { fromNewState = false }
+
+        val result = filterMessages(listOf(fresh, worked), "New State")
+
+        assertThat(result).containsExactly(fresh)
+    }
+
+    @Test
+    fun newState_dropsDirectedMessages() {
+        // A directed reply isn't a callable CQ even if it's from a new state.
+        val directedNewState = directed("W1AW", "K2DEF").apply { fromNewState = true }
+
+        val result = filterMessages(listOf(directedNewState), "New State")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
     fun newGrid_keepsCqFromUnworkedGrid() {
         // No grids worked yet, so every 4-char grid counts as new.
         val cqMsg = cqFromGrid("K1ABC", "FN42")

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreenTest.kt
@@ -67,6 +67,17 @@ class DecodeScreenTest {
     }
 
     @Test
+    fun newStateFilter_showsStateEmptyCopy() {
+        val title = context.getString(R.string.decode_empty_state_title)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            EmptyState(selectedFilter = "New State")
+        }
+
+        composeRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
     fun newGridFilter_showsGridEmptyCopy() {
         val title = context.getString(R.string.decode_empty_grid_title)
         composeRule.mainClock.autoAdvance = false

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewStateTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewStateTest.kt
@@ -1,0 +1,114 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import radio.ks3ckc.ft8af.ui.components.QsoStatus
+
+/**
+ * Unit-tests the NEW_STATE (Worked All States) decode-row pill wired off the
+ * decode-time [Ft8Message.fromNewState] flag, plus its priority relative to the
+ * neighbouring NEW_ZONE and NEW_GRID badges. The filter side is covered in
+ * [DecodeFilterTest]; this keeps the two in agreement on what counts as an
+ * unworked US state.
+ *
+ * Robolectric is needed only because [Ft8Message] reaches android.util.Log on
+ * construction; the logic under test is pure.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NewStateTest {
+
+    private var savedHighlightPota = false
+    private var savedHighlightNewDxcc = false
+    private var savedHighlightNewZone = false
+    private var savedHighlightNewState = false
+    private var savedHighlightNewGrid = false
+    private var savedHighlightNewBand = false
+    private var savedHighlightWorked = false
+
+    @Before
+    fun setUp() {
+        savedHighlightPota = GeneralVariables.highlightPota
+        savedHighlightNewDxcc = GeneralVariables.highlightNewDxcc
+        savedHighlightNewZone = GeneralVariables.highlightNewZone
+        savedHighlightNewState = GeneralVariables.highlightNewState
+        savedHighlightNewGrid = GeneralVariables.highlightNewGrid
+        savedHighlightNewBand = GeneralVariables.highlightNewBand
+        savedHighlightWorked = GeneralVariables.highlightWorked
+        GeneralVariables.QSL_Grid_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+        // Isolate the branch under test: only the state highlight is on unless a
+        // test opts another in.
+        GeneralVariables.highlightPota = false
+        GeneralVariables.highlightNewDxcc = false
+        GeneralVariables.highlightNewZone = false
+        GeneralVariables.highlightNewState = true
+        GeneralVariables.highlightNewGrid = false
+        GeneralVariables.highlightNewBand = false
+        GeneralVariables.highlightWorked = false
+    }
+
+    @After
+    fun tearDown() {
+        GeneralVariables.highlightPota = savedHighlightPota
+        GeneralVariables.highlightNewDxcc = savedHighlightNewDxcc
+        GeneralVariables.highlightNewZone = savedHighlightNewZone
+        GeneralVariables.highlightNewState = savedHighlightNewState
+        GeneralVariables.highlightNewGrid = savedHighlightNewGrid
+        GeneralVariables.highlightNewBand = savedHighlightNewBand
+        GeneralVariables.highlightWorked = savedHighlightWorked
+        GeneralVariables.QSL_Grid_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+    }
+
+    private fun cq(from: String): Ft8Message = Ft8Message("CQ", from, "TEST")
+
+    @Test
+    fun newStatePill_surfacesWhenHighlightEnabledAndFromNewState() {
+        val msg = cq("K1ABC").apply { fromNewState = true }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.NEW_STATE)
+    }
+
+    @Test
+    fun newStatePill_hiddenWhenHighlightDisabled() {
+        GeneralVariables.highlightNewState = false
+        val msg = cq("K1ABC").apply { fromNewState = true }
+        // Falls through to the plain CQ badge instead of NEW_STATE.
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.CQ)
+    }
+
+    @Test
+    fun newStatePill_hiddenWhenStateAlreadyWorked() {
+        val msg = cq("K1ABC").apply { fromNewState = false }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.CQ)
+    }
+
+    @Test
+    fun newZone_outranksNewState() {
+        // Only 40 CQ zones exist, so an unworked one is rarer than an unworked
+        // state — NEW_ZONE wins when both apply.
+        GeneralVariables.highlightNewZone = true
+        val msg = cq("K1ABC").apply {
+            fromCq = true
+            fromNewState = true
+        }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.NEW_ZONE)
+    }
+
+    @Test
+    fun newState_outranksNewGrid() {
+        // WAS is far more chased than a bare new grid field, so NEW_STATE wins
+        // when a station is both a new state and a new grid.
+        GeneralVariables.highlightNewGrid = true
+        val msg = cq("K1ABC").apply {
+            fromNewState = true
+            maidenGrid = "FN42" // unworked grid (QSL_Grid_list is empty)
+        }
+        assertThat(resolveQsoStatus(msg)).isEqualTo(QsoStatus.NEW_STATE)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewStateTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewStateTest.kt
@@ -6,8 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import radio.ks3ckc.ft8af.ui.components.QsoStatus
 
 /**
@@ -17,10 +15,10 @@ import radio.ks3ckc.ft8af.ui.components.QsoStatus
  * [DecodeFilterTest]; this keeps the two in agreement on what counts as an
  * unworked US state.
  *
- * Robolectric is needed only because [Ft8Message] reaches android.util.Log on
- * construction; the logic under test is pure.
+ * Pure JVM — the [Ft8Message] 3-arg constructor only uppercases its fields and
+ * the [resolveQsoStatus] path reads plain [GeneralVariables] state, so no
+ * Android framework is touched and no Robolectric runner is needed.
  */
-@RunWith(RobolectricTestRunner::class)
 class NewStateTest {
 
     private var savedHighlightPota = false


### PR DESCRIPTION
## What & why

**Worked All States (WAS)** is one of the most-chased awards in US amateur radio, yet FT8AF gave state hunters no help spotting a needed one in the decode list. The decode-time unworked-state flag (`Ft8Message.fromNewState`, US-grid → state via the bundled `us_grid_states.json`, US-only) was **already computed** alongside `fromDxcc`/`fromCq`, but only the "new state" *alert* ever consumed it — the decode list never showed it and there was no way to filter on it.

This wires that existing signal into the two places WAS chasers look, exactly mirroring the recent **New DXCC** / **New Zone** (#688) / **New Grid** work:

- **"New State" filter chip** on the Decode screen — a one-tap "who's calling from a state I still need" view (`base.filter { checkIsCQ() && fromNewState }`). Available to everyone.
- **NEW STATE status pill** (teal) on the decode row, shown when the highlight is enabled. Priority sits **between NEW_ZONE and NEW_GRID**: WAS is far more chased than a bare new grid field, so a new state outranks a new grid, but still yields to the rarer new CQ zone (and the headline new DXCC).
- **Settings → Decode Highlights → New State** toggle (`highlightNewState`, persisted via `writeConfig`, loaded in `DatabaseOpr`).

### "If I released this today, would users notice?"
US operators chasing WAS immediately get a colored badge on every station calling from a state they still need, plus a dedicated filter to see only those stations — no more cross-referencing a paper list.

## Design notes / assumptions

- **Highlight defaults OFF** (like New Grid). `fromNewState` only fires for US-grid stations, so defaulting it *on* would flood non-US operators — who don't track states — with teal pills. WAS chasers enable it once in Settings. The **filter chip is available regardless of the toggle**, matching how New Zone/New Grid filters behave.
- **No decoder or transmit code paths change.** This only reads a flag the decode pipeline already sets and renders/filters on it.

## Testing

`./gradlew :app:testDebugUnitTest` — full suite green. New/updated coverage:
- `NewStateTest` — pill surfaces on `fromNewState`, hidden when the toggle is off or the state is already worked, and the priority ordering vs `NEW_ZONE` (outranks state) and `NEW_GRID` (state outranks).
- `DecodeFilterTest` — "New State" keeps only CQ stations from an unworked state and drops directed messages.
- `DecodeScreenTest` — the "No new states" empty-state copy renders for the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)