### PR TITLE
Make the early and full-slot decoders work in tandem instead of competing

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -251,29 +251,38 @@ public class FT8SignalListener {
                         onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
                     }
 
-                    final long deepDecodeBudgetMs = mode.deepDecodeBudgetMillis();
-                    // Budget the subtract-and-redecode loop by ITS OWN elapsed time, not the total
-                    // decode time. On a slow device the initial fast + first deep pass can already
-                    // exceed the budget, which would abort subtraction before it ran even once.
-                    final long deepLoopStart = System.currentTimeMillis();
-                    // Passes inside the loop also stop their candidate scan at this instant,
-                    // so one pass over a huge candidate list can't blow through the budget.
-                    final long passDeadline = DeepDecodeBudget.passDeadline(deepLoopStart, deepDecodeBudgetMs);
-                    do {
-                        if (DeepDecodeBudget.loopExhausted(deepLoopStart, System.currentTimeMillis(), deepDecodeBudgetMs)) break;// stop once the subtraction loop has spent its budget
-                        // subtract decoded signals
-                        subtractDecode(ft8Decoder, a91List, fromSource);
+                    // The subtract-and-redecode loop runs on the early buffer ONLY when no
+                    // late full-slot pass is scheduled (early decode off, or FT4/FT2).
+                    // With a late pass pending, the loop is deferred to the full-slot
+                    // buffer (a strict superset of this one): running it here doubled the
+                    // deep work and pushed the late pass's start past the next slot's
+                    // early decode, whose first gate contention then aborted the late
+                    // candidate scan almost every cycle. See LateDecode.deepLoopRunsOnEarlyBuffer.
+                    if (LateDecode.deepLoopRunsOnEarlyBuffer(lateHandoff)) {
+                        final long deepDecodeBudgetMs = mode.deepDecodeBudgetMillis();
+                        // Budget the subtract-and-redecode loop by ITS OWN elapsed time, not the total
+                        // decode time. On a slow device the initial fast + first deep pass can already
+                        // exceed the budget, which would abort subtraction before it ran even once.
+                        final long deepLoopStart = System.currentTimeMillis();
+                        // Passes inside the loop also stop their candidate scan at this instant,
+                        // so one pass over a huge candidate list can't blow through the budget.
+                        final long passDeadline = DeepDecodeBudget.passDeadline(deepLoopStart, deepDecodeBudgetMs);
+                        do {
+                            if (DeepDecodeBudget.loopExhausted(deepLoopStart, System.currentTimeMillis(), deepDecodeBudgetMs)) break;// stop once the subtraction loop has spent its budget
+                            // subtract decoded signals
+                            subtractDecode(ft8Decoder, a91List, fromSource);
 
-                        // perform another decode pass
-                        msgs = runDecode(ft8Decoder, utc, true, mode, passDeadline, a91List, null);
-                        addMsgToList(allMsg, msgs);
-                        timeSec = System.currentTimeMillis() - time;
-                        decodeTimeSec.postValue(timeSec);// decode elapsed time
-                        if (onFt8Listen != null) {
-                            onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
-                        }
+                            // perform another decode pass
+                            msgs = runDecode(ft8Decoder, utc, true, mode, passDeadline, a91List, null);
+                            addMsgToList(allMsg, msgs);
+                            timeSec = System.currentTimeMillis() - time;
+                            decodeTimeSec.postValue(timeSec);// decode elapsed time
+                            if (onFt8Listen != null) {
+                                onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
+                            }
 
-                    } while (msgs.size() > 0 );
+                        } while (msgs.size() > 0 );
+                    }
 
                 }
                 // Moved to finalize() method
