### PR TITLE
Complete the server trip when the operator discards it locally

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaTripManager.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaTripManager.kt
@@ -732,4 +732,4 @@ internal fun shouldCompleteAbandonedTrip(
     tripId: String,
     pendingCreate: Boolean,
     apiKey: String,
-): Boolean = tripId.isNotEmpty() && !pendingCreate && apiKey.isNotBlank()
+): Boolean = tripId.isNotBlank() && !pendingCreate && apiKey.isNotBlank()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaTripManager.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaTripManager.kt
@@ -280,11 +280,22 @@ object RotaTripManager {
     }
 
     /**
-     * Give up on a trip that can't be delivered (bad key, deleted trip). Drops
-     * the local queue and forgets the trip — the end-of-trip ADIF upload from the
-     * logbook remains the way to publish it.
+     * Give up on a trip: drop the local queue and forget it — the end-of-trip
+     * ADIF upload from the logbook remains the way to publish its contacts.
+     *
+     * The server row is still completed, best-effort. Discarding used to be
+     * local-only, which stranded a created trip as `active` forever: the site
+     * called the rover live for a day and badged the trip active after that,
+     * with no client left that could end it. One fire-and-forget attempt is
+     * deliberate — for the failure cases this button also serves (bad key,
+     * deleted trip) the call fails and the row was unreachable anyway.
      */
     fun abandonTrip() {
+        // Snapshot before clearTrip wipes them; the coroutine below outlives it.
+        val tripId = RotaSettings.tripId
+        val pendingCreate = RotaSettings.tripPendingCreate
+        val baseUrl = RotaSettings.baseUrl
+        val apiKey = RotaSettings.apiKey
         RotaCqSession.release()
         stopTracking()
         queue?.clear()
@@ -294,6 +305,13 @@ object RotaTripManager {
         resumeHandshakePending = false
         _state.value = RotaTripState()
         log("abandonTrip — local queue dropped")
+        if (shouldCompleteAbandonedTrip(tripId, pendingCreate, apiKey)) {
+            scope.launch {
+                RotaClient.completeTrip(baseUrl, apiKey, tripId)
+                    .onSuccess { log("abandonTrip — server trip $tripId completed") }
+                    .onFailure { log("abandonTrip — server complete failed (${it.message}); row may stay active") }
+            }
+        }
     }
 
     private fun defaultTripName(startedMs: Long): String {
@@ -703,3 +721,15 @@ object RotaTripManager {
         }
     }
 }
+
+/**
+ * Whether abandoning a trip should still complete it server-side. Only when a
+ * server row actually exists to complete: a trip still pending creation has no
+ * id (and nothing to strand), and without an API key the call cannot succeed —
+ * skipping it keeps the abandon path free of a doomed network attempt.
+ */
+internal fun shouldCompleteAbandonedTrip(
+    tripId: String,
+    pendingCreate: Boolean,
+    apiKey: String,
+): Boolean = tripId.isNotEmpty() && !pendingCreate && apiKey.isNotBlank()

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rota/RoadTripScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rota/RoadTripScreen.kt
@@ -537,6 +537,13 @@ private fun ActiveTripCard(
                 Text(stringResource(R.string.rota_abandon), color = TextMuted)
             }
         }
+        // Discard is not the harmless-looking local cleanup it reads as — it
+        // throws away undelivered data. Say what it does before it's tapped.
+        Text(
+            text = stringResource(R.string.rota_abandon_desc),
+            color = TextFaint,
+            fontSize = 11.sp,
+        )
     }
 }
 

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -938,7 +938,7 @@
     <string name="rota_end_trip">End trip</string>
     <string name="rota_ending">Finishing up — uploading the rest…</string>
     <string name="rota_abandon">Discard local trip</string>
