### PR TITLE
Add "Direct USB TX" toggle to bypass the mixer on transmit

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DirectUsbTx.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/DirectUsbTx.kt
@@ -1,0 +1,50 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+/**
+ * Decision logic for the "Direct USB TX" toggle in [RadioAudioSettings].
+ *
+ * <p>The transmit path is chosen in {@code FT8TransmitSignal.playFT8Signal} by
+ * the same two persisted fields this toggle drives:
+ * {@code audioOutputDeviceId == -1 && usbAudioOutputVendorId != 0} selects the
+ * direct libusb output (bypassing Android's shared mixer, so notification and
+ * other-app sounds can't leak on air); anything else goes out the AudioTrack
+ * sink. Keeping the toggle's on/off state derived from — and written back to —
+ * exactly those fields means the toggle and the existing "Audio Output" device
+ * picker stay consistent: they are two views of one setting.
+ *
+ * <p>The Composable is a thin wrapper; the on/off predicate and the field
+ * values for each direction live here as pure functions so they are unit-tested
+ * without Android.
+ */
+
+/** The three persisted audio-output fields the toggle reads and writes. */
+internal data class AudioOutputSelection(
+    val audioOutputDeviceId: Int,
+    val usbVendorId: Int,
+    val usbProductId: Int,
+)
+
+/**
+ * True when the persisted selection routes TX through the direct libusb path.
+ * Mirrors the branch condition in {@code FT8TransmitSignal.playFT8Signal}
+ * exactly — if that condition changes, this must change with it.
+ */
+internal fun isDirectUsbTxEnabled(audioOutputDeviceId: Int, usbOutputVendorId: Int): Boolean =
+    audioOutputDeviceId == -1 && usbOutputVendorId != 0
+
+/**
+ * Selection that enables the direct libusb TX path for a radio codec identified
+ * by [vendorId]/[productId] (from a discovered USB audio output device). The
+ * caller must only apply this when a real device was found: a `vendorId` of 0
+ * would fail the enable predicate and silently leave TX on the AudioTrack sink.
+ */
+internal fun directUsbTxSelection(vendorId: Int, productId: Int): AudioOutputSelection =
+    AudioOutputSelection(audioOutputDeviceId = -1, usbVendorId = vendorId, usbProductId = productId)
+
+/**
+ * Selection that disables the direct path, falling back to Android's
+ * system-default output sink (device id 0). Clears the USB VID/PID so a later
+ * read of [isDirectUsbTxEnabled] reports off even though device id alone would.
+ */
+internal fun systemDefaultTxSelection(): AudioOutputSelection =
+    AudioOutputSelection(audioOutputDeviceId = 0, usbVendorId = 0, usbProductId = 0)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -1,6 +1,7 @@
 package radio.ks3ckc.ft8af.ui.settings
 
 import android.media.AudioManager
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -644,6 +645,60 @@ fun RadioAudioSettings(
                         },
                     )
                     SectionDivider()
