### PR TITLE
Protect a pending band selection from being overwritten by rig echoes

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -628,6 +628,11 @@ public class GeneralVariables {
     public static void operatorChoseDial(long hz) {
         commandedBandHz = hz;
         operatorDialAssertedAtMs = System.currentTimeMillis();
+        // A stale stamp from an OLDER selection must not make this one look
+        // delivered: normally deliveredAt < assertedAt covers that, but this
+        // app's clock is GPS-disciplined and can step backwards, which could
+        // leave an old deliveredAt >= the new assertedAt. Zero is unambiguous.
+        operatorDialDeliveredAtMs = 0L;
     }
     //Posted each time a GPS fix disciplines the clock, so the Time Sync screen can recompose
     //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -598,6 +598,37 @@ public class GeneralVariables {
      * {@link com.k1af.ft8af.rigs.RigDialTarget#DESYNC_DISTRUST_MS}.
      */
     public static volatile long rigRejectedAtMs = 0L;
+
+    /**
+     * When the operator last explicitly selected a dial in the app (band picker, mode
+     * retune), or 0 when there is no unconfirmed selection. While set, a rig report that
+     * differs from {@link #commandedBandHz} is an echo of the past — the selection may not
+     * even have reached the wire yet — and must not be adopted as the commanded dial.
+     * Cleared when the rig confirms the selection. See
+     * {@link com.k1af.ft8af.rigs.RigDialTarget}. Set via {@link #operatorChoseDial(long)}.
+     */
+    public static volatile long operatorDialAssertedAtMs = 0L;
+
+    /**
+     * When {@link #commandedBandHz} was last actually dispatched to the rig (the FA write
+     * in {@code setOperationBand}'s delayed runnable), or 0 if not yet. Distinguishes a
+     * selection the rig has had a chance to act on from one dropped by the
+     * connected-gate — the 2026-08-04 failure where a 30m tap was silently skipped and a
+     * healthy poll of the still-on-20m rig overwrote the choice within 2 s. See
+     * {@link com.k1af.ft8af.rigs.RigDialTarget#CONFIRM_GRACE_MS}.
+     */
+    public static volatile long operatorDialDeliveredAtMs = 0L;
+
+    /**
+     * Record an explicit operator dial selection: the dial the app asserts from now on,
+     * protected from being overwritten by rig reports until the rig confirms it. One
+     * helper so every band-selection entry point (Compose picker, legacy spinner/dialog,
+     * mode retune) keeps the two fields in step.
+     */
+    public static void operatorChoseDial(long hz) {
+        commandedBandHz = hz;
+        operatorDialAssertedAtMs = System.currentTimeMillis();
+    }
     //Posted each time a GPS fix disciplines the clock, so the Time Sync screen can recompose
     //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.
     public static MutableLiveData<Long> mutableGpsClockSync = new MutableLiveData<>();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -352,18 +352,28 @@ public class MainViewModel extends ViewModel {
             String oldWaveLength = BaseRigOperation.getMeterFromFreq(GeneralVariables.band);
             GeneralVariables.band = freq;
             // Observing a frequency is not the same as choosing one. Adopt it as the dial
-            // we COMMAND only while the CAT stream is healthy — otherwise a reading taken
-            // during a "?;" desync gets pushed back at the rig by the reassert heartbeat
-            // and fights the operator's band selection (measured: a 30m tap took ~59s and
-            // four attempts because the app kept re-commanding a 14239985 it never chose).
+            // we COMMAND only while the CAT stream is healthy AND no explicit operator
+            // selection is pending — otherwise a reading gets pushed back at the rig by
+            // the reassert heartbeat and fights the operator's band selection. Two
+            // measured failures: a "?;"-desync reading of 14239985 (took a 30m tap ~59s
+            // and four attempts), and a healthy echo of the OLD band overwriting a tap
+            // the connected-gate had dropped before it reached the wire (2026-08-04, the
+            // heartbeat then re-asserted 20m against 30m taps all evening).
             // See RigDialTarget.
+            if (freq == GeneralVariables.commandedBandHz) {
+                // The rig confirmed the operator's selection — back to follow mode.
+                GeneralVariables.operatorDialAssertedAtMs = 0L;
+            }
             if (RigDialTarget.shouldAdoptAsTarget(System.currentTimeMillis(),
-                    GeneralVariables.rigRejectedAtMs, freq)) {
+                    GeneralVariables.rigRejectedAtMs, freq,
+                    GeneralVariables.commandedBandHz,
+                    GeneralVariables.operatorDialAssertedAtMs,
+                    GeneralVariables.operatorDialDeliveredAtMs)) {
                 GeneralVariables.commandedBandHz = freq;
             } else {
                 fileLog("rig echo ignored as command target: reported " + freq
-                        + " while CAT desynced; still asserting "
-                        + GeneralVariables.commandedBandHz);
+                        + " while CAT desynced or operator selection pending;"
+                        + " still asserting " + GeneralVariables.commandedBandHz);
             }
             GeneralVariables.bandListIndex = OperationBand.getIndexByFreq(freq);
             GeneralVariables.mutableBandChange.postValue(GeneralVariables.bandListIndex);
@@ -1753,6 +1763,10 @@ public class MainViewModel extends ViewModel {
                         + " (rig.getFreq=" + baseRig.getFreq() + ")");
                 baseRig.setFreq(sendHz);//set frequency
                 baseRig.setFreqToRig();
+                // A pending operator selection has now actually been dispatched (the
+                // connected-gate above passed): start the confirm grace, after which a
+                // still-differing rig report is trusted again. See RigDialTarget.
+                GeneralVariables.operatorDialDeliveredAtMs = System.currentTimeMillis();
             }
         }, 800);
     }