-    <string name="rota_abandon_desc">Stops tracking, drops anything not yet uploaded, and ends the trip on the server</string>
+    <string name="rota_abandon_desc">Discard stops tracking, drops anything not yet uploaded, and still ends the trip on roadsontheair.com</string>
     <string name="rota_stat_miles">Miles</string>
     <string name="rota_stat_qsos">Contacts sent</string>
     <string name="rota_stat_pending">Waiting to upload</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -938,7 +938,7 @@
     <string name="rota_end_trip">End trip</string>
     <string name="rota_ending">Finishing up — uploading the rest…</string>
     <string name="rota_abandon">Discard local trip</string>
-    <string name="rota_abandon_desc">Stops tracking and drops anything not yet uploaded</string>
+    <string name="rota_abandon_desc">Stops tracking, drops anything not yet uploaded, and ends the trip on the server</string>
     <string name="rota_stat_miles">Miles</string>
     <string name="rota_stat_qsos">Contacts sent</string>
     <string name="rota_stat_pending">Waiting to upload</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RotaAbandonTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RotaAbandonTest.kt
@@ -25,6 +25,8 @@ class RotaAbandonTest {
     @Test
     fun `no id or no key means no doomed network attempt`() {
         assertThat(shouldCompleteAbandonedTrip("", false, "rota_key")).isFalse()
+        // Blank, not merely empty: an id of stray whitespace is still "no id".
+        assertThat(shouldCompleteAbandonedTrip("   ", false, "rota_key")).isFalse()
         assertThat(shouldCompleteAbandonedTrip("trip-123", false, "")).isFalse()
         assertThat(shouldCompleteAbandonedTrip("trip-123", false, "   ")).isFalse()
     }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RotaAbandonTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RotaAbandonTest.kt
@@ -1,0 +1,31 @@
+package radio.ks3ckc.ft8af.rota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Abandoning a trip must still complete the server row when one exists —
+ * discard used to be local-only, which left the trip `active` on
+ * roadsontheair.com forever, with no client able to end it.
+ */
+class RotaAbandonTest {
+    @Test
+    fun `a created trip gets its server row completed`() {
+        assertThat(shouldCompleteAbandonedTrip("trip-123", false, "rota_key")).isTrue()
+    }
+
+    @Test
+    fun `a trip still pending creation has no row to complete`() {
+        assertThat(shouldCompleteAbandonedTrip("", true, "rota_key")).isFalse()
+        // Belt and braces: even if an id were somehow present mid-create, the
+        // row the id names is not confirmed to exist yet.
+        assertThat(shouldCompleteAbandonedTrip("trip-123", true, "rota_key")).isFalse()
+    }
+
+    @Test
+    fun `no id or no key means no doomed network attempt`() {
+        assertThat(shouldCompleteAbandonedTrip("", false, "rota_key")).isFalse()
+        assertThat(shouldCompleteAbandonedTrip("trip-123", false, "")).isFalse()
+        assertThat(shouldCompleteAbandonedTrip("trip-123", false, "   ")).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

**Discard local trip** dropped the phone's queue and forgot the trip, but never touched the server — so a trip row already created on roadsontheair.com stayed `active` forever. The site (correctly, per its heard-from-recently rule) called the rover **Live** for 24 hours and badged the trip active indefinitely after that, and with the app's local state gone there was no client left that could complete it. This stranded `K1AF 2026-08-03` in production last night.

`abandonTrip` now snapshots the trip id, base URL and API key *before* `clearTrip()` wipes them, finishes the local teardown exactly as before, then fires one best-effort `completeTrip`:

- **Fire-and-forget by design** — the button also serves the broken cases (bad key, deleted trip) where the call fails and the row was unreachable anyway; retry loops belong to End Trip's `tripPendingComplete` path, not here.
- `shouldCompleteAbandonedTrip` (pure, tested) skips the doomed attempt when the trip was never created server-side or no API key is stored.
- The Discard row's description now says it ends the trip on the server.

Companion site PR (patrickrb/road-trips-on-the-air-site#30) adds an owner-facing "End this trip" on the trip page for rows already stranded.

## Testing

New `RotaAbandonTest` covers the eligibility decision. Full `testDebugUnitTest` passes. `ktlintCheck`/`detekt` remain red on clean `dev` in untouched files (Wsjtx*, DebugInject.kt) — no new issues from this change (verified against the reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)