### PR TITLE
Report a POTA share result on the main thread, not the IO worker

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporter.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporter.kt
@@ -3,6 +3,8 @@ package radio.ks3ckc.ft8af.ui.pota
 import android.content.Context
 import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
+import android.os.Handler
+import android.os.Looper
 import androidx.core.content.FileProvider
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.log.AdifFormat
@@ -140,6 +142,39 @@ object PotaAdifExporter {
         }
     }
 
+    /**
+     * Deliver [result] to [onResult] on the main thread, immediately when the
+     * caller is already there and via the main [Looper] otherwise.
+     *
+     * Every callback out of [shareActivationAdif] goes through here, because the
+     * body that produces them runs on [Dispatchers.IO] and callers legitimately
+     * touch UI in the callback — the existing one shows a Toast, and
+     * `Toast.makeText` throws "Can't toast on a thread that has not called
+     * Looper.prepare()" off the main thread. Issue #700 was exactly that: sharing
+     * an activation with no QSOs takes the empty-documents exit, which reported
+     * failure from an IO worker and crashed the app.
+     *
+     * Making the guarantee the *exporter's* rather than each caller's is the
+     * point. A caller cannot see which thread the callback arrives on, so a fix
+     * at the one Toast would leave the next caller to rediscover this.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun deliverOnMain(
+        result: Boolean,
+        onResult: (Boolean) -> Unit,
+    ) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            onResult(result)
+        } else {
+            Handler(Looper.getMainLooper()).post { onResult(result) }
+        }
+    }
+
+    /**
+     * Build this activation's ADIF documents and hand them to the system share
+     * sheet. [onResult] reports whether anything was shared, and is always
+     * invoked on the main thread — see [deliverOnMain].
+     */
     fun shareActivationAdif(
         context: Context,
         mainViewModel: MainViewModel,
@@ -147,7 +182,7 @@ object PotaAdifExporter {
         onResult: (Boolean) -> Unit,
     ) {
         val db = mainViewModel.databaseOpr?.db ?: run {
-            onResult(false)
+            deliverOnMain(false, onResult)
             return
         }
         scope.launch {
@@ -155,11 +190,11 @@ object PotaAdifExporter {
                 val docs = buildActivationAdif(db, activation)
                 if (docs.isEmpty()) {
                     // No QSOs matched this activation — nothing to share.
-                    onResult(false)
+                    deliverOnMain(false, onResult)
                     return@launch
                 }
                 val dir = context.getExternalFilesDir(null) ?: run {
-                    onResult(false)
+                    deliverOnMain(false, onResult)
                     return@launch
                 }
                 val parks = activation.parkRefs
@@ -190,11 +225,13 @@ object PotaAdifExporter {
                 val chooser = Intent.createChooser(send, "Share POTA ADIF").apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
+                // Legal from a background thread because of FLAG_ACTIVITY_NEW_TASK
+                // above; only the callback has a main-thread requirement.
                 context.startActivity(chooser)
-                onResult(true)
+                deliverOnMain(true, onResult)
             } catch (e: Exception) {
                 e.printStackTrace()
-                onResult(false)
+                deliverOnMain(false, onResult)
             }
         }
     }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporterThreadingTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/pota/PotaAdifExporterThreadingTest.kt
@@ -1,0 +1,75 @@
+package radio.ks3ckc.ft8af.ui.pota
+
+import android.os.Looper
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * The main-thread guarantee on PotaAdifExporter's result callback (issue #700).
+ *
+ * shareActivationAdif does its work on Dispatchers.IO, and its callers touch UI
+ * in the callback — the POTA screen shows a Toast, which throws "Can't toast on
+ * a thread that has not called Looper.prepare()" anywhere but the main thread.
+ * Sharing an activation with no QSOs takes the empty-documents exit and crashed
+ * the app that way, so what needs pinning is the *thread* the callback arrives
+ * on, not the sharing itself (that part is DB/Intent-bound).
+ */
+@RunWith(RobolectricTestRunner::class)
+class PotaAdifExporterThreadingTest {
+
+    @Test
+    fun deliverOnMain_fromBackgroundThread_runsCallbackOnMainLooper() {
+        val ran = AtomicBoolean(false)
+        val callbackLooper = AtomicReference<Looper?>(null)
+        val received = AtomicReference<Boolean?>(null)
+
+        // The crashing path: reporting failure from a worker thread, as the IO
+        // coroutine does when an activation has no QSOs to share.
+        val worker = Thread {
+            PotaAdifExporter.deliverOnMain(false) { result ->
+                ran.set(true)
+                callbackLooper.set(Looper.myLooper())
+                received.set(result)
+            }
+        }
+        worker.start()
+        worker.join()
+
+        // It must be posted, not run inline on the worker — that inline call is
+        // precisely what threw before.
+        assertThat(ran.get()).isFalse()
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(ran.get()).isTrue()
+        assertThat(callbackLooper.get()).isEqualTo(Looper.getMainLooper())
+        assertThat(received.get()).isFalse()
+    }
+
+    @Test
+    fun deliverOnMain_fromMainThread_runsCallbackImmediately() {
+        // Robolectric runs the test body on the main thread, which is also where
+        // the null-database early return happens. Posting there would defer a
+        // result the caller can have now, so it is delivered inline instead.
+        val received = AtomicReference<Boolean?>(null)
+
+        PotaAdifExporter.deliverOnMain(true) { received.set(it) }
+
+        assertThat(received.get()).isTrue()
+    }
+
+    @Test
+    fun deliverOnMain_passesTheResultThrough() {
+        // Both outcomes reach the caller unchanged: the screen only toasts on
+        // false, so a flipped value would silently swallow the error message.
+        val seen = mutableListOf<Boolean>()
+        PotaAdifExporter.deliverOnMain(true) { seen.add(it) }
+        PotaAdifExporter.deliverOnMain(false) { seen.add(it) }
+        assertThat(seen).containsExactly(true, false).inOrder()
+    }
+}


### PR DESCRIPTION
Fixes #700.

## The crash

Sharing a POTA activation with no QSOs crashes:

```
java.lang.NullPointerException: Can't toast on a thread that has not called Looper.prepare()
    at android.widget.Toast.makeText(Toast.java:521)
```

`PotaAdifExporter` holds a `CoroutineScope(SupervisorJob() + Dispatchers.IO)` and runs the whole share body inside it. With zero matching QSOs, `buildActivationAdif` returns an empty list and the early exit calls `onResult(false)` **on the IO worker**. The POTA screen's callback is `{ ok -> if (!ok) Toast.makeText(...).show() }`, and `Toast.makeText` needs a Looper.

The empty-activation case is just the most reachable of four in-coroutine exits — the missing external-files-dir exit and the catch-all did the same thing. Only the null-database early return was safe, because it never leaves the caller's thread.

## The fix

The guarantee belongs to the exporter, not to the one Toast. A caller cannot see which thread its callback arrives on, so patching the symptom would leave the next caller to rediscover this. Every callback now goes through `deliverOnMain`, which runs inline when already on the main thread and posts to the main `Looper` otherwise — so the null-database path stays synchronous as before.

`startActivity` stays on the IO thread: `FLAG_ACTIVITY_NEW_TASK` makes that legal, and only the callback had a main-thread requirement.

## Not changed

The reporter guessed "save/close"; the actual trigger is the **Share ADIF** button. The Upload-to-POTA path is already correct — `PotaScreen.kt:701` scopes `withContext(Dispatchers.IO)` to just the DB read, so its Toast lands on Main and an empty activation shows "upload failed" rather than crashing.

The reporter also noted untranslated strings. `"TUNE"` (`TransmissionSettings.kt:539`) and `"DX"` (`TxStrip.kt:258`, `HuntOptionsSheet.kt:50`) are indeed hardcoded literals with no string resource, so they can't be translated in any locale. That's a separate issue from this crash and is left for its own PR.

## Testing

New `PotaAdifExporterThreadingTest` (Robolectric) pins the contract: a callback raised from a background thread is **not** run inline — the inline call is exactly what threw — and after idling the main looper it runs with `Looper.myLooper() == Looper.getMainLooper()`. Plus main-thread-inline delivery and result pass-through.

- `testDebugUnitTest`: 3200 tests / 350 classes, 0 failures
- `detekt`: 9 findings, identical to `dev` — none in `PotaAdifExporter`, baseline still matches
- `installDebug`: builds and installs on a Pixel 8

I did not drive the crash flow manually on-device, because reproducing it means starting a real POTA activation on your phone and writing a session record into your logbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)