### PR TITLE
iOS decode: cross-slot hashed-call resolution + junk rejection

### DIFF
--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -17,6 +17,12 @@ final class LiveEngine {
     private var engineTask: Task<Void, Never>?
     private var rxOffsetMs: Int64 = 0
 
+    // Persistent callsign-hash store, shared across every per-slot decoder so a
+    // hashed compound call (`<...>`) resolves against a full call heard in an
+    // earlier slot (matching Android's static hashList). Lives for the engine's
+    // lifetime; bounds its own growth internally.
+    private let hashTable = HashTable()
+
     // WSJT-X UDP interface (broadcast + inbound requests).
     private let udp = WsjtxUdpService()
     private var udpStatusTask: Task<Void, Never>?
@@ -369,7 +375,9 @@ final class LiveEngine {
 
             // Extract the slot's audio and decode.
             let samples = accumulator.takeSlot()
-            let decoder = FT8Decoder()
+            // Share the engine-lifetime hash table so `<...>` compound calls
+            // resolve across slots (a fresh decoder is built each slot).
+            let decoder = FT8Decoder(hashTable: hashTable)
             decoder.feedSlot(samples)
             decoder.findSync()
             let decoded = decoder.decodeAll()

--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
@@ -37,10 +37,17 @@ public final class FT8Decoder {
     private var candidates = [candidate_t](repeating: candidate_t(), count: FT8Decoder.maxCandidates)
     private var numCandidates = 0
     private var ldpcIters = FT8Decoder.ldpcItersNormal
-    private let hashtable = HashTable()
+    private let hashtable: HashTable
 
     /// Create a decoder for the given sample rate. `isFT8 = false` selects FT4.
-    public init(sampleRate: Int32 = FT8.sampleRate, isFT8: Bool = true) {
+    ///
+    /// `hashTable` is the callsign-hash store used to resolve hashed compound
+    /// calls (`<...>`). Pass a shared, long-lived table (as LiveEngine does) so
+    /// hashes resolve across slots even though a fresh decoder is built each
+    /// slot; the default is a private per-decoder table (same-slot resolution
+    /// only), which keeps standalone/one-shot decodes isolated.
+    public init(sampleRate: Int32 = FT8.sampleRate, isFT8: Bool = true, hashTable: HashTable = HashTable()) {
+        self.hashtable = hashTable
         var cfg = monitor_config_t()
         cfg.f_min = 100
         cfg.f_max = 3500
@@ -64,10 +71,10 @@ public final class FT8Decoder {
         let block = Int(mon.block_size)
         if block == 0 { return }
         monitor_reset(&mon)
-        // Reset the callsign cache per slot: hashes resolve only against calls
-        // seen "earlier in the same slot", and a never-cleared table would grow
-        // unbounded across slots on a long-lived decoder.
-        hashtable.clear()
+        // The callsign hash table is intentionally NOT cleared here: it persists
+        // across slots so a `<...>` hash resolves against a full compound call
+        // decoded in an earlier slot (matching Android's static hashList). The
+        // table bounds its own growth (see HashTable.capacity).
         samples.withUnsafeBufferPointer { buf in
             guard let base = buf.baseAddress else { return }
             var pos = 0
@@ -206,6 +213,9 @@ public final class FT8Decoder {
             // Free text + contest sub-types: full text already in rawText.
             m.extra = m.rawText
         }
+        // Drop CRC-collision garbage before it reaches the UI/log (mirrors
+        // Android Ft8Message.isJunkDecode). Free text / telemetry are exempt.
+        if isJunkDecode(i3: m.i3, n3: m.n3, callFrom: m.callFrom) { return nil }
         return m
     }
 }

--- a/ios/FT8AFKit/Sources/FT8DSP/HashTable.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/HashTable.swift
@@ -1,52 +1,85 @@
 import CFT8
 import Foundation
 
-/// Per-decoder callsign hash table, ported from desktop dsp/hashtable.rs (itself
-/// from ft8af_glue/ft8_decoder.cpp). FT8 messages can carry 10/12/22-bit *hashes*
-/// of compound/nonstandard callsigns instead of the full call; ft8_lib resolves
-/// them through the `ftx_callsign_hash_interface_t` save/lookup callbacks, which
-/// need somewhere to stash calls seen earlier in the same slot.
-final class HashTable {
-    static let size = 256
+/// Callsign hash table for resolving hashed compound/nonstandard calls (the
+/// `<...>` placeholders FT8 carries as 10/12/22-bit *hashes* instead of the full
+/// call). ft8_lib resolves them through the `ftx_callsign_hash_interface_t`
+/// save/lookup callbacks, which need a store of calls seen earlier.
+///
+/// Unlike the original per-slot table (ported from desktop dsp/hashtable.rs /
+/// ft8af_glue/ft8_decoder.cpp, which cleared every slot), this table is meant to
+/// **persist across slots** so a `<...>` in one slot resolves against a full call
+/// decoded in an *earlier* slot — matching Android, which keeps the store in a
+/// process-wide `static MessageHashMap hashList` (Ft8Message.java) that is never
+/// cleared. LiveEngine owns one instance and injects it into every per-slot
+/// `FT8Decoder` (a fresh decoder is built each slot), so the store outlives the
+/// decoder.
+///
+/// Android's map is unbounded; on a phone we cap the store at `capacity` entries
+/// and evict oldest-first (insertion-order FIFO) on overflow. A session sees far
+/// fewer than `capacity` distinct compound calls inside the window where a
+/// `<...>` back-reference is still useful, and the oldest calls are the least
+/// likely to be referenced again — so the cap bounds memory without losing
+/// resolvable hashes in practice.
+///
+/// Every method takes an internal lock, so one table can be shared safely across
+/// concurrent or re-entrant decode passes: the thread-local active-table plumbing
+/// below may point several threads at the same instance at once.
+public final class HashTable: @unchecked Sendable {
+    // @unchecked Sendable: all mutable state is guarded by `lock`, so instances
+    // are safe to share across actors/threads (e.g. the engine passing one into
+    // each nonisolated per-slot decode).
+
+    /// Max stored callsigns before oldest-first eviction bounds a long-lived
+    /// (process-lifetime) table. See the type doc for the rationale.
+    static let capacity = 512
 
     private struct Entry {
-        var callsign = [UInt8](repeating: 0, count: 12)
-        var hash: UInt32 = 0   // 22-bit
-        var used = false
+        let callsign: String
+        let hash22: UInt32   // 22-bit hash, masked to 0x3FFFFF
     }
-    private var entries = [Entry](repeating: Entry(), count: HashTable.size)
+    // Insertion-ordered: newest appended at the end, oldest (index 0) evicted
+    // first once `capacity` is exceeded.
+    private var entries: [Entry] = []
+    // 22-bit hashes currently stored, for O(1) duplicate rejection.
+    private var stored = Set<UInt32>()
+    private let lock = NSLock()
 
+    public init() {}
+
+    /// Drop every stored callsign. No longer called per slot (the table now
+    /// persists), but kept for tests and explicit resets.
     func clear() {
-        entries = [Entry](repeating: Entry(), count: HashTable.size)
+        lock.lock(); defer { lock.unlock() }
+        entries.removeAll(keepingCapacity: true)
+        stored.removeAll(keepingCapacity: true)
     }
 
-    /// Mirror of `hash_save` in ft8_decoder.cpp.
+    /// Mirror of `hash_save` / `MessageHashMap.addHash`: store `callsign` under
+    /// its 22-bit hash. Skips empties and the `<...>`-wrapped placeholder form,
+    /// dedupes on the 22-bit hash, and evicts the oldest entry once full.
     func save(_ callsign: String, _ n22: UInt32) {
-        let bytes = Array(callsign.utf8)
-        if bytes.isEmpty || bytes[0] == UInt8(ascii: "<") { return }
-        let h10 = (n22 >> 12) & 0x3FF
-        var idx = (Int(h10) * 23) % HashTable.size
-        var probes = 0
-        while entries[idx].used {
-            if entries[idx].hash == n22 { return } // already stored
-            idx = (idx + 1) % HashTable.size
-            probes += 1
-            if probes >= HashTable.size { return } // table full: drop, never spin
+        if callsign.isEmpty || callsign.hasPrefix("<") { return }
+        let hash22 = n22 & 0x3F_FFFF
+        lock.lock(); defer { lock.unlock() }
+        if stored.contains(hash22) { return } // already stored
+        entries.append(Entry(callsign: callsign, hash22: hash22))
+        stored.insert(hash22)
+        if entries.count > HashTable.capacity {
+            let evicted = entries.removeFirst()
+            stored.remove(evicted.hash22)
         }
-        let n = min(bytes.count, 11)
-        var cs = [UInt8](repeating: 0, count: 12)
-        cs.replaceSubrange(0..<n, with: bytes[0..<n])
-        entries[idx].callsign = cs
-        entries[idx].hash = n22
-        entries[idx].used = true
     }
 
-    /// Mirror of `hash_lookup`. `shift` selects the hash width (0 / 10 / 12).
+    /// Mirror of `hash_lookup`: find a stored call whose 22-bit hash, shifted
+    /// right by `shift` (0 / 10 / 12 for the 22/12/10-bit lookups), equals
+    /// `hash`. Newest match wins, so a recently re-heard call supersedes a stale
+    /// collision on the narrower widths.
     func lookup(shift: UInt8, hash: UInt32) -> String? {
-        for e in entries where e.used {
-            if ((e.hash & 0x3F_FFFF) >> shift) == hash {
-                let len = e.callsign.firstIndex(of: 0) ?? 11
-                return String(decoding: e.callsign[0..<len], as: UTF8.self)
+        lock.lock(); defer { lock.unlock() }
+        for e in entries.reversed() {
+            if (e.hash22 >> shift) == hash {
+                return e.callsign
             }
         }
         return nil

--- a/ios/FT8AFKit/Sources/FT8DSP/JunkFilter.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/JunkFilter.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// CRC-collision / false-decode rejection, ported from Android
+/// `Ft8Message.isPlausibleCallsign` / `isJunkDecode`.
+///
+/// FT8 guards each 77-bit frame with only a 14-bit CRC, so roughly one noise
+/// event in 16k slips through as a "valid" decode. When that garbage lands in a
+/// callsign-bearing frame, the corrupt sender field renders as junk like
+/// `.<. >`. These pure predicates let the decode path drop such frames before
+/// they reach the UI/log.
+
+/// Whether a callsign field could be a real call.
+///
+/// A real field uses only the `[A-Z0-9/]` alphabet, optionally wrapped in a
+/// single `<...>` (a hashed / nonstandard call), or is the bare `<...>`
+/// placeholder shown before a hash resolves. Anything else — stray angle
+/// brackets, embedded spaces, dots — is the junk a CRC-collision false decode
+/// renders into the sender field.
+func isPlausibleCallsign(_ callsign: String) -> Bool {
+    var s = callsign.trimmingCharacters(in: .whitespacesAndNewlines)
+    if s.isEmpty { return false }
+    if s == "<...>" { return true } // unresolved hashed-call placeholder
+    // Strip a single matching <...> wrapper around a hashed / nonstandard call.
+    if s.count > 2, s.hasPrefix("<"), s.hasSuffix(">") {
+        s = String(s.dropFirst().dropLast())
+    }
+    // Only the call alphabet may remain — no leftover brackets, spaces, dots.
+    // Manual scan keeps this off the regex compiler on the decode hot-path.
+    for c in s.utf8 {
+        let inAlphabet = (c >= UInt8(ascii: "A") && c <= UInt8(ascii: "Z"))
+            || (c >= UInt8(ascii: "0") && c <= UInt8(ascii: "9"))
+            || c == UInt8(ascii: "/")
+        if !inAlphabet { return false }
+    }
+    return true
+}
+
+/// Whether a decode is CRC-collision garbage that should be dropped.
+///
+/// A structured decode is junk when its sender isn't a plausible callsign. Free
+/// text (`i3=0, n3=0`) and telemetry (`i3=0, n3=5`) legitimately carry
+/// non-callsign text in that field, so they are never treated as junk.
+func isJunkDecode(i3: UInt8, n3: UInt8, callFrom: String) -> Bool {
+    let freeText = (i3 == 0 && n3 == 0)
+    let telemetry = (i3 == 0 && n3 == 5)
+    if freeText || telemetry { return false }
+    return !isPlausibleCallsign(callFrom)
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/FT8DecoderTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/FT8DecoderTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CFT8
 @testable import FT8DSP
 
 /// Phase 1 gate: prove the from-source decode path works end to end by encoding
@@ -68,7 +69,7 @@ final class FT8DecoderTests: XCTestCase {
     }
 
     /// A long-lived decoder must stay correct across repeated feedSlot calls
-    /// (feedSlot clears the per-slot callsign cache; no stale-state corruption).
+    /// (no stale monitor/candidate state corrupting later slots).
     func testDecoderReusableAcrossSlots() {
         guard let s = slot(for: "CQ K1ABC FN42", baseFreqHz: 1200) else { return XCTFail("encode") }
         let dec = FT8Decoder()
@@ -78,6 +79,81 @@ final class FT8DecoderTests: XCTestCase {
         let second = Set(dec.decodeAll().map { $0.rawText })
         XCTAssertEqual(first, second)
         XCTAssertTrue(first.contains("CQ K1ABC FN42"))
+    }
+
+    /// A hashed compound call (`<...>`) must resolve against a full call heard in
+    /// an EARLIER slot when the decoders share one persistent hash table — the
+    /// cross-slot resolution LiveEngine relies on (a fresh decoder per slot).
+    func testHashedCallResolvesAcrossSlots() {
+        // Slot 1: `CQ PJ4/K1ABC` as a genuine Type 4 frame carries PJ4/K1ABC in
+        // full (58-bit), so decoding it saves the call's hash into the table.
+        guard let s1 = nonstdSlot(callTo: "CQ", callDe: "PJ4/K1ABC", baseFreqHz: 1500) else {
+            return XCTFail("encode s1")
+        }
+        // Slot 2: `PJ4/K1ABC W9XYZ` sends PJ4/K1ABC only as a 12-bit hash, so it
+        // renders `<...>` unless that hash is already known.
+        guard let s2 = nonstdSlot(callTo: "PJ4/K1ABC", callDe: "W9XYZ", baseFreqHz: 1500) else {
+            return XCTFail("encode s2")
+        }
+
+        let shared = HashTable()
+
+        // Fresh decoder per slot (as LiveEngine builds), sharing one table.
+        let d1 = FT8Decoder(hashTable: shared)
+        d1.feedSlot(s1); d1.findSync()
+        let m1 = d1.decodeAll().map { $0.rawText.trimmingCharacters(in: .whitespaces) }
+        XCTAssertTrue(m1.contains("CQ PJ4/K1ABC"), "slot 1 should decode the defining call: \(m1)")
+
+        let d2 = FT8Decoder(hashTable: shared)
+        d2.feedSlot(s2); d2.findSync()
+        let m2 = d2.decodeAll().map { $0.rawText.trimmingCharacters(in: .whitespaces) }
+        // The hash saved in slot 1 now resolves in slot 2 -> full call rendered as
+        // `<PJ4/K1ABC>` (brackets mark a resolved-from-hash call), not `<...>`.
+        XCTAssertTrue(m2.contains { $0.contains("<PJ4/K1ABC>") }, "slot 2 should resolve earlier hash: \(m2)")
+        XCTAssertFalse(m2.contains { $0.contains("<...>") }, "no unresolved placeholder expected: \(m2)")
+    }
+
+    /// The same hashed-call slot stays UNresolved when the table never saw the
+    /// defining call — proving resolution comes from the persistent store, not
+    /// something intrinsic to the frame.
+    func testHashedCallUnresolvedWhenNeverSeen() {
+        guard let s2 = nonstdSlot(callTo: "PJ4/K1ABC", callDe: "W9XYZ", baseFreqHz: 1500) else {
+            return XCTFail("encode s2")
+        }
+        let fresh = HashTable() // never saw the defining call
+        let d = FT8Decoder(hashTable: fresh)
+        d.feedSlot(s2); d.findSync()
+        let m = d.decodeAll().map(\.rawText)
+        XCTAssertTrue(m.contains { $0.contains("<...>") }, "unknown hash should render <...>: \(m)")
+    }
+
+    /// Lay a genuine Type 4 (nonstandard/hashed-call) FT8 frame at the start of a
+    /// 15 s slot. The legacy `pack77` path can't emit Type 4, so we drive
+    /// `ftx_message_encode_nonstd` directly (as WSJT-X does over the air).
+    private func nonstdSlot(callTo: String, callDe: String, extra: String = "",
+                            baseFreqHz: Float, gain: Float = 0.5) -> [Float]? {
+        var msg = ftx_message_t()
+        var iface = makeHashInterface()
+        // encode_nonstd hashes the compound call through the interface; give the
+        // save callback a throwaway active table to write into.
+        let scratch = HashTable()
+        installActiveHashTable(scratch)
+        defer { clearActiveHashTable() }
+        let rc = callTo.withCString { ct in
+            callDe.withCString { cd in
+                extra.withCString { ex in
+                    ftx_message_encode_nonstd(&msg, &iface, ct, cd, ex)
+                }
+            }
+        }
+        guard rc == FTX_MESSAGE_RC_OK else { return nil }
+        var payload = [UInt8](repeating: 0, count: 10)
+        withUnsafeBytes(of: msg.payload) { raw in for i in 0..<10 { payload[i] = raw[i] } }
+        let tones = FT8Encoder.encodeTones(payload)
+        var s = [Float](repeating: 0, count: FT8.slotSamples)
+        FT8Encoder.synthGFSK(tones: tones, f0: baseFreqHz, sampleRate: FT8.sampleRate, into: &s, offset: 0)
+        for i in 0..<s.count { s[i] *= gain }
+        return s
     }
 
     /// feedSlot populates the waterfall so a heatmap can be built (Phase 2 UI).
@@ -112,15 +188,21 @@ final class HashTableTests: XCTestCase {
         XCTAssertNil(t.lookup(shift: 0, hash: FT8Hash.n22("W9XYZ") & 0x3F_FFFF))
     }
 
-    /// Saving past capacity must terminate (bounded linear probe), never hang,
-    /// and the table must still answer a hash stored before it filled.
-    func testSaveIsBoundedWhenTableFull() {
+    /// Saving past capacity must stay bounded and evict oldest-first (FIFO):
+    /// the newest entries survive, the oldest are dropped, and lookups never hang.
+    func testBoundedGrowthEvictsOldest() {
         let t = HashTable()
-        for i in 0..<(HashTable.size + 10) {
-            t.save("C\(i)", (UInt32(i) << 12) & 0x3F_FFFF)
+        let overflow = 10
+        let total = HashTable.capacity + overflow
+        for i in 1...total {
+            t.save("C\(i)", UInt32(i) & 0x3F_FFFF) // distinct non-zero hashes
         }
-        // Reaching here means every save() returned (no infinite loop).
-        XCTAssertNotNil(t.lookup(shift: 0, hash: 0)) // "C0" (n22 == 0) stored first
+        // Newest survives; first `overflow` entries were evicted.
+        XCTAssertEqual(t.lookup(shift: 0, hash: UInt32(total)), "C\(total)")
+        XCTAssertNil(t.lookup(shift: 0, hash: 1), "oldest should be evicted")
+        XCTAssertNil(t.lookup(shift: 0, hash: UInt32(overflow)), "oldest window evicted")
+        // First entry that should still fit under the cap.
+        XCTAssertEqual(t.lookup(shift: 0, hash: UInt32(overflow + 1)), "C\(overflow + 1)")
     }
 
     func testClearEmptiesTable() {
@@ -140,5 +222,38 @@ final class HashTableTests: XCTestCase {
         XCTAssertFalse(looksLikeGrid("SN42"))  // S > R
         XCTAssertFalse(looksLikeGrid("F142"))  // second char not a letter
         XCTAssertFalse(looksLikeGrid("FNAB"))  // last two not digits
+    }
+}
+
+/// Junk / false-decode rejection (ported from Android isPlausibleCallsign /
+/// isJunkDecode).
+final class JunkFilterTests: XCTestCase {
+    func testPlausibleCallsignsAccepted() {
+        // Standard, portable, compound, and hashed forms are all plausible.
+        for c in ["W1AW", "K1ABC", "K1ABC/P", "VE3/K1ABC", "G4ABC/P", "PJ4/K1ABC",
+                  "<...>", "<PJ4/K1ABC>"] {
+            XCTAssertTrue(isPlausibleCallsign(c), "\(c) should be plausible")
+        }
+    }
+
+    func testJunkCallsignsRejected() {
+        // CRC-collision garbage: stray brackets, spaces, dots.
+        for c in [".<. >", "<>", "< >", "K1 ABC", "K1.ABC", "", "   ", "<<K1ABC>>"] {
+            XCTAssertFalse(isPlausibleCallsign(c), "\(c) should be rejected")
+        }
+    }
+
+    func testJunkDecodeExemptsFreeTextAndTelemetry() {
+        // Free text (i3=0,n3=0) and telemetry (i3=0,n3=5) legitimately carry
+        // non-callsign text in the sender field — never junk.
+        XCTAssertFalse(isJunkDecode(i3: 0, n3: 0, callFrom: "TNX 73 GL"))
+        XCTAssertFalse(isJunkDecode(i3: 0, n3: 5, callFrom: "123456789ABCDE"))
+    }
+
+    func testJunkDecodeDropsImplausibleSender() {
+        XCTAssertTrue(isJunkDecode(i3: 1, n3: 0, callFrom: ".<. >"))
+        XCTAssertFalse(isJunkDecode(i3: 1, n3: 0, callFrom: "K1ABC"))
+        XCTAssertFalse(isJunkDecode(i3: 4, n3: 0, callFrom: "<...>"))       // unresolved hash ok
+        XCTAssertFalse(isJunkDecode(i3: 4, n3: 0, callFrom: "<PJ4/K1ABC>")) // resolved hash ok
     }
 }


### PR DESCRIPTION
## What
Two self-contained iOS decode-parity fixes matching Android.

### 1. Cross-slot `<...>` hashed-callsign resolution
iOS cleared its callsign hash table **every slot** and built a fresh `FT8Decoder` per slot, so a hashed compound call (`<...>`) could never resolve against the full call heard in an *earlier* slot. Android keeps a process-wide `static MessageHashMap`.

- `HashTable` is now **engine-owned** (`LiveEngine` holds one) and injected into each per-slot `FT8Decoder(hashTable:)`; `feedSlot` no longer clears it.
- Rewritten to be `NSLock`-guarded / `@unchecked Sendable` (safe across the concurrent per-slot decode passes and the thread-local active-table callbacks), **bounded at 512 entries with oldest-first FIFO eviction** (Android's is unbounded; capped for phone memory), preserving 22/12/10-bit widest-first lookup.

### 2. Junk / false-decode rejection
FT8's 14-bit CRC lets ~1/16k noise events through as garbage decodes. New pure `JunkFilter` (`isPlausibleCallsign` / `isJunkDecode`, ported from `Ft8Message`) drops them in `buildMessage` before they reach the UI/log. Free-text and telemetry frames are exempt.

## Tests
364 FT8AFKit tests pass — cross-slot resolve (via real Type-4 nonstd frames), unresolved-when-unseen, bounded-eviction, and junk/plausible-callsign cases. App builds clean.

Part of the iOS↔Android parity sweep (decode domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)