### PR TITLE
Stop USB permission dialog storms and reconnect-loop leaks on link flap

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -63,6 +63,7 @@ import com.k1af.ft8af.connector.CableSerialPort;
 import com.k1af.ft8af.connector.ConnectMode;
 import com.k1af.ft8af.connector.FlexConnector;
 import com.k1af.ft8af.connector.IComWifiConnector;
+import com.k1af.ft8af.connector.UsbPermissionThrottle;
 import com.k1af.ft8af.connector.X6100Connector;
 import com.k1af.ft8af.database.ControlMode;
 import com.k1af.ft8af.database.DatabaseOpr;
@@ -1884,6 +1885,16 @@ public class MainViewModel extends ViewModel {
             databaseOpr.writeConfig("ctrMode", String.valueOf(ControlMode.CAT), null);
             GeneralVariables.mutableControlMode.postValue(GeneralVariables.controlMode);
         }
+        // Tear down any previous connector FIRST. It owns an open port and an
+        // auto-reconnect loop; just overwriting the reference leaked both, so every
+        // re-enumeration of a flapping link stacked another live connector — measured
+        // 2026-08-04 as an orphaned port's poll timers spamming "port not open!"
+        // interleaved with the live port's sends, and concurrent reconnect loops each
+        // hammering port opens. disconnect() sets that connector's userDisconnected,
+        // which is what actually ends its loop.
+        if (baseRig != null && baseRig.getConnector() != null) {
+            baseRig.getConnector().disconnect();
+        }
         connectRig();
 
         if (baseRig == null) {
@@ -2517,6 +2528,18 @@ public class MainViewModel extends ViewModel {
             Log.d(TAG, "USB audio device already has permission");
             return;
         }
+
+        // Same nag-storm containment as the serial path (CableSerialPort.connect):
+        // a flapping link re-fires the ATTACH handler per bounce, and each call here
+        // raised a fresh system dialog for the audio device.
+        if (!UsbPermissionThrottle.shouldRequestNow(
+                device.getVendorId(), System.currentTimeMillis())) {
+            fileLog(String.format("usbPermission: audio request for vendor 0x%04x throttled"
+                    + " (asked <%ds ago)", device.getVendorId(),
+                    UsbPermissionThrottle.REQUEST_COOLDOWN_MS / 1000));
+            return;
+        }
+        UsbPermissionThrottle.markRequested(device.getVendorId(), System.currentTimeMillis());
 
         Log.d(TAG, "Requesting USB permission for audio device: " + device.getProductName());
         PendingIntent permissionIntent = UsbPermissionIntentsKt.createUsbPermissionIntent(

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
@@ -166,11 +166,15 @@ public class CableConnector extends BaseRigConnector {
                 }
                 // The while-condition ended the loop: the device left the bus before the
                 // first attempt (a deliberate user disconnect returns above instead).
-                // Surface it so the UI leaves the "connecting" state set at burst start.
+                // Tear the port down rather than just notifying: each connect() attempt
+                // re-registers the permission-grant receiver via prepare(), so exiting
+                // without disconnect() would leak it (and any half-open port state).
+                // disconnect() fires onDisconnected itself, which also moves the UI
+                // out of the "connecting" state set at burst start.
                 if (!userDisconnected) {
                     Log.d(TAG, "CAT auto-reconnect: device left the bus, stopping"
                             + " (attach broadcast will restart)");
-                    getOnConnectorStateChanged().onDisconnected();
+                    cableSerialPort.disconnect();
                 }
             } finally {
                 reconnecting = false;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableConnector.java
@@ -118,11 +118,16 @@ public class CableConnector extends BaseRigConnector {
         getOnConnectorStateChanged().onConnecting();
         new Thread(() -> {
             try {
-                // Unbounded by design: giving up would strand the operator with no CAT
-                // until they noticed the retry chip. The backoff escalates to
-                // MAX_BACKOFF_MS and stays there, so a persistently flaky link costs one
-                // attempt every 8 s instead of two per second.
-                while (!userDisconnected) {
+                // Unbounded in TIME by design: giving up on a still-present device would
+                // strand the operator with no CAT until they noticed the retry chip. The
+                // backoff escalates to MAX_BACKOFF_MS and stays there, so a persistently
+                // flaky link costs one attempt every 8 s instead of two per second. But a
+                // device that has LEFT the bus ends the loop: retrying can't bring it
+                // back, and each fresh attempt was raising the system USB-permission
+                // dialog — the "asks for permission when I unplug the cable" storm. The
+                // USB ATTACH broadcast restarts auto-connect when it returns.
+                while (CatReconnectPolicy.shouldKeepRetrying(
+                        userDisconnected, cableSerialPort.isDevicePresent())) {
                     // The burst counter persists across opens, so a link that keeps
                     // dropping keeps escalating instead of resetting to the first step.
                     int attempt = reconnectAttempt.incrementAndGet();
@@ -137,6 +142,9 @@ public class CableConnector extends BaseRigConnector {
                     }
                     if (userDisconnected) {
                         return;
+                    }
+                    if (!cableSerialPort.isDevicePresent()) {
+                        break; // gone mid-backoff — surfaced after the loop
                     }
                     // The port already tore itself down (SerialInputOutputManager
                     // calls disconnect() after onRunError); re-open it fresh.
@@ -155,6 +163,14 @@ public class CableConnector extends BaseRigConnector {
                         Log.d(TAG, "CAT port re-opened on attempt " + attempt);
                         return; // connect() already fired onConnected()
                     }
+                }
+                // The while-condition ended the loop: the device left the bus before the
+                // first attempt (a deliberate user disconnect returns above instead).
+                // Surface it so the UI leaves the "connecting" state set at burst start.
+                if (!userDisconnected) {
+                    Log.d(TAG, "CAT auto-reconnect: device left the bus, stopping"
+                            + " (attach broadcast will restart)");
+                    getOnConnectorStateChanged().onDisconnected();
                 }
             } finally {
                 reconnecting = false;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
@@ -131,6 +131,23 @@ public class CableSerialPort {
         return portNum >= 0 && portNum < portCount;
     }
 
+    /**
+     * Whether a USB device with this port's vendor id is currently on the bus (the same
+     * match {@link #prepare()} uses to find the device). The auto-reconnect loop consults
+     * this to stop retrying a device that has been unplugged — see
+     * {@link CatReconnectPolicy#shouldKeepRetrying(boolean, boolean)}.
+     */
+    public boolean isDevicePresent() {
+        UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+        if (manager == null) return false;
+        for (UsbDevice v : manager.getDeviceList().values()) {
+            if (v.getVendorId() == vendorId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean prepare() {
         registerRigSerialPort(context);
         UsbDevice device = null;
@@ -184,14 +201,24 @@ public class CableSerialPort {
         }
         if (usbConnection == null && usbPermission == UsbPermission.Unknown
                 && !usbManager.hasPermission(driver.getDevice())) {
-            usbPermission = UsbPermission.Requested;
+            // The Unknown guard above is per-instance and every auto-connect builds a
+            // fresh instance, so on a flapping link it alone raised a system dialog per
+            // bounce. The process-wide throttle is what actually spaces the dialogs out.
+            if (UsbPermissionThrottle.shouldRequestNow(vendorId, System.currentTimeMillis())) {
+                usbPermission = UsbPermission.Requested;
+                UsbPermissionThrottle.markRequested(vendorId, System.currentTimeMillis());
 
-            PendingIntent usbPermissionIntent =
-                    UsbPermissionIntentsKt.createUsbPermissionIntent(context, INTENT_ACTION_GRANT_USB);
+                PendingIntent usbPermissionIntent =
+                        UsbPermissionIntentsKt.createUsbPermissionIntent(context, INTENT_ACTION_GRANT_USB);
 
 
-            usbManager.requestPermission(driver.getDevice(), usbPermissionIntent);
-            prepare();
+                usbManager.requestPermission(driver.getDevice(), usbPermissionIntent);
+                prepare();
+            } else {
+                fileLog(String.format("usbPermission: request for vendor 0x%04x throttled"
+                        + " (asked <%ds ago)", vendorId,
+                        UsbPermissionThrottle.REQUEST_COOLDOWN_MS / 1000));
+            }
         }
         if (usbConnection == null) {
             if (onStateChanged!=null){

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CableSerialPort.java
@@ -136,8 +136,10 @@ public class CableSerialPort {
      * match {@link #prepare()} uses to find the device). The auto-reconnect loop consults
      * this to stop retrying a device that has been unplugged — see
      * {@link CatReconnectPolicy#shouldKeepRetrying(boolean, boolean)}.
+     * Package-private on purpose: an internal reconnect helper, not part of the
+     * port's supported surface.
      */
-    public boolean isDevicePresent() {
+    boolean isDevicePresent() {
         UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
         if (manager == null) return false;
         for (UsbDevice v : manager.getDeviceList().values()) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/CatReconnectPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/CatReconnectPolicy.java
@@ -163,6 +163,24 @@ public final class CatReconnectPolicy {
     }
 
     /**
+     * Whether the auto-reconnect loop should run another attempt.
+     *
+     * <p>Retrying is pointless once the USB device has left the bus: the port cannot
+     * open without it, and retrying anyway is what turned a cable unplug into a storm
+     * (the plug bounce re-enumerates the devices several times on the way out, each
+     * bounce spawning a fresh connect attempt and its system USB-permission dialog,
+     * 2026-08-04). A device that comes back re-enters through the USB ATTACH
+     * broadcast, which restarts auto-connect from scratch — so stopping here loses
+     * nothing.
+     *
+     * @param userDisconnected whether the user asked to disconnect
+     * @param devicePresent    whether a matching USB device is currently on the bus
+     */
+    public static boolean shouldKeepRetrying(boolean userDisconnected, boolean devicePresent) {
+        return !userDisconnected && devicePresent;
+    }
+
+    /**
      * Delay before the given auto-reconnect attempt. Exponential
      * ({@code 500&nbsp;ms, 1&nbsp;s, 2&nbsp;s, 4&nbsp;s, 8&nbsp;s}) capped at
      * {@link #MAX_BACKOFF_MS}. The first attempt ({@code attempt == 1}) also acts

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/UsbPermissionThrottle.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/UsbPermissionThrottle.java
@@ -1,0 +1,70 @@
+package com.k1af.ft8af.connector;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Rate-limits {@code UsbManager.requestPermission()} dialogs per USB vendor.
+ *
+ * <p>The system permission dialog was being raised on every link flap: each auto-connect
+ * builds a brand-new {@link CableSerialPort}, whose per-instance {@code usbPermission}
+ * state starts at {@code Unknown}, so the "already asked?" guard reset every time. On a
+ * marginal cable that re-enumerates every few seconds — or on the bounce of a deliberate
+ * unplug — that meant a fresh dialog per bounce (measured 2026-08-04, both the CAT serial
+ * and the C-Media audio device). The ask-state must therefore outlive any single port
+ * instance; it lives here, process-wide, keyed by vendor id (the same key
+ * {@code CableSerialPort.prepare()} matches devices by).
+ *
+ * <p>This throttles how often the QUESTION is asked; it never grants or denies anything.
+ * A user who wants no dialogs at all should tick the system dialog's
+ * "Always open FT8AF…" checkbox, which persists the grant across replugs — this class
+ * just keeps the app from nagging every few seconds until they do.
+ *
+ * <p>Pure decision logic is separated from the static registry for unit-testing, matching
+ * {@link CatReconnectPolicy}.
+ */
+public final class UsbPermissionThrottle {
+
+    private UsbPermissionThrottle() {}
+
+    /**
+     * Minimum interval between permission dialogs for the same vendor. Long enough that
+     * a flapping link nags at most twice a minute instead of once per bounce; short
+     * enough that a genuinely new session (fresh cable plug-in after a while) asks
+     * promptly.
+     */
+    public static final long REQUEST_COOLDOWN_MS = 30_000;
+
+    private static final ConcurrentHashMap<Integer, Long> lastRequestAtByVendor =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Whether a permission request may be shown now, given when one was last shown.
+     *
+     * @param lastRequestAtMs when a dialog was last raised for this device, or 0 if never
+     * @param nowMs           current wall clock
+     */
+    public static boolean shouldRequest(long lastRequestAtMs, long nowMs) {
+        if (lastRequestAtMs <= 0) return true;
+        long since = nowMs - lastRequestAtMs;
+        // A backwards clock correction errs toward asking: one extra dialog beats a
+        // lock-out that lasts until the clock catches back up.
+        if (since < 0) return true;
+        return since >= REQUEST_COOLDOWN_MS;
+    }
+
+    /** Registry form of {@link #shouldRequest(long, long)} for the given vendor. */
+    public static boolean shouldRequestNow(int vendorId, long nowMs) {
+        Long last = lastRequestAtByVendor.get(vendorId);
+        return shouldRequest(last == null ? 0L : last, nowMs);
+    }
+
+    /** Record that a permission dialog has just been raised for the given vendor. */
+    public static void markRequested(int vendorId, long nowMs) {
+        lastRequestAtByVendor.put(vendorId, nowMs);
+    }
+
+    /** Test isolation only: forget every recorded request. */
+    static void reset() {
+        lastRequestAtByVendor.clear();
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/UsbPermissionThrottle.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/UsbPermissionThrottle.java
@@ -58,9 +58,15 @@ public final class UsbPermissionThrottle {
         return shouldRequest(last == null ? 0L : last, nowMs);
     }
 
-    /** Record that a permission dialog has just been raised for the given vendor. */
+    /**
+     * Record that a permission dialog has just been raised for the given vendor.
+     *
+     * <p>Monotonic: two threads racing here (a bounce re-enumerates both serial ports
+     * near-simultaneously) must not let the later stamp be overwritten by the earlier
+     * one, which would shorten the cooldown and let an extra dialog through.
+     */
     public static void markRequested(int vendorId, long nowMs) {
-        lastRequestAtByVendor.put(vendorId, nowMs);
+        lastRequestAtByVendor.merge(vendorId, nowMs, Math::max);
     }
 
     /** Test isolation only: forget every recorded request. */

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/CatReconnectPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/CatReconnectPolicyTest.java
@@ -213,4 +213,32 @@ public class CatReconnectPolicyTest {
         assertThat(CatReconnectPolicy.backoffMs(5)).isEqualTo(CatReconnectPolicy.MAX_BACKOFF_MS);
         assertThat(CatReconnectPolicy.backoffMs(50)).isEqualTo(CatReconnectPolicy.MAX_BACKOFF_MS);
     }
+
+    // ---- shouldKeepRetrying -------------------------------------------------
+    //
+    // The 2026-08-04 storm: unplugging the cable re-enumerates the devices several
+    // times on the way out, and the loop retried each bounce — every fresh attempt
+    // raising the system USB-permission dialog ("asks for permission when I
+    // DISCONNECT the cable").
+
+    @Test
+    public void retry_keepsGoingWhileDevicePresent() {
+        // The unbounded-in-time behaviour is unchanged for a device that is still
+        // on the bus: a flaky-but-present link keeps recovering unattended.
+        assertThat(CatReconnectPolicy.shouldKeepRetrying(false, true)).isTrue();
+    }
+
+    @Test
+    public void retry_stopsWhenDeviceLeavesTheBus() {
+        // Retrying can't bring an unplugged device back; the ATTACH broadcast
+        // restarts auto-connect when it returns, so stopping loses nothing.
+        assertThat(CatReconnectPolicy.shouldKeepRetrying(false, false)).isFalse();
+    }
+
+    @Test
+    public void retry_userDisconnectAlwaysStops() {
+        // A deliberate disconnect wins regardless of what the bus says.
+        assertThat(CatReconnectPolicy.shouldKeepRetrying(true, true)).isFalse();
+        assertThat(CatReconnectPolicy.shouldKeepRetrying(true, false)).isFalse();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/UsbPermissionThrottleTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/UsbPermissionThrottleTest.java
@@ -87,6 +87,19 @@ public class UsbPermissionThrottleTest {
     }
 
     @Test
+    public void registry_outOfOrderMarksCannotShortenTheCooldown() {
+        // Two threads racing markRequested (a bounce re-enumerates both serial
+        // ports near-simultaneously) can land out of order. The earlier stamp must
+        // not overwrite the later one — that would end the cooldown early and let
+        // an extra dialog through.
+        UsbPermissionThrottle.markRequested(VENDOR_SERIAL, T0);
+        UsbPermissionThrottle.markRequested(VENDOR_SERIAL, T0 - 25_000);
+        assertThat(UsbPermissionThrottle.shouldRequestNow(VENDOR_SERIAL, T0 + 10_000)).isFalse();
+        assertThat(UsbPermissionThrottle.shouldRequestNow(VENDOR_SERIAL,
+                T0 + UsbPermissionThrottle.REQUEST_COOLDOWN_MS)).isTrue();
+    }
+
+    @Test
     public void registry_outlivesAPortInstance() {
         // The whole point: the state is static, so a "new CableSerialPort" (modelled
         // here by nothing at all — there is no per-instance state to reset) still sees

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/UsbPermissionThrottleTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/UsbPermissionThrottleTest.java
@@ -1,0 +1,97 @@
+package com.k1af.ft8af.connector;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link UsbPermissionThrottle} — the process-wide rate limit on the
+ * system USB-permission dialog.
+ *
+ * <p>Reported as "the app keeps constantly asking for USB permission… and it's doing it
+ * when I disconnect the USB cable". Every auto-connect builds a fresh
+ * {@code CableSerialPort} whose per-instance ask-state starts at {@code Unknown}, so on a
+ * flapping link (or the plug bounce of an unplug) each bounce raised a fresh dialog. The
+ * ask-state has to outlive the port instance; this registry is that state.
+ */
+public class UsbPermissionThrottleTest {
+
+    private static final long T0 = 1_700_000_000_000L;
+    /** CP2105 dual UART (the CAT serial bridge from the 2026-08-04 log). */
+    private static final int VENDOR_SERIAL = 0x10c4;
+    /** C-Media USB audio (same log). */
+    private static final int VENDOR_AUDIO = 0x0d8c;
+
+    @Before
+    public void resetRegistry() {
+        UsbPermissionThrottle.reset();
+    }
+
+    // ---- shouldRequest (pure) ----------------------------------------------
+
+    @Test
+    public void neverAsked_asksImmediately() {
+        assertThat(UsbPermissionThrottle.shouldRequest(0L, T0)).isTrue();
+    }
+
+    @Test
+    public void justAsked_staysQuiet() {
+        // The flapping-link case: a bounce milliseconds after the last dialog must
+        // not raise another one.
+        assertThat(UsbPermissionThrottle.shouldRequest(T0, T0 + 1)).isFalse();
+    }
+
+    @Test
+    public void asksAgainOnceTheCooldownExpires() {
+        long after = T0 + UsbPermissionThrottle.REQUEST_COOLDOWN_MS;
+        assertThat(UsbPermissionThrottle.shouldRequest(T0, after)).isTrue();
+        assertThat(UsbPermissionThrottle.shouldRequest(T0, after - 1)).isFalse();
+    }
+
+    @Test
+    public void backwardsClockErrsTowardAsking() {
+        // The clock is disciplined by GPS/decode sync and can step backwards. One
+        // extra dialog beats a lock-out that lasts until the clock catches back up.
+        assertThat(UsbPermissionThrottle.shouldRequest(T0, T0 - 60_000)).isTrue();
+    }
+
+    @Test
+    public void cooldownIsLongEnoughToTameAFlappingLink() {
+        // The measured link flapped every few seconds; a cooldown shorter than that
+        // would not reduce the dialog rate at all.
+        assertThat(UsbPermissionThrottle.REQUEST_COOLDOWN_MS).isAtLeast(10_000L);
+    }
+
+    // ---- registry (per-vendor) ---------------------------------------------
+
+    @Test
+    public void registry_unknownVendorAsksImmediately() {
+        assertThat(UsbPermissionThrottle.shouldRequestNow(VENDOR_SERIAL, T0)).isTrue();
+    }
+
+    @Test
+    public void registry_markThenAskWithinCooldownIsThrottled() {
+        UsbPermissionThrottle.markRequested(VENDOR_SERIAL, T0);
+        assertThat(UsbPermissionThrottle.shouldRequestNow(VENDOR_SERIAL, T0 + 5_000)).isFalse();
+        assertThat(UsbPermissionThrottle.shouldRequestNow(VENDOR_SERIAL,
+                T0 + UsbPermissionThrottle.REQUEST_COOLDOWN_MS)).isTrue();
+    }
+
+    @Test
+    public void registry_vendorsAreIndependent() {
+        // Throttling the serial bridge must not silence the audio device's one
+        // legitimate ask (they arrive near-simultaneously on attach).
+        UsbPermissionThrottle.markRequested(VENDOR_SERIAL, T0);
+        assertThat(UsbPermissionThrottle.shouldRequestNow(VENDOR_AUDIO, T0 + 1)).isTrue();
+    }
+
+    @Test
+    public void registry_outlivesAPortInstance() {
+        // The whole point: the state is static, so a "new CableSerialPort" (modelled
+        // here by nothing at all — there is no per-instance state to reset) still sees
+        // the earlier ask.
+        UsbPermissionThrottle.markRequested(VENDOR_SERIAL, T0);
+        assertThat(UsbPermissionThrottle.shouldRequestNow(VENDOR_SERIAL, T0 + 1_000)).isFalse();
+    }
+}


### PR DESCRIPTION
## Problem

"The app keeps constantly asking for USB permission… and for some reason it's doing it when I disconnect the USB cable. Can I prevent it from trying to reconnect over and over?"

Three compounding causes found in the 2026-08-04 debug.log + code trace:

1. **Reconnect loop outlives the device.** `CableConnector.startAutoReconnect` retried while `!userDisconnected` — *"unbounded by design"* — even after the USB device left the bus. Unplugging the cable re-enumerates the devices several times on the way out, so each bounce spawned fresh connect attempts, each raising the system USB-permission dialog: the "asks for permission when I *disconnect*" symptom.
2. **Per-instance permission guard.** `CableSerialPort.usbPermission` starts at `Unknown` on every new instance, and every auto-connect builds a new instance — so the "already asked?" guard reset on every link flap and a fresh dialog appeared per bounce (serial *and* C-Media audio, via `requestUsbPermissionIfNeeded`).
3. **Leaked connectors.** `connectCableRig` overwrote the previous connector without disconnecting it, leaking its open port and its immortal reconnect loop per re-enumeration — measured as an orphaned port's poll timers spamming `port not open!` interleaved with the live port's sends (same log; also the historical "13,190 port opens in 88 minutes").

## Fix

- `CatReconnectPolicy.shouldKeepRetrying(userDisconnected, devicePresent)` — pure, tested; the loop stops (and surfaces the disconnect so the UI leaves "connecting") once the device is gone. The USB ATTACH broadcast restarts auto-connect when it returns, so a flaky-but-present link still recovers unattended exactly as before.
- `UsbPermissionThrottle` — process-wide, per-vendor 30 s cooldown on `requestPermission` dialogs, consulted by both the serial (`CableSerialPort.connect`) and audio (`MainViewModel.requestUsbPermissionIfNeeded`) request sites. Throttles the *asking* only; ticking the system dialog's "Always open FT8AF…" checkbox remains the way to silence it permanently.
- `connectCableRig` now `disconnect()`s the previous connector (ending its loop via `userDisconnected`) before creating a new one.

## Testing

- New unit tests: 3 for `shouldKeepRetrying`, 9 for `UsbPermissionThrottle`.
- Full `testDebugUnitTest` suite green.
- On-device: will verify unplugging the cable produces no permission dialogs and no reconnect churn in debug.log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)