### PR TITLE
Car status dashboard (Android Auto) — design-doc pane with colored badges

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
@@ -137,17 +137,41 @@ internal fun selectCarPaneRows(priorities: List<Int>, limit: Int): List<Int> {
         .sorted()
 }
 
-/**
- * "POTA K-1234 · 3 QSOs" (multi-park refs arrive pre-joined as "K-1234 + K-5678").
- * Null when no activation is running, which removes the row entirely.
- */
-internal fun buildCarPotaLine(parkRefsDisplay: String?, qsoCount: Int?): CarStringSpec? {
-    if (parkRefsDisplay.isNullOrBlank()) return null
-    return CarStringSpec(R.string.car_pota_line, listOf(parkRefsDisplay, qsoCount ?: 0))
-}
+// --- Design dashboard model (Pane template "1a") ---------------------------
+// The status pane follows the FT8AF Android Auto design doc: every row carries a
+// colored circular leading badge and its text uses colored emphasis spans. The
+// decision/format/color logic is decided here (pure, unit-tested); QsoStatusScreen
+// only renders the badges as bitmaps and the spans as CarText.
 
-/** A two-line row of the Android Auto status pane: a title and an optional secondary line. */
-internal data class CarPaneRow(val title: CarStringSpec, val secondary: CarStringSpec? = null)
+/** Standard car text-emphasis colors (host renders its own accessible shade). */
+internal enum class CarSpanColor { GREEN, YELLOW, BLUE }
+
+/** A run of row text, optionally emphasized with a [CarSpanColor]. */
+internal data class CarSpan(val text: String, val color: CarSpanColor? = null)
+
+/**
+ * The colored leading badge on a row: a short glyph ("P", "R", "Σ", "20m", or ""
+ * for a plain dot) drawn in [fgArgb] over a filled circle of [bgArgb].
+ */
+internal data class CarBadge(val text: String, val fgArgb: Int, val bgArgb: Int)
+
+/** One dashboard row: leading [badge], [title] runs, optional [secondary] runs, and row [priority]. */
+internal data class CarDashRow(
+    val badge: CarBadge,
+    val title: List<CarSpan>,
+    val secondary: List<CarSpan>? = null,
+    val priority: Int = CAR_ROW_ACTIVATION,
+)
+
+// Palette from the FT8AF Android Auto design doc (fg glyph / bg circle per role).
+internal const val CAR_GREEN_FG = 0xFF81C995.toInt()
+internal const val CAR_GREEN_BG = 0xFF0D2818.toInt()
+internal const val CAR_BLUE_FG = 0xFF8AB4F8.toInt()
+internal const val CAR_BLUE_BG = 0xFF1F2430.toInt()
+internal const val CAR_AMBER_FG = 0xFFFFB45C.toInt()
+internal const val CAR_AMBER_BG = 0xFF2B2114.toInt()
+internal const val CAR_GRAY_FG = 0xFF9AA0A6.toInt()
+internal const val CAR_GRAY_BG = 0xFF17181C.toInt()
 
 /**
  * QSOs a POTA activation needs before it counts under the POTA program rules.
@@ -156,20 +180,6 @@ internal data class CarPaneRow(val title: CarStringSpec, val secondary: CarStrin
  * here where the car dashboard uses it.
  */
 internal const val POTA_ACTIVATION_TARGET = 10
-
-/**
- * Secondary line for the POTA row: "N more to validate the activation" while the
- * count is below [POTA_ACTIVATION_TARGET], then "Activation validated". Counts at
- * or above the target (including hand-logged overshoot) clamp to validated.
- */
-internal fun potaValidateSpec(qsoCount: Int): CarStringSpec {
-    val remaining = (POTA_ACTIVATION_TARGET - qsoCount).coerceAtLeast(0)
-    return if (remaining > 0) {
-        CarStringSpec(R.string.car_pota_to_validate, listOf(remaining))
-    } else {
-        CarStringSpec(R.string.car_pota_validated)
-    }
-}
 
 /** "0.0" / "12.3" — one decimal, locale-independent so tests are stable. */
 internal fun formatMiles(miles: Double): String =
@@ -189,81 +199,129 @@ internal fun minutesAgo(nowMs: Long, thenMs: Long?): Int? {
 }
 
 /**
- * The session-summary row shown when no POTA/ROTA activation is running. The title
- * is always the session QSO count; the secondary reports the most recent logged
- * contact ("Last logged JA1XYZ · 20m · 41 min") when one is known, degrading to a
- * band-less form, then to "No QSOs logged yet" when [lastQsoCallsign] or
- * [lastQsoMinutesAgo] is missing.
+ * The status row: a green dot badge (gray when TX is off), a "<state> · <countdown>"
+ * title (countdown green while armed), and a secondary that names the target with a
+ * yellow SNR and the TX-queue state — "Waiting for W1ABC · −8 dB · no TX queued".
  */
