### PR TITLE
Add a "signal reach" summary to the map PSK "Heard me" overlay

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/MapScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -97,13 +98,13 @@ private data class StationMarker(
 // PSK Reporter overlay (issue #33) — the other station in a reception report
 // (a receiver that heard us, or a sender we heard, per the direction filter).
 private data class PskSpotMarker(
-    val callsign: String,
+    override val callsign: String,
     val grid: String,
-    val lat: Double,
-    val lon: Double,
-    val snr: Int,
+    override val lat: Double,
+    override val lon: Double,
+    override val snr: Int,
     override val frequencyHz: Long,
-) : HasFrequencyHz
+) : HasFrequencyHz, ReachSpot
 
 private const val PSK_POLL_INTERVAL_MS = 5L * 60L * 1000L
 
@@ -553,7 +554,15 @@ fun MapScreen(mainViewModel: MainViewModel) {
         }
 
         // Bottom: the PSK filter sheet takes the bottom slot when open; otherwise the
-        // selected-station card. (Mutually exclusive so they don't stack.)
+        // selected-station card, or — when the "Heard me" overlay is on and nothing is
+        // selected — the signal-reach summary. (Mutually exclusive so they don't stack.)
+        val reach = remember(pskSpots, opLatLng, pskFilter.direction) {
+            if (pskFilter.direction == PskDirection.WHO_HEARD_ME) {
+                summarizeSignalReach(pskSpots, opLatLng?.latitude, opLatLng?.longitude)
+            } else {
+                null
+            }
+        }
         if (pskOverlayEnabled && filterSheetOpen) {
             PskFilterSheet(
                 filter = pskFilter,
@@ -570,6 +579,14 @@ fun MapScreen(mainViewModel: MainViewModel) {
                 opLat = opLat,
                 opLon = opLon,
                 onDismiss = { selectedCallsign = null },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(12.dp)
+                    .fillMaxWidth(),
+            )
+        } else if (pskOverlayEnabled && reach != null) {
+            SignalReachCard(
+                reach = reach,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(12.dp)
@@ -1636,6 +1653,59 @@ private fun SelectedStationCard(
                 InfoChip(MaidenheadGrid.formatDist(distKm), stringResource(R.string.map_info_distance))
                 InfoChip("${String.format("%.0f", bearing)}\u00B0", stringResource(R.string.map_info_bearing))
                 InfoChip("${station.snr} dB", stringResource(R.string.map_info_snr))
+            }
+        }
+    }
+}
+
+/**
+ * Bottom card summarising how far the operator's own signal is reaching, derived
+ * from PSK Reporter "heard me" spots by [summarizeSignalReach]. Shown when the
+ * overlay is on in the "Heard me" direction and no individual station is
+ * selected — the glanceable answer to "is my signal getting out, and how far?".
+ */
+@Composable
+private fun SignalReachCard(reach: SignalReach, modifier: Modifier = Modifier) {
+    GlassCard(modifier = modifier) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.map_reach_title),
+                    color = Signal,
+                    fontFamily = GeistMonoFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp,
+                )
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.map_reach_receivers,
+                        reach.receivers,
+                        reach.receivers,
+                    ),
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                if (reach.furthestCall.isNotEmpty()) {
+                    InfoChip(
+                        MaidenheadGrid.formatDist(reach.furthestKm),
+                        stringResource(R.string.map_reach_furthest, reach.furthestCall),
+                    )
+                }
+                if (reach.strongestCall.isNotEmpty()) {
+                    InfoChip(
+                        "${reach.strongestSnr} dB",
+                        stringResource(R.string.map_reach_best, reach.strongestCall),
+                    )
+                }
             }
         }
     }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/SignalReach.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/map/SignalReach.kt
