### PR TITLE
Add Hunt options: target priority + smart filters (pileup avoidance, min-SNR floor)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -493,6 +493,12 @@ public class GeneralVariables {
     // volatile: written from the Compose UI thread (DecodeScreen) and read from the
     // transmit/decode processing thread (FT8TransmitSignal), like zoneMapReady above.
     public static volatile boolean huntPotaOnly = false;//Mirror of the "CQ POTA" decode filter: Hunt only calls POTA CQs (issue #333)
+    // Hunt options (sheet on the HUNT button). volatile: written from the Compose UI
+    // thread, read from the transmit/decode processing thread (like huntPotaOnly).
+    public static volatile String huntPriority = "LATEST";//HuntPriority enum name: which CQ Hunt answers first
+    public static volatile boolean huntAvoidPileups = false;//Hunt: prefer CQs no one else is answering
+    public static final int HUNT_MIN_SNR_OFF = -999;//sentinel: min-SNR floor disabled
+    public static volatile int huntMinSnr = HUNT_MIN_SNR_OFF;//Hunt: skip CQs below this SNR (dB)
     public static boolean autoCallFollow = true;//Auto-call followed callsigns
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static boolean disciplineClockFromGPS = false;//Discipline the app clock (UtcTimer.delay) from GPS satellite time (issue #373). Off by default — consensual.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2733,6 +2733,16 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("autoFollowCQ")) {//Auto-follow CQ
                     GeneralVariables.autoFollowCQ = result.equals("1");
                 }
