### PR TITLE
iOS decode: FT4 mode (RX + mode-parameterized timing)

### DIFF
--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -1,4 +1,5 @@
 import FT8Audio
+import FT8DSP
 import FT8Engine
 import Foundation
 import Observation
@@ -204,6 +205,10 @@ final class SettingsState {
     var myCall: String = ""
     var myGrid: String = ""
     var band: String = "20M"
+    // Operating mode. FT8 (15 s) is the default; FT4 (7.5 s) is RX + timing
+    // only for now — FT4 TX is deferred (see LiveEngine.scheduleTx). The active
+    // `ModeProfile` (via `mode.profile`) drives all slot/decode/waterfall timing.
+    var mode: Mode = .ft8
     var rigModel: RigModel = .none
     var pttMode: PttMode = .vox
     var txPowerWatts: Int = 5
@@ -383,6 +388,7 @@ enum SettingsPersistence {
         d.set(s.myCall, forKey: key("myCall"))
         d.set(s.myGrid, forKey: key("myGrid"))
         d.set(s.band, forKey: key("band"))
+        d.set(s.mode.rawValue, forKey: key("mode"))
         d.set(s.rigModel.rawValue, forKey: key("rigModel"))
         d.set(s.pttMode.rawValue, forKey: key("pttMode"))
         d.set(s.txPowerWatts, forKey: key("txPowerWatts"))
@@ -435,6 +441,7 @@ enum SettingsPersistence {
         if let v = d.string(forKey: key("myCall")) { s.myCall = v }
         if let v = d.string(forKey: key("myGrid")) { s.myGrid = v }
         if let v = d.string(forKey: key("band")) { s.band = v }
+        if let v = d.string(forKey: key("mode")), let m = Mode(rawValue: v) { s.mode = m }
         if let v = d.string(forKey: key("rigModel")),
            let m = RigModel(rawValue: v) { s.rigModel = m }
         if let v = d.string(forKey: key("pttMode")),

--- a/ios/FT8AF/FT8AF/Components/SlotTimerBar.swift
+++ b/ios/FT8AF/FT8AF/Components/SlotTimerBar.swift
@@ -1,16 +1,19 @@
 import FT8Audio
+import FT8DSP
 import SwiftUI
 
-/// Thin progress bar showing the current position in the 15 s FT8 cycle.
-/// Color alternates by slot parity: even slots = accent/orange, odd = signal/blue.
-/// Guard time (last ~2.36 s) is highlighted brighter.
+/// Thin progress bar showing the current position in the active mode's cycle
+/// (15 s FT8 / 7.5 s FT4). Color alternates by slot parity: even slots =
+/// accent/orange, odd = signal/blue. Guard time (the waveform-to-boundary
+/// slack) is highlighted brighter.
 struct SlotTimerBar: View {
+    @Environment(AppState.self) private var appState
+
     @State private var progress: Double = 0
     @State private var isGuard: Bool = false
     @State private var isEvenSlot: Bool = true
 
     private let timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
-    private static let guardThresholdMs: Int64 = 12_640 // FT8 message duration
 
     var body: some View {
         GeometryReader { geo in
@@ -25,12 +28,14 @@ struct SlotTimerBar: View {
         }
         .frame(height: 3)
         .onReceive(timer) { _ in
+            let profile = appState.settings.mode.profile
             let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
-            let ms = SlotClock.msIntoCycle(atUtcMs: nowMs)
-            progress = Double(ms) / Double(SlotClock.cycleMs)
-            isGuard = ms >= Self.guardThresholdMs
+            let ms = SlotClock.msIntoCycle(atUtcMs: nowMs, cycleMs: profile.cycleMs)
+            progress = Double(ms) / Double(profile.cycleMs)
+            // Guard band = the mode's message duration to the slot boundary.
+            isGuard = ms >= profile.waveformMs
             // Determine slot parity from current slot ID
-            let slotID = SlotClock.rxSlotID(atUtcMs: nowMs, rxOffsetMs: 0)
+            let slotID = SlotClock.rxSlotID(atUtcMs: nowMs, rxOffsetMs: 0, cycleMs: profile.cycleMs)
             isEvenSlot = SlotClock.parity(slotID: slotID) == 0
         }
     }

--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -1,3 +1,4 @@
+import FT8DSP
 import FT8Engine
 import SwiftUI
 import UIKit
@@ -36,9 +37,25 @@ struct TxStrip: View {
 
                 // Right: mode + frequency + tune chips
                 HStack(spacing: 6) {
-                    // Mode pill — static "FT8" (FT4/FT2 deferred; plain,
-                    // non-interactive).
-                    TxChip(label: "FT8", color: accent)
+                    // Mode pill — pick FT8 / FT4. FT4 is RX + timing only for
+                    // now (TX deferred). FT2 is out of scope (no iOS decode
+                    // entry point). Switching re-grids the slot clock live.
+                    Menu {
+                        Picker("Mode", selection: Binding(
+                            get: { settings.mode },
+                            set: { newMode in
+                                settings.mode = newMode
+                                SettingsPersistence.save(appState.settings)
+                            }
+                        )) {
+                            ForEach(Mode.allCases) { m in
+                                Text(m.rawValue).tag(m)
+                            }
+                        }
+                    } label: {
+                        TxChip(label: settings.mode.rawValue, color: accent)
+                    }
+                    .buttonStyle(.plain)
 
                     // Tappable frequency/band chip
                     Button { onOpenFrequencyPicker() } label: {

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -872,6 +872,9 @@ final class LiveEngine {
         // it can be verified transmitting we run FT4 as RX + timing only — never
         // key a mutilated / off-grid signal. FT8 is unaffected.
         guard appState.settings.mode.profile.isFT8 else { return }
+        // Capture the profile NOW so a mid-delay FT8->FT4 mode switch can't make
+        // beginTxPlayback clip this (FT8) signal with FT4 timing.
+        let profile = appState.settings.mode.profile
         guard let samples = FT8Encoder.generateFT8(message, baseFreqHz: freqHz) else { return }
 
         // Wait out the cycle remainder for an early-decoded reply, then the
@@ -884,7 +887,7 @@ final class LiveEngine {
                 try? await Task.sleep(for: .milliseconds(totalDelayMs))
             }
             guard !Task.isCancelled else { return }
-            self?.beginTxPlayback(message: message, samples: samples)
+            self?.beginTxPlayback(message: message, samples: samples, profile: profile)
         }
     }
 
@@ -896,13 +899,13 @@ final class LiveEngine {
     /// them audible but undecodable (see CLAUDE.md, TX pipeline gotcha #2).
     /// The late-start-tolerance setting is a SKIP threshold instead: when more
     /// than that much leading audio would be clipped, the slot is skipped.
-    private func beginTxPlayback(message: String, samples: [Float]) {
+    private func beginTxPlayback(message: String, samples: [Float], profile: ModeProfile) {
         guard let appState else { return }
         let nowMs = nowMs()
-        // Use the active mode's cycle + physical slack so the clip math is
-        // correct per mode. For FT8 (the only mode that reaches here today) this
-        // is byte-identical to the old constants (15000 / 2360).
-        let profile = appState.settings.mode.profile
+        // `profile` is captured at schedule time (see scheduleTx) so a mode
+        // switch during the TX delay can't clip this signal with another mode's
+        // timing. For FT8 (the only mode that reaches here today) the cycle +
+        // slack are byte-identical to the old constants (15000 / 2360).
         let clipMs = TxTiming.lateStartClipMs(
             msIntoCycle: SlotClock.msIntoCycle(atUtcMs: nowMs, cycleMs: profile.cycleMs),
             slackMs: profile.slackMs

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -105,12 +105,19 @@ final class LiveEngine {
         let readSpectrumWidthHz: @Sendable @MainActor () -> Int = {
             appState.settings.spectrumWidthHz
         }
+        // Live slot length for the waterfall's UTC-boundary gridline: read each
+        // tick so an FT8↔FT4 switch re-grids the labels (7.5 s vs 15 s) without
+        // restarting. WaterfallTimestampGate re-baselines on a slotMs change.
+        let readSlotMs: @Sendable @MainActor () -> Int64 = {
+            appState.settings.mode.profile.cycleMs
+        }
         // Live decode options for the decode loop: read on the main actor each
         // slot so toggling deep/early decode applies without restarting.
         let readDecodeOptions: @Sendable @MainActor () -> DecodeOptions = {
             DecodeOptions(
                 deep: appState.settings.deepDecode,
-                early: appState.settings.earlyDecode
+                early: appState.settings.earlyDecode,
+                profile: appState.settings.mode.profile
             )
         }
         // Live whole-clock offset (NTP + manual) for the decode loop's slot/TX
@@ -167,6 +174,7 @@ final class LiveEngine {
                     await self?.runWaterfallLoop(
                         accumulator: accumulator,
                         readSpectrumWidthHz: readSpectrumWidthHz,
+                        readSlotMs: readSlotMs,
                         applyWaterfall: applyWaterfall
                     )
                 }
@@ -397,6 +405,12 @@ final class LiveEngine {
             atUtcMs: Int64(Date().timeIntervalSince1970 * 1000) + initialClockOffsetMs,
             rxOffsetMs: rxOffsetMs
         ) - 1
+        // The cadence the slot cursor above was computed under (the pre-loop
+        // seed used the default FT8 grid). A mode switch changes it and forces a
+        // reseed, since slot indices aren't comparable across cycle lengths.
+        // Seeding this to the FT8 default means an FT8 session never reseeds/skips
+        // on the first tick (byte-identical startup); an FT4 session reseeds once.
+        var lastCycleMs: Int64 = SlotClock.cycleMs
 
         while !Task.isCancelled {
             try? await Task.sleep(for: .milliseconds(200))
@@ -406,10 +420,24 @@ final class LiveEngine {
             let (opts, clockOffsetMs) = await MainActor.run {
                 (readDecodeOptions(), readClockOffsetMs())
             }
+            let profile = opts.profile
             // The whole-clock correction (NTP + manual) shifts every slot/TX
             // time read below; DtCalibrator's rxOffsetMs is applied separately
             // inside rxSlotID (RX-only capture-latency comp).
             let nowMs = Int64(Date().timeIntervalSince1970 * 1000) + clockOffsetMs
+
+            // Mode switch (or first pass): the slot grid changed length, so the
+            // cursor from the old cadence is meaningless. Reseed one slot back on
+            // the new grid — the RX clock cleanly restarts without tearing down
+            // the audio session — and skip this tick so we don't decode a
+            // stale-width window straddling the switch.
+            if profile.cycleMs != lastCycleMs {
+                lastCycleMs = profile.cycleMs
+                lastDecodedAudioSlot = SlotClock.rxSlotID(
+                    atUtcMs: nowMs, rxOffsetMs: rxOffsetMs, cycleMs: profile.cycleMs
+                ) - 1
+                continue
+            }
 
             // Decide whether to decode now (boundary vs. early), which slot's
             // audio, and how big a trailing window — see DecodeScheduler.
@@ -418,7 +446,8 @@ final class LiveEngine {
                 rxOffsetMs: rxOffsetMs,
                 earlyDecode: opts.early,
                 lastDecodedAudioSlotID: lastDecodedAudioSlot,
-                sampleRate: Int(FT8.sampleRate)
+                sampleRate: Int(FT8.sampleRate),
+                profile: profile
             ) else { continue }
             lastDecodedAudioSlot = plan.audioSlotID
 
@@ -427,7 +456,7 @@ final class LiveEngine {
             let samples = accumulator.takeTrailing(plan.windowSamples)
             // Share the engine-lifetime hash table so `<...>` compound calls
             // resolve across slots (a fresh decoder is built each slot).
-            let decoder = FT8Decoder(hashTable: hashTable)
+            let decoder = FT8Decoder(isFT8: profile.isFT8, hashTable: hashTable)
             decoder.setDeep(opts.deep) // raise LDPC iterations when deep decode is on
             decoder.feedSlot(samples)
             // decodeSlotDeep runs the initial pass and, only when deep decode is
@@ -455,7 +484,8 @@ final class LiveEngine {
             // clock). Zero when decoding at the boundary already.
             let txBoundaryDelayMs = DecodeScheduler.replyBoundaryDelayMs(
                 earlyDecode: opts.early,
-                msIntoCycle: SlotClock.msIntoCycle(atUtcMs: nowMs)
+                msIntoCycle: SlotClock.msIntoCycle(atUtcMs: nowMs, cycleMs: profile.cycleMs),
+                profile: profile
             )
 
             // Map to UI messages and update state on MainActor.
@@ -834,6 +864,14 @@ final class LiveEngine {
     private func scheduleTx(message: String, freqHz: Float, boundaryDelayMs: Int64 = 0) {
         guard let appState else { return }
         guard !appState.tx.isTuning else { return } // tune and FT8 TX are exclusive
+        // FT4 TX is DEFERRED: the iOS `FT8Encoder` only synthesizes FT8 waveforms
+        // (`ft8_encode`, 79 tones, 0.160 s / BT 2.0), and the whole TX audio
+        // pipeline (late-start slack, sequencer cadence) is FT8-tuned and
+        // unvalidated on-air for FT4. The native `ft4_encode` + parameterized
+        // `synth_gfsk_offset` make enabling it a bounded future change, but until
+        // it can be verified transmitting we run FT4 as RX + timing only — never
+        // key a mutilated / off-grid signal. FT8 is unaffected.
+        guard appState.settings.mode.profile.isFT8 else { return }
         guard let samples = FT8Encoder.generateFT8(message, baseFreqHz: freqHz) else { return }
 
         // Wait out the cycle remainder for an early-decoded reply, then the
@@ -861,8 +899,13 @@ final class LiveEngine {
     private func beginTxPlayback(message: String, samples: [Float]) {
         guard let appState else { return }
         let nowMs = nowMs()
+        // Use the active mode's cycle + physical slack so the clip math is
+        // correct per mode. For FT8 (the only mode that reaches here today) this
+        // is byte-identical to the old constants (15000 / 2360).
+        let profile = appState.settings.mode.profile
         let clipMs = TxTiming.lateStartClipMs(
-            msIntoCycle: SlotClock.msIntoCycle(atUtcMs: nowMs)
+            msIntoCycle: SlotClock.msIntoCycle(atUtcMs: nowMs, cycleMs: profile.cycleMs),
+            slackMs: profile.slackMs
         )
         guard !TxTiming.shouldSkip(
             clipMs: clipMs,
@@ -913,6 +956,7 @@ final class LiveEngine {
     private nonisolated func runWaterfallLoop(
         accumulator: SlotAccumulator,
         readSpectrumWidthHz: @escaping @Sendable @MainActor () -> Int,
+        readSlotMs: @escaping @Sendable @MainActor () -> Int64,
         applyWaterfall: @escaping @Sendable @MainActor (WaterfallUpdate) -> Void
     ) async {
         let sampleRate = Int(FT8.sampleRate)
@@ -924,7 +968,8 @@ final class LiveEngine {
             try? await Task.sleep(for: .milliseconds(250))
             if Task.isCancelled { break }
 
-            let displayMaxHz = Float(await MainActor.run { readSpectrumWidthHz() })
+            let (widthHz, slotMs) = await MainActor.run { (readSpectrumWidthHz(), readSlotMs()) }
+            let displayMaxHz = Float(widthHz)
             let columns = WaterfallRowBuilder.columns(sampleRate: sampleRate, maxHz: displayMaxHz)
 
             let samples = accumulator.peekRecent(needed)
@@ -949,13 +994,14 @@ final class LiveEngine {
             let scale = maxPower > 0 ? 1.0 / maxPower : 1.0
             let spectrum = power.map { min($0 * scale, 1.0) }
 
-            // Stamp the UTC label once on the first row of each FT8 period
-            // (label shows the period start, matching Android).
+            // Stamp the UTC label once on the first row of each slot period
+            // (label shows the period start, matching Android). slotMs tracks the
+            // active mode (15 s FT8 / 7.5 s FT4); the gate re-baselines on change.
             let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
             var timestamp: String?
-            if timestampGate.shouldDraw(utcMs: nowMs) {
+            if timestampGate.shouldDraw(utcMs: nowMs, slotMs: slotMs) {
                 timestamp = WaterfallTimestampGate.utcLabel(
-                    forUtcMs: WaterfallTimestampGate.slotStartMs(utcMs: nowMs)
+                    forUtcMs: WaterfallTimestampGate.slotStartMs(utcMs: nowMs, slotMs: slotMs)
                 )
             }
 
@@ -1154,14 +1200,15 @@ final class LiveEngine {
         let qsoStatus = qsoEngine?.status()
         let dialMhz = Double(bandToFreqMhz(s?.band ?? "20M")) ?? 14.074
         let df = UInt32(max(0, Int(appState?.waterfall.txFreqHz ?? 1500)))
+        let profile = (s?.mode ?? .ft8).profile
         return WsjtxCodec.Status(
-            dialFreqHz: UInt64(dialMhz * 1_000_000), mode: "FT8",
-            dxCall: qsoStatus?.target ?? "", report: "", txMode: "FT8",
+            dialFreqHz: UInt64(dialMhz * 1_000_000), mode: profile.displayName,
+            dxCall: qsoStatus?.target ?? "", report: "", txMode: profile.displayName,
             txEnabled: qsoStatus?.active ?? false,
             transmitting: appState?.tx.isTransmitting ?? false, decoding: isRunning,
             rxDf: df, txDf: df, deCall: s?.myCall ?? "", deGrid: s?.myGrid ?? "",
             dxGrid: "", txWatchdog: false, subMode: "", fastMode: false,
-            specialOpMode: 0, freqTolerance: 0xFFFF_FFFF, trPeriod: 15,
+            specialOpMode: 0, freqTolerance: 0xFFFF_FFFF, trPeriod: profile.trPeriodSeconds,
             configName: "Default", txMessage: qsoStatus?.txMessage ?? ""
         )
     }
@@ -1169,11 +1216,12 @@ final class LiveEngine {
     private func broadcastUdpDecodes(_ decoded: [DecodedMessage]) {
         guard udp.isEnabled, !decoded.isEmpty else { return }
         let timeMs = UInt32(nowMs() % 86_400_000)
+        let modeName = (appState?.settings.mode ?? .ft8).rawValue
         for m in decoded {
             let text = m.rawText.isEmpty ? "\(m.callTo) \(m.callFrom) \(m.extra)" : m.rawText
             udp.sendDecode(WsjtxCodec.Decode(
                 isNew: true, timeMs: timeMs, snr: Int32(m.snr), deltaTime: Double(m.timeSec),
-                deltaFreq: UInt32(max(0, Int(m.freqHz))), mode: "FT8", message: text,
+                deltaFreq: UInt32(max(0, Int(m.freqHz))), mode: modeName, message: text,
                 lowConfidence: false, offAir: false
             ))
         }
@@ -1215,12 +1263,16 @@ struct WaterfallUpdate: Sendable {
 }
 
 /// Live decode toggles read on the main actor at the start of each slot and
-/// handed to the background decode loop: deep decode (LDPC iteration cap) and
-/// early decode (decode ~1.5 s before the boundary). Read fresh each slot so a
-/// settings change applies without restarting the session.
+/// handed to the background decode loop: deep decode (LDPC iteration cap),
+/// early decode (decode ~1.5 s before the boundary), and the active operating
+/// mode's `ModeProfile` (slot cadence + decoder protocol). Read fresh each slot
+/// so a settings change — including an FT8↔FT4 switch — applies without
+/// restarting the session; the loop reseeds its slot cursor when `cycleMs`
+/// changes so the new cadence takes effect cleanly.
 struct DecodeOptions: Sendable {
     let deep: Bool
     let early: Bool
+    let profile: ModeProfile
 }
 
 /// Initializer extension on DecodedMessage for constructing from individual

--- a/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
@@ -1,3 +1,4 @@
+import FT8DSP
 import SwiftUI
 
 struct TransmissionSettings: View {
@@ -69,6 +70,24 @@ struct TransmissionSettings: View {
             } header: {
                 Text("Audio")
                     .foregroundStyle(textMuted)
+            }
+            .listRowBackground(bgSurface)
+
+            // Mode selection
+            Section {
+                Picker("Mode", selection: $settings.mode) {
+                    ForEach(Mode.allCases) { m in
+                        Text(m.rawValue).tag(m)
+                    }
+                }
+                .foregroundStyle(textPrimary)
+            } header: {
+                Text("Mode")
+                    .foregroundStyle(textMuted)
+            } footer: {
+                Text("FT4 receives and shows timing; FT4 transmit is not yet enabled. FT8 transmits normally.")
+                    .font(.ft8afUI(size: 11))
+                    .foregroundStyle(textFaint)
             }
             .listRowBackground(bgSurface)
 
@@ -218,6 +237,7 @@ struct TransmissionSettings: View {
         .onChange(of: settings.pttMode) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.txVolume) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.band) { _, _ in SettingsPersistence.save(appState.settings) }
+        .onChange(of: settings.mode) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.huntCallsCQ) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.autoCallFollow) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.earlyDecode) { _, _ in SettingsPersistence.save(appState.settings) }

--- a/ios/FT8AFKit/Sources/FT8Audio/DecodeScheduler.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/DecodeScheduler.swift
@@ -1,3 +1,4 @@
+import FT8DSP
 import Foundation
 
 /// Pure timing math for the RX decode loop: at each poll tick it decides whether
@@ -70,16 +71,18 @@ public enum DecodeScheduler {
         rxOffsetMs: Int64,
         earlyDecode: Bool,
         lastDecodedAudioSlotID: Int64,
-        sampleRate: Int
+        sampleRate: Int,
+        profile: ModeProfile = .ft8
     ) -> Plan? {
-        let currentSlot = SlotClock.rxSlotID(atUtcMs: nowMs, rxOffsetMs: rxOffsetMs)
+        let cycleMs = profile.cycleMs
+        let currentSlot = SlotClock.rxSlotID(atUtcMs: nowMs, rxOffsetMs: rxOffsetMs, cycleMs: cycleMs)
         // RX-shifted position within the current slot (audio-aligned clock).
-        let msInto = SlotClock.msIntoCycle(atUtcMs: nowMs - rxOffsetMs)
+        let msInto = SlotClock.msIntoCycle(atUtcMs: nowMs - rxOffsetMs, cycleMs: cycleMs)
 
         if earlyDecode {
-            // Decode the in-progress slot once it is ~13.5 s along.
+            // Decode the in-progress slot once it is ~earlyDecodeMillis along.
             let audioSlot = currentSlot
-            guard audioSlot > lastDecodedAudioSlotID, msInto >= earlyDecodeMillis else {
+            guard audioSlot > lastDecodedAudioSlotID, msInto >= profile.earlyDecodeMillis else {
                 return nil
             }
             // Window = audio captured since slot start (>= earlyDecodeMillis).
@@ -92,13 +95,13 @@ public enum DecodeScheduler {
                 windowSamples: windowSampleCount(windowMs: msInto, sampleRate: sampleRate)
             )
         } else {
-            // Decode the slot that just ended, over the full 15 s slot.
+            // Decode the slot that just ended, over the full slot.
             let audioSlot = currentSlot - 1
             guard audioSlot > lastDecodedAudioSlotID else { return nil }
             return Plan(
                 audioSlotID: audioSlot,
                 replySlotID: audioSlot + 1,
-                windowSamples: windowSampleCount(windowMs: SlotClock.cycleMs, sampleRate: sampleRate)
+                windowSamples: windowSampleCount(windowMs: cycleMs, sampleRate: sampleRate)
             )
         }
     }
@@ -110,8 +113,12 @@ public enum DecodeScheduler {
     ///
     /// - Parameter msIntoCycle: the unshifted `SlotClock.msIntoCycle(nowMs)` (TX
     ///   uses the unshifted clock, unlike the RX-aligned `plan` above).
-    public static func replyBoundaryDelayMs(earlyDecode: Bool, msIntoCycle: Int64) -> Int64 {
+    public static func replyBoundaryDelayMs(
+        earlyDecode: Bool,
+        msIntoCycle: Int64,
+        profile: ModeProfile = .ft8
+    ) -> Int64 {
         guard earlyDecode else { return 0 }
-        return max(0, SlotClock.cycleMs - msIntoCycle)
+        return max(0, profile.cycleMs - msIntoCycle)
     }
 }

--- a/ios/FT8AFKit/Sources/FT8Audio/SlotClock.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/SlotClock.swift
@@ -8,23 +8,25 @@ import Foundation
 /// pushes the effective time slightly negative (matches Rust `div_euclid` /
 /// `rem_euclid`, which the desktop relies on).
 public enum SlotClock {
+    /// Default cycle length (FT8, ms). Mode-parameterized callers pass the
+    /// active `ModeProfile.cycleMs`; the default keeps FT8 callers unchanged.
     public static let cycleMs: Int64 = 15_000
 
-    /// The slot index containing `nowMs` (15 s slots since the epoch).
-    public static func slotID(atUtcMs nowMs: Int64) -> Int64 {
+    /// The slot index containing `nowMs` (`cycleMs`-length slots since the epoch).
+    public static func slotID(atUtcMs nowMs: Int64, cycleMs: Int64 = SlotClock.cycleMs) -> Int64 {
         floorDiv(nowMs, cycleMs)
     }
 
-    /// Milliseconds elapsed into the current 15 s slot (0..<15000).
-    public static func msIntoCycle(atUtcMs nowMs: Int64) -> Int64 {
+    /// Milliseconds elapsed into the current slot (0..<cycleMs).
+    public static func msIntoCycle(atUtcMs nowMs: Int64, cycleMs: Int64 = SlotClock.cycleMs) -> Int64 {
         floorMod(nowMs, cycleMs)
     }
 
     /// The RX-window slot index. The RX boundary runs on a clock shifted later by
-    /// the capture-latency compensation (`rxOffsetMs`) so the sliced 15 s slot
-    /// aligns with the audio that has actually arrived in the buffer; UTC display
-    /// and TX still use the unshifted clock.
-    public static func rxSlotID(atUtcMs nowMs: Int64, rxOffsetMs: Int64) -> Int64 {
+    /// the capture-latency compensation (`rxOffsetMs`) so the sliced slot aligns
+    /// with the audio that has actually arrived in the buffer; UTC display and TX
+    /// still use the unshifted clock.
+    public static func rxSlotID(atUtcMs nowMs: Int64, rxOffsetMs: Int64, cycleMs: Int64 = SlotClock.cycleMs) -> Int64 {
         floorDiv(nowMs - rxOffsetMs, cycleMs)
     }
 

--- a/ios/FT8AFKit/Sources/FT8DSP/ModeProfile.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/ModeProfile.swift
@@ -84,7 +84,8 @@ public struct ModeProfile: Equatable, Sendable {
         self.sampleRate = sampleRate
         // Compute in Double then round, matching Android `Math.round(...)`.
         self.waveformMs = Int64((Double(numTones) * Double(symbolPeriod) * 1000.0).rounded())
-        self.slackMs = cycleMs - Int64((Double(numTones) * Double(symbolPeriod) * 1000.0).rounded())
+        // Reuse waveformMs so slack can never drift if the rounding changes.
+        self.slackMs = cycleMs - self.waveformMs
         self.slotSamples = Int(sampleRate) * Int(cycleMs) / 1000
     }
 

--- a/ios/FT8AFKit/Sources/FT8DSP/ModeProfile.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/ModeProfile.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// The operating modes the iOS app can select at runtime. The iOS analog of
+/// Android's `FT8Common.*_MODE` ids + `ModeProfile` enum.
+///
+/// FT2 is intentionally absent: its `*Ft2` native decode entry points are not
+/// exposed in the iOS `CFT8` shim (only `FTX_PROTOCOL_FT8` / `FTX_PROTOCOL_FT4`
+/// reach Swift), so a faithful FT2 profile can't be decoded here. It is deferred
+/// rather than faked — see the port notes on the C surface.
+public enum Mode: String, CaseIterable, Identifiable, Sendable {
+    case ft8 = "FT8"
+    case ft4 = "FT4"
+
+    public var id: String { rawValue }
+
+    /// The timing/codec descriptor for this mode.
+    public var profile: ModeProfile {
+        switch self {
+        case .ft8: return .ft8
+        case .ft4: return .ft4
+        }
+    }
+}
+
+/// Per-mode timing, symbol, and synthesis parameters — the iOS port of Android
+/// `com.k1af.ft8af.ModeProfile`. The rest of the app stays mode-agnostic by
+/// reading the active descriptor (from `SettingsState.mode`) instead of
+/// hard-coding the 15 s / 12.64 s / 79-tone FT8 assumptions.
+///
+/// Constants match Android's `ModeProfile` exactly (FT8 15 s / FT4 7.5 s). The
+/// derived `waveformMs`, `slackMs`, and `slotSamples` use the same formulas as
+/// Android's `audioMillis` / `audioSlackMillis` so the two frontends agree
+/// byte-for-byte on slot geometry.
+public struct ModeProfile: Equatable, Sendable {
+    /// Which mode this describes.
+    public let mode: Mode
+    /// Human/protocol-facing name ("FT8"/"FT4") — logs, PSKReporter, ADIF, the
+    /// WSJT-X UDP `mode`/`txMode` fields.
+    public let displayName: String
+    /// TX/RX cycle length in ms (15000 FT8, 7500 FT4); the slot grid the
+    /// `SlotClock` fires boundaries on.
+    public let cycleMs: Int64
+    /// Shorter RX capture window used when early/fast decode is on (13500 FT8,
+    /// 6500 FT4). Always exceeds `waveformMs`, so an on-time signal is never
+    /// clipped by the early window.
+    public let earlyDecodeMillis: Int64
+    /// GFSK symbol period in seconds (0.160 FT8, 0.048 FT4).
+    public let symbolPeriod: Float
+    /// Gaussian BT product for GFSK (2.0 FT8, 1.0 FT4).
+    public let symbolBT: Float
+    /// Number of channel symbols/tones (79 FT8, 105 FT4).
+    public let numTones: Int
+    /// Whether the native decoder/encoder should use the FT8 protocol
+    /// (`FTX_PROTOCOL_FT8`); false selects FT4.
+    public let isFT8: Bool
+    /// Codec sample rate (12 kHz for both modes; the native lib is fixed here).
+    public let sampleRate: Int32
+
+    /// Audio waveform length in ms: `round(numTones * symbolPeriod * 1000)`
+    /// (12640 FT8, 5040 FT4). Mirror of Android `audioMillis`.
+    public let waveformMs: Int64
+    /// Slack between the waveform end and the slot boundary
+    /// (`cycleMs - waveformMs`): 2360 FT8, 2460 FT4. Drives the late-start clip
+    /// math in transmit so a normal on-time TX is never clipped. Mirror of
+    /// Android `audioSlackMillis`.
+    public let slackMs: Int64
+    /// Samples in one full slot at `sampleRate` (`sampleRate * cycleMs / 1000`):
+    /// 180000 FT8, 90000 FT4.
+    public let slotSamples: Int
+
+    private init(
+        mode: Mode, cycleMs: Int64, earlyDecodeMillis: Int64,
+        symbolPeriod: Float, symbolBT: Float, numTones: Int, isFT8: Bool,
+        sampleRate: Int32 = FT8.sampleRate
+    ) {
+        self.mode = mode
+        self.displayName = mode.rawValue
+        self.cycleMs = cycleMs
+        self.earlyDecodeMillis = earlyDecodeMillis
+        self.symbolPeriod = symbolPeriod
+        self.symbolBT = symbolBT
+        self.numTones = numTones
+        self.isFT8 = isFT8
+        self.sampleRate = sampleRate
+        // Compute in Double then round, matching Android `Math.round(...)`.
+        self.waveformMs = Int64((Double(numTones) * Double(symbolPeriod) * 1000.0).rounded())
+        self.slackMs = cycleMs - Int64((Double(numTones) * Double(symbolPeriod) * 1000.0).rounded())
+        self.slotSamples = Int(sampleRate) * Int(cycleMs) / 1000
+    }
+
+    /// Wall-clock budget for the deep-decode subtract-and-redecode loop in ms.
+    /// Scales with the slot (0.75x) with a 2.5 s floor — the iOS twin of
+    /// Android `ModeProfile.deepDecodeBudgetMillis()` (11250 FT8, 5625 FT4).
+    public var deepDecodeBudgetMillis: Int64 {
+        max(2500, Int64((Double(cycleMs) * 0.75).rounded()))
+    }
+
+    /// The WSJT-X UDP `TR Period` in whole seconds (`cycleMs / 1000`): 15 FT8,
+    /// 7 FT4. GridTracker/JTAlert key their period grid off this + the mode name.
+    public var trPeriodSeconds: UInt32 {
+        UInt32(cycleMs / 1000)
+    }
+
+    // MARK: - Profiles (exact Android constants)
+
+    /// FT8: 15 s slot, 12.64 s / 79-tone waveform, 0.160 s symbols.
+    public static let ft8 = ModeProfile(
+        mode: .ft8, cycleMs: 15_000, earlyDecodeMillis: 13_500,
+        symbolPeriod: 0.160, symbolBT: 2.0, numTones: 79, isFT8: true
+    )
+
+    /// FT4: 7.5 s slot, 5.04 s / 105-tone waveform, 0.048 s symbols.
+    public static let ft4 = ModeProfile(
+        mode: .ft4, cycleMs: 7_500, earlyDecodeMillis: 6_500,
+        symbolPeriod: 0.048, symbolBT: 1.0, numTones: 105, isFT8: false
+    )
+}

--- a/ios/FT8AFKit/Tests/FT8AudioTests/ModeTimingTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/ModeTimingTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import FT8Audio
+import FT8DSP
+
+/// SlotClock + DecodeScheduler math under a non-FT8 `ModeProfile`. Proves the
+/// FT4 (7.5 s) profile shifts slot boundaries and window sizes correctly, that
+/// FT4's shorter waveform is never clipped, and that omitting the profile (the
+/// FT8 default) reproduces the existing FT8 behavior exactly (regression guard).
+final class ModeTimingTests: XCTestCase {
+
+    private let sr = 12_000
+    private let ft4 = ModeProfile.ft4
+
+    // MARK: - SlotClock under FT4 cadence
+
+    func testSlotBoundariesAtSevenAndAHalfSeconds() {
+        // 3 full FT4 slots + 4.2 s into the 4th.
+        let now: Int64 = 3 * 7_500 + 4_200
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: now, cycleMs: ft4.cycleMs), 3)
+        XCTAssertEqual(SlotClock.msIntoCycle(atUtcMs: now, cycleMs: ft4.cycleMs), 4_200)
+        // Exact boundary.
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: 22_500, cycleMs: ft4.cycleMs), 3)
+        XCTAssertEqual(SlotClock.msIntoCycle(atUtcMs: 22_500, cycleMs: ft4.cycleMs), 0)
+    }
+
+    /// The same wall-clock instant lands in different slots under FT8 vs FT4,
+    /// so cadence is genuinely driven by the profile, not a hidden constant.
+    func testFT4AndFT8DisagreeOnSlotAtSameInstant() {
+        let now: Int64 = 15_000 // exactly slot 1 boundary for FT8, slot 2 for FT4
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: now), 1) // FT8 default
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: now, cycleMs: ft4.cycleMs), 2)
+    }
+
+    // MARK: - DecodeScheduler off-mode (boundary) under FT4
+
+    func testFT4OffModeFullSlotWindowIs90000() {
+        // Just past the boundary into FT4 slot 5 (msInto = 100), last decoded 3.
+        let now: Int64 = 5 * 7_500 + 100
+        let plan = DecodeScheduler.plan(
+            nowMs: now, rxOffsetMs: 0, earlyDecode: false,
+            lastDecodedAudioSlotID: 3, sampleRate: sr, profile: ft4)
+        XCTAssertEqual(plan?.audioSlotID, 4)
+        XCTAssertEqual(plan?.replySlotID, 5)
+        // Full FT4 slot = 7.5 s * 12 kHz = 90000 samples = profile.slotSamples.
+        XCTAssertEqual(plan?.windowSamples, 90_000)
+        XCTAssertEqual(plan?.windowSamples, ft4.slotSamples)
+    }
+
+    // MARK: - DecodeScheduler early-mode under FT4
+
+    func testFT4EarlyModeDoesNotFireBeforeSixPointFive() {
+        // 6.0 s into FT4 slot 5, before the 6.5 s early mark.
+        let now: Int64 = 5 * 7_500 + 6_000
+        let plan = DecodeScheduler.plan(
+            nowMs: now, rxOffsetMs: 0, earlyDecode: true,
+            lastDecodedAudioSlotID: 4, sampleRate: sr, profile: ft4)
+        XCTAssertNil(plan, "must wait until msInto >= FT4 earlyDecodeMillis (6500)")
+    }
+
+    func testFT4EarlyModeFiresAtSixPointFiveOnCurrentSlot() {
+        let msInto: Int64 = 6_600
+        let now: Int64 = 5 * 7_500 + msInto
+        let plan = DecodeScheduler.plan(
+            nowMs: now, rxOffsetMs: 0, earlyDecode: true,
+            lastDecodedAudioSlotID: 4, sampleRate: sr, profile: ft4)
+        XCTAssertEqual(plan?.audioSlotID, 5)
+        XCTAssertEqual(plan?.replySlotID, 6)
+        XCTAssertEqual(plan?.windowSamples,
+                       DecodeScheduler.windowSampleCount(windowMs: msInto, sampleRate: sr))
+    }
+
+    /// The FT4 early window (min 6.5 s = 78000 samples) must exceed the FT4
+    /// waveform (5.04 s = 60480 samples), so an on-time FT4 signal is never
+    /// clipped by the early trigger — the FT4 twin of the FT8 invariant.
+    func testFT4EarlyWindowNeverClipsWaveform() {
+        let minEarly = DecodeScheduler.windowSampleCount(windowMs: ft4.earlyDecodeMillis, sampleRate: sr)
+        let waveform = DecodeScheduler.windowSampleCount(windowMs: ft4.waveformMs, sampleRate: sr)
+        XCTAssertEqual(minEarly, 78_000)
+        XCTAssertEqual(waveform, 60_480)
+        XCTAssertGreaterThan(minEarly, waveform)
+    }
+
+    // MARK: - Reply boundary delay under FT4
+
+    func testFT4ReplyBoundaryDelayWaitsToTheFT4Boundary() {
+        // Early decode 6.6 s into a 7.5 s FT4 cycle -> wait remaining 0.9 s.
+        XCTAssertEqual(
+            DecodeScheduler.replyBoundaryDelayMs(earlyDecode: true, msIntoCycle: 6_600, profile: ft4),
+            900)
+        // Off mode never waits.
+        XCTAssertEqual(
+            DecodeScheduler.replyBoundaryDelayMs(earlyDecode: false, msIntoCycle: 6_600, profile: ft4),
+            0)
+    }
+
+    // MARK: - FT8 default regression: no profile == profile:.ft8 == legacy
+
+    func testOmittingProfileReproducesFT8Exactly() {
+        let now: Int64 = 5 * 15_000 + 13_600
+        let noProfile = DecodeScheduler.plan(
+            nowMs: now, rxOffsetMs: 0, earlyDecode: true,
+            lastDecodedAudioSlotID: 4, sampleRate: sr)
+        let explicitFT8 = DecodeScheduler.plan(
+            nowMs: now, rxOffsetMs: 0, earlyDecode: true,
+            lastDecodedAudioSlotID: 4, sampleRate: sr, profile: .ft8)
+        XCTAssertEqual(noProfile, explicitFT8)
+        XCTAssertEqual(noProfile?.audioSlotID, 5)
+
+        // Off-mode full-slot window is still the FT8 180000, not FT4's 90000.
+        let off = DecodeScheduler.plan(
+            nowMs: 5 * 15_000 + 100, rxOffsetMs: 0, earlyDecode: false,
+            lastDecodedAudioSlotID: 3, sampleRate: sr)
+        XCTAssertEqual(off?.windowSamples, 180_000)
+
+        // SlotClock default cycle is unchanged.
+        XCTAssertEqual(SlotClock.slotID(atUtcMs: now),
+                       SlotClock.slotID(atUtcMs: now, cycleMs: ModeProfile.ft8.cycleMs))
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8DSPTests/ModeProfileTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/ModeProfileTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import FT8DSP
+
+/// Locks the per-mode timing/codec constants to Android's `ModeProfile`
+/// (FT8 15 s / FT4 7.5 s) and guards that the FT8 profile still reproduces the
+/// pre-existing `FT8.*` constants byte-for-byte (regression guard).
+final class ModeProfileTests: XCTestCase {
+
+    // MARK: - FT8 profile == the historical FT8 constants (regression guard)
+
+    func testFT8ProfileMatchesAndroidAndLegacyConstants() {
+        let p = ModeProfile.ft8
+        XCTAssertEqual(p.mode, .ft8)
+        XCTAssertEqual(p.displayName, "FT8")
+        XCTAssertEqual(p.cycleMs, 15_000)
+        XCTAssertEqual(p.earlyDecodeMillis, 13_500)
+        XCTAssertEqual(p.symbolPeriod, 0.160)
+        XCTAssertEqual(p.symbolBT, 2.0)
+        XCTAssertEqual(p.numTones, 79)
+        XCTAssertTrue(p.isFT8)
+        XCTAssertEqual(p.waveformMs, 12_640)
+        XCTAssertEqual(p.slackMs, 2_360)
+        XCTAssertEqual(p.slotSamples, 180_000)
+        XCTAssertEqual(p.trPeriodSeconds, 15)
+        XCTAssertEqual(p.deepDecodeBudgetMillis, 11_250)
+    }
+
+    /// The FT8 profile must not drift from the standalone `FT8.*` constants the
+    /// encoder/decoder/accumulator still use directly.
+    func testFT8ProfileAgreesWithFT8Constants() {
+        XCTAssertEqual(ModeProfile.ft8.numTones, FT8.nn)
+        XCTAssertEqual(ModeProfile.ft8.symbolPeriod, FT8.symbolPeriod)
+        XCTAssertEqual(ModeProfile.ft8.symbolBT, FT8.symbolBT)
+        XCTAssertEqual(ModeProfile.ft8.sampleRate, FT8.sampleRate)
+        XCTAssertEqual(ModeProfile.ft8.slotSamples, FT8.slotSamples)
+    }
+
+    // MARK: - FT4 profile == Android's FT4 constants exactly
+
+    func testFT4ProfileMatchesAndroid() {
+        let p = ModeProfile.ft4
+        XCTAssertEqual(p.mode, .ft4)
+        XCTAssertEqual(p.displayName, "FT4")
+        XCTAssertEqual(p.cycleMs, 7_500)
+        XCTAssertEqual(p.earlyDecodeMillis, 6_500)
+        XCTAssertEqual(p.symbolPeriod, 0.048)
+        XCTAssertEqual(p.symbolBT, 1.0)
+        XCTAssertEqual(p.numTones, 105)
+        XCTAssertFalse(p.isFT8)
+        // audioMillis = round(105 * 0.048 * 1000) = 5040
+        XCTAssertEqual(p.waveformMs, 5_040)
+        // audioSlackMillis = 7500 - 5040 = 2460
+        XCTAssertEqual(p.slackMs, 2_460)
+        // sampleRate * cycleMs / 1000 = 12000 * 7.5 = 90000
+        XCTAssertEqual(p.slotSamples, 90_000)
+        XCTAssertEqual(p.trPeriodSeconds, 7)
+        // max(2500, round(7500 * 0.75)) = 5625
+        XCTAssertEqual(p.deepDecodeBudgetMillis, 5_625)
+    }
+
+    /// FT4's early-decode window must exceed its own waveform, else an on-time
+    /// FT4 signal would be clipped by the early trigger (the same invariant FT8
+    /// relies on).
+    func testFT4EarlyWindowExceedsWaveform() {
+        XCTAssertGreaterThan(ModeProfile.ft4.earlyDecodeMillis, ModeProfile.ft4.waveformMs)
+        XCTAssertGreaterThan(ModeProfile.ft8.earlyDecodeMillis, ModeProfile.ft8.waveformMs)
+    }
+
+    // MARK: - Mode <-> profile mapping
+
+    func testModeProfileMapping() {
+        XCTAssertEqual(Mode.ft8.profile, .ft8)
+        XCTAssertEqual(Mode.ft4.profile, .ft4)
+        XCTAssertEqual(Mode.allCases, [.ft8, .ft4])
+        XCTAssertEqual(Mode.ft8.rawValue, "FT8")
+        XCTAssertEqual(Mode.ft4.rawValue, "FT4")
+        XCTAssertEqual(Mode(rawValue: "FT4"), .ft4)
+        XCTAssertNil(Mode(rawValue: "FT2")) // out of scope, must not resolve
+    }
+}

--- a/ios/FT8AFKit/Tests/FT8EngineTests/TxTimingTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/TxTimingTests.swift
@@ -103,7 +103,8 @@ final class TxTimingTests: XCTestCase {
     /// smaller slack still clips nothing here. Guards that slack is per-mode.
     func testFT4SlackIsWiderThanFT8() {
         XCTAssertGreaterThan(ModeProfile.ft4.slackMs, ModeProfile.ft8.slackMs)
-        // 2400 ms in: clipped under nothing for either mode (both slacks > 2400).
+        // 2400 ms in: FT4's wider 2460 ms slack clips nothing, but FT8's 2360 ms
+        // slack is already exceeded, so FT8 clips the 40 ms overage.
         XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 2_400, slackMs: ModeProfile.ft4.slackMs), 0)
         XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 2_400, slackMs: ModeProfile.ft8.slackMs), 40)
     }

--- a/ios/FT8AFKit/Tests/FT8EngineTests/TxTimingTests.swift
+++ b/ios/FT8AFKit/Tests/FT8EngineTests/TxTimingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import FT8Engine
+import FT8DSP
 
 final class TxTimingTests: XCTestCase {
 
@@ -77,5 +78,33 @@ final class TxTimingTests: XCTestCase {
         XCTAssertEqual(TxTiming.clipSampleCount(clipMs: 640, sampleRate: 12_000), 7680)
         XCTAssertEqual(TxTiming.clipSampleCount(clipMs: 1000, sampleRate: 12_000), 12_000)
         XCTAssertEqual(TxTiming.clipSampleCount(clipMs: -5, sampleRate: 12_000), 0)
+    }
+
+    // MARK: FT4 slack — the clip math must use the FT4 profile's 2460 ms slack
+
+    /// FT4's waveform is 5.04 s in a 7.5 s cycle, so its physical slack is 2460
+    /// ms (not FT8's 2360). A normal on-time FT4 TX firing within that slack
+    /// clips nothing (the leading Costas array is preserved); only the overrun
+    /// past 2460 ms is clipped. This mirrors the FT8 on-time invariant with the
+    /// mode-specific slack the LiveEngine now passes.
+    func testFT4OnTimeStartClipsNothingWithinFT4Slack() {
+        let slack = ModeProfile.ft4.slackMs
+        XCTAssertEqual(slack, 2_460)
+        XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 0, slackMs: slack), 0)
+        XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 800, slackMs: slack), 0)
+        XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 2_460, slackMs: slack), 0)
+        // Just past the FT4 slack: only the overrun is clipped.
+        XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 2_461, slackMs: slack), 1)
+        XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 3_000, slackMs: slack), 540)
+    }
+
+    /// At an msInto within FT8's slack but past nothing for FT4 either — the
+    /// wider FT4 slack means a start that would clip under a hypothetical
+    /// smaller slack still clips nothing here. Guards that slack is per-mode.
+    func testFT4SlackIsWiderThanFT8() {
+        XCTAssertGreaterThan(ModeProfile.ft4.slackMs, ModeProfile.ft8.slackMs)
+        // 2400 ms in: clipped under nothing for either mode (both slacks > 2400).
+        XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 2_400, slackMs: ModeProfile.ft4.slackMs), 0)
+        XCTAssertEqual(TxTiming.lateStartClipMs(msIntoCycle: 2_400, slackMs: ModeProfile.ft8.slackMs), 40)
     }
 }


### PR DESCRIPTION
## What
Adds **FT4** as a selectable mode (iOS was FT8-only at runtime). FT8 stays the default and **byte-identical**.

- **`ModeProfile`** abstraction (`Mode {ft8, ft4}` + per-mode constants), the iOS analog of Android's `ModeProfile`: **FT8** 15000/12640/2360 ms, 79 tones; **FT4** 7500/5040/2460 ms, 105 tones — with Android's exact derived formulas (deep-decode budget, `trPeriod`). **FT2 omitted** (no iOS decode entry point).
- **Parameterized** the FT8-hardcoded timing consumers by the active profile: `SlotClock` (cycleMs), `DecodeScheduler` (full/early windows + reply boundary), `TxTiming` (slack), `WaterfallTimestampGate`, `SlotTimerBar`, and `LiveEngine` (decoder `isFT8`, UDP mode/`trPeriod`, and a clean slot-cursor reseed on mode switch — no audio teardown). Omitting the profile reproduces FT8 exactly (regression-guarded).
- **Mode picker**: `SettingsState.mode` (persisted) + a `TxStrip` mode pill and a Transmission-settings picker.

## FT4 TX deferred (with evidence)
The native C *can* do FT4 (`ft4_encode` is exposed), but the iOS **Swift** encoder (`generateFT8`) is FT8-only (hardcoded `ft8_encode`, 79 tones, 0.160 s). So `scheduleTx` guards `profile.isFT8` and **no-ops FT4** rather than keying an off-grid signal. **FT4 ships RX + timing only.** Enabling FT4 TX later is a bounded Swift change (105-tone `generateFT4` + mode-branch) needing no new C.

## Tests
548 FT8AFKit tests pass — `ModeProfileTests` (constants + FT8 regression), `ModeTimingTests` (FT4 7.5 s boundaries, windows, no-clip, reply delay, and an explicit "omitting profile == FT8" guard), `TxTiming` FT4 slack. App builds.

Part of the iOS↔Android parity sweep (decode/timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)