### PR TITLE
Fix FlexRadio 6000 CAT: coalesced replies silently dropped frequency updates

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Flex6000Rig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/Flex6000Rig.java
@@ -13,7 +13,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 /**
- * KENWOOD TS590, similar to YAESU gen-3 commands. Uses Yaesu3Command structure, commands in KenwoodTK90RigConstant.
+ * FLEX 6000 series. Replies are {@code ';'}-terminated {@code ZZ}-prefixed
+ * commands (e.g. {@code ZZFA00014074000;}); parsed via {@link Flex6000Command}.
  */
 public class Flex6000Rig extends BaseRig {
     private static final String TAG = "KenwoodTS590Rig";
@@ -95,33 +96,47 @@ public class Flex6000Rig extends BaseRig {
     public void onReceiveData(byte[] data) {
         String s = new String(data);
 
-        if (!s.contains(";"))
-        {
-            buffer.append(s);
-            if (buffer.length()>1000) clearBufferData();
-            return;//data reception not yet complete.
-        }else {
-            if (s.indexOf(";")>0){//received end-of-data, and ';' is not the first character
-              buffer.append(s.substring(0,s.indexOf(";")));
-            }
-            //begin parsing data
-            Flex6000Command flex6000Command = Flex6000Command.getCommand(buffer.toString());
-            clearBufferData();//clear buffer
-            //put remaining data into buffer
-            buffer.append(s.substring(s.indexOf(";")+1));
+        // FlexRadio 6000 frames every reply as <ID><data>';' (e.g. ZZFA00014074000;).
+        // The old parser consumed only the FIRST ';'-terminated command in a read
+        // and re-buffered the rest WITH its terminator, where the next poll's
+        // clearBufferData() wiped it -- so when the network/serial transport
+        // coalesced two replies into one read (common on the TCP SmartSDR link),
+        // the second frequency reply was permanently lost and the retained
+        // terminator poisoned the next parse. Drain every complete ';'-terminated
+        // command in this read and carry only the trailing, unterminated fragment.
+        CatLineSplitter.Result result = CatLineSplitter.split(buffer.toString(), s, ';');
+        clearBufferData();
+        buffer.append(result.remainder);
+        // A runaway unterminated buffer must not grow without bound.
+        if (buffer.length() > 1000) clearBufferData();
 
-            if (flex6000Command == null) {
-                return;
+        for (String frame : result.frames) {
+            long freq = frequencyFromFrame(frame);
+            if (freq != -1) {
+                setFreq(freq);
             }
-            if (flex6000Command.getCommandID().equalsIgnoreCase("ZZFA")) {
-                long tempFreq=Flex6000Command.getFrequency(flex6000Command);
-                if (tempFreq!=0) {//if tempFreq==0, frequency is invalid
-                    setFreq(Flex6000Command.getFrequency(flex6000Command));
-                }
-            }
-
         }
+    }
 
+    /**
+     * Pure dispatch for a single drained command frame: the frequency this frame
+     * asks the rig to tune to, or {@code -1} when the frame carries no valid
+     * frequency update (unparseable frame, a non-ZZFA command, or an invalid
+     * {@code 0} read-back). Extracted so the coalesced-drain and freq-selection
+     * logic is unit-testable without rig/Android state.
+     */
+    static long frequencyFromFrame(String frame) {
+        Flex6000Command flex6000Command = Flex6000Command.getCommand(frame);
+        if (flex6000Command == null) {
+            return -1;
+        }
+        if (flex6000Command.getCommandID().equalsIgnoreCase("ZZFA")) {
+            long tempFreq = Flex6000Command.getFrequency(flex6000Command);
+            if (tempFreq != 0) {//if tempFreq==0, frequency is invalid
+                return tempFreq;
+            }
+        }
+        return -1;
     }
 
     @Override

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Flex6000RigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/Flex6000RigTest.java
@@ -1,0 +1,95 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pure-logic coverage for the FlexRadio 6000 reply handling: the coalesced-frame
+ * drain (via {@link CatLineSplitter}) and {@link Flex6000Rig#frequencyFromFrame},
+ * the per-frame dispatch that decides which frequency a drained command applies.
+ *
+ * <p>FlexRadio frames every reply as {@code ZZ<cmd><data>';'} (e.g.
+ * {@code ZZFA00014074000;}) and the transport — the SmartSDR TCP link in
+ * particular — delivers bytes in arbitrary chunks, routinely coalescing two
+ * replies into one read. The old parser consumed only the <em>first</em>
+ * {@code ';'}-terminated command and re-buffered the rest <em>with</em> its
+ * terminator, where the next poll's {@code clearBufferData()} wiped it — so the
+ * second reply was permanently lost and the retained terminator poisoned the
+ * next parse. These tests pin the drain-then-dispatch contract.
+ *
+ * <p>No Android types are touched, so no Robolectric runner is needed.
+ */
+public class Flex6000RigTest {
+
+    /** Drain a coalesced read the way {@code onReceiveData} now does. */
+    private static CatLineSplitter.Result drain(String buffered, String incoming) {
+        return CatLineSplitter.split(buffered, incoming, ';');
+    }
+
+    @Test
+    public void frequencyFromFrame_zzfa_returnsParsedFrequency() {
+        assertThat(Flex6000Rig.frequencyFromFrame("ZZFA00014074000")).isEqualTo(14074000L);
+    }
+
+    @Test
+    public void frequencyFromFrame_zeroReadback_isRejected() {
+        // A 0 read-back is treated as invalid and must not overwrite the freq.
+        assertThat(Flex6000Rig.frequencyFromFrame("ZZFA00000000000")).isEqualTo(-1L);
+    }
+
+    @Test
+    public void frequencyFromFrame_nonFrequencyCommand_isIgnored() {
+        // A well-formed but unrelated command (e.g. a status reply) yields no update.
+        assertThat(Flex6000Rig.frequencyFromFrame("ZZSW001")).isEqualTo(-1L);
+    }
+
+    @Test
+    public void frequencyFromFrame_malformedFrame_isIgnored() {
+        assertThat(Flex6000Rig.frequencyFromFrame("ZZ")).isEqualTo(-1L);
+        assertThat(Flex6000Rig.frequencyFromFrame("")).isEqualTo(-1L);
+    }
+
+    @Test
+    public void singleReply_frequencyApplied() {
+        CatLineSplitter.Result r = drain("", "ZZFA00014074000;");
+
+        assertThat(r.frames).containsExactly("ZZFA00014074000");
+        assertThat(r.remainder).isEmpty();
+        assertThat(Flex6000Rig.frequencyFromFrame(r.frames.get(0))).isEqualTo(14074000L);
+    }
+
+    @Test
+    public void twoCoalescedReplies_bothFrequenciesRecovered() {
+        // The regression: two ZZFA replies coalesce into one read. The old parser
+        // applied only the first and dropped the second; both must now drain so
+        // the latest frequency (14075000) wins.
+        CatLineSplitter.Result r = drain("", "ZZFA00014074000;ZZFA00014075000;");
+
+        assertThat(r.frames).containsExactly("ZZFA00014074000", "ZZFA00014075000").inOrder();
+        assertThat(r.remainder).isEmpty();
+        assertThat(Flex6000Rig.frequencyFromFrame(r.frames.get(0))).isEqualTo(14074000L);
+        assertThat(Flex6000Rig.frequencyFromFrame(r.frames.get(1))).isEqualTo(14075000L);
+    }
+
+    @Test
+    public void completeReplyPlusPartialTail_tailCarried() {
+        CatLineSplitter.Result r = drain("", "ZZFA00014074000;ZZFA000140");
+
+        assertThat(r.frames).containsExactly("ZZFA00014074000");
+        assertThat(r.remainder).isEqualTo("ZZFA000140");
+    }
+
+    @Test
+    public void replySplitAcrossReads_reassemblesViaRemainderCarry() {
+        // First read has no terminator: its bytes become the remainder that the
+        // caller re-feeds with the next read.
+        CatLineSplitter.Result first = drain("", "ZZFA000140");
+        assertThat(first.frames).isEmpty();
+        assertThat(first.remainder).isEqualTo("ZZFA000140");
+
+        CatLineSplitter.Result second = drain(first.remainder, "74000;");
+        assertThat(second.frames).containsExactly("ZZFA00014074000");
+        assertThat(Flex6000Rig.frequencyFromFrame(second.frames.get(0))).isEqualTo(14074000L);
+    }
+}


### PR DESCRIPTION
## Summary

`Flex6000Rig.onReceiveData` reassembled the `';'`-framed FlexRadio 6000 CAT
stream with the old single-command pattern: it parsed only the **first**
`';'`-terminated command in a read and re-buffered the remainder **with** its
terminator, where the next poll's `clearBufferData()` wiped it. So when the
transport coalesced two replies into one read, the second frequency reply was
**permanently lost**, and a retained terminator poisoned the following parse
(the stale ID was read as the command and the real payload was discarded into
the data field).

This is exactly the regression that `CatLineSplitter` already fixed for the
Yaesu / Kenwood / Elecraft `';'`-framed rigs (#665 / #667 / #669 / #671 / #685) —
`CatLineSplitter`'s own Javadoc even names *"Flex-6000 class rigs"* — but
`Flex6000Rig` was never converted to use it.

## Root cause

```java
// old onReceiveData
buffer.append(s.substring(0, s.indexOf(";")));
Flex6000Command cmd = Flex6000Command.getCommand(buffer.toString()); // first cmd only
clearBufferData();
buffer.append(s.substring(s.indexOf(";") + 1));  // 2nd+ cmds re-buffered, then wiped next poll
```

`FA` coalescing is realistic here: the FlexRadio SmartSDR link is TCP, which
routinely merges back-to-back `;`-terminated responses into a single read; slow
serial can fragment/coalesce too.

## Fix

Drain **every** complete `';'`-terminated command via the existing, tested
`CatLineSplitter` and carry only the trailing unterminated fragment forward
(with the same 1000-char runaway guard the sibling rigs use). The per-frame
frequency dispatch is extracted into a pure, package-private static
`frequencyFromFrame(String)` (returns `-1` for "no update"), keeping the
`onReceiveData` wrapper thin and making the drain + freq-selection unit-testable
without rig/Android state.

Behavior is otherwise unchanged: only `ZZFA` replies update the VFO, and a `0`
read-back is still rejected as invalid.

Also corrected the class Javadoc — a stale copy-paste that described the Kenwood
TS-590 rig.

## Testing

New `Flex6000RigTest` (pure JUnit4 + Truth, no Robolectric):

- `frequencyFromFrame` — valid `ZZFA`, `0`-read-back rejection, non-frequency
  command ignored, malformed/empty frames ignored.
- Drain contract — single reply, **two coalesced replies both recovered**
  (the fail-before regression: old code applied only the first), complete +
  partial tail, and a reply split across two reads reassembled via the
  remainder carry.

```
./gradlew :app:testDebugUnitTest    # full suite: BUILD SUCCESSFUL
```

Full unit-test suite is green. Ran on JDK 17 / NDK 27 headless Linux.

## Risk

Low and localized to one rig class. Reuses the already-proven, already-tested
`CatLineSplitter` (same fix applied to 9 sibling rigs). No protocol, DSP, or
cross-platform behavior changes; no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)