### PR TITLE
iOS timing: automatic DT calibration now moves the whole clock

### DIFF
--- a/ios/FT8AF/FT8AF/AppState.swift
+++ b/ios/FT8AF/FT8AF/AppState.swift
@@ -267,9 +267,10 @@ final class SettingsState {
     // Tune
     var tuneTimeoutSec: Int = 30
     // Manual whole-clock correction (ms), ±5 s, persisted. Combined with the
-    // runtime NTP offset (`ClockState.ntpOffsetMs`) into the unified clock
-    // offset the engine adds to every wall-clock read (RX slot detection, TX
-    // key-up, logged UTC). Distinct from DtCalibrator's RX-only rxOffsetMs.
+    // runtime NTP offset (`ClockState.ntpOffsetMs`) and the automatic band-median
+    // DT correction (`ClockState.autoOffsetMs`) into the unified clock offset the
+    // engine adds to every wall-clock read (RX slot detection, TX key-up, logged
+    // UTC).
     var manualClockOffsetMs: Int = 0
     // Preferred audio input port name ("" = system default); matched by name
     // so the choice survives replug/relaunch.
@@ -370,11 +371,19 @@ final class ClockState {
     /// nil until the first decode this session. A consistent bias across the
     /// stations we hear proxies our own clock offset — the clock-health source.
     var dtOffsetSec: Float?
+    /// Automatic band-median DT correction (ms) from `DtCalibrator`, written by
+    /// the decode loop as it self-syncs the clock off the band. Whole-clock (it
+    /// moves RX + TX + logged UTC), runtime-only (reset to 0 each session, like
+    /// `ntpOffsetMs`). Mirrors Android's `ClockSelfSync` → `UtcTimer.delay`.
+    var autoOffsetMs: Int64 = 0
 
     /// The unified whole-clock offset combining NTP + the persisted manual
-    /// correction. The engine adds `combinedMs` to every wall-clock read.
+    /// correction + the automatic band-median DT correction. The engine adds
+    /// `combinedMs` to every wall-clock read.
     func clockOffset(manualMs: Int) -> ClockOffset {
-        ClockOffset(ntpOffsetMs: ntpOffsetMs, manualOffsetMs: Int64(manualMs))
+        ClockOffset(ntpOffsetMs: ntpOffsetMs,
+                    manualOffsetMs: Int64(manualMs),
+                    autoOffsetMs: autoOffsetMs)
     }
 }
 

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -15,7 +15,6 @@ final class LiveEngine {
     private let audio = AudioCaptureService()
     private let txPlayer = TxPlayerService()
     private var engineTask: Task<Void, Never>?
-    private var rxOffsetMs: Int64 = 0
 
     // Persistent callsign-hash store, shared across every per-slot decoder so a
     // hashed compound call (`<...>`) resolves against a full call heard in an
@@ -78,12 +77,14 @@ final class LiveEngine {
         supervisor = TxSupervisor(nowMs: nowMs())
         callerQueue.removeAll()
         appState.tx.queuedCallers = []
+        // The automatic band-median DT correction is runtime-only: start each
+        // session from a clean slate and let the band re-discipline the clock.
+        appState.clock.autoOffsetMs = 0
 
         // Bring up the WSJT-X UDP interface for this session.
         setupUdp(appState: appState)
 
         let accumulator = audio.accumulator
-        let rxOffset = rxOffsetMs
         // Seed the decode loop with the current whole-clock offset so its first
         // slot boundary is anchored correctly; it re-reads the live value each
         // slot via readClockOffsetMs below.
@@ -120,8 +121,9 @@ final class LiveEngine {
                 profile: appState.settings.mode.profile
             )
         }
-        // Live whole-clock offset (NTP + manual) for the decode loop's slot/TX
-        // time math, read on the main actor each slot so a change applies live.
+        // Live whole-clock offset (NTP + manual + auto-DT) for the decode loop's
+        // slot/TX time math, read on the main actor each slot so a change applies
+        // live — including the auto-DT correction this loop itself publishes.
         let readClockOffsetMs: @Sendable @MainActor () -> Int64 = {
             appState.clock
                 .clockOffset(manualMs: appState.settings.manualClockOffsetMs)
@@ -130,6 +132,12 @@ final class LiveEngine {
         // Publish the mean decode DT for the clock-health indicator.
         let applyClockDt: @Sendable @MainActor (Float) -> Void = { dt in
             appState.clock.dtOffsetSec = dt
+        }
+        // Publish the automatic band-median DT correction (whole-clock). Folded
+        // into `clockOffset.combinedMs`, so the very next slot's `nowMs` — and
+        // therefore RX slot detection, TX key-up, and logged UTC — shift with it.
+        let applyAutoOffsetMs: @Sendable @MainActor (Int64) -> Void = { ms in
+            appState.clock.autoOffsetMs = ms
         }
         let applyWaterfall: @Sendable @MainActor (WaterfallUpdate) -> Void = { update in
             let wf = appState.waterfall
@@ -161,11 +169,11 @@ final class LiveEngine {
                 group.addTask {
                     await self?.runDecodeLoop(
                         accumulator: accumulator,
-                        initialRxOffset: rxOffset,
                         initialClockOffsetMs: initialClockOffset,
                         readDecodeOptions: readDecodeOptions,
                         readClockOffsetMs: readClockOffsetMs,
                         applyDecodes: applyDecodes,
+                        applyAutoOffsetMs: applyAutoOffsetMs,
                         applyClockDt: applyClockDt
                     )
                 }
@@ -389,14 +397,24 @@ final class LiveEngine {
     /// After decoding, feeds results to the QSO engine and handles TX scheduling.
     private nonisolated func runDecodeLoop(
         accumulator: SlotAccumulator,
-        initialRxOffset: Int64,
         initialClockOffsetMs: Int64,
         readDecodeOptions: @escaping @Sendable @MainActor () -> DecodeOptions,
         readClockOffsetMs: @escaping @Sendable @MainActor () -> Int64,
         applyDecodes: @escaping @Sendable @MainActor ([DecodeMessage]) -> Void,
+        applyAutoOffsetMs: @escaping @Sendable @MainActor (Int64) -> Void,
         applyClockDt: @escaping @Sendable @MainActor (Float) -> Void
     ) async {
-        var rxOffsetMs = initialRxOffset
+        // The automatic DT correction now feeds the WHOLE clock (folded into
+        // `readClockOffsetMs` / `nowMs` below), so the RX slice needs no separate
+        // capture-latency offset — the shifted clock corrects RX exactly once.
+        let rxOffsetMs: Int64 = 0
+        // Local mirror of the published whole-clock auto offset (this loop is its
+        // only writer). `DtCalibrator` reads it as its base and returns the next
+        // value, which we publish so the following slot's `nowMs` picks it up.
+        var autoOffsetMs: Int64 = 0
+        // Per-session calibrator state (confirmation streak for the two-slot
+        // same-sign gate); one instance mutated once per decoded slot.
+        var calibrator = DtCalibrator()
         // Seed one slot back so the first completed slot still decodes (the
         // scheduler fires when `audioSlotID > lastDecodedAudioSlot`). The seed
         // uses the whole-clock offset so it lands on the same slot grid the loop
@@ -421,9 +439,9 @@ final class LiveEngine {
                 (readDecodeOptions(), readClockOffsetMs())
             }
             let profile = opts.profile
-            // The whole-clock correction (NTP + manual) shifts every slot/TX
-            // time read below; DtCalibrator's rxOffsetMs is applied separately
-            // inside rxSlotID (RX-only capture-latency comp).
+            // The whole-clock correction (NTP + manual + automatic DT) shifts
+            // every slot/TX time read below; `rxOffsetMs` is a fixed 0 now that
+            // the auto-DT correction rides the whole clock (RX corrected once).
             let nowMs = Int64(Date().timeIntervalSince1970 * 1000) + clockOffsetMs
 
             // Mode switch (or first pass): the slot grid changed length, so the
@@ -465,18 +483,28 @@ final class LiveEngine {
             // subtraction). With deep off it is exactly one findSync+decodeAll.
             let decoded = decoder.decodeSlotDeep()
 
-            // DT calibration from this slot's decodes.
+            // DT calibration from this slot's decodes. The result feeds the
+            // WHOLE clock (autoOffsetMs) — MAD outlier rejection + a two-slot
+            // same-sign confirmation keep a single noisy slot from jerking it.
             if !decoded.isEmpty {
                 let dtValues = decoded.map(\.timeSec)
-                rxOffsetMs = DtCalibrator.calibrate(
-                    rxOffsetMs: rxOffsetMs,
+                let newAuto = calibrator.calibrate(
+                    autoOffsetMs: autoOffsetMs,
                     decodedDtSec: dtValues
                 )
                 // Publish the mean DT for the clock-health indicator (a
                 // consistent bias across the stations we hear proxies our own
                 // clock offset — mirrors Android's ClockSync source).
                 let meanDt = dtValues.reduce(0, +) / Float(dtValues.count)
-                await MainActor.run { applyClockDt(meanDt) }
+                if let newAuto {
+                    autoOffsetMs = newAuto
+                    await MainActor.run {
+                        applyAutoOffsetMs(newAuto)
+                        applyClockDt(meanDt)
+                    }
+                } else {
+                    await MainActor.run { applyClockDt(meanDt) }
+                }
             }
 
             // With early decode the reply must wait out the rest of the cycle so
@@ -1023,11 +1051,10 @@ final class LiveEngine {
     // MARK: - Helpers
 
     /// Wall clock (epoch ms) shifted by the unified whole-clock correction
-    /// (NTP + manual). This is the single accessor every MainActor slot/TX/log
-    /// time read routes through, so a manual or NTP offset moves RX slot
-    /// detection, TX key-up, and logged UTC together — matching Android's
-    /// `UtcTimer.getSystemTime()`. Distinct from DtCalibrator's RX-only
-    /// rxOffsetMs, which is applied separately inside `rxSlotID`.
+    /// (NTP + manual + automatic band-median DT). This is the single accessor
+    /// every MainActor slot/TX/log time read routes through, so an NTP, manual,
+    /// or auto-DT offset moves RX slot detection, TX key-up, and logged UTC
+    /// together — matching Android's `UtcTimer.getSystemTime()`.
     private func nowMs() -> Int64 {
         let wallMs = Int64(Date().timeIntervalSince1970 * 1000)
         guard let appState else { return wallMs }

--- a/ios/FT8AFKit/Sources/FT8Audio/ClockOffset.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/ClockOffset.swift
@@ -11,23 +11,38 @@ import Foundation
 ///
 /// The combined value is added to **every** wall-clock read the engine uses for
 /// slot/TX math and for logged/displayed UTC — RX slot detection, TX key-up
-/// timing, and QSO timestamps all shift together. This is deliberately distinct
-/// from ``DtCalibrator``'s `rxOffsetMs`, which is an RX-only capture-latency
-/// compensation and must *not* move TX or logged times: the clock offset here
-/// corrects the device clock itself.
+/// timing, and QSO timestamps all shift together.
+///
+/// Three independent sources feed it:
+///
+///  - `ntpOffsetMs`   — from an SNTP "Sync now" query (see ``Sntp``).
+///  - `manualOffsetMs`— an operator nudge for operating offline (bounded ±5 s).
+///  - `autoOffsetMs`  — the automatic band-median DT calibration (see
+///    ``DtCalibrator``). Historically the auto-DT correction moved an RX-only
+///    `rxOffsetMs` that shifted *only* the RX slice; folding it in here makes it
+///    a whole-clock term, matching Android's `ClockSelfSync` → `UtcTimer.delay`,
+///    so TX key-up and logged UTC benefit from the auto correction too. Because
+///    RX slot detection already reads the shifted clock, the separate RX-only
+///    offset is retired — the correction is applied to RX exactly once, via this
+///    combined value.
 public struct ClockOffset: Equatable, Sendable {
     /// NTP-derived correction (ms). Positive = device clock is behind UTC.
     public var ntpOffsetMs: Int64
     /// Manual operator correction (ms), clamped to ``manualMinMs``…``manualMaxMs``.
     public var manualOffsetMs: Int64
+    /// Automatic band-median DT correction (ms) from ``DtCalibrator``. Bounded by
+    /// the calibrator to ±``DtCalibrator/maxOffsetMs``; runtime-only (re-derived
+    /// from the band each session, not persisted).
+    public var autoOffsetMs: Int64
 
-    public init(ntpOffsetMs: Int64 = 0, manualOffsetMs: Int64 = 0) {
+    public init(ntpOffsetMs: Int64 = 0, manualOffsetMs: Int64 = 0, autoOffsetMs: Int64 = 0) {
         self.ntpOffsetMs = ntpOffsetMs
         self.manualOffsetMs = ClockOffset.clampManualMs(manualOffsetMs)
+        self.autoOffsetMs = autoOffsetMs
     }
 
-    /// Total correction added to the wall clock (`ntp + manual`).
-    public var combinedMs: Int64 { ntpOffsetMs + manualOffsetMs }
+    /// Total correction added to the wall clock (`ntp + manual + auto`).
+    public var combinedMs: Int64 { ntpOffsetMs + manualOffsetMs + autoOffsetMs }
 
     /// Apply the whole-clock correction to a wall-clock epoch-ms value. This is
     /// the single transform every engine time read routes through so the manual

--- a/ios/FT8AFKit/Sources/FT8Audio/DtCalibrator.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/DtCalibrator.swift
@@ -1,35 +1,124 @@
 import Foundation
 
-/// Capture-latency (DT) calibration — port of `calibrate_dt` in desktop
-/// engine.rs, as a pure function so it is testable off the audio/engine thread.
+/// Automatic capture-latency / clock-residual (DT) calibration — the iOS port of
+/// Android's `ClockSelfSync`, keeping the desktop `calibrate_dt` math
+/// (median + slow EMA + deadband) and layering Android's per-slot robustness
+/// (MAD outlier rejection + a two-slot same-sign confirmation) on top.
 ///
 /// The FT8 network is NTP-synced, so the *median* DT of a slot's decodes is a
-/// robust estimate of our own systematic timing error (clock residual + audio
-/// buffering latency). We nudge the RX-window offset toward zeroing it with a
-/// slow EMA so it tracks without chasing noise. The engine owns `rxOffsetMs`,
-/// persists it, and re-anchors the boundary; this type only computes the value.
-public enum DtCalibrator {
-    /// Need a few independent decodes for the median to be meaningful.
+/// robust estimate of our own systematic timing error (device-clock residual +
+/// audio buffering latency). Driving it toward zero with a damped correction
+/// tracks the truth without chasing noise.
+///
+/// **Whole-clock, not RX-only.** The correction produced here feeds the unified
+/// whole-clock offset (``ClockOffset/autoOffsetMs``), which shifts RX slot
+/// detection, TX key-up, and logged UTC together — matching Android, where the
+/// self-sync writes `UtcTimer.delay`. This replaces the earlier RX-only
+/// `rxOffsetMs` path (which moved only the RX slice); the correction now reaches
+/// RX exactly once, through the shifted clock.
+///
+/// **Sign.** The whole-clock offset is *added* to the wall clock
+/// (`nowMs = wall + combinedMs`), the opposite convention from the retired
+/// `rxOffsetMs` (which was *subtracted* inside `rxSlotID`). A positive median DT
+/// means decodes land late in our window — our clock is fast — so the correction
+/// *subtracts* here to pull the clock back, exactly as Android does
+/// (`delay - round(median * gain)`).
+///
+/// The type is a value struct holding only the confirmation streak, so the
+/// decision logic stays pure and unit-testable off the audio/engine thread; the
+/// engine owns an instance per decode session and mutates it once per decoded
+/// slot.
+public struct DtCalibrator {
+    /// Minimum surviving (post-outlier-rejection) decodes for a slot to count.
     public static let minDecodes = 4
-    /// Correction fraction applied per slot.
+    /// Correction fraction applied per confirmed slot (EMA / proportional gain).
     public static let alpha = 0.6
-    /// Ignore tiny residuals to avoid jitter.
+    /// Ignore |median DT| at/below this (ms) to avoid jitter around a good clock.
     public static let deadbandMs: Int64 = 60
-    /// Clamp the accumulated offset to a sane range.
+    /// Clamp the accumulated whole-clock auto offset to a sane range.
     public static let maxOffsetMs: Int64 = 4_000
 
-    /// Given the current `rxOffsetMs` and this slot's decoded DTs (seconds),
-    /// return the updated `rxOffsetMs`. Returns the input unchanged when there
-    /// aren't enough decodes, the median residual is within the deadband, or the
-    /// nudge rounds to no change.
-    public static func calibrate(rxOffsetMs: Int64, decodedDtSec: [Float]) -> Int64 {
-        if decodedDtSec.count < minDecodes { return rxOffsetMs }
+    /// Absolute floor (seconds) for the MAD-based rejection threshold — keeps a
+    /// tight cluster (MAD near 0) from rejecting everything but the exact median.
+    public static let madFloorSec: Float = 0.2
+    /// Rejection threshold is `max(madFloorSec, madMultiplier * MAD)`.
+    public static let madMultiplier: Float = 3
+    /// Consecutive qualifying same-sign slots required before a correction lands.
+    public static let confirmSlots = 2
 
-        let sorted = decodedDtSec.sorted()
-        let medianDtMs = Int64(sorted[sorted.count / 2] * 1000.0) // truncates toward 0, as Rust `as i64`
-        if abs(medianDtMs) <= deadbandMs { return rxOffsetMs }
+    // Confirmation streak: how many consecutive qualifying slots have agreed and
+    // the sign (+1/-1) they agreed on. 0 sign = no streak in progress.
+    private var streak = 0
+    private var streakSign = 0
 
-        let adjusted = rxOffsetMs + Int64((Double(medianDtMs) * alpha).rounded())
-        return min(max(adjusted, -maxOffsetMs), maxOffsetMs)
+    public init() {}
+
+    // MARK: - Pure helpers (static, so they unit-test without an instance)
+
+    /// Median of `values` using the upper-middle element (`sorted[count/2]`),
+    /// matching the desktop `calibrate_dt` convention. Empty input yields 0 —
+    /// callers gate on sample count anyway.
+    public static func median(_ values: [Float]) -> Float {
+        if values.isEmpty { return 0 }
+        let sorted = values.sorted()
+        return sorted[sorted.count / 2]
+    }
+
+    /// MAD-based outlier rejection: samples farther than
+    /// `max(madFloorSec, madMultiplier * MAD)` from the median are dropped, so a
+    /// single wild DT can't drag the slot's median (and thus the clock).
+    public static func rejectOutliers(_ dtSec: [Float]) -> [Float] {
+        if dtSec.isEmpty { return [] }
+        let med = median(dtSec)
+        let mad = median(dtSec.map { abs($0 - med) })
+        let threshold = max(madFloorSec, madMultiplier * mad)
+        return dtSec.filter { abs($0 - med) <= threshold }
+    }
+
+    // MARK: - Per-slot decision
+
+    /// Feed one slot's decode DTs (seconds) through outlier rejection, the
+    /// sample-count gate, the deadband, and the two-slot same-sign confirmation.
+    /// Returns the NEW clamped whole-clock auto offset (ms) to apply, or `nil`
+    /// for no change this slot.
+    ///
+    /// - Parameters:
+    ///   - autoOffsetMs: the live ``ClockOffset/autoOffsetMs`` at decision time.
+    ///   - decodedDtSec: this slot's per-decode DTs (seconds); own-TX echoes
+    ///     already filtered out upstream.
+    public mutating func calibrate(autoOffsetMs: Int64, decodedDtSec: [Float]) -> Int64? {
+        let survivors = Self.rejectOutliers(decodedDtSec)
+        if survivors.count < Self.minDecodes {
+            // Too little evidence — leave the streak untouched so a sparse slot
+            // doesn't break up a genuine bias building over adjacent slots.
+            return nil
+        }
+
+        let medianMs = Int64(Self.median(survivors) * 1000.0) // truncates toward 0
+        if abs(medianMs) <= Self.deadbandMs {
+            // Clock is healthy; any streak that was building was noise.
+            streak = 0
+            streakSign = 0
+            return nil
+        }
+
+        let sign = medianMs > 0 ? 1 : -1
+        if sign != streakSign {
+            // First qualifying slot in this direction (or a direction flip):
+            // start the streak, and only act once a later slot confirms.
+            streakSign = sign
+            streak = 1
+        } else {
+            streak += 1
+        }
+        if streak < Self.confirmSlots { return nil }
+
+        // Confirmed bias: apply the damped correction. Subtract (whole-clock is
+        // added to the wall clock, so a positive DT / fast clock pulls it back).
+        let corrected = autoOffsetMs - Int64((Double(medianMs) * Self.alpha).rounded())
+        let clamped = min(max(corrected, -Self.maxOffsetMs), Self.maxOffsetMs)
+        streak = 0
+        streakSign = 0
+        return clamped
     }
 }

--- a/ios/FT8AFKit/Tests/FT8AudioTests/ClockOffsetTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/ClockOffsetTests.swift
@@ -61,6 +61,95 @@ final class ClockOffsetTests: XCTestCase {
         XCTAssertEqual(SlotClock.slotID(atUtcMs: shifted), 200)
     }
 
+    // MARK: - Auto-DT is a whole-clock term (the primary change)
+
+    func testCombinedIncludesAutoComponent() {
+        let off = ClockOffset(ntpOffsetMs: 100, manualOffsetMs: 50, autoOffsetMs: -300)
+        XCTAssertEqual(off.combinedMs, -150)
+        XCTAssertEqual(off.apply(toUtcMs: 1_000_000), 999_850)
+    }
+
+    func testAutoDefaultsToZeroSoExistingCallSitesAreUnchanged() {
+        let off = ClockOffset(ntpOffsetMs: 200, manualOffsetMs: -50)
+        XCTAssertEqual(off.autoOffsetMs, 0)
+        XCTAssertEqual(off.combinedMs, 150)
+    }
+
+    func testAutoOffsetShiftsRxSlotAndTxCycleByTheSameAmount() {
+        // A confirmed auto-DT correction feeds autoOffsetMs; RX slot detection and
+        // TX cycle position must move together (whole-clock), unlike the retired
+        // RX-only path that moved only the RX slice.
+        let wallMs: Int64 = 15_000 * 100 + 5_000 // 5.000 s into slot 100
+        let auto: Int64 = -300                    // a DtCalibrator correction
+        let off = ClockOffset(autoOffsetMs: auto)
+        let shifted = off.apply(toUtcMs: wallMs)
+
+        // RX: pass rxOffsetMs 0 — the only correction now rides the shifted clock.
+        let baseRx = SlotClock.msIntoCycle(atUtcMs: wallMs)
+        let shiftedRx = SlotClock.rxSlotID(atUtcMs: shifted, rxOffsetMs: 0)
+        XCTAssertEqual(SlotClock.rxSlotID(atUtcMs: wallMs, rxOffsetMs: 0), shiftedRx) // same slot
+        // TX: msIntoCycle off the shifted clock moves by exactly the auto offset.
+        let shiftedTx = SlotClock.msIntoCycle(atUtcMs: shifted)
+        XCTAssertEqual(shiftedTx - baseRx, auto)
+    }
+
+    func testAutoCorrectionAppliedToRxExactlyOnce() {
+        // Regression guard against double-correcting RX: with the auto-DT folded
+        // into the whole clock and rxOffsetMs pinned to 0, the RX cycle position
+        // shifts by exactly `auto` — not 2×auto (which a lingering rxOffsetMs
+        // path would produce).
+        let wallMs: Int64 = 15_000 * 40 + 7_000
+        let auto: Int64 = 450
+        let shifted = ClockOffset(autoOffsetMs: auto).apply(toUtcMs: wallMs)
+
+        // RX read uses the shifted clock with NO separate rxOffset (0).
+        let rxShift = SlotClock.msIntoCycle(atUtcMs: shifted - 0)
+            - SlotClock.msIntoCycle(atUtcMs: wallMs)
+        XCTAssertEqual(rxShift, auto)
+        // A hypothetical double-apply (auto folded in *and* an equal rxOffset)
+        // would shift by 2×auto — assert we are NOT doing that.
+        let doubled = SlotClock.msIntoCycle(atUtcMs: shifted - auto)
+            - SlotClock.msIntoCycle(atUtcMs: wallMs)
+        XCTAssertEqual(doubled, 0)
+        XCTAssertNotEqual(rxShift, 2 * auto)
+    }
+
+    func testCalibratorResultDrivesTheWholeClockConsistently() {
+        // End-to-end: a consistent +0.5 s band bias over CONFIRM_SLOTS produces a
+        // DtCalibrator correction, and feeding it into autoOffsetMs shifts an RX
+        // slot read and a TX msIntoCycle read by the identical amount.
+        var cal = DtCalibrator()
+        let dts = [Float](repeating: 0.5, count: 4)
+        XCTAssertNil(cal.calibrate(autoOffsetMs: 0, decodedDtSec: dts)) // building
+        guard let correction = cal.calibrate(autoOffsetMs: 0, decodedDtSec: dts) else {
+            return XCTFail("expected a correction after the confirm slot")
+        }
+        XCTAssertEqual(correction, -300)
+
+        let wallMs: Int64 = 15_000 * 10 + 6_000
+        let shifted = ClockOffset(autoOffsetMs: correction).apply(toUtcMs: wallMs)
+        let rxShift = SlotClock.msIntoCycle(atUtcMs: shifted, cycleMs: SlotClock.cycleMs)
+            - SlotClock.msIntoCycle(atUtcMs: wallMs)
+        let txShift = SlotClock.msIntoCycle(atUtcMs: shifted)
+            - SlotClock.msIntoCycle(atUtcMs: wallMs)
+        XCTAssertEqual(rxShift, correction)
+        XCTAssertEqual(txShift, correction)
+    }
+
+    func testPlausibleAutoCorrectionKeepsOnTimeTxOutOfClipTerritory() {
+        // TX safety: the auto offset drives the clock toward truth, so an on-time
+        // key-up stays inside the 2.36 s slack (no leading-Costas clip). Even the
+        // *maximum* auto correction, applied to a key-up that fires ~0.6 s into
+        // the corrected cycle, leaves the cycle position well under the slack.
+        let auto = ClockOffset(autoOffsetMs: DtCalibrator.maxOffsetMs)
+        let correctedNow: Int64 = 15_000 * 3 + 600 // ~0.6 s into the corrected cycle
+        let wallMs = correctedNow - auto.combinedMs
+        let msInto = ClockOffset(autoOffsetMs: DtCalibrator.maxOffsetMs)
+            .apply(toUtcMs: wallMs)
+        let clip = max(0, SlotClock.msIntoCycle(atUtcMs: msInto) - 2_360)
+        XCTAssertEqual(clip, 0)
+    }
+
     // MARK: - Manual clamping
 
     func testManualClampToRange() {

--- a/ios/FT8AFKit/Tests/FT8AudioTests/DtCalibratorTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/DtCalibratorTests.swift
@@ -3,45 +3,139 @@ import XCTest
 
 final class DtCalibratorTests: XCTestCase {
 
-    func testTooFewDecodesLeavesOffsetUnchanged() {
+    // A consistent bias needs CONFIRM_SLOTS qualifying slots before it lands, so
+    // most tests feed the same slot twice. Helper: run one slot and return the
+    // (possibly nil) new whole-clock auto offset.
+    private func slot(_ cal: inout DtCalibrator, _ dts: [Float], base: Int64 = 0) -> Int64? {
+        cal.calibrate(autoOffsetMs: base, decodedDtSec: dts)
+    }
+
+    // MARK: - Sample-count / deadband gates
+
+    func testTooFewDecodesDoesNothing() {
+        var cal = DtCalibrator()
         let dts: [Float] = [0.5, 0.5, 0.5] // < minDecodes (4)
-        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 0, decodedDtSec: dts), 0)
+        XCTAssertNil(slot(&cal, dts))
+        XCTAssertNil(slot(&cal, dts)) // still nothing, even repeated
     }
 
-    func testWithinDeadbandLeavesOffsetUnchanged() {
-        // Median DT 40 ms < 60 ms deadband -> no change.
+    func testWithinDeadbandDoesNothing() {
+        var cal = DtCalibrator()
+        // Median DT 40 ms < 60 ms deadband -> no change on either slot.
         let dts: [Float] = [0.04, 0.04, 0.04, 0.04, 0.04]
-        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 123, decodedDtSec: dts), 123)
+        XCTAssertNil(slot(&cal, dts, base: 123))
+        XCTAssertNil(slot(&cal, dts, base: 123))
     }
 
-    func testNudgesTowardMedianByAlpha() {
-        // Median DT = 0.5 s = 500 ms; nudge = round(500 * 0.6) = 300.
-        let dts: [Float] = [0.5, 0.5, 0.5, 0.5]
-        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 0, decodedDtSec: dts), 300)
+    // MARK: - Confirmation streak
+
+    func testSingleQualifyingSlotDoesNotMoveClock() {
+        var cal = DtCalibrator()
+        // One slot with a real +0.5 s bias: qualifies, but must be CONFIRMED by a
+        // second same-sign slot before any correction is applied.
+        let dts = [Float](repeating: 0.5, count: 4)
+        XCTAssertNil(slot(&cal, dts))
     }
 
-    func testNegativeMedianNudgesNegative() {
-        let dts: [Float] = [-0.2, -0.2, -0.2, -0.2] // -200 ms median
-        // round(-200 * 0.6) = -120, from a starting offset of 100 -> -20.
-        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 100, decodedDtSec: dts), -20)
+    func testConsistentBiasAppliesAfterConfirmSlots() {
+        var cal = DtCalibrator()
+        let dts = [Float](repeating: 0.5, count: 4) // +500 ms median
+        XCTAssertNil(slot(&cal, dts))               // slot 1: streak building
+        // slot 2 confirms: whole-clock offset SUBTRACTS the damped correction
+        // (positive DT = fast clock). round(500 * 0.6) = 300, from base 0 -> -300.
+        XCTAssertEqual(slot(&cal, dts), -300)
     }
 
-    func testMedianIsOrderIndependentAndUsesUpperMiddle() {
-        // 5 values; index 5/2 = 2 of the sorted list is the median (0.5).
-        let unsorted: [Float] = [0.9, 0.1, 0.5, 0.5, 0.5]
-        XCTAssertEqual(DtCalibrator.calibrate(rxOffsetMs: 0, decodedDtSec: unsorted), 300)
+    func testStreakResetsAfterApplyingSoItReconfirms() {
+        var cal = DtCalibrator()
+        let dts = [Float](repeating: 0.5, count: 4)
+        XCTAssertNil(slot(&cal, dts))          // slot 1
+        XCTAssertEqual(slot(&cal, dts), -300)  // slot 2 applies, streak resets
+        XCTAssertNil(slot(&cal, dts))          // slot 3 must re-confirm
+        XCTAssertEqual(slot(&cal, dts), -300)  // slot 4 applies again
     }
+
+    func testSignFlipRestartsTheStreak() {
+        var cal = DtCalibrator()
+        // One +0.5 s slot, then a -0.5 s slot: the direction flip restarts the
+        // streak, so nothing is applied on the flip itself.
+        XCTAssertNil(slot(&cal, [Float](repeating: 0.5, count: 4)))
+        XCTAssertNil(slot(&cal, [Float](repeating: -0.5, count: 4)))
+        // A second negative slot now confirms the negative bias: base 0 + 300.
+        XCTAssertEqual(slot(&cal, [Float](repeating: -0.5, count: 4)), 300)
+    }
+
+    func testDeadbandSlotBreaksAStreak() {
+        var cal = DtCalibrator()
+        XCTAssertNil(slot(&cal, [Float](repeating: 0.5, count: 4))) // streak = 1
+        // A healthy (in-deadband) slot resets the streak to noise...
+        XCTAssertNil(slot(&cal, [Float](repeating: 0.02, count: 4)))
+        // ...so the next biased slot is only the first of a fresh streak.
+        XCTAssertNil(slot(&cal, [Float](repeating: 0.5, count: 4)))
+    }
+
+    // MARK: - MAD outlier rejection
+
+    func testSingleWildOutlierIsRejectedAndClockDoesNotMove() {
+        var cal = DtCalibrator()
+        // Four tight in-deadband decodes plus one 5 s flyer. MAD rejection drops
+        // the flyer; the surviving median is ~0.03 s (in deadband) -> no move,
+        // even across two slots.
+        let dts: [Float] = [0.03, 0.03, 0.03, 0.03, 5.0]
+        XCTAssertNil(slot(&cal, dts))
+        XCTAssertNil(slot(&cal, dts))
+    }
+
+    func testOutlierRejectionCanStarveTheSampleGate() {
+        // 4 raw decodes but one is an outlier -> 3 survivors < minDecodes (4),
+        // so the slot produces no correction.
+        let survivors = DtCalibrator.rejectOutliers([0.5, 0.5, 0.5, 3.0])
+        XCTAssertEqual(survivors.count, 3)
+        var cal = DtCalibrator()
+        XCTAssertNil(slot(&cal, [0.5, 0.5, 0.5, 3.0]))
+    }
+
+    func testOutlierDoesNotDragTheMedian() {
+        // Real +0.5 s bias with one -4 s flyer. The flyer is rejected, the
+        // median stays 0.5, and two confirming slots apply -300.
+        let dts: [Float] = [0.5, 0.5, 0.5, 0.5, 0.5, -4.0]
+        var cal = DtCalibrator()
+        XCTAssertNil(slot(&cal, dts))
+        XCTAssertEqual(slot(&cal, dts), -300)
+    }
+
+    func testRejectOutliersKeepsATightCluster() {
+        // MAD near 0: the floor (0.2 s) keeps the whole tight cluster rather than
+        // rejecting everything but the exact median.
+        let kept = DtCalibrator.rejectOutliers([0.30, 0.31, 0.29, 0.30, 0.32])
+        XCTAssertEqual(kept.count, 5)
+    }
+
+    // MARK: - Clamping
 
     func testClampsToMaxOffset() {
-        // Huge positive median pushes well past the +4000 ms clamp.
-        let dts = [Float](repeating: 9.0, count: 4) // 9000 ms median
-        let out = DtCalibrator.calibrate(rxOffsetMs: 3_900, decodedDtSec: dts)
+        var cal = DtCalibrator()
+        // Huge negative median (fast-clock direction pushes the auto offset down)
+        // from a base near the floor clamps to -maxOffsetMs.
+        let dts = [Float](repeating: 9.0, count: 4) // +9000 ms median
+        XCTAssertNil(cal.calibrate(autoOffsetMs: -3_900, decodedDtSec: dts))
+        let out = cal.calibrate(autoOffsetMs: -3_900, decodedDtSec: dts)
+        XCTAssertEqual(out, -DtCalibrator.maxOffsetMs)
+    }
+
+    func testClampsToMinOffsetOtherDirection() {
+        var cal = DtCalibrator()
+        let dts = [Float](repeating: -9.0, count: 4) // -9000 ms median
+        XCTAssertNil(cal.calibrate(autoOffsetMs: 3_900, decodedDtSec: dts))
+        let out = cal.calibrate(autoOffsetMs: 3_900, decodedDtSec: dts)
         XCTAssertEqual(out, DtCalibrator.maxOffsetMs)
     }
 
-    func testClampsToMinOffset() {
-        let dts = [Float](repeating: -9.0, count: 4)
-        let out = DtCalibrator.calibrate(rxOffsetMs: -3_900, decodedDtSec: dts)
-        XCTAssertEqual(out, -DtCalibrator.maxOffsetMs)
+    // MARK: - Pure median helper
+
+    func testMedianUsesUpperMiddleAndIsOrderIndependent() {
+        // 5 values; index 5/2 = 2 of the sorted list is the median (0.5).
+        XCTAssertEqual(DtCalibrator.median([0.9, 0.1, 0.5, 0.5, 0.5]), 0.5)
+        XCTAssertEqual(DtCalibrator.median([]), 0)
     }
 }


### PR DESCRIPTION
## What
iOS's automatic DT calibration nudged an **RX-only** `rxOffsetMs` (only the RX slicing window benefited). Android's `ClockSelfSync` moves the **whole clock**, so an auto-corrected clock also fixes TX key-up and logged/displayed UTC. This routes iOS auto-calibration into the whole-clock offset added in #742.

- **`ClockOffset`** gains `autoOffsetMs` (`combined = ntp + manual + auto`), defaulting to 0 so all call sites compile unchanged; runtime-only (re-disciplined each session).
- **`DtCalibrator`** rewritten to a stateful struct — keeps the existing math (median, EMA α 0.6, deadband 60 ms, max 4000 ms) and **ports Android's robustness**: **MAD outlier rejection** + **two-slot same-sign confirmation**, so a single noisy slot can't jerk the clock. The correction **subtracts** the damped median (whole-clock sign, opposite the old subtracted `rxOffsetMs`).
- **`LiveEngine`** removes the `rxOffsetMs` field/path, pins `rxOffsetMs = 0`, owns a per-session calibrator, and publishes to `ClockState.autoOffsetMs`; `nowMs()`/`combinedMs` carry it to RX slicing, TX key-up, and UTC **together**. RX is corrected **exactly once** (regression-tested), never doubled.

## TX safety
The correction drives `nowMs` toward true UTC (reduces clip risk, doesn't create it), bounded by deadband + 2-slot confirm + ±4 s clamp; `beginTxPlayback` still re-checks the real cycle position. A test confirms even the max correction leaves an on-time TX at `clip == 0`.

## Pileup mechanisms — analyzed
Android's `FastDecodeGate` / `FastPassDisposition` are **N/A** on iOS: it decodes **synchronously inline** (`decodeSlotDeep()` returns before `scheduleTx`), so a decode is never delivered after key-up — the exact race those mechanisms fix can't occur. Mid-cycle TX message swap (`requestTxRestart`) is **deferred** (a substantial `TxPlayerService`/`beginTxPlayback` rewrite, explicitly out of scope).

## Tests
585 FT8AFKit tests pass — 31 across `DtCalibratorTests` (MAD single-outlier rejection, 2-slot confirm, streak reset/sign-flip, deadband, clamp) + `ClockOffsetTests` (auto included in combined; RX+TX shift by the same amount; **RX corrected once, not 2×**; max-correction TX-clip safety). App builds.

Part of the iOS↔Android parity sweep (timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)