### PR TITLE
iOS POTA: activation writes (CQ-POTA modifier, QSO stamping, P2P ADIF)

### DIFF
--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -700,6 +700,16 @@ final class LiveEngine {
         // Assign a unique ID based on the current record count.
         let nextId = Int64((appState.logbook.records.map { $0.id ?? 0 }.max() ?? 0) + 1)
         record.id = nextId
+        // Stamp POTA ADIF fields (Android: PotaSessionManager.stampQso). MY_SIG /
+        // MY_SIG_INFO mark it as part of our own activation; SIG / SIG_INFO record
+        // the worked station's park when they're a currently-spotted activator
+        // (park-to-park). Both are no-ops when their input is nil.
+        let stamp = potaQsoStamp(
+            activationParkRef: appState.pota.current?.parkRef,
+            workedParkRef: PotaSpots.parkRef(
+                forCallsign: record.call, in: PotaService.shared.spots)
+        )
+        applyPotaStamp(stamp, to: &record)
         appState.logbook.records.insert(record, at: 0)
         QsoLogStore.save(appState.logbook.records)
         // Broadcast the logged QSO over the WSJT-X UDP interface.
@@ -867,6 +877,10 @@ final class LiveEngine {
         qso.band = s.band
         qso.freqMhz = bandToFreqMhz(s.band)
         qso.autoReturnToCq = s.autoCQAfterQSO
+        // While a POTA activation is running, transmit "CQ POTA <call> <grid>"
+        // (Android forces GeneralVariables.toModifier = "POTA" on start and
+        // clears it on end — mirrored here so every CQ-building path picks it up).
+        qso.cqModifier = appState.pota.isActivating ? potaSigProgram : ""
     }
 
     /// Reflect QSO engine status into the UI TxState.

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaAdif.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaAdif.swift
@@ -60,6 +60,11 @@ extension Adif {
                 potaField(&out, "MY_SIG", "POTA")
                 // Pinned to this single park (not the comma-separated activation ref).
                 potaField(&out, "MY_SIG_INFO", parkRef)
+                // Park-to-park: the worked station's park, stamped at log time when
+                // they were a spotted activator. Empty (omitted) for a normal QSO.
+                // Matches Android's buildActivationAdif SIG/SIG_INFO emission.
+                potaField(&out, "SIG", r.sig)
+                potaField(&out, "SIG_INFO", r.sigInfo)
                 out += "<EOR>\n"
             }
             return PotaDocument(

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaSpots.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaSpots.swift
@@ -131,6 +131,36 @@ public enum PotaSpots {
         }
     }
 
+    // MARK: - Park-to-park activator lookup
+
+    /// Normalize a decoded callsign into the spot-cache match key. Port of
+    /// Android's `spotLookupKey`: strip the angle brackets FT8 non-standard /
+    /// hashed calls come wrapped in (`<K1ABC/P>`, or `<...>` when unresolved),
+    /// trim, and uppercase. Returns nil for an empty/whitespace-only result so
+    /// callers can bail early.
+    public static func spotLookupKey(_ callsign: String?) -> String? {
+        guard let raw = callsign else { return nil }
+        let key = raw
+            .replacingOccurrences(of: "<", with: "")
+            .replacingOccurrences(of: ">", with: "")
+            .trimmingCharacters(in: .whitespaces)
+            .uppercased()
+        return key.isEmpty ? nil : key
+    }
+
+    /// The park reference `callsign` is currently spotted activating, or nil when
+    /// they aren't a current activator. Port of Android
+    /// `PotaSpotsRepository.parkRefFor`: match the live spots by uppercased
+    /// activator call (after `spotLookupKey` normalization) and return their
+    /// non-empty reference. Used at QSO-log time to fill SIG/SIG_INFO for a
+    /// park-to-park contact.
+    public static func parkRef(forCallsign callsign: String?, in spots: [PotaSpot]) -> String? {
+        guard let key = spotLookupKey(callsign) else { return nil }
+        let ref = spots.first { $0.activator.uppercased() == key }?.reference
+        guard let ref, !ref.isEmpty else { return nil }
+        return ref
+    }
+
     // MARK: - Tolerant JSON field extraction
 
     private static func str(_ any: Any?) -> String {

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaStamp.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaStamp.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// POTA ADIF fields stamped onto a logged QSO. Port of the four columns Android's
+/// `PotaSessionManager.stampQso` writes onto a `QSLRecord`: MY_SIG/MY_SIG_INFO
+/// identify the contact as part of *our* activation; SIG/SIG_INFO record the
+/// worked station's park for a park-to-park (P2P) contact. Empty strings mean
+/// "don't emit" (the ADIF writer skips empty fields).
+public struct PotaStampFields: Equatable, Sendable {
+    public var mySig: String
+    public var mySigInfo: String
+    public var sig: String
+    public var sigInfo: String
+
+    public init(
+        mySig: String = "", mySigInfo: String = "",
+        sig: String = "", sigInfo: String = ""
+    ) {
+        self.mySig = mySig
+        self.mySigInfo = mySigInfo
+        self.sig = sig
+        self.sigInfo = sigInfo
+    }
+}
+
+/// The `MY_SIG`/`SIG` program value POTA expects.
+public let potaSigProgram = "POTA"
+
+/// Pure POTA stamping decision — port of Android `PotaSessionManager.stampQso`.
+///
+/// - `activationParkRef`: the active activation's (possibly comma-separated
+///   two-fer) park ref, or nil when no activation is running. When present it
+///   stamps MY_SIG=POTA / MY_SIG_INFO=<ref> so the export identifies the QSO as
+///   part of our activation.
+/// - `workedParkRef`: the worked station's park reference when they are a
+///   currently-spotted POTA activator (resolve via `PotaSpots.parkRef`), or nil
+///   otherwise. When present it stamps SIG=POTA / SIG_INFO=<ref> for P2P.
+///
+/// The two are independent: a QSO can be neither, either, or both (a P2P logged
+/// during our own activation carries all four fields).
+public func potaQsoStamp(
+    activationParkRef: String?, workedParkRef: String?
+) -> PotaStampFields {
+    var fields = PotaStampFields()
+    if let mine = activationParkRef?.trimmingCharacters(in: .whitespaces),
+       !mine.isEmpty {
+        fields.mySig = potaSigProgram
+        fields.mySigInfo = mine
+    }
+    if let theirs = workedParkRef?.trimmingCharacters(in: .whitespaces),
+       !theirs.isEmpty {
+        fields.sig = potaSigProgram
+        fields.sigInfo = theirs
+    }
+    return fields
+}
+
+/// Apply POTA stamp fields onto a QSO record in place — mirrors the mutating
+/// half of Android's `stampQso(record, spottedParkRef)`. Keeps the caller
+/// (LiveEngine's log path) a thin wire between the pure decision and the record.
+public func applyPotaStamp(_ fields: PotaStampFields, to record: inout QsoRecord) {
+    record.mySig = fields.mySig
+    record.mySigInfo = fields.mySigInfo
+    record.sig = fields.sig
+    record.sigInfo = fields.sigInfo
+}

--- a/ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/QsoEngine.swift
@@ -52,6 +52,12 @@ public final class QsoEngine {
     public var freqMhz: String = ""
     public var active: Bool = false
     public var autoReturnToCq: Bool = true
+    /// CQ modifier inserted between "CQ" and our callsign — the iOS analog of
+    /// Android's `GeneralVariables.toModifier`. Empty for a plain "CQ <call>
+    /// <grid>"; "POTA" while a POTA activation is running, so CQs go out as
+    /// "CQ POTA <call> <grid>". Set/cleared by the engine wiring (LiveEngine)
+    /// from the activation state.
+    public var cqModifier: String = ""
 
     private var stage: TxStage = .idle
     private var target: String?
@@ -98,7 +104,7 @@ public final class QsoEngine {
         resetQso()
         active = true
         stage = .cq
-        pendingTx = "CQ \(myCall) \(myGrid)"
+        pendingTx = buildCqMessage(modifier: cqModifier, myCall: myCall, myGrid: myGrid)
     }
 
     /// Begin answering a specific decoded CQ (operator tapped a station).
@@ -330,11 +336,28 @@ public final class QsoEngine {
         if autoReturnToCq {
             resetQso()
             stage = .cq
-            pendingTx = "CQ \(myCall) \(myGrid)"
+            pendingTx = buildCqMessage(modifier: cqModifier, myCall: myCall, myGrid: myGrid)
         } else {
             stop()
         }
     }
+}
+
+/// Build the CQ transmit message, optionally with a CQ modifier (e.g. "POTA")
+/// inserted between "CQ" and the callsign — the iOS analog of Android building
+/// "CQ <toModifier> <call> <grid>" via `Ft8Message`. FT8 only packs a standard
+/// CQ modifier of 1–4 alphanumeric characters ("CQ POTA W1AW FN31"); a modifier
+/// outside that shape (empty, too long, punctuation) is dropped so we never hand
+/// the encoder a message it can't pack. Callsign/grid are passed through
+/// verbatim (already uppercased by the engine).
+func buildCqMessage(modifier: String, myCall: String, myGrid: String) -> String {
+    let mod = modifier.trimmingCharacters(in: .whitespaces).uppercased()
+    let valid = (1...4).contains(mod.count)
+        && mod.allSatisfy { $0.isLetter || $0.isNumber }
+    if valid {
+        return "CQ \(mod) \(myCall) \(myGrid)"
+    }
+    return "CQ \(myCall) \(myGrid)"
 }
 
 /// FT8 reports are clamped to roughly [-30, +30].

--- a/ios/FT8AFKit/Sources/FT8Engine/QsoRecord.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/QsoRecord.swift
@@ -27,6 +27,15 @@ public struct QsoRecord: Equatable, Codable {
     /// Whether this QSO has been accepted by the QRZ.com logbook
     /// (Android: QSLTable.synced_qrz).
     public var syncedQrz: Bool
+    /// POTA activation ADIF fields (Android: QSLTable.my_sig / my_sig_info /
+    /// sig / sig_info). `mySig`/`mySigInfo` = "POTA"/<my park ref> when this QSO
+    /// was logged during our own activation; `sig`/`sigInfo` = "POTA"/<their
+    /// park ref> for a park-to-park contact with a spotted activator. All empty
+    /// for a normal QSO. Stamped at log time by `potaQsoStamp`.
+    public var mySig: String
+    public var mySigInfo: String
+    public var sig: String
+    public var sigInfo: String
 
     public init(
         id: Int64? = nil,
@@ -45,7 +54,11 @@ public struct QsoRecord: Equatable, Codable {
         myGridsquare: String,
         comment: String,
         syncedCloudlog: Bool = false,
-        syncedQrz: Bool = false
+        syncedQrz: Bool = false,
+        mySig: String = "",
+        mySigInfo: String = "",
+        sig: String = "",
+        sigInfo: String = ""
     ) {
         self.id = id
         self.call = call
@@ -64,6 +77,10 @@ public struct QsoRecord: Equatable, Codable {
         self.comment = comment
         self.syncedCloudlog = syncedCloudlog
         self.syncedQrz = syncedQrz
+        self.mySig = mySig
+        self.mySigInfo = mySigInfo
+        self.sig = sig
+        self.sigInfo = sigInfo
     }
 
     /// Custom decode so JSON logs written before the sync flags existed still
@@ -88,5 +105,9 @@ public struct QsoRecord: Equatable, Codable {
         comment = try c.decode(String.self, forKey: .comment)
         syncedCloudlog = try c.decodeIfPresent(Bool.self, forKey: .syncedCloudlog) ?? false
         syncedQrz = try c.decodeIfPresent(Bool.self, forKey: .syncedQrz) ?? false
+        mySig = try c.decodeIfPresent(String.self, forKey: .mySig) ?? ""
+        mySigInfo = try c.decodeIfPresent(String.self, forKey: .mySigInfo) ?? ""
+        sig = try c.decodeIfPresent(String.self, forKey: .sig) ?? ""
+        sigInfo = try c.decodeIfPresent(String.self, forKey: .sigInfo) ?? ""
     }
 }

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaAdifTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaAdifTests.swift
@@ -9,13 +9,13 @@ final class PotaAdifTests: XCTestCase {
     private func rec(
         call: String, grid: String = "FN31", mode: String = "FT8",
         qsoDate: String = "20260713", timeOn: String = "123000",
-        timeOff: String = "123115"
+        timeOff: String = "123115", sig: String = "", sigInfo: String = ""
     ) -> QsoRecord {
         QsoRecord(
             call: call, gridsquare: grid, mode: mode, rstSent: "-05", rstRcvd: "-08",
             qsoDate: qsoDate, timeOn: timeOn, qsoDateOff: qsoDate, timeOff: timeOff,
             band: "20M", freq: "14.074", stationCallsign: "KD2OGR",
-            myGridsquare: "FN20", comment: "")
+            myGridsquare: "FN20", comment: "", sig: sig, sigInfo: sigInfo)
     }
 
     private func activation(
@@ -84,6 +84,34 @@ final class PotaAdifTests: XCTestCase {
             records: [rec(call: "W1AW", mode: "FT8")], activation: activation())
         XCTAssertTrue(docs[0].content.contains("<MODE:3>FT8 "))
         XCTAssertFalse(docs[0].content.contains("SUBMODE"))
+    }
+
+    // MARK: - Park-to-park SIG / SIG_INFO
+
+    func testParkToParkQsoEmitsSigAndSigInfo() {
+        let docs = Adif.potaActivationExport(
+            records: [rec(call: "K1ABC", sig: "POTA", sigInfo: "K-1234")],
+            activation: activation())
+        let content = docs[0].content
+        // Our own park.
+        XCTAssertTrue(content.contains("<MY_SIG:4>POTA "))
+        XCTAssertTrue(content.contains("<MY_SIG_INFO:7>US-7443 "))
+        // Their park (park-to-park).
+        XCTAssertTrue(content.contains("<SIG:4>POTA "))
+        XCTAssertTrue(content.contains("<SIG_INFO:6>K-1234 "))
+        // SIG must follow MY_SIG_INFO (matches Android field order).
+        let mySigInfoRange = content.range(of: "<MY_SIG_INFO")!
+        let sigRange = content.range(of: "<SIG:")!
+        XCTAssertTrue(sigRange.lowerBound > mySigInfoRange.lowerBound)
+    }
+
+    func testNormalQsoOmitsSigAndSigInfo() {
+        let docs = Adif.potaActivationExport(
+            records: [rec(call: "W1AW")], activation: activation())
+        let content = docs[0].content
+        XCTAssertTrue(content.contains("<MY_SIG:4>POTA "))
+        XCTAssertFalse(content.contains("<SIG:"))
+        XCTAssertFalse(content.contains("<SIG_INFO:"))
     }
 
     // MARK: - Multi-park (two-fer)

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaCqModifierTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaCqModifierTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import FT8DSP
+@testable import FT8Engine
+
+/// Covers the iOS analog of Android's `GeneralVariables.toModifier`: while a POTA
+/// activation is running the CQ transmits as "CQ POTA <call> <grid>" instead of
+/// a plain "CQ <call> <grid>".
+final class PotaCqModifierTests: XCTestCase {
+
+    // MARK: - Pure builder
+
+    func testPlainCqWhenNoModifier() {
+        XCTAssertEqual(
+            buildCqMessage(modifier: "", myCall: "W1AW", myGrid: "FN31"),
+            "CQ W1AW FN31")
+    }
+
+    func testPotaModifierProducesCqPota() {
+        XCTAssertEqual(
+            buildCqMessage(modifier: "POTA", myCall: "W1AW", myGrid: "FN31"),
+            "CQ POTA W1AW FN31")
+    }
+
+    func testModifierIsUppercasedAndTrimmed() {
+        XCTAssertEqual(
+            buildCqMessage(modifier: "  pota ", myCall: "W1AW", myGrid: "FN31"),
+            "CQ POTA W1AW FN31")
+    }
+
+    func testWhitespaceOnlyModifierDroppedToPlainCq() {
+        XCTAssertEqual(
+            buildCqMessage(modifier: "   ", myCall: "W1AW", myGrid: "FN31"),
+            "CQ W1AW FN31")
+    }
+
+    func testOverlongModifierDroppedSoMessageNeverOverflows() {
+        // FT8 only packs a 1–4 char alphanumeric CQ modifier; a 5-char modifier
+        // is dropped rather than building an unencodable message.
+        XCTAssertEqual(
+            buildCqMessage(modifier: "PARKS", myCall: "W1AW", myGrid: "FN31"),
+            "CQ W1AW FN31")
+    }
+
+    func testPunctuationModifierDropped() {
+        XCTAssertEqual(
+            buildCqMessage(modifier: "P-1", myCall: "W1AW", myGrid: "FN31"),
+            "CQ W1AW FN31")
+    }
+
+    // MARK: - Engine integration (start CQ + auto-return to CQ)
+
+    func testEngineStartCqUsesModifierWhenActive() {
+        let e = QsoEngine(myCall: "W1AW", myGrid: "FN31")
+        e.cqModifier = "POTA"
+        e.startCq()
+        XCTAssertEqual(e.txMessage, "CQ POTA W1AW FN31")
+    }
+
+    func testEngineStartCqPlainWhenInactive() {
+        let e = QsoEngine(myCall: "W1AW", myGrid: "FN31")
+        e.startCq() // cqModifier defaults to ""
+        XCTAssertEqual(e.txMessage, "CQ W1AW FN31")
+    }
+
+    func testAutoReturnToCqKeepsModifier() {
+        // After a completed QSO the engine returns to CQ; the POTA modifier must
+        // survive so the run keeps calling "CQ POTA ...".
+        let e = QsoEngine(myCall: "K0XYZ", myGrid: "EN37")
+        e.cqModifier = "POTA"
+        e.answer(DecodedMessage.cq(from: "K1ABC", grid: "FN42", snr: -5))
+        _ = e.processRx([DecodedMessage.to("K0XYZ", from: "K1ABC", extra: "-12")])
+        let out = e.processRx([DecodedMessage.to("K0XYZ", from: "K1ABC", extra: "RR73")])
+        guard case .completed? = out else { return XCTFail("expected completed QSO") }
+        e.notifyTransmitted()
+        _ = e.processRx([])
+        XCTAssertEqual(e.txMessage, "CQ POTA K0XYZ EN37")
+    }
+}
+
+private extension DecodedMessage {
+    static func cq(from: String, grid: String, snr: Int) -> DecodedMessage {
+        to("CQ", from: from, extra: grid, grid: grid, snr: snr)
+    }
+
+    static func to(
+        _ to: String, from: String, extra: String, grid: String = "", snr: Int = -10
+    ) -> DecodedMessage {
+        var m = DecodedMessage()
+        m.callTo = to
+        m.callFrom = from
+        m.extra = extra
+        m.grid = grid
+        m.rawText = "\(to) \(from) \(extra)"
+        m.snr = snr
+        m.freqHz = 1500
+        m.timeSec = 0.5
+        return m
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaStampTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaStampTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import FT8Engine
+
+/// POTA QSO stamping + park-to-park activator resolution — the iOS port of
+/// Android `PotaSessionManager.stampQso` and `PotaSpotsRepository.parkRefFor`.
+final class PotaStampTests: XCTestCase {
+
+    private func spot(_ activator: String, _ reference: String) -> PotaSpot {
+        PotaSpot(
+            activator: activator, frequencyKhz: 14_074, mode: "FT8",
+            reference: reference, parkName: "Test Park", locationDesc: "US-XX",
+            spotter: "N0CALL", spotTimeUtc: "2026-07-13T19:44:50", comments: "")
+    }
+
+    // MARK: - Stamping decision
+
+    func testMyParkAlwaysStampedWhenActivating() {
+        let f = potaQsoStamp(activationParkRef: "US-7443", workedParkRef: nil)
+        XCTAssertEqual(f.mySig, "POTA")
+        XCTAssertEqual(f.mySigInfo, "US-7443")
+        // Not park-to-park → no SIG.
+        XCTAssertEqual(f.sig, "")
+        XCTAssertEqual(f.sigInfo, "")
+    }
+
+    func testNoStampWhenNotActivatingAndNotP2P() {
+        let f = potaQsoStamp(activationParkRef: nil, workedParkRef: nil)
+        XCTAssertEqual(f, PotaStampFields())
+    }
+
+    func testTheirParkStampedForParkToPark() {
+        let f = potaQsoStamp(activationParkRef: "US-7443", workedParkRef: "K-1234")
+        XCTAssertEqual(f.mySig, "POTA")
+        XCTAssertEqual(f.mySigInfo, "US-7443")
+        XCTAssertEqual(f.sig, "POTA")
+        XCTAssertEqual(f.sigInfo, "K-1234")
+    }
+
+    func testP2POutsideOwnActivationStampsSigOnly() {
+        // Hunting a P2P station while not activating ourselves: SIG only.
+        let f = potaQsoStamp(activationParkRef: nil, workedParkRef: "K-1234")
+        XCTAssertEqual(f.mySig, "")
+        XCTAssertEqual(f.mySigInfo, "")
+        XCTAssertEqual(f.sig, "POTA")
+        XCTAssertEqual(f.sigInfo, "K-1234")
+    }
+
+    func testEmptyRefsTreatedAsAbsent() {
+        let f = potaQsoStamp(activationParkRef: "", workedParkRef: "   ")
+        XCTAssertEqual(f, PotaStampFields())
+    }
+
+    func testApplyStampMutatesRecord() {
+        var r = QsoRecord(
+            call: "W1AW", gridsquare: "FN31", mode: "FT8", rstSent: "-05",
+            rstRcvd: "-08", qsoDate: "20260713", timeOn: "123000",
+            qsoDateOff: "20260713", timeOff: "123115", band: "20M",
+            freq: "14.074", stationCallsign: "KD2OGR", myGridsquare: "FN20",
+            comment: "")
+        applyPotaStamp(
+            potaQsoStamp(activationParkRef: "US-7443", workedParkRef: "K-1234"),
+            to: &r)
+        XCTAssertEqual(r.mySig, "POTA")
+        XCTAssertEqual(r.mySigInfo, "US-7443")
+        XCTAssertEqual(r.sig, "POTA")
+        XCTAssertEqual(r.sigInfo, "K-1234")
+    }
+
+    // MARK: - Park-to-park resolution against the live spots
+
+    func testParkRefResolvesSpottedActivator() {
+        let spots = [spot("K1ABC", "K-1234"), spot("JA1XYZ", "JA-0001")]
+        XCTAssertEqual(PotaSpots.parkRef(forCallsign: "K1ABC", in: spots), "K-1234")
+    }
+
+    func testParkRefNilForUnspottedCallsign() {
+        let spots = [spot("K1ABC", "K-1234")]
+        XCTAssertNil(PotaSpots.parkRef(forCallsign: "W1AW", in: spots))
+    }
+
+    func testParkRefStripsAngleBracketsOnNonStandardCall() {
+        // FT8 non-standard/hashed calls come wrapped as "<K1ABC/P>".
+        let spots = [spot("K1ABC/P", "K-1234")]
+        XCTAssertEqual(PotaSpots.parkRef(forCallsign: "<K1ABC/P>", in: spots), "K-1234")
+    }
+
+    func testParkRefCaseInsensitive() {
+        let spots = [spot("K1ABC", "K-1234")]
+        XCTAssertEqual(PotaSpots.parkRef(forCallsign: "k1abc", in: spots), "K-1234")
+    }
+
+    func testParkRefNilForEmptyReference() {
+        let spots = [spot("K1ABC", "")]
+        XCTAssertNil(PotaSpots.parkRef(forCallsign: "K1ABC", in: spots))
+    }
+
+    func testParkRefNilForNilOrEmptyCallsign() {
+        let spots = [spot("K1ABC", "K-1234")]
+        XCTAssertNil(PotaSpots.parkRef(forCallsign: nil, in: spots))
+        XCTAssertNil(PotaSpots.parkRef(forCallsign: "  ", in: spots))
+    }
+}


### PR DESCRIPTION
## What
Brings iOS POTA activation to Android parity for the **write side** of an activation. (Still no auth / self-spot / upload — those remain separate future PRs.)

1. **CQ-POTA transmit modifier** — `QsoEngine.cqModifier` is the iOS analog of Android's `GeneralVariables.toModifier`. The pure `buildCqMessage(modifier:myCall:myGrid:)` emits `"CQ POTA W1AW FN31"` for a valid 1–4 char alphanumeric modifier, else plain `"CQ …"` (invalid tokens dropped so the encoder never gets an unpackable message). `LiveEngine` sets it to `POTA` while `pota.isActivating`, cleared on end, before every CQ path.
2. **QSO stamping + park-to-park** — `QsoRecord` gains `MY_SIG` / `MY_SIG_INFO` / `SIG` / `SIG_INFO` (backward-compatible JSON). `PotaStamp.potaQsoStamp()` (port of `stampQso`) stamps *my* park always; stamps the *worked* park for P2P when the worked call is a currently-spotted activator — resolved by `PotaSpots.parkRef(forCallsign:in:)`, the `parkRefFor` analog. Applied at log time.
3. **ADIF export** — `Adif.potaActivationExport` now emits `SIG`/`SIG_INFO` for P2P QSOs (field order matches `buildActivationAdif`); empty fields omitted, so normal-QSO output is byte-identical (existing golden test still passes).

## Known follow-up (tracked separately, P2b)
`PotaService` only polls spots while the Hunt tab is visible, so P2P `SIG`/`SIG_INFO` populate only when the spot cache is loaded. The resolution logic is correct + fully tested; a small follow-up will keep spots refreshing during an active activation (Android's poller is always-on).

## Tests
437 FT8AFKit tests pass — new `PotaCqModifierTests`, `PotaStampTests`; `PotaAdifTests` extended (P2P emits SIG/SIG_INFO, normal QSO omits them). App builds clean.

Part of the iOS↔Android parity sweep (POTA domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)