### PR TITLE
iOS POTA: park search/picker parity

### DIFF
--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		035DDD710715AAC0100E0871 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3B4836E62F9DC32FAB0DE /* Colors.swift */; };
 		072D76FFDC706DE3E537A3C2 /* BlockedCallsignsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFDE0644205A9AE050BC0 /* BlockedCallsignsSettings.swift */; };
+		092F3A3A654939270685CC27 /* ParkPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F3AF234143FDFFA45B0AC8 /* ParkPickerSheet.swift */; };
+		094BBB2F12228E68B26D2DB1 /* PotaParkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8887498A3FE21F5B9ADAE63A /* PotaParkService.swift */; };
 		0FD449B6C15FD3407D8E3BC0 /* LogbookCharts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DFF1DC42A9F8F8066F97F7 /* LogbookCharts.swift */; };
 		208767EE6D89D470D7C88E77 /* WaterfallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */; };
 		26F661F120C34995BFF73F2D /* FT8DSP in Frameworks */ = {isa = PBXBuildFile; productRef = 93510ED81B9D113E387D0D45 /* FT8DSP */; };
@@ -90,6 +92,7 @@
 		4E09812700CD93E6187CC4BC /* LiveEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveEngine.swift; sourceTree = "<group>"; };
 		504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		5306EE5215AE14F95F3329F8 /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
+		55F3AF234143FDFFA45B0AC8 /* ParkPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkPickerSheet.swift; sourceTree = "<group>"; };
 		64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxStrip.swift; sourceTree = "<group>"; };
 		654EF0B6A0E279E65F355821 /* FT8AF.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FT8AF.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B9E40312EA203F05764FA56 /* QsoLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoLogStore.swift; sourceTree = "<group>"; };
@@ -100,6 +103,7 @@
 		82A0D66684F5C2F323454D9B /* FT8AFKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FT8AFKit; path = ../FT8AFKit; sourceTree = SOURCE_ROOT; };
 		8493B7CF97F9744DED622F15 /* ToastOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastOverlay.swift; sourceTree = "<group>"; };
 		87C51D7CB8A8FA5C3F883285 /* geist_mono_bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = geist_mono_bold.ttf; sourceTree = "<group>"; };
+		8887498A3FE21F5B9ADAE63A /* PotaParkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaParkService.swift; sourceTree = "<group>"; };
 		89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioAudioSettings.swift; sourceTree = "<group>"; };
 		8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldMapCanvas.swift; sourceTree = "<group>"; };
 		91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookStats.swift; sourceTree = "<group>"; };
@@ -274,6 +278,7 @@
 		948E7F983E403C535796BAB0 /* POTA */ = {
 			isa = PBXGroup;
 			children = (
+				55F3AF234143FDFFA45B0AC8 /* ParkPickerSheet.swift */,
 				B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */,
 			);
 			path = POTA;
@@ -330,6 +335,7 @@
 				4E09812700CD93E6187CC4BC /* LiveEngine.swift */,
 				D131B05E27A96EC4BEB28782 /* OnlineLogService.swift */,
 				FA66E8CE63C02CC35A2BC010 /* PotaActivationStore.swift */,
+				8887498A3FE21F5B9ADAE63A /* PotaParkService.swift */,
 				7E27EE4248BF38A15E0F3B2D /* PotaService.swift */,
 				6B9E40312EA203F05764FA56 /* QsoLogStore.swift */,
 				29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */,
@@ -464,7 +470,9 @@
 				6F7F961AB6678F3E6E60A97A /* LoggingSettings.swift in Sources */,
 				72300AB5D2B37428777C824D /* MapScreen.swift in Sources */,
 				8EF984B5816F012A2DF93FDF /* OnlineLogService.swift in Sources */,
+				092F3A3A654939270685CC27 /* ParkPickerSheet.swift in Sources */,
 				6A8A11D49F8CA3F24D9DED29 /* PotaActivationStore.swift in Sources */,
+				094BBB2F12228E68B26D2DB1 /* PotaParkService.swift in Sources */,
 				595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */,
 				B4122A07A833C6746F51D5D6 /* PotaService.swift in Sources */,
 				4D87F21162B4DCEC806D8785 /* QsoCelebration.swift in Sources */,

--- a/ios/FT8AF/FT8AF/Engine/PotaParkService.swift
+++ b/ios/FT8AF/FT8AF/Engine/PotaParkService.swift
@@ -1,0 +1,134 @@
+import FT8Engine
+import Foundation
+
+/// Read-only POTA park discovery for the Activate-tab park picker. Fetches park
+/// details, location codes, and per-location park lists from pota.app's public
+/// (no-auth) read API; all decoding + distance ranking is pure kit logic in
+/// `FT8Engine.PotaParks` (tested there with canned fixtures).
+///
+/// Direct port of Android's `PotaClient` (read endpoints) + `PotaParkRepository`
+/// discovery: same endpoints, same 30-minute in-memory cache TTL, same
+/// wide-candidate + max-distance nearby ranking. An `actor` gives the caches the
+/// same thread-safety Android gets from `ConcurrentHashMap`/`@Volatile` without a
+/// lock, since overlapping sheet opens can fetch concurrently.
+///
+/// SCOPE: read-only. No self-spot / upload / auth here — those are separate work.
+actor PotaParkService {
+    static let shared = PotaParkService()
+
+    private let userAgent = "ft8af-1.0"
+    private let timeout: TimeInterval = 10
+    private let cacheTTL: TimeInterval = 30 * 60  // 30 minutes, matching Android
+
+    // Caches (actor-isolated → no data races even under overlapping fetches).
+    private var cachedLocations: [PotaLocation]?
+    private var locationsTimestamp: Date?
+    private var parkCache: [String: [PotaPark]] = [:]
+    private var parkCacheTimestamp: [String: Date] = [:]
+    private var lookupCache: [String: PotaPark] = [:]
+
+    private init() {}
+
+    // MARK: - Discovery (mirrors PotaParkRepository)
+
+    /// The `PotaParks.nearbyLimit` closest parks to (`userLat`, `userLng`),
+    /// sorted ascending by distance. Fetches parks for the
+    /// `nearbyLocationCandidates` closest location codes concurrently (a wide net
+    /// to absorb POTA's mislocated region centers), then ranks by each park's own
+    /// coordinates and drops anything beyond `nearbyMaxDistanceKm`. Returns [] on
+    /// any network failure (the picker degrades to recents + manual entry).
+    func nearbyParks(userLat: Double, userLng: Double) async -> [PotaParkWithDistance] {
+        guard let locations = await locations() else { return [] }
+        let closest = PotaParks.findNearestLocationCodes(
+            userLat: userLat, userLng: userLng,
+            locations: locations, count: PotaParks.nearbyLocationCandidates)
+
+        // Fetch the candidate park lists concurrently — one slow region shouldn't
+        // serialize the whole sheet open (Android uses async/awaitAll).
+        var allParks: [PotaPark] = []
+        await withTaskGroup(of: [PotaPark]?.self) { group in
+            for code in closest {
+                group.addTask { await self.parksForLocation(code) }
+            }
+            for await result in group {
+                if let result { allParks.append(contentsOf: result) }
+            }
+        }
+        return PotaParks.sortParksByDistance(
+            allParks, userLat: userLat, userLng: userLng,
+            limit: PotaParks.nearbyLimit, maxDistanceKm: PotaParks.nearbyMaxDistanceKm)
+    }
+
+    /// Park details for recent park references (from activation history), newest
+    /// first. Refs are deduped/split; details resolved via the cached lookup
+    /// endpoint. Unknown refs (lookup failed) are dropped.
+    func recentParksWithDetails(rawRefs: [String]) async -> [PotaPark] {
+        let refs = PotaParks.deduplicateRefs(rawRefs)
+        var out: [PotaPark] = []
+        for ref in refs {
+            if let park = await lookupParkCached(ref) { out.append(park) }
+        }
+        return out
+    }
+
+    // MARK: - Endpoint wrappers with caching
+
+    private func lookupParkCached(_ reference: String) async -> PotaPark? {
+        let key = reference.trimmingCharacters(in: .whitespaces).uppercased()
+        if key.isEmpty { return nil }
+        if let hit = lookupCache[key] { return hit }
+        guard let data = await httpGet(PotaParks.parkURLString(reference: key)),
+              let park = PotaParks.decodePark(data, reference: key) else { return nil }
+        lookupCache[key] = park
+        return park
+    }
+
+    private func locations() async -> [PotaLocation]? {
+        if let cached = cachedLocations, let ts = locationsTimestamp,
+           Date().timeIntervalSince(ts) < cacheTTL {
+            return cached
+        }
+        guard let data = await httpGet(PotaParks.locationsURLString),
+              let result = PotaParks.decodeLocations(data) else {
+            return cachedLocations  // fall back to a stale cache if present
+        }
+        cachedLocations = result
+        locationsTimestamp = Date()
+        return result
+    }
+
+    private func parksForLocation(_ locationCode: String) async -> [PotaPark]? {
+        let code = locationCode.trimmingCharacters(in: .whitespaces).uppercased()
+        if code.isEmpty { return nil }
+        if let cached = parkCache[code], let ts = parkCacheTimestamp[code],
+           Date().timeIntervalSince(ts) < cacheTTL {
+            return cached
+        }
+        guard let data = await httpGet(PotaParks.locationParksURLString(locationCode: code)),
+              let result = PotaParks.decodeParks(data) else {
+            return parkCache[code]  // stale fallback
+        }
+        parkCache[code] = result
+        parkCacheTimestamp[code] = Date()
+        return result
+    }
+
+    // MARK: - HTTP
+
+    /// One GET returning the raw body on HTTP 200, nil on any error/non-200.
+    /// Mirrors `PotaService.refresh`'s request shaping (timeout + headers).
+    private func httpGet(_ urlString: String) async -> Data? {
+        guard let url = URL(string: urlString) else { return nil }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = timeout
+        req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            return data
+        } catch {
+            return nil
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/POTA/ParkPickerSheet.swift
+++ b/ios/FT8AF/FT8AF/Screens/POTA/ParkPickerSheet.swift
@@ -1,0 +1,219 @@
+import FT8Engine
+import SwiftUI
+
+/// Bottom-sheet park picker for the POTA Activate tab: recent activations and
+/// nearby parks (ranked by distance) from pota.app's read API, with a text
+/// filter. Selecting a park hands its reference back to fill the park-ref field;
+/// free-text entry remains as a fallback.
+///
+/// Port of Android's `ParkPickerSheet`. Nearby uses the operator's configured
+/// Maidenhead grid (Settings → `myGrid`) converted to lat/lon — iOS has no
+/// separate location permission, so an unset/invalid grid degrades gracefully to
+/// recents + manual entry (no prompt). Network failures are non-fatal: recents
+/// stay usable and a soft error is shown for nearby.
+struct ParkPickerSheet: View {
+    /// Operator grid from Settings (e.g. "FN20"); "" when unset.
+    let myGrid: String
+    /// Raw (possibly comma-joined) park refs from activation history, newest first.
+    let recentRefs: [String]
+    let onSelect: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var filter = ""
+
+    @State private var recentParks: [PotaPark] = []
+    @State private var recentLoading = true
+
+    @State private var nearbyParks: [PotaParkWithDistance] = []
+    @State private var nearbyLoading = true
+    /// nil while unknown; false when the grid can't provide coordinates.
+    @State private var locationAvailable = true
+
+    private var service: PotaParkService { PotaParkService.shared }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Grab handle + title
+            HStack {
+                Text("Search Parks")
+                    .font(.ft8afUI(size: 16, weight: .bold))
+                    .foregroundStyle(textPrimary)
+                Spacer()
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.ft8afUI(size: 20))
+                        .foregroundStyle(textFaint)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, 10)
+
+            // Search / filter field
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.ft8afUI(size: 14))
+                    .foregroundStyle(textMuted)
+                TextField("Filter by name or reference", text: $filter)
+                    .font(.ft8afUI(size: 14))
+                    .foregroundStyle(textPrimary)
+                    .textInputAutocapitalization(.characters)
+                    .autocorrectionDisabled()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 10).fill(bgSurface)
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(borderSubtle, lineWidth: 1))
+            )
+            .padding(.horizontal, 16)
+            .padding(.bottom, 8)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionHeader("RECENT PARKS")
+                    recentSection
+                    Spacer().frame(height: 10)
+                    sectionHeader("NEARBY PARKS")
+                    nearbySection
+                    Spacer().frame(height: 24)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 6)
+            }
+        }
+        .background(bgApp)
+        .task { await load() }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var recentSection: some View {
+        if recentLoading {
+            loadingRow("Loading recent parks…")
+        } else {
+            let filtered = PotaParks.filterParks(recentParks, query: filter)
+            if filtered.isEmpty {
+                emptyRow("No recent parks")
+            } else {
+                ForEach(filtered) { park in
+                    parkRow(reference: park.reference, name: park.name, subtitle: park.locationDesc)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var nearbySection: some View {
+        if nearbyLoading {
+            loadingRow("Finding nearby parks…")
+        } else if !locationAvailable {
+            emptyRow("Set your grid in Settings to see nearby parks")
+        } else {
+            let filtered = PotaParks.filterNearbyParks(nearbyParks, query: filter)
+            if filtered.isEmpty {
+                emptyRow("No nearby parks")
+            } else {
+                ForEach(filtered) { item in
+                    parkRow(
+                        reference: item.park.reference,
+                        name: item.park.name,
+                        subtitle: formatQsoDistance(km: item.distanceKm, inMiles: false))
+                }
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.ft8afMono(size: 11, weight: .semibold))
+            .foregroundStyle(textMuted)
+            .padding(.leading, 2)
+    }
+
+    private func parkRow(reference: String, name: String, subtitle: String) -> some View {
+        Button {
+            onSelect(reference)
+            dismiss()
+        } label: {
+            HStack(spacing: 8) {
+                Text(reference)
+                    .font(.ft8afMono(size: 11, weight: .semibold))
+                    .foregroundStyle(statusConfirmed)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6).fill(bgSurface2)
+                            .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(borderSubtle, lineWidth: 1))
+                    )
+                VStack(alignment: .leading, spacing: 1) {
+                    if !name.isEmpty {
+                        Text(name)
+                            .font(.ft8afUI(size: 13))
+                            .foregroundStyle(textPrimary)
+                            .lineLimit(1)
+                    }
+                    if !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(.ft8afUI(size: 11))
+                            .foregroundStyle(textMuted)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 10).fill(bgSurface)
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(borderSubtle, lineWidth: 1))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func loadingRow(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView().tint(accent)
+            Text(message)
+                .font(.ft8afUI(size: 12))
+                .foregroundStyle(textMuted)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+    }
+
+    private func emptyRow(_ message: String) -> some View {
+        Text(message)
+            .font(.ft8afUI(size: 12))
+            .foregroundStyle(textMuted)
+            .padding(.horizontal, 2)
+            .padding(.vertical, 8)
+    }
+
+    // MARK: - Loading
+
+    private func load() async {
+        // Recent parks — resolve details for recently-activated refs.
+        recentParks = await service.recentParksWithDetails(rawRefs: recentRefs)
+        recentLoading = false
+
+        // Nearby parks — derive coordinates from the operator's grid. No grid
+        // (or a malformed one) → degrade to recents + manual entry, no prompt.
+        if let coord = gridToLatLon(myGrid) {
+            nearbyParks = await service.nearbyParks(userLat: coord.0, userLng: coord.1)
+        } else {
+            locationAvailable = false
+        }
+        nearbyLoading = false
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
@@ -15,6 +15,7 @@ struct PotaScreen: View {
     @State private var selectedTab: PotaTab = .hunt
     @State private var shareURLs: [URL] = []
     @State private var showShare = false
+    @State private var showParkPicker = false
 
     private var spotService: PotaService { PotaService.shared }
 
@@ -78,6 +79,23 @@ struct PotaScreen: View {
         .sheet(isPresented: $showShare) {
             PotaShareSheet(items: shareURLs)
         }
+        .sheet(isPresented: $showParkPicker) {
+            ParkPickerSheet(
+                myGrid: appState.settings.myGrid,
+                recentRefs: recentParkRefs
+            ) { reference in
+                appState.pota.parkInput = reference
+            }
+        }
+    }
+
+    /// Park references from activation history, newest first, for the picker's
+    /// "Recent" section. Each record's `parkRef` may be comma-joined (two-fers);
+    /// the picker splits + dedupes via `PotaParks.deduplicateRefs`.
+    private var recentParkRefs: [String] {
+        appState.pota.activations
+            .sorted { $0.startedAtMs > $1.startedAtMs }
+            .map(\.parkRef)
     }
 
     // MARK: - Activation persistence
@@ -135,6 +153,32 @@ struct PotaScreen: View {
                         .textInputAutocapitalization(.characters)
                         .autocorrectionDisabled()
                 }
+                .padding(.horizontal, 40)
+
+                // Search parks (recent + nearby picker); free-text entry above
+                // remains the fallback.
+                Button {
+                    showParkPicker = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.ft8afUI(size: 12, weight: .semibold))
+                        Text("Search parks")
+                            .font(.ft8afUI(size: 13, weight: .semibold))
+                    }
+                    .foregroundStyle(accent)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 38)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(accent.opacity(0.12))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .strokeBorder(accent.opacity(0.3), lineWidth: 1)
+                            )
+                    )
+                }
+                .buttonStyle(.plain)
                 .padding(.horizontal, 40)
 
                 // Notes field

--- a/ios/FT8AFKit/Sources/FT8Engine/DisplayFormatters.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/DisplayFormatters.swift
@@ -17,20 +17,28 @@ public func relativeAge(secondsAgo: Int) -> String {
     }
 }
 
