### PR TITLE
Drop the non-ADIF QSL_MANUAL tag from the desktop and iOS exporters

### DIFF
--- a/desktop/src-tauri/src/db.rs
+++ b/desktop/src-tauri/src/db.rs
@@ -375,7 +375,7 @@ impl Db {
         {
             out.push_str(&adif_field("call", &r.call));
             let qsl = if r.confirmed { "Y" } else { "N" };
-            out.push_str(&format!("<QSL_RCVD:1>{qsl} <QSL_MANUAL:1>N "));
+            out.push_str(&format!("<QSL_RCVD:1>{qsl} "));
             adif_opt(&mut out, "gridsquare", &r.gridsquare);
             adif_opt(&mut out, "mode", &r.mode);
             adif_opt(&mut out, "rst_sent", &r.rst_sent);
@@ -422,7 +422,7 @@ pub fn adif_record(r: &QsoRecord) -> String {
     let mut out = String::new();
     out.push_str(&adif_field("call", &r.call));
     let qsl = if r.confirmed { "Y" } else { "N" };
-    out.push_str(&format!("<QSL_RCVD:1>{qsl} <QSL_MANUAL:1>N "));
+    out.push_str(&format!("<QSL_RCVD:1>{qsl} "));
     adif_opt(&mut out, "gridsquare", &r.gridsquare);
     adif_opt(&mut out, "mode", &r.mode);
     adif_opt(&mut out, "rst_sent", &r.rst_sent);
@@ -480,6 +480,29 @@ mod tests {
         assert!(adif.contains("<gridsquare:4>FN42 "));
         assert!(adif.contains("<band:3>20m "));
         assert!(adif.trim_end().ends_with("<eor>"));
+    }
+
+    #[test]
+    fn export_omits_the_non_adif_qsl_manual_tag() {
+        // QSL_MANUAL is not in the ADIF spec (issue #697), and strict importers
+        // reject or silently drop unknown tags. Both emitters are covered: the
+        // file export and adif_record(), which is what goes out over the WSJT-X
+        // "Logged ADIF" UDP message to JTAlert/N1MM.
+        let db = Db::open_in_memory().unwrap();
+        let confirmed = rec("K1ABC", "20260604", "120000", true);
+        let unconfirmed = rec("W1AW", "20260604", "130000", false);
+        db.insert_qso(&confirmed).unwrap();
+        db.insert_qso(&unconfirmed).unwrap();
+
+        let adif = db.export_adif();
+        assert!(!adif.contains("QSL_MANUAL"));
+        assert!(!adif_record(&confirmed).contains("QSL_MANUAL"));
+
+        // QSL_RCVD is a real ADIF field and still carries the confirmed flag,
+        // which is the only QSL information these records ever held.
+        assert!(adif.contains("<call:5>K1ABC <QSL_RCVD:1>Y "));
+        assert!(adif.contains("<call:4>W1AW <QSL_RCVD:1>N "));
+        assert!(adif_record(&confirmed).contains("<QSL_RCVD:1>Y "));
     }
 
     #[test]

--- a/ios/FT8AFKit/Sources/FT8Engine/Adif.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/Adif.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// ADIF import/export for the QSO log. `export` is a byte-for-byte port of desktop
-/// db.rs `export_adif` (same header, field set, order, and the fixed QSL flags),
+/// db.rs `export_adif` (same header, field set, order, and the fixed QSL flag),
 /// so logs round-trip identically across the iOS app, the desktop port, and
 /// ShareLogs. `parse` is the inverse (new on iOS — users import existing logs),
 /// a lenient length-prefixed `<field:len>value` tokenizer.
@@ -11,12 +11,13 @@ public enum Adif {
 
     /// Render `records` as an ADIF string in the given order. Matches desktop
     /// db.rs export_adif exactly: a fixed header, then per record the CALL field,
-    /// the fixed QSL flags, every non-empty optional field, and comment + <eor>.
+    /// `QSL_RCVD` (iOS has no confirmation state yet, so always `N`), every
+    /// non-empty optional field, and comment + <eor>.
     public static func export(_ records: [QsoRecord]) -> String {
         var out = "FT8AF ADIF Export<eoh>\n"
         for r in records {
             out += field("call", r.call)
-            out += "<QSL_RCVD:1>N <QSL_MANUAL:1>N "
+            out += "<QSL_RCVD:1>N "
             opt(&out, "gridsquare", r.gridsquare)
             opt(&out, "mode", r.mode)
             opt(&out, "rst_sent", r.rstSent)

--- a/ios/FT8AFKit/Tests/FT8EngineTests/AdifTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/AdifTests.swift
@@ -36,7 +36,7 @@ final class AdifTests: XCTestCase {
         let expected =
             "FT8AF ADIF Export<eoh>\n"
             + "<call:5>K1ABC "
-            + "<QSL_RCVD:1>N <QSL_MANUAL:1>N "
+            + "<QSL_RCVD:1>N "
             + "<gridsquare:4>FN42 "
             + "<mode:3>FT8 "
             + "<rst_sent:3>-08 "
@@ -56,7 +56,7 @@ final class AdifTests: XCTestCase {
     func testExportOmitsEmptyOptionalsButKeepsCallFlagsAndComment() {
         let out = Adif.export([rec(call: "W1AW")]) // all optionals empty
         XCTAssertEqual(out,
-            "FT8AF ADIF Export<eoh>\n<call:4>W1AW <QSL_RCVD:1>N <QSL_MANUAL:1>N <comment:0> <eor>\n")
+            "FT8AF ADIF Export<eoh>\n<call:4>W1AW <QSL_RCVD:1>N <comment:0> <eor>\n")
     }
 
     func testExportUsesUtf8ByteLengthForComment() {


### PR DESCRIPTION
Fixes #697.

## What was left

`QSL_MANUAL` is not a field in the ADIF spec, so strict consumers (LoTW's upload validator, Club Log, other loggers) can reject it or silently drop the record's tail.

**Android was already fixed** by #701, which moved the flag to `APP_FT8AF_QSL_MANUAL` — the spec's `APP_<PROGRAMID>_<FIELD>` escape hatch — and kept the bare name as a read-only legacy alias so older exports still import. That's a better answer than the issue proposed (drop it / use `QSLMSG`), because `QSL_RCVD` is **not** a substitute: it means a QSL was received, which is a different fact from "operator ticked manually confirmed".

The two ports were missed and still emitted the bare name:

| Location | What |
|---|---|
| `desktop/src-tauri/src/db.rs:378` | file export |
| `desktop/src-tauri/src/db.rs:425` | `adif_record()` — the WSJT-X "Logged ADIF" UDP message to JTAlert/N1MM |
| `ios/FT8AFKit/Sources/FT8Engine/Adif.swift:19` | iOS export |

## Why dropping is right here, not the APP_ field

On both ports the tag is a **hardcoded `N` carrying no information**:

- Desktop's `QSL_RCVD` does vary with `r.confirmed`, but `QSL_MANUAL` was always `N`
- iOS's `QsoRecord` has no confirmation state at all, so both QSL flags are constants

And nothing reads it back: desktop has no ADIF import path, and the iOS parser explicitly ignores QSL flags (`Adif.swift:103`). Android's importer sets `isQSL` only when the key is present, so an absent field and an explicit `N` produce the identical import. Emitting `APP_FT8AF_QSL_MANUAL:N` from these two would just be a conformant way to write nothing.

## Two corrections to the issue

- It cites `DatabaseOpr.java:1255-1257` as an emitter. On current `dev` those are commented-out dead code (`:1158`/`:1160`); the live Android path goes through `AdifRecord`.
- It flags `QSLRecord.java:191-192`'s "present in LoTW" comment as suspect. That comment sits on **`QSL_RCVD`** (line 190), which genuinely is a real ADIF field present in LoTW exports — the `QSL_MANUAL` handling is separate and correctly documented as legacy-compat.

## Testing

- New Rust `export_omits_the_non_adif_qsl_manual_tag` covers **both** emitters and asserts `QSL_RCVD` still carries the confirmed flag. `cargo test --lib`: **108 passed, 0 failed**.
- The two iOS tests assert full-string equality, so they pin the absence by construction; updated to match.
- `cargo fmt`: my changed lines are clean (the file has pre-existing drift at lines 127/203/241 that I deliberately left alone to keep the diff readable).

**I could not run `swift test` — this was done on Windows, which has no Swift toolchain.** The iOS changes are a mechanical string edit in one source line and two expected-string assertions, but they need the `swift test + simulator build` CI job to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)