@@ -1810,7 +1824,7 @@ public class MainViewModel extends ViewModel {
         if (newFreq > 0 && newFreq != GeneralVariables.band) {
             GeneralVariables.band = newFreq;
             // Mode retune within the same band is an explicit choice too. See RigDialTarget.
-            GeneralVariables.commandedBandHz = newFreq;
+            GeneralVariables.operatorChoseDial(newFreq);
             GeneralVariables.bandListIndex = OperationBand.getIndexByFreq(newFreq);
             databaseOpr.writeConfig("bandFreq", String.valueOf(newFreq), null);
             retuned = true;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -1765,8 +1765,15 @@ public class MainViewModel extends ViewModel {
                 baseRig.setFreqToRig();
                 // A pending operator selection has now actually been dispatched (the
                 // connected-gate above passed): start the confirm grace, after which a
-                // still-differing rig report is trusted again. See RigDialTarget.
-                GeneralVariables.operatorDialDeliveredAtMs = System.currentTimeMillis();
+                // still-differing rig report is trusted again. Only if the write really
+                // reached the rig, though — a port that died between the gate and the
+                // send returns false from sendData without throwing, and stamping that
+                // as delivered would re-open the overwrite. See RigDialTarget.
+                boolean catOk = baseRig.getConnector() != null
+                        && baseRig.getConnector().isLastCatWriteOk();
+                GeneralVariables.operatorDialDeliveredAtMs = RigDialTarget.deliveredStamp(
+                        catOk, System.currentTimeMillis(),
+                        GeneralVariables.operatorDialDeliveredAtMs);
             }
         }, 800);
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
@@ -84,6 +84,20 @@ public class BaseRigConnector {
      */
     public boolean isLastPttWriteOk(){ return true; }
 
+    /**
+     * Whether the most recent {@link #sendData} write actually reached the rig.
+     *
+     * <p>Same posture as {@link #isLastPttWriteOk()}: lets the band-change path tell
+     * "frequency command sent" from "command attempted at a port that had already gone
+     * away" — the difference between an operator selection that has been DELIVERED
+     * (and may be superseded by what the rig reports back) and one that is still
+     * pending. Connectors that cannot fail silently keep the optimistic default; the
+     * USB cable path overrides it.
+     *
+     * @return true if the last CAT data write is believed delivered
+     */
+    public boolean isLastCatWriteOk(){ return true; }
+
     public void setControlMode(int mode){
         controlMode=mode;
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
@@ -164,7 +164,15 @@ public class CableConnector extends BaseRigConnector {
 
     @Override
     public synchronized void sendData(byte[] data) {
-        cableSerialPort.sendData(data);
+        lastCatWriteOk = cableSerialPort.sendData(data);
+    }
+
+    /** See {@link BaseRigConnector#isLastCatWriteOk()}. Optimistic until a write fails. */
+    private volatile boolean lastCatWriteOk = true;
+
+    @Override
+    public boolean isLastCatWriteOk() {
+        return lastCatWriteOk;
     }
 
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RigDialTarget.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RigDialTarget.java
@@ -29,23 +29,32 @@ package com.k1af.ft8af.rigs;
  * 29 rejections followed an {@code FA} set-frequency, and the bogus reading appeared inside
  * that window. A reading taken while the command stream is known to be desynchronised is
  * not trustworthy enough to command back.
+ *
+ * <p>A second measured way an observation steals the target, from the 2026-08-04 session,
+ * on a USB link that was flapping (write errors + auto-reconnect every few seconds):
+ *
+ * <pre>
+ * 20:19:40  bandSelect: band=10136000, rigConnected=false   &lt;- operator taps 30m
+ * 20:19:41  setOperationBand: rig not connected, skipping   &lt;- FA never dispatched
+ * 20:19:4x  poll reads the rig, still on 14074000           &lt;- healthy stream, no "?;"
+ *           -&gt; adopted as commandedBandHz                   &lt;- the tap is ERASED
+ * 20:23:35  serial.send: FA014074000;                       &lt;- heartbeat re-asserts 20m,
+ *                                                              every ~2 min, all evening
+ * </pre>
+ *
+ * <p>The desync window can't catch this: the stream is healthy, the reading is truthful —
+ * the rig really is still on 20m, precisely because the operator's command was dropped by
+ * the connected-gate before ever reaching the wire. So an explicit operator selection is
+ * additionally tracked as PENDING until the app has actually dispatched it
+ * ({@code operatorDialAssertedAtMs} / {@code operatorDialDeliveredAtMs} in
+ * {@code GeneralVariables}); while pending, a differing report is an echo of the past, not
+ * the operator's intent, and must not be adopted. Delivery plus a short settle grace ends
+ * the protection, so a hand-turned VFO is followed again within seconds.
  */
 public final class RigDialTarget {
 
     private RigDialTarget() {}
 
-    /**
-     * Whether a frequency the rig has just reported should become the dial the app asserts.
-     *
-     * <p>Adopting is the normal case: it is how the app follows the operator turning the
-     * VFO. It is refused only while the rig is rejecting our commands, where the reading
-     * may be a mis-parse or a stale frame rather than the operator's intent.
-     *
-     * @param nowMs           current wall clock
-     * @param rigRejectedAtMs when the rig last answered with an error / unparseable frame,
-     *                        or 0 if never
-     * @param reportedHz      the frequency just reported
-     */
     /**
      * How long after a rejection the rig's frequency reports stay untrusted.
      *
@@ -61,8 +70,65 @@ public final class RigDialTarget {
      */
     public static final long DESYNC_DISTRUST_MS = 3_000;
 
+    /**
+     * How long after an operator selection is actually dispatched to the rig its reports
+     * stay untrusted, so the rig has time to QSY and the next poll reflects it.
+     *
+     * <p>Sized to cover the 2 s freq-poll interval plus rig settle time: a differing
+     * report landing later than this after the last dispatch means the rig refused the
+     * command or the operator turned the VFO by hand — either way, follow the rig.
+     */
+    public static final long CONFIRM_GRACE_MS = 5_000;
+
+    /**
+     * Legacy form: no operator selection is pending. Kept because "no pending state"
+     * is a meaningful default (config load, first run), not just a test convenience.
+     */
     public static boolean shouldAdoptAsTarget(long nowMs, long rigRejectedAtMs, long reportedHz) {
+        return shouldAdoptAsTarget(nowMs, rigRejectedAtMs, reportedHz, 0L, 0L, 0L);
+    }
+
+    /**
+     * Whether a frequency the rig has just reported should become the dial the app asserts,
+     * given the state of the operator's most recent explicit selection.
+     *
+     * <p>Refusal cases, each from a measured field failure (class javadoc):
+     * <ul>
+     *   <li>the stream is desynchronised ({@code DESYNC_DISTRUST_MS} after a "?;"), or</li>
+     *   <li>an operator selection is pending and has not yet been dispatched to the rig
+     *       (the 20:19:40 dropped-tap trace), or</li>
+     *   <li>it was dispatched less than {@link #CONFIRM_GRACE_MS} ago, so a differing
+     *       report may predate the rig's QSY.</li>
+     * </ul>
+     *
+     * <p>A report that matches the commanded dial is always adopted (a no-op write) — the
+     * caller uses that same equality to clear the pending state.
+     *
+     * @param nowMs                    current wall clock
+     * @param rigRejectedAtMs          when the rig last answered with an error /
+     *                                 unparseable frame, or 0 if never
+     * @param reportedHz               the frequency just reported
+     * @param commandedHz              the dial the app currently asserts
+     *                                 ({@code GeneralVariables.commandedBandHz})
+     * @param operatorAssertedAtMs     when the operator last explicitly selected a dial in
+     *                                 the app, or 0 if never / already confirmed
+     * @param operatorDeliveredAtMs    when that selection was last actually dispatched to
+     *                                 the rig, or 0 if not yet
+     */
+    public static boolean shouldAdoptAsTarget(long nowMs, long rigRejectedAtMs, long reportedHz,
+                                              long commandedHz, long operatorAssertedAtMs,
+                                              long operatorDeliveredAtMs) {
         if (reportedHz <= 0) return false;
+        if (reportedHz != commandedHz && operatorAssertedAtMs > 0) {
+            // An explicit selection the rig has not confirmed yet. Undelivered, it is
+            // protected unconditionally: the report is an echo of the dial the operator
+            // just left, not a choice. (No time limit — while the link is down no reports
+            // arrive anyway, and the moment it is back the ~1 Hz reassert delivers.)
+            if (operatorDeliveredAtMs < operatorAssertedAtMs) return false;
+            long sinceDelivery = nowMs - operatorDeliveredAtMs;
+            // Backwards clock (< 0) is treated as still-in-grace, same posture as below.
+            if (sinceDelivery < CONFIRM_GRACE_MS) return false;
+        }
         if (rigRejectedAtMs <= 0) return true;
         long since = nowMs - rigRejectedAtMs;
         // A backwards clock correction must not silently re-trust the stream.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RigDialTarget.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/RigDialTarget.java
@@ -137,6 +137,23 @@ public final class RigDialTarget {
     }
 
     /**
+     * The delivery stamp to record after a set-frequency dispatch.
+     *
+     * <p>The CAT write can fail without throwing — {@code CableSerialPort.sendData}
+     * returns {@code false} on a port that has already gone away — and stamping such an
+     * attempt as "delivered" would start the {@link #CONFIRM_GRACE_MS} countdown on a
+     * command the rig never saw, re-opening the overwrite this class exists to prevent.
+     * Only a write the connector believes reached the rig advances the stamp.
+     *
+     * @param writeOk         whether the connector reports the write as delivered
+     * @param nowMs           current wall clock
+     * @param previousStampMs the stamp as it stood before this dispatch
+     */
+    public static long deliveredStamp(boolean writeOk, long nowMs, long previousStampMs) {
+        return writeOk ? nowMs : previousStampMs;
+    }
+
+    /**
      * The dial {@code setOperationBand()} should actually send.
      *
      * <p>Falls back to the observed band when no commanded dial has been established yet

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ConfigFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ConfigFragment.java
@@ -750,6 +750,10 @@ public class ConfigFragment extends Fragment {
                     public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
                         GeneralVariables.bandListIndex = i;
                         GeneralVariables.band = OperationBand.getBandFreq(i);// Save the current band frequency
+                        // An explicit operator choice — this path used to leave
+                        // commandedBandHz stale, so setOperationBand re-commanded the OLD
+                        // dial. See RigDialTarget.
+                        GeneralVariables.operatorChoseDial(GeneralVariables.band);
 
                         mainViewModel.databaseOpr.getAllQSLCallsigns();// Load successfully contacted callsigns
                         writeConfig("bandFreq", String.valueOf(GeneralVariables.band));

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/FreqDialog.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/FreqDialog.java
@@ -184,6 +184,9 @@ public class FreqDialog extends Dialog {
                public void onClick(View view) {
                    GeneralVariables.bandListIndex = OperationBand.getIndexByFreq(holder.band);
                    GeneralVariables.band = holder.band;
+                   // An explicit operator choice — this path used to leave commandedBandHz
+                   // stale, so setOperationBand re-commanded the OLD dial. See RigDialTarget.
+                   GeneralVariables.operatorChoseDial(holder.band);
 
                    mainViewModel.databaseOpr.getAllQSLCallsigns();// Load successfully contacted callsigns
                    mainViewModel.databaseOpr.writeConfig("bandFreq"

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/FrequencyPickerSheet.kt
@@ -47,8 +47,9 @@ fun selectBandIndex(mainViewModel: MainViewModel, context: Context, index: Int) 
     GeneralVariables.bandListIndex = index
     GeneralVariables.band = OperationBand.getBandFreq(index)
     // An explicit operator choice: this is the dial the app asserts from now on, and the
-    // one the reassert heartbeat re-sends. See RigDialTarget.
-    GeneralVariables.commandedBandHz = GeneralVariables.band
+    // one the reassert heartbeat re-sends — protected from being overwritten by rig
+    // echoes until the rig confirms it. See RigDialTarget.
+    GeneralVariables.operatorChoseDial(GeneralVariables.band)
     val newWaveLength = BaseRigOperation.getMeterFromFreq(GeneralVariables.band)
     mainViewModel.databaseOpr.writeConfig(
         "bandFreq", GeneralVariables.band.toString(), null,

--- a/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesOperatorDialTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/GeneralVariablesOperatorDialTest.java
@@ -1,0 +1,45 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * {@link GeneralVariables#operatorChoseDial(long)} — the single entry point every
+ * band-selection path funnels through.
+ *
+ * <p>Robolectric because GeneralVariables reaches Android types at class-load.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class GeneralVariablesOperatorDialTest {
+
+    private static final long M30 = 10_136_000L;
+
+    @Before
+    public void resetState() {
+        GeneralVariables.commandedBandHz = 0L;
+        GeneralVariables.operatorDialAssertedAtMs = 0L;
+        GeneralVariables.operatorDialDeliveredAtMs = 0L;
+    }
+
+    @Test
+    public void recordsTheChoiceAndStampsTheAssert() {
+        GeneralVariables.operatorChoseDial(M30);
+        assertThat(GeneralVariables.commandedBandHz).isEqualTo(M30);
+        assertThat(GeneralVariables.operatorDialAssertedAtMs).isGreaterThan(0L);
+    }
+
+    @Test
+    public void aNewChoiceResetsTheDeliveryStamp() {
+        // A stale stamp from an older selection must not make the new one look
+        // delivered. deliveredAt < assertedAt usually covers it, but this app's
+        // clock is GPS-disciplined and can step backwards, which could leave an
+        // old deliveredAt at or beyond the new assertedAt. Zero is unambiguous.
+        GeneralVariables.operatorDialDeliveredAtMs = Long.MAX_VALUE;
+        GeneralVariables.operatorChoseDial(M30);
+        assertThat(GeneralVariables.operatorDialDeliveredAtMs).isEqualTo(0L);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RigDialTargetTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RigDialTargetTest.java
@@ -190,6 +190,32 @@ public class RigDialTargetTest {
         assertThat(RigDialTarget.dialToCommand(commanded, M30)).isEqualTo(M30);
     }
 
+    // ---- deliveredStamp -----------------------------------------------------
+
+    @Test
+    public void successfulWriteAdvancesTheDeliveryStamp() {
+        assertThat(RigDialTarget.deliveredStamp(true, T0, 0L)).isEqualTo(T0);
+    }
+
+    @Test
+    public void failedWriteLeavesTheStampAlone() {
+        // sendData returns false (port died between the connected-gate and the
+        // write) without throwing; stamping that as delivered would start the
+        // confirm grace on a command the rig never saw.
+        assertThat(RigDialTarget.deliveredStamp(false, T0, 0L)).isEqualTo(0L);
+        long previous = T0 - 60_000;
+        assertThat(RigDialTarget.deliveredStamp(false, T0, previous)).isEqualTo(previous);
+    }
+
+    @Test
+    public void failedWriteKeepsTheSelectionProtected() {
+        // End-to-end: tap at T0, dispatch fails, stamp stays 0 -> the poll echo of
+        // the old band is still refused, exactly as if never dispatched.
+        long stamp = RigDialTarget.deliveredStamp(false, T0 + 1_000, 0L);
+        assertThat(RigDialTarget.shouldAdoptAsTarget(T0 + 2_000, 0L, M20, M30, T0, stamp))
+                .isFalse();
+    }
+
     // ---- dialToCommand ------------------------------------------------------
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RigDialTargetTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/RigDialTargetTest.java
@@ -80,6 +80,116 @@ public class RigDialTargetTest {
         assertThat(RigDialTarget.shouldAdoptAsTarget(T0, 0L, M20)).isTrue();
     }
 
+    // ---- shouldAdoptAsTarget: pending operator selection ---------------------
+    //
+    // The 2026-08-04 failure: a 30m tap while the flapping USB link was down was
+    // dropped by the connected-gate, a healthy poll then echoed the still-on-20m rig,
+    // the echo was adopted as the commanded dial, and the reassert heartbeat pushed 20m
+    // back at the rig every ~2 minutes all evening — against repeated 30m taps.
+
+    @Test
+    public void undeliveredSelection_pollEchoOfOldBandIsNotAdopted() {
+        // Tap 30m at T0, never dispatched (delivered=0). The rig truthfully reports the
+        // OLD band — that report must not overwrite the operator's choice.
+        assertThat(RigDialTarget.shouldAdoptAsTarget(T0 + 2_000, 0L, M20, M30, T0, 0L))
+                .isFalse();
+    }
+
+    @Test
+    public void undeliveredSelection_protectedWithoutTimeLimit() {
+        // The link can stay down for minutes; while it is, no dispatch can happen, and
+        // the choice must survive until the reconnect push delivers it.
+        assertThat(RigDialTarget.shouldAdoptAsTarget(T0 + 600_000, 0L, M20, M30, T0, 0L))
+                .isFalse();
+    }
+
+    @Test
+    public void deliveryFromAnEarlierSelectionDoesNotCount() {
+        // delivered stamp predates this selection: it belongs to the previous choice.
+        assertThat(RigDialTarget.shouldAdoptAsTarget(
+                T0 + 60_000, 0L, M20, M30, T0, T0 - 10_000)).isFalse();
+    }
+
+    @Test
+    public void justDelivered_differingReportStillRefusedDuringGrace() {
+        // The FA went out; the rig needs a moment to QSY and the next poll may still
+        // carry the old dial. Inside the grace, keep asserting the choice.
+        long delivered = T0 + 1_000;
+        long stillInGrace = delivered + RigDialTarget.CONFIRM_GRACE_MS - 1;
+        assertThat(RigDialTarget.shouldAdoptAsTarget(
+                stillInGrace, 0L, M20, M30, T0, delivered)).isFalse();
+    }
+
+    @Test
+    public void afterGrace_differingReportIsFollowedAgain() {
+        // Delivered, grace expired, rig still reports something else: either the rig
+        // refused the command or the operator turned the VFO by hand. Follow the rig —
+        // fighting a manual tune would be its own bug.
+        long delivered = T0 + 1_000;
+        long afterGrace = delivered + RigDialTarget.CONFIRM_GRACE_MS;
+        assertThat(RigDialTarget.shouldAdoptAsTarget(
+                afterGrace, 0L, M20, M30, T0, delivered)).isTrue();
+    }
+
+    @Test
+    public void matchingReportIsAlwaysAdoptable() {
+        // The rig confirming the commanded dial is a no-op write, never refused by the
+        // pending guard (the caller also uses this equality to clear the pending state).
+        assertThat(RigDialTarget.shouldAdoptAsTarget(T0 + 1, 0L, M30, M30, T0, 0L))
+                .isTrue();
+    }
+
+    @Test
+    public void noPendingSelection_behavesExactlyAsBefore() {
+        // operatorAssertedAtMs == 0 (config load, first run, or already confirmed):
+        // the guard is inert and only the desync window applies.
+        assertThat(RigDialTarget.shouldAdoptAsTarget(T0, 0L, M20, M30, 0L, 0L)).isTrue();
+        assertThat(RigDialTarget.shouldAdoptAsTarget(T0, T0, M20, M30, 0L, 0L)).isFalse();
+    }
+
+    @Test
+    public void desyncStillRefusesEvenAfterGrace() {
+        // The two guards compose: surviving the pending guard does not bypass the
+        // desync window.
+        long delivered = T0 + 1_000;
+        long afterGrace = delivered + RigDialTarget.CONFIRM_GRACE_MS;
+        assertThat(RigDialTarget.shouldAdoptAsTarget(
+                afterGrace, afterGrace, M20, M30, T0, delivered)).isFalse();
+    }
+
+    @Test
+    public void backwardsClockDuringGraceDoesNotReTrust() {
+        // The clock is disciplined by GPS/decode sync and can step backwards; a
+        // now < deliveredAt must read as still-in-grace, not as grace-expired.
+        long delivered = T0 + 1_000;
+        assertThat(RigDialTarget.shouldAdoptAsTarget(
+                delivered - 60_000, 0L, M20, M30, T0, delivered)).isFalse();
+    }
+
+    @Test
+    public void theMeasuredDroppedTapNowHolds() {
+        // 20:19:40 — operator taps 30m; the connected-gate drops the send.
+        long commanded = M30;
+        long assertedAt = T0;
+        long deliveredAt = 0L;
+        // 20:19:4x — healthy poll echoes the still-on-20m rig. Old behaviour adopted it.
+        if (RigDialTarget.shouldAdoptAsTarget(T0 + 2_000, 0L, M20,
+                commanded, assertedAt, deliveredAt)) {
+            commanded = M20;
+        }
+        // The heartbeat fires: it must still push the operator's 30m, not 20m.
+        assertThat(RigDialTarget.dialToCommand(commanded, M20)).isEqualTo(M30);
+
+        // Link recovers; the reassert dispatches the FA for 30m.
+        deliveredAt = T0 + 30_000;
+        // The rig QSYs and confirms; the caller clears the pending state on equality.
+        if (RigDialTarget.shouldAdoptAsTarget(deliveredAt + 2_000, 0L, M30,
+                commanded, assertedAt, deliveredAt)) {
+            commanded = M30;
+        }
+        assertThat(RigDialTarget.dialToCommand(commanded, M30)).isEqualTo(M30);
+    }
+
     // ---- dialToCommand ------------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Problem

"Whenever I try to change the band, the radio seems to ignore it… once in a while it will change but not often."

From the 2026-08-04 debug.log (FT-891, USB link flapping with write errors + auto-reconnect bursts):

```
20:19:40  bandSelect: band=10136000, rigConnected=false   <- operator taps 30m
20:19:41  setOperationBand: rig not connected, skipping   <- FA never dispatched
20:19:4x  poll reads the rig, still on 14074000           <- healthy stream, no "?;"
          -> adopted as commandedBandHz                   <- the tap is ERASED
20:23:35  serial.send: FA014074000;                       <- heartbeat re-asserts 20m,
                                                             every ~2 min, all evening
```

Every band tap that lands during a link-down window is dropped by the connected-gate, then within ~2 s a healthy frequency poll echoes the rig's *old* dial and `onFreqChanged` adopts it as `commandedBandHz` — erasing the operator's choice. The reassert heartbeat then actively pushes the old band back at the rig. "Once in a while it works" = the tap happened to land while the link was up (confirmed at 15:49:48 in the same log).

The `RigDialTarget` desync window (#previous fix for the 59-second band change) can't catch this: the stream is healthy and the reading is truthful — the rig really is still on the old band, *because* the command never reached the wire.

## Fix

Track an explicit operator selection as **pending** until it is actually dispatched:

- `GeneralVariables.operatorDialAssertedAtMs` — stamped by every band-selection entry point via a new `operatorChoseDial()` helper.
- `GeneralVariables.operatorDialDeliveredAtMs` — stamped when `setOperationBand`'s delayed runnable actually writes the FA.
- `RigDialTarget.shouldAdoptAsTarget()` (extended, old 3-arg form kept for the no-pending default): while pending and undelivered, a differing rig report is never adopted (no time limit — while the link is down no reports arrive anyway, and on recovery the ~1 Hz reassert delivers within seconds). After dispatch, a 5 s `CONFIRM_GRACE_MS` lets the rig QSY; past that, a still-differing report is followed again so a hand-turned VFO wins.
- `onFreqChanged` clears the pending state when the rig confirms the commanded dial.

Also fixes a latent bug found while tracing: the two **legacy** band-selection paths (`ConfigFragment` spinner, `FreqDialog`) never set `commandedBandHz` at all, so `setOperationBand` re-commanded the *stale* dial after selecting through those screens.

## Testing

- 10 new unit tests in `RigDialTargetTest`, including a replay of the measured dropped-tap trace; existing 3-arg tests unchanged and passing.
- Full `testDebugUnitTest` suite green.
- On-device verification pending (debug keystore mismatch on this machine); will verify band changes stick on the FT-891 across USB link flaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)