### PR TITLE
Show DT on every decode, as WSJT-X does

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDt.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDt.kt
@@ -1,5 +1,6 @@
 package radio.ks3ckc.ft8af.ui.decode
 
+import radio.ks3ckc.ft8af.ui.components.CLOCK_SYNC_FAIR_SEC
 import java.util.Locale
 import kotlin.math.abs
 
@@ -31,7 +32,7 @@ import kotlin.math.abs
  * A value that rounds to zero renders unsigned: "-0.0" is noise, and an operator
  * scanning a column of numbers for a sign should not have to discount it.
  */
-fun formatDecodeDt(seconds: Float): String {
+internal fun formatDecodeDt(seconds: Float): String {
     if (seconds.isNaN() || seconds.isInfinite()) return "--"
     val rounded = Math.round(seconds * 10f) / 10f
     if (abs(rounded) < 0.05f) return "0.0"
@@ -41,9 +42,10 @@ fun formatDecodeDt(seconds: Float): String {
 /**
  * True when a decode's DT is far enough out to be worth the operator's eye.
  *
- * Used only to colour the label. The threshold matches `CLOCK_SYNC_FAIR_SEC` in
- * the slot bar's sync pill, so a row does not call a value alarming while the
- * pill upstream still calls it fair.
+ * Used only to colour the label. Shares [CLOCK_SYNC_FAIR_SEC] with the slot
+ * bar's sync pill rather than repeating its value, so a row can never call a
+ * reading alarming while the averaged indicator above it still calls it fair —
+ * the two would otherwise be free to drift apart the moment either is retuned.
  */
-fun isDecodeDtNotable(seconds: Float): Boolean =
-    !seconds.isNaN() && !seconds.isInfinite() && abs(seconds) > 1.0f
+internal fun isDecodeDtNotable(seconds: Float): Boolean =
+    !seconds.isNaN() && !seconds.isInfinite() && abs(seconds) > CLOCK_SYNC_FAIR_SEC

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDt.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDt.kt
@@ -1,0 +1,49 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import java.util.Locale
+import kotlin.math.abs
+
+/**
+ * DT — how far into our receive window a decoded signal actually started, in
+ * seconds. WSJT-X shows this on every decode line, and it is the single most
+ * useful number for diagnosing a clock problem.
+ *
+ * Read it as a fleet, not one at a time. Other stations are mostly synced, so a
+ * *consistent* bias across every decode is almost certainly our own clock, while
+ * one outlier is just a station with a bad clock (or a signal that arrived via a
+ * long path). The mean of these is what drives the sync pill on the slot bar and
+ * the correction suggestion in Time Sync settings; showing the per-decode value
+ * as well is what lets an operator tell "everyone is at -1.3" (my clock) from
+ * "one guy is at -1.3" (his clock).
+ *
+ * FT8 tolerates roughly ±2 s before decoding collapses, so anything past about
+ * ±1 s is worth acting on.
+ */
+
+/**
+ * A decode's DT, WSJT-X style: signed, one decimal, no unit — `-1.3`, `+0.2`,
+ * `0.0`.
+ *
+ * Prefixed "DT" by the caller rather than suffixed with a unit, because the
+ * metadata row already carries an "ago" time and a bare "-1.3 s" next to it
+ * reads as another duration rather than an offset.
+ *
+ * A value that rounds to zero renders unsigned: "-0.0" is noise, and an operator
+ * scanning a column of numbers for a sign should not have to discount it.
+ */
+fun formatDecodeDt(seconds: Float): String {
+    if (seconds.isNaN() || seconds.isInfinite()) return "--"
+    val rounded = Math.round(seconds * 10f) / 10f
+    if (abs(rounded) < 0.05f) return "0.0"
+    return String.format(Locale.US, "%+.1f", rounded)
+}
+
+/**
+ * True when a decode's DT is far enough out to be worth the operator's eye.
+ *
+ * Used only to colour the label. The threshold matches `CLOCK_SYNC_FAIR_SEC` in
+ * the slot bar's sync pill, so a row does not call a value alarming while the
+ * pill upstream still calls it fair.
+ */
+fun isDecodeDtNotable(seconds: Float): Boolean =
+    !seconds.isNaN() && !seconds.isInfinite() && abs(seconds) > 1.0f

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeRow.kt
@@ -221,6 +221,16 @@ fun DecodeRow(
                 MetaText(if (message.hasSnr()) "${message.snr} dB" else "-- dB")
                 MetaText("${message.getFreq_hz()} Hz")
 
+                // DT, as WSJT-X shows it: how far into our RX window this signal
+                // started. Per-decode rather than only the averaged pill on the slot
+                // bar, because the two answer different questions — every station
+                // sitting at the same offset is our clock, one station out on its own
+                // is that station's.
+                MetaText(
+                    text = "DT ${formatDecodeDt(message.time_sec)}",
+                    color = if (isDecodeDtNotable(message.time_sec)) StatusWarn else TextFaint,
+                )
+
                 // Distance (computed from grid)
                 val distanceText = computeDistanceText(message)
                 if (distanceText.isNotEmpty()) {
@@ -338,10 +348,13 @@ private fun MessageLabel(
  * Small metadata text used in the bottom info row.
  */
 @Composable
-private fun MetaText(text: String) {
+private fun MetaText(
+    text: String,
+    color: androidx.compose.ui.graphics.Color = TextFaint,
+) {
     Text(
         text = text,
-        color = TextFaint,
+        color = color,
         fontFamily = GeistMonoFamily,
         fontSize = 10.5.sp,
         letterSpacing = 0.02.sp,

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDtTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDtTest.kt
@@ -1,0 +1,59 @@
+package radio.ks3ckc.ft8af.ui.decode
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The per-decode DT label.
+ *
+ * The sign is the whole point of this field — it tells an operator which way
+ * their clock is wrong — so the cases here are mostly about the sign surviving
+ * rounding, and about "-0.0" never reaching the screen.
+ */
+class DecodeDtTest {
+    @Test
+    fun `sign is always explicit for non-zero values`() {
+        assertThat(formatDecodeDt(1.3f)).isEqualTo("+1.3")
+        assertThat(formatDecodeDt(-1.3f)).isEqualTo("-1.3")
+        assertThat(formatDecodeDt(0.2f)).isEqualTo("+0.2")
+        assertThat(formatDecodeDt(-0.2f)).isEqualTo("-0.2")
+    }
+
+    @Test
+    fun `values rounding to zero render unsigned`() {
+        // "-0.0" is noise in a column an operator is scanning for a sign.
+        assertThat(formatDecodeDt(0f)).isEqualTo("0.0")
+        assertThat(formatDecodeDt(-0.01f)).isEqualTo("0.0")
+        assertThat(formatDecodeDt(0.04f)).isEqualTo("0.0")
+        assertThat(formatDecodeDt(-0.04f)).isEqualTo("0.0")
+    }
+
+    @Test
+    fun `rounds to one decimal like WSJT-X`() {
+        assertThat(formatDecodeDt(1.24f)).isEqualTo("+1.2")
+        assertThat(formatDecodeDt(1.26f)).isEqualTo("+1.3")
+        assertThat(formatDecodeDt(-2.55f)).isEqualTo("-2.5")
+    }
+
+    @Test
+    fun `a non-finite reading degrades to a placeholder rather than crashing`() {
+        assertThat(formatDecodeDt(Float.NaN)).isEqualTo("--")
+        assertThat(formatDecodeDt(Float.POSITIVE_INFINITY)).isEqualTo("--")
+        assertThat(formatDecodeDt(Float.NEGATIVE_INFINITY)).isEqualTo("--")
+    }
+
+    @Test
+    fun `notable threshold matches the slot bar's fair boundary`() {
+        // A row must not shout while the averaged pill upstream still says "fair".
+        assertThat(isDecodeDtNotable(0.3f)).isFalse()
+        assertThat(isDecodeDtNotable(1.0f)).isFalse()
+        assertThat(isDecodeDtNotable(1.1f)).isTrue()
+        assertThat(isDecodeDtNotable(-1.1f)).isTrue()
+    }
+
+    @Test
+    fun `a non-finite reading is never notable`() {
+        assertThat(isDecodeDtNotable(Float.NaN)).isFalse()
+        assertThat(isDecodeDtNotable(Float.POSITIVE_INFINITY)).isFalse()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDtTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/decode/DecodeDtTest.kt
@@ -1,6 +1,7 @@
 package radio.ks3ckc.ft8af.ui.decode
 
 import com.google.common.truth.Truth.assertThat
+import radio.ks3ckc.ft8af.ui.components.CLOCK_SYNC_FAIR_SEC
 import org.junit.Test
 
 /**
@@ -43,12 +44,14 @@ class DecodeDtTest {
     }
 
     @Test
-    fun `notable threshold matches the slot bar's fair boundary`() {
-        // A row must not shout while the averaged pill upstream still says "fair".
-        assertThat(isDecodeDtNotable(0.3f)).isFalse()
-        assertThat(isDecodeDtNotable(1.0f)).isFalse()
-        assertThat(isDecodeDtNotable(1.1f)).isTrue()
-        assertThat(isDecodeDtNotable(-1.1f)).isTrue()
+    fun `notable threshold is the slot bar's fair boundary, not a copy of it`() {
+        // A row must not shout while the averaged pill upstream still says "fair",
+        // so the boundary is asserted against the shared constant rather than a
+        // repeated literal — a literal here would pass even after the two drifted.
+        assertThat(isDecodeDtNotable(CLOCK_SYNC_FAIR_SEC)).isFalse()
+        assertThat(isDecodeDtNotable(CLOCK_SYNC_FAIR_SEC + 0.1f)).isTrue()
+        assertThat(isDecodeDtNotable(-(CLOCK_SYNC_FAIR_SEC + 0.1f))).isTrue()
+        assertThat(isDecodeDtNotable(CLOCK_SYNC_FAIR_SEC - 0.7f)).isFalse()
     }
 
     @Test


### PR DESCRIPTION
The slot bar has carried a clock-sync pill for a while, but it shows the **mean** DT across the cycle — and a mean can't answer the question an operator actually has when it reads badly:

- *every* station at −1.3 → **my** clock is wrong
- *one* station at −1.3 → **his** clock is wrong

Same number, opposite fixes, and until now no way to tell them apart from the operating screen.

## Nothing new is measured

The value was already there and already trusted. `Ft8Message.time_sec` is the per-decode offset, and `mutableTimerOffset.postValue(time_sec)` is what feeds both the existing sync pill and the correction suggestion in Time Sync settings. This puts it on the row it belongs to.

## Presentation choices

- **WSJT-X style**: signed, one decimal, no unit — `DT +0.2`, `DT -1.3`.
- **Prefixed `DT`, not suffixed with seconds.** The metadata row already ends in an "ago" time; a bare `-1.3 s` next to it reads as another duration rather than an offset.
- **Zero renders unsigned.** `-0.0` is noise in a column you're scanning for a sign.
- **Amber past ±1.0 s** — deliberately the same threshold the slot bar's pill uses for the edge of "fair", so a row never shouts while the averaged indicator above it is still calm.

## Testing

Six unit tests over the pure formatter (sign retention through rounding, the `-0.0` case, non-finite readings degrading to `--`, and the notable-threshold boundary matching `CLOCK_SYNC_FAIR_SEC`). Full suite green.

**Not visually confirmed**: rendering it needs live decodes and no radio was attached, so the label itself is unverified on screen. Everything behind it is covered by tests.

## Context

This came out of chasing a real clock problem: a stale manual `timeCorrectionMs` was re-seeding at every launch and leaving the app ~1.3 s out until GPS discipline got a fix — which indoors is never. The averaged pill showed the symptom; per-decode DT is what would have identified the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
