### PR TITLE
Hold key-up while this slot's fast decode is still running

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -990,6 +990,11 @@ public class MainViewModel extends ViewModel {
         });
 
 
+        // Let the transmitter hold key-up while this slot's fast decode is still running,
+        // so a busy band answers callers in the right cycle instead of one late.
+        // See FastDecodeGate.
+        ft8TransmitSignal.setFastDecodeGate(ft8SignalListener.getFastDecodeGate());
+
         //create meter protection controller (ALC auto-volume + SWR halt)
         meterProtectionController = new MeterProtectionController();
         meterProtectionController.setTransmitSignal(ft8TransmitSignal);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -218,7 +218,7 @@ public class FT8SignalListener {
             @Override
             public void run() {
                 try {
-                runDecodeThread();
+                    runDecodeThread();
                 } finally {
                     // Backstop. The timely release happens right after delivery below, but
                     // anything throwing before it — JNI init, a decode failure, OOM —

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -52,6 +52,17 @@ public class FT8SignalListener {
     // work never slows the next slot's early decode. See LateDecode.AnalysisGate.
     private static final LateDecode.AnalysisGate ANALYSIS_GATE = new LateDecode.AnalysisGate();
 
+    /**
+     * Lets the transmitter hold key-up while this slot's fast pass is still running, so a
+     * busy band answers callers in the right cycle instead of one late. See
+     * {@link FastDecodeGate}.
+     */
+    private final FastDecodeGate fastDecodeGate = new FastDecodeGate();
+
+    public FastDecodeGate getFastDecodeGate() {
+        return fastDecodeGate;
+    }
+
 
     static {
         try {
@@ -199,6 +210,10 @@ public class FT8SignalListener {
 //        int data[][] = reader.getData();
         //----------------------------------------------------------
 
+        // Marked in flight BEFORE the thread starts, not inside it: the transmitter can
+        // reach its key-up check before this thread is scheduled, and would then see an
+        // idle gate and key up against a decode that was about to run.
+        fastDecodeGate.begin();
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -235,8 +250,16 @@ public class FT8SignalListener {
                 addMsgToList(allMsg, msgs);
                 timeSec = System.currentTimeMillis() - time;
                 decodeTimeSec.postValue(timeSec);// decode elapsed time
-                if (onFt8Listen != null) {
-                    onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, false);
+                try {
+                    if (onFt8Listen != null) {
+                        onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, false);
+                    }
+                } finally {
+                    // Released only after DELIVERY, not merely after decoding: the
+                    // sequencer acts inside afterDecode, so a transmitter waiting on this
+                    // would otherwise still race it. finally, so a throw in a listener
+                    // cannot strand TX waiting out the full hold. See FastDecodeGate.
+                    fastDecodeGate.end();
                 }
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -217,6 +217,18 @@ public class FT8SignalListener {
         new Thread(new Runnable() {
             @Override
             public void run() {
+                try {
+                runDecodeThread();
+                } finally {
+                    // Backstop. The timely release happens right after delivery below, but
+                    // anything throwing before it — JNI init, a decode failure, OOM —
+                    // would otherwise strand the gate in flight FOREVER, making every
+                    // later key-up wait out the full hold. end() is idempotent.
+                    fastDecodeGate.end();
+                }
+            }
+
+            private void runDecodeThread() {
                 long time = System.currentTimeMillis();
                 if (onFt8Listen != null) {
                     onFt8Listen.beforeListen(utc);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastDecodeGate.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastDecodeGate.java
@@ -1,0 +1,92 @@
+package com.k1af.ft8af.ft8listener;
+
+/**
+ * Lets the transmitter wait for the fast decode of the slot that just ended, instead of
+ * keying up while it is still running and acting on the result a cycle late.
+ *
+ * <p>The fast pass is delivered about {@code earlyDecodeMillis} plus decode time into the
+ * slot, and key-up happens roughly 0.45 s into the next one — so the decode has under two
+ * seconds to finish. Whether it does depends entirely on how busy the band is. Measured
+ * across one morning's activation:
+ *
+ * <table>
+ *   <tr><td></td><td>busy (09:15-09:45)</td><td>quiet (09:45 on)</td></tr>
+ *   <tr><td>decodes kept per cycle</td><td>14.2</td><td>6.3</td></tr>
+ *   <tr><td>deliveries landing after key-up</td><td>35</td><td>0</td></tr>
+ * </table>
+ *
+ * <p>That is backwards from what an operator needs: the busier the band, the more likely
+ * the app is to miss the station calling them. A pileup is precisely when auto-answer
+ * matters most. Those late deliveries are no longer lost — they are stashed and replayed —
+ * but a replay acts on the NEXT cycle, so a third of callers were answered 15 s late.
+ *
+ * <p>There is roughly 1.9 s of unused headroom before the audio slack runs out, so the fix
+ * is to spend it only when there is something to wait for. On a quiet band the decode has
+ * already finished and {@link #awaitIdle} returns immediately, leaving key-up timing
+ * untouched. On a busy band the transmitter waits the few hundred milliseconds the decode
+ * still needs and then sends the RIGHT message, in the right cycle.
+ *
+ * <p>A fixed delay would have been the wrong shape — it would tax every transmission to fix
+ * a load-dependent problem. This is conditional, so it costs nothing when idle.
+ */
+public final class FastDecodeGate {
+
+    private final Object lock = new Object();
+    private boolean inFlight;
+
+    /** Called by the decode thread when a fast (non-deep) pass starts. */
+    public void begin() {
+        synchronized (lock) {
+            inFlight = true;
+        }
+    }
+
+    /**
+     * Called by the decode thread once the fast pass has been DELIVERED — not merely
+     * decoded. Waiting only until decode finished would still race the sequencer, which
+     * acts inside the delivery callback.
+     */
+    public void end() {
+        synchronized (lock) {
+            inFlight = false;
+            lock.notifyAll();
+        }
+    }
+
+    /** Whether a fast pass is currently running. */
+    public boolean inFlight() {
+        synchronized (lock) {
+            return inFlight;
+        }
+    }
+
+    /**
+     * Block until no fast pass is in flight, or {@code deadlineEpochMs} passes.
+     *
+     * <p>Returns immediately when nothing is running, which is the common case on a quiet
+     * band — so this must stay cheap.
+     *
+     * @param deadlineEpochMs absolute wall-clock instant to give up at; see
+     *                        {@code FT8TransmitSignal.keyUpHoldDeadline}
+     * @param nowMs           current wall clock
+     * @return true if the decode finished (or was never running) before the deadline
+     */
+    public boolean awaitIdle(long deadlineEpochMs, long nowMs) {
+        synchronized (lock) {
+            long remaining = deadlineEpochMs - nowMs;
+            while (inFlight && remaining > 0) {
+                try {
+                    lock.wait(remaining);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return !inFlight;
+                }
+                // Recompute from the clock rather than trusting a single wake: wait() can
+                // return spuriously, and notifyAll() from end() must not be mistaken for
+                // the deadline having arrived.
+                remaining = deadlineEpochMs - System.currentTimeMillis();
+            }
+            return !inFlight;
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastDecodeGate.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FastDecodeGate.java
@@ -34,7 +34,13 @@ public final class FastDecodeGate {
     private final Object lock = new Object();
     private boolean inFlight;
 
-    /** Called by the decode thread when a fast (non-deep) pass starts. */
+    /**
+     * Marks a fast (non-deep) pass as pending. Called by whichever thread is about to
+     * SPAWN the decode thread — deliberately not by the decode thread itself, which may
+     * not be scheduled before the transmitter reaches its key-up check and would leave it
+     * looking at an idle gate. See the comment at the {@code begin()} call site in
+     * {@code FT8SignalListener.decodeFt8}.
+     */
     public void begin() {
         synchronized (lock) {
             inFlight = true;
@@ -45,6 +51,9 @@ public final class FastDecodeGate {
      * Called by the decode thread once the fast pass has been DELIVERED — not merely
      * decoded. Waiting only until decode finished would still race the sequencer, which
      * acts inside the delivery callback.
+     *
+     * <p>Also called from a finally around the whole decode thread body, so a throw before
+     * delivery cannot strand the gate in flight. Idempotent, so the two paths can both fire.
      */
     public void end() {
         synchronized (lock) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -24,6 +24,7 @@ import androidx.lifecycle.MutableLiveData;
 
 import com.k1af.ft8af.FT8Common;
 import com.k1af.ft8af.ModeProfile;
+import com.k1af.ft8af.ft8listener.FastDecodeGate;
 import com.k1af.ft8af.Ft8Message;
 import com.k1af.ft8af.ft8signal.FT8Package;
 import com.k1af.ft8af.GeneralVariables;
@@ -281,6 +282,13 @@ public class FT8TransmitSignal {
                         ToastMessage.show(GeneralVariables.getStringFromResource(R.string.callsign_error));
                         return;
                     }
+                    // Wait for this slot's fast decode if it is still running. Costs
+                    // nothing when it has already finished (the quiet-band case, which is
+                    // most cycles); on a busy band it spends part of the otherwise-idle
+                    // audio slack so the sequencer keys up with the reply it is about to
+                    // learn about, rather than answering that caller a cycle late. Bounded
+                    // so a held start still clips no leading audio. See FastDecodeGate.
+                    holdForFastDecode(utc);
                     doTransmit();// transmit action follows precise timing; delay is the audio signal delay
                 }
             }
@@ -365,6 +373,86 @@ public class FT8TransmitSignal {
      * exact defect this feature exists to avoid.
      */
     static final int RESTART_HEADROOM_MS = 250;
+
+    /**
+     * Work that still has to happen after key-up is released and before audio starts:
+     * the PTT round trip, waveform generation, and opening the output path. Reserved out
+     * of the audio slack so a hold can never eat the margin that keeps the leading Costas
+     * sync array intact — the one failure this codebase must never reintroduce.
+     *
+     * <p>{@code pttDelay} is subtracted separately because it is user-configurable; this
+     * covers the rest.
+     */
+    static final int KEYUP_HOLD_RESERVE_MS = 500;
+
+    /**
+     * Latest point in the slot, in ms from the boundary, that key-up may be held to while
+     * waiting for the fast decode of the slot that just ended.
+     *
+     * <p>The waveform occupies {@code slotMillis - audioSlackMillis}, so any start within
+     * the slack fits with zero clipping. This spends part of that otherwise-idle headroom —
+     * but only the part left after reserving what key-up itself costs, so a held
+     * transmission still starts within the slack and clips nothing.
+     *
+     * <p>Returns 0 (no hold at all) if the reserves already consume the slack, which keeps
+     * a mode with little or no slack, or an extreme {@code pttDelay}, strictly at today's
+     * behaviour rather than borrowing margin it does not have.
+     *
+     * @param audioSlackMillis {@link ModeProfile#audioSlackMillis} — free slack before clipping
+     * @param pttDelayMs       {@code GeneralVariables.pttDelay}, the configured PTT settle time
+     */
+    static long keyUpHoldLimitMs(int audioSlackMillis, int pttDelayMs) {
+        long limit = (long) audioSlackMillis - Math.max(0, pttDelayMs) - KEYUP_HOLD_RESERVE_MS;
+        return Math.max(0, limit);
+    }
+
+    /**
+     * Absolute instant to stop waiting for the fast decode, or {@code boundaryMs} (i.e. no
+     * wait) when there is no headroom to spend.
+     *
+     * @param boundaryMs       wall-clock instant of the slot boundary this TX belongs to
+     * @param audioSlackMillis see {@link #keyUpHoldLimitMs}
+     * @param pttDelayMs       see {@link #keyUpHoldLimitMs}
+     */
+    static long keyUpHoldDeadline(long boundaryMs, int audioSlackMillis, int pttDelayMs) {
+        return boundaryMs + keyUpHoldLimitMs(audioSlackMillis, pttDelayMs);
+    }
+
+    /** Set by MainViewModel once the listener exists; null until then (and in tests). */
+    private volatile FastDecodeGate fastDecodeGate;
+
+    public void setFastDecodeGate(FastDecodeGate gate) {
+        this.fastDecodeGate = gate;
+    }
+
+    /**
+     * Block briefly, if needed, so this transmission carries the result of the fast decode
+     * of the slot that just ended. No-op when nothing is decoding.
+     *
+     * <p>Runs on the cycle-timer's pooled callback thread. Blocking there is safe — the
+     * pool creates threads on demand and this timer fires once per slot — and the wait is
+     * hard-bounded by {@link #keyUpHoldDeadline}, so a decode that never finishes delays
+     * key-up by at most the spare slack rather than stalling the cycle.
+     */
+    private void holdForFastDecode(long utc) {
+        FastDecodeGate gate = fastDecodeGate;
+        if (gate == null || !gate.inFlight()) return;
+        ModeProfile mode = GeneralVariables.currentMode();
+        long nowMs = System.currentTimeMillis();
+        // Anchor the deadline to THIS slot's boundary, derived from the same corrected
+        // clock the cycle timer fires on, so a clock correction cannot make the hold
+        // measure from the wrong place.
+        long boundaryMs = nowMs - (UtcTimer.getSystemTime() % mode.slotMillis);
+        long deadline = keyUpHoldDeadline(boundaryMs, mode.audioSlackMillis,
+                GeneralVariables.pttDelay);
+        if (deadline <= nowMs) return;
+        boolean landed = gate.awaitIdle(deadline, nowMs);
+        long heldMs = System.currentTimeMillis() - nowMs;
+        if (heldMs > 0) {
+            GeneralVariables.fileLog("QSO: held key-up " + heldMs + "ms for fast decode ("
+                    + (landed ? "landed" : "timed out") + ")");
+        }
+    }
 
     /**
      * Whether the playback path these modes select can actually be interrupted mid-buffer.

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/FastDecodeGateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8listener/FastDecodeGateTest.java
@@ -1,0 +1,98 @@
+package com.k1af.ft8af.ft8listener;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link FastDecodeGate}, the handshake that lets the transmitter wait for the
+ * fast decode of the slot that just ended.
+ *
+ * <p>Why it exists, measured across one morning's activation: on a busy band (14.2 decodes
+ * per cycle) 35 fast deliveries landed after key-up and their callers were answered a cycle
+ * late; once the band quietened (6.3 per cycle) that count was zero. The failure scales
+ * with band activity, which is backwards — a pileup is when auto-answer matters most.
+ *
+ * <p>The bound that keeps the wait safe lives in {@code FT8TransmitSignalKeyUpHoldTest}
+ * (package-private to ft8transmit).
+ */
+public class FastDecodeGateTest {
+
+    @Test
+    public void idleGateReturnsImmediately() {
+        // The quiet-band case, and most cycles: key-up timing must be untouched.
+        FastDecodeGate gate = new FastDecodeGate();
+        assertThat(gate.inFlight()).isFalse();
+        long before = System.currentTimeMillis();
+        assertThat(gate.awaitIdle(before + 5_000, before)).isTrue();
+        assertThat(System.currentTimeMillis() - before).isLessThan(500L);
+    }
+
+    @Test
+    public void beginMarksInFlight() {
+        FastDecodeGate gate = new FastDecodeGate();
+        gate.begin();
+        assertThat(gate.inFlight()).isTrue();
+        gate.end();
+        assertThat(gate.inFlight()).isFalse();
+    }
+
+    @Test
+    public void awaitReturnsWhenTheDecodeFinishes() throws Exception {
+        FastDecodeGate gate = new FastDecodeGate();
+        gate.begin();
+        Thread decode = new Thread(() -> {
+            try {
+                Thread.sleep(80);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            gate.end();
+        });
+        decode.start();
+
+        long before = System.currentTimeMillis();
+        boolean landed = gate.awaitIdle(before + 5_000, before);
+        long waited = System.currentTimeMillis() - before;
+        decode.join();
+
+        assertThat(landed).isTrue();
+        assertThat(gate.inFlight()).isFalse();
+        // Released by the decode finishing, not by burning the whole deadline.
+        assertThat(waited).isLessThan(4_000L);
+    }
+
+    @Test
+    public void awaitGivesUpAtTheDeadlineWhenTheDecodeNeverFinishes() {
+        // A hung decode must delay key-up by the bound, never indefinitely.
+        FastDecodeGate gate = new FastDecodeGate();
+        gate.begin();
+        long before = System.currentTimeMillis();
+        boolean landed = gate.awaitIdle(before + 120, before);
+        long waited = System.currentTimeMillis() - before;
+
+        assertThat(landed).isFalse();
+        assertThat(waited).isAtLeast(100L);
+        assertThat(waited).isLessThan(3_000L);
+    }
+
+    @Test
+    public void aDeadlineAlreadyPastDoesNotWait() {
+        FastDecodeGate gate = new FastDecodeGate();
+        gate.begin();
+        long now = System.currentTimeMillis();
+        long before = System.currentTimeMillis();
+        assertThat(gate.awaitIdle(now - 1_000, now)).isFalse();
+        assertThat(System.currentTimeMillis() - before).isLessThan(500L);
+    }
+
+    @Test
+    public void endIsIdempotentAndUnblocksEvenIfCalledTwice() {
+        FastDecodeGate gate = new FastDecodeGate();
+        gate.begin();
+        gate.end();
+        gate.end();
+        long now = System.currentTimeMillis();
+        assertThat(gate.awaitIdle(now + 5_000, now)).isTrue();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalKeyUpHoldTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignalKeyUpHoldTest.java
@@ -1,0 +1,89 @@
+package com.k1af.ft8af.ft8transmit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for the bound on the adaptive key-up hold — how long the transmitter may wait for
+ * the fast decode of the slot that just ended before it must key up regardless.
+ *
+ * <p>The hold spends otherwise-idle audio slack, so the load-bearing property is that it
+ * can never spend so much that the transmission starts past the slack and has its leading
+ * Costas sync array clipped. That defect makes a signal loud on the air and undecodable,
+ * and this codebase has already shipped it twice; the reserves below exist to keep a third
+ * time from being possible.
+ *
+ * <p>The gate itself is covered by {@code FastDecodeGateTest}.
+ */
+public class FT8TransmitSignalKeyUpHoldTest {
+
+    /** FT8: 15000 ms slot, 12640 ms of audio. */
+    private static final int FT8_SLACK_MS = 2360;
+    /** FT4: 7500 ms slot, 5040 ms of audio. */
+    private static final int FT4_SLACK_MS = 2460;
+    private static final long T0 = 1_700_000_000_000L;
+
+    @Test
+    public void holdLimitLeavesRoomForKeyUpCosts() {
+        long limit = FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, 100);
+        assertThat(limit)
+                .isEqualTo(FT8_SLACK_MS - 100 - FT8TransmitSignal.KEYUP_HOLD_RESERVE_MS);
+    }
+
+    @Test
+    public void aHeldStartStillFitsInsideTheSlack() {
+        // The property that matters, stated directly: hold + PTT + generation must not
+        // exceed the slack, or the waveform gets its leading sync array clipped.
+        for (int ptt : new int[] {0, 100, 400, 1_000}) {
+            long limit = FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, ptt);
+            assertThat(limit + ptt + FT8TransmitSignal.KEYUP_HOLD_RESERVE_MS)
+                    .isAtMost((long) FT8_SLACK_MS);
+        }
+    }
+
+    @Test
+    public void holdLimitIsWorthHaving() {
+        // Key-up currently lands ~450 ms into the slot, so the limit must be meaningfully
+        // beyond that or the hold buys no decode time at all.
+        assertThat(FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, 100)).isGreaterThan(450L);
+    }
+
+    @Test
+    public void aLargePttDelayShrinksTheHoldRatherThanBorrowingMargin() {
+        assertThat(FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, 1_500))
+                .isEqualTo(FT8_SLACK_MS - 1_500 - FT8TransmitSignal.KEYUP_HOLD_RESERVE_MS);
+    }
+
+    @Test
+    public void noSlackToSpendMeansNoHold() {
+        // Reserves exceed the slack: fall back to today's behaviour rather than clipping.
+        assertThat(FT8TransmitSignal.keyUpHoldLimitMs(400, 100)).isEqualTo(0L);
+        assertThat(FT8TransmitSignal.keyUpHoldLimitMs(0, 0)).isEqualTo(0L);
+        assertThat(FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, 99_999)).isEqualTo(0L);
+    }
+
+    @Test
+    public void negativePttDelayIsTreatedAsZero() {
+        assertThat(FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, -50))
+                .isEqualTo(FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, 0));
+    }
+
+    @Test
+    public void ft4GetsItsOwnSlack() {
+        assertThat(FT8TransmitSignal.keyUpHoldLimitMs(FT4_SLACK_MS, 100))
+                .isGreaterThan(FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, 100));
+    }
+
+    @Test
+    public void deadlineIsAnchoredToTheBoundary() {
+        assertThat(FT8TransmitSignal.keyUpHoldDeadline(T0, FT8_SLACK_MS, 100))
+                .isEqualTo(T0 + FT8TransmitSignal.keyUpHoldLimitMs(FT8_SLACK_MS, 100));
+    }
+
+    @Test
+    public void deadlineWithNoHeadroomEqualsTheBoundary() {
+        // Equal to "now at the boundary", which the caller treats as "do not wait".
+        assertThat(FT8TransmitSignal.keyUpHoldDeadline(T0, 400, 100)).isEqualTo(T0);
+    }
+}


### PR DESCRIPTION
## Missing callers is a load-dependent bug

Measured across one morning's activation, split at the point the operator noticed things start working:

| | busy (09:15–09:45) | quiet (09:45 on) |
|---|---|---|
| Decodes kept per cycle | **14.2** | **6.3** |
| Deliveries landing after key-up | **35** | **0** |
| Callers per 15 min | 20–25 | 15 → 12 → 2 |

The operator attributed the improvement to adjusting the time controls. It wasn't — nothing time-related appears in the log at the transition, and the clock was already stable (GPS applying cleanly every 5 min, settling near −540 ms). **The band simply quietened.**

That's backwards from what's wanted: the busier the band, the more likely the app is to miss the station calling you, and a pileup is exactly when auto-answer matters most.

## Why

The fast pass is delivered ~`earlyDecodeMillis` + decode time into the slot; key-up fires ~0.45 s into the next one. So the decode has under two seconds. On a busy band it doesn't make it, delivery slips past the boundary, and the sequencer has already committed to its message.

#709 stopped those being discarded — but a stashed decode is replayed on the **next** cycle, so a third of callers were still answered 15 seconds late. That's the behaviour being worked around by hand.

## Fix

There's ~1.9 s of unused headroom before the audio slack runs out. Spend it, but only when there's something to wait for.

`FastDecodeGate` marks a fast pass in flight; the cycle-timer callback waits for it before keying up. On a quiet band the decode has already finished, the wait returns immediately, and key-up timing is unchanged — which is most cycles.

A **fixed** delay would have been the wrong shape: it would tax every transmission to fix a load-dependent problem. That's why the "hold key-up ~1.2 s" option was rejected earlier in favour of #704's mid-cycle restart. Conditional on a decode actually running, that objection doesn't apply.

## The bound is the load-bearing part

`keyUpHoldLimitMs` reserves the configured `pttDelay` plus `KEYUP_HOLD_RESERVE_MS` (waveform generation, output setup) out of the slack, so a held start still begins **inside** the slack and clips no leading Costas array. That defect makes a signal loud on the air and undecodable, and this codebase has already shipped it twice.

When the reserves exceed the slack the limit floors at zero and behaviour is exactly as today — no borrowing margin that isn't there.

Two ordering details worth review:

- The gate is marked in flight **before** the decode thread starts. The transmitter can reach its check first and would otherwise see an idle gate and key up against a decode about to run.
- It's released after **delivery**, not after decoding, in a `finally` — the sequencer acts inside the delivery callback, so releasing earlier would still race it, and a throwing listener must not strand TX waiting out the full hold.

## Testing

`FastDecodeGateTest` (6 cases): idle returns immediately and cheaply, wakes on completion rather than burning the deadline, gives up at the deadline on a hung decode, a past deadline doesn't wait, `end()` idempotent.

`FT8TransmitSignalKeyUpHoldTest` (9 cases): the safety property asserted directly across a range of `pttDelay` values (hold + PTT + generation ≤ slack), the limit is large enough to be worth having, a large `pttDelay` shrinks the hold rather than borrowing margin, zero-slack floors to no hold, FT4's wider slack, and deadline anchoring.

Full `testDebugUnitTest` green; `installDebug` verified on a Pixel 8.

## Verification

`QSO: held key-up NNNms for fast decode (landed|timed out)` is logged whenever a hold occurs. The measurable success criterion is `landed after key-up` going to near zero **while the band is busy** — the previous sessions only achieved that by the band going quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)