### PR TITLE
Log MY_LAT/MY_LON in ADIF export when location is available

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -63,7 +63,7 @@ public class DatabaseOpr extends SQLiteOpenHelper {
 
     public static synchronized DatabaseOpr getInstance(@Nullable Context context, @Nullable String databaseName) {
         if (instance == null) {
-            instance = new DatabaseOpr(context, databaseName, null, 19);
+            instance = new DatabaseOpr(context, databaseName, null, 20);
         }
         return instance;
     }
@@ -272,6 +272,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     , "sig TEXT");
             alterTable(sqLiteDatabase, "QSLTable", "sig_info"
                     , "sig_info TEXT");
+            // Device lat/lon captured at QSO time, decimal degrees; NULL when location was
+            // unavailable. Exported as ADIF MY_LAT/MY_LON.
+            alterTable(sqLiteDatabase, "QSLTable", "my_lat"
+                    , "my_lat REAL");
+            alterTable(sqLiteDatabase, "QSLTable", "my_lon"
+                    , "my_lon REAL");
 
         } else {
             sqLiteDatabase.execSQL("CREATE TABLE QSLTable (\n" +
@@ -300,7 +306,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     "my_sig TEXT,\n" +//POTA: activator's program ("POTA")
                     "my_sig_info TEXT,\n" +//POTA: activator's park ref
                     "sig TEXT,\n" +//POTA: worked station's program
-                    "sig_info TEXT)");//POTA: worked station's park ref
+                    "sig_info TEXT,\n" +//POTA: worked station's park ref
+                    "my_lat REAL,\n" +//device lat at QSO time, decimal degrees; NULL if unavailable
+                    "my_lon REAL)");//device lon at QSO time, decimal degrees; NULL if unavailable
         }
 
 
