### PR TITLE
Bound GPS clock discipline to corrections FT8 can survive, and log them

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
@@ -48,11 +48,35 @@ public class GpsClockUpdater extends LocationSubscriber {
      * A fix implying a correction larger than this is treated as bad data and ignored
      * (see {@link #isOffsetSane}). Fix age is not checked separately: {@link #gpsUtcNow}
      * folds it into the implied offset, so a stale fix shows up here as a large offset.
-     * GPS UTC and the device clock are never legitimately an hour apart; a value that
-     * big means a mock provider, a bogus fix, or a timezone confusion, none of which
-     * should be allowed to yank the transmit timing.
+     *
+     * <p>This bound was ±1 hour, which is far looser than anything FT8 can survive: the
+     * offset it admits is written straight into {@link UtcTimer#delay}, which moves the
+     * WHOLE cycle grid — every decode window and every transmit key-up. A phone that is
+     * even a few seconds out cannot work FT8 at all, so an hour-scale "correction" can
+     * only ever be a mock provider, a bogus fix, or a timezone confusion. 60 s still
+     * covers a genuinely unsynced clock (no network for days) while refusing the
+     * nonsense; past it the operator has a clock problem to fix, not one to paper over.
      */
-    static final long MAX_SANE_OFFSET_MS = 60L * 60L * 1000L;
+    static final long MAX_SANE_OFFSET_MS = 60L * 1000L;
+
+    /**
+     * Largest jump allowed between consecutive GPS-applied offsets within one session.
+     *
+     * <p>The absolute bound above cannot catch the failure that actually bites: a single
+     * bad fix whose implied correction is small enough to look plausible but large enough
+     * to slide the FT8 grid off the air. On the 2026-07-30 activation the app spent two
+     * stretches transmitting 5.06 s and 7.63 s off grid — every over in them keyed up
+     * past the 2.36 s audio slack, so {@code lateStartSkipMs} clipped the leading Costas
+     * sync array out of 13.5% of that session's transmissions: loud on the air, invisible
+     * to receivers.
+     *
+     * <p>Physics makes this cheap to detect. GPS time does not jump, and a device clock
+     * drifts on the order of milliseconds between fixes minutes apart. A multi-second
+     * STEP is therefore bad data by definition, whatever its absolute value. Only the
+     * first fix of a session gets to move the clock freely (there is no baseline to
+     * compare against, and that fix is the one legitimately correcting real drift).
+     */
+    static final long MAX_OFFSET_STEP_MS = 500L;
 
     /** Configurable update-interval bounds (minutes), per issue #373. */
     static final int MIN_INTERVAL_MINUTES = 1;
@@ -74,6 +98,12 @@ public class GpsClockUpdater extends LocationSubscriber {
     // so disabling GPS returns the clock to its pre-GPS state instead of clobbering it with
     // manualTimeCorrectionMs, which NTP never writes. NO_SAVED_DELAY means "not disciplining".
     private int savedDelayBeforeGps = NO_SAVED_DELAY;
+
+    // Baseline for the step bound (see MAX_OFFSET_STEP_MS): the last offset GPS actually
+    // applied, and whether there has been one at all this discipline run. Reset by stop()
+    // so a fresh run's first fix is again free to correct real accumulated drift.
+    private volatile boolean hasAppliedOffset = false;
+    private volatile int lastAppliedOffsetMs = 0;
 
     private GpsClockUpdater(Context context) {
         super(context);
@@ -194,6 +224,11 @@ public class GpsClockUpdater extends LocationSubscriber {
         // Return UtcTimer.delay to whatever it was before GPS took over (an NTP sync, a manual
         // correction, or 0) rather than to manualTimeCorrectionMs — NTP writes delay but never
         // manualTimeCorrectionMs, so restoring the latter would silently discard the NTP sync.
+        // A new discipline run starts with no baseline, so its first fix may again correct
+        // whatever drift accumulated while GPS was off.
+        hasAppliedOffset = false;
+        lastAppliedOffsetMs = 0;
+
         if (savedDelayBeforeGps != NO_SAVED_DELAY) {
             UtcTimer.delay = savedDelayBeforeGps;
             Log.d(TAG, "Stopped GPS clock discipline; restored pre-GPS offset "
@@ -209,18 +244,37 @@ public class GpsClockUpdater extends LocationSubscriber {
         // computeAppliedOffset also re-checks running, so a fix that was already queued on the
         // main looper when the user disabled discipline (stop() flipped running=false) is
         // dropped instead of re-writing the clock after we've handed it back.
+        int rawOffsetMs = gpsClockOffsetMs(fixUtcMs, location.getElapsedRealtimeNanos(),
+                SystemClock.elapsedRealtimeNanos(), System.currentTimeMillis());
         Integer offsetMs = computeAppliedOffset(
                 isRunning(),
                 fixUtcMs,
                 location.getElapsedRealtimeNanos(),
                 SystemClock.elapsedRealtimeNanos(),
-                System.currentTimeMillis());
+                System.currentTimeMillis(),
+                hasAppliedOffset,
+                lastAppliedOffsetMs);
 
         if (offsetMs == null) {
             Log.d(TAG, "Ignoring GPS fix (not running or implausible): fixUtc=" + fixUtcMs);
+            // debug.log, not just logcat: this path moves the whole FT8 cycle grid, so a
+            // rejected fix has to be visible in the same log the on-air symptoms are.
+            // (The old code logged only to logcat, which is why the 2026-07-30 activation
+            // could not be diagnosed from the pulled debug.log.)
+            if (isRunning()) {
+                GeneralVariables.fileLog("GpsClock: REJECTED fix offset=" + rawOffsetMs
+                        + "ms (prior=" + (hasAppliedOffset ? lastAppliedOffsetMs + "ms" : "none")
+                        + ", absMax=" + MAX_SANE_OFFSET_MS + "ms, maxStep=" + MAX_OFFSET_STEP_MS
+                        + "ms) — clock left at " + UtcTimer.delay + "ms");
+            }
             return;
         }
 
+        GeneralVariables.fileLog("GpsClock: applied offset " + offsetMs + "ms (was "
+                + UtcTimer.delay + "ms, prior GPS="
+                + (hasAppliedOffset ? lastAppliedOffsetMs + "ms" : "none") + ")");
+        lastAppliedOffsetMs = offsetMs;
+        hasAppliedOffset = true;
         UtcTimer.delay = offsetMs;
         GeneralVariables.gpsClockOffsetMs = offsetMs;
         // The UI renders this as "... UTC", so post the disciplined time, not the raw
@@ -266,6 +320,22 @@ public class GpsClockUpdater extends LocationSubscriber {
     static boolean isOffsetSane(long fixUtcMs, int offsetMs) {
         if (fixUtcMs <= 0) return false;
         return Math.abs((long) offsetMs) <= MAX_SANE_OFFSET_MS;
+    }
+
+    /**
+     * Whether {@code offsetMs} is a believable successor to the offset already applied
+     * this session. See {@link #MAX_OFFSET_STEP_MS} for why a step bound catches what the
+     * absolute bound cannot.
+     *
+     * @param hasPriorOffset whether GPS has already disciplined the clock this session;
+     *                       false for the first fix, which is unconstrained by this check
+     * @param priorOffsetMs  the offset currently applied (meaningless when no prior)
+     * @param offsetMs       the offset this fix implies
+     */
+    static boolean isOffsetStepSane(boolean hasPriorOffset, int priorOffsetMs, int offsetMs) {
+        if (!hasPriorOffset) return true;
+        long step = Math.abs((long) offsetMs - (long) priorOffsetMs);
+        return step <= MAX_OFFSET_STEP_MS;
     }
 
     /** Coerce a configured update interval into the allowed range (minutes). */
@@ -314,10 +384,12 @@ public class GpsClockUpdater extends LocationSubscriber {
      * without a {@link LocationManager}.
      */
     static Integer computeAppliedOffset(boolean running, long fixUtcMs, long fixElapsedRealtimeNanos,
-                                        long nowElapsedRealtimeNanos, long nowSystemMs) {
+                                        long nowElapsedRealtimeNanos, long nowSystemMs,
+                                        boolean hasPriorOffset, int priorOffsetMs) {
         if (!running) return null;
         int offsetMs = gpsClockOffsetMs(fixUtcMs, fixElapsedRealtimeNanos, nowElapsedRealtimeNanos, nowSystemMs);
         if (!isOffsetSane(fixUtcMs, offsetMs)) return null;
+        if (!isOffsetStepSane(hasPriorOffset, priorOffsetMs, offsetMs)) return null;
         return offsetMs;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
@@ -244,14 +244,21 @@ public class GpsClockUpdater extends LocationSubscriber {
         // computeAppliedOffset also re-checks running, so a fix that was already queued on the
         // main looper when the user disabled discipline (stop() flipped running=false) is
         // dropped instead of re-writing the clock after we've handed it back.
-        int rawOffsetMs = gpsClockOffsetMs(fixUtcMs, location.getElapsedRealtimeNanos(),
-                SystemClock.elapsedRealtimeNanos(), System.currentTimeMillis());
+        // Sample both clocks EXACTLY once and feed the same readings to the evaluation and
+        // to the log. Reading them twice let the logged "REJECTED fix offset=" disagree
+        // with the number actually judged against the bounds — which would undermine the
+        // diagnostics this logging exists to provide, and is most likely to bite in the
+        // very situation being diagnosed (a clock being corrected underneath us).
+        final long fixElapsedNanos = location.getElapsedRealtimeNanos();
+        final long nowElapsedNanos = SystemClock.elapsedRealtimeNanos();
+        final long nowSystemMs = System.currentTimeMillis();
+        int rawOffsetMs = gpsClockOffsetMs(fixUtcMs, fixElapsedNanos, nowElapsedNanos, nowSystemMs);
         Integer offsetMs = computeAppliedOffset(
                 isRunning(),
                 fixUtcMs,
-                location.getElapsedRealtimeNanos(),
-                SystemClock.elapsedRealtimeNanos(),
-                System.currentTimeMillis(),
+                fixElapsedNanos,
+                nowElapsedNanos,
+                nowSystemMs,
                 hasAppliedOffset,
                 lastAppliedOffsetMs);
 
@@ -279,8 +286,9 @@ public class GpsClockUpdater extends LocationSubscriber {
         GeneralVariables.gpsClockOffsetMs = offsetMs;
         // The UI renders this as "... UTC", so post the disciplined time, not the raw
         // (possibly-wrong) system clock we just computed a correction for.
-        GeneralVariables.mutableGpsClockSync.postValue(
-                disciplinedUtcMs(System.currentTimeMillis(), offsetMs));
+        // Same single sampling as the evaluation above, so the displayed last-sync instant
+        // is the one this offset was actually computed against.
+        GeneralVariables.mutableGpsClockSync.postValue(disciplinedUtcMs(nowSystemMs, offsetMs));
         Log.d(TAG, "GPS clock discipline applied offset " + offsetMs + "ms");
     }
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/location/GpsClockUpdaterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/location/GpsClockUpdaterTest.java
@@ -84,7 +84,7 @@ public class GpsClockUpdaterTest {
 
     @Test
     public void sane_rejectsAbsurdOffset() {
-        // Beyond an hour: mock provider / timezone confusion / bogus fix.
+        // Beyond the absolute bound: mock provider / timezone confusion / bogus fix.
         int tooBig = (int) (GpsClockUpdater.MAX_SANE_OFFSET_MS + 1);
         assertThat(GpsClockUpdater.isOffsetSane(1_700_000_000_000L, tooBig)).isFalse();
         assertThat(GpsClockUpdater.isOffsetSane(1_700_000_000_000L, -tooBig)).isFalse();
@@ -94,6 +94,86 @@ public class GpsClockUpdaterTest {
     public void sane_acceptsExactlyAtBound() {
         int atBound = (int) GpsClockUpdater.MAX_SANE_OFFSET_MS;
         assertThat(GpsClockUpdater.isOffsetSane(1_700_000_000_000L, atBound)).isTrue();
+    }
+
+    @Test
+    public void sane_absoluteBoundIsTightEnoughForFt8() {
+        // Guards the tightening itself. The old ±1 h bound let an hour-scale "correction"
+        // be written straight into UtcTimer.delay, which moves every decode window and
+        // every transmit key-up. Anything near that is unusable for FT8 by definition.
+        assertThat(GpsClockUpdater.MAX_SANE_OFFSET_MS).isAtMost(60_000L);
+        // ...but still generous enough to fix a genuinely unsynced clock.
+        assertThat(GpsClockUpdater.MAX_SANE_OFFSET_MS).isAtLeast(30_000L);
+    }
+
+    // ---- isOffsetStepSane (the bound that catches a plausible-looking bad fix) ----
+
+    @Test
+    public void step_firstFixIsUnconstrained() {
+        // No baseline yet, and this is the fix that legitimately corrects accumulated
+        // drift — it must be allowed to move the clock by a lot.
+        assertThat(GpsClockUpdater.isOffsetStepSane(false, 0, 45_000)).isTrue();
+        assertThat(GpsClockUpdater.isOffsetStepSane(false, 0, -45_000)).isTrue();
+    }
+
+    @Test
+    public void step_rejectsTheMultiSecondJumpThatWentOnAir() {
+        // The 2026-07-30 activation: the grid slid 5.06 s and 7.63 s, and every over in
+        // those stretches keyed up past the audio slack with its leading Costas array
+        // clipped. Both are within the absolute bound, so only the step check stops them.
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, 0, 5_060)).isFalse();
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, 0, 7_630)).isFalse();
+        // ...and each is still "sane" by the absolute bound alone, which is the point.
+        assertThat(GpsClockUpdater.isOffsetSane(1_700_000_000_000L, 5_060)).isTrue();
+    }
+
+    @Test
+    public void step_acceptsOrdinaryDriftBetweenFixes() {
+        // A device clock drifts milliseconds between fixes minutes apart.
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, 120, 145)).isTrue();
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, -80, -60)).isTrue();
+    }
+
+    @Test
+    public void step_boundaryIsInclusive() {
+        int prior = 100;
+        int atBound = prior + (int) GpsClockUpdater.MAX_OFFSET_STEP_MS;
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, prior, atBound)).isTrue();
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, prior, atBound + 1)).isFalse();
+    }
+
+    @Test
+    public void step_measuredAgainstPriorNotZero() {
+        // A large but STABLE offset must keep being accepted: once the first fix has
+        // corrected a badly-unsynced clock, later fixes near that value are correct and
+        // must not be rejected for being far from zero.
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, 40_000, 40_050)).isTrue();
+    }
+
+    @Test
+    public void step_rejectsJumpBackToZeroFromLargeOffset() {
+        // The mirror image: having disciplined to +40 s, a fix implying ~0 is a bad fix,
+        // not the clock spontaneously fixing itself.
+        assertThat(GpsClockUpdater.isOffsetStepSane(true, 40_000, 0)).isFalse();
+    }
+
+    // ---- computeAppliedOffset with the step bound wired in ----
+
+    @Test
+    public void appliedOffset_nullWhenStepTooLarge() {
+        // Running, absolute-sane, but a 3 s jump from the applied offset: dropped.
+        Integer r = GpsClockUpdater.computeAppliedOffset(
+                true, 11_000L, 5000L * MS, 5000L * MS, 8_000L, true, 0);
+        assertThat(r).isNull();
+    }
+
+    @Test
+    public void appliedOffset_allowsSmallStepFromPrior() {
+        // Same fix geometry as appliedOffset_returnsOffsetWhenRunningAndSane (+2000),
+        // with a prior offset close enough that the step passes.
+        Integer r = GpsClockUpdater.computeAppliedOffset(
+                true, 10_000L, 5000L * MS, 5000L * MS, 8_000L, true, 1_800);
+        assertThat(r).isEqualTo(2_000);
     }
 
     // ---- clampIntervalMinutes ----
@@ -156,21 +236,21 @@ public class GpsClockUpdaterTest {
     @Test
     public void appliedOffset_nullWhenNotRunning() {
         // A fix that raced past a disable (running flipped false) must not touch the clock.
-        Integer r = GpsClockUpdater.computeAppliedOffset(false, 10_000L, 5000L * MS, 5000L * MS, 8_000L);
+        Integer r = GpsClockUpdater.computeAppliedOffset(false, 10_000L, 5000L * MS, 5000L * MS, 8_000L, false, 0);
         assertThat(r).isNull();
     }
 
     @Test
     public void appliedOffset_nullWhenInsane() {
         // fixUtc==0 (no time in the fix) is rejected even while running.
-        Integer r = GpsClockUpdater.computeAppliedOffset(true, 0L, 5000L * MS, 5000L * MS, 8_000L);
+        Integer r = GpsClockUpdater.computeAppliedOffset(true, 0L, 5000L * MS, 5000L * MS, 8_000L, false, 0);
         assertThat(r).isNull();
     }
 
     @Test
     public void appliedOffset_returnsOffsetWhenRunningAndSane() {
         // GPS UTC now = 10_000 (fresh fix), device reads 8_000 => +2_000.
-        Integer r = GpsClockUpdater.computeAppliedOffset(true, 10_000L, 5000L * MS, 5000L * MS, 8_000L);
+        Integer r = GpsClockUpdater.computeAppliedOffset(true, 10_000L, 5000L * MS, 5000L * MS, 8_000L, false, 0);
         assertThat(r).isEqualTo(2_000);
     }
 


### PR DESCRIPTION
## Why

`GpsClockUpdater.applyFix()` writes `UtcTimer.delay` from every GPS fix — on by default, 5-minute cadence. That value moves the **whole cycle grid**: every decode window and every transmit key-up. Its only guard was an absolute ±1 hour bound.

From the 2026-07-30 POTA activation, the app spent two stretches transmitting **5.06 s and 7.63 s off grid**. RX and TX shifted together by the same amount, which is the signature of `UtcTimer.delay` being rewritten mid-session rather than of a slow decoder. In those stretches every over keyed up past the 2.36 s audio slack, so `lateStartSkipMs` clipped the leading Costas sync array out of **17 of 126 transmissions (13.5%)** — loud on the air, undecodable at the far end.

Both offsets sit comfortably inside the old ±1 h bound.

## What changed

**`MAX_SANE_OFFSET_MS`: 1 hour → 60 s.** A phone even a few seconds out cannot work FT8 at all, so an hour-scale "correction" can only be a mock provider, a bogus fix, or a timezone confusion. 60 s still covers a genuinely unsynced clock (no network for days); past that the operator has a clock problem to fix, not one to paper over.

**New step bound, `MAX_OFFSET_STEP_MS` = 500 ms.** The absolute bound cannot catch the failure that actually bites — a single bad fix whose implied correction looks plausible but slides the grid off the air. Physics makes it cheap to detect: GPS time does not jump, and a device clock drifts on the order of milliseconds between fixes minutes apart, so a multi-second **step** is bad data by definition whatever its absolute value. Only a discipline run's first fix is unconstrained, since that is the one legitimately correcting accumulated drift; `stop()` clears the baseline so a later run is free again.

The step is measured against the last *applied* offset, not against zero — so once a badly-unsynced clock has been corrected to, say, +40 s, later fixes near that value keep being accepted.

## Honest status

**That GPS discipline caused those two stretches is inferred, not proven.** `applyFix` only ever logged to logcat, so the pulled `debug.log` couldn't show it. The circumstantial case is strong (RX and TX shifted in lockstep by a constant amount; episodes bounded by USB re-enumeration; it bites in the field where fixes actually flow, not at home) but it is circumstantial.

So the other half of this PR is diagnosis: every applied offset and every rejection now goes to `debug.log` with the prior offset and the bound that refused it:

```
GpsClock: applied offset 143ms (was 0ms, prior GPS=none)
GpsClock: REJECTED fix offset=5060ms (prior=143ms, absMax=60000ms, maxStep=500ms) — clock left at 143ms
```

If the next activation shows a `REJECTED` line with a multi-second offset, that confirms it. If it shows nothing and the grid still slips, the cause is elsewhere and this PR is a cheap hardening either way.

## Testing

`GpsClockUpdaterTest` extended with 10 cases covering the step bound: first fix unconstrained, the two real 5.06 s / 7.63 s jumps rejected (with an assertion that each is still "sane" by the absolute bound alone — the point of the new check), ordinary sub-second drift accepted, inclusive boundary, step measured against prior rather than zero, and the jump-back-to-zero mirror case. Existing `computeAppliedOffset` tests updated for the new signature; a guard test pins the absolute bound into the 30–60 s range so it can't quietly drift back.

Full `testDebugUnitTest` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)