### PR TITLE
iOS decode: subtract-and-redecode weak-signal recovery (deep mode)

### DIFF
--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -430,8 +430,11 @@ final class LiveEngine {
             let decoder = FT8Decoder(hashTable: hashTable)
             decoder.setDeep(opts.deep) // raise LDPC iterations when deep decode is on
             decoder.feedSlot(samples)
-            decoder.findSync()
-            let decoded = decoder.decodeAll()
+            // decodeSlotDeep runs the initial pass and, only when deep decode is
+            // on, the subtract-and-redecode loop that recovers weak signals
+            // hidden under stronger overlapping ones (Android's deep-decode
+            // subtraction). With deep off it is exactly one findSync+decodeAll.
+            let decoded = decoder.decodeSlotDeep()
 
             // DT calibration from this slot's decodes.
             if !decoded.isEmpty {

--- a/ios/FT8AFKit/Sources/CFT8/include/CFT8.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/CFT8.h
@@ -24,6 +24,13 @@
 #include <ft8/decode.h>    // waterfall_t, candidate_t, decode_status_t, ft8_find_sync, ft8_decode
 #include <common/monitor.h> // monitor_t, monitor_config_t, monitor_init/reset/process/free
 
+// --- ft8af_glue deep-decode subtraction -------------------------------------
+// ft8_subtract_signal (waterfall-domain) + ft8_subtract_signal_time (coherent
+// time-domain). Resolves via the CFT8 target's -I .../ft8af_glue flag; the
+// implementations are compiled by shim_subtract.c. Swift's subtract-and-redecode
+// loop (FT8Decoder.swift) drives the time-domain variant.
+#include <ft8_subtract.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/ios/FT8AFKit/Sources/CFT8/include/ft8_subtract.h
+++ b/ios/FT8AFKit/Sources/CFT8/include/ft8_subtract.h
@@ -1,0 +1,1 @@
+../../../../../ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.h

--- a/ios/FT8AFKit/Sources/CFT8/shim_subtract.c
+++ b/ios/FT8AFKit/Sources/CFT8/shim_subtract.c
@@ -1,0 +1,10 @@
+// Shim TU: compiles the real ft8af_glue subtraction source in place (no copy).
+// See Package.swift / ios/README.md for why the C lives outside this package.
+//
+// This pulls in both ft8_subtract_signal (waterfall-domain) and
+// ft8_subtract_signal_time (coherent time-domain, WSJT-X subtractft8 approach),
+// the exact same C the Android JNI glue (ft8_decode_jni.cpp) calls from
+// ReBuildSignal.doSubtractSignal. ft8_subtract.c references synth_gfsk_dphi_alloc
+// (compiled by shim_gfsk.c) and ft8_encode (compiled by shim_encode.c); both are
+// separate TUs in this same CFT8 target, so the symbols resolve at link time.
+#include "../../../../ft8af/app/src/main/cpp/ft8af_glue/ft8_subtract.c"

--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
@@ -39,6 +39,17 @@ public final class FT8Decoder {
     private var mon = monitor_t()
     private var candidates = [candidate_t](repeating: candidate_t(), count: FT8Decoder.maxCandidates)
     private var numCandidates = 0
+
+    /// The codec sample rate (needed by the time-domain subtraction, which works
+    /// in the raw sample domain rather than the waterfall).
+    let sampleRate: Int32
+    /// Retained copy of the samples last fed through the monitor. The subtract-
+    /// and-redecode loop edits this in place (removing each decoded signal) and
+    /// re-runs the STFT over it — mirroring ft8_decoder_state.samples/num_fed in
+    /// the Android JNI glue, which keeps the slot's audio for exactly this. Only
+    /// the block-aligned prefix [0, numFed) was actually processed by the monitor.
+    private(set) var fedSamples: [Float] = []
+    private(set) var numFed = 0
     /// Current LDPC iteration cap fed to `ft8_decode`. Exposed read-only so
     /// callers/tests can confirm `setDeep` took effect.
     public private(set) var ldpcIterations = FT8Decoder.ldpcItersNormal
@@ -56,6 +67,7 @@ public final class FT8Decoder {
     /// only), which keeps standalone/one-shot decodes isolated.
     public init(sampleRate: Int32 = FT8.sampleRate, isFT8: Bool = true, hashTable: HashTable = HashTable()) {
         self.hashtable = hashTable
+        self.sampleRate = sampleRate
         var cfg = monitor_config_t()
         cfg.f_min = 100
         cfg.f_max = 3500
@@ -83,12 +95,49 @@ public final class FT8Decoder {
         // across slots so a `<...>` hash resolves against a full compound call
         // decoded in an earlier slot (matching Android's static hashList). The
         // table bounds its own growth (see HashTable.capacity).
+        // Retain the samples so the deep-decode subtract loop can edit them in
+        // place and re-run the STFT (see runSubtractLoop / rerunMonitor).
+        fedSamples = samples
+        numFed = (samples.count / block) * block
         samples.withUnsafeBufferPointer { buf in
             guard let base = buf.baseAddress else { return }
             var pos = 0
             while pos + block <= buf.count {
                 monitor_process(&mon, base + pos)
                 pos += block
+            }
+        }
+    }
+
+    /// Recompute the waterfall from the (possibly subtraction-edited) retained
+    /// samples, so the next `findSync` sees the residual. Mirrors the
+    /// wf_dirty branch of Android's DecoderFt8FindSync.
+    internal func rerunMonitor() {
+        let block = Int(mon.block_size)
+        if block == 0 || numFed <= 0 { return }
+        monitor_reset(&mon)
+        fedSamples.withUnsafeBufferPointer { buf in
+            guard let base = buf.baseAddress else { return }
+            var pos = 0
+            while pos + block <= numFed {
+                monitor_process(&mon, base + pos)
+                pos += block
+            }
+        }
+    }
+
+    /// Coherently subtract one decoded signal's GFSK waveform from the retained
+    /// samples, in place (the native WSJT-X-style time-domain subtraction). The
+    /// caller must `rerunMonitor` before decoding again. Returns false (samples
+    /// unchanged) on degenerate input, matching `ft8_subtract_signal_time`.
+    @discardableResult
+    internal func subtractSignalTime(a91: [UInt8], freqHz: Float, timeSec: Float) -> Bool {
+        guard numFed > 0, a91.count >= 10 else { return false }
+        return fedSamples.withUnsafeMutableBufferPointer { sp -> Bool in
+            guard let sbase = sp.baseAddress else { return false }
+            return a91.withUnsafeBufferPointer { ap in
+                ft8_subtract_signal_time(&mon, sbase, Int32(numFed), sampleRate,
+                                         ap.baseAddress, freqHz, timeSec)
             }
         }
     }

--- a/ios/FT8AFKit/Sources/FT8DSP/SubtractDecode.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/SubtractDecode.swift
@@ -1,0 +1,127 @@
+import CFT8
+import Foundation
+
+/// Subtract-and-redecode: the iOS port of Android's deep-decode weak-signal
+/// recovery (FT8SignalListener's subtract loop + ReBuildSignal.doSubtractSignal
+/// + DeepDecodeBudget, all over ft8af_glue/ft8_subtract.c).
+///
+/// A single decode pass loses a weak signal sitting under a stronger one that
+/// shares its tone bins (the FT8 Costas sync arrays are identical for every
+/// signal, so co-channel transmissions reinforce into one candidate and the
+/// louder message wins the demod). The fix — same as WSJT-X's `subtractft8` and
+/// Android's loop — is: decode, reconstruct each decoded signal's exact GFSK
+/// waveform, coherently subtract it from the retained sample buffer, recompute
+/// the waterfall from the residual, and decode again; repeat while new messages
+/// keep surfacing, bounded so it always terminates inside the 15 s slot.
+///
+/// The decision/merge/budget logic here is deliberately plain Swift so it is
+/// unit-testable; the only native call is `ft8_subtract_signal_time`, the exact
+/// C the Android JNI path uses.
+public extension FT8Decoder {
+
+    // MARK: Budget (mirror DeepDecodeBudget)
+
+    /// Max subtract→redecode rounds after the initial pass. Each round costs one
+    /// full-buffer STFT recompute + find_sync + decode; on device the whole loop
+    /// shares the slot with the next slot's capture, so it must stay small.
+    /// Empirically 2-3 rounds surface essentially everything a stronger signal
+    /// masks; 4 is a safe ceiling that also caps a pathological (never-converging)
+    /// buffer. Android bounds by wall-clock budget instead; an explicit round cap
+    /// is the deterministic, testable equivalent here.
+    static let subtractMaxRounds = 4
+
+    /// Hard ceiling on total merged messages — a second, independent guarantee of
+    /// termination if a corrupt residual keeps manufacturing "new" CRC-valid junk
+    /// every round. A real slot never approaches this (FT8AF_MAX_CANDIDATES is
+    /// 140); it exists purely so the loop cannot run away.
+    static let subtractMaxMessages = 200
+
+    /// Full deep-decode of the slot most recently `feedSlot`-ed: the initial
+    /// pass, then — only when deep mode is on (`isDeep`) — the subtract-and-
+    /// redecode loop. When deep is off this is exactly one `findSync`+`decodeAll`,
+    /// so it is safe to call unconditionally in place of the single-pass path.
+    ///
+    /// Requires `feedSlot` to have run first (it retains the samples the loop
+    /// subtracts from). Returns every message found across all passes, deduped by
+    /// text with the highest SNR kept (mirrors Android addMsgToList/
+    /// checkMessageSame).
+    func decodeSlotDeep() -> [DecodedMessage] {
+        findSync()
+        var all = decodeAll()
+        guard isDeep else { return all }
+        runSubtractLoop(into: &all)
+        return all
+    }
+
+    /// The subtract-and-redecode loop, factored out so it can be exercised
+    /// directly. `all` enters holding the initial pass's decodes and leaves
+    /// holding the full, merged, SNR-upgraded set. `lastPass` seeds the first
+    /// round's subtraction targets (the messages just decoded).
+    ///
+    /// Termination is triple-guaranteed: (1) the round cap, (2) the message cap,
+    /// and (3) convergence — a round that subtracts nothing new, or that surfaces
+    /// no new message, ends the loop (Android's `while (msgs.size() > 0)` plus the
+    /// per-transmission subtract-once rule).
+    internal func runSubtractLoop(into all: inout [DecodedMessage]) {
+        // Each transmission is subtracted at most once: the same message decodes
+        // from several neighboring candidates and again from its own residual in
+        // later passes; a second subtraction fits the fine sync to junk and
+        // pollutes the residual (mirrors ft8_decoder_state.sub_done in the JNI
+        // glue, which lives in the wrapper, not in the shared shim function).
+        var subtracted = Set<[UInt8]>()
+        var lastPass = all
+        var round = 0
+
+        while round < FT8Decoder.subtractMaxRounds,
+              all.count < FT8Decoder.subtractMaxMessages {
+            // Subtract every not-yet-subtracted signal the last pass decoded.
+            var didSubtract = false
+            for m in lastPass {
+                if m.a91.allSatisfy({ $0 == 0 }) { continue } // no payload to re-encode
+                if subtracted.contains(m.a91) { continue }
+                if subtractSignalTime(a91: m.a91, freqHz: m.freqHz, timeSec: m.timeSec) {
+                    subtracted.insert(m.a91)
+                    didSubtract = true
+                }
+            }
+            if !didSubtract { break } // nothing left to remove -> converged
+
+            // Recompute the waterfall from the residual and decode again.
+            rerunMonitor()
+            findSync()
+            let msgs = decodeAll()
+
+            // Merge: new messages get appended, repeats upgrade the kept SNR.
+            let newOnes = mergeDecodes(into: &all, msgs)
+            lastPass = msgs
+            round += 1
+            if newOnes.isEmpty { break } // a pass with nothing new -> converged
+        }
+    }
+}
+
+/// Merge `newMsgs` into `all`, the slot-wide dedup scope, keyed on decoded text.
+/// A message already present upgrades the kept copy's SNR when the new one is
+/// higher; a genuinely new message is appended. Returns the messages that were
+/// new (appended), mirroring how Android's addMsgToList leaves `newMsg` holding
+/// only the fresh decodes. Free-standing and pure so it is unit-testable without
+/// a monitor.
+///
+/// Port of FT8SignalListener.addMsgToList + checkMessageSame: dedup by
+/// getMessageText, keep the higher SNR.
+@discardableResult
+func mergeDecodes(into all: inout [DecodedMessage], _ newMsgs: [DecodedMessage]) -> [DecodedMessage] {
+    var added: [DecodedMessage] = []
+    for m in newMsgs {
+        // Empty text never dedups against itself (matches decodeAll, which keeps
+        // every empty-text decode); treat it as always-new so it is not dropped.
+        if !m.rawText.isEmpty,
+           let idx = all.firstIndex(where: { $0.rawText == m.rawText }) {
+            if m.snr > all[idx].snr { all[idx].snr = m.snr }
+        } else {
+            all.append(m)
+            added.append(m)
+        }
+    }
+    return added
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/SubtractDecodeTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/SubtractDecodeTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+import CFT8
+@testable import FT8DSP
+
+/// Subtract-and-redecode (deep-decode weak-signal recovery): the iOS port of
+/// Android's FT8SignalListener subtract loop over ft8af_glue/ft8_subtract.c.
+final class SubtractDecodeTests: XCTestCase {
+
+    /// Sum of two GFSK signals (each at its own base freq + linear gain) laid at
+    /// the start of a 15 s slot. Gains model relative SNR: a much smaller gain is
+    /// a much weaker signal.
+    private func mixedSlot(_ specs: [(text: String, freq: Float, gain: Float)]) -> [Float]? {
+        var s = [Float](repeating: 0, count: FT8.slotSamples)
+        for spec in specs {
+            guard let audio = FT8Encoder.generateFT8(spec.text, baseFreqHz: spec.freq) else { return nil }
+            for i in 0..<min(audio.count, s.count) { s[i] += audio[i] * spec.gain }
+        }
+        return s
+    }
+
+    /// Goertzel power at one frequency over the whole buffer.
+    private func goertzelPower(_ x: [Float], freq: Float, sampleRate: Float) -> Double {
+        let w = 2.0 * Double.pi * Double(freq) / Double(sampleRate)
+        let coeff = 2.0 * cos(w)
+        var s1 = 0.0, s2 = 0.0
+        for v in x {
+            let s0 = Double(v) + coeff * s1 - s2
+            s2 = s1
+            s1 = s0
+        }
+        return s1 * s1 + s2 * s2 - coeff * s1 * s2
+    }
+
+    /// Total power over the eight FT8 tone bins an audio signal based at `freq`
+    /// can occupy (freq .. freq + 7*6.25 Hz) — "energy near the signal".
+    private func bandEnergy(_ x: [Float], baseFreq: Float) -> Double {
+        var e = 0.0
+        for i in 0..<8 {
+            e += goertzelPower(x, freq: baseFreq + Float(i) * 6.25, sampleRate: Float(FT8.sampleRate))
+        }
+        return e
+    }
+
+    // MARK: Weak-signal recovery
+
+    /// The headline behaviour: a weak signal overlapping a much stronger one
+    /// (here two tone-bins / 12.5 Hz apart, so their spectra overlap) is lost by
+    /// a single pass — find_sync locks onto the dominant signal and the louder
+    /// message wins the demod — but the subtract-and-redecode loop removes the
+    /// strong signal and decodes the weak one from the residual.
+    func testSubtractRedecodeSurfacesMaskedSignal() {
+        let strong = "CQ K1ABC FN42"
+        let weak = "W9XYZ K1ABC RR73"
+        // ~12 Hz apart (two 6.25 Hz tone bins), weak ~12 dB down: overlapping
+        // spectra, weak masked in a single pass but cleanly separable once the
+        // strong signal's full waveform is subtracted.
+        guard let s = mixedSlot([(strong, 1500, 0.50), (weak, 1512, 0.12)]) else {
+            return XCTFail("encode failed")
+        }
+
+        // Single deep pass (no subtraction): should get the strong one only.
+        let single = FT8Decoder()
+        single.setDeep(true)
+        single.feedSlot(s)
+        single.findSync()
+        let singleTexts = Set(single.decodeAll().map { $0.rawText })
+        XCTAssertTrue(singleTexts.contains(strong), "single pass should decode the strong signal: \(singleTexts)")
+        XCTAssertFalse(singleTexts.contains(weak),
+                       "single pass is expected to MISS the masked weak signal: \(singleTexts)")
+
+        // Full deep decode with the subtract-and-redecode loop: both surface.
+        let deep = FT8Decoder()
+        deep.setDeep(true)
+        deep.feedSlot(s)
+        let deepTexts = Set(deep.decodeSlotDeep().map { $0.rawText })
+        XCTAssertTrue(deepTexts.contains(strong), "deep decode keeps the strong signal: \(deepTexts)")
+        XCTAssertTrue(deepTexts.contains(weak),
+                      "subtract-and-redecode should recover the masked weak signal: \(deepTexts)")
+    }
+
+    /// The subtraction must actually remove energy from the buffer near the
+    /// subtracted signal's frequency (a wrong-phase/amplitude subtraction would
+    /// ADD energy and corrupt the residual).
+    func testSubtractionReducesEnergyNearFrequency() {
+        let text = "CQ K1ABC FN42"
+        let f: Float = 1500
+        guard let s = mixedSlot([(text, f, 0.5)]) else { return XCTFail("encode failed") }
+
+        let dec = FT8Decoder()
+        dec.setDeep(true)
+        dec.feedSlot(s)
+        dec.findSync()
+        guard let m = dec.decodeAll().first(where: { $0.rawText == text }) else {
+            return XCTFail("expected to decode \(text)")
+        }
+
+        let before = bandEnergy(dec.fedSamples, baseFreq: f)
+        XCTAssertTrue(dec.subtractSignalTime(a91: m.a91, freqHz: m.freqHz, timeSec: m.timeSec),
+                      "subtraction should apply")
+        let after = bandEnergy(dec.fedSamples, baseFreq: f)
+
+        XCTAssertLessThan(after, before * 0.25,
+                          "subtraction should cut in-band energy by >6 dB (before=\(before), after=\(after))")
+    }
+
+    // MARK: Merge / dedup / SNR upgrade (pure logic)
+
+    /// A repeat decode with a higher SNR upgrades the kept copy; a lower one does
+    /// not; and only genuinely new messages are returned.
+    func testMergeKeepsHigherSnrAndReturnsOnlyNew() {
+        func msg(_ text: String, _ snr: Int) -> DecodedMessage {
+            var m = DecodedMessage(); m.rawText = text; m.snr = snr; return m
+        }
+        var all = [msg("CQ K1ABC FN42", -12), msg("W9XYZ K1ABC RR73", -5)]
+
+        // Same texts (one higher SNR, one lower) + one new message.
+        let newMsgs = [msg("CQ K1ABC FN42", -3),   // higher -> upgrade
+                       msg("W9XYZ K1ABC RR73", -9), // lower -> keep -5
+                       msg("K1ABC W9XYZ 73", -8)]   // new -> append
+        let added = mergeDecodes(into: &all, newMsgs)
+
+        XCTAssertEqual(added.map { $0.rawText }, ["K1ABC W9XYZ 73"], "only the new message is returned")
+        XCTAssertEqual(all.count, 3)
+        XCTAssertEqual(all.first { $0.rawText == "CQ K1ABC FN42" }?.snr, -3, "higher SNR upgrades")
+        XCTAssertEqual(all.first { $0.rawText == "W9XYZ K1ABC RR73" }?.snr, -5, "lower SNR does not downgrade")
+    }
+
+    // MARK: Termination / budget
+
+    /// The loop must terminate on a pathological (pure-noise) buffer: no infinite
+    /// loop, and the result stays under the hard message cap. Bounded by the round
+    /// cap regardless of what find_sync keeps manufacturing.
+    func testBudgetTerminatesOnPathologicalBuffer() {
+        var rng = SystemRandomNumberGenerator()
+        var noise = [Float](repeating: 0, count: FT8.slotSamples)
+        for i in 0..<noise.count { noise[i] = Float.random(in: -0.3...0.3, using: &rng) }
+
+        let dec = FT8Decoder()
+        dec.setDeep(true)
+        dec.feedSlot(noise)
+        // Returns (does not hang); the round cap guarantees termination.
+        let result = dec.decodeSlotDeep()
+        XCTAssertLessThanOrEqual(result.count, FT8Decoder.subtractMaxMessages,
+                                 "message count stays under the hard cap")
+    }
+
+    /// With deep mode OFF, decodeSlotDeep is exactly one pass (no subtraction) —
+    /// so it never differs from the plain single-pass path.
+    func testDeepOffIsSinglePass() {
+        guard let s = mixedSlot([("CQ K1ABC FN42", 1500, 0.5)]) else { return XCTFail("encode") }
+
+        let a = FT8Decoder() // deep off
+        a.feedSlot(s)
+        let deepOff = Set(a.decodeSlotDeep().map { $0.rawText })
+
+        let b = FT8Decoder()
+        b.feedSlot(s)
+        b.findSync()
+        let single = Set(b.decodeAll().map { $0.rawText })
+
+        XCTAssertEqual(deepOff, single, "deep-off decodeSlotDeep equals a single pass")
+    }
+}


### PR DESCRIPTION
## What
Ports Android's deep-decode **subtract-and-redecode** to iOS — the single biggest decode-yield gap. It recovers weak signals masked by stronger overlapping ones.

- **Native**: `shim_subtract.c` compiles the **same vendored `ft8af_glue/ft8_subtract.c`** the Android JNI path uses (`ft8_subtract_signal_time`: re-encode `a91`→79 tones→synth GFSK reference, fine time/freq sync, complex-gain estimate, subtract `2·Re(gain·ref)` in place). Header exposed via an `include/` symlink — **identical to how every other ft8_lib header is exposed** (the whole `include/` tree is symlinks into `ft8af/.../cpp`). No reimplementation, no guessed math — byte-identical to Android.
- **Swift**: `SubtractDecode.decodeSlotDeep()` runs the initial pass, then **only when deep mode is on** a bounded subtract loop (≤4 rounds, ≤200 msgs, stops on convergence): subtract each newly-decoded signal → `monitor_reset` + reprocess residual → re-decode. **Deep off = exactly one `findSync`+`decodeAll`** (safe drop-in). `mergeDecodes` dedups by text keeping the **higher SNR** (port of `addMsgToList`/`checkMessageSame`); the cross-slot hash table + junk filter still apply to later-pass messages.
- **LiveEngine** uses `decodeSlotDeep()` per slot, gated by the existing deep-decode setting (from #741).

## Tests
516 FT8AFKit tests pass — masking recovery (strong+weak overlapping signals: single pass gets only the strong, deep recovers both), >6 dB in-band energy reduction after subtraction, SNR-upgrade dedup, budget termination on a pathological buffer, and deep-off single-pass. App builds (device + simulator).

## Notes
Together with #741 (deep decode + earlyDecode), this is the decode-sensitivity core of Android's PR-#702 tandem scheduling. The remaining piece — the *late full-slot* pass scheduling — is a smaller follow-up.

Part of the iOS↔Android parity sweep (decode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)