### PR TITLE
iOS timing: NTP sync + manual clock offset + clock-health indicator

### DIFF
--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		4D87F21162B4DCEC806D8785 /* QsoCelebration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8DAEDCAE1AD9DE02EB1480 /* QsoCelebration.swift */; };
 		4F742232FB7AE5A02DF90DE8 /* geist_mono_semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CFC0DD2F717A726A4887913B /* geist_mono_semibold.ttf */; };
 		51B44F6A9F0A05A7B3CB71FC /* FrequencyPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C698656C5709343F4AEEF0 /* FrequencyPickerSheet.swift */; };
+		5487A5FF7F27849B22C01C42 /* ClockSyncIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9EBD1E2440476261F01908 /* ClockSyncIndicator.swift */; };
 		595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */; };
 		5C76E98A4BD4854709C3D0E9 /* AppTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53063BBF11F97C62BC0AFC9 /* AppTabView.swift */; };
 		5E2B3105FFFE6C84D86ACD85 /* TransmitGlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF04207CDB5BE8A1CCDD5F5B /* TransmitGlow.swift */; };
@@ -41,6 +42,7 @@
 		8DA0D562E25925F56B638B00 /* GridDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = E429D8A3556534F05374F12A /* GridDistance.swift */; };
 		8EA75A450404FB948C0A6CDC /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */; };
 		8EF984B5816F012A2DF93FDF /* OnlineLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D131B05E27A96EC4BEB28782 /* OnlineLogService.swift */; };
+		980F4378857DD26E47B84694 /* SntpSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3A88D466226E098AA8666 /* SntpSyncService.swift */; };
 		9D3A2D37F171D6B4D7AA48A3 /* inter_variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B42060FC68A03D3F64A7C2EF /* inter_variable.ttf */; };
 		9F4A1DE79693EF68A7B1A4D2 /* LogbookAwards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CCA018AEEE169EDCA338FD /* LogbookAwards.swift */; };
 		A037B00B861024FA2CA4919F /* QsoPathMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0187218903BBFF71931246 /* QsoPathMap.swift */; };
@@ -66,6 +68,7 @@
 		EC59A75E444DC6AB44913CB7 /* FT8AFApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1E760AEB31EF3855951728 /* FT8AFApp.swift */; };
 		ED838E6889186A96DB5E68A3 /* ToastOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8493B7CF97F9744DED622F15 /* ToastOverlay.swift */; };
 		EEA0D2F1B9A7E0345F68E909 /* ExportLogSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16235B470705C04E596C8A5B /* ExportLogSheet.swift */; };
+		EF1D5B0255D0C061CE756F5A /* TimeSyncSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467569ADBF392233E7AA71DC /* TimeSyncSettings.swift */; };
 		F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DF7123A737FE9F5236677F /* DecodeRow.swift */; };
 		F4E60463DA065CDAE7B84EF3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E706B1D26B550FE4D798B68 /* Accelerate.framework */; };
 		F56F35C07C7374F28A21ADE3 /* AudioRouteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B94D7FBAC132C5854796F79 /* AudioRouteController.swift */; };
@@ -83,16 +86,19 @@
 		1E4787AD687D89D858D3C075 /* WaterfallScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallScreen.swift; sourceTree = "<group>"; };
 		1E706B1D26B550FE4D798B68 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxPlayerService.swift; sourceTree = "<group>"; };
+		2A9EBD1E2440476261F01908 /* ClockSyncIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockSyncIndicator.swift; sourceTree = "<group>"; };
 		2CFCB3285583184390D9E9BF /* AboutScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutScreen.swift; sourceTree = "<group>"; };
 		33CCA018AEEE169EDCA338FD /* LogbookAwards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookAwards.swift; sourceTree = "<group>"; };
 		3B94D7FBAC132C5854796F79 /* AudioRouteController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRouteController.swift; sourceTree = "<group>"; };
 		4217D8419318D6A336873605 /* AudioRoutePickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRoutePickerButton.swift; sourceTree = "<group>"; };
+		467569ADBF392233E7AA71DC /* TimeSyncSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSyncSettings.swift; sourceTree = "<group>"; };
 		4A8FFDE0644205A9AE050BC0 /* BlockedCallsignsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedCallsignsSettings.swift; sourceTree = "<group>"; };
 		4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSettings.swift; sourceTree = "<group>"; };
 		4E09812700CD93E6187CC4BC /* LiveEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveEngine.swift; sourceTree = "<group>"; };
 		504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		5306EE5215AE14F95F3329F8 /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
 		55F3AF234143FDFFA45B0AC8 /* ParkPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkPickerSheet.swift; sourceTree = "<group>"; };
+		58F3A88D466226E098AA8666 /* SntpSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SntpSyncService.swift; sourceTree = "<group>"; };
 		64B1202A7633AE8CBBFCF2C3 /* TxStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxStrip.swift; sourceTree = "<group>"; };
 		654EF0B6A0E279E65F355821 /* FT8AF.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FT8AF.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B9E40312EA203F05764FA56 /* QsoLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoLogStore.swift; sourceTree = "<group>"; };
@@ -200,6 +206,7 @@
 				BB0565117E35A6C64BBF519D /* LoggingSettings.swift */,
 				89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */,
 				504C9AD4C6667267DFCABEF9 /* SettingsScreen.swift */,
+				467569ADBF392233E7AA71DC /* TimeSyncSettings.swift */,
 				4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */,
 			);
 			path = Settings;
@@ -249,6 +256,7 @@
 			children = (
 				0244EBDFC2ADDAE77418FF53 /* ActiveQsoPanel.swift */,
 				4217D8419318D6A336873605 /* AudioRoutePickerButton.swift */,
+				2A9EBD1E2440476261F01908 /* ClockSyncIndicator.swift */,
 				5306EE5215AE14F95F3329F8 /* FilterChip.swift */,
 				F3C698656C5709343F4AEEF0 /* FrequencyPickerSheet.swift */,
 				AC8DAEDCAE1AD9DE02EB1480 /* QsoCelebration.swift */,
@@ -338,6 +346,7 @@
 				8887498A3FE21F5B9ADAE63A /* PotaParkService.swift */,
 				7E27EE4248BF38A15E0F3B2D /* PotaService.swift */,
 				6B9E40312EA203F05764FA56 /* QsoLogStore.swift */,
+				58F3A88D466226E098AA8666 /* SntpSyncService.swift */,
 				29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */,
 			);
 			path = Engine;
@@ -450,6 +459,7 @@
 				3BCBA78527E44AD070AA1E48 /* AudioRoutePickerButton.swift in Sources */,
 				BCEB9305C3EA84C758FAFBA7 /* AzimuthalMapCanvas.swift in Sources */,
 				072D76FFDC706DE3E537A3C2 /* BlockedCallsignsSettings.swift in Sources */,
+				5487A5FF7F27849B22C01C42 /* ClockSyncIndicator.swift in Sources */,
 				035DDD710715AAC0100E0871 /* Colors.swift in Sources */,
 				3BA2BC0EFAF62534D39C3A4A /* DecodeFilterSettings.swift in Sources */,
 				F3CB49EBF218C3BB9FAE02D6 /* DecodeRow.swift in Sources */,
