### PR TITLE
Stop discarding fast-pass decodes that land after key-up

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -700,38 +700,21 @@ public class MainViewModel extends ViewModel {
                     long replyCostMs = ft8SignalListener.timeSec
                             + GeneralVariables.pttDelay
                             + GeneralVariables.transmitDelay;
-                    FastPassDisposition.Action action = FastPassDisposition.decide(
-                            ft8TransmitSignal.isTransmitting(), replyCostMs, autoReplyBudgetMs);
-                    if (action == FastPassDisposition.Action.PARSE) {
+                    // Sample TX state ONCE: it is read by the decision and again by the
+                    // branch that words the log line, and it can flip between the two.
+                    final boolean transmitting = ft8TransmitSignal.isTransmitting();
+                    // Never dropped — a decode too late to act on this cycle is still
+                    // evidence for the next one. See FastPassDisposition.
+                    if (FastPassDisposition.decide(transmitting, replyCostMs, autoReplyBudgetMs)
+                            == FastPassDisposition.Action.PARSE) {
                         ft8TransmitSignal.parseMessageToFunction(messages);//parse messages and process
-                    } else if (ft8TransmitSignal.isTransmitting()) {
-                        // The fast pass landed AFTER key-up. It used to be dropped outright
-                        // here — the single biggest cause of "the app doesn't see replies to
-                        // my CQ". On the 2026-07-31 activation 34 of the 66 cycles where a
-                        // station called us (52%) were discarded this way: decoded fine,
-                        // replyToMe=true, never shown to the sequencer, so we kept calling CQ
-                        // at someone who was answering. The fast decode arrives ~13.5s +
-                        // decode time into the slot, so a ~2s decode puts it a few hundred ms
-                        // PAST the boundary and past key-up.
-                        //
-                        // Deep passes in exactly this situation were already stashed and
-                        // replayed; the fast pass — the one that matters most — had no such
-                        // path. It does now. Replay goes through the evidence-only parse,
-                        // which still answers a station calling us (see
-                        // FT8TransmitSignal.parseMessageToFunctionInner: the
-                        // checkCQMeOrFollowCQMessage call sits ABOVE the evidenceOnly guard);
-                        // only absence-of-evidence decisions are suppressed, which is right —
-                        // this cycle's no-reply call was already made.
-                        pendingSequencerDecodes.stash(messages, UtcTimer.getSystemTime());
-                        fileLog("QSO: fast decode landed after key-up — stashed "
-                                + messages.size() + " msg(s) for replay");
                     } else {
-                        // Too slow to key up this cycle, but the evidence is still good for
-                        // the next one. Previously also dropped, and — like the branch above
-                        // — invisible in debug.log, which is why this went unnoticed.
                         pendingSequencerDecodes.stash(messages, UtcTimer.getSystemTime());
-                        fileLog("QSO: fast decode over reply budget (" + replyCostMs
-                                + "ms > " + autoReplyBudgetMs + "ms) — stashed for replay");
+                        fileLog(transmitting
+                                ? "QSO: fast decode landed after key-up — stashed "
+                                        + messages.size() + " msg(s) for replay"
+                                : "QSO: fast decode over reply budget (" + replyCostMs
+                                        + "ms > " + autoReplyBudgetMs + "ms) — stashed for replay");
                     }
                 }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -72,6 +72,7 @@ import com.k1af.ft8af.database.RigNameList;
 import com.k1af.ft8af.database.WorkedModeFilter;
 import com.k1af.ft8af.flex.FlexRadio;
 import com.k1af.ft8af.flex.RadioTcpClient;
+import com.k1af.ft8af.ft8listener.FastPassDisposition;
 import com.k1af.ft8af.ft8listener.FT8SignalListener;
 import com.k1af.ft8af.ft8listener.OnFt8Listen;
 import com.k1af.ft8af.ft8transmit.FT8TransmitSignal;
@@ -695,12 +696,43 @@ public class MainViewModel extends ViewModel {
                 //check transmit procedure. Parse transmit procedure from message list
                 //if exceeded cycle by 2 seconds, should not parse
                 int autoReplyBudgetMs = Math.max(2000, GeneralVariables.lateStartTolerance);
-                if (!ft8TransmitSignal.isTransmitting()
-                        && !isDeep//deep passes go through the evidence-only path below
-                        && (ft8SignalListener.timeSec
-                        + GeneralVariables.pttDelay
-                        + GeneralVariables.transmitDelay <= autoReplyBudgetMs)) {//budget scales with late-start tolerance
-                    ft8TransmitSignal.parseMessageToFunction(messages);//parse messages and process
+                if (!isDeep) {//deep passes go through the evidence-only path below
+                    long replyCostMs = ft8SignalListener.timeSec
+                            + GeneralVariables.pttDelay
+                            + GeneralVariables.transmitDelay;
+                    FastPassDisposition.Action action = FastPassDisposition.decide(
+                            ft8TransmitSignal.isTransmitting(), replyCostMs, autoReplyBudgetMs);
+                    if (action == FastPassDisposition.Action.PARSE) {
+                        ft8TransmitSignal.parseMessageToFunction(messages);//parse messages and process
+                    } else if (ft8TransmitSignal.isTransmitting()) {
+                        // The fast pass landed AFTER key-up. It used to be dropped outright
+                        // here — the single biggest cause of "the app doesn't see replies to
+                        // my CQ". On the 2026-07-31 activation 34 of the 66 cycles where a
+                        // station called us (52%) were discarded this way: decoded fine,
+                        // replyToMe=true, never shown to the sequencer, so we kept calling CQ
+                        // at someone who was answering. The fast decode arrives ~13.5s +
+                        // decode time into the slot, so a ~2s decode puts it a few hundred ms
+                        // PAST the boundary and past key-up.
+                        //
+                        // Deep passes in exactly this situation were already stashed and
+                        // replayed; the fast pass — the one that matters most — had no such
+                        // path. It does now. Replay goes through the evidence-only parse,
+                        // which still answers a station calling us (see
+                        // FT8TransmitSignal.parseMessageToFunctionInner: the
+                        // checkCQMeOrFollowCQMessage call sits ABOVE the evidenceOnly guard);
+                        // only absence-of-evidence decisions are suppressed, which is right —
+                        // this cycle's no-reply call was already made.
+                        pendingSequencerDecodes.stash(messages, UtcTimer.getSystemTime());
+                        fileLog("QSO: fast decode landed after key-up — stashed "
+                                + messages.size() + " msg(s) for replay");
+                    } else {
+                        // Too slow to key up this cycle, but the evidence is still good for
+                        // the next one. Previously also dropped, and — like the branch above
+                        // — invisible in debug.log, which is why this went unnoticed.
+                        pendingSequencerDecodes.stash(messages, UtcTimer.getSystemTime());
+                        fileLog("QSO: fast decode over reply budget (" + replyCostMs
+                                + "ms > " + autoReplyBudgetMs + "ms) — stashed for replay");
+                    }
                 }
 
                 // Deep/subtraction/late passes routinely find replies the fast

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastPassDisposition.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastPassDisposition.java
@@ -1,0 +1,54 @@
+package com.k1af.ft8af.ft8listener;
+
+/**
+ * What {@code MainViewModel.afterDecode} does with a FAST-pass decode: act on it now, or
+ * stash it for replay on the next delivery.
+ *
+ * <p>Before this existed the answer was "act on it now, or throw it away". Two conditions
+ * dropped it silently — the transmitter had already keyed, or the decode had eaten the
+ * auto-reply budget — and neither was logged. Measured on the 2026-07-31 activation:
+ * <strong>34 of the 66 cycles where a station called us (52%) were discarded that way</strong>.
+ * They decoded correctly ({@code replyToMe=true} in the log) and the sequencer never saw
+ * them, so the operator kept calling CQ at people who were answering, and had to pick
+ * callers by hand.
+ *
+ * <p>The timing is unforgiving by construction: a fast decode is delivered about
+ * {@code earlyDecodeMillis} plus decode time into the slot, so a ~2 s decode puts delivery
+ * a few hundred milliseconds PAST the slot boundary — and therefore past key-up, which
+ * happens within the first half second. Deep passes landing in exactly that window were
+ * already stashed and replayed; the fast pass, the one carrying the timely reply, was not.
+ *
+ * <p>Stashing is never wrong here: replay runs through the evidence-only parse, which still
+ * answers a station calling us but suppresses absence-of-evidence decisions (no-reply
+ * counting, give-up). Those belong to the cycle that already made them.
+ */
+public final class FastPassDisposition {
+
+    private FastPassDisposition() {}
+
+    /** What to do with this fast-pass delivery. */
+    public enum Action {
+        /** Hand it to the sequencer now — it can still key up this cycle. */
+        PARSE,
+        /** Too late to act on this cycle; keep it for replay as evidence next cycle. */
+        STASH
+    }
+
+    /**
+     * Decide the disposition of one fast-pass delivery.
+     *
+     * <p>Ordering matters: an in-flight transmission is checked first, because once we are
+     * keyed the reply budget is irrelevant — no decode, however quick, can change what is
+     * already going out over the air.
+     *
+     * @param transmitting whether TX has already keyed for this cycle
+     * @param replyCostMs  decode elapsed time plus the PTT and transmit delays — what it
+     *                     would cost to still get a reply out this cycle
+     * @param budgetMs     the auto-reply budget (scales with the late-start tolerance)
+     */
+    public static Action decide(boolean transmitting, long replyCostMs, long budgetMs) {
+        if (transmitting) return Action.STASH;
+        if (replyCostMs > budgetMs) return Action.STASH;
+        return Action.PARSE;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastPassDisposition.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastPassDisposition.java
@@ -20,7 +20,11 @@ package com.k1af.ft8af.ft8listener;
  *
  * <p>Stashing is never wrong here: replay runs through the evidence-only parse, which still
  * answers a station calling us but suppresses absence-of-evidence decisions (no-reply
- * counting, give-up). Those belong to the cycle that already made them.
+ * counting, give-up). Those belong to the cycle that already made them. The load-bearing
+ * detail is that {@code FT8TransmitSignal.parseMessageToFunctionInner} calls
+ * {@code checkCQMeOrFollowCQMessage} <em>above</em> its {@code evidenceOnly} guard — if that
+ * call ever moves below the guard, a replayed decode silently stops answering callers and
+ * this whole mechanism goes quiet again.
  */
 public final class FastPassDisposition {
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/FastPassDispositionTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/FastPassDispositionTest.java
@@ -1,0 +1,82 @@
+package com.k1af.ft8af.ft8listener;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.ft8listener.FastPassDisposition.Action;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link FastPassDisposition} — what happens to a fast-pass decode that
+ * arrives too late to act on this cycle.
+ *
+ * <p>The bug this closes: both late cases used to DROP the decode. Measured on the
+ * 2026-07-31 activation, 34 of the 66 cycles where a station called us (52%) were
+ * discarded — decoded correctly, sequencer never saw them, operator kept calling CQ at
+ * people who were answering and had to pick callers by hand.
+ *
+ * <p>Pure JVM: no Android types.
+ */
+public class FastPassDispositionTest {
+
+    private static final long BUDGET_MS = 2_000;
+
+    @Test
+    public void inTimeAndIdle_parses() {
+        assertThat(FastPassDisposition.decide(false, 400, BUDGET_MS)).isEqualTo(Action.PARSE);
+    }
+
+    @Test
+    public void exactlyAtBudget_stillParses() {
+        // The budget is what it costs to still get a reply out; spending all of it is fine.
+        assertThat(FastPassDisposition.decide(false, BUDGET_MS, BUDGET_MS)).isEqualTo(Action.PARSE);
+    }
+
+    @Test
+    public void justOverBudget_stashesRatherThanDropping() {
+        assertThat(FastPassDisposition.decide(false, BUDGET_MS + 1, BUDGET_MS))
+                .isEqualTo(Action.STASH);
+    }
+
+    @Test
+    public void alreadyKeyed_stashesRatherThanDropping() {
+        // THE case. The fast decode is delivered ~earlyDecodeMillis + decode time into the
+        // slot, so a ~2 s decode lands a few hundred ms past the boundary — and key-up
+        // happens within the first half second. This is the reply to our CQ arriving
+        // moments too late to act on, which is worth keeping, not discarding.
+        assertThat(FastPassDisposition.decide(true, 200, BUDGET_MS)).isEqualTo(Action.STASH);
+    }
+
+    @Test
+    public void alreadyKeyedBeatsAHealthyBudget() {
+        // Ordering matters: once keyed, no decode however quick can change what is already
+        // going out over the air, so the budget must not be able to override this.
+        assertThat(FastPassDisposition.decide(true, 0, BUDGET_MS)).isEqualTo(Action.STASH);
+    }
+
+    @Test
+    public void alreadyKeyedAndOverBudget_stashes() {
+        assertThat(FastPassDisposition.decide(true, 9_000, BUDGET_MS)).isEqualTo(Action.STASH);
+    }
+
+    @Test
+    public void nothingIsEverDropped() {
+        // The whole point: every combination resolves to PARSE or STASH. There is no
+        // third outcome, because a decoded reply is always worth acting on — this cycle
+        // if we can, the next one if we can't.
+        for (boolean tx : new boolean[] {false, true}) {
+            for (long cost : new long[] {0, 400, BUDGET_MS, BUDGET_MS + 1, 30_000}) {
+                Action a = FastPassDisposition.decide(tx, cost, BUDGET_MS);
+                assertThat(a).isAnyOf(Action.PARSE, Action.STASH);
+            }
+        }
+    }
+
+    @Test
+    public void aLargerLateStartToleranceWidensTheParseWindow() {
+        // autoReplyBudgetMs is max(2000, lateStartTolerance), so raising the tolerance
+        // should let a slower decode still reply in the same cycle.
+        assertThat(FastPassDisposition.decide(false, 3_000, 2_000)).isEqualTo(Action.STASH);
+        assertThat(FastPassDisposition.decide(false, 3_000, 4_000)).isEqualTo(Action.PARSE);
+    }
+}


### PR DESCRIPTION
## The app was not seeing half the stations calling it

From the 2026-07-31 activation:

| | |
|---|---|
| Cycles where a station addressed us (`replyToMe=true`) | **66** |
| Reached the auto-sequencer | 32 |
| **Silently discarded** | **34 (52%)** |
| `enqueue caller` fired | **2**, all session |

They decoded correctly and were thrown away before the sequencer ever evaluated them — so the operator kept calling CQ at people who were answering, and had to pick callers by hand.

## Cause

`MainViewModel.afterDecode` gated the fast-pass parse on three conditions and dropped the decode outright when any failed:

```java
if (!ft8TransmitSignal.isTransmitting() && !isDeep && replyCost <= budget) {
    ft8TransmitSignal.parseMessageToFunction(messages);
}
```

Two of those discard live evidence, and the decisive one is `isTransmitting`. A fast decode is delivered about `earlyDecodeMillis` + decode time into the slot, so a ~2 s decode lands a few hundred milliseconds **past** the boundary — and key-up happens within the first half second. Measuring the gap between key-up and the delivery that followed it: **55 deliveries landed 0–0.4 s after key-up**.

Four consecutive cycles of it in the log:

```
16:39:01.841  QSO: TX  msg=[CQ POTA K1AF EM28]
16:39:02.101  DECODE: kept=14 replyToMe=true      ← 0.26 s late, discarded
16:39:31.842  QSO: TX  msg=[CQ POTA K1AF EM28]
16:40:01.835  QSO: TX  msg=[CQ POTA K1AF EM28]
16:40:31.840  QSO: TX  msg=[CQ POTA K1AF EM28]
16:41:01.841  QSO: TX  msg=[W3HH K1AF -16]        ← only after the operator stepped in
```

**Deep passes landing in that same window were already stashed and replayed.** The fast pass — the one carrying the timely reply — had no such path.

## Fix

Route both late cases into the existing `PendingSequencerDecodes` stash, which already ages and evicts.

Replay goes through the evidence-only parse, and that still answers a station calling us: `checkCQMeOrFollowCQMessage` is invoked **above** the `evidenceOnly` guard in `parseMessageToFunctionInner`. Only absence-of-evidence decisions (no-reply counting, give-up) stay suppressed, which is correct — this cycle's no-reply call was already made.

The over-budget branch is stashed for the same reason: too slow to key up *this* cycle doesn't make the evidence worthless *next* cycle.

Both drops were also invisible in `debug.log`. That's why this survived four PRs of me chasing adjacent problems — the timing symptoms (clipped Costas, off-grid TX) were visible and this was not. Both now log.

## Testing

Decision extracted to `FastPassDisposition` and unit-tested (8 cases, pure JVM). Its contract is that **there is no third outcome** — every delivery either parses now or is stashed for replay, and one test asserts that exhaustively across the input space. Also covers ordering (already-keyed beats a healthy budget), the budget boundary either side, and the late-start tolerance widening the parse window.

Full `testDebugUnitTest` green.

## Scope

Independent of #708 (GPS step bound / reconnect storm), which is still open. This is the sequencer-side defect; #708 is the timing-side one. Both contribute to the same operator experience.

Not yet exercised on air.

🤖 Generated with [Claude Code](https://claude.com/claude-code)