### PR TITLE
Name a trip from the plans already saved on rtota.app

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rtota/RtotaClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rtota/RtotaClient.kt
@@ -167,6 +167,22 @@ object RtotaClient {
             }
         }
 
+    /**
+     * The operator's own planned trips, soonest first.
+     *
+     * Read from `/api/me` rather than `/api/activations`: the public listing only
+     * carries what a stranger may see, and a plan the operator marked `private`
+     * or `followers` — the ones most likely to be a real upcoming trip — would be
+     * missing from exactly the list they are trying to pick from.
+     */
+    suspend fun fetchMyActivations(
+        baseUrl: String,
+        apiKey: String,
+    ): Result<List<RtotaActivation>> =
+        withContext(Dispatchers.IO) {
+            request("GET", "$baseUrl/api/me", apiKey, null).map { parseMyActivations(it) }
+        }
+
     suspend fun completeTrip(
         baseUrl: String,
         apiKey: String,

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rtota/RtotaModels.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rtota/RtotaModels.kt
@@ -59,6 +59,23 @@ data class TripQso(
 data class RtotaTripHandle(val id: String, val shareToken: String?)
 
 /**
+ * A trip the operator planned on rtota.app — what the site's plan wizard saves.
+ *
+ * The wizard writes a *scheduled activation*, not a trip: a trip only exists
+ * once someone actually drives it. So this is the thing to pick a trip's name
+ * from, and the plan's privacy choices ride along server-side when the trip
+ * turns out to fulfil it (see [activationMatchesNow]).
+ */
+data class RtotaActivation(
+    val id: String,
+    val title: String,
+    val startTimeMs: Long,
+    /** Planned finish, or null when the plan is open-ended. */
+    val endTimeMs: Long?,
+    val detail: String?,
+)
+
+/**
  * What `GET /api/trips/:id/sync-state` says the server already holds — the
  * resume handshake for a client that has been out of touch long enough not to
  * know what it still owes.
@@ -371,6 +388,91 @@ fun parseSyncState(body: String?): RtotaSyncState? {
         )
     } catch (_: Exception) {
         null
+    }
+}
+
+/**
+ * Parse an ISO-8601 instant of the shape the API returns
+ * (`2026-08-04T11:00:00.000Z`), or null when it is missing or unusable.
+ *
+ * Deliberately narrow: the API always emits UTC with milliseconds, and a
+ * hand-rolled lenient parser would happily accept a local-time string and place
+ * a trip several hours from where it belongs.
+ */
+fun parseIsoUtc(value: String?): Long? {
+    val raw = value?.trim().orEmpty()
+    if (raw.isEmpty()) return null
+    return try {
+        val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        fmt.timeZone = TimeZone.getTimeZone("UTC")
+        fmt.isLenient = false
+        fmt.parse(raw)?.time
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * How much slack the server allows either side of a planned window when
+ * deciding which activation a trip fulfils.
+ *
+ * Mirrors `MATCH_SLACK_HOURS` in the service's lib/activation-match.ts.
+ * Departures rarely run on time, and the app only uses this to *tell the
+ * operator* whether starting now will pick the plan up — the server remains the
+ * one that actually decides.
+ */
+const val ACTIVATION_MATCH_SLACK_MS = 12 * 60 * 60 * 1000L
+
+/** An activation with no end time is assumed to span this long, as on the server. */
+private const val ACTIVATION_DEFAULT_SPAN_MS = 24 * 60 * 60 * 1000L
+
+/**
+ * Whether a trip started at [nowMs] would fall inside [activation]'s matching
+ * window, and so inherit the privacy the plan wizard chose.
+ *
+ * Worth surfacing because the consequence is invisible otherwise: a trip started
+ * outside the window is created with the operator's *default* privacy, which for
+ * a plan marked `delayed` means publishing a live position that was meant to lag.
+ */
+fun activationMatchesNow(
+    activation: RtotaActivation,
+    nowMs: Long,
+): Boolean {
+    val windowStart = activation.startTimeMs - ACTIVATION_MATCH_SLACK_MS
+    val windowEnd =
+        (activation.endTimeMs ?: (activation.startTimeMs + ACTIVATION_DEFAULT_SPAN_MS)) +
+            ACTIVATION_MATCH_SLACK_MS
+    return nowMs in windowStart..windowEnd
+}
+
+/**
+ * Pull the operator's own planned trips out of a `GET /api/me` body, soonest
+ * departure first. Rows missing an id, title or start time are dropped rather
+ * than shown as blanks in the picker.
+ */
+fun parseMyActivations(body: String?): List<RtotaActivation> {
+    if (body.isNullOrBlank()) return emptyList()
+    return try {
+        val array = JSONObject(body).optJSONArray("activations") ?: return emptyList()
+        buildList {
+            for (i in 0 until array.length()) {
+                val o = array.optJSONObject(i) ?: continue
+                val id = o.optString("id").takeIf { it.isNotEmpty() } ?: continue
+                val title = o.optString("title").takeIf { it.isNotEmpty() } ?: continue
+                val start = parseIsoUtc(o.optString("startTime")) ?: continue
+                add(
+                    RtotaActivation(
+                        id = id,
+                        title = title,
+                        startTimeMs = start,
+                        endTimeMs = parseIsoUtc(o.optString("endTime")),
+                        detail = o.optString("detail").takeIf { it.isNotEmpty() },
+                    ),
+                )
+            }
+        }.sortedBy { it.startTimeMs }
+    } catch (_: Exception) {
+        emptyList()
     }
 }
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rtota/RoadTripScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rtota/RoadTripScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -38,6 +39,9 @@ import com.k1af.ft8af.R
 import kotlinx.coroutines.launch
 import radio.ks3ckc.ft8af.location.hasLocationPermission
 import radio.ks3ckc.ft8af.rtota.BeaconReason
+import radio.ks3ckc.ft8af.rtota.RtotaActivation
+import radio.ks3ckc.ft8af.rtota.RtotaHttpException
+import radio.ks3ckc.ft8af.rtota.activationMatchesNow
 import radio.ks3ckc.ft8af.rtota.RTOTA_CQ_MODIFIER
 import radio.ks3ckc.ft8af.rtota.RtotaClient
 import radio.ks3ckc.ft8af.rtota.RtotaSettings
@@ -82,6 +86,10 @@ fun RoadTripScreen(onBack: () -> Unit) {
     var showServerDialog by remember { mutableStateOf(false) }
     var showKeyDialog by remember { mutableStateOf(false) }
     var showTripNameDialog by remember { mutableStateOf(false) }
+    var showPlanPicker by remember { mutableStateOf(false) }
+    var plans by remember { mutableStateOf<List<RtotaActivation>>(emptyList()) }
+    var plansLoading by remember { mutableStateOf(false) }
+    var plansError by remember { mutableStateOf<String?>(null) }
     var showAnnounceDialog by remember { mutableStateOf(false) }
 
     // Trip tracking needs location; ask here rather than at the moment the user
@@ -146,6 +154,24 @@ fun RoadTripScreen(onBack: () -> Unit) {
                 // A key that arrives after a trip started offline unblocks the
                 // whole backlog.
                 RtotaTripManager.requestFlush("api-key-set")
+            },
+        )
+    }
+
+    if (showPlanPicker) {
+        TripPlanPickerDialog(
+            plans = plans,
+            loading = plansLoading,
+            error = plansError,
+            nowMs = System.currentTimeMillis(),
+            onDismiss = { showPlanPicker = false },
+            onPick = { picked ->
+                tripName = picked
+                showPlanPicker = false
+            },
+            onTypeName = {
+                showPlanPicker = false
+                showTripNameDialog = true
             },
         )
     }
@@ -293,7 +319,33 @@ fun RoadTripScreen(onBack: () -> Unit) {
                             label = stringResource(R.string.rtota_trip_name),
                             value = tripName.ifBlank { "--" },
                             showChevron = true,
-                            onClick = { showTripNameDialog = true },
+                            onClick = {
+                                // Straight to the free-text box when there is no key —
+                                // the plans live behind it, and an empty picker with an
+                                // auth error in it explains nothing.
+                                if (RtotaSettings.apiKey.isBlank()) {
+                                    showTripNameDialog = true
+                                    return@SettingsRow
+                                }
+                                showPlanPicker = true
+                                plansLoading = true
+                                plansError = null
+                                scope.launch {
+                                    RtotaClient.fetchMyActivations(
+                                        RtotaSettings.baseUrl,
+                                        RtotaSettings.apiKey,
+                                    ).fold(
+                                        onSuccess = { plans = it },
+                                        onFailure = { e ->
+                                            plansError =
+                                                (e as? RtotaHttpException)?.serverMessage
+                                                    ?: e.message
+                                                    ?: e.javaClass.simpleName
+                                        },
+                                    )
+                                    plansLoading = false
+                                }
+                            },
                         )
                         SettingsRow(
                             label = stringResource(R.string.rtota_privacy),
@@ -490,6 +542,112 @@ private fun NoticeText(text: String) {
         modifier = Modifier.padding(start = 4.dp, top = 4.dp),
     )
 }
+
+/**
+ * Pick the trip's name from the plans already saved on rtota.app, or type one.
+ *
+ * The plans are *scheduled activations* — what the site's plan wizard writes —
+ * because a trip only exists once someone drives it. Choosing one here does not
+ * bind anything: the server decides which plan a trip fulfils by comparing start
+ * times (±12 h), so the value of picking is that the name matches the plan and
+ * the operator can see, before setting off, whether starting now will inherit
+ * the privacy they chose in the wizard. A plan outside that window is still
+ * listed — driving early is normal — just marked so the inheritance isn't a
+ * surprise.
+ */
+@Composable
+private fun TripPlanPickerDialog(
+    plans: List<RtotaActivation>,
+    loading: Boolean,
+    error: String?,
+    nowMs: Long,
+    onDismiss: () -> Unit,
+    onPick: (String) -> Unit,
+    onTypeName: () -> Unit,
+) {
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(BgSurface2)
+                    .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.rtota_pick_plan),
+                color = TextPrimary,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            when {
+                loading ->
+                    Text(
+                        text = stringResource(R.string.rtota_pick_plan_loading),
+                        color = TextMuted,
+                        fontSize = 13.sp,
+                    )
+                error != null ->
+                    Text(
+                        text = stringResource(R.string.rtota_error, error),
+                        color = StatusBad,
+                        fontSize = 13.sp,
+                    )
+                plans.isEmpty() ->
+                    Text(
+                        text = stringResource(R.string.rtota_pick_plan_empty),
+                        color = TextMuted,
+                        fontSize = 13.sp,
+                    )
+                else ->
+                    plans.forEach { plan ->
+                        val matches = activationMatchesNow(plan, nowMs)
+                        Column(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .clickable { onPick(plan.title) }
+                                    .padding(vertical = 10.dp, horizontal = 12.dp),
+                        ) {
+                            Text(text = plan.title, color = TextPrimary, fontSize = 15.sp)
+                            Text(
+                                text =
+                                    if (matches) {
+                                        stringResource(R.string.rtota_plan_matches_now)
+                                    } else {
+                                        stringResource(
+                                            R.string.rtota_plan_starts,
+                                            formatPlanStart(plan.startTimeMs),
+                                        )
+                                    },
+                                color = if (matches) Accent else TextFaint,
+                                fontSize = 12.sp,
+                            )
+                        }
+                    }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.action_cancel), color = TextMuted)
+                }
+                TextButton(onClick = onTypeName) {
+                    Text(stringResource(R.string.rtota_pick_plan_custom), color = Accent)
+                }
+            }
+        }
+    }
+}
+
+/** Local-time "Aug 4, 11:00" for a plan's departure, so it reads as the operator's clock. */
+internal fun formatPlanStart(startMs: Long): String =
+    SimpleDateFormat("MMM d, HH:mm", Locale.US).format(Date(startMs))
 
 /** Single-field dialog shared by the callsign / server / key / trip-name rows. */
 @Composable

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rtota/RoadTripScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rtota/RoadTripScreen.kt
@@ -5,10 +5,13 @@ import android.app.Activity
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -590,8 +593,11 @@ private fun TripPlanPickerDialog(
                         fontSize = 13.sp,
                     )
                 error != null ->
