### PR TITLE
Fix non-portable ADIF export fields and surface upload failure reasons

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -30,6 +30,7 @@ import com.k1af.ft8af.callsign.CallsignInfo;
 import com.k1af.ft8af.connector.ConnectMode;
 import com.k1af.ft8af.ft8signal.FT8Package;
 import com.k1af.ft8af.log.AdifFormat;
+import com.k1af.ft8af.log.AdifRecord;
 import com.k1af.ft8af.log.OnQueryQSLCallsign;
 import com.k1af.ft8af.log.OnQueryQSLRecordCallsign;
 import com.k1af.ft8af.log.QSLCallsignRecord;
@@ -1240,144 +1241,63 @@ public class DatabaseOpr extends SQLiteOpenHelper {
     public String downQSLTable(Cursor cursor, boolean isSWL) {
         StringBuilder logStr = new StringBuilder();
 
-        logStr.append("FT8AF ADIF Export<eoh>\n");
+        logStr.append(AdifRecord.HEADER);
         cursor.moveToPosition(-1);
         while (cursor.moveToNext()) {
-            logStr.append(com.k1af.ft8af.log.AdifFormat.callField(
-                    cursor.getString(cursor.getColumnIndex("call"))));
-            if (!isSWL) {
-                if (cursor.getInt(cursor.getColumnIndex("isLotW_QSL")) == 1) {
-                    logStr.append("<QSL_RCVD:1>Y ");
-                } else {
-                    logStr.append("<QSL_RCVD:1>N ");
-                }
-                if (cursor.getInt(cursor.getColumnIndex("isQSL")) == 1) {
-                    logStr.append("<QSL_MANUAL:1>Y ");
-                } else {
-                    logStr.append("<QSL_MANUAL:1>N ");
-                }
-            } else {
-                logStr.append("<swl:1>Y ");
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("gridsquare")) != null) {
-                logStr.append(String.format(Locale.US, "<gridsquare:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("gridsquare")))
-                        , cursor.getString(cursor.getColumnIndex("gridsquare"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("mode")) != null) {
-                // FT4/FT2 are ADIF submodes of MFSK, not standalone modes — a bare
-                // <mode>FT2 is rejected as invalid by pota.app and other ADIF consumers.
-                String mode = cursor.getString(cursor.getColumnIndex("mode"));
-                String submode = AdifFormat.mfskSubmode(mode);
-                if (submode != null) {
-                    logStr.append(String.format(Locale.US, "<mode:4>MFSK <submode:%d>%s "
-                            , AdifFormat.utf8Length(submode), submode));
-                } else {
-                    logStr.append(String.format(Locale.US, "<mode:%d>%s "
-                            , AdifFormat.utf8Length(mode), mode));
-                }
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("rst_sent")) != null) {
-                logStr.append(String.format(Locale.US, "<rst_sent:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("rst_sent")))
-                        , cursor.getString(cursor.getColumnIndex("rst_sent"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("rst_rcvd")) != null) {
-                logStr.append(String.format(Locale.US, "<rst_rcvd:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("rst_rcvd")))
-                        , cursor.getString(cursor.getColumnIndex("rst_rcvd"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("qso_date")) != null) {
-                logStr.append(String.format(Locale.US, "<qso_date:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("qso_date")))
-                        , cursor.getString(cursor.getColumnIndex("qso_date"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("time_on")) != null) {
-                logStr.append(String.format(Locale.US, "<time_on:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("time_on")))
-                        , cursor.getString(cursor.getColumnIndex("time_on"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("qso_date_off")) != null) {
-                logStr.append(String.format(Locale.US, "<qso_date_off:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("qso_date_off")))
-                        , cursor.getString(cursor.getColumnIndex("qso_date_off"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("time_off")) != null) {
-                logStr.append(String.format(Locale.US, "<time_off:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("time_off")))
-                        , cursor.getString(cursor.getColumnIndex("time_off"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("band")) != null) {
-                logStr.append(String.format(Locale.US, "<band:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("band")))
-                        , cursor.getString(cursor.getColumnIndex("band"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("freq")) != null) {
-                logStr.append(String.format(Locale.US, "<freq:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("freq")))
-                        , cursor.getString(cursor.getColumnIndex("freq"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("station_callsign")) != null) {
-                logStr.append(String.format(Locale.US, "<station_callsign:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("station_callsign")))
-                        , cursor.getString(cursor.getColumnIndex("station_callsign"))));
-            }
-
-            if (cursor.getString(cursor.getColumnIndex("my_gridsquare")) != null) {
-                logStr.append(String.format(Locale.US, "<my_gridsquare:%d>%s "
-                        , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("my_gridsquare")))
-                        , cursor.getString(cursor.getColumnIndex("my_gridsquare"))));
-            }
-
-            if (cursor.getColumnIndex("operator") != -1) {
-                if (cursor.getString(cursor.getColumnIndex("operator")) != null) {
-                    logStr.append(String.format(Locale.US, "<operator:%d>%s "
-                            , AdifFormat.utf8Length(cursor.getString(cursor.getColumnIndex("operator")))
-                            , cursor.getString(cursor.getColumnIndex("operator"))));
-                }
-            }
-
-            // POTA ADIF fields — emitted only when populated so non-POTA rows
-            // remain byte-identical to the prior upload format.
-            appendPotaField(logStr, cursor, "my_sig", "MY_SIG");
-            appendPotaField(logStr, cursor, "my_sig_info", "MY_SIG_INFO");
-            appendPotaField(logStr, cursor, "sig", "SIG");
-            appendPotaField(logStr, cursor, "sig_info", "SIG_INFO");
-
-            String comment = cursor.getString(cursor.getColumnIndex("comment"));
-            if (comment == null) {
-                comment = "";
-            }
-
-            //<comment:15>Distance: 99 km <eor>
-            //When writing to db, must append " km"
-            logStr.append(String.format(Locale.US, "<comment:%d>%s <eor>\n"
-                    , AdifFormat.utf8Length(comment)
-                    , comment));
+            logStr.append(adifRecordFromCursor(cursor, isSWL).build());
         }
 
         cursor.close();
         return logStr.toString();
     }
 
-    /** Append a POTA ADIF field if the column exists and is non-empty. */
-    private static void appendPotaField(StringBuilder sb, Cursor cursor, String column, String adifName) {
+    /**
+     * Map one QSLTable cursor row onto the shared {@link AdifRecord} builder.
+     *
+     * <p>This used to hand-roll the whole record inline, duplicating
+     * {@link AdifRecord#build()} field for field — and the two copies drifted. Routing
+     * both through the one builder means a formatting fix lands in every export at once
+     * instead of only in whichever twin someone remembered to edit.
+     *
+     * <p>{@code operator} and the POTA columns are read defensively: this cursor arrives
+     * from several different queries and not all of them select those columns.
+     */
+    static AdifRecord adifRecordFromCursor(Cursor cursor, boolean isSWL) {
+        return new AdifRecord()
+                .call(colStr(cursor, "call"))
+                .swl(isSWL)
+                .lotwQsl(colInt(cursor, "isLotW_QSL") == 1)
+                .manualQsl(colInt(cursor, "isQSL") == 1)
+                .gridsquare(colStr(cursor, "gridsquare"))
+                .mode(colStr(cursor, "mode"))
+                .rstSent(colStr(cursor, "rst_sent"))
+                .rstRcvd(colStr(cursor, "rst_rcvd"))
+                .qsoDate(colStr(cursor, "qso_date"))
+                .timeOn(colStr(cursor, "time_on"))
+                .qsoDateOff(colStr(cursor, "qso_date_off"))
+                .timeOff(colStr(cursor, "time_off"))
+                .band(colStr(cursor, "band"))
+                .freq(colStr(cursor, "freq"))
+                .stationCallsign(colStr(cursor, "station_callsign"))
+                .myGridsquare(colStr(cursor, "my_gridsquare"))
+                .operator(colStr(cursor, "operator"))
+                .mySig(colStr(cursor, "my_sig"))
+                .mySigInfo(colStr(cursor, "my_sig_info"))
+                .sig(colStr(cursor, "sig"))
+                .sigInfo(colStr(cursor, "sig_info"))
+                .comment(colStr(cursor, "comment"));
+    }
+
+    /** Cursor string read that tolerates the column being absent from this query. */
+    private static String colStr(Cursor cursor, String column) {
         int idx = cursor.getColumnIndex(column);
-        if (idx < 0) return;
-        String value = cursor.getString(idx);
-        if (value == null || value.isEmpty()) return;
-        sb.append(String.format(Locale.US, "<%s:%d>%s ", adifName, AdifFormat.utf8Length(value), value));
+        return idx < 0 ? null : cursor.getString(idx);
+    }
+
+    /** Cursor int read that tolerates the column being absent from this query. */
+    private static int colInt(Cursor cursor, String column) {
+        int idx = cursor.getColumnIndex(column);
+        return idx < 0 ? 0 : cursor.getInt(idx);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifRecord.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/AdifRecord.java
@@ -22,16 +22,28 @@ import java.util.Locale;
  *       value, not UTF-16 chars, so non-ASCII content (comments, park names) stays aligned.</li>
  * </ul>
  *
- * <p>Fields left {@code null} are omitted entirely; a field set to {@code ""} is still
- * emitted (as a zero-length field) to match the historical export behaviour. The POTA
- * fields ({@code MY_SIG}, {@code MY_SIG_INFO}, {@code SIG}, {@code SIG_INFO}) are the
- * exception: they are emitted only when non-null <em>and</em> non-empty so ordinary
- * non-POTA contacts stay clean.
+ * <p>Fields that are {@code null} <em>or</em> empty are omitted entirely. Emitting a
+ * zero-length field ({@code <gridsquare:0> }) instead — as this class used to for empty
+ * strings — is not portable: several ADIF importers treat a length-0 field as malformed
+ * and reject the whole record rather than reading it as "absent". An absent optional
+ * field means the same thing to every parser, so that is what we write.
  */
 public final class AdifRecord {
 
     /** Header (with {@code <eoh>}) written once at the top of a fresh ADIF file. */
     public static final String HEADER = "FT8AF ADIF Export<eoh>\n";
+
+    /**
+     * Application-defined field carrying the "manually confirmed" flag. ADIF has no
+     * {@code QSL_MANUAL} field — that bare name (which FT8AF wrote until this change)
+     * is non-conformant. {@code APP_<PROGRAMID>_<FIELD>} is the spec's escape hatch for
+     * program-specific data. {@link QSLRecord} still reads the legacy bare name so ADIF
+     * files exported by older builds keep round-tripping.
+     */
+    public static final String APP_QSL_MANUAL = "APP_FT8AF_QSL_MANUAL";
+
+    /** Legacy, non-conformant name for {@link #APP_QSL_MANUAL}. Read-only: never emitted. */
+    public static final String LEGACY_QSL_MANUAL = "QSL_MANUAL";
 
     private String call;
     private boolean swl;
@@ -58,7 +70,7 @@ public final class AdifRecord {
 
     public AdifRecord call(String v) { this.call = v; return this; }
 
-    /** SWL record: emits {@code <swl:1>Y } instead of the QSL_RCVD/QSL_MANUAL pair. */
+    /** SWL record: emits {@code <swl:1>Y } instead of the QSL_RCVD/APP_FT8AF_QSL_MANUAL pair. */
     public AdifRecord swl(boolean v) { this.swl = v; return this; }
 
     public AdifRecord lotwQsl(boolean v) { this.lotwQsl = v; return this; }
@@ -112,10 +124,18 @@ public final class AdifRecord {
             sb.append("<swl:1>Y ");
         } else {
             sb.append(lotwQsl ? "<QSL_RCVD:1>Y " : "<QSL_RCVD:1>N ");
-            sb.append(manualQsl ? "<QSL_MANUAL:1>Y " : "<QSL_MANUAL:1>N ");
+            // QSL_MANUAL is not an ADIF field. The spec reserves the APP_<PROGRAMID>_
+            // prefix for application-defined fields, so a strict importer can skip ours
+            // instead of erroring on an unrecognised bare name. QSL_RCVD above *is*
+            // standard and keeps its name.
+            sb.append(manualQsl
+                    ? "<" + APP_QSL_MANUAL + ":1>Y "
+                    : "<" + APP_QSL_MANUAL + ":1>N ");
         }
-        appendIfNotNull(sb, "gridsquare", gridsquare);
-        if (mode != null) {
+        appendIfNotEmpty(sb, "gridsquare", gridsquare);
+        // Empty as well as null: mode has its own branch (for the MFSK submode split) and
+        // so bypasses appendIfNotEmpty, which is exactly how it kept emitting <mode:0>.
+        if (mode != null && !mode.isEmpty()) {
             // FT4/FT2 are ADIF submodes of MFSK, not standalone modes — a bare <mode>FT2 is
             // rejected as invalid by pota.app and other ADIF consumers.
             String submode = AdifFormat.mfskSubmode(mode);
@@ -126,24 +146,24 @@ public final class AdifRecord {
                 appendField(sb, "mode", mode);
             }
         }
-        appendIfNotNull(sb, "rst_sent", rstSent);
-        appendIfNotNull(sb, "rst_rcvd", rstRcvd);
-        appendIfNotNull(sb, "qso_date", qsoDate);
-        appendIfNotNull(sb, "time_on", timeOn);
-        appendIfNotNull(sb, "qso_date_off", qsoDateOff);
-        appendIfNotNull(sb, "time_off", timeOff);
-        appendIfNotNull(sb, "band", band);
-        appendIfNotNull(sb, "freq", freq);
-        appendIfNotNull(sb, "station_callsign", stationCallsign);
-        appendIfNotNull(sb, "my_gridsquare", myGridsquare);
-        appendIfNotNull(sb, "operator", operator);
+        appendIfNotEmpty(sb, "rst_sent", rstSent);
+        appendIfNotEmpty(sb, "rst_rcvd", rstRcvd);
+        appendIfNotEmpty(sb, "qso_date", qsoDate);
+        appendIfNotEmpty(sb, "time_on", timeOn);
+        appendIfNotEmpty(sb, "qso_date_off", qsoDateOff);
+        appendIfNotEmpty(sb, "time_off", timeOff);
+        appendIfNotEmpty(sb, "band", band);
+        appendIfNotEmpty(sb, "freq", freq);
+        appendIfNotEmpty(sb, "station_callsign", stationCallsign);
+        appendIfNotEmpty(sb, "my_gridsquare", myGridsquare);
+        appendIfNotEmpty(sb, "operator", operator);
         // POTA fields. Only emit when populated so non-POTA QSOs stay clean.
         appendIfNotEmpty(sb, "MY_SIG", mySig);
         appendIfNotEmpty(sb, "MY_SIG_INFO", mySigInfo);
         appendIfNotEmpty(sb, "SIG", sig);
         appendIfNotEmpty(sb, "SIG_INFO", sigInfo);
-        String c = comment == null ? "" : comment;
-        sb.append(String.format(Locale.US, "<comment:%d>%s <eor>\n", utf8Length(c), c));
+        appendIfNotEmpty(sb, "comment", comment);
+        sb.append("<eor>\n");
         return sb.toString();
     }
 
@@ -152,13 +172,11 @@ public final class AdifRecord {
         return build().getBytes(StandardCharsets.UTF_8);
     }
 
-    /** Emit a field when the value is non-null (an empty value still emits a zero-length field). */
-    private static void appendIfNotNull(StringBuilder sb, String name, String value) {
-        if (value == null) return;
-        appendField(sb, name, value);
-    }
-
-    /** Emit a field only when the value is non-null and non-empty (POTA fields). */
+    /**
+     * Emit a field only when the value is non-null and non-empty. Omitting an empty
+     * optional field is the portable way to say "no value"; a zero-length field is not
+     * (see the class javadoc).
+     */
     private static void appendIfNotEmpty(StringBuilder sb, String name, String value) {
         if (value == null || value.isEmpty()) return;
         appendField(sb, name, value);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/QSLRecord.java
@@ -188,8 +188,17 @@ public class QSLRecord {
         if (map.containsKey("LOTW_QSL_RCVD")) {//QSO confirmation; present in Log32.
             isLotW_QSL = Objects.requireNonNull(map.get("LOTW_QSL_RCVD")).equalsIgnoreCase("Y");
         }
-        if (map.containsKey("QSL_MANUAL")) {//Manual QSO confirmation; present in LoTW.
-            isQSL = Objects.requireNonNull(map.get("QSL_MANUAL")).equalsIgnoreCase("Y");
+        // Manual QSO confirmation. We now export this as APP_FT8AF_QSL_MANUAL (ADIF has
+        // no QSL_MANUAL field), but files written by older FT8AF builds — and by other
+        // loggers that copied the bare name — must keep importing, so accept both. The
+        // conformant name wins when a file somehow carries both.
+        if (map.containsKey(AdifRecord.LEGACY_QSL_MANUAL)) {
+            isQSL = Objects.requireNonNull(
+                    map.get(AdifRecord.LEGACY_QSL_MANUAL)).equalsIgnoreCase("Y");
+        }
+        if (map.containsKey(AdifRecord.APP_QSL_MANUAL)) {
+            isQSL = Objects.requireNonNull(
+                    map.get(AdifRecord.APP_QSL_MANUAL)).equalsIgnoreCase("Y");
         }
 
         if (map.containsKey("MY_GRIDSQUARE")) {//My grid (present in LoTW/Log32, may be absent depending on LoTW settings); N1MM has no grid

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -328,8 +328,20 @@ public class ThirdPartyService {
      * Returns true on HTTP 2xx, false otherwise.
      */
     public static boolean uploadAdifToCloudlog(String adif) {
+        return uploadAdifToCloudlog(adif, null);
+    }
+
+    /**
+     * As {@link #uploadAdifToCloudlog(String)}, but records why the upload failed into
+     * {@code failureOut} when one is supplied, so callers can surface the server's own
+     * explanation instead of a bare "0 uploaded".
+     */
+    public static boolean uploadAdifToCloudlog(String adif, StringBuilder failureOut) {
         String address = GeneralVariables.getCloudlogServerAddress();
-        if (address == null || address.isEmpty()) return false;
+        if (address == null || address.isEmpty()) {
+            appendFailure(failureOut, "no server address configured");
+            return false;
+        }
         if (!address.endsWith("/")){
             address+="/";
         }
@@ -340,11 +352,13 @@ public class ThirdPartyService {
             // Cloudlog's documented endpoint is /api/qso (no trailing slash). Wavelog and
             // Nextlog both 308-redirect when the trailing slash is present, which
             // HttpURLConnection won't follow on a POST.
-            String clRes = sendPostRequest(address+"api/qso",result);
+            String clRes = sendPostRequest(address+"api/qso", result, failureOut);
             Log.d(TAG, "Cloudlog upload " + (clRes != null ? "succeeded" : "failed"));
             return clRes != null;
         }catch (Exception k){
             Log.d(TAG, "Cloudlog upload error: " + k.getClass().getSimpleName());
+            appendFailure(failureOut, k.getClass().getSimpleName()
+                    + (k.getMessage() != null ? ": " + k.getMessage() : ""));
             return false;
         }
     }
@@ -409,8 +423,20 @@ public class ThirdPartyService {
      * still a success from a "the record is now on QRZ" standpoint).
      */
     public static boolean uploadAdifToQrz(String adif) {
+        return uploadAdifToQrz(adif, null);
+    }
+
+    /**
+     * As {@link #uploadAdifToQrz(String)}, but records the rejection reason into
+     * {@code failureOut} when one is supplied. QRZ answers with {@code RESULT=FAIL}
+     * plus a {@code REASON=...} pair, which is worth showing verbatim.
+     */
+    public static boolean uploadAdifToQrz(String adif, StringBuilder failureOut) {
         String apikey = GeneralVariables.getQrzApiKey();
-        if (apikey == null || apikey.isEmpty()) return false;
+        if (apikey == null || apikey.isEmpty()) {
+            appendFailure(failureOut, "no API key configured");
+            return false;
+        }
         try {
             // POST keeps both the API key and the ADIF payload out of the URL.
             String body = "KEY=" + URLEncoder.encode(apikey, StandardCharsets.UTF_8.name())
@@ -418,14 +444,52 @@ public class ThirdPartyService {
                     + "&ADIF=" + URLEncoder.encode(adif, StandardCharsets.UTF_8.name());
             String result = sendPostFormRequest("https://logbook.qrz.com/api", body);
             Log.d(TAG, "QRZ upload " + (result != null ? "succeeded" : "failed"));
-            if (result == null) return false;
+            if (result == null) {
+                appendFailure(failureOut, "no response from QRZ");
+                return false;
+            }
             // QRZ encodes status as RESULT=OK|FAIL|REPLACE within an &-separated body
             String qrzResult = parseQrzResult(result);
-            return "OK".equals(qrzResult) || "REPLACE".equals(qrzResult);
+            if ("OK".equals(qrzResult) || "REPLACE".equals(qrzResult)) {
+                return true;
+            }
+            appendFailure(failureOut, describeQrzFailure(result));
+            return false;
         }catch (Exception k){
             Log.d(TAG, "QRZ upload error: " + k.getClass().getSimpleName());
+            appendFailure(failureOut, k.getClass().getSimpleName()
+                    + (k.getMessage() != null ? ": " + k.getMessage() : ""));
             return false;
         }
+    }
+
+    /**
+     * Summarise a rejected QRZ upload as {@code RESULT=<r>} plus QRZ's {@code REASON}
+     * when it supplied one. Pure (no network) so it is unit-testable.
+     *
+     * <p>Deliberately does not echo the whole response: it contains the submitted ADIF,
+     * and this string is written to {@code debug.log}.
+     */
+    static String describeQrzFailure(String response) {
+        String result = parseQrzResult(response);
+        StringBuilder sb = new StringBuilder("RESULT=")
+                .append(result == null ? "(none)" : result);
+        if (response != null) {
+            for (String s : response.split("&")) {
+                String[] kv = s.split("=", 2);
+                if (kv.length > 1 && "REASON".equalsIgnoreCase(kv[0].trim())) {
+                    String reason = kv[1].replaceAll("\\s+", " ").trim();
+                    if (!reason.isEmpty()) {
+                        if (reason.length() > MAX_FAILURE_LEN) {
+                            reason = reason.substring(0, MAX_FAILURE_LEN) + "…";
+                        }
+                        sb.append(": ").append(reason);
+                    }
+                    break;
+                }
+            }
+        }
+        return sb.toString();
     }
 
     /**
@@ -458,14 +522,30 @@ public class ThirdPartyService {
         public final int qrzOk;
         public final boolean cloudlogAttempted;
         public final boolean qrzAttempted;
+        /**
+         * Why the first failed Cloudlog upload of this run failed, or null if none did.
+         * Only the first is kept: when a server is broken every row fails the same way,
+         * and repeating that 113 times helps nobody.
+         */
+        public final String cloudlogError;
+        /** Same, for QRZ. */
+        public final String qrzError;
 
-        SyncResult(int total, int cloudlogOk, int qrzOk,
-                   boolean cloudlogAttempted, boolean qrzAttempted) {
+        public SyncResult(int total, int cloudlogOk, int qrzOk,
+                          boolean cloudlogAttempted, boolean qrzAttempted) {
+            this(total, cloudlogOk, qrzOk, cloudlogAttempted, qrzAttempted, null, null);
+        }
+
+        public SyncResult(int total, int cloudlogOk, int qrzOk,
+                          boolean cloudlogAttempted, boolean qrzAttempted,
+                          String cloudlogError, String qrzError) {
             this.total = total;
             this.cloudlogOk = cloudlogOk;
             this.qrzOk = qrzOk;
             this.cloudlogAttempted = cloudlogAttempted;
             this.qrzAttempted = qrzAttempted;
+            this.cloudlogError = cloudlogError;
+            this.qrzError = qrzError;
         }
     }
 
@@ -523,6 +603,8 @@ public class ThirdPartyService {
         int total = 0;
         int cloudlogOk = 0;
         int qrzOk = 0;
+        String cloudlogError = null;
+        String qrzError = null;
         if (db == null || (!cl && !qrz)) {
             return new SyncResult(0, 0, 0, cl, qrz);
         }
@@ -545,16 +627,22 @@ public class ThirdPartyService {
                 boolean alreadyQrz = syncedQrzCol >= 0 && cursor.getInt(syncedQrzCol) == 1;
                 if (cl && !alreadyCl) {
                     String adif = buildAdifFromCursor(cursor, ServiceType.Cloudlog);
-                    if (uploadAdifToCloudlog(adif)) {
+                    StringBuilder why = cloudlogError == null ? new StringBuilder() : null;
+                    if (uploadAdifToCloudlog(adif, why)) {
                         cloudlogOk++;
                         if (rowId >= 0) markRowSynced(db, rowId, "synced_cloudlog");
+                    } else if (why != null && why.length() > 0) {
+                        cloudlogError = why.toString();
                     }
                 }
                 if (qrz && !alreadyQrz) {
                     String adif = buildAdifFromCursor(cursor, ServiceType.QRZ);
-                    if (uploadAdifToQrz(adif)) {
+                    StringBuilder why = qrzError == null ? new StringBuilder() : null;
+                    if (uploadAdifToQrz(adif, why)) {
                         qrzOk++;
                         if (rowId >= 0) markRowSynced(db, rowId, "synced_qrz");
+                    } else if (why != null && why.length() > 0) {
+                        qrzError = why.toString();
                     }
                 }
                 done++;
@@ -565,7 +653,7 @@ public class ThirdPartyService {
         } finally {
             if (cursor != null) cursor.close();
         }
-        return new SyncResult(total, cloudlogOk, qrzOk, cl, qrz);
+        return new SyncResult(total, cloudlogOk, qrzOk, cl, qrz, cloudlogError, qrzError);
     }
 
     /**
@@ -664,6 +752,21 @@ public class ThirdPartyService {
     }
 
     public static String sendPostRequest(String url, String json) throws IOException {
+        return sendPostRequest(url, json, null);
+    }
+
+    /**
+     * As {@link #sendPostRequest(String, String)}, but when the POST fails and
+     * {@code failureOut} is non-null, the reason is appended to it — HTTP status plus
+     * whatever the server said in the error body.
+     *
+     * <p>Why this exists: the failure reason used to go only to {@code Log.d}, so a server
+     * that rejected every upload looked identical in {@code debug.log} to "nothing to do".
+     * A Cloudlog-compatible backend reports real, actionable problems this way (a missing
+     * DB column, a bad station id, an expired key), and none of it was reaching the user.
+     */
+    static String sendPostRequest(String url, String json, StringBuilder failureOut)
+            throws IOException {
         // HttpURLConnection does not auto-follow 30x on a POST. Walk redirects manually
         // (capped) so deployments that rewrite trailing slashes, http→https, or move
         // the API path still work.
@@ -703,6 +806,8 @@ public class ThirdPartyService {
                     if (loc == null || loc.isEmpty()) {
                         Log.d(TAG, "POST " + redactUrlApiKey(currentUrl) + " -> HTTP "
                                 + responseCode + " (no Location header)");
+                        appendFailure(failureOut,
+                                "HTTP " + responseCode + " redirect with no Location header");
                         return null;
                     }
                     // Resolve relative redirect against the previous URL.
@@ -730,6 +835,7 @@ public class ThirdPartyService {
                 } catch (Exception ignored) {}
                 Log.d(TAG, "POST " + redactUrlApiKey(currentUrl) + " -> HTTP " + responseCode
                         + (err.length() > 0 ? " body=" + err : ""));
+                appendFailure(failureOut, describeHttpFailure(responseCode, err.toString()));
                 return null;
             } finally {
                 if (conn != null) {
@@ -741,7 +847,40 @@ public class ThirdPartyService {
             }
         }
         Log.d(TAG, "POST " + redactUrlApiKey(url) + " exceeded redirect limit");
+        appendFailure(failureOut, "exceeded redirect limit");
         return null;
+    }
+
+    private static void appendFailure(StringBuilder failureOut, String reason) {
+        if (failureOut == null || reason == null || reason.isEmpty()) return;
+        if (failureOut.length() > 0) failureOut.append("; ");
+        failureOut.append(reason);
+    }
+
+    /** Longest failure description we keep. Server error bodies can be whole HTML pages. */
+    private static final int MAX_FAILURE_LEN = 200;
+
+    /**
+     * Render an HTTP failure as one short line: the status, plus the server's error body
+     * when it carried one. Pure (no network, no Android) so it is unit-testable.
+     *
+     * <p>The body is collapsed to a single line and truncated — Cloudlog-compatible
+     * backends answer with a compact JSON envelope whose {@code messages} array holds the
+     * real cause, but a misconfigured proxy can just as easily return an HTML error page,
+     * and neither {@code debug.log} nor a toast wants all of that.
+     */
+    static String describeHttpFailure(int responseCode, String body) {
+        StringBuilder sb = new StringBuilder("HTTP ").append(responseCode);
+        if (body != null) {
+            String flat = body.replaceAll("\\s+", " ").trim();
+            if (!flat.isEmpty()) {
+                if (flat.length() > MAX_FAILURE_LEN) {
+                    flat = flat.substring(0, MAX_FAILURE_LEN) + "…";
+                }
+                sb.append(": ").append(flat);
+            }
+        }
+        return sb.toString();
     }
     public static String sendPostFormRequest(String url, String formBody) throws IOException {
         HttpURLConnection conn = null;

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSync.kt
@@ -57,6 +57,24 @@ internal class QsoSyncGate(private val minIntervalMs: Long = 15_000L) {
 }
 
 /**
+ * Render a finished sync run as the one line that goes into `debug.log`.
+ *
+ * Always reports the counts; appends each service's failure reason when it had one. The
+ * counts alone are ambiguous in the worst case — `cloudlog=0 of 113` reads the same
+ * whether the network was down, the API key expired, or the server was rejecting every
+ * record — and that ambiguity once hid a broken logbook server for three days. Pure
+ * (no Android types) so it is unit-testable.
+ */
+internal fun summarize(result: ThirdPartyService.SyncResult): String {
+    val sb = StringBuilder(
+        "cloudlog=${result.cloudlogOk} qrz=${result.qrzOk} of ${result.total}"
+    )
+    result.cloudlogError?.takeIf { it.isNotEmpty() }?.let { sb.append(" cloudlogError=").append(it) }
+    result.qrzError?.takeIf { it.isNotEmpty() }?.let { sb.append(" qrzError=").append(it) }
+    return sb.toString()
+}
+
+/**
  * Auto-uploads QSOs that failed to upload while offline. When a QSO is logged with no
  * internet, the immediate post-QSO upload fails and the row's `synced_*` flags stay 0;
  * this re-runs the existing catch-up uploader ([ThirdPartyService.syncAllQSOs]) the
@@ -149,7 +167,7 @@ class QsoAutoSync(private val appContext: Context) {
                 }
                 log("start ($reason): $pending pending")
                 val result = ThirdPartyService.syncAllQSOs(db, null)
-                log("done ($reason): cloudlog=${result.cloudlogOk} qrz=${result.qrzOk} of ${result.total}")
+                log("done ($reason): " + summarize(result))
             } catch (e: Exception) {
                 log("error ($reason): ${e.javaClass.simpleName} ${e.message}")
             } finally {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifLengthTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprAdifLengthTest.java
@@ -23,9 +23,11 @@ import org.robolectric.RobolectricTestRunner;
  * requires), not the UTF-16 {@link String#length()} char count. The two differ for any non-ASCII
  * content (an accented comment, an international POTA park name): declaring the shorter char count
  * makes a byte-correct consumer (LoTW/QRZ/Cloudlog) read fewer bytes than were written, truncating
- * the field and mis-aligning the record boundary. The canonical writer {@link
- * com.k1af.ft8af.log.AdifRecord} already uses {@code AdifFormat.utf8Length}; this covers the
- * un-migrated {@code downQSLTable} twin used by the built-in web logbook download.
+ * the field and mis-aligning the record boundary.
+ *
+ * <p>{@code downQSLTable} — the built-in web logbook's download — now builds its records through
+ * the canonical {@link com.k1af.ft8af.log.AdifRecord} rather than its own inline copy, so these
+ * cases are covered twice over. They stay here as the guard on the cursor-to-record mapping.
  */
 @RunWith(RobolectricTestRunner.class)
 public class DatabaseOprAdifLengthTest {
@@ -103,10 +105,39 @@ public class DatabaseOprAdifLengthTest {
     }
 
     @Test
-    public void nullComment_doesNotThrow_emitsEmptyField() {
+    public void nullComment_doesNotThrow_andIsOmittedEntirely() {
         // Previously comment.length() NPE'd on a NULL comment, aborting the whole download.
+        // It then emitted "<comment:0> " instead; a zero-length field is not portable, so an
+        // absent comment is now simply absent.
         String adif = export(null, null, null);
-        assertThat(adif).contains("<comment:0> <eor>");
+        assertThat(adif).doesNotContain("comment");
+        assertThat(adif).endsWith("<eor>\n");
+    }
+
+    @Test
+    public void emptyOptionalColumns_produceNoZeroLengthFields() {
+        // Regression: a QSO logged without a grid (the other station never sent one) used to
+        // export "<gridsquare:0> ", which strict ADIF importers reject.
+        MatrixCursor cursor = new MatrixCursor(COLUMNS);
+        cursor.addRow(new Object[]{
+                "W1AW", 0, 0, "", "FT8", "", "",
+                "20260101", "1200", "", "", "20m", "14074000",
+                "", "", "",
+                "", "", "", "", ""
+        });
+        String adif = opr.downQSLTable(cursor, false);
+
+        assertThat(adif).doesNotContain(":0>");
+        assertThat(adif).contains("<call:4>W1AW ");
+        assertThat(adif).endsWith("<eor>\n");
+    }
+
+    @Test
+    public void webLogbookExport_usesTheConformantManualQslFieldName() {
+        // The web logbook download and the file export must agree; both go through AdifRecord.
+        String adif = export("QSO by FT8AF", null, null);
+        assertThat(adif).contains("<APP_FT8AF_QSL_MANUAL:1>N ");
+        assertThat(adif).doesNotContain("<QSL_MANUAL:");
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifRecordTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/AdifRecordTest.java
@@ -20,7 +20,7 @@ public class AdifRecordTest {
 
     /** Matches an ADIF field: name, declared length, then value up to the trailing space. */
     private static final Pattern FIELD =
-            Pattern.compile("<([A-Za-z_]+):(\\d+)>([^<]*?) (?=<|$)");
+            Pattern.compile("<([A-Za-z0-9_]+):(\\d+)>([^<]*?) (?=<|$)");
 
     @Test
     public void oneQso_producesExactlyOneEorRecord() {
@@ -45,8 +45,18 @@ public class AdifRecordTest {
     public void nonSwl_emitsQslRcvdAndManualPair() {
         String out = new AdifRecord().call("W1AW").lotwQsl(true).manualQsl(false).build();
         assertThat(out).contains("<QSL_RCVD:1>Y ");
-        assertThat(out).contains("<QSL_MANUAL:1>N ");
+        assertThat(out).contains("<APP_FT8AF_QSL_MANUAL:1>N ");
         assertThat(out).doesNotContain("<swl:");
+    }
+
+    @Test
+    public void manualQsl_usesAppPrefixNotTheBareNonStandardName() {
+        // ADIF has no QSL_MANUAL field. Emitting the bare name makes a strict importer
+        // reject or warn on every record; APP_<PROGRAMID>_<FIELD> is the spec's mechanism
+        // for program-specific data and is safely skippable by consumers that don't know it.
+        String out = new AdifRecord().call("W1AW").manualQsl(true).build();
+        assertThat(out).contains("<APP_FT8AF_QSL_MANUAL:1>Y ");
+        assertThat(out).doesNotContain("<QSL_MANUAL:");
     }
 
     @Test
@@ -54,7 +64,7 @@ public class AdifRecordTest {
         String out = new AdifRecord().call("W1AW").swl(true).lotwQsl(true).build();
         assertThat(out).contains("<swl:1>Y ");
         assertThat(out).doesNotContain("<QSL_RCVD:");
-        assertThat(out).doesNotContain("<QSL_MANUAL:");
+        assertThat(out).doesNotContain("QSL_MANUAL");
     }
 
     @Test
@@ -100,19 +110,44 @@ public class AdifRecordTest {
     }
 
     @Test
-    public void nullFieldsAreOmittedButEmptyStringsAreEmitted() {
-        // gridsquare == null -> omitted entirely.
+    public void nullAndEmptyFieldsAreBothOmitted() {
+        // Regression: an empty grid used to emit "<gridsquare:0> ". Several ADIF importers
+        // treat a length-0 field as malformed and reject the whole record, so an absent
+        // optional field is the only portable way to say "no value".
         assertThat(new AdifRecord().call("W1AW").gridsquare(null).build())
                 .doesNotContain("gridsquare");
-        // gridsquare == "" -> still emitted as a zero-length field (historical behaviour).
         assertThat(new AdifRecord().call("W1AW").gridsquare("").build())
-                .contains("<gridsquare:0> ");
+                .doesNotContain("gridsquare");
     }
 
     @Test
-    public void comment_isAlwaysEmittedEvenWhenNull() {
+    public void noFieldIsEverEmittedWithZeroLength() {
+        // A record where every optional field is empty must still be a valid record —
+        // just a sparse one — with no "<name:0>" anywhere in it.
+        String out = new AdifRecord()
+                .call("W1AW")
+                .gridsquare("").mode("").rstSent("").rstRcvd("")
+                .qsoDate("").timeOn("").qsoDateOff("").timeOff("")
+                .band("").freq("").stationCallsign("").myGridsquare("")
+                .operator("").mySig("").mySigInfo("").sig("").sigInfo("")
+                .comment("")
+                .build();
+
+        assertThat(out).doesNotContain(":0>");
+        assertThat(out).contains("<call:4>W1AW ");
+        assertThat(out).endsWith("<eor>\n");
+    }
+
+    @Test
+    public void comment_isOmittedWhenNullOrEmptyButRecordStillTerminates() {
+        // The <eor> used to be glued onto the comment field, so a commentless QSO got a
+        // zero-length comment purely to carry the terminator. They are separate now.
         assertThat(new AdifRecord().call("W1AW").comment(null).build())
-                .contains("<comment:0> <eor>\n");
+                .isEqualTo("<call:4>W1AW <QSL_RCVD:1>N <APP_FT8AF_QSL_MANUAL:1>N <eor>\n");
+        assertThat(new AdifRecord().call("W1AW").comment("").build())
+                .doesNotContain("comment");
+        assertThat(new AdifRecord().call("W1AW").comment("hi").build())
+                .contains("<comment:2>hi <eor>\n");
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/QSLRecordTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/QSLRecordTest.java
@@ -112,6 +112,53 @@ public class QSLRecordTest {
     }
 
     @Test
+    public void mapConstructor_readsManualQslUnderTheAppPrefixedName() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put(AdifRecord.APP_QSL_MANUAL, "Y");
+
+        assertThat(new QSLRecord(map).isQSL).isTrue();
+    }
+
+    @Test
+    public void mapConstructor_stillReadsTheLegacyBareQslManualName() {
+        // ADIF files written by FT8AF before the APP_ prefix — and by other loggers that
+        // copied the bare name — must keep importing with their confirmation flag intact.
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put(AdifRecord.LEGACY_QSL_MANUAL, "Y");
+
+        assertThat(new QSLRecord(map).isQSL).isTrue();
+    }
+
+    @Test
+    public void mapConstructor_manualQslDefaultsToFalseAndHonoursN() {
+        HashMap<String, String> plain = new HashMap<>();
+        plain.put("CALL", "W1AW");
+        plain.put("COMMENT", "imported");
+        assertThat(new QSLRecord(plain).isQSL).isFalse();
+
+        HashMap<String, String> explicitN = new HashMap<>();
+        explicitN.put("CALL", "W1AW");
+        explicitN.put("COMMENT", "imported");
+        explicitN.put(AdifRecord.APP_QSL_MANUAL, "N");
+        assertThat(new QSLRecord(explicitN).isQSL).isFalse();
+    }
+
+    @Test
+    public void mapConstructor_conformantNameWinsWhenBothArePresent() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("CALL", "W1AW");
+        map.put("COMMENT", "imported");
+        map.put(AdifRecord.LEGACY_QSL_MANUAL, "Y");
+        map.put(AdifRecord.APP_QSL_MANUAL, "N");
+
+        assertThat(new QSLRecord(map).isQSL).isFalse();
+    }
+
+    @Test
     public void mapConstructor_mfskSubmodeResolvesToFt2() {
         HashMap<String, String> map = new HashMap<>();
         map.put("CALL", "W1AW");

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceFailureReasonTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceFailureReasonTest.java
@@ -1,0 +1,100 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the upload-failure descriptions in {@link ThirdPartyService}.
+ *
+ * <p>Motivation: a Cloudlog-compatible server that rejects every QSO (say, its
+ * {@code contacts} table is missing a column its INSERT references) used to be
+ * indistinguishable in {@code debug.log} from having nothing to upload — both printed
+ * {@code cloudlog=0}. These helpers turn the server's own explanation into one short line.
+ * Pure string logic, no network.
+ */
+public class ThirdPartyServiceFailureReasonTest {
+
+    @Test
+    public void httpFailure_includesStatusAndServerBody() {
+        String body = "{\"status\":\"abort\",\"adif_errors\":1,"
+                + "\"messages\":[\"column \\\"tx_pwr\\\" of relation \\\"contacts\\\" does not exist\"]}";
+        String out = ThirdPartyService.describeHttpFailure(400, body);
+
+        assertThat(out).startsWith("HTTP 400: ");
+        assertThat(out).contains("tx_pwr");
+        assertThat(out).contains("does not exist");
+    }
+
+    @Test
+    public void httpFailure_withNoBody_isJustTheStatus() {
+        assertThat(ThirdPartyService.describeHttpFailure(502, null)).isEqualTo("HTTP 502");
+        assertThat(ThirdPartyService.describeHttpFailure(502, "")).isEqualTo("HTTP 502");
+        assertThat(ThirdPartyService.describeHttpFailure(502, "   \n  ")).isEqualTo("HTTP 502");
+    }
+
+    @Test
+    public void httpFailure_collapsesNewlinesSoTheLogStaysOneLinePerEntry() {
+        String out = ThirdPartyService.describeHttpFailure(500, "line one\nline two\r\n\tline three");
+
+        assertThat(out).doesNotContain("\n");
+        assertThat(out).doesNotContain("\r");
+        assertThat(out).isEqualTo("HTTP 500: line one line two line three");
+    }
+
+    @Test
+    public void httpFailure_truncatesAnEnormousBody() {
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 500; i++) {
+            huge.append("<html>error page</html>");
+        }
+        String out = ThirdPartyService.describeHttpFailure(500, huge.toString());
+
+        // "HTTP 500: " + 200 chars + the ellipsis.
+        assertThat(out.length()).isLessThan(240);
+        assertThat(out).endsWith("…");
+    }
+
+    @Test
+    public void qrzFailure_reportsResultAndReason() {
+        String out = ThirdPartyService.describeQrzFailure(
+                "RESULT=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED=");
+
+        assertThat(out).isEqualTo("RESULT=FAIL: Unable to add QSO to database: duplicate");
+    }
+
+    @Test
+    public void qrzFailure_withoutReason_reportsResultAlone() {
+        assertThat(ThirdPartyService.describeQrzFailure("RESULT=FAIL&COUNT=0"))
+                .isEqualTo("RESULT=FAIL");
+    }
+
+    @Test
+    public void qrzFailure_withUnparseableResponse_saysSo() {
+        assertThat(ThirdPartyService.describeQrzFailure("")).isEqualTo("RESULT=(none)");
+        assertThat(ThirdPartyService.describeQrzFailure(null)).isEqualTo("RESULT=(none)");
+        assertThat(ThirdPartyService.describeQrzFailure("<html>gateway timeout</html>"))
+                .isEqualTo("RESULT=(none)");
+    }
+
+    @Test
+    public void qrzFailure_neverEchoesTheSubmittedAdif() {
+        // The response echoes back what we sent; debug.log must not accumulate whole logbooks.
+        String response = "RESULT=FAIL&REASON=bad record&ADIF=<call:4>W1AW <comment:9>secret ok <eor>";
+        String out = ThirdPartyService.describeQrzFailure(response);
+
+        assertThat(out).doesNotContain("W1AW");
+        assertThat(out).doesNotContain("secret");
+    }
+
+    @Test
+    public void syncResult_defaultsToNoRecordedErrors() {
+        ThirdPartyService.SyncResult r =
+                new ThirdPartyService.SyncResult(5, 5, 0, true, false);
+
+        assertThat(r.cloudlogError).isNull();
+        assertThat(r.qrzError).isNull();
+        assertThat(r.total).isEqualTo(5);
+        assertThat(r.cloudlogOk).isEqualTo(5);
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSyncSummaryTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/sync/QsoAutoSyncSummaryTest.kt
@@ -1,0 +1,78 @@
+package radio.ks3ckc.ft8af.sync
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.log.ThirdPartyService
+import org.junit.Test
+
+/**
+ * Unit tests for [summarize], the `debug.log` line for a finished auto-sync run.
+ *
+ * The counts alone were ambiguous: `cloudlog=0 qrz=0 of 113` reads identically whether the
+ * network was down, the key expired, or the server rejected every record. Attaching the
+ * server's own reason is what turns that line into a diagnosis.
+ */
+class QsoAutoSyncSummaryTest {
+    private fun result(
+        total: Int,
+        cloudlogOk: Int,
+        qrzOk: Int,
+        cloudlogError: String? = null,
+        qrzError: String? = null,
+    ): ThirdPartyService.SyncResult =
+        ThirdPartyService.SyncResult(
+            total,
+            cloudlogOk,
+            qrzOk,
+            true,
+            true,
+            cloudlogError,
+            qrzError,
+        )
+
+    @Test
+    fun `fully successful run reports counts only`() {
+        val summary = summarize(result(12, 12, 12))
+
+        assertThat(summary).isEqualTo("cloudlog=12 qrz=12 of 12")
+    }
+
+    @Test
+    fun `failing cloudlog run carries the server explanation`() {
+        val reason = "HTTP 400: column \"tx_pwr\" of relation \"contacts\" does not exist"
+        val summary = summarize(result(113, 0, 113, cloudlogError = reason))
+
+        assertThat(summary).startsWith("cloudlog=0 qrz=113 of 113")
+        assertThat(summary).contains("cloudlogError=HTTP 400:")
+        assertThat(summary).contains("tx_pwr")
+        assertThat(summary).doesNotContain("qrzError=")
+    }
+
+    @Test
+    fun `both services failing report both reasons`() {
+        val summary =
+            summarize(
+                result(4, 0, 0, cloudlogError = "HTTP 401", qrzError = "RESULT=FAIL: bad key"),
+            )
+
+        assertThat(summary)
+            .isEqualTo("cloudlog=0 qrz=0 of 4 cloudlogError=HTTP 401 qrzError=RESULT=FAIL: bad key")
+    }
+
+    @Test
+    fun `empty error strings are treated as absent`() {
+        // An empty StringBuilder must not produce a dangling "cloudlogError=".
+        val summary = summarize(result(1, 1, 1, cloudlogError = "", qrzError = ""))
+
+        assertThat(summary).isEqualTo("cloudlog=1 qrz=1 of 1")
+    }
+
+    @Test
+    fun `summary is a single line so it cannot corrupt the log`() {
+        val summary =
+            summarize(
+                result(2, 0, 0, cloudlogError = "HTTP 500: a b c", qrzError = "RESULT=FAIL"),
+            )
+
+        assertThat(summary).doesNotContain("\n")
+    }
+}


### PR DESCRIPTION
Found while diagnosing why every QSO upload to a Cloudlog-compatible server had
been failing silently for three days. The server-side cause was its own
problem, but getting there surfaced three real app-side ones.

## Zero-length fields make records unimportable

An optional value that was present-but-empty exported as `<gridsquare:0> `.
Several ADIF importers treat a length-0 field as malformed and reject the whole
record instead of reading it as "absent" — 39 of 384 records in a real export
carried one, from QSOs where the other station never sent a grid.

Empty now means omitted, which every parser agrees on.

Two follow-ons the new tests caught:

- `mode` had its own null-only guard (it branches separately for the MFSK
  submode split) and so kept emitting `<mode:0>` after the shared helper was
  fixed.
- `comment` was emitted unconditionally because the `<eor>` terminator was
  glued onto it. They are separate now, so a commentless QSO no longer carries
  a zero-length comment purely to hold the terminator.

## `QSL_MANUAL` is not an ADIF field

The bare name is non-conformant — ADIF reserves `APP_<PROGRAMID>_` for
program-specific data, precisely so consumers can skip what they don't know
instead of erroring on it.

We now write `APP_FT8AF_QSL_MANUAL`. `QSLRecord` reads both names, so ADIF
files written by older FT8AF builds keep importing with their confirmation flag
intact.

## Upload failures were invisible

`uploadAdifToCloudlog` returned a bare boolean, and the server's own
explanation went only to `Log.d`. So `debug.log` recorded:

```
QsoAutoSync: done (app-start): cloudlog=0 qrz=0 of 113
```

…which reads identically whether the network was down, the API key expired, or
the server was rejecting every single record. The backlog grew from 74 to 113
QSOs across three days with nothing to point at.

The reason now flows through `SyncResult` into that line:

```
QsoAutoSync: done (app-start): cloudlog=0 qrz=0 of 113
  cloudlogError=HTTP 400: {"status":"abort","adif_errors":1,"messages":
  ["column \"tx_pwr\" of relation \"contacts\" does not exist"]}
```

That is a 30-second diagnosis. The description is collapsed to one line and
truncated (a misconfigured proxy can return a whole HTML error page), and the
QRZ variant deliberately reports only `RESULT`/`REASON` — the rest of QRZ's
response echoes the submitted ADIF back, which has no business accumulating in
`debug.log`.

## Also: one ADIF builder instead of two

`DatabaseOpr.downQSLTable` — the built-in web logbook's ADIF download — was a
line-for-line duplicate of `AdifRecord.build()`, same fields in the same order.
The copies had drifted: it still carried both bugs above long after the
file-export path was fixed. It now maps its cursor onto `AdifRecord` and
nothing else (-95 lines), so the next formatting fix can't land in only one of
them. Its existing tests cover the mapping, plus new ones for the empty-value
and field-name behaviour.

## Testing

`testDebugUnitTest`: 2881 pass. New coverage for zero-length omission across
every optional field, the `APP_` prefix and legacy-name import round-trip, and
the failure-reason formatting (status + body, newline collapsing, truncation,
and never echoing submitted ADIF).

Built and installed on a Pixel 8. The device disconnected before the
`debug.log` line could be observed in the wild, so that last confirmation is
still outstanding — the log format itself is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