+/// Great-circle distance in kilometers between two latitude/longitude points
+/// (degrees). Shared haversine used by grid-based distance and by the POTA park
+/// picker's nearby ranking (`PotaParks`), mirroring Android's
+/// `MaidenheadGrid.getDist`.
+public func haversineKm(lat1: Double, lon1: Double, lat2: Double, lon2: Double) -> Double {
+    let earthRadiusKm = 6371.0
+    let dLat = (lat2 - lat1) * .pi / 180
+    let dLon = (lon2 - lon1) * .pi / 180
+    let a = lat1 * .pi / 180
+    let b = lat2 * .pi / 180
+    let sinDLat = sin(dLat / 2)
+    let sinDLon = sin(dLon / 2)
+    let h = sinDLat * sinDLat + cos(a) * cos(b) * sinDLon * sinDLon
+    return 2 * earthRadiusKm * asin(min(1, sqrt(h)))
+}
+
 /// Great-circle distance in kilometers between two Maidenhead locators, or
 /// nil when either grid is malformed (uses the shared `gridToLatLon`, which
 /// also rejects the "RR73"/"RR" sign-off tokens).
 public func gridDistanceKm(from myGrid: String, to theirGrid: String) -> Double? {
     guard let a = gridToLatLon(myGrid), let b = gridToLatLon(theirGrid) else { return nil }
-    let earthRadiusKm = 6371.0
-    let dLat = (b.0 - a.0) * .pi / 180
-    let dLon = (b.1 - a.1) * .pi / 180
-    let lat1 = a.0 * .pi / 180
-    let lat2 = b.0 * .pi / 180
-    let sinDLat = sin(dLat / 2)
-    let sinDLon = sin(dLon / 2)
-    let h = sinDLat * sinDLat + cos(lat1) * cos(lat2) * sinDLon * sinDLon
-    return 2 * earthRadiusKm * asin(min(1, sqrt(h)))
+    return haversineKm(lat1: a.0, lon1: a.1, lat2: b.0, lon2: b.1)
 }
 
 /// Kilometers → miles.

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaParks.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaParks.swift
@@ -1,0 +1,285 @@
+import Foundation
+
+/// Park metadata from pota.app's read API. Mirrors Android
+/// `radio.ks3ckc.ft8af.pota.model.PotaPark`: filled from the park-lookup
+/// endpoint (`/park/<ref>`) or the location-parks endpoint
+/// (`/location/parks/<code>`).
+public struct PotaPark: Equatable, Identifiable, Sendable {
+    public var reference: String
+    public var name: String
+    public var locationDesc: String
+    public var latitude: Double
+    public var longitude: Double
+    public var grid: String
+    public var activations: Int
+    public var qsos: Int
+
+    public var id: String { reference }
+
+    public init(
+        reference: String,
+        name: String,
+        locationDesc: String,
+        latitude: Double = 0.0,
+        longitude: Double = 0.0,
+        grid: String = "",
+        activations: Int = 0,
+        qsos: Int = 0
+    ) {
+        self.reference = reference
+        self.name = name
+        self.locationDesc = locationDesc
+        self.latitude = latitude
+        self.longitude = longitude
+        self.grid = grid
+        self.activations = activations
+        self.qsos = qsos
+    }
+}
+
+/// A POTA location code (e.g. "US-PA", "VE-ON") with its center coordinates.
+/// Mirrors Android `radio.ks3ckc.ft8af.pota.model.PotaLocation`.
+public struct PotaLocation: Equatable, Sendable {
+    public var locationDesc: String
+    public var locationName: String
+    public var latitude: Double
+    public var longitude: Double
+
+    public init(locationDesc: String, locationName: String, latitude: Double, longitude: Double) {
+        self.locationDesc = locationDesc
+        self.locationName = locationName
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}
+
+/// A park paired with its distance (km) from the user's position.
+/// Mirrors Android `radio.ks3ckc.ft8af.pota.model.PotaParkWithDistance`.
+public struct PotaParkWithDistance: Equatable, Identifiable, Sendable {
+    public var park: PotaPark
+    public var distanceKm: Double
+
+    public var id: String { park.reference }
+
+    public init(park: PotaPark, distanceKm: Double) {
+        self.park = park
+        self.distanceKm = distanceKm
+    }
+}
+
+/// Pure decode + ranking logic for the POTA park picker (recent + nearby park
+/// discovery). Network-free; the app-side `PotaParkService` owns the URLSession
+/// fetches. A faithful port of Android's `PotaClient` (read endpoints) and the
+/// pure helpers in `PotaParkRepository`.
+public enum PotaParks {
+
+    // MARK: - Endpoints (read-only; no auth)
+
+    /// pota.app read API base. Same host Android's `PotaClient` uses.
+    public static let baseURL = "https://api.pota.app"
+
+    /// GET park details by reference (e.g. "US-1234").
+    public static func parkURLString(reference: String) -> String {
+        "\(baseURL)/park/\(urlEncode(reference.trimmingCharacters(in: .whitespaces).uppercased()))"
+    }
+
+    /// GET all POTA location codes with their center coordinates.
+    public static let locationsURLString = "\(baseURL)/locations"
+
+    /// GET all parks within a POTA location code (e.g. "US-PA").
+    public static func locationParksURLString(locationCode: String) -> String {
+        "\(baseURL)/location/parks/\(urlEncode(locationCode.trimmingCharacters(in: .whitespaces).uppercased()))"
+    }
+
+    // MARK: - Ranking constants (ported from PotaParkRepository)
+
+    /// Number of nearest parks returned by `nearbyParks`.
+    public static let nearbyLimit = 50
+
+    /// POTA's `/locations` endpoint ships wrong center coordinates for a chunk
+    /// of foreign regions (ZA-FS, RU-VL, RO-OT all report centers in Kansas),
+    /// so the nearest-by-center ranking is noisy. We pull parks from a generous
+    /// set of candidate regions — enough that the user's true region(s) are
+    /// always included despite the bad rows — then rank by each park's own
+    /// (correct) coordinates.
+    public static let nearbyLocationCandidates = 12
+
+    /// Final safety net: drop parks farther than this so a continent-away park
+    /// (from a mislocated region) never surfaces under "Nearby".
+    public static let nearbyMaxDistanceKm = 1_000.0
+
+    // MARK: - Decoding (tolerant, mirroring Android optString/optDouble/optInt)
+
+    /// Decode a single `/park/<ref>` response into a `PotaPark`. The response has
+    /// no `reference` field, so the caller's requested `reference` (uppercased,
+    /// trimmed) is used. Returns nil when the payload isn't a JSON object.
+    public static func decodePark(_ data: Data, reference: String) -> PotaPark? {
+        guard let root = try? JSONSerialization.jsonObject(with: data),
+              let o = root as? [String: Any] else { return nil }
+        return PotaPark(
+            reference: reference.trimmingCharacters(in: .whitespaces).uppercased(),
+            name: str(o["name"]),
+            locationDesc: str(o["locationDesc"]),
+            latitude: dbl(o["latitude"]),
+            longitude: dbl(o["longitude"]),
+            grid: str(o["grid"]),
+            activations: int(o["activations"]),
+            qsos: int(o["qsos"])
+        )
+    }
+
+    /// Decode the `/locations` JSON array. Rows missing a latitude/longitude are
+    /// skipped (Android drops NaN rows). Returns nil only when the payload isn't
+    /// a JSON array.
+    public static func decodeLocations(_ data: Data) -> [PotaLocation]? {
+        guard let root = try? JSONSerialization.jsonObject(with: data),
+              let arr = root as? [Any] else { return nil }
+        var out: [PotaLocation] = []
+        out.reserveCapacity(arr.count)
+        for element in arr {
+            guard let o = element as? [String: Any] else { continue }
+            guard let lat = optDbl(o["latitude"]), let lng = optDbl(o["longitude"]) else { continue }
+            out.append(PotaLocation(
+                locationDesc: str(o["locationDesc"]),
+                locationName: str(o["locationName"]),
+                latitude: lat,
+                longitude: lng
+            ))
+        }
+        return out
+    }
+
+    /// Decode a `/location/parks/<code>` JSON array. Malformed elements are
+    /// skipped. Returns nil only when the payload isn't a JSON array.
+    public static func decodeParks(_ data: Data) -> [PotaPark]? {
+        guard let root = try? JSONSerialization.jsonObject(with: data),
+              let arr = root as? [Any] else { return nil }
+        var out: [PotaPark] = []
+        out.reserveCapacity(arr.count)
+        for element in arr {
+            guard let o = element as? [String: Any] else { continue }
+            out.append(PotaPark(
+                reference: str(o["reference"]),
+                name: str(o["name"]),
+                locationDesc: str(o["locationDesc"]),
+                latitude: dbl(o["latitude"]),
+                longitude: dbl(o["longitude"]),
+                grid: str(o["grid"]),
+                activations: int(o["activations"]),
+                qsos: int(o["qsos"])
+            ))
+        }
+        return out
+    }
+
+    // MARK: - Pure ranking helpers (unit-tested; port of PotaParkRepository)
+
+    /// Pick the `count` POTA location codes whose center is nearest to
+    /// (`userLat`, `userLng`). Returns each row's `locationDesc` (e.g. "US-PA").
+    public static func findNearestLocationCodes(
+        userLat: Double,
+        userLng: Double,
+        locations: [PotaLocation],
+        count: Int
+    ) -> [String] {
+        locations
+            .map { ($0, haversineKm(lat1: userLat, lon1: userLng, lat2: $0.latitude, lon2: $0.longitude)) }
+            .sorted { $0.1 < $1.1 }
+            .prefix(count)
+            .map { $0.0.locationDesc }
+    }
+
+    /// Compute the distance from (`userLat`, `userLng`) to each park, sort
+    /// ascending, and return the closest `limit`. Parks farther than
+    /// `maxDistanceKm` are dropped (defaults to no cap). Parks whose coordinates
+    /// are both zero (no coordinates) are skipped, matching Android.
+    public static func sortParksByDistance(
+        _ parks: [PotaPark],
+        userLat: Double,
+        userLng: Double,
+        limit: Int,
+        maxDistanceKm: Double = .greatestFiniteMagnitude
+    ) -> [PotaParkWithDistance] {
+        parks
+            .filter { $0.latitude != 0.0 || $0.longitude != 0.0 }
+            .map {
+                PotaParkWithDistance(
+                    park: $0,
+                    distanceKm: haversineKm(
+                        lat1: userLat, lon1: userLng, lat2: $0.latitude, lon2: $0.longitude)
+                )
+            }
+            .filter { $0.distanceKm <= maxDistanceKm }
+            .sorted { $0.distanceKm < $1.distanceKm }
+            .prefix(limit)
+            .map { $0 }
+    }
+
+    /// Split comma-separated park reference strings and deduplicate, preserving
+    /// first-seen (most-recent) order. Port of Android's `deduplicateRefs`.
+    public static func deduplicateRefs(_ rawRefs: [String]) -> [String] {
+        var seen: [String] = []
+        var seenSet = Set<String>()
+        for raw in rawRefs {
+            for part in raw.split(separator: ",", omittingEmptySubsequences: false) {
+                let ref = part.trimmingCharacters(in: .whitespaces)
+                if !ref.isEmpty && seenSet.insert(ref).inserted {
+                    seen.append(ref)
+                }
+            }
+        }
+        return seen
+    }
+
+    /// Filter parks by name or reference (case-insensitive substring match).
+    /// Port of Android's `filterParks`.
+    public static func filterParks(_ parks: [PotaPark], query: String) -> [PotaPark] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        if q.isEmpty { return parks }
+        return parks.filter {
+            $0.reference.lowercased().contains(q) || $0.name.lowercased().contains(q)
+        }
+    }
+
+    /// Filter nearby parks by name or reference (case-insensitive substring
+    /// match). Port of Android's `filterNearbyParks`.
+    public static func filterNearbyParks(
+        _ parks: [PotaParkWithDistance], query: String
+    ) -> [PotaParkWithDistance] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        if q.isEmpty { return parks }
+        return parks.filter {
+            $0.park.reference.lowercased().contains(q) || $0.park.name.lowercased().contains(q)
+        }
+    }
+
+    // MARK: - Tolerant JSON field extraction (matches PotaSpots)
+
+    private static func str(_ any: Any?) -> String {
+        if let s = any as? String { return s }
+        if any == nil || any is NSNull { return "" }
+        if let n = any as? NSNumber { return n.stringValue }
+        return ""
+    }
+
+    /// Double with a 0 default (Android `optDouble(key, 0.0)`).
+    private static func dbl(_ any: Any?) -> Double { optDbl(any) ?? 0 }
+
+    /// Optional double: nil when the field is absent/null/unparseable
+    /// (Android `optDouble(key, NaN)` + `isNaN` check for locations).
+    private static func optDbl(_ any: Any?) -> Double? {
+        if let n = any as? NSNumber { return n.doubleValue }
+        if let s = any as? String { return Double(s) }
+        return nil
+    }
+
+    private static func int(_ any: Any?) -> Int {
+        if let n = any as? NSNumber { return n.intValue }
+        if let s = any as? String { return Int(s) ?? 0 }
+        return 0
+    }
+
+    private static func urlEncode(_ s: String) -> String {
+        s.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? s
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaParks.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaParks.swift
@@ -280,6 +280,13 @@ public enum PotaParks {
     }
 
     private static func urlEncode(_ s: String) -> String {
-        s.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? s
+        // Encode as a SINGLE path segment: `.urlPathAllowed` permits `/` (and
+        // `%`), so a user-typed ref/location code could otherwise inject extra
+        // path segments. Restrict to RFC 3986 unreserved chars so `/`, `%`, etc.
+        // are percent-encoded. Real refs ("US-1234") / codes ("US-PA") are
+        // unaffected.
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return s.addingPercentEncoding(withAllowedCharacters: allowed) ?? s
     }
 }

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaParksTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaParksTests.swift
@@ -278,4 +278,13 @@ final class PotaParksTests: XCTestCase {
             PotaParks.locationParksURLString(locationCode: "us-pa"),
             "https://api.pota.app/location/parks/US-PA")
     }
