### PR TITLE
Fix DX/watchlist alert notification showing "-2147483648 dB" when the decoder gives no SNR

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/alert/DxAlertNotifier.java
@@ -168,16 +168,23 @@ public class DxAlertNotifier {
                 body.toString(), call, qslRecord.getBandFreq());
     }
 
-    private static String defaultBody(Ft8Message msg) {
+    static String defaultBody(Ft8Message msg) {
         StringBuilder body = new StringBuilder(msg.getCallsignFrom());
         if (msg.maidenGrid != null && !msg.maidenGrid.isEmpty()) {
             body.append("  ").append(msg.maidenGrid);
         }
-        body.append("  ").append(msg.snr).append(" dB");
+        // The decoder can emit a valid message with no SNR (FT8SignalListener logs
+        // "SNR not set by decoder" and still adds it to the decode list), so snr may be
+        // the SNR_UNKNOWN sentinel (Integer.MIN_VALUE). Appending it unconditionally
+        // rendered "-2147483648 dB" in the notification body — mirror cqReplyBody and
+        // drop the SNR line when it is unknown.
+        if (msg.snr != Ft8Message.SNR_UNKNOWN) {
+            body.append("  ").append(msg.snr).append(" dB");
+        }
         return body.toString();
     }
 
-    private static String cqReplyBody(Ft8Message msg) {
+    static String cqReplyBody(Ft8Message msg) {
         StringBuilder body = new StringBuilder(msg.getMessageText());
         if (msg.snr != Ft8Message.SNR_UNKNOWN) {
             body.append("  ").append(msg.snr).append(" dB");

--- a/ft8af/app/src/test/java/com/k1af/ft8af/alert/DxAlertBodyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/alert/DxAlertBodyTest.java
@@ -7,8 +7,9 @@ import com.k1af.ft8af.Ft8Message;
 import org.junit.Test;
 
 /**
- * Pure-JVM tests for {@link DxAlertNotifier#defaultBody}/{@link DxAlertNotifier#cqReplyBody}
- * notification-body formatting. The interesting case is an unknown SNR: a valid decode can
+ * Pure-JVM tests for the {@link DxAlertNotifier#defaultBody} and
+ * {@link DxAlertNotifier#cqReplyBody} notification-body formatting. The interesting
+ * case is an unknown SNR: a valid decode can
  * reach the alert path with {@code snr == Ft8Message.SNR_UNKNOWN} (the decoder does not always
  * set it — FT8SignalListener logs "SNR not set by decoder" and still lists the message), and the
  * DX/watchlist/New-DXCC/New-State body must not render the {@link Integer#MIN_VALUE} sentinel.
@@ -45,7 +46,7 @@ public class DxAlertBodyTest {
     }
 
     @Test
-    public void defaultBody_gridOnlyWhenSnrUnknownAndGridMissing() {
+    public void defaultBody_callsignOnlyWhenSnrUnknownAndGridMissing() {
         assertThat(DxAlertNotifier.defaultBody(msg("JA1ABC", null, Ft8Message.SNR_UNKNOWN)))
                 .isEqualTo("JA1ABC");
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/alert/DxAlertBodyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/alert/DxAlertBodyTest.java
@@ -1,0 +1,61 @@
+package com.k1af.ft8af.alert;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.Ft8Message;
+
+import org.junit.Test;
+
+/**
+ * Pure-JVM tests for {@link DxAlertNotifier#defaultBody}/{@link DxAlertNotifier#cqReplyBody}
+ * notification-body formatting. The interesting case is an unknown SNR: a valid decode can
+ * reach the alert path with {@code snr == Ft8Message.SNR_UNKNOWN} (the decoder does not always
+ * set it — FT8SignalListener logs "SNR not set by decoder" and still lists the message), and the
+ * DX/watchlist/New-DXCC/New-State body must not render the {@link Integer#MIN_VALUE} sentinel.
+ */
+public class DxAlertBodyTest {
+
+    private static Ft8Message msg(String from, String grid, int snr) {
+        Ft8Message m = new Ft8Message(0);
+        m.callsignFrom = from;
+        m.maidenGrid = grid;
+        m.snr = snr;
+        return m;
+    }
+
+    @Test
+    public void defaultBody_includesSnrWhenKnown() {
+        String body = DxAlertNotifier.defaultBody(msg("JA1ABC", "PM95", -12));
+        assertThat(body).isEqualTo("JA1ABC  PM95  -12 dB");
+    }
+
+    @Test
+    public void defaultBody_omitsSnrWhenUnknown() {
+        String body = DxAlertNotifier.defaultBody(msg("JA1ABC", "PM95", Ft8Message.SNR_UNKNOWN));
+        // Before the fix this appended "-2147483648 dB"; the sentinel must never surface.
+        assertThat(body).isEqualTo("JA1ABC  PM95");
+        assertThat(body).doesNotContain("dB");
+        assertThat(body).doesNotContain(String.valueOf(Integer.MIN_VALUE));
+    }
+
+    @Test
+    public void defaultBody_omitsGridWhenEmpty() {
+        assertThat(DxAlertNotifier.defaultBody(msg("JA1ABC", "", 3))).isEqualTo("JA1ABC  3 dB");
+        assertThat(DxAlertNotifier.defaultBody(msg("JA1ABC", null, 3))).isEqualTo("JA1ABC  3 dB");
+    }
+
+    @Test
+    public void defaultBody_gridOnlyWhenSnrUnknownAndGridMissing() {
+        assertThat(DxAlertNotifier.defaultBody(msg("JA1ABC", null, Ft8Message.SNR_UNKNOWN)))
+                .isEqualTo("JA1ABC");
+    }
+
+    @Test
+    public void cqReplyBody_alsoOmitsUnknownSnr_forParity() {
+        Ft8Message m = new Ft8Message(0, 0, "MYCALL", "JA1ABC", "RR73");
+        m.snr = Ft8Message.SNR_UNKNOWN;
+        String body = DxAlertNotifier.cqReplyBody(m);
+        assertThat(body).doesNotContain("dB");
+        assertThat(body).doesNotContain(String.valueOf(Integer.MIN_VALUE));
+    }
+}


### PR DESCRIPTION
## Summary

Needed-DX / watchlist / new-DXCC / new-state notifications can render a garbage SNR line — literally `-2147483648 dB` — in the alert body.

`DxAlertNotifier.defaultBody()` appended `msg.snr` unconditionally:

```java
body.append("  ").append(msg.snr).append(" dB");
```

But a decoded message can be **valid yet carry no SNR**. `FT8SignalListener` explicitly handles this — it logs `"SNR not set by decoder"` and *still* adds the candidate to the decode list (`FT8SignalListener.java:399-413`). That list is exactly what `MainViewModel.GetQTHRunnable.run()` hands to `DxAlertNotifier.processDecodes()`. `Ft8Message.snr` defaults to the `SNR_UNKNOWN` sentinel (`Integer.MIN_VALUE`), so when such a station is a new DXCC/state, a CQ-reply target, or on the user's watchlist, the notification body shows `…  -2147483648 dB`.

The sibling formatter `cqReplyBody()` already guards this precise case:

```java
if (msg.snr != Ft8Message.SNR_UNKNOWN) {
    body.append("  ").append(msg.snr).append(" dB");
}
```

`defaultBody()` was simply missing the same guard.

## Root cause

Inconsistent SNR-unknown handling between the two notification-body builders in `DxAlertNotifier`: `cqReplyBody` gated the `" dB"` line on `snr != SNR_UNKNOWN`; `defaultBody` (used by the watchlist, new-DXCC, and new-state alerts) did not.

## Fix

Mirror `cqReplyBody`'s guard in `defaultBody` so the SNR line is dropped when the value is the `SNR_UNKNOWN` sentinel. No behavior change when the SNR is known. Both helpers were made package-private `static` so the pure formatting logic is unit-testable without a `Context`.

## Testing

- New pure-JVM `DxAlertBodyTest` (5 cases): SNR shown when known, SNR line omitted when unknown (the two unknown-SNR cases **fail before** the fix with the `-2147483648 dB` output and pass after), grid omitted when empty/null, callsign-only when both grid and SNR are absent, and a parity check that `cqReplyBody` also suppresses the sentinel.
- `./gradlew :app:testDebugUnitTest` — full suite green.

## Risk

Very low. One-line behavioral guard on notification text only; no protocol, DSP, threading, or native code touched. Matches the existing convention already used elsewhere in the same class.