### PR TITLE
iOS POTA: authenticated log upload (Cognito hosted-UI OAuth + Keychain)

### DIFF
--- a/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
+++ b/ios/FT8AF/FT8AF.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		035DDD710715AAC0100E0871 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3B4836E62F9DC32FAB0DE /* Colors.swift */; };
+		05297DA0C772567908E3A63F /* PotaUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A452443C4DDC4233D8E466 /* PotaUploadService.swift */; };
 		072D76FFDC706DE3E537A3C2 /* BlockedCallsignsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8FFDE0644205A9AE050BC0 /* BlockedCallsignsSettings.swift */; };
 		092F3A3A654939270685CC27 /* ParkPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F3AF234143FDFFA45B0AC8 /* ParkPickerSheet.swift */; };
 		094BBB2F12228E68B26D2DB1 /* PotaParkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8887498A3FE21F5B9ADAE63A /* PotaParkService.swift */; };
@@ -18,9 +19,11 @@
 		33736A682F52CCBB13E8168A /* LogbookScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76108617D9AEDEE84BAD1054 /* LogbookScreen.swift */; };
 		3BA2BC0EFAF62534D39C3A4A /* DecodeFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88688AC6AFBEDC8AC3EF844 /* DecodeFilterSettings.swift */; };
 		3BCBA78527E44AD070AA1E48 /* AudioRoutePickerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4217D8419318D6A336873605 /* AudioRoutePickerButton.swift */; };
+		3E123C57BE6C3282B2D616C5 /* PotaAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A6A51948436E153F5CB8F4 /* PotaAuthService.swift */; };
 		49DFEC8ED0237764EA3EE3BF /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF21F5D95598018B8A46ED8D /* AppState.swift */; };
 		4C0C9DCC39ED6528F0D4CDFF /* RadioAudioSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89642B9763C7FA33CFF0EE57 /* RadioAudioSettings.swift */; };
 		4D87F21162B4DCEC806D8785 /* QsoCelebration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8DAEDCAE1AD9DE02EB1480 /* QsoCelebration.swift */; };
+		4F6EF07DDECF04B6321DEEC4 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0A25416CDB1102C9AD749 /* KeychainStore.swift */; };
 		4F742232FB7AE5A02DF90DE8 /* geist_mono_semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CFC0DD2F717A726A4887913B /* geist_mono_semibold.ttf */; };
 		51B44F6A9F0A05A7B3CB71FC /* FrequencyPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C698656C5709343F4AEEF0 /* FrequencyPickerSheet.swift */; };
 		5487A5FF7F27849B22C01C42 /* ClockSyncIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9EBD1E2440476261F01908 /* ClockSyncIndicator.swift */; };
@@ -46,6 +49,7 @@
 		9D3A2D37F171D6B4D7AA48A3 /* inter_variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B42060FC68A03D3F64A7C2EF /* inter_variable.ttf */; };
 		9F4A1DE79693EF68A7B1A4D2 /* LogbookAwards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CCA018AEEE169EDCA338FD /* LogbookAwards.swift */; };
 		A037B00B861024FA2CA4919F /* QsoPathMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0187218903BBFF71931246 /* QsoPathMap.swift */; };
+		A22812B271EAC5752068D757 /* PotaLoginWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9621EA239E0A39263C4CD2F2 /* PotaLoginWebView.swift */; };
 		A5C16922F13DEDBDF69DFCF6 /* FT8AFTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41EFDE500F865A3B393171D /* FT8AFTab.swift */; };
 		AA448D315E29A08A6A925951 /* geist_mono_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BF1653386B026C49C8A42365 /* geist_mono_medium.ttf */; };
 		AA7457556E40D0C0B8F75958 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306EE5215AE14F95F3329F8 /* FilterChip.swift */; };
@@ -93,6 +97,7 @@
 		3B94D7FBAC132C5854796F79 /* AudioRouteController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRouteController.swift; sourceTree = "<group>"; };
 		4217D8419318D6A336873605 /* AudioRoutePickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRoutePickerButton.swift; sourceTree = "<group>"; };
 		467569ADBF392233E7AA71DC /* TimeSyncSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSyncSettings.swift; sourceTree = "<group>"; };
+		47F0A25416CDB1102C9AD749 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		4A8FFDE0644205A9AE050BC0 /* BlockedCallsignsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedCallsignsSettings.swift; sourceTree = "<group>"; };
 		4B08B1AA6951B99CEFAA521F /* TransmissionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionSettings.swift; sourceTree = "<group>"; };
 		4E09812700CD93E6187CC4BC /* LiveEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveEngine.swift; sourceTree = "<group>"; };
@@ -115,6 +120,7 @@
 		8BDDB723455CB7AE2BB68EF0 /* WorldMapCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldMapCanvas.swift; sourceTree = "<group>"; };
 		91DB096C5FC7481CA1B7B49B /* LogbookStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookStats.swift; sourceTree = "<group>"; };
 		93DFF1DC42A9F8F8066F97F7 /* LogbookCharts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookCharts.swift; sourceTree = "<group>"; };
+		9621EA239E0A39263C4CD2F2 /* PotaLoginWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaLoginWebView.swift; sourceTree = "<group>"; };
 		9BCE0C13DF4842EC394EFADF /* MapScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapScreen.swift; sourceTree = "<group>"; };
 		9F16B3079DF2D804F3F08F77 /* PotaSelfSpotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaSelfSpotService.swift; sourceTree = "<group>"; };
 		A3A872FCC168F7F5523C8D69 /* SplashScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreen.swift; sourceTree = "<group>"; };
@@ -125,12 +131,14 @@
 		B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaScreen.swift; sourceTree = "<group>"; };
 		B42060FC68A03D3F64A7C2EF /* inter_variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = inter_variable.ttf; sourceTree = "<group>"; };
 		B681B14FC4FED15C628471DF /* WaterfallCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallCanvas.swift; sourceTree = "<group>"; };
+		B9A6A51948436E153F5CB8F4 /* PotaAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaAuthService.swift; sourceTree = "<group>"; };
 		BB0565117E35A6C64BBF519D /* LoggingSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingSettings.swift; sourceTree = "<group>"; };
 		BD0187218903BBFF71931246 /* QsoPathMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QsoPathMap.swift; sourceTree = "<group>"; };
 		BE0DCBA7E647113F08F32531 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		BF1653386B026C49C8A42365 /* geist_mono_medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = geist_mono_medium.ttf; sourceTree = "<group>"; };
 		BF21F5D95598018B8A46ED8D /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		C42FB097015693FF14B27553 /* AudioCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureService.swift; sourceTree = "<group>"; };
+		C4A452443C4DDC4233D8E466 /* PotaUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotaUploadService.swift; sourceTree = "<group>"; };
 		C79C0E0096ADDC018120C361 /* DecodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeScreen.swift; sourceTree = "<group>"; };
 		C81C53609B2CDC9FB3B71116 /* FrequencyRuler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencyRuler.swift; sourceTree = "<group>"; };
 		C96D9C69CFC1480E6A5B64B5 /* SpectrumStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumStrip.swift; sourceTree = "<group>"; };
@@ -289,6 +297,7 @@
 			isa = PBXGroup;
 			children = (
 				55F3AF234143FDFFA45B0AC8 /* ParkPickerSheet.swift */,
+				9621EA239E0A39263C4CD2F2 /* PotaLoginWebView.swift */,
 				B35E490F93FDCACEC4FBF66F /* PotaScreen.swift */,
 			);
 			path = POTA;
@@ -342,12 +351,15 @@
 				C42FB097015693FF14B27553 /* AudioCaptureService.swift */,
 				3B94D7FBAC132C5854796F79 /* AudioRouteController.swift */,
 				F287F167508A8E4114F44116 /* FFTProcessor.swift */,
+				47F0A25416CDB1102C9AD749 /* KeychainStore.swift */,
 				4E09812700CD93E6187CC4BC /* LiveEngine.swift */,
 				D131B05E27A96EC4BEB28782 /* OnlineLogService.swift */,
 				FA66E8CE63C02CC35A2BC010 /* PotaActivationStore.swift */,
+				B9A6A51948436E153F5CB8F4 /* PotaAuthService.swift */,
 				8887498A3FE21F5B9ADAE63A /* PotaParkService.swift */,
 				9F16B3079DF2D804F3F08F77 /* PotaSelfSpotService.swift */,
 				7E27EE4248BF38A15E0F3B2D /* PotaService.swift */,
+				C4A452443C4DDC4233D8E466 /* PotaUploadService.swift */,
 				6B9E40312EA203F05764FA56 /* QsoLogStore.swift */,
 				58F3A88D466226E098AA8666 /* SntpSyncService.swift */,
 				29B5962B70F4510D76A5BC0A /* TxPlayerService.swift */,
@@ -475,6 +487,7 @@
 				51B44F6A9F0A05A7B3CB71FC /* FrequencyPickerSheet.swift in Sources */,
 				637BC14B19B728028FD01F07 /* FrequencyRuler.swift in Sources */,
 				8DA0D562E25925F56B638B00 /* GridDistance.swift in Sources */,