+                    // Not rtota_error ("Last error: …") — that phrasing belongs to the
+                    // trip's own upload failures, and reusing it here would report a
+                    // failed plan fetch as though the running trip were in trouble.
                     Text(
-                        text = stringResource(R.string.rtota_error, error),
+                        text = stringResource(R.string.rtota_pick_plan_error, error),
                         color = StatusBad,
                         fontSize = 13.sp,
                     )
@@ -602,30 +608,44 @@ private fun TripPlanPickerDialog(
                         fontSize = 13.sp,
                     )
                 else ->
-                    plans.forEach { plan ->
-                        val matches = activationMatchesNow(plan, nowMs)
-                        Column(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .clip(RoundedCornerShape(10.dp))
-                                    .clickable { onPick(plan.title) }
-                                    .padding(vertical = 10.dp, horizontal = 12.dp),
-                        ) {
-                            Text(text = plan.title, color = TextPrimary, fontSize = 15.sp)
-                            Text(
-                                text =
-                                    if (matches) {
-                                        stringResource(R.string.rtota_plan_matches_now)
-                                    } else {
-                                        stringResource(
-                                            R.string.rtota_plan_starts,
-                                            formatPlanStart(plan.startTimeMs),
-                                        )
-                                    },
-                                color = if (matches) Accent else TextFaint,
-                                fontSize = 12.sp,
-                            )
+                    // Bounded and scrollable: a rover who plans a season of trips can
+                    // have a long list, and an unconstrained Column inside a Dialog
+                    // simply runs off the bottom of a small screen — the rows below the
+                    // fold become unreachable, which on a *picker* means unselectable.
+                    // Height-capped rather than a LazyColumn so the dialog still hugs a
+                    // short list instead of always claiming the cap.
+                    Column(
+                        modifier =
+                            Modifier
+                                .heightIn(max = 320.dp)
+                                .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        plans.forEach { plan ->
+                            val matches = activationMatchesNow(plan, nowMs)
+                            Column(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(10.dp))
+                                        .clickable { onPick(plan.title) }
+                                        .padding(vertical = 10.dp, horizontal = 12.dp),
+                            ) {
+                                Text(text = plan.title, color = TextPrimary, fontSize = 15.sp)
+                                Text(
+                                    text =
+                                        if (matches) {
+                                            stringResource(R.string.rtota_plan_matches_now)
+                                        } else {
+                                            stringResource(
+                                                R.string.rtota_plan_starts,
+                                                formatPlanStart(plan.startTimeMs),
+                                            )
+                                        },
+                                    color = if (matches) Accent else TextFaint,
+                                    fontSize = 12.sp,
+                                )
+                            }
                         }
                     }
             }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -914,6 +914,12 @@
     <string name="rtota_section_tracking">TRACKING</string>
     <string name="rtota_beacon_heading">SmartBeaconing</string>
     <string name="rtota_stat_last_point">Last point</string>
