### PR TITLE
CI: fix Play upload — stop forcing changesNotSentForReview

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -616,15 +616,15 @@ jobs:
           track: ${{ steps.tag.outputs.play_track }}
           status: completed
           releaseName: ${{ steps.tag.outputs.release_tag }}
-          # The app has pending Play Console changes that require review (e.g. the
-          # Android Auto removal / store-listing edits), so Google refuses to
-          # auto-send the edit for review from the API and the upload fails with
-          # "Changes cannot be sent for review automatically. Please set the query
-          # parameter changesNotSentForReview to true." Committing the edit WITHOUT
-          # auto-review lets the AAB land on the track; the release is then sent for
-          # review manually from the Play Console UI (Publishing overview -> Send
-          # for review). Harmless once no review-gated changes are pending.
-          changesNotSentForReview: true
+          # Let Google auto-send the release for review (the normal path). Do NOT
+          # set this true: that bypass is only accepted while the app has
+          # review-gated changes pending. Once it's a normal reviewed app, Google
+          # auto-sends changes for review and the edit-commit rejects the flag with
+          # "Changes are sent for review automatically. The query parameter
+          # changesNotSentForReview must not be set." — which failed the internal
+          # upload for the android-dev.1026 staging build. Flip back to true only if
+          # a future upload fails demanding it (a new review-gated change is pending).
+          changesNotSentForReview: false
 
       # Make a swallowed publish failure visible (annotation on the run) without
       # failing the job — the artifact + GitHub Release already succeeded.


### PR DESCRIPTION
## Problem

The `staging → main`/`dev → staging` Play uploads are silently failing. The signed AAB builds and the GitHub Release is created, but the **Play edit never commits**, so nothing reaches the track. The publish step is `continue-on-error`, so the CI run still shows green — the only signal is a `::warning::` annotation.

From the `android-dev.1026` staging run (the #732 promotion):

```
Successfully uploaded 1 artifacts
Committing the Edit
##[error]Changes are sent for review automatically. The query parameter changesNotSentForReview must not be set.
```

## Cause

`android.yml` hard-coded `changesNotSentForReview: true` on the `r0adkll/upload-google-play` step. Its own comment noted this was only needed **while the app had review-gated Play Console changes pending** (the Android Auto removal / store-listing edits) and was *"harmless once no review-gated changes are pending."*

That condition has flipped: the app is a normal reviewed app now, so Google **auto-sends** edits for review and **rejects** the `changesNotSentForReview` parameter entirely — the inverse of when the flag was added.

## Fix

Set `changesNotSentForReview: false` (auto-send for review — the default path), so the edit commits again. One-line value flip + updated comment explaining both states. Flip back to `true` only if a future upload fails demanding it (i.e. a new review-gated change is pending).

## Effect

- No app-code change; CI-only.
- Once this reaches `staging`, the next push to `staging` re-attempts the internal-track upload and should commit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)