+				4F6EF07DDECF04B6321DEEC4 /* KeychainStore.swift in Sources */,
 				AB5310FE1F9048626DC6406B /* LiveEngine.swift in Sources */,
 				9F4A1DE79693EF68A7B1A4D2 /* LogbookAwards.swift in Sources */,
 				0FD449B6C15FD3407D8E3BC0 /* LogbookCharts.swift in Sources */,
@@ -485,10 +498,13 @@
 				8EF984B5816F012A2DF93FDF /* OnlineLogService.swift in Sources */,
 				092F3A3A654939270685CC27 /* ParkPickerSheet.swift in Sources */,
 				6A8A11D49F8CA3F24D9DED29 /* PotaActivationStore.swift in Sources */,
+				3E123C57BE6C3282B2D616C5 /* PotaAuthService.swift in Sources */,
+				A22812B271EAC5752068D757 /* PotaLoginWebView.swift in Sources */,
 				094BBB2F12228E68B26D2DB1 /* PotaParkService.swift in Sources */,
 				595BBF17D95723947D5BFFC4 /* PotaScreen.swift in Sources */,
 				F6878A4D126EF8AA903D1582 /* PotaSelfSpotService.swift in Sources */,
 				B4122A07A833C6746F51D5D6 /* PotaService.swift in Sources */,
+				05297DA0C772567908E3A63F /* PotaUploadService.swift in Sources */,
 				4D87F21162B4DCEC806D8785 /* QsoCelebration.swift in Sources */,
 				E375A4D50C25F5437C2C9F7F /* QsoLogStore.swift in Sources */,
 				A037B00B861024FA2CA4919F /* QsoPathMap.swift in Sources */,