@@ -1,0 +1,104 @@
+package radio.ks3ckc.ft8af.ui.map
+
+/**
+ * "Signal reach" summary — the glanceable answer to the single most-asked FT8
+ * question: *is my signal getting out, and how far?*
+ *
+ * The map already fetches PSK Reporter reception reports for the operator's own
+ * callsign (the "Heard me" direction) and plots each receiver as a dot. This
+ * pure helper reduces that same set of spots to a one-card headline: how many
+ * distinct stations heard us, the furthest one (great-circle from our grid),
+ * and the receiver that copied us with the strongest signal.
+ *
+ * Kept free of Compose/Android types so it can be unit-tested directly; the
+ * card composable in [MapScreen] is a thin renderer over [summarizeSignalReach].
+ */
+
+/** Minimal view of a reception report the reach summary needs. */
+internal interface ReachSpot {
+    val callsign: String
+    val lat: Double
+    val lon: Double
+    /** SNR (dB) at which this receiver decoded us; higher == copied us stronger. */
+    val snr: Int
+}
+
+/**
+ * Headline reach numbers.
+ *
+ * @property receivers      distinct stations that heard us
+ * @property furthestKm     great-circle distance to the furthest receiver (km);
+ *                          0.0 when the operator grid is unknown (no distances)
+ * @property furthestCall   callsign of the furthest receiver ("" when unknown)
+ * @property strongestSnr   best SNR any receiver reported for us
+ * @property strongestCall  callsign of that best-SNR receiver
+ */
+internal data class SignalReach(
+    val receivers: Int,
+    val furthestKm: Double,
+    val furthestCall: String,
+    val strongestSnr: Int,
+    val strongestCall: String,
+)
+
+/**
+ * Summarise [spots] (receivers that heard us) into a [SignalReach], or null when
+ * there is nothing to report.
+ *
+ * Reports are de-duplicated by callsign — a single station often appears more
+ * than once (multiple decodes / bands in the window), and "12 stations heard
+ * you" should count stations, not lines. For a repeated callsign the strongest
+ * SNR and the (identical) location are kept.
+ *
+ * [opLat]/[opLon] are the operator's position; when null (no grid configured)
+ * distances can't be computed, so [SignalReach.furthestKm] is 0.0 and
+ * [SignalReach.furthestCall] is empty. The strongest-signal figures never depend
+ * on our own position, so they're always populated.
+ */
+internal fun summarizeSignalReach(
+    spots: List<ReachSpot>,
+    opLat: Double?,
+    opLon: Double?,
+): SignalReach? {
+    if (spots.isEmpty()) return null
+
+    // Collapse to one entry per callsign, keeping the strongest report we have.
+    val byCall = LinkedHashMap<String, ReachSpot>()
+    for (spot in spots) {
+        val key = spot.callsign.trim().uppercase()
+        if (key.isEmpty()) continue
+        val existing = byCall[key]
+        if (existing == null || spot.snr > existing.snr) {
+            byCall[key] = spot
+        }
+    }
+    if (byCall.isEmpty()) return null
+
+    var furthestKm = 0.0
+    var furthestCall = ""
+    var strongestSnr = Int.MIN_VALUE
+    var strongestCall = ""
+
+    val haveOrigin = opLat != null && opLon != null
+    for ((call, spot) in byCall) {
+        if (haveOrigin) {
+            val km = greatCircleKm(opLat!!, opLon!!, spot.lat, spot.lon)
+            if (km > furthestKm) {
+                furthestKm = km
+                furthestCall = call
+            }
+        }
+        if (spot.snr > strongestSnr) {
+            strongestSnr = spot.snr
+            strongestCall = call
+        }
+    }
+
+    return SignalReach(
+        receivers = byCall.size,
+        furthestKm = furthestKm,
+        furthestCall = furthestCall,
+        strongestSnr = strongestSnr,
+        strongestCall = strongestCall,
+    )
+}

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -391,6 +391,13 @@
     <string name="map_info_distance">Distance</string>
     <string name="map_info_bearing">Bearing</string>
     <string name="map_info_snr">SNR</string>
+    <string name="map_reach_title">Your signal reach</string>
+    <plurals name="map_reach_receivers">
+        <item quantity="one">%1$d heard you</item>
+        <item quantity="other">%1$d heard you</item>
+    </plurals>
+    <string name="map_reach_furthest">Furthest · %1$s</string>
+    <string name="map_reach_best">Best · %1$s</string>
     <string name="waterfall_title">Waterfall</string>
     <string name="waterfall_toggle_nr">NR</string>
     <string name="waterfall_toggle_msg">MSG</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/SignalReachTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/map/SignalReachTest.kt
