### PR TITLE
Redesign TX strip (3a) + Band & Mode sheet (3b)

### DIFF
--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/FT8AFApp.kt
@@ -53,9 +53,10 @@ import radio.ks3ckc.ft8af.ui.components.shouldPersistSection
 import radio.ks3ckc.ft8af.hunt.huntPriorityFromConfig
 import radio.ks3ckc.ft8af.ui.components.FT8AFTab
 import radio.ks3ckc.ft8af.ui.components.FrequencyPickerSheet
+import radio.ks3ckc.ft8af.ui.components.BandModeSheet
 import radio.ks3ckc.ft8af.ui.components.HoundSetupSheet
 import radio.ks3ckc.ft8af.ui.components.HuntOptionsSheet
-import radio.ks3ckc.ft8af.ui.components.huntStripSubtitle
+import radio.ks3ckc.ft8af.hunt.HuntPriority
 import radio.ks3ckc.ft8af.ui.components.formatMhz
 import radio.ks3ckc.ft8af.ui.components.QsoCelebration
 import radio.ks3ckc.ft8af.ui.components.SlotTimerBar
@@ -217,6 +218,13 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
 
     // Frequency picker sheet state
     var showFrequencyPicker by rememberSaveable { mutableStateOf(false) }
+
+    // Band & Mode sheet (option 3b) — opened from the strip's band/mode row.
+    var showBandModeSheet by rememberSaveable { mutableStateOf(false) }
+    // Daytime hint for the band sheet's "Best now · …" copy (local wall-clock).
+    val isDaytimeHint = remember {
+        java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY) in 8..17
+    }
 
     // A tapped Needed-DX notification asks us to jump to the Decode tab (DecodeScreen
     // then scrolls to + highlights the alerted station).
@@ -440,25 +448,42 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                 offsetSec = avgDtSec,
             )
 
-            // TX status strip — always visible above tab bar
+            // TX status strip — always visible above tab bar (redesigned, option 3a). The
+            // slot bar + clock-sync pill remain in the SlotTimerBar above; the strip's
+            // status row shows the plain-language "next transmit window" countdown.
+            val slotMillis = ModeProfile.fromId(operatingMode).slotMillis.toLong()
+            val bandModeLabel = "$frequencyLabel · $modeName"
+            val huntOptionLabel = if (huntEnabled) {
+                stringResource(
+                    when (huntPriority) {
+                        HuntPriority.LATEST -> R.string.hunt_priority_latest
+                        HuntPriority.STRONGEST -> R.string.hunt_priority_strongest
+                        HuntPriority.WEAKEST -> R.string.hunt_priority_weakest
+                        HuntPriority.FARTHEST -> R.string.hunt_priority_farthest
+                        HuntPriority.POTA_FIRST -> R.string.hunt_priority_pota
+                        HuntPriority.NEW_DXCC_FIRST -> R.string.hunt_priority_new_dxcc
+                        HuntPriority.NEW_GRID_FIRST -> R.string.hunt_priority_new_grid
+                    },
+                )
+            } else {
+                stringResource(R.string.tx_hunt_off)
+            }
             TxStrip(
                 isTransmitting = isTransmitting,
                 isActivated = isActivated,
-                frequencyLabel = frequencyLabel,
+                bandModeLabel = bandModeLabel,
+                slotMillis = slotMillis,
                 txSlot = txSlot,
                 huntEnabled = huntEnabled,
-                modeName = modeName,
-                modeSwitchEnabled = !isTransmitting,
+                huntOptionLabel = huntOptionLabel,
                 dxEnabled = dxEnabled,
                 catState = catState,
                 showCatChip = showCatChip,
-                expanded = qsoPanelExpanded,
                 txVolume = txVolume,
                 showVolumeSlider = showVolumeSlider,
                 cqModifier = cqModifier,
                 isFreeTextMode = isFreeTextMode,
                 fieldDayEnabled = fieldDayEnabled,
-                huntPriorityTag = huntStripSubtitle(huntPriority),
                 isTuning = isTuning,
                 tuneRemainingSec = tuneRemainingSec,
                 onToggleTune = {
@@ -529,7 +554,7 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                         mainViewModel.databaseOpr.writeConfig("toModifier", "", null)
                     }
                 },
-                onLongPressCQ = { showCqOptions = true },
+                onOpenCqOptions = { showCqOptions = true },
                 onToggleDx = {
                     if (dxEnabled || GeneralVariables.houndMode) {
                         mainViewModel.stopHoundMode()
@@ -538,9 +563,7 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                         showHoundSetup = true
                     }
                 },
-                onToggleSlot = {
-                    val current = mainViewModel.ft8TransmitSignal.sequential
-                    val newSlot = if (current == 0) 1 else 0
+                onSelectTxPeriod = { newSlot ->
                     mainViewModel.ft8TransmitSignal.sequential = newSlot
                     mainViewModel.ft8TransmitSignal.mutableSequential.postValue(newSlot)
                     // Switching slots mid-QSO abandons the current contact.
@@ -550,31 +573,9 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
                     }
                 },
                 onToggleHunt = { setHuntEnabled(!huntEnabled) },
-                onLongPressHunt = { showHuntOptions = true },
-                onCycleMode = {
-                    // Cycle through the shipped ModeProfile entries in declaration order
-                    // (FT8 -> FT4 -> FT2 -> ...), wrapping around. An unknown current mode
-                    // (indexOfFirst == -1) falls back to the first entry (FT8).
-                    val modes = ModeProfile.values()
-                    val curIdx = modes.indexOfFirst { it.id == operatingMode }
-                    val next = modes[(curIdx + 1) % modes.size].id
-                    if (mainViewModel.setOperatingMode(next)) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.app_mode_switched, ModeProfile.fromId(next).displayName),
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    } else {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.app_mode_switch_busy),
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    }
-                },
+                onOpenHuntOptions = { showHuntOptions = true },
                 onReconnectCat = { mainViewModel.reconnectRig() },
-                onOpenFrequencyPicker = { showFrequencyPicker = true },
-                onToggleExpand = { qsoPanelExpanded = !qsoPanelExpanded },
+                onOpenBandMode = { showBandModeSheet = true },
             )
 
             // Bottom tab bar
