### PR TITLE
ROTA: let the trip picker re-attach to a trip already active on the server

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaClient.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaClient.kt
@@ -222,21 +222,35 @@ object RotaClient {
             }
         }
 
+    /** Both halves of the trip picker, from one `GET /api/me`. */
+    data class MyTrips(
+        val planned: List<RotaPlannedTrip>,
+        val active: List<RotaActiveTrip>,
+    )
+
     /**
-     * The operator's own announced trips, soonest first.
+     * The operator's own announced trips (soonest first) and any trip of theirs
+     * still `active` on the server (most recently started first).
      *
-     * Read from `/api/me` rather than the public `GET /api/trips?status=planned`:
-     * the public listing only carries what a stranger may see, and a plan the
+     * Read from `/api/me` rather than the public `GET /api/trips?...` listings:
+     * the public listing only carries what a stranger may see, and a trip the
      * operator marked `private` or `followers` — the ones most likely to be a
-     * real upcoming trip — would be missing from exactly the list they are
+     * real trip of theirs — would be missing from exactly the list they are
      * trying to pick from.
+     *
+     * Active trips ride along so the picker can offer "continue" after a
+     * reinstall wiped the Keystore-encrypted local trip state (2026-08-04) or
+     * when a second device joins a drive; both parse from the same body, so one
+     * round-trip serves the whole picker.
      */