--- a/ios/FT8AF/FT8AF/Engine/KeychainStore.swift
+++ b/ios/FT8AF/FT8AF/Engine/KeychainStore.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Security
+
+/// Tiny wrapper over the iOS Keychain for the app's few long-lived secrets —
+/// currently just the POTA refresh token (standing account access) and the
+/// display email that goes with it. Items are `kSecClassGenericPassword` scoped
+/// by `service` + `account`, accessible only after first unlock and never synced
+/// off the device (`AfterFirstUnlockThisDeviceOnly`), which keeps the refresh
+/// token out of iCloud Keychain and encrypted device backups.
+///
+/// This is the app's first Keychain use; kept deliberately minimal — three
+/// operations, no generics, no caching. Mirrors the *intent* of Android's
+/// EncryptedSharedPreferences (Keystore-backed at-rest encryption for the
+/// refresh token) without the SharedPreferences surface.
+enum KeychainStore {
+    /// Namespacing service string. Ties items to this app; a reinstall starts
+    /// fresh (the user signs in again), matching the Android behaviour.
+    private static let service = "radio.ks3ckc.ft8af.pota"
+
+    /// Store (or replace) a string for `account`. Returns false on any OSStatus
+    /// error so callers can decide whether a failed persist is fatal (for the
+    /// refresh token it isn't — the user just re-authenticates next time).
+    @discardableResult
+    static func set(_ value: String, account: String) -> Bool {
+        let data = Data(value.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        // Delete any existing item first so this is an upsert (SecItemUpdate
+        // can't add, and add fails with errSecDuplicateItem if one exists).
+        SecItemDelete(query as CFDictionary)
+
+        var attributes = query
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        return SecItemAdd(attributes as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// Read the string for `account`, or nil if absent / unreadable.
+    static func get(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var out: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Remove the item for `account` (no-op if absent).
+    static func remove(account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/KeychainStore.swift
+++ b/ios/FT8AF/FT8AF/Engine/KeychainStore.swift
@@ -13,8 +13,10 @@ import Security
 /// EncryptedSharedPreferences (Keystore-backed at-rest encryption for the
 /// refresh token) without the SharedPreferences surface.
 enum KeychainStore {
-    /// Namespacing service string. Ties items to this app; a reinstall starts
-    /// fresh (the user signs in again), matching the Android behaviour.
+    /// Namespacing service string. Ties items to this app. Note: unlike
+    /// Android's EncryptedSharedPreferences (wiped on uninstall), iOS Keychain
+    /// items can survive an app reinstall, so a signed-in session may persist
+    /// across reinstalls; `signOut()` is the reliable way to clear it.
     private static let service = "radio.ks3ckc.ft8af.pota"
 
     /// Store (or replace) a string for `account`. Returns false on any OSStatus

--- a/ios/FT8AF/FT8AF/Engine/PotaAuthService.swift
+++ b/ios/FT8AF/FT8AF/Engine/PotaAuthService.swift
@@ -1,0 +1,125 @@
+import FT8Engine
+import Foundation
+
+/// App-side driver for POTA's Cognito hosted-UI login. All request shaping and
+/// parsing is pure kit logic in `FT8Engine.PotaAuth` (unit-tested); this class
+/// just moves bytes with URLSession, keeps the refresh token in the Keychain,
+/// and caches the short-lived ID token in memory.
+///
+/// Mirrors Android `PotaAuth`: the WKWebView captures an authorization `code`,
+/// `exchange(code:verifier:)` trades it for tokens (storing the refresh token),
+/// and `idToken()` mints a fresh ID token on demand from the stored refresh
+/// token via REFRESH_TOKEN_AUTH when the cached one is missing / near expiry.
+///
+/// Security: only the **refresh token** (and the display email) touch the
+/// Keychain. The ID token stays in memory. Tokens are never logged.
+@Observable @MainActor
+final class PotaAuthService {
+    static let shared = PotaAuthService()
+
+    private static let refreshAccount = "refresh_token"
+    private static let emailAccount = "email"
+
+    /// The account email from the last login (`email` claim of the ID token),
+    /// for display. Loaded from the Keychain at init.
+    private(set) var email: String?
+
+    // Cached ID token + its effective expiry. Never persisted.
+    private var cachedIdToken: String?
+    private var cachedIdTokenExpiry: Date?
+    // Serialises concurrent idToken() callers so a burst of uploads triggers at
+    // most one refresh round-trip.
+    private var refreshTask: Task<String?, Never>?
+
+    private init() {
+        email = KeychainStore.get(account: Self.emailAccount)
+    }
+
+    /// Whether a refresh token is stored (the user has logged in at least once).
+    var isSignedIn: Bool {
+        !(KeychainStore.get(account: Self.refreshAccount) ?? "").isEmpty
+    }
+
+    /// Sign out: drop the cached ID token and wipe the stored refresh token/email.
+    func signOut() {
+        cachedIdToken = nil
+        cachedIdTokenExpiry = nil
+        refreshTask?.cancel()
+        refreshTask = nil
+        KeychainStore.remove(account: Self.refreshAccount)
+        KeychainStore.remove(account: Self.emailAccount)
+        email = nil
+    }
+
+    /// Exchange a hosted-UI authorization `code` (with the PKCE `verifier` used to
+    /// build the authorize URL) for tokens. Stores the refresh token + email and
+    /// caches the ID token. Returns true on success.
+    func exchange(code: String, verifier: String) async -> Bool {
+        let req = PotaAuth.tokenExchangeRequest(code: code, codeVerifier: verifier)
+        guard let data = await Self.send(req),
+              let tokens = PotaAuth.parseTokenResponse(data)
+        else { return false }
+
+        KeychainStore.set(tokens.refreshToken, account: Self.refreshAccount)
+        let claimedEmail = PotaAuth.emailClaim(tokens.idToken) ?? ""
+        KeychainStore.set(claimedEmail, account: Self.emailAccount)
+        email = claimedEmail.isEmpty ? nil : claimedEmail
+        cache(idToken: tokens.idToken)
+        return true
+    }
+
+    /// A valid ID token, refreshed from the stored refresh token when the cached
+    /// one is missing or near expiry. Returns nil if the user has never logged in
+    /// or the refresh failed (e.g. the refresh token was revoked) — callers
+    /// should then prompt for login.
+    func idToken() async -> String? {
+        if let token = cachedIdToken, !PotaAuth.needsRefresh(expiry: cachedIdTokenExpiry) {
+            return token
+        }
+        // Coalesce concurrent refreshes.
+        if let inFlight = refreshTask { return await inFlight.value }
+        let task = Task { () -> String? in await self.refreshFromKeychain() }
+        refreshTask = task
+        let result = await task.value
+        refreshTask = nil
+        return result
+    }
+
+    private func refreshFromKeychain() async -> String? {
+        guard let refresh = KeychainStore.get(account: Self.refreshAccount), !refresh.isEmpty
+        else { return nil }
+        let req = PotaAuth.refreshRequest(refreshToken: refresh)
+        guard let data = await Self.send(req),
+              let id = PotaAuth.parseRefreshResponse(data)
+        else { return nil }
+        cache(idToken: id)
+        return id
+    }
+
+    private func cache(idToken: String) {
+        cachedIdToken = idToken
+        cachedIdTokenExpiry = PotaAuth.cacheExpiry(forIdToken: idToken)
+    }
+
+    /// Send a pre-built kit request. Returns the response body only on a 2xx
+    /// (the token/refresh endpoints answer JSON either way, but a non-2xx carries
+    /// an error shape our parsers already reject — treating it as nil keeps the
+    /// "prompt for login" path simple). nonisolated so the round-trip runs off
+    /// the main actor.
+    private nonisolated static func send(_ req: PotaAuth.Request) async -> Data? {
+        guard let url = URL(string: req.url) else { return nil }
+        var r = URLRequest(url: url)
+        r.httpMethod = req.method
+        r.httpBody = req.body
+        r.timeoutInterval = 15
+        for (k, v) in req.headers { r.setValue(v, forHTTPHeaderField: k) }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: r)
+            guard let http = resp as? HTTPURLResponse, (200...299).contains(http.statusCode)
+            else { return nil }
+            return data
+        } catch {
+            return nil
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/PotaUploadService.swift
+++ b/ios/FT8AF/FT8AF/Engine/PotaUploadService.swift
@@ -1,0 +1,92 @@
+import FT8Engine
+import Foundation
+
+/// Posts one ADIF document to POTA's authenticated `/adif` endpoint with the
+/// retry/backoff policy defined (and unit-tested) in `FT8Engine.PotaUpload`.
+/// Networking only; request shaping, retry classification, and backoff timing
+/// all live in the kit.
+///
+/// Direct port of Android's `PotaClient.uploadAdif`: raw-JWT Authorization
+/// header, single multipart `adif` part, up to 3 attempts with 1s/2s/4s backoff,
+/// retrying ONLY on 502/503/504 or a transport error (a 4xx / plain 500 is
+/// terminal). A 401/403 surfaces as `.unauthorized` so the caller can re-prompt
+/// for sign-in and retry.
+actor PotaUploadService {
+    static let shared = PotaUploadService()
+
+    private init() {}
+
+    /// The outcome of one document upload.
+    enum Outcome: Equatable {
+        case success
+        /// Token rejected — the caller should re-authenticate and retry.
+        case unauthorized
+        /// Terminal failure, classified for a user-facing message.
+        case failure(PotaUpload.FailureKind)
+    }
+
+    /// Upload a single ADIF document. `idToken` is a raw Cognito ID token.
+    func uploadAdif(idToken: String, filename: String, adif: String) async -> Outcome {
+        var last: Outcome = .failure(.other)
+        for attempt in 1...PotaUpload.maxAttempts {
+            if attempt > 1 {
+                let backoff = PotaUpload.backoffSeconds(attempt: attempt - 1)
+                try? await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000))
+            }
+            let (outcome, retryable) = await attemptOnce(
+                idToken: idToken, filename: filename, adif: adif)
+            last = outcome
+            if !retryable { break }
+        }
+        return last
+    }
+
+    /// One HTTP attempt. Returns the outcome and whether it's worth retrying
+    /// (a transient gateway status or a transport error).
+    private func attemptOnce(
+        idToken: String, filename: String, adif: String
+    ) async -> (Outcome, retryable: Bool) {
+        let req = PotaUpload.uploadRequest(
+            idToken: idToken, filename: filename, adif: adif,
+            boundary: PotaUpload.newBoundary())
+        guard let url = URL(string: req.url) else { return (.failure(.other), false) }
+
+        var r = URLRequest(url: url)
+        r.httpMethod = req.method
+        r.httpBody = req.body
+        r.timeoutInterval = 30
+        for (k, v) in req.headers { r.setValue(v, forHTTPHeaderField: k) }
+
+        do {
+            let (_, resp) = try await URLSession.shared.data(for: r)
+            let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+            if PotaUpload.isSuccess(status: code) { return (.success, false) }
+            if PotaUpload.isUnauthorized(status: code) { return (.unauthorized, false) }
+            let retryable = PotaUpload.isRetryable(status: code)
+            return (.failure(PotaUpload.classifyFailure(status: code)), retryable)
+        } catch is CancellationError {
+            return (.failure(.network), false)
+        } catch {
+            // Transport error (timeout, connection reset) — retryable.
+            return (.failure(.network), true)
+        }
+    }
+
+    /// Fetch the user's recent upload/processing jobs (authenticated). Raw JSON
+    /// string, or nil on any failure. Not retried — it's a best-effort status peek.
+    func jobs(idToken: String) async -> String? {
+        let req = PotaUpload.jobsRequest(idToken: idToken)
+        guard let url = URL(string: req.url) else { return nil }
+        var r = URLRequest(url: url)
+        r.httpMethod = req.method
+        r.timeoutInterval = 15
+        for (k, v) in req.headers { r.setValue(v, forHTTPHeaderField: k) }
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: r)
+            guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            return String(data: data, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Engine/PotaUploadService.swift
+++ b/ios/FT8AF/FT8AF/Engine/PotaUploadService.swift
@@ -7,7 +7,8 @@ import Foundation
 /// all live in the kit.
 ///
 /// Direct port of Android's `PotaClient.uploadAdif`: raw-JWT Authorization
-/// header, single multipart `adif` part, up to 3 attempts with 1s/2s/4s backoff,
+/// header, single multipart `adif` part, up to 3 attempts with exponential
+/// backoff between them (1s, then 2s),
 /// retrying ONLY on 502/503/504 or a transport error (a 4xx / plain 500 is
 /// terminal). A 401/403 surfaces as `.unauthorized` so the caller can re-prompt
 /// for sign-in and retry.

--- a/ios/FT8AF/FT8AF/Screens/POTA/PotaLoginWebView.swift
+++ b/ios/FT8AF/FT8AF/Screens/POTA/PotaLoginWebView.swift
@@ -1,0 +1,170 @@
+import FT8Engine
+import SwiftUI
+import WebKit
+
+/// Full-screen sheet that drives POTA's Cognito hosted-UI OAuth2 flow in a
+/// WKWebView, so any POTA account — email/password *or* federated (Google /
+/// Facebook / Login-with-Amazon) — can authenticate. The hosted UI serves both
+/// through the same authorization-code + PKCE redirect.
+///
+/// Why a WebView and not `ASWebAuthenticationSession`/`SFSafariViewController`:
+/// POTA's Cognito app client registers exactly one redirect URI —
+/// `https://pota.app/` — and rejects anything we could claim from the app
+/// (custom scheme, etc.). A system auth session needs a scheme it can hand back;
+/// a WKWebView instead lets us watch navigation and lift the `?code=` out the
+/// instant Cognito redirects, before pota.app's page loads.
+///
+/// Ports the Android `PotaOAuthDialog` gotchas:
+///  - a Safari-like `customUserAgent` in case a federated provider rejects the
+///    default WebView UA (WKWebView's UA has no ";wv" token, unlike Android, so
+///    this is usually unnecessary — but harmless and future-proof);
+///  - `window.open` popups (Google's account chooser) routed back into the main
+///    web view via `WKUIDelegate` so they aren't silently dropped.
+///
+/// `onFinished(success:)` fires exactly once: true if a refresh token was
+/// obtained and stored, false on cancel / error.
+struct PotaLoginSheet: View {
+    let onFinished: (_ success: Bool) -> Void
+
+    @State private var pkce = PotaAuth.newPkce()
+    @State private var exchanging = false
+    // Guard so onFinished fires exactly once across the delegate + Cancel button.
+    @State private var finished = false
+
+    var body: some View {
+        ZStack {
+            bgApp.ignoresSafeArea()
+            VStack(spacing: 0) {
+                HStack {
+                    Text("Sign in to POTA")
+                        .font(.ft8afUI(size: 14, weight: .semibold))
+                        .foregroundStyle(textPrimary)
+                    Spacer()
+                    Button("Cancel") { finish(false) }
+                        .font(.ft8afUI(size: 14))
+                        .foregroundStyle(textMuted)
+                        .disabled(exchanging)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+
+                ZStack {
+                    PotaOAuthWebView(
+                        authorizeURL: PotaAuth.authorizeURL(codeChallenge: pkce.challenge),
+                        onCode: handleCode,
+                        onCancel: { finish(false) })
+                    if exchanging {
+                        bgApp.opacity(0.7).ignoresSafeArea()
+                        ProgressView().tint(accent)
+                    }
+                }
+            }
+        }
+    }
+
+    private func handleCode(_ code: String) {
+        guard !finished else { return }
+        exchanging = true
+        Task {
+            let ok = await PotaAuthService.shared.exchange(code: code, verifier: pkce.verifier)
+            exchanging = false
+            finish(ok)
+        }
+    }
+
+    private func finish(_ success: Bool) {
+        guard !finished else { return }
+        finished = true
+        onFinished(success)
+    }
+}
+
+/// The WKWebView itself. Loads the authorize URL and intercepts navigation to
+/// `https://pota.app/?code=…`, handing the code up (never letting pota.app load).
+/// Redirect classification is the security-critical `PotaAuth.classifyRedirect`,
+/// which matches scheme + host exactly so a lookalike host can't steal the code.
+private struct PotaOAuthWebView: UIViewRepresentable {
+    let authorizeURL: String
+    let onCode: (String) -> Void
+    let onCancel: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCode: onCode, onCancel: onCancel)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent() // clean start, no stale session
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+        // A plain Safari-ish UA in case a federated provider is picky. WKWebView's
+        // default UA already omits Android's ";wv" token, so this is belt-and-braces.
+        webView.customUserAgent =
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+            + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+        if let url = URL(string: authorizeURL) {
+            webView.load(URLRequest(url: url))
+        }
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+        private let onCode: (String) -> Void
+        private let onCancel: () -> Void
+        // Once we capture (or reject) the redirect, ignore later navigations.
+        private var captured = false
+
+        init(onCode: @escaping (String) -> Void, onCancel: @escaping () -> Void) {
+            self.onCode = onCode
+            self.onCancel = onCancel
+        }
+
+        /// Intercept every navigation. Returns true (and .cancel) when it was our
+        /// redirect URI; otherwise the navigation is allowed to proceed.
+        private func handle(_ url: URL?) -> Bool {
+            guard !captured, let url else { return false }
+            switch PotaAuth.classifyRedirect(url.absoluteString) {
+            case .notRedirect:
+                return false
+            case .noCode:
+                // error=… or the user bailed at the provider — treat as cancel.
+                captured = true
+                onCancel()
+                return true
+            case .withCode(let code):
+                captured = true
+                onCode(code)
+                return true
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if handle(navigationAction.request.url) {
+                decisionHandler(.cancel)
+            } else {
+                decisionHandler(.allow)
+            }
+        }
+
+        // Route a popup (window.open / target=_blank — e.g. Google's account
+        // chooser) back into the main web view instead of dropping it.
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            if let url = navigationAction.request.url, !handle(url) {
+                webView.load(URLRequest(url: url))
+            }
+            return nil
+        }
+    }
+}

--- a/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
+++ b/ios/FT8AF/FT8AF/Screens/POTA/PotaScreen.swift
@@ -19,6 +19,12 @@ struct PotaScreen: View {
     /// True while a self-spot POST is in flight (drives the button spinner and
     /// prevents double-posts). One user tap per activation — never automatic.
     @State private var isSelfSpotting = false
+    /// True while an authenticated ADIF upload is in flight (button spinner).
+    @State private var isUploading = false
+    /// Presents the hosted-UI OAuth WebView. Set when an upload needs sign-in.
+    @State private var showLogin = false
+    /// The activation to (re-)upload once sign-in completes.
+    @State private var pendingUploadActivation: PotaActivationRecord?
 
     private var spotService: PotaService { PotaService.shared }
 
@@ -81,6 +87,16 @@ struct PotaScreen: View {
         }
         .sheet(isPresented: $showShare) {
             PotaShareSheet(items: shareURLs)
+        }
+        .sheet(isPresented: $showLogin) {
+            PotaLoginSheet { success in
+                showLogin = false
+                // On a successful sign-in, resume the upload that triggered it.
+                if success, let activation = pendingUploadActivation {
+                    uploadActivation(activation)
+                }
+                pendingUploadActivation = nil
+            }
         }
         .sheet(isPresented: $showParkPicker) {
             ParkPickerSheet(
@@ -330,6 +346,35 @@ struct PotaScreen: View {
             .disabled(isSelfSpotting)
             .padding(.horizontal, 16)
 
+            // Upload to POTA (authenticated). Signs in via the hosted-UI WebView
+            // first when there's no usable token, then uploads one file per park.
+            Button {
+                uploadActivation(current)
+            } label: {
+                HStack(spacing: 6) {
+                    if isUploading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(bgApp)
+                    } else {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.ft8afUI(size: 13, weight: .semibold))
+                    }
+                    Text(isUploading ? "Uploading…" : "Upload to POTA")
+                        .font(.ft8afUI(size: 14, weight: .bold))
+                }
+                .foregroundStyle(bgApp)
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(accent.opacity(qsoCount > 0 ? 1 : 0.4))
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(qsoCount == 0 || isUploading)
+            .padding(.horizontal, 16)
+
             // Export ADIF (share sheet) — one file per park, MY_SIG_INFO pinned.
             Button {
                 exportAdif(for: current)
@@ -514,6 +559,84 @@ struct PotaScreen: View {
         showShare = true
     }
 
+    // MARK: - Authenticated upload
+
+    /// Build the per-park ADIF documents and upload each to POTA's authenticated
+    /// `/adif` endpoint. Mirrors Android's `uploadActivation` + `startUpload`
+    /// flow: a missing/revoked token (or a 401) presents the hosted-UI login
+    /// WebView and, on success, resumes this upload. Failures are classified into
+    /// a user-facing toast.
+    private func uploadActivation(_ activation: PotaActivationRecord) {
+        guard !isUploading else { return }
+        let docs = Adif.potaActivationExport(
+            records: appState.logbook.records, activation: activation)
+        guard !docs.isEmpty else {
+            appState.toast.show("No QSOs in this activation yet", icon: "tree")
+            return
+        }
+
+        isUploading = true
+        Task {
+            guard let token = await PotaAuthService.shared.idToken() else {
+                // Never signed in / refresh token revoked — prompt for login and
+                // resume this upload when it succeeds.
+                isUploading = false
+                promptLogin(for: activation)
+                return
+            }
+
+            var uploaded = 0
+            var firstFailure: PotaUpload.FailureKind?
+            var needsLogin = false
+            for doc in docs {
+                let outcome = await PotaUploadService.shared.uploadAdif(
+                    idToken: token, filename: doc.filename, adif: doc.content)
+                switch outcome {
+                case .success:
+                    uploaded += 1
+                case .unauthorized:
+                    needsLogin = true
+                case .failure(let kind):
+                    if firstFailure == nil { firstFailure = kind }
+                }
+                if needsLogin { break }
+            }
+            isUploading = false
+
+            if needsLogin {
+                promptLogin(for: activation)
+            } else if uploaded == docs.count {
+                let msg = docs.count == 1
+                    ? "Uploaded to pota.app"
+                    : "Uploaded \(uploaded) parks to pota.app"
+                appState.toast.show(msg, icon: "checkmark.circle")
+            } else {
+                appState.toast.show(uploadFailureMessage(firstFailure),
+                                    icon: "exclamationmark.triangle")
+            }
+        }
+    }
+
+    private func promptLogin(for activation: PotaActivationRecord) {
+        pendingUploadActivation = activation
+        showLogin = true
+    }
+
+    /// Map an upload failure to a user-facing message, mirroring Android's
+    /// `UploadFailureKind` strings.
+    private func uploadFailureMessage(_ kind: PotaUpload.FailureKind?) -> String {
+        switch kind {
+        case .busy:
+            return "POTA is busy — try again in a moment"
+        case .serverError:
+            return "POTA rejected the log — check your park reference"
+        case .network:
+            return "Upload failed — check your connection"
+        case .other, nil:
+            return "Upload failed"
+        }
+    }
+
     // MARK: - Hunt Tab
 
     private var huntTab: some View {
@@ -693,6 +816,23 @@ struct PotaScreen: View {
             Text("\(activation.qsoCount) QSO\(activation.qsoCount == 1 ? "" : "s")")
                 .font(.ft8afMono(size: 11, weight: .semibold))
                 .foregroundStyle(activation.qsoCount >= 10 ? statusConfirmed : textMuted)
+
+            if activation.qsoCount > 0 {
+                Button {
+                    uploadActivation(activation)
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.ft8afUI(size: 14, weight: .semibold))
+                        .foregroundStyle(accent)
+                        .frame(width: 34, height: 34)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(accent.opacity(0.14))
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(isUploading)
+            }
 
             Button {
                 exportAdif(for: activation)

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaAuth.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaAuth.swift
@@ -1,0 +1,321 @@
+import CryptoKit
+import Foundation
+import Security
+
+/// Pure request-builders, response-parsers and OAuth helpers for pota.app's AWS
+/// Cognito hosted-UI login (authorization-code + PKCE) and token refresh. No
+/// networking here — the app-side `PotaAuthService` performs the actual
+/// URLSession calls, stores the refresh token in the Keychain, and drives the
+/// WKWebView. Ports the wire shapes verbatim from Android `PotaAuth.kt`.
+///
+/// POTA's pool / app-client IDs are public — they ship in pota.app's own JS
+/// bundle and the open-source `pota-adif-upload` client. The app client is a
+/// *public* client (no secret), so token exchange sends no Basic auth.
+public enum PotaAuth {
+
+    // MARK: - Public POTA Cognito identifiers
+
+    /// Cognito user pool.
+    public static let poolId = "us-east-2_nA5jZ0klh"
+    /// Public app client (no secret).
+    public static let clientId = "7hluqct0n2nckib7i7sd5753oa"
+    /// Cognito IDP endpoint used for REFRESH_TOKEN_AUTH.
+    public static let cognitoIdpURL = "https://cognito-idp.us-east-2.amazonaws.com/"
+    /// Hosted-UI (managed login) origin for the OAuth2 code flow.
+    public static let hostedUI = "https://parksontheair.auth.us-east-2.amazoncognito.com"
+    /// OAuth scope requested at the authorize endpoint.
+    public static let scope = "openid email phone profile"
+    /// The single redirect URI POTA registered on its Cognito app client. We
+    /// can't register our own (custom scheme / localhost all return
+    /// redirect_mismatch), so the WebView watches for navigation to this URL and
+    /// lifts the `?code=` out before pota.app actually loads.
+    public static let redirectURI = "https://pota.app/"
+
+    /// Refresh ~5 min before the ID token's nominal 60-min lifetime expires.
+    public static let idTokenTTL: TimeInterval = 55 * 60
+
+    // MARK: - Request value type
+
+    /// A fully-built HTTP request the app layer just has to send.
+    public struct Request: Equatable, Sendable {
+        public let url: String
+        public let method: String
+        public let headers: [String: String]
+        public let body: Data
+
+        public init(url: String, method: String, headers: [String: String], body: Data) {
+            self.url = url
+            self.method = method
+            self.headers = headers
+            self.body = body
+        }
+    }
+
+    // MARK: - PKCE
+
+    /// A PKCE verifier/challenge pair for one hosted-UI login attempt (S256).
+    public struct Pkce: Equatable, Sendable {
+        public let verifier: String
+        public let challenge: String
+
+        public init(verifier: String, challenge: String) {
+            self.verifier = verifier
+            self.challenge = challenge
+        }
+    }
+
+    /// Mint a fresh PKCE pair: verifier = 32 random bytes base64url (no padding),
+    /// challenge = base64url(SHA256(verifier ASCII bytes)). Hold onto it for the
+    /// matching `tokenExchangeRequest`.
+    public static func newPkce() -> Pkce {
+        var raw = [UInt8](repeating: 0, count: 32)
+        // SecRandomCopyBytes is the CSPRNG; fall back to SystemRandomNumberGenerator
+        // only if it ever fails (it effectively never does on iOS).
+        if SecRandomCopyBytes(kSecRandomDefault, raw.count, &raw) != errSecSuccess {
+            var rng = SystemRandomNumberGenerator()
+            for i in raw.indices { raw[i] = UInt8.random(in: .min ... .max, using: &rng) }
+        }
+        let verifier = base64url(Data(raw))
+        return Pkce(verifier: verifier, challenge: codeChallenge(forVerifier: verifier))
+    }
+
+    /// The S256 code challenge for a given verifier: base64url(SHA256(ascii)).
+    /// Split out from `newPkce` so it's deterministically unit-testable.
+    public static func codeChallenge(forVerifier verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return base64url(Data(digest))
+    }
+
+    // MARK: - Authorize URL
+
+    /// The hosted-UI authorize URL to load in the login WebView for `codeChallenge`.
+    /// GET {hostedUI}/oauth2/authorize?client_id=…&response_type=code&scope=…&
+    /// redirect_uri=…&code_challenge=…&code_challenge_method=S256
+    public static func authorizeURL(codeChallenge: String) -> String {
+        let q = "client_id=\(clientId)"
+            + "&response_type=code"
+            + "&scope=\(formEncode(scope))"
+            + "&redirect_uri=\(formEncode(redirectURI))"
+            + "&code_challenge=\(codeChallenge)"
+            + "&code_challenge_method=S256"
+        return "\(hostedUI)/oauth2/authorize?\(q)"
+    }
+
+    // MARK: - Token exchange (authorization_code)
+
+    /// Build the `POST {hostedUI}/oauth2/token` request that trades an
+    /// authorization `code` for tokens. Public client → no client secret / no
+    /// Basic auth; the body is application/x-www-form-urlencoded.
+    public static func tokenExchangeRequest(code: String, codeVerifier: String) -> Request {
+        let form = "grant_type=authorization_code"
+            + "&client_id=\(clientId)"
+            + "&code=\(formEncode(code))"
+            + "&redirect_uri=\(formEncode(redirectURI))"
+            + "&code_verifier=\(formEncode(codeVerifier))"
+        return Request(
+            url: "\(hostedUI)/oauth2/token",
+            method: "POST",
+            headers: [
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            ],
+            body: Data(form.utf8))
+    }
+
+    /// The tokens returned by the token endpoint.
+    public struct TokenResponse: Equatable, Sendable {
+        public let idToken: String
+        public let refreshToken: String
+
+        public init(idToken: String, refreshToken: String) {
+            self.idToken = idToken
+            self.refreshToken = refreshToken
+        }
+    }
+
+    /// Parse the token-endpoint JSON: `{ id_token, refresh_token, … }`. Returns
+    /// nil if the body isn't JSON or is missing either token (e.g. an
+    /// `{"error":"invalid_grant"}` shape).
+    public static func parseTokenResponse(_ data: Data?) -> TokenResponse? {
+        guard let data,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = obj["id_token"] as? String, !id.isEmpty,
+              let refresh = obj["refresh_token"] as? String, !refresh.isEmpty
+        else { return nil }
+        return TokenResponse(idToken: id, refreshToken: refresh)
+    }
+
+    // MARK: - Refresh (REFRESH_TOKEN_AUTH)
+
+    /// Build the Cognito `InitiateAuth` request that trades the stored refresh
+    /// token for a fresh ID token — a plain x-amz-json-1.1 POST, no SRP, no SDK.
+    public static func refreshRequest(refreshToken: String) -> Request {
+        // Hand-built so the body is deterministic (byte-stable) for tests; the
+        // shape matches Android's JSONObject output.
+        let body = "{\"AuthFlow\":\"REFRESH_TOKEN_AUTH\""
+            + ",\"ClientId\":\"\(clientId)\""
+            + ",\"AuthParameters\":{\"REFRESH_TOKEN\":\(jsonString(refreshToken))}}"
+        return Request(
+            url: cognitoIdpURL,
+            method: "POST",
+            headers: [
+                "Content-Type": "application/x-amz-json-1.1",
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+            ],
+            body: Data(body.utf8))
+    }
+
+    /// Parse the refresh response: `{ "AuthenticationResult": { "IdToken": … } }`.
+    /// Returns nil on a non-JSON body or an error shape (missing IdToken).
+    public static func parseRefreshResponse(_ data: Data?) -> String? {
+        guard let data,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let result = obj["AuthenticationResult"] as? [String: Any],
+              let id = result["IdToken"] as? String, !id.isEmpty
+        else { return nil }
+        return id
+    }
+
+    // MARK: - Redirect classification (security-critical)
+
+    /// Where a navigation in the OAuth WebView lands relative to POTA's
+    /// registered redirect URI.
+    public enum RedirectClassification: Equatable, Sendable {
+        /// Not the redirect URI — let the WebView load it (Google, Cognito, …).
+        case notRedirect
+        /// The redirect URI but with no `code` (provider error / user cancelled).
+        case noCode
+        /// The redirect URI carrying the authorization `code` to exchange.
+        case withCode(String)
+    }
+
+    /// Classify a WebView navigation against POTA's hosted-UI redirect URI
+    /// (`https://pota.app/`). **Security-critical:** origin is matched on parsed
+    /// scheme + host + (absence of) port — never a raw `startsWith` — so a
+    /// lookalike like `https://pota.app.evil.com/?code=…`, an `http://` downgrade,
+    /// a `https://pota.app@evil.com/` userinfo trick, or an explicit alternate
+    /// port can't masquerade as the redirect and trick us into exchanging an
+    /// attacker-supplied code.
+    public static func classifyRedirect(_ url: String) -> RedirectClassification {
+        guard let comps = URLComponents(string: url) else { return .notRedirect }
+        // Exact scheme (https) + host (pota.app), case-insensitive; reject any
+        // explicit port (the real redirect carries none).
+        guard comps.scheme?.lowercased() == "https",
+              comps.host?.lowercased() == "pota.app",
+              comps.port == nil
+        else { return .notRedirect }
+        // Path is always "/" or deeper for an https URL with a host; the redirect
+        // lives at the origin root, so accept any path on the exact host.
+        let code = comps.queryItems?.first(where: { $0.name == "code" })?.value
+        if let code, !code.isEmpty { return .withCode(code) }
+        return .noCode
+    }
+
+    // MARK: - JWT claims
+
+    /// Decode a JWT ID token's `exp` claim to an absolute expiry `Date`. Returns
+    /// nil if the token is malformed or carries no numeric `exp`. Used to drive
+    /// the near-expiry refresh — never for signature verification (the token is
+    /// only ever forwarded to POTA, which validates it).
+    public static func jwtExpiry(_ idToken: String) -> Date? {
+        guard let exp = jwtClaims(idToken)?["exp"] else { return nil }
+        if let n = exp as? Double { return Date(timeIntervalSince1970: n) }
+        if let n = exp as? Int { return Date(timeIntervalSince1970: Double(n)) }
+        return nil
+    }
+
+    /// Pull the `email` claim out of a JWT ID token (for display only).
+    public static func emailClaim(_ idToken: String) -> String? {
+        guard let email = jwtClaims(idToken)?["email"] as? String, !email.isEmpty
+        else { return nil }
+        return email
+    }
+
+    /// Whether a cached ID token with the given `expiry` should be refreshed now:
+    /// true when it has passed, or is within `skew` seconds of, `now`. A nil
+    /// expiry (unreadable token) is treated as "refresh" so a bad token is never
+    /// reused indefinitely.
+    public static func needsRefresh(expiry: Date?, now: Date = Date(), skew: TimeInterval = 5 * 60) -> Bool {
+        guard let expiry else { return true }
+        return now.addingTimeInterval(skew) >= expiry
+    }
+
+    /// The effective expiry to cache for a freshly-obtained ID token: the earlier
+    /// of the JWT's own `exp` and `now + idTokenTTL` (matches Android's fixed
+    /// 55-min cap while still honouring a shorter server-side lifetime).
+    public static func cacheExpiry(forIdToken idToken: String, now: Date = Date()) -> Date {
+        let ttlBound = now.addingTimeInterval(idTokenTTL)
+        guard let jwtExp = jwtExpiry(idToken) else { return ttlBound }
+        return min(jwtExp, ttlBound)
+    }
+
+    private static func jwtClaims(_ idToken: String) -> [String: Any]? {
+        let parts = idToken.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count >= 2, let payload = base64urlDecode(String(parts[1])) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: payload)) as? [String: Any]
+    }
+
+    // MARK: - Encoding helpers
+
+    /// base64url with no padding (`+`→`-`, `/`→`_`, strip `=`).
+    static func base64url(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Decode a base64url (no-padding) string back to bytes.
+    static func base64urlDecode(_ s: String) -> Data? {
+        var b64 = s.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let pad = (4 - b64.count % 4) % 4
+        b64 += String(repeating: "=", count: pad)
+        return Data(base64Encoded: b64)
+    }
+
+    /// application/x-www-form-urlencoded percent-encoding matching Java's
+    /// `URLEncoder.encode(s, UTF-8)`, so query/body params are byte-identical to
+    /// Android: unreserved `[A-Za-z0-9.*_-]` pass through, space→`+`, else %XX per
+    /// UTF-8 byte. (Same routine as QrzLogbookClient.formEncode.)
+    static func formEncode(_ s: String) -> String {
+        var out = ""
+        for byte in Array(s.utf8) {
+            switch byte {
+            case UInt8(ascii: "a")...UInt8(ascii: "z"),
+                 UInt8(ascii: "A")...UInt8(ascii: "Z"),
+                 UInt8(ascii: "0")...UInt8(ascii: "9"),
+                 UInt8(ascii: "."), UInt8(ascii: "-"),
+                 UInt8(ascii: "*"), UInt8(ascii: "_"):
+                out.append(Character(UnicodeScalar(byte)))
+            case UInt8(ascii: " "):
+                out.append("+")
+            default:
+                out += String(format: "%%%02X", byte)
+            }
+        }
+        return out
+    }
+
+    /// Minimal JSON string literal encoder (same as CloudlogClient.jsonString) so
+    /// the refresh body is deterministic and unit-testable byte-for-byte.
+    static func jsonString(_ s: String) -> String {
+        var out = "\""
+        for scalar in s.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            default:
+                if scalar.value < 0x20 {
+                    out += String(format: "\\u%04x", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out + "\""
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaAuth.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaAuth.swift
@@ -200,12 +200,16 @@ public enum PotaAuth {
         guard let comps = URLComponents(string: url) else { return .notRedirect }
         // Exact scheme (https) + host (pota.app), case-insensitive; reject any
         // explicit port (the real redirect carries none).
+        // The registered redirect is exactly https://pota.app/ , so pin the
+        // path to the root ("" or "/") in addition to scheme/host/no-port —
+        // defence in depth against a code being lifted from any other pota.app
+        // URL. An https URL with a host has an empty or "/"-prefixed path.
+        let path = comps.path
         guard comps.scheme?.lowercased() == "https",
               comps.host?.lowercased() == "pota.app",
-              comps.port == nil
+              comps.port == nil,
+              path.isEmpty || path == "/"
         else { return .notRedirect }
-        // Path is always "/" or deeper for an https URL with a host; the redirect
-        // lives at the origin root, so accept any path on the exact host.
         let code = comps.queryItems?.first(where: { $0.name == "code" })?.value
         if let code, !code.isEmpty { return .withCode(code) }
         return .noCode

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaUpload.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaUpload.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Pure request-builders and retry policy for pota.app's *authenticated*
+/// endpoints (ADIF upload + user jobs). No networking here — the app-side
+/// `PotaUploadService` performs the URLSession calls and the retry loop. Ports
+/// the wire shapes verbatim from Android `PotaClient.uploadAdif` / `getJobs`.
+///
+/// Auth note: POTA's API Gateway expects the Cognito ID token in the
+/// `Authorization` header **as the raw JWT — not `Bearer <jwt>`**. Sending the
+/// `Bearer` prefix gets a 401.
+public enum PotaUpload {
+
+    /// Base for the authenticated API (same host as the public spot feed).
+    public static let baseURL = "https://api.pota.app"
+    public static let userAgent = "ft8af-1.0"
+
+    /// Total upload attempts (the initial try plus retries) before giving up.
+    public static let maxAttempts = 3
+
+    /// HTTP statuses that mean POTA's backend was *transiently* unavailable (a
+    /// gateway timed out / the upstream Lambda was cold) rather than rejecting the
+    /// log itself. Worth retrying; a 4xx or a plain 500 is not — it would fail
+    /// again identically. POTA returns 502 when its API Gateway can't reach the
+    /// upstream, exactly the failure observed in the field.
+    static let retryableStatuses: Set<Int> = [502, 503, 504]
+
+    /// True when a response `status` is a transient gateway failure worth
+    /// retrying. (Transport errors — timeouts, connection resets — are retryable
+    /// too, but that's judged at the call site where the error is in hand.)
+    public static func isRetryable(status: Int) -> Bool {
+        retryableStatuses.contains(status)
+    }
+
+    /// True when `status` means the token was rejected (401) or forbidden (403):
+    /// the caller should re-prompt for sign-in rather than surface a hard error.
+    public static func isUnauthorized(status: Int) -> Bool {
+        status == 401 || status == 403
+    }
+
+    /// Whether an HTTP status counts as upload success (2xx).
+    public static func isSuccess(status: Int) -> Bool {
+        (200...299).contains(status)
+    }
+
+    /// Exponential backoff before retry `attempt` (1-based): 1s, 2s, 4s, … Keeps
+    /// the total wait modest while giving a flapping gateway time to recover.
+    public static func backoffSeconds(attempt: Int) -> Double {
+        Double(1 << max(0, attempt - 1))
+    }
+
+    /// How an upload failed, mapped to a user-facing message by the screen.
+    ///
+    ///  - `.busy`: a gateway status (502/503/504) — POTA's backend was
+    ///    transiently down. The service already retried with backoff, so tell the
+    ///    user to try again shortly, *not* to go check their park ref.
+    ///  - `.serverError`: any other 5xx — POTA accepted the request but rejected
+    ///    the log, almost always a bad park ref or a callsign not registered to
+    ///    the account.
+    ///  - `.network`: a transport error (no HTTP status) — connectivity on our
+    ///    side.
+    ///  - `.other`: anything else (an unexpected 4xx, etc.).
+    public enum FailureKind: Equatable, Sendable {
+        case busy
+        case serverError
+        case network
+        case other
+    }
+
+    /// Classify a failed upload for the UI. `status` is the HTTP status (nil for
+    /// a transport error). Mirrors Android's `classifyUploadFailure`.
+    public static func classifyFailure(status: Int?) -> FailureKind {
+        guard let status else { return .network }
+        if retryableStatuses.contains(status) { return .busy }
+        if (500...599).contains(status) { return .serverError }
+        return .other
+    }
+
+    // MARK: - Requests
+
+    /// Build the multipart `POST {base}/adif` upload request. `idToken` goes in
+    /// the `Authorization` header verbatim (raw JWT). The body is
+    /// multipart/form-data with a SINGLE part named `adif`
+    /// (Content-Type: application/octet-stream) carrying the ADIF UTF-8 document,
+    /// matching the pota.app website uploader. `boundary` is injected so the body
+    /// is deterministic under test; the app passes a fresh unique one.
+    public static func uploadRequest(
+        idToken: String, filename: String, adif: String, boundary: String
+    ) -> PotaAuth.Request {
+        var body = Data()
+        var pre = "--\(boundary)\r\n"
+        pre += "Content-Disposition: form-data; name=\"adif\"; filename=\"\(filename)\"\r\n"
+        pre += "Content-Type: application/octet-stream\r\n\r\n"
+        body.append(Data(pre.utf8))
+        body.append(Data(adif.utf8))
+        body.append(Data("\r\n--\(boundary)--\r\n".utf8))
+
+        return PotaAuth.Request(
+            url: "\(baseURL)/adif",
+            method: "POST",
+            headers: [
+                "Authorization": idToken,
+                "User-Agent": userAgent,
+                "Accept": "application/json",
+                "Content-Type": "multipart/form-data; boundary=\(boundary)",
+            ],
+            body: body)
+    }
+
+    /// Build the authenticated `GET {base}/user/jobs` request (raw-JWT auth).
+    public static func jobsRequest(idToken: String) -> PotaAuth.Request {
+        PotaAuth.Request(
+            url: "\(baseURL)/user/jobs",
+            method: "GET",
+            headers: [
+                "Authorization": idToken,
+                "User-Agent": userAgent,
+                "Accept": "application/json",
+            ],
+            body: Data())
+    }
+
+    /// A fresh, unique multipart boundary (matches Android's
+    /// `----ft8af<nanoTime>` shape). Not pure — used by the app when actually
+    /// sending; tests pass a fixed boundary to `uploadRequest`.
+    public static func newBoundary() -> String {
+        "----ft8af\(UInt64(Date().timeIntervalSince1970 * 1_000_000))\(Int.random(in: 0..<1_000_000))"
+    }
+}

--- a/ios/FT8AFKit/Sources/FT8Engine/PotaUpload.swift
+++ b/ios/FT8AFKit/Sources/FT8Engine/PotaUpload.swift
@@ -14,7 +14,10 @@ public enum PotaUpload {
     public static let baseURL = "https://api.pota.app"
     public static let userAgent = "ft8af-1.0"
 
-    /// Total upload attempts (the initial try plus retries) before giving up.
+    /// Total upload attempts (the initial try plus retries) before giving up —
+    /// matches Android's MAX_UPLOAD_ATTEMPTS. With 3 attempts the sleeps used are
+    /// backoffSeconds(1)=1s and backoffSeconds(2)=2s (the 4s the formula would
+    /// yield for a 4th attempt is never reached).
     public static let maxAttempts = 3
 
     /// HTTP statuses that mean POTA's backend was *transiently* unavailable (a

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaAuthTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaAuthTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+import FT8Engine
+
+final class PotaAuthTests: XCTestCase {
+
+    // Local base64url (no padding) so tests don't depend on FT8Engine internals.
+    private func b64url(_ s: String) -> String {
+        Data(s.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Build a `header.payload.sig` JWT with the given JSON payload.
+    private func jwt(payload: String) -> String {
+        "\(b64url("{\"alg\":\"none\"}")).\(b64url(payload)).sig"
+    }
+
+    // MARK: - PKCE
+
+    func testCodeChallengeMatchesRfc7636Example() {
+        // RFC 7636 Appendix B known verifier/challenge vector.
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        XCTAssertEqual(
+            PotaAuth.codeChallenge(forVerifier: verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    func testNewPkceProducesUnpaddedUrlSafeVerifierAndMatchingChallenge() {
+        let pkce = PotaAuth.newPkce()
+        // 32 random bytes → 43-char base64url, no padding, url-safe alphabet only.
+        XCTAssertEqual(pkce.verifier.count, 43)
+        XCTAssertFalse(pkce.verifier.contains("="))
+        XCTAssertFalse(pkce.verifier.contains("+"))
+        XCTAssertFalse(pkce.verifier.contains("/"))
+        XCTAssertEqual(pkce.challenge, PotaAuth.codeChallenge(forVerifier: pkce.verifier))
+        // Two mints must differ (real randomness).
+        XCTAssertNotEqual(pkce.verifier, PotaAuth.newPkce().verifier)
+    }
+
+    // MARK: - authorizeURL
+
+    func testAuthorizeURLContainsAllOAuthParams() {
+        let url = PotaAuth.authorizeURL(codeChallenge: "CHAL123")
+        XCTAssertTrue(url.hasPrefix(
+            "https://parksontheair.auth.us-east-2.amazoncognito.com/oauth2/authorize?"))
+        XCTAssertTrue(url.contains("client_id=7hluqct0n2nckib7i7sd5753oa"))
+        XCTAssertTrue(url.contains("response_type=code"))
+        // Scope spaces are form-encoded as '+' (verbatim from Android's URLEncoder).
+        XCTAssertTrue(url.contains("scope=openid+email+phone+profile"))
+        // redirect_uri must be exactly https://pota.app/ percent-encoded.
+        XCTAssertTrue(url.contains("redirect_uri=https%3A%2F%2Fpota.app%2F"))
+        XCTAssertTrue(url.contains("code_challenge=CHAL123"))
+        XCTAssertTrue(url.contains("code_challenge_method=S256"))
+    }
+
+    // MARK: - tokenExchangeRequest
+
+    func testTokenExchangeRequestShape() {
+        let req = PotaAuth.tokenExchangeRequest(code: "abc/123", codeVerifier: "ver-XYZ")
+        XCTAssertEqual(req.url,
+            "https://parksontheair.auth.us-east-2.amazoncognito.com/oauth2/token")
+        XCTAssertEqual(req.method, "POST")
+        XCTAssertEqual(req.headers["Content-Type"], "application/x-www-form-urlencoded")
+        // Public client: no Authorization / Basic header.
+        XCTAssertNil(req.headers["Authorization"])
+        let body = String(data: req.body, encoding: .utf8) ?? ""
+        XCTAssertEqual(
+            body,
+            "grant_type=authorization_code"
+                + "&client_id=7hluqct0n2nckib7i7sd5753oa"
+                + "&code=abc%2F123"
+                + "&redirect_uri=https%3A%2F%2Fpota.app%2F"
+                + "&code_verifier=ver-XYZ")
+    }
+
+    func testParseTokenResponseValid() {
+        let json = #"{"id_token":"ID.jwt.sig","refresh_token":"RT123","token_type":"Bearer"}"#
+        let parsed = PotaAuth.parseTokenResponse(Data(json.utf8))
+        XCTAssertEqual(parsed?.idToken, "ID.jwt.sig")
+        XCTAssertEqual(parsed?.refreshToken, "RT123")
+    }
+
+    func testParseTokenResponseErrorShapesReturnNil() {
+        XCTAssertNil(PotaAuth.parseTokenResponse(Data(#"{"error":"invalid_grant"}"#.utf8)))
+        // Missing refresh_token → nil (can't persist a session).
+        XCTAssertNil(PotaAuth.parseTokenResponse(Data(#"{"id_token":"x"}"#.utf8)))
+        XCTAssertNil(PotaAuth.parseTokenResponse(Data("not json".utf8)))
+        XCTAssertNil(PotaAuth.parseTokenResponse(nil))
+    }
+
+    // MARK: - refreshRequest
+
+    func testRefreshRequestShape() {
+        let req = PotaAuth.refreshRequest(refreshToken: "RT-9")
+        XCTAssertEqual(req.url, "https://cognito-idp.us-east-2.amazonaws.com/")
+        XCTAssertEqual(req.method, "POST")
+        XCTAssertEqual(req.headers["Content-Type"], "application/x-amz-json-1.1")
+        XCTAssertEqual(req.headers["X-Amz-Target"],
+            "AWSCognitoIdentityProviderService.InitiateAuth")
+        let body = String(data: req.body, encoding: .utf8) ?? ""
+        XCTAssertEqual(
+            body,
+            "{\"AuthFlow\":\"REFRESH_TOKEN_AUTH\""
+                + ",\"ClientId\":\"7hluqct0n2nckib7i7sd5753oa\""
+                + ",\"AuthParameters\":{\"REFRESH_TOKEN\":\"RT-9\"}}")
+        // Body must be valid JSON with the refresh token nested correctly.
+        let obj = try? JSONSerialization.jsonObject(with: req.body) as? [String: Any]
+        let params = obj?["AuthParameters"] as? [String: Any]
+        XCTAssertEqual(params?["REFRESH_TOKEN"] as? String, "RT-9")
+    }
+
+    func testParseRefreshResponse() {
+        let ok = #"{"AuthenticationResult":{"IdToken":"NEW.jwt.sig","ExpiresIn":3600}}"#
+        XCTAssertEqual(PotaAuth.parseRefreshResponse(Data(ok.utf8)), "NEW.jwt.sig")
+        // Revoked refresh token → error shape, no AuthenticationResult.
+        let err = #"{"__type":"NotAuthorizedException","message":"Refresh Token has been revoked"}"#
+        XCTAssertNil(PotaAuth.parseRefreshResponse(Data(err.utf8)))
+        XCTAssertNil(PotaAuth.parseRefreshResponse(nil))
+    }
+
+    // MARK: - classifyRedirect (security-critical)
+
+    func testClassifyRedirectExtractsCode() {
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app/?code=abc"),
+                       .withCode("abc"))
+        // Case-insensitive host is still legit.
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://POTA.APP/?code=Xy9"),
+                       .withCode("Xy9"))
+    }
+
+    func testClassifyRedirectNoCode() {
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app/"), .noCode)
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app/?error=access_denied"),
+                       .noCode)
+    }
+
+    func testClassifyRedirectRejectsSpoofs() {
+        // Lookalike host — the whole point of the parsed-origin check.
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app.evil.com/?code=steal"),
+                       .notRedirect)
+        // Scheme downgrade.
+        XCTAssertEqual(PotaAuth.classifyRedirect("http://pota.app/?code=steal"),
+                       .notRedirect)
+        // Userinfo trick: real host is evil.com.
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app@evil.com/?code=steal"),
+                       .notRedirect)
+        // Explicit alternate port.
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app:8443/?code=steal"),
+                       .notRedirect)
+        // Different host entirely.
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://notpota.app/?code=steal"),
+                       .notRedirect)
+        // Cognito hosted-UI page mid-flow — not the redirect.
+        XCTAssertEqual(
+            PotaAuth.classifyRedirect(
+                "https://parksontheair.auth.us-east-2.amazoncognito.com/oauth2/authorize?x=1"),
+            .notRedirect)
+    }
+
+    // MARK: - JWT claims
+
+    func testJwtExpiryAndEmail() {
+        let exp = 1_800_000_000.0 // fixed epoch seconds
+        let token = jwt(payload: "{\"email\":\"ken@example.com\",\"exp\":\(Int(exp))}")
+        XCTAssertEqual(PotaAuth.jwtExpiry(token), Date(timeIntervalSince1970: exp))
+        XCTAssertEqual(PotaAuth.emailClaim(token), "ken@example.com")
+    }
+
+    func testJwtMalformedReturnsNil() {
+        XCTAssertNil(PotaAuth.jwtExpiry("not-a-jwt"))
+        XCTAssertNil(PotaAuth.jwtExpiry("only.two"))  // payload "two" isn't base64 JSON
+        XCTAssertNil(PotaAuth.emailClaim(""))
+    }
+
+    func testNeedsRefreshNearExpiry() {
+        let exp = Date(timeIntervalSince1970: 1_000_000)
+        // 10 min before expiry, 5-min skew → still good.
+        XCTAssertFalse(PotaAuth.needsRefresh(
+            expiry: exp, now: exp.addingTimeInterval(-600), skew: 300))
+        // 2 min before expiry, 5-min skew → refresh.
+        XCTAssertTrue(PotaAuth.needsRefresh(
+            expiry: exp, now: exp.addingTimeInterval(-120), skew: 300))
+        // Already expired → refresh.
+        XCTAssertTrue(PotaAuth.needsRefresh(
+            expiry: exp, now: exp.addingTimeInterval(60), skew: 300))
+        // Unknown expiry → refresh.
+        XCTAssertTrue(PotaAuth.needsRefresh(expiry: nil))
+    }
+
+    func testCacheExpiryHonoursShorterOfJwtExpAndTtl() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        // JWT exp far in the future → capped at now + 55 min.
+        let farToken = jwt(payload: "{\"exp\":\(Int(now.timeIntervalSince1970) + 100_000)}")
+        XCTAssertEqual(
+            PotaAuth.cacheExpiry(forIdToken: farToken, now: now),
+            now.addingTimeInterval(PotaAuth.idTokenTTL))
+        // JWT exp sooner than 55 min → use the JWT's own exp.
+        let soonEpoch = Int(now.timeIntervalSince1970) + 600
+        let soonToken = jwt(payload: "{\"exp\":\(soonEpoch)}")
+        XCTAssertEqual(
+            PotaAuth.cacheExpiry(forIdToken: soonToken, now: now),
+            Date(timeIntervalSince1970: Double(soonEpoch)))
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaAuthTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaAuthTests.swift
@@ -148,6 +148,9 @@ final class PotaAuthTests: XCTestCase {
         // Explicit alternate port.
         XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app:8443/?code=steal"),
                        .notRedirect)
+        // Non-root path on the exact host — the redirect only ever lands at "/".
+        XCTAssertEqual(PotaAuth.classifyRedirect("https://pota.app/login/callback?code=steal"),
+                       .notRedirect)
         // Different host entirely.
         XCTAssertEqual(PotaAuth.classifyRedirect("https://notpota.app/?code=steal"),
                        .notRedirect)

--- a/ios/FT8AFKit/Tests/FT8EngineTests/PotaUploadTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/PotaUploadTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import FT8Engine
+
+final class PotaUploadTests: XCTestCase {
+
+    // MARK: - uploadRequest (multipart)
+
+    func testUploadRequestMultipartShape() {
+        let req = PotaUpload.uploadRequest(
+            idToken: "JWT.ID.TOKEN",
+            filename: "pota-US-1234-20260817-1200.adi",
+            adif: "FT8AF POTA\n<EOH>\n<CALL:5>K1ABC <EOR>\n",
+            boundary: "----ft8afTESTBOUND")
+
+        XCTAssertEqual(req.url, "https://api.pota.app/adif")
+        XCTAssertEqual(req.method, "POST")
+        // RAW JWT — never "Bearer <jwt>".
+        XCTAssertEqual(req.headers["Authorization"], "JWT.ID.TOKEN")
+        XCTAssertFalse(req.headers["Authorization"]?.hasPrefix("Bearer") ?? true)
+        XCTAssertEqual(req.headers["User-Agent"], "ft8af-1.0")
+        XCTAssertEqual(req.headers["Accept"], "application/json")
+        XCTAssertEqual(req.headers["Content-Type"],
+                       "multipart/form-data; boundary=----ft8afTESTBOUND")
+
+        let body = String(data: req.body, encoding: .utf8) ?? ""
+        let expected = "------ft8afTESTBOUND\r\n"
+            + "Content-Disposition: form-data; name=\"adif\"; "
+            + "filename=\"pota-US-1234-20260817-1200.adi\"\r\n"
+            + "Content-Type: application/octet-stream\r\n\r\n"
+            + "FT8AF POTA\n<EOH>\n<CALL:5>K1ABC <EOR>\n"
+            + "\r\n------ft8afTESTBOUND--\r\n"
+        XCTAssertEqual(body, expected)
+        // Exactly one part named "adif".
+        let occurrences = body.components(separatedBy: "name=\"adif\"").count - 1
+        XCTAssertEqual(occurrences, 1)
+    }
+
+    func testNewBoundaryIsUniqueAndPrefixed() {
+        let a = PotaUpload.newBoundary()
+        let b = PotaUpload.newBoundary()
+        XCTAssertTrue(a.hasPrefix("----ft8af"))
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - jobsRequest
+
+    func testJobsRequestShape() {
+        let req = PotaUpload.jobsRequest(idToken: "JWT.ID")
+        XCTAssertEqual(req.url, "https://api.pota.app/user/jobs")
+        XCTAssertEqual(req.method, "GET")
+        XCTAssertEqual(req.headers["Authorization"], "JWT.ID")
+        XCTAssertEqual(req.headers["User-Agent"], "ft8af-1.0")
+        XCTAssertEqual(req.headers["Accept"], "application/json")
+        XCTAssertTrue(req.body.isEmpty)
+    }
+
+    // MARK: - retry classification + backoff
+
+    func testIsRetryable() {
+        for s in [502, 503, 504] { XCTAssertTrue(PotaUpload.isRetryable(status: s)) }
+        for s in [200, 400, 401, 403, 404, 500, 501] {
+            XCTAssertFalse(PotaUpload.isRetryable(status: s))
+        }
+    }
+
+    func testIsUnauthorized() {
+        XCTAssertTrue(PotaUpload.isUnauthorized(status: 401))
+        XCTAssertTrue(PotaUpload.isUnauthorized(status: 403))
+        XCTAssertFalse(PotaUpload.isUnauthorized(status: 500))
+        XCTAssertFalse(PotaUpload.isUnauthorized(status: 200))
+    }
+
+    func testIsSuccess() {
+        XCTAssertTrue(PotaUpload.isSuccess(status: 200))
+        XCTAssertTrue(PotaUpload.isSuccess(status: 201))
+        XCTAssertFalse(PotaUpload.isSuccess(status: 302))
+        XCTAssertFalse(PotaUpload.isSuccess(status: 502))
+    }
+
+    func testBackoffSequence() {
+        XCTAssertEqual(PotaUpload.backoffSeconds(attempt: 1), 1)
+        XCTAssertEqual(PotaUpload.backoffSeconds(attempt: 2), 2)
+        XCTAssertEqual(PotaUpload.backoffSeconds(attempt: 3), 4)
+    }
+
+    func testMaxAttempts() {
+        XCTAssertEqual(PotaUpload.maxAttempts, 3)
+    }
+
+    // MARK: - failure classification
+
+    func testClassifyFailure() {
+        XCTAssertEqual(PotaUpload.classifyFailure(status: 502), .busy)
+        XCTAssertEqual(PotaUpload.classifyFailure(status: 503), .busy)
+        XCTAssertEqual(PotaUpload.classifyFailure(status: 500), .serverError)
+        XCTAssertEqual(PotaUpload.classifyFailure(status: 599), .serverError)
+        XCTAssertEqual(PotaUpload.classifyFailure(status: nil), .network)
+        XCTAssertEqual(PotaUpload.classifyFailure(status: 404), .other)
+    }
+}


### PR DESCRIPTION
## What
Completes POTA parity — the last piece: **sign in and upload activation ADIF to pota.app**.

Uses POTA's **Cognito hosted UI** (authorization-code + PKCE) in a `WKWebView`, so both **email/password and federated** (Google/etc.) sign-in work through the same flow. **No AWS SDK, no Amplify, no hand-rolled SRP** — all `URLSession` / `CryptoKit` / Keychain, matching the app's first-party style. Reuses POTA's public app client + `https://pota.app/` redirect (**no registration needed on our side**).

- **Pure, tested (FT8Engine):** `PotaAuth` — PKCE (verifier/challenge), `authorizeURL`, token-exchange + refresh request builders & parsers, JWT `exp`/`email` claims, and **`classifyRedirect`**. `PotaUpload` — multipart `/adif` with **raw-JWT** `Authorization` (not `Bearer`), `/user/jobs`, retry 3× (backoff 1/2/4 s, only 502/503/504 or transport), failure classification.
- **App:** `KeychainStore` (refresh token only, `AfterFirstUnlockThisDeviceOnly`), `PotaAuthService` (on-demand id-token refresh, coalesced), `PotaUploadService`, `PotaLoginWebView` (WKWebView intercepting the `pota.app` redirect), and **Upload to POTA** on the active session + History rows (prompts login on 401, one file per park, classified toasts).

## Security
`classifyRedirect` requires exact `https` + `host == pota.app` + **no port** via `URLComponents`, rejecting subdomain (`pota.app.evil.com`), `http://` downgrade, userinfo (`pota.app@evil.com` → real host evil.com), and explicit-port spoofs — all unit-tested. Only the **refresh token** is persisted (Keychain); the id token stays in memory; tokens are never logged. JWT `exp` is used only for refresh timing, never as trust.

## Tests
557 FT8AFKit tests pass — 24 new (`PotaAuthTests` incl. the RFC 7636 PKCE vector + the full spoof-rejection matrix; `PotaUploadTests` multipart/retry). App builds; `xcodegen` regenerated.

## Can't verify without live creds
The real OAuth round-trip (hosted-UI render, code capture, `/adif` accept, `/user/jobs`) needs actual POTA credentials — only the wire shapes + redirect handling are proven by tests. `jobs()` is wired/tested but not yet surfaced in UI (upload toast only).

Completes the iOS↔Android POTA parity sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)