+                    run {
+                        // "Direct USB TX" is a second view of the audio-output
+                        // selection above: on == route TX straight to the USB
+                        // radio (bypasses Android's mixer, so notification/app
+                        // sounds can't leak on air); off == normal AudioTrack
+                        // sink. Both write the same GeneralVariables + config
+                        // keys, so this toggle and the picker stay in step.
+                        var directUsb by remember {
+                            mutableStateOf(
+                                isDirectUsbTxEnabled(
+                                    GeneralVariables.audioOutputDeviceId,
+                                    GeneralVariables.usbAudioOutputVendorId,
+                                ),
+                            )
+                        }
+                        SettingsRow(
+                            label = stringResource(R.string.settings_direct_usb_tx),
+                            description = stringResource(R.string.settings_direct_usb_tx_desc),
+                            toggle = directUsb,
+                            onToggleChange = { enabled ->
+                                if (enabled) {
+                                    audioOutputAdapter.refreshDevices()
+                                    val usbInfo = firstUsbOutputDevice(audioOutputAdapter)
+                                    if (usbInfo == null) {
+                                        // Can't enable with no USB sound card present;
+                                        // leave the toggle off and say why.
+                                        Toast.makeText(
+                                            context,
+                                            context.getString(R.string.settings_direct_usb_tx_none),
+                                            Toast.LENGTH_LONG,
+                                        ).show()
+                                    } else {
+                                        applyAudioOutputSelection(
+                                            mainViewModel,
+                                            directUsbTxSelection(
+                                                usbInfo.device.vendorId,
+                                                usbInfo.device.productId,
+                                            ),
+                                        )
+                                        mainViewModel.requestUsbPermissionIfNeeded(usbInfo.device)
+                                        audioOutputName = audioOutputAdapter.getDeviceDisplayName(
+                                            audioOutputAdapter.getPositionByDeviceId(-1),
+                                        )
+                                        directUsb = true
+                                    }
+                                } else {
+                                    applyAudioOutputSelection(mainViewModel, systemDefaultTxSelection())
+                                    audioOutputName = audioOutputAdapter.getDeviceDisplayName(0)
+                                    directUsb = false
+                                }
+                            },
+                        )
+                    }
+                    SectionDivider()
                     SettingsRow(
                         label = stringResource(R.string.settings_input_volume),
                         description = stringResource(R.string.settings_input_volume_desc),
@@ -1003,3 +1058,41 @@ internal const val INPUT_VOLUME_MAX = 200
  * re-persisted unchanged on dismiss.
  */
 internal fun clampVolumePercent(value: Int, maxValue: Int): Int = value.coerceIn(0, maxValue)
+
+/**
+ * First USB-audio output device the adapter knows about, or null if none is
+ * connected. The output adapter's USB list is already filtered to
+ * output-capable devices, so the first non-null entry is a valid TX sink.
+ */
+private fun firstUsbOutputDevice(
+    adapter: AudioDeviceSpinnerAdapter,
+): com.k1af.ft8af.wave.UsbAudioDevice.UsbAudioDeviceInfo? {
+    for (pos in 0 until adapter.count) {
+        val info = adapter.getUsbAudioDeviceInfo(pos)
+        if (info != null) return info
+    }
+    return null
+}
+
+/**
+ * Apply an [AudioOutputSelection] to the live fields and persist it, using the
+ * same three config keys the "Audio Output" device picker writes so the two
+ * controls round-trip identically across restarts.
+ */
+private fun applyAudioOutputSelection(
+    mainViewModel: MainViewModel,
+    selection: AudioOutputSelection,
+) {
+    GeneralVariables.audioOutputDeviceId = selection.audioOutputDeviceId
+    GeneralVariables.usbAudioOutputVendorId = selection.usbVendorId
+    GeneralVariables.usbAudioOutputProductId = selection.usbProductId
+    mainViewModel.databaseOpr.writeConfig(
+        "audioOutputDevice", selection.audioOutputDeviceId.toString(), null,
+    )
+    mainViewModel.databaseOpr.writeConfig(
+        "usbAudioOutputVid", selection.usbVendorId.toString(), null,
+    )
+    mainViewModel.databaseOpr.writeConfig(
+        "usbAudioOutputPid", selection.usbProductId.toString(), null,
+    )
+}

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -615,6 +615,9 @@
     <string name="settings_per_band_volume">Save Output Level per Band</string>
     <string name="settings_per_band_volume_desc">Remember the TX volume separately for each band and restore it on band change</string>
     <string name="per_band_volume_restored">TX volume %1$d%% restored for %2$s</string>
+    <string name="settings_direct_usb_tx">Direct USB TX</string>
+    <string name="settings_direct_usb_tx_desc">Send transmit audio straight to the USB radio, bypassing Android\'s mixer. Keeps notification and other app sounds off the air. Turn off to transmit through the normal audio output.</string>
+    <string name="settings_direct_usb_tx_none">No USB audio device found. Connect the radio\'s sound card and try again.</string>
 
     <!-- ===== Settings: transmission ===== -->
     <string name="settings_tx_rx_split">TX/RX Split</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/DirectUsbTxTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/DirectUsbTxTest.kt
@@ -1,0 +1,58 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Tests the decision logic behind the "Direct USB TX" toggle
+ * ([isDirectUsbTxEnabled], [directUsbTxSelection], [systemDefaultTxSelection]).
+ *
+ * The toggle is a second view of the audio-output selection also driven by the
+ * device picker, so its predicate must match the TX-path branch in
+ * {@code FT8TransmitSignal.playFT8Signal} (deviceId == -1 && vendorId != 0)
+ * exactly, and each direction must produce field values that round-trip through
+ * that predicate.
+ */
+class DirectUsbTxTest {
+
+    @Test
+    fun enabledOnlyWhenDirectDeviceAndVendorPresent() {
+        // Both conditions met: direct sentinel device id + a real VID.
+        assertThat(isDirectUsbTxEnabled(-1, 0x0D8C)).isTrue()
+    }
+
+    @Test
+    fun notEnabledForAudioTrackDevice() {
+        // System default (0) and a specific AudioManager device (>0) are the
+        // AudioTrack sink regardless of any stale VID left in the fields.
+        assertThat(isDirectUsbTxEnabled(0, 0x0D8C)).isFalse()
+        assertThat(isDirectUsbTxEnabled(5, 0x0D8C)).isFalse()
+        assertThat(isDirectUsbTxEnabled(0, 0)).isFalse()
+    }
+
+    @Test
+    fun notEnabledWhenVendorMissingEvenIfDirectDeviceId() {
+        // deviceId == -1 alone is not enough — the path needs a VID to locate
+        // the device, so a -1 with vendor 0 must read as off (and it would in
+        // fact fall through to AudioTrack).
+        assertThat(isDirectUsbTxEnabled(-1, 0)).isFalse()
+    }
+
+    @Test
+    fun directSelectionRoundTripsToEnabled() {
+        val sel = directUsbTxSelection(0x0D8C, 0x0012)
+        assertThat(sel.audioOutputDeviceId).isEqualTo(-1)
+        assertThat(sel.usbVendorId).isEqualTo(0x0D8C)
+        assertThat(sel.usbProductId).isEqualTo(0x0012)
+        assertThat(isDirectUsbTxEnabled(sel.audioOutputDeviceId, sel.usbVendorId)).isTrue()
+    }
+
+    @Test
+    fun systemDefaultSelectionRoundTripsToDisabled() {
+        val sel = systemDefaultTxSelection()
+        assertThat(sel.audioOutputDeviceId).isEqualTo(0)
+        assertThat(sel.usbVendorId).isEqualTo(0)
+        assertThat(sel.usbProductId).isEqualTo(0)
+        assertThat(isDirectUsbTxEnabled(sel.audioOutputDeviceId, sel.usbVendorId)).isFalse()
+    }
+}


### PR DESCRIPTION
## What

Adds a **Direct USB TX** on/off toggle in **Settings → Radio & Audio → Audio** (right under Audio Output).

- **On** — TX audio goes straight to the USB radio over the direct libusb path, bypassing Android's shared mixer. Notification and other-app sounds can no longer be mixed into the transmission and go out on air.
- **Off** — normal AudioTrack output (system-default sink).

## Why

The direct-libusb TX path already existed in `FT8TransmitSignal` (chosen when `audioOutputDeviceId == -1 && usbAudioOutputVendorId != 0`), but the only way to select it was to find the `… (USB direct)` row in the Audio Output device picker — sitting right next to the AudioManager `USB Audio` entry for the *same* card, hard to tell apart. The direct path is the robust fix for the mixer-bleed class of problem (other apps' sounds transmitted on air) that the advisory audio-focus work in #597 can only partially mitigate, since notification sounds ignore audio focus.

This exposes it as a clear, reversible toggle instead of touching the (working, timing-sensitive) TX pipeline.

## How

- The toggle is a second view of the same audio-output selection: it reads and writes the exact three persisted config keys (`audioOutputDevice`, `usbAudioOutputVid`, `usbAudioOutputPid`) the device picker uses, so the two controls stay in sync and the setting round-trips across restarts.
- Enabling with no USB sound card attached refuses and toasts why; enabling requests USB permission just like the picker path.
- Decision logic extracted to `DirectUsbTx.kt` (`isDirectUsbTxEnabled` / `directUsbTxSelection` / `systemDefaultTxSelection`) — pure functions, unit-tested. The enable predicate deliberately mirrors the engine's TX-path branch condition so the two can't drift.

## Testing

- New `DirectUsbTxTest` covers the on/off predicate (including the deviceId-is-−1-but-no-VID edge) and the round-trip of each selection back through the predicate. Passes.
- `./gradlew assembleDebug` clean.
- Not yet exercised on-device (no phone attached this session). Scope is TX-path only; RX capture is a separate setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)