@@ -295,12 +304,20 @@ public class FT8SignalListener {
     }
 
     /**
-     * Decode the full-slot buffer captured alongside the early window, recovering signals
-     * whose DT pushed them past the early window's end. Deliveries reuse the slot's
-     * {@code allMsg} dedup scope, so everything the early passes already reported is
-     * filtered out and only genuinely new messages reach {@code afterDecode} — flagged
-     * isDeep=true so the auto-sequencer (which already acted on the early results) is not
-     * triggered a second time.
+     * Decode the full-slot buffer captured alongside the early window: the slot's DEPTH
+     * pass, complementing the early buffer's SPEED pass. It recovers signals whose DT
+     * pushed them past the early window's end, and — with deep decode on — hosts the
+     * slot's subtract-and-redecode loop (deferred here from the early buffer, which is a
+     * strict prefix of this one; see {@link LateDecode#deepLoopRunsOnEarlyBuffer}).
+     * Deliveries reuse the slot's {@code allMsg} dedup scope, so everything the early
+     * passes already reported is filtered out and only genuinely new messages reach
+     * {@code afterDecode} — flagged isDeep=true so the auto-sequencer treats them as
+     * evidence rather than re-triggering on them.
+     *
+     * <p>Every candidate loop in here is bounded by the ABSOLUTE window deadline (next
+     * slot boundary + early window − safety margin, capped by the mode's deep budget):
+     * the pass must finish before the next slot's early decode thread starts, so the
+     * analysis-gate abort is a backstop for overruns, not the routine exit path.
      *
      * <p>Deliberately does NOT touch {@link #timeSec}/{@link #decodeTimeSec}: by the time
      * this runs the next slot may already be decoding, and clobbering the shared elapsed
@@ -323,19 +340,36 @@ public class FT8SignalListener {
         long lateDecoder = initDecoder(utc, fullData.length, mode);
         try {
             pressFloatDecode(fullData, lateDecoder, fromSource);
-            // Bound the whole late pass (fast + deep candidate loops) by the mode's deep
-            // budget so a slow device can't chain late work across multiple later slots.
-            final long deadline = DeepDecodeBudget.passDeadline(time,
-                    mode.deepDecodeBudgetMillis());
+            final long deadline = LateDecode.effectiveLatePassDeadline(
+                    handoff.latePassDeadlineEpochMs,
+                    DeepDecodeBudget.passDeadline(time, mode.deepDecodeBudgetMillis()));
             // Best-effort priority: the first analysis-gate contention with the next
             // slot's early decode trips this and the late pass gives up the rest of its
-            // candidates (and the deep pass). See LateDecode.AnalysisGate.
+            // candidates (and the deep loop). See LateDecode.AnalysisGate.
             final LateDecode.LateAbort lateAbort = new LateDecode.LateAbort();
             deliverLateMessages(utc, allMsg,
                     runDecode(lateDecoder, utc, false, mode, deadline, a91List, lateAbort));
             if (GeneralVariables.deepDecodeMode && !lateAbort.tripped()) {
-                deliverLateMessages(utc, allMsg,
-                        runDecode(lateDecoder, utc, true, mode, deadline, a91List, lateAbort));
+                ArrayList<Ft8Message> msgs =
+                        runDecode(lateDecoder, utc, true, mode, deadline, a91List, lateAbort);
+                deliverLateMessages(utc, allMsg, msgs);
+                // Subtract-and-redecode on the full buffer. Same convergence rule as the
+                // early-buffer loop this replaces (do/while: at least one subtraction
+                // round even when the deep pass above surfaced nothing new — subtraction
+                // is what uncovers weak signals UNDER the already-decoded strong ones):
+                // keep going while a pass still yields NEW messages (deliverLateMessages
+                // strips already-delivered ones from msgs in place) and the deadline
+                // hasn't passed. a91List holds the previous pass's decodes — exactly
+                // what the next subtraction removes.
+                do {
+                    if (lateAbort.tripped()
+                            || DeepDecodeBudget.passExpired(deadline, System.currentTimeMillis())) {
+                        break;
+                    }
+                    subtractDecode(lateDecoder, a91List, fromSource);
+                    msgs = runDecode(lateDecoder, utc, true, mode, deadline, a91List, lateAbort);
+                    deliverLateMessages(utc, allMsg, msgs);
+                } while (!msgs.isEmpty());
             }
         } finally {
             deleteDecoder(lateDecoder, fromSource);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
@@ -22,8 +22,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * full-slot pass for DEPTH (high-DT recovery, and — with deep decode on — the
  * subtract-and-redecode loop, which runs here instead of on the truncated early buffer;
  * see {@link #deepLoopRunsOnEarlyBuffer}). The full-slot pass is bounded by
- * {@link #latePassDeadlineMillis} so it finishes before the next slot's early decode
- * starts rather than colliding with it.
+ * {@link #latePassDeadlineMillis} so it normally finishes before the next slot's early
+ * decode starts rather than colliding with it, with the {@link AnalysisGate} contention
+ * abort as the backstop when it can't (per-candidate overrun, or a mid-slot timer
+ * rebuild moving the next boundary).
  *
  * <p>This class holds the parts of that feature that are decisions/state rather than
  * native-decoder plumbing, so they stay unit-testable: the should-run predicate, the
@@ -57,7 +59,12 @@ public final class LateDecode {
     /**
      * Absolute wall-clock instant the late full-slot pass must finish by: when the NEXT
      * slot's early decode thread starts (next boundary + early window), minus
-     * {@link #LATE_PASS_SAFETY_MS}. Before this bound existed the late pass was only
+     * {@link #LATE_PASS_SAFETY_MS}. Computed from the slot's RECORD-TIME mode snapshot,
+     * so it assumes the next slot keeps the same cycle timing; if the operator switches
+     * modes mid-slot, {@code FT8SignalListener.rebuildTimer(...)} moves the actual next
+     * boundary and this bound no longer tracks it — in that (rare) case the
+     * {@link AnalysisGate} contention abort is the backstop, exactly as it is for a
+     * per-candidate overrun. Before this bound existed the late pass was only
      * budget-bounded; with deep decode on, the early buffer's subtraction loop pushed its
      * start right up against the next early decode, so its first gate contention aborted
      * the whole candidate scan almost every slot — the two decode passes fought instead

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/LateDecode.java
@@ -17,6 +17,14 @@ import java.util.concurrent.locks.ReentrantLock;
  * second buffer; the still-running decode thread picks that buffer up after the early
  * passes finish and decodes it as an extra, late delivery.
  *
+ * <p>The two buffers are complementary, not competing: the early pass exists for SPEED
+ * (its fast results feed the auto-sequencer in time for the next slot's TX), the
+ * full-slot pass for DEPTH (high-DT recovery, and — with deep decode on — the
+ * subtract-and-redecode loop, which runs here instead of on the truncated early buffer;
+ * see {@link #deepLoopRunsOnEarlyBuffer}). The full-slot pass is bounded by
+ * {@link #latePassDeadlineMillis} so it finishes before the next slot's early decode
+ * starts rather than colliding with it.
+ *
  * <p>This class holds the parts of that feature that are decisions/state rather than
  * native-decoder plumbing, so they stay unit-testable: the should-run predicate, the
  * bounded-wait math, and the one-shot buffer handoff between the recorder's monitor
@@ -34,7 +42,57 @@ public final class LateDecode {
      */
     static final long DELIVERY_GRACE_MS = 3000;
 
