### PR TITLE
NTP clock discipline, pt-BR translation, notch-safe layout (from PR #757 by @mrgadotti)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -641,6 +641,30 @@ public class GeneralVariables {
     //Posted each time a GPS fix disciplines the clock, so the Time Sync screen can recompose
     //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.
     public static MutableLiveData<Long> mutableGpsClockSync = new MutableLiveData<>();
+    public static final String DEFAULT_NTP_SERVER = "a.ntp.br";//Default NTP server for clock discipline.
+    public static boolean disciplineClockFromNtp = false;//Discipline the app clock (UtcTimer.delay) from a network NTP server, periodically. Off by default. Mutually exclusive with disciplineClockFromGPS — TimeSyncSettings enforces this by disabling the other on toggle.
+    public static String ntpServer = DEFAULT_NTP_SERVER;//NTP server hostname/IP for periodic clock discipline. Resolved for both A and AAAA records (dual-stack) by NtpClockUpdater.
+    public static int ntpClockIntervalMinutes = 5;//How often to re-sync from the NTP server. Clamped 1-30 by NtpClockUpdater.
+    //Runtime status for the Time Sync UI (not persisted): the offset the last successful NTP
+    //sync applied to UtcTimer.delay. The last-sync *timestamp* is the retained value of
+    //mutableNtpClockSync below, so there's no separate field for it.
+    public static volatile int ntpClockOffsetMs = 0;
+    //Posted each time an NTP sync disciplines the clock, so the Time Sync screen can recompose
+    //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.
+    public static MutableLiveData<Long> mutableNtpClockSync = new MutableLiveData<>();
+    //Posted true when the most recent NTP sync attempt exhausted every resolved address
+    //without success (no network, blocked UDP port, bad server name); posted false right
+    //before applying a successful sync. Unlike GPS, NTP failure is common enough (no
+    //internet, restrictive NAT) that silent periodic retries with zero feedback would look
+    //broken, so the Time Sync screen surfaces it.
+    public static MutableLiveData<Boolean> mutableNtpClockSyncFailed = new MutableLiveData<>();
+
+    /** Trimmed NTP server, falling back to {@link #DEFAULT_NTP_SERVER} when unset/blank. */
+    public static String getNtpServer() {
+        if (ntpServer == null || ntpServer.trim().isEmpty()) return DEFAULT_NTP_SERVER;
+        return ntpServer.trim();
+    }
+
     //Posted each time the self-syncing clock (ClockSelfSync) applies a correction, so the
     //Time Sync screen can show that auto-sync is doing the work instead of asking the
     //operator to apply the suggestion by hand. Carries the UtcTimer.getSystemTime() timestamp.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -575,7 +575,7 @@ public class GeneralVariables {
     public static boolean autoUpdateGridFromGPS = false;//Use device GPS to keep Maidenhead grid current
     public static boolean disciplineClockFromGPS = false;//Discipline the app clock (UtcTimer.delay) from GPS satellite time (issue #373). Off by default — consensual.
     public static int gpsClockIntervalMinutes = 5;//How often to re-read GPS time for clock discipline. Clamped 1-30 by GpsClockUpdater.
-    public static boolean autoSyncClockFromDecodes = true;//Self-syncing clock: continuously trim UtcTimer.delay from the median decode DT (see ClockSelfSync). Inert while disciplineClockFromGPS is on. ON by default (PR #758): the band is the time source every operator has, and the estimator is conservative enough (median + MAD rejection + deadband + confirmation) to run unattended.
+    public static boolean autoSyncClockFromDecodes = true;//Self-syncing clock: continuously trim UtcTimer.delay from the median decode DT (see ClockSelfSync). Inert while disciplineClockFromGPS or disciplineClockFromNtp is on (see ClockSelfSync.mayRun). ON by default (PR #758): the band is the time source every operator has, and the estimator is conservative enough (median + MAD rejection + deadband + confirmation) to run unattended.
     //Runtime status for the Time Sync UI (not persisted): the offset the last GPS fix applied
     //to UtcTimer.delay. The last-sync *timestamp* is the retained value of mutableGpsClockSync
     //below, so there's no separate field for it.
@@ -641,7 +641,7 @@ public class GeneralVariables {
     //Posted each time a GPS fix disciplines the clock, so the Time Sync screen can recompose
     //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.
     public static MutableLiveData<Long> mutableGpsClockSync = new MutableLiveData<>();
-    public static final String DEFAULT_NTP_SERVER = "a.ntp.br";//Default NTP server for clock discipline.
+    public static final String DEFAULT_NTP_SERVER = "pool.ntp.org";//Default NTP server for clock discipline: the worldwide anycast pool, which resolves to servers near the device. Regional pools (a.ntp.br, time.nist.gov, …) can be typed in.
     public static boolean disciplineClockFromNtp = false;//Discipline the app clock (UtcTimer.delay) from a network NTP server, periodically. Off by default. Mutually exclusive with disciplineClockFromGPS — TimeSyncSettings enforces this by disabling the other on toggle.
     public static String ntpServer = DEFAULT_NTP_SERVER;//NTP server hostname/IP for periodic clock discipline. Resolved for both A and AAAA records (dual-stack) by NtpClockUpdater.
     public static int ntpClockIntervalMinutes = 5;//How often to re-sync from the NTP server. Clamped 1-30 by NtpClockUpdater.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -650,7 +650,8 @@ public class GeneralVariables {
     //mutableNtpClockSync below, so there's no separate field for it.
     public static volatile int ntpClockOffsetMs = 0;
     //Posted each time an NTP sync disciplines the clock, so the Time Sync screen can recompose
-    //its "last sync"/offset readout. Carries the sync's System.currentTimeMillis() timestamp.
+    //its "last sync"/offset readout. Carries the disciplined UTC timestamp (System.currentTimeMillis()
+    //plus the applied offset), not the raw system clock reading.
     public static MutableLiveData<Long> mutableNtpClockSync = new MutableLiveData<>();
     //Posted true when the most recent NTP sync attempt exhausted every resolved address
     //without success (no network, blocked UDP port, bad server name); posted false right

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -679,10 +679,11 @@ public class MainViewModel extends ViewModel {
                     // that pass's own (deduped, echo-filtered) messages. Deep/late
                     // passes re-deliver the same slot and are skipped by the isDeep
                     // gate; beginSlot() dedupes by slot utc as a second line of
-                    // defense. GPS discipline owns the clock when enabled, so this
-                    // stands down (and clears its state) rather than fight it.
-                    if (GeneralVariables.autoSyncClockFromDecodes
-                            && !GeneralVariables.disciplineClockFromGPS) {
+                    // defense. GPS or NTP discipline owns the clock when enabled, so
+                    // this stands down (and clears its state) rather than fight it.
+                    if (ClockSelfSync.mayRun(GeneralVariables.autoSyncClockFromDecodes,
+                            GeneralVariables.disciplineClockFromGPS,
+                            GeneralVariables.disciplineClockFromNtp)) {
                         float[] dtSamples = new float[messages.size()];
                         for (int i = 0; i < messages.size(); i++) {
                             dtSamples[i] = messages.get(i).time_sec;
@@ -710,7 +711,7 @@ public class MainViewModel extends ViewModel {
                                     + dtSamples.length + " decodes, slot utc=" + utc + ")");
                         }
                     } else {
-                        // Feature off or GPS disciplining: drop any half-built
+                        // Feature off or GPS/NTP disciplining: drop any half-built
                         // confirmation streak so stale state can't act later.
                         clockSelfSync.reset();
                     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2839,6 +2839,17 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     GeneralVariables.gpsClockIntervalMinutes =
                             com.k1af.ft8af.location.GpsClockUpdater.parseIntervalMinutes(result);
                 }
+                if (name.equalsIgnoreCase("disciplineClockFromNtp")) {//Discipline clock from NTP (parallel to GPS)
+                    GeneralVariables.disciplineClockFromNtp = result.equals("1");
+                }
+                if (name.equalsIgnoreCase("ntpServer")) {//NTP server hostname/IP for periodic clock discipline
+                    GeneralVariables.ntpServer = result.trim().isEmpty()
+                            ? GeneralVariables.DEFAULT_NTP_SERVER : result.trim();
+                }
+                if (name.equalsIgnoreCase("ntpClockIntervalMin")) {//NTP discipline update interval (minutes)
+                    GeneralVariables.ntpClockIntervalMinutes =
+                            com.k1af.ft8af.timer.NtpClockUpdater.parseIntervalMinutes(result);
+                }
                 if (name.equalsIgnoreCase("pttDelay")) {//PTT delay setting
                     GeneralVariables.pttDelay = parseConfigInt(result, 100);
                 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/ClockSelfSync.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/ClockSelfSync.java
@@ -160,6 +160,18 @@ public class ClockSelfSync {
         return Arrays.copyOf(survivors, kept);
     }
 
+    /**
+     * Whether the estimator may act this slot. It runs only when the operator has it on
+     * AND nothing authoritative owns the clock: GPS and NTP discipline each rewrite
+     * {@link UtcTimer#delay} on their own schedule, and a second writer nudging the same
+     * field from decode DTs would fight every one of their corrections. One definition,
+     * shared by the decode-time gate and the settings screen's lock-out.
+     */
+    public static boolean mayRun(boolean autoSyncFromDecodes, boolean disciplineFromGps,
+                                 boolean disciplineFromNtp) {
+        return autoSyncFromDecodes && !disciplineFromGps && !disciplineFromNtp;
+    }
+
     /** Clamp to the shared manual-correction range (±5000 ms). */
     static int clampDelayMs(int ms) {
         return Math.max(GeneralVariables.MANUAL_TIME_CORRECTION_MIN_MS,

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/NtpClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/NtpClockUpdater.java
@@ -211,8 +211,8 @@ public class NtpClockUpdater {
         GeneralVariables.mutableNtpClockSyncFailed.postValue(true);
     }
 
-    /** Compute, sanity-check, and apply the offset from a single NTP reply. */
-    private void applySyncResult(long serverTransmitMs) {
+    /** Compute, sanity-check, and apply the offset from a single NTP reply. Package-private, for tests. */
+    void applySyncResult(long serverTransmitMs) {
         long nowSystemMs = System.currentTimeMillis();
         // Sample once and feed the same reading to the evaluation and the log, so a logged
         // "REJECTED" offset can't disagree with the number actually judged against the bound.
@@ -224,6 +224,7 @@ public class NtpClockUpdater {
             if (isRunning()) {
                 GeneralVariables.fileLog("NtpClock: REJECTED sync offset=" + rawOffsetMs
                         + "ms (absMax=" + MAX_SANE_OFFSET_MS + "ms) — clock left at " + UtcTimer.delay + "ms");
+                GeneralVariables.mutableNtpClockSyncFailed.postValue(true);
             }
             return;
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/NtpClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/NtpClockUpdater.java
@@ -1,0 +1,322 @@
+package com.k1af.ft8af.timer;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.location.GpsClockUpdater;
+
+import org.apache.commons.net.ntp.NTPUDPClient;
+import org.apache.commons.net.ntp.TimeInfo;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+/**
+ * Disciplines the app clock from a network NTP server while
+ * {@link GeneralVariables#disciplineClockFromNtp} is enabled — the NTP counterpart to
+ * {@link GpsClockUpdater}. Same target ({@link UtcTimer#delay}), same periodic-discipline
+ * shape (capture the pre-discipline baseline, apply a fresh offset on every sync, restore
+ * the baseline on stop), but no {@code LocationManager}/runtime permission — only
+ * {@code INTERNET}, already declared and install-time granted — so this self-schedules on a
+ * {@link Handler} instead of subscribing through
+ * {@link com.k1af.ft8af.location.LocationSubscriber}.
+ *
+ * <p>Mutually exclusive with GPS discipline: {@code TimeSyncSettings} enforces that only one
+ * is ever running, disabling the other (synchronously, via its own {@code refresh()}) before
+ * enabling this one, so each updater's captured baseline is the true pre-discipline offset
+ * rather than the other's still-applied one.
+ *
+ * <p>Resolves the configured server for both A and AAAA records
+ * ({@link InetAddress#getAllByName}) and tries each with a fresh {@link NTPUDPClient} and a
+ * timeout, so a network with no route for one address family still gets a reply from the
+ * other rather than waiting out a dead address's full timeout — ported from FT8CN's
+ * {@code UtcTimer.syncTimeByNtp}. The offset applies the FULL server/device delta (no
+ * cycle-modulo truncation), matching how GPS discipline and the manual correction both write
+ * {@link UtcTimer#delay}.
+ *
+ * <p>Singleton — call {@link #refresh(Context)} whenever the toggle/interval/server changes
+ * or the activity starts.
+ */
+public class NtpClockUpdater {
+    private static final String TAG = "NtpClockUpdater";
+
+    /**
+     * A sync implying a correction larger than this is treated as bad data and ignored (see
+     * {@link #isOffsetSane}). Matches {@link GpsClockUpdater#MAX_SANE_OFFSET_MS}: the offset
+     * is written straight into {@link UtcTimer#delay}, which moves the whole FT8 cycle grid,
+     * so an hour-scale "correction" can only be a corrupt/spoofed reply or a badly
+     * misconfigured server.
+     */
+    static final long MAX_SANE_OFFSET_MS = 60L * 60L * 1000L;
+
+    /** Per-address NTP request timeout (ms), matching FT8CN's reference implementation. */
+    static final int NTP_TIMEOUT_MS = 5000;
+
+    /** Configurable update-interval bounds (minutes), matching GPS discipline. */
+    static final int MIN_INTERVAL_MINUTES = 1;
+    static final int MAX_INTERVAL_MINUTES = 30;
+    /** Default interval (minutes) when the persisted value is absent or unparseable. */
+    static final int DEFAULT_INTERVAL_MINUTES = 5;
+
+    /** Sentinel for {@link #savedDelayBeforeNtp}: no pre-NTP offset captured. */
+    private static final int NO_SAVED_DELAY = Integer.MIN_VALUE;
+
+    private static NtpClockUpdater instance;
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private volatile boolean running = false;
+    private long subscribedIntervalMs = -1;
+    // The offset UtcTimer.delay held *before* NTP discipline took it over (GPS, a manual
+    // correction, or 0). Captured on the first start() and restored by stop() so disabling
+    // NTP returns the clock to its pre-NTP state instead of clobbering it with
+    // manualTimeCorrectionMs, which NTP itself never writes. NO_SAVED_DELAY means "not
+    // disciplining".
+    private int savedDelayBeforeNtp = NO_SAVED_DELAY;
+
+    // Single reusable Runnable so removeCallbacks(periodicSyncTask) on stop()/retune reliably
+    // cancels a pending tick — a fresh Runnable per call would not match (Handler.removeCallbacks
+    // matches on the exact Runnable instance).
+    private final Runnable periodicSyncTask = new Runnable() {
+        @Override
+        public void run() {
+            kickBackgroundSync();
+            synchronized (NtpClockUpdater.this) {
+                if (running) mainHandler.postDelayed(this, subscribedIntervalMs);
+            }
+        }
+    };
+
+    private NtpClockUpdater(Context context) {
+        // context kept implicitly unused beyond construction: nothing here needs it (no
+        // LocationManager/permission checks), but the ctor mirrors GpsClockUpdater's shape.
+    }
+
+    public static synchronized NtpClockUpdater getInstance(Context context) {
+        if (instance == null) {
+            instance = new NtpClockUpdater(context);
+        }
+        return instance;
+    }
+
+    /**
+     * Start, stop, or re-tune the updater to match the current toggle and interval. Safe to
+     * call repeatedly.
+     */
+    public static synchronized void refresh(Context context) {
+        getInstance(context).refreshSubscription();
+    }
+
+    private synchronized void refreshSubscription() {
+        if (GeneralVariables.disciplineClockFromNtp) {
+            start();
+        } else {
+            stop();
+        }
+    }
+
+    private synchronized void start() {
+        long intervalMs = clampIntervalMinutes(GeneralVariables.ntpClockIntervalMinutes) * 60_000L;
+
+        // Already running at the requested cadence — nothing to do.
+        if (!shouldReschedule(running, subscribedIntervalMs, intervalMs)) return;
+
+        // Drop any pending tick from a prior cadence before rescheduling at the new one.
+        mainHandler.removeCallbacks(periodicSyncTask);
+
+        // Capture the pre-NTP offset once, before any sync overwrites UtcTimer.delay, so
+        // stop() can hand the clock back exactly as it was. Only on the first start() — a
+        // re-tune reaches here with delay already holding an NTP offset, which must not be
+        // captured.
+        if (savedDelayBeforeNtp == NO_SAVED_DELAY) {
+            savedDelayBeforeNtp = UtcTimer.delay;
+        }
+        subscribedIntervalMs = intervalMs;
+        running = true;
+
+        // First sync fires on the next looper iteration, not inline, so refresh() returns
+        // immediately and a slow/hung server can't block the caller (the Compose toggle
+        // handler).
+        mainHandler.post(periodicSyncTask);
+        Log.d(TAG, "Started NTP clock discipline, interval " + intervalMs + "ms, server "
+                + GeneralVariables.getNtpServer());
+    }
+
+    /** Disable discipline: cancel the pending tick and restore the clock to its pre-NTP offset. */
+    private synchronized void stop() {
+        if (!running && savedDelayBeforeNtp == NO_SAVED_DELAY) return;
+        mainHandler.removeCallbacks(periodicSyncTask);
+        running = false;
+        subscribedIntervalMs = -1;
+
+        if (savedDelayBeforeNtp != NO_SAVED_DELAY) {
+            UtcTimer.delay = savedDelayBeforeNtp;
+            GeneralVariables.fileLog("NtpClock: stopped discipline; restored pre-NTP offset "
+                    + savedDelayBeforeNtp + "ms");
+            savedDelayBeforeNtp = NO_SAVED_DELAY;
+        }
+    }
+
+    /** Whether discipline is currently running. Package-private, for tests. */
+    boolean isRunning() {
+        return running;
+    }
+
+    // Fire-and-forget: does NOT block periodicSyncTask.run(), so the next tick is scheduled
+    // subscribedIntervalMs after this one STARTED, not after the network round trip finished
+    // — a hung/slow server can't stall the reschedule chain.
+    private void kickBackgroundSync() {
+        new Thread(this::performDualStackSync).start();
+    }
+
+    /**
+     * Resolve the configured server for both A and AAAA records and try each with a fresh
+     * client until one replies. Ported from FT8CN's {@code UtcTimer.syncTimeByNtp}: a fresh
+     * {@link NTPUDPClient} per address avoids a late reply from a prior timed-out attempt
+     * being misattributed to the next attempt. Only a network-level failure (timeout, no
+     * route, {@link IOException}) advances to the next address — a received-but-implausible
+     * reply is rejected by {@link #applySyncResult} and the loop stops there, since a bad
+     * reply is a data problem, not a connectivity one.
+     */
+    private void performDualStackSync() {
+        String server = GeneralVariables.getNtpServer();
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(server);
+        } catch (IOException e) {
+            Log.d(TAG, "NTP resolve failed for " + server + ": " + e.getMessage());
+            GeneralVariables.fileLog("NtpClock: resolve failed for " + server + ": " + e.getMessage());
+            GeneralVariables.mutableNtpClockSyncFailed.postValue(true);
+            return;
+        }
+
+        for (InetAddress address : addresses) {
+            NTPUDPClient timeClient = new NTPUDPClient();
+            try {
+                timeClient.setDefaultTimeout(NTP_TIMEOUT_MS);
+                TimeInfo timeInfo = timeClient.getTime(address);
+                long serverTransmitMs = timeInfo.getMessage().getTransmitTimeStamp().getTime();
+                applySyncResult(serverTransmitMs);
+                return; // got a reply (accepted or rejected) — connectivity succeeded
+            } catch (IOException e) {
+                Log.d(TAG, "NTP attempt failed for " + address + ": " + e.getMessage());
+            } finally {
+                timeClient.close();
+            }
+        }
+
+        GeneralVariables.fileLog("NtpClock: all addresses for " + server + " unreachable");
+        GeneralVariables.mutableNtpClockSyncFailed.postValue(true);
+    }
+
+    /** Compute, sanity-check, and apply the offset from a single NTP reply. */
+    private void applySyncResult(long serverTransmitMs) {
+        long nowSystemMs = System.currentTimeMillis();
+        // Sample once and feed the same reading to the evaluation and the log, so a logged
+        // "REJECTED" offset can't disagree with the number actually judged against the bound.
+        int rawOffsetMs = ntpClockOffsetMs(serverTransmitMs, nowSystemMs);
+        Integer offsetMs = computeAppliedOffset(isRunning(), serverTransmitMs, nowSystemMs);
+
+        if (offsetMs == null) {
+            Log.d(TAG, "Ignoring NTP reply (not running or implausible): serverTransmitMs=" + serverTransmitMs);
+            if (isRunning()) {
+                GeneralVariables.fileLog("NtpClock: REJECTED sync offset=" + rawOffsetMs
+                        + "ms (absMax=" + MAX_SANE_OFFSET_MS + "ms) — clock left at " + UtcTimer.delay + "ms");
+            }
+            return;
+        }
+
+        GeneralVariables.fileLog("NtpClock: applied offset " + offsetMs + "ms (was " + UtcTimer.delay + "ms)");
+        UtcTimer.delay = offsetMs;
+        GeneralVariables.ntpClockOffsetMs = offsetMs;
+        GeneralVariables.mutableNtpClockSyncFailed.postValue(false);
+        // The UI renders this as "... UTC", so post the disciplined time, not the raw
+        // (possibly-wrong) system clock we just computed a correction for.
+        GeneralVariables.mutableNtpClockSync.postValue(disciplinedUtcMs(nowSystemMs, offsetMs));
+        Log.d(TAG, "NTP clock discipline applied offset " + offsetMs + "ms");
+    }
+
+    // =====================================================================
+    // Pure, testable decision logic (no network needed).
+    // =====================================================================
+
+    /**
+     * Offset to add to {@link System#currentTimeMillis()} so the app clock matches the NTP
+     * server's transmit timestamp. Positive means the device clock is slow (behind the
+     * server) and needs shifting forward. The full delta is used, not truncated to one FT8
+     * cycle — {@code UtcTimer.isCycleBoundary} only needs the offset modulo the slot length
+     * for RX/TX alignment, but truncating here would leave the on-screen clock, QSO
+     * timestamps, and PSKReporter spot times off by a whole multiple of 15s whenever the
+     * device clock is more than one cycle out.
+     */
+    static int ntpClockOffsetMs(long serverTransmitMs, long nowSystemMs) {
+        long offset = serverTransmitMs - nowSystemMs;
+        if (offset > Integer.MAX_VALUE) offset = Integer.MAX_VALUE;
+        if (offset < Integer.MIN_VALUE) offset = Integer.MIN_VALUE;
+        return (int) offset;
+    }
+
+    /**
+     * Whether a reply should be trusted to discipline the clock: the server must have sent a
+     * real transmit timestamp ({@code > 0}) and the implied correction must be within
+     * {@link #MAX_SANE_OFFSET_MS}.
+     */
+    static boolean isOffsetSane(long serverTransmitMs, int offsetMs) {
+        if (serverTransmitMs <= 0) return false;
+        return Math.abs((long) offsetMs) <= MAX_SANE_OFFSET_MS;
+    }
+
+    /** Coerce a configured update interval into the allowed range (minutes). */
+    public static int clampIntervalMinutes(int minutes) {
+        if (minutes < MIN_INTERVAL_MINUTES) return MIN_INTERVAL_MINUTES;
+        return Math.min(minutes, MAX_INTERVAL_MINUTES);
+    }
+
+    /**
+     * Parse a persisted interval string into a valid interval (minutes): the default when it
+     * is null/blank/non-numeric, otherwise the parsed value clamped into range. Shared with
+     * {@code DatabaseOpr}'s config load so the fallback and clamp are covered by one test.
+     */
+    public static int parseIntervalMinutes(String raw) {
+        if (raw == null) return DEFAULT_INTERVAL_MINUTES;
+        int minutes;
+        try {
+            minutes = Integer.parseInt(raw.trim());
+        } catch (NumberFormatException e) {
+            return DEFAULT_INTERVAL_MINUTES;
+        }
+        return clampIntervalMinutes(minutes);
+    }
+
+    /**
+     * The corrected UTC instant for a system-clock reading: what the disciplined clock says
+     * "now" is. Used for the last-sync timestamp shown (as UTC) in settings.
+     */
+    static long disciplinedUtcMs(long nowSystemMs, int offsetMs) {
+        return nowSystemMs + offsetMs;
+    }
+
+    /**
+     * Whether {@code start()} needs to (re)schedule: yes when not currently running, or when
+     * running at a cadence different from the one requested. A no-op when already scheduled at
+     * the requested interval, so repeated refreshes don't churn the periodic task.
+     */
+    static boolean shouldReschedule(boolean running, long subscribedIntervalMs, long requestedIntervalMs) {
+        return !running || subscribedIntervalMs != requestedIntervalMs;
+    }
+
+    /**
+     * The offset to apply for a reply, or {@code null} to ignore it. Ignored when discipline is
+     * no longer running (a reply that raced past a disable) or when the implied correction is
+     * implausible ({@link #isOffsetSane}). Kept pure so both guard branches are unit-tested
+     * without a network round trip.
+     */
+    static Integer computeAppliedOffset(boolean running, long serverTransmitMs, long nowSystemMs) {
+        if (!running) return null;
+        int offsetMs = ntpClockOffsetMs(serverTransmitMs, nowSystemMs);
+        if (!isOffsetSane(serverTransmitMs, offsetMs)) return null;
+        return offsetMs;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/timer/NtpClockUpdater.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/timer/NtpClockUpdater.java
@@ -45,10 +45,12 @@ public class NtpClockUpdater {
 
     /**
      * A sync implying a correction larger than this is treated as bad data and ignored (see
-     * {@link #isOffsetSane}). Matches {@link GpsClockUpdater#MAX_SANE_OFFSET_MS}: the offset
-     * is written straight into {@link UtcTimer#delay}, which moves the whole FT8 cycle grid,
-     * so an hour-scale "correction" can only be a corrupt/spoofed reply or a badly
-     * misconfigured server.
+     * {@link #isOffsetSane}). Deliberately looser than {@link GpsClockUpdater#MAX_SANE_OFFSET_MS}
+     * (60 s): a GPS fix hours out is a mock provider or a bogus fix, but an NTP reply hours
+     * out is usually a device whose clock really is hours wrong (dead RTC, timezone set by
+     * hand, no network for weeks) — exactly the case NTP exists to fix, and what the one-shot
+     * "Sync now" ({@link UtcTimer#syncTime}) already corrects with no bound at all. Past an
+     * hour the reply itself is the suspect (corrupt/spoofed packet, misconfigured server).
      */
     static final long MAX_SANE_OFFSET_MS = 60L * 60L * 1000L;
 
@@ -197,8 +199,7 @@ public class NtpClockUpdater {
             try {
                 timeClient.setDefaultTimeout(NTP_TIMEOUT_MS);
                 TimeInfo timeInfo = timeClient.getTime(address);
-                long serverTransmitMs = timeInfo.getMessage().getTransmitTimeStamp().getTime();
-                applySyncResult(serverTransmitMs);
+                applySyncResult(referenceUtcMs(timeInfo));
                 return; // got a reply (accepted or rejected) — connectivity succeeded
             } catch (IOException e) {
                 Log.d(TAG, "NTP attempt failed for " + address + ": " + e.getMessage());
@@ -211,8 +212,18 @@ public class NtpClockUpdater {
         GeneralVariables.mutableNtpClockSyncFailed.postValue(true);
     }
 
-    /** Compute, sanity-check, and apply the offset from a single NTP reply. Package-private, for tests. */
-    void applySyncResult(long serverTransmitMs) {
+    /**
+     * Compute, sanity-check, and apply the offset from a single NTP reply. Package-private,
+     * for tests.
+     *
+     * <p>{@code synchronized} on the same monitor as {@link #stop()}: the running check and
+     * the write to {@link UtcTimer#delay} must be one atomic step, or a reply that arrives
+     * while the user flips the toggle off could pass the check, lose the race to stop()'s
+     * baseline restore, and then re-write the clock with a now-unwanted NTP offset.
+     *
+     * @param serverTransmitMs the server's UTC "now" as of this call — see {@link #referenceUtcMs}
+     */
+    synchronized void applySyncResult(long serverTransmitMs) {
         long nowSystemMs = System.currentTimeMillis();
         // Sample once and feed the same reading to the evaluation and the log, so a logged
         // "REJECTED" offset can't disagree with the number actually judged against the bound.
@@ -253,10 +264,23 @@ public class NtpClockUpdater {
      * device clock is more than one cycle out.
      */
     static int ntpClockOffsetMs(long serverTransmitMs, long nowSystemMs) {
-        long offset = serverTransmitMs - nowSystemMs;
-        if (offset > Integer.MAX_VALUE) offset = Integer.MAX_VALUE;
-        if (offset < Integer.MIN_VALUE) offset = Integer.MIN_VALUE;
-        return (int) offset;
+        // Same arithmetic (and int clamp) the one-shot "Sync now" uses; one definition.
+        return UtcTimer.ntpClockOffsetMs(serverTransmitMs, nowSystemMs);
+    }
+
+    /**
+     * The server's UTC "now" as of the moment its reply arrived. Uses the RFC 4330 offset
+     * {@code ((t2 - t1) + (t3 - t4)) / 2}, which cancels the symmetric half of the network
+     * round trip — reading the transmit timestamp alone would leave the clock behind the
+     * server by half the RTT (tens to hundreds of ms on mobile data), a bias every sync
+     * would then re-apply. Falls back to the raw transmit timestamp when the reply carries
+     * no originate timestamp to compute against (commons-net reports {@code null}).
+     */
+    static long referenceUtcMs(TimeInfo timeInfo) {
+        timeInfo.computeDetails();
+        Long offsetMs = timeInfo.getOffset();
+        if (offsetMs != null) return timeInfo.getReturnTime() + offsetMs;
+        return timeInfo.getMessage().getTransmitTimeStamp().getTime();
     }
 
     /**

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/AppInsets.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/AppInsets.kt
@@ -1,0 +1,30 @@
+package radio.ks3ckc.ft8af
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+
+/**
+ * Which sides of the safe-drawing insets the app's root content is padded away from.
+ *
+ * The app runs edge-to-edge with the system bars hidden (see [ImmersiveBars]), and since
+ * Android 15 a fullscreen window is laid out *under* the display cutout instead of being
+ * letterboxed below it — so without this, the page title and top-row actions sit behind
+ * the camera on notched phones. [WindowInsets.safeDrawing] is the union of system bars,
+ * display cutout and IME, which makes it the right source: with the bars hidden only the
+ * cutout contributes, and if the bars do come back (split-screen, a device that refuses
+ * immersive mode) the status bar is covered too, with no double-padding risk because the
+ * app's own scaffolds apply no insets of their own.
+ *
+ * Top handles the portrait notch. Horizontal handles the same notch after rotation —
+ * the app rotates freely (it owns `orientation` in `configChanges`), and in landscape
+ * the cutout sits on the left or right edge, where a top-only pad would leave content
+ * under it. It also covers waterfall (curved-edge) insets. Bottom is deliberately left
+ * out: the navigation bar is hidden, and the IME is handled by the focused field.
+ */
+internal val APP_CONTENT_INSET_SIDES: WindowInsetsSides =
+    WindowInsetsSides.Top + WindowInsetsSides.Horizontal
+
+/** The subset of [safeDrawing] the root content pads for — see [APP_CONTENT_INSET_SIDES]. */
+internal fun appContentInsets(safeDrawing: WindowInsets): WindowInsets =
+    safeDrawing.only(APP_CONTENT_INSET_SIDES)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -51,6 +51,7 @@ import com.k1af.ft8af.database.DatabaseOpr
 import com.k1af.ft8af.database.OnAfterQueryConfig
 import com.k1af.ft8af.database.OperationBand
 import com.k1af.ft8af.location.GpsClockUpdater
+import com.k1af.ft8af.timer.NtpClockUpdater
 import com.k1af.ft8af.location.GridLocationUpdater
 import com.k1af.ft8af.log.ImportSharedLogs
 import com.k1af.ft8af.wave.UsbAudioNative
@@ -418,8 +419,18 @@ class ComposeMainActivity : AppCompatActivity() {
                     }
                     GridLocationUpdater.refresh(applicationContext, mainViewModel)
                 }
+                // Defensive: a hand-edited or pre-feature-restore config could have both
+                // flags persisted true. Enforce the mutual-exclusion invariant here too —
+                // GPS wins as the original feature — before either updater starts.
+                if (GeneralVariables.disciplineClockFromGPS && GeneralVariables.disciplineClockFromNtp) {
+                    GeneralVariables.disciplineClockFromNtp = false
+                    mainViewModel.databaseOpr.writeConfig("disciplineClockFromNtp", "0", null)
+                }
                 if (GeneralVariables.disciplineClockFromGPS) {
                     GpsClockUpdater.refresh(applicationContext)
+                }
+                if (GeneralVariables.disciplineClockFromNtp) {
+                    NtpClockUpdater.refresh(applicationContext)
                 }
                 mainViewModel.ft8TransmitSignal.setTimer_sec(GeneralVariables.transmitDelay)
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -6,10 +6,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import android.widget.Toast
@@ -329,7 +334,9 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
 
     Box(modifier = Modifier.fillMaxSize().background(BgApp)) {
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top)),
         ) {
             // SWR lockout banner — red warning at top when SWR halt triggered
             if (swrLocked) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -7,10 +7,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
@@ -333,10 +331,14 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
     }
 
     Box(modifier = Modifier.fillMaxSize().background(BgApp)) {
+        // Keep the content clear of the display cutout (and the status bar, should it
+        // ever be visible) — the Box behind still paints BgApp into the padded band so a
+        // notched phone shows app background beside the camera, not a black strip.
+        // Which sides, and why: see AppInsets.kt.
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top)),
+                .windowInsetsPadding(appContentInsets(WindowInsets.safeDrawing)),
         ) {
             // SWR lockout banner — red warning at top when SWR halt triggered
             if (swrLocked) {

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSync.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSync.kt
@@ -96,12 +96,19 @@ internal fun clockSyncStatusText(level: ClockSyncLevel): Int = when (level) {
 /**
  * Which automatic clock source, if any, is disciplining the clock right now — shown as a
  * small badge on the pill so the operator can see the DT is being handled for them.
- * GPS wins when both are on, because the self-sync estimator stands down while GPS
- * discipline is active (see MainViewModel.afterDecode). Null means manual only.
+ * GPS or NTP wins over self-sync when both are on, because the estimator stands down
+ * while either discipline is active (see ClockSelfSync.mayRun). GPS and NTP are mutually
+ * exclusive in the settings UI; GPS is listed first only as the tie-break for a
+ * hand-edited config. Null means manual only.
  */
-internal fun clockSyncAutoBadge(autoSyncFromDecodes: Boolean, disciplineFromGps: Boolean): Int? =
+internal fun clockSyncAutoBadge(
+    autoSyncFromDecodes: Boolean,
+    disciplineFromGps: Boolean,
+    disciplineFromNtp: Boolean = false,
+): Int? =
     when {
         disciplineFromGps -> R.string.clock_sync_badge_gps
+        disciplineFromNtp -> R.string.clock_sync_badge_ntp
         autoSyncFromDecodes -> R.string.clock_sync_badge_auto
         else -> null
     }
@@ -118,13 +125,14 @@ internal fun ClockSyncIndicator(
     modifier: Modifier = Modifier,
     autoSyncFromDecodes: Boolean = false,
     disciplineFromGps: Boolean = false,
+    disciplineFromNtp: Boolean = false,
 ) {
     val level = clockSyncLevel(offsetSec)
     val color = clockSyncColor(level)
     val offsetLabel = clockSyncOffsetLabel(offsetSec)
     val statusWord = stringResource(clockSyncStatusText(level))
     val label = stringResource(R.string.clock_sync_label)
-    val badgeRes = clockSyncAutoBadge(autoSyncFromDecodes, disciplineFromGps)
+    val badgeRes = clockSyncAutoBadge(autoSyncFromDecodes, disciplineFromGps, disciplineFromNtp)
     val badge = badgeRes?.let { stringResource(it) }
     val cd = if (badge == null) {
         stringResource(R.string.clock_sync_cd, offsetLabel, statusWord)

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SlotTimerBar.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SlotTimerBar.kt
@@ -67,6 +67,7 @@ fun SlotTimerBar(
                 offsetSec = offsetSec,
                 autoSyncFromDecodes = GeneralVariables.autoSyncClockFromDecodes,
                 disciplineFromGps = GeneralVariables.disciplineClockFromGPS,
+                disciplineFromNtp = GeneralVariables.disciplineClockFromNtp,
             )
         }
         Box(

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/AdvancedSettings.kt
@@ -88,6 +88,7 @@ internal val SUPPORTED_LANGUAGES: List<AppLanguage> = listOf(
     AppLanguage("id", R.string.language_name_id),
     AppLanguage("uk", R.string.language_name_uk),
     AppLanguage("ar", R.string.language_name_ar),
+    AppLanguage("pt-BR", R.string.language_name_pt_br),
 )
 
 /**

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/NtpClockSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/NtpClockSettings.kt
@@ -1,0 +1,20 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.R
+
+/** Trims [raw] and falls back to the default NTP server when blank. */
+internal fun normalizeNtpServer(raw: String): String =
+    raw.trim().ifEmpty { GeneralVariables.DEFAULT_NTP_SERVER }
+
+/**
+ * Which "clock locked" string to show above the manual correction stepper in
+ * [TimeSyncSettings], or null when manual entry is live. GPS takes precedence if both are
+ * somehow on at once (should not normally happen — the toggle handlers enforce mutual
+ * exclusion — but a hand-edited or pre-feature config restore could persist both).
+ */
+internal fun clockLockedMessageRes(disciplineFromGps: Boolean, disciplineFromNtp: Boolean): Int? = when {
+    disciplineFromGps -> R.string.settings_time_correction_gps_locked
+    disciplineFromNtp -> R.string.settings_time_correction_ntp_locked
+    else -> null
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeCorrection.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeCorrection.kt
@@ -61,11 +61,15 @@ internal fun suggestedCorrectionMs(currentDelayMs: Int, avgDtSec: Float): Int =
  * Only when nothing automatic owns the clock. With auto-sync on, the estimator
  * is already driving the same DT toward zero — offering the tap on top of it
  * made operators keep applying the residual by hand (and every manual apply
- * fights the estimator's next step). With GPS discipline on, the manual
+ * fights the estimator's next step). With GPS or NTP discipline on, the manual
  * controls are locked for the same reason, and the suggestion must be too.
  */
-internal fun showSuggestionApply(autoSyncFromDecodes: Boolean, disciplineFromGps: Boolean): Boolean =
-    !autoSyncFromDecodes && !disciplineFromGps
+internal fun showSuggestionApply(
+    autoSyncFromDecodes: Boolean,
+    disciplineFromGps: Boolean,
+    disciplineFromNtp: Boolean = false,
+): Boolean =
+    !autoSyncFromDecodes && !disciplineFromGps && !disciplineFromNtp
 
 /**
  * Human-readable offset, e.g. "+0.6 s", "-0.3 s", "0.0 s". Used for both the

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeSyncSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeSyncSettings.kt
@@ -10,6 +10,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,9 +25,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -36,6 +44,7 @@ import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
 import com.k1af.ft8af.location.GpsClockUpdater
+import com.k1af.ft8af.timer.NtpClockUpdater
 import com.k1af.ft8af.timer.UtcTimer
 import radio.ks3ckc.ft8af.theme.*
 import radio.ks3ckc.ft8af.ui.components.GlassCard
@@ -74,6 +83,17 @@ fun TimeSyncSettings(
         GeneralVariables.mutableGpsClockSync.value
     )
 
+    // NTP clock discipline — parallel to GPS, mutually exclusive with it.
+    var disciplineFromNtp by remember { mutableStateOf(GeneralVariables.disciplineClockFromNtp) }
+    var ntpServerInput by remember { mutableStateOf(TextFieldValue(GeneralVariables.getNtpServer())) }
+    var ntpIntervalMin by remember { mutableIntStateOf(GeneralVariables.ntpClockIntervalMinutes) }
+    val lastNtpSync by GeneralVariables.mutableNtpClockSync.observeAsState(
+        GeneralVariables.mutableNtpClockSync.value
+    )
+    val ntpSyncFailed by GeneralVariables.mutableNtpClockSyncFailed.observeAsState(
+        GeneralVariables.mutableNtpClockSyncFailed.value
+    )
+
     // Latest cycle's average decode DT (seconds), posted in MainViewModel.afterDecode.
     // Null until the first decode this session.
     val avgDtSec by mainViewModel.mutableTimerOffset.observeAsState()
@@ -85,10 +105,11 @@ fun TimeSyncSettings(
         GeneralVariables.mutableSelfSyncApplied.value
     )
 
-    // While GPS discipline owns the clock, each fix rewrites UtcTimer.delay behind this
-    // screen's back — and disabling it restores the pre-GPS offset. Re-read the live value
-    // on every posted sync and on toggle changes so the "Current" readout can't go stale.
-    LaunchedEffect(lastGpsSync, disciplineFromGps) {
+    // While GPS or NTP discipline owns the clock, each sync rewrites UtcTimer.delay behind
+    // this screen's back — and disabling it restores the pre-discipline offset. Re-read the
+    // live value on every posted sync and on toggle changes so the "Current" readout can't
+    // go stale.
+    LaunchedEffect(lastGpsSync, lastNtpSync, disciplineFromGps, disciplineFromNtp) {
         correctionMs = UtcTimer.delay
     }
 
@@ -129,10 +150,10 @@ fun TimeSyncSettings(
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth(),
                     )
-                    // While GPS discipline owns the clock the manual controls are inert —
-                    // editing them would fight the next GPS fix and overwrite the persisted
-                    // manual value. Disable them and say why.
-                    val manualEnabled = !disciplineFromGps
+                    // While GPS or NTP discipline owns the clock the manual controls are
+                    // inert — editing them would fight the next sync and overwrite the
+                    // persisted manual value. Disable them and say why.
+                    val manualEnabled = !disciplineFromGps && !disciplineFromNtp
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -143,9 +164,10 @@ fun TimeSyncSettings(
                         StepButton("+0.1", Modifier.weight(1f), manualEnabled) { apply(stepCorrectionMs(correctionMs, 100)) }
                         StepButton("+0.5", Modifier.weight(1f), manualEnabled) { apply(stepCorrectionMs(correctionMs, 500)) }
                     }
-                    if (disciplineFromGps) {
+                    val lockedMessageRes = clockLockedMessageRes(disciplineFromGps, disciplineFromNtp)
+                    if (lockedMessageRes != null) {
                         Text(
-                            text = stringResource(R.string.settings_time_correction_gps_locked),
+                            text = stringResource(lockedMessageRes),
                             color = TextMuted,
                             fontSize = 13.sp,
                             textAlign = TextAlign.Center,
@@ -285,10 +307,24 @@ fun TimeSyncSettings(
                     description = stringResource(R.string.settings_gps_clock_toggle_desc),
                     toggle = disciplineFromGps,
                     onToggleChange = { checked ->
-                        // On enable, make sure we have location permission — the
-                        // updater silently no-ops without it (same pattern as the
-                        // GPS grid toggle).
                         if (checked) {
+                            // Mutual exclusion: stop+persist NTP off first (synchronously)
+                            // so its stop() restores UtcTimer.delay to the shared
+                            // pre-discipline baseline before GPS captures its own baseline
+                            // — otherwise GPS would capture NTP's still-applied offset
+                            // instead of the true pre-discipline value.
+                            if (disciplineFromNtp) {
+                                disciplineFromNtp = false
+                                GeneralVariables.disciplineClockFromNtp = false
+                                mainViewModel.databaseOpr.writeConfig(
+                                    "disciplineClockFromNtp", "0", null,
+                                )
+                                NtpClockUpdater.refresh(context)
+                            }
+
+                            // Make sure we have location permission — the updater
+                            // silently no-ops without it (same pattern as the GPS
+                            // grid toggle).
                             val granted = ContextCompat.checkSelfPermission(
                                 context, Manifest.permission.ACCESS_FINE_LOCATION,
                             ) == PackageManager.PERMISSION_GRANTED
@@ -334,7 +370,7 @@ fun TimeSyncSettings(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            for (min in GPS_INTERVAL_OPTIONS) {
+                            for (min in CLOCK_INTERVAL_OPTIONS) {
                                 IntervalChip(
                                     label = stringResource(R.string.settings_gps_clock_interval_value, min),
                                     selected = gpsIntervalMin == min,
@@ -383,11 +419,161 @@ fun TimeSyncSettings(
                 }
             }
         }
+
+        // =====================================================================
+        // NTP CLOCK DISCIPLINE
+        // =====================================================================
+        SettingsSection(title = stringResource(R.string.settings_ntp_clock_section)) {
+            GlassCard(modifier = Modifier.fillMaxWidth()) {
+                SettingsRow(
+                    label = stringResource(R.string.settings_ntp_clock_toggle),
+                    description = stringResource(R.string.settings_ntp_clock_toggle_desc),
+                    toggle = disciplineFromNtp,
+                    onToggleChange = { checked ->
+                        if (checked && disciplineFromGps) {
+                            // Symmetric mutual exclusion: stop+persist GPS off first so
+                            // its stop() restores UtcTimer.delay to the shared
+                            // pre-discipline baseline before NTP captures its own.
+                            disciplineFromGps = false
+                            GeneralVariables.disciplineClockFromGPS = false
+                            mainViewModel.databaseOpr.writeConfig(
+                                "disciplineClockFromGPS", "0", null,
+                            )
+                            GpsClockUpdater.refresh(context)
+                        }
+                        disciplineFromNtp = checked
+                        GeneralVariables.disciplineClockFromNtp = checked
+                        mainViewModel.databaseOpr.writeConfig(
+                            "disciplineClockFromNtp", if (checked) "1" else "0", null,
+                        )
+                        NtpClockUpdater.refresh(context)
+                    },
+                )
+            }
+
+            if (disciplineFromNtp) {
+                GlassCard(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        fun commitNtpServer() {
+                            val normalized = normalizeNtpServer(ntpServerInput.text)
+                            ntpServerInput = TextFieldValue(normalized)
+                            GeneralVariables.ntpServer = normalized
+                            mainViewModel.databaseOpr.writeConfig("ntpServer", normalized, null)
+                            // No NtpClockUpdater.refresh() needed: the next scheduled
+                            // sync reads GeneralVariables.getNtpServer() live.
+                        }
+
+                        OutlinedTextField(
+                            value = ntpServerInput,
+                            onValueChange = { ntpServerInput = it },
+                            label = { Text(stringResource(R.string.settings_ntp_clock_server_label)) },
+                            placeholder = {
+                                Text(
+                                    text = stringResource(R.string.settings_ntp_clock_server_hint),
+                                    color = TextFaint,
+                                )
+                            },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                            keyboardActions = KeyboardActions(onDone = { commitNtpServer() }),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedTextColor = TextPrimary,
+                                unfocusedTextColor = TextPrimary,
+                                cursorColor = Accent,
+                                focusedBorderColor = Accent,
+                                unfocusedBorderColor = BorderStrong,
+                                focusedLabelColor = Accent,
+                                unfocusedLabelColor = TextMuted,
+                            ),
+                            textStyle = TextStyle(fontFamily = GeistMonoFamily, fontSize = 15.sp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .onFocusChanged { if (!it.isFocused) commitNtpServer() },
+                        )
+
+                        Text(
+                            text = stringResource(R.string.settings_gps_clock_interval),
+                            color = TextMuted,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            for (min in CLOCK_INTERVAL_OPTIONS) {
+                                IntervalChip(
+                                    label = stringResource(R.string.settings_gps_clock_interval_value, min),
+                                    selected = ntpIntervalMin == min,
+                                    modifier = Modifier.weight(1f),
+                                ) {
+                                    ntpIntervalMin = min
+                                    GeneralVariables.ntpClockIntervalMinutes = min
+                                    mainViewModel.databaseOpr.writeConfig(
+                                        "ntpClockIntervalMin", min.toString(), null,
+                                    )
+                                    NtpClockUpdater.refresh(context)
+                                }
+                            }
+                        }
+
+                        // Status readout: last sync + applied offset, waiting, or failed.
+                        val syncMs = lastNtpSync
+                        when {
+                            syncMs == null && ntpSyncFailed == true -> {
+                                Text(
+                                    text = stringResource(R.string.settings_ntp_clock_sync_failed),
+                                    color = TextMuted,
+                                    fontSize = 14.sp,
+                                )
+                            }
+                            syncMs == null -> {
+                                Text(
+                                    text = stringResource(R.string.settings_ntp_clock_waiting),
+                                    color = TextMuted,
+                                    fontSize = 14.sp,
+                                )
+                            }
+                            else -> {
+                                Text(
+                                    text = stringResource(
+                                        R.string.settings_ntp_clock_last_sync,
+                                        UtcTimer.getDatetimeStr(syncMs),
+                                    ),
+                                    color = TextPrimary,
+                                    fontSize = 14.sp,
+                                    fontFamily = GeistMonoFamily,
+                                )
+                                Text(
+                                    text = stringResource(
+                                        R.string.settings_ntp_clock_offset,
+                                        formatOffsetMs(GeneralVariables.ntpClockOffsetMs),
+                                    ),
+                                    color = if (GeneralVariables.ntpClockOffsetMs == 0) TextPrimary else Accent,
+                                    fontSize = 14.sp,
+                                    fontFamily = GeistMonoFamily,
+                                )
+                                if (ntpSyncFailed == true) {
+                                    Text(
+                                        text = stringResource(R.string.settings_ntp_clock_sync_failed),
+                                        color = TextMuted,
+                                        fontSize = 12.sp,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
-/** Update-interval presets (minutes) offered for GPS clock discipline. */
-private val GPS_INTERVAL_OPTIONS = intArrayOf(1, 5, 10, 15, 30)
+/** Update-interval presets (minutes) offered for GPS/NTP clock discipline. */
+private val CLOCK_INTERVAL_OPTIONS = intArrayOf(1, 5, 10, 15, 30)
 
 /**
  * A bordered, tappable interval chip that highlights when selected. Local to this screen.

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeSyncSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeSyncSettings.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -44,6 +45,7 @@ import com.k1af.ft8af.GeneralVariables
 import com.k1af.ft8af.MainViewModel
 import com.k1af.ft8af.R
 import com.k1af.ft8af.location.GpsClockUpdater
+import com.k1af.ft8af.timer.ClockSelfSync
 import com.k1af.ft8af.timer.NtpClockUpdater
 import com.k1af.ft8af.timer.UtcTimer
 import radio.ks3ckc.ft8af.theme.*
@@ -205,9 +207,10 @@ fun TimeSyncSettings(
                     label = stringResource(R.string.settings_selfsync_toggle),
                     description = stringResource(R.string.settings_selfsync_toggle_desc),
                     toggle = autoSyncFromDecodes,
-                    // Same lock-out as the manual controls: while GPS discipline owns
-                    // the clock this estimator must not fight it, so the row is inert.
-                    enabled = !disciplineFromGps,
+                    // Same lock-out as the manual controls: while GPS or NTP discipline
+                    // owns the clock this estimator must not fight it, so the row is
+                    // inert. Mirrors the decode-time gate (ClockSelfSync.mayRun).
+                    enabled = !disciplineFromGps && !disciplineFromNtp,
                     onToggleChange = { checked ->
                         autoSyncFromDecodes = checked
                         GeneralVariables.autoSyncClockFromDecodes = checked
@@ -253,7 +256,8 @@ fun TimeSyncSettings(
                             fontSize = 15.sp,
                             fontFamily = GeistMonoFamily,
                         )
-                        if (showSuggestionApply(autoSyncFromDecodes, disciplineFromGps)) {
+                        val suggestLockedRes = clockLockedMessageRes(disciplineFromGps, disciplineFromNtp)
+                        if (showSuggestionApply(autoSyncFromDecodes, disciplineFromGps, disciplineFromNtp)) {
                             Text(
                                 text = stringResource(R.string.settings_time_suggest_apply),
                                 color = Accent,
@@ -263,9 +267,9 @@ fun TimeSyncSettings(
                                     .clickable { apply(suggestedCorrectionMs(correctionMs, dt)) }
                                     .padding(vertical = 6.dp),
                             )
-                        } else if (disciplineFromGps) {
+                        } else if (suggestLockedRes != null) {
                             Text(
-                                text = stringResource(R.string.settings_time_correction_gps_locked),
+                                text = stringResource(suggestLockedRes),
                                 color = TextMuted,
                                 fontSize = 13.sp,
                             )
@@ -446,6 +450,12 @@ fun TimeSyncSettings(
                         mainViewModel.databaseOpr.writeConfig(
                             "disciplineClockFromNtp", if (checked) "1" else "0", null,
                         )
+                        if (checked) {
+                            // NTP takes over the clock; the self-sync estimator stands
+                            // down (ClockSelfSync.mayRun) — clear its streak so stale
+                            // pre-NTP evidence can't act if NTP is later disabled.
+                            mainViewModel.clockSelfSync.reset()
+                        }
                         NtpClockUpdater.refresh(context)
                     },
                 )
@@ -459,7 +469,9 @@ fun TimeSyncSettings(
                     ) {
                         fun commitNtpServer() {
                             val normalized = normalizeNtpServer(ntpServerInput.text)
-                            ntpServerInput = TextFieldValue(normalized)
+                            // Keep the caret at the end of the committed text rather than
+                            // letting a fresh TextFieldValue reset it to position 0.
+                            ntpServerInput = TextFieldValue(normalized, TextRange(normalized.length))
                             GeneralVariables.ntpServer = normalized
                             mainViewModel.databaseOpr.writeConfig("ntpServer", normalized, null)
                             // No NtpClockUpdater.refresh() needed: the next scheduled

--- a/ft8af/app/src/main/res/values-pt-rBR/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pt-rBR/strings_compose.xml
@@ -439,6 +439,7 @@
     <string name="settings_time_suggest_label">Média recente de DT: %1$s</string>
     <string name="settings_time_suggest_apply">Aplicar correção sugerida</string>
     <string name="settings_time_correction_gps_locked">A disciplina de relógio por GPS está controlando o relógio — desative-a abaixo para ajustar manualmente.</string>
+    <string name="settings_time_correction_ntp_locked">A disciplina de relógio por NTP está controlando o relógio — desative-a abaixo para ajustar manualmente.</string>
 
     <!-- ===== Settings: Time Sync (GPS clock discipline, issue #373) ===== -->
     <string name="settings_gps_clock_section">Disciplina de Relógio por GPS</string>
@@ -449,6 +450,17 @@
     <string name="settings_gps_clock_waiting">Aguardando um fix de GPS…</string>
     <string name="settings_gps_clock_last_sync">Última sincronização GPS: %1$s UTC</string>
     <string name="settings_gps_clock_offset">Offset aplicado: %1$s</string>
+
+    <!-- ===== Settings: Time Sync (NTP clock discipline) ===== -->
+    <string name="settings_ntp_clock_section">Disciplina de Relógio por NTP</string>
+    <string name="settings_ntp_clock_toggle">Disciplinar relógio por NTP</string>
+    <string name="settings_ntp_clock_toggle_desc">Sincroniza periodicamente com um servidor de hora de rede para alinhar o ciclo FT8 ao UTC verdadeiro. Substitui a correção manual enquanto ativado. Requer acesso à internet.</string>
+    <string name="settings_ntp_clock_server_label">Servidor NTP</string>
+    <string name="settings_ntp_clock_server_hint">ex.: a.ntp.br</string>
+    <string name="settings_ntp_clock_waiting">Aguardando a primeira sincronização NTP…</string>
+    <string name="settings_ntp_clock_last_sync">Última sincronização NTP: %1$s UTC</string>
+    <string name="settings_ntp_clock_offset">Offset aplicado: %1$s</string>
+    <string name="settings_ntp_clock_sync_failed">Última tentativa de sincronização falhou — tentando novamente…</string>
 
     <!-- ===== Settings: operator identity ===== -->
     <string name="settings_auto_update_grid">Atualizar Grade Automaticamente (GPS)</string>

--- a/ft8af/app/src/main/res/values-pt-rBR/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pt-rBR/strings_compose.xml
@@ -1,0 +1,675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- ===== Common / shared ===== -->
+    <string name="action_cancel">Cancelar</string>
+    <string name="action_save">Salvar</string>
+    <string name="action_done">Pronto</string>
+    <string name="action_ok">OK</string>
+    <string name="action_exit">Sair</string>
+    <string name="common_none">Nenhum</string>
+    <string name="common_off">Desativado</string>
+    <string name="common_not_configured">Não configurado</string>
+    <string name="common_configured">Configurado</string>
+    <string name="common_not_connected">Não conectado</string>
+    <string name="common_pass">Aprovado</string>
+    <string name="common_fail">Falha</string>
+    <string name="common_test_connection">Testar Conexão</string>
+
+    <!-- ===== Continents ===== -->
+    <string name="continent_na">América do Norte</string>
+    <string name="continent_sa">América do Sul</string>
+    <string name="continent_eu">Europa</string>
+    <string name="continent_af">África</string>
+    <string name="continent_as">Ásia</string>
+    <string name="continent_oc">Oceania</string>
+    <string name="continent_an">Antártida</string>
+
+    <!-- ===== Bottom navigation tabs ===== -->
+    <string name="tab_decode">RX</string>
+    <string name="tab_map">Mapa</string>
+    <string name="tab_waterfall">Cascata</string>
+    <string name="tab_pota">POTA</string>
+    <string name="tab_logbook">Registro</string>
+    <string name="tab_settings">Ajustes</string>
+
+    <!-- ===== Status pills (decode list badges) ===== -->
+    <string name="status_new_dxcc">NOVO DXCC</string>
+    <string name="status_new_grid">NOVA GRADE</string>
+    <string name="status_new_band">NOVA BANDA</string>
+    <string name="status_pota">POTA</string>
+    <string name="status_new_pota">NOVO POTA</string>
+    <string name="status_sota">SOTA</string>
+    <string name="status_needed">NECESSÁRIO</string>
+    <string name="status_worked">CONTATADO</string>
+    <string name="status_confirmed">CONFIRMADO</string>
+    <string name="status_cq">CQ</string>
+    <string name="status_pending">PENDENTE</string>
+
+    <!-- ===== Splash / app-level ===== -->
+    <string name="splash_tagline">FT8 · COMPANHEIRO MÓVEL</string>
+    <string name="splash_initializing">INICIALIZANDO RÁDIO</string>
+    <string name="splash_version">v%1$s · build %2$s</string>
+    <string name="app_set_callsign_first">Defina seu indicativo em Configurações antes de chamar CQ</string>
+    <string name="app_hunt_on">Caça ativada — respondendo CQs automaticamente</string>
+    <string name="app_hunt_off">Caça desativada — chamando CQ, trabalhando apenas as respostas</string>
+    <string name="app_mode_switched">Modo: %1$s</string>
+    <string name="app_mode_switch_busy">Não é possível trocar o modo durante a transmissão</string>
+    <string name="main_tx_volume">Volume TX: %1$d%%</string>
+
+    <!-- ===== Exit dialog ===== -->
+    <string name="exit_title">SAIR DO FT8AF?</string>
+    <string name="exit_message">Tem certeza de que deseja fechar o aplicativo? Qualquer QSO ativo será cancelado.</string>
+
+    <!-- ===== Frequency picker ===== -->
+    <string name="freq_select_title">SELECIONAR FREQUÊNCIA</string>
+    <string name="freq_show_alternates">MOSTRAR ALTERNATIVAS</string>
+    <string name="freq_hide_alternates">OCULTAR ALTERNATIVAS</string>
+    <string name="freq_alt_prefix">"ALT "</string>
+
+    <!-- ===== Operator card ===== -->
+    <string name="op_no_call">SEM INDICATIVO</string>
+    <string name="op_no_grid">Nenhuma grade definida</string>
+    <string name="op_tap_to_edit">Toque para editar</string>
+    <string name="op_stat_rig">RIG</string>
+    <string name="op_stat_antenna">ANTENA</string>
+    <string name="op_stat_power">POTÊNCIA</string>
+
+    <!-- ===== Export log sheet ===== -->
+    <string name="export_title">EXPORTAR QSOS</string>
+    <string name="export_date_range">INTERVALO DE DATAS</string>
+    <string name="export_date_from_placeholder">"De  AAAAMMDD"</string>
+    <string name="export_date_to_placeholder">"Até  AAAAMMDD"</string>
+    <string name="export_share">Compartilhar</string>
+    <string name="export_filter_confirmed">apenas confirmados</string>
+    <string name="export_filter_unconfirmed">apenas não confirmados</string>
+    <string name="export_record_singular">registro</string>
+    <string name="export_record_plural">registros</string>
+    <string name="export_summary_all">todos</string>
+    <string name="export_summary_key">\'%1$s\'</string>
+    <string name="export_summary_suffix">" · %1$s"</string>
+    <string name="export_summary">%1$d %2$s correspondentes a %3$s%4$s</string>
+    <string name="export_preparing">Preparando…</string>
+    <string name="export_share_chooser_title">Compartilhar registros de QSO</string>
+    <string name="export_saved_to">Salvo em %1$s</string>
+    <string name="export_save_failed">Falha ao salvar em Downloads</string>
+    <string name="export_temp_file_failed">Não foi possível criar o arquivo temporário</string>
+
+    <!-- ===== TX strip ===== -->
+    <string name="tx_transmitting">TRANSMITINDO</string>
+    <string name="tx_listening">OUVINDO</string>
+    <string name="tx_hunt">Caça</string>
+    <string name="tx_call_cq">Chamar CQ</string>
+    <string name="tx_stop">Parar</string>
+    <string name="tx_volume_decrease">Diminuir volume de TX</string>
+    <string name="tx_volume_increase">Aumentar volume de TX</string>
+    <string name="tx_cq_options">Opções de mensagem CQ (modificador, texto livre, Field Day)</string>
+
+    <!-- ===== CQ options sheet (free text / saved custom CQ) ===== -->
+    <string name="cq_directed_too_long">CQ + texto + indicativo não cabe em uma única mensagem FT8 (máx. 13 caracteres, conjunto de caracteres limitado)</string>
+    <string name="cq_saved_label">Salvo</string>
+    <string name="cq_saved_remove">Remover CQ salvo</string>
+
+    <!-- ===== Hound (DXpedition) setup ===== -->
+    <string name="hound_title">Contatar uma DXpedição (Hound)</string>
+    <string name="hound_help">Primeiro sintonize o rig na frequência de dial publicada do Fox. Você chama alto (1000–4000 Hz); o app faz o QSY automático para onde o Fox responde e envia o seu report.</string>
+    <string name="hound_fox_callsign">Indicativo do Fox</string>
+    <string name="hound_call_frequency">Frequência de chamada (Hz, 1000–4000)</string>
+    <string name="hound_start">Iniciar</string>
+
+    <!-- ===== CAT status chip ===== -->
+    <string name="cat_status_chip_label">CAT</string>
+    <string name="cat_status_connected">CAT conectado — toque para reconectar</string>
+    <string name="cat_status_connecting">Conectando CAT…</string>
+    <string name="cat_status_disconnected">CAT desconectado — toque para conectar</string>
+    <string name="cat_status_error">Erro na conexão CAT — toque para tentar novamente</string>
+
+    <!-- ===== SWR lockout banner ===== -->
+    <string name="swr_lockout_title">TX INTERROMPIDO — SWR alto detectado (%1$s)</string>
+    <string name="swr_lockout_body">Verifique a antena / linha de alimentação antes de transmitir.</string>
+    <string name="swr_lockout_dismiss">DISPENSAR</string>
+    <string name="swr_lockout_toast">TX bloqueado — bloqueio por SWR ativo. Dispense o aviso primeiro.</string>
+
+    <!-- ===== Active QSO panel ===== -->
+    <string name="qsopanel_calling_cq">Chamando CQ</string>
+    <string name="qsopanel_hunting">Ouvindo CQ</string>
+    <string name="qsopanel_searching">Buscando...</string>
+    <string name="qsopanel_qsoing_with">QSO com %1$s</string>
+    <string name="qsopanel_waiting_for">Aguardando %1$s</string>
+    <string name="qsopanel_tap_to_view">toque para ver ↗</string>
+    <string name="qsopanel_tx_message">TX: %1$s</string>
+    <string name="qsopanel_waiting_messages">Aguardando mensagens...</string>
+    <string name="qsopanel_log_action">LOG</string>
+    <string name="qsopanel_queue">FILA</string>
+
+    <!-- ===== Decode screen ===== -->
+    <string name="decode_title">Decodificar</string>
+    <string name="decode_subtitle">"%1$s  •  %2$d decodificados neste ciclo"</string>
+    <string name="decode_clear_list">Limpar lista de decodificação</string>
+    <string name="decode_utc_placeholder">UTC : --:--:--</string>
+    <string name="decode_time_group_utc">%1$s UTC</string>
+    <string name="decode_filter_all">Todos</string>
+    <string name="decode_filter_cq_calls">Chamadas CQ</string>
+    <string name="decode_filter_cq_pota">CQ POTA</string>
+    <string name="decode_filter_new_dxcc">Novo DXCC</string>
+    <string name="decode_filter_needed">Necessários</string>
+    <string name="decode_filter_for_me">Para Mim</string>
+    <string name="decode_empty_cq_title">Nenhuma chamada CQ</string>
+    <string name="decode_empty_cq_body">Nenhuma estação está chamando CQ nesta banda no momento.</string>
+    <string name="decode_empty_pota_title">Nenhum spot POTA</string>
+    <string name="decode_empty_pota_body">Nenhuma ativação de parque decodificada nesta banda ainda — abra POTA → Caça para ver a lista de spots.</string>
+    <string name="decode_empty_dxcc_title">Nenhum DXCC novo</string>
+    <string name="decode_empty_dxcc_body">Nenhuma entidade DXCC não contatada foi decodificada ainda.</string>
+    <string name="decode_empty_needed_title">Nada necessário</string>
+    <string name="decode_empty_needed_body">Nenhuma estação precisando de confirmação encontrada.</string>
+    <string name="decode_empty_forme_title">Nenhuma chamada para você</string>
+    <string name="decode_empty_forme_body">Nenhuma estação está chamando o seu indicativo no momento.</string>
+    <string name="decode_empty_default_title">Nenhum sinal decodificado</string>
+    <string name="decode_empty_default_body">Aguardando sinais de %1$s aparecerem...</string>
+    <string name="decode_label_calling">→ CHAMANDO</string>
+    <string name="decode_label_cq">CQ</string>
+    <string name="decode_label_to_you">↓ PARA VOCÊ</string>
+
+    <!-- ===== QSO sheet ===== -->
+    <string name="qso_complete">QSO Completo</string>
+    <string name="qso_call_action">Chamar %1$s</string>
+    <string name="qso_qrz_link">QRZ ↗</string>
+    <string name="qso_stat_signal">Sinal</string>
+    <string name="qso_stat_distance">Distância</string>
+    <string name="qso_stat_azimuth">Azimute</string>
+    <string name="qso_stat_band">Banda</string>
+    <string name="qso_sequence_header">SEQUÊNCIA DO QSO</string>
+    <string name="qso_step_send_call">Enviar indicativo</string>
+    <string name="qso_step_report_sent">Report enviado</string>
+    <string name="qso_step_roger">Roger</string>
+    <string name="qso_step_confirm">Confirmar</string>
+    <string name="qso_step_logged">Registrado</string>
+    <string name="qso_live_sending">QSO com %1$s — Enviando %2$s</string>
+    <string name="qso_live_waiting">Aguardando resposta de %1$s…</string>
+    <string name="qso_live_transmitting">Transmitindo…</string>
+    <string name="qso_live_step_fallback">mensagem</string>
+    <string name="qso_tx_now">TX AGORA</string>
+    <string name="qso_tx_next">TX SEGUINTE</string>
+
+    <!-- ===== Logbook ===== -->
+    <string name="log_tab_stats">Resumo</string>
+    <string name="log_tab_recent">Recentes</string>
+    <string name="log_tab_awards">Prêmios</string>
+    <string name="log_title">Registro</string>
+    <string name="log_subtitle_qsos_all_bands">%1$d QSOs · Todas as bandas</string>
+    <string name="log_cd_sync_to_logging_services">Sincronizar com serviços de registro</string>
+    <string name="log_cd_export_qsos">Exportar QSOs</string>
+    <string name="log_stat_total_qsos">Total de QSOs</string>
+    <string name="log_stat_dxcc_entities">Entidades DXCC</string>
+    <string name="log_stat_cq_zones">Zonas CQ</string>
+    <string name="log_stat_itu_zones">Zonas ITU</string>
+    <string name="log_section_band_distribution">Distribuição por Banda</string>
+    <string name="log_section_award_progress">Progresso dos Prêmios</string>
+    <string name="log_award_dxcc_mixed">DXCC Misto</string>
+    <string name="log_award_vucc_grid_squares">Quadrículas VUCC</string>
+    <string name="log_award_dxcc_challenge">DXCC Challenge</string>
+    <string name="log_section_grid_coverage">Cobertura de Grade</string>
+    <string name="log_section_signal_trend">Tendência de Sinal</string>
+    <string name="log_no_qsos_yet">Nenhum QSO ainda</string>
+    <string name="log_no_qsos_recorded_yet">Nenhum QSO registrado ainda</string>
+    <string name="log_state_usa">%1$s, EUA</string>
+    <string name="log_cd_qso_actions">Ações do QSO</string>
+    <string name="log_action_edit">Editar</string>
+    <string name="log_action_delete">Excluir</string>
+    <string name="log_award_dxcc_mixed_desc">Contate e confirme 100 entidades DXCC em qualquer banda/modo</string>
+    <string name="log_award_was">WAS</string>
+    <string name="log_award_was_desc">Contate e confirme os 50 estados dos EUA</string>
+    <string name="log_award_waz">WAZ</string>
+    <string name="log_award_waz_desc">Contate e confirme as 40 zonas CQ</string>
+    <string name="log_award_vucc">VUCC</string>
+    <string name="log_award_vucc_desc">VHF/UHF Century Club -- 100 quadrículas em uma única banda</string>
+    <string name="log_award_iota">IOTA</string>
+    <string name="log_award_iota_desc">Islands on the Air -- contate estações em ilhas designadas</string>
+    <string name="log_edit_qso">Editar QSO</string>
+    <string name="log_field_callsign">Indicativo</string>
+    <string name="log_field_grid_locator">Locator de Grade</string>
+    <string name="log_field_mode">Modo</string>
+    <string name="log_delete_qso_title">EXCLUIR QSO?</string>
+    <string name="log_delete_qso_body_callsign">Remover o QSO com %1$s do registro? Esta ação não pode ser desfeita.</string>
+    <string name="log_delete_qso_body">Remover este QSO do registro? Esta ação não pode ser desfeita.</string>
+    <string name="log_sync_title_no_services">NENHUM SERVIÇO ATIVADO</string>
+    <string name="log_sync_title_syncing">SINCRONIZANDO…</string>
+    <string name="log_sync_title_complete">SINCRONIZAÇÃO CONCLUÍDA</string>
+    <string name="log_sync_enable_services">Ative o Cloudlog/Wavelog/Nextlog ou o QRZ em Configurações e tente novamente.</string>
+    <string name="log_sync_progress_count">%1$d de %2$d QSOs</string>
+    <string name="log_sync_cloudlog_accepted">Cloudlog / Wavelog / Nextlog: %1$d aceitos</string>
+    <string name="log_sync_qrz_accepted">QRZ: %1$d aceitos</string>
+    <string name="log_sync_nothing_to_upload">Nenhum QSO no registro para enviar ainda.</string>
+    <string name="log_sync_working">Processando…</string>
+
+    <!-- ===== POTA ===== -->
+    <string name="pota_tab_activate">Ativar</string>
+    <string name="pota_tab_hunt">Caça</string>
+    <string name="pota_tab_history">Histórico</string>
+    <string name="pota_start_activation">Iniciar ativação</string>
+    <string name="pota_park_reference_label">Referência do parque (ex.: K-1234)</string>
+    <string name="pota_notes_optional_label">Notas (opcional)</string>
+    <string name="pota_enter_park_reference_first">Informe primeiro uma referência de parque</string>
+    <string name="pota_activating">Ativando %1$s</string>
+    <string name="pota_activation_ended">Ativação encerrada</string>
+    <string name="pota_set_callsign_first">Defina primeiro seu indicativo em Configurações</string>
+    <string name="pota_self_spot_posted">Auto-spot publicado</string>
+    <string name="pota_self_spot_failed">Falha no auto-spot — verifique o log</string>
+    <string name="pota_active_park">ATIVO — %1$s</string>
+    <string name="pota_qsos">QSOs</string>
+    <string name="pota_contacts_map">Mapa de contatos</string>
+    <string name="pota_back">Voltar</string>
+    <string name="pota_valid_activation">ativação válida</string>
+    <string name="pota_to_valid">%1$d para validar</string>
+    <string name="pota_elapsed">Decorrido</string>
+    <string name="pota_since_start">desde o início</string>
+    <string name="pota_self_spot">Auto-spot</string>
+    <string name="pota_end_activation">Encerrar ativação</string>
+    <string name="pota_notes_quote">“%1$s”</string>
+    <string name="pota_tx_cq_preview">O TX CQ será enviado como “CQ POTA %1$s %2$s”.</string>
+    <string name="pota_no_spots">Nenhum spot FT8 POTA no momento.</string>
+    <string name="pota_active_spots">%1$d spots FT8 ativos</string>
+    <string name="pota_targeting">Almejando %1$s @ %2$s kHz (%3$s) — mude para Decodificar para chamar</string>
+    <string name="pota_no_past_activations">Nenhuma ativação anterior ainda.</string>
+    <string name="pota_no_browser_available">Nenhum navegador disponível</string>
+    <string name="pota_export_failed">Falha na exportação — verifique o log</string>
+    <string name="pota_status_active">ativo</string>
+    <string name="pota_qso_count">%1$d QSO</string>
+    <string name="pota_share_adif">Compartilhar ADIF</string>
+    <string name="pota_open_pota_app">Abrir pota.app</string>
+    <string name="pota_upload_to_pota">Enviar para o POTA</string>
+    <string name="pota_upload_success">%1$d registro(s) de parque enviado(s) para o POTA</string>
+    <string name="pota_upload_failed">Falha no envio: %1$s</string>
+    <string name="pota_upload_server_error">O POTA não conseguiu processar o envio. Verifique se a referência do parque é válida e se o seu indicativo está registrado no POTA, depois tente novamente.</string>
+    <string name="pota_upload_busy">Os servidores do POTA estão temporariamente indisponíveis. Tentamos algumas vezes sem sucesso — tente novamente em alguns minutos.</string>
+    <string name="pota_upload_network_error">Não foi possível acessar o POTA. Verifique sua conexão com a internet e tente novamente.</string>
+    <string name="pota_login_title">Entrar no POTA</string>
+    <string name="pota_login_desc">Use o e-mail e a senha da sua conta pota.app.</string>
+    <string name="pota_login_email">E-mail</string>
+    <string name="pota_login_password">Senha</string>
+    <string name="pota_login_button">Entrar</string>
+    <string name="pota_login_cancel">Cancelar</string>
+    <string name="pota_login_failed">Falha ao entrar: %1$s</string>
+    <string name="pota_login_or">ou</string>
+    <string name="pota_login_social">Entrar com Google / Facebook / Amazon</string>
+    <string name="pota_oauth_title">Entrar no POTA</string>
+    <string name="pota_add_park">Novo parque</string>
+    <string name="pota_remove_park">Remover</string>
+    <string name="pota_max_parks_reached">Máximo de 10 parques atingido</string>
+    <string name="pota_spotted_n_parks">Spotado em %1$d parques</string>
+    <string name="pota_parks_more">+%1$d mais</string>
+    <string name="pota_search_parks">Pesquisar parques</string>
+    <string name="pota_search_parks_hint">Filtrar por nome ou referência</string>
+    <string name="pota_recent_parks">PARQUES RECENTES</string>
+    <string name="pota_nearby_parks">PARQUES PRÓXIMOS</string>
+    <string name="pota_no_recent_parks">Nenhuma ativação recente</string>
+    <string name="pota_no_nearby_parks">Nenhum parque encontrado por perto</string>
+    <string name="pota_loading_nearby">Carregando parques próximos…</string>
+    <string name="pota_loading_recent">Carregando parques recentes…</string>
+    <string name="pota_location_unavailable">Localização indisponível — ative o GPS</string>
+
+    <!-- ===== Debug log / Map / Waterfall ===== -->
+    <string name="debug_title">Depuração</string>
+    <string name="debug_line_count">%1$d linhas</string>
+    <string name="debug_logcat_on_suffix">" · logcat ATIVADO"</string>
+    <string name="debug_close">Fechar</string>
+    <string name="debug_share">Compartilhar</string>
+    <string name="debug_clear">Limpar</string>
+    <string name="debug_logcat_on">Logcat: ATIVADO</string>
+    <string name="debug_logcat_off">Logcat: DESATIVADO</string>
+    <string name="debug_no_log_file">nenhum arquivo de log</string>
+    <string name="debug_log_cleared">log limpo</string>
+    <string name="debug_share_chooser_title">Compartilhar debug.log</string>
+    <string name="map_title">Mapa</string>
+    <string name="map_no_grid_set">Nenhuma grade definida</string>
+    <string name="map_station_count">%1$d estações</string>
+    <string name="map_station_count_with_heard">%1$d estações · %2$d ouvidas</string>
+    <string name="map_psk_error">PSK Reporter indisponível: %1$s</string>
+    <string name="map_projection_equirectangular">Equirretangular</string>
+    <string name="map_projection_azimuthal">Azimutal Equidistante</string>
+    <string name="map_mode_standard">STD</string>
+    <string name="map_mode_azimuthal">AZ</string>
+    <string name="map_overlay_psk">PSK</string>
+    <string name="map_filter">Filtro</string>
+    <string name="map_filter_title">Filtros PSK</string>
+    <string name="map_filter_done">Pronto</string>
+    <string name="map_filter_time">Hora</string>
+    <string name="map_filter_band">Banda</string>
+    <string name="map_filter_mode">Modo</string>
+    <string name="map_filter_direction">Direção</string>
+    <string name="map_filter_all">Todos</string>
+    <string name="map_info_distance">Distância</string>
+    <string name="map_info_bearing">Rumo</string>
+    <string name="map_info_snr">SNR</string>
+    <string name="waterfall_title">Cascata</string>
+    <string name="waterfall_toggle_nr">NR</string>
+    <string name="waterfall_toggle_msg">MSG</string>
+    <string name="waterfall_status_live">AO VIVO</string>
+
+    <!-- ===== Settings: format helpers ===== -->
+    <string name="settings_minutes_format">%1$d min</string>
+    <string name="settings_tries_format">%1$d tentativas</string>
+    <string name="settings_milliseconds_format">%1$d ms</string>
+    <string name="settings_hz_format">%1$d Hz</string>
+    <string name="settings_hz_str_format">%1$s Hz</string>
+    <string name="settings_percent_format">%1$d%%</string>
+    <string name="settings_bands_enabled_format">%1$d de %2$d ativadas</string>
+    <string name="settings_min_max_suffix">%1$d–%2$d %3$s</string>
+    <string name="settings_build_date_format">Build %1$s</string>
+    <string name="settings_version_value">v%1$s</string>
+
+    <!-- ===== Settings: sections ===== -->
+    <string name="settings_title">Configurações</string>
+    <string name="settings_section_operator_identity">IDENTIDADE DO OPERADOR</string>
+    <string name="settings_section_radio">RÁDIO</string>
+    <string name="settings_section_audio">ÁUDIO</string>
+    <string name="settings_section_transmission">TRANSMISSÃO</string>
+    <string name="settings_section_auto_sequence">AUTO-SEQUÊNCIA</string>
+    <string name="settings_section_decode_highlights">DESTAQUES DE DECODIFICAÇÃO</string>
+    <string name="settings_section_callsign_blocklist">BLOQUEIO DE INDICATIVOS</string>
+    <string name="settings_section_decode_filters">FILTROS DE DECODIFICAÇÃO</string>
+    <string name="settings_section_needed_dx_alerts">ALERTAS DE DX NECESSÁRIO</string>
+    <string name="settings_section_logging_awards">REGISTRO E PRÊMIOS</string>
+    <string name="settings_section_advanced">AVANÇADO</string>
+    <string name="settings_section_about">SOBRE</string>
+    <string name="settings_section_language">IDIOMA</string>
+    <string name="settings_section_appearance">APARÊNCIA</string>
+    <string name="settings_section_backup">BACKUP E RESTAURAÇÃO</string>
+    <string name="settings_section_fft_waterfall">FFT / CASCATA (DESENVOLVEDOR)</string>
+
+    <!-- ===== Settings: FFT / waterfall developer knobs (issue #428) ===== -->
+    <string name="settings_fft_window">Função de janela FFT</string>
+    <string name="settings_fft_window_desc">Janela pré-FFT para a exibição de espectro/cascata; Hann reduz o vazamento espectral</string>
+    <string name="settings_fft_window_rect">Retangular (nenhuma)</string>
+    <string name="settings_fft_window_hann">Hann</string>
+    <string name="settings_fft_window_hamming">Hamming</string>
+    <string name="settings_fft_window_blackman">Blackman</string>
+    <string name="settings_fft_window_blackman_harris">Blackman-Harris</string>
+    <string name="settings_fft_averaging">Média de quadros</string>
+    <string name="settings_fft_averaging_desc">Suaviza a exibição entre os quadros FFT; Desativado mostra cada quadro como está</string>
+    <string name="settings_fft_avg_off">Desativado</string>
+    <string name="settings_fft_avg_light">Leve (EMA 0.5)</string>
+    <string name="settings_fft_avg_heavy">Forte (EMA 0.25)</string>
+    <string name="settings_bin_agg">Combinação de bins do espectro</string>
+    <string name="settings_bin_agg_desc">Como os bins FFT adjacentes se combinam em uma barra do espectro</string>
+    <string name="settings_bin_agg_max">Máximo</string>
+    <string name="settings_bin_agg_avg">Média</string>
+    <string name="settings_bin_agg_rms">RMS</string>
+
+    <!-- ===== Settings: backup / restore (export & import config) ===== -->
+    <string name="settings_export">Exportar configurações</string>
+    <string name="settings_export_desc">Salvar todas as configurações em um arquivo de backup</string>
+    <string name="settings_import">Importar configurações</string>
+    <string name="settings_import_desc">Restaurar configurações a partir de um arquivo de backup</string>
+    <string name="settings_export_dialog_title">Exportar configurações</string>
+    <string name="settings_backup_include_sensitive">Incluir dados sensíveis</string>
+    <string name="settings_backup_include_sensitive_desc">Chaves de API e senhas (Cloudlog, QRZ, login do rig)</string>
+    <string name="action_export">Exportar</string>
+    <string name="action_import">Importar</string>
+    <string name="settings_import_confirm_title">Importar configurações?</string>
+    <string name="settings_import_confirm_msg">Isso substituirá %1$d configuração(ões) pelos valores do backup criado em %2$s.</string>
+    <string name="settings_export_success">Configurações exportadas</string>
+    <string name="settings_export_failed">Falha na exportação: %1$s</string>
+    <string name="settings_import_success">Configurações importadas — reinicie o app para aplicar todas as alterações</string>
+    <string name="settings_import_failed">Falha na importação: %1$s</string>
+
+    <!-- ===== Settings: appearance / theme ===== -->
+    <string name="settings_theme">Tema</string>
+    <string name="settings_theme_desc">Tema de cores do app</string>
+    <string name="theme_name_dark">Escuro</string>
+    <string name="theme_name_light">Claro</string>
+
+    <!-- ===== Settings: drill-down category labels ===== -->
+    <string name="settings_cat_radio_audio">Rádio e Áudio</string>
+    <string name="settings_cat_transmission">Transmissão</string>
+    <string name="settings_cat_decode_filters">Decodificação e Filtros</string>
+    <string name="settings_cat_logging">Registro e Prêmios</string>
+    <string name="settings_cat_advanced">Avançado</string>
+    <string name="settings_cat_about">Sobre</string>
+    <string name="settings_cat_time_sync">Sincronização de Hora</string>
+    <string name="settings_cat_time_sync_desc">Correção manual do relógio para operar offline</string>
+
+    <!-- ===== Settings: Time Sync (manual clock correction) ===== -->
+    <string name="settings_time_correction_section">Correção Manual</string>
+    <string name="settings_time_current_label">Correção atual</string>
+    <string name="settings_time_correction_reset">Redefinir para 0</string>
+    <string name="settings_time_correction_desc">Ajuste o relógio do app quando você não tiver internet para sincronizar. O FT8 precisa do UTC com precisão de cerca de 1 segundo. Ajuste até que a coluna DT das estações decodificadas fique próxima de 0.</string>
+    <string name="settings_time_suggest_section">Sugerido a partir das decodificações</string>
+    <string name="settings_time_suggest_none">Nenhuma decodificação ainda — comece a receber para obter uma sugestão.</string>
+    <string name="settings_time_suggest_label">Média recente de DT: %1$s</string>
+    <string name="settings_time_suggest_apply">Aplicar correção sugerida</string>
+    <string name="settings_time_correction_gps_locked">A disciplina de relógio por GPS está controlando o relógio — desative-a abaixo para ajustar manualmente.</string>
+
+    <!-- ===== Settings: Time Sync (GPS clock discipline, issue #373) ===== -->
+    <string name="settings_gps_clock_section">Disciplina de Relógio por GPS</string>
+    <string name="settings_gps_clock_toggle">Disciplinar relógio pelo GPS</string>
+    <string name="settings_gps_clock_toggle_desc">Usa a hora do satélite para alinhar o ciclo FT8 ao UTC verdadeiro. Substitui a correção manual enquanto ativado. Requer permissão de localização e um fix de GPS.</string>
+    <string name="settings_gps_clock_interval">Intervalo de atualização</string>
+    <string name="settings_gps_clock_interval_value">%1$d min</string>
+    <string name="settings_gps_clock_waiting">Aguardando um fix de GPS…</string>
+    <string name="settings_gps_clock_last_sync">Última sincronização GPS: %1$s UTC</string>
+    <string name="settings_gps_clock_offset">Offset aplicado: %1$s</string>
+
+    <!-- ===== Settings: operator identity ===== -->
+    <string name="settings_auto_update_grid">Atualizar Grade Automaticamente (GPS)</string>
+    <string name="settings_auto_update_grid_desc">Usa o GPS do dispositivo para manter sua grade Maidenhead atualizada</string>
+
+    <!-- ===== Settings: radio ===== -->
+    <string name="settings_rig_model">Modelo do Rig</string>
+    <string name="settings_control_mode">Modo de Controle</string>
+    <string name="settings_connection_mode">Modo de Conexão</string>
+    <string name="settings_baud_rate">Taxa de Baud</string>
+    <string name="settings_band_frequency">Banda e Frequência</string>
+    <string name="settings_enabled_bands">Bandas Ativadas</string>
+    <string name="settings_audio_frequency">Frequência de Áudio</string>
+    <string name="settings_spectrum_width">Largura do Espectro</string>
+
+    <!-- ===== Settings: audio ===== -->
+    <string name="settings_audio_input">Entrada de Áudio</string>
+    <string name="settings_audio_output">Saída de Áudio</string>
+    <string name="settings_tx_volume">Volume TX</string>
+    <string name="settings_tx_volume_desc" formatted="false">Nível de áudio de transmissão (botões físicos ±5%)</string>
+    <string name="settings_show_volume_slider">Mostrar Controle de Volume</string>
+    <string name="settings_show_volume_slider_desc">Exibir o controle de volume de TX na tela principal</string>
+    <string name="settings_per_band_volume">Salvar Nível de Saída por Banda</string>
+    <string name="settings_per_band_volume_desc">Memoriza o volume de TX separadamente para cada banda e o restaura ao trocar de banda</string>
+    <string name="per_band_volume_restored">Volume de TX %1$d%% restaurado para %2$s</string>
+
+    <!-- ===== Settings: transmission ===== -->
+    <string name="settings_tx_rx_split">Split TX/RX</string>
+    <string name="settings_tx_rx_split_desc">Transmitir em uma frequência diferente da de recepção</string>
+    <string name="settings_hold_tx_freq">Manter frequência de TX</string>
+    <string name="settings_hold_tx_freq_desc">Mantém seu offset de TX ao responder uma estação, em vez de movê-lo para o dela</string>
+    <string name="settings_clear_on_change">Limpar decodificações ao trocar de banda/modo</string>
+    <string name="settings_clear_on_change_desc">Limpa a lista de decodificação e redefine o alvo de TX para CQ ao trocar de banda ou modo</string>
+    <string name="settings_tx_watchdog">Watchdog de TX</string>
+    <string name="settings_tx_watchdog_desc">Interrompe a transmissão automaticamente após o tempo limite</string>
+    <string name="settings_stop_after">Parar Após</string>
+    <string name="settings_stop_after_desc">Para de chamar após N tentativas sem resposta</string>
+
+    <!-- ===== Settings: auto-sequence ===== -->
+    <string name="settings_hunt">Caça (responder CQ automaticamente)</string>
+    <string name="settings_hunt_desc">Chama proativamente estações que estão chamando CQ. Igual ao botão HUNT na barra de TX. Desativado = chama CQ e trabalha apenas as estações que responderem.</string>
+    <string name="settings_hunt_cq">Caça + CQ</string>
+    <string name="settings_hunt_cq_desc">Chama CQ quando a Caça está ociosa (nenhuma estação ouvida). Quando um CQ é detectado, para automaticamente o CQ e responde.</string>
+    <string name="settings_auto_call_followed">Chamar Seguidos Automaticamente</string>
+    <string name="settings_auto_call_followed_desc">Continua chamando automaticamente os indicativos seguidos</string>
+    <string name="settings_fast_turnaround">Resposta rápida</string>
+    <string name="settings_fast_turnaround_desc">Decodifica ~1s mais cedo para que você possa responder a um CQ no próximo slot em vez de esperar. Pode perder estações com grande desvio de relógio.</string>
+    <string name="settings_auto_cq_after_qso">Auto-CQ após o QSO</string>
+    <string name="settings_auto_cq_after_qso_desc">Continua chamando CQ automaticamente após cada contato concluído — sem precisar tocar novamente. Permanece na sua frequência (ignora a Caça). Funciona até você parar ou o Watchdog de TX expirar sem respostas.</string>
+
+    <!-- ===== Settings: decode highlights ===== -->
+    <string name="settings_highlight_new_dxcc">Novo DXCC</string>
+    <string name="settings_highlight_new_dxcc_desc">Destaca estações de uma entidade DXCC não contatada</string>
+    <string name="settings_highlight_new_grid">Nova Grade</string>
+    <string name="settings_highlight_new_grid_desc">Destaca grades Maidenhead ainda não contatadas</string>
+    <string name="settings_highlight_new_band">Nova Banda</string>
+    <string name="settings_highlight_new_band_desc">Destaca estações contatadas apenas em outras bandas</string>
+    <string name="settings_highlight_pota">Ativadores POTA</string>
+    <string name="settings_highlight_pota_desc">Destaca ativadores POTA reportados; novos parques se destacam</string>
+    <string name="settings_highlight_worked">Já Contatado</string>
+    <string name="settings_highlight_worked_desc">Marca estações que já estão no seu registro</string>
+    <string name="settings_distance_unit">Distância em Milhas</string>
+    <string name="settings_distance_unit_desc">Mostra distâncias em milhas em vez de quilômetros</string>
+
+    <!-- ===== Settings: callsign blocklist ===== -->
+    <string name="settings_exact_callsigns">Indicativos Exatos</string>
+    <string name="settings_exact_callsigns_desc">Bloqueia correspondências de indicativo completo</string>
+    <string name="settings_prefixes">Prefixos</string>
+    <string name="settings_prefixes_desc">Bloqueia por prefixo de indicativo (ex.: RA)</string>
+    <string name="settings_keywords">Palavras-chave</string>
+    <string name="settings_keywords_desc">Bloqueia por substring no indicativo ou na mensagem (ex.: POTA, /P)</string>
+
+    <!-- ===== Settings: decode filters ===== -->
+    <string name="settings_show_only_cq">Mostrar Apenas CQ</string>
+    <string name="settings_show_only_cq_desc">Oculta tudo, exceto mensagens do tipo CQ</string>
+    <string name="settings_dx_only">Apenas DX</string>
+    <string name="settings_dx_only_desc">Mostra apenas estações fora do seu próprio continente</string>
+    <string name="settings_needed_only">Apenas Necessários</string>
+    <string name="settings_needed_only_desc">Mostra apenas estações ainda não confirmadas (QSL)</string>
+    <string name="settings_filter_by_continent">Filtrar Por Continente</string>
+    <string name="settings_filter_by_continent_desc">Mostra apenas estações de um continente escolhido</string>
+    <string name="settings_continent">Continente</string>
+    <string name="settings_skip_directional_cq">Ignorar CQs Direcionais (resposta automática)</string>
+    <string name="settings_skip_directional_cq_desc">Não responde automaticamente a CQ DX/EU/JA… direcionados a outro DXCC</string>
+    <string name="settings_hide_directional_cq">Ocultar CQs Direcionais Que Não São Para Mim</string>
+    <string name="settings_hide_directional_cq_desc">Oculta CQs direcionados a uma região que não visam seu DXCC</string>
+
+    <!-- ===== Settings: needed-DX alerts ===== -->
+    <string name="settings_alert_new_dxcc">Novo DXCC</string>
+    <string name="settings_alert_new_dxcc_desc">Som + vibração + notificação quando uma entidade DXCC não contatada chamar CQ</string>
+    <string name="settings_alert_new_state">Novo Estado dos EUA</string>
+    <string name="settings_alert_new_state_desc">Som + vibração + notificação quando uma estação de um estado dos EUA não contatado chamar CQ (estado obtido da grade)</string>
+    <string name="settings_alert_cq_reply">Resposta a CQ</string>
+    <string name="settings_alert_cq_reply_desc">Som + vibração + notificação quando uma estação te chamar (qualquer mensagem endereçada ao seu indicativo)</string>
+    <string name="settings_alert_qso_complete">QSO concluído</string>
+    <string name="settings_alert_qso_complete_desc">Som + vibração + notificação quando um QSO for registrado</string>
+    <string name="alert_cq_reply_title">Chamando você: %1$s</string>
+    <string name="alert_qso_complete_title">QSO concluído</string>
+    <string name="rx_service_channel_name">Recepção em segundo plano</string>
+    <string name="rx_service_channel_desc">Mantém a decodificação FT8 em execução enquanto o app está em segundo plano ou a tela está desligada</string>
+    <string name="rx_service_title">O FT8AF está recebendo</string>
+    <string name="rx_service_text">Decodificando em segundo plano</string>
+
+    <!-- ===== Settings: logging &amp; awards ===== -->
+    <string name="settings_save_swl_decodes">Salvar Decodificações SWL</string>
+    <string name="settings_save_swl_decodes_desc">Registra todas as mensagens decodificadas no banco de dados</string>
+    <string name="settings_save_swl_qsos">Salvar QSOs SWL</string>
+    <string name="settings_save_swl_qsos_desc">Registra QSOs detectados entre outras estações</string>
+    <string name="settings_pskreporter">PSKReporter</string>
+    <string name="settings_pskreporter_desc">Envia spots decodificados para pskreporter.info</string>
+    <string name="settings_qrz_com">QRZ.com</string>
+    <string name="settings_qrz_com_desc">Envia QSOs automaticamente para o QRZ Logbook (requer uma chave de API do Logbook)</string>
+    <string name="settings_qrz_logbook">QRZ Logbook</string>
+    <string name="settings_qrz_logbook_desc">Chave de API do Logbook, obtida em QRZ Logbook → Settings (não é a senha da sua conta).</string>
+    <string name="settings_qrz_api_key_hint">Sua chave de API do QRZ Logbook</string>
+    <string name="settings_qrz_profile_lookup">Consulta de Perfil QRZ</string>
+    <string name="settings_qrz_profile_lookup_desc">Usuário + senha para a API XML do QRZ (avatares)</string>
+    <string name="settings_cloudlog">Cloudlog / Wavelog / Nextlog</string>
+    <string name="settings_cloudlog_desc">Envia QSOs automaticamente para uma instância do Cloudlog, Wavelog ou Nextlog</string>
+
+    <!-- ===== Settings: advanced ===== -->
+    <string name="settings_ptt_delay">Atraso de PTT</string>
+    <string name="settings_ptt_delay_desc">Atraso após o PTT antes de o áudio de transmissão começar</string>
+    <string name="settings_tx_delay">Atraso de TX</string>
+    <string name="settings_tx_delay_desc">Atraso antes de transmitir para permitir a decodificação do ciclo anterior</string>
+    <string name="settings_late_start_tolerance">Tolerância de Início Tardio</string>
+    <string name="settings_late_start_tolerance_desc">Permite iniciar o TX até N ms após o início de um ciclo; o áudio inicial é cortado para que o TX termine no limite do ciclo</string>
+
+    <!-- ===== Settings: about ===== -->
+    <string name="settings_faq_support">Perguntas Frequentes e Suporte</string>
+    <string name="settings_report_bug">Reportar um Bug</string>
+    <string name="bug_report_description_hint">Descreva o que deu errado…</string>
+    <string name="bug_report_send_email">Enviar e-mail</string>
+    <string name="bug_report_no_email_app">Nenhum app de e-mail encontrado para enviar o relatório</string>
+    <string name="bug_report_open_github">Abrir issue no GitHub</string>
+    <string name="settings_debug">Depuração</string>
+    <string name="settings_debug_desc">Ver / compartilhar debug.log</string>
+    <string name="settings_about_body">Versão %1$s (build %2$s)\nData do build %3$s\n\nFT8, feito fácil.\n\nUm aplicativo de transceptor FT8 independente para Android. Controle de rig via USB, Bluetooth e rede, com sequenciamento e registro automáticos.</string>
+    <string name="settings_website">Site</string>
+    <string name="settings_community">Comunidade</string>
+    <string name="settings_built_by">Desenvolvido por</string>
+    <string name="about_font_attribution">Fonte da interface: Inter, de Rasmus Andersson (SIL OFL 1.1)</string>
+
+    <!-- ===== Settings: dialogs ===== -->
+    <string name="settings_block_exact_title">Bloquear Indicativos Exatos</string>
+    <string name="settings_block_exact_desc">Correspondência de indicativo completo. Separados por vírgula ou espaço, ex.: W1AW, K1ABC.</string>
+    <string name="settings_block_prefix_title">Bloquear Prefixos de Indicativo</string>
+    <string name="settings_block_prefix_desc">Correspondência de prefixo, ex.: RA bloqueia RA0AA..RA9ZZ. Separados por vírgula ou espaço.</string>
+    <string name="settings_block_keyword_title">Bloquear Palavras-chave</string>
+    <string name="settings_block_keyword_desc">Correspondência de substring no indicativo e no texto da mensagem, ex.: POTA, /P, QRP.</string>
+    <string name="settings_blocklist_hint">ex.: W1AW, RA, /P</string>
+    <string name="settings_filter_continent_title">Filtrar Continente</string>
+    <string name="settings_conn_usb_cable">Cabo USB</string>
+    <string name="settings_conn_bluetooth">Bluetooth</string>
+    <string name="settings_conn_network">Rede</string>
+    <string name="settings_no_usb_serial">Nenhum dispositivo serial USB detectado. Conecte um cabo USB ao seu rádio e tente novamente.</string>
+    <string name="settings_no_bluetooth_devices">Nenhum dispositivo Bluetooth pareado encontrado. Pareie um dispositivo nas configurações de Bluetooth do Android primeiro.</string>
+    <string name="settings_debug_mode_enabled">Modo de depuração ativado</string>
+    <string name="settings_debug_mode_disabled">Modo de depuração desativado</string>
+    <string name="settings_edit_operator_identity">Editar Identidade do Operador</string>
+    <string name="settings_callsign">Indicativo</string>
+    <string name="settings_callsign_hint">ex.: W1AW</string>
+    <string name="settings_grid_locator">Locator de Grade</string>
+    <string name="settings_grid_locator_hint">ex.: FN31pr</string>
+    <string name="settings_logging_server">Servidor de Registro</string>
+    <string name="settings_logging_server_desc">Cloudlog, Wavelog e Nextlog aceitam os mesmos envios.</string>
+    <string name="settings_server_address">Endereço do Servidor</string>
+    <string name="settings_api_key">Chave de API</string>
+    <string name="settings_api_key_hint">Sua chave de API do Cloudlog</string>
+    <string name="settings_loading_stations">Carregando estações...</string>
+    <string name="settings_station_id">ID da Estação</string>
+    <string name="settings_station_id_hint">ex.: 1</string>
+    <string name="settings_select_a_station">Selecione uma estação</string>
+    <string name="settings_enter_manually">Inserir manualmente</string>
+    <string name="settings_choose_from_server">Escolher do servidor</string>
+    <string name="settings_station_profile">Perfil da Estação</string>
+    <string name="settings_qrz_creds_desc">Usado para buscar fotos de perfil dos indicativos decodificados através da API XML do QRZ. Requer uma assinatura QRZ XML.</string>
+    <string name="settings_username">Usuário</string>
+    <string name="settings_username_hint">Seu nome de usuário no QRZ.com</string>
+    <string name="settings_password">Senha</string>
+    <string name="settings_enabled_bands_dialog_desc">Bandas ocultas não aparecerão nos seletores de frequência.</string>
+    <string name="settings_select_serial_port">Selecionar Porta Serial</string>
+    <string name="settings_tx_volume_advice">Ajuste ao vivo — seu próximo TX usará este nível. Observe o ALC do seu rádio e reduza até que ele quase não toque a linha.</string>
+    <string name="settings_input_volume">Volume de Entrada</string>
+    <string name="settings_input_volume_desc" formatted="false">Ganho de áudio RX aplicado antes da decodificação (100% = sem alteração)</string>
+    <string name="settings_input_volume_advice">Aplicado ao áudio recebido antes da decodificação. Observe o medidor de nível RX na cascata e busque a zona verde; vermelho indica corte.</string>
+    <string name="input_level_too_low">Baixo</string>
+    <string name="input_level_good">Bom</string>
+    <string name="input_level_too_high">Alto</string>
+    <string name="input_level_clipping">Corte</string>
+
+    <!-- ===== Settings: language picker ===== -->
+    <string name="settings_language">Idioma</string>
+    <string name="settings_language_desc">Idioma de exibição do app</string>
+    <string name="settings_language_system">Padrão do sistema</string>
+
+    <string name="tx_audio_dropped">Falha no áudio de TX — nenhum sinal foi enviado neste ciclo (erro de áudio USB)</string>
+    <string name="cq_offset_moved">Offset de CQ movido para um espaço livre: %1$d Hz</string>
+    <string name="settings_auto_clear_tx">Limpar offset de TX automaticamente</string>
+    <string name="settings_auto_clear_tx_desc">Ao chamar CQ, escolhe um espaço livre com base na atividade recente da banda e se afasta se ele ficar ocupado</string>
+    <string name="tune_content_description">Tune — inicia o sintonizador do rig ou transmite uma portadora contínua para sintonia de antena</string>
+    <string name="tune_stopped_timeout">Tune interrompido após %1$d s</string>
+    <string name="tune_blocked_tx">Pare o CQ/QSO antes de sintonizar</string>
+    <string name="tune_unavailable_route">Tune ainda não é suportado nesta rota de áudio</string>
+    <string name="tune_atu_started">Sintonizador de antena do rig iniciado</string>
+    <string name="tune_atu_unavailable">Sintonizador do rig indisponível — conecte um rádio CAT com sintonizador interno</string>
+    <string name="settings_tune_method">Método de sintonia</string>
+    <string name="settings_tune_method_desc">Automático inicia o sintonizador interno do rig via CAT quando disponível; caso contrário, reproduz o tom de baixa potência</string>
+    <string name="tune_method_automatic">Automático</string>
+    <string name="tune_method_internal">Sintonizador interno</string>
+    <string name="tune_method_tone">Tom de baixa potência</string>
+
+    <!-- Android Auto status screens (read-only). Headlines reuse the qsopanel_* strings. -->
+    <string name="car_open_phone">Abra o FT8AF no seu celular para iniciar o motor FT8</string>
+    <string name="car_monitoring">Monitorando — TX desligado</string>
+    <string name="car_no_tx">Nenhuma transmissão na fila</string>
+    <string name="car_seq_step">Etapa %1$s (%2$d/%3$d)</string>
+    <string name="car_slot_tx">Slot de TX · %1$d s</string>
+    <string name="car_slot_rx">Slot de RX · %1$d s</string>
+    <string name="car_decodes_action">Decodificações</string>
+    <string name="car_decodes_title">Decodificações recentes</string>
+    <string name="car_no_decodes">Nenhuma decodificação ainda</string>
+    <string name="car_pota_line">POTA %1$s · %2$d QSOs</string>
+</resources>

--- a/ft8af/app/src/main/res/values-pt-rBR/strings_compose.xml
+++ b/ft8af/app/src/main/res/values-pt-rBR/strings_compose.xml
@@ -456,7 +456,7 @@
     <string name="settings_ntp_clock_toggle">Disciplinar relógio por NTP</string>
     <string name="settings_ntp_clock_toggle_desc">Sincroniza periodicamente com um servidor de hora de rede para alinhar o ciclo FT8 ao UTC verdadeiro. Substitui a correção manual enquanto ativado. Requer acesso à internet.</string>
     <string name="settings_ntp_clock_server_label">Servidor NTP</string>
-    <string name="settings_ntp_clock_server_hint">ex.: a.ntp.br</string>
+    <string name="settings_ntp_clock_server_hint">ex.: pool.ntp.org</string>
     <string name="settings_ntp_clock_waiting">Aguardando a primeira sincronização NTP…</string>
     <string name="settings_ntp_clock_last_sync">Última sincronização NTP: %1$s UTC</string>
     <string name="settings_ntp_clock_offset">Offset aplicado: %1$s</string>
@@ -676,12 +676,10 @@
     <!-- Android Auto status screens (read-only). Headlines reuse the qsopanel_* strings. -->
     <string name="car_open_phone">Abra o FT8AF no seu celular para iniciar o motor FT8</string>
     <string name="car_monitoring">Monitorando — TX desligado</string>
-    <string name="car_no_tx">Nenhuma transmissão na fila</string>
     <string name="car_seq_step">Etapa %1$s (%2$d/%3$d)</string>
     <string name="car_slot_tx">Slot de TX · %1$d s</string>
     <string name="car_slot_rx">Slot de RX · %1$d s</string>
     <string name="car_decodes_action">Decodificações</string>
     <string name="car_decodes_title">Decodificações recentes</string>
     <string name="car_no_decodes">Nenhuma decodificação ainda</string>
-    <string name="car_pota_line">POTA %1$s · %2$d QSOs</string>
 </resources>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -600,7 +600,7 @@
     <string name="settings_ntp_clock_toggle">Discipline clock from NTP</string>
     <string name="settings_ntp_clock_toggle_desc">Periodically sync from a network time server to align the FT8 cycle to true UTC. Overrides the manual correction while on. Needs internet access.</string>
     <string name="settings_ntp_clock_server_label">NTP server</string>
-    <string name="settings_ntp_clock_server_hint">e.g. a.ntp.br</string>
+    <string name="settings_ntp_clock_server_hint">e.g. pool.ntp.org</string>
     <string name="settings_ntp_clock_waiting">Waiting for the first NTP sync…</string>
     <string name="settings_ntp_clock_last_sync">Last NTP sync: %1$s UTC</string>
     <string name="settings_ntp_clock_offset">Applied offset: %1$s</string>
@@ -879,6 +879,7 @@
     <string name="clock_sync_cd_auto">Clock sync: average decode offset %1$s, %2$s, %3$s</string>
     <string name="clock_sync_badge_auto" translatable="false">AUTO</string>
     <string name="clock_sync_badge_gps" translatable="false">GPS</string>
+    <string name="clock_sync_badge_ntp" translatable="false">NTP</string>
 
     <!-- ===== Settings: language picker ===== -->
     <string name="settings_language">Language</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -583,7 +583,7 @@
     <!-- ===== Settings: Time Sync (self-syncing clock from decodes) ===== -->
     <string name="settings_selfsync_section">Self-Syncing Clock</string>
     <string name="settings_selfsync_toggle">Auto-sync clock from decodes</string>
-    <string name="settings_selfsync_toggle_desc">On by default. Keeps the clock locked to the stations you hear — the band itself is the time source, no internet or GPS needed. A clock that is clearly off is fixed from the first busy slot; small drift is trimmed gently. Unavailable while GPS clock discipline is on.</string>
+    <string name="settings_selfsync_toggle_desc">On by default. Keeps the clock locked to the stations you hear — the band itself is the time source, no internet or GPS needed. A clock that is clearly off is fixed from the first busy slot; small drift is trimmed gently. Unavailable while GPS or NTP clock discipline is on.</string>
 
     <!-- ===== Settings: Time Sync (GPS clock discipline, issue #373) ===== -->
     <string name="settings_gps_clock_section">GPS Clock Discipline</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -890,6 +890,7 @@
     <string name="language_name_id" translatable="false">Bahasa Indonesia</string>
     <string name="language_name_uk" translatable="false">Українська</string>
     <string name="language_name_ar" translatable="false">العربية</string>
+    <string name="language_name_pt_br" translatable="false">Português (Brasil)</string>
 
     <string name="tx_audio_dropped">TX audio failed — no signal was sent this cycle (USB audio error)</string>
     <string name="cq_offset_moved">CQ offset moved to a clear spot: %1$d Hz</string>

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -578,6 +578,7 @@
     <string name="settings_time_suggest_auto_waiting">Waiting for agreeing decodes before the first auto-correction…</string>
     <string name="settings_time_suggest_auto_last">Last auto-correction: %1$s at %2$s</string>
     <string name="settings_time_correction_gps_locked">GPS clock discipline is controlling the clock — turn it off below to adjust manually.</string>
+    <string name="settings_time_correction_ntp_locked">NTP clock discipline is controlling the clock — turn it off below to adjust manually.</string>
 
     <!-- ===== Settings: Time Sync (self-syncing clock from decodes) ===== -->
     <string name="settings_selfsync_section">Self-Syncing Clock</string>
@@ -593,6 +594,17 @@
     <string name="settings_gps_clock_waiting">Waiting for a GPS fix…</string>
     <string name="settings_gps_clock_last_sync">Last GPS sync: %1$s UTC</string>
     <string name="settings_gps_clock_offset">Applied offset: %1$s</string>
+
+    <!-- ===== Settings: Time Sync (NTP clock discipline) ===== -->
+    <string name="settings_ntp_clock_section">NTP Clock Discipline</string>
+    <string name="settings_ntp_clock_toggle">Discipline clock from NTP</string>
+    <string name="settings_ntp_clock_toggle_desc">Periodically sync from a network time server to align the FT8 cycle to true UTC. Overrides the manual correction while on. Needs internet access.</string>
+    <string name="settings_ntp_clock_server_label">NTP server</string>
+    <string name="settings_ntp_clock_server_hint">e.g. a.ntp.br</string>
+    <string name="settings_ntp_clock_waiting">Waiting for the first NTP sync…</string>
+    <string name="settings_ntp_clock_last_sync">Last NTP sync: %1$s UTC</string>
+    <string name="settings_ntp_clock_offset">Applied offset: %1$s</string>
+    <string name="settings_ntp_clock_sync_failed">Last sync attempt failed — retrying…</string>
 
     <!-- ===== Settings: operator identity ===== -->
     <string name="settings_auto_update_grid">Auto-update Grid (GPS)</string>

--- a/ft8af/app/src/main/res/xml/locales_config.xml
+++ b/ft8af/app/src/main/res/xml/locales_config.xml
@@ -22,4 +22,5 @@
     <locale android:name="id" />
     <locale android:name="uk" />
     <locale android:name="ar" />
+    <locale android:name="pt-BR" />
 </locale-config>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/timer/ClockSelfSyncTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/timer/ClockSelfSyncTest.java
@@ -23,6 +23,26 @@ import java.util.Arrays;
  */
 public class ClockSelfSyncTest {
 
+    // ---- mayRun: the decode-time gate shared with the settings lock-out ----
+
+    @Test
+    public void mayRun_onlyWhenEnabledAndNothingAuthoritativeOwnsTheClock() {
+        assertThat(ClockSelfSync.mayRun(true, false, false)).isTrue();
+        assertThat(ClockSelfSync.mayRun(false, false, false)).isFalse();
+    }
+
+    @Test
+    public void mayRun_standsDownForGpsDiscipline() {
+        assertThat(ClockSelfSync.mayRun(true, true, false)).isFalse();
+    }
+
+    @Test
+    public void mayRun_standsDownForNtpDiscipline() {
+        // NTP rewrites UtcTimer.delay on its own schedule; a second writer would fight it.
+        assertThat(ClockSelfSync.mayRun(true, false, true)).isFalse();
+        assertThat(ClockSelfSync.mayRun(true, true, true)).isFalse();
+    }
+
     /** A slot of {@code n} identical DTs (survives rejection unchanged). */
     private static float[] slot(float dtSec, int n) {
         float[] a = new float[n];

--- a/ft8af/app/src/test/java/com/k1af/ft8af/timer/NtpClockUpdaterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/timer/NtpClockUpdaterTest.java
@@ -1,0 +1,207 @@
+package com.k1af.ft8af.timer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.k1af.ft8af.GeneralVariables;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Covers the pure offset/should-apply/interval logic in {@link NtpClockUpdater} — the NTP
+ * counterpart to {@code GpsClockUpdaterTest} — plus the toggle/lifecycle gating. Robolectric
+ * is used so the Android-typed class (Handler/Looper) links cleanly; the arithmetic under
+ * test never touches a real network, and the lifecycle tests never idle the main looper, so
+ * no real NTP sync ever fires.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class NtpClockUpdaterTest {
+
+    // ---- ntpClockOffsetMs: offset to add to System.currentTimeMillis() ----
+
+    @Test
+    public void offset_isPositive_whenDeviceClockIsSlow() {
+        // Server time 2000ms ahead of the device clock => +2000 to catch up.
+        int offset = NtpClockUpdater.ntpClockOffsetMs(10_000L, 8_000L);
+        assertThat(offset).isEqualTo(2_000);
+    }
+
+    @Test
+    public void offset_isNegative_whenDeviceClockIsFast() {
+        int offset = NtpClockUpdater.ntpClockOffsetMs(10_000L, 12_500L);
+        assertThat(offset).isEqualTo(-2_500);
+    }
+
+    @Test
+    public void offset_zeroWhenClocksMatch() {
+        assertThat(NtpClockUpdater.ntpClockOffsetMs(10_000L, 10_000L)).isEqualTo(0);
+    }
+
+    // ---- isOffsetSane: reject bad/implausible replies ----
+
+    @Test
+    public void sane_acceptsRealisticOffset() {
+        assertThat(NtpClockUpdater.isOffsetSane(1_700_000_000_000L, 2_500)).isTrue();
+        assertThat(NtpClockUpdater.isOffsetSane(1_700_000_000_000L, -30_000)).isTrue();
+    }
+
+    @Test
+    public void sane_rejectsZeroTransmitTime() {
+        // A transmit timestamp of 0 means "no time in this reply" — never trust it.
+        assertThat(NtpClockUpdater.isOffsetSane(0L, 500)).isFalse();
+    }
+
+    @Test
+    public void sane_rejectsAbsurdOffset() {
+        // Beyond an hour: corrupt/spoofed reply or a badly misconfigured server.
+        int tooBig = (int) (NtpClockUpdater.MAX_SANE_OFFSET_MS + 1);
+        assertThat(NtpClockUpdater.isOffsetSane(1_700_000_000_000L, tooBig)).isFalse();
+        assertThat(NtpClockUpdater.isOffsetSane(1_700_000_000_000L, -tooBig)).isFalse();
+    }
+
+    @Test
+    public void sane_acceptsExactlyAtBound() {
+        int atBound = (int) NtpClockUpdater.MAX_SANE_OFFSET_MS;
+        assertThat(NtpClockUpdater.isOffsetSane(1_700_000_000_000L, atBound)).isTrue();
+    }
+
+    // ---- clampIntervalMinutes ----
+
+    @Test
+    public void interval_clampsBelowMin() {
+        assertThat(NtpClockUpdater.clampIntervalMinutes(0)).isEqualTo(NtpClockUpdater.MIN_INTERVAL_MINUTES);
+        assertThat(NtpClockUpdater.clampIntervalMinutes(-5)).isEqualTo(NtpClockUpdater.MIN_INTERVAL_MINUTES);
+    }
+
+    @Test
+    public void interval_clampsAboveMax() {
+        assertThat(NtpClockUpdater.clampIntervalMinutes(1000)).isEqualTo(NtpClockUpdater.MAX_INTERVAL_MINUTES);
+    }
+
+    @Test
+    public void interval_passesThroughInRange() {
+        assertThat(NtpClockUpdater.clampIntervalMinutes(5)).isEqualTo(5);
+        assertThat(NtpClockUpdater.clampIntervalMinutes(1)).isEqualTo(1);
+        assertThat(NtpClockUpdater.clampIntervalMinutes(30)).isEqualTo(30);
+    }
+
+    // ---- parseIntervalMinutes (shared with DatabaseOpr config load) ----
+
+    @Test
+    public void parseInterval_nullOrBlankOrGarbage_fallsBackToDefault() {
+        assertThat(NtpClockUpdater.parseIntervalMinutes(null)).isEqualTo(NtpClockUpdater.DEFAULT_INTERVAL_MINUTES);
+        assertThat(NtpClockUpdater.parseIntervalMinutes("")).isEqualTo(NtpClockUpdater.DEFAULT_INTERVAL_MINUTES);
+        assertThat(NtpClockUpdater.parseIntervalMinutes("abc")).isEqualTo(NtpClockUpdater.DEFAULT_INTERVAL_MINUTES);
+    }
+
+    @Test
+    public void parseInterval_parsesAndClamps() {
+        assertThat(NtpClockUpdater.parseIntervalMinutes(" 10 ")).isEqualTo(10);
+        assertThat(NtpClockUpdater.parseIntervalMinutes("0")).isEqualTo(NtpClockUpdater.MIN_INTERVAL_MINUTES);
+        assertThat(NtpClockUpdater.parseIntervalMinutes("999")).isEqualTo(NtpClockUpdater.MAX_INTERVAL_MINUTES);
+    }
+
+    // ---- shouldReschedule (start()'s re-tune / no-op decision) ----
+
+    @Test
+    public void reschedule_whenNotRunning() {
+        assertThat(NtpClockUpdater.shouldReschedule(false, -1, 300_000L)).isTrue();
+    }
+
+    @Test
+    public void reschedule_falseWhenAlreadyAtRequestedCadence() {
+        assertThat(NtpClockUpdater.shouldReschedule(true, 300_000L, 300_000L)).isFalse();
+    }
+
+    @Test
+    public void reschedule_trueWhenCadenceChanges() {
+        assertThat(NtpClockUpdater.shouldReschedule(true, 300_000L, 60_000L)).isTrue();
+    }
+
+    // ---- computeAppliedOffset (applySyncResult guard: not-running / insane are dropped) ----
+
+    @Test
+    public void appliedOffset_nullWhenNotRunning() {
+        // A reply that raced past a disable must not touch the clock.
+        Integer r = NtpClockUpdater.computeAppliedOffset(false, 1_700_000_010_000L, 1_700_000_008_000L);
+        assertThat(r).isNull();
+    }
+
+    @Test
+    public void appliedOffset_nullWhenInsane() {
+        // serverTransmitMs==0 (no time in the reply) is rejected even while running.
+        Integer r = NtpClockUpdater.computeAppliedOffset(true, 0L, 1_700_000_008_000L);
+        assertThat(r).isNull();
+    }
+
+    @Test
+    public void appliedOffset_returnsOffsetWhenRunningAndSane() {
+        Integer r = NtpClockUpdater.computeAppliedOffset(true, 1_700_000_010_000L, 1_700_000_008_000L);
+        assertThat(r).isEqualTo(2_000);
+    }
+
+    // ---- disciplinedUtcMs (last-sync timestamp shown as UTC in settings) ----
+
+    @Test
+    public void disciplinedUtc_shiftsSlowClockForward() {
+        assertThat(NtpClockUpdater.disciplinedUtcMs(8_000L, 2_000)).isEqualTo(10_000L);
+    }
+
+    @Test
+    public void disciplinedUtc_shiftsFastClockBack() {
+        assertThat(NtpClockUpdater.disciplinedUtcMs(10_000L, -1_500)).isEqualTo(8_500L);
+    }
+
+    // ---- Lifecycle wiring: toggle gating, without ever touching the network ----
+
+    @Test
+    public void refresh_toggleOff_leavesDisciplineStopped() {
+        Context ctx = ApplicationProvider.getApplicationContext();
+        GeneralVariables.disciplineClockFromNtp = false;
+        NtpClockUpdater.refresh(ctx);
+        assertThat(NtpClockUpdater.getInstance(ctx).isRunning()).isFalse();
+    }
+
+    @Test
+    public void refresh_toggleOn_startsWithoutBlockingOnNetwork() {
+        // The first sync is posted to the main Handler (not run inline), and this test never
+        // idles the Robolectric main looper, so refresh() must return with the updater marked
+        // running but UtcTimer.delay untouched — no real sync has actually fired yet.
+        Context ctx = ApplicationProvider.getApplicationContext();
+        int delayBefore = UtcTimer.delay;
+        GeneralVariables.disciplineClockFromNtp = true;
+        try {
+            NtpClockUpdater.refresh(ctx);
+            assertThat(NtpClockUpdater.getInstance(ctx).isRunning()).isTrue();
+            assertThat(UtcTimer.delay).isEqualTo(delayBefore);
+        } finally {
+            GeneralVariables.disciplineClockFromNtp = false;
+            NtpClockUpdater.refresh(ctx);
+        }
+    }
+
+    @Test
+    public void refresh_toggleOffAfterOn_restoresPreNtpBaseline() {
+        Context ctx = ApplicationProvider.getApplicationContext();
+        int originalDelay = 1234;
+        UtcTimer.delay = originalDelay;
+        try {
+            GeneralVariables.disciplineClockFromNtp = true;
+            NtpClockUpdater.refresh(ctx); // captures originalDelay as the pre-NTP baseline
+            assertThat(NtpClockUpdater.getInstance(ctx).isRunning()).isTrue();
+
+            GeneralVariables.disciplineClockFromNtp = false;
+            NtpClockUpdater.refresh(ctx); // no sync ever ran (looper never idled), so this
+            // must restore the captured baseline, not just leave delay untouched by chance.
+            assertThat(NtpClockUpdater.getInstance(ctx).isRunning()).isFalse();
+            assertThat(UtcTimer.delay).isEqualTo(originalDelay);
+        } finally {
+            UtcTimer.delay = 0;
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/timer/NtpClockUpdaterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/timer/NtpClockUpdaterTest.java
@@ -1,8 +1,10 @@
 package com.k1af.ft8af.timer;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
+import android.os.Looper;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -202,6 +204,58 @@ public class NtpClockUpdaterTest {
             assertThat(UtcTimer.delay).isEqualTo(originalDelay);
         } finally {
             UtcTimer.delay = 0;
+        }
+    }
+
+    // ---- applySyncResult: UI failure-flag wiring for a rejected-while-running reply ----
+
+    @Test
+    public void applySyncResult_rejectedWhileRunning_marksSyncFailed() {
+        // A reply with no usable transmit timestamp is rejected by computeAppliedOffset even
+        // while running; the Time Sync screen must still be told the attempt failed, or it's
+        // left showing stale/"Waiting..." status forever despite sync attempts being rejected.
+        Context ctx = ApplicationProvider.getApplicationContext();
+        GeneralVariables.disciplineClockFromNtp = true;
+        NtpClockUpdater.refresh(ctx);
+        try {
+            GeneralVariables.mutableNtpClockSyncFailed.setValue(false);
+            NtpClockUpdater.getInstance(ctx).applySyncResult(0L);
+            shadowOf(Looper.getMainLooper()).idle();
+            assertThat(GeneralVariables.mutableNtpClockSyncFailed.getValue()).isTrue();
+        } finally {
+            GeneralVariables.disciplineClockFromNtp = false;
+            NtpClockUpdater.refresh(ctx);
+        }
+    }
+
+    @Test
+    public void applySyncResult_rejectedWhileNotRunning_leavesSyncFailedUntouched() {
+        // A reply that races past a disable is silently dropped — it must not report a
+        // failure the UI has no running sync to attribute it to.
+        Context ctx = ApplicationProvider.getApplicationContext();
+        GeneralVariables.disciplineClockFromNtp = false;
+        NtpClockUpdater.refresh(ctx);
+        GeneralVariables.mutableNtpClockSyncFailed.setValue(false);
+
+        NtpClockUpdater.getInstance(ctx).applySyncResult(0L);
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertThat(GeneralVariables.mutableNtpClockSyncFailed.getValue()).isFalse();
+    }
+
+    @Test
+    public void applySyncResult_acceptedWhileRunning_clearsSyncFailed() {
+        Context ctx = ApplicationProvider.getApplicationContext();
+        GeneralVariables.disciplineClockFromNtp = true;
+        NtpClockUpdater.refresh(ctx);
+        try {
+            GeneralVariables.mutableNtpClockSyncFailed.setValue(true);
+            NtpClockUpdater.getInstance(ctx).applySyncResult(System.currentTimeMillis());
+            shadowOf(Looper.getMainLooper()).idle();
+            assertThat(GeneralVariables.mutableNtpClockSyncFailed.getValue()).isFalse();
+        } finally {
+            GeneralVariables.disciplineClockFromNtp = false;
+            NtpClockUpdater.refresh(ctx);
         }
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/timer/NtpClockUpdaterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/timer/NtpClockUpdaterTest.java
@@ -10,6 +10,10 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.k1af.ft8af.GeneralVariables;
 
+import org.apache.commons.net.ntp.NtpV3Impl;
+import org.apache.commons.net.ntp.TimeInfo;
+import org.apache.commons.net.ntp.TimeStamp;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -42,6 +46,58 @@ public class NtpClockUpdaterTest {
     @Test
     public void offset_zeroWhenClocksMatch() {
         assertThat(NtpClockUpdater.ntpClockOffsetMs(10_000L, 10_000L)).isEqualTo(0);
+    }
+
+    @Test
+    public void offset_sharesUtcTimersIntClamp() {
+        // One definition with the one-shot "Sync now": an absurd delta clamps, not overflows.
+        assertThat(NtpClockUpdater.ntpClockOffsetMs(Long.MAX_VALUE, 0L))
+                .isEqualTo(UtcTimer.ntpClockOffsetMs(Long.MAX_VALUE, 0L));
+        assertThat(NtpClockUpdater.ntpClockOffsetMs(Long.MAX_VALUE, 0L)).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    // ---- referenceUtcMs: RTT-compensated server "now" from a reply ----
+
+    /** Whole-second epoch base so NTP fixed-point conversion is exact in the tests. */
+    private static final long T0 = 1_700_000_000_000L;
+
+    private static TimeInfo reply(long originateMs, long receiveMs, long transmitMs, long returnMs) {
+        NtpV3Impl msg = new NtpV3Impl();
+        if (originateMs != 0) msg.setOriginateTimeStamp(TimeStamp.getNtpTime(originateMs));
+        if (receiveMs != 0) msg.setReceiveTimeStamp(TimeStamp.getNtpTime(receiveMs));
+        if (transmitMs != 0) msg.setTransmitTime(TimeStamp.getNtpTime(transmitMs));
+        return new TimeInfo(msg, returnMs);
+    }
+
+    @Test
+    public void reference_cancelsHalfTheRoundTrip() {
+        // t1 = T0 sent, t4 = T0+1000 received (1 s RTT); the server stamped both t2 and t3
+        // at T0+3000, so it is 2500 ms ahead: ((t2-t1)+(t3-t4))/2 = (3000+2000)/2.
+        TimeInfo info = reply(T0, T0 + 3000, T0 + 3000, T0 + 1000);
+        assertThat(NtpClockUpdater.referenceUtcMs(info)).isEqualTo(T0 + 1000 + 2500);
+        // The raw transmit stamp would have under-corrected by half the RTT (500 ms).
+        assertThat(info.getMessage().getTransmitTimeStamp().getTime()).isEqualTo(T0 + 3000);
+    }
+
+    @Test
+    public void reference_fallsBackToTransmitStampWithoutOriginate() {
+        // No originate stamp: commons-net can still derive offset = t3 - t4, which lands
+        // on the transmit stamp exactly — the pre-compensation behaviour.
+        TimeInfo info = reply(0, 0, T0 + 3000, T0 + 1000);
+        assertThat(NtpClockUpdater.referenceUtcMs(info)).isEqualTo(T0 + 3000);
+    }
+
+    @Test
+    public void reference_emptyReplyIsRejectedByTheSanityBound() {
+        // Nothing stamped at all: commons-net can't compute an offset (null), so the raw
+        // transmit stamp is used — and a zero NTP timestamp does NOT decode to Java time 0:
+        // TimeStamp maps it to the 2036 era rollover (2085978496000). The `<= 0` guard in
+        // isOffsetSane therefore never sees it; what actually refuses an empty reply is the
+        // hour-scale sanity bound (the implied correction is ~10 years).
+        TimeInfo info = reply(0, 0, 0, T0 + 1000);
+        long ref = NtpClockUpdater.referenceUtcMs(info);
+        assertThat(ref).isEqualTo(2_085_978_496_000L);
+        assertThat(NtpClockUpdater.computeAppliedOffset(true, ref, T0 + 1000)).isNull();
     }
 
     // ---- isOffsetSane: reject bad/implausible replies ----

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/AppInsetsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/AppInsetsTest.kt
@@ -1,0 +1,46 @@
+package radio.ks3ckc.ft8af
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Guards which safe-drawing sides the root content pads for. The Composable itself can't
+ * be unit-tested, so the side selection lives in [appContentInsets] and is checked here
+ * against synthetic insets: top and both horizontal sides must survive (portrait notch,
+ * landscape notch on either edge), bottom must be dropped (hidden nav bar / IME).
+ */
+class AppInsetsTest {
+
+    private val density = Density(1f)
+
+    /** Asymmetric values so each side is distinguishable in the assertions. */
+    private val raw = WindowInsets(left = 10, top = 20, right = 30, bottom = 40)
+
+    @Test
+    fun keepsTop_forThePortraitNotch() {
+        assertThat(appContentInsets(raw).getTop(density)).isEqualTo(20)
+    }
+
+    @Test
+    fun keepsBothHorizontalSides_forTheLandscapeNotch() {
+        val insets = appContentInsets(raw)
+        assertThat(insets.getLeft(density, LayoutDirection.Ltr)).isEqualTo(10)
+        assertThat(insets.getRight(density, LayoutDirection.Ltr)).isEqualTo(30)
+    }
+
+    @Test
+    fun dropsBottom_navBarIsHiddenAndImeIsHandledByTheField() {
+        assertThat(appContentInsets(raw).getBottom(density)).isEqualTo(0)
+    }
+
+    @Test
+    fun zeroInsetsPadNothing_layoutUnchangedOnPhonesWithoutACutout() {
+        val insets = appContentInsets(WindowInsets(0, 0, 0, 0))
+        assertThat(insets.getTop(density)).isEqualTo(0)
+        assertThat(insets.getLeft(density, LayoutDirection.Ltr)).isEqualTo(0)
+        assertThat(insets.getRight(density, LayoutDirection.Ltr)).isEqualTo(0)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSyncTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/ClockSyncTest.kt
@@ -77,4 +77,20 @@ class ClockSyncTest {
         assertThat(clockSyncAutoBadge(autoSyncFromDecodes = false, disciplineFromGps = true))
             .isEqualTo(com.k1af.ft8af.R.string.clock_sync_badge_gps)
     }
+
+    @Test
+    fun autoBadge_ntpWinsOverSelfSync() {
+        // Same stand-down rule as GPS: while NTP disciplines the clock the estimator is
+        // inert, so NTP is what the operator is actually relying on.
+        assertThat(clockSyncAutoBadge(autoSyncFromDecodes = true, disciplineFromGps = false, disciplineFromNtp = true))
+            .isEqualTo(com.k1af.ft8af.R.string.clock_sync_badge_ntp)
+        assertThat(clockSyncAutoBadge(autoSyncFromDecodes = false, disciplineFromGps = false, disciplineFromNtp = true))
+            .isEqualTo(com.k1af.ft8af.R.string.clock_sync_badge_ntp)
+    }
+
+    @Test
+    fun autoBadge_gpsTieBreaksOverNtpIfBothSomehowOn() {
+        assertThat(clockSyncAutoBadge(autoSyncFromDecodes = true, disciplineFromGps = true, disciplineFromNtp = true))
+            .isEqualTo(com.k1af.ft8af.R.string.clock_sync_badge_gps)
+    }
 }

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/LanguagePickerTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/LanguagePickerTest.kt
@@ -97,6 +97,7 @@ class LanguagePickerTest {
     private fun valuesDir(tag: String): String = when (tag) {
         "zh-CN" -> "values-zh-rCN"
         "zh-TW" -> "values-zh-rTW"
+        "pt-BR" -> "values-pt-rBR"
         // Indonesian: AAPT2 canonicalizes the obsolete "id" code to the legacy
         // "in", so the resources live in values-in even though the BCP-47 tag is "id".
         "id" -> "values-in"

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/NtpClockSettingsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/NtpClockSettingsTest.kt
@@ -1,0 +1,52 @@
+package radio.ks3ckc.ft8af.ui.settings
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.R
+import org.junit.Test
+
+/**
+ * Pure unit tests for the NTP clock-discipline settings helpers (no Android/Compose deps,
+ * so no Robolectric runner needed).
+ */
+class NtpClockSettingsTest {
+
+    @Test
+    fun normalize_trimsWhitespace() {
+        assertThat(normalizeNtpServer("  a.ntp.br  ")).isEqualTo("a.ntp.br")
+    }
+
+    @Test
+    fun normalize_blankFallsBackToDefault() {
+        assertThat(normalizeNtpServer("")).isEqualTo(GeneralVariables.DEFAULT_NTP_SERVER)
+        assertThat(normalizeNtpServer("   ")).isEqualTo(GeneralVariables.DEFAULT_NTP_SERVER)
+    }
+
+    @Test
+    fun normalize_passesThroughNonBlankUnchangedOnceTrimmed() {
+        assertThat(normalizeNtpServer("pool.ntp.org")).isEqualTo("pool.ntp.org")
+    }
+
+    @Test
+    fun lockedMessage_gpsTakesPrecedenceWhenBothSomehowTrue() {
+        assertThat(clockLockedMessageRes(disciplineFromGps = true, disciplineFromNtp = true))
+            .isEqualTo(R.string.settings_time_correction_gps_locked)
+    }
+
+    @Test
+    fun lockedMessage_gpsWhenOnlyGpsOn() {
+        assertThat(clockLockedMessageRes(disciplineFromGps = true, disciplineFromNtp = false))
+            .isEqualTo(R.string.settings_time_correction_gps_locked)
+    }
+
+    @Test
+    fun lockedMessage_ntpWhenOnlyNtpOn() {
+        assertThat(clockLockedMessageRes(disciplineFromGps = false, disciplineFromNtp = true))
+            .isEqualTo(R.string.settings_time_correction_ntp_locked)
+    }
+
+    @Test
+    fun lockedMessage_nullWhenNeitherOn() {
+        assertThat(clockLockedMessageRes(disciplineFromGps = false, disciplineFromNtp = false)).isNull()
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/NtpClockSettingsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/NtpClockSettingsTest.kt
@@ -24,7 +24,14 @@ class NtpClockSettingsTest {
 
     @Test
     fun normalize_passesThroughNonBlankUnchangedOnceTrimmed() {
-        assertThat(normalizeNtpServer("pool.ntp.org")).isEqualTo("pool.ntp.org")
+        assertThat(normalizeNtpServer("time.nist.gov")).isEqualTo("time.nist.gov")
+    }
+
+    @Test
+    fun defaultServer_isTheWorldwidePool() {
+        // Not a national server: the app ships everywhere, and pool.ntp.org resolves to
+        // servers near the device. Regional pools stay one text field away.
+        assertThat(GeneralVariables.DEFAULT_NTP_SERVER).isEqualTo("pool.ntp.org")
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeCorrectionTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/settings/TimeCorrectionTest.kt
@@ -91,4 +91,10 @@ class TimeCorrectionTest {
         assertThat(showSuggestionApply(autoSyncFromDecodes = false, disciplineFromGps = true)).isFalse()
         assertThat(showSuggestionApply(autoSyncFromDecodes = true, disciplineFromGps = true)).isFalse()
     }
+
+    @Test
+    fun suggestionApply_hiddenWhileNtpDisciplinesTheClock() {
+        assertThat(showSuggestionApply(autoSyncFromDecodes = false, disciplineFromGps = false, disciplineFromNtp = true)).isFalse()
+        assertThat(showSuggestionApply(autoSyncFromDecodes = true, disciplineFromGps = false, disciplineFromNtp = true)).isFalse()
+    }
 }


### PR DESCRIPTION
Supersedes #757 by @mrgadotti (PP5MGT). That PR was branched from `main`, which had drifted ~490 commits behind `dev` (the self-sync clock from #720/#758 conflicted), so his four commits are **cherry-picked here onto `dev` with authorship intact**; the remaining commits are review follow-ups.

## From @mrgadotti
- **pt-BR translation** — `values-pt-rBR/strings_compose.xml` (595 strings), registered in `locales_config.xml` and the in-app language picker.
- **NTP clock discipline** — `NtpClockUpdater`, the network twin of GPS discipline: periodic sync (1–30 min) into `UtcTimer.delay`, pre-NTP offset restored on toggle-off, mutually exclusive with GPS, status readout in Settings → Time Sync.
- **Notch-safe layout** — root content padded by the `safeDrawing` insets so the title row clears the display cutout (Android 15 lays fullscreen windows under the cutout).

## Review fixes on top
- **Self-sync clock now stands down for NTP** exactly as for GPS (`ClockSelfSync.mayRun`), otherwise both would write `UtcTimer.delay` every slot. Settings lock-outs and the DT pill ("NTP" badge) follow the same rule; NTP toggle-on resets the estimator streak.
- **RTT-compensated offset** via `TimeInfo.computeDetails()` (RFC 4330) instead of the raw transmit stamp, which under-corrected by half the round trip.
- `applySyncResult` synchronized with `stop()` (race flagged by Copilot on #757); `ntpClockOffsetMs` delegates to the existing `UtcTimer` helper; sanity-bound comment corrected (GPS is 60 s on `dev`, NTP keeps 1 h on purpose).
- Default server `pool.ntp.org` instead of `a.ntp.br` (regional pools still work when typed in); caret kept at end after committing the server field.
- **Landscape notch**: pad `Horizontal` as well as `Top` — the app rotates, and in landscape the cutout sits on a side edge. Side selection extracted to `AppInsets.kt` + `AppInsetsTest`.
- pt-BR: dropped two strings removed from `dev` with Android Auto.

## Verification
- Full unit suite: 3,462 tests, 0 failures (12 new).
- Emulator (API 36): NTP toggle → `Started … server pool.ntp.org` → `applied offset 3014ms`; status card, lock-outs, and restart-on-relaunch confirmed. Notch padding verified in portrait and landscape with the system cutout emulation (126 px).

**Merge with a merge commit or rebase — not squash — so @mrgadotti's commits keep his authorship.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