+                if (name.equalsIgnoreCase("huntPriority")) {//Hunt target priority (HuntPriority enum name)
+                    GeneralVariables.huntPriority = result;
+                }
+                if (name.equalsIgnoreCase("huntAvoidPileups")) {//Hunt: prefer CQs no one else is answering
+                    GeneralVariables.huntAvoidPileups = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("huntMinSnr")) {//Hunt: min-SNR floor (dB), HUNT_MIN_SNR_OFF = off
+                    GeneralVariables.huntMinSnr =
+                            parseConfigInt(result, GeneralVariables.HUNT_MIN_SNR_OFF);
+                }
                 if (name.equalsIgnoreCase("huntCallsCQ")) {//Hunt+CQ hybrid
                     GeneralVariables.huntCallsCQ = result.equals("1");
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -1356,6 +1356,12 @@ public class FT8TransmitSignal {
         // just abandoned by pressing CQ), which made auto-answer "randomly" lock
         // onto an inactive station and call it forever. Live decodes only, matching
         // the "calling me" loops.
+        //
+        // All qualifying CQs are collected (most-recent-first) and the Hunt options
+        // (priority, pileup avoidance, min-SNR floor) decide which one to answer via
+        // HuntTargetSelector — LATEST with no filters reproduces the historical
+        // first-qualifying-match behavior.
+        ArrayList<Ft8Message> eligible = new ArrayList<>();
         for (int i = messages.size() - 1; i >= 0; i--) {
             Ft8Message msg = messages.get(i);
             if (isExcludeMessage(msg)) continue;// check if this is an excluded message
@@ -1376,9 +1382,17 @@ public class FT8TransmitSignal {
                     || GeneralVariables.directionalCQIsForMe(msg.callsignTo))
                     && !GeneralVariables.checkQSLCallsign(msg.getCallsignFrom())// not previously contacted successfully
                     && !GeneralVariables.checkIsMyCallsign(msg.callsignFrom)) {// not myself
+                eligible.add(msg);
+            }
+        }
 
+        if (!eligible.isEmpty()) {
+            Ft8Message msg = radio.ks3ckc.ft8af.hunt.HuntTargetSelector.pick(eligible, messages);
+            if (msg != null) {
                 GeneralVariables.fileLog("QSO: auto-follow CQ from " + msg.getCallsignFrom()
-                        + " (Hunt=" + GeneralVariables.autoFollowCQ + ")");
+                        + " (Hunt=" + GeneralVariables.autoFollowCQ
+                        + ", priority=" + GeneralVariables.huntPriority
+                        + ", candidates=" + eligible.size() + ")");
                 resetTargetReport();
                 setTransmit(new TransmitCallsign(msg.i3, msg.n3, msg.getCallsignFrom(), msg.freq_hz
                         , msg.getSequence(), msg.hasSnr() ? msg.snr : 0), 1, msg.extraInfo);

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -47,9 +47,12 @@ import radio.ks3ckc.ft8af.ui.components.CqOptionsSheet
 import radio.ks3ckc.ft8af.ui.components.canEnableFieldDay
 import radio.ks3ckc.ft8af.ui.components.shouldPersistFreeText
 import radio.ks3ckc.ft8af.ui.components.shouldPersistSection
+import radio.ks3ckc.ft8af.hunt.huntPriorityFromConfig
 import radio.ks3ckc.ft8af.ui.components.FT8AFTab
 import radio.ks3ckc.ft8af.ui.components.FrequencyPickerSheet
 import radio.ks3ckc.ft8af.ui.components.HoundSetupSheet
+import radio.ks3ckc.ft8af.ui.components.HuntOptionsSheet
+import radio.ks3ckc.ft8af.ui.components.huntStripSubtitle
 import radio.ks3ckc.ft8af.ui.components.formatMhz
 import radio.ks3ckc.ft8af.ui.components.QsoCelebration
 import radio.ks3ckc.ft8af.ui.components.SlotTimerBar
@@ -144,6 +147,52 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
     // editable in Settings, which provides the persisted default at startup).
     var huntEnabled by remember { mutableStateOf(GeneralVariables.autoFollowCQ) }
 
+    // Hunt Options sheet state — the notch on (or a long-press of) the HUNT
+    // button opens it. Mirrors the GeneralVariables.hunt* statics the transmit
+    // engine's HuntTargetSelector reads each decode cycle.
+    var showHuntOptions by remember { mutableStateOf(false) }
+    var huntPriority by remember {
+        mutableStateOf(huntPriorityFromConfig(GeneralVariables.huntPriority))
+    }
+    var huntAvoidPileups by remember { mutableStateOf(GeneralVariables.huntAvoidPileups) }
+    var huntMinSnr by remember {
+        mutableStateOf(
+            GeneralVariables.huntMinSnr.takeIf { it != GeneralVariables.HUNT_MIN_SNR_OFF },
+        )
+    }
+
+    // Turn Hunt on/off — shared by the TX-strip HUNT toggle and the Hunt options
+    // sheet's Start button so both arm the sequencer identically.
+    val setHuntEnabled: (Boolean) -> Unit = setHunt@{ newVal ->
+        if (newVal && GeneralVariables.myCallsign.isNullOrEmpty()) {
+            // Hunt transmits replies, so it needs a callsign just like CQ does.
+            Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()
+            return@setHunt
+        }
+        huntEnabled = newVal
+        GeneralVariables.autoFollowCQ = newVal
+        mainViewModel.databaseOpr.writeConfig(
+            "autoFollowCQ", if (newVal) "1" else "0", null,
+        )
+        if (newVal) {
+            // Arm the sequencer so Hunt actually answers CQs. It stays silent
+            // (transmit path suppresses calling CQ) until it hears a CQ to work.
+            // armForHunt (not userResetToCQ) so Hunt can answer on the very next
+            // cycle instead of skipping one via pendingUserCQ.
+            mainViewModel.ft8TransmitSignal.armForHunt()
+            mainViewModel.ft8TransmitSignal.setActivated(true)
+            GeneralVariables.resetLaunchSupervision()
+        } else {
+            mainViewModel.ft8TransmitSignal.setActivated(false)
+        }
+        Toast.makeText(
+            context,
+            if (newVal) context.getString(R.string.app_hunt_on)
+            else context.getString(R.string.app_hunt_off),
+            Toast.LENGTH_SHORT,
+        ).show()
+    }
+
     // DXpedition Hound mode. Mirrors GeneralVariables.houndMode; the setup sheet
     // collects the Fox call + call frequency before starting.
     var dxEnabled by remember { mutableStateOf(GeneralVariables.houndMode) }
@@ -184,6 +233,11 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
             // chip reflects the correct state even when arming is skipped
             // (e.g. callsign not yet configured).
             huntEnabled = GeneralVariables.autoFollowCQ
+            // Hunt options load with the rest of the config, after first composition.
+            huntPriority = huntPriorityFromConfig(GeneralVariables.huntPriority)
+            huntAvoidPileups = GeneralVariables.huntAvoidPileups
+            huntMinSnr = GeneralVariables.huntMinSnr
+                .takeIf { it != GeneralVariables.HUNT_MIN_SNR_OFF }
             // Config (incl. the saved custom CQ) loads after first composition, so
             // pull it in once it's ready and seed the field if untouched.
             savedCqFreeText = GeneralVariables.cqFreeText ?: ""
@@ -375,6 +429,7 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 cqModifier = cqModifier,
                 isFreeTextMode = isFreeTextMode,
                 fieldDayEnabled = fieldDayEnabled,
+                huntPriorityTag = huntStripSubtitle(huntPriority),
                 isTuning = isTuning,
                 tuneRemainingSec = tuneRemainingSec,
                 onToggleTune = {
@@ -465,36 +520,8 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                         mainViewModel.ft8TransmitSignal.userResetToCQ()
                     }
                 },
-                onToggleHunt = {
-                    val newVal = !huntEnabled
-                    if (newVal && GeneralVariables.myCallsign.isNullOrEmpty()) {
-                        // Hunt transmits replies, so it needs a callsign just like CQ does.
-                        Toast.makeText(context, context.getString(R.string.app_set_callsign_first), Toast.LENGTH_SHORT).show()
-                    } else {
-                        huntEnabled = newVal
-                        GeneralVariables.autoFollowCQ = newVal
-                        mainViewModel.databaseOpr.writeConfig(
-                            "autoFollowCQ", if (newVal) "1" else "0", null,
-                        )
-                        if (newVal) {
-                            // Arm the sequencer so Hunt actually answers CQs. It stays silent
-                            // (transmit path suppresses calling CQ) until it hears a CQ to work.
-                            // armForHunt (not userResetToCQ) so Hunt can answer on the very next
-                            // cycle instead of skipping one via pendingUserCQ.
-                            mainViewModel.ft8TransmitSignal.armForHunt()
-                            mainViewModel.ft8TransmitSignal.setActivated(true)
-                            GeneralVariables.resetLaunchSupervision()
-                        } else {
-                            mainViewModel.ft8TransmitSignal.setActivated(false)
-                        }
-                        Toast.makeText(
-                            context,
-                            if (newVal) context.getString(R.string.app_hunt_on)
-                            else context.getString(R.string.app_hunt_off),
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    }
-                },
+                onToggleHunt = { setHuntEnabled(!huntEnabled) },
+                onLongPressHunt = { showHuntOptions = true },
                 onCycleMode = {
                     // Cycle through the shipped ModeProfile entries in declaration order
                     // (FT8 -> FT4 -> FT2 -> ...), wrapping around. An unknown current mode
@@ -704,6 +731,37 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                     GeneralVariables.resetLaunchSupervision()
                 }
             },
+        )
+
+        // Hunt Options — target priority + smart filters. Selections apply
+        // immediately (the engine reads the GeneralVariables.hunt* mirrors every
+        // decode cycle), so mid-hunt changes take effect on the next cycle.
+        HuntOptionsSheet(
+            visible = showHuntOptions,
+            huntEnabled = huntEnabled,
+            priority = huntPriority,
+            avoidPileups = huntAvoidPileups,
+            minSnrDb = huntMinSnr,
+            onDismiss = { showHuntOptions = false },
+            onSelectPriority = { p ->
+                huntPriority = p
+                GeneralVariables.huntPriority = p.name
+                mainViewModel.databaseOpr.writeConfig("huntPriority", p.name, null)
+            },
+            onAvoidPileupsChange = { enabled ->
+                huntAvoidPileups = enabled
+                GeneralVariables.huntAvoidPileups = enabled
+                mainViewModel.databaseOpr.writeConfig(
+                    "huntAvoidPileups", if (enabled) "1" else "0", null,
+                )
+            },
+            onMinSnrChange = { floor ->
+                huntMinSnr = floor
+                val stored = floor ?: GeneralVariables.HUNT_MIN_SNR_OFF
+                GeneralVariables.huntMinSnr = stored
+                mainViewModel.databaseOpr.writeConfig("huntMinSnr", stored.toString(), null)
+            },
+            onStartHunt = { setHuntEnabled(true) },
         )
     }
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelector.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelector.kt
@@ -1,0 +1,188 @@
+package radio.ks3ckc.ft8af.hunt
+
+import com.k1af.ft8af.Ft8Message
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.maidenhead.MaidenheadGrid
+import radio.ks3ckc.ft8af.pota.PotaCqClassifier
+import radio.ks3ckc.ft8af.pota.PotaSpotsRepository
+
+/**
+ * How Hunt picks which qualifying CQ to answer when several are decoded in the
+ * same cycle. [LATEST] is the historical behavior (most recent decode wins).
+ */
+enum class HuntPriority {
+    LATEST,
+    STRONGEST,
+    WEAKEST,
+    FARTHEST,
+    POTA_FIRST,
+    NEW_DXCC_FIRST,
+    NEW_GRID_FIRST,
+}
+
+/**
+ * Parse the persisted config value back to a [HuntPriority]. Unknown/blank/null
+ * values (fresh install, downgrade, hand-edited config) fall back to [HuntPriority.LATEST]
+ * so Hunt never breaks on a bad stored string.
+ */
+fun huntPriorityFromConfig(value: String?): HuntPriority =
+    HuntPriority.entries.firstOrNull { it.name.equals(value?.trim(), ignoreCase = true) }
+        ?: HuntPriority.LATEST
+
+/**
+ * One eligible CQ caller, reduced to the facts the ranking needs. Pure data so
+ * [selectHuntCandidate] can be unit-tested without Android.
+ *
+ * @param index        position in the eligible list; the list is most-recent-first,
+ *                     so a smaller index means a fresher decode
+ * @param snr          decoder SNR in dB, or null when the decoder didn't set one
+ * @param distanceKm   great-circle distance to the caller, or null when unknown
+ * @param isActivator  the CQ is a POTA/SOTA activation
+ * @param isNewPark    the activation is from a park not yet in the hunted log
+ * @param isNewDxcc    the caller's DXCC entity hasn't been worked
+ * @param isNewGrid    the caller's grid square hasn't been worked
+ * @param pileupCalls  how many other stations were heard answering this caller
+ *                     in the same decode window
+ */
+data class HuntCandidate(
+    val index: Int,
+    val snr: Int? = null,
+    val distanceKm: Double? = null,
+    val isActivator: Boolean = false,
+    val isNewPark: Boolean = false,
+    val isNewDxcc: Boolean = false,
+    val isNewGrid: Boolean = false,
+    val pileupCalls: Int = 0,
+)
+
+/**
+ * Whether a candidate clears the minimum-signal floor. A null floor disables the
+ * check; a candidate with no SNR passes (the decoder occasionally omits SNR, and
+ * silently dropping those stations would make Hunt look randomly deaf).
+ */
+internal fun passesSnrFloor(snr: Int?, minSnrDb: Int?): Boolean =
+    minSnrDb == null || snr == null || snr >= minSnrDb
+
+/** POTA_FIRST tier: unhunted park > any activation > everyone else. */
+internal fun activatorRank(c: HuntCandidate): Int = when {
+    c.isNewPark -> 2
+    c.isActivator -> 1
+    else -> 0
+}
+
+/**
+ * Pick the best CQ to answer from this cycle's eligible callers.
+ *
+ * The floor is a hard filter (a too-weak CQ is never answered — better to wait a
+ * cycle than start a QSO that fizzles). Pileup avoidance is a soft preference:
+ * candidates nobody else is answering win, but when every caller has a pileup we
+ * still pick one rather than sit silent. Ties always go to the freshest decode
+ * (the input is most-recent-first and the sort is stable).
+ */
+internal fun selectHuntCandidate(
+    candidates: List<HuntCandidate>,
+    priority: HuntPriority,
+    avoidPileups: Boolean,
+    minSnrDb: Int?,
+): HuntCandidate? {
+    val floored = candidates.filter { passesSnrFloor(it.snr, minSnrDb) }
+    if (floored.isEmpty()) return null
+    val pool = if (avoidPileups) {
+        floored.filter { it.pileupCalls == 0 }.ifEmpty { floored }
+    } else {
+        floored
+    }
+    val comparator: Comparator<HuntCandidate> = when (priority) {
+        HuntPriority.LATEST -> return pool.first()
+        HuntPriority.STRONGEST -> compareByDescending { it.snr ?: Int.MIN_VALUE }
+        // For WEAKEST an unknown SNR must not win the "weakest" crown, so it sorts last.
+        HuntPriority.WEAKEST -> compareBy { it.snr ?: Int.MAX_VALUE }
+        HuntPriority.FARTHEST -> compareByDescending { it.distanceKm ?: -1.0 }
+        HuntPriority.POTA_FIRST ->
+            compareByDescending<HuntCandidate> { activatorRank(it) }
+                .thenByDescending { it.snr ?: Int.MIN_VALUE }
+        HuntPriority.NEW_DXCC_FIRST ->
+            compareByDescending<HuntCandidate> { it.isNewDxcc }
+                .thenByDescending { it.snr ?: Int.MIN_VALUE }
+        HuntPriority.NEW_GRID_FIRST ->
+            compareByDescending<HuntCandidate> { it.isNewGrid }
+                .thenByDescending { it.snr ?: Int.MIN_VALUE }
+    }
+    return pool.sortedWith(comparator).first()
+}
+
+/**
+ * Count the other stations heard answering [cqCallsign] in the same decode
+ * window: any non-CQ message directed at the caller counts as a competitor.
+ */
+internal fun countRepliesTo(cqCallsign: String?, messages: List<Ft8Message>): Int {
+    if (cqCallsign.isNullOrEmpty()) return 0
+    return messages.count { m ->
+        !m.checkIsCQ() && cqCallsign.equals(m.callsignTo, ignoreCase = true)
+    }
+}
+
+/**
+ * Bridge for the Java transmit engine: rank this cycle's eligible CQ callers by
+ * the operator's Hunt options and return the one to answer.
+ *
+ * The engine keeps its existing eligibility filters (is CQ, not worked, not
+ * excluded, POTA-only filter, directional-CQ respect, …) and hands over only the
+ * survivors; this decides *which* survivor gets the call, replacing the old
+ * take-the-most-recent behavior (which [HuntPriority.LATEST] reproduces).
+ */
+object HuntTargetSelector {
+
+    @JvmStatic
+    fun pick(eligible: List<Ft8Message>, allMessages: List<Ft8Message>): Ft8Message? {
+        if (eligible.isEmpty()) return null
+        val priority = huntPriorityFromConfig(GeneralVariables.huntPriority)
+        val avoidPileups = GeneralVariables.huntAvoidPileups
+        val minSnr = GeneralVariables.huntMinSnr
+            .takeIf { it != GeneralVariables.HUNT_MIN_SNR_OFF }
+
+        // Nothing to rank: default priority with no filters active picks the most
+        // recent caller without paying for distance/park/pileup lookups per cycle.
+        if (priority == HuntPriority.LATEST && !avoidPileups && minSnr == null) {
+            return eligible.first()
+        }
+
+        val myGrid = GeneralVariables.getMyMaidenheadGrid()
+        val candidates = eligible.mapIndexed { index, msg ->
+            // Only resolve the facts the active options actually rank on — the
+            // park-spot map, worked-grid set, and distance math run every decode
+            // cycle otherwise.
+            val parkRef = if (priority == HuntPriority.POTA_FIRST) {
+                PotaSpotsRepository.parkRefFor(msg.callsignFrom)
+            } else null
+            HuntCandidate(
+                index = index,
+                snr = if (msg.hasSnr()) msg.snr else null,
+                distanceKm = if (priority == HuntPriority.FARTHEST) {
+                    distanceKmTo(myGrid, msg.maidenGrid)
+                } else null,
+                isActivator = priority == HuntPriority.POTA_FIRST &&
+                    (PotaCqClassifier.isPotaCq(msg) || msg.modifier == "SOTA"),
+                isNewPark = parkRef != null && !GeneralVariables.checkQSLPark(parkRef),
+                isNewDxcc = msg.fromDxcc,
+                isNewGrid = priority == HuntPriority.NEW_GRID_FIRST &&
+                    isUnworkedGrid(msg.maidenGrid),
+                pileupCalls = if (avoidPileups) {
+                    countRepliesTo(msg.callsignFrom, allMessages)
+                } else 0,
+            )
+        }
+        val chosen = selectHuntCandidate(candidates, priority, avoidPileups, minSnr)
+            ?: return null
+        return eligible[chosen.index]
+    }
+
+    private fun distanceKmTo(myGrid: String?, theirGrid: String?): Double? {
+        if (myGrid.isNullOrEmpty() || theirGrid.isNullOrEmpty()) return null
+        // getDist returns 0 for an unparseable grid; treat that as unknown.
+        return MaidenheadGrid.getDist(myGrid, theirGrid).takeIf { it > 0 }
+    }
+
+    private fun isUnworkedGrid(grid: String?): Boolean =
+        !grid.isNullOrEmpty() && grid.length >= 4 && !GeneralVariables.checkQSLGrid(grid)
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelector.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelector.kt
@@ -76,8 +76,9 @@ internal fun activatorRank(c: HuntCandidate): Int = when {
  * The floor is a hard filter (a too-weak CQ is never answered — better to wait a
  * cycle than start a QSO that fizzles). Pileup avoidance is a soft preference:
  * candidates nobody else is answering win, but when every caller has a pileup we
- * still pick one rather than sit silent. Ties always go to the freshest decode
- * (the input is most-recent-first and the sort is stable).
+ * still pick one rather than sit silent. Ties always go to the freshest decode:
+ * the input is most-recent-first and every comparator ends with an explicit
+ * [HuntCandidate.index] tie-breaker, so the winner never depends on sort stability.
  */
 internal fun selectHuntCandidate(
     candidates: List<HuntCandidate>,
@@ -108,7 +109,10 @@ internal fun selectHuntCandidate(
             compareByDescending<HuntCandidate> { it.isNewGrid }
                 .thenByDescending { it.snr ?: Int.MIN_VALUE }
     }
-    return pool.sortedWith(comparator).first()
+    // index is unique, so the composed comparator is a total order: the freshest
+    // decode wins ties by contract, not by sort stability. minWithOrNull also skips
+    // sorting/allocating a ranked copy of the pool every decode cycle.
+    return pool.minWithOrNull(comparator.thenBy { it.index })
 }
 
 /**

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/HuntOptionsSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/HuntOptionsSheet.kt
@@ -1,0 +1,302 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.R
+import radio.ks3ckc.ft8af.hunt.HuntPriority
+import radio.ks3ckc.ft8af.theme.*
+
+// ---- Pure logic (extracted for unit testing) ----
+
+/**
+ * The min-SNR floor choices offered in the sheet; null = no floor. Values follow
+ * the practical FT8 range: −10 dB is "armchair copy", −20 dB is near the decode
+ * limit where a completed QSO becomes a coin flip.
+ */
+internal val HUNT_MIN_SNR_CHOICES: List<Int?> = listOf(null, -10, -15, -20)
+
+/**
+ * The short tag shown on the HUNT button while a non-default priority is armed
+ * (mirrors the CQ button's FREE/FD subtitle). Null for the default so the
+ * button stays clean when Hunt behaves classically.
+ */
+internal fun huntStripSubtitle(priority: HuntPriority): String? = when (priority) {
+    HuntPriority.LATEST -> null
+    HuntPriority.STRONGEST -> "STRONG"
+    HuntPriority.WEAKEST -> "WEAK"
+    HuntPriority.FARTHEST -> "DX"
+    HuntPriority.POTA_FIRST -> "POTA"
+    HuntPriority.NEW_DXCC_FIRST -> "DXCC"
+    HuntPriority.NEW_GRID_FIRST -> "GRID"
+}
+
+/** Chip label for a min-SNR choice, e.g. "−15 dB"; null (= off) is localized by the caller. */
+internal fun huntMinSnrChipLabel(minSnrDb: Int): String = "−${-minSnrDb} dB"
+
+// ---- Composable ----
+
+@Composable
+private fun priorityChipLabel(priority: HuntPriority): String = stringResource(
+    when (priority) {
+        HuntPriority.LATEST -> R.string.hunt_priority_latest
+        HuntPriority.STRONGEST -> R.string.hunt_priority_strongest
+        HuntPriority.WEAKEST -> R.string.hunt_priority_weakest
+        HuntPriority.FARTHEST -> R.string.hunt_priority_farthest
+        HuntPriority.POTA_FIRST -> R.string.hunt_priority_pota
+        HuntPriority.NEW_DXCC_FIRST -> R.string.hunt_priority_new_dxcc
+        HuntPriority.NEW_GRID_FIRST -> R.string.hunt_priority_new_grid
+    },
+)
+
+@Composable
+private fun priorityDescription(priority: HuntPriority): String = stringResource(
+    when (priority) {
+        HuntPriority.LATEST -> R.string.hunt_priority_desc_latest
+        HuntPriority.STRONGEST -> R.string.hunt_priority_desc_strongest
+        HuntPriority.WEAKEST -> R.string.hunt_priority_desc_weakest
+        HuntPriority.FARTHEST -> R.string.hunt_priority_desc_farthest
+        HuntPriority.POTA_FIRST -> R.string.hunt_priority_desc_pota
+        HuntPriority.NEW_DXCC_FIRST -> R.string.hunt_priority_desc_new_dxcc
+        HuntPriority.NEW_GRID_FIRST -> R.string.hunt_priority_desc_new_grid
+    },
+)
+
+/**
+ * Hunt options — opened from the notch on the HUNT button (mirroring the CQ
+ * options sheet). Lets the operator pick which CQ Hunt answers first when
+ * several are decoded in the same cycle, plus two "smart filter" preferences
+ * (pileup avoidance, minimum-signal floor).
+ */
+@Composable
+fun HuntOptionsSheet(
+    visible: Boolean,
+    huntEnabled: Boolean,
+    priority: HuntPriority,
+    avoidPileups: Boolean,
+    minSnrDb: Int?,
+    onDismiss: () -> Unit,
+    onSelectPriority: (HuntPriority) -> Unit,
+    onAvoidPileupsChange: (Boolean) -> Unit,
+    onMinSnrChange: (Int?) -> Unit,
+    onStartHunt: () -> Unit,
+) {
+    FT8AFBottomSheet(
+        visible = visible,
+        onDismiss = onDismiss,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+        ) {
+            // ---- Section: HUNT PRIORITY ----
+            SheetSectionHeader(stringResource(R.string.hunt_priority_title))
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val chipShape = RoundedCornerShape(999.dp)
+            val scrollState = rememberScrollState()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                for (p in HuntPriority.entries) {
+                    val isSelected = priority == p
+                    Row(
+                        modifier = Modifier
+                            .height(32.dp)
+                            .clip(chipShape)
+                            .background(if (isSelected) AccentSoft else BgSurface2, chipShape)
+                            .border(1.dp, if (isSelected) BorderAmber else Border, chipShape)
+                            .clickable { onSelectPriority(p) }
+                            .padding(horizontal = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = priorityChipLabel(p),
+                            color = if (isSelected) Accent else TextMuted,
+                            fontSize = 12.sp,
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                            fontFamily = GeistMonoFamily,
+                            letterSpacing = 0.02.sp,
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // What the selected priority actually does — keeps the short chip
+            // labels honest without cluttering the row.
+            Text(
+                text = priorityDescription(priority),
+                color = TextFaint,
+                fontSize = 11.sp,
+                fontFamily = GeistMonoFamily,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // ---- Section: SMART FILTERS ----
+            SheetSectionHeader(stringResource(R.string.hunt_filters_title))
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // Avoid pileups
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.hunt_avoid_pileups),
+                        color = TextPrimary,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        fontFamily = GeistMonoFamily,
+                    )
+                    Text(
+                        text = stringResource(R.string.hunt_avoid_pileups_desc),
+                        color = TextFaint,
+                        fontSize = 11.sp,
+                        fontFamily = GeistMonoFamily,
+                    )
+                }
+                Switch(
+                    checked = avoidPileups,
+                    onCheckedChange = onAvoidPileupsChange,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Accent,
+                        checkedTrackColor = AccentSoft,
+                        uncheckedThumbColor = TextMuted,
+                        uncheckedTrackColor = BgSurface3,
+                    ),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Min-signal floor
+            Text(
+                text = stringResource(R.string.hunt_min_snr),
+                color = TextPrimary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
+            )
+            Text(
+                text = stringResource(R.string.hunt_min_snr_desc),
+                color = TextFaint,
+                fontSize = 11.sp,
+                fontFamily = GeistMonoFamily,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                for (choice in HUNT_MIN_SNR_CHOICES) {
+                    val isSelected = minSnrDb == choice
+                    Row(
+                        modifier = Modifier
+                            .height(32.dp)
+                            .clip(chipShape)
+                            .background(if (isSelected) AccentSoft else BgSurface2, chipShape)
+                            .border(1.dp, if (isSelected) BorderAmber else Border, chipShape)
+                            .clickable { onMinSnrChange(choice) }
+                            .padding(horizontal = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = choice?.let { huntMinSnrChipLabel(it) }
+                                ?: stringResource(R.string.hunt_min_snr_off),
+                            color = if (isSelected) Accent else TextMuted,
+                            fontSize = 12.sp,
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                            fontFamily = GeistMonoFamily,
+                            letterSpacing = 0.02.sp,
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = stringResource(R.string.hunt_footer_note),
+                color = TextFaint,
+                fontSize = 10.sp,
+                fontFamily = GeistMonoFamily,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // ---- Action button: start Hunt with these options (or just close) ----
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Accent)
+                    .clickable {
+                        if (!huntEnabled) onStartHunt()
+                        onDismiss()
+                    }
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FT8AFIcons.Target(size = 18.dp, color = BgApp, strokeWidth = 1.8f)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = if (huntEnabled) stringResource(R.string.hunt_done)
+                    else stringResource(R.string.hunt_start),
+                    color = BgApp,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.04.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SheetSectionHeader(text: String) {
+    Text(
+        text = text,
+        color = TextMuted,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        fontFamily = GeistMonoFamily,
+        letterSpacing = 0.08.sp,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -119,6 +119,7 @@ fun TxStrip(
     cqModifier: String = "",
     isFreeTextMode: Boolean = false,
     fieldDayEnabled: Boolean = false,
+    huntPriorityTag: String? = null,
     isTuning: Boolean = false,
     tuneRemainingSec: Int = 0,
     onToggleTune: () -> Unit = {},
@@ -127,6 +128,7 @@ fun TxStrip(
     onCallCQ: () -> Unit,
     onStop: () -> Unit,
     onLongPressCQ: () -> Unit = {},
+    onLongPressHunt: () -> Unit = {},
     onToggleSlot: () -> Unit,
     onToggleHunt: () -> Unit,
     onCycleMode: () -> Unit,
@@ -297,9 +299,13 @@ fun TxStrip(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             // HUNT — stacked icon + label. Locked off during an active CQ/QSO.
+            // The notch (and a long-press) opens the Hunt options sheet; the
+            // subtitle tag mirrors the armed non-default priority (like the CQ
+            // button's FREE/FD subtitle).
             StackedActionButton(
                 modifier = Modifier.weight(1f),
                 label = stringResource(R.string.tx_hunt),
+                subtitle = huntPriorityTag,
                 background = when {
                     actions.huntDisabled -> BgSurface3.copy(alpha = 0.4f)
                     actions.huntActive -> Signal.copy(alpha = 0.18f)
@@ -313,6 +319,8 @@ fun TxStrip(
                 borderColor = if (actions.huntActive) Signal.copy(alpha = 0.5f) else Border,
                 enabled = !actions.huntDisabled,
                 onClick = onToggleHunt,
+                onLongClick = onLongPressHunt,
+                optionsContentDescription = stringResource(R.string.tx_hunt_options),
             ) { color -> FT8AFIcons.Target(size = 18.dp, color = color, strokeWidth = 1.8f) }
 
             // CQ / STOP — the primary action. Filled amber to call CQ, red to stop.
@@ -469,6 +477,7 @@ private fun TxChip(
 }
 
 /** A large secondary button with the icon stacked above the label (HUNT, TX slot). */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun StackedActionButton(
     label: String,
@@ -478,30 +487,75 @@ private fun StackedActionButton(
     enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    onLongClick: (() -> Unit)? = null,
+    optionsContentDescription: String = "",
     icon: @Composable (Color) -> Unit,
 ) {
-    Column(
+    Row(
         modifier = modifier
             .height(54.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(background)
             .border(1.dp, borderColor, RoundedCornerShape(12.dp))
-            .clickable(enabled = enabled) { onClick() }
-            .padding(vertical = 8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(3.dp, Alignment.CenterVertically),
+            .combinedClickable(
+                enabled = enabled,
+                onClick = onClick,
+                onLongClick = onLongClick,
+            )
+            .padding(horizontal = 4.dp, vertical = if (subtitle != null) 4.dp else 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        icon(contentColor)
-        Text(
-            text = label,
-            color = contentColor,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.SemiBold,
-            fontFamily = GeistMonoFamily,
-            letterSpacing = 0.02.sp,
-            maxLines = 1,
-            softWrap = false,
-        )
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(
+                if (subtitle != null) 1.dp else 3.dp, Alignment.CenterVertically,
+            ),
+        ) {
+            icon(contentColor)
+            Text(
+                text = label,
+                color = contentColor,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
+                letterSpacing = 0.02.sp,
+                maxLines = 1,
+                softWrap = false,
+            )
+            if (subtitle != null) {
+                Text(
+                    text = subtitle,
+                    color = contentColor.copy(alpha = 0.6f),
+                    fontSize = 8.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    letterSpacing = 0.02.sp,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            }
+        }
+        if (onLongClick != null) {
+            // Same visible "more options" affordance as the CQ button — a plain
+            // tap opens the options sheet (discoverable), long-press on the whole
+            // button is the shortcut.
+            Box(
+                modifier = Modifier
+                    .size(width = 22.dp, height = 38.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(contentColor.copy(alpha = 0.16f))
+                    .clickable(enabled = enabled, onClick = onLongClick)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = optionsContentDescription
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                FT8AFIcons.ChevronDown(size = 14.dp, color = contentColor, strokeWidth = 2.2f)
+            }
+        }
     }
 }
 

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -115,6 +115,33 @@
     <string name="tx_volume_decrease">Decrease TX volume</string>
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_cq_options">CQ message options (modifier, free text, Field Day)</string>
+    <string name="tx_hunt_options">Hunt options (priority, smart filters)</string>
+
+    <!-- ===== Hunt options sheet ===== -->
+    <string name="hunt_priority_title">HUNT PRIORITY</string>
+    <string name="hunt_priority_latest">Latest</string>
+    <string name="hunt_priority_strongest">Strongest</string>
+    <string name="hunt_priority_weakest">Weakest</string>
+    <string name="hunt_priority_farthest">Farthest</string>
+    <string name="hunt_priority_pota">POTA/SOTA</string>
+    <string name="hunt_priority_new_dxcc">New DXCC</string>
+    <string name="hunt_priority_new_grid">New grid</string>
+    <string name="hunt_priority_desc_latest">Answer the most recently decoded CQ (classic behavior)</string>
+    <string name="hunt_priority_desc_strongest">Answer the loudest CQ first — best odds of completing</string>
+    <string name="hunt_priority_desc_weakest">Answer the weakest CQ first — QRP and challenge hunting</string>
+    <string name="hunt_priority_desc_farthest">Answer the most distant CQ first — chase DX</string>
+    <string name="hunt_priority_desc_pota">Answer park/summit activators first — parks you haven\'t hunted rank highest</string>
+    <string name="hunt_priority_desc_new_dxcc">Answer CQs from DXCC entities you haven\'t worked first</string>
+    <string name="hunt_priority_desc_new_grid">Answer CQs from grid squares you haven\'t worked first</string>
+    <string name="hunt_filters_title">SMART FILTERS</string>
+    <string name="hunt_avoid_pileups">Avoid pileups</string>
+    <string name="hunt_avoid_pileups_desc">Prefer CQs no one else is answering this cycle</string>
+    <string name="hunt_min_snr">Minimum signal</string>
+    <string name="hunt_min_snr_desc">Skip CQs weaker than this — fewer QSOs that fizzle out</string>
+    <string name="hunt_min_snr_off">Off</string>
+    <string name="hunt_footer_note">Hunt always skips stations you\'ve already worked and your excluded prefixes.</string>
+    <string name="hunt_start">Start Hunt</string>
+    <string name="hunt_done">Done</string>
 
     <!-- ===== CQ options sheet (free text / saved custom CQ) ===== -->
     <string name="cq_directed_too_long">CQ + text + call doesn\'t fit in one FT8 message (max 13 chars, limited character set)</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelectorTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelectorTest.kt
@@ -1,0 +1,265 @@
+package radio.ks3ckc.ft8af.hunt
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.Ft8Message
+import org.junit.Test
+
+/**
+ * Coverage for the pure Hunt-options ranking logic in HuntTargetSelector.kt:
+ * config parsing, the min-SNR floor, pileup avoidance, and each [HuntPriority]
+ * mode including unknown-SNR/-distance handling and freshest-decode tie breaks.
+ *
+ * Plain JUnit: only the pure top-level functions are exercised (the
+ * HuntTargetSelector object bridge touches GeneralVariables/Android and is
+ * covered by the engine's on-device behavior).
+ */
+class HuntTargetSelectorTest {
+
+    private fun candidate(
+        index: Int,
+        snr: Int? = null,
+        distanceKm: Double? = null,
+        isActivator: Boolean = false,
+        isNewPark: Boolean = false,
+        isNewDxcc: Boolean = false,
+        isNewGrid: Boolean = false,
+        pileupCalls: Int = 0,
+    ) = HuntCandidate(index, snr, distanceKm, isActivator, isNewPark, isNewDxcc, isNewGrid, pileupCalls)
+
+    private fun select(
+        candidates: List<HuntCandidate>,
+        priority: HuntPriority = HuntPriority.LATEST,
+        avoidPileups: Boolean = false,
+        minSnrDb: Int? = null,
+    ) = selectHuntCandidate(candidates, priority, avoidPileups, minSnrDb)
+
+    // ---- huntPriorityFromConfig ----
+
+    @Test
+    fun configParse_roundTripsEveryEnumName() {
+        for (p in HuntPriority.entries) {
+            assertThat(huntPriorityFromConfig(p.name)).isEqualTo(p)
+        }
+    }
+
+    @Test
+    fun configParse_isCaseInsensitiveAndTrims() {
+        assertThat(huntPriorityFromConfig(" strongest ")).isEqualTo(HuntPriority.STRONGEST)
+    }
+
+    @Test
+    fun configParse_fallsBackToLatestOnBadValues() {
+        assertThat(huntPriorityFromConfig(null)).isEqualTo(HuntPriority.LATEST)
+        assertThat(huntPriorityFromConfig("")).isEqualTo(HuntPriority.LATEST)
+        assertThat(huntPriorityFromConfig("BOGUS")).isEqualTo(HuntPriority.LATEST)
+    }
+
+    // ---- passesSnrFloor ----
+
+    @Test
+    fun snrFloor_disabledPassesEverything() {
+        assertThat(passesSnrFloor(-24, null)).isTrue()
+        assertThat(passesSnrFloor(null, null)).isTrue()
+    }
+
+    @Test
+    fun snrFloor_filtersBelowAndKeepsAtOrAbove() {
+        assertThat(passesSnrFloor(-16, -15)).isFalse()
+        assertThat(passesSnrFloor(-15, -15)).isTrue()
+        assertThat(passesSnrFloor(3, -15)).isTrue()
+    }
+
+    @Test
+    fun snrFloor_unknownSnrPasses() {
+        // The decoder occasionally omits SNR; those stations must not silently vanish.
+        assertThat(passesSnrFloor(null, -15)).isTrue()
+    }
+
+    // ---- floor + empty handling ----
+
+    @Test
+    fun select_emptyListReturnsNull() {
+        assertThat(select(emptyList())).isNull()
+    }
+
+    @Test
+    fun select_returnsNullWhenFloorEliminatesEveryone() {
+        val all = listOf(candidate(0, snr = -20), candidate(1, snr = -22))
+        assertThat(select(all, minSnrDb = -15)).isNull()
+    }
+
+    @Test
+    fun select_floorAppliesBeforePriority() {
+        val strongButFloored = candidate(0, snr = -20)
+        val weakerButPassing = candidate(1, snr = -10)
+        val picked = select(
+            listOf(strongButFloored, weakerButPassing),
+            priority = HuntPriority.WEAKEST, minSnrDb = -15,
+        )
+        assertThat(picked).isEqualTo(weakerButPassing)
+    }
+
+    // ---- LATEST (historical behavior) ----
+
+    @Test
+    fun latest_picksFirstCandidate_listIsMostRecentFirst() {
+        val newest = candidate(0, snr = -20)
+        val older = candidate(1, snr = 5)
+        assertThat(select(listOf(newest, older))).isEqualTo(newest)
+    }
+
+    // ---- STRONGEST / WEAKEST ----
+
+    @Test
+    fun strongest_picksHighestSnr() {
+        val weak = candidate(0, snr = -18)
+        val loud = candidate(1, snr = 4)
+        assertThat(select(listOf(weak, loud), HuntPriority.STRONGEST)).isEqualTo(loud)
+    }
+
+    @Test
+    fun strongest_unknownSnrLosesToAnyKnown() {
+        val unknown = candidate(0, snr = null)
+        val faint = candidate(1, snr = -24)
+        assertThat(select(listOf(unknown, faint), HuntPriority.STRONGEST)).isEqualTo(faint)
+    }
+
+    @Test
+    fun weakest_picksLowestSnr() {
+        val loud = candidate(0, snr = 4)
+        val weak = candidate(1, snr = -18)
+        assertThat(select(listOf(loud, weak), HuntPriority.WEAKEST)).isEqualTo(weak)
+    }
+
+    @Test
+    fun weakest_unknownSnrNeverWins() {
+        val unknown = candidate(0, snr = null)
+        val weak = candidate(1, snr = -5)
+        assertThat(select(listOf(unknown, weak), HuntPriority.WEAKEST)).isEqualTo(weak)
+    }
+
+    @Test
+    fun strongest_tieGoesToFreshestDecode() {
+        val newer = candidate(0, snr = -3)
+        val older = candidate(1, snr = -3)
+        assertThat(select(listOf(newer, older), HuntPriority.STRONGEST)).isEqualTo(newer)
+    }
+
+    // ---- FARTHEST ----
+
+    @Test
+    fun farthest_picksLargestDistance() {
+        val near = candidate(0, distanceKm = 120.0)
+        val far = candidate(1, distanceKm = 8400.0)
+        assertThat(select(listOf(near, far), HuntPriority.FARTHEST)).isEqualTo(far)
+    }
+
+    @Test
+    fun farthest_unknownDistanceLosesToAnyKnown() {
+        val unknown = candidate(0, distanceKm = null)
+        val near = candidate(1, distanceKm = 15.0)
+        assertThat(select(listOf(unknown, near), HuntPriority.FARTHEST)).isEqualTo(near)
+    }
+
+    // ---- POTA_FIRST ----
+
+    @Test
+    fun potaFirst_newParkBeatsAnyActivatorBeatsPlainCq() {
+        val plain = candidate(0, snr = 10)
+        val activator = candidate(1, snr = -10, isActivator = true)
+        val newPark = candidate(2, snr = -20, isActivator = true, isNewPark = true)
+        assertThat(select(listOf(plain, activator, newPark), HuntPriority.POTA_FIRST))
+            .isEqualTo(newPark)
+        assertThat(select(listOf(plain, activator), HuntPriority.POTA_FIRST))
+            .isEqualTo(activator)
+    }
+
+    @Test
+    fun potaFirst_snrBreaksTiesWithinTier() {
+        val faintActivator = candidate(0, snr = -15, isActivator = true)
+        val loudActivator = candidate(1, snr = 0, isActivator = true)
+        assertThat(select(listOf(faintActivator, loudActivator), HuntPriority.POTA_FIRST))
+            .isEqualTo(loudActivator)
+    }
+
+    @Test
+    fun activatorRank_tiers() {
+        assertThat(activatorRank(candidate(0, isActivator = true, isNewPark = true))).isEqualTo(2)
+        assertThat(activatorRank(candidate(0, isActivator = true))).isEqualTo(1)
+        assertThat(activatorRank(candidate(0))).isEqualTo(0)
+    }
+
+    // ---- NEW_DXCC_FIRST / NEW_GRID_FIRST ----
+
+    @Test
+    fun newDxccFirst_newEntityBeatsLouderKnownEntity() {
+        val loudKnown = candidate(0, snr = 10)
+        val faintNew = candidate(1, snr = -19, isNewDxcc = true)
+        assertThat(select(listOf(loudKnown, faintNew), HuntPriority.NEW_DXCC_FIRST))
+            .isEqualTo(faintNew)
+    }
+
+    @Test
+    fun newDxccFirst_fallsBackToStrongestWhenNoNewEntity() {
+        val faint = candidate(0, snr = -12)
+        val loud = candidate(1, snr = -2)
+        assertThat(select(listOf(faint, loud), HuntPriority.NEW_DXCC_FIRST)).isEqualTo(loud)
+    }
+
+    @Test
+    fun newGridFirst_newGridBeatsLouderKnownGrid() {
+        val loudKnown = candidate(0, snr = 7)
+        val faintNew = candidate(1, snr = -14, isNewGrid = true)
+        assertThat(select(listOf(loudKnown, faintNew), HuntPriority.NEW_GRID_FIRST))
+            .isEqualTo(faintNew)
+    }
+
+    // ---- Pileup avoidance ----
+
+    @Test
+    fun avoidPileups_prefersUncontestedCaller() {
+        val contested = candidate(0, snr = 10, pileupCalls = 3)
+        val clear = candidate(1, snr = -12, pileupCalls = 0)
+        assertThat(select(listOf(contested, clear), HuntPriority.STRONGEST, avoidPileups = true))
+            .isEqualTo(clear)
+    }
+
+    @Test
+    fun avoidPileups_fallsBackWhenEveryoneIsContested() {
+        // A soft preference: when every caller has a pileup, still hunt rather than sit idle.
+        val a = candidate(0, snr = -12, pileupCalls = 2)
+        val b = candidate(1, snr = 3, pileupCalls = 1)
+        assertThat(select(listOf(a, b), HuntPriority.STRONGEST, avoidPileups = true))
+            .isEqualTo(b)
+    }
+
+    @Test
+    fun avoidPileups_offIgnoresPileupCounts() {
+        val contested = candidate(0, snr = 10, pileupCalls = 5)
+        val clear = candidate(1, snr = -12, pileupCalls = 0)
+        assertThat(select(listOf(contested, clear), HuntPriority.STRONGEST)).isEqualTo(contested)
+    }
+
+    // ---- countRepliesTo ----
+
+    @Test
+    fun countReplies_countsDirectedNonCqMessages() {
+        val messages = listOf(
+            Ft8Message("CQ", "W1ABC", "FN42"), // the CQer himself — not a reply
+            Ft8Message("W1ABC", "K2DEF", "-10"), // reply to W1ABC
+            Ft8Message("W1ABC", "N3GHI", "EM73"), // reply to W1ABC
+            Ft8Message("K9ZZZ", "W4JKL", "R-05"), // reply to someone else
+        )
+        assertThat(countRepliesTo("W1ABC", messages)).isEqualTo(2)
+        assertThat(countRepliesTo("K9ZZZ", messages)).isEqualTo(1)
+        assertThat(countRepliesTo("NOBODY", messages)).isEqualTo(0)
+    }
+
+    @Test
+    fun countReplies_isCaseInsensitiveAndNullSafe() {
+        val messages = listOf(Ft8Message("w1abc", "K2DEF", "-10"))
+        assertThat(countRepliesTo("W1ABC", messages)).isEqualTo(1)
+        assertThat(countRepliesTo(null, messages)).isEqualTo(0)
+        assertThat(countRepliesTo("", messages)).isEqualTo(0)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelectorTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/hunt/HuntTargetSelectorTest.kt
@@ -145,6 +145,29 @@ class HuntTargetSelectorTest {
         assertThat(select(listOf(newer, older), HuntPriority.STRONGEST)).isEqualTo(newer)
     }
 
+    @Test
+    fun tieBreak_usesIndexNotListPosition() {
+        // The tie-break is the explicit index comparator, not sort stability: even if
+        // the pool arrives out of freshness order, the smaller index still wins.
+        val older = candidate(3, snr = -3)
+        val newer = candidate(1, snr = -3)
+        assertThat(select(listOf(older, newer), HuntPriority.STRONGEST)).isEqualTo(newer)
+    }
+
+    @Test
+    fun farthest_tieGoesToFreshestDecode() {
+        val newer = candidate(0, distanceKm = 5000.0)
+        val older = candidate(1, distanceKm = 5000.0)
+        assertThat(select(listOf(newer, older), HuntPriority.FARTHEST)).isEqualTo(newer)
+    }
+
+    @Test
+    fun potaFirst_fullTieGoesToFreshestDecode() {
+        val newer = candidate(0, snr = -8, isActivator = true)
+        val older = candidate(1, snr = -8, isActivator = true)
+        assertThat(select(listOf(newer, older), HuntPriority.POTA_FIRST)).isEqualTo(newer)
+    }
+
     // ---- FARTHEST ----
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/HuntOptionsLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/HuntOptionsLogicTest.kt
@@ -1,0 +1,56 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import radio.ks3ckc.ft8af.hunt.HuntPriority
+
+/**
+ * Coverage for the pure helpers extracted from HuntOptionsSheet.kt (the sheet's
+ * chip data and the HUNT-button subtitle tag), mirroring CqOptionsLogicTest.
+ */
+class HuntOptionsLogicTest {
+
+    @Test
+    fun stripSubtitle_defaultPriorityShowsNothing() {
+        assertThat(huntStripSubtitle(HuntPriority.LATEST)).isNull()
+    }
+
+    @Test
+    fun stripSubtitle_nonDefaultPrioritiesShowShortTags() {
+        assertThat(huntStripSubtitle(HuntPriority.STRONGEST)).isEqualTo("STRONG")
+        assertThat(huntStripSubtitle(HuntPriority.WEAKEST)).isEqualTo("WEAK")
+        assertThat(huntStripSubtitle(HuntPriority.FARTHEST)).isEqualTo("DX")
+        assertThat(huntStripSubtitle(HuntPriority.POTA_FIRST)).isEqualTo("POTA")
+        assertThat(huntStripSubtitle(HuntPriority.NEW_DXCC_FIRST)).isEqualTo("DXCC")
+        assertThat(huntStripSubtitle(HuntPriority.NEW_GRID_FIRST)).isEqualTo("GRID")
+    }
+
+    @Test
+    fun stripSubtitle_everyPriorityIsCoveredAndFitsTheButton() {
+        // A new HuntPriority must get an explicit (short) tag decision — the
+        // stacked button clips anything longer than ~6 monospace chars.
+        for (p in HuntPriority.entries) {
+            val tag = huntStripSubtitle(p)
+            if (p == HuntPriority.LATEST) {
+                assertThat(tag).isNull()
+            } else {
+                assertThat(tag).isNotEmpty()
+                assertThat(tag!!.length).isAtMost(6)
+            }
+        }
+    }
+
+    @Test
+    fun minSnrChoices_startWithOffAndDescend() {
+        assertThat(HUNT_MIN_SNR_CHOICES.first()).isNull()
+        val values = HUNT_MIN_SNR_CHOICES.filterNotNull()
+        assertThat(values).isEqualTo(values.sortedDescending())
+        assertThat(values).isNotEmpty()
+    }
+
+    @Test
+    fun minSnrChipLabel_formatsWithTypographicMinus() {
+        assertThat(huntMinSnrChipLabel(-10)).isEqualTo("−10 dB")
+        assertThat(huntMinSnrChipLabel(-20)).isEqualTo("−20 dB")
+    }
+}


### PR DESCRIPTION
## What

The **HUNT** button gets the same notch / long-press affordance as the CQ button, opening a new **Hunt options** sheet:

### Hunt priority (which CQ Hunt answers first when several decode in one cycle)
- **Latest** — most recent decode (historical behavior, default)
- **Strongest** — best SNR first, best odds of completing
- **Weakest** — weakest first, for QRP/challenge hunting
- **Farthest** — chase DX first (grid-distance based)
- **POTA/SOTA** — activators first; parks not yet in the hunted log rank above already-hunted parks
- **New DXCC** — unworked entities first
- **New grid** — unworked grid squares first

### Smart filters (features other FT8 apps don't have)
- **Avoid pileups** — prefers CQ callers no one else in the decode window is already answering. Soft preference: if every caller has a pileup, Hunt still picks one rather than sit idle.
- **Minimum signal** (Off / −10 / −15 / −20 dB) — hard floor so Hunt doesn't start QSOs that are likely to fizzle. Decodes with no SNR still pass (the decoder occasionally omits it).

A non-default priority shows a short tag under the HUNT label (STRONG/WEAK/DX/POTA/DXCC/GRID), mirroring the CQ button's FREE/FD subtitle. Options apply immediately mid-hunt and persist across launches.

## How

- **`HuntTargetSelector.kt`** (new): pure ranking logic (`selectHuntCandidate`, `passesSnrFloor`, `countRepliesTo`, `huntPriorityFromConfig`) plus a `@JvmStatic pick()` bridge for the Java engine. Distance/park/pileup lookups only run when the active options need them; `LATEST` with no filters short-circuits to the old behavior with zero extra per-cycle work.
- **`FT8TransmitSignal.checkCQMeOrFollowCQMessage`**: the hunt scan now collects all qualifying CQs (same eligibility filters as before: worked-before skip, exclusions, POTA-only filter, directional-CQ respect) and lets the selector choose, instead of taking the first match. The debug log line now includes the active priority and candidate count.
- **Persistence**: three new config keys (`huntPriority`, `huntAvoidPileups`, `huntMinSnr`) following the `GeneralVariables` static + `DatabaseOpr.writeConfig`/parse pattern; statics are `volatile` (UI thread writes, transmit thread reads), matching `huntPotaOnly`.
- **`TxStrip.StackedActionButton`**: gains an optional options notch + long-press + subtitle, mirroring `PrimaryActionButton`; the TX-slot button is unchanged.
- **`HuntOptionsSheet.kt`** (new): follows the `CqOptionsSheet` layout/chip conventions.

## Tests

- `HuntTargetSelectorTest` — 24 cases: config parsing fallback, SNR-floor semantics (incl. unknown SNR), every priority mode incl. unknown-SNR/-distance handling, freshest-decode tie-breaks, pileup soft-fallback, reply counting.
- `HuntOptionsLogicTest` — subtitle tags (exhaustive over the enum, length-bounded), min-SNR chip data/labels.
- Full `testDebugUnitTest` suite green; `assembleDebug` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)