### PR TITLE
Stop setOperationBand re-sending an unchanged dial to the rig ~1x/second

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -90,6 +90,7 @@ import com.k1af.ft8af.log.ThirdPartyService;
 import com.k1af.ft8af.rigs.BaseRig;
 import com.k1af.ft8af.rigs.BaseRigOperation;
 import com.k1af.ft8af.rigs.CatConnectionState;
+import com.k1af.ft8af.rigs.RetunePolicy;
 import com.k1af.ft8af.rigs.CatLiveness;
 import com.k1af.ft8af.rigs.DiscoveryTX500Rig;
 import com.k1af.ft8af.rigs.ElecraftRig;
@@ -1515,14 +1516,47 @@ public class MainViewModel extends ViewModel {
         return false;
     }
 
+    // Rate-limit state for setOperationBand(). See RetunePolicy for why this exists and
+    // what is still unexplained about the caller.
+    private long lastPushedBandFreq = RetunePolicy.NO_PUSH;
+    private long lastBandPushAtMs = 0L;
+    private long lastRetuneSuppressionLogAtMs = 0L;
+    private int suppressedRetunes = 0;
+
     /**
      * Set the operating carrier frequency. Only operates if the rig is connected.
+     *
+     * <p>Redundant requests — same dial as the last push, rig already reporting it — are
+     * suppressed down to a slow reassert heartbeat by {@link RetunePolicy}. A genuine
+     * retune (new dial, or a rig that has moved) is never delayed. This is containment for
+     * a ~1 Hz caller that has not been identified; the suppression log below names it.
      */
     public void setOperationBand() {
         if (!isRigConnected()) {
             fileLog("setOperationBand: rig not connected, skipping");
             return;
         }
+
+        long nowMs = System.currentTimeMillis();
+        if (!RetunePolicy.shouldRetune(GeneralVariables.band, baseRig.getFreq(),
+                lastPushedBandFreq, nowMs, lastBandPushAtMs)) {
+            suppressedRetunes++;
+            if (RetunePolicy.shouldLogSuppression(nowMs, lastRetuneSuppressionLogAtMs)) {
+                // Name the caller: the ~1 Hz driver of this loop is not identifiable from
+                // the source, so record who is actually asking. Only on the rate-limited
+                // path — building a stack trace per suppressed call would be its own leak.
+                fileLog("setOperationBand: suppressed " + suppressedRetunes
+                        + " redundant retunes (freq=" + GeneralVariables.band
+                        + " already set) caller=" + RetunePolicy.callerOf(
+                                Thread.currentThread().getStackTrace(),
+                                MainViewModel.class.getName()));
+                lastRetuneSuppressionLogAtMs = nowMs;
+                suppressedRetunes = 0;
+            }
+            return;
+        }
+        lastPushedBandFreq = GeneralVariables.band;
+        lastBandPushAtMs = nowMs;
 
         fileLog("setOperationBand: sending USB mode, then freq=" + GeneralVariables.band
                 + " in 800ms (controlMode=" + GeneralVariables.controlMode + ")");

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -289,6 +289,18 @@ public class MainViewModel extends ViewModel {
             //connected to rig
             setCatConnectionState(CatConnectionState.CONNECTED);
             ToastMessage.show(getStringFromResource(R.string.connected_rig));
+            // A new link is a new session for the retune rate limit, so the push below is
+            // treated as a first push and can never be throttled. Without this the
+            // reconnect case the comment below describes would silently regress: the
+            // requested dial still equals the last one we pushed and baseRig's cached
+            // freq still matches it, so a reconnect inside the reassert window would be
+            // suppressed and the rig would keep whatever it powered up on.
+            //
+            // Deliberately NOT reset from setOperationBand()'s not-connected branch: in
+            // the ~1 Hz loop this rate limit exists to contain, half the calls observe
+            // the rig disconnected, so resetting there would re-arm the loop every other
+            // iteration and defeat the fix entirely.
+            resetRetuneRateLimit();
             // Push the app's current band/frequency to the rig on every connect —
             // including an automatic reconnect, which previously left the rig on
             // whatever frequency it powered up on ("no frequency set after connecting").
@@ -1520,8 +1532,19 @@ public class MainViewModel extends ViewModel {
     // what is still unexplained about the caller.
     private long lastPushedBandFreq = RetunePolicy.NO_PUSH;
     private long lastBandPushAtMs = 0L;
-    private long lastRetuneSuppressionLogAtMs = 0L;
+    private long lastRetuneSuppressionLogAtMs = RetunePolicy.NEVER_LOGGED;
     private int suppressedRetunes = 0;
+
+    /**
+     * Forget what we last pushed, so the next {@code setOperationBand()} is treated as a
+     * first push and goes out unthrottled. Called on every successful connect.
+     */
+    private void resetRetuneRateLimit() {
+        lastPushedBandFreq = RetunePolicy.NO_PUSH;
+        lastBandPushAtMs = 0L;
+        lastRetuneSuppressionLogAtMs = RetunePolicy.NEVER_LOGGED;
+        suppressedRetunes = 0;
+    }
 
     /**
      * Set the operating carrier frequency. Only operates if the rig is connected.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RetunePolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RetunePolicy.java
@@ -42,7 +42,26 @@ public final class RetunePolicy {
     /** {@link #shouldRetune} sentinel for "nothing pushed yet this session". */
     public static final long NO_PUSH = 0L;
 
+    /** {@link #shouldLogSuppression} sentinel for "no suppression logged yet". */
+    public static final long NEVER_LOGGED = Long.MIN_VALUE;
+
     private RetunePolicy() {}
+
+    /**
+     * Milliseconds from {@code thenMs} to {@code nowMs}, treating a clock that has moved
+     * BACKWARDS as "the interval has elapsed".
+     *
+     * <p>Both intervals here are measured with {@link System#currentTimeMillis()}, which is
+     * not monotonic — an OS time correction can move it backwards under us, and this app
+     * runs on devices whose clocks are actively disciplined. A raw subtraction would then
+     * go negative and wedge the caller: retunes suppressed, or the suppression log silenced,
+     * until wall time caught back up. Saturating at "elapsed" fails safe in both cases (one
+     * extra CAT write, one extra log line) instead of silently disabling them.
+     */
+    static long elapsedSince(long nowMs, long thenMs) {
+        long delta = nowMs - thenMs;
+        return delta < 0 ? Long.MAX_VALUE : delta;
+    }
 
     /**
      * Whether this retune request should actually reach the rig.
@@ -70,12 +89,20 @@ public final class RetunePolicy {
         // The rig disagrees with us (front-panel move, dropped command): correct it now.
         if (rigFreq != requestedFreq) return true;
         // Fully redundant. Re-assert only on the slow heartbeat.
-        return nowMs - lastPushAtMs >= REASSERT_INTERVAL_MS;
+        return elapsedSince(nowMs, lastPushAtMs) >= REASSERT_INTERVAL_MS;
     }
 
-    /** Whether enough time has passed to emit another suppression summary. */
+    /**
+     * Whether enough time has passed to emit another suppression summary.
+     *
+     * <p>{@link #NEVER_LOGGED} is handled explicitly rather than relying on a sentinel of 0
+     * being far enough below an epoch {@code nowMs} to clear the interval by arithmetic —
+     * that coupling would silently delay the first line if this were ever fed a monotonic
+     * clock.
+     */
     public static boolean shouldLogSuppression(long nowMs, long lastLogAtMs) {
-        return nowMs - lastLogAtMs >= SUPPRESSION_LOG_INTERVAL_MS;
+        if (lastLogAtMs == NEVER_LOGGED) return true;
+        return elapsedSince(nowMs, lastLogAtMs) >= SUPPRESSION_LOG_INTERVAL_MS;
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RetunePolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RetunePolicy.java
@@ -1,0 +1,105 @@
+package com.k1af.ft8af.rigs;
+
+/**
+ * Rate limiting for {@code MainViewModel.setOperationBand()} — the CAT retune that pushes
+ * the app's dial and USB mode to the rig.
+ *
+ * <p>Motivating data (2026-07-30 POTA activation, from {@code debug.log}): {@code
+ * setOperationBand()} ran in a continuous ~1 Hz loop for the ENTIRE session, re-sending
+ * {@code FA014074000; MD0C; NA00;SH0117;} about 57 times a minute to a rig that was
+ * already on that exact frequency and mode — {@code rig.getFreq} matched the target on
+ * every single iteration. 20,124 occurrences across the pulled log, present in every POTA
+ * session in it.
+ *
+ * <p><strong>This is containment, not a root-cause fix.</strong> The caller driving that
+ * loop has not been identified. It is provably not the connect path (only 11 autoConnect
+ * attempts in the whole window, and no connect/disconnect churn logged), not a band change
+ * (no {@code bandSelect:} lines), and not self-triggering through {@code onFreqChanged}
+ * ({@code BaseRig.setFreq} early-returns on an unchanged dial, and the dial never changed).
+ * Two independent ~1.05 s series interleave about 0.53 s apart, one always observing the
+ * rig connected and one always observing it disconnected, which suggests duplicated
+ * observers or two live view-model instances rather than one runaway timer.
+ *
+ * <p>So this class does two things: makes the retune idempotent so the spam stops whatever
+ * the caller turns out to be, and gives {@code setOperationBand()} a rate-limited
+ * suppression log that names the caller — so the next activation's {@code debug.log}
+ * identifies the culprit instead of leaving it to inference.
+ */
+public final class RetunePolicy {
+
+    /**
+     * How often an unchanged dial is re-asserted to the rig anyway. A push that changes
+     * nothing is not useless — a rig can be moved at the front panel, or drop a command —
+     * so we keep a slow heartbeat rather than going fully edge-triggered. 30 s is two
+     * orders of magnitude below the observed 1 Hz loop and far above any legitimate
+     * retune cadence.
+     */
+    public static final long REASSERT_INTERVAL_MS = 30_000L;
+
+    /** Minimum gap between "suppressed N retunes" log lines, so the fix can't itself spam. */
+    public static final long SUPPRESSION_LOG_INTERVAL_MS = 10_000L;
+
+    /** {@link #shouldRetune} sentinel for "nothing pushed yet this session". */
+    public static final long NO_PUSH = 0L;
+
+    private RetunePolicy() {}
+
+    /**
+     * Whether this retune request should actually reach the rig.
+     *
+     * <p>Ordered so correctness always beats the rate limit: a genuinely new target, or a
+     * rig that is not where we want it, is pushed immediately and unconditionally. Only a
+     * request that is redundant in BOTH senses — same target as last time, and the rig
+     * already reports being there — is subject to the reassert interval.
+     *
+     * @param requestedFreq  the dial we want the rig on ({@code GeneralVariables.band})
+     * @param rigFreq        what the rig last reported ({@code baseRig.getFreq()})
+     * @param lastPushedFreq the dial we last actually pushed, or {@link #NO_PUSH}
+     * @param nowMs          current wall clock
+     * @param lastPushAtMs   when we last actually pushed (meaningless if {@link #NO_PUSH})
+     */
+    public static boolean shouldRetune(long requestedFreq, long rigFreq, long lastPushedFreq,
+                                       long nowMs, long lastPushAtMs) {
+        // Never throttle the first push of a session: on connect the rig may still be on
+        // whatever frequency it powered up on, and its cached freq may coincidentally
+        // match ours without the mode ever having been sent.
+        if (lastPushedFreq == NO_PUSH) return true;
+        // A real band/dial change must go out at once — this is the whole point of the
+        // call, and delaying it would leave the operator transmitting on the old dial.
+        if (requestedFreq != lastPushedFreq) return true;
+        // The rig disagrees with us (front-panel move, dropped command): correct it now.
+        if (rigFreq != requestedFreq) return true;
+        // Fully redundant. Re-assert only on the slow heartbeat.
+        return nowMs - lastPushAtMs >= REASSERT_INTERVAL_MS;
+    }
+
+    /** Whether enough time has passed to emit another suppression summary. */
+    public static boolean shouldLogSuppression(long nowMs, long lastLogAtMs) {
+        return nowMs - lastLogAtMs >= SUPPRESSION_LOG_INTERVAL_MS;
+    }
+
+    /**
+     * First stack frame outside {@code selfClassName} — i.e. whoever called the method
+     * doing the logging. Returns {@code "unknown"} rather than throwing on a stack that
+     * doesn't contain one (possible under aggressive inlining or a synthetic frame).
+     *
+     * <p>Exists so the suppression log can name the runaway caller. Only ever invoked on
+     * the rate-limited log path, never per suppressed call.
+     */
+    public static String callerOf(StackTraceElement[] stack, String selfClassName) {
+        if (stack == null || selfClassName == null) return "unknown";
+        boolean seenSelf = false;
+        for (StackTraceElement frame : stack) {
+            String cls = frame.getClassName();
+            if (cls == null) continue;
+            // Skip the Thread.getStackTrace()/Throwable frames that precede the caller.
+            if (cls.equals(selfClassName)) {
+                seenSelf = true;
+                continue;
+            }
+            if (!seenSelf) continue;
+            return cls + "." + frame.getMethodName() + ":" + frame.getLineNumber();
+        }
+        return "unknown";
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RetunePolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RetunePolicyTest.java
@@ -47,6 +47,19 @@ public class RetunePolicyTest {
     }
 
     @Test
+    public void reconnectIsNotThrottled_whenStateIsResetOnConnect() {
+        // MainViewModel.onConnected() calls resetRetuneRateLimit(), which restores
+        // NO_PUSH. That is what keeps the connect-time retune working: without it, a
+        // reconnect inside the reassert window has the same dial as the last push AND a
+        // cached rig freq that matches, so it would be suppressed and the rig would keep
+        // whatever frequency it powered up on — the exact bug that retune was added for.
+        assertThat(RetunePolicy.shouldRetune(
+                FREQ, FREQ, FREQ, T0 + 1_000, T0)).isFalse();      // without the reset
+        assertThat(RetunePolicy.shouldRetune(
+                FREQ, FREQ, RetunePolicy.NO_PUSH, T0 + 1_000, T0)).isTrue();  // with it
+    }
+
+    @Test
     public void newDialWinsEvenWhenRigAlreadyReportsIt() {
         // The rig can report the new dial before we have pushed the mode for it.
         assertThat(RetunePolicy.shouldRetune(
@@ -110,8 +123,36 @@ public class RetunePolicyTest {
 
     @Test
     public void firstSuppressionLogsImmediately() {
-        // lastLogAt == 0 (never logged) must not wait out the interval.
-        assertThat(RetunePolicy.shouldLogSuppression(T0, 0L)).isTrue();
+        // NEVER_LOGGED is an explicit sentinel, not a 0 that happens to be far enough
+        // below an epoch timestamp to clear the interval by arithmetic.
+        assertThat(RetunePolicy.shouldLogSuppression(T0, RetunePolicy.NEVER_LOGGED)).isTrue();
+        // ...and it holds for a small (monotonic-style) clock too, which the old
+        // arithmetic-only form would have got wrong.
+        assertThat(RetunePolicy.shouldLogSuppression(5L, RetunePolicy.NEVER_LOGGED)).isTrue();
+    }
+
+    // ---------------------------------------------------------------
+    // Non-monotonic wall clock (System.currentTimeMillis can move backwards)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void clockMovingBackwardsDoesNotWedgeTheReassertHeartbeat() {
+        // An OS time correction lands between the push and the next call. A raw
+        // subtraction would go negative and suppress every retune until wall time caught
+        // back up; failing safe means one extra CAT write instead.
+        assertThat(RetunePolicy.shouldRetune(FREQ, FREQ, FREQ, T0 - 60_000, T0)).isTrue();
+    }
+
+    @Test
+    public void clockMovingBackwardsDoesNotSilenceTheSuppressionLog() {
+        assertThat(RetunePolicy.shouldLogSuppression(T0 - 60_000, T0)).isTrue();
+    }
+
+    @Test
+    public void elapsedSinceSaturatesOnBackwardsTime() {
+        assertThat(RetunePolicy.elapsedSince(T0 + 500, T0)).isEqualTo(500L);
+        assertThat(RetunePolicy.elapsedSince(T0, T0)).isEqualTo(0L);
+        assertThat(RetunePolicy.elapsedSince(T0 - 1, T0)).isEqualTo(Long.MAX_VALUE);
     }
 
     // ---------------------------------------------------------------

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RetunePolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RetunePolicyTest.java
@@ -1,0 +1,157 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RetunePolicy} — the rate limit that stops {@code
+ * MainViewModel.setOperationBand()} re-sending an unchanged dial to the rig about once a
+ * second, all session (20,124 occurrences in the pulled 2026-07-30 log).
+ *
+ * <p>The load-bearing property is the ordering: correctness beats the rate limit. Every
+ * "must not be throttled" case below is a way the operator could otherwise end up
+ * transmitting on the wrong dial.
+ */
+public class RetunePolicyTest {
+
+    private static final long FREQ = 14_074_000L;
+    private static final long OTHER_FREQ = 7_074_000L;
+    private static final long T0 = 1_700_000_000_000L;
+
+    // ---------------------------------------------------------------
+    // Must never be throttled
+    // ---------------------------------------------------------------
+
+    @Test
+    public void firstPushOfSessionAlwaysGoesOut() {
+        // On connect the rig may still be on its power-up frequency, and its cached freq
+        // can match ours without the USB mode ever having been sent.
+        assertThat(RetunePolicy.shouldRetune(
+                FREQ, FREQ, RetunePolicy.NO_PUSH, T0, 0L)).isTrue();
+    }
+
+    @Test
+    public void newDialGoesOutImmediately() {
+        // A real band change. Delaying this leaves the operator on the old dial.
+        assertThat(RetunePolicy.shouldRetune(
+                OTHER_FREQ, FREQ, FREQ, T0 + 10, T0)).isTrue();
+    }
+
+    @Test
+    public void rigOnAWrongFrequencyIsCorrectedImmediately() {
+        // Front-panel move, or the rig dropped our command. Same target as last push,
+        // but the rig is not there — push regardless of how recently we pushed.
+        assertThat(RetunePolicy.shouldRetune(
+                FREQ, OTHER_FREQ, FREQ, T0 + 10, T0)).isTrue();
+    }
+
+    @Test
+    public void newDialWinsEvenWhenRigAlreadyReportsIt() {
+        // The rig can report the new dial before we have pushed the mode for it.
+        assertThat(RetunePolicy.shouldRetune(
+                OTHER_FREQ, OTHER_FREQ, FREQ, T0 + 10, T0)).isTrue();
+    }
+
+    // ---------------------------------------------------------------
+    // The loop this exists to kill
+    // ---------------------------------------------------------------
+
+    @Test
+    public void redundantRepeatIsSuppressed() {
+        // The observed loop: same dial, rig already there, ~1 s after the last push.
+        assertThat(RetunePolicy.shouldRetune(
+                FREQ, FREQ, FREQ, T0 + 1_050, T0)).isFalse();
+    }
+
+    @Test
+    public void aFullSecondOfLoopIterationsIsAllSuppressed() {
+        // 57 calls/min was the measured rate; none of them should reach the rig.
+        for (long dt = 100; dt < RetunePolicy.REASSERT_INTERVAL_MS; dt += 1_050) {
+            assertThat(RetunePolicy.shouldRetune(FREQ, FREQ, FREQ, T0 + dt, T0)).isFalse();
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // The slow reassert heartbeat
+    // ---------------------------------------------------------------
+
+    @Test
+    public void redundantRepeatIsReassertedAfterTheInterval() {
+        assertThat(RetunePolicy.shouldRetune(
+                FREQ, FREQ, FREQ, T0 + RetunePolicy.REASSERT_INTERVAL_MS, T0)).isTrue();
+    }
+
+    @Test
+    public void justBeforeTheIntervalIsStillSuppressed() {
+        assertThat(RetunePolicy.shouldRetune(
+                FREQ, FREQ, FREQ, T0 + RetunePolicy.REASSERT_INTERVAL_MS - 1, T0)).isFalse();
+    }
+
+    @Test
+    public void reassertIntervalIsFarBelowTheObservedLoopRate() {
+        // Guards the constant: the loop ran at ~1.05 s, so anything in that neighbourhood
+        // would fail to contain it.
+        assertThat(RetunePolicy.REASSERT_INTERVAL_MS).isAtLeast(10_000L);
+    }
+
+    // ---------------------------------------------------------------
+    // Suppression logging
+    // ---------------------------------------------------------------
+
+    @Test
+    public void suppressionLogIsRateLimited() {
+        assertThat(RetunePolicy.shouldLogSuppression(T0, T0)).isFalse();
+        assertThat(RetunePolicy.shouldLogSuppression(
+                T0 + RetunePolicy.SUPPRESSION_LOG_INTERVAL_MS - 1, T0)).isFalse();
+        assertThat(RetunePolicy.shouldLogSuppression(
+                T0 + RetunePolicy.SUPPRESSION_LOG_INTERVAL_MS, T0)).isTrue();
+    }
+
+    @Test
+    public void firstSuppressionLogsImmediately() {
+        // lastLogAt == 0 (never logged) must not wait out the interval.
+        assertThat(RetunePolicy.shouldLogSuppression(T0, 0L)).isTrue();
+    }
+
+    // ---------------------------------------------------------------
+    // Caller identification (the diagnostic half)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void callerOf_returnsFirstFrameAfterSelf() {
+        StackTraceElement[] stack = {
+                new StackTraceElement("java.lang.Thread", "getStackTrace", "Thread.java", 1),
+                new StackTraceElement("com.k1af.ft8af.MainViewModel", "setOperationBand", "MainViewModel.java", 1521),
+                new StackTraceElement("com.k1af.ft8af.Mystery", "tick", "Mystery.java", 42),
+                new StackTraceElement("java.util.TimerThread", "run", "Timer.java", 1),
+        };
+        assertThat(RetunePolicy.callerOf(stack, "com.k1af.ft8af.MainViewModel"))
+                .isEqualTo("com.k1af.ft8af.Mystery.tick:42");
+    }
+
+    @Test
+    public void callerOf_skipsConsecutiveSelfFrames() {
+        // setOperationBand called from another MainViewModel method: report the first
+        // frame OUTSIDE the class, not the internal hop.
+        StackTraceElement[] stack = {
+                new StackTraceElement("java.lang.Thread", "getStackTrace", "Thread.java", 1),
+                new StackTraceElement("com.k1af.ft8af.MainViewModel", "setOperationBand", "MainViewModel.java", 1521),
+                new StackTraceElement("com.k1af.ft8af.MainViewModel", "lambda$onConnected$0", "MainViewModel.java", 297),
+                new StackTraceElement("android.os.Handler", "handleCallback", "Handler.java", 1),
+        };
+        assertThat(RetunePolicy.callerOf(stack, "com.k1af.ft8af.MainViewModel"))
+                .isEqualTo("android.os.Handler.handleCallback:1");
+    }
+
+    @Test
+    public void callerOf_handlesMissingSelfAndNulls() {
+        StackTraceElement[] noSelf = {
+                new StackTraceElement("java.lang.Thread", "getStackTrace", "Thread.java", 1),
+        };
+        assertThat(RetunePolicy.callerOf(noSelf, "com.k1af.ft8af.MainViewModel")).isEqualTo("unknown");
+        assertThat(RetunePolicy.callerOf(null, "com.k1af.ft8af.MainViewModel")).isEqualTo("unknown");
+        assertThat(RetunePolicy.callerOf(noSelf, null)).isEqualTo("unknown");
+        assertThat(RetunePolicy.callerOf(new StackTraceElement[0], "x")).isEqualTo("unknown");
+    }
+}


### PR DESCRIPTION
## What's happening

From the 2026-07-30 POTA activation's `debug.log`, `setOperationBand()` ran in a **continuous ~1 Hz loop for the entire session**, re-sending

```
FA014074000;  MD0C;  NA00;SH0117;
```

about **57 times a minute** to a rig that was already on that exact frequency and mode — `rig.getFreq=14074000` matched the target on every single iteration. 20,124 occurrences across the pulled log, present in every POTA session in it, at the same steady rate during completely healthy stretches:

```
17:30:00.346 setOperationBand: sending USB mode, then freq=14074000 in 800ms
17:30:00.882 setOperationBand: rig not connected, skipping
17:30:01.161 setOperationBand: setting freq=14074000 (rig.getFreq=14074000)
17:30:01.401 setOperationBand: sending USB mode, then freq=14074000 in 800ms
17:30:01.929 setOperationBand: rig not connected, skipping
        ... repeats all session ...
```

## What this PR does

`RetunePolicy` makes the retune idempotent. A request reaches the rig only when it is a **new dial**, or the **rig isn't where we want it**, or a **30 s reassert heartbeat** is due.

The ordering is the load-bearing part, and it's what the tests pin: correctness beats the rate limit. A genuine retune is never delayed, so the operator can never be left transmitting on the old dial. Only a request redundant in *both* senses — same target as the last push **and** the rig already reporting it — gets throttled. The reassert heartbeat is kept (rather than going fully edge-triggered) because a rig can be moved at the front panel or drop a command.

## This is containment, not a root-cause fix

**The caller driving the loop is still unidentified.** What I could rule out from the log and source:

- **Not the connect path** — only 11 `autoConnect` attempts in the whole window, and no connect/disconnect churn logged.
- **Not a band change** — no `bandSelect:` lines at all.
- **Not self-triggering through `onFreqChanged`** — `BaseRig.setFreq` early-returns on an unchanged dial, and the dial never changed.

The shape of it: two independent ~1.05 s series interleaved ~0.53 s apart, one *always* observing the rig connected and one *always* observing it disconnected. That pattern points at duplicated observers or two live view-model instances rather than one runaway timer — but that is inference, not evidence.

So the PR also adds a rate-limited suppression log that names the caller from its stack frame:

```
setOperationBand: suppressed 28 redundant retunes (freq=14074000 already set) caller=com.k1af.ft8af.Xyz.tick:42
```

The stack is only walked on the rate-limited log path, never per suppressed call. The next activation's `debug.log` should name the culprit so the real fix can follow.

## Testing

New `RetunePolicyTest`, 13 cases. The four "must never be throttled" paths each correspond to a way the operator could otherwise end up on the wrong dial (first push of a session, new dial, rig moved at the front panel, new dial the rig already reports). Plus the suppressed loop — including a sweep asserting every iteration across a full reassert window is dropped — the heartbeat boundary either side, log rate-limiting including the never-logged-yet case, and caller extraction (normal, consecutive self-frames, and null/empty/no-self inputs).

Full `testDebugUnitTest` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)