### PR TITLE
Add a "New Prefix" (WPX) decode highlight + filter for prefix chasers

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -588,6 +588,7 @@ public class GeneralVariables {
     public static HashSet<String> QSL_Callsign_list_today = new HashSet<>();//Callsigns worked today or yesterday (any band); a set for O(1) membership checks
     public static HashSet<String> QSL_Grid_list = new HashSet<>();//Distinct worked 4-char Maidenhead grids (any band)
     public static HashSet<String> QSL_Pota_list = new HashSet<>();//Distinct hunted POTA park refs (UPPER), any band
+    public static HashSet<String> QSL_Prefix_list = new HashSet<>();//Distinct worked CQ WPX prefixes (any band), see WpxPrefix
 
     // Decode-list highlight toggles (Settings → Decode Highlights). Gate the
     // status pill shown for each worked-before category in resolveQsoStatus().
@@ -595,6 +596,7 @@ public class GeneralVariables {
     public static boolean highlightNewZone = true;//Highlight stations from an unworked CQ zone (Worked All Zones)
     public static boolean highlightNewState = false;//Off by default — US-only (Worked All States); noise for non-US ops
     public static boolean highlightNewGrid = false;//Off by default — most grids are "new", so it's noisy
+    public static boolean highlightNewPrefix = false;//Off by default — many prefixes are "new" early on (Worked All Prefixes / WPX)
     public static boolean highlightNewBand = true;//Highlight stations worked only on other bands
     public static boolean highlightWorked = true;//Master enable for worked-station handling (see workedStationMode)
     public static boolean highlightPota = true;//Highlight spotted POTA activators (new parks stand out)
@@ -956,6 +958,16 @@ public class GeneralVariables {
     public static boolean checkQSLGrid(String grid) {
         if (grid == null || grid.length() < 4) return false;
         return QSL_Grid_list.contains(grid.substring(0, 4).toUpperCase());
+    }
+
+    /**
+     * Check whether a CQ WPX prefix (e.g. "W1", "DL0") has already been worked on
+     * any band. Caller should pass a prefix already normalized by
+     * {@link com.k1af.ft8af.callsign.WpxPrefix#of(String)} (upper case).
+     */
+    public static boolean checkQSLPrefix(String prefix) {
+        if (prefix == null || prefix.isEmpty()) return false;
+        return QSL_Prefix_list.contains(prefix);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/callsign/WpxPrefix.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/callsign/WpxPrefix.java
@@ -20,8 +20,14 @@ import java.util.Locale;
  *       {@code 9A1AA}&rarr;{@code 9A1}, {@code 3DA0RS}&rarr;{@code 3DA0}.</li>
  *   <li>Call with no numeral (rare/historic, e.g. {@code RAEM}) — first two
  *       letters plus {@code 0} &rarr; {@code RA0}.</li>
- *   <li>Portable number {@code CALL/n} — the base call's leading letters plus
- *       the new number. {@code W1AW/4}&rarr;{@code W4}, {@code VE3ABC/7}&rarr;{@code VE7}.</li>
+ *   <li>Portable number {@code CALL/n} — the base call's own prefix with its
+ *       numeral swapped for the new one. {@code W1AW/4}&rarr;{@code W4},
+ *       {@code VE3ABC/7}&rarr;{@code VE7}, {@code 9A1AA/7}&rarr;{@code 9A7},
+ *       {@code RAEM/4}&rarr;{@code RA4}. Deriving the base with the same
+ *       simple-call rule (rather than lifting leading letters off the raw token)
+ *       is what makes digit-leading and no-numeral calls behave; it also means a
+ *       token that isn't a whole callsign — {@code W1/7}, {@code FN42/7} — stays
+ *       {@code null} instead of inventing a prefix.</li>
  *   <li>Portable prefix {@code pfx/CALL} — the designator prefix, adding a
  *       {@code 0} when it carries no numeral. {@code DL/W1AW}&rarr;{@code DL0},
  *       {@code PJ4/K1ABC}&rarr;{@code PJ4}, {@code W1AW/KH6}&rarr;{@code KH6}.</li>
@@ -107,7 +113,8 @@ public final class WpxPrefix {
             return simple(parts.get(0));
         }
 
-        // Portable number: CALL/n → base's leading letters + the new number.
+        // Portable number: CALL/n → the base call's own prefix with its numeral
+        // swapped for the new one.
         String numeric = null;
         for (String p : parts) {
             if (isAllDigits(p) && p.length() <= 2) {
@@ -117,8 +124,8 @@ public final class WpxPrefix {
         if (numeric != null) {
             for (String p : parts) {
                 if (!isAllDigits(p)) {
-                    String letters = leadingLetters(p);
-                    return letters.isEmpty() ? null : letters + numeric;
+                    String base = simple(p);
+                    return base == null ? null : withPortableNumber(base, numeric);
                 }
             }
             return null;
@@ -195,11 +202,27 @@ public final class WpxPrefix {
         return false;
     }
 
-    private static String leadingLetters(String s) {
-        int i = 0;
-        while (i < s.length() && s.charAt(i) >= 'A' && s.charAt(i) <= 'Z') {
-            i++;
+    /**
+     * Swap the trailing numerals of an already-derived prefix for the portable
+     * number, e.g. {@code ("9A1","7")}&rarr;{@code 9A7}, {@code ("RA0","4")}&rarr;
+     * {@code RA4}, {@code ("W1","4")}&rarr;{@code W4}.
+     *
+     * <p>Working from {@link #simple(String)}'s output rather than the raw token's
+     * leading letters is what makes the digit-leading and no-numeral cases come
+     * out right: {@code 9A1AA} has no leading letters at all, and {@code RAEM}
+     * is all letters, so lifting letters off the raw call yielded nothing or the
+     * whole token. {@code simple} has already resolved both to a real prefix
+     * ({@code 9A1}, {@code RA0}), and every prefix it returns ends in a numeral,
+     * so replacing that numeral is well defined.
+     *
+     * @return the adjusted prefix, or {@code null} if nothing but digits remains
+     */
+    private static String withPortableNumber(String base, String number) {
+        int end = base.length();
+        while (end > 0 && base.charAt(end - 1) >= '0' && base.charAt(end - 1) <= '9') {
+            end--;
         }
-        return s.substring(0, i);
+        String letters = base.substring(0, end);
+        return letters.isEmpty() ? null : letters + number;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/callsign/WpxPrefix.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/callsign/WpxPrefix.java
@@ -1,0 +1,205 @@
+package com.k1af.ft8af.callsign;
+
+import java.util.ArrayList;
+import java.util.Locale;
+
+/**
+ * Extract the <b>CQ WPX prefix</b> from a callsign.
+ *
+ * <p>WPX (Worked All Prefixes) is one of the most-chased amateur-radio award
+ * programs: each distinct callsign prefix (e.g. {@code W1}, {@code VE3},
+ * {@code 9A1}, {@code DL0}) counts once, so operators hunt for "new prefixes"
+ * the same way they hunt new DXCC entities or grids. This helper turns a
+ * decoded callsign into its prefix so the decode list can flag unworked ones.
+ *
+ * <p>Rules implemented (per the CQ WPX definition), scoped to what actually
+ * appears in FT8 traffic:
+ * <ul>
+ *   <li>Simple call — the letters/numerals up to and including the last numeral
+ *       of the prefix. {@code W1AW}&rarr;{@code W1}, {@code VE3ABC}&rarr;{@code VE3},
+ *       {@code 9A1AA}&rarr;{@code 9A1}, {@code 3DA0RS}&rarr;{@code 3DA0}.</li>
+ *   <li>Call with no numeral (rare/historic, e.g. {@code RAEM}) — first two
+ *       letters plus {@code 0} &rarr; {@code RA0}.</li>
+ *   <li>Portable number {@code CALL/n} — the base call's leading letters plus
+ *       the new number. {@code W1AW/4}&rarr;{@code W4}, {@code VE3ABC/7}&rarr;{@code VE7}.</li>
+ *   <li>Portable prefix {@code pfx/CALL} — the designator prefix, adding a
+ *       {@code 0} when it carries no numeral. {@code DL/W1AW}&rarr;{@code DL0},
+ *       {@code PJ4/K1ABC}&rarr;{@code PJ4}, {@code W1AW/KH6}&rarr;{@code KH6}.</li>
+ *   <li>Operational suffixes {@code /P /M /MM /AM /QRP} are ignored (they don't
+ *       change the prefix). {@code G4XYZ/P}&rarr;{@code G4}.</li>
+ * </ul>
+ *
+ * <p>Anything that isn't a plausible callsign (grids, signal reports, hashed
+ * {@code <...>} calls, empty/garbled tokens) returns {@code null} so callers
+ * simply don't flag it — a conservative choice that never invents a prefix.
+ * Pure and dependency-free so it can be unit-tested on the host and shared by
+ * both the DB worked-prefix loader (DatabaseOpr.GetAllQSLCallsign) and the
+ * decode-list "New Prefix" predicate (DecodeRow.isNewPrefixStation).
+ */
+public final class WpxPrefix {
+
+    private WpxPrefix() {
+    }
+
+    /**
+     * @param raw a callsign (case/whitespace-insensitive), possibly compound
+     * @return the WPX prefix in upper case, or {@code null} if none can be
+     * determined
+     */
+    public static String of(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String call = raw.trim().toUpperCase(Locale.ROOT);
+        if (call.isEmpty()) {
+            return null;
+        }
+        if (call.indexOf('/') < 0) {
+            return simple(call);
+        }
+        return compound(call);
+    }
+
+    /** Prefix of a plain (non-slashed) callsign, or null if implausible. */
+    private static String simple(String call) {
+        if (!isAlnum(call)) {
+            return null;
+        }
+        int lastDigit = -1;
+        boolean hasLetter = false;
+        for (int i = 0; i < call.length(); i++) {
+            char c = call.charAt(i);
+            if (c >= '0' && c <= '9') {
+                lastDigit = i;
+            } else {
+                hasLetter = true;
+            }
+        }
+        if (!hasLetter) {
+            return null; // all-digit token (signal report, "73", …) — not a call
+        }
+        if (lastDigit < 0) {
+            // No numeral at all (historic call like RAEM): first two letters + 0.
+            return call.length() >= 2 ? call.substring(0, 2) + "0" : null;
+        }
+        // A full callsign carries a letter suffix after its prefix numeral.
+        // Requiring one keeps bare prefixes / partial tokens ("W1") and grids
+        // ("FN42") from being mistaken for a whole callsign.
+        if (lastDigit == call.length() - 1) {
+            return null;
+        }
+        String prefix = call.substring(0, lastDigit + 1);
+        return containsLetter(prefix) ? prefix : null;
+    }
+
+    /** Prefix of a compound (slashed) callsign, or null if indeterminate. */
+    private static String compound(String call) {
+        ArrayList<String> parts = new ArrayList<>();
+        for (String p : call.split("/")) {
+            if (!p.isEmpty() && !isIgnoredSuffix(p)) {
+                parts.add(p);
+            }
+        }
+        if (parts.isEmpty()) {
+            return null;
+        }
+        if (parts.size() == 1) {
+            return simple(parts.get(0));
+        }
+
+        // Portable number: CALL/n → base's leading letters + the new number.
+        String numeric = null;
+        for (String p : parts) {
+            if (isAllDigits(p) && p.length() <= 2) {
+                numeric = p;
+            }
+        }
+        if (numeric != null) {
+            for (String p : parts) {
+                if (!isAllDigits(p)) {
+                    String letters = leadingLetters(p);
+                    return letters.isEmpty() ? null : letters + numeric;
+                }
+            }
+            return null;
+        }
+
+        // Portable prefix: pfx/CALL. The designator is conventionally the shorter
+        // token (e.g. "DL" in DL/W1AW, "KH6" in W1AW/KH6).
+        String a = parts.get(0);
+        String b = parts.get(1);
+        String designator = a.length() <= b.length() ? a : b;
+        if (!isAlnum(designator) || !containsLetter(designator)) {
+            return null;
+        }
+        int lastDigit = -1;
+        for (int i = 0; i < designator.length(); i++) {
+            char c = designator.charAt(i);
+            if (c >= '0' && c <= '9') {
+                lastDigit = i;
+            }
+        }
+        if (lastDigit >= 0) {
+            return designator.substring(0, lastDigit + 1);
+        }
+        // Designator without a numeral (bare prefix like "DL"): first two letters + 0.
+        return designator.length() >= 2
+                ? designator.substring(0, 2) + "0"
+                : designator + "0";
+    }
+
+    private static boolean isIgnoredSuffix(String s) {
+        switch (s) {
+            case "P":
+            case "M":
+            case "MM":
+            case "AM":
+            case "QRP":
+            case "QRPP":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isAlnum(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (!((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAllDigits(String s) {
+        if (s.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean containsLetter(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c >= 'A' && c <= 'Z') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String leadingLetters(String s) {
+        int i = 0;
+        while (i < s.length() && s.charAt(i) >= 'A' && s.charAt(i) <= 'Z') {
+            i++;
+        }
+        return s.substring(0, i);
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2467,6 +2467,27 @@ public class DatabaseOpr extends SQLiteOpenHelper {
             }
             GeneralVariables.QSL_Grid_list = grids;
 
+            // Load distinct worked CQ WPX prefixes (any band) into an in-memory
+            // set backing the decode list's "New Prefix" highlight/filter. Derive
+            // each prefix from the logged callsign via the shared WpxPrefix helper
+            // so the "worked" set and the live decode predicate agree exactly.
+            querySQL = "select distinct [call] from QSLTable where [call] is not null and [call]<>''";
+            cursor = db.rawQuery(querySQL, null);
+            java.util.HashSet<String> prefixes = new java.util.HashSet<>();
+            try {
+                while (cursor.moveToNext()) {
+                    @SuppressLint("Range")
+                    String c = cursor.getString(cursor.getColumnIndex("call"));
+                    String pfx = com.k1af.ft8af.callsign.WpxPrefix.of(c);
+                    if (pfx != null) {
+                        prefixes.add(pfx);
+                    }
+                }
+            } finally {
+                cursor.close();
+            }
+            GeneralVariables.QSL_Prefix_list = prefixes;
+
             // Load distinct hunted POTA park refs (any band) into in-memory set.
             // sig/sig_info may be absent on some upgraded installs (see note in
             // onUpgrade), so guard the query defensively.
@@ -3150,6 +3171,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
                 if (name.equalsIgnoreCase("highlightNewGrid")) {
                     GeneralVariables.highlightNewGrid = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("highlightNewPrefix")) {
+                    GeneralVariables.highlightNewPrefix = result.equals("1");
                 }
                 if (name.equalsIgnoreCase("highlightNewBand")) {
                     GeneralVariables.highlightNewBand = result.equals("1");

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/theme/Color.kt
@@ -163,6 +163,9 @@ val StatusZone = Color(0xFF60A5FA)
 // Teal, distinct from the blue NEW-ZONE, cyan NEW-BAND and green POTA pills, for
 // the NEW-STATE (Worked All States) badge.
 val StatusState = Color(0xFF2DD4BF)
+// Rose/pink, distinct from the purple NEW-DXCC, blue NEW-ZONE, teal NEW-STATE and
+// yellow NEW-GRID badges, for the NEW-PREFIX (Worked All Prefixes / WPX) badge.
+val StatusPrefix = Color(0xFFF472B6)
 val StatusBad = Color(0xFFEF4444)
 
 // Band colors (for donut chart / logbook)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/StatusPill.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/StatusPill.kt
@@ -54,6 +54,12 @@ enum class QsoStatus(
         Color(0x1FFACC15),  // rgba(250,204,21,0.12)
         Color(0x47FACC15),  // rgba(250,204,21,0.28)
     ),
+    NEW_PREFIX(
+        R.string.status_new_prefix,
+        StatusPrefix,
+        Color(0x1FF472B6),  // rgba(244,114,182,0.12)
+        Color(0x47F472B6),  // rgba(244,114,182,0.28)
+    ),
     NEW_BAND(
         R.string.status_new_band,
         Signal,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
@@ -364,6 +364,19 @@ internal fun isNewGridStation(message: Ft8Message): Boolean {
 }
 
 /**
+ * Whether [message]'s sender carries a CQ WPX prefix (e.g. "W1", "DL0") the
+ * operator hasn't logged yet — a "new prefix" for Worked-All-Prefixes chasing.
+ * The prefix is derived from the callsign via [com.k1af.ft8af.callsign.WpxPrefix]
+ * (the same helper that builds the worked-prefix set in the log loader), so the
+ * NEW_PREFIX pill and the "New Prefix" filter always agree. Callsigns that don't
+ * yield a prefix (grids, reports, hashed calls) are never counted as new.
+ */
+internal fun isNewPrefixStation(message: Ft8Message): Boolean {
+    val prefix = com.k1af.ft8af.callsign.WpxPrefix.of(message.callsignFrom) ?: return false
+    return !GeneralVariables.checkQSLPrefix(prefix)
+}
+
+/**
  * Resolve the [QsoStatus] for a given [Ft8Message] based on its state.
  *
  * Returns null when there is no useful state to surface (e.g. a station
@@ -371,7 +384,7 @@ internal fun isNewGridStation(message: Ft8Message): Boolean {
  * should skip rendering the pill in that case.
  *
  * Priority (highest first): calling me, POTA/SOTA activation, new DXCC,
- * new grid, new band, plain CQ, already worked.
+ * new zone, new state, new grid, new prefix, new band, plain CQ, already worked.
  */
 internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
     val isCQ = message.checkIsCQ()
@@ -384,6 +397,7 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
     val modifier = message.modifier
 
     val newGrid = isNewGridStation(message)
+    val newPrefix = isNewPrefixStation(message)
     val newBand = !isWorked &&
         GeneralVariables.checkQSLCallsign_OtherBand(message.callsignFrom ?: "")
 
@@ -422,6 +436,9 @@ internal fun resolveQsoStatus(message: Ft8Message): QsoStatus? {
         // leave it false.
         GeneralVariables.highlightNewState && message.fromNewState -> QsoStatus.NEW_STATE
         GeneralVariables.highlightNewGrid && newGrid -> QsoStatus.NEW_GRID
+        // A new WPX prefix (Worked All Prefixes) ranks just below a new grid: both
+        // are common early on, so they sit under the rarer DXCC/zone/state catches.
+        GeneralVariables.highlightNewPrefix && newPrefix -> QsoStatus.NEW_PREFIX
         GeneralVariables.highlightNewBand && newBand -> QsoStatus.NEW_BAND
         effectiveWorkedMode() == WorkedStationMode.HIGHLIGHT &&
             isWorkedStation(message) -> QsoStatus.WORKED

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeScreen.kt
@@ -67,7 +67,7 @@ fun DecodeScreen(
     // Filter state. Backed by the ViewModel so the chosen filter survives
     // navigation away from Decode and back (the screen is recreated by the
     // tab switch, which would otherwise reset a local rememberSaveable).
-    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "New Zone", "New State", "New Grid", "Needed", "For Me")
+    val filterOptions = listOf("All", "CQ Calls", "CQ POTA", "New DXCC", "New Zone", "New State", "New Grid", "New Prefix", "Needed", "For Me")
     val selectedFilter by mainViewModel.decodeFilter.observeAsState("All")
 
     // Couple the "CQ POTA" display filter to Hunt: while it's selected, the auto-call
@@ -525,6 +525,7 @@ private fun filterLabel(key: String): String = when (key) {
     "New Zone" -> stringResource(R.string.decode_filter_new_zone)
     "New State" -> stringResource(R.string.decode_filter_new_state)
     "New Grid" -> stringResource(R.string.decode_filter_new_grid)
+    "New Prefix" -> stringResource(R.string.decode_filter_new_prefix)
     "Needed" -> stringResource(R.string.decode_filter_needed)
     "For Me" -> stringResource(R.string.decode_filter_for_me)
     else -> stringResource(R.string.decode_filter_all)
@@ -604,6 +605,10 @@ internal fun filterMessages(
         // stations whose grid field the operator hasn't logged yet, so the list
         // becomes a one-tap "who's calling from a grid I still need" view.
         "New Grid" -> base.filter { it.checkIsCQ() && isNewGridStation(it) }
+        // Mirror of "New DXCC" for prefix chasers (Worked All Prefixes / WPX):
+        // only CQ stations whose callsign prefix the operator hasn't logged yet,
+        // so the list becomes a one-tap "who's a new prefix" view.
+        "New Prefix" -> base.filter { it.checkIsCQ() && isNewPrefixStation(it) }
         "Needed" -> base.filter {
             !it.isQSL_Callsign &&
                 !GeneralVariables.checkQSLCallsign(it.callsignFrom ?: "")
@@ -631,6 +636,7 @@ internal fun EmptyState(
         "New Zone" -> stringResource(R.string.decode_empty_zone_title) to stringResource(R.string.decode_empty_zone_body)
         "New State" -> stringResource(R.string.decode_empty_state_title) to stringResource(R.string.decode_empty_state_body)
         "New Grid" -> stringResource(R.string.decode_empty_grid_title) to stringResource(R.string.decode_empty_grid_body)
+        "New Prefix" -> stringResource(R.string.decode_empty_prefix_title) to stringResource(R.string.decode_empty_prefix_body)
         "Needed" -> stringResource(R.string.decode_empty_needed_title) to stringResource(R.string.decode_empty_needed_body)
         "For Me" -> stringResource(R.string.decode_empty_forme_title) to stringResource(R.string.decode_empty_forme_body)
         else -> stringResource(R.string.decode_empty_default_title) to stringResource(R.string.decode_empty_default_body, GeneralVariables.currentMode().displayName)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DecodeFilterSettings.kt
@@ -30,6 +30,7 @@ fun DecodeFilterSettings(
     var highlightNewZone by remember { mutableStateOf(GeneralVariables.highlightNewZone) }
     var highlightNewState by remember { mutableStateOf(GeneralVariables.highlightNewState) }
     var highlightNewGrid by remember { mutableStateOf(GeneralVariables.highlightNewGrid) }
+    var highlightNewPrefix by remember { mutableStateOf(GeneralVariables.highlightNewPrefix) }
     var highlightNewBand by remember { mutableStateOf(GeneralVariables.highlightNewBand) }
     var highlightWorked by remember { mutableStateOf(GeneralVariables.highlightWorked) }
     var workedStationMode by remember { mutableStateOf(GeneralVariables.workedStationMode) }
@@ -282,6 +283,19 @@ fun DecodeFilterSettings(
                             GeneralVariables.highlightNewGrid = checked
                             mainViewModel.databaseOpr.writeConfig(
                                 "highlightNewGrid", if (checked) "1" else "0", null,
+                            )
+                        },
+                    )
+                    SectionDivider()
+                    SettingsRow(
+                        label = stringResource(R.string.settings_highlight_new_prefix),
+                        description = stringResource(R.string.settings_highlight_new_prefix_desc),
+                        toggle = highlightNewPrefix,
+                        onToggleChange = { checked ->
+                            highlightNewPrefix = checked
+                            GeneralVariables.highlightNewPrefix = checked
+                            mainViewModel.databaseOpr.writeConfig(
+                                "highlightNewPrefix", if (checked) "1" else "0", null,
                             )
                         },
                     )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -49,6 +49,7 @@
     <string name="status_new_zone">NEW ZONE</string>
     <string name="status_new_state">NEW STATE</string>
     <string name="status_new_grid">NEW GRID</string>
+    <string name="status_new_prefix">NEW PFX</string>
     <string name="status_new_band">NEW BAND</string>
     <string name="status_pota">POTA</string>
     <string name="status_new_pota">NEW POTA</string>
@@ -179,6 +180,7 @@
     <string name="decode_filter_new_zone">New Zone</string>
     <string name="decode_filter_new_state">New State</string>
     <string name="decode_filter_new_grid">New Grid</string>
+    <string name="decode_filter_new_prefix">New Prefix</string>
     <string name="decode_filter_needed">Needed</string>
     <string name="decode_filter_for_me">For Me</string>
     <string name="decode_empty_cq_title">No CQ calls</string>
@@ -193,6 +195,8 @@
     <string name="decode_empty_state_body">No stations calling from an unworked US state have been decoded yet.</string>
     <string name="decode_empty_grid_title">No new grids</string>
     <string name="decode_empty_grid_body">No stations calling from an unworked grid square have been decoded yet.</string>
+    <string name="decode_empty_prefix_title">No new prefixes</string>
+    <string name="decode_empty_prefix_body">No stations calling from an unworked callsign prefix (WPX) have been decoded yet.</string>
     <string name="decode_empty_needed_title">Nothing needed</string>
     <string name="decode_empty_needed_body">No stations needing confirmation found.</string>
     <string name="decode_empty_forme_title">No calls for you</string>
@@ -618,6 +622,8 @@
     <string name="settings_highlight_new_state_desc">Highlight not-yet-worked US states (Worked All States)</string>
     <string name="settings_highlight_new_grid">New Grid</string>
     <string name="settings_highlight_new_grid_desc">Highlight not-yet-worked Maidenhead grids</string>
+    <string name="settings_highlight_new_prefix">New Prefix</string>
+    <string name="settings_highlight_new_prefix_desc">Highlight not-yet-worked callsign prefixes (Worked All Prefixes / WPX)</string>
     <string name="settings_highlight_new_band">New Band</string>
     <string name="settings_highlight_new_band_desc">Highlight stations worked only on other bands</string>
     <string name="settings_highlight_pota">POTA Activators</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/callsign/WpxPrefixTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/callsign/WpxPrefixTest.java
@@ -1,0 +1,85 @@
+package com.k1af.ft8af.callsign;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link WpxPrefix#of(String)} — the CQ WPX prefix extractor that
+ * backs the decode list's "New Prefix" highlight/filter. Pure logic, no runner.
+ */
+public class WpxPrefixTest {
+
+    @Test
+    public void simpleCalls() {
+        assertThat(WpxPrefix.of("W1AW")).isEqualTo("W1");
+        assertThat(WpxPrefix.of("K5XYZ")).isEqualTo("K5");
+        assertThat(WpxPrefix.of("VE3ABC")).isEqualTo("VE3");
+        assertThat(WpxPrefix.of("EA8XYZ")).isEqualTo("EA8");
+        assertThat(WpxPrefix.of("PY2AA")).isEqualTo("PY2");
+        assertThat(WpxPrefix.of("KH6ABC")).isEqualTo("KH6");
+    }
+
+    @Test
+    public void leadingDigitPrefixes() {
+        // Countries whose prefix starts with a digit keep every char up to and
+        // including the last prefix numeral.
+        assertThat(WpxPrefix.of("9A1AA")).isEqualTo("9A1");
+        assertThat(WpxPrefix.of("4X4AAA")).isEqualTo("4X4");
+        assertThat(WpxPrefix.of("3DA0RS")).isEqualTo("3DA0");
+    }
+
+    @Test
+    public void caseAndWhitespaceInsensitive() {
+        assertThat(WpxPrefix.of("  ve3abc  ")).isEqualTo("VE3");
+    }
+
+    @Test
+    public void noNumeralCall_getsZero() {
+        // Historic calls with no digit: first two letters + 0.
+        assertThat(WpxPrefix.of("RAEM")).isEqualTo("RA0");
+    }
+
+    @Test
+    public void portableNumber_replacesPrefixDigit() {
+        assertThat(WpxPrefix.of("W1AW/4")).isEqualTo("W4");
+        assertThat(WpxPrefix.of("VE3ABC/7")).isEqualTo("VE7");
+        assertThat(WpxPrefix.of("PY2AA/0")).isEqualTo("PY0");
+    }
+
+    @Test
+    public void portablePrefix_designatorWins() {
+        assertThat(WpxPrefix.of("DL/W1AW")).isEqualTo("DL0");
+        assertThat(WpxPrefix.of("PJ4/K1ABC")).isEqualTo("PJ4");
+        assertThat(WpxPrefix.of("PA3/G4XYZ")).isEqualTo("PA3");
+        // Home call listed first, portable region second — still the region wins.
+        assertThat(WpxPrefix.of("W1AW/KH6")).isEqualTo("KH6");
+    }
+
+    @Test
+    public void operationalSuffixesIgnored() {
+        assertThat(WpxPrefix.of("G4XYZ/P")).isEqualTo("G4");
+        assertThat(WpxPrefix.of("W1AW/M")).isEqualTo("W1");
+        assertThat(WpxPrefix.of("VK2ABC/QRP")).isEqualTo("VK2");
+        assertThat(WpxPrefix.of("K1ABC/MM")).isEqualTo("K1");
+        // Suffix combined with a portable number: number still applies.
+        assertThat(WpxPrefix.of("W1AW/4/QRP")).isEqualTo("W4");
+    }
+
+    @Test
+    public void nonCallsignTokens_returnNull() {
+        assertThat(WpxPrefix.of(null)).isNull();
+        assertThat(WpxPrefix.of("")).isNull();
+        assertThat(WpxPrefix.of("   ")).isNull();
+        assertThat(WpxPrefix.of("73")).isNull();
+        assertThat(WpxPrefix.of("RR73")).isNull();
+        assertThat(WpxPrefix.of("599")).isNull();
+        assertThat(WpxPrefix.of("<...>")).isNull();
+        assertThat(WpxPrefix.of("R-12")).isNull();
+        // A Maidenhead grid ends in its digits, so it has no letter suffix and is
+        // correctly rejected as a callsign.
+        assertThat(WpxPrefix.of("FN42")).isNull();
+        // Bare prefix with no suffix isn't a whole callsign.
+        assertThat(WpxPrefix.of("W1")).isNull();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/callsign/WpxPrefixTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/callsign/WpxPrefixTest.java
@@ -48,6 +48,31 @@ public class WpxPrefixTest {
     }
 
     @Test
+    public void portableNumber_digitLeadingPrefix() {
+        // The prefix starts with a numeral, so the call has no leading letters to
+        // lift — the base prefix has to come from the simple-call rule first.
+        assertThat(WpxPrefix.of("9A1AA/7")).isEqualTo("9A7");
+        assertThat(WpxPrefix.of("4X4AAA/1")).isEqualTo("4X1");
+        // Only the prefix's own numeral is replaced, not the leading digit.
+        assertThat(WpxPrefix.of("3DA0RS/7")).isEqualTo("3DA7");
+    }
+
+    @Test
+    public void portableNumber_noNumeralCall() {
+        // RAEM has no digit at all: it resolves to RA0 on its own, so a portable
+        // number swaps that 0 rather than being appended to the whole call.
+        assertThat(WpxPrefix.of("RAEM/4")).isEqualTo("RA4");
+    }
+
+    @Test
+    public void portableNumber_onNonCallsignToken_staysNull() {
+        // A bare prefix or a grid isn't a whole callsign, so adding a portable
+        // number must not conjure one up.
+        assertThat(WpxPrefix.of("W1/7")).isNull();
+        assertThat(WpxPrefix.of("FN42/7")).isNull();
+    }
+
+    @Test
     public void portablePrefix_designatorWins() {
         assertThat(WpxPrefix.of("DL/W1AW")).isEqualTo("DL0");
         assertThat(WpxPrefix.of("PJ4/K1ABC")).isEqualTo("PJ4");

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewPrefixTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/NewPrefixTest.kt
@@ -1,0 +1,133 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import radio.ks3ckc.ft8af.ui.components.QsoStatus
+
+/**
+ * Unit-tests the shared [isNewPrefixStation] predicate (and its NEW_PREFIX pill /
+ * "New Prefix" filter) that back the Worked-All-Prefixes (WPX) chase, so the pill
+ * and the filter never disagree on what counts as an unworked prefix.
+ *
+ * Robolectric is needed only because [Ft8Message] reaches android.util.Log on
+ * construction; the logic under test is pure.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NewPrefixTest {
+
+    private var savedHighlightPota = false
+    private var savedHighlightNewDxcc = false
+    private var savedHighlightNewZone = false
+    private var savedHighlightNewState = false
+    private var savedHighlightNewGrid = false
+    private var savedHighlightNewPrefix = false
+    private var savedHighlightNewBand = false
+    private var savedHighlightWorked = false
+
+    @Before
+    fun setUp() {
+        savedHighlightPota = GeneralVariables.highlightPota
+        savedHighlightNewDxcc = GeneralVariables.highlightNewDxcc
+        savedHighlightNewZone = GeneralVariables.highlightNewZone
+        savedHighlightNewState = GeneralVariables.highlightNewState
+        savedHighlightNewGrid = GeneralVariables.highlightNewGrid
+        savedHighlightNewPrefix = GeneralVariables.highlightNewPrefix
+        savedHighlightNewBand = GeneralVariables.highlightNewBand
+        savedHighlightWorked = GeneralVariables.highlightWorked
+        GeneralVariables.QSL_Prefix_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+    }
+
+    @After
+    fun tearDown() {
+        GeneralVariables.highlightPota = savedHighlightPota
+        GeneralVariables.highlightNewDxcc = savedHighlightNewDxcc
+        GeneralVariables.highlightNewZone = savedHighlightNewZone
+        GeneralVariables.highlightNewState = savedHighlightNewState
+        GeneralVariables.highlightNewGrid = savedHighlightNewGrid
+        GeneralVariables.highlightNewPrefix = savedHighlightNewPrefix
+        GeneralVariables.highlightNewBand = savedHighlightNewBand
+        GeneralVariables.highlightWorked = savedHighlightWorked
+        GeneralVariables.QSL_Prefix_list.clear()
+        GeneralVariables.QSL_Callsign_list.clear()
+    }
+
+    private fun cqFrom(from: String): Ft8Message = Ft8Message("CQ", from, "TEST")
+
+    @Test
+    fun unworkedPrefix_isNew() {
+        assertThat(isNewPrefixStation(cqFrom("W1ABC"))).isTrue()
+    }
+
+    @Test
+    fun workedPrefix_isNotNew() {
+        GeneralVariables.QSL_Prefix_list.add("W1")
+        assertThat(isNewPrefixStation(cqFrom("W1ABC"))).isFalse()
+    }
+
+    @Test
+    fun differentSuffixSamePrefix_isNotNew() {
+        // Prefix keys on "W1", not the whole call, so a different W1 station is
+        // no longer a new prefix once any W1 has been worked.
+        GeneralVariables.QSL_Prefix_list.add("W1")
+        assertThat(isNewPrefixStation(cqFrom("W1XYZ"))).isFalse()
+        // ...but a different prefix from the same country is still new.
+        assertThat(isNewPrefixStation(cqFrom("W5XYZ"))).isTrue()
+    }
+
+    @Test
+    fun nonCallsignFrom_isNotNew() {
+        // A token that yields no WPX prefix must never be flagged.
+        assertThat(isNewPrefixStation(cqFrom("73"))).isFalse()
+    }
+
+    @Test
+    fun newPrefixPill_surfacesWhenHighlightEnabled() {
+        GeneralVariables.highlightPota = false
+        GeneralVariables.highlightNewDxcc = false
+        GeneralVariables.highlightNewZone = false
+        GeneralVariables.highlightNewState = false
+        GeneralVariables.highlightNewGrid = false
+        GeneralVariables.highlightNewPrefix = true
+        GeneralVariables.highlightNewBand = false
+        GeneralVariables.highlightWorked = false
+
+        assertThat(resolveQsoStatus(cqFrom("DL1ABC")))
+            .isEqualTo(QsoStatus.NEW_PREFIX)
+    }
+
+    @Test
+    fun newPrefixPill_suppressedWhenPrefixWorked() {
+        GeneralVariables.highlightPota = false
+        GeneralVariables.highlightNewDxcc = false
+        GeneralVariables.highlightNewZone = false
+        GeneralVariables.highlightNewState = false
+        GeneralVariables.highlightNewGrid = false
+        GeneralVariables.highlightNewPrefix = true
+        GeneralVariables.highlightNewBand = false
+        GeneralVariables.highlightWorked = false
+        GeneralVariables.QSL_Prefix_list.add("DL1")
+
+        // Worked prefix falls through to the plain CQ pill.
+        assertThat(resolveQsoStatus(cqFrom("DL1ABC")))
+            .isEqualTo(QsoStatus.CQ)
+    }
+
+    @Test
+    fun newPrefixFilter_keepsOnlyUnworkedCqPrefixes() {
+        GeneralVariables.QSL_Prefix_list.add("W1")
+        val messages = listOf(
+            cqFrom("W1ABC"),                        // worked prefix -> dropped
+            cqFrom("VE3XYZ"),                       // new prefix, CQ -> kept
+            Ft8Message("K9AAA", "DL1ABC", "TEST"),  // new prefix but not a CQ -> dropped
+        )
+        val filtered = filterMessages(messages, "New Prefix")
+        assertThat(filtered.map { it.callsignFrom }).containsExactly("VE3XYZ")
+    }
+}


### PR DESCRIPTION
## What & why

Worked All Prefixes (**CQ WPX**) is one of the most popular amateur-radio award programs — each distinct callsign prefix (`W1`, `VE3`, `9A1`, `DL0`, …) counts once, so operators actively hunt "new prefixes" the same way they chase new DXCC entities, zones, states or grids.

The decode list already flags **New DXCC / New Zone / New State / New Grid / New Band**, but not new prefixes. This PR closes that gap so a WPX chaser can:

- **see a `NEW PFX` pill** on any decoded CQ station whose prefix they haven't logged, and
- **one-tap the "New Prefix" filter** to reduce the decode list to only unworked prefixes.

> *"Wow, I wish every FT8 app did this."* — WPX is a top-three award chase and no Android FT8 app surfaces it live in the decode list.

## How it works

- **`WpxPrefix.of()`** — a pure, dependency-free CQ WPX prefix extractor:
  - simple calls (`W1AW`→`W1`, `9A1AA`→`9A1`, `3DA0RS`→`3DA0`),
  - no-numeral historic calls (`RAEM`→`RA0`),
  - portable numbers (`W1AW/4`→`W4`),
  - portable prefixes (`DL/W1AW`→`DL0`, `W1AW/KH6`→`KH6`),
  - ignored operational suffixes (`/P /M /MM /AM /QRP`),
  - anything that isn't a plausible callsign (grids, reports, hashed calls) returns `null` so it's never flagged.
  It's shared by the worked-prefix loader and the live decode predicate so the two can never disagree.
- **`GetAllQSLCallsign`** builds a distinct worked-prefix set (any band), mirroring the existing worked-grid set; refreshed on the same cadence.
- New **`NEW_PREFIX`** status pill (rose, distinct from the other badges), **`isNewPrefixStation`** predicate wired into `resolveQsoStatus` just below New Grid, a **"New Prefix"** filter chip + empty state, and a **Settings → Decode Highlights** toggle.

## Defaults

The highlight is **off by default** (like New Grid) — early in an operator's WPX chase almost every prefix is "new", so opt-in keeps the default decode list quiet. The filter chip is always available regardless of the toggle.

## Tests

- `WpxPrefixTest` (pure JUnit) — the extractor across simple, leading-digit, no-numeral, portable-number, portable-prefix, suffix and non-callsign cases.
- `NewPrefixTest` (Robolectric) — the shared predicate, worked-vs-new behaviour, the pill priority in `resolveQsoStatus`, and the `filterMessages` "New Prefix" filter (CQ-only, unworked-only).

All decode + callsign unit tests pass locally (`testDebugUnitTest`).

## Scope / compatibility

Pure UI/logging surface — no change to the decoder, TX pipeline, or FT8/WSJT-X protocol. Follows the exact New DXCC/Zone/State/Grid pattern; the legacy `CallingListAdapter` is intentionally left untouched (New Zone/State weren't wired there either — the modern Compose decode list is the live path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)