-internal fun buildCarSessionRow(
+internal fun carStatusDashRow(
+    txState: CarTxState,
+    secondsRemaining: Int,
+    target: String?,
+    snrLabel: String?,
+    txMessage: String?,
+    hunting: Boolean,
+): CarDashRow {
+    val (stateWord, countdown, armed) = when (txState) {
+        CarTxState.TRANSMITTING -> Triple("Transmitting", " · $secondsRemaining s left", true)
+        CarTxState.ARMED_RX -> Triple("Receiving", " · next TX in $secondsRemaining s", true)
+        CarTxState.OFF -> Triple("Monitoring", " · TX off", false)
+    }
+    val title = listOf(CarSpan(stateWord), CarSpan(countdown, if (armed) CarSpanColor.GREEN else null))
+
+    val lead = when {
+        target != null && txState == CarTxState.TRANSMITTING -> "Working $target"
+        target != null -> "Waiting for $target"
+        txState == CarTxState.OFF -> "Monitoring — TX off"
+        hunting -> "Hunting for CQ"
+        else -> "Calling CQ"
+    }
+    val secondary = mutableListOf(CarSpan(lead))
+    if (target != null && snrLabel != null) {
+        secondary.add(CarSpan(" · "))
+        secondary.add(CarSpan(snrLabel, CarSpanColor.YELLOW))
+    }
+    if (txState != CarTxState.OFF) {
+        secondary.add(CarSpan(" · " + (txMessage?.takeIf { it.isNotEmpty() } ?: "no TX queued")))
+    }
+    val badge = if (armed) CarBadge("", CAR_GREEN_FG, CAR_GREEN_BG) else CarBadge("", CAR_GRAY_FG, CAR_GRAY_BG)
+    return CarDashRow(badge, title, secondary, CAR_ROW_HEADLINE)
+}
+
+/**
+ * The band row: a blue badge showing the band name ("20m"), a "14.074 MHz · FT8"
+ * title, and a "N decodes last cycle" secondary (dropped when the last cycle was
+ * silent, so the row shows the frequency alone rather than "0 decodes").
+ */
+internal fun carBandDashRow(freqHz: Long, bandName: String, modeName: String, decodeCount: Int): CarDashRow {
+    val title = listOf(CarSpan("${formatMhz(freqHz)} MHz · $modeName"))
+    val secondary = if (decodeCount > 0) listOf(CarSpan("$decodeCount decodes last cycle")) else null
+    val badge = CarBadge(bandName.trim().ifEmpty { "RF" }, CAR_BLUE_FG, CAR_BLUE_BG)
+    return CarDashRow(badge, title, secondary, CAR_ROW_BAND)
+}
+
+/**
+ * The POTA row: amber "P" badge, "POTA <park> · N QSOs" title (green QSO count),
+ * and a "N more to validate the activation" / "Activation validated" secondary
+ * (POTA's [POTA_ACTIVATION_TARGET]-QSO program rule). Null when no activation runs.
+ */
+internal fun carPotaDashRow(parkRefsDisplay: String?, qsoCount: Int): CarDashRow? {
+    if (parkRefsDisplay.isNullOrBlank()) return null
+    val title = listOf(CarSpan("POTA $parkRefsDisplay"), CarSpan(" · $qsoCount QSOs", CarSpanColor.GREEN))
+    val remaining = (POTA_ACTIVATION_TARGET - qsoCount).coerceAtLeast(0)
+    val secondary = listOf(
+        CarSpan(if (remaining > 0) "$remaining more to validate the activation" else "Activation validated"),
+    )
+    return CarDashRow(CarBadge("P", CAR_AMBER_FG, CAR_AMBER_BG), title, secondary, CAR_ROW_ACTIVATION)
+}
+
+/**
+ * The ROTA row: amber "R" badge, "ROTA <trip> · N QSOs" title (QSOs = sent+pending
+ * so out-of-coverage contacts still count), and a "X.X mi driven this activation"
+ * secondary. Null when no trip is running or the trip has no name.
+ */
+internal fun carRotaDashRow(active: Boolean, tripName: String?, qsoCount: Int, miles: Double): CarDashRow? {
+    if (!active || tripName.isNullOrBlank()) return null
+    val title = listOf(CarSpan("ROTA $tripName · $qsoCount QSOs"))
+    val secondary = listOf(CarSpan("${formatMiles(miles)} mi driven this activation"))
+    return CarDashRow(CarBadge("R", CAR_AMBER_FG, CAR_AMBER_BG), title, secondary, CAR_ROW_ACTIVATION)
+}
+
+/**
+ * The session-summary row shown when no POTA/ROTA activation is running (the design's
+ * "activation rows drop out, session stats take the slot"): gray "Σ" badge,
+ * "Session · N QSOs" title, and a "Last logged JA1XYZ · 20m · 41 min" secondary that
+ * degrades to a band-less form, then to "No QSOs logged yet" when the last contact or
+ * its timestamp is unknown.
+ */
+internal fun carSessionDashRow(
     sessionQsoCount: Int,
     lastQsoCallsign: String?,
     lastQsoBandName: String?,
     lastQsoMinutesAgo: Int?,
-): CarPaneRow {
-    val title = CarStringSpec(R.string.car_session_line, listOf(sessionQsoCount))
+): CarDashRow {
+    val title = listOf(CarSpan("Session · $sessionQsoCount QSOs"))
     val call = lastQsoCallsign?.takeIf { it.isNotBlank() }
     val secondary = if (call != null && lastQsoMinutesAgo != null) {
         val band = lastQsoBandName?.takeIf { it.isNotBlank() }
         if (band != null) {
-            CarStringSpec(R.string.car_session_last, listOf(call, band, lastQsoMinutesAgo))
+            listOf(CarSpan("Last logged $call · $band · $lastQsoMinutesAgo min"))
         } else {
-            CarStringSpec(R.string.car_session_last_noband, listOf(call, lastQsoMinutesAgo))
+            listOf(CarSpan("Last logged $call · $lastQsoMinutesAgo min"))
         }
     } else {
-        CarStringSpec(R.string.car_session_none)
+        listOf(CarSpan("No QSOs logged yet"))
     }
-    return CarPaneRow(title, secondary)
+    return CarDashRow(CarBadge("Σ", CAR_GRAY_FG, CAR_GRAY_BG), title, secondary, CAR_ROW_ACTIVATION)
 }
 
 /**
- * The activation block of the car status pane. Emits a POTA row (with a
- * "N to validate" secondary) and/or a ROTA row (with a "X.X mi driven this
- * activation" secondary) for whichever activations are running; when neither is
- * active the block collapses to a single session-summary row (the design's
- * "activation rows drop out, session stats take the slot"). POTA and ROTA are
- * practically mutually exclusive — parked at a park vs. roving on roads — but
- * both are emitted if both happen to be active, ordered POTA then ROTA.
+ * Assembles the pane in design order: status, band, then the POTA and/or ROTA
+ * activation rows — or, when neither is active, the single [session] row in their
+ * place. The Screen then applies [selectCarPaneRows] so the band row (not an
+ * activation) is the first to drop on a row-limited host.
  */
-internal fun buildCarActivationRows(
-    potaActive: Boolean,
-    potaParkRefsDisplay: String?,
-    potaQsoCount: Int,
-    rotaActive: Boolean,
-    rotaTripName: String?,
-    rotaQsoCount: Int,
-    rotaMiles: Double,
-    sessionQsoCount: Int,
-    lastQsoCallsign: String?,
-    lastQsoBandName: String?,
-    lastQsoMinutesAgo: Int?,
-): List<CarPaneRow> {
-    val rows = mutableListOf<CarPaneRow>()
-    if (potaActive) {
-        buildCarPotaLine(potaParkRefsDisplay, potaQsoCount)?.let {
-            rows.add(CarPaneRow(title = it, secondary = potaValidateSpec(potaQsoCount)))
-        }
-    }
-    if (rotaActive && !rotaTripName.isNullOrBlank()) {
-        rows.add(
-            CarPaneRow(
-                title = CarStringSpec(R.string.car_rota_line, listOf(rotaTripName, rotaQsoCount)),
-                secondary = CarStringSpec(R.string.car_rota_miles, listOf(formatMiles(rotaMiles))),
-            ),
-        )
-    }
-    if (rows.isEmpty()) {
-        rows.add(buildCarSessionRow(sessionQsoCount, lastQsoCallsign, lastQsoBandName, lastQsoMinutesAgo))
-    }
+internal fun buildCarDashboardRows(
+    status: CarDashRow,
+    band: CarDashRow,
+    pota: CarDashRow?,
+    rota: CarDashRow?,
+    session: CarDashRow,
+): List<CarDashRow> {
+    val rows = mutableListOf(status, band)
+    val activations = listOfNotNull(pota, rota)
+    if (activations.isEmpty()) rows.add(session) else rows.addAll(activations)
     return rows
 }
-
-/**
- * Secondary line for the band row: "N decodes last cycle" (null when there were no
- * decodes, so the row shows the frequency alone rather than "0 decodes").
- */
-internal fun carDecodesSecondary(decodeCount: Int): CarStringSpec? =
-    if (decodeCount > 0) CarStringSpec(R.string.car_decodes_last_cycle, listOf(decodeCount)) else null
 
 /** One row of the car's recent-decodes list. */
 internal data class CarDecodeRow(val utcTimeMs: Long, val text: String, val snrLabel: String?)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
@@ -146,23 +146,124 @@ internal fun buildCarPotaLine(parkRefsDisplay: String?, qsoCount: Int?): CarStri
     return CarStringSpec(R.string.car_pota_line, listOf(parkRefsDisplay, qsoCount ?: 0))
 }
 
+/** A two-line row of the Android Auto status pane: a title and an optional secondary line. */
+internal data class CarPaneRow(val title: CarStringSpec, val secondary: CarStringSpec? = null)
+
 /**
- * "ROTA Route 66 · 12 QSOs · 45.3 mi"; null when no trip is running. The QSO
- * count is sent+pending so contacts logged out of coverage still show, and the
- * miles match the trip notification's one-decimal format.
+ * QSOs a POTA activation needs before it counts under the POTA program rules.
+ * There is no constant for this in the POTA session code (the phone UI never
+ * shows a remaining-to-validate figure), so the well-known program rule lives
+ * here where the car dashboard uses it.
  */
-internal fun buildCarRotaLine(
-    active: Boolean,
-    tripName: String,
-    sentQsos: Int,
-    pendingQsos: Int,
-    miles: Double,
-): CarStringSpec? {
-    if (!active) return null
-    val name = tripName.trim().ifEmpty { "trip" }
-    val milesLabel = String.format(java.util.Locale.US, "%.1f", miles)
-    return CarStringSpec(R.string.car_rota_line, listOf(name, sentQsos + pendingQsos, milesLabel))
+internal const val POTA_ACTIVATION_TARGET = 10
+
+/**
+ * Secondary line for the POTA row: "N more to validate the activation" while the
+ * count is below [POTA_ACTIVATION_TARGET], then "Activation validated". Counts at
+ * or above the target (including hand-logged overshoot) clamp to validated.
+ */
+internal fun potaValidateSpec(qsoCount: Int): CarStringSpec {
+    val remaining = (POTA_ACTIVATION_TARGET - qsoCount).coerceAtLeast(0)
+    return if (remaining > 0) {
+        CarStringSpec(R.string.car_pota_to_validate, listOf(remaining))
+    } else {
+        CarStringSpec(R.string.car_pota_validated)
+    }
 }
+
+/** "0.0" / "12.3" — one decimal, locale-independent so tests are stable. */
+internal fun formatMiles(miles: Double): String =
+    String.format(java.util.Locale.US, "%.1f", miles)
+
+/**
+ * Whole minutes between [thenMs] and [nowMs] for the "last logged … N min" line.
+ * Returns null when there is no timestamp (0/null) or the clock is skewed so [thenMs]
+ * is in the future, so the session row degrades to "No QSOs logged yet" rather than
+ * showing a nonsense figure.
+ */
+internal fun minutesAgo(nowMs: Long, thenMs: Long?): Int? {
+    if (thenMs == null || thenMs <= 0L) return null
+    val delta = nowMs - thenMs
+    if (delta < 0L) return null
+    return (delta / 60_000L).toInt()
+}
+
+/**
+ * The session-summary row shown when no POTA/ROTA activation is running. The title
+ * is always the session QSO count; the secondary reports the most recent logged
+ * contact ("Last logged JA1XYZ · 20m · 41 min") when one is known, degrading to a
+ * band-less form, then to "No QSOs logged yet" when [lastQsoCallsign] or
+ * [lastQsoMinutesAgo] is missing.
+ */
+internal fun buildCarSessionRow(
+    sessionQsoCount: Int,
+    lastQsoCallsign: String?,
+    lastQsoBandName: String?,
+    lastQsoMinutesAgo: Int?,
+): CarPaneRow {
+    val title = CarStringSpec(R.string.car_session_line, listOf(sessionQsoCount))
+    val call = lastQsoCallsign?.takeIf { it.isNotBlank() }
+    val secondary = if (call != null && lastQsoMinutesAgo != null) {
+        val band = lastQsoBandName?.takeIf { it.isNotBlank() }
+        if (band != null) {
+            CarStringSpec(R.string.car_session_last, listOf(call, band, lastQsoMinutesAgo))
+        } else {
+            CarStringSpec(R.string.car_session_last_noband, listOf(call, lastQsoMinutesAgo))
+        }
+    } else {
+        CarStringSpec(R.string.car_session_none)
+    }
+    return CarPaneRow(title, secondary)
+}
+
+/**
+ * The activation block of the car status pane. Emits a POTA row (with a
+ * "N to validate" secondary) and/or a ROTA row (with a "X.X mi driven this
+ * activation" secondary) for whichever activations are running; when neither is
+ * active the block collapses to a single session-summary row (the design's
+ * "activation rows drop out, session stats take the slot"). POTA and ROTA are
+ * practically mutually exclusive — parked at a park vs. roving on roads — but
+ * both are emitted if both happen to be active, ordered POTA then ROTA.
+ */
+internal fun buildCarActivationRows(
+    potaActive: Boolean,
+    potaParkRefsDisplay: String?,
+    potaQsoCount: Int,
+    rotaActive: Boolean,
+    rotaTripName: String?,
+    rotaQsoCount: Int,
+    rotaMiles: Double,
+    sessionQsoCount: Int,
+    lastQsoCallsign: String?,
+    lastQsoBandName: String?,
+    lastQsoMinutesAgo: Int?,
+): List<CarPaneRow> {
+    val rows = mutableListOf<CarPaneRow>()
+    if (potaActive) {
+        buildCarPotaLine(potaParkRefsDisplay, potaQsoCount)?.let {
+            rows.add(CarPaneRow(title = it, secondary = potaValidateSpec(potaQsoCount)))
+        }
+    }
+    if (rotaActive && !rotaTripName.isNullOrBlank()) {
+        rows.add(
+            CarPaneRow(
+                title = CarStringSpec(R.string.car_rota_line, listOf(rotaTripName, rotaQsoCount)),
+                secondary = CarStringSpec(R.string.car_rota_miles, listOf(formatMiles(rotaMiles))),
+            ),
+        )
+    }
+    if (rows.isEmpty()) {
+        rows.add(buildCarSessionRow(sessionQsoCount, lastQsoCallsign, lastQsoBandName, lastQsoMinutesAgo))
+    }
+    return rows
+}
+
+/**
+ * Secondary line for the band row: "N decodes last cycle" (null when there were no
+ * decodes, so the row shows the frequency alone rather than "0 decodes").
+ */
+internal fun carDecodesSecondary(decodeCount: Int): CarStringSpec? =
+    if (decodeCount > 0) CarStringSpec(R.string.car_decodes_last_cycle, listOf(decodeCount)) else null
 
 /** One row of the car's recent-decodes list. */
 internal data class CarDecodeRow(val utcTimeMs: Long, val text: String, val snrLabel: String?)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatus.kt
@@ -173,6 +173,12 @@ internal const val CAR_AMBER_BG = 0xFF2B2114.toInt()
 internal const val CAR_GRAY_FG = 0xFF9AA0A6.toInt()
 internal const val CAR_GRAY_BG = 0xFF17181C.toInt()
 
+/** "1 QSO" / "0 QSOs" / "3 QSOs" — singular only at exactly one. */
+internal fun qsosLabel(count: Int): String = if (count == 1) "1 QSO" else "$count QSOs"
+
+/** "1 decode" / "12 decodes" — singular only at exactly one. */
+internal fun decodesLabel(count: Int): String = if (count == 1) "1 decode" else "$count decodes"
+
 /**
  * QSOs a POTA activation needs before it counts under the POTA program rules.
  * There is no constant for this in the POTA session code (the phone UI never
@@ -244,7 +250,7 @@ internal fun carStatusDashRow(
  */
 internal fun carBandDashRow(freqHz: Long, bandName: String, modeName: String, decodeCount: Int): CarDashRow {
     val title = listOf(CarSpan("${formatMhz(freqHz)} MHz · $modeName"))
-    val secondary = if (decodeCount > 0) listOf(CarSpan("$decodeCount decodes last cycle")) else null
+    val secondary = if (decodeCount > 0) listOf(CarSpan("${decodesLabel(decodeCount)} last cycle")) else null
     val badge = CarBadge(bandName.trim().ifEmpty { "RF" }, CAR_BLUE_FG, CAR_BLUE_BG)
     return CarDashRow(badge, title, secondary, CAR_ROW_BAND)
 }
@@ -256,7 +262,7 @@ internal fun carBandDashRow(freqHz: Long, bandName: String, modeName: String, de
  */
 internal fun carPotaDashRow(parkRefsDisplay: String?, qsoCount: Int): CarDashRow? {
     if (parkRefsDisplay.isNullOrBlank()) return null
-    val title = listOf(CarSpan("POTA $parkRefsDisplay"), CarSpan(" · $qsoCount QSOs", CarSpanColor.GREEN))
+    val title = listOf(CarSpan("POTA $parkRefsDisplay"), CarSpan(" · ${qsosLabel(qsoCount)}", CarSpanColor.GREEN))
     val remaining = (POTA_ACTIVATION_TARGET - qsoCount).coerceAtLeast(0)
     val secondary = listOf(
         CarSpan(if (remaining > 0) "$remaining more to validate the activation" else "Activation validated"),
@@ -271,7 +277,7 @@ internal fun carPotaDashRow(parkRefsDisplay: String?, qsoCount: Int): CarDashRow
  */
 internal fun carRotaDashRow(active: Boolean, tripName: String?, qsoCount: Int, miles: Double): CarDashRow? {
     if (!active || tripName.isNullOrBlank()) return null
-    val title = listOf(CarSpan("ROTA $tripName · $qsoCount QSOs"))
+    val title = listOf(CarSpan("ROTA $tripName · ${qsosLabel(qsoCount)}"))
     val secondary = listOf(CarSpan("${formatMiles(miles)} mi driven this activation"))
     return CarDashRow(CarBadge("R", CAR_AMBER_FG, CAR_AMBER_BG), title, secondary, CAR_ROW_ACTIVATION)
 }
@@ -289,7 +295,7 @@ internal fun carSessionDashRow(
     lastQsoBandName: String?,
     lastQsoMinutesAgo: Int?,
 ): CarDashRow {
-    val title = listOf(CarSpan("Session · $sessionQsoCount QSOs"))
+    val title = listOf(CarSpan("Session · ${qsosLabel(sessionQsoCount)}"))
     val call = lastQsoCallsign?.takeIf { it.isNotBlank() }
     val secondary = if (call != null && lastQsoMinutesAgo != null) {
         val band = lastQsoBandName?.takeIf { it.isNotBlank() }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
@@ -1,18 +1,29 @@
 package radio.ks3ckc.ft8af.car
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Typeface
 import android.os.Handler
 import android.os.Looper
+import android.text.SpannableStringBuilder
+import android.text.Spanned
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
 import androidx.car.app.constraints.ConstraintManager
 import androidx.car.app.model.Action
 import androidx.car.app.model.ActionStrip
+import androidx.car.app.model.CarColor
+import androidx.car.app.model.CarIcon
+import androidx.car.app.model.CarText
+import androidx.car.app.model.ForegroundCarColorSpan
 import androidx.car.app.model.MessageTemplate
 import androidx.car.app.model.Pane
 import androidx.car.app.model.PaneTemplate
 import androidx.car.app.model.Row
 import androidx.car.app.model.Template
 import androidx.car.app.versioning.CarAppApiLevels
+import androidx.core.graphics.drawable.IconCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
@@ -117,42 +128,43 @@ class QsoStatusScreen(carContext: CarContext) : Screen(carContext), DefaultLifec
             huntCallsCQ = GeneralVariables.huntCallsCQ,
         )
 
-        val headline = resolve(status.headline) +
-            (status.snrLabel?.let { " · $it" } ?: "")
-        val rows = mutableListOf(
-            Row.Builder()
-                .setTitle(headline)
-                .addText(status.messageLine ?: carContext.getString(R.string.car_no_tx))
-                .build(),
-            Row.Builder()
-                .setTitle(status.seqLine?.let { resolve(it) } ?: resolve(status.slotLine))
-                .apply { if (status.seqLine != null) addText(resolve(status.slotLine)) }
-                .build(),
-            Row.Builder().setTitle(status.bandLine)
-                .apply {
-                    // Per-cycle decode count: currentMessages is the label overlay,
-                    // refreshed each cycle and cleared on a silent slot, so it drops
-                    // to 0 correctly (mutableFt8MessageList accumulates across cycles
-                    // when clearDecodesEveryCycle is off, the default).
-                    carDecodesSecondary(vm.currentMessages?.size ?: 0)?.let { addText(resolve(it)) }
-                }
-                .build(),
+        val target = toCallsign?.callsign?.takeIf { it.isNotEmpty() && it != "CQ" }
+        // Status row (state + green countdown, target + yellow SNR + TX-queue state).
+        val statusRow = carStatusDashRow(
+            txState = status.txState,
+            secondsRemaining = slot.secondsRemaining,
+            target = target,
+            snrLabel = status.snrLabel,
+            txMessage = status.messageLine,
+            hunting = GeneralVariables.autoFollowCQ && !GeneralVariables.huntCallsCQ,
         )
-        val priorities = mutableListOf(CAR_ROW_HEADLINE, CAR_ROW_SEQ_SLOT, CAR_ROW_BAND)
-        // Activation dashboard: POTA and/or ROTA rows while activating, otherwise a
-        // single session-summary row (see buildCarActivationRows). Plain StateFlow
-        // reads are enough for freshness — the 1 Hz tick re-renders every second.
-        buildActivationPaneRows(vm).forEach { row ->
-            rows.add(
-                Row.Builder()
-                    .setTitle(resolve(row.title))
-                    .apply { row.secondary?.let { addText(resolve(it)) } }
-                    .build(),
-            )
-            priorities.add(CAR_ROW_ACTIVATION)
-        }
+        // Band row: "20m" badge + "14.074 MHz · FT8" + per-cycle decode count.
+        // currentMessages is the label overlay (refreshed each cycle, cleared on a
+        // silent slot, so it drops to 0), not the cross-cycle mutableFt8MessageList.
+        val bandRow = carBandDashRow(
+            freqHz = GeneralVariables.band,
+            bandName = currentBandName(),
+            modeName = mode.displayName,
+            decodeCount = vm.currentMessages?.size ?: 0,
+        )
+        // Activation rows while a POTA/ROTA is live, otherwise a session-summary row.
+        // Plain StateFlow reads are enough for freshness — the 1 Hz tick re-renders.
+        val pota = PotaSessionManager.currentActivation.value
+        val rota = RotaTripManager.state.value
+        val potaRow = carPotaDashRow(pota?.parkRefsDisplay, pota?.qsoCount ?: 0)
+        val rotaRow = carRotaDashRow(rota.active, rota.tripName, rota.sentQsos + rota.pendingQsos, rota.miles)
+        val sessionRow = carSessionDashRow(
+            sessionQsoCount = GeneralVariables.QSL_Callsign_list_today.size,
+            lastQsoCallsign = target,
+            lastQsoBandName = currentBandName(),
+            lastQsoMinutesAgo = minutesAgo(UtcTimer.getSystemTime(), ts.mutableQsoCompletedAt.value),
+        )
+
+        val dashRows = buildCarDashboardRows(statusRow, bandRow, potaRow, rotaRow, sessionRow)
+        val builtRows = dashRows.map { renderDashRow(it) }
         val pane = Pane.Builder().apply {
-            selectCarPaneRows(priorities, paneRowLimit(carContext)).forEach { addRow(rows[it]) }
+            selectCarPaneRows(dashRows.map { it.priority }, paneRowLimit(carContext))
+                .forEach { addRow(builtRows[it]) }
         }.build()
         return PaneTemplate.Builder(pane)
             .setTitle(carContext.getString(R.string.car_screen_title))
@@ -173,37 +185,68 @@ class QsoStatusScreen(carContext: CarContext) : Screen(carContext), DefaultLifec
     }
 
     /**
-     * Reads the current POTA/ROTA activation and session state and maps it to the
-     * pane's activation rows via the pure [buildCarActivationRows]. "Session QSOs"
-     * uses the today/yesterday worked-callsign set
-     * ([GeneralVariables.QSL_Callsign_list_today]) — the only cheap in-memory count —
-     * and "last logged" is best-effort: the just-completed QSO timestamp
-     * ([com.k1af.ft8af.ft8transmit.FT8TransmitSignal.mutableQsoCompletedAt], stamped
-     * with [UtcTimer]) with the current partner callsign and tuned band.
+     * A dashboard row → a Pane Row with its colored leading badge. The Car App
+     * Library only permits [ForegroundCarColorSpan] on a row's secondary text, not
+     * its title (Row.setTitle validates against a no-color constraint and throws),
+     * so the title is rendered as plain text and color emphasis lives on the
+     * secondary line.
      */
-    private fun buildActivationPaneRows(vm: MainViewModel): List<CarPaneRow> {
-        val pota = PotaSessionManager.currentActivation.value
-        val rota = RotaTripManager.state.value
-        return buildCarActivationRows(
-            potaActive = pota != null,
-            potaParkRefsDisplay = pota?.parkRefsDisplay,
-            potaQsoCount = pota?.qsoCount ?: 0,
-            rotaActive = rota.active,
-            rotaTripName = rota.tripName,
-            rotaQsoCount = rota.sentQsos + rota.pendingQsos,
-            rotaMiles = rota.miles,
-            sessionQsoCount = GeneralVariables.QSL_Callsign_list_today.size,
-            lastQsoCallsign = vm.ft8TransmitSignal.mutableToCallsign.value?.callsign,
-            lastQsoBandName = currentBandName(),
-            lastQsoMinutesAgo = minutesAgo(
-                UtcTimer.getSystemTime(),
-                vm.ft8TransmitSignal.mutableQsoCompletedAt.value,
-            ),
-        )
+    private fun renderDashRow(row: CarDashRow): Row =
+        Row.Builder()
+            .setImage(badgeIcon(row.badge))
+            .setTitle(row.title.joinToString("") { it.text })
+            .apply { row.secondary?.let { addText(carText(it)) } }
+            .build()
+
+    /** Concatenate [spans] into a CarText, applying a [ForegroundCarColorSpan] over each colored run. */
+    private fun carText(spans: List<CarSpan>): CarText {
+        val sb = SpannableStringBuilder()
+        for (span in spans) {
+            val start = sb.length
+            sb.append(span.text)
+            span.color?.let {
+                sb.setSpan(
+                    ForegroundCarColorSpan.create(spanColor(it)),
+                    start,
+                    sb.length,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+            }
+        }
+        return CarText.create(sb)
     }
 
-    private fun resolve(spec: CarStringSpec): String =
-        carContext.getString(spec.resId, *spec.args.toTypedArray())
+    private fun spanColor(color: CarSpanColor): CarColor = when (color) {
+        CarSpanColor.GREEN -> CarColor.GREEN
+        CarSpanColor.YELLOW -> CarColor.YELLOW
+        CarSpanColor.BLUE -> CarColor.BLUE
+    }
+
+    /**
+     * A [CarBadge] rendered as a colored circle with its glyph centered (an empty
+     * glyph becomes a filled dot — the status indicator). Cached by badge so the
+     * 1 Hz re-render doesn't re-rasterize the same icon every second.
+     */
+    private fun badgeIcon(badge: CarBadge): CarIcon = badgeCache.getOrPut(badge) {
+        val size = 96
+        val bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        val center = size / 2f
+        canvas.drawCircle(center, center, center, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = badge.bgArgb })
+        val fg = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = badge.fgArgb }
+        if (badge.text.isEmpty()) {
+            canvas.drawCircle(center, center, size * 0.2f, fg)
+        } else {
+            fg.textAlign = Paint.Align.CENTER
+            fg.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            fg.textSize = if (badge.text.length <= 1) size * 0.5f else size * 0.32f
+            val fm = fg.fontMetrics
+            canvas.drawText(badge.text, center, center - (fm.ascent + fm.descent) / 2f, fg)
+        }
+        CarIcon.Builder(IconCompat.createWithBitmap(bmp)).build()
+    }
+
+    private val badgeCache = HashMap<CarBadge, CarIcon>()
 
     private companion object {
         const val TICK_MS = 1000L

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
@@ -128,20 +128,27 @@ class QsoStatusScreen(carContext: CarContext) : Screen(carContext), DefaultLifec
                 .setTitle(status.seqLine?.let { resolve(it) } ?: resolve(status.slotLine))
                 .apply { if (status.seqLine != null) addText(resolve(status.slotLine)) }
                 .build(),
-            Row.Builder().setTitle(status.bandLine).build(),
+            Row.Builder().setTitle(status.bandLine)
+                .apply {
+                    // Per-cycle decode count: currentMessages is the label overlay,
+                    // refreshed each cycle and cleared on a silent slot, so it drops
+                    // to 0 correctly (mutableFt8MessageList accumulates across cycles
+                    // when clearDecodesEveryCycle is off, the default).
+                    carDecodesSecondary(vm.currentMessages?.size ?: 0)?.let { addText(resolve(it)) }
+                }
+                .build(),
         )
         val priorities = mutableListOf(CAR_ROW_HEADLINE, CAR_ROW_SEQ_SLOT, CAR_ROW_BAND)
-        // POTA / ROTA rows only exist while an activation or trip is running.
-        // StateFlow reads (not observers) are enough for freshness: the 1 Hz tick
-        // re-renders the pane every second anyway.
-        val activation = PotaSessionManager.currentActivation.value
-        buildCarPotaLine(activation?.parkRefsDisplay, activation?.qsoCount)?.let {
-            rows.add(Row.Builder().setTitle(resolve(it)).build())
-            priorities.add(CAR_ROW_ACTIVATION)
-        }
-        val trip = RotaTripManager.state.value
-        buildCarRotaLine(trip.active, trip.tripName, trip.sentQsos, trip.pendingQsos, trip.miles)?.let {
-            rows.add(Row.Builder().setTitle(resolve(it)).build())
+        // Activation dashboard: POTA and/or ROTA rows while activating, otherwise a
+        // single session-summary row (see buildCarActivationRows). Plain StateFlow
+        // reads are enough for freshness — the 1 Hz tick re-renders every second.
+        buildActivationPaneRows(vm).forEach { row ->
+            rows.add(
+                Row.Builder()
+                    .setTitle(resolve(row.title))
+                    .apply { row.secondary?.let { addText(resolve(it)) } }
+                    .build(),
+            )
             priorities.add(CAR_ROW_ACTIVATION)
         }
         val pane = Pane.Builder().apply {
@@ -163,6 +170,36 @@ class QsoStatusScreen(carContext: CarContext) : Screen(carContext), DefaultLifec
                     .build(),
             )
             .build()
+    }
+
+    /**
+     * Reads the current POTA/ROTA activation and session state and maps it to the
+     * pane's activation rows via the pure [buildCarActivationRows]. "Session QSOs"
+     * uses the today/yesterday worked-callsign set
+     * ([GeneralVariables.QSL_Callsign_list_today]) — the only cheap in-memory count —
+     * and "last logged" is best-effort: the just-completed QSO timestamp
+     * ([com.k1af.ft8af.ft8transmit.FT8TransmitSignal.mutableQsoCompletedAt], stamped
+     * with [UtcTimer]) with the current partner callsign and tuned band.
+     */
+    private fun buildActivationPaneRows(vm: MainViewModel): List<CarPaneRow> {
+        val pota = PotaSessionManager.currentActivation.value
+        val rota = RotaTripManager.state.value
+        return buildCarActivationRows(
+            potaActive = pota != null,
+            potaParkRefsDisplay = pota?.parkRefsDisplay,
+            potaQsoCount = pota?.qsoCount ?: 0,
+            rotaActive = rota.active,
+            rotaTripName = rota.tripName,
+            rotaQsoCount = rota.sentQsos + rota.pendingQsos,
+            rotaMiles = rota.miles,
+            sessionQsoCount = GeneralVariables.QSL_Callsign_list_today.size,
+            lastQsoCallsign = vm.ft8TransmitSignal.mutableToCallsign.value?.callsign,
+            lastQsoBandName = currentBandName(),
+            lastQsoMinutesAgo = minutesAgo(
+                UtcTimer.getSystemTime(),
+                vm.ft8TransmitSignal.mutableQsoCompletedAt.value,
+            ),
+        )
     }
 
     private fun resolve(spec: CarStringSpec): String =

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/car/QsoStatusScreen.kt
@@ -155,7 +155,10 @@ class QsoStatusScreen(carContext: CarContext) : Screen(carContext), DefaultLifec
         val rotaRow = carRotaDashRow(rota.active, rota.tripName, rota.sentQsos + rota.pendingQsos, rota.miles)
         val sessionRow = carSessionDashRow(
             sessionQsoCount = GeneralVariables.QSL_Callsign_list_today.size,
-            lastQsoCallsign = target,
+            // Last *logged* callsign (worked-list is appended in completion order),
+            // not the current TX target — those differ when calling CQ right after a
+            // QSO completes, and the target would then hide a real "last logged" line.
+            lastQsoCallsign = GeneralVariables.QSL_Callsign_list.lastOrNull(),
             lastQsoBandName = currentBandName(),
             lastQsoMinutesAgo = minutesAgo(UtcTimer.getSystemTime(), ts.mutableQsoCompletedAt.value),
         )

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -906,23 +906,12 @@
     <string name="car_screen_title" translatable="false">FT8AF</string>
     <string name="car_open_phone">Open FT8AF on your phone to start the FT8 engine</string>
     <string name="car_monitoring">Monitoring — TX off</string>
-    <string name="car_no_tx">No transmission queued</string>
     <string name="car_seq_step">Step %1$s (%2$d/%3$d)</string>
     <string name="car_slot_tx">TX slot · %1$d s</string>
     <string name="car_slot_rx">RX slot · %1$d s</string>
     <string name="car_decodes_action">Decodes</string>
     <string name="car_decodes_title">Recent decodes</string>
     <string name="car_no_decodes">No decodes yet</string>
-    <string name="car_pota_line">POTA %1$s · %2$d QSOs</string>
-    <string name="car_pota_to_validate">%1$d more to validate the activation</string>
-    <string name="car_pota_validated">Activation validated</string>
-    <string name="car_rota_line">ROTA %1$s · %2$d QSOs</string>
-    <string name="car_rota_miles">%1$s mi driven this activation</string>
-    <string name="car_decodes_last_cycle">%1$d decodes last cycle</string>
-    <string name="car_session_line">Session · %1$d QSOs</string>
-    <string name="car_session_last">Last logged %1$s · %2$s · %3$d min</string>
-    <string name="car_session_last_noband">Last logged %1$s · %2$d min</string>
-    <string name="car_session_none">No QSOs logged yet</string>
 
     <!-- ROTA (Roads On The Air) trip mode -->
     <string name="rota_title">Roads On The Air (ROTA)</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -914,7 +914,15 @@
     <string name="car_decodes_title">Recent decodes</string>
     <string name="car_no_decodes">No decodes yet</string>
     <string name="car_pota_line">POTA %1$s · %2$d QSOs</string>
-    <string name="car_rota_line">ROTA %1$s · %2$d QSOs · %3$s mi</string>
+    <string name="car_pota_to_validate">%1$d more to validate the activation</string>
+    <string name="car_pota_validated">Activation validated</string>
+    <string name="car_rota_line">ROTA %1$s · %2$d QSOs</string>
+    <string name="car_rota_miles">%1$s mi driven this activation</string>
+    <string name="car_decodes_last_cycle">%1$d decodes last cycle</string>
+    <string name="car_session_line">Session · %1$d QSOs</string>
+    <string name="car_session_last">Last logged %1$s · %2$s · %3$d min</string>
+    <string name="car_session_last_noband">Last logged %1$s · %2$d min</string>
+    <string name="car_session_none">No QSOs logged yet</string>
 
     <!-- ROTA (Roads On The Air) trip mode -->
     <string name="rota_title">Roads On The Air (ROTA)</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarDashboardTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarDashboardTest.kt
@@ -198,4 +198,27 @@ class CarDashboardTest {
         assertThat(minutesAgo(41 * 60_000L + 1L, 1L)).isEqualTo(41)
         assertThat(minutesAgo(30_000L, 1L)).isEqualTo(0)
     }
+
+    // -- singular/plural labels --
+
+    @Test
+    fun qsosLabel_singularOnlyAtOne() {
+        assertThat(qsosLabel(0)).isEqualTo("0 QSOs")
+        assertThat(qsosLabel(1)).isEqualTo("1 QSO")
+        assertThat(qsosLabel(2)).isEqualTo("2 QSOs")
+    }
+
+    @Test
+    fun decodesLabel_singularOnlyAtOne() {
+        assertThat(decodesLabel(1)).isEqualTo("1 decode")
+        assertThat(decodesLabel(12)).isEqualTo("12 decodes")
+    }
+
+    @Test
+    fun rows_useSingularAtCountOfOne() {
+        assertThat(text(carPotaDashRow("K-1234", 1)!!.title)).isEqualTo("POTA K-1234 · 1 QSO")
+        assertThat(text(carRotaDashRow(true, "Route 66", 1, 1.0)!!.title)).isEqualTo("ROTA Route 66 · 1 QSO")
+        assertThat(text(carSessionDashRow(1, "JA1XYZ", "20m", 41).title)).isEqualTo("Session · 1 QSO")
+        assertThat(text(carBandDashRow(14_074_000L, "20m", "FT8", 1).secondary!!)).isEqualTo("1 decode last cycle")
+    }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarDashboardTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarDashboardTest.kt
@@ -1,0 +1,182 @@
+package radio.ks3ckc.ft8af.car
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import org.junit.Test
+
+/**
+ * Tests for the pure Android Auto dashboard helpers — the POTA/ROTA/session
+ * activation block, the "N to validate" figure, mileage formatting, and the
+ * "minutes ago" clamp. The Screen only resolves the returned specs, so these
+ * tests pin the row-selection and formatting rules.
+ */
+class CarDashboardTest {
+
+    // -- potaValidateSpec --
+
+    @Test
+    fun potaValidate_belowTarget_countsRemaining() {
+        val spec = potaValidateSpec(qsoCount = 3)
+        assertThat(spec.resId).isEqualTo(R.string.car_pota_to_validate)
+        assertThat(spec.args).containsExactly(POTA_ACTIVATION_TARGET - 3)
+    }
+
+    @Test
+    fun potaValidate_zeroQsos_remainingIsFullTarget() {
+        assertThat(potaValidateSpec(0).args).containsExactly(POTA_ACTIVATION_TARGET)
+    }
+
+    @Test
+    fun potaValidate_atOrAboveTarget_isValidated() {
+        for (count in listOf(POTA_ACTIVATION_TARGET, POTA_ACTIVATION_TARGET + 5)) {
+            assertThat(potaValidateSpec(count).resId).isEqualTo(R.string.car_pota_validated)
+        }
+    }
+
+    // -- formatMiles --
+
+    @Test
+    fun formatMiles_oneDecimal_localeIndependent() {
+        assertThat(formatMiles(0.0)).isEqualTo("0.0")
+        assertThat(formatMiles(12.34)).isEqualTo("12.3")
+        assertThat(formatMiles(12.36)).isEqualTo("12.4")
+    }
+
+    // -- minutesAgo --
+
+    @Test
+    fun minutesAgo_nullOrNonPositiveTimestamp_isNull() {
+        assertThat(minutesAgo(nowMs = 60_000L, thenMs = null)).isNull()
+        assertThat(minutesAgo(nowMs = 60_000L, thenMs = 0L)).isNull()
+        assertThat(minutesAgo(nowMs = 60_000L, thenMs = -5L)).isNull()
+    }
+
+    @Test
+    fun minutesAgo_futureTimestamp_isNull() {
+        assertThat(minutesAgo(nowMs = 1_000L, thenMs = 5_000L)).isNull()
+    }
+
+    @Test
+    fun minutesAgo_flooredToWholeMinutes() {
+        assertThat(minutesAgo(nowMs = 41 * 60_000L, thenMs = 0L + 1L)).isEqualTo(40)
+        assertThat(minutesAgo(nowMs = 90_000L, thenMs = 1L)).isEqualTo(1)
+        assertThat(minutesAgo(nowMs = 30_000L, thenMs = 1L)).isEqualTo(0)
+    }
+
+    // -- buildCarSessionRow --
+
+    @Test
+    fun sessionRow_titleCarriesCount() {
+        val row = buildCarSessionRow(5, "JA1XYZ", "20m", 41)
+        assertThat(row.title.resId).isEqualTo(R.string.car_session_line)
+        assertThat(row.title.args).containsExactly(5)
+    }
+
+    @Test
+    fun sessionRow_fullLastLogged_withBand() {
+        val row = buildCarSessionRow(5, "JA1XYZ", "20m", 41)
+        assertThat(row.secondary?.resId).isEqualTo(R.string.car_session_last)
+        assertThat(row.secondary?.args).containsExactly("JA1XYZ", "20m", 41).inOrder()
+    }
+
+    @Test
+    fun sessionRow_lastLogged_blankBandDropsToNoBandForm() {
+        for (band in listOf(null, "", "  ")) {
+            val row = buildCarSessionRow(5, "JA1XYZ", band, 41)
+            assertThat(row.secondary?.resId).isEqualTo(R.string.car_session_last_noband)
+            assertThat(row.secondary?.args).containsExactly("JA1XYZ", 41).inOrder()
+        }
+    }
+
+    @Test
+    fun sessionRow_noneWhenCallsignOrMinutesMissing() {
+        assertThat(buildCarSessionRow(0, null, "20m", 41).secondary?.resId)
+            .isEqualTo(R.string.car_session_none)
+        assertThat(buildCarSessionRow(0, "  ", "20m", 41).secondary?.resId)
+            .isEqualTo(R.string.car_session_none)
+        assertThat(buildCarSessionRow(3, "JA1XYZ", "20m", null).secondary?.resId)
+            .isEqualTo(R.string.car_session_none)
+    }
+
+    // -- buildCarActivationRows --
+
+    private fun rows(
+        potaActive: Boolean = false,
+        potaParkRefsDisplay: String? = null,
+        potaQsoCount: Int = 0,
+        rotaActive: Boolean = false,
+        rotaTripName: String? = null,
+        rotaQsoCount: Int = 0,
+        rotaMiles: Double = 0.0,
+        sessionQsoCount: Int = 5,
+        lastQsoCallsign: String? = "JA1XYZ",
+        lastQsoBandName: String? = "20m",
+        lastQsoMinutesAgo: Int? = 41,
+    ) = buildCarActivationRows(
+        potaActive, potaParkRefsDisplay, potaQsoCount,
+        rotaActive, rotaTripName, rotaQsoCount, rotaMiles,
+        sessionQsoCount, lastQsoCallsign, lastQsoBandName, lastQsoMinutesAgo,
+    )
+
+    @Test
+    fun activationRows_potaOnly_potaRowWithValidateSecondary() {
+        val r = rows(potaActive = true, potaParkRefsDisplay = "K-1234", potaQsoCount = 12)
+        assertThat(r).hasSize(1)
+        assertThat(r[0].title.resId).isEqualTo(R.string.car_pota_line)
+        assertThat(r[0].title.args).containsExactly("K-1234", 12).inOrder()
+        // 12 >= target → validated
+        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_pota_validated)
+    }
+
+    @Test
+    fun activationRows_rotaOnly_rotaRowWithMilesSecondary() {
+        val r = rows(rotaActive = true, rotaTripName = "Route 66", rotaQsoCount = 0, rotaMiles = 0.0)
+        assertThat(r).hasSize(1)
+        assertThat(r[0].title.resId).isEqualTo(R.string.car_rota_line)
+        assertThat(r[0].title.args).containsExactly("Route 66", 0).inOrder()
+        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_rota_miles)
+        assertThat(r[0].secondary?.args).containsExactly("0.0")
+    }
+
+    @Test
+    fun activationRows_bothActive_potaThenRota_noSession() {
+        val r = rows(
+            potaActive = true, potaParkRefsDisplay = "K-1234", potaQsoCount = 3,
+            rotaActive = true, rotaTripName = "Route 66", rotaQsoCount = 2, rotaMiles = 8.7,
+        )
+        assertThat(r).hasSize(2)
+        assertThat(r[0].title.resId).isEqualTo(R.string.car_pota_line)
+        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_pota_to_validate)
+        assertThat(r[1].title.resId).isEqualTo(R.string.car_rota_line)
+    }
+
+    @Test
+    fun activationRows_neitherActive_collapsesToSessionRow() {
+        val r = rows()
+        assertThat(r).hasSize(1)
+        assertThat(r[0].title.resId).isEqualTo(R.string.car_session_line)
+        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_session_last)
+    }
+
+    @Test
+    fun activationRows_activeFlagButBlankLabel_treatedAsInactive() {
+        // POTA "active" with no park ref and ROTA "active" with no trip name both
+        // drop out, so the block collapses to the session row.
+        val r = rows(
+            potaActive = true, potaParkRefsDisplay = "  ",
+            rotaActive = true, rotaTripName = "",
+        )
+        assertThat(r).hasSize(1)
+        assertThat(r[0].title.resId).isEqualTo(R.string.car_session_line)
+    }
+
+    // -- carDecodesSecondary --
+
+    @Test
+    fun decodesSecondary_nullWhenZero_specWhenPositive() {
+        assertThat(carDecodesSecondary(0)).isNull()
+        val spec = carDecodesSecondary(12)
+        assertThat(spec?.resId).isEqualTo(R.string.car_decodes_last_cycle)
+        assertThat(spec?.args).containsExactly(12)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarDashboardTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarDashboardTest.kt
@@ -1,39 +1,187 @@
 package radio.ks3ckc.ft8af.car
 
 import com.google.common.truth.Truth.assertThat
-import com.k1af.ft8af.R
 import org.junit.Test
 
 /**
- * Tests for the pure Android Auto dashboard helpers — the POTA/ROTA/session
- * activation block, the "N to validate" figure, mileage formatting, and the
- * "minutes ago" clamp. The Screen only resolves the returned specs, so these
- * tests pin the row-selection and formatting rules.
+ * Tests for the pure Android Auto dashboard helpers (design "1a" Pane): the
+ * status/band/POTA/ROTA/session row builders, their colored badges and emphasis
+ * spans, the "N to validate" figure, mileage formatting, and the "minutes ago"
+ * clamp. The Screen only rasterizes the badges and applies the spans, so these
+ * tests pin the row content, ordering, and color rules.
  */
 class CarDashboardTest {
 
-    // -- potaValidateSpec --
+    private fun text(spans: List<CarSpan>) = spans.joinToString("") { it.text }
+
+    // -- carStatusDashRow --
 
     @Test
-    fun potaValidate_belowTarget_countsRemaining() {
-        val spec = potaValidateSpec(qsoCount = 3)
-        assertThat(spec.resId).isEqualTo(R.string.car_pota_to_validate)
-        assertThat(spec.args).containsExactly(POTA_ACTIVATION_TARGET - 3)
+    fun status_receiving_greenCountdown_targetAndSnr() {
+        val row = carStatusDashRow(
+            txState = CarTxState.ARMED_RX,
+            secondsRemaining = 9,
+            target = "W1ABC",
+            snrLabel = "-8 dB",
+            txMessage = null,
+            hunting = false,
+        )
+        assertThat(text(row.title)).isEqualTo("Receiving · next TX in 9 s")
+        // The countdown run is green; the state word is not.
+        assertThat(row.title.first { it.text.contains("9 s") }.color).isEqualTo(CarSpanColor.GREEN)
+        assertThat(row.title.first().color).isNull()
+        assertThat(text(row.secondary!!)).isEqualTo("Waiting for W1ABC · -8 dB · no TX queued")
+        assertThat(row.secondary!!.first { it.text == "-8 dB" }.color).isEqualTo(CarSpanColor.YELLOW)
+        // Armed → green dot badge (empty glyph).
+        assertThat(row.badge).isEqualTo(CarBadge("", CAR_GREEN_FG, CAR_GREEN_BG))
+        assertThat(row.priority).isEqualTo(CAR_ROW_HEADLINE)
     }
 
     @Test
-    fun potaValidate_zeroQsos_remainingIsFullTarget() {
-        assertThat(potaValidateSpec(0).args).containsExactly(POTA_ACTIVATION_TARGET)
+    fun status_transmitting_showsWorkingAndMessage() {
+        val row = carStatusDashRow(
+            txState = CarTxState.TRANSMITTING,
+            secondsRemaining = 4,
+            target = "W1ABC",
+            snrLabel = "-8 dB",
+            txMessage = "W1ABC K7XYZ RR73",
+            hunting = false,
+        )
+        assertThat(text(row.title)).isEqualTo("Transmitting · 4 s left")
+        assertThat(text(row.secondary!!)).isEqualTo("Working W1ABC · -8 dB · W1ABC K7XYZ RR73")
     }
 
     @Test
-    fun potaValidate_atOrAboveTarget_isValidated() {
+    fun status_txOff_grayBadge_monitoring_noCountdownColor_noTxSegment() {
+        val row = carStatusDashRow(
+            txState = CarTxState.OFF,
+            secondsRemaining = 7,
+            target = null,
+            snrLabel = null,
+            txMessage = null,
+            hunting = false,
+        )
+        assertThat(text(row.title)).isEqualTo("Monitoring · TX off")
+        assertThat(row.title.last().color).isNull()
+        // No target and TX off → secondary is just the monitoring line, no "no TX queued".
+        assertThat(text(row.secondary!!)).isEqualTo("Monitoring — TX off")
+        assertThat(row.badge).isEqualTo(CarBadge("", CAR_GRAY_FG, CAR_GRAY_BG))
+    }
+
+    @Test
+    fun status_callingCq_and_hunting_secondaries() {
+        val cq = carStatusDashRow(CarTxState.ARMED_RX, 5, null, null, null, hunting = false)
+        assertThat(text(cq.secondary!!)).isEqualTo("Calling CQ · no TX queued")
+        val hunt = carStatusDashRow(CarTxState.ARMED_RX, 5, null, null, null, hunting = true)
+        assertThat(text(hunt.secondary!!)).isEqualTo("Hunting for CQ · no TX queued")
+    }
+
+    // -- carBandDashRow --
+
+    @Test
+    fun band_badgeIsBandName_titleHasMhzAndMode_decodesSecondary() {
+        val row = carBandDashRow(freqHz = 14_074_000L, bandName = "20m", modeName = "FT8", decodeCount = 12)
+        assertThat(row.badge).isEqualTo(CarBadge("20m", CAR_BLUE_FG, CAR_BLUE_BG))
+        assertThat(text(row.title)).isEqualTo("14.074 MHz · FT8")
+        assertThat(text(row.secondary!!)).isEqualTo("12 decodes last cycle")
+        assertThat(row.priority).isEqualTo(CAR_ROW_BAND)
+    }
+
+    @Test
+    fun band_silentCycle_dropsDecodesSecondary_blankBandFallsBackToRf() {
+        val row = carBandDashRow(freqHz = 7_074_000L, bandName = "  ", modeName = "FT8", decodeCount = 0)
+        assertThat(row.secondary).isNull()
+        assertThat(row.badge.text).isEqualTo("RF")
+    }
+
+    // -- carPotaDashRow --
+
+    @Test
+    fun pota_nullWhenNoActivation() {
+        assertThat(carPotaDashRow(null, 3)).isNull()
+        assertThat(carPotaDashRow("  ", 3)).isNull()
+    }
+
+    @Test
+    fun pota_greenQsoCount_and_toValidateSecondary() {
+        val row = carPotaDashRow("K-1234", 3)!!
+        assertThat(text(row.title)).isEqualTo("POTA K-1234 · 3 QSOs")
+        assertThat(row.title.first { it.text.contains("QSOs") }.color).isEqualTo(CarSpanColor.GREEN)
+        assertThat(text(row.secondary!!)).isEqualTo("7 more to validate the activation")
+        assertThat(row.badge).isEqualTo(CarBadge("P", CAR_AMBER_FG, CAR_AMBER_BG))
+    }
+
+    @Test
+    fun pota_atOrAboveTarget_isValidated() {
         for (count in listOf(POTA_ACTIVATION_TARGET, POTA_ACTIVATION_TARGET + 5)) {
-            assertThat(potaValidateSpec(count).resId).isEqualTo(R.string.car_pota_validated)
+            assertThat(text(carPotaDashRow("K-1234", count)!!.secondary!!)).isEqualTo("Activation validated")
         }
     }
 
-    // -- formatMiles --
+    // -- carRotaDashRow --
+
+    @Test
+    fun rota_nullWhenInactiveOrBlank() {
+        assertThat(carRotaDashRow(false, "Route 66", 5, 12.0)).isNull()
+        assertThat(carRotaDashRow(true, "  ", 5, 12.0)).isNull()
+    }
+
+    @Test
+    fun rota_titleAndMilesSecondary() {
+        val row = carRotaDashRow(true, "Route 66", 0, 0.0)!!
+        assertThat(text(row.title)).isEqualTo("ROTA Route 66 · 0 QSOs")
+        assertThat(text(row.secondary!!)).isEqualTo("0.0 mi driven this activation")
+        assertThat(row.badge).isEqualTo(CarBadge("R", CAR_AMBER_FG, CAR_AMBER_BG))
+    }
+
+    // -- carSessionDashRow --
+
+    @Test
+    fun session_title_and_lastLoggedVariants() {
+        val full = carSessionDashRow(5, "JA1XYZ", "20m", 41)
+        assertThat(text(full.title)).isEqualTo("Session · 5 QSOs")
+        assertThat(text(full.secondary!!)).isEqualTo("Last logged JA1XYZ · 20m · 41 min")
+        assertThat(full.badge).isEqualTo(CarBadge("Σ", CAR_GRAY_FG, CAR_GRAY_BG))
+
+        val noBand = carSessionDashRow(5, "JA1XYZ", "  ", 41)
+        assertThat(text(noBand.secondary!!)).isEqualTo("Last logged JA1XYZ · 41 min")
+
+        val none = carSessionDashRow(0, null, "20m", 41)
+        assertThat(text(none.secondary!!)).isEqualTo("No QSOs logged yet")
+        val noneMinutes = carSessionDashRow(3, "JA1XYZ", "20m", null)
+        assertThat(text(noneMinutes.secondary!!)).isEqualTo("No QSOs logged yet")
+    }
+
+    // -- buildCarDashboardRows --
+
+    private val status = carStatusDashRow(CarTxState.ARMED_RX, 9, "W1ABC", "-8 dB", null, false)
+    private val band = carBandDashRow(14_074_000L, "20m", "FT8", 12)
+    private val session = carSessionDashRow(5, "JA1XYZ", "20m", 41)
+
+    @Test
+    fun dashboard_bothActive_statusBandPotaRota_noSession() {
+        val rows = buildCarDashboardRows(
+            status, band,
+            carPotaDashRow("K-1234", 3), carRotaDashRow(true, "Route 66", 2, 8.7), session,
+        )
+        assertThat(rows.map { it.badge.text }).containsExactly("", "20m", "P", "R").inOrder()
+        assertThat(text(rows[3].title)).isEqualTo("ROTA Route 66 · 2 QSOs")
+    }
+
+    @Test
+    fun dashboard_neitherActive_collapsesToSession() {
+        val rows = buildCarDashboardRows(status, band, null, null, session)
+        assertThat(rows).hasSize(3)
+        assertThat(rows[2].badge.text).isEqualTo("Σ")
+    }
+
+    @Test
+    fun dashboard_onlyPota_noSessionRow() {
+        val rows = buildCarDashboardRows(status, band, carPotaDashRow("K-1234", 3), null, session)
+        assertThat(rows.map { it.badge.text }).containsExactly("", "20m", "P").inOrder()
+    }
+
+    // -- formatMiles / minutesAgo --
 
     @Test
     fun formatMiles_oneDecimal_localeIndependent() {
@@ -42,141 +190,12 @@ class CarDashboardTest {
         assertThat(formatMiles(12.36)).isEqualTo("12.4")
     }
 
-    // -- minutesAgo --
-
     @Test
-    fun minutesAgo_nullOrNonPositiveTimestamp_isNull() {
-        assertThat(minutesAgo(nowMs = 60_000L, thenMs = null)).isNull()
-        assertThat(minutesAgo(nowMs = 60_000L, thenMs = 0L)).isNull()
-        assertThat(minutesAgo(nowMs = 60_000L, thenMs = -5L)).isNull()
-    }
-
-    @Test
-    fun minutesAgo_futureTimestamp_isNull() {
-        assertThat(minutesAgo(nowMs = 1_000L, thenMs = 5_000L)).isNull()
-    }
-
-    @Test
-    fun minutesAgo_flooredToWholeMinutes() {
-        assertThat(minutesAgo(nowMs = 41 * 60_000L, thenMs = 0L + 1L)).isEqualTo(40)
-        assertThat(minutesAgo(nowMs = 90_000L, thenMs = 1L)).isEqualTo(1)
-        assertThat(minutesAgo(nowMs = 30_000L, thenMs = 1L)).isEqualTo(0)
-    }
-
-    // -- buildCarSessionRow --
-
-    @Test
-    fun sessionRow_titleCarriesCount() {
-        val row = buildCarSessionRow(5, "JA1XYZ", "20m", 41)
-        assertThat(row.title.resId).isEqualTo(R.string.car_session_line)
-        assertThat(row.title.args).containsExactly(5)
-    }
-
-    @Test
-    fun sessionRow_fullLastLogged_withBand() {
-        val row = buildCarSessionRow(5, "JA1XYZ", "20m", 41)
-        assertThat(row.secondary?.resId).isEqualTo(R.string.car_session_last)
-        assertThat(row.secondary?.args).containsExactly("JA1XYZ", "20m", 41).inOrder()
-    }
-
-    @Test
-    fun sessionRow_lastLogged_blankBandDropsToNoBandForm() {
-        for (band in listOf(null, "", "  ")) {
-            val row = buildCarSessionRow(5, "JA1XYZ", band, 41)
-            assertThat(row.secondary?.resId).isEqualTo(R.string.car_session_last_noband)
-            assertThat(row.secondary?.args).containsExactly("JA1XYZ", 41).inOrder()
-        }
-    }
-
-    @Test
-    fun sessionRow_noneWhenCallsignOrMinutesMissing() {
-        assertThat(buildCarSessionRow(0, null, "20m", 41).secondary?.resId)
-            .isEqualTo(R.string.car_session_none)
-        assertThat(buildCarSessionRow(0, "  ", "20m", 41).secondary?.resId)
-            .isEqualTo(R.string.car_session_none)
-        assertThat(buildCarSessionRow(3, "JA1XYZ", "20m", null).secondary?.resId)
-            .isEqualTo(R.string.car_session_none)
-    }
-
-    // -- buildCarActivationRows --
-
-    private fun rows(
-        potaActive: Boolean = false,
-        potaParkRefsDisplay: String? = null,
-        potaQsoCount: Int = 0,
-        rotaActive: Boolean = false,
-        rotaTripName: String? = null,
-        rotaQsoCount: Int = 0,
-        rotaMiles: Double = 0.0,
-        sessionQsoCount: Int = 5,
-        lastQsoCallsign: String? = "JA1XYZ",
-        lastQsoBandName: String? = "20m",
-        lastQsoMinutesAgo: Int? = 41,
-    ) = buildCarActivationRows(
-        potaActive, potaParkRefsDisplay, potaQsoCount,
-        rotaActive, rotaTripName, rotaQsoCount, rotaMiles,
-        sessionQsoCount, lastQsoCallsign, lastQsoBandName, lastQsoMinutesAgo,
-    )
-
-    @Test
-    fun activationRows_potaOnly_potaRowWithValidateSecondary() {
-        val r = rows(potaActive = true, potaParkRefsDisplay = "K-1234", potaQsoCount = 12)
-        assertThat(r).hasSize(1)
-        assertThat(r[0].title.resId).isEqualTo(R.string.car_pota_line)
-        assertThat(r[0].title.args).containsExactly("K-1234", 12).inOrder()
-        // 12 >= target → validated
-        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_pota_validated)
-    }
-
-    @Test
-    fun activationRows_rotaOnly_rotaRowWithMilesSecondary() {
-        val r = rows(rotaActive = true, rotaTripName = "Route 66", rotaQsoCount = 0, rotaMiles = 0.0)
-        assertThat(r).hasSize(1)
-        assertThat(r[0].title.resId).isEqualTo(R.string.car_rota_line)
-        assertThat(r[0].title.args).containsExactly("Route 66", 0).inOrder()
-        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_rota_miles)
-        assertThat(r[0].secondary?.args).containsExactly("0.0")
-    }
-
-    @Test
-    fun activationRows_bothActive_potaThenRota_noSession() {
-        val r = rows(
-            potaActive = true, potaParkRefsDisplay = "K-1234", potaQsoCount = 3,
-            rotaActive = true, rotaTripName = "Route 66", rotaQsoCount = 2, rotaMiles = 8.7,
-        )
-        assertThat(r).hasSize(2)
-        assertThat(r[0].title.resId).isEqualTo(R.string.car_pota_line)
-        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_pota_to_validate)
-        assertThat(r[1].title.resId).isEqualTo(R.string.car_rota_line)
-    }
-
-    @Test
-    fun activationRows_neitherActive_collapsesToSessionRow() {
-        val r = rows()
-        assertThat(r).hasSize(1)
-        assertThat(r[0].title.resId).isEqualTo(R.string.car_session_line)
-        assertThat(r[0].secondary?.resId).isEqualTo(R.string.car_session_last)
-    }
-
-    @Test
-    fun activationRows_activeFlagButBlankLabel_treatedAsInactive() {
-        // POTA "active" with no park ref and ROTA "active" with no trip name both
-        // drop out, so the block collapses to the session row.
-        val r = rows(
-            potaActive = true, potaParkRefsDisplay = "  ",
-            rotaActive = true, rotaTripName = "",
-        )
-        assertThat(r).hasSize(1)
-        assertThat(r[0].title.resId).isEqualTo(R.string.car_session_line)
-    }
-
-    // -- carDecodesSecondary --
-
-    @Test
-    fun decodesSecondary_nullWhenZero_specWhenPositive() {
-        assertThat(carDecodesSecondary(0)).isNull()
-        val spec = carDecodesSecondary(12)
-        assertThat(spec?.resId).isEqualTo(R.string.car_decodes_last_cycle)
-        assertThat(spec?.args).containsExactly(12)
+    fun minutesAgo_nullOnMissingOrFutureTimestamp_flooredOtherwise() {
+        assertThat(minutesAgo(60_000L, null)).isNull()
+        assertThat(minutesAgo(60_000L, 0L)).isNull()
+        assertThat(minutesAgo(1_000L, 5_000L)).isNull()
+        assertThat(minutesAgo(41 * 60_000L + 1L, 1L)).isEqualTo(41)
+        assertThat(minutesAgo(30_000L, 1L)).isEqualTo(0)
     }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatusTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatusTest.kt
@@ -216,30 +216,9 @@ class CarQsoStatusTest {
         assertThat(shouldInvalidateForTick(lastSecond = -1, newSecond = 15)).isTrue()
     }
 
-    // --- POTA / ROTA activation rows ---------------------------------------
-
-    @Test
-    fun buildCarPotaLine_nullOrBlankPark_hidesRow() {
-        assertThat(buildCarPotaLine(null, 3)).isNull()
-        assertThat(buildCarPotaLine("", 3)).isNull()
-        assertThat(buildCarPotaLine("  ", 3)).isNull()
-    }
-
-    @Test
-    fun buildCarPotaLine_formatsParkAndCount() {
-        val spec = buildCarPotaLine("K-1234 + K-5678", 7)!!
-        assertThat(spec.resId).isEqualTo(R.string.car_pota_line)
-        assertThat(spec.args).containsExactly("K-1234 + K-5678", 7).inOrder()
-    }
-
-    @Test
-    fun buildCarPotaLine_nullCount_showsZero() {
-        assertThat(buildCarPotaLine("K-1234", null)!!.args).containsExactly("K-1234", 0).inOrder()
-    }
-
-    // The ROTA row (title + miles secondary) and the session-fallback row are
-    // built inside buildCarActivationRows; their formatting is covered in
-    // CarDashboardTest.
+    // --- Pane row selection ------------------------------------------------
+    // The status/band/POTA/ROTA/session row content, badges, and color spans are
+    // built by the design dashboard helpers, covered in CarDashboardTest.
 
     @Test
     fun selectCarPaneRows_underLimit_keepsAllInOrder() {

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatusTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/car/CarQsoStatusTest.kt
@@ -237,25 +237,9 @@ class CarQsoStatusTest {
         assertThat(buildCarPotaLine("K-1234", null)!!.args).containsExactly("K-1234", 0).inOrder()
     }
 
-    @Test
-    fun buildCarRotaLine_inactiveTrip_hidesRow() {
-        assertThat(buildCarRotaLine(false, "Route 66", 5, 2, 12.0)).isNull()
-    }
-
-    @Test
-    fun buildCarRotaLine_sumsSentAndPendingQsos_andFormatsMiles() {
-        val spec = buildCarRotaLine(true, "Route 66", 10, 2, 45.34)!!
-        assertThat(spec.resId).isEqualTo(R.string.car_rota_line)
-        // 12 = 10 sent + 2 still queued offline; miles use the trip
-        // notification's one-decimal format.
-        assertThat(spec.args).containsExactly("Route 66", 12, "45.3").inOrder()
-    }
-
-    @Test
-    fun buildCarRotaLine_blankTripName_fallsBackToTrip() {
-        assertThat(buildCarRotaLine(true, "   ", 0, 0, 0.0)!!.args)
-            .containsExactly("trip", 0, "0.0").inOrder()
-    }
+    // The ROTA row (title + miles secondary) and the session-fallback row are
+    // built inside buildCarActivationRows; their formatting is covered in
+    // CarDashboardTest.
 
     @Test
     fun selectCarPaneRows_underLimit_keepsAllInOrder() {


### PR DESCRIPTION
## What

Implements the FT8AF Android Auto **status dashboard** from the [Claude Design project](https://claude.ai/design/p/0396e73a-0e0f-4002-a525-078f4d5015b1) (`FT8AF Android Auto.dc.html`, the **1a** Pane variant) on the read-only `PaneTemplate`. Supersedes the closed #730 (which was built on the map/Surface path #729 removed).

Every row carries a **colored circular leading badge** and the rows follow the design's shape:

- **Status** — green dot badge (gray when TX off): `Receiving · next TX in 9 s` / `Monitoring · TX off`, secondary `Waiting for W1ABC · −8 dB · no TX queued`.
- **Band** — blue `20m` badge: `14.074 MHz · FT8`, secondary `12 decodes last cycle`.
- **POTA** — amber `P` badge: `POTA K-1234 · N QSOs`, secondary `N more to validate the activation` → `Activation validated` (`POTA_ACTIVATION_TARGET = 10`).
- **ROTA** — amber `R` badge: `ROTA <trip> · N QSOs`, secondary `X.X mi driven this activation`.
- **Session-fallback** — gray `Σ` badge, shown only when neither POTA nor ROTA is active: `Session · N QSOs` / `Last logged JA1XYZ · 20m · 41 min` (the design's "activation rows drop out, session stats take the slot").

## How

Decision/format/color logic is pure and Android-free in `CarQsoStatus.kt` (`carStatusDashRow`, `carBandDashRow`, `carPotaDashRow`, `carRotaDashRow`, `carSessionDashRow`, `buildCarDashboardRows`, `formatMiles`, `minutesAgo`), unit-tested in `CarDashboardTest`. `QsoStatusScreen` rasterizes each `CarBadge` to a `CarIcon` bitmap (cached) and applies color spans, staying a thin wrapper. Activation rows keep #729's row-priority selection so the band row (not an activation) is the first to drop on a row-limited host.

Per-cycle decode count reads `vm.currentMessages` (the label overlay, cleared on a silent slot) rather than the cross-cycle `mutableFt8MessageList` — so "N decodes last cycle" is per-cycle and drops to 0. Read-only: the only action is `Decodes` (no TX control from the car).

## Crash fix (found during on-device verification)

The Car App Library **rejects `ForegroundCarColorSpan` on a Row title** — `Row.setTitle` validates against a no-color `CarTextConstraints` and throws `IllegalArgumentException`, which killed the CarAppService process the instant a populated pane rendered (the screen only ever fell back to the "open phone" `MessageTemplate`). Titles are now plain text; color spans are applied only to secondary lines, where the library permits them. This was invisible to unit tests (the crash is in the Android render layer) and only surfaced when driving the app on an emulator.

## Testing

- `CarDashboardTest` (pure model: badges, spans, rows, POTA/session variants) + full `testDebugUnitTest` — green.
- `assembleDebug` — clean (validates resources + manifest merge).
- **Verified live on an Android Automotive emulator** (`ft8af_aaos`, API 35): the pane renders with the colored badges and the POTA "to validate" secondary, no crash.

## Notes / caveats

- The design mockup colors row *titles* (green countdown, green QSO counts); the Car App Library only allows color on secondary text, so title emphasis is conveyed via the colored badges instead. Yellow SNR emphasis lives on the status secondary, which is allowed.
- Not exercised on-emulator: the ROTA row (a persisted trip made `startTrip` a no-op in the test harness) and the green "armed" state (the debug injector doesn't set `isActivated`) — both code paths are unit-tested.

## Supersedes

Replaces the closed #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)