+    <string name="rtota_pick_plan">Use a saved plan</string>
+    <string name="rtota_pick_plan_loading">Loading your plans…</string>
+    <string name="rtota_pick_plan_empty">No plans saved on rtota.app yet. Plan one on the site, or type a name.</string>
+    <string name="rtota_pick_plan_custom">Type a name</string>
+    <string name="rtota_plan_matches_now">Starting now uses this plan\'s privacy settings</string>
+    <string name="rtota_plan_starts">Starts %1$s — outside the window, so its privacy won\'t apply</string>
     <string name="rtota_stat_cq">Calling</string>
     <string name="rtota_beacon_first">trip start</string>
     <string name="rtota_beacon_rate">interval</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -918,6 +918,7 @@
     <string name="rtota_pick_plan_loading">Loading your plans…</string>
     <string name="rtota_pick_plan_empty">No plans saved on rtota.app yet. Plan one on the site, or type a name.</string>
     <string name="rtota_pick_plan_custom">Type a name</string>
+    <string name="rtota_pick_plan_error">Couldn\'t load your plans: %1$s</string>
     <string name="rtota_plan_matches_now">Starting now uses this plan\'s privacy settings</string>
     <string name="rtota_plan_starts">Starts %1$s — outside the window, so its privacy won\'t apply</string>
     <string name="rtota_stat_cq">Calling</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rtota/RtotaActivationTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rtota/RtotaActivationTest.kt