-    suspend fun fetchMyPlannedTrips(
+    suspend fun fetchMyTrips(
         baseUrl: String,
         apiKey: String,
-    ): Result<List<RotaPlannedTrip>> =
+    ): Result<MyTrips> =
         withContext(Dispatchers.IO) {
-            request("GET", "$baseUrl/api/me", apiKey, null).map { parseMyPlannedTrips(it) }
+            request("GET", "$baseUrl/api/me", apiKey, null).map {
+                MyTrips(planned = parseMyPlannedTrips(it), active = parseMyActiveTrips(it))
+            }
         }
 
     suspend fun completeTrip(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaModels.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaModels.kt
@@ -76,6 +76,25 @@ data class RotaPlannedTrip(
 )
 
 /**
+ * A trip of the operator's that is `active` on the server right now — one this
+ * install can re-attach to and continue.
+ *
+ * Exists for the reinstall recovery (2026-08-04): the in-flight trip id lives in
+ * Keystore-encrypted prefs, which no backup can carry across an uninstall, so a
+ * reinstalled app came up with the trip still running server-side (716 mi /
+ * 138 QSOs that day) and no way to rejoin it — the picker only listed `planned`
+ * trips. The progress numbers ride along so the picker row reads as "this is the
+ * drive you're on", not just a name.
+ */
+data class RotaActiveTrip(
+    val id: String,
+    val name: String,
+    val startTimeMs: Long,
+    val qsoCount: Int,
+    val totalDistanceMiles: Double,
+)
+
+/**
  * What `GET /api/trips/:id/sync-state` says the server already holds — the
  * resume handshake for a client that has been out of touch long enough not to
  * know what it still owes.
@@ -465,6 +484,43 @@ fun parseMyPlannedTrips(body: String?): List<RotaPlannedTrip> {
                 )
             }
         }.sortedBy { it.startTimeMs }
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
+/**
+ * Pull the operator's own trips that are `active` right now out of the same
+ * `GET /api/me` body, most recently started first.
+ *
+ * They live under `recentTrips` (which mixes `active` and `completed` rows,
+ * each carrying a `status`), not `plannedTrips` — verified against the live
+ * server 2026-08-04. Same defensive posture as [parseMyPlannedTrips]: rows
+ * missing an id, name or start time are dropped, and a shape mismatch parses
+ * as "nothing to continue" rather than an error.
+ */
+fun parseMyActiveTrips(body: String?): List<RotaActiveTrip> {
+    if (body.isNullOrBlank()) return emptyList()
+    return try {
+        val array = JSONObject(body).optJSONArray("recentTrips") ?: return emptyList()
+        buildList {
+            for (i in 0 until array.length()) {
+                val o = array.optJSONObject(i) ?: continue
+                if (o.optString("status") != "active") continue
+                val id = o.optString("id").takeIf { it.isNotEmpty() } ?: continue
+                val name = o.optString("name").takeIf { it.isNotEmpty() } ?: continue
+                val start = parseIsoUtc(o.optString("startTime")) ?: continue
+                add(
+                    RotaActiveTrip(
+                        id = id,
+                        name = name,
+                        startTimeMs = start,
+                        qsoCount = o.optInt("qsoCount", 0),
+                        totalDistanceMiles = o.optDouble("totalDistanceMiles", 0.0),
+                    ),
+                )
+            }
+        }.sortedByDescending { it.startTimeMs }
     } catch (_: Exception) {
         emptyList()
     }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaTripManager.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/rota/RotaTripManager.kt
@@ -257,6 +257,56 @@ object RotaTripManager {
     private var pendingNotes: String? = null
 
     /**
+     * Re-attach to a trip that is already `active` on the server and keep driving
+     * it — the recovery for a reinstall (the in-flight trip id lives in
+     * Keystore-encrypted prefs, which no backup can carry across an uninstall) or
+     * for a second device joining a drive.
+     *
+     * Mirrors [restore], not [startTrip]: the trip exists server-side, so there is
+     * nothing to create ([RotaSettings.tripPendingCreate] stays false), and what
+     * the server already holds is unknown to this process — the resume handshake
+     * reconciles via sync-state before anything is re-sent. The share token is not
+     * carried by `/api/me`'s trip rows, so the share link stays unavailable for a
+     * continued trip; every upload and completion path works without it.
+     */
+    fun continueTrip(trip: RotaActiveTrip) {
+        if (RotaSettings.hasActiveTrip) {
+            log("continueTrip ignored — a trip is already running")
+            return
+        }
+        RotaSettings.tripName = trip.name
+        RotaSettings.tripStartedMs = trip.startTimeMs
+        RotaSettings.tripPrivacy = ""
+        RotaSettings.tripPlanId = ""
+        RotaSettings.tripPendingCreate = false
+        RotaSettings.tripPendingComplete = false
+        RotaSettings.tripId = trip.id
+        RotaSettings.tripShareToken = ""
+
+        // Same reasoning as restore(): the gap while this install wasn't tracking
+        // is real, so the first fix becomes a FIRST beacon rather than a straight
+        // line drawn from wherever the old install last reported.
+        sampler = SmartBeaconSampler()
+        highwayResolver?.reset()
+        lastRawFix = null
+        // An adopted trip is one this process did not start; what the server
+        // already holds is exactly as unknown as a trip resumed from disk.
+        resumeHandshakePending = true
+        queue?.clear()
+        _state.value =
+            RotaTripState(
+                active = true,
+                tripId = trip.id,
+                tripName = trip.name,
+                startedMs = trip.startTimeMs,
+            )
+        log("continueTrip '${trip.name}' id=${trip.id} (server has ${trip.qsoCount} QSOs)")
+        RotaCqSession.apply()
+        startTracking()
+        requestFlush("continue-trip")
+    }
+
+    /**
      * End the trip: stop tracking, flush what's left, then finalize on the
      * server. Out of coverage this leaves a "complete when possible" flag, and
      * the flush loop finishes the job once the phone is back online.

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rota/RoadTripScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rota/RoadTripScreen.kt
@@ -42,6 +42,7 @@ import com.k1af.ft8af.R
 import kotlinx.coroutines.launch
 import radio.ks3ckc.ft8af.location.hasLocationPermission
 import radio.ks3ckc.ft8af.rota.BeaconReason
+import radio.ks3ckc.ft8af.rota.RotaActiveTrip
 import radio.ks3ckc.ft8af.rota.RotaPlannedTrip
 import radio.ks3ckc.ft8af.rota.RotaHttpException
 import radio.ks3ckc.ft8af.rota.ROTA_CQ_MODIFIER
@@ -93,6 +94,7 @@ fun RoadTripScreen(onBack: () -> Unit) {
     var showTripNameDialog by remember { mutableStateOf(false) }
     var showPlanPicker by remember { mutableStateOf(false) }
     var plans by remember { mutableStateOf<List<RotaPlannedTrip>>(emptyList()) }
+    var activeTrips by remember { mutableStateOf<List<RotaActiveTrip>>(emptyList()) }
     var plansLoading by remember { mutableStateOf(false) }
     var plansError by remember { mutableStateOf<String?>(null) }
     var showAnnounceDialog by remember { mutableStateOf(false) }
@@ -167,9 +169,24 @@ fun RoadTripScreen(onBack: () -> Unit) {
     if (showPlanPicker) {
         TripPlanPickerDialog(
             plans = plans,
+            activeTrips = activeTrips,
             loading = plansLoading,
             error = plansError,
             onDismiss = { showPlanPicker = false },
+            onContinue = { trip ->
+                showPlanPicker = false
+                // Same gate as the Start row: a continued trip tracks location too.
+                if (!ensureLocationPermission()) {
+                    message = context.getString(R.string.rota_need_location)
+                } else {
+                    if (!RotaSettings.enabled) {
+                        RotaSettings.enabled = true
+                        enabled = true
+                    }
+                    RotaTripManager.init(context)
+                    RotaTripManager.continueTrip(trip)
+                }
+            },
             onPick = { picked ->
                 tripName = picked.name
                 tripPlanId = picked.id
@@ -352,11 +369,14 @@ fun RoadTripScreen(onBack: () -> Unit) {
                                 plansLoading = true
                                 plansError = null
                                 scope.launch {
-                                    RotaClient.fetchMyPlannedTrips(
+                                    RotaClient.fetchMyTrips(
                                         RotaSettings.baseUrl,
                                         RotaSettings.apiKey,
                                     ).fold(
-                                        onSuccess = { plans = it },
+                                        onSuccess = {
+                                            plans = it.planned
+                                            activeTrips = it.active
+                                        },
                                         onFailure = { e ->
                                             plansError =
                                                 (e as? RotaHttpException)?.serverMessage
@@ -586,9 +606,11 @@ private fun NoticeText(text: String) {
 @Composable
 private fun TripPlanPickerDialog(
     plans: List<RotaPlannedTrip>,
+    activeTrips: List<RotaActiveTrip>,
     loading: Boolean,
     error: String?,
     onDismiss: () -> Unit,
+    onContinue: (RotaActiveTrip) -> Unit,
     onPick: (RotaPlannedTrip) -> Unit,
     onTypeName: () -> Unit,
 ) {
@@ -625,7 +647,7 @@ private fun TripPlanPickerDialog(
                         color = StatusBad,
                         fontSize = 13.sp,
                     )
-                plans.isEmpty() ->
+                plans.isEmpty() && activeTrips.isEmpty() ->
                     Text(
                         text = stringResource(R.string.rota_pick_plan_empty),
                         color = TextMuted,
@@ -645,6 +667,41 @@ private fun TripPlanPickerDialog(
                                 .verticalScroll(rememberScrollState()),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
+                        // Trips already active on the server (a reinstall lost the local
+                        // attachment, or another device started it) come first: someone
+                        // mid-drive opening this picker almost certainly wants to rejoin,
+                        // not start a duplicate.
+                        if (activeTrips.isNotEmpty()) {
+                            Text(
+                                text = stringResource(R.string.rota_pick_continue_header),
+                                color = TextMuted,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            activeTrips.forEach { trip ->
+                                Column(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .clip(RoundedCornerShape(10.dp))
+                                            .clickable { onContinue(trip) }
+                                            .padding(vertical = 10.dp, horizontal = 12.dp),
+                                ) {
+                                    Text(text = trip.name, color = Accent, fontSize = 15.sp)
+                                    Text(
+                                        text =
+                                            stringResource(
+                                                R.string.rota_active_trip_summary,
+                                                formatPlanStart(trip.startTimeMs),
+                                                trip.qsoCount,
+                                                trip.totalDistanceMiles.toInt(),
+                                            ),
+                                        color = TextFaint,
+                                        fontSize = 12.sp,
+                                    )
+                                }
+                            }
+                        }
                         plans.forEach { plan ->
                             Column(
                                 modifier =

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rota/RoadTripScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/rota/RoadTripScreen.kt
@@ -694,7 +694,7 @@ private fun TripPlanPickerDialog(
                                                 R.string.rota_active_trip_summary,
                                                 formatPlanStart(trip.startTimeMs),
                                                 trip.qsoCount,
-                                                trip.totalDistanceMiles.toInt(),
+                                                wholeMiles(trip.totalDistanceMiles),
                                             ),
                                         color = TextFaint,
                                         fontSize = 12.sp,
@@ -744,6 +744,13 @@ private fun TripPlanPickerDialog(
 /** Local-time "Aug 4, 11:00" for a plan's departure, so it reads as the operator's clock. */
 internal fun formatPlanStart(startMs: Long): String =
     SimpleDateFormat("MMM d, HH:mm", Locale.US).format(Date(startMs))
+
+/**
+ * Miles for the picker row, rounded to the nearest whole mile. Rounded rather than
+ * truncated — 716.55 reads as 717, not 716; a rover mid-drive notices their odometer
+ * going backwards.
+ */
+internal fun wholeMiles(miles: Double): Int = Math.round(miles).toInt()
 
 /** Single-field dialog shared by the callsign / server / key / trip-name rows. */
 @Composable

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -956,6 +956,8 @@
     <string name="rota_pick_plan_custom">Type a name</string>
     <string name="rota_pick_plan_error">Couldn\'t load your plans: %1$s</string>
     <string name="rota_plan_starts">Starts %1$s</string>
+    <string name="rota_pick_continue_header">On the road now</string>
+    <string name="rota_active_trip_summary">Started %1$s · %2$d QSOs · %3$d mi</string>
     <string name="rota_stat_cq">Calling</string>
     <string name="rota_beacon_first">trip start</string>
     <string name="rota_beacon_rate">interval</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RoadTripScreenLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RoadTripScreenLogicTest.kt
@@ -7,6 +7,7 @@ import org.robolectric.RobolectricTestRunner
 import radio.ks3ckc.ft8af.ui.rota.describeProfile
 import radio.ks3ckc.ft8af.ui.rota.maskKey
 import radio.ks3ckc.ft8af.ui.rota.nextPrivacy
+import radio.ks3ckc.ft8af.ui.rota.wholeMiles
 
 /**
  * The decision logic pulled out of the Compose screen (tap-to-cycle rows, key
@@ -15,6 +16,15 @@ import radio.ks3ckc.ft8af.ui.rota.nextPrivacy
  */
 @RunWith(RobolectricTestRunner::class)
 class RoadTripScreenLogicTest {
+    @Test
+    fun `picker miles are rounded, not truncated`() {
+        // 716.55 must read as 717 — truncation shows a rover's odometer going
+        // backwards relative to what the site reports.
+        assertThat(wholeMiles(716.55)).isEqualTo(717)
+        assertThat(wholeMiles(716.45)).isEqualTo(716)
+        assertThat(wholeMiles(0.0)).isEqualTo(0)
+    }
+
     @Test
     fun `key masking never shows a usable credential`() {
         assertThat(maskKey("rota_1234567890abcdef")).isEqualTo("rota_…cdef")

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RotaActiveTripTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/rota/RotaActiveTripTest.kt
@@ -1,0 +1,102 @@
+package radio.ks3ckc.ft8af.rota
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Reading the operator's still-`active` trips off `GET /api/me` — the "continue"
+ * half of the trip picker.
+ *
+ * Exists for the reinstall recovery (2026-08-04): the in-flight trip id lives in
+ * Keystore-encrypted prefs, so a reinstall came up with the trip still running
+ * server-side (716 mi / 138 QSOs) and no way to rejoin it. Active rows live under
+ * `recentTrips`, which MIXES `active` and `completed` rows distinguished by a
+ * `status` field — the shape was verified against the live server that day and is
+ * pinned here the same way [RotaPlannedTripTest] pins `plannedTrips`.
+ *
+ * Robolectric because org.json is an Android stub on the plain JVM classpath.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RotaActiveTripTest {
+    /** Abbreviated from the live 2026-08-04 `/api/me` response. */
+    private val liveBody =
+        """
+        {
+          "operator": {"callsign": "K1AF"},
+          "recentTrips": [
+            {"id":"2d6df3e4","name":"Kansas City to DEF CON!!","status":"active",
+             "privacy":"delayed","startTime":"2026-08-04T14:42:14.227Z","endTime":null,
+             "totalDistanceMiles":716.55,"qsoCount":138,"statesVisited":["CO","KS","NE"]},
+            {"id":"dac0d839","name":"K1AF 2026-08-03","status":"completed",
+             "privacy":"public","startTime":"2026-08-03T18:59:52.583Z",
+             "endTime":"2026-08-03T21:12:31.391Z","totalDistanceMiles":32.65,"qsoCount":12}
+          ],
+          "plannedTrips": [
+            {"id":"60204fc7","name":"DEFCON To Kansas City","status":"planned",
+             "startTime":"2026-08-10T11:00:00.000Z"}
+          ]
+        }
+        """.trimIndent()
+
+    @Test
+    fun `only active rows survive - completed and planned do not`() {
+        val active = parseMyActiveTrips(liveBody)
+        assertThat(active.map { it.id }).containsExactly("2d6df3e4")
+        assertThat(active[0].name).isEqualTo("Kansas City to DEF CON!!")
+        assertThat(active[0].qsoCount).isEqualTo(138)
+        assertThat(active[0].totalDistanceMiles).isWithin(0.01).of(716.55)
+    }
+
+    @Test
+    fun `most recently started first`() {
+        val body =
+            """
+            {"recentTrips":[
+              {"id":"old","name":"Old drive","status":"active","startTime":"2026-08-01T10:00:00.000Z"},
+              {"id":"new","name":"New drive","status":"active","startTime":"2026-08-04T14:42:14.227Z"}
+            ]}
+            """.trimIndent()
+        assertThat(parseMyActiveTrips(body).map { it.id })
+            .containsExactly("new", "old")
+            .inOrder()
+    }
+
+    @Test
+    fun `rows missing id, name or startTime are dropped, not shown blank`() {
+        val body =
+            """
+            {"recentTrips":[
+              {"name":"No id","status":"active","startTime":"2026-08-04T14:42:14.227Z"},
+              {"id":"x","status":"active","startTime":"2026-08-04T14:42:14.227Z"},
+              {"id":"y","name":"Bad clock","status":"active","startTime":"yesterday-ish"},
+              {"id":"ok","name":"Good","status":"active","startTime":"2026-08-04T14:42:14.227Z"}
+            ]}
+            """.trimIndent()
+        assertThat(parseMyActiveTrips(body).map { it.id }).containsExactly("ok")
+    }
+
+    @Test
+    fun `progress fields are optional`() {
+        // A trip started seconds ago may not carry counts yet.
+        val body =
+            """
+            {"recentTrips":[
+              {"id":"a","name":"Fresh","status":"active","startTime":"2026-08-04T14:42:14.227Z"}
+            ]}
+            """.trimIndent()
+        val trip = parseMyActiveTrips(body).single()
+        assertThat(trip.qsoCount).isEqualTo(0)
+        assertThat(trip.totalDistanceMiles).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `a shape mismatch parses as nothing to continue, not an error`() {
+        assertThat(parseMyActiveTrips(null)).isEmpty()
+        assertThat(parseMyActiveTrips("")).isEmpty()
+        assertThat(parseMyActiveTrips("not json")).isEmpty()
+        assertThat(parseMyActiveTrips("""{"recentTrips":{}}""")).isEmpty()
+        assertThat(parseMyActiveTrips("""{"plannedTrips":[]}""")).isEmpty()
+    }
+}


### PR DESCRIPTION
## Problem

After a reinstall, the operator's in-flight ROTA trip could not be continued: the local trip attachment (trip id, name, start time) lives in Keystore-encrypted prefs whose master key is destroyed on uninstall — no backup can carry it. The trip itself was fine server-side ("Kansas City to DEF CON!!", 716 mi / 138 QSOs when measured on 2026-08-04), but the picker only lists `plannedTrips` from `/api/me`, so an `active` trip was invisible and there was no way to rejoin it.

## Fix

- **`parseMyActiveTrips`** — `/api/me` carries the operator's active trips under `recentTrips` (mixed `active`+`completed` rows, each with a `status` field; shape verified against the live server and pinned in tests the same way `RotaPlannedTripTest` pins `plannedTrips`). Same fail-quiet posture as the planned parser.
- **`RotaClient.fetchMyTrips`** — replaces `fetchMyPlannedTrips`; both picker halves parse from the one `GET /api/me` round-trip.
- **`RotaTripManager.continueTrip`** — re-attach and keep driving. Mirrors `restore()`, not `startTrip()`: `tripPendingCreate` stays false (nothing to create), the beacon sampler starts fresh (the tracking gap is real), and `resumeHandshakePending` is armed so sync-state reconciles before anything is re-sent — the same adopted-row posture as the plan-start 409 path. Also covers a second device joining a drive.
- **Picker UI** — an "On the road now" section above the planned trips, most recently started first, showing started time / QSO count / miles; tapping continues immediately (with the same location-permission gate as Start).

The share link stays unavailable for a continued trip (`/api/me` trip rows don't carry the share token); every upload and completion path works without it.

## Testing

- New `RotaActiveTripTest` (5 tests) pinning the `recentTrips` shape: status filtering, ordering, dropped incomplete rows, optional progress fields, fail-quiet mismatches.
- Full `testDebugUnitTest` suite green.
- On-device: verified against the live server (the DEF CON trip lists and continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)