@@ -602,6 +603,41 @@ fun FT8AFApp(mainViewModel: MainViewModel) {
             onSelect = { idx ->
                 selectBandIndex(mainViewModel, context, idx)
                 showFrequencyPicker = false
+            },
+        )
+
+        // Band & Mode sheet (option 3b) — mode toggle + curated band list, opened from the
+        // strip's band/mode row. Picking a band retunes (CAT if connected) and closes.
+        BandModeSheet(
+            visible = showBandModeSheet,
+            selectedModeId = operatingMode,
+            currentBandIndex = bandIndex,
+            catConnected = catState == CatConnectionState.CONNECTED,
+            isDaytime = isDaytimeHint,
+            onDismiss = { showBandModeSheet = false },
+            onSelectMode = { modeId ->
+                // Was the strip's mode-pill cycle; now a direct pick from the sheet.
+                if (mainViewModel.setOperatingMode(modeId)) {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.app_mode_switched, ModeProfile.fromId(modeId).displayName),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                } else {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.app_mode_switch_busy),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                }
+            },
+            onSelectBand = { idx ->
+                selectBandIndex(mainViewModel, context, idx)
+                showBandModeSheet = false
+            },
+            onOpenAllBands = {
+                showBandModeSheet = false
+                showFrequencyPicker = true
             },
         )
 

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/BandModeSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/BandModeSheet.kt
@@ -1,0 +1,347 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.ModeProfile
+import com.k1af.ft8af.R
+import com.k1af.ft8af.database.OperationBand
+import radio.ks3ckc.ft8af.theme.Accent
+import radio.ks3ckc.ft8af.theme.BgSurface
+import radio.ks3ckc.ft8af.theme.BgSurface3
+import radio.ks3ckc.ft8af.theme.Border
+import radio.ks3ckc.ft8af.theme.GeistMonoFamily
+import radio.ks3ckc.ft8af.theme.InterFamily
+import radio.ks3ckc.ft8af.theme.TextFaint
+import radio.ks3ckc.ft8af.theme.TextMuted
+import radio.ks3ckc.ft8af.theme.TextPrimary
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested without Compose)
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a slot length (in ms) as the plain seconds label the mode toggle shows next to
+ * each mode name: 15000 -> "15s", 7500 -> "7.5s", 3750 -> "3.75s". Trailing zeros are
+ * dropped so whole seconds don't render as "15.0s".
+ */
+internal fun formatSlotSeconds(slotMillis: Int): String {
+    val secs = slotMillis / 1000.0
+    val label = if (secs % 1.0 == 0.0) {
+        secs.toInt().toString()
+    } else {
+        secs.toString().trimEnd('0').trimEnd('.')
+    }
+    return "${label}s"
+}
+
+/**
+ * The plain-English hint under each band in the sheet, as a string resource id. 20m alone is
+ * time-of-day aware ("Best now · …" during daytime); the rest are static copy. Returns 0 for a
+ * band with no hint so the caller can omit the line.
+ */
+internal fun bandHintRes(waveLength: String, isDaytime: Boolean): Int = when (waveLength) {
+    "20m" -> if (isDaytime) R.string.band_hint_20m_best else R.string.band_hint_20m
+    "40m" -> R.string.band_hint_40m
+    "17m" -> R.string.band_hint_17m
+    "15m" -> R.string.band_hint_15m
+    "10m" -> R.string.band_hint_10m
+    "80m" -> R.string.band_hint_80m
+    else -> 0
+}
+
+/** One band row surfaced in the sheet: name, dial frequency, and its index into bandList. */
+internal data class BandRow(
+    val waveLength: String,
+    val freqHz: Long,
+    val bandIndex: Int,
+)
+
+/**
+ * The curated "most used" band names shown in the sheet, in display order — the subset the
+ * design calls out. The full band plan stays reachable via the "All bands & custom frequency"
+ * footer (the existing frequency picker).
+ */
+internal val MOST_USED_BANDS = listOf("20m", "40m", "17m", "15m", "10m")
+
+/**
+ * Build the sheet's band rows for [modeId] from [bands] (normally [OperationBand.bandList]):
+ * for each name in [MOST_USED_BANDS], pick that band's dial for the mode — preferring the
+ * marked (*) entry, else the first match — and skip names with no entry in that mode. Pure so
+ * it can be unit-tested with hand-built [OperationBand.Band] lists.
+ */
+internal fun mostUsedBands(bands: List<OperationBand.Band>, modeId: Int): List<BandRow> {
+    val out = ArrayList<BandRow>()
+    for (wave in MOST_USED_BANDS) {
+        var chosenIdx = -1
+        var chosenFreq = 0L
+        for (i in bands.indices) {
+            val b = bands[i]
+            if (b.mode != modeId || b.waveLength != wave) continue
+            if (b.marked) {
+                chosenIdx = i
+                chosenFreq = b.band
+                break
+            }
+            if (chosenIdx == -1) {
+                chosenIdx = i
+                chosenFreq = b.band
+            }
+        }
+        if (chosenIdx != -1) {
+            out.add(BandRow(wave, chosenFreq, chosenIdx))
+        }
+    }
+    return out
+}
+
+// ---------------------------------------------------------------------------
+// Band & Mode bottom sheet (option 3b)
+// ---------------------------------------------------------------------------
+
+/**
+ * The Band & Mode bottom sheet (design option 3b): a mode toggle (FT8/FT4/FT2 with cycle
+ * times) over a short list of the most-used bands for that mode, plus a footer that opens the
+ * full band / custom-frequency picker. Picking a band retunes via the caller's [onSelectBand]
+ * (CAT if connected) and dismisses.
+ */
+@Composable
+fun BandModeSheet(
+    visible: Boolean,
+    selectedModeId: Int,
+    currentBandIndex: Int,
+    catConnected: Boolean,
+    isDaytime: Boolean,
+    onDismiss: () -> Unit,
+    onSelectMode: (Int) -> Unit,
+    onSelectBand: (Int) -> Unit,
+    onOpenAllBands: () -> Unit,
+) {
+    FT8AFBottomSheet(visible = visible, onDismiss = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, bottom = 24.dp),
+        ) {
+            // ---- Header ----
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.band_sheet_title),
+                        color = TextPrimary,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        fontFamily = InterFamily,
+                    )
+                    if (catConnected) {
+                        Text(
+                            text = stringResource(R.string.band_sheet_subtitle),
+                            color = TextMuted,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Normal,
+                            fontFamily = InterFamily,
+                            modifier = Modifier.padding(top = 1.dp),
+                        )
+                    }
+                }
+                val closeLabel = stringResource(R.string.band_sheet_close)
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(BgSurface3)
+                        .clickable(onClickLabel = closeLabel) { onDismiss() }
+                        .semantics { role = Role.Button; contentDescription = closeLabel },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    FT8AFIcons.Close(size = 16.dp, color = TextMuted, strokeWidth = 2f)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // ---- Mode toggle (FT8 / FT4 / FT2) ----
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(BgSurface)
+                    .padding(4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                for (mode in ModeProfile.values()) {
+                    ModeSegment(
+                        name = mode.displayName,
+                        cycle = formatSlotSeconds(mode.slotMillis),
+                        selected = mode.id == selectedModeId,
+                        modifier = Modifier.weight(1f),
+                        onClick = { if (mode.id != selectedModeId) onSelectMode(mode.id) },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // ---- Band list for the selected mode ----
+            val bands = remember(selectedModeId, GeneralVariables.excludedBands.toSet()) {
+                mostUsedBands(OperationBand.bandList, selectedModeId)
+                    .filterNot { GeneralVariables.isBandExcluded(it.waveLength) }
+            }
+            val selectedWave = OperationBand.bandList.getOrNull(currentBandIndex)?.waveLength
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                for (row in bands) {
+                    BandSheetRow(
+                        row = row,
+                        selected = row.waveLength == selectedWave,
+                        isDaytime = isDaytime,
+                        onClick = { onSelectBand(row.bandIndex) },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // ---- Footer: full picker ----
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(BgSurface3)
+                    .border(1.dp, Border, RoundedCornerShape(12.dp))
+                    .clickable { onOpenAllBands() },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
+            ) {
+                Text(
+                    text = stringResource(R.string.band_sheet_all_bands),
+                    color = TextMuted,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = InterFamily,
+                )
+                FT8AFIcons.Chevron(size = 13.dp, color = TextMuted, strokeWidth = 2f)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModeSegment(
+    name: String,
+    cycle: String,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .height(44.dp)
+            .clip(RoundedCornerShape(7.dp))
+            .background(if (selected) Accent.copy(alpha = 0.18f) else Color.Transparent)
+            .clickable { onClick() },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = name,
+            color = if (selected) Accent else TextMuted,
+            fontSize = 13.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+            fontFamily = InterFamily,
+        )
+        Text(
+            text = cycle,
+            color = if (selected) Accent.copy(alpha = 0.8f) else TextFaint,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Normal,
+            fontFamily = InterFamily,
+        )
+    }
+}
+
+@Composable
+private fun BandSheetRow(
+    row: BandRow,
+    selected: Boolean,
+    isDaytime: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(if (selected) Accent.copy(alpha = 0.10f) else BgSurface3)
+            .border(
+                1.dp,
+                if (selected) Accent.copy(alpha = 0.28f) else Border,
+                RoundedCornerShape(12.dp),
+            )
+            .clickable { onClick() }
+            .padding(horizontal = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = row.waveLength,
+            color = if (selected) Accent else TextMuted,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = GeistMonoFamily,
+            modifier = Modifier.width(42.dp),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "${formatMhz(row.freqHz)} MHz",
+                color = TextPrimary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = GeistMonoFamily,
+            )
+            val hintRes = bandHintRes(row.waveLength, isDaytime)
+            if (hintRes != 0) {
+                Text(
+                    text = stringResource(hintRes),
+                    color = TextMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Normal,
+                    fontFamily = InterFamily,
+                )
+            }
+        }
+        if (selected) {
+            FT8AFIcons.Check(size = 18.dp, color = Accent, strokeWidth = 2.2f)
+        }
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/BandModeSheet.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/BandModeSheet.kt
@@ -3,6 +3,7 @@ package radio.ks3ckc.ft8af.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -217,12 +218,16 @@ fun BandModeSheet(
                 mostUsedBands(OperationBand.bandList, selectedModeId)
                     .filterNot { GeneralVariables.isBandExcluded(it.waveLength) }
             }
-            val selectedWave = OperationBand.bandList.getOrNull(currentBandIndex)?.waveLength
+            // Compare the exact band index, not just the wavelength: one band can have
+            // several dial entries (bands.txt lists 14.074 and 14.090 for 20m), so matching
+            // by wavelength would light up the curated 14.074 row while the rig is actually on
+            // 14.090. When the rig is on an alternate dial no curated row is marked (the full
+            // picker behind the footer owns alternates).
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 for (row in bands) {
                     BandSheetRow(
                         row = row,
-                        selected = row.waveLength == selectedWave,
+                        selected = row.bandIndex == currentBandIndex,
                         isDaytime = isDaytime,
                         onClick = { onSelectBand(row.bandIndex) },
                     )
@@ -269,7 +274,7 @@ private fun ModeSegment(
             .height(44.dp)
             .clip(RoundedCornerShape(7.dp))
             .background(if (selected) Accent.copy(alpha = 0.18f) else Color.Transparent)
-            .clickable { onClick() },
+            .selectable(selected = selected, role = Role.RadioButton) { onClick() },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -308,7 +313,7 @@ private fun BandSheetRow(
                 if (selected) Accent.copy(alpha = 0.28f) else Border,
                 RoundedCornerShape(12.dp),
             )
-            .clickable { onClick() }
+            .selectable(selected = selected, role = Role.RadioButton) { onClick() }
             .padding(horizontal = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CatStatusChip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/CatStatusChip.kt
@@ -41,32 +41,44 @@ internal data class CatChipVisuals(
     val dotColor: Color,
     val pulsing: Boolean,
     val contentDescriptionRes: Int,
+    /**
+     * Visible plain-language label for the redesigned strip: "Radio linked" once a link is
+     * up, "Radio not linked" otherwise. The dot color still varies per state (amber while
+     * connecting, red on error); only the two-word status text is collapsed so non-expert
+     * operators aren't shown "CAT connecting…".
+     */
+    val labelRes: Int,
 )
 
 /**
- * Map a CAT connection state to its dot color / pulse / accessibility label.
- * grey = disconnected, amber pulsing = connecting, green = connected, red = error.
+ * Map a CAT connection state to its dot color / pulse / accessibility label / visible label.
+ * grey = disconnected, amber pulsing = connecting, green = connected, red = error. The visible
+ * label reads "Radio linked" only when CONNECTED, "Radio not linked" in every other state.
  */
 internal fun catChipVisuals(state: CatConnectionState): CatChipVisuals = when (state) {
     CatConnectionState.DISCONNECTED -> CatChipVisuals(
         dotColor = TextMuted,
         pulsing = false,
         contentDescriptionRes = R.string.cat_status_disconnected,
+        labelRes = R.string.cat_status_not_linked,
     )
     CatConnectionState.CONNECTING -> CatChipVisuals(
         dotColor = Accent,
         pulsing = true,
         contentDescriptionRes = R.string.cat_status_connecting,
+        labelRes = R.string.cat_status_not_linked,
     )
     CatConnectionState.CONNECTED -> CatChipVisuals(
         dotColor = StatusConfirmed,
         pulsing = false,
         contentDescriptionRes = R.string.cat_status_connected,
+        labelRes = R.string.cat_status_linked,
     )
     CatConnectionState.ERROR -> CatChipVisuals(
         dotColor = StatusBad,
         pulsing = false,
         contentDescriptionRes = R.string.cat_status_error,
+        labelRes = R.string.cat_status_not_linked,
     )
 }
 
@@ -95,22 +107,21 @@ fun CatStatusChip(
 
     Row(
         modifier = modifier
-            .clip(RoundedCornerShape(6.dp))
+            .clip(RoundedCornerShape(8.dp))
             .background(BgSurface3)
             .clickable(onClickLabel = description) { onReconnect() }
             .semantics { contentDescription = description }
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+            .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         StatusDot(color = visuals.dotColor, pulsing = visuals.pulsing)
         Text(
-            text = stringResource(R.string.cat_status_chip_label),
+            text = stringResource(visuals.labelRes),
             color = TextMuted,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.SemiBold,
-            fontFamily = GeistMonoFamily,
-            letterSpacing = 0.02.sp,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            fontFamily = InterFamily,
             maxLines = 1,
             softWrap = false,
         )

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SlotTimerBar.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/SlotTimerBar.kt
@@ -18,19 +18,27 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.geometry.Size
 import androidx.compose.runtime.withFrameMillis
 import com.k1af.ft8af.GeneralVariables
+import com.k1af.ft8af.R
 import com.k1af.ft8af.timer.UtcTimer
+import kotlinx.coroutines.delay
 import radio.ks3ckc.ft8af.theme.Accent
 import radio.ks3ckc.ft8af.theme.Border
 import radio.ks3ckc.ft8af.theme.GeistMonoFamily
+import radio.ks3ckc.ft8af.theme.InterFamily
 import radio.ks3ckc.ft8af.theme.Signal
 import radio.ks3ckc.ft8af.theme.TextMuted
+import radio.ks3ckc.ft8af.theme.TextPrimary
 
 @Composable
 fun SlotTimerBar(
@@ -134,4 +142,59 @@ internal fun slotTimerState(nowMs: Long, slotMillis: Long): SlotTimerState {
     // disagree if the bar is ever driven by a non-global slot.
     val currentSlot = UtcTimer.sequential(nowMs, slot.toInt())
     return SlotTimerState(progress, secondsRemaining, currentSlot)
+}
+
+/**
+ * The redesigned strip's status-row countdown: "Next transmit window in Xs", with the seconds
+ * in the mono data font and the rest in Inter. Self-ticks ~4x/second (enough for a per-second
+ * countdown) so it doesn't churn the whole composition every frame.
+ */
+@Composable
+fun NextTxWindowLabel(
+    slotMillis: Long,
+    txSlot: Int,
+    modifier: Modifier = Modifier,
+) {
+    var nowMs by remember { mutableLongStateOf(UtcTimer.getSystemTime()) }
+
+    LaunchedEffect(slotMillis, txSlot) {
+        while (true) {
+            nowMs = UtcTimer.getSystemTime()
+            delay(250L)
+        }
+    }
+
+    val seconds = nextTxWindowSeconds(nowMs, slotMillis, txSlot)
+    val prefix = stringResource(R.string.tx_next_window)
+    val text = buildAnnotatedString {
+        withStyle(SpanStyle(fontFamily = InterFamily, color = TextMuted, fontWeight = FontWeight.Normal)) {
+            append(prefix)
+            append(" ")
+        }
+        withStyle(SpanStyle(fontFamily = GeistMonoFamily, color = TextPrimary)) {
+            append("${seconds}s")
+        }
+    }
+
+    Text(text = text, fontSize = 11.sp, maxLines = 1, modifier = modifier)
+}
+
+/**
+ * Seconds until the start of the operator's next transmit slot, given the current time, the
+ * slot length, and which parity ([txSlot]: 0 = 1st/even, 1 = 2nd/odd) the operator transmits on.
+ * Walks forward to the next slot boundary whose parity matches and returns the wall-clock
+ * seconds until it (rounded up); while the operator is *in* their own slot it points at the
+ * following one, so it always describes a genuinely upcoming window. Pure/testable; guards a
+ * non-positive [slotMillis] like [slotTimerState].
+ */
+internal fun nextTxWindowSeconds(nowMs: Long, slotMillis: Long, txSlot: Int): Int {
+    val slot = if (slotMillis > 0L) slotMillis else 15_000L
+    val parity = ((txSlot.toLong() % 2) + 2) % 2
+    val currentIndex = Math.floorDiv(nowMs, slot)
+    var nextIndex = currentIndex + 1
+    if ((((nextIndex % 2) + 2) % 2) != parity) {
+        nextIndex += 1
+    }
+    val boundaryMs = nextIndex * slot
+    return (((boundaryMs - nowMs) + 999L) / 1000L).toInt()
 }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -76,7 +75,7 @@ internal fun txStripActionState(isActivated: Boolean, huntEnabled: Boolean) = Tx
 
 /**
  * Label for the TUNE chip: the plain label when idle, "label countdown" while
- * the carrier is up (e.g. "TUNE 7s") so the operator sees the safety timeout
+ * the carrier is up (e.g. "Tune 7s") so the operator sees the safety timeout
  * running. Extracted so it can be unit-tested without Compose.
  */
 internal fun tuneChipLabel(label: String, isTuning: Boolean, remainingSec: Int): String =
@@ -100,49 +99,68 @@ internal fun cqStripSubtitle(
     else -> null
 }
 
+/**
+ * Which of the three status states the strip's status row shows, and whether the "next window"
+ * countdown should appear (only while Listening). Extracted so the mapping is unit-testable
+ * without Compose. The pulse-dot color is amber ([Accent]) for Tuning/Transmitting, cyan
+ * ([Signal]) for Listening.
+ */
+internal data class TxStatusVisuals(
+    val labelRes: Int,
+    val listening: Boolean,
+)
+
+internal fun txStatusVisuals(isTransmitting: Boolean, isTuning: Boolean): TxStatusVisuals = when {
+    isTuning -> TxStatusVisuals(R.string.tx_status_tuning, listening = false)
+    isTransmitting -> TxStatusVisuals(R.string.tx_status_transmitting, listening = false)
+    else -> TxStatusVisuals(R.string.tx_status_listening, listening = true)
+}
+
+/**
+ * The redesigned bottom-anchored TX strip (design option 3a). Rows: status + CAT chip, a
+ * tappable Band & Mode card, the primary Call CQ button (with an attached MORE split-button)
+ * alongside the Hunt tile, then the TX-period segmented control with Tune / DX. The slot
+ * progress bar and clock-sync pill stay in the separate [SlotTimerBar] rendered just above.
+ */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TxStrip(
     isTransmitting: Boolean,
     isActivated: Boolean,
-    frequencyLabel: String,
+    bandModeLabel: String,
+    slotMillis: Long,
     txSlot: Int,
     huntEnabled: Boolean,
-    modeName: String,
-    modeSwitchEnabled: Boolean,
+    huntOptionLabel: String,
+    onCallCQ: () -> Unit,
+    onStop: () -> Unit,
+    onSelectTxPeriod: (Int) -> Unit,
+    onToggleHunt: () -> Unit,
+    onOpenHuntOptions: () -> Unit,
+    onOpenBandMode: () -> Unit,
+    isTuning: Boolean = false,
     dxEnabled: Boolean = false,
     catState: CatConnectionState = CatConnectionState.DISCONNECTED,
     showCatChip: Boolean = false,
-    expanded: Boolean = false,
     txVolume: Int = 80,
     showVolumeSlider: Boolean = false,
     cqModifier: String = "",
     isFreeTextMode: Boolean = false,
     fieldDayEnabled: Boolean = false,
-    huntPriorityTag: String? = null,
-    isTuning: Boolean = false,
     tuneRemainingSec: Int = 0,
     onToggleTune: () -> Unit = {},
     onVolumeChange: (Int) -> Unit = {},
     onVolumeChangeFinished: () -> Unit = {},
-    onCallCQ: () -> Unit,
-    onStop: () -> Unit,
-    onLongPressCQ: () -> Unit = {},
-    onLongPressHunt: () -> Unit = {},
-    onToggleSlot: () -> Unit,
-    onToggleHunt: () -> Unit,
-    onCycleMode: () -> Unit,
+    onOpenCqOptions: () -> Unit = {},
     onToggleDx: () -> Unit = {},
     onReconnectCat: () -> Unit = {},
-    onOpenFrequencyPicker: () -> Unit,
-    onToggleExpand: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val bgColor = if (isTransmitting) {
         Brush.horizontalGradient(
             listOf(
-                Color(0x1FFFAF5E),  // rgba(255,175,94,0.12)
-                Color(0x0AFFAF5E),  // rgba(255,175,94,0.04)
+                Color(0x1FFFAF5E), // rgba(255,175,94,0.12)
+                Color(0x0AFFAF5E), // rgba(255,175,94,0.04)
             )
         )
     } else {
@@ -151,10 +169,6 @@ fun TxStrip(
 
     val actions = txStripActionState(isActivated, huntEnabled)
 
-    // Two stacked rows (vs. the old single cramped FlowRow): an info line with the small
-    // status/mode/frequency/DX chips, and a row of three large primary buttons
-    // (HUNT · CQ/STOP · TX slot) sized like the design prototype so the main action is a
-    // comfortable tap target on a phone.
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -167,199 +181,138 @@ fun TxStrip(
                     strokeWidth = 1f,
                 )
             }
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(start = 16.dp, end = 16.dp, top = 10.dp, bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        // ---- Info row: status (left) · mode / frequency / DX chips (right) ----
+        // ---- Row 1: status + CAT chip ----
+        val status = txStatusVisuals(isTransmitting, isTuning)
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            // Left: expand chevron (when QSO active) + pulse dot + state + CAT chip.
-            // weight(1f, fill=false) lets the status label ellipsize before it can shove
-            // the right-hand chips off screen on a narrow device.
             Row(
                 modifier = Modifier.weight(1f, fill = false),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                if (isActivated) {
-                    Box(
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clip(RoundedCornerShape(4.dp))
-                            .clickable { onToggleExpand() }
-                            .rotate(if (expanded) 0f else 180f),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        FT8AFIcons.ChevronDown(size = 14.dp, color = TextMuted, strokeWidth = 2f)
+                PulseDot(color = if (status.listening) Signal else Accent)
+                Column {
+                    Text(
+                        text = stringResource(status.labelRes),
+                        color = TextPrimary,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        fontFamily = InterFamily,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (status.listening) {
+                        NextTxWindowLabel(slotMillis = slotMillis, txSlot = txSlot)
                     }
                 }
-                PulseDot(color = if (isTransmitting) Accent else Signal)
-                Text(
-                    text = if (isTransmitting) stringResource(R.string.tx_transmitting)
-                    else stringResource(R.string.tx_listening),
-                    color = TextPrimary,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    fontFamily = GeistMonoFamily,
-                    letterSpacing = 0.02.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                if (showCatChip) {
-                    CatStatusChip(state = catState, onReconnect = onReconnectCat)
-                }
             }
-
-            // Right: mode pill, frequency/band pill, DX pill.
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                // Mode pill (FT8/FT4/FT2) — taps cycle the operating mode. Disabled
-                // mid-transmit so we never switch the cycle out from under a live TX.
-                TxChip(
-                    label = modeName,
-                    background = if (modeSwitchEnabled) Accent.copy(alpha = 0.18f) else BgSurface3,
-                    textColor = if (modeSwitchEnabled) Accent else TextFaint,
-                    bold = true,
-                    enabled = modeSwitchEnabled,
-                    onClick = onCycleMode,
-                )
-
-                // Frequency / band pill — opens the frequency picker.
-                Row(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(BgSurface3)
-                        .clickable { onOpenFrequencyPicker() }
-                        .padding(horizontal = 10.dp, vertical = 7.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Text(
-                        text = frequencyLabel,
-                        color = TextPrimary,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        fontFamily = GeistMonoFamily,
-                        letterSpacing = 0.02.sp,
-                        maxLines = 1,
-                        softWrap = false,
-                    )
-                    FT8AFIcons.ChevronDown(size = 12.dp, color = TextMuted, strokeWidth = 2f)
-                }
-
-                // DX (DXpedition Hound) toggle pill. On = working a Fox (call high,
-                // auto-QSY when answered). Mutually exclusive with HUNT/CQ.
-                TxChip(
-                    label = "DX",
-                    background = if (dxEnabled) Accent.copy(alpha = 0.18f) else BgSurface3,
-                    textColor = if (dxEnabled) Accent else TextMuted,
-                    bold = false,
-                    enabled = true,
-                    onClick = onToggleDx,
-                )
-
-                // TUNE toggle pill (issue #408): tap keys a steady carrier at the
-                // TX offset for antenna/amplifier tuning; tap again stops it. While
-                // active it turns red and counts down the code-enforced safety
-                // timeout. Locked off while the sequencer is armed/transmitting —
-                // tune and FT8 TX are mutually exclusive.
-                val tuneDescription = stringResource(R.string.tune_content_description)
-                Box(modifier = Modifier.semantics { contentDescription = tuneDescription }) {
-                    TxChip(
-                        label = tuneChipLabel(
-                            stringResource(R.string.tune_button), isTuning, tuneRemainingSec,
-                        ),
-                        background = when {
-                            isTuning -> StatusBad
-                            isActivated || isTransmitting -> BgSurface3.copy(alpha = 0.4f)
-                            else -> BgSurface3
-                        },
-                        textColor = when {
-                            isTuning -> Color.White
-                            isActivated || isTransmitting -> TextMuted.copy(alpha = 0.4f)
-                            else -> TextMuted
-                        },
-                        bold = isTuning,
-                        enabled = isTuning || (!isActivated && !isTransmitting),
-                        onClick = onToggleTune,
-                    )
-                }
+            if (showCatChip) {
+                CatStatusChip(state = catState, onReconnect = onReconnectCat)
             }
         }
 
-        // ---- Action row: HUNT · CQ/STOP · TX slot ----
+        // ---- Row 2: band & mode row (opens the Band & Mode sheet) ----
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(BgSurface3)
+                .border(1.dp, Border, RoundedCornerShape(12.dp))
+                .clickable { onOpenBandMode() }
+                .padding(horizontal = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = stringResource(R.string.tx_band_mode_label),
+                color = TextFaint,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = InterFamily,
+                letterSpacing = 0.8.sp,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = bandModeLabel,
+                    color = TextPrimary,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = GeistMonoFamily,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+                FT8AFIcons.ChevronDown(size = 14.dp, color = TextMuted, strokeWidth = 2f)
+            }
+        }
+
+        // ---- Row 3: Call CQ (+ MORE) · Hunt tile ----
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // HUNT — stacked icon + label. Locked off during an active CQ/QSO.
-            // The notch (and a long-press) opens the Hunt options sheet; the
-            // subtitle tag mirrors the armed non-default priority (like the CQ
-            // button's FREE/FD subtitle).
-            StackedActionButton(
-                modifier = Modifier.weight(1f),
-                label = stringResource(R.string.tx_hunt),
-                subtitle = huntPriorityTag,
-                background = when {
-                    actions.huntDisabled -> BgSurface3.copy(alpha = 0.4f)
-                    actions.huntActive -> Signal.copy(alpha = 0.18f)
-                    else -> BgSurface3
-                },
-                contentColor = when {
-                    actions.huntDisabled -> TextMuted.copy(alpha = 0.4f)
-                    actions.huntActive -> Signal
-                    else -> TextMuted
-                },
-                borderColor = if (actions.huntActive) Signal.copy(alpha = 0.5f) else Border,
-                enabled = !actions.huntDisabled,
-                onClick = onToggleHunt,
-                onLongClick = onLongPressHunt,
-                optionsContentDescription = stringResource(R.string.tx_hunt_options),
-            ) { color -> FT8AFIcons.Target(size = 18.dp, color = color, strokeWidth = 1.8f) }
-
-            // CQ / STOP — the primary action. Filled amber to call CQ, red to stop.
-            // Locked off while HUNT is armed (and no QSO yet).
-            // Long-press opens CQ options (modifier, free text, Field Day).
             val cqIsStop = actions.cqIsStop
-            val cqSubtitle = cqStripSubtitle(cqIsStop, isFreeTextMode, fieldDayEnabled, cqModifier)
-            PrimaryActionButton(
-                modifier = Modifier.weight(1.7f),
-                label = if (cqIsStop) stringResource(R.string.tx_stop) else stringResource(R.string.tx_call_cq),
+            val variantSubtitle = cqStripSubtitle(cqIsStop, isFreeTextMode, fieldDayEnabled, cqModifier)
+            val cqSubtitle = variantSubtitle
+                ?: if (!cqIsStop) stringResource(R.string.tx_call_cq_subtitle) else null
+            CallCqButton(
+                modifier = Modifier.weight(1.6f),
+                cqIsStop = cqIsStop,
+                cqDisabled = actions.cqDisabled,
                 subtitle = cqSubtitle,
-                background = when {
-                    cqIsStop -> StatusBad
-                    actions.cqDisabled -> Accent.copy(alpha = 0.35f)
-                    else -> Accent
-                },
-                contentColor = if (cqIsStop) Color.White else BgApp,
-                enabled = !actions.cqDisabled,
                 onClick = { if (cqIsStop) onStop() else onCallCQ() },
-                onLongClick = if (!cqIsStop) onLongPressCQ else null,
+                onOpenOptions = onOpenCqOptions,
                 optionsContentDescription = stringResource(R.string.tx_cq_options),
-            ) { color ->
-                if (cqIsStop) {
-                    FT8AFIcons.Close(size = 18.dp, color = color, strokeWidth = 2f)
-                } else {
-                    FT8AFIcons.Transmit(size = 18.dp, color = color, strokeWidth = 1.8f)
-                }
-            }
+                moreLabel = stringResource(R.string.tx_more),
+            )
 
-            // TX time-slot toggle — stacked arrow + TX1/TX2.
-            StackedActionButton(
+            HuntTile(
                 modifier = Modifier.weight(1f),
-                label = if (txSlot == 0) "TX1" else "TX2",
-                background = BgSurface3,
-                contentColor = TextMuted,
-                borderColor = Border,
+                huntEnabled = actions.huntActive,
+                huntDisabled = actions.huntDisabled,
+                optionLabel = huntOptionLabel,
+                onToggle = onToggleHunt,
+                onOpenOptions = onOpenHuntOptions,
+                optionsContentDescription = stringResource(R.string.tx_hunt_options),
+            )
+        }
+
+        // ---- Row 4: TX period segmented control · Tune · DX ----
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TxPeriodControl(
+                modifier = Modifier.weight(1.7f),
+                txSlot = txSlot,
+                onSelect = onSelectTxPeriod,
+            )
+            val tuneEnabled = isTuning || (!isActivated && !isTransmitting)
+            SecondaryButton(
+                modifier = Modifier.weight(0.45f),
+                label = tuneChipLabel(stringResource(R.string.tune_button), isTuning, tuneRemainingSec),
+                active = isTuning,
+                enabled = tuneEnabled,
+                onClick = onToggleTune,
+            )
+            SecondaryButton(
+                modifier = Modifier.weight(0.45f),
+                label = stringResource(R.string.tx_dx),
+                active = dxEnabled,
                 enabled = true,
-                onClick = onToggleSlot,
-            ) { color -> FT8AFIcons.ArrowUp(size = 18.dp, color = color, strokeWidth = 1.8f) }
+                onClick = onToggleDx,
+            )
         }
 
         // ---- Inline TX volume slider (togglable from Settings) ----
@@ -371,7 +324,6 @@ fun TxStrip(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                // Minus button
                 Box(
                     modifier = Modifier
                         .size(36.dp)
@@ -385,7 +337,7 @@ fun TxStrip(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = "\u2212", // minus sign
+                        text = "−",
                         color = TextMuted,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Bold,
@@ -393,12 +345,9 @@ fun TxStrip(
                     )
                 }
 
-                // Slider
                 IntSlider(
                     value = txVolume,
-                    onValueChange = { v ->
-                        onVolumeChange(v.coerceIn(0, 100))
-                    },
+                    onValueChange = { v -> onVolumeChange(v.coerceIn(0, 100)) },
                     onValueChangeFinished = onVolumeChangeFinished,
                     valueRange = 0f..100f,
                     modifier = Modifier.weight(1f),
@@ -406,7 +355,6 @@ fun TxStrip(
                     activeTrackColor = Accent,
                 )
 
-                // Plus button
                 Box(
                     modifier = Modifier
                         .size(36.dp)
@@ -428,7 +376,6 @@ fun TxStrip(
                     )
                 }
 
-                // Percentage label
                 Text(
                     text = "${txVolume}%",
                     color = TextPrimary,
@@ -442,208 +389,325 @@ fun TxStrip(
     }
 }
 
-/** A small rounded text chip (mode / DX). Keeps button semantics when disabled. */
+/**
+ * The primary Call CQ button (72dp): amber with a stacked label + helper subtitle and an
+ * attached "MORE" split button that opens the CQ-variant options. Turns into the red STOP
+ * button (centered, no split) once a CQ/QSO is running.
+ */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun TxChip(
+private fun CallCqButton(
+    cqIsStop: Boolean,
+    cqDisabled: Boolean,
+    subtitle: String?,
+    onClick: () -> Unit,
+    onOpenOptions: () -> Unit,
+    optionsContentDescription: String,
+    moreLabel: String,
+    modifier: Modifier = Modifier,
+) {
+    val background = when {
+        cqIsStop -> StatusBad
+        cqDisabled -> Accent.copy(alpha = 0.35f)
+        else -> Accent
+    }
+    val contentColor = if (cqIsStop) Color.White else BgApp
+
+    Row(
+        modifier = modifier
+            .height(72.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(background)
+            .combinedClickable(
+                enabled = !cqDisabled,
+                onClick = onClick,
+                onLongClick = if (!cqIsStop) onOpenOptions else null,
+            )
+            .padding(start = if (cqIsStop) 12.dp else 16.dp, end = if (cqIsStop) 12.dp else 4.dp),
+        horizontalArrangement = if (cqIsStop) {
+            Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
+        } else {
+            Arrangement.SpaceBetween
+        },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (cqIsStop) {
+            FT8AFIcons.Close(size = 18.dp, color = contentColor, strokeWidth = 2f)
+            Text(
+                text = stringResource(R.string.tx_stop),
+                color = contentColor,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = InterFamily,
+                maxLines = 1,
+                softWrap = false,
+            )
+        } else {
+            Column {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    FT8AFIcons.Transmit(size = 20.dp, color = contentColor, strokeWidth = 1.8f)
+                    Text(
+                        text = stringResource(R.string.tx_call_cq),
+                        color = contentColor,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = InterFamily,
+                        maxLines = 1,
+                        softWrap = false,
+                    )
+                }
+                if (subtitle != null) {
+                    Text(
+                        text = subtitle,
+                        color = contentColor.copy(alpha = 0.65f),
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Medium,
+                        fontFamily = InterFamily,
+                        maxLines = 1,
+                        softWrap = false,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+            }
+
+            // Attached MORE split button — a discoverable, separately-tappable affordance
+            // for the CQ options (the whole button also long-presses to the same menu).
+            Column(
+                modifier = Modifier
+                    .size(width = 48.dp, height = 60.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(contentColor.copy(alpha = 0.16f))
+                    .clickable(enabled = !cqDisabled, onClick = onOpenOptions)
+                    .semantics { role = Role.Button; contentDescription = optionsContentDescription },
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically),
+            ) {
+                FT8AFIcons.ChevronDown(size = 18.dp, color = contentColor, strokeWidth = 2.2f)
+                Text(
+                    text = moreLabel,
+                    color = contentColor.copy(alpha = 0.65f),
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = InterFamily,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The Hunt tile (72dp): tapping the tile toggles Hunt; the amber chip shows the active hunt
+ * option and, when tapped, opens the hunt-options picker. Dimmed and locked while a CQ/QSO is
+ * running (Hunt and calling CQ are mutually exclusive).
+ */
+@Composable
+private fun HuntTile(
+    huntEnabled: Boolean,
+    huntDisabled: Boolean,
+    optionLabel: String,
+    onToggle: () -> Unit,
+    onOpenOptions: () -> Unit,
+    optionsContentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val contentAlpha = if (huntDisabled) 0.4f else 1f
+    Column(
+        modifier = modifier
+            .height(72.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(if (huntDisabled) BgSurface3.copy(alpha = 0.4f) else BgSurface3)
+            .border(1.dp, Border, RoundedCornerShape(14.dp))
+            .clickable(enabled = !huntDisabled) { onToggle() }
+            .padding(horizontal = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterVertically),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            FT8AFIcons.Target(size = 18.dp, color = TextMuted.copy(alpha = contentAlpha), strokeWidth = 1.8f)
+            Text(
+                text = stringResource(R.string.tx_hunt),
+                color = TextPrimary.copy(alpha = contentAlpha),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = InterFamily,
+                maxLines = 1,
+                softWrap = false,
+            )
+        }
+        HuntChip(
+            label = optionLabel,
+            active = huntEnabled,
+            enabled = !huntDisabled,
+            onClick = onOpenOptions,
+            contentDescription = optionsContentDescription,
+        )
+    }
+}
+
+@Composable
+private fun HuntChip(
     label: String,
-    background: Color,
-    textColor: Color,
-    bold: Boolean,
+    active: Boolean,
     enabled: Boolean,
+    onClick: () -> Unit,
+    contentDescription: String,
+) {
+    Row(
+        modifier = Modifier
+            .height(22.dp)
+            .clip(RoundedCornerShape(999.dp))
+            .background(if (active) AccentSoft else BgSurface)
+            .then(
+                if (active) Modifier.border(1.dp, BorderAmber, RoundedCornerShape(999.dp))
+                else Modifier
+            )
+            .clickable(enabled = enabled, onClickLabel = contentDescription) { onClick() }
+            .semantics { role = Role.Button; this.contentDescription = contentDescription }
+            .padding(horizontal = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = label,
+            color = if (active) Accent else TextFaint,
+            fontSize = 10.5.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = InterFamily,
+            maxLines = 1,
+            softWrap = false,
+        )
+        FT8AFIcons.ChevronDown(
+            size = 10.dp,
+            color = if (active) Accent else TextFaint,
+            strokeWidth = 2.4f,
+        )
+    }
+}
+
+/**
+ * The TX-period card (52dp): a label plus a two-segment control choosing the 1st (even) or
+ * 2nd (odd) transmit slot. [txSlot] 0 selects "1st (even)", 1 selects "2nd (odd)".
+ */
+@Composable
+private fun TxPeriodControl(
+    txSlot: Int,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .height(52.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(BgSurface3)
+            .border(1.dp, Border, RoundedCornerShape(12.dp))
+            .padding(start = 12.dp, end = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.tx_period_label),
+            color = TextFaint,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = InterFamily,
+            letterSpacing = 0.6.sp,
+            maxLines = 1,
+            softWrap = false,
+        )
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .clip(RoundedCornerShape(9.dp))
+                .background(BgSurface)
+                .padding(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            PeriodSegment(
+                label = stringResource(R.string.tx_period_first),
+                selected = txSlot == 0,
+                modifier = Modifier.weight(1f),
+                onClick = { if (txSlot != 0) onSelect(0) },
+            )
+            PeriodSegment(
+                label = stringResource(R.string.tx_period_second),
+                selected = txSlot == 1,
+                modifier = Modifier.weight(1f),
+                onClick = { if (txSlot != 1) onSelect(1) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PeriodSegment(
+    label: String,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = Modifier
-            .clip(RoundedCornerShape(6.dp))
-            .background(background)
-            // Disable via clickable(enabled=…) rather than dropping the modifier, so the
-            // chip keeps its button semantics and TalkBack still announces it as a disabled
-            // control instead of vanishing from accessibility entirely.
-            .clickable(enabled = enabled) { onClick() }
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+        modifier = modifier
+            .height(36.dp)
+            .clip(RoundedCornerShape(7.dp))
+            .background(if (selected) Accent.copy(alpha = 0.18f) else Color.Transparent)
+            .clickable { onClick() }
+            .padding(horizontal = 6.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = label,
-            color = textColor,
+            color = if (selected) Accent else TextMuted,
             fontSize = 11.sp,
-            fontWeight = if (bold) FontWeight.Bold else FontWeight.SemiBold,
-            fontFamily = GeistMonoFamily,
-            letterSpacing = 0.02.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+            fontFamily = InterFamily,
             maxLines = 1,
             softWrap = false,
         )
     }
 }
 
-/** A large secondary button with the icon stacked above the label (HUNT, TX slot). */
-@OptIn(ExperimentalFoundationApi::class)
+/** A small 52dp secondary button (Tune / DX): amber-tinted when active, muted otherwise. */
 @Composable
-private fun StackedActionButton(
+private fun SecondaryButton(
     label: String,
-    background: Color,
-    contentColor: Color,
-    borderColor: Color,
+    active: Boolean,
     enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    subtitle: String? = null,
-    onLongClick: (() -> Unit)? = null,
-    optionsContentDescription: String = "",
-    icon: @Composable (Color) -> Unit,
 ) {
-    Row(
+    Box(
         modifier = modifier
-            .height(54.dp)
+            .height(52.dp)
             .clip(RoundedCornerShape(12.dp))
-            .background(background)
-            .border(1.dp, borderColor, RoundedCornerShape(12.dp))
-            .combinedClickable(
-                enabled = enabled,
-                onClick = onClick,
-                onLongClick = onLongClick,
+            .background(if (active) Accent.copy(alpha = 0.18f) else BgSurface3)
+            .border(
+                1.dp,
+                if (active) Accent.copy(alpha = 0.28f) else Border,
+                RoundedCornerShape(12.dp),
             )
-            .padding(horizontal = 4.dp, vertical = if (subtitle != null) 4.dp else 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
+            .clickable(enabled = enabled) { onClick() }
+            .padding(horizontal = 6.dp),
+        contentAlignment = Alignment.Center,
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(
-                if (subtitle != null) 1.dp else 3.dp, Alignment.CenterVertically,
-            ),
-        ) {
-            icon(contentColor)
-            Text(
-                text = label,
-                color = contentColor,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.02.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-            if (subtitle != null) {
-                Text(
-                    text = subtitle,
-                    color = contentColor.copy(alpha = 0.6f),
-                    fontSize = 8.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    fontFamily = GeistMonoFamily,
-                    letterSpacing = 0.02.sp,
-                    maxLines = 1,
-                    softWrap = false,
-                )
-            }
-        }
-        if (onLongClick != null) {
-            // Same visible "more options" affordance as the CQ button — a plain
-            // tap opens the options sheet (discoverable), long-press on the whole
-            // button is the shortcut.
-            Box(
-                modifier = Modifier
-                    .size(width = 22.dp, height = 38.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(contentColor.copy(alpha = 0.16f))
-                    .clickable(enabled = enabled, onClick = onLongClick)
-                    .semantics {
-                        role = Role.Button
-                        contentDescription = optionsContentDescription
-                    },
-                contentAlignment = Alignment.Center,
-            ) {
-                FT8AFIcons.ChevronDown(size = 14.dp, color = contentColor, strokeWidth = 2.2f)
-            }
-        }
-    }
-}
-
-/** The large primary button with the icon beside the label (CQ / STOP). */
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun PrimaryActionButton(
-    label: String,
-    background: Color,
-    contentColor: Color,
-    enabled: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    subtitle: String? = null,
-    onLongClick: (() -> Unit)? = null,
-    optionsContentDescription: String = "",
-    icon: @Composable (Color) -> Unit,
-) {
-    Row(
-        modifier = modifier
-            .height(54.dp)
-            .clip(RoundedCornerShape(12.dp))
-            .background(background)
-            .combinedClickable(
-                enabled = enabled,
-                onClick = onClick,
-                onLongClick = onLongClick,
-            )
-            .padding(horizontal = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        icon(contentColor)
-        if (subtitle != null) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = label,
-                    color = contentColor,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Bold,
-                    fontFamily = GeistMonoFamily,
-                    letterSpacing = 0.04.sp,
-                    maxLines = 1,
-                    softWrap = false,
-                )
-                Text(
-                    text = subtitle,
-                    color = contentColor.copy(alpha = 0.6f),
-                    fontSize = 9.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    fontFamily = GeistMonoFamily,
-                    letterSpacing = 0.02.sp,
-                    maxLines = 1,
-                    softWrap = false,
-                )
-            }
-        } else {
-            Text(
-                text = label,
-                color = contentColor,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Bold,
-                fontFamily = GeistMonoFamily,
-                letterSpacing = 0.04.sp,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
-        if (onLongClick != null) {
-            // A visible, separately-tappable "more options" affordance. A plain tap opens the
-            // CQ options sheet (discoverable), and the whole button still long-presses to the
-            // same sheet as a shortcut. Without this the sheet was effectively hidden — a tester
-            // reported they'd never have found the long-press.
-            Box(
-                modifier = Modifier
-                    .size(width = 30.dp, height = 38.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(contentColor.copy(alpha = 0.16f))
-                    .clickable(enabled = enabled, onClick = onLongClick)
-                    .semantics {
-                        role = Role.Button
-                        contentDescription = optionsContentDescription
-                    },
-                contentAlignment = Alignment.Center,
-            ) {
-                FT8AFIcons.ChevronDown(size = 16.dp, color = contentColor, strokeWidth = 2.2f)
-            }
-        }
+        Text(
+            text = label,
+            color = when {
+                active -> Accent
+                enabled -> TextMuted
+                else -> TextMuted.copy(alpha = 0.4f)
+            },
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = InterFamily,
+            maxLines = 1,
+            softWrap = false,
+        )
     }
 }
 
@@ -673,17 +737,15 @@ private fun PulseDot(color: Color) {
         modifier = Modifier.size(22.dp),
         contentAlignment = Alignment.Center,
     ) {
-        // Pulse ring
         Box(
             modifier = Modifier
-                .size((6 + pulseSize * 2).dp)
+                .size((7 + pulseSize * 2).dp)
                 .clip(CircleShape)
                 .background(color.copy(alpha = pulseAlpha * 0.18f))
         )
-        // Solid dot
         Box(
             modifier = Modifier
-                .size(6.dp)
+                .size(7.dp)
                 .clip(CircleShape)
                 .background(color)
         )

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/components/TxStrip.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,10 +33,12 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -568,7 +572,13 @@ private fun HuntChip(
                 else Modifier
             )
             .clickable(enabled = enabled, onClickLabel = contentDescription) { onClick() }
-            .semantics { role = Role.Button; this.contentDescription = contentDescription }
+            .semantics {
+                role = Role.Button
+                this.contentDescription = contentDescription
+                // Surface the visible label ("Off" / the active priority) so a screen reader
+                // announces the current hunt option, not just "Hunt options".
+                stateDescription = label
+            }
             .padding(horizontal = 9.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -656,7 +666,7 @@ private fun PeriodSegment(
             .height(36.dp)
             .clip(RoundedCornerShape(7.dp))
             .background(if (selected) Accent.copy(alpha = 0.18f) else Color.Transparent)
-            .clickable { onClick() }
+            .selectable(selected = selected, role = Role.RadioButton) { onClick() }
             .padding(horizontal = 6.dp),
         contentAlignment = Alignment.Center,
     ) {
@@ -691,7 +701,9 @@ private fun SecondaryButton(
                 if (active) Accent.copy(alpha = 0.28f) else Border,
                 RoundedCornerShape(12.dp),
             )
-            .clickable(enabled = enabled) { onClick() }
+            // toggleable (not clickable) so TalkBack announces the on/off state — the DX
+            // button's label never changes, so color alone can't convey whether it's active.
+            .toggleable(value = active, enabled = enabled, onValueChange = { onClick() })
             .padding(horizontal = 6.dp),
         contentAlignment = Alignment.Center,
     ) {
@@ -705,8 +717,10 @@ private fun SecondaryButton(
             fontSize = 12.sp,
             fontWeight = FontWeight.SemiBold,
             fontFamily = InterFamily,
-            maxLines = 1,
-            softWrap = false,
+            // The active "Tune 60s" countdown can be wider than the ~42dp available on a
+            // narrow phone; allow it to wrap to a second line instead of clipping the seconds.
+            maxLines = 2,
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/ft8af/app/src/main/res/values/strings_compose.xml
+++ b/ft8af/app/src/main/res/values/strings_compose.xml
@@ -119,6 +119,36 @@
     <string name="tx_volume_increase">Increase TX volume</string>
     <string name="tx_cq_options">CQ message options (modifier, free text, Field Day)</string>
     <string name="tx_hunt_options">Hunt options (priority, smart filters)</string>
+    <!-- Redesigned TX strip (option 3a) -->
+    <string name="tx_status_listening">Listening</string>
+    <string name="tx_status_transmitting">Transmitting</string>
+    <string name="tx_status_tuning">Tuning</string>
+    <string name="tx_next_window">Next transmit window in</string>
+    <string name="tx_call_cq_subtitle">Start calling for contacts</string>
+    <string name="tx_more">MORE</string>
+    <string name="tx_band_mode_label">BAND &amp; MODE</string>
+    <string name="tx_period_label">TX PERIOD</string>
+    <string name="tx_period_first">1st (even)</string>
+    <string name="tx_period_second">2nd (odd)</string>
+    <string name="tx_dx">DX</string>
+    <string name="tx_hunt_off">Off</string>
+
+    <!-- ===== Band &amp; Mode sheet (option 3b) ===== -->
+    <string name="band_sheet_title">Band &amp; mode</string>
+    <string name="band_sheet_subtitle">Your radio retunes when you pick a band</string>
+    <string name="band_sheet_close">Close</string>
+    <string name="band_sheet_all_bands">All bands &amp; custom frequency</string>
+    <string name="band_hint_20m_best">Best now · daytime, worldwide</string>
+    <string name="band_hint_20m">Daytime, worldwide</string>
+    <string name="band_hint_40m">Evenings and nights</string>
+    <string name="band_hint_17m">Quieter daytime band</string>
+    <string name="band_hint_15m">Good when the sun is active</string>
+    <string name="band_hint_10m">Long distance when open</string>
+    <string name="band_hint_80m">Local, evenings</string>
+
+    <!-- Plain-language CAT chip labels for the redesigned TX strip -->
+    <string name="cat_status_linked">Radio linked</string>
+    <string name="cat_status_not_linked">Radio not linked</string>
 
     <!-- ===== Hunt options sheet ===== -->
     <string name="hunt_priority_title">HUNT PRIORITY</string>

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/BandModeSheetLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/BandModeSheetLogicTest.kt
@@ -1,0 +1,94 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.ModeProfile
+import com.k1af.ft8af.R
+import com.k1af.ft8af.database.OperationBand
+import org.junit.Test
+
+/**
+ * Unit tests for the pure Band & Mode sheet helpers ([formatSlotSeconds], [bandHintRes],
+ * [mostUsedBands]). No Android runtime needed: OperationBand.Band is a plain data holder,
+ * ModeProfile is an enum, and R.string ids are compile-time ints.
+ */
+class BandModeSheetLogicTest {
+
+    private fun band(freq: Long, wave: String, modeId: Int, marked: Boolean): OperationBand.Band {
+        val b = OperationBand.Band(freq, wave)
+        b.mode = modeId
+        b.marked = marked
+        return b
+    }
+
+    @Test
+    fun `formatSlotSeconds trims whole and fractional seconds`() {
+        assertThat(formatSlotSeconds(15_000)).isEqualTo("15s")
+        assertThat(formatSlotSeconds(7_500)).isEqualTo("7.5s")
+        assertThat(formatSlotSeconds(3_750)).isEqualTo("3.75s")
+    }
+
+    @Test
+    fun `formatSlotSeconds matches the shipped mode profiles`() {
+        assertThat(formatSlotSeconds(ModeProfile.FT8.slotMillis)).isEqualTo("15s")
+        assertThat(formatSlotSeconds(ModeProfile.FT4.slotMillis)).isEqualTo("7.5s")
+        assertThat(formatSlotSeconds(ModeProfile.FT2.slotMillis)).isEqualTo("3.75s")
+    }
+
+    @Test
+    fun `20m hint is time-of-day aware, others are static`() {
+        assertThat(bandHintRes("20m", isDaytime = true)).isEqualTo(R.string.band_hint_20m_best)
+        assertThat(bandHintRes("20m", isDaytime = false)).isEqualTo(R.string.band_hint_20m)
+        assertThat(bandHintRes("40m", isDaytime = true)).isEqualTo(R.string.band_hint_40m)
+        assertThat(bandHintRes("17m", isDaytime = false)).isEqualTo(R.string.band_hint_17m)
+        assertThat(bandHintRes("15m", isDaytime = true)).isEqualTo(R.string.band_hint_15m)
+        assertThat(bandHintRes("10m", isDaytime = false)).isEqualTo(R.string.band_hint_10m)
+        assertThat(bandHintRes("80m", isDaytime = true)).isEqualTo(R.string.band_hint_80m)
+    }
+
+    @Test
+    fun `bandHintRes returns 0 for a band with no hint`() {
+        assertThat(bandHintRes("6m", isDaytime = true)).isEqualTo(0)
+    }
+
+    @Test
+    fun `mostUsedBands keeps display order and the mode's dials`() {
+        val ft8 = ModeProfile.FT8.id
+        val ft4 = ModeProfile.FT4.id
+        val bands = listOf(
+            band(7_074_000, "40m", ft8, marked = true),
+            band(14_074_000, "20m", ft8, marked = true),
+            band(14_080_000, "20m", ft4, marked = true), // wrong mode — must be ignored
+            band(21_074_000, "15m", ft8, marked = true),
+        )
+        val rows = mostUsedBands(bands, ft8)
+        assertThat(rows.map { it.waveLength }).containsExactly("20m", "40m", "15m").inOrder()
+        val twenty = rows.first { it.waveLength == "20m" }
+        assertThat(twenty.freqHz).isEqualTo(14_074_000)
+        assertThat(twenty.bandIndex).isEqualTo(1)
+    }
+
+    @Test
+    fun `mostUsedBands prefers the marked entry over an earlier unmarked one`() {
+        val ft8 = ModeProfile.FT8.id
+        val bands = listOf(
+            band(14_071_000, "20m", ft8, marked = false),
+            band(14_074_000, "20m", ft8, marked = true),
+        )
+        val rows = mostUsedBands(bands, ft8)
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].freqHz).isEqualTo(14_074_000)
+        assertThat(rows[0].bandIndex).isEqualTo(1)
+    }
+
+    @Test
+    fun `mostUsedBands falls back to first match when nothing is marked`() {
+        val ft8 = ModeProfile.FT8.id
+        val bands = listOf(
+            band(14_071_000, "20m", ft8, marked = false),
+            band(14_090_000, "20m", ft8, marked = false),
+        )
+        val rows = mostUsedBands(bands, ft8)
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].freqHz).isEqualTo(14_071_000)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CatStatusChipLogicTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/CatStatusChipLogicTest.kt
@@ -19,35 +19,47 @@ import radio.ks3ckc.ft8af.theme.TextMuted
 class CatStatusChipLogicTest {
 
     @Test
-    fun `disconnected is muted, not pulsing`() {
+    fun `disconnected is muted, not pulsing, not linked`() {
         val v = catChipVisuals(CatConnectionState.DISCONNECTED)
         assertThat(v.dotColor).isEqualTo(TextMuted)
         assertThat(v.pulsing).isFalse()
         assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_disconnected)
+        assertThat(v.labelRes).isEqualTo(R.string.cat_status_not_linked)
     }
 
     @Test
-    fun `connecting is amber and pulsing`() {
+    fun `connecting is amber and pulsing, not linked yet`() {
         val v = catChipVisuals(CatConnectionState.CONNECTING)
         assertThat(v.dotColor).isEqualTo(Accent)
         assertThat(v.pulsing).isTrue()
         assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_connecting)
+        assertThat(v.labelRes).isEqualTo(R.string.cat_status_not_linked)
     }
 
     @Test
-    fun `connected is green, not pulsing`() {
+    fun `connected is green, not pulsing, linked`() {
         val v = catChipVisuals(CatConnectionState.CONNECTED)
         assertThat(v.dotColor).isEqualTo(StatusConfirmed)
         assertThat(v.pulsing).isFalse()
         assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_connected)
+        assertThat(v.labelRes).isEqualTo(R.string.cat_status_linked)
     }
 
     @Test
-    fun `error is red, not pulsing`() {
+    fun `error is red, not pulsing, not linked`() {
         val v = catChipVisuals(CatConnectionState.ERROR)
         assertThat(v.dotColor).isEqualTo(StatusBad)
         assertThat(v.pulsing).isFalse()
         assertThat(v.contentDescriptionRes).isEqualTo(R.string.cat_status_error)
+        assertThat(v.labelRes).isEqualTo(R.string.cat_status_not_linked)
+    }
+
+    @Test
+    fun `only the connected state reads as linked`() {
+        val linked = CatConnectionState.values().filter {
+            catChipVisuals(it).labelRes == R.string.cat_status_linked
+        }
+        assertThat(linked).containsExactly(CatConnectionState.CONNECTED)
     }
 
     @Test

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/NextTxWindowTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/NextTxWindowTest.kt
@@ -1,0 +1,52 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [nextTxWindowSeconds] — the pure "seconds until my next transmit slot" math
+ * for the redesigned strip's status-row countdown. No Android runtime needed.
+ */
+class NextTxWindowTest {
+
+    @Test
+    fun `off-slot counts down to the next boundary`() {
+        // now is in slot index 1 (odd); the operator transmits on even slots (txSlot 0), so
+        // the next window is the very next boundary at 30_000ms — 6s away.
+        assertThat(nextTxWindowSeconds(nowMs = 24_000L, slotMillis = 15_000L, txSlot = 0))
+            .isEqualTo(6)
+    }
+
+    @Test
+    fun `matching slot points at the following window, never zero`() {
+        assertThat(nextTxWindowSeconds(nowMs = 0L, slotMillis = 15_000L, txSlot = 0))
+            .isEqualTo(30)
+    }
+
+    @Test
+    fun `odd txSlot mirrors even txSlot`() {
+        assertThat(nextTxWindowSeconds(nowMs = 0L, slotMillis = 15_000L, txSlot = 1))
+            .isEqualTo(15)
+    }
+
+    @Test
+    fun `always a positive, upcoming number across a whole cycle`() {
+        for (ms in 0 until 30_000 step 250) {
+            val secs = nextTxWindowSeconds(ms.toLong(), 15_000L, txSlot = 0)
+            assertThat(secs).isAtLeast(1)
+            assertThat(secs).isAtMost(30)
+        }
+    }
+
+    @Test
+    fun `ft4 fast slot scales the window`() {
+        assertThat(nextTxWindowSeconds(nowMs = 0L, slotMillis = 7_500L, txSlot = 0))
+            .isEqualTo(15)
+    }
+
+    @Test
+    fun `non-positive slotMillis falls back to 15s grid`() {
+        assertThat(nextTxWindowSeconds(nowMs = 0L, slotMillis = 0L, txSlot = 1))
+            .isEqualTo(15)
+    }
+}

--- a/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/TxStatusVisualsTest.kt
+++ b/ft8af/app/src/test/kotlin/radio/ks3ckc/ft8af/ui/components/TxStatusVisualsTest.kt
@@ -1,0 +1,40 @@
+package radio.ks3ckc.ft8af.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import com.k1af.ft8af.R
+import org.junit.Test
+
+/**
+ * Unit tests for [txStatusVisuals] — the pure status-row state mapping for the redesigned TX
+ * strip. Verifies the three states and that Tuning wins over Transmitting, and that the "next
+ * window" countdown only shows while Listening.
+ */
+class TxStatusVisualsTest {
+
+    @Test
+    fun `listening when idle, shows the countdown`() {
+        val v = txStatusVisuals(isTransmitting = false, isTuning = false)
+        assertThat(v.labelRes).isEqualTo(R.string.tx_status_listening)
+        assertThat(v.listening).isTrue()
+    }
+
+    @Test
+    fun `transmitting hides the countdown`() {
+        val v = txStatusVisuals(isTransmitting = true, isTuning = false)
+        assertThat(v.labelRes).isEqualTo(R.string.tx_status_transmitting)
+        assertThat(v.listening).isFalse()
+    }
+
+    @Test
+    fun `tuning hides the countdown`() {
+        val v = txStatusVisuals(isTransmitting = false, isTuning = true)
+        assertThat(v.labelRes).isEqualTo(R.string.tx_status_tuning)
+        assertThat(v.listening).isFalse()
+    }
+
+    @Test
+    fun `tuning takes precedence over transmitting`() {
+        val v = txStatusVisuals(isTransmitting = true, isTuning = true)
+        assertThat(v.labelRes).isEqualTo(R.string.tx_status_tuning)
+    }
+}


### PR DESCRIPTION
Reworks the TX strip to the high-fidelity design (**option 3a**) and adds the **Band & Mode** bottom sheet (**option 3b**) from `design_handoff_tx_strip_redesign`. Rebased onto current `dev` and **wired into dev's existing Hunt-options feature** (this PR does not duplicate it).

### TX strip (`TxStrip.kt`)
- Status row: pulse dot + Listening/Transmitting/Tuning + a live, parity-aware **"Next transmit window in Xs"** countdown, and the CAT chip.
- 48dp **BAND & MODE** row ("14.074 MHz · 20m · FT8") opening the new sheet.
- 72dp **Call CQ** with a visible **MORE** split-button (replaces the long-press-only affordance; opens the existing CQ-variants menu).
- **Hunt tile** whose amber chip shows the active hunt priority (or "Off") and opens **dev's** `HuntOptionsSheet`; tapping the tile toggles Hunt.
- **TX PERIOD** segmented control (1st even / 2nd odd) replacing the TX1 toggle.
- Tune / DX buttons; inline volume slider preserved.

### Band & Mode sheet (`BandModeSheet.kt`)
- FT8/FT4/FT2 mode toggle with cycle times (15s / 7.5s / 3.75s).
- Curated most-used band list from `assets/bands.txt` with plain-English hints (20m is time-of-day aware) and an "All bands & custom frequency" footer → the existing full picker.

### Other
- `CatStatusChip` now reads "Radio linked" / "Radio not linked" (Inter).
- `SlotTimerBar` gains `NextTxWindowLabel` + the pure, tested `nextTxWindowSeconds`; **dev's slot bar + clock-sync pill are left in place** above the strip.
- Theme tokens + `FT8AFIcons` reused; all tap targets ≥44dp; px→dp 1:1.

### Scope note
An earlier revision of this branch was cut from a stale `main` and also re-implemented the Hunt priority/smart-filters feature — which already exists on `dev`. That duplication has been **dropped**; this PR is now redesign-only and layers on dev's hunt backend.

### Tests
Unit tests for the extracted pure logic: `nextTxWindowSeconds`, `txStatusVisuals`, `formatSlotSeconds`, `bandHintRes`, `mostUsedBands`, and the CAT chip labels. Full `testDebugUnitTest` green.

### Verification
Built and driven on an emulator against `dev`: redesigned strip, Band & Mode sheet, TX-period toggle, MORE menu, and the Hunt tile opening dev's Hunt sheet — with dev's clock-sync pill and slot bar intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)