### PR TITLE
Self-syncing clock: auto-trim the clock offset from decode DT medians

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -575,6 +575,7 @@ public class GeneralVariables {
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static boolean disciplineClockFromGPS = false;//Discipline the app clock (UtcTimer.delay) from GPS satellite time (issue #373). Off by default — consensual.
     public static int gpsClockIntervalMinutes = 5;//How often to re-read GPS time for clock discipline. Clamped 1-30 by GpsClockUpdater.
+    public static boolean autoSyncClockFromDecodes = false;//Self-syncing clock: continuously trim UtcTimer.delay from the median decode DT (see ClockSelfSync). Inert while disciplineClockFromGPS is on. Off by default.
     //Runtime status for the Time Sync UI (not persisted): the offset the last GPS fix applied
     //to UtcTimer.delay. The last-sync *timestamp* is the retained value of mutableGpsClockSync
     //below, so there's no separate field for it.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -120,6 +120,7 @@ import com.k1af.ft8af.rigs.Yaesu38_450Rig;
 import com.k1af.ft8af.rigs.Yaesu39Rig;
 import com.k1af.ft8af.rigs.YaesuDX10Rig;
 import com.k1af.ft8af.spectrum.SpectrumListener;
+import com.k1af.ft8af.timer.ClockSelfSync;
 import com.k1af.ft8af.timer.OnUtcTimer;
 import com.k1af.ft8af.timer.UtcTimer;
 import com.k1af.ft8af.ui.ToastMessage;
@@ -169,6 +170,12 @@ public class MainViewModel extends ViewModel {
     //public int decoded_counter = 0;//total decoded count
     public final ArrayList<Ft8Message> ft8Messages = new ArrayList<>();//message list
     public UtcTimer utcTimer;//timer for sync-triggered actions.
+
+    // Self-syncing clock (opt-in): per-slot median-DT estimator that trims
+    // UtcTimer.delay from the band itself. Fed from afterDecode's fast pass;
+    // reset by the settings toggle / GPS discipline takeover. Public so
+    // TimeSyncSettings can reset it when the operator flips the toggles.
+    public final ClockSelfSync clockSelfSync = new ClockSelfSync();
 
 
     //public CallsignDatabase callsignDatabase = null;//callsign information database
@@ -667,6 +674,41 @@ public class MainViewModel extends ViewModel {
                 // passes to avoid log spam (they re-report the same cycle).
                 if (!isDeep) {
                     fileLog(filtered.decodeLogLine(sequential));
+
+                    // Self-syncing clock (opt-in): sample this slot's per-decode DTs
+                    // from the fast pass only — it fires exactly once per slot with
+                    // that pass's own (deduped, echo-filtered) messages. Deep/late
+                    // passes re-deliver the same slot and are skipped by the isDeep
+                    // gate; beginSlot() dedupes by slot utc as a second line of
+                    // defense. GPS discipline owns the clock when enabled, so this
+                    // stands down (and clears its state) rather than fight it.
+                    if (GeneralVariables.autoSyncClockFromDecodes
+                            && !GeneralVariables.disciplineClockFromGPS) {
+                        if (clockSelfSync.beginSlot(utc)) {
+                            float[] dtSamples = new float[messages.size()];
+                            for (int i = 0; i < messages.size(); i++) {
+                                dtSamples[i] = messages.get(i).time_sec;
+                            }
+                            Integer newDelay =
+                                    clockSelfSync.onSlotDecodes(dtSamples, UtcTimer.delay);
+                            if (newDelay != null) {
+                                int oldDelay = UtcTimer.delay;
+                                // Same three-way fan-out as TimeSyncSettings.apply():
+                                // live timer, in-memory config mirror, and DB.
+                                UtcTimer.delay = newDelay;
+                                GeneralVariables.manualTimeCorrectionMs = newDelay;
+                                databaseOpr.writeConfig("timeCorrectionMs",
+                                        String.valueOf(newDelay), null);
+                                fileLog("selfSync: applied clock correction "
+                                        + oldDelay + " -> " + newDelay + " ms ("
+                                        + dtSamples.length + " decodes, slot utc=" + utc + ")");
+                            }
+                        }
+                    } else {
+                        // Feature off or GPS disciplining: drop any half-built
+                        // confirmation streak so stale state can't act later.
+                        clockSelfSync.reset();
+                    }
                 }
                 if (messages.size() == 0) {
                     //nothing left after filtering own echoes

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -684,25 +684,26 @@ public class MainViewModel extends ViewModel {
                     // stands down (and clears its state) rather than fight it.
                     if (GeneralVariables.autoSyncClockFromDecodes
                             && !GeneralVariables.disciplineClockFromGPS) {
-                        if (clockSelfSync.beginSlot(utc)) {
-                            float[] dtSamples = new float[messages.size()];
-                            for (int i = 0; i < messages.size(); i++) {
-                                dtSamples[i] = messages.get(i).time_sec;
-                            }
-                            Integer newDelay =
-                                    clockSelfSync.onSlotDecodes(dtSamples, UtcTimer.delay);
-                            if (newDelay != null) {
-                                int oldDelay = UtcTimer.delay;
-                                // Same three-way fan-out as TimeSyncSettings.apply():
-                                // live timer, in-memory config mirror, and DB.
-                                UtcTimer.delay = newDelay;
-                                GeneralVariables.manualTimeCorrectionMs = newDelay;
-                                databaseOpr.writeConfig("timeCorrectionMs",
-                                        String.valueOf(newDelay), null);
-                                fileLog("selfSync: applied clock correction "
-                                        + oldDelay + " -> " + newDelay + " ms ("
-                                        + dtSamples.length + " decodes, slot utc=" + utc + ")");
-                            }
+                        float[] dtSamples = new float[messages.size()];
+                        for (int i = 0; i < messages.size(); i++) {
+                            dtSamples[i] = messages.get(i).time_sec;
+                        }
+                        // onSlot is atomic: slot dedup/ordering + streak update under
+                        // one lock, so concurrent adjacent-slot deliveries can't
+                        // interleave (out-of-order slots are rejected inside).
+                        Integer newDelay =
+                                clockSelfSync.onSlot(utc, dtSamples, UtcTimer.delay);
+                        if (newDelay != null) {
+                            int oldDelay = UtcTimer.delay;
+                            // Same three-way fan-out as TimeSyncSettings.apply():
+                            // live timer, in-memory config mirror, and DB.
+                            UtcTimer.delay = newDelay;
+                            GeneralVariables.manualTimeCorrectionMs = newDelay;
+                            databaseOpr.writeConfig("timeCorrectionMs",
+                                    String.valueOf(newDelay), null);
+                            fileLog("selfSync: applied clock correction "
+                                    + oldDelay + " -> " + newDelay + " ms ("
+                                    + dtSamples.length + " decodes, slot utc=" + utc + ")");
                         }
                     } else {
                         // Feature off or GPS disciplining: drop any half-built

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2828,6 +2828,9 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 if (name.equalsIgnoreCase("disciplineClockFromGPS")) {//Discipline clock from GPS (issue #373)
                     GeneralVariables.disciplineClockFromGPS = result.equals("1");
                 }
+                if (name.equalsIgnoreCase("autoSyncClockFromDecodes")) {//Self-syncing clock from decode DT medians (ClockSelfSync)
+                    GeneralVariables.autoSyncClockFromDecodes = result.equals("1");
+                }
                 if (name.equalsIgnoreCase("gpsClockIntervalMin")) {//GPS discipline update interval (minutes)
                     GeneralVariables.gpsClockIntervalMinutes =
                             com.k1af.ft8af.location.GpsClockUpdater.parseIntervalMinutes(result);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/ClockSelfSync.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/ClockSelfSync.java
@@ -1,0 +1,186 @@
+package com.k1af.ft8af.timer;
+
+import com.k1af.ft8af.GeneralVariables;
+
+import java.util.Arrays;
+
+/**
+ * Self-syncing clock: estimates the local clock error from the per-decode time
+ * offsets (WSJT-style DT, seconds) of the stations we hear each slot, and decides
+ * when — and by how much — to trim the app's global clock offset
+ * ({@link UtcTimer#delay}). The band itself becomes the time source: no NTP or
+ * GPS needed.
+ *
+ * <p><b>Sign convention</b> (matches {@code suggestedCorrectionMs} in
+ * {@code TimeCorrection.kt}): a positive median DT means decodes land late in our
+ * RX window — our clock is fast — so the correction <em>subtracts</em> from the
+ * current delay. Negative DT adds. The goal is to drive the measured DT toward 0.
+ *
+ * <p><b>Damping, not step-limiting.</b> Each applied correction shifts the next
+ * slot's measured DT, so a full-step correction would ring. A proportional gain
+ * ({@link #GAIN}) halves the error per step instead. There is deliberately NO
+ * hard cap on step size: see the long comment in {@code GpsClockUpdater} (a step
+ * limiter shipped there once and locked in a bad baseline for a whole activation
+ * — proportional gain always converges, a step cap can refuse the truth forever).
+ *
+ * <p>Robustness per slot: a median (not mean) over the slot's DTs, MAD-based
+ * outlier rejection on top of it, a minimum surviving-sample count, a deadband
+ * matching the UI's "good clock" threshold, and two-consecutive-slot same-sign
+ * confirmation before any correction is applied.
+ *
+ * <p>Pure Java, no Android imports (the {@link GeneralVariables} references are
+ * {@code static final int} constant expressions, inlined at compile time), so
+ * this is unit-testable without Robolectric. Public entry points are
+ * synchronized: decode passes for adjacent slots can deliver concurrently.
+ */
+public class ClockSelfSync {
+
+    /** Minimum surviving (post-outlier-rejection) decodes for a slot to count. */
+    public static final int MIN_SLOT_SAMPLES = 4;
+
+    /**
+     * |median DT| at/below this (seconds) is left alone. Matches
+     * {@code CLOCK_SYNC_GOOD_SEC} in {@code ui/components/ClockSync.kt} — the
+     * threshold the clock-health indicator already calls "good".
+     */
+    public static final float DEADBAND_SEC = 0.30f;
+
+    /** Proportional gain applied to the measured error (damps the feedback loop). */
+    public static final float GAIN = 0.5f;
+
+    /** Consecutive qualifying same-sign slots required before a correction is applied. */
+    public static final int CONFIRM_SLOTS = 2;
+
+    /** Absolute floor (seconds) for the MAD-based rejection threshold. */
+    static final float MAD_FLOOR_SEC = 0.2f;
+
+    /** Rejection threshold is max(floor, this multiple of the MAD). */
+    static final float MAD_MULTIPLIER = 3f;
+
+    // Confirmation streak: how many consecutive qualifying slots have agreed, and
+    // the sign (+1/-1) they agreed on. 0 sign = no streak.
+    private int streak = 0;
+    private int streakSign = 0;
+
+    // Slot dedup: afterDecode fires several times per slot (fast, deep, late
+    // passes); only the first qualifying delivery per slot utc may be sampled.
+    private long lastProcessedUtc = Long.MIN_VALUE;
+
+    /**
+     * Median of {@code a}; the mean of the two middle values for even lengths.
+     * An empty (or null) array yields 0 — callers gate on sample count anyway.
+     */
+    public static float medianOf(float[] a) {
+        if (a == null || a.length == 0) {
+            return 0f;
+        }
+        float[] sorted = a.clone();
+        Arrays.sort(sorted);
+        int mid = sorted.length / 2;
+        if (sorted.length % 2 == 1) {
+            return sorted[mid];
+        }
+        return (sorted[mid - 1] + sorted[mid]) / 2f;
+    }
+
+    /**
+     * MAD-based outlier rejection: samples farther than
+     * max({@link #MAD_FLOOR_SEC}, {@link #MAD_MULTIPLIER} x MAD) from the median
+     * are dropped. The floor keeps a tight cluster (MAD near 0) from rejecting
+     * everything but the exact median value.
+     */
+    static float[] rejectOutliers(float[] dtSec) {
+        if (dtSec == null || dtSec.length == 0) {
+            return new float[0];
+        }
+        float median = medianOf(dtSec);
+        float[] deviations = new float[dtSec.length];
+        for (int i = 0; i < dtSec.length; i++) {
+            deviations[i] = Math.abs(dtSec[i] - median);
+        }
+        float mad = medianOf(deviations);
+        float threshold = Math.max(MAD_FLOOR_SEC, MAD_MULTIPLIER * mad);
+        int kept = 0;
+        float[] survivors = new float[dtSec.length];
+        for (float dt : dtSec) {
+            if (Math.abs(dt - median) <= threshold) {
+                survivors[kept++] = dt;
+            }
+        }
+        return Arrays.copyOf(survivors, kept);
+    }
+
+    /** Clamp to the shared manual-correction range (±5000 ms). */
+    static int clampDelayMs(int ms) {
+        return Math.max(GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS,
+                Math.min(GeneralVariables.MANUAL_TIME_CORRECTION_MAX_MS, ms));
+    }
+
+    /**
+     * Mark the slot identified by {@code utc} as processed. Returns true exactly
+     * once per slot — callers must only sample DTs (and call
+     * {@link #onSlotDecodes}) when this returns true, so the multiple decode
+     * passes of one slot cannot be double-counted.
+     */
+    public synchronized boolean beginSlot(long utc) {
+        if (utc == lastProcessedUtc) {
+            return false;
+        }
+        lastProcessedUtc = utc;
+        return true;
+    }
+
+    /**
+     * Per-slot decision. Feeds one slot's decode DTs (seconds) through outlier
+     * rejection, the sample-count gate, the deadband, and the two-slot same-sign
+     * confirmation, and returns the NEW total clock delay (ms) to apply — or
+     * null for no action this slot.
+     *
+     * @param dtSec          this slot's per-decode DTs (seconds), own-TX echoes
+     *                       already filtered out
+     * @param currentDelayMs the live {@link UtcTimer#delay} at decision time
+     * @return the new clamped delay to fan out, or null to do nothing
+     */
+    public synchronized Integer onSlotDecodes(float[] dtSec, int currentDelayMs) {
+        float[] survivors = rejectOutliers(dtSec);
+        if (survivors.length < MIN_SLOT_SAMPLES) {
+            // Too little evidence — leave the confirmation state untouched so a
+            // sparse slot doesn't break up a real streak.
+            return null;
+        }
+        float median = medianOf(survivors);
+        if (Math.abs(median) <= DEADBAND_SEC) {
+            // Clock is healthy; a streak that was building was noise.
+            streak = 0;
+            streakSign = 0;
+            return null;
+        }
+        int sign = median > 0 ? 1 : -1;
+        if (sign != streakSign) {
+            // First qualifying slot in this direction (or a direction flip):
+            // start/restart the streak, act only if a later slot confirms.
+            streakSign = sign;
+            streak = 1;
+        } else {
+            streak++;
+        }
+        if (streak < CONFIRM_SLOTS) {
+            return null;
+        }
+        int newDelay = clampDelayMs(
+                currentDelayMs - Math.round(median * 1000f * GAIN));
+        streak = 0;
+        streakSign = 0;
+        return newDelay;
+    }
+
+    /**
+     * Clears the confirmation streak and the last-processed-slot tracking.
+     * Called when the feature is toggled off or GPS clock discipline takes over.
+     */
+    public synchronized void reset() {
+        streak = 0;
+        streakSign = 0;
+        lastProcessedUtc = Long.MIN_VALUE;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/ClockSelfSync.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/ClockSelfSync.java
@@ -118,16 +118,32 @@ public class ClockSelfSync {
 
     /**
      * Mark the slot identified by {@code utc} as processed. Returns true exactly
-     * once per slot — callers must only sample DTs (and call
-     * {@link #onSlotDecodes}) when this returns true, so the multiple decode
-     * passes of one slot cannot be double-counted.
+     * once per slot, and only for slots NEWER than the last processed one —
+     * decode threads for adjacent slots run concurrently, so a slow slot's
+     * delivery can arrive after its successor's; accepting it then would feed
+     * stale evidence into the confirmation streak. Monotonic rejection makes
+     * late stragglers a no-op.
      */
     public synchronized boolean beginSlot(long utc) {
-        if (utc == lastProcessedUtc) {
+        if (utc <= lastProcessedUtc) {
             return false;
         }
         lastProcessedUtc = utc;
         return true;
+    }
+
+    /**
+     * Atomic per-slot entry point: slot dedup/ordering ({@link #beginSlot}) and
+     * the correction decision ({@link #onSlotDecodes}) under one lock, so two
+     * decode threads delivering different slots cannot interleave between the
+     * dedup check and the streak update. Production code must use this; the
+     * two-step methods stay public for targeted unit tests.
+     */
+    public synchronized Integer onSlot(long utc, float[] dtSec, int currentDelayMs) {
+        if (!beginSlot(utc)) {
+            return null;
+        }
+        return onSlotDecodes(dtSec, currentDelayMs);
     }
 
     /**

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SettingsRow.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SettingsRow.kt
@@ -28,6 +28,7 @@ fun SettingsRow(
     onToggleChange: ((Boolean) -> Unit)? = null,
     showChevron: Boolean = false,
     onClick: (() -> Unit)? = null,
+    enabled: Boolean = true,
 ) {
     Row(
         modifier = modifier
@@ -70,6 +71,7 @@ fun SettingsRow(
                 Toggle(
                     checked = toggle,
                     onCheckedChange = onToggleChange,
+                    enabled = enabled,
                 )
             }
             if (showChevron) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeSyncSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeSyncSettings.kt
@@ -63,6 +63,9 @@ fun TimeSyncSettings(
 
     // GPS clock discipline (issue #373).
     var disciplineFromGps by remember { mutableStateOf(GeneralVariables.disciplineClockFromGPS) }
+
+    // Self-syncing clock: auto-trim the correction from decode DT medians.
+    var autoSyncFromDecodes by remember { mutableStateOf(GeneralVariables.autoSyncClockFromDecodes) }
     var gpsIntervalMin by remember { mutableIntStateOf(GeneralVariables.gpsClockIntervalMinutes) }
     // Re-read the status readout whenever a GPS fix disciplines the clock. The LiveData
     // retains its last posted timestamp, so seeding from .value shows a prior sync when the
@@ -165,6 +168,36 @@ fun TimeSyncSettings(
         }
 
         // =====================================================================
+        // SELF-SYNCING CLOCK (auto-correct from decode DT medians)
+        // =====================================================================
+        SettingsSection(title = stringResource(R.string.settings_selfsync_section)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                SettingsRow(
+                    label = stringResource(R.string.settings_selfsync_toggle),
+                    description = stringResource(R.string.settings_selfsync_toggle_desc),
+                    toggle = autoSyncFromDecodes,
+                    // Same lock-out as the manual controls: while GPS discipline owns
+                    // the clock this estimator must not fight it, so the row is inert.
+                    enabled = !disciplineFromGps,
+                    onToggleChange = { checked ->
+                        autoSyncFromDecodes = checked
+                        GeneralVariables.autoSyncClockFromDecodes = checked
+                        mainViewModel.databaseOpr.writeConfig(
+                            "autoSyncClockFromDecodes",
+                            if (checked) "1" else "0",
+                            null,
+                        )
+                        if (!checked) {
+                            // Drop any half-built confirmation streak so re-enabling
+                            // later starts from a clean slate.
+                            mainViewModel.clockSelfSync.reset()
+                        }
+                    },
+                )
+            }
+        }
+
+        // =====================================================================
         // SUGGESTION (from decode DT)
         // =====================================================================
         SettingsSection(title = stringResource(R.string.settings_time_suggest_section)) {
@@ -237,6 +270,12 @@ fun TimeSyncSettings(
                         mainViewModel.databaseOpr.writeConfig(
                             "disciplineClockFromGPS", if (checked) "1" else "0", null,
                         )
+                        if (checked) {
+                            // GPS discipline takes over the clock; the self-sync
+                            // estimator stands down — clear its streak so stale
+                            // pre-GPS evidence can't act if GPS is later disabled.
+                            mainViewModel.clockSelfSync.reset()
+                        }
                         GpsClockUpdater.refresh(context)
                     },
                 )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -576,6 +576,11 @@
     <string name="settings_time_suggest_apply">Apply suggested correction</string>
     <string name="settings_time_correction_gps_locked">GPS clock discipline is controlling the clock — turn it off below to adjust manually.</string>
 
+    <!-- ===== Settings: Time Sync (self-syncing clock from decodes) ===== -->
+    <string name="settings_selfsync_section">Self-Syncing Clock</string>
+    <string name="settings_selfsync_toggle">Auto-sync clock from decodes</string>
+    <string name="settings_selfsync_toggle_desc">Continuously trim the clock using the median DT of received stations — the band itself becomes the time source. No internet or GPS needed. Unavailable while GPS clock discipline is on.</string>
+
     <!-- ===== Settings: Time Sync (GPS clock discipline, issue #373) ===== -->
     <string name="settings_gps_clock_section">GPS Clock Discipline</string>
     <string name="settings_gps_clock_toggle">Discipline clock from GPS</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -54,6 +54,7 @@ public class DatabaseOprConfigHydrationTest {
     private int origAlcTargetLow;
     private boolean origDeepDecodeMode;
     private boolean origKeepScreenOn;
+    private boolean origAutoSyncClockFromDecodes;
 
     @Before
     public void setUp() {
@@ -71,6 +72,7 @@ public class DatabaseOprConfigHydrationTest {
         origAlcTargetLow = GeneralVariables.alcTargetLow;
         origDeepDecodeMode = GeneralVariables.deepDecodeMode;
         origKeepScreenOn = GeneralVariables.keepScreenOn;
+        origAutoSyncClockFromDecodes = GeneralVariables.autoSyncClockFromDecodes;
 
         opr = new DatabaseOpr(ApplicationProvider.getApplicationContext(), null, null, 18);
     }
@@ -94,6 +96,7 @@ public class DatabaseOprConfigHydrationTest {
             GeneralVariables.alcTargetLow = origAlcTargetLow;
             GeneralVariables.deepDecodeMode = origDeepDecodeMode;
             GeneralVariables.keepScreenOn = origKeepScreenOn;
+            GeneralVariables.autoSyncClockFromDecodes = origAutoSyncClockFromDecodes;
         }
     }
 
@@ -282,6 +285,35 @@ public class DatabaseOprConfigHydrationTest {
         hydrate();
 
         assertThat(GeneralVariables.keepScreenOn).isTrue();
+    }
+
+    // ---- self-syncing clock (ClockSelfSync) -----------------------------------
+    // New "autoSyncClockFromDecodes" key: the classic bug this guards against is
+    // adding the field + writeConfig on toggle but forgetting the hydration arm,
+    // which silently reverts the setting to off on every relaunch.
+
+    @Test
+    public void autoSyncClockFromDecodes_hydratesOnAndOff() {
+        GeneralVariables.autoSyncClockFromDecodes = false;
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("autoSyncClockFromDecodes", "1");
+        opr.writeConfigSync(config);
+        hydrate();
+        assertThat(GeneralVariables.autoSyncClockFromDecodes).isTrue();
+
+        GeneralVariables.autoSyncClockFromDecodes = true;
+        config.put("autoSyncClockFromDecodes", "0");
+        opr.writeConfigSync(config);
+        hydrate();
+        assertThat(GeneralVariables.autoSyncClockFromDecodes).isFalse();
+    }
+
+    @Test
+    public void autoSyncClockFromDecodes_absentRowLeavesDefaultOff() {
+        GeneralVariables.autoSyncClockFromDecodes = false;
+        // No row written for the key at all (fresh install / pre-feature backup).
+        hydrate();
+        assertThat(GeneralVariables.autoSyncClockFromDecodes).isFalse();
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/timer/ClockSelfSyncTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/timer/ClockSelfSyncTest.java
@@ -256,6 +256,40 @@ public class ClockSelfSyncTest {
     }
 
     @Test
+    public void beginSlot_rejectsOlderSlotArrivingLate() {
+        // Adjacent-slot decode threads run concurrently: a slow slot's delivery
+        // can land AFTER its successor's. Monotonic dedup must reject it.
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.beginSlot(30_000L)).isTrue();
+        assertThat(sync.beginSlot(15_000L)).isFalse(); // straggler from the past
+        assertThat(sync.beginSlot(45_000L)).isTrue();
+    }
+
+    // ------------------------------------------------------------------
+    // onSlot — the atomic production entry (dedup + decision in one lock)
+    // ------------------------------------------------------------------
+
+    @Test
+    public void onSlot_redeliveredSlot_isIgnoredEvenWithQualifyingSamples() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.onSlot(15_000L, slot(1.0f, 4), 0)).isNull(); // streak = 1
+        // Redelivery of the same slot must not advance the streak to a step.
+        assertThat(sync.onSlot(15_000L, slot(1.0f, 4), 0)).isNull();
+        // The genuine second slot confirms and steps: -median*1000*GAIN.
+        assertThat(sync.onSlot(30_000L, slot(1.0f, 4), 0)).isEqualTo(-500);
+    }
+
+    @Test
+    public void onSlot_lateOlderSlot_cannotAffectStreak() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.onSlot(30_000L, slot(1.0f, 4), 0)).isNull(); // streak = 1
+        // A stale slot from the past, even with opposite-sign evidence that
+        // would reset the streak, is rejected by the monotonic dedup.
+        assertThat(sync.onSlot(15_000L, slot(-1.0f, 4), 0)).isNull();
+        assertThat(sync.onSlot(45_000L, slot(1.0f, 4), 0)).isEqualTo(-500);
+    }
+
+    @Test
     public void reset_clearsStreakAndSlotTracking() {
         ClockSelfSync sync = new ClockSelfSync();
         assertThat(sync.beginSlot(15_000L)).isTrue();

--- a/ft8af/app/src/test/java/com/k1af/ft8af/timer/ClockSelfSyncTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/timer/ClockSelfSyncTest.java
@@ -1,0 +1,269 @@
+package com.k1af.ft8af.timer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Pure unit tests for {@link ClockSelfSync} — the self-syncing clock estimator
+ * (median + MAD rejection + deadband + two-slot confirmation + proportional
+ * gain). No Android types are touched (the GeneralVariables clamp bounds are
+ * compile-time constants), so no Robolectric runner is needed.
+ *
+ * <p>Sign convention under test matches {@code suggestedCorrectionMs} in
+ * {@code TimeCorrection.kt}: positive DT (decodes late in our window = clock
+ * fast) must DECREASE the delay.
+ */
+public class ClockSelfSyncTest {
+
+    // ------------------------------------------------------------------
+    // medianOf
+    // ------------------------------------------------------------------
+
+    @Test
+    public void median_oddLength_returnsMiddleValue() {
+        assertThat(ClockSelfSync.medianOf(new float[]{0.3f, 0.1f, 0.2f})).isEqualTo(0.2f);
+        assertThat(ClockSelfSync.medianOf(new float[]{5f})).isEqualTo(5f);
+    }
+
+    @Test
+    public void median_evenLength_returnsMeanOfMiddleTwo() {
+        assertThat(ClockSelfSync.medianOf(new float[]{0.1f, 0.2f, 0.3f, 0.4f}))
+                .isWithin(1e-6f).of(0.25f);
+        assertThat(ClockSelfSync.medianOf(new float[]{2f, 1f})).isWithin(1e-6f).of(1.5f);
+    }
+
+    @Test
+    public void median_empty_isZero() {
+        assertThat(ClockSelfSync.medianOf(new float[0])).isEqualTo(0f);
+        assertThat(ClockSelfSync.medianOf(null)).isEqualTo(0f);
+    }
+
+    @Test
+    public void median_doesNotMutateInput() {
+        float[] input = {0.3f, 0.1f, 0.2f};
+        ClockSelfSync.medianOf(input);
+        assertThat(input).usingExactEquality().containsExactly(0.3f, 0.1f, 0.2f).inOrder();
+    }
+
+    // ------------------------------------------------------------------
+    // MAD-based outlier rejection
+    // ------------------------------------------------------------------
+
+    @Test
+    public void rejectOutliers_dropsFarOutlier_keepsTightCluster() {
+        // Cluster near 0.5 s plus one wild -3 s decode (e.g. a wrong-slot signal).
+        float[] dt = {0.48f, 0.50f, 0.52f, 0.49f, -3.0f};
+        float[] survivors = ClockSelfSync.rejectOutliers(dt);
+        assertThat(survivors.length).isEqualTo(4);
+        for (float s : survivors) {
+            assertThat(s).isGreaterThan(0.4f);
+        }
+    }
+
+    @Test
+    public void rejectOutliers_identicalSamples_allSurviveViaMadFloor() {
+        // MAD == 0 for identical values; without the 0.2 s floor everything but
+        // exact matches of the median would be rejected on real (jittery) data.
+        float[] dt = {0.7f, 0.7f, 0.7f, 0.7f};
+        assertThat(ClockSelfSync.rejectOutliers(dt).length).isEqualTo(4);
+    }
+
+    @Test
+    public void rejectOutliers_jitterWithinFloor_allSurvive() {
+        // Spread of ±0.15 s around the median is inside the 0.2 s floor even
+        // though 3xMAD alone would be tighter.
+        float[] dt = {0.55f, 0.60f, 0.65f, 0.70f, 0.75f};
+        assertThat(ClockSelfSync.rejectOutliers(dt).length).isEqualTo(5);
+    }
+
+    @Test
+    public void rejectOutliers_empty_returnsEmpty() {
+        assertThat(ClockSelfSync.rejectOutliers(new float[0]).length).isEqualTo(0);
+        assertThat(ClockSelfSync.rejectOutliers(null).length).isEqualTo(0);
+    }
+
+    // ------------------------------------------------------------------
+    // onSlotDecodes: gates
+    // ------------------------------------------------------------------
+
+    /** A slot of {@code n} identical DTs (survives rejection unchanged). */
+    private static float[] slot(float dtSec, int n) {
+        float[] a = new float[n];
+        Arrays.fill(a, dtSec);
+        return a;
+    }
+
+    @Test
+    public void fewerThanMinSamples_returnsNull() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.onSlotDecodes(slot(1.0f, ClockSelfSync.MIN_SLOT_SAMPLES - 1), 0))
+                .isNull();
+        assertThat(sync.onSlotDecodes(new float[0], 0)).isNull();
+    }
+
+    @Test
+    public void sparseSlot_doesNotTouchConfirmationState() {
+        ClockSelfSync sync = new ClockSelfSync();
+        // Slot 1: qualifying out-of-deadband slot starts the streak.
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNull();
+        // Slot 2: too few samples — must NOT reset the streak.
+        assertThat(sync.onSlotDecodes(slot(1.0f, 2), 0)).isNull();
+        // Slot 3: same sign again — confirmation completes, correction applied.
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNotNull();
+    }
+
+    @Test
+    public void medianInsideDeadband_returnsNullAndResetsStreak() {
+        ClockSelfSync sync = new ClockSelfSync();
+        // Start a streak with an out-of-deadband slot...
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNull();
+        // ...then a healthy slot (|median| <= 0.30) clears it...
+        assertThat(sync.onSlotDecodes(slot(0.25f, 4), 0)).isNull();
+        // ...so the next qualifying slot is a FIRST slot again (null), not a second.
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNull();
+        // And only its confirmation acts.
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNotNull();
+    }
+
+    @Test
+    public void deadbandBoundary_isInclusive() {
+        ClockSelfSync sync = new ClockSelfSync();
+        // Exactly 0.30 s is still "good" (matches CLOCK_SYNC_GOOD_SEC semantics).
+        assertThat(sync.onSlotDecodes(slot(ClockSelfSync.DEADBAND_SEC, 4), 0)).isNull();
+        assertThat(sync.onSlotDecodes(slot(ClockSelfSync.DEADBAND_SEC, 4), 0)).isNull();
+        assertThat(sync.onSlotDecodes(slot(-ClockSelfSync.DEADBAND_SEC, 4), 0)).isNull();
+    }
+
+    // ------------------------------------------------------------------
+    // onSlotDecodes: hysteresis
+    // ------------------------------------------------------------------
+
+    @Test
+    public void firstQualifyingSlot_isNull_secondSameSign_steps() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.onSlotDecodes(slot(1.0f, 5), 0)).isNull();
+        Integer applied = sync.onSlotDecodes(slot(1.0f, 5), 0);
+        assertThat(applied).isNotNull();
+        // GAIN 0.5: 1.0 s median -> -500 ms step from a 0 baseline.
+        assertThat(applied).isEqualTo(-500);
+    }
+
+    @Test
+    public void oppositeSignSecondSlot_restartsStreak() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNull();  // +streak = 1
+        assertThat(sync.onSlotDecodes(slot(-1.0f, 4), 0)).isNull(); // flip: -streak = 1
+        // Confirming the NEW (negative) direction acts; sign is the negative one's.
+        Integer applied = sync.onSlotDecodes(slot(-1.0f, 4), 0);
+        assertThat(applied).isEqualTo(500);
+    }
+
+    @Test
+    public void afterApplying_streakResets_soNextCorrectionNeedsTwoMoreSlots() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNull();
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNotNull(); // applied
+        // Immediately after an apply, one more qualifying slot is not enough.
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), -500)).isNull();
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), -500)).isNotNull();
+    }
+
+    // ------------------------------------------------------------------
+    // onSlotDecodes: step math, sign convention, clamp
+    // ------------------------------------------------------------------
+
+    @Test
+    public void stepMath_halvesTheMeasuredError_matchingSuggestedCorrectionSign() {
+        ClockSelfSync sync = new ClockSelfSync();
+        // Positive DT (clock fast) => delay DECREASES — same direction as
+        // suggestedCorrectionMs(currentDelayMs, avgDtSec), at half magnitude.
+        sync.onSlotDecodes(slot(0.8f, 4), 200);
+        assertThat(sync.onSlotDecodes(slot(0.8f, 4), 200))
+                .isEqualTo(200 - Math.round(0.8f * 1000f * ClockSelfSync.GAIN)); // = -200
+        // Negative DT (clock slow) => delay INCREASES.
+        sync.reset();
+        sync.onSlotDecodes(slot(-0.6f, 4), -100);
+        assertThat(sync.onSlotDecodes(slot(-0.6f, 4), -100)).isEqualTo(-100 + 300);
+    }
+
+    @Test
+    public void stepUsesMedianOfSurvivors_notTheRawMean() {
+        ClockSelfSync sync = new ClockSelfSync();
+        // One -3 s outlier among a 1.0 s cluster: the mean would be dragged to
+        // 0.2 s (inside the deadband!), but MAD rejection + median stays at 1.0 s.
+        float[] withOutlier = {1.0f, 1.0f, 1.0f, 1.0f, -3.0f};
+        assertThat(sync.onSlotDecodes(withOutlier, 0)).isNull();
+        assertThat(sync.onSlotDecodes(withOutlier, 0)).isEqualTo(-500);
+    }
+
+    @Test
+    public void newDelay_clampsAtPlusMinus5000() {
+        ClockSelfSync sync = new ClockSelfSync();
+        sync.onSlotDecodes(slot(4.0f, 4), -4000);
+        // -4000 - 2000 = -6000 -> clamped to -5000.
+        assertThat(sync.onSlotDecodes(slot(4.0f, 4), -4000)).isEqualTo(-5000);
+        sync.reset();
+        sync.onSlotDecodes(slot(-4.0f, 4), 4000);
+        // 4000 + 2000 = 6000 -> clamped to +5000.
+        assertThat(sync.onSlotDecodes(slot(-4.0f, 4), 4000)).isEqualTo(5000);
+    }
+
+    // ------------------------------------------------------------------
+    // Convergence property
+    // ------------------------------------------------------------------
+
+    @Test
+    public void convergence_from1500msOff_reachesDeadbandMonotonically() {
+        ClockSelfSync sync = new ClockSelfSync();
+        // trueErrorMs: how far the app clock is from the band. Each slot's
+        // measured DT is exactly that error (consistent signals); each applied
+        // correction shifts the clock and therefore the next slot's DT.
+        int delayMs = 0;
+        float trueErrorSec = 1.5f; // clock 1500 ms fast: decodes land at +1.5 s DT
+        float prevAbs = Math.abs(trueErrorSec);
+        int slots = 0;
+        while (Math.abs(trueErrorSec) > ClockSelfSync.DEADBAND_SEC && slots < 20) {
+            slots++;
+            Integer newDelay = sync.onSlotDecodes(slot(trueErrorSec, 6), delayMs);
+            if (newDelay != null) {
+                // The applied correction moves the clock; the band's apparent DT
+                // shrinks by the same amount.
+                trueErrorSec -= (delayMs - newDelay) / 1000f;
+                delayMs = newDelay;
+                // Monotonic approach: never overshoots into a larger |error|.
+                assertThat(Math.abs(trueErrorSec)).isLessThan(prevAbs);
+                prevAbs = Math.abs(trueErrorSec);
+            }
+        }
+        // 1500 -> 750 -> 375 -> 187.5 ms: three corrections, two slots each.
+        assertThat(Math.abs(trueErrorSec)).isAtMost(ClockSelfSync.DEADBAND_SEC);
+        assertThat(slots).isAtMost(6);
+    }
+
+    // ------------------------------------------------------------------
+    // beginSlot / reset
+    // ------------------------------------------------------------------
+
+    @Test
+    public void beginSlot_trueOncePerUtc() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.beginSlot(15_000L)).isTrue();
+        assertThat(sync.beginSlot(15_000L)).isFalse(); // same slot redelivered
+        assertThat(sync.beginSlot(30_000L)).isTrue();  // next slot
+    }
+
+    @Test
+    public void reset_clearsStreakAndSlotTracking() {
+        ClockSelfSync sync = new ClockSelfSync();
+        assertThat(sync.beginSlot(15_000L)).isTrue();
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNull(); // streak = 1
+        sync.reset();
+        // Streak gone: the next qualifying slot is a first slot again.
+        assertThat(sync.onSlotDecodes(slot(1.0f, 4), 0)).isNull();
+        // Slot tracking gone: the same utc is processable again.
+        assertThat(sync.beginSlot(15_000L)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Opt-in **Time Sync** setting that makes the band itself the time source — FT8/FT4/FT2 keep working with a drifted clock and no NTP or GPS (offline POTA, mountaintops, car dashes).

- New pure estimator `timer/ClockSelfSync.java`: each slot's per-decode DTs (fast pass only, own-TX echoes excluded, `beginSlot(utc)` dedup as a second line of defense against multi-pass delivery) go through a **median with MAD outlier rejection** (threshold `max(0.2 s, 3×MAD)`), a **≥4 surviving-samples** gate, a **0.30 s deadband** (matches `CLOCK_SYNC_GOOD_SEC`, the UI's "good clock" threshold), and **two consecutive same-sign slots** of confirmation before anything is applied.
- Corrections use a **0.5 proportional gain** — each applied step shifts the next slot's measured DT, so full steps would ring. Deliberately no hard step cap, per the `GpsClockUpdater` step-limiter post-mortem (a cap can refuse the truth forever; proportional gain always converges).
- Applies through the exact three-way fan-out the manual control uses (`UtcTimer.delay` / `GeneralVariables.manualTimeCorrectionMs` / `timeCorrectionMs` config row), so RX windows, TX key-up, the UI clock, and persistence all follow — TX needs no separate handling.
- **Arbitration:** stands down (and clears its confirmation streak) while GPS clock discipline owns the clock; the settings row is disabled then too, mirroring the manual-correction lock-out. Applied corrections are logged to `debug.log` (`selfSync: applied clock correction …`).
- Settings toggle persists via the standard config-table pattern including the hydration arm; strings are English-only (locale fallback).
- `SettingsRow` gained an `enabled` param (pass-through to `Toggle`, which already supported it); existing callers unaffected.

## Test plan

- [x] `ClockSelfSyncTest` — 21 tests: median odd/even/empty, MAD rejection (drops far outlier, keeps tight cluster, floor), min-sample gate preserving the streak, deadband no-op + streak reset + boundary, two-slot hysteresis, sign-flip restart, gain-0.5 step math with the same sign convention as `suggestedCorrectionMs`, ±5000 ms clamp, convergence from 1500 ms error into the deadband in ≤6 slots (monotonic), `beginSlot` dedup, `reset()`.
- [x] `DatabaseOprConfigHydrationTest` — new key hydrates 1/0, absent row keeps default off.
- [x] Full `testDebugUnitTest`: 3247 tests, 0 failures.
- [x] ktlint/detekt: no new violations in touched files (remaining hits are pre-existing lines; baseline untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)