@@ -1,0 +1,96 @@
+package radio.ks3ckc.ft8af.ui.map
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for [summarizeSignalReach] — the "how far is my signal
+ * getting?" headline derived from PSK Reporter "heard me" spots. No
+ * Android/Compose runtime is touched.
+ */
+class SignalReachTest {
+
+    private data class Spot(
+        override val callsign: String,
+        override val lat: Double,
+        override val lon: Double,
+        override val snr: Int,
+    ) : ReachSpot
+
+    // Operator sits roughly at Kansas (EM29-ish) for distance sanity checks.
+    private val opLat = 39.0
+    private val opLon = -95.0
+
+    @Test
+    fun emptyList_returnsNull() {
+        assertThat(summarizeSignalReach(emptyList(), opLat, opLon)).isNull()
+    }
+
+    @Test
+    fun countsReceivers_andPicksFurthest() {
+        val spots = listOf(
+            Spot("W1AW", 41.7, -72.7, -5),    // Connecticut — close
+            Spot("G0ABC", 51.5, 0.0, -12),    // England — ~7000 km
+            Spot("VK3XYZ", -37.8, 144.9, -18), // Australia — ~16000 km, furthest
+        )
+        val reach = summarizeSignalReach(spots, opLat, opLon)!!
+        assertThat(reach.receivers).isEqualTo(3)
+        assertThat(reach.furthestCall).isEqualTo("VK3XYZ")
+        assertThat(reach.furthestKm).isGreaterThan(14000.0)
+    }
+
+    @Test
+    fun picksStrongestSnr() {
+        val spots = listOf(
+            Spot("W1AW", 41.7, -72.7, -15),
+            Spot("K5AAA", 30.0, -97.0, -3),   // strongest
+            Spot("G0ABC", 51.5, 0.0, -12),
+        )
+        val reach = summarizeSignalReach(spots, opLat, opLon)!!
+        assertThat(reach.strongestCall).isEqualTo("K5AAA")
+        assertThat(reach.strongestSnr).isEqualTo(-3)
+    }
+
+    @Test
+    fun deduplicatesByCallsign_keepingStrongestReport() {
+        // Same station heard us twice; count it once and keep the better SNR.
+        val spots = listOf(
+            Spot("W1AW", 41.7, -72.7, -18),
+            Spot("w1aw", 41.7, -72.7, -6),    // lower-case + stronger
+        )
+        val reach = summarizeSignalReach(spots, opLat, opLon)!!
+        assertThat(reach.receivers).isEqualTo(1)
+        assertThat(reach.strongestCall).isEqualTo("W1AW")
+        assertThat(reach.strongestSnr).isEqualTo(-6)
+    }
+
+    @Test
+    fun noOperatorGrid_stillReportsCountAndSignal_butNoDistance() {
+        val spots = listOf(
+            Spot("W1AW", 41.7, -72.7, -5),
+            Spot("G0ABC", 51.5, 0.0, -12),
+        )
+        val reach = summarizeSignalReach(spots, null, null)!!
+        assertThat(reach.receivers).isEqualTo(2)
+        assertThat(reach.strongestCall).isEqualTo("W1AW")
+        assertThat(reach.furthestKm).isEqualTo(0.0)
+        assertThat(reach.furthestCall).isEmpty()
+    }
+
+    @Test
+    fun blankCallsigns_areIgnored() {
+        val spots = listOf(
+            Spot("   ", 41.7, -72.7, -5),
+            Spot("G0ABC", 51.5, 0.0, -12),
+        )
+        val reach = summarizeSignalReach(spots, opLat, opLon)!!
+        assertThat(reach.receivers).isEqualTo(1)
+        assertThat(reach.strongestCall).isEqualTo("G0ABC")
+    }
+
+    @Test
+    fun allBlankCallsigns_returnNull() {
+        val spots = listOf(Spot("", 41.7, -72.7, -5), Spot("  ", 51.5, 0.0, -12))
+        assertThat(summarizeSignalReach(spots, opLat, opLon)).isNull()
+    }
+}


### PR DESCRIPTION
## What & why

FT8 operators constantly ask one question: **"Is my signal getting out, and how far?"** The world map already fetches PSK Reporter reception reports for the operator's own callsign (the **Heard me** direction) and plots every receiver as a dot — but reading *reach* off a scattering of dots means panning and zooming around.

This PR adds a small, glanceable **Signal reach** card at the bottom of the map that answers the question at a glance:

- **N heard you** — how many distinct stations copied our last transmissions
- **Furthest · CALL** — great-circle distance to the furthest receiver (respects the miles/km preference)
- **Best · CALL** — the station that decoded us with the strongest SNR

## Behaviour

- Shows only when the PSK overlay is on **and** the direction is **Heard me**, and only when no individual station is selected and the filter sheet is closed — so it never competes with the existing station-detail / filter cards for the bottom slot.
- **No extra network traffic:** it summarises the spots already fetched by the map's existing 5-minute PSK poll.
- Gracefully degrades when the operator grid isn't set: still shows the receiver count and strongest-signal figures, just omits distances.

## Implementation

Following the repo convention of "extract the decision/geometry logic into a plain testable helper, keep the Composable a thin wrapper":

- **`SignalReach.kt`** — pure `summarizeSignalReach(spots, opLat, opLon)` reducer (no Compose/Android types). De-duplicates reports by callsign (keeping the strongest), reuses the existing `greatCircleKm`, tolerates a missing grid, and ignores blank callsigns.
- **`MapScreen.kt`** — `PskSpotMarker` now implements the tiny `ReachSpot` interface; a new thin `SignalReachCard` renders the summary.

## Tests

New `SignalReachTest` (7 cases): receiver count + furthest pick, strongest-SNR pick, callsign de-duplication, missing-grid degradation, blank-callsign filtering, and the empty/all-blank → null cases.

```
./gradlew :app:testDebugUnitTest --tests radio.ks3ckc.ft8af.ui.map.SignalReachTest
BUILD SUCCESSFUL — 7 tests, 0 failures
```

No decoder, transmit, or protocol paths are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)