### PR TITLE
Swap the TX message mid-cycle when a late decode advances the QSO

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -121,6 +121,19 @@ public class FT8TransmitSignal {
     // sound-card playback.
     private volatile boolean txAudioCancelled = false;
 
+    // Mid-cycle message swap (the late-decode TX race). Set by requestTxRestart()
+    // when the late full-slot pass advances the QSO after we have already keyed up
+    // with the previous over's message. The playback loops break on txAudioCancelled
+    // exactly as they do for a STOP, but afterPlayAudio() sees this flag and tears
+    // down ONLY the audio — PTT stays keyed — and DoTransmitRunnable then replays
+    // the newly chosen message inside the same over. Consumed by consumeTxRestart().
+    private volatile boolean txRestartPending = false;
+
+    // functionOrder captured at key-up, so an evidence-only (deep/late) pass can tell
+    // whether it actually changed what we should be sending. Read/written from the
+    // decode thread and the TX worker.
+    private volatile int orderAtKeyUp = -1;
+
     public UtcTimer utcTimer;
 
 
@@ -344,6 +357,62 @@ public class FT8TransmitSignal {
     }
 
     /**
+     * Time reserved for the swap itself: regenerating the waveform for the new message
+     * and getting the first samples to the sound card. The restart decision is made on
+     * the decode thread but playback restarts on the TX worker, so the guard must leave
+     * room for that hop — otherwise a swap approved at the very edge of the slack would
+     * begin playing past it and clip its own leading Costas array, reintroducing the
+     * exact defect this feature exists to avoid.
+     */
+    static final int RESTART_HEADROOM_MS = 250;
+
+    /**
+     * Whether an in-flight transmission should be aborted and restarted with a different
+     * message (the late-decode TX race).
+     *
+     * <p>With early decode on, the fast pass delivers ~13.5&nbsp;s into the slot and the
+     * auto-sequencer keys up ~0.45&nbsp;s into the next one. The late full-slot pass
+     * (issue #363) routinely delivers its recovered decodes 0&ndash;3.5&nbsp;s into that
+     * next slot — i.e. AFTER key-up. When one of those recovered decodes is the partner's
+     * reply, the sequencer advances the over a few hundred milliseconds too late and we
+     * spend the whole cycle re-sending the message we had already sent, instead of the
+     * RR73 that would have finished the QSO.
+     *
+     * <p>The swap is free inside the audio slack. The waveform occupies
+     * {@code slotMillis - audioSlackMillis}, so a restart at any {@code msInCycle} within
+     * the slack still plays the new message COMPLETE and ends on the boundary — the
+     * receiver simply sees it at a slightly larger DT, which every FT8 decoder searches
+     * anyway. Past the slack the new message could not fit without clipping its leading
+     * sync array, so we let the original over finish rather than put a mutilated signal
+     * on the air; the sequencer picks the change up on the next cycle as it does today.
+     *
+     * <p>PTT is deliberately NOT dropped for the swap — see {@link #requestTxRestart}.
+     *
+     * @param transmitting      whether an over is currently on the air
+     * @param transmitFreeText  whether free text is armed — its content does not depend on
+     *                          {@code functionOrder}, so a swap would replay the identical
+     *                          message and put a discontinuity on the air for nothing
+     * @param orderAtKeyUp      {@code functionOrder} captured when we keyed up
+     * @param orderNow          {@code functionOrder} after this decode pass
+     * @param msInCycle         ms elapsed since the current slot boundary (&gt;= 0)
+     * @param audioSlackMillis  {@link ModeProfile#audioSlackMillis} — free slack before clipping
+     */
+    static boolean shouldRestartForNewOrder(boolean transmitting, boolean transmitFreeText,
+                                            int orderAtKeyUp, int orderNow, long msInCycle,
+                                            int audioSlackMillis) {
+        if (!transmitting) return false;
+        if (transmitFreeText) return false;
+        // Nothing new to say: same over we already keyed up with. Also covers the
+        // "no reply decoded" case, where the sequencer leaves functionOrder alone.
+        if (orderNow == orderAtKeyUp) return false;
+        // orderAtKeyUp is only -1 before the first key-up of a run; without a known
+        // starting point we cannot tell a real change from initialization.
+        if (orderAtKeyUp == -1) return false;
+        if (msInCycle < 0) return false;
+        return msInCycle + RESTART_HEADROOM_MS <= audioSlackMillis;
+    }
+
+    /**
      * Build the replacement cycle timer for a new operating mode, carrying the manual
      * TX-delay offset ({@link UtcTimer#getTime_sec()}) from the outgoing timer onto the
      * fresh one. A new {@link UtcTimer} starts with {@code time_sec = 0}, so without this
@@ -424,6 +493,10 @@ public class FT8TransmitSignal {
         // serial.send TX1/TX0 keying lines, so the QSO trace shows the message text.
         GeneralVariables.fileLog("QSO: TX slot=" + sequential + " order=" + functionOrder
                 + " msg=[" + getFunctionCommand(functionOrder).getMessageText() + "]");
+        // Baseline for the mid-cycle swap: anything that moves functionOrder off this
+        // value while we are on the air is a late decode we keyed up too early for.
+        orderAtKeyUp = functionOrder;
+        txRestartPending = false;
         doTransmitThreadPool.execute(doTransmitRunnable);
 
         mutableFunctions.postValue(snapshotForUi(functionList));
@@ -1106,9 +1179,89 @@ public class FT8TransmitSignal {
     }
 
     /**
+     * Abort the audio currently on the air and replay this same over with the message the
+     * sequencer has just chosen. Called from the decode thread when the late full-slot
+     * pass advances the QSO after key-up; see {@link #shouldRestartForNewOrder} for when
+     * that is safe.
+     *
+     * <p>Uses the same cancel machinery as a STOP ({@code setTransmitting(false)}) to stop
+     * the writers mid-buffer, but deliberately leaves {@code isTransmitting} set and never
+     * calls {@code onAfterTransmit}: <strong>PTT stays keyed across the swap</strong>.
+     * Dropping and re-raising PTT would add the rig's full key-up delay (plus, on many
+     * rigs, a relay cycle) in the middle of a transmission — far more disruptive than the
+     * message change itself, and on some rigs enough to miss the slack window entirely.
+     * The TX worker's replay loop in {@link DoTransmitRunnable} picks it up from here.
+     */
+    private void requestTxRestart() {
+        txRestartPending = true;
+        // Same two writers setTransmitting(false) stops: the native/fallback USB write
+        // and the chunked MODE_STREAM AudioTrack loop.
+        UsbAudioNative.cancelWrite();
+        txAudioCancelled = true;
+        AudioTrack t = audioTrack;
+        if (t != null) {
+            try {
+                if (t.getState() != AudioTrack.STATE_UNINITIALIZED
+                        && t.getPlayState() != AudioTrack.PLAYSTATE_STOPPED) {
+                    t.pause();
+                    t.flush();
+                }
+            } catch (IllegalStateException ignored) {
+                // Worker already released the track between our read and here.
+            }
+        }
+    }
+
+    /** One-shot read of the restart request; clears it so each swap replays exactly once. */
+    private boolean consumeTxRestart() {
+        if (!txRestartPending) return false;
+        txRestartPending = false;
+        return true;
+    }
+
+    /**
+     * The message to put on the air right now: the armed free text if one is set,
+     * otherwise the standard message for the current {@code functionOrder}. Shared by the
+     * initial key-up and the mid-cycle swap replay so both resolve the over identically.
+     */
+    private Ft8Message currentTransmitMessage() {
+        Ft8Message msg;
+        if (transmitFreeText) {
+            msg = new Ft8Message("CQ", GeneralVariables.myCallsign, freeText);
+            msg.i3 = 0;
+            msg.n3 = 0;
+        } else {
+            msg = getFunctionCommand(functionOrder);
+        }
+        msg.modifier = GeneralVariables.toModifier;
+        return msg;
+    }
+
+    /** Push the on-air message text to the TX banner / mini-log. */
+    @SuppressLint("DefaultLocale")
+    private void postTransmittingMessage(Ft8Message msg) {
+        mutableTransmittingMessage.postValue(String.format(" (%.0fHz) %s",
+                GeneralVariables.getBaseFrequency(), msg.getMessageText()));
+    }
+
+    /**
      * Actions after audio playback completes, including the onAfterTransmit callback for closing PTT.
+     *
+     * <p>A pending mid-cycle message swap takes an early exit that releases only the audio
+     * resources: PTT stays keyed, {@code isTransmitting} stays true, and no
+     * {@code onAfterTransmit} fires, so the over continues seamlessly with the new message
+     * (see {@link #requestTxRestart}). Everything below the exit is genuine end-of-over
+     * teardown and must not run mid-swap.
      */
     private void afterPlayAudio() {
+        if (txRestartPending) {
+            if (audioTrack != null) {
+                audioTrack.release();
+                audioTrack = null;
+            }
+            txAudioFocus.release();
+            return;
+        }
         if (onDoTransmitted != null) {
             onDoTransmitted.onAfterTransmit(getFunctionCommand(functionOrder), functionOrder);
         }
@@ -1638,6 +1791,27 @@ public class FT8TransmitSignal {
      * @param evidenceOnly true for deep/late-pass decodes
      */
     public void parseMessageToFunction(ArrayList<Ft8Message> msgList, boolean evidenceOnly) {
+        parseMessageToFunctionInner(msgList, evidenceOnly);
+
+        // Mid-cycle message swap. Only the evidence-only (deep/late) pass can land after
+        // key-up — the fast pass delivers before the slot boundary, in time for the normal
+        // TX decision — so only it can leave us transmitting last over's message. Checked
+        // here, outside the body, so EVERY path that moves functionOrder above is covered
+        // (RR73 reply, completion, give-up) rather than just the ones we remembered to
+        // instrument. See shouldRestartForNewOrder for the safety window.
+        if (!evidenceOnly) return;
+        ModeProfile mode = GeneralVariables.currentMode();
+        long msInCycle = UtcTimer.getSystemTime() % mode.slotMillis;
+        if (shouldRestartForNewOrder(isTransmitting, transmitFreeText, orderAtKeyUp,
+                functionOrder, msInCycle, mode.audioSlackMillis)) {
+            GeneralVariables.fileLog("QSO: late decode advanced order " + orderAtKeyUp
+                    + " -> " + functionOrder + " at " + msInCycle
+                    + "ms into slot; restarting TX with the new message");
+            requestTxRestart();
+        }
+    }
+
+    private void parseMessageToFunctionInner(ArrayList<Ft8Message> msgList, boolean evidenceOnly) {
         if (GeneralVariables.myCallsign.length() < 3) {
             return;
         }
@@ -2949,15 +3123,7 @@ public class FT8TransmitSignal {
             }
 
             // for displaying the message content to be transmitted
-            Ft8Message msg;
-            if (transmitSignal.transmitFreeText) {
-                msg = new Ft8Message("CQ", GeneralVariables.myCallsign, transmitSignal.freeText);
-                msg.i3 = 0;
-                msg.n3 = 0;
-            } else {
-                msg = transmitSignal.getFunctionCommand(transmitSignal.functionOrder);
-            }
-            msg.modifier = GeneralVariables.toModifier;
+            Ft8Message msg = transmitSignal.currentTransmitMessage();
 
             if (transmitSignal.onDoTransmitted != null) {
                 // handle PTT and other events here
@@ -2968,9 +3134,7 @@ public class FT8TransmitSignal {
             transmitSignal.mutableIsTransmitting.postValue(true);
 
 
-            transmitSignal.mutableTransmittingMessage.postValue(String.format(" (%.0fHz) %s"
-                    , GeneralVariables.getBaseFrequency()
-                    , msg.getMessageText()));
+            transmitSignal.postTransmittingMessage(msg);
             // generate signal
 //            float[] buffer=GenerateFT8.generateFt8(msg, GeneralVariables.getBaseFrequency());
 //            if (buffer==null) {
@@ -3003,24 +3167,43 @@ public class FT8TransmitSignal {
             // New behavior: skip only the excess past the slack. On-time and
             // mildly-late TXs send the full waveform; only genuinely late starts
             // begin clipping leading audio.
-            ModeProfile mode = GeneralVariables.currentMode();
-            int msIntoCycle = (int) (UtcTimer.getSystemTime() % mode.slotMillis);
-            int msMaxStart = mode.audioSlackMillis; // last moment we can start without overrunning
-            int msLate = msIntoCycle - msMaxStart;
-            if (msLate < 0) msLate = 0;
-            if (msLate >= mode.slotMillis) msLate = mode.slotMillis - 1;
-            transmitSignal.lateStartSkipMs = msLate;
-            if (msLate > 100) {
-                Log.d(TAG, String.format("Late start: skipping %d ms of leading audio", msLate));
-                ToastMessage.show(String.format("Late start: −%d ms", msLate));
-            }
+            // Replay loop for the mid-cycle message swap (the late-decode TX race). The
+            // common case runs the body exactly once. When the late full-slot pass
+            // advances the QSO while this over is on the air, requestTxRestart() stops
+            // the audio and afterPlayAudio() skips its end-of-over teardown, so we come
+            // back here with PTT still keyed and send the newly chosen message instead.
+            // The clip math below is recomputed each pass, so the replay is timed against
+            // when IT starts, not when the original over did.
+            do {
+                ModeProfile mode = GeneralVariables.currentMode();
+                int msIntoCycle = (int) (UtcTimer.getSystemTime() % mode.slotMillis);
+                int msMaxStart = mode.audioSlackMillis; // last moment we can start without overrunning
+                int msLate = msIntoCycle - msMaxStart;
+                if (msLate < 0) msLate = 0;
+                if (msLate >= mode.slotMillis) msLate = mode.slotMillis - 1;
+                transmitSignal.lateStartSkipMs = msLate;
+                if (msLate > 100) {
+                    Log.d(TAG, String.format("Late start: skipping %d ms of leading audio", msLate));
+                    ToastMessage.show(String.format("Late start: −%d ms", msLate));
+                }
 
 //            if (transmitSignal.onDoTransmitted != null) {//process audio data for ICOM network mode transmission
 //                transmitSignal.onDoTransmitted.onAfterGenerate(buffer);
 //            }
-            // play audio
-            //transmitSignal.playFT8Signal(buffer);
-            transmitSignal.playFT8Signal(msg);
+                // play audio
+                //transmitSignal.playFT8Signal(buffer);
+                transmitSignal.playFT8Signal(msg);
+
+                if (!transmitSignal.consumeTxRestart()) break;
+                // Swap: pick up whatever the sequencer settled on and replay this over.
+                msg = transmitSignal.currentTransmitMessage();
+                transmitSignal.orderAtKeyUp = transmitSignal.functionOrder;
+                transmitSignal.postTransmittingMessage(msg);
+                GeneralVariables.fileLog("QSO: TX restart slot=" + transmitSignal.sequential
+                        + " order=" + transmitSignal.functionOrder
+                        + " at=" + (UtcTimer.getSystemTime() % GeneralVariables.currentMode().slotMillis)
+                        + "ms msg=[" + msg.getMessageText() + "]");
+            } while (true);
         }
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -367,6 +367,37 @@ public class FT8TransmitSignal {
     static final int RESTART_HEADROOM_MS = 250;
 
     /**
+     * Whether the playback path these modes select can actually be interrupted mid-buffer.
+     *
+     * <p>Only the sound-card paths can. {@code playViaUsbAudio} and {@code
+     * playViaAudioTrack} both poll the cancel flags {@link #requestTxRestart} sets and
+     * unwind within a chunk. The other two branches of {@code playFT8Signal} do not:
+     *
+     * <ul>
+     *   <li>NETWORK hands the message to the ICOM network transmit callback and then
+     *       spins {@code while (isTransmitting)} for up to 13.1 s;
+     *   <li>CAT audio (controlMode CAT on a rig whose connector reports
+     *       {@code supportTransmitOverCAT()}) does the same for up to 13.0 s.
+     * </ul>
+     *
+     * <p>Neither observes {@code txAudioCancelled}, and {@link #requestTxRestart}
+     * deliberately leaves {@code isTransmitting} set, so a swap requested on those paths
+     * would not interrupt anything — it would sit queued until the wait expired and then
+     * replay ~13 s into the slot, where the clip math strips almost the whole message.
+     * That is worse than not swapping at all, so refuse up front and let the sequencer
+     * pick the change up next cycle as it did before.
+     *
+     * @param connectMode    {@code GeneralVariables.connectMode} (see {@link ConnectMode})
+     * @param controlMode    {@code GeneralVariables.controlMode} (see {@link ControlMode})
+     * @param catAudioInUse  whether the connector actually transmits audio over CAT
+     */
+    static boolean playbackSupportsMidCycleRestart(int connectMode, int controlMode,
+                                                   boolean catAudioInUse) {
+        if (connectMode == ConnectMode.NETWORK) return false;
+        return !(controlMode == ControlMode.CAT && catAudioInUse);
+    }
+
+    /**
      * Whether an in-flight transmission should be aborted and restarted with a different
      * message (the late-decode TX race).
      *
@@ -389,6 +420,8 @@ public class FT8TransmitSignal {
      * <p>PTT is deliberately NOT dropped for the swap — see {@link #requestTxRestart}.
      *
      * @param transmitting      whether an over is currently on the air
+     * @param playbackRestartable whether this playback path can be interrupted at all —
+     *                          see {@link #playbackSupportsMidCycleRestart}
      * @param transmitFreeText  whether free text is armed — its content does not depend on
      *                          {@code functionOrder}, so a swap would replay the identical
      *                          message and put a discontinuity on the air for nothing
@@ -397,10 +430,12 @@ public class FT8TransmitSignal {
      * @param msInCycle         ms elapsed since the current slot boundary (&gt;= 0)
      * @param audioSlackMillis  {@link ModeProfile#audioSlackMillis} — free slack before clipping
      */
-    static boolean shouldRestartForNewOrder(boolean transmitting, boolean transmitFreeText,
+    static boolean shouldRestartForNewOrder(boolean transmitting, boolean playbackRestartable,
+                                            boolean transmitFreeText,
                                             int orderAtKeyUp, int orderNow, long msInCycle,
                                             int audioSlackMillis) {
         if (!transmitting) return false;
+        if (!playbackRestartable) return false;
         if (transmitFreeText) return false;
         // Nothing new to say: same over we already keyed up with. Also covers the
         // "no reply decoded" case, where the sequencer leaves functionOrder alone.
@@ -1254,7 +1289,13 @@ public class FT8TransmitSignal {
      * teardown and must not run mid-swap.
      */
     private void afterPlayAudio() {
-        if (txRestartPending) {
+        // The swap exit is conditional on STILL TRANSMITTING. A STOP or deactivation
+        // (setTransmitting(false) / setActivated(false)) can land between the swap being
+        // queued and the writers unwinding; taking the early exit then would skip
+        // onAfterTransmit and leave the rig KEYED, and would leave txRestartPending set
+        // for a replay the operator just cancelled. Falling through instead drops the
+        // swap and runs the real end-of-over teardown, which is what a stop means.
+        if (txRestartPending && isTransmitting) {
             if (audioTrack != null) {
                 audioTrack.release();
                 audioTrack = null;
@@ -1262,6 +1303,7 @@ public class FT8TransmitSignal {
             txAudioFocus.release();
             return;
         }
+        txRestartPending = false;
         if (onDoTransmitted != null) {
             onDoTransmitted.onAfterTransmit(getFunctionCommand(functionOrder), functionOrder);
         }
@@ -1802,8 +1844,11 @@ public class FT8TransmitSignal {
         if (!evidenceOnly) return;
         ModeProfile mode = GeneralVariables.currentMode();
         long msInCycle = UtcTimer.getSystemTime() % mode.slotMillis;
-        if (shouldRestartForNewOrder(isTransmitting, transmitFreeText, orderAtKeyUp,
-                functionOrder, msInCycle, mode.audioSlackMillis)) {
+        boolean playbackRestartable = playbackSupportsMidCycleRestart(
+                GeneralVariables.connectMode, GeneralVariables.controlMode,
+                onDoTransmitted != null && onDoTransmitted.supportTransmitOverCAT());
+        if (shouldRestartForNewOrder(isTransmitting, playbackRestartable, transmitFreeText,
+                orderAtKeyUp, functionOrder, msInCycle, mode.audioSlackMillis)) {
             GeneralVariables.fileLog("QSO: late decode advanced order " + orderAtKeyUp
                     + " -> " + functionOrder + " at " + msInCycle
                     + "ms into slot; restarting TX with the new message");
@@ -3194,7 +3239,9 @@ public class FT8TransmitSignal {
                 //transmitSignal.playFT8Signal(buffer);
                 transmitSignal.playFT8Signal(msg);
 
-                if (!transmitSignal.consumeTxRestart()) break;
+                // isTransmitting re-checked alongside the flag: a STOP racing the swap
+                // request could otherwise replay an over the operator just cancelled.
+                if (!transmitSignal.consumeTxRestart() || !transmitSignal.isTransmitting) break;
                 // Swap: pick up whatever the sequencer settled on and replay this over.
                 msg = transmitSignal.currentTransmitMessage();
                 transmitSignal.orderAtKeyUp = transmitSignal.functionOrder;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/LateDecodeTxRestartTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/LateDecodeTxRestartTest.java
@@ -1,0 +1,150 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link FT8TransmitSignal#shouldRestartForNewOrder} — the mid-cycle
+ * message swap that closes the late-decode TX race.
+ *
+ * <p>The race, measured from a real POTA activation: the fast pass delivers ~13.5 s into
+ * the slot, the auto-sequencer keys up ~0.45 s into the next one, and the late full-slot
+ * pass (issue #363) then delivers its recovered decodes 0&ndash;3.5 s into that next slot.
+ * When one of those recovered decodes is the partner's reply, the sequencer advances the
+ * over just after key-up — in the logged case by 9 ms — and the whole cycle is spent
+ * re-sending the previous message instead of the RR73 that would have completed the QSO.
+ *
+ * <p>The swap is free inside the audio slack (FT8: 2360 ms) because the replayed message
+ * still fits the slot complete; past it the new message could not fit without clipping its
+ * leading Costas sync array, which is the one thing that must never happen.
+ *
+ * <p>Pure JVM: the predicate is static and touches no Android types.
+ */
+public class LateDecodeTxRestartTest {
+
+    /** FT8: 15000 ms slot, 12640 ms of audio. */
+    private static final int FT8_SLACK_MS = 2360;
+    /** FT4: 7500 ms slot, 5040 ms of audio. */
+    private static final int FT4_SLACK_MS = 2460;
+
+    // ---------------------------------------------------------------
+    // The case this exists for
+    // ---------------------------------------------------------------
+
+    @Test
+    public void lateDecodeJustAfterKeyUp_restarts() {
+        // The logged 17:50 K5UUT case: keyed up at order 3 (R-10), the late pass
+        // advanced to order 2 about half a second into the slot.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 2, 507, FT8_SLACK_MS)).isTrue();
+    }
+
+    @Test
+    public void lateDecodeAtTheVeryStartOfTheSlot_restarts() {
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, 0, FT8_SLACK_MS)).isTrue();
+    }
+
+    @Test
+    public void lateDecodeWellInsideTheSlack_restarts() {
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 2, 3, 1500, FT8_SLACK_MS)).isTrue();
+    }
+
+    // ---------------------------------------------------------------
+    // The slack boundary — a restart past it would clip the new message
+    // ---------------------------------------------------------------
+
+    @Test
+    public void restartExactlyAtTheHeadroomLimit_stillRestarts() {
+        int lastSafe = FT8_SLACK_MS - FT8TransmitSignal.RESTART_HEADROOM_MS;
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, lastSafe, FT8_SLACK_MS)).isTrue();
+    }
+
+    @Test
+    public void oneMsPastTheHeadroomLimit_doesNotRestart() {
+        int firstUnsafe = FT8_SLACK_MS - FT8TransmitSignal.RESTART_HEADROOM_MS + 1;
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, firstUnsafe, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void restartInsideRawSlackButInsideHeadroom_doesNotRestart() {
+        // 2300 ms is within the 2360 ms slack, but the swap itself would push the
+        // replay past it — exactly the clipping this guard exists to prevent.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, 2300, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void lateDecodeWellPastTheSlack_doesNotRestart() {
+        // The 2.5-3.5 s arrivals: unsaveable, let the original over finish.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, 3000, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void ft4UsesItsOwnSlack() {
+        // FT4's slack is wider than FT8's, so a swap FT8 would refuse is fine here.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, 2200, FT4_SLACK_MS)).isTrue();
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, 2200, FT8_SLACK_MS)).isFalse();
+    }
+
+    // ---------------------------------------------------------------
+    // Cases that must never restart
+    // ---------------------------------------------------------------
+
+    @Test
+    public void notTransmitting_doesNotRestart() {
+        // The ordinary case: the late pass advanced the sequencer between overs.
+        // Nothing is on the air, so the next key-up already sends the right message.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                false, false, 3, 4, 500, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void orderUnchanged_doesNotRestart() {
+        // The overwhelmingly common late-pass outcome: decodes arrive, none of them
+        // advance the QSO. Restarting here would swap the message for an identical
+        // one and put a needless discontinuity on the air.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 3, 500, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void noKeyUpBaseline_doesNotRestart() {
+        // Before the first key-up of a run there is no baseline to compare against,
+        // so a non-matching order is initialization, not a real change.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, -1, 6, 500, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void negativeMsInCycle_doesNotRestart() {
+        // A clock correction landing mid-over can produce this; refuse rather than
+        // reason about a slot position we don't trust.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, 3, 4, -50, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void freeTextArmed_doesNotRestart() {
+        // Free text does not depend on functionOrder, so the replay would send the
+        // identical message — a discontinuity on the air that buys nothing. Same
+        // inputs as lateDecodeJustAfterKeyUp_restarts, which does swap.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, true, 3, 2, 507, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void headroomIsPositive() {
+        // A zero/negative headroom would let a swap start at the slack boundary and
+        // clip its own leading sync array by the time playback actually began.
+        assertThat(FT8TransmitSignal.RESTART_HEADROOM_MS).isGreaterThan(0);
+        assertThat(FT8TransmitSignal.RESTART_HEADROOM_MS).isLessThan(FT8_SLACK_MS);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/LateDecodeTxRestartTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/LateDecodeTxRestartTest.java
@@ -2,6 +2,9 @@ package com.k1af.ft8af.ft8transmit;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.k1af.ft8af.connector.ConnectMode;
+import com.k1af.ft8af.database.ControlMode;
+
 import org.junit.Test;
 
 /**
@@ -37,19 +40,19 @@ public class LateDecodeTxRestartTest {
         // The logged 17:50 K5UUT case: keyed up at order 3 (R-10), the late pass
         // advanced to order 2 about half a second into the slot.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 2, 507, FT8_SLACK_MS)).isTrue();
+                true, true, false, 3, 2, 507, FT8_SLACK_MS)).isTrue();
     }
 
     @Test
     public void lateDecodeAtTheVeryStartOfTheSlot_restarts() {
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, 0, FT8_SLACK_MS)).isTrue();
+                true, true, false, 3, 4, 0, FT8_SLACK_MS)).isTrue();
     }
 
     @Test
     public void lateDecodeWellInsideTheSlack_restarts() {
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 2, 3, 1500, FT8_SLACK_MS)).isTrue();
+                true, true, false, 2, 3, 1500, FT8_SLACK_MS)).isTrue();
     }
 
     // ---------------------------------------------------------------
@@ -60,14 +63,14 @@ public class LateDecodeTxRestartTest {
     public void restartExactlyAtTheHeadroomLimit_stillRestarts() {
         int lastSafe = FT8_SLACK_MS - FT8TransmitSignal.RESTART_HEADROOM_MS;
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, lastSafe, FT8_SLACK_MS)).isTrue();
+                true, true, false, 3, 4, lastSafe, FT8_SLACK_MS)).isTrue();
     }
 
     @Test
     public void oneMsPastTheHeadroomLimit_doesNotRestart() {
         int firstUnsafe = FT8_SLACK_MS - FT8TransmitSignal.RESTART_HEADROOM_MS + 1;
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, firstUnsafe, FT8_SLACK_MS)).isFalse();
+                true, true, false, 3, 4, firstUnsafe, FT8_SLACK_MS)).isFalse();
     }
 
     @Test
@@ -75,23 +78,23 @@ public class LateDecodeTxRestartTest {
         // 2300 ms is within the 2360 ms slack, but the swap itself would push the
         // replay past it — exactly the clipping this guard exists to prevent.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, 2300, FT8_SLACK_MS)).isFalse();
+                true, true, false, 3, 4, 2300, FT8_SLACK_MS)).isFalse();
     }
 
     @Test
     public void lateDecodeWellPastTheSlack_doesNotRestart() {
         // The 2.5-3.5 s arrivals: unsaveable, let the original over finish.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, 3000, FT8_SLACK_MS)).isFalse();
+                true, true, false, 3, 4, 3000, FT8_SLACK_MS)).isFalse();
     }
 
     @Test
     public void ft4UsesItsOwnSlack() {
         // FT4's slack is wider than FT8's, so a swap FT8 would refuse is fine here.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, 2200, FT4_SLACK_MS)).isTrue();
+                true, true, false, 3, 4, 2200, FT4_SLACK_MS)).isTrue();
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, 2200, FT8_SLACK_MS)).isFalse();
+                true, true, false, 3, 4, 2200, FT8_SLACK_MS)).isFalse();
     }
 
     // ---------------------------------------------------------------
@@ -103,7 +106,7 @@ public class LateDecodeTxRestartTest {
         // The ordinary case: the late pass advanced the sequencer between overs.
         // Nothing is on the air, so the next key-up already sends the right message.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                false, false, 3, 4, 500, FT8_SLACK_MS)).isFalse();
+                false, true, false, 3, 4, 500, FT8_SLACK_MS)).isFalse();
     }
 
     @Test
@@ -112,7 +115,7 @@ public class LateDecodeTxRestartTest {
         // advance the QSO. Restarting here would swap the message for an identical
         // one and put a needless discontinuity on the air.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 3, 500, FT8_SLACK_MS)).isFalse();
+                true, true, false, 3, 3, 500, FT8_SLACK_MS)).isFalse();
     }
 
     @Test
@@ -120,7 +123,7 @@ public class LateDecodeTxRestartTest {
         // Before the first key-up of a run there is no baseline to compare against,
         // so a non-matching order is initialization, not a real change.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, -1, 6, 500, FT8_SLACK_MS)).isFalse();
+                true, true, false, -1, 6, 500, FT8_SLACK_MS)).isFalse();
     }
 
     @Test
@@ -128,7 +131,7 @@ public class LateDecodeTxRestartTest {
         // A clock correction landing mid-over can produce this; refuse rather than
         // reason about a slot position we don't trust.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, false, 3, 4, -50, FT8_SLACK_MS)).isFalse();
+                true, true, false, 3, 4, -50, FT8_SLACK_MS)).isFalse();
     }
 
     @Test
@@ -137,7 +140,50 @@ public class LateDecodeTxRestartTest {
         // identical message — a discontinuity on the air that buys nothing. Same
         // inputs as lateDecodeJustAfterKeyUp_restarts, which does swap.
         assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
-                true, true, 3, 2, 507, FT8_SLACK_MS)).isFalse();
+                true, true, true, 3, 2, 507, FT8_SLACK_MS)).isFalse();
+    }
+
+    @Test
+    public void uninterruptiblePlaybackPath_doesNotRestart() {
+        // NETWORK and CAT-audio playback spin on isTransmitting for ~13 s and never
+        // observe the cancel flags, so a queued swap would not interrupt anything — it
+        // would fire ~13 s into the slot and the clip math would strip nearly the whole
+        // message. Same inputs as lateDecodeJustAfterKeyUp_restarts, which does swap.
+        assertThat(FT8TransmitSignal.shouldRestartForNewOrder(
+                true, false, false, 3, 2, 507, FT8_SLACK_MS)).isFalse();
+    }
+
+    // ---------------------------------------------------------------
+    // Which playback paths can be interrupted at all
+    // ---------------------------------------------------------------
+
+    @Test
+    public void soundCardPathsAreRestartable() {
+        // USB-direct and AudioTrack both poll the cancel flags and unwind within a chunk.
+        assertThat(FT8TransmitSignal.playbackSupportsMidCycleRestart(
+                ConnectMode.USB_CABLE, ControlMode.VOX, false)).isTrue();
+        assertThat(FT8TransmitSignal.playbackSupportsMidCycleRestart(
+                ConnectMode.BLUE_TOOTH, ControlMode.RTS, false)).isTrue();
+    }
+
+    @Test
+    public void networkPlaybackIsNotRestartable() {
+        assertThat(FT8TransmitSignal.playbackSupportsMidCycleRestart(
+                ConnectMode.NETWORK, ControlMode.VOX, false)).isFalse();
+        // ...regardless of control mode.
+        assertThat(FT8TransmitSignal.playbackSupportsMidCycleRestart(
+                ConnectMode.NETWORK, ControlMode.CAT, true)).isFalse();
+    }
+
+    @Test
+    public void catAudioIsNotRestartableButCatControlAloneIs() {
+        // The CAT branch is only taken when the connector actually transmits audio over
+        // CAT (truSDX-style). A CAT-*controlled* rig whose audio goes out the sound card
+        // still uses the interruptible path and must keep the swap.
+        assertThat(FT8TransmitSignal.playbackSupportsMidCycleRestart(
+                ConnectMode.USB_CABLE, ControlMode.CAT, true)).isFalse();
+        assertThat(FT8TransmitSignal.playbackSupportsMidCycleRestart(
+                ConnectMode.USB_CABLE, ControlMode.CAT, false)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## The problem

Reported from a POTA activation: *"I'd be trying to call a station back and it TXs their signal strength; about half a second to a second after starting the transmission I'd see that they had replied to me in the last cycle with their signal already. I could have just sent RR73 and finished the QSO."*

That is a race between the two decode passes, and it is not the one #702 fixed. #702 is working — the early pass delivered within ~1 s of the 13.5 s early window in 193 of 260 cycles that day.

The remaining race:

- the fast pass delivers ~13.5 s into the slot, and the auto-sequencer keys up ~0.45 s into the next one;
- the late full-slot pass (#363) delivers its recovered decodes **0–3.5 s into that next slot** — after key-up.

When one of those recovered decodes is the partner's reply, the sequencer advances the over a few hundred milliseconds too late, and the whole cycle goes out as a repeat of the message we had already sent.

## Evidence

From `debug.log`, 2026-07-30 activation (126 transmissions). **45 late-pass deliveries landed 0–3.5 s into the slot**, i.e. after the ~0.45 s key-up. The clearest case:

```
17:50:14.063  off=14.06  QSO: cycle       order=3 newOrder=-1 to=K5UUT      <- fast pass: nothing new
17:50:15.498  off= 0.50  QSO: TX          order=3 msg=[K5UUT K1AF R-10]     <- key up, resend the report
17:50:15.507  off= 0.51  QSO: cycle(deep) order=3 newOrder=2  to=K5UUT      <- 9 ms too late
```

The cycle was spent re-sending `K5UUT K1AF R-10`. It is genuinely a coin flip: at 17:46 the same race was *won*, W0PPA's late decode landing 43 ms **before** key-up.

## The fix

Swap the message mid-transmission when a late decode advances the QSO, provided we are still inside the audio slack.

This is free inside the slack. The waveform occupies `slotMillis - audioSlackMillis` (FT8: 12.64 s of a 15 s slot), so a restart anywhere within the slack still plays the new message **complete** and ends on the boundary — the receiver just sees it at a slightly larger DT, which every FT8 decoder searches anyway. Past the slack the new message could not fit without clipping its leading Costas array, so the original over is left to finish and the change is picked up next cycle, exactly as today.

Two properties the implementation depends on:

- **PTT is not dropped for the swap.** `requestTxRestart()` reuses the STOP cancel machinery to stop the writers mid-buffer, but leaves `isTransmitting` set and never fires `onAfterTransmit`; `afterPlayAudio()` takes an early exit releasing only the audio. Dropping and re-raising PTT would add the rig's key-up delay mid-transmission — on some rigs enough to miss the slack window entirely.
- **The guard reserves `RESTART_HEADROOM_MS` for the swap itself.** The decision is made on the decode thread but playback restarts on the TX worker; a swap approved at the very edge of the slack would begin playing past it and clip its own leading Costas array, reintroducing the exact defect the feature exists to avoid.

The check sits outside `parseMessageToFunction`'s body, so every path that moves `functionOrder` is covered (RR73 reply, completion, give-up) rather than only the ones we remembered to instrument. Free text is excluded — its content doesn't depend on `functionOrder`, so a swap would replay the identical message.

## Testing

New `LateDecodeTxRestartTest` (14 cases, pure JVM) covers the swap window and every refusal: the logged K5UUT timing, the headroom boundary either side, inside-raw-slack-but-inside-headroom, past the slack, FT4's different slack, not transmitting, order unchanged, no key-up baseline, negative `msInCycle`, and free text armed.

Full `testDebugUnitTest` suite green; `installDebug` verified on a Pixel 8. Not yet exercised on the air — worth one activation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)