+
+    func testEndpointURLsEncodeSinglePathSegment() {
+        // A ref/code containing '/' must be percent-encoded so it can't inject
+        // extra path segments into the request URL.
+        XCTAssertEqual(
+            PotaParks.parkURLString(reference: "us-1/../admin"),
+            "https://api.pota.app/park/US-1%2F..%2FADMIN")
+        XCTAssertFalse(PotaParks.locationParksURLString(locationCode: "a/b").contains("/parks/A/B"))
+    }
 }

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaParksTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaParksTests.swift
@@ -1,0 +1,281 @@
+import XCTest
+import FT8Engine
+
+/// Unit tests for the pure park-picker helpers in `PotaParks`: distance ranking,
+/// nearest-location selection, ref deduplication, filtering, and tolerant JSON
+/// decoding of the pota.app read-API responses. Direct port of Android's
+/// `PotaParkPickerLogicTest` (plus decode coverage for the endpoints ported from
+/// `PotaClient`).
+final class PotaParksTests: XCTestCase {
+
+    private func park(
+        _ ref: String, _ name: String, lat: Double = 0, lng: Double = 0
+    ) -> PotaPark {
+        PotaPark(reference: ref, name: name, locationDesc: "", latitude: lat, longitude: lng)
+    }
+
+    // MARK: - deduplicateRefs
+
+    func testDeduplicateRefsSplitsCommaSeparated() {
+        XCTAssertEqual(PotaParks.deduplicateRefs(["K-1234,K-5678"]), ["K-1234", "K-5678"])
+    }
+
+    func testDeduplicateRefsRemovesDuplicatesPreservingFirst() {
+        XCTAssertEqual(
+            PotaParks.deduplicateRefs(["K-1234", "K-5678,K-1234"]),
+            ["K-1234", "K-5678"])
+    }
+
+    func testDeduplicateRefsTrimsWhitespaceAndSkipsEmpty() {
+        XCTAssertEqual(
+            PotaParks.deduplicateRefs([" K-0001 , , K-0002 "]),
+            ["K-0001", "K-0002"])
+    }
+
+    func testDeduplicateRefsEmptyInput() {
+        XCTAssertTrue(PotaParks.deduplicateRefs([]).isEmpty)
+    }
+
+    func testDeduplicateRefsPreservesMostRecentFirstOrder() {
+        XCTAssertEqual(
+            PotaParks.deduplicateRefs(["K-0003", "K-0002", "K-0001"]),
+            ["K-0003", "K-0002", "K-0001"])
+    }
+
+    // MARK: - findNearestLocationCodes
+
+    func testFindNearestLocationCodesPicksNClosest() {
+        // Philadelphia (39.95, -75.17); PA and NJ are closest.
+        let locations = [
+            PotaLocation(locationDesc: "US-PA", locationName: "Pennsylvania", latitude: 40.27, longitude: -76.88),
+            PotaLocation(locationDesc: "US-CA", locationName: "California", latitude: 36.78, longitude: -119.42),
+            PotaLocation(locationDesc: "US-NJ", locationName: "New Jersey", latitude: 40.06, longitude: -74.41),
+            PotaLocation(locationDesc: "US-TX", locationName: "Texas", latitude: 31.97, longitude: -99.90),
+        ]
+        let result = PotaParks.findNearestLocationCodes(
+            userLat: 39.95, userLng: -75.17, locations: locations, count: 2)
+        XCTAssertEqual(result, ["US-NJ", "US-PA"])
+    }
+
+    func testFindNearestLocationCodesReturnsFewerWhenInputSmall() {
+        let locations = [
+            PotaLocation(locationDesc: "US-PA", locationName: "Pennsylvania", latitude: 40.27, longitude: -76.88),
+        ]
+        let result = PotaParks.findNearestLocationCodes(
+            userLat: 39.95, userLng: -75.17, locations: locations, count: 5)
+        XCTAssertEqual(result, ["US-PA"])
+    }
+
+    func testBroadeningCandidateCountRescuesRealRegionFromBadCenters() {
+        // POTA ships wrong centers for some foreign regions: ZA-FS, RU-VL, RO-OT
+        // all report centers in Kansas, out-ranking a Kansas user's real state.
+        let locations = [
+            PotaLocation(locationDesc: "ZA-FS", locationName: "Free State", latitude: 38.9717, longitude: -95.2355),
+            PotaLocation(locationDesc: "RU-VL", locationName: "Vladimir", latitude: 39.0904, longitude: -94.5877),
+            PotaLocation(locationDesc: "RO-OT", locationName: "Olt", latitude: 39.768, longitude: -94.8509),
+            PotaLocation(locationDesc: "US-KS", locationName: "Kansas", latitude: 38.5266, longitude: -96.7265),
+            PotaLocation(locationDesc: "US-MO", locationName: "Missouri", latitude: 38.4561, longitude: -92.2884),
+        ]
+        let narrow = PotaParks.findNearestLocationCodes(
+            userLat: 39.0, userLng: -94.6, locations: locations, count: 3)
+        XCTAssertFalse(narrow.contains("US-KS"))
+
+        let wide = PotaParks.findNearestLocationCodes(
+            userLat: 39.0, userLng: -94.6, locations: locations,
+            count: PotaParks.nearbyLocationCandidates)
+        XCTAssertTrue(wide.contains("US-KS"))
+        XCTAssertTrue(wide.contains("US-MO"))
+    }
+
+    // MARK: - sortParksByDistance
+
+    func testSortParksByDistanceOrdersAscending() {
+        let parks = [
+            park("K-0001", "Far Park", lat: 34.05, lng: -118.24),   // LA
+            park("K-0002", "Near Park", lat: 40.06, lng: -74.41),   // NJ
+            park("K-0003", "Medium Park", lat: 38.90, lng: -77.03), // DC
+        ]
+        let result = PotaParks.sortParksByDistance(parks, userLat: 39.95, userLng: -75.17, limit: 50)
+        XCTAssertEqual(result.map(\.park.reference), ["K-0002", "K-0003", "K-0001"])
+    }
+
+    func testSortParksByDistanceRespectsLimit() {
+        let parks = (1...100).map { i in
+            park(String(format: "K-%04d", i), "Park \(i)", lat: 40.0 + Double(i) * 0.01, lng: -75.0)
+        }
+        let result = PotaParks.sortParksByDistance(parks, userLat: 40.0, userLng: -75.0, limit: 50)
+        XCTAssertEqual(result.count, 50)
+    }
+
+    func testSortParksByDistanceSkipsZeroCoordinates() {
+        let parks = [
+            park("K-0001", "No Coords", lat: 0.0, lng: 0.0),
+            park("K-0002", "Real Park", lat: 40.06, lng: -74.41),
+        ]
+        let result = PotaParks.sortParksByDistance(parks, userLat: 39.95, userLng: -75.17, limit: 50)
+        XCTAssertEqual(result.map(\.park.reference), ["K-0002"])
+    }
+
+    func testSortParksByDistanceDropsBeyondMaxDistance() {
+        let parks = [
+            park("US-0001", "Local Park", lat: 40.06, lng: -74.41),  // NJ near Philadelphia
+            park("RU-0024", "Far Park", lat: 55.0, lng: 40.0),       // Russia ~8000 km
+        ]
+        let result = PotaParks.sortParksByDistance(
+            parks, userLat: 39.95, userLng: -75.17, limit: 50, maxDistanceKm: 1_000.0)
+        XCTAssertEqual(result.map(\.park.reference), ["US-0001"])
+    }
+
+    func testSortParksByDistanceKeepsAllWhenNoCap() {
+        let parks = [
+            park("US-0001", "Local Park", lat: 40.06, lng: -74.41),
+            park("RU-0024", "Far Park", lat: 55.0, lng: 40.0),
+        ]
+        let result = PotaParks.sortParksByDistance(parks, userLat: 39.95, userLng: -75.17, limit: 50)
+        XCTAssertEqual(result.map(\.park.reference), ["US-0001", "RU-0024"])
+    }
+
+    func testSortParksByDistanceIncludesDistance() {
+        let parks = [park("K-0001", "Park", lat: 40.06, lng: -74.41)]
+        let result = PotaParks.sortParksByDistance(parks, userLat: 39.95, userLng: -75.17, limit: 50)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertGreaterThan(result[0].distanceKm, 0.0)
+    }
+
+    // MARK: - filterParks / filterNearbyParks
+
+    func testFilterParksReturnsAllWhenBlank() {
+        let parks = [park("K-0001", "Valley Forge"), park("K-0002", "Liberty Bell")]
+        XCTAssertEqual(PotaParks.filterParks(parks, query: "").count, 2)
+        XCTAssertEqual(PotaParks.filterParks(parks, query: "  ").count, 2)
+    }
+
+    func testFilterParksMatchesReferenceCaseInsensitive() {
+        let parks = [park("K-0001", "Valley Forge"), park("K-0002", "Liberty Bell")]
+        let result = PotaParks.filterParks(parks, query: "k-0001")
+        XCTAssertEqual(result.map(\.reference), ["K-0001"])
+    }
+
+    func testFilterParksMatchesNameSubstring() {
+        let parks = [
+            park("K-0001", "Valley Forge National Historical Park"),
+            park("K-0002", "Liberty Bell Trail"),
+        ]
+        let result = PotaParks.filterParks(parks, query: "forge")
+        XCTAssertEqual(result.count, 1)
+        XCTAssertTrue(result[0].name.contains("Forge"))
+    }
+
+    func testFilterParksEmptyWhenNoMatch() {
+        XCTAssertTrue(PotaParks.filterParks([park("K-0001", "Valley Forge")], query: "xyz").isEmpty)
+    }
+
+    func testFilterNearbyParksReturnsAllWhenBlank() {
+        let items = [
+            PotaParkWithDistance(park: park("K-0001", "Park One"), distanceKm: 10),
+            PotaParkWithDistance(park: park("K-0002", "Park Two"), distanceKm: 20),
+        ]
+        XCTAssertEqual(PotaParks.filterNearbyParks(items, query: "").count, 2)
+    }
+
+    func testFilterNearbyParksMatchesByReferenceOrName() {
+        let items = [
+            PotaParkWithDistance(park: park("K-0001", "Park Alpha"), distanceKm: 10),
+            PotaParkWithDistance(park: park("K-0002", "Park Beta"), distanceKm: 20),
+        ]
+        XCTAssertEqual(PotaParks.filterNearbyParks(items, query: "alpha").count, 1)
+        XCTAssertEqual(PotaParks.filterNearbyParks(items, query: "K-0002").count, 1)
+    }
+
+    // MARK: - JSON decoding (pota.app read API shapes from PotaClient.kt)
+
+    func testDecodeParkParsesFields() throws {
+        // GET /park/<ref> — object without a "reference" field (caller supplies it).
+        let json = """
+        {"parkId": 6789, "reference": "US-1234", "name": "Valley Forge National Historical Park",
+         "latitude": 40.1015, "longitude": -75.4210, "grid": "FN20id",
+         "locationDesc": "US-PA", "activations": 342, "qsos": 51234,
+         "firstActivator": "K3XYZ", "firstActivationDate": "2015-06-13"}
+        """
+        let park = try XCTUnwrap(PotaParks.decodePark(Data(json.utf8), reference: "us-1234"))
+        XCTAssertEqual(park.reference, "US-1234")  // from the requested ref, uppercased
+        XCTAssertEqual(park.name, "Valley Forge National Historical Park")
+        XCTAssertEqual(park.locationDesc, "US-PA")
+        XCTAssertEqual(park.latitude, 40.1015, accuracy: 0.0001)
+        XCTAssertEqual(park.longitude, -75.4210, accuracy: 0.0001)
+        XCTAssertEqual(park.grid, "FN20id")
+        XCTAssertEqual(park.activations, 342)
+        XCTAssertEqual(park.qsos, 51234)
+    }
+
+    func testDecodeParkToleratesMissingFields() throws {
+        let park = try XCTUnwrap(PotaParks.decodePark(Data("{}".utf8), reference: "US-9999"))
+        XCTAssertEqual(park.reference, "US-9999")
+        XCTAssertEqual(park.name, "")
+        XCTAssertEqual(park.latitude, 0.0)
+        XCTAssertEqual(park.activations, 0)
+    }
+
+    func testDecodeParkReturnsNilOnNonObject() {
+        XCTAssertNil(PotaParks.decodePark(Data("[1,2,3]".utf8), reference: "US-1"))
+        XCTAssertNil(PotaParks.decodePark(Data("not json".utf8), reference: "US-1"))
+    }
+
+    func testDecodeLocationsParsesAndSkipsMissingCoords() throws {
+        // GET /locations — array; a row lacking coordinates is dropped.
+        let json = """
+        [
+          {"locationId": 1, "locationDesc": "US-PA", "locationName": "Pennsylvania",
+           "latitude": 40.9946, "longitude": -77.6055, "parks": 3100},
+          {"locationId": 2, "locationDesc": "US-XX", "locationName": "No Coords", "parks": 0},
+          {"locationId": 3, "locationDesc": "CA-ON", "locationName": "Ontario",
+           "latitude": 50.0, "longitude": -85.0, "parks": 900}
+        ]
+        """
+        let locations = try XCTUnwrap(PotaParks.decodeLocations(Data(json.utf8)))
+        XCTAssertEqual(locations.count, 2)
+        XCTAssertEqual(locations[0].locationDesc, "US-PA")
+        XCTAssertEqual(locations[0].locationName, "Pennsylvania")
+        XCTAssertEqual(locations[0].latitude, 40.9946, accuracy: 0.0001)
+        XCTAssertEqual(locations[1].locationDesc, "CA-ON")
+    }
+
+    func testDecodeLocationsReturnsNilOnNonArray() {
+        XCTAssertNil(PotaParks.decodeLocations(Data("{}".utf8)))
+    }
+
+    func testDecodeParksParsesArray() throws {
+        // GET /location/parks/<code> — array of parks with their own coordinates.
+        let json = """
+        [
+          {"reference": "US-1234", "name": "Valley Forge NHP", "latitude": 40.1015,
+           "longitude": -75.4210, "grid": "FN20id", "locationDesc": "US-PA",
+           "parktypeDesc": "National Historical Park", "activations": 342, "qsos": 51234},
+          {"reference": "US-5678", "name": "Ridley Creek State Park", "latitude": 39.9490,
+           "longitude": -75.4530, "grid": "FN20", "locationDesc": "US-PA",
+           "activations": 88, "qsos": 9001}
+        ]
+        """
+        let parks = try XCTUnwrap(PotaParks.decodeParks(Data(json.utf8)))
+        XCTAssertEqual(parks.count, 2)
+        XCTAssertEqual(parks[0].reference, "US-1234")
+        XCTAssertEqual(parks[0].name, "Valley Forge NHP")
+        XCTAssertEqual(parks[0].latitude, 40.1015, accuracy: 0.0001)
+        XCTAssertEqual(parks[1].reference, "US-5678")
+        XCTAssertEqual(parks[1].activations, 88)
+    }
+
+    func testDecodeParksReturnsNilOnNonArray() {
+        XCTAssertNil(PotaParks.decodeParks(Data("{}".utf8)))
+    }
+
+    // MARK: - Endpoint URL construction
+
+    func testEndpointURLs() {
+        XCTAssertEqual(PotaParks.parkURLString(reference: "us-1234"), "https://api.pota.app/park/US-1234")
+        XCTAssertEqual(PotaParks.locationsURLString, "https://api.pota.app/locations")
+        XCTAssertEqual(
+            PotaParks.locationParksURLString(locationCode: "us-pa"),
+            "https://api.pota.app/location/parks/US-PA")
+    }
+}