@@ -1597,9 +1605,11 @@ public class DatabaseOpr extends SQLiteOpenHelper {
         if (!checkIsQSL(record)) {//If log data doesn't exist, add it
             querySQL = "INSERT INTO QSLTable(call, isQSL,isLotW_import,isLotW_QSL,gridsquare, mode, rst_sent, rst_rcvd, qso_date, " +
                     "time_on, qso_date_off, time_off, band, freq, station_callsign, my_gridsquare," +
-                    "comment,my_sig,my_sig_info,sig,sig_info)VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+                    "comment,my_sig,my_sig_info,sig,sig_info,my_lat,my_lon)VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
-            db.execSQL(querySQL, new String[]{record.getToCallsign()
+            // Object[] (not String[]) so a null myLat/myLon binds as SQL NULL rather than the
+            // literal string "null" — the rest of the fields are never null here.
+            db.execSQL(querySQL, new Object[]{record.getToCallsign()
                     , String.valueOf(record.isQSL ? 1 : 0)
                     , String.valueOf(record.isLotW_import ? 1 : 0)
                     , String.valueOf(record.isLotW_QSL ? 1 : 0)
@@ -1620,7 +1630,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     , record.getMySig()
                     , record.getMySigInfo()
                     , record.getSig()
-                    , record.getSigInfo()});
+                    , record.getSigInfo()
+                    , record.getMyLat()
+                    , record.getMyLon()});
             // If this QSO was logged during an active POTA activation, bump its qso_count.
             if (record.getMySigInfo() != null && !record.getMySigInfo().isEmpty()) {
                 db.execSQL("UPDATE pota_activation SET qso_count = qso_count + 1 "

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -19,6 +19,7 @@ import android.util.Log;
 
 import com.k1af.ft8af.wave.UsbAudioDevice;
 import com.k1af.ft8af.wave.UsbAudioNative;
+import com.google.android.gms.maps.model.LatLng;
 
 import androidx.lifecycle.MutableLiveData;
 
@@ -32,6 +33,7 @@ import com.k1af.ft8af.connector.ConnectMode;
 import com.k1af.ft8af.database.ControlMode;
 import com.k1af.ft8af.database.DatabaseOpr;
 import com.k1af.ft8af.log.QSLRecord;
+import com.k1af.ft8af.maidenhead.MaidenheadGrid;
 import com.k1af.ft8af.rigs.BaseRigOperation;
 import com.k1af.ft8af.timer.OnUtcTimer;
 import com.k1af.ft8af.timer.UtcTimer;
@@ -1183,7 +1185,7 @@ public class FT8TransmitSignal {
 
         messageEndTime = UtcTimer.getSystemTime();
         if (onDoTransmitted != null) {// for saving QSO records
-            onTransmitSuccess.doAfterTransmit(new QSLRecord(
+            QSLRecord newRecord = new QSLRecord(
                     messageStartTime,
                     messageEndTime,
                     GeneralVariables.myCallsign,
@@ -1195,7 +1197,11 @@ public class FT8TransmitSignal {
                     GeneralVariables.currentMode().displayName,
                     GeneralVariables.band,
                     Math.round(GeneralVariables.getBaseFrequency())
-            ));
+            );
+            LatLng myLocation = MaidenheadGrid.getLocalLocation(GeneralVariables.getMainContext());
+            newRecord.setMyLatLon(myLocation != null ? myLocation.latitude : null
+                    , myLocation != null ? myLocation.longitude : null);
+            onTransmitSuccess.doAfterTransmit(newRecord);
 
             GeneralVariables.addQSLCallsign(toCallsign.callsign);// add successfully contacted callsign to the list
             ToastMessage.show(String.format("QSO : %s , at %s", toCallsign.callsign
@@ -1523,7 +1529,7 @@ public class FT8TransmitSignal {
         QSLRecord record = GeneralVariables.qslRecordList.getRecordByCallsign(toCall.callsign);
         if (record == null) {
             toMaidenheadGrid = GeneralVariables.getGridByCallsign(toCallsign.callsign, databaseOpr);
-            record = GeneralVariables.qslRecordList.addQSLRecord(new QSLRecord(
+            QSLRecord newRecord = new QSLRecord(
                     messageStartTime,
                     messageEndTime,
                     GeneralVariables.myCallsign,
@@ -1535,7 +1541,11 @@ public class FT8TransmitSignal {
                     GeneralVariables.currentMode().displayName,
                     GeneralVariables.band,
                     Math.round(GeneralVariables.getBaseFrequency()
-                    )));
+                    ));
+            LatLng myLocation = MaidenheadGrid.getLocalLocation(GeneralVariables.getMainContext());
+            newRecord.setMyLatLon(myLocation != null ? myLocation.latitude : null
+                    , myLocation != null ? myLocation.longitude : null);
+            record = GeneralVariables.qslRecordList.addQSLRecord(newRecord);
         }
         // update content based on message sequence
         switch (order) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -159,14 +159,17 @@ public final class AdifFormat {
         }
         char dir = Character.toUpperCase(v.charAt(0));
         int sign;
+        int maxDegrees;
         switch (dir) {
             case 'N':
-            case 'E':
-                sign = 1;
-                break;
             case 'S':
+                sign = dir == 'N' ? 1 : -1;
+                maxDegrees = 90;
+                break;
+            case 'E':
             case 'W':
-                sign = -1;
+                sign = dir == 'E' ? 1 : -1;
+                maxDegrees = 180;
                 break;
             default:
                 return null;
@@ -179,6 +182,12 @@ public final class AdifFormat {
         try {
             int degrees = Integer.parseInt(rest.substring(0, space));
             double minutes = Double.parseDouble(rest.substring(space + 1).trim());
+            // Reject malformed ADIF Location values rather than silently importing them:
+            // negative/out-of-range degrees (>90 for lat, >180 for lon) or minutes outside
+            // [0, 60).
+            if (degrees < 0 || degrees > maxDegrees || minutes < 0 || minutes >= 60) {
+                return null;
+            }
             return sign * (degrees + minutes / 60.0);
         } catch (NumberFormatException e) {
             return null;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifFormat.java
@@ -107,6 +107,85 @@ public final class AdifFormat {
     }
 
     /**
+     * Format a latitude as the ADIF {@code Location} type ({@code XDDD MM.MMM}), e.g.
+     * {@code 40.858333 -> "N040 51.500"}, {@code -40.858333 -> "S040 51.500"}.
+     */
+    public static String formatLat(double lat) {
+        return formatLocation(lat, 'N', 'S');
+    }
+
+    /**
+     * Format a longitude as the ADIF {@code Location} type ({@code XDDD MM.MMM}), e.g.
+     * {@code -73.925 -> "W073 55.500"}, {@code 73.925 -> "E073 55.500"}.
+     */
+    public static String formatLon(double lon) {
+        return formatLocation(lon, 'E', 'W');
+    }
+
+    /**
+     * The ADIF {@code Location} data type: a direction letter, 3-digit zero-padded degrees
+     * (used for both latitude, 0-90, and longitude, 0-180, per the ADIF spec), a space, and
+     * minutes to 3 decimal places, e.g. {@code "N040 51.500"}. {@code positive}/{@code negative}
+     * are the direction letters for a non-negative/negative {@code value} (N/S for latitude,
+     * E/W for longitude).
+     */
+    private static String formatLocation(double value, char positive, char negative) {
+        char dir = value >= 0 ? positive : negative;
+        double abs = Math.abs(value);
+        int degrees = (int) abs;
+        double minutes = (abs - degrees) * 60.0;
+        // Rounding minutes to 3 decimals can carry into 60.000 (e.g. 40.999999 degrees);
+        // normalize so it never renders as "MM.MMM" == "60.000".
+        if (minutes >= 59.9995) {
+            minutes = 0;
+            degrees++;
+        }
+        return String.format(Locale.US, "%c%03d %06.3f", dir, degrees, minutes);
+    }
+
+    /**
+     * Parse an ADIF {@code Location} value ({@code XDDD MM.MMM}) back to signed decimal
+     * degrees, the inverse of {@link #formatLat}/{@link #formatLon}. Returns {@code null} for
+     * {@code null}, empty, or malformed input rather than throwing, since this is used on
+     * import of files this app did not necessarily write.
+     */
+    public static Double parseLocation(String value) {
+        if (value == null) {
+            return null;
+        }
+        String v = value.trim();
+        if (v.length() < 2) {
+            return null;
+        }
+        char dir = Character.toUpperCase(v.charAt(0));
+        int sign;
+        switch (dir) {
+            case 'N':
+            case 'E':
+                sign = 1;
+                break;
+            case 'S':
+            case 'W':
+                sign = -1;
+                break;
+            default:
+                return null;
+        }
+        String rest = v.substring(1).trim();
+        int space = rest.indexOf(' ');
+        if (space < 0) {
+            return null;
+        }
+        try {
+            int degrees = Integer.parseInt(rest.substring(0, space));
+            double minutes = Double.parseDouble(rest.substring(space + 1).trim());
+            return sign * (degrees + minutes / 60.0);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
      * The number of UTF-8 <em>bytes</em> in {@code value} — the length an ADIF
      * {@code <field:len>value } declaration must carry, not the UTF-16
      * {@link String#length()} (char count). The two differ for any non-ASCII content

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifLogFile.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifLogFile.java
@@ -89,6 +89,8 @@ public final class AdifLogFile {
                 .freq(BaseRigOperation.getFrequencyFloat(record.getBandFreq()))
                 .stationCallsign(record.getMyCallsign())
                 .myGridsquare(record.getMyMaidenGrid())
+                .myLat(record.getMyLat() != null ? AdifFormat.formatLat(record.getMyLat()) : null)
+                .myLon(record.getMyLon() != null ? AdifFormat.formatLon(record.getMyLon()) : null)
                 .mySig(record.getMySig())
                 .mySigInfo(record.getMySigInfo())
                 .sig(record.getSig())

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifRecord.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifRecord.java
@@ -49,6 +49,8 @@ public final class AdifRecord {
     private String freq;
     private String stationCallsign;
     private String myGridsquare;
+    private String myLat;
+    private String myLon;
     private String operator;
     private String mySig;
     private String mySigInfo;
@@ -88,6 +90,12 @@ public final class AdifRecord {
     public AdifRecord stationCallsign(String v) { this.stationCallsign = v; return this; }
 
     public AdifRecord myGridsquare(String v) { this.myGridsquare = v; return this; }
+
+    /** MY_LAT, already formatted as the ADIF {@code Location} type (e.g. via {@link AdifFormat#formatLat}). */
+    public AdifRecord myLat(String v) { this.myLat = v; return this; }
+
+    /** MY_LON, already formatted as the ADIF {@code Location} type (e.g. via {@link AdifFormat#formatLon}). */
+    public AdifRecord myLon(String v) { this.myLon = v; return this; }
 
     public AdifRecord operator(String v) { this.operator = v; return this; }
 
@@ -136,6 +144,8 @@ public final class AdifRecord {
         appendIfNotNull(sb, "freq", freq);
         appendIfNotNull(sb, "station_callsign", stationCallsign);
         appendIfNotNull(sb, "my_gridsquare", myGridsquare);
+        appendIfNotNull(sb, "my_lat", myLat);
+        appendIfNotNull(sb, "my_lon", myLon);
         appendIfNotNull(sb, "operator", operator);
         // POTA fields. Only emit when populated so non-POTA QSOs stay clean.
         appendIfNotEmpty(sb, "MY_SIG", mySig);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
@@ -33,6 +33,8 @@ public class QSLRecord {
 
     private final String myCallsign;//My callsign
     private String myMaidenGrid;//My grid
+    private Double myLat;//My latitude at QSO time, decimal degrees; null when location was unavailable
+    private Double myLon;//My longitude at QSO time, decimal degrees; null when location was unavailable
     private String toCallsign;//Other party's callsign
     private String toMaidenGrid;//Other party's grid
     private int sendReport;//Report received by other party (i.e., signal strength I sent)
@@ -204,6 +206,9 @@ public class QSLRecord {
             toMaidenGrid = "";
         }
 
+        if (map.containsKey("MY_LAT")) myLat = AdifFormat.parseLocation(map.get("MY_LAT"));
+        if (map.containsKey("MY_LON")) myLon = AdifFormat.parseLocation(map.get("MY_LON"));
+
 
         if (map.containsKey("RST_RCVD")) {//Received report. Signal report present in N1MM, Log32, JTDX, but not in LoTW
             try {//Convert float to Long
@@ -341,6 +346,20 @@ public class QSLRecord {
 
     public void setMyMaidenGrid(String myMaidenGrid) {
         this.myMaidenGrid = myMaidenGrid;
+    }
+
+    public Double getMyLat() {
+        return myLat;
+    }
+
+    public Double getMyLon() {
+        return myLon;
+    }
+
+    /** Set the device location captured at QSO time; either may be null when unavailable. */
+    public void setMyLatLon(Double myLat, Double myLon) {
+        this.myLat = myLat;
+        this.myLon = myLon;
     }
 
     public int getSendReport() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ShareLogs.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ShareLogs.java
@@ -314,6 +314,8 @@ public class ShareLogs {
                 .freq(col(cursor, "freq"))
                 .stationCallsign(col(cursor, "station_callsign"))
                 .myGridsquare(col(cursor, "my_gridsquare"))
+                .myLat(formatLocationOrNull(colDouble(cursor, "my_lat"), true))
+                .myLon(formatLocationOrNull(colDouble(cursor, "my_lon"), false))
                 .operator(col(cursor, "operator"))
                 // POTA fields. Only emitted when populated so non-POTA QSOs stay clean.
                 .mySig(col(cursor, "my_sig"))
@@ -334,6 +336,19 @@ public class ShareLogs {
         int idx = cursor.getColumnIndex(column);
         if (idx < 0) return null;
         return cursor.getString(idx);
+    }
+
+    /** Cursor nullable double value (e.g. my_lat/my_lon), or null when absent/column-missing. */
+    private static Double colDouble(android.database.Cursor cursor, String column) {
+        int idx = cursor.getColumnIndex(column);
+        if (idx < 0 || cursor.isNull(idx)) return null;
+        return cursor.getDouble(idx);
+    }
+
+    /** {@code value} formatted as an ADIF Location (MY_LAT/MY_LON), or null when unavailable. */
+    private static String formatLocationOrNull(Double value, boolean isLatitude) {
+        if (value == null) return null;
+        return isLatitude ? AdifFormat.formatLat(value) : AdifFormat.formatLon(value);
     }
 
     /** Cursor int value, or 0 when the column is absent. */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/maidenhead/MaidenheadGrid.java
@@ -5,10 +5,14 @@ package com.k1af.ft8af.maidenhead;
  * @date 2023-03-20
  */
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationManager;
+
+import androidx.core.content.ContextCompat;
 
 import com.k1af.ft8af.GeneralVariables;
 import com.k1af.ft8af.R;
@@ -486,6 +490,19 @@ public class MaidenheadGrid {
      * @return latitude/longitude
      */
     public static LatLng getLocalLocation(Context context) {
+        if (context == null) {
+            return null;
+        }
+        // LocationManager#getLastKnownLocation throws SecurityException without this
+        // permission (the @SuppressLint below only silences the lint warning, it doesn't
+        // make the call safe), so callers outside the permission-gated GPS-grid-update flow
+        // need this checked here rather than crashing.
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED
+                && ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
+            return null;
+        }
         // Get location service
         String serviceName = Context.LOCATION_SERVICE;
         // Call getSystemService() to obtain the LocationManager object

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
@@ -264,4 +264,19 @@ public class AdifFormatTest {
         assertThat(AdifFormat.parseLocation("garbage")).isNull();
         assertThat(AdifFormat.parseLocation("X040 51.500")).isNull();
     }
+
+    @Test
+    public void parseLocation_rejectsOutOfRangeDegreesAndMinutes() {
+        // Latitude degrees > 90, longitude degrees > 180, negative degrees, and minutes
+        // outside [0, 60) are all malformed per the ADIF Location type and must not
+        // silently produce a value.
+        assertThat(AdifFormat.parseLocation("N091 00.000")).isNull();
+        assertThat(AdifFormat.parseLocation("E181 00.000")).isNull();
+        assertThat(AdifFormat.parseLocation("N-05 00.000")).isNull();
+        assertThat(AdifFormat.parseLocation("N040 60.000")).isNull();
+        assertThat(AdifFormat.parseLocation("N040 -1.000")).isNull();
+        // In range: accepted.
+        assertThat(AdifFormat.parseLocation("N090 00.000")).isWithin(1e-9).of(90.0);
+        assertThat(AdifFormat.parseLocation("W180 00.000")).isWithin(1e-9).of(-180.0);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifFormatTest.java
@@ -222,4 +222,46 @@ public class AdifFormatTest {
         assertThat(AdifFormat.sliceByUtf8Length(emoji, AdifFormat.utf8Length(emoji)))
                 .isEqualTo(emoji);
     }
+
+    // ---- formatLat / formatLon / parseLocation: ADIF MY_LAT / MY_LON ----
+
+    @Test
+    public void formatLat_northAndSouth() {
+        assertThat(AdifFormat.formatLat(40.858333)).isEqualTo("N040 51.500");
+        assertThat(AdifFormat.formatLat(-40.858333)).isEqualTo("S040 51.500");
+        assertThat(AdifFormat.formatLat(0.0)).isEqualTo("N000 00.000");
+    }
+
+    @Test
+    public void formatLon_eastAndWest() {
+        assertThat(AdifFormat.formatLon(-73.925)).isEqualTo("W073 55.500");
+        assertThat(AdifFormat.formatLon(73.925)).isEqualTo("E073 55.500");
+    }
+
+    @Test
+    public void formatLon_threeDigitDegrees() {
+        // Longitude can reach 180, so degrees must be zero-padded to 3 digits like latitude.
+        assertThat(AdifFormat.formatLon(-179.5)).isEqualTo("W179 30.000");
+    }
+
+    @Test
+    public void formatLocation_roundsMinutesWithoutOverflowingTo60() {
+        // 40 degrees + 59.9997 minutes rounds to 60.000 minutes, which must carry into
+        // the next whole degree rather than rendering the invalid "MM.MMM" == "60.000".
+        assertThat(AdifFormat.formatLat(40.0 + 59.9997 / 60.0)).isEqualTo("N041 00.000");
+    }
+
+    @Test
+    public void parseLocation_isTheInverseOfFormat() {
+        assertThat(AdifFormat.parseLocation(AdifFormat.formatLat(40.858333))).isWithin(1e-3).of(40.858333);
+        assertThat(AdifFormat.parseLocation(AdifFormat.formatLon(-73.925))).isWithin(1e-3).of(-73.925);
+    }
+
+    @Test
+    public void parseLocation_handlesMalformedInput() {
+        assertThat(AdifFormat.parseLocation(null)).isNull();
+        assertThat(AdifFormat.parseLocation("")).isNull();
+        assertThat(AdifFormat.parseLocation("garbage")).isNull();
+        assertThat(AdifFormat.parseLocation("X040 51.500")).isNull();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifRecordTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifRecordTest.java
@@ -110,6 +110,23 @@ public class AdifRecordTest {
     }
 
     @Test
+    public void myLatLon_emittedWhenSet() {
+        String out = new AdifRecord().call("W1AW")
+                .myLat(AdifFormat.formatLat(40.858333))
+                .myLon(AdifFormat.formatLon(-73.925))
+                .build();
+        assertThat(out).contains("<my_lat:11>N040 51.500 ");
+        assertThat(out).contains("<my_lon:11>W073 55.500 ");
+    }
+
+    @Test
+    public void myLatLon_omittedWhenLocationUnavailable() {
+        String out = new AdifRecord().call("W1AW").build();
+        assertThat(out).doesNotContain("my_lat");
+        assertThat(out).doesNotContain("my_lon");
+    }
+
+    @Test
     public void comment_isAlwaysEmittedEvenWhenNull() {
         assertThat(new AdifRecord().call("W1AW").comment(null).build())
                 .contains("<comment:0> <eor>\n");


### PR DESCRIPTION
## Summary
- Captures the device's lat/lon at QSO completion time (permission-gated, best last-known location) and emits it in ADIF exports as `MY_LAT`/`MY_LON` per ADIF 3.1.7, formatted as the spec's `XDDD MM.MMM` Location type.
- Fields are omitted entirely (not emitted empty/zero) when location isn't available.
- Wired through both ADIF export paths: the incremental live `ft8af_log.adi` append and the bulk `ShareLogs` export, plus round-trip parsing on ADIF import.
- New `my_lat`/`my_lon REAL` columns on `QSLTable` with a migration (DB version 19 -> 20).

Closes #696.

cc @patrickrb

## Test plan
- [x] New unit tests in `AdifFormatTest` and `AdifRecordTest` - `./gradlew testDebugUnitTest` passes.
- [x] Built `assembleDebug` and installed on a physical device; confirmed with location permission granted, exported ADIF records include `MY_LAT`/`MY_LON`.