### PR TITLE
Pileup: work the strongest caller first (opt-in) + SNR on caller-queue chips

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -550,6 +550,9 @@ public class GeneralVariables {
     // transmit/decode processing thread (FT8TransmitSignal), like zoneMapReady above.
     public static volatile boolean huntPotaOnly = false;//Mirror of the "CQ POTA" decode filter: Hunt only calls POTA CQs (issue #333)
     public static boolean autoCallFollow = true;//Auto-call followed callsigns
+    // volatile: written from the Compose settings UI thread and read from the
+    // transmit thread (FT8TransmitSignal.dequeueNextCaller), like huntPotaOnly above.
+    public static volatile boolean pileupStrongestFirst = false;//Pileup: auto-work the strongest waiting caller next instead of the oldest (FIFO)
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static boolean disciplineClockFromGPS = false;//Discipline the app clock (UtcTimer.delay) from GPS satellite time (issue #373). Off by default — consensual.
     public static int gpsClockIntervalMinutes = 5;//How often to re-read GPS time for clock discipline. Clamped 1-30 by GpsClockUpdater.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2754,6 +2754,10 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.clearDecodesEveryCycle = result.equals("1");
                 }
 
+                if (name.equalsIgnoreCase("pileupStrongestFirst")) {
+                    GeneralVariables.pileupStrongestFirst = result.equals("1");
+                }
+
                 if (name.equalsIgnoreCase("decodeSortMode")) {
                     // parseConfigInt, not Integer.parseInt: a whitespace/non-numeric value in
                     // the config table would otherwise throw during startup hydration.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/CallerQueueOrdering.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/CallerQueueOrdering.java
@@ -1,0 +1,55 @@
+package com.k1af.ft8af.ft8transmit;
+
+import java.util.List;
+
+/**
+ * Pileup caller-selection policy: given the queue of stations waiting to be
+ * worked after the current QSO, decide which one to pick next.
+ *
+ * <p>Two policies:
+ * <ul>
+ *   <li><b>First-heard (FIFO)</b> — the default. The station that has been
+ *       waiting longest (index 0, the head of the queue) is worked next. This
+ *       is the fairest order and matches the historic behavior.</li>
+ *   <li><b>Strongest-first</b> — the waiting caller with the highest SNR is
+ *       worked next, so a busy DXpedition/POTA/contest run completes the
+ *       best-copy exchanges first and wastes fewer cycles on marginal signals.
+ *       Ties break toward the earliest-queued caller (lowest index), so equal
+ *       signals are still worked in the order they called.</li>
+ * </ul>
+ *
+ * <p>Pure and side-effect free so the policy is unit-testable without the
+ * transmit engine or any Android types.
+ */
+public final class CallerQueueOrdering {
+
+    private CallerQueueOrdering() {
+    }
+
+    /**
+     * Index into {@code queue} of the caller to work next, or {@code -1} when the
+     * queue is empty/null.
+     *
+     * @param queue          the pending callers, head-first (index 0 = queued earliest)
+     * @param strongestFirst when true, pick the highest-SNR caller; otherwise FIFO (index 0)
+     */
+    public static int pickNextIndex(List<QueuedCaller> queue, boolean strongestFirst) {
+        if (queue == null || queue.isEmpty()) {
+            return -1;
+        }
+        if (!strongestFirst) {
+            return 0;
+        }
+        int bestIndex = 0;
+        int bestSnr = queue.get(0).snr;
+        for (int i = 1; i < queue.size(); i++) {
+            int snr = queue.get(i).snr;
+            // Strictly greater keeps ties on the earliest-queued caller.
+            if (snr > bestSnr) {
+                bestSnr = snr;
+                bestIndex = i;
+            }
+        }
+        return bestIndex;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -2435,7 +2435,12 @@ public class FT8TransmitSignal {
     public boolean dequeueNextCaller() {
         synchronized (callerQueue) {
             while (!callerQueue.isEmpty()) {
-                QueuedCaller caller = callerQueue.remove(0);
+                // Pileup pick order: FIFO by default, or the strongest waiting
+                // caller when the operator has turned that on (issue #333 sibling).
+                int idx = CallerQueueOrdering.pickNextIndex(
+                        callerQueue, GeneralVariables.pileupStrongestFirst);
+                if (idx < 0) break;
+                QueuedCaller caller = callerQueue.remove(idx);
                 mutableCallerQueue.postValue(new ArrayList<>(callerQueue));
 
                 // Skip if caller is now excluded or already worked

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ActiveQsoPanel.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ActiveQsoPanel.kt
@@ -669,6 +669,26 @@ private fun TxSelector(
     }
 }
 
+/**
+ * Order the pileup caller chips for display. When [strongestFirst] the queue is
+ * sorted by SNR descending (best copy first) — matching the auto-dequeue policy
+ * in [com.k1af.ft8af.ft8transmit.CallerQueueOrdering] — so the chip the operator
+ * is nudged to tap next is the same station the engine would pick. [sortedByDescending]
+ * is stable, so equal-SNR callers keep their first-heard order. Off preserves the
+ * raw queue (first-heard) order. Extracted for unit testing.
+ */
+internal fun orderCallerQueue(
+    queue: List<QueuedCaller>,
+    strongestFirst: Boolean,
+): List<QueuedCaller> =
+    if (strongestFirst) queue.sortedByDescending { it.snr } else queue
+
+/**
+ * Signed SNR label for a queued caller chip (e.g. "+5", "-12"). A queued caller
+ * with no reported SNR carries 0, which renders as "+0".
+ */
+internal fun callerSnrLabel(snr: Int): String = if (snr >= 0) "+$snr" else "$snr"
+
 @OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
 @Composable
 private fun CallerQueueBar(
@@ -678,6 +698,12 @@ private fun CallerQueueBar(
     if (queue.isEmpty()) return
 
     Spacer(modifier = Modifier.height(6.dp))
+
+    // Display order tracks the auto-dequeue policy so the leftmost chip is the
+    // station the engine would work next. Computed inline (the queue is capped at
+    // ~10 callers) rather than remember()d, so an SNR update that mutates a queued
+    // caller in place still re-sorts on the next recomposition.
+    val ordered = orderCallerQueue(queue, GeneralVariables.pileupStrongestFirst)
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -697,8 +723,8 @@ private fun CallerQueueBar(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
-            queue.forEach { caller ->
-                Box(
+            ordered.forEach { caller ->
+                Row(
                     modifier = Modifier
                         .clip(RoundedCornerShape(4.dp))
                         .background(SignalSoft)
@@ -707,13 +733,20 @@ private fun CallerQueueBar(
                             else Modifier
                         )
                         .padding(horizontal = 6.dp, vertical = 2.dp),
-                    contentAlignment = Alignment.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     Text(
                         text = caller.callsign,
                         color = Signal,
                         fontSize = 10.sp,
                         fontWeight = FontWeight.Medium,
+                        fontFamily = GeistMonoFamily,
+                    )
+                    Text(
+                        text = callerSnrLabel(caller.snr),
+                        color = Signal.copy(alpha = 0.65f),
+                        fontSize = 9.sp,
                         fontFamily = GeistMonoFamily,
                     )
                 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TransmissionSettings.kt
@@ -114,6 +114,7 @@ fun TransmissionSettings(
     var autoCallFollow by remember { mutableStateOf(GeneralVariables.autoCallFollow) }
     var earlyDecode by remember { mutableStateOf(GeneralVariables.earlyDecode) }
     var autoCQAfterQSO by remember { mutableStateOf(GeneralVariables.autoCQAfterQSO) }
+    var pileupStrongestFirst by remember { mutableStateOf(GeneralVariables.pileupStrongestFirst) }
 
     var showWatchdog by remember { mutableStateOf(false) }
     var showStopAfter by remember { mutableStateOf(false) }
@@ -677,6 +678,19 @@ fun TransmissionSettings(
                             GeneralVariables.autoCQAfterQSO = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "autoCQAfterQSO", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_pileup_strongest),
+                        description = stringResource(R.string.settings_pileup_strongest_desc),
+                        toggle = pileupStrongestFirst,
+                        onToggleChange = { checked ->
+                            pileupStrongestFirst = checked
+                            GeneralVariables.pileupStrongestFirst = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "pileupStrongestFirst", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -571,6 +571,8 @@
     <string name="settings_fast_turnaround_desc">Decode ~1s earlier so you can answer a CQ on the next slot instead of waiting. May miss stations with a large clock offset.</string>
     <string name="settings_auto_cq_after_qso">Auto-CQ after QSO</string>
     <string name="settings_auto_cq_after_qso_desc">Keep calling CQ automatically after each completed contact — no re-tap. Stays on your frequency (ignores Hunt). Runs until you stop or the TX Watchdog times out with no answers.</string>
+    <string name="settings_pileup_strongest">Work strongest caller first</string>
+    <string name="settings_pileup_strongest_desc">In a pileup, auto-work the strongest waiting caller next instead of the one who called earliest. Completes the best-copy contacts first on a busy run. The caller queue lists callers strongest-first to match.</string>
 
     <!-- ===== Settings: decode highlights ===== -->
     <string name="settings_highlight_new_dxcc">New DXCC</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/CallerQueueOrderingTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/CallerQueueOrderingTest.java
@@ -1,0 +1,124 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CallerQueueOrdering#pickNextIndex} — the pileup
+ * caller-selection policy (first-heard FIFO vs. strongest-SNR-first).
+ */
+public class CallerQueueOrderingTest {
+
+    private static QueuedCaller caller(String call, int snr) {
+        return new QueuedCaller(call, 1000f, 0, snr, 0, 0, "");
+    }
+
+    @Test
+    public void emptyQueue_returnsMinusOne() {
+        assertThat(CallerQueueOrdering.pickNextIndex(new ArrayList<>(), false)).isEqualTo(-1);
+        assertThat(CallerQueueOrdering.pickNextIndex(new ArrayList<>(), true)).isEqualTo(-1);
+    }
+
+    @Test
+    public void nullQueue_returnsMinusOne() {
+        assertThat(CallerQueueOrdering.pickNextIndex(null, true)).isEqualTo(-1);
+    }
+
+    @Test
+    public void fifo_alwaysPicksHead() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", -5));
+        q.add(caller("B", +12));   // stronger, but FIFO ignores SNR
+        q.add(caller("C", 0));
+        assertThat(CallerQueueOrdering.pickNextIndex(q, false)).isEqualTo(0);
+    }
+
+    @Test
+    public void strongestFirst_picksHighestSnr() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", -5));
+        q.add(caller("B", +12));
+        q.add(caller("C", +3));
+        assertThat(CallerQueueOrdering.pickNextIndex(q, true)).isEqualTo(1);
+    }
+
+    @Test
+    public void strongestFirst_negativeSnrs_picksLeastNegative() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", -20));
+        q.add(caller("B", -3));
+        q.add(caller("C", -15));
+        assertThat(CallerQueueOrdering.pickNextIndex(q, true)).isEqualTo(1);
+    }
+
+    @Test
+    public void strongestFirst_tieBreaksToEarliest() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", +7));
+        q.add(caller("B", +7));   // equal SNR, queued later
+        assertThat(CallerQueueOrdering.pickNextIndex(q, true)).isEqualTo(0);
+    }
+
+    @Test
+    public void strongestFirst_singleCaller() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", -30));
+        assertThat(CallerQueueOrdering.pickNextIndex(q, true)).isEqualTo(0);
+    }
+
+    @Test
+    public void strongestFirst_headIsAlreadyStrongest() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", +15));
+        q.add(caller("B", +2));
+        assertThat(CallerQueueOrdering.pickNextIndex(q, true)).isEqualTo(0);
+    }
+
+    @Test
+    public void draining_strongestFirst_yieldsDescendingOrder() {
+        // Simulate repeatedly picking-and-removing to confirm the whole pileup
+        // drains strongest-first.
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", -5));
+        q.add(caller("B", +12));
+        q.add(caller("C", +3));
+        q.add(caller("D", -18));
+
+        List<String> worked = new ArrayList<>();
+        while (!q.isEmpty()) {
+            int idx = CallerQueueOrdering.pickNextIndex(q, true);
+            worked.add(q.remove(idx).callsign);
+        }
+        assertThat(worked).containsExactly("B", "C", "A", "D").inOrder();
+    }
+
+    @Test
+    public void draining_fifo_yieldsQueueOrder() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", -5));
+        q.add(caller("B", +12));
+        q.add(caller("C", +3));
+
+        List<String> worked = new ArrayList<>();
+        while (!q.isEmpty()) {
+            int idx = CallerQueueOrdering.pickNextIndex(q, false);
+            worked.add(q.remove(idx).callsign);
+        }
+        assertThat(worked).containsExactly("A", "B", "C").inOrder();
+    }
+
+    @Test
+    public void pickNextIndex_doesNotMutateQueue() {
+        List<QueuedCaller> q = new ArrayList<>();
+        q.add(caller("A", -5));
+        q.add(caller("B", +12));
+        List<QueuedCaller> snapshot = Collections.unmodifiableList(new ArrayList<>(q));
+        CallerQueueOrdering.pickNextIndex(q, true);
+        assertThat(q).containsExactlyElementsIn(snapshot).inOrder();
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CallerQueueDisplayTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CallerQueueDisplayTest.kt
@@ -1,0 +1,62 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.ft8transmit.QueuedCaller
+import org.junit.Test
+
+/**
+ * Unit tests for the pileup caller-chip display helpers [orderCallerQueue] and
+ * [callerSnrLabel]. The display order must mirror the auto-dequeue policy
+ * (CallerQueueOrdering) so the leftmost chip is the station the engine works next.
+ */
+class CallerQueueDisplayTest {
+
+    private fun caller(call: String, snr: Int) =
+        QueuedCaller(call, 1000f, 0, snr, 0, 0, "")
+
+    @Test
+    fun fifo_preservesQueueOrder() {
+        val q = listOf(caller("A", -5), caller("B", 12), caller("C", 3))
+        val ordered = orderCallerQueue(q, strongestFirst = false)
+        assertThat(ordered.map { it.callsign }).containsExactly("A", "B", "C").inOrder()
+    }
+
+    @Test
+    fun strongestFirst_sortsBySnrDescending() {
+        val q = listOf(caller("A", -5), caller("B", 12), caller("C", 3))
+        val ordered = orderCallerQueue(q, strongestFirst = true)
+        assertThat(ordered.map { it.callsign }).containsExactly("B", "C", "A").inOrder()
+    }
+
+    @Test
+    fun strongestFirst_stableForTies() {
+        // Equal SNR keeps first-heard order (sortedByDescending is stable).
+        val q = listOf(caller("A", 7), caller("B", 7), caller("C", 7))
+        val ordered = orderCallerQueue(q, strongestFirst = true)
+        assertThat(ordered.map { it.callsign }).containsExactly("A", "B", "C").inOrder()
+    }
+
+    @Test
+    fun orderCallerQueue_doesNotMutateInput() {
+        val q = listOf(caller("A", -5), caller("B", 12))
+        orderCallerQueue(q, strongestFirst = true)
+        assertThat(q.map { it.callsign }).containsExactly("A", "B").inOrder()
+    }
+
+    @Test
+    fun emptyQueue_returnsEmpty() {
+        assertThat(orderCallerQueue(emptyList(), strongestFirst = true)).isEmpty()
+        assertThat(orderCallerQueue(emptyList(), strongestFirst = false)).isEmpty()
+    }
+
+    @Test
+    fun snrLabel_positiveGetsPlusSign() {
+        assertThat(callerSnrLabel(5)).isEqualTo("+5")
+        assertThat(callerSnrLabel(0)).isEqualTo("+0")
+    }
+
+    @Test
+    fun snrLabel_negativeKeepsMinus() {
+        assertThat(callerSnrLabel(-12)).isEqualTo("-12")
+    }
+}


### PR DESCRIPTION
## What & why

When you run a **pileup** — calling CQ and getting several answers in the same slot during a DXpedition, POTA activation, or contest — FT8AF queues the extra callers and works them one after another. Until now that queue was strict **FIFO**: the station that called *earliest* was always worked next, regardless of how well you were copying it. On a busy run that means strong, easy-to-complete stations sit waiting behind marginal ones, and you burn cycles on exchanges that may never finish.

This adds an opt-in operating option that lets the app **work the strongest waiting caller next** instead, so you complete the best-copy contacts first and keep the run moving.

## What changed

- **New Auto-Sequence setting — "Work strongest caller first"** (Settings → CAT & Transmission → Auto-Sequence). Off by default, preserving the historic first-heard/FIFO order for anyone who prefers it.
- When on, the pileup auto-dequeue picks the **highest-SNR** waiting caller next. Ties break toward the earliest-queued caller, so equal signals still go in the order they called (fair, deterministic).
- The **caller-queue chips** in the active-QSO panel now show each waiting caller's **SNR** and sort strongest-first to match, so you can see at a glance who the engine will work next — and still tap any chip to pick someone else.

## Implementation

- `GeneralVariables.pileupStrongestFirst` (persisted via DB key `pileupStrongestFirst`, default off; `volatile` — written on the UI thread, read on the transmit thread).
- Selection policy extracted to a pure, side-effect-free `CallerQueueOrdering.pickNextIndex(queue, strongestFirst)`; `FT8TransmitSignal.dequeueNextCaller()` now uses it instead of `remove(0)`.
- Display helpers `orderCallerQueue` / `callerSnrLabel` extracted from `ActiveQsoPanel` for testing.
- No change to the FT8 protocol, decoder, or waveform — this only reorders which already-queued caller is answered next.

## Tests

- `CallerQueueOrderingTest` (Java, pure): FIFO vs. strongest-first selection, negative-SNR handling, tie-break to earliest, full-drain ordering, no-mutation, empty/null guards.
- `CallerQueueDisplayTest` (Kotlin, pure): display ordering mirrors the engine policy, stable-for-ties, SNR label formatting.

## Verification

- `./gradlew :app:testDebugUnitTest` — full suite green.
- `./gradlew :app:assembleDebug` — APK builds clean.