### PR TITLE
Bump the schema version so my_lat/my_lon actually get added (fixes a crash)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -62,9 +62,24 @@ public class DatabaseOpr extends SQLiteOpenHelper {
     private SQLiteDatabase db;
 
 
+    /**
+     * Schema version. <b>Bump this whenever a column is added</b> — the {@code alterTable}
+     * calls in {@code createQSLTable} and friends only ever execute from {@link #onCreate}
+     * and {@link #onUpgrade}, and {@code onUpgrade} fires only when this number increases.
+     *
+     * <p>Adding a column without bumping it produces a bug that is invisible in
+     * development and fatal in the field: a fresh install gets the column from
+     * {@code CREATE TABLE} and works perfectly, while every existing install keeps the old
+     * table and crashes the moment something writes the new column. That is exactly what
+     * v20 fixes — {@code my_lat}/{@code my_lon} shipped without a bump, so
+     * {@code doInsertQSLData} threw "table QSLTable has no column named my_lat" on every
+     * logged QSO for anyone upgrading rather than installing clean.
+     */
+    static final int SCHEMA_VERSION = 20;
+
     public static synchronized DatabaseOpr getInstance(@Nullable Context context, @Nullable String databaseName) {
         if (instance == null) {
-            instance = new DatabaseOpr(context, databaseName, null, 19);
+            instance = new DatabaseOpr(context, databaseName, null, SCHEMA_VERSION);
         }
         return instance;
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprQslTableUpgradeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprQslTableUpgradeTest.java
@@ -54,8 +54,13 @@ public class DatabaseOprQslTableUpgradeTest {
 
     private static Set<String> columnsOf(SQLiteDatabase db, String table) {
         Set<String> names = new HashSet<>();
-        try (Cursor c = db.rawQuery("PRAGMA table_info(" + table + ")", null)) {
-            int nameIdx = c.getColumnIndex("name");
+        // PRAGMA takes no bind parameters, so the identifier has to be inlined; quote it
+        // rather than concatenating it bare. getColumnIndexOrThrow because the silent
+        // alternative is getString(-1), which fails as an opaque index error several
+        // frames from the actual cause.
+        String pragma = "PRAGMA table_info(\"" + table.replace("\"", "\"\"") + "\")";
+        try (Cursor c = db.rawQuery(pragma, null)) {
+            int nameIdx = c.getColumnIndexOrThrow("name");
             while (c.moveToNext()) {
                 names.add(c.getString(nameIdx));
             }
@@ -63,22 +68,36 @@ public class DatabaseOprQslTableUpgradeTest {
         return names;
     }
 
-    @Test
-    public void openingAnOlderDatabase_addsThePositionColumns() {
-        Context context = ApplicationProvider.getApplicationContext();
-        File dbFile = context.getDatabasePath("upgrade_probe.db");
+    /**
+     * Lay down a database exactly as the previous release left it: the old table, stamped
+     * with the old schema version so the helper sees an upgrade rather than a create.
+     *
+     * <p>Closed in a finally so a failure while building it cannot leak the handle — an
+     * open handle keeps the file locked on Windows, which would then defeat the
+     * {@code delete()} each test does on the way out and leave the next test to open a
+     * database it believes it created fresh.
+     */
+    private static void writeLegacyDatabase(File dbFile) {
         //noinspection ResultOfMethodCallIgnored
         dbFile.getParentFile().mkdirs();
         //noinspection ResultOfMethodCallIgnored
         dbFile.delete();
 
-        // Stand up a database as the previous release left it: the old table, stamped
-        // with the old schema version so the helper sees an upgrade rather than a create.
         SQLiteDatabase legacy = SQLiteDatabase.openOrCreateDatabase(dbFile, null);
-        legacy.execSQL(LEGACY_QSL_TABLE);
-        legacy.setVersion(19);
-        assertThat(columnsOf(legacy, "QSLTable")).doesNotContain("my_lat");
-        legacy.close();
+        try {
+            legacy.execSQL(LEGACY_QSL_TABLE);
+            legacy.setVersion(19);
+            assertThat(columnsOf(legacy, "QSLTable")).doesNotContain("my_lat");
+        } finally {
+            legacy.close();
+        }
+    }
+
+    @Test
+    public void openingAnOlderDatabase_addsThePositionColumns() {
+        Context context = ApplicationProvider.getApplicationContext();
+        File dbFile = context.getDatabasePath("upgrade_probe.db");
+        writeLegacyDatabase(dbFile);
 
         DatabaseOpr opr = new DatabaseOpr(context, dbFile.getName(), null, DatabaseOpr.SCHEMA_VERSION);
         try {
@@ -109,15 +128,7 @@ public class DatabaseOprQslTableUpgradeTest {
         // INSERT without a migration should fail here, not in a car.
         Context context = ApplicationProvider.getApplicationContext();
         File dbFile = context.getDatabasePath("upgrade_columns_probe.db");
-        //noinspection ResultOfMethodCallIgnored
-        dbFile.getParentFile().mkdirs();
-        //noinspection ResultOfMethodCallIgnored
-        dbFile.delete();
-
-        SQLiteDatabase legacy = SQLiteDatabase.openOrCreateDatabase(dbFile, null);
-        legacy.execSQL(LEGACY_QSL_TABLE);
-        legacy.setVersion(19);
-        legacy.close();
+        writeLegacyDatabase(dbFile);
 
         DatabaseOpr opr = new DatabaseOpr(context, dbFile.getName(), null, DatabaseOpr.SCHEMA_VERSION);
         try {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprQslTableUpgradeTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprQslTableUpgradeTest.java
@@ -1,0 +1,138 @@
+package com.k1af.ft8af.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import androidx.test.core.app.ApplicationProvider;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The QSLTable upgrade path — that an <em>existing</em> database gains the columns
+ * {@link DatabaseOpr#doInsertQSLData} writes.
+ *
+ * <p>This exists because of a shipped crash. {@code my_lat}/{@code my_lon} were added to
+ * the {@code CREATE TABLE} and to the {@code alterTable} block, but the schema version was
+ * left at 19 — and {@code onUpgrade} (the only thing that runs those ALTERs on an existing
+ * database) fires solely when that number increases. The result was invisible in
+ * development and fatal in the field: a fresh install got the columns from CREATE TABLE
+ * and behaved perfectly, while every upgraded install kept the old table and died with
+ * "table QSLTable has no column named my_lat" on the first logged QSO.
+ *
+ * <p>So the meaningful test is not "does a new database have the column" — that passed
+ * throughout the bug. It is "does a database created by the <em>previous</em> version have
+ * it after the helper opens it", which is what {@link #openingAnOlderDatabase_addsThePositionColumns}
+ * checks by building a v19-era table by hand and then letting DatabaseOpr upgrade it.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseOprQslTableUpgradeTest {
+
+    /** The QSLTable exactly as it stood before the position columns were added. */
+    private static final String LEGACY_QSL_TABLE =
+            "CREATE TABLE QSLTable (\n"
+                    + "id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
+                    + "isQSL INTEGER DEFAULT 0,\n"
+                    + "isLotW_import INTEGER DEFAULT 0,\n"
+                    + "isLotW_QSL INTEGER DEFAULT 0,\n"
+                    + "synced_cloudlog INTEGER DEFAULT 0,\n"
+                    + "synced_qrz INTEGER DEFAULT 0,\n"
+                    + "call TEXT,\ngridsquare TEXT,\nmode TEXT,\nrst_sent TEXT,\n"
+                    + "rst_rcvd TEXT,\nqso_date TEXT,\ntime_on TEXT,\nqso_date_off TEXT,\n"
+                    + "time_off TEXT,\nband TEXT,\nfreq TEXT,\nstation_callsign TEXT,\n"
+                    + "my_gridsquare TEXT,\ncomment TEXT,\nmy_sig TEXT,\nmy_sig_info TEXT,\n"
+                    + "sig TEXT,\nsig_info TEXT)";
+
+    private static Set<String> columnsOf(SQLiteDatabase db, String table) {
+        Set<String> names = new HashSet<>();
+        try (Cursor c = db.rawQuery("PRAGMA table_info(" + table + ")", null)) {
+            int nameIdx = c.getColumnIndex("name");
+            while (c.moveToNext()) {
+                names.add(c.getString(nameIdx));
+            }
+        }
+        return names;
+    }
+
+    @Test
+    public void openingAnOlderDatabase_addsThePositionColumns() {
+        Context context = ApplicationProvider.getApplicationContext();
+        File dbFile = context.getDatabasePath("upgrade_probe.db");
+        //noinspection ResultOfMethodCallIgnored
+        dbFile.getParentFile().mkdirs();
+        //noinspection ResultOfMethodCallIgnored
+        dbFile.delete();
+
+        // Stand up a database as the previous release left it: the old table, stamped
+        // with the old schema version so the helper sees an upgrade rather than a create.
+        SQLiteDatabase legacy = SQLiteDatabase.openOrCreateDatabase(dbFile, null);
+        legacy.execSQL(LEGACY_QSL_TABLE);
+        legacy.setVersion(19);
+        assertThat(columnsOf(legacy, "QSLTable")).doesNotContain("my_lat");
+        legacy.close();
+
+        DatabaseOpr opr = new DatabaseOpr(context, dbFile.getName(), null, DatabaseOpr.SCHEMA_VERSION);
+        try {
+            Set<String> columns = columnsOf(opr.getWritableDatabase(), "QSLTable");
+            assertThat(columns).contains("my_lat");
+            assertThat(columns).contains("my_lon");
+            // The upgrade must not have dropped and recreated the table.
+            assertThat(columns).contains("my_sig_info");
+        } finally {
+            opr.close();
+            //noinspection ResultOfMethodCallIgnored
+            dbFile.delete();
+        }
+    }
+
+    @Test
+    public void schemaVersionIsAheadOfTheReleaseThatShippedWithoutTheColumns() {
+        // 19 is the version that shipped my_lat in CREATE TABLE but never ran the ALTER.
+        // Anything at or below it leaves upgraded installs crashing on every QSO.
+        assertThat(DatabaseOpr.SCHEMA_VERSION).isGreaterThan(19);
+    }
+
+    @Test
+    public void upgradedTableCarriesEveryColumnTheInsertNames() {
+        // Guards the next occurrence rather than just this one: doInsertQSLData writes
+        // these column names, so an upgraded database missing any of them crashes the
+        // app on the first logged QSO exactly as my_lat did. Adding a column to that
+        // INSERT without a migration should fail here, not in a car.
+        Context context = ApplicationProvider.getApplicationContext();
+        File dbFile = context.getDatabasePath("upgrade_columns_probe.db");
+        //noinspection ResultOfMethodCallIgnored
+        dbFile.getParentFile().mkdirs();
+        //noinspection ResultOfMethodCallIgnored
+        dbFile.delete();
+
+        SQLiteDatabase legacy = SQLiteDatabase.openOrCreateDatabase(dbFile, null);
+        legacy.execSQL(LEGACY_QSL_TABLE);
+        legacy.setVersion(19);
+        legacy.close();
+
+        DatabaseOpr opr = new DatabaseOpr(context, dbFile.getName(), null, DatabaseOpr.SCHEMA_VERSION);
+        try {
+            Set<String> columns = columnsOf(opr.getWritableDatabase(), "QSLTable");
+            for (String required : new String[]{
+                    "call", "isQSL", "isLotW_import", "isLotW_QSL", "gridsquare", "mode",
+                    "rst_sent", "rst_rcvd", "qso_date", "time_on", "qso_date_off", "time_off",
+                    "band", "freq", "station_callsign", "my_gridsquare", "comment",
+                    "my_sig", "my_sig_info", "sig", "sig_info", "my_lat", "my_lon"}) {
+                assertThat(columns).contains(required);
+            }
+        } finally {
+            opr.close();
+            //noinspection ResultOfMethodCallIgnored
+            dbFile.delete();
+        }
+    }
+}


### PR DESCRIPTION
Every logged QSO crashed the app for anyone who **upgraded** rather than installed clean:

```
SQLiteException: table QSLTable has no column named my_lat
  at DatabaseOpr.doInsertQSLData(DatabaseOpr.java:1565)
  at DatabaseOpr$AddQSL_Info.doInBackground(DatabaseOpr.java:1928)
```

Caught in the field on a real drive — two contacts, two crashes, identical traces.

## Cause

The position columns were added in two places — the `CREATE TABLE` and the `alterTable` block — but the schema version was left at **19**. Those ALTERs only ever run from `onCreate` or `onUpgrade`, and `onUpgrade` fires *solely* when that number increases. So on an existing database they never executed, while the INSERT went on naming the columns regardless.

## Why nothing caught it

This is the part worth internalising. A **fresh install takes the `CREATE TABLE` path and works perfectly** — so the bug is invisible in development, invisible on a clean emulator, and invisible to any test that starts from an empty database. It appears only on a device that already had a logbook, which is every real user and no one running the tests.

The QSO also never reached rtota.app, because the RTOTA hook runs *after* the insert that was dying.

## Fix

Version bumped to 20, and the constant now has a name and a comment explaining the trap — the consequence isn't visible from the call site where someone would next add a column.

## Test

The regression test builds a **v19-era `QSLTable` by hand**, stamps it with the old version, lets `DatabaseOpr` open it, and asserts the columns arrive. That's deliberate: it tests the *upgrade* path, not the create path, because the create path passed happily throughout the bug. A third case asserts every column `doInsertQSLData` names is present after upgrade, so the next column added without a migration fails here instead of in a car.

**Verified both directions:** reverting the constant to 19 fails all three tests; at 20 they pass. On the affected device the database upgraded in place to version 20, both columns present, **all 564 existing QSOs intact**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
