### PR TITLE
Remove the GPS step bound and debounce the retune reset (both made things worse)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -289,18 +289,23 @@ public class MainViewModel extends ViewModel {
             //connected to rig
             setCatConnectionState(CatConnectionState.CONNECTED);
             ToastMessage.show(getStringFromResource(R.string.connected_rig));
-            // A new link is a new session for the retune rate limit, so the push below is
-            // treated as a first push and can never be throttled. Without this the
-            // reconnect case the comment below describes would silently regress: the
-            // requested dial still equals the last one we pushed and baseRig's cached
-            // freq still matches it, so a reconnect inside the reassert window would be
-            // suppressed and the rig would keep whatever it powered up on.
+            // A genuinely new link is a new session for the retune rate limit, so its
+            // push below must be unthrottleable — otherwise the reconnect case the
+            // comment below describes silently regresses.
             //
-            // Deliberately NOT reset from setOperationBand()'s not-connected branch: in
-            // the ~1 Hz loop this rate limit exists to contain, half the calls observe
-            // the rig disconnected, so resetting there would re-arm the loop every other
-            // iteration and defeat the fix entirely.
-            resetRetuneRateLimit();
+            // DEBOUNCED, because this callback is itself the ~1 Hz retune driver:
+            // CableSerialPort fires it on every successful port open(), and the port was
+            // re-opening about once a second on the 2026-07-31 activation. Resetting
+            // unconditionally re-armed the limiter on every iteration of the very loop it
+            // contains, and retunes went up to 73/min from the 57/min measured before the
+            // limit existed. A burst of connects seconds apart is one flapping link; a
+            // reconnect after a real outage is minutes later. See
+            // RetunePolicy.CONNECT_RESET_DEBOUNCE_MS.
+            long connectAtMs = System.currentTimeMillis();
+            if (RetunePolicy.shouldResetOnConnect(connectAtMs, lastConnectCallbackAtMs)) {
+                resetRetuneRateLimit();
+            }
+            lastConnectCallbackAtMs = connectAtMs;
             // Push the app's current band/frequency to the rig on every connect —
             // including an automatic reconnect, which previously left the rig on
             // whatever frequency it powered up on ("no frequency set after connecting").
@@ -1534,6 +1539,8 @@ public class MainViewModel extends ViewModel {
     private long lastBandPushAtMs = 0L;
     private long lastRetuneSuppressionLogAtMs = RetunePolicy.NEVER_LOGGED;
     private int suppressedRetunes = 0;
+    /** When the previous onConnected() callback arrived; see RetunePolicy.shouldResetOnConnect. */
+    private volatile long lastConnectCallbackAtMs = RetunePolicy.NO_CONNECT;
 
     /**
      * Forget what we last pushed, so the next {@code setOperationBand()} is treated as a

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
@@ -37,7 +37,14 @@ public class CableConnector extends BaseRigConnector {
     // CatReconnectPolicy.STABLE_CONNECTION_MS — a port that opens is not a link that works,
     // and treating an open as success is what pinned the backoff at its first step and
     // produced 13,190 port opens in 88 minutes.
-    private volatile int reconnectAttempt = 0;
+    //
+    // AtomicInteger, not a volatile int: the increment below runs on the
+    // CAT-Auto-Reconnect thread while handleSerialError() (serial IO thread) and
+    // connect() (UI thread) reset it. `++` on a volatile is a read-modify-write and is
+    // NOT atomic, so a lost update would hold the counter down — pinning the backoff near
+    // BASE_BACKOFF_MS and reviving the exact storm this guards against.
+    private final java.util.concurrent.atomic.AtomicInteger reconnectAttempt =
+            new java.util.concurrent.atomic.AtomicInteger();
     private volatile long portOpenedAtMs = 0L;
 
     public CableConnector(Context context, CableSerialPort.SerialPort serialPort, int baudRate
@@ -75,10 +82,16 @@ public class CableConnector extends BaseRigConnector {
         // Only a connection that actually HELD counts as a recovery. Without this the
         // burst restarted on every open and the backoff never escalated past its first
         // 500 ms step, which is the reconnect storm this guards against.
+        // Reset and snapshot as one logical step so the value handed to decide() is the
+        // one this call established, not whatever the reconnect thread has since reached.
+        int attemptsSoFar;
         if (CatReconnectPolicy.shouldResetBurst(System.currentTimeMillis(), portOpenedAtMs)) {
-            reconnectAttempt = 0;
+            reconnectAttempt.set(0);
+            attemptsSoFar = 0;
+        } else {
+            attemptsSoFar = reconnectAttempt.get();
         }
-        switch (CatReconnectPolicy.decide(userDisconnected, kind, reconnectAttempt)) {
+        switch (CatReconnectPolicy.decide(userDisconnected, kind, attemptsSoFar)) {
             case IGNORE:
                 // User asked to disconnect; closing the port interrupts the blocking
                 // read with an IOException we expect — don't surface "Lost connection".
@@ -112,7 +125,7 @@ public class CableConnector extends BaseRigConnector {
                 while (!userDisconnected) {
                     // The burst counter persists across opens, so a link that keeps
                     // dropping keeps escalating instead of resetting to the first step.
-                    int attempt = ++reconnectAttempt;
+                    int attempt = reconnectAttempt.incrementAndGet();
                     long backoff = CatReconnectPolicy.backoffMs(attempt);
                     Log.d(TAG, "CAT auto-reconnect attempt " + attempt
                             + " in " + backoff + "ms");
@@ -245,7 +258,7 @@ public class CableConnector extends BaseRigConnector {
         userDisconnected = false;
         // A user-initiated connect is a fresh start: clear any escalation left over from a
         // previous flapping session so the first glitch is again absorbed at 500 ms.
-        reconnectAttempt = 0;
+        reconnectAttempt.set(0);
         super.connect();
         getOnConnectorStateChanged().onConnecting();
         if (cableSerialPort.connect()) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
@@ -32,6 +32,13 @@ public class CableConnector extends BaseRigConnector {
     // auto-reconnect first (CatReconnectPolicy).
     private volatile boolean userDisconnected = false;
     private volatile boolean reconnecting = false;
+    // Burst state for the escalating backoff. reconnectAttempt PERSISTS across successful
+    // opens and resets only once a connection has held for
+    // CatReconnectPolicy.STABLE_CONNECTION_MS — a port that opens is not a link that works,
+    // and treating an open as success is what pinned the backoff at its first step and
+    // produced 13,190 port opens in 88 minutes.
+    private volatile int reconnectAttempt = 0;
+    private volatile long portOpenedAtMs = 0L;
 
     public CableConnector(Context context, CableSerialPort.SerialPort serialPort, int baudRate
                           //, int controlMode) {
@@ -65,13 +72,19 @@ public class CableConnector extends BaseRigConnector {
      */
     private void handleSerialError(Exception e) {
         CatReconnectPolicy.Kind kind = CatReconnectPolicy.classify(e);
-        switch (CatReconnectPolicy.decide(userDisconnected, kind, 0)) {
+        // Only a connection that actually HELD counts as a recovery. Without this the
+        // burst restarted on every open and the backoff never escalated past its first
+        // 500 ms step, which is the reconnect storm this guards against.
+        if (CatReconnectPolicy.shouldResetBurst(System.currentTimeMillis(), portOpenedAtMs)) {
+            reconnectAttempt = 0;
+        }
+        switch (CatReconnectPolicy.decide(userDisconnected, kind, reconnectAttempt)) {
             case IGNORE:
                 // User asked to disconnect; closing the port interrupts the blocking
                 // read with an IOException we expect — don't surface "Lost connection".
                 return;
             case RECONNECT:
-                startAutoReconnect(e);
+                startAutoReconnect();
                 return;
             case SURFACE:
             default:
@@ -84,7 +97,7 @@ public class CableConnector extends BaseRigConnector {
                 "Lost connection to serial port: " + (e == null ? "" : e.getMessage()));
     }
 
-    private synchronized void startAutoReconnect(final Exception firstError) {
+    private synchronized void startAutoReconnect() {
         if (reconnecting) return; // a burst is already being handled
         reconnecting = true;
         // Reflect an in-progress reconnect rather than an error so the UI doesn't
@@ -92,13 +105,14 @@ public class CableConnector extends BaseRigConnector {
         getOnConnectorStateChanged().onConnecting();
         new Thread(() -> {
             try {
-                for (int attempt = 1;
-                     CatReconnectPolicy.shouldAutoReconnect(
-                             CatReconnectPolicy.Kind.TRANSIENT, attempt - 1);
-                     attempt++) {
-                    if (userDisconnected) {
-                        return;
-                    }
+                // Unbounded by design: giving up would strand the operator with no CAT
+                // until they noticed the retry chip. The backoff escalates to
+                // MAX_BACKOFF_MS and stays there, so a persistently flaky link costs one
+                // attempt every 8 s instead of two per second.
+                while (!userDisconnected) {
+                    // The burst counter persists across opens, so a link that keeps
+                    // dropping keeps escalating instead of resetting to the first step.
+                    int attempt = ++reconnectAttempt;
                     long backoff = CatReconnectPolicy.backoffMs(attempt);
                     Log.d(TAG, "CAT auto-reconnect attempt " + attempt
                             + " in " + backoff + "ms");
@@ -121,13 +135,14 @@ public class CableConnector extends BaseRigConnector {
                             cableSerialPort.disconnect();
                             return;
                         }
-                        Log.d(TAG, "CAT auto-reconnect succeeded on attempt " + attempt);
+                        // NOT a burst reset: the port is open, which is not yet proof the
+                        // link works. handleSerialError() resets the counter only once
+                        // this connection has held for STABLE_CONNECTION_MS.
+                        portOpenedAtMs = System.currentTimeMillis();
+                        Log.d(TAG, "CAT port re-opened on attempt " + attempt);
                         return; // connect() already fired onConnected()
                     }
                 }
-                // Budget exhausted — hand back to the manual retry state.
-                Log.e(TAG, "CAT auto-reconnect exhausted; surfacing manual retry");
-                surfaceLostConnection(firstError);
             } finally {
                 reconnecting = false;
             }
@@ -228,9 +243,14 @@ public class CableConnector extends BaseRigConnector {
     @Override
     public void connect() {
         userDisconnected = false;
+        // A user-initiated connect is a fresh start: clear any escalation left over from a
+        // previous flapping session so the first glitch is again absorbed at 500 ms.
+        reconnectAttempt = 0;
         super.connect();
         getOnConnectorStateChanged().onConnecting();
-        cableSerialPort.connect();
+        if (cableSerialPort.connect()) {
+            portOpenedAtMs = System.currentTimeMillis();
+        }
     }
 
     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CatReconnectPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CatReconnectPolicy.java
@@ -17,9 +17,11 @@ package com.k1af.ft8af.connector;
  *       {@link Exception}s are a brief I/O stall the device recovers from by
  *       re-enumerating with the same VID/PID. Only a message that names the
  *       device as genuinely gone or access-denied is fatal.</li>
- *   <li><b>Should we auto-reconnect, and after how long?</b> A bounded number of
- *       attempts with exponential backoff. If they are exhausted we surface the
- *       manual retry state; a single glitch is absorbed silently.</li>
+ *   <li><b>Should we auto-reconnect, and after how long?</b> A transient error
+ *       retries indefinitely with exponential backoff, escalating to
+ *       {@link #MAX_BACKOFF_MS} and staying there — containment comes from the
+ *       interval, not from giving up. A single glitch is absorbed silently. Only a
+ *       FATAL classification surfaces the manual retry state.</li>
  * </ol>
  */
 public final class CatReconnectPolicy {
@@ -38,9 +40,9 @@ public final class CatReconnectPolicy {
     public enum Action {
         /** A deliberate user disconnect caused it — expected, do nothing. */
         IGNORE,
-        /** Transient glitch with budget left — attempt a bounded auto-reconnect. */
+        /** Transient glitch — auto-reconnect with escalating backoff. */
         RECONNECT,
-        /** Fatal, or reconnect budget exhausted — surface the manual retry state. */
+        /** Fatal (device gone / access denied) — surface the manual retry state. */
         SURFACE
     }
 
@@ -50,12 +52,13 @@ public final class CatReconnectPolicy {
      * <p>A deliberate user disconnect closes the port to interrupt the blocking
      * read, which itself raises an {@code IOException} on the read loop. That
      * error is <em>expected</em> and must be ignored rather than surfaced as a
-     * "Lost connection" error state. Otherwise a transient error with reconnect
-     * budget left reconnects; a fatal error or an exhausted budget surfaces.
+     * "Lost connection" error state. Otherwise a transient error reconnects (always —
+     * see {@link #BACKOFF_ESCALATION_ATTEMPTS}); only a fatal error surfaces.
      *
      * @param userDisconnected whether the user asked to disconnect
      * @param kind             the classification of the error
-     * @param attemptsSoFar    auto-reconnects already tried this burst ({@code 0} first)
+     * @param attemptsSoFar    auto-reconnects already tried this burst ({@code 0} first);
+     *                         no longer gates the outcome, retained for callers that log it
      */
     public static Action decide(boolean userDisconnected, Kind kind, int attemptsSoFar) {
         if (userDisconnected) return Action.IGNORE;
@@ -111,7 +114,7 @@ public final class CatReconnectPolicy {
      * <p>A FATAL classification still surfaces immediately — a device that has left the bus
      * or refused permission will not come back by retrying.
      */
-    public static final int MAX_AUTO_RECONNECT_ATTEMPTS = 5;
+    public static final int BACKOFF_ESCALATION_ATTEMPTS = 5;
 
     /** First backoff step; also the debounce window that swallows a lone glitch. */
     public static final long BASE_BACKOFF_MS = 500;
@@ -146,7 +149,7 @@ public final class CatReconnectPolicy {
     /**
      * Whether an automatic reconnect should be attempted.
      *
-     * <p>Transient errors retry without limit — see {@link #MAX_AUTO_RECONNECT_ATTEMPTS}
+     * <p>Transient errors retry without limit — see {@link #BACKOFF_ESCALATION_ATTEMPTS}
      * for why the budget was dropped. {@code attemptsSoFar} no longer gates the decision;
      * it survives only so callers reading this alongside {@link #backoffMs} see the same
      * burst counter, and so the signature stays stable for existing callers.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CatReconnectPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CatReconnectPolicy.java
@@ -64,9 +64,52 @@ public final class CatReconnectPolicy {
     }
 
     /**
-     * Most bounded auto-reconnect attempts before falling back to the manual
-     * <em>tap to retry</em> chip. Chosen so a device that re-enumerates within a
-     * few seconds is picked back up, but a truly-gone cable stops churning.
+     * How long a freshly-opened port must survive before the link counts as recovered and
+     * the escalating backoff resets.
+     *
+     * <p>This is the fix for the reconnect storm measured on the 2026-07-31 activation:
+     * {@code CableConnector} treated {@code connect()} returning true — the port merely
+     * <em>opening</em> — as success, ended the burst there, and reset the escalation. With
+     * a link that opened and immediately errored again, every error therefore started a
+     * fresh burst at attempt 1, so the backoff never got past its first step. Result:
+     * <strong>13,190 port opens in 88 minutes</strong> (2.5/s), inter-arrival pinned at
+     * 0.51–0.53 s — exactly {@link #BASE_BACKOFF_MS} plus the open — and the
+     * budget-exhausted path never reached once.
+     *
+     * <p>A port that opens is not a link that works. Only elapsed time proves that, so the
+     * burst now persists across opens and resets only after the connection has genuinely
+     * held for this long.
+     */
+    public static final long STABLE_CONNECTION_MS = 10_000;
+
+    /**
+     * Whether a connection that has just failed had lasted long enough to count as a
+     * recovery, meaning the next failure starts a fresh escalation rather than continuing
+     * the previous burst.
+     *
+     * @param nowMs         when the failure arrived
+     * @param connectedAtMs when the port was last opened, or {@code 0} if never
+     */
+    public static boolean shouldResetBurst(long nowMs, long connectedAtMs) {
+        if (connectedAtMs <= 0) return true;
+        long held = nowMs - connectedAtMs;
+        // A backwards clock correction must not make a brief connection look stable.
+        if (held < 0) return false;
+        return held >= STABLE_CONNECTION_MS;
+    }
+
+    /**
+     * Attempts over which the backoff escalates before pinning at {@link #MAX_BACKOFF_MS}.
+     *
+     * <p>No longer a give-up budget. A transient error now retries indefinitely, because
+     * giving up strands the operator: the storm this policy failed to prevent was at least
+     * landing CAT commands intermittently, and surfacing the manual <em>tap to retry</em>
+     * chip mid-activation would have taken CAT away entirely until the user noticed and
+     * tapped. Escalating to one attempt per {@link #MAX_BACKOFF_MS} is a ~20x reduction in
+     * churn (2.5/s measured, down to 0.125/s) while the link still recovers unattended.
+     *
+     * <p>A FATAL classification still surfaces immediately — a device that has left the bus
+     * or refused permission will not come back by retrying.
      */
     public static final int MAX_AUTO_RECONNECT_ATTEMPTS = 5;
 
@@ -103,13 +146,17 @@ public final class CatReconnectPolicy {
     /**
      * Whether an automatic reconnect should be attempted.
      *
+     * <p>Transient errors retry without limit — see {@link #MAX_AUTO_RECONNECT_ATTEMPTS}
+     * for why the budget was dropped. {@code attemptsSoFar} no longer gates the decision;
+     * it survives only so callers reading this alongside {@link #backoffMs} see the same
+     * burst counter, and so the signature stays stable for existing callers.
+     *
      * @param kind          the classification of the error
      * @param attemptsSoFar how many auto-reconnects have already been tried in
      *                      this burst ({@code 0} on the first error)
      */
     public static boolean shouldAutoReconnect(Kind kind, int attemptsSoFar) {
-        if (kind == Kind.FATAL) return false;
-        return attemptsSoFar < MAX_AUTO_RECONNECT_ATTEMPTS;
+        return kind != Kind.FATAL;
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/location/GpsClockUpdater.java
@@ -59,24 +59,28 @@ public class GpsClockUpdater extends LocationSubscriber {
      */
     static final long MAX_SANE_OFFSET_MS = 60L * 1000L;
 
-    /**
-     * Largest jump allowed between consecutive GPS-applied offsets within one session.
-     *
-     * <p>The absolute bound above cannot catch the failure that actually bites: a single
-     * bad fix whose implied correction is small enough to look plausible but large enough
-     * to slide the FT8 grid off the air. On the 2026-07-30 activation the app spent two
-     * stretches transmitting 5.06 s and 7.63 s off grid — every over in them keyed up
-     * past the 2.36 s audio slack, so {@code lateStartSkipMs} clipped the leading Costas
-     * sync array out of 13.5% of that session's transmissions: loud on the air, invisible
-     * to receivers.
-     *
-     * <p>Physics makes this cheap to detect. GPS time does not jump, and a device clock
-     * drifts on the order of milliseconds between fixes minutes apart. A multi-second
-     * STEP is therefore bad data by definition, whatever its absolute value. Only the
-     * first fix of a session gets to move the clock freely (there is no baseline to
-     * compare against, and that fix is the one legitimately correcting real drift).
-     */
-    static final long MAX_OFFSET_STEP_MS = 500L;
+    // A step bound (reject a fix that moves the applied offset by more than 500 ms) was
+    // added here and REMOVED again after one activation, because it was actively harmful.
+    //
+    // The reasoning behind it — GPS time does not jump, so a multi-second step is bad
+    // data — is sound in isolation and wrong as a rule, because it has no way to
+    // distinguish "this fix is bad" from "the baseline is bad". Pairing it with an
+    // unconstrained first fix made the first fix of a run permanent: on the 2026-07-31
+    // activation a cold fix 2.6 s after startup applied -1331 ms, and the next ELEVEN
+    // fixes — spread over an hour and all agreeing on about -2200 ms — were each refused
+    // for being ~870 ms away from it. The clock stayed wrong for the whole session:
+    // decodes fell to 5.9/cycle against 8.7 immediately after GPS finally got through,
+    // and transmit timing scattered (14 of 110 overs keyed up 5 s or more into the slot).
+    //
+    // One outlier is noise; eleven consecutive fixes agreeing with each other and
+    // disagreeing with the baseline are the truth, and the rule could never act on that.
+    // Rejecting a correction is not the safe default it looks like — a stale offset is
+    // just as capable of putting the grid off the air as a bad fix is, and unlike a bad
+    // fix it never self-corrects.
+    //
+    // If step-limiting is revisited, it must be able to re-baseline: e.g. accept a run of
+    // consecutive fixes that agree with each other and disagree with the applied offset.
+    // Don't reintroduce a bare step check.
 
     /** Configurable update-interval bounds (minutes), per issue #373. */
     static final int MIN_INTERVAL_MINUTES = 1;
@@ -258,9 +262,7 @@ public class GpsClockUpdater extends LocationSubscriber {
                 fixUtcMs,
                 fixElapsedNanos,
                 nowElapsedNanos,
-                nowSystemMs,
-                hasAppliedOffset,
-                lastAppliedOffsetMs);
+                nowSystemMs);
 
         if (offsetMs == null) {
             Log.d(TAG, "Ignoring GPS fix (not running or implausible): fixUtc=" + fixUtcMs);
@@ -271,7 +273,7 @@ public class GpsClockUpdater extends LocationSubscriber {
             if (isRunning()) {
                 GeneralVariables.fileLog("GpsClock: REJECTED fix offset=" + rawOffsetMs
                         + "ms (prior=" + (hasAppliedOffset ? lastAppliedOffsetMs + "ms" : "none")
-                        + ", absMax=" + MAX_SANE_OFFSET_MS + "ms, maxStep=" + MAX_OFFSET_STEP_MS
+                        + ", absMax=" + MAX_SANE_OFFSET_MS
                         + "ms) — clock left at " + UtcTimer.delay + "ms");
             }
             return;
@@ -330,22 +332,6 @@ public class GpsClockUpdater extends LocationSubscriber {
         return Math.abs((long) offsetMs) <= MAX_SANE_OFFSET_MS;
     }
 
-    /**
-     * Whether {@code offsetMs} is a believable successor to the offset already applied
-     * this session. See {@link #MAX_OFFSET_STEP_MS} for why a step bound catches what the
-     * absolute bound cannot.
-     *
-     * @param hasPriorOffset whether GPS has already disciplined the clock this session;
-     *                       false for the first fix, which is unconstrained by this check
-     * @param priorOffsetMs  the offset currently applied (meaningless when no prior)
-     * @param offsetMs       the offset this fix implies
-     */
-    static boolean isOffsetStepSane(boolean hasPriorOffset, int priorOffsetMs, int offsetMs) {
-        if (!hasPriorOffset) return true;
-        long step = Math.abs((long) offsetMs - (long) priorOffsetMs);
-        return step <= MAX_OFFSET_STEP_MS;
-    }
-
     /** Coerce a configured update interval into the allowed range (minutes). */
     public static int clampIntervalMinutes(int minutes) {
         if (minutes < MIN_INTERVAL_MINUTES) return MIN_INTERVAL_MINUTES;
@@ -392,12 +378,10 @@ public class GpsClockUpdater extends LocationSubscriber {
      * without a {@link LocationManager}.
      */
     static Integer computeAppliedOffset(boolean running, long fixUtcMs, long fixElapsedRealtimeNanos,
-                                        long nowElapsedRealtimeNanos, long nowSystemMs,
-                                        boolean hasPriorOffset, int priorOffsetMs) {
+                                        long nowElapsedRealtimeNanos, long nowSystemMs) {
         if (!running) return null;
         int offsetMs = gpsClockOffsetMs(fixUtcMs, fixElapsedRealtimeNanos, nowElapsedRealtimeNanos, nowSystemMs);
         if (!isOffsetSane(fixUtcMs, offsetMs)) return null;
-        if (!isOffsetStepSane(hasPriorOffset, priorOffsetMs, offsetMs)) return null;
         return offsetMs;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RetunePolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RetunePolicy.java
@@ -39,6 +39,30 @@ public final class RetunePolicy {
     /** Minimum gap between "suppressed N retunes" log lines, so the fix can't itself spam. */
     public static final long SUPPRESSION_LOG_INTERVAL_MS = 10_000L;
 
+    /**
+     * How far apart two {@code onConnected()} callbacks must be to count as two separate
+     * connections for the purpose of re-arming the rate limit.
+     *
+     * <p>Resetting on every {@code onConnected()} looked right — a new link genuinely is a
+     * new session — but the 2026-07-31 activation showed that callback IS the runaway. The
+     * suppression log named it directly:
+     * {@code caller=com.k1af.ft8af.MainViewModel$1$$ExternalSyntheticLambda0.run:0}, i.e.
+     * the {@code MainViewModel.this::setOperationBand} posted from {@code onConnected()}.
+     * {@code CableSerialPort} fires that callback on every successful port {@code open()},
+     * and the port was re-opening about once a second, so the reset re-armed the limiter on
+     * every iteration of the loop it exists to contain — retunes went UP, to 73/min from
+     * the 57/min measured before the rate limit existed.
+     *
+     * <p>Debouncing distinguishes the two cases without needing to know why the port
+     * churns: a burst of connects seconds apart is one flapping link and must not re-arm
+     * anything, while a reconnect after a real outage is minutes later and should. The
+     * underlying re-open storm is a separate bug still to be fixed.
+     */
+    public static final long CONNECT_RESET_DEBOUNCE_MS = 30_000L;
+
+    /** {@link #shouldResetOnConnect} sentinel for "no connect seen yet this run". */
+    public static final long NO_CONNECT = Long.MIN_VALUE;
+
     /** {@link #shouldRetune} sentinel for "nothing pushed yet this session". */
     public static final long NO_PUSH = 0L;
 
@@ -90,6 +114,19 @@ public final class RetunePolicy {
         if (rigFreq != requestedFreq) return true;
         // Fully redundant. Re-assert only on the slow heartbeat.
         return elapsedSince(nowMs, lastPushAtMs) >= REASSERT_INTERVAL_MS;
+    }
+
+    /**
+     * Whether this {@code onConnected()} represents a genuinely new connection, and so
+     * should re-arm the retune rate limit. See {@link #CONNECT_RESET_DEBOUNCE_MS}.
+     *
+     * @param nowMs           current wall clock
+     * @param lastConnectAtMs when the previous connect callback arrived, or
+     *                        {@link #NO_CONNECT} if this is the first
+     */
+    public static boolean shouldResetOnConnect(long nowMs, long lastConnectAtMs) {
+        if (lastConnectAtMs == NO_CONNECT) return true;
+        return elapsedSince(nowMs, lastConnectAtMs) >= CONNECT_RESET_DEBOUNCE_MS;
     }
 
     /**

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/CatReconnectPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/CatReconnectPolicyTest.java
@@ -15,6 +15,9 @@ import java.io.IOException;
  */
 public class CatReconnectPolicyTest {
 
+    /** Fixed epoch-like instant for the burst-timing cases. */
+    private static final long T0 = 1_700_000_000_000L;
+
     // ---- classify -----------------------------------------------------------
 
     @Test
@@ -54,9 +57,13 @@ public class CatReconnectPolicyTest {
     }
 
     @Test
-    public void autoReconnect_budgetExhausted_denied() {
+    public void autoReconnect_transientRetriesWithoutLimit() {
+        // The budget was dropped deliberately: giving up strands the operator with no CAT
+        // until they notice the retry chip. Containment comes from the backoff escalating
+        // to MAX_BACKOFF_MS and staying there, not from stopping.
         assertThat(CatReconnectPolicy.shouldAutoReconnect(
-                Kind.TRANSIENT, CatReconnectPolicy.MAX_AUTO_RECONNECT_ATTEMPTS)).isFalse();
+                Kind.TRANSIENT, CatReconnectPolicy.MAX_AUTO_RECONNECT_ATTEMPTS)).isTrue();
+        assertThat(CatReconnectPolicy.shouldAutoReconnect(Kind.TRANSIENT, 1_000)).isTrue();
     }
 
     @Test
@@ -144,9 +151,55 @@ public class CatReconnectPolicyTest {
     }
 
     @Test
-    public void decide_transientBudgetExhausted_surfaces() {
+    public void decide_transientKeepsReconnectingPastTheOldBudget() {
         assertThat(CatReconnectPolicy.decide(
                 false, Kind.TRANSIENT, CatReconnectPolicy.MAX_AUTO_RECONNECT_ATTEMPTS))
-                .isEqualTo(CatReconnectPolicy.Action.SURFACE);
+                .isEqualTo(CatReconnectPolicy.Action.RECONNECT);
+    }
+
+    // ---- shouldResetBurst: the reconnect-storm fix -------------------------
+
+    @Test
+    public void burst_neverConnected_resets() {
+        assertThat(CatReconnectPolicy.shouldResetBurst(T0, 0L)).isTrue();
+    }
+
+    @Test
+    public void burst_portThatDiesImmediatelyDoesNotReset() {
+        // THE bug. CableConnector treated connect() returning true as success and reset
+        // the escalation there, so a port that opened and immediately errored restarted
+        // the burst at attempt 1 every time — backoff pinned at BASE_BACKOFF_MS (500 ms).
+        // Measured result: 13,190 port opens in 88 minutes, inter-arrival 0.51-0.53 s,
+        // and the give-up path never reached once.
+        assertThat(CatReconnectPolicy.shouldResetBurst(T0 + 30, T0)).isFalse();
+        assertThat(CatReconnectPolicy.shouldResetBurst(T0 + 530, T0)).isFalse();
+    }
+
+    @Test
+    public void burst_connectionThatHeldResets() {
+        assertThat(CatReconnectPolicy.shouldResetBurst(
+                T0 + CatReconnectPolicy.STABLE_CONNECTION_MS, T0)).isTrue();
+    }
+
+    @Test
+    public void burst_justUnderStableDoesNotReset() {
+        assertThat(CatReconnectPolicy.shouldResetBurst(
+                T0 + CatReconnectPolicy.STABLE_CONNECTION_MS - 1, T0)).isFalse();
+    }
+
+    @Test
+    public void burst_backwardsClockDoesNotFakeStability() {
+        // System.currentTimeMillis() is not monotonic and this app disciplines its own
+        // clock; a backwards correction must not make a 30 ms connection look stable.
+        assertThat(CatReconnectPolicy.shouldResetBurst(T0 - 60_000, T0)).isFalse();
+    }
+
+    @Test
+    public void burst_escalationReachesTheCeilingQuickly() {
+        // With the counter persisting, a flapping link walks up to the ceiling in a
+        // handful of attempts instead of sitting at the first step forever.
+        assertThat(CatReconnectPolicy.backoffMs(1)).isEqualTo(CatReconnectPolicy.BASE_BACKOFF_MS);
+        assertThat(CatReconnectPolicy.backoffMs(5)).isEqualTo(CatReconnectPolicy.MAX_BACKOFF_MS);
+        assertThat(CatReconnectPolicy.backoffMs(50)).isEqualTo(CatReconnectPolicy.MAX_BACKOFF_MS);
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/CatReconnectPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/CatReconnectPolicyTest.java
@@ -53,7 +53,7 @@ public class CatReconnectPolicyTest {
     public void autoReconnect_transientWithinBudget_allowed() {
         assertThat(CatReconnectPolicy.shouldAutoReconnect(Kind.TRANSIENT, 0)).isTrue();
         assertThat(CatReconnectPolicy.shouldAutoReconnect(
-                Kind.TRANSIENT, CatReconnectPolicy.MAX_AUTO_RECONNECT_ATTEMPTS - 1)).isTrue();
+                Kind.TRANSIENT, CatReconnectPolicy.BACKOFF_ESCALATION_ATTEMPTS - 1)).isTrue();
     }
 
     @Test
@@ -62,7 +62,7 @@ public class CatReconnectPolicyTest {
         // until they notice the retry chip. Containment comes from the backoff escalating
         // to MAX_BACKOFF_MS and staying there, not from stopping.
         assertThat(CatReconnectPolicy.shouldAutoReconnect(
-                Kind.TRANSIENT, CatReconnectPolicy.MAX_AUTO_RECONNECT_ATTEMPTS)).isTrue();
+                Kind.TRANSIENT, CatReconnectPolicy.BACKOFF_ESCALATION_ATTEMPTS)).isTrue();
         assertThat(CatReconnectPolicy.shouldAutoReconnect(Kind.TRANSIENT, 1_000)).isTrue();
     }
 
@@ -153,7 +153,7 @@ public class CatReconnectPolicyTest {
     @Test
     public void decide_transientKeepsReconnectingPastTheOldBudget() {
         assertThat(CatReconnectPolicy.decide(
-                false, Kind.TRANSIENT, CatReconnectPolicy.MAX_AUTO_RECONNECT_ATTEMPTS))
+                false, Kind.TRANSIENT, CatReconnectPolicy.BACKOFF_ESCALATION_ATTEMPTS))
                 .isEqualTo(CatReconnectPolicy.Action.RECONNECT);
     }
 
@@ -192,6 +192,17 @@ public class CatReconnectPolicyTest {
         // System.currentTimeMillis() is not monotonic and this app disciplines its own
         // clock; a backwards correction must not make a 30 ms connection look stable.
         assertThat(CatReconnectPolicy.shouldResetBurst(T0 - 60_000, T0)).isFalse();
+    }
+
+    @Test
+    public void escalationConstantMatchesWhenTheCeilingIsReached() {
+        // BACKOFF_ESCALATION_ATTEMPTS is no longer a give-up budget, so it only earns its
+        // place by describing something real: the attempt at which backoff hits the
+        // ceiling. Pin that, or the name drifts from the behaviour again.
+        assertThat(CatReconnectPolicy.backoffMs(CatReconnectPolicy.BACKOFF_ESCALATION_ATTEMPTS))
+                .isEqualTo(CatReconnectPolicy.MAX_BACKOFF_MS);
+        assertThat(CatReconnectPolicy.backoffMs(CatReconnectPolicy.BACKOFF_ESCALATION_ATTEMPTS - 1))
+                .isLessThan(CatReconnectPolicy.MAX_BACKOFF_MS);
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/location/GpsClockUpdaterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/location/GpsClockUpdaterTest.java
@@ -106,74 +106,31 @@ public class GpsClockUpdaterTest {
         assertThat(GpsClockUpdater.MAX_SANE_OFFSET_MS).isAtLeast(30_000L);
     }
 
-    // ---- isOffsetStepSane (the bound that catches a plausible-looking bad fix) ----
+    // ---- regression: a consistent correction must never be refused ----
 
     @Test
-    public void step_firstFixIsUnconstrained() {
-        // No baseline yet, and this is the fix that legitimately corrects accumulated
-        // drift — it must be allowed to move the clock by a lot.
-        assertThat(GpsClockUpdater.isOffsetStepSane(false, 0, 45_000)).isTrue();
-        assertThat(GpsClockUpdater.isOffsetStepSane(false, 0, -45_000)).isTrue();
-    }
-
-    @Test
-    public void step_rejectsTheMultiSecondJumpThatWentOnAir() {
-        // The 2026-07-30 activation: the grid slid 5.06 s and 7.63 s, and every over in
-        // those stretches keyed up past the audio slack with its leading Costas array
-        // clipped. Both are within the absolute bound, so only the step check stops them.
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, 0, 5_060)).isFalse();
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, 0, 7_630)).isFalse();
-        // ...and each is still "sane" by the absolute bound alone, which is the point.
-        assertThat(GpsClockUpdater.isOffsetSane(1_700_000_000_000L, 5_060)).isTrue();
-    }
-
-    @Test
-    public void step_acceptsOrdinaryDriftBetweenFixes() {
-        // A device clock drifts milliseconds between fixes minutes apart.
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, 120, 145)).isTrue();
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, -80, -60)).isTrue();
-    }
-
-    @Test
-    public void step_boundaryIsInclusive() {
-        int prior = 100;
-        int atBound = prior + (int) GpsClockUpdater.MAX_OFFSET_STEP_MS;
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, prior, atBound)).isTrue();
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, prior, atBound + 1)).isFalse();
-    }
-
-    @Test
-    public void step_measuredAgainstPriorNotZero() {
-        // A large but STABLE offset must keep being accepted: once the first fix has
-        // corrected a badly-unsynced clock, later fixes near that value are correct and
-        // must not be rejected for being far from zero.
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, 40_000, 40_050)).isTrue();
-    }
-
-    @Test
-    public void step_rejectsJumpBackToZeroFromLargeOffset() {
-        // The mirror image: having disciplined to +40 s, a fix implying ~0 is a bad fix,
-        // not the clock spontaneously fixing itself.
-        assertThat(GpsClockUpdater.isOffsetStepSane(true, 40_000, 0)).isFalse();
-    }
-
-    // ---- computeAppliedOffset with the step bound wired in ----
-
-    @Test
-    public void appliedOffset_nullWhenStepTooLarge() {
-        // Running, absolute-sane, but a 3 s jump from the applied offset: dropped.
+    public void aMultiSecondCorrectionIsApplied_notRefusedForBeingFarFromThePrevious() {
+        // The 2026-07-31 activation, reproduced: a cold fix 2.6s after startup applied
+        // -1331ms, then eleven fixes over the following hour all implied about -2200ms
+        // and were each refused by a 500ms step bound for being ~870ms away from it. The
+        // clock stayed ~870ms wrong all session — decodes 5.9/cycle against 8.7 right
+        // after GPS finally got through, and 14 of 110 overs keying up 5s+ into the slot.
+        //
+        // A stale offset puts the FT8 grid off the air just as surely as a bad fix does,
+        // and unlike a bad fix it never self-corrects. Within the absolute bound, apply.
         Integer r = GpsClockUpdater.computeAppliedOffset(
-                true, 11_000L, 5000L * MS, 5000L * MS, 8_000L, true, 0);
-        assertThat(r).isNull();
+                true, 10_000L - 2_200L, 5000L * MS, 5000L * MS, 10_000L);
+        assertThat(r).isEqualTo(-2_200);
     }
 
     @Test
-    public void appliedOffset_allowsSmallStepFromPrior() {
-        // Same fix geometry as appliedOffset_returnsOffsetWhenRunningAndSane (+2000),
-        // with a prior offset close enough that the step passes.
-        Integer r = GpsClockUpdater.computeAppliedOffset(
-                true, 10_000L, 5000L * MS, 5000L * MS, 8_000L, true, 1_800);
-        assertThat(r).isEqualTo(2_000);
+    public void repeatedAgreeingFixesAllApply() {
+        // Whatever the previously applied offset was, each of a consistent run is applied.
+        for (int impliedOffset : new int[] {-2_112, -2_159, -2_143, -2_156, -2_213}) {
+            Integer r = GpsClockUpdater.computeAppliedOffset(
+                    true, 10_000L + impliedOffset, 5000L * MS, 5000L * MS, 10_000L);
+            assertThat(r).isEqualTo(impliedOffset);
+        }
     }
 
     // ---- clampIntervalMinutes ----
@@ -236,21 +193,21 @@ public class GpsClockUpdaterTest {
     @Test
     public void appliedOffset_nullWhenNotRunning() {
         // A fix that raced past a disable (running flipped false) must not touch the clock.
-        Integer r = GpsClockUpdater.computeAppliedOffset(false, 10_000L, 5000L * MS, 5000L * MS, 8_000L, false, 0);
+        Integer r = GpsClockUpdater.computeAppliedOffset(false, 10_000L, 5000L * MS, 5000L * MS, 8_000L);
         assertThat(r).isNull();
     }
 
     @Test
     public void appliedOffset_nullWhenInsane() {
         // fixUtc==0 (no time in the fix) is rejected even while running.
-        Integer r = GpsClockUpdater.computeAppliedOffset(true, 0L, 5000L * MS, 5000L * MS, 8_000L, false, 0);
+        Integer r = GpsClockUpdater.computeAppliedOffset(true, 0L, 5000L * MS, 5000L * MS, 8_000L);
         assertThat(r).isNull();
     }
 
     @Test
     public void appliedOffset_returnsOffsetWhenRunningAndSane() {
         // GPS UTC now = 10_000 (fresh fix), device reads 8_000 => +2_000.
-        Integer r = GpsClockUpdater.computeAppliedOffset(true, 10_000L, 5000L * MS, 5000L * MS, 8_000L, false, 0);
+        Integer r = GpsClockUpdater.computeAppliedOffset(true, 10_000L, 5000L * MS, 5000L * MS, 8_000L);
         assertThat(r).isEqualTo(2_000);
     }
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RetunePolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RetunePolicyTest.java
@@ -46,6 +46,44 @@ public class RetunePolicyTest {
                 FREQ, OTHER_FREQ, FREQ, T0 + 10, T0)).isTrue();
     }
 
+    // ---------------------------------------------------------------
+    // Connect-reset debounce (onConnected IS the ~1 Hz retune driver)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void firstConnectResets() {
+        assertThat(RetunePolicy.shouldResetOnConnect(T0, RetunePolicy.NO_CONNECT)).isTrue();
+    }
+
+    @Test
+    public void aFlappingPortDoesNotReArmTheRateLimit() {
+        // The measured failure: CableSerialPort fires onConnected() on every successful
+        // port open() and the port was re-opening about once a second, so an
+        // unconditional reset re-armed the limiter on every iteration of the loop it
+        // exists to contain — retunes rose to 73/min from the 57/min measured before the
+        // rate limit existed.
+        assertThat(RetunePolicy.shouldResetOnConnect(T0 + 1_000, T0)).isFalse();
+        assertThat(RetunePolicy.shouldResetOnConnect(T0 + 5_000, T0)).isFalse();
+    }
+
+    @Test
+    public void aReconnectAfterARealOutageResets() {
+        assertThat(RetunePolicy.shouldResetOnConnect(
+                T0 + RetunePolicy.CONNECT_RESET_DEBOUNCE_MS, T0)).isTrue();
+    }
+
+    @Test
+    public void connectDebounceToleratesBackwardsTime() {
+        assertThat(RetunePolicy.shouldResetOnConnect(T0 - 60_000, T0)).isTrue();
+    }
+
+    @Test
+    public void connectDebounceOutlastsTheObservedFlapRate() {
+        // Must be far above the ~1 s flap; the reassert heartbeat and the rig-freq check
+        // cover a genuine reconnect that lands inside the window.
+        assertThat(RetunePolicy.CONNECT_RESET_DEBOUNCE_MS).isAtLeast(10_000L);
+    }
+
     @Test
     public void reconnectIsNotThrottled_whenStateIsResetOnConnect() {
         // MainViewModel.onConnected() calls resetRetuneRateLimit(), which restores


### PR DESCRIPTION
Two regressions from #705 and #706, caught in the field on 2026-07-31 by the diagnostics those PRs added — which is the one part that worked as intended.

## 1. Remove `MAX_OFFSET_STEP_MS` (#705)

The reasoning behind it — GPS time doesn't jump, so a multi-second step is bad data — is sound in isolation and **wrong as a rule**, because it can't distinguish *"this fix is bad"* from *"the baseline is bad"*. Paired with an unconstrained first fix, it made the first fix of a run permanent:

```
16:11:31  applied  offset -1331ms (was -5000ms, prior GPS=none)   ← cold fix, 2.6s after startup
16:23:53  REJECTED offset -2112ms (prior=-1331ms, maxStep=500ms)
16:28:50  REJECTED offset -2159ms
16:33:35  REJECTED offset -2143ms
   ... eleven consecutive rejections over an hour, all agreeing on ~-2200ms ...
```

The clock sat ~870 ms off true UTC for the whole session while GPS repeatedly reported the correct value.

**Cost, measured across the 17:23 boundary where GPS finally got through:**

| | Before (clock pinned) | After (GPS applying) |
|---|---|---|
| Decodes kept/cycle | 5.9 | 8.7 |
| TX timing | scattered, **14 of 110** overs ≥5 s late | **21 of 23** tight |

One outlier is noise; eleven consecutive fixes agreeing with each other and disagreeing with the baseline are the truth, and the rule had no way to ever act on that. Rejecting a correction is not the safe default it looks like — a stale offset puts the FT8 grid off the air just as surely as a bad fix does, and unlike a bad fix it never self-corrects.

The absolute bound (60 s) and the logging both stay — the logging is what made this diagnosable. A comment records why a bare step check must not be reintroduced, and what a workable version would need (re-baselining on a run of agreeing fixes).

## 2. Debounce the retune rate-limit reset (#706)

The suppression log named the runaway caller outright:

```
caller=com.k1af.ft8af.MainViewModel$1$$ExternalSyntheticLambda0.run:0
```

That's the `MainViewModel.this::setOperationBand` posted from **`onConnected()`**. `CableSerialPort` fires that callback on every successful port `open()`, and the port was re-opening about once a second — so the reset I added in code review re-armed the limiter on every iteration of the loop it exists to contain. Every suppression line read `suppressed 1`, and retunes rose to **73/min, above the 57/min measured before the rate limit existed**.

Resetting is still correct for a genuinely new link, so it's now debounced: a burst of connects seconds apart is one flapping link and doesn't re-arm; a reconnect after a real outage does. A genuine reconnect landing inside the debounce window is still covered by the reassert heartbeat and the `rigFreq != requestedFreq` branch.

**Correcting the record on #706:** I originally ruled out the connect path because 7/30 showed few `autoConnect` attempts. That proxy was meaningless — `onConnected()` fires per port `open()` without a fresh `autoConnect`. **The port re-open storm is the real root cause and is still to be fixed**; this PR only stops the containment from being defeated.

## What isn't in scope

- The ~1 Hz port re-open itself. Next task.
- #704's mid-cycle swap never fired this session (`QSO: TX restart` = 0), so it's untouched here — and still unproven on air.

## Testing

`GpsClockUpdaterTest`: step-bound tests removed; two regression tests added that reproduce the field case — a −2200 ms correction applies regardless of what preceded it, and a run of the five actual logged offsets each applies.

`RetunePolicyTest`: five cases for the debounce — first connect resets, a ~1 s flap doesn't, a real outage does, backwards time tolerated, and a guard that the window outlasts the observed flap rate.

Full `testDebugUnitTest` green; `installDebug` verified on a Pixel 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)