+    /**
+     * Safety margin subtracted from the late pass's absolute deadline (next slot boundary
+     * + early window = the instant the next slot's early decode thread starts). The
+     * deadline is only checked between candidates, so the late pass can overrun it by one
+     * candidate's analysis — deep multi-iteration LDPC on a busy band runs into the
+     * hundreds of milliseconds. The margin absorbs that plus scheduling jitter, so the
+     * analysis-gate abort stays a backstop instead of the routine exit path.
+     */
+    static final long LATE_PASS_SAFETY_MS = 750;
+
     private LateDecode() {}
+
+    /**
+     * Absolute wall-clock instant the late full-slot pass must finish by: when the NEXT
+     * slot's early decode thread starts (next boundary + early window), minus
+     * {@link #LATE_PASS_SAFETY_MS}. Before this bound existed the late pass was only
+     * budget-bounded; with deep decode on, the early buffer's subtraction loop pushed its
+     * start right up against the next early decode, so its first gate contention aborted
+     * the whole candidate scan almost every slot — the two decode passes fought instead
+     * of cooperating.
+     *
+     * @param registeredAtMs wall-clock time the full-slot monitor was registered
+     *                       (the slot boundary)
+     * @param mode           the slot's RECORD-TIME mode snapshot
+     */
+    static long latePassDeadlineMillis(long registeredAtMs, ModeProfile mode) {
+        return registeredAtMs + mode.slotMillis + mode.earlyDecodeMillis - LATE_PASS_SAFETY_MS;
+    }
+
+    /**
+     * The deadline the late full-slot pass actually runs under: the window bound above
+     * capped by the mode's deep budget (a slow device must not chain late work across
+     * multiple later slots even when the window would allow it).
+     */
+    public static long effectiveLatePassDeadline(long windowDeadlineEpochMs,
+                                                 long budgetDeadlineEpochMs) {
+        return Math.min(windowDeadlineEpochMs, budgetDeadlineEpochMs);
+    }
+
+    /**
+     * Where this slot's deep subtract-and-redecode loop runs. With no late pass scheduled
+     * (early decode off, or FT4/FT2) the early buffer is the only buffer, so the loop runs
+     * there. When a late full-slot pass IS scheduled, the early buffer is a strict prefix
+     * of the full-slot buffer — running the loop on both would duplicate the deep work AND
+     * delay the late pass past the next slot's early decode (the "decoders fighting"
+     * failure). So the loop is deferred to the full-slot pass, which becomes the slot's
+     * single deep engine.
+     */
+    public static boolean deepLoopRunsOnEarlyBuffer(Handoff lateHandoff) {
+        return lateHandoff == null;
+    }
 
     /**
      * Whether this cycle should schedule the second, full-slot decode pass.
@@ -68,7 +126,7 @@ public final class LateDecode {
     public static SlotPlan planSlot(boolean earlyDecode, ModeProfile mode, long nowMs) {
         int recordMillis = earlyDecode ? mode.earlyDecodeMillis : mode.slotMillis;
         Handoff lateHandoff = shouldRunLatePass(earlyDecode, mode)
-                ? new Handoff(nowMs, mode.slotMillis)
+                ? new Handoff(nowMs, mode)
                 : null;
         return new SlotPlan(mode, recordMillis, lateHandoff);
     }
@@ -120,13 +178,20 @@ public final class LateDecode {
     public static final class Handoff {
         private final ArrayBlockingQueue<float[]> queue = new ArrayBlockingQueue<>(1);
         private final long deadlineEpochMs;
+        /**
+         * Absolute instant the late full-slot pass must finish by — the next slot's
+         * early-decode start minus the safety margin. See {@link #latePassDeadlineMillis}.
+         */
+        public final long latePassDeadlineEpochMs;
 
         /**
          * @param registeredAtMs wall-clock time the full-slot voice monitor was registered
-         * @param slotMillis     the mode's slot length (== the monitor's duration)
+         *                       (the slot boundary)
+         * @param mode           the slot's RECORD-TIME mode snapshot
          */