### PR DESCRIPTION
## What
Brings iOS POTA to Android parity for **park discovery** — iOS previously only allowed typing a park reference by hand.

Ports Android's park search (read-only pota.app API, **no auth**):
- **`PotaParks`** (FT8Engine, pure/tested): models + tolerant JSON decoders for `/park/<ref>`, `/locations`, `/location/parks/<code>`, and the ranking helpers (`findNearestLocationCodes`, `sortParksByDistance`, `deduplicateRefs`) ported from `PotaParkRepository`, including the mislocated-region distance cap.
- **`PotaParkService`** (app): `URLSession` fetches + 30-min `actor` cache.
- **`ParkPickerSheet`**: **Recent** (from activation history) + **Nearby** (ranked by the operator's Maidenhead grid) + a filter field.
- Wired into the **Activate** tab via a "Search parks" button; free-text entry kept as fallback. Degrades gracefully with no grid / offline (recents + manual entry stay usable).

## Scope
Read-only park discovery only. Self-spot / authenticated upload / OAuth are **not** in this PR (separate future work).

## Tests
386 FT8AFKit tests pass — 29 new `PotaParksTests` (mirroring Android's `PotaParkPickerLogicTest` + JSON-decode coverage). App builds clean. `project.pbxproj` regenerated via `xcodegen` for the two new app-level files.

Part of the iOS↔Android parity sweep (POTA domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)