@@ -1,0 +1,118 @@
+package radio.ks3ckc.ft8af.rtota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Reading the operator's saved plans off `/api/me`, and deciding whether
+ * starting a trip now would actually pick one up.
+ *
+ * The window check mirrors `MATCH_SLACK_HOURS` in the service's
+ * lib/activation-match.ts. It is advisory — the server still decides — but the
+ * consequence of the app disagreeing is a silent one: a plan marked `delayed`
+ * whose privacy doesn't apply publishes a live position that was meant to lag,
+ * and nothing on screen would have said so.
+ *
+ * Robolectric because org.json is an Android stub on the plain JVM classpath.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RtotaActivationTest {
+    // 2026-08-01T22:00:00Z
+    private val start = 1_785_621_600_000L
+    private val hour = 3_600_000L
+
+    private fun plan(
+        startMs: Long = start,
+        endMs: Long? = start + 8 * hour,
+    ) = RtotaActivation("id", "Shakedown", startMs, endMs, null)
+
+    @Test
+    fun `parses the plans an api-me body carries, soonest first`() {
+        val body =
+            """
+            {
+              "operator": {"callsign": "K1AF"},
+              "activations": [
+                {"id":"b","title":"DEFCON To Kansas City","startTime":"2026-08-10T11:00:00.000Z",
+                 "endTime":"2026-08-11T11:00:00.000Z","detail":"return leg"},
+                {"id":"a","title":"Shakedown test drive","startTime":"2026-08-01T22:00:00.000Z",
+                 "endTime":"2026-08-02T06:00:00.000Z"}
+              ]
+            }
+            """.trimIndent()
+
+        val plans = parseMyActivations(body)
+        assertThat(plans.map { it.title })
+            .containsExactly("Shakedown test drive", "DEFCON To Kansas City")
+            .inOrder()
+        assertThat(plans[0].startTimeMs).isEqualTo(start)
+        assertThat(plans[1].detail).isEqualTo("return leg")
+    }
+
+    @Test
+    fun `an open-ended plan parses with a null end`() {
+        val body = """{"activations":[{"id":"a","title":"Open","startTime":"2026-08-01T22:00:00.000Z"}]}"""
+        assertThat(parseMyActivations(body).single().endTimeMs).isNull()
+    }
+
+    @Test
+    fun `rows missing an id, title or start are dropped rather than shown blank`() {
+        val body =
+            """
+            {"activations":[
+              {"title":"No id","startTime":"2026-08-01T22:00:00.000Z"},
+              {"id":"b","startTime":"2026-08-01T22:00:00.000Z"},
+              {"id":"c","title":"No start"},
+              {"id":"d","title":"Good","startTime":"2026-08-01T22:00:00.000Z"}
+            ]}
+            """.trimIndent()
+        assertThat(parseMyActivations(body).map { it.title }).containsExactly("Good")
+    }
+
+    @Test
+    fun `a missing or unusable body yields no plans rather than throwing`() {
+        assertThat(parseMyActivations(null)).isEmpty()
+        assertThat(parseMyActivations("")).isEmpty()
+        assertThat(parseMyActivations("not json")).isEmpty()
+        assertThat(parseMyActivations("""{"operator":{}}""")).isEmpty()
+    }
+
+    @Test
+    fun `iso timestamps parse as UTC, and junk does not`() {
+        assertThat(parseIsoUtc("2026-08-01T22:00:00.000Z")).isEqualTo(start)
+        assertThat(parseIsoUtc(null)).isNull()
+        assertThat(parseIsoUtc("")).isNull()
+        // A local-time string would silently place a plan hours away.
+        assertThat(parseIsoUtc("2026-08-01 22:00:00")).isNull()
+        assertThat(parseIsoUtc("tomorrow")).isNull()
+    }
+
+    @Test
+    fun `a trip started inside the planned window matches`() {
+        assertThat(activationMatchesNow(plan(), start)).isTrue()
+        assertThat(activationMatchesNow(plan(), start + 4 * hour)).isTrue()
+    }
+
+    @Test
+    fun `the twelve-hour slack either side matches, mirroring the server`() {
+        // Departures rarely run on time, which is why the server allows this at all.
+        assertThat(activationMatchesNow(plan(), start - 11 * hour)).isTrue()
+        assertThat(activationMatchesNow(plan(), start + 8 * hour + 11 * hour)).isTrue()
+    }
+
+    @Test
+    fun `outside the slack does not match`() {
+        assertThat(activationMatchesNow(plan(), start - 13 * hour)).isFalse()
+        assertThat(activationMatchesNow(plan(), start + 8 * hour + 13 * hour)).isFalse()
+    }
+
+    @Test
+    fun `an open-ended plan is assumed to span a day, as on the server`() {
+        val open = plan(endMs = null)
+        assertThat(activationMatchesNow(open, start + 20 * hour)).isTrue()
+        // 24 h span + 12 h slack = 36 h; past that it is over.
+        assertThat(activationMatchesNow(open, start + 37 * hour)).isFalse()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rtota/RtotaActivationTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rtota/RtotaActivationTest.kt
@@ -103,6 +103,27 @@ class RtotaActivationTest {
     }
 
     @Test
+    fun `the slack boundary itself is inclusive, to the millisecond`() {
+        // The server's check is `t >= windowStart && t <= windowEnd`, so exactly
+        // twelve hours out still matches. Asserting only an hour inside the edge
+        // (as the test above does) would pass just as happily against an eleven-
+        // or thirteen-hour rule — the boundary is the only place the constant is
+        // actually pinned.
+        val windowStart = start - ACTIVATION_MATCH_SLACK_MS
+        val windowEnd = start + 8 * hour + ACTIVATION_MATCH_SLACK_MS
+
+        assertThat(activationMatchesNow(plan(), windowStart)).isTrue()
+        assertThat(activationMatchesNow(plan(), windowStart - 1)).isFalse()
+        assertThat(activationMatchesNow(plan(), windowEnd)).isTrue()
+        assertThat(activationMatchesNow(plan(), windowEnd + 1)).isFalse()
+    }
+
+    @Test
+    fun `the slack is twelve hours, not some other span`() {
+        assertThat(ACTIVATION_MATCH_SLACK_MS).isEqualTo(12 * 60 * 60 * 1000L)
+    }
+
+    @Test
     fun `outside the slack does not match`() {
         assertThat(activationMatchesNow(plan(), start - 13 * hour)).isFalse()
         assertThat(activationMatchesNow(plan(), start + 8 * hour + 13 * hour)).isFalse()
@@ -112,7 +133,10 @@ class RtotaActivationTest {
     fun `an open-ended plan is assumed to span a day, as on the server`() {
         val open = plan(endMs = null)
         assertThat(activationMatchesNow(open, start + 20 * hour)).isTrue()
-        // 24 h span + 12 h slack = 36 h; past that it is over.
-        assertThat(activationMatchesNow(open, start + 37 * hour)).isFalse()
+        // 24 h assumed span + 12 h slack = 36 h, and the edge is inclusive. Pinned at
+        // the boundary rather than an hour past it, so this can't keep passing if the
+        // assumed span drifts.
+        assertThat(activationMatchesNow(open, start + 36 * hour)).isTrue()
+        assertThat(activationMatchesNow(open, start + 36 * hour + 1)).isFalse()
     }
 }


### PR DESCRIPTION
Tapping **Trip name** opened an empty text box, so a trip planned on the site had to be re-typed from memory — and a name that doesn't match is a trip nobody can line up with the plan that announced it.

## What's in the list

**Scheduled activations**, because that is what the site's plan wizard actually writes (`POST /api/activations`). A *trip* only exists once someone drives it.

Read from **`/api/me`**, not the public `/api/activations`: the public listing carries only what a stranger may see, so a plan marked `private` or `followers` — the ones most likely to be a real upcoming trip — would be missing from exactly the list the operator is trying to pick from.

## Picking binds nothing

The server already decides which plan a trip fulfils, by comparing start times with **±12 h** of slack (`pickActivationForTrip`). So the value here is twofold: the name matches the plan, and the operator can see *before setting off* whether starting now will inherit the privacy chosen in the wizard.

Plans outside that window are still listed — driving early is normal — but they say so, because the consequence is otherwise silent: a plan marked `delayed` whose privacy doesn't apply publishes a live position that was meant to lag, and nothing on screen would have mentioned it.

The window check mirrors `MATCH_SLACK_HOURS` in the service's `lib/activation-match.ts`, including its assumption that an open-ended plan spans a day. It is **advisory only** — the server remains the decider.

With no API key the row goes straight to the free-text box as before. The plans live behind that key, and an empty picker with an auth error in it explains nothing.

## Verification

Tested against the live service with a real account: all three of its plans listed, the in-window one marked *"Starting now uses this plan's privacy settings"*, the other two marked as outside the window, and picking one set the trip name.

Nine unit tests over the parsing and the window logic — including the ±12 h boundaries, the open-ended-plan span, rows missing an id/title/start being dropped rather than rendered blank, and a local-time string being rejected by the ISO parser rather than silently placing a plan hours away.

## One judgement call worth a look

Departure times render in **local** time (`Aug 4, 06:00` for an 11:00 UTC plan). Local is right for "when do I leave", but the rest of this app is UTC-centric — the decode header is literally `UTC : hh:mm:ss`. Happy to switch it to UTC or label it explicitly if you'd rather it match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