-        public Handoff(long registeredAtMs, int slotMillis) {
-            this.deadlineEpochMs = deliveryDeadlineMillis(registeredAtMs, slotMillis);
+        public Handoff(long registeredAtMs, ModeProfile mode) {
+            this.deadlineEpochMs = deliveryDeadlineMillis(registeredAtMs, mode.slotMillis);
+            this.latePassDeadlineEpochMs = latePassDeadlineMillis(registeredAtMs, mode);
         }
 
         /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateDecodeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/LateDecodeTest.java
@@ -65,7 +65,7 @@ public class LateDecodeTest {
     private static LateDecode.Handoff handoffWithLiveDeadline() {
         // Registered "now": deadline is ~18s away, so an offered buffer is returned
         // immediately and no test ever actually waits that long.
-        return new LateDecode.Handoff(System.currentTimeMillis(), 15_000);
+        return new LateDecode.Handoff(System.currentTimeMillis(), ModeProfile.FT8);
     }
 
     private static LateDecode.Handoff handoffWithExpiredDeadline() {
@@ -73,7 +73,7 @@ public class LateDecodeTest {
         // awaitBuffer must return null without blocking.
         return new LateDecode.Handoff(
                 System.currentTimeMillis() - 15_000 - LateDecode.DELIVERY_GRACE_MS - 1_000,
-                15_000);
+                ModeProfile.FT8);
     }
 
     @Test
@@ -161,6 +161,73 @@ public class LateDecodeTest {
             assertThat(plan.recordMillis).isEqualTo(mode.earlyDecodeMillis);
             assertThat(plan.lateHandoff).isNull();
         }
+    }
+
+    // ---- late-pass scheduling: the full-slot pass must coexist with the NEXT slot's
+    // early decode instead of fighting it (the "decoders working against each other" bug:
+    // the early buffer's subtraction loop delayed the late pass until it collided with
+    // the next early decode and aborted its whole candidate scan).
+
+    @Test
+    public void latePassDeadline_endsBeforeNextSlotsEarlyDecodeStarts() {
+        // Next slot's early decode thread starts at boundary + slot + earlyWindow; the
+        // late pass must be done a safety margin before that.
+        long registeredAt = 1_000_000L;
+        long nextEarlyDecodeStart = registeredAt + ModeProfile.FT8.slotMillis
+                + ModeProfile.FT8.earlyDecodeMillis;
+        assertThat(LateDecode.latePassDeadlineMillis(registeredAt, ModeProfile.FT8))
+                .isEqualTo(nextEarlyDecodeStart - LateDecode.LATE_PASS_SAFETY_MS);
+    }
+
+    @Test
+    public void latePassDeadline_leavesUsefulDecodeWindow() {
+        // Sanity on the constants: the window between buffer arrival (boundary + slot)
+        // and the deadline must stay big enough for real deep work — if a future tuning
+        // of earlyDecodeMillis/safety collapses it, the late pass silently degenerates
+        // back into an abort-every-slot pass.
+        long registeredAt = 0L;
+        long bufferArrival = ModeProfile.FT8.slotMillis;
+        long window = LateDecode.latePassDeadlineMillis(registeredAt, ModeProfile.FT8)
+                - bufferArrival;
+        assertThat(window).isAtLeast(10_000L);
+    }
+
+    @Test
+    public void effectiveLatePassDeadline_isTheEarlierOfWindowAndBudget() {
+        assertThat(LateDecode.effectiveLatePassDeadline(1_000L, 2_000L)).isEqualTo(1_000L);
+        assertThat(LateDecode.effectiveLatePassDeadline(2_000L, 1_000L)).isEqualTo(1_000L);
+        assertThat(LateDecode.effectiveLatePassDeadline(1_500L, 1_500L)).isEqualTo(1_500L);
+    }
+
+    @Test
+    public void handoff_carriesLatePassDeadline() {
+        long registeredAt = 1_000_000L;
+        LateDecode.Handoff handoff = new LateDecode.Handoff(registeredAt, ModeProfile.FT8);
+        assertThat(handoff.latePassDeadlineEpochMs)
+                .isEqualTo(LateDecode.latePassDeadlineMillis(registeredAt, ModeProfile.FT8));
+    }
+
+    // ---- deep-loop placement: exactly one buffer per slot hosts the subtraction loop --
+
+    @Test
+    public void deepLoop_runsOnEarlyBuffer_whenNoLatePassScheduled() {
+        // Early decode off (or FT4/FT2): the early buffer is the only buffer.
+        assertThat(LateDecode.deepLoopRunsOnEarlyBuffer(null)).isTrue();
+    }
+
+    @Test
+    public void deepLoop_deferredToFullSlotPass_whenLatePassScheduled() {
+        // With a full-slot pass pending, deep work on the (strict-prefix) early buffer
+        // would be duplicated AND delay the late pass into the next slot's early decode.
+        LateDecode.SlotPlan plan = LateDecode.planSlot(true, ModeProfile.FT8, 1_000_000L);
+        assertThat(LateDecode.deepLoopRunsOnEarlyBuffer(plan.lateHandoff)).isFalse();
+    }
+
+    @Test
+    public void planSlot_handoffLatePassDeadline_anchoredAtPlanTime() {
+        LateDecode.SlotPlan plan = LateDecode.planSlot(true, ModeProfile.FT8, 1_000_000L);
+        assertThat(plan.lateHandoff.latePassDeadlineEpochMs)
+                .isEqualTo(LateDecode.latePassDeadlineMillis(1_000_000L, ModeProfile.FT8));
     }
 
     @Test


### PR DESCRIPTION
## Problem

With deep decode + early decode both on (FT8), the two decode passes fight each other:

- The subtract-and-redecode loop ran on the **truncated early buffer** (13.5s) with an 11.25s budget, after an *unbounded* first deep pass — grinding until ~27s+ into the cycle.
- The full-slot buffer arrived at 15s but sat waiting the whole time. The late pass finally started right as the next slot's early decode began (~28.5s), so its first `AnalysisGate` contention tripped `LateAbort` and threw away the entire remaining candidate scan — almost every cycle.

Net effect: the high-DT signals the late pass exists to recover (issue #363) were dropped most slots, the deep work was duplicated (the early buffer is a strict prefix of the full-slot buffer), and what did decode arrived ~2 slots stale — after the auto-sequencer had already made its call.

## Fix

Split the work between the buffers instead of duplicating it:

- **Early buffer = speed** (unchanged): fast pass feeds the sequencer for next-slot TX; the quick first deep pass still delivers pre-key-up evidence.
- **Full-slot buffer = depth**: the subtraction loop moves here (`LateDecode.deepLoopRunsOnEarlyBuffer`), making it the slot's single deep engine. High-DT signals now decode ~12s earlier and reach the sequencer's evidence path while still fresh.
- The whole full-slot pass is bounded by an **absolute deadline** — next slot boundary + early window − 750ms safety, capped by the mode's deep budget (`LateDecode.latePassDeadlineMillis` / `effectiveLatePassDeadline`) — so it finishes before the next slot's early decode starts. The gate abort remains as a backstop for overruns only.

No behavior change when no late pass is scheduled (early decode off, or FT4/FT2): the early-buffer subtraction loop runs exactly as before.

## Tests

- New `LateDecodeTest` coverage: deadline math, deadline-before-next-early-decode property, min-with-budget, `Handoff` carrying the deadline, deep-loop placement for both plan shapes, and a constants sanity check that the late window stays ≥10s.
- Full `testDebugUnitTest` suite passes (JDK 21, macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)