@@ -482,8 +492,10 @@
 				4C0C9DCC39ED6528F0D4CDFF /* RadioAudioSettings.swift in Sources */,
 				8EA75A450404FB948C0A6CDC /* SettingsScreen.swift in Sources */,
 				CE1ECA0C5BB350A1EDDA7018 /* SlotTimerBar.swift in Sources */,
+				980F4378857DD26E47B84694 /* SntpSyncService.swift in Sources */,
 				D36ECEB73B847787DE373072 /* SpectrumStrip.swift in Sources */,
 				F917448B524020C565485D03 /* SplashScreen.swift in Sources */,
+				EF1D5B0255D0C061CE756F5A /* TimeSyncSettings.swift in Sources */,
 				ED838E6889186A96DB5E68A3 /* ToastOverlay.swift in Sources */,
 				7F9F3D670DE6755252D023A3 /* TransmissionSettings.swift in Sources */,
 				5E2B3105FFFE6C84D86ACD85 /* TransmitGlow.swift in Sources */,

--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -1,3 +1,4 @@
+import FT8Audio
 import FT8Engine
 import Foundation
 import Observation
@@ -14,6 +15,7 @@ final class AppState {
     let tx = TxState()
     let pota = PotaState()
     let toast = ToastState()
+    let clock = ClockState()
 
     /// The live engine is set once by `FT8AFApp` at startup. Views access it
     /// through `appState.engine` instead of a separate `@Environment` entry,
@@ -245,6 +247,11 @@ final class SettingsState {
     var distanceInMiles: Bool = false
     // Tune
     var tuneTimeoutSec: Int = 30
+    // Manual whole-clock correction (ms), ±5 s, persisted. Combined with the
+    // runtime NTP offset (`ClockState.ntpOffsetMs`) into the unified clock
+    // offset the engine adds to every wall-clock read (RX slot detection, TX
+    // key-up, logged UTC). Distinct from DtCalibrator's RX-only rxOffsetMs.
+    var manualClockOffsetMs: Int = 0
     // Preferred audio input port name ("" = system default); matched by name
     // so the choice survives replug/relaunch.
     var preferredInputPort: String = ""
@@ -324,6 +331,34 @@ final class PotaState {
     var isActivating: Bool { current != nil }
 }
 
+// MARK: - Clock
+
+/// Runtime clock-sync state (the persisted manual correction lives in
+/// `SettingsState.manualClockOffsetMs`). Combined via `clockOffset` into the
+/// unified whole-clock correction the engine applies to RX + TX + logged UTC.
+@Observable @MainActor
+final class ClockState {
+    /// NTP-derived correction (ms) from the most recent "Sync now"; 0 until a
+    /// successful sync this install (not persisted — re-fetched on demand).
+    var ntpOffsetMs: Int64 = 0
+    /// When the last successful NTP sync landed (for the settings readout).
+    var lastSyncDate: Date?
+    /// Human-readable failure from the last sync attempt, or nil.
+    var lastSyncError: String?
+    /// True while a sync request is in flight (drives the button spinner).
+    var isSyncing: Bool = false
+    /// Mean decode DT (seconds) of the most recent slot that decoded anything;
+    /// nil until the first decode this session. A consistent bias across the
+    /// stations we hear proxies our own clock offset — the clock-health source.
+    var dtOffsetSec: Float?
+
+    /// The unified whole-clock offset combining NTP + the persisted manual
+    /// correction. The engine adds `combinedMs` to every wall-clock read.
+    func clockOffset(manualMs: Int) -> ClockOffset {
+        ClockOffset(ntpOffsetMs: ntpOffsetMs, manualOffsetMs: Int64(manualMs))
+    }
+}
+
 // MARK: - Settings Persistence
 
 enum SettingsPersistence {
@@ -374,6 +409,7 @@ enum SettingsPersistence {
         d.set(s.distanceInMiles, forKey: key("distanceInMiles"))
         d.set(s.tuneTimeoutSec, forKey: key("tuneTimeoutSec"))
         d.set(s.preferredInputPort, forKey: key("preferredInputPort"))
+        d.set(s.manualClockOffsetMs, forKey: key("manualClockOffsetMs"))
     }
 
     @MainActor static func load(into s: SettingsState) {
@@ -489,6 +525,12 @@ enum SettingsPersistence {
         }
         if let v = d.string(forKey: key("preferredInputPort")) {
             s.preferredInputPort = v
+        }
+        if d.object(forKey: key("manualClockOffsetMs")) != nil {
+            // Coerce a persisted value into the allowed ±5 s range in case an
+            // older/edited build wrote something out of bounds.
+            s.manualClockOffsetMs = Int(ClockOffset.clampManualMs(
+                Int64(d.integer(forKey: key("manualClockOffsetMs")))))
         }
     }
 

--- a/ios/FT8AF/FT8AF/Components/ClockSyncIndicator.swift
+++ b/ios/FT8AF/FT8AF/Components/ClockSyncIndicator.swift
@@ -1,0 +1,41 @@
+import FT8Audio
+import SwiftUI
+
+/// Compact clock-sync health pill: a color-coded dot, a "DT" label operators
+/// know from WSJT-X, and the signed offset. Port of Android's
+/// `ClockSyncIndicator`. All classification/format logic lives in the pure,
+/// tested `ClockHealth` type in FT8Audio; this view only draws and wires
+/// accessibility.
+struct ClockSyncIndicator: View {
+    /// Mean decode DT (seconds); nil until the first decode this session.
+    let offsetSec: Float?
+
+    var body: some View {
+        let level = ClockHealth.level(offsetSec: offsetSec)
+        let label = ClockHealth.offsetLabel(offsetSec: offsetSec)
+
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color(for: level))
+                .frame(width: 6, height: 6)
+            Text("DT")
+                .font(.ft8afMono(size: 9, weight: .bold))
+                .foregroundStyle(textMuted)
+            Text(label)
+                .font(.ft8afMono(size: 11, weight: .semibold))
+                .foregroundStyle(color(for: level))
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Clock sync \(label), \(ClockHealth.statusText(level))")
+    }
+
+    /// Green in-sync, amber worth-a-resync, red clock-off, grey unknown.
+    private func color(for level: ClockHealthLevel) -> Color {
+        switch level {
+        case .good: return statusConfirmed
+        case .fair: return statusWarn
+        case .poor: return statusBad
+        case .unknown: return textMuted
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -75,7 +75,7 @@ final class LiveEngine {
         qsoEngine = qso
 
         // Fresh TX safety-net + caller-queue state for this session.
-        supervisor = TxSupervisor(nowMs: Int64(Date().timeIntervalSince1970 * 1000))
+        supervisor = TxSupervisor(nowMs: nowMs())
         callerQueue.removeAll()
         appState.tx.queuedCallers = []
 
@@ -84,6 +84,10 @@ final class LiveEngine {
 
         let accumulator = audio.accumulator
         let rxOffset = rxOffsetMs
+        // Seed the decode loop with the current whole-clock offset so its first
+        // slot boundary is anchored correctly; it re-reads the live value each
+        // slot via readClockOffsetMs below.
+        let initialClockOffset = currentClockOffsetMs()
 
         // Build the MainActor state-mutation closures here, on the main actor, so
         // the background loops never reference `AppState` directly. The closures
@@ -108,6 +112,17 @@ final class LiveEngine {
                 deep: appState.settings.deepDecode,
                 early: appState.settings.earlyDecode
             )
+        }
+        // Live whole-clock offset (NTP + manual) for the decode loop's slot/TX
+        // time math, read on the main actor each slot so a change applies live.
+        let readClockOffsetMs: @Sendable @MainActor () -> Int64 = {
+            appState.clock
+                .clockOffset(manualMs: appState.settings.manualClockOffsetMs)
+                .combinedMs
+        }
+        // Publish the mean decode DT for the clock-health indicator.
+        let applyClockDt: @Sendable @MainActor (Float) -> Void = { dt in
+            appState.clock.dtOffsetSec = dt
         }
         let applyWaterfall: @Sendable @MainActor (WaterfallUpdate) -> Void = { update in
             let wf = appState.waterfall
@@ -140,8 +155,11 @@ final class LiveEngine {
                     await self?.runDecodeLoop(
                         accumulator: accumulator,
                         initialRxOffset: rxOffset,
+                        initialClockOffsetMs: initialClockOffset,
                         readDecodeOptions: readDecodeOptions,
-                        applyDecodes: applyDecodes
+                        readClockOffsetMs: readClockOffsetMs,
+                        applyDecodes: applyDecodes,
+                        applyClockDt: applyClockDt
                     )
                 }
                 // Waterfall pipeline
@@ -255,7 +273,7 @@ final class LiveEngine {
     /// Mirrors Android `forceLogAndMoveOn`.
     func forceLogAndMoveOn(nextCallsign: String? = nil) {
         guard let qso = qsoEngine, let appState else { return }
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let nowMs = nowMs()
 
         if case .completed(let record)? = qso.forceLog() {
             logCompletedQso(record)
@@ -285,7 +303,7 @@ final class LiveEngine {
         appState.tx.targetSnr = nil
         appState.tx.conversationLog.removeAll()
         supervisor.resetAttempts()
-        supervisor.resetWatchdog(nowMs: Int64(Date().timeIntervalSince1970 * 1000))
+        supervisor.resetWatchdog(nowMs: nowMs())
         syncQsoStatusToUI()
     }
 
@@ -364,14 +382,19 @@ final class LiveEngine {
     private nonisolated func runDecodeLoop(
         accumulator: SlotAccumulator,
         initialRxOffset: Int64,
+        initialClockOffsetMs: Int64,
         readDecodeOptions: @escaping @Sendable @MainActor () -> DecodeOptions,
-        applyDecodes: @escaping @Sendable @MainActor ([DecodeMessage]) -> Void
+        readClockOffsetMs: @escaping @Sendable @MainActor () -> Int64,
+        applyDecodes: @escaping @Sendable @MainActor ([DecodeMessage]) -> Void,
+        applyClockDt: @escaping @Sendable @MainActor (Float) -> Void
     ) async {
         var rxOffsetMs = initialRxOffset
         // Seed one slot back so the first completed slot still decodes (the
-        // scheduler fires when `audioSlotID > lastDecodedAudioSlot`).
+        // scheduler fires when `audioSlotID > lastDecodedAudioSlot`). The seed
+        // uses the whole-clock offset so it lands on the same slot grid the loop
+        // will use below.
         var lastDecodedAudioSlot: Int64 = SlotClock.rxSlotID(
-            atUtcMs: Int64(Date().timeIntervalSince1970 * 1000),
+            atUtcMs: Int64(Date().timeIntervalSince1970 * 1000) + initialClockOffsetMs,
             rxOffsetMs: rxOffsetMs
         ) - 1
 
@@ -379,8 +402,14 @@ final class LiveEngine {
             try? await Task.sleep(for: .milliseconds(200))
             if Task.isCancelled { break }
 
-            let opts = await MainActor.run { readDecodeOptions() }
-            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            // Read the live decode options and whole-clock offset in one hop.
+            let (opts, clockOffsetMs) = await MainActor.run {
+                (readDecodeOptions(), readClockOffsetMs())
+            }
+            // The whole-clock correction (NTP + manual) shifts every slot/TX
+            // time read below; DtCalibrator's rxOffsetMs is applied separately
+            // inside rxSlotID (RX-only capture-latency comp).
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000) + clockOffsetMs
 
             // Decide whether to decode now (boundary vs. early), which slot's
             // audio, and how big a trailing window — see DecodeScheduler.
@@ -411,6 +440,11 @@ final class LiveEngine {
                     rxOffsetMs: rxOffsetMs,
                     decodedDtSec: dtValues
                 )
+                // Publish the mean DT for the clock-health indicator (a
+                // consistent bias across the stations we hear proxies our own
+                // clock offset — mirrors Android's ClockSync source).
+                let meanDt = dtValues.reduce(0, +) / Float(dtValues.count)
+                await MainActor.run { applyClockDt(meanDt) }
             }
 
             // With early decode the reply must wait out the rest of the cycle so
@@ -472,7 +506,7 @@ final class LiveEngine {
         OnlineLogService.shared.enqueuePskDecodes(decoded, dialFreqHz: dialHz, appState: appState)
 
         let settings = appState.settings
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let nowMs = nowMs()
 
         // Log incoming RX messages addressed to us for the conversation panel.
         let myCall = settings.myCall.uppercased()
@@ -520,7 +554,7 @@ final class LiveEngine {
             // Find the decoded message from this station to use as autoOpenMessage.
             if let answerMsg = decoded.first(where: { $0.callFrom.uppercased() == dx.uppercased() }) {
                 appState.tx.autoOpenMessage = DecodeMessage(
-                    utcTime: Self.utcTimeString(from: Int64(Date().timeIntervalSince1970 * 1000)),
+                    utcTime: Self.utcTimeString(from: nowMs),
                     callFrom: answerMsg.callFrom,
                     callTo: answerMsg.callTo,
                     snr: answerMsg.snr,
@@ -760,7 +794,7 @@ final class LiveEngine {
 
     /// Restart both TX safety nets (fresh CQ run / new target).
     private func armSupervisor() {
-        supervisor.resetWatchdog(nowMs: Int64(Date().timeIntervalSince1970 * 1000))
+        supervisor.resetWatchdog(nowMs: nowMs())
         supervisor.resetAttempts()
     }
 
@@ -795,7 +829,7 @@ final class LiveEngine {
     /// than that much leading audio would be clipped, the slot is skipped.
     private func beginTxPlayback(message: String, samples: [Float]) {
         guard let appState else { return }
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let nowMs = nowMs()
         let clipMs = TxTiming.lateStartClipMs(
             msIntoCycle: SlotClock.msIntoCycle(atUtcMs: nowMs)
         )
@@ -908,6 +942,30 @@ final class LiveEngine {
 
     // MARK: - Helpers
 
+    /// Wall clock (epoch ms) shifted by the unified whole-clock correction
+    /// (NTP + manual). This is the single accessor every MainActor slot/TX/log
+    /// time read routes through, so a manual or NTP offset moves RX slot
+    /// detection, TX key-up, and logged UTC together — matching Android's
+    /// `UtcTimer.getSystemTime()`. Distinct from DtCalibrator's RX-only
+    /// rxOffsetMs, which is applied separately inside `rxSlotID`.
+    private func nowMs() -> Int64 {
+        let wallMs = Int64(Date().timeIntervalSince1970 * 1000)
+        guard let appState else { return wallMs }
+        return appState.clock
+            .clockOffset(manualMs: appState.settings.manualClockOffsetMs)
+            .apply(toUtcMs: wallMs)
+    }
+
+    /// The current combined whole-clock offset (ms) for the detached decode loop
+    /// to fold into its wall-clock reads. Read on the MainActor each slot so a
+    /// live manual/NTP change applies without restarting the session.
+    private func currentClockOffsetMs() -> Int64 {
+        guard let appState else { return 0 }
+        return appState.clock
+            .clockOffset(manualMs: appState.settings.manualClockOffsetMs)
+            .combinedMs
+    }
+
     /// Push current user settings into the QSO engine.
     private func syncSettingsToQso() {
         guard let qso = qsoEngine, let appState else { return }
@@ -991,7 +1049,7 @@ final class LiveEngine {
                 appState.waterfall.txFreqHz = txHz
             }
             let msg = DecodeMessage(
-                utcTime: Self.utcTimeString(from: Int64(Date().timeIntervalSince1970 * 1000)),
+                utcTime: Self.utcTimeString(from: self.nowMs()),
                 callFrom: call, callTo: "", snr: Int(snr),
                 freqHz: appState.waterfall.txFreqHz, grid: grid, extra: "", slotIndex: 0
             )
@@ -1042,7 +1100,7 @@ final class LiveEngine {
             udp.clearReplayCache()
         }
         udp.sendStatus(buildUdpStatus())
-        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let nowMs = nowMs()
         if nowMs - lastUdpHeartbeatMs >= 15_000 {
             lastUdpHeartbeatMs = nowMs
             udp.sendHeartbeat(version: Self.appVersion)
@@ -1079,7 +1137,7 @@ final class LiveEngine {
 
     private func broadcastUdpDecodes(_ decoded: [DecodedMessage]) {
         guard udp.isEnabled, !decoded.isEmpty else { return }
-        let timeMs = UInt32(Int64(Date().timeIntervalSince1970 * 1000) % 86_400_000)
+        let timeMs = UInt32(nowMs() % 86_400_000)
         for m in decoded {
             let text = m.rawText.isEmpty ? "\(m.callTo) \(m.callFrom) \(m.extra)" : m.rawText
             udp.sendDecode(WsjtxCodec.Decode(

--- a/ios/FT8AF/FT8AF/Engine/SntpSyncService.swift
+++ b/ios/FT8AF/FT8AF/Engine/SntpSyncService.swift
@@ -1,0 +1,121 @@
+import FT8Audio
+import Foundation
+import Network
+
+/// UDP transport for a one-shot SNTP "Sync now" query. The byte build/parse and
+/// the offset math live in the pure, unit-tested `Sntp` type in FT8Audio; this
+/// service only owns the network I/O (open UDP:123, send the 48-byte request,
+/// await one reply, time out). Mirrors the pure-codec / networking split used by
+/// `WsjtxCodec` vs `WsjtxUdpService`.
+///
+/// Runs entirely off the audio/decode loop and resolves via an async
+/// continuation, so a slow or dead time server never blocks receive/TX.
+enum SntpSyncService {
+    /// Default pool server. Apple's NTP pool is reachable on iOS without extra
+    /// entitlements and is geographically load-balanced.
+    static let defaultServer = "time.apple.com"
+    static let defaultTimeout: TimeInterval = 5.0
+
+    enum SyncError: LocalizedError {
+        case timeout
+        case network(String)
+        case invalidResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .timeout: return "Time server did not respond"
+            case .network(let m): return "Network error: \(m)"
+            case .invalidResponse: return "Invalid time server response"
+            }
+        }
+    }
+
+    /// Query `server` and return the whole-clock offset (ms) to add to the
+    /// device clock so it matches UTC. Never throws; failures come back as
+    /// `.failure`. Guaranteed to resume its continuation exactly once.
+    static func fetchOffsetMs(
+        server: String = defaultServer,
+        timeout: TimeInterval = defaultTimeout
+    ) async -> Result<Int64, SyncError> {
+        await withCheckedContinuation { continuation in
+            let conn = NWConnection(
+                host: NWEndpoint.Host(server),
+                port: NWEndpoint.Port(rawValue: 123)!,
+                using: .udp
+            )
+            let box = ResumeBox()
+
+            func finish(_ result: Result<Int64, SyncError>) {
+                guard box.complete() else { return } // resume at most once
+                conn.cancel()
+                continuation.resume(returning: result)
+            }
+
+            // Hard timeout independent of the connection's own state machine.
+            let timer = DispatchSource.makeTimerSource(queue: .global())
+            timer.schedule(deadline: .now() + timeout)
+            timer.setEventHandler { finish(.failure(.timeout)) }
+            timer.resume()
+            box.timer = timer
+
+            conn.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    let request = Data(Sntp.makeRequest())
+                    conn.send(content: request, completion: .contentProcessed { sendErr in
+                        if let sendErr {
+                            finish(.failure(.network(sendErr.localizedDescription)))
+                            return
+                        }
+                        conn.receiveMessage { data, _, _, recvErr in
+                            if let recvErr {
+                                finish(.failure(.network(recvErr.localizedDescription)))
+                                return
+                            }
+                            guard let data, data.count >= Sntp.packetSize else {
+                                finish(.failure(.invalidResponse))
+                                return
+                            }
+                            // Sample the device clock at reception; local NTP
+                            // round-trips are short, so reference - now is a
+                            // good offset (matches Android's simple approach).
+                            let deviceNowMs = Int64(Date().timeIntervalSince1970 * 1000)
+                            guard let refMs = Sntp.transmitTimeUnixMs(
+                                fromResponse: [UInt8](data)
+                            ) else {
+                                finish(.failure(.invalidResponse))
+                                return
+                            }
+                            finish(.success(Sntp.offsetMs(
+                                referenceUnixMs: refMs, deviceNowMs: deviceNowMs)))
+                        }
+                    })
+                case .failed(let err):
+                    finish(.failure(.network(err.localizedDescription)))
+                case .cancelled:
+                    break
+                default:
+                    break
+                }
+            }
+            conn.start(queue: .global())
+        }
+    }
+}
+
+/// Single-shot guard so the SNTP continuation is resumed exactly once across the
+/// timeout timer and the connection's async callbacks.
+private final class ResumeBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var done = false
+    var timer: DispatchSourceTimer?
+
+    func complete() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if done { return false }
+        done = true
+        timer?.cancel()
+        timer = nil
+        return true
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Decode/DecodeScreen.swift
@@ -15,6 +15,10 @@ struct DecodeScreen: View {
                     .font(.ft8afUI(size: 18, weight: .bold))
                     .foregroundStyle(textPrimary)
 
+                // Clock-sync health from the mean decode DT.
+                ClockSyncIndicator(offsetSec: appState.clock.dtOffsetSec)
+                    .padding(.leading, 8)
+
                 Spacer()
 
                 // Compact mode toggle

--- a/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/SettingsScreen.swift
@@ -1,3 +1,4 @@
+import FT8Audio
 import FT8Engine
 import SwiftUI
 
@@ -146,6 +147,23 @@ struct SettingsScreen: View {
 
                 // Advanced section
                 Section {
+                    NavigationLink {
+                        TimeSyncSettings()
+                    } label: {
+                        HStack {
+                            Image(systemName: "clock.arrow.2.circlepath")
+                                .font(.ft8afUI(size: 14))
+                                .foregroundStyle(accent)
+                                .frame(width: 24)
+                            Text("Time Sync")
+                                .foregroundStyle(textPrimary)
+                            Spacer()
+                            Text(ClockHealth.offsetLabel(offsetSec: appState.clock.dtOffsetSec))
+                                .font(.ft8afMono(size: 14))
+                                .foregroundStyle(textMuted)
+                        }
+                    }
+
                     NavigationLink {
                         AdvancedSettings()
                     } label: {

--- a/ios/FT8AF/FT8AF/Screens/Settings/TimeSyncSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/TimeSyncSettings.swift
@@ -1,0 +1,163 @@
+import FT8Audio
+import SwiftUI
+
+/// Time & clock-sync settings: an NTP "Sync now" (needs internet) plus a manual
+/// ±5 s correction for operating offline. Both feed the unified whole-clock
+/// offset the engine adds to every RX slot / TX key-up / logged-UTC read
+/// (`ClockState` + `SettingsState.manualClockOffsetMs`). Mirrors Android's
+/// TimeSyncSettings + TimeCorrection.
+struct TimeSyncSettings: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        @Bindable var settings = appState.settings
+        let clock = appState.clock
+
+        List {
+            // MARK: Health
+            Section {
+                HStack {
+                    Text("Clock Sync")
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    ClockSyncIndicator(offsetSec: clock.dtOffsetSec)
+                }
+            } header: {
+                Text("Status").foregroundStyle(textMuted)
+            } footer: {
+                Text("Derived from the mean DT of the stations you decode — a good proxy for your own clock offset. Green is in the FT8 sweet spot; amber or red means resync.")
+                    .foregroundStyle(textFaint)
+            }
+            .listRowBackground(bgSurface)
+
+            // MARK: NTP sync
+            Section {
+                Button {
+                    Task { await syncNow() }
+                } label: {
+                    HStack {
+                        if clock.isSyncing {
+                            ProgressView().tint(accent)
+                        } else {
+                            Image(systemName: "clock.arrow.2.circlepath")
+                                .foregroundStyle(accent)
+                        }
+                        Text(clock.isSyncing ? "Syncing…" : "Sync now")
+                            .foregroundStyle(accent)
+                            .fontWeight(.semibold)
+                        Spacer()
+                    }
+                }
+                .disabled(clock.isSyncing)
+
+                if let date = clock.lastSyncDate {
+                    HStack {
+                        Text("NTP offset").foregroundStyle(textMuted)
+                        Spacer()
+                        Text(ClockOffset.formatMs(clock.ntpOffsetMs))
+                            .font(.ft8afMono(size: 14))
+                            .foregroundStyle(clock.ntpOffsetMs == 0 ? textPrimary : accent)
+                    }
+                    HStack {
+                        Text("Last sync").foregroundStyle(textMuted)
+                        Spacer()
+                        Text(date.formatted(date: .omitted, time: .standard))
+                            .font(.ft8afMono(size: 13))
+                            .foregroundStyle(textFaint)
+                    }
+                }
+                if let err = clock.lastSyncError {
+                    Text(err)
+                        .font(.ft8afUI(size: 13))
+                        .foregroundStyle(statusBad)
+                }
+            } header: {
+                Text("Network Time (\(SntpSyncService.defaultServer))").foregroundStyle(textMuted)
+            } footer: {
+                Text("Queries an SNTP time server and corrects the whole app clock — receive, transmit, and logged times all shift together. Needs internet.")
+                    .foregroundStyle(textFaint)
+            }
+            .listRowBackground(bgSurface)
+
+            // MARK: Manual correction
+            Section {
+                VStack(spacing: 14) {
+                    Text(ClockOffset.formatMs(Int64(settings.manualClockOffsetMs)))
+                        .font(.ft8afMono(size: 30, weight: .bold))
+                        .foregroundStyle(settings.manualClockOffsetMs == 0 ? textPrimary : accent)
+                        .frame(maxWidth: .infinity)
+
+                    HStack(spacing: 8) {
+                        stepButton("-0.5", deltaMs: -500)
+                        stepButton("-0.1", deltaMs: -100)
+                        stepButton("+0.1", deltaMs: 100)
+                        stepButton("+0.5", deltaMs: 500)
+                    }
+
+                    Button {
+                        setManual(0)
+                    } label: {
+                        Text("Reset to 0.0 s")
+                            .font(.ft8afUI(size: 14, weight: .semibold))
+                            .foregroundStyle(settings.manualClockOffsetMs == 0 ? textFaint : accent)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .disabled(settings.manualClockOffsetMs == 0)
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("Manual Correction").foregroundStyle(textMuted)
+            } footer: {
+                Text("For operating offline where NTP can't reach a server. Range ±5 s. Positive shifts the clock forward. This moves transmit timing too, not just receive.")
+                    .foregroundStyle(textFaint)
+            }
+            .listRowBackground(bgSurface)
+        }
+        .scrollContentBackground(.hidden)
+        .background(bgApp)
+        .navigationTitle("Time Sync")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    // MARK: - Actions
+
+    private func stepButton(_ label: String, deltaMs: Int64) -> some View {
+        Button {
+            setManual(ClockOffset.stepManualMs(Int64(appState.settings.manualClockOffsetMs), byMs: deltaMs))
+        } label: {
+            Text(label)
+                .font(.ft8afMono(size: 15, weight: .bold))
+                .foregroundStyle(accent)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(borderStrong, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func setManual(_ ms: Int64) {
+        appState.settings.manualClockOffsetMs = Int(ClockOffset.clampManualMs(ms))
+        SettingsPersistence.save(appState.settings)
+    }
+
+    private func syncNow() async {
+        appState.clock.isSyncing = true
+        appState.clock.lastSyncError = nil
+        let result = await SntpSyncService.fetchOffsetMs()
+        appState.clock.isSyncing = false
+        switch result {
+        case .success(let offsetMs):
+            appState.clock.ntpOffsetMs = offsetMs
+            appState.clock.lastSyncDate = Date()
+            appState.toast.show("Clock synced: \(ClockOffset.formatMs(offsetMs))", icon: "clock.badge.checkmark")
+        case .failure(let err):
+            // Leave the prior offset intact; just surface the error.
+            appState.clock.lastSyncError = err.errorDescription ?? "Sync failed"
+            appState.toast.show("Time sync failed", icon: "exclamationmark.triangle")
+        }
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Audio/ClockHealth.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/ClockHealth.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Clock-sync health classification derived from the mean decode DT (the time
+/// offset, in seconds, of the stations we're hearing). Port of Android's
+/// `ClockSync.kt`.
+///
+/// FT8 tolerates only ~2 s of clock error before decoding collapses both ways —
+/// a mis-set clock stops you decoding others *and* pushes your transmissions to
+/// the edge of everyone else's receive window. The mean DT of the stations you
+/// decode is a good proxy for your own clock offset: most stations are
+/// themselves NTP-synced, so a consistent bias across all of them is almost
+/// certainly yours. All decision/format logic is pure so it can be unit-tested;
+/// the SwiftUI indicator is a thin wrapper.
+public enum ClockHealthLevel: Equatable, Sendable {
+    case good, fair, poor, unknown
+}
+
+public enum ClockHealth {
+    /// |DT| at/below this (seconds) is a healthy, in-the-sweet-spot clock.
+    public static let goodSec: Float = 0.3
+    /// |DT| at/below this (seconds) still decodes but is worth a resync; above
+    /// it is POOR.
+    public static let fairSec: Float = 1.0
+
+    /// Classify the mean decode DT into a sync-health level. A `nil` value means
+    /// no decode cycle has reported yet this session; a non-finite value is
+    /// treated the same way so a bad reading can never mis-classify.
+    public static func level(offsetSec: Float?) -> ClockHealthLevel {
+        guard let offsetSec, offsetSec.isFinite else { return .unknown }
+        let mag = abs(offsetSec)
+        switch mag {
+        case ...goodSec: return .good
+        case ...fairSec: return .fair
+        default: return .poor
+        }
+    }
+
+    /// Signed, one-decimal-second DT label (WSJT-X style), e.g. "+0.1 s",
+    /// "-1.3 s", "0.0 s", or an em dash when unknown. A value that rounds to
+    /// zero renders unsigned (never "-0.0 s").
+    public static func offsetLabel(offsetSec: Float?) -> String {
+        guard let offsetSec, offsetSec.isFinite else { return "—" }
+        let mag = String(format: "%.1f", abs(offsetSec))
+        let sign = mag == "0.0" ? "" : (offsetSec < 0 ? "-" : "+")
+        return "\(sign)\(mag) s"
+    }
+
+    /// Short status word for accessibility / screen readers.
+    public static func statusText(_ level: ClockHealthLevel) -> String {
+        switch level {
+        case .good: return "In sync"
+        case .fair: return "Resync soon"
+        case .poor: return "Clock off"
+        case .unknown: return "Unknown"
+        }
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Audio/ClockOffset.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/ClockOffset.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Whole-clock correction applied to the device wall clock so the app's UTC
+/// matches an authoritative reference. Port of Android's `UtcTimer.delay`
+/// (`getSystemTime() = delay + System.currentTimeMillis()`), split into its two
+/// independent sources so each can be set and persisted on its own:
+///
+///  - `ntpOffsetMs`   — from an SNTP "Sync now" query (see ``Sntp``).
+///  - `manualOffsetMs`— an operator nudge for operating offline where NTP can't
+///    reach a time server (mirrors Android's manual TimeCorrection).
+///
+/// The combined value is added to **every** wall-clock read the engine uses for
+/// slot/TX math and for logged/displayed UTC — RX slot detection, TX key-up
+/// timing, and QSO timestamps all shift together. This is deliberately distinct
+/// from ``DtCalibrator``'s `rxOffsetMs`, which is an RX-only capture-latency
+/// compensation and must *not* move TX or logged times: the clock offset here
+/// corrects the device clock itself.
+public struct ClockOffset: Equatable, Sendable {
+    /// NTP-derived correction (ms). Positive = device clock is behind UTC.
+    public var ntpOffsetMs: Int64
+    /// Manual operator correction (ms), clamped to ``manualMinMs``…``manualMaxMs``.
+    public var manualOffsetMs: Int64
+
+    public init(ntpOffsetMs: Int64 = 0, manualOffsetMs: Int64 = 0) {
+        self.ntpOffsetMs = ntpOffsetMs
+        self.manualOffsetMs = ClockOffset.clampManualMs(manualOffsetMs)
+    }
+
+    /// Total correction added to the wall clock (`ntp + manual`).
+    public var combinedMs: Int64 { ntpOffsetMs + manualOffsetMs }
+
+    /// Apply the whole-clock correction to a wall-clock epoch-ms value. This is
+    /// the single transform every engine time read routes through so the manual
+    /// / NTP offset reaches RX slot detection, TX scheduling, and timestamps
+    /// identically.
+    public func apply(toUtcMs wallMs: Int64) -> Int64 { wallMs + combinedMs }
+
+    // MARK: - Manual-offset range
+
+    /// Inclusive bounds for the manual correction, in milliseconds. ±5 s (not
+    /// the much tighter FT8 decode tolerance) because it has to cover *device
+    /// clock error*: a phone offline for a while can drift several seconds, and
+    /// the correction is what pulls that back toward 0 (mirrors Android's
+    /// `MANUAL_TIME_CORRECTION_MIN_MS` / `MAX_MS`).
+    public static let manualMinMs: Int64 = -5_000
+    public static let manualMaxMs: Int64 = 5_000
+
+    /// Coerce an arbitrary manual correction into the allowed range.
+    public static func clampManualMs(_ ms: Int64) -> Int64 {
+        min(max(ms, manualMinMs), manualMaxMs)
+    }
+
+    /// Apply a stepper nudge (e.g. +100 or -500 ms) to a manual value and clamp.
+    public static func stepManualMs(_ current: Int64, byMs deltaMs: Int64) -> Int64 {
+        clampManualMs(current + deltaMs)
+    }
+
+    /// Human-readable signed offset, e.g. "+0.6 s", "-0.3 s", "0.0 s" (a value
+    /// that rounds to zero renders unsigned, never "-0.0 s"). Mirrors Android's
+    /// `formatOffsetMs`.
+    public static func formatMs(_ ms: Int64) -> String {
+        let mag = String(format: "%.1f", abs(Double(ms)) / 1000.0)
+        let sign = mag == "0.0" ? "" : (ms < 0 ? "-" : "+")
+        return "\(sign)\(mag) s"
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Audio/Sntp.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/Sntp.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Pure SNTP (RFC 4330) packet build/parse, kept off the networking layer so
+/// the byte math is unit-testable. The UDP transport that sends the request and
+/// awaits the reply lives in the app (`SntpSyncService`), the same split as the
+/// WSJT-X `WsjtxCodec` (pure) vs `WsjtxUdpService` (transport) pair.
+///
+/// Mirrors the offset math in Android's `UtcTimer.syncTime` /
+/// `ntpClockOffsetMs`: query a time server, take its transmit timestamp, and
+/// compute `reference - deviceNow` as the whole-clock correction.
+public enum Sntp {
+    /// A client-mode SNTP request is exactly 48 bytes.
+    public static let packetSize = 48
+
+    /// Seconds between the NTP epoch (1900-01-01) and the Unix epoch
+    /// (1970-01-01). NTP timestamps count seconds since 1900.
+    public static let ntpUnixEpochDeltaSec: Int64 = 2_208_988_800
+
+    /// Build a minimal client request packet: LI = 0 (no warning), VN = 4,
+    /// Mode = 3 (client) in the first byte, the rest zero.
+    public static func makeRequest() -> [UInt8] {
+        var packet = [UInt8](repeating: 0, count: packetSize)
+        packet[0] = 0x23 // 00_100_011 : LI=0, VN=4, Mode=3 (client)
+        return packet
+    }
+
+    /// Extract the server's Transmit Timestamp (bytes 40..47) from a response
+    /// and convert it to Unix epoch milliseconds. Returns `nil` when the packet
+    /// is too short or carries a zero (unset / Kiss-o'-Death) timestamp.
+    public static func transmitTimeUnixMs(fromResponse bytes: [UInt8]) -> Int64? {
+        guard bytes.count >= packetSize else { return nil }
+        let seconds = beUInt32(bytes, at: 40)
+        let fraction = beUInt32(bytes, at: 44)
+        if seconds == 0 { return nil } // no valid timestamp in the reply
+
+        let unixSec = Int64(seconds) - ntpUnixEpochDeltaSec
+        // The 32-bit fraction is a binary fraction of one second.
+        let fractionMs = Int64((Double(fraction) / 4_294_967_296.0) * 1_000.0)
+        return unixSec * 1_000 + fractionMs
+    }
+
+    /// The whole-clock offset (ms) to add to the device clock so it matches the
+    /// reference: `reference - deviceNow`. Positive means the device clock is
+    /// behind the reference and must be shifted forward. The full offset is
+    /// returned (not just its remainder within one FT8 cycle) so a device clock
+    /// more than a cycle out is fully corrected — matching Android's
+    /// `ntpClockOffsetMs`.
+    public static func offsetMs(referenceUnixMs: Int64, deviceNowMs: Int64) -> Int64 {
+        referenceUnixMs - deviceNowMs
+    }
+
+    /// Read a big-endian (network byte order) 32-bit unsigned int at `offset`.
+    static func beUInt32(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+        (UInt32(bytes[offset]) << 24)
+            | (UInt32(bytes[offset + 1]) << 16)
+            | (UInt32(bytes[offset + 2]) << 8)
+            | UInt32(bytes[offset + 3])
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/ClockHealthTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/ClockHealthTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import FT8Audio
+
+final class ClockHealthTests: XCTestCase {
+
+    // MARK: - Level thresholds around 0.3 s (good) and 1.0 s (fair)
+
+    func testUnknownWhenNil() {
+        XCTAssertEqual(ClockHealth.level(offsetSec: nil), .unknown)
+    }
+
+    func testNonFiniteIsUnknown() {
+        XCTAssertEqual(ClockHealth.level(offsetSec: .nan), .unknown)
+        XCTAssertEqual(ClockHealth.level(offsetSec: .infinity), .unknown)
+    }
+
+    func testGoodBoundary() {
+        XCTAssertEqual(ClockHealth.level(offsetSec: 0.0), .good)
+        XCTAssertEqual(ClockHealth.level(offsetSec: 0.29), .good)
+        XCTAssertEqual(ClockHealth.level(offsetSec: 0.3), .good)   // inclusive
+        XCTAssertEqual(ClockHealth.level(offsetSec: -0.3), .good)  // magnitude
+    }
+
+    func testFairBand() {
+        XCTAssertEqual(ClockHealth.level(offsetSec: 0.31), .fair)
+        XCTAssertEqual(ClockHealth.level(offsetSec: 1.0), .fair)   // inclusive
+        XCTAssertEqual(ClockHealth.level(offsetSec: -0.8), .fair)
+    }
+
+    func testPoorAboveFair() {
+        XCTAssertEqual(ClockHealth.level(offsetSec: 1.01), .poor)
+        XCTAssertEqual(ClockHealth.level(offsetSec: -2.5), .poor)
+    }
+
+    // MARK: - Offset label
+
+    func testOffsetLabel() {
+        XCTAssertEqual(ClockHealth.offsetLabel(offsetSec: nil), "—")
+        XCTAssertEqual(ClockHealth.offsetLabel(offsetSec: .nan), "—")
+        XCTAssertEqual(ClockHealth.offsetLabel(offsetSec: 0.1), "+0.1 s")
+        XCTAssertEqual(ClockHealth.offsetLabel(offsetSec: -1.3), "-1.3 s")
+        XCTAssertEqual(ClockHealth.offsetLabel(offsetSec: 0.0), "0.0 s")
+        // Rounds to zero -> no sign (never "-0.0 s").
+        XCTAssertEqual(ClockHealth.offsetLabel(offsetSec: -0.02), "0.0 s")
+    }
+
+    // MARK: - Status text
+
+    func testStatusText() {
+        XCTAssertEqual(ClockHealth.statusText(.good), "In sync")
+        XCTAssertEqual(ClockHealth.statusText(.fair), "Resync soon")
+        XCTAssertEqual(ClockHealth.statusText(.poor), "Clock off")
+        XCTAssertEqual(ClockHealth.statusText(.unknown), "Unknown")
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/ClockOffsetTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/ClockOffsetTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import FT8Audio
+
+final class ClockOffsetTests: XCTestCase {
+
+    // MARK: - Combine math
+
+    func testCombinedIsNtpPlusManual() {
+        let off = ClockOffset(ntpOffsetMs: 200, manualOffsetMs: -50)
+        XCTAssertEqual(off.combinedMs, 150)
+    }
+
+    func testDefaultsAreZero() {
+        let off = ClockOffset()
+        XCTAssertEqual(off.combinedMs, 0)
+        XCTAssertEqual(off.apply(toUtcMs: 12_345), 12_345)
+    }
+
+    func testApplyShiftsWallClock() {
+        let off = ClockOffset(ntpOffsetMs: 300, manualOffsetMs: 500)
+        XCTAssertEqual(off.apply(toUtcMs: 1_000_000), 1_000_800)
+    }
+
+    // MARK: - The whole point: the offset must move BOTH RX slot detection and
+    // TX cycle position by the same amount (Android's whole-clock model), while
+    // the DtCalibrator rxOffsetMs stays an independent RX-only term.
+
+    func testOffsetShiftsRxSlotAndTxCycleConsistently() {
+        // Pick a wall time deep inside a slot so a +0.5 s manual nudge stays in
+        // the same slot but visibly advances the cycle position.
+        let wallMs: Int64 = 15_000 * 100 + 5_000 // 5.000 s into slot 100
+        let manual: Int64 = 500                   // +0.5 s whole-clock correction
+        let off = ClockOffset(manualOffsetMs: manual)
+        let rxOffset: Int64 = 120                  // independent capture-latency comp
+
+        let baseNow = wallMs
+        let shiftedNow = off.apply(toUtcMs: wallMs)
+
+        // RX slot detection sees the shifted clock AND the rxOffset; the cycle
+        // position it implies advances by exactly the manual offset.
+        let baseRxSlot = SlotClock.rxSlotID(atUtcMs: baseNow, rxOffsetMs: rxOffset)
+        let shiftedRxSlot = SlotClock.rxSlotID(atUtcMs: shiftedNow, rxOffsetMs: rxOffset)
+        XCTAssertEqual(baseRxSlot, shiftedRxSlot) // same slot for a small nudge
+
+        // TX timing reads msIntoCycle off the shifted clock (no rxOffset): the
+        // cycle position moves by exactly the manual offset.
+        let baseTxCycle = SlotClock.msIntoCycle(atUtcMs: baseNow)
+        let shiftedTxCycle = SlotClock.msIntoCycle(atUtcMs: shiftedNow)
+        XCTAssertEqual(shiftedTxCycle - baseTxCycle, manual)
+    }
+
+    func testOffsetCanPushAcrossASlotBoundaryForBothReads() {
+        // 200 ms before a slot boundary; a +0.5 s correction crosses into the
+        // next slot for both the RX and TX reads (they move together).
+        let wallMs: Int64 = 15_000 * 200 - 200
+        let off = ClockOffset(ntpOffsetMs: 500)
+        let shifted = off.apply(toUtcMs: wallMs)
+
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: wallMs), 199)
+        XCTAssertEqual(SlotClock.rxSlotID(atUtcMs: shifted, rxOffsetMs: 0), 200)
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: shifted), 200)
+    }
+
+    // MARK: - Manual clamping
+
+    func testManualClampToRange() {
+        XCTAssertEqual(ClockOffset.clampManualMs(9_999), ClockOffset.manualMaxMs)
+        XCTAssertEqual(ClockOffset.clampManualMs(-9_999), ClockOffset.manualMinMs)
+        XCTAssertEqual(ClockOffset.clampManualMs(250), 250)
+    }
+
+    func testInitClampsManualOffset() {
+        let hi = ClockOffset(manualOffsetMs: 100_000)
+        XCTAssertEqual(hi.manualOffsetMs, ClockOffset.manualMaxMs)
+        let lo = ClockOffset(manualOffsetMs: -100_000)
+        XCTAssertEqual(lo.manualOffsetMs, ClockOffset.manualMinMs)
+    }
+
+    func testStepManualNudgesAndClamps() {
+        XCTAssertEqual(ClockOffset.stepManualMs(0, byMs: 100), 100)
+        XCTAssertEqual(ClockOffset.stepManualMs(0, byMs: -500), -500)
+        // Step past the ceiling clamps to the max.
+        XCTAssertEqual(ClockOffset.stepManualMs(4_800, byMs: 500), ClockOffset.manualMaxMs)
+        XCTAssertEqual(ClockOffset.stepManualMs(-4_800, byMs: -500), ClockOffset.manualMinMs)
+    }
+
+    // MARK: - Formatting
+
+    func testFormatMs() {
+        XCTAssertEqual(ClockOffset.formatMs(600), "+0.6 s")
+        XCTAssertEqual(ClockOffset.formatMs(-300), "-0.3 s")
+        XCTAssertEqual(ClockOffset.formatMs(0), "0.0 s")
+        // A value that rounds to 0.0 never renders a sign.
+        XCTAssertEqual(ClockOffset.formatMs(40), "0.0 s")
+        XCTAssertEqual(ClockOffset.formatMs(-40), "0.0 s")
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SntpTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SntpTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import FT8Audio
+
+final class SntpTests: XCTestCase {
+
+    /// Write a big-endian UInt32 into `bytes` at `offset`.
+    private func putBE(_ value: UInt32, into bytes: inout [UInt8], at offset: Int) {
+        bytes[offset] = UInt8((value >> 24) & 0xFF)
+        bytes[offset + 1] = UInt8((value >> 16) & 0xFF)
+        bytes[offset + 2] = UInt8((value >> 8) & 0xFF)
+        bytes[offset + 3] = UInt8(value & 0xFF)
+    }
+
+    // MARK: - Request
+
+    func testRequestIs48BytesClientMode() {
+        let req = Sntp.makeRequest()
+        XCTAssertEqual(req.count, 48)
+        XCTAssertEqual(req[0], 0x23) // LI=0, VN=4, Mode=3 (client)
+        XCTAssertTrue(req[1...].allSatisfy { $0 == 0 })
+    }
+
+    // MARK: - Parse (programmatic)
+
+    func testParseTransmitTimestampToUnixMs() {
+        // Reference: 2023-11-14 22:13:20 UTC = 1_700_000_000 s, plus 0.5 s.
+        let unixSec: Int64 = 1_700_000_000
+        let ntpSec = UInt32(unixSec + Sntp.ntpUnixEpochDeltaSec)
+        let halfSecondFraction: UInt32 = 0x8000_0000 // 0.5 s
+
+        var packet = [UInt8](repeating: 0, count: 48)
+        putBE(ntpSec, into: &packet, at: 40)
+        putBE(halfSecondFraction, into: &packet, at: 44)
+
+        let ms = Sntp.transmitTimeUnixMs(fromResponse: packet)
+        XCTAssertEqual(ms, unixSec * 1_000 + 500)
+    }
+
+    // MARK: - Parse (literal captured bytes)
+
+    func testParseLiteralResponseAndOffset() {
+        // A full 48-byte response whose transmit timestamp encodes
+        // 1_700_000_000.500 s Unix (NTP seconds 0xE8FE6F80, fraction 0x80000000).
+        var packet = [UInt8](repeating: 0, count: 48)
+        packet[0] = 0x24 // LI=0, VN=4, Mode=4 (server)
+        packet[1] = 2    // stratum
+        // Transmit Timestamp @ bytes 40..47
+        packet[40] = 0xE8; packet[41] = 0xFE; packet[42] = 0x6F; packet[43] = 0x80
+        packet[44] = 0x80; packet[45] = 0x00; packet[46] = 0x00; packet[47] = 0x00
+
+        let ref = Sntp.transmitTimeUnixMs(fromResponse: packet)
+        XCTAssertEqual(ref, 1_700_000_000_500)
+
+        // Device clock 0.5 s behind the reference -> +500 ms correction.
+        let offset = Sntp.offsetMs(referenceUnixMs: ref!, deviceNowMs: 1_700_000_000_000)
+        XCTAssertEqual(offset, 500)
+    }
+
+    // MARK: - Offset sign
+
+    func testOffsetSignForFastAndSlowClocks() {
+        // Device ahead of reference -> negative correction (pull it back).
+        XCTAssertEqual(Sntp.offsetMs(referenceUnixMs: 1_000, deviceNowMs: 1_800), -800)
+        // Device behind reference -> positive correction (push it forward).
+        XCTAssertEqual(Sntp.offsetMs(referenceUnixMs: 2_000, deviceNowMs: 1_200), 800)
+    }
+
+    // MARK: - Malformed / degenerate responses
+
+    func testTooShortResponseReturnsNil() {
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: [UInt8](repeating: 0, count: 47)))
+    }
+
+    func testZeroTimestampReturnsNil() {
+        // All-zero transmit timestamp (unset / Kiss-o'-Death) is rejected.
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: [UInt8](repeating: 0, count: 48)))
+    }
+}


### PR DESCRIPTION
## What
Adds the three time-discipline controls iOS lacked (Android ships all): **NTP sync**, **manual clock offset**, and a **clock-health indicator**. iOS previously had only automatic DT calibration (RX-only).

- **Whole-clock offset** — `ClockOffset` (`ntpOffsetMs + manualOffsetMs`), the iOS analog of Android `UtcTimer.delay`. Threaded through a single `LiveEngine.nowMs()` so it shifts **both RX slot detection and TX key-up timing** (and logged/displayed UTC) together. Deliberately **distinct** from `DtCalibrator.rxOffsetMs` (RX-only capture-latency comp), which is left untouched — the point is that a manual/NTP correction moves *transmit* too.
- **NTP "Sync now"** — pure `Sntp` (48-byte request, big-endian transmit-timestamp parse) + `SntpSyncService` (`NWConnection` UDP:123 to `time.apple.com`, 5 s hard timeout, single-resume guard so a dead server never blocks the audio/decode loop). Failures keep the prior offset and surface an error.
- **Manual offset** — ±5 s (covers real device-clock drift), 0.1/0.5 s steppers, in a new **Time Sync** settings screen; persisted + clamped on load.
- **Clock-health indicator** — `ClockHealth` (good ≤ 0.3 s, fair ≤ 1.0 s, else poor), driven by the mean decode DT, rendered as a dot+offset in the Decode header and the Time Sync screen.

## TX-timing safety
The offset feeds `SlotClock.msIntoCycle`, which is the late-start-clip input; the correction is small (±seconds) and `beginTxPlayback` still re-checks real cycle position, so on-time TX is not pushed into clip territory.

## Tests
483 FT8AFKit tests pass — 21 new: offset combine + an RX-slot/TX-cycle consistency test, SNTP parse from known bytes (offset sign), health boundaries at 0.3/1.0 s, manual clamp/step. App builds; `xcodegen` regenerated for the new app files.

Part of the iOS↔Android parity sweep (timing). Related follow-ups: T3 (whole-clock DT calibration), T4 (GPS discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)