### PR TITLE
Keep the QSO panel's RX history instead of re-deriving it each recomposition

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ActiveQsoPanel.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ActiveQsoPanel.kt
@@ -158,6 +158,15 @@ internal fun qsoLogKey(entry: QsoLogEntry): String =
  * same message reappears in every later snapshot, and the late full-slot pass re-delivers
  * a slot's messages alongside newly recovered ones.
  *
+ * <p>A repeat of a known key REPLACES the stored row rather than being discarded, because
+ * a row's metadata is not fixed once seen. `FT8SignalListener.checkMessageSame` upgrades a
+ * stored message's SNR *in place* when a later pass decodes the same text better ("prefer
+ * known SNR over unknown; when both are known, keep the higher"), so the same key can
+ * legitimately arrive with a better SNR than the one first captured. Keeping the first
+ * would pin the panel to a stale — often unknown — report for the rest of the QSO.
+ * Latest-wins matches that upstream resolution, which only ever moves toward the better
+ * value.
+ *
  * @param existing rows already accumulated for the current target
  * @param incoming rows just derived from the live decode list
  * @return the union, ascending by time, trimmed to [MAX_RX_LOG_ENTRIES] newest
@@ -167,11 +176,20 @@ internal fun mergeRxLog(
     incoming: List<QsoLogEntry>,
 ): List<QsoLogEntry> {
     if (incoming.isEmpty()) return existing
-    val seen = existing.mapTo(HashSet()) { qsoLogKey(it) }
-    val merged = ArrayList(existing)
-    incoming.forEach { if (seen.add(qsoLogKey(it))) merged.add(it) }
-    if (merged.size == existing.size) return existing
-    merged.sortBy { it.utcTime }
+    val byKey = LinkedHashMap<String, QsoLogEntry>(existing.size + incoming.size)
+    existing.forEach { byKey[qsoLogKey(it)] = it }
+    var changed = false
+    incoming.forEach { entry ->
+        val key = qsoLogKey(entry)
+        // Structural inequality, so an unchanged repeat (the common case, every cycle)
+        // still costs nothing and preserves the caller's instance below.
+        if (byKey[key] != entry) {
+            byKey[key] = entry
+            changed = true
+        }
+    }
+    if (!changed) return existing
+    val merged = byKey.values.sortedBy { it.utcTime }
     if (merged.size <= MAX_RX_LOG_ENTRIES) return merged
     return merged.subList(merged.size - MAX_RX_LOG_ENTRIES, merged.size).toList()
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ActiveQsoPanel.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ActiveQsoPanel.kt
@@ -125,6 +125,58 @@ internal fun buildQsoLog(
 }
 
 /**
+ * Upper bound on the accumulated RX log for a single target, so a QSO that never
+ * completes (a stuck target on a busy frequency) can't grow the list without limit.
+ * Far above any real exchange — a standard QSO is 4-6 rows, and a stubborn one with
+ * repeats is a couple of dozen.
+ */
+internal const val MAX_RX_LOG_ENTRIES = 100
+
+/**
+ * Stable identity for one conversation row, used to de-duplicate across snapshots.
+ *
+ * <p>Time is part of the key on purpose: a station that sends the same text in two
+ * different cycles produced two real transmissions and gets two rows, matching how TX
+ * rows are logged per transmission rather than per unique message.
+ */
+internal fun qsoLogKey(entry: QsoLogEntry): String =
+    "${entry.direction}|${entry.utcTime}|${entry.messageText}"
+
+/**
+ * Merge freshly-decoded rows into the rows this panel has already shown.
+ *
+ * <p>This is what makes the panel's RX history durable. The decode list it is derived
+ * from is shared, capped, and periodically emptied — `trimToMessageCount` drops from the
+ * front once it hits `MESSAGE_COUNT` (about an hour of busy-band operating), the
+ * clear-every-cycle setting wipes it at each slot boundary, a band change or the Clear
+ * button empties it outright. Re-deriving the conversation from it on every recomposition
+ * meant any of those retroactively erased messages the operator had already read, and the
+ * log box — which sizes to its content — visibly shrank. TX rows never had this problem
+ * because they live in the composable's own state; now RX rows don't either.
+ *
+ * <p>Duplicates are expected input, not an error: the decode list is cumulative, so the
+ * same message reappears in every later snapshot, and the late full-slot pass re-delivers
+ * a slot's messages alongside newly recovered ones.
+ *
+ * @param existing rows already accumulated for the current target
+ * @param incoming rows just derived from the live decode list
+ * @return the union, ascending by time, trimmed to [MAX_RX_LOG_ENTRIES] newest
+ */
+internal fun mergeRxLog(
+    existing: List<QsoLogEntry>,
+    incoming: List<QsoLogEntry>,
+): List<QsoLogEntry> {
+    if (incoming.isEmpty()) return existing
+    val seen = existing.mapTo(HashSet()) { qsoLogKey(it) }
+    val merged = ArrayList(existing)
+    incoming.forEach { if (seen.add(qsoLogKey(it))) merged.add(it) }
+    if (merged.size == existing.size) return existing
+    merged.sortBy { it.utcTime }
+    if (merged.size <= MAX_RX_LOG_ENTRIES) return merged
+    return merged.subList(merged.size - MAX_RX_LOG_ENTRIES, merged.size).toList()
+}
+
+/**
  * Outcome of one evaluation of the synthesized-TX-log effect.
  *
  * @property shouldLog            append a TX row now (with the current transmit message)
@@ -224,6 +276,13 @@ fun ActiveQsoPanel(
     var pendingTxLog by remember { mutableStateOf(false) }
     var synthTxTarget by remember { mutableStateOf<String?>(null) }
 
+    // Accumulated RX/BUSY rows for the current target, held here for the same reason
+    // synthTxLog is: the panel must not lose conversation it has already shown. These
+    // used to be re-derived from the shared decode list on every recomposition, so a
+    // trim, a clear-every-cycle wipe, a band change, or the Clear button silently
+    // erased them mid-QSO and the log box shrank. See mergeRxLog.
+    val rxLog = remember { mutableStateListOf<QsoLogEntry>() }
+
     // Clear TX state when the target genuinely changes to a different station.
     // Also handles the same-callsign-new-QSO edge case: when a QSO ends
     // (displayCallsign → null for > 500ms) and the same station is worked
@@ -235,6 +294,7 @@ fun ActiveQsoPanel(
         if (displayCallsign != null) {
             if (displayCallsign != synthTxTarget) {
                 synthTxLog.clear()
+                rxLog.clear()
                 wasTransmitting = false
                 pendingTxLog = false
             }
@@ -271,16 +331,43 @@ fun ActiveQsoPanel(
         }
     }
 
-    // Build the conversation log to/from the target station. The classification
-    // and ordering live in buildQsoLog() so they can be unit tested.
-    val qsoMessages: List<QsoLogEntry> = remember(messageList, messageList?.size, displayCallsign, transmittingMessage, synthTxLog.size) {
-        buildQsoLog(
+    // The target the conversation log belongs to. Falls back to synthTxTarget — which
+    // LaunchedEffect(displayCallsign) only clears after a 500ms settle — so the same
+    // LiveData null-flicker on tab switches that #250 fixed for the TX rows can no
+    // longer blank the RX rows either. A genuine QSO end still clears both, one target
+    // change later, exactly as before.
+    val logTarget = displayCallsign ?: synthTxTarget
+
+    // Fold this snapshot's decodes for the target into the durable RX log. Only new
+    // rows survive the merge, so the cumulative decode list re-presenting the same
+    // messages every cycle is a no-op rather than a source of duplicates.
+    LaunchedEffect(messageList, messageList?.size, logTarget) {
+        val target = logTarget ?: return@LaunchedEffect
+        val incoming = buildQsoLog(
             messageList = messageList,
-            displayCallsign = displayCallsign ?: "",
+            displayCallsign = target,
             myCallsign = GeneralVariables.myCallsign ?: "",
-            synthTx = synthTxLog.toList(),
+            synthTx = emptyList(),
         )
+        val existing = rxLog.toList()
+        val merged = mergeRxLog(existing, incoming)
+        // mergeRxLog returns the caller's OWN instance when it added nothing, so this
+        // identity check keeps snapshot writes (and the recomposition each triggers) to
+        // real changes. Size alone would miss a merge that both added and trimmed at
+        // MAX_RX_LOG_ENTRIES.
+        if (merged !== existing) {
+            rxLog.clear()
+            rxLog.addAll(merged)
+        }
     }
+
+    // The conversation shown: durable RX/BUSY rows plus our own TX rows, in time order.
+    // Computed inline rather than remember()d — these are snapshot state lists, so
+    // reading them here registers the dependency and any change recomposes. A remember
+    // keyed on sizes would miss a merge that trims as it appends.
+    val qsoMessages: List<QsoLogEntry> =
+        if (logTarget == null) emptyList()
+        else (rxLog + synthTxLog).sortedBy { it.utcTime }
 
     AnimatedVisibility(
         visible = expanded && (hasTarget || isActivated),

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/QsoPanelRxHistoryTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/QsoPanelRxHistoryTest.kt
@@ -114,6 +114,56 @@ class QsoPanelRxHistoryTest {
     // Identity contract the composable's write-skip depends on
     // ---------------------------------------------------------------
 
+    // ---------------------------------------------------------------
+    // Metadata on a known row can still improve
+    // ---------------------------------------------------------------
+
+    @Test
+    fun aBetterSnrForAKnownRowReplacesIt() {
+        // FT8SignalListener.checkMessageSame upgrades a stored message's SNR in place
+        // when a later pass decodes the same text better ("prefer known SNR over
+        // unknown; when both are known, keep the higher"), so the same key legitimately
+        // arrives again carrying a better report. Discarding it would pin the panel to
+        // the first — often unknown — value for the rest of the QSO.
+        val first = mergeRxLog(
+            emptyList(),
+            listOf(QsoLogEntry(QsoLogEntry.Direction.RX, 1_000, "K1AF RA3XYZ -12", null)),
+        )
+        val updated = mergeRxLog(
+            first,
+            listOf(QsoLogEntry(QsoLogEntry.Direction.RX, 1_000, "K1AF RA3XYZ -12", -9)),
+        )
+
+        assertThat(updated).hasSize(1)
+        assertThat(updated.single().snr).isEqualTo(-9)
+        assertThat(updated).isNotSameInstanceAs(first)
+    }
+
+    @Test
+    fun anUnchangedRepeatDoesNotCountAsAnUpdate() {
+        // The common case every cycle: identical row, including SNR. Must stay a no-op
+        // so it costs no recomposition.
+        val entry = QsoLogEntry(QsoLogEntry.Direction.RX, 1_000, "K1AF RA3XYZ -12", -9)
+        val first = mergeRxLog(emptyList(), listOf(entry))
+
+        assertThat(mergeRxLog(first, listOf(entry))).isSameInstanceAs(first)
+    }
+
+    @Test
+    fun updatingARowDoesNotDisturbOrderOrCount() {
+        var log = mergeRxLog(
+            emptyList(),
+            listOf(rx(1_000, "first"), rx(2_000, "second"), rx(3_000, "third")),
+        )
+        log = mergeRxLog(
+            log,
+            listOf(QsoLogEntry(QsoLogEntry.Direction.RX, 2_000, "second", -3)),
+        )
+
+        assertThat(log.map { it.messageText }).containsExactly("first", "second", "third").inOrder()
+        assertThat(log[1].snr).isEqualTo(-3)
+    }
+
     @Test
     fun mergeReturnsTheSameInstanceWhenNothingIsAdded() {
         // ActiveQsoPanel skips the snapshot write (and the recomposition it triggers)

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/QsoPanelRxHistoryTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/QsoPanelRxHistoryTest.kt
@@ -1,0 +1,181 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [mergeRxLog] / [qsoLogKey] — the accumulation that makes the QSO panel's
+ * RX history durable.
+ *
+ * Reported symptom: "sometimes the little QSO details pane would lose the RX messages I
+ * had received and it would resize smaller."
+ *
+ * Cause: the panel owned its TX rows (a remembered state list) but *derived* its RX rows
+ * from the shared decode list on every recomposition. That list is capped
+ * (`trimToMessageCount` drops from the front at `MESSAGE_COUNT`, roughly an hour of
+ * busy-band operating), wiped by the clear-every-cycle setting, and emptied outright by a
+ * band change or the Clear button — so any of those retroactively erased conversation the
+ * operator had already read, and the log box, which sizes to its content, visibly shrank.
+ *
+ * These tests pin the merge behaviour that fixes it. Pure JVM: no Android types.
+ */
+class QsoPanelRxHistoryTest {
+
+    private fun rx(time: Long, text: String) =
+        QsoLogEntry(QsoLogEntry.Direction.RX, time, text)
+
+    private fun busy(time: Long, text: String) =
+        QsoLogEntry(QsoLogEntry.Direction.BUSY, time, text)
+
+    // ---------------------------------------------------------------
+    // The bug: history must survive the shared list losing entries
+    // ---------------------------------------------------------------
+
+    @Test
+    fun historySurvivesTheDecodeListBeingCleared() {
+        // Three exchanges accumulated, then the shared decode list is wiped
+        // (clear-every-cycle, band change, or the Clear button) so the next snapshot
+        // derives nothing. The panel must still show what it already showed.
+        var log = mergeRxLog(emptyList(), listOf(rx(1_000, "K1AF RA3XYZ -12")))
+        log = mergeRxLog(log, listOf(rx(2_000, "K1AF RA3XYZ R-09")))
+        log = mergeRxLog(log, listOf(rx(3_000, "K1AF RA3XYZ RR73")))
+        assertThat(log).hasSize(3)
+
+        val afterClear = mergeRxLog(log, emptyList())
+
+        assertThat(afterClear).hasSize(3)
+        assertThat(afterClear.map { it.messageText })
+            .containsExactly("K1AF RA3XYZ -12", "K1AF RA3XYZ R-09", "K1AF RA3XYZ RR73")
+            .inOrder()
+    }
+
+    @Test
+    fun historySurvivesTheOldestEntriesBeingTrimmedAway() {
+        // trimToMessageCount drops from the FRONT of the shared list, so a later
+        // snapshot can be missing the QSO's earliest messages. They must not vanish
+        // from the panel.
+        val full = mergeRxLog(emptyList(), listOf(rx(1_000, "first"), rx(2_000, "second")))
+        val trimmedSnapshot = listOf(rx(2_000, "second"))
+
+        val merged = mergeRxLog(full, trimmedSnapshot)
+
+        assertThat(merged.map { it.messageText }).containsExactly("first", "second").inOrder()
+    }
+
+    // ---------------------------------------------------------------
+    // Duplicates are expected input, not an error
+    // ---------------------------------------------------------------
+
+    @Test
+    fun cumulativeSnapshotsDoNotDuplicateRows() {
+        // The decode list is cumulative, so every later snapshot re-presents the same
+        // messages. Re-merging one must be a no-op.
+        val first = mergeRxLog(emptyList(), listOf(rx(1_000, "K1AF RA3XYZ -12")))
+        val again = mergeRxLog(first, listOf(rx(1_000, "K1AF RA3XYZ -12")))
+
+        assertThat(again).hasSize(1)
+    }
+
+    @Test
+    fun lateFullSlotPassRedeliveryDoesNotDuplicate() {
+        // The late pass re-delivers a slot's messages alongside newly recovered ones:
+        // the known row must not double, the new one must land.
+        val afterFast = mergeRxLog(emptyList(), listOf(rx(1_000, "K1AF RA3XYZ -12")))
+        val afterLate = mergeRxLog(
+            afterFast,
+            listOf(rx(1_000, "K1AF RA3XYZ -12"), rx(1_000, "W9ABC RA3XYZ -05")),
+        )
+
+        assertThat(afterLate).hasSize(2)
+    }
+
+    @Test
+    fun sameTextInDifferentCyclesGetsItsOwnRow() {
+        // Two real transmissions, e.g. an unanswered report repeated next cycle.
+        // Mirrors how TX rows are logged per transmission rather than per unique text.
+        val log = mergeRxLog(
+            emptyList(),
+            listOf(rx(1_000, "K1AF RA3XYZ RR73"), rx(16_000, "K1AF RA3XYZ RR73")),
+        )
+
+        assertThat(log).hasSize(2)
+    }
+
+    @Test
+    fun directionIsPartOfIdentity() {
+        // Same text and time but a different classification is a different row.
+        val log = mergeRxLog(emptyList(), listOf(rx(1_000, "CQ RA3XYZ"), busy(1_000, "CQ RA3XYZ")))
+
+        assertThat(log).hasSize(2)
+        assertThat(qsoLogKey(rx(1_000, "x"))).isNotEqualTo(qsoLogKey(busy(1_000, "x")))
+    }
+
+    // ---------------------------------------------------------------
+    // Identity contract the composable's write-skip depends on
+    // ---------------------------------------------------------------
+
+    @Test
+    fun mergeReturnsTheSameInstanceWhenNothingIsAdded() {
+        // ActiveQsoPanel skips the snapshot write (and the recomposition it triggers)
+        // on referential equality, so this is load-bearing, not an optimisation detail.
+        val existing = mergeRxLog(emptyList(), listOf(rx(1_000, "a")))
+
+        assertThat(mergeRxLog(existing, emptyList())).isSameInstanceAs(existing)
+        assertThat(mergeRxLog(existing, listOf(rx(1_000, "a")))).isSameInstanceAs(existing)
+    }
+
+    @Test
+    fun mergeReturnsANewInstanceWhenSomethingIsAdded() {
+        val existing = mergeRxLog(emptyList(), listOf(rx(1_000, "a")))
+
+        assertThat(mergeRxLog(existing, listOf(rx(2_000, "b")))).isNotSameInstanceAs(existing)
+    }
+
+    // ---------------------------------------------------------------
+    // Ordering and the growth bound
+    // ---------------------------------------------------------------
+
+    @Test
+    fun mergedRowsAreOrderedByTime() {
+        // Out-of-order arrival is normal: the late pass recovers a message from earlier
+        // in the slot after the fast pass has already delivered a later one.
+        val log = mergeRxLog(
+            mergeRxLog(emptyList(), listOf(rx(3_000, "third"))),
+            listOf(rx(1_000, "first"), rx(2_000, "second")),
+        )
+
+        assertThat(log.map { it.messageText }).containsExactly("first", "second", "third").inOrder()
+    }
+
+    @Test
+    fun growthIsBoundedKeepingTheNewestRows() {
+        // A target that never completes must not grow the log without limit.
+        var log: List<QsoLogEntry> = emptyList()
+        for (i in 1..MAX_RX_LOG_ENTRIES + 20) {
+            log = mergeRxLog(log, listOf(rx(i.toLong() * 1_000, "msg$i")))
+        }
+
+        assertThat(log).hasSize(MAX_RX_LOG_ENTRIES)
+        // Oldest dropped, newest kept — the recent exchange is what matters on screen.
+        assertThat(log.first().messageText).isEqualTo("msg21")
+        assertThat(log.last().messageText).isEqualTo("msg${MAX_RX_LOG_ENTRIES + 20}")
+    }
+
+    @Test
+    fun trimAndAppendInOneMergeStillReturnsANewInstance() {
+        // The case a size-only change check would miss: at the cap, a merge that appends
+        // one row and drops one row leaves the size identical but the content different.
+        var log: List<QsoLogEntry> = emptyList()
+        for (i in 1..MAX_RX_LOG_ENTRIES) {
+            log = mergeRxLog(log, listOf(rx(i.toLong() * 1_000, "msg$i")))
+        }
+        assertThat(log).hasSize(MAX_RX_LOG_ENTRIES)
+
+        val merged = mergeRxLog(log, listOf(rx(999_000, "newest")))
+
+        assertThat(merged).hasSize(MAX_RX_LOG_ENTRIES)
+        assertThat(merged).isNotSameInstanceAs(log)
+        assertThat(merged.last().messageText).isEqualTo("newest")
+        assertThat(merged.first().messageText).isEqualTo("msg2")
+    }
+}


### PR DESCRIPTION
## The report

> "sometimes the little QSO details pane would lose the RX messages I had received and it would resize smaller"

## The asymmetry

`ActiveQsoPanel` **owned** its TX rows — `synthTxLog`, a remembered state list — but **derived** its RX/BUSY rows by filtering the shared decode list on every recomposition (`buildQsoLog`, `ActiveQsoPanel.kt:276`).

That list is not stable storage:

| What empties or shrinks it | Where | When |
|---|---|---|
| `trimToMessageCount` at `MESSAGE_COUNT = 3000` | `MainViewModel.java:667` | every decode batch — drops from the **front** |
| `clearDecodesEveryCycle` | `MainViewModel.beforeListen` | start of every cycle |
| `clearDecodesAndTarget()` | `MainViewModel.java:345`, `FrequencyPickerSheet.kt:67` | band change, frequency picker |
| `clearFt8MessageList()` | Clear button | on demand |

Any of those retroactively erased conversation the operator had already read, while the TX rows stayed put — exactly the reported asymmetry. The trim is the one that needs no user action at all: at the ~50 kept decodes/min measured on the 2026-07-30 activation, 3000 fills in about an hour, right in the middle of a long session.

**The resize:** `MessageLog`'s `LazyColumn` is `heightIn(max = 160.dp)` with no minimum (`ActiveQsoPanel.kt:500`), so it sizes to its content. Fewer rows literally shrank the box; zero rows swapped in a fixed `40.dp` placeholder.

## The fix

RX rows now accumulate per target into their own remembered list, folded forward by `mergeRxLog()` and reset on a genuine target change alongside `synthTxLog`.

Duplicates are expected input rather than an error — the decode list is cumulative, and the late full-slot pass re-delivers a slot's messages alongside newly recovered ones. Identity is `(direction, utcTime, messageText)`, with time included on purpose so a station repeating itself in a later cycle still gets its own row, matching how TX rows are logged per transmission rather than per unique text. Growth is bounded at `MAX_RX_LOG_ENTRIES` newest, so a QSO that never completes can't grow the list without limit.

## Also fixes the flicker path to the same symptom

`buildQsoLog` returns an empty list when `displayCallsign` is empty, and that value comes from a LiveData `observeAsState` which the code **already documents** as briefly emitting null on tab switches — the `#250` comment at `ActiveQsoPanel.kt:219`. #250 fixed this for the TX rows with a 500 ms settle on `synthTxTarget`, but left the conversation keyed on the raw value.

The log now targets `displayCallsign ?: synthTxTarget`, so a flicker can't blank it. A real QSO end still clears both, one target change later, exactly as before.

## One implementation detail worth reviewing

`mergeRxLog` returns the caller's **own instance** when it adds nothing, and the composable skips the snapshot write on referential equality — so a cumulative snapshot contributing no new rows costs no recomposition. That contract is load-bearing, not an optimisation detail, and has its own test.

A size-only check would have been wrong: at the cap, a merge can append and trim in the same step, leaving the size identical and the content different. `qsoMessages` is likewise computed inline rather than `remember`ed on sizes, for the same reason — the state lists register their own reads.

## Testing

New `QsoPanelRxHistoryTest`, 11 cases, pure JVM: history surviving a full clear and a front-trim, cumulative snapshots and late-pass re-delivery not duplicating, same text in different cycles keeping separate rows, direction as part of identity, both sides of the instance-identity contract, time ordering with out-of-order arrival, the growth bound keeping newest, and the append-and-trim-at-cap case.

Full `testDebugUnitTest` suite green; `installDebug` verified on a Pixel 8.

**Not yet exercised against a live QSO** — the accumulation is unit-tested but no real station has driven the panel. Worth watching during the next activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)