### PR TITLE
iOS: fix 4 Copilot review findings from PR #763

### DIFF
--- a/ios/FT8AF/FT8AF/Components/SlotTimerBar.swift
+++ b/ios/FT8AF/FT8AF/Components/SlotTimerBar.swift
@@ -29,7 +29,13 @@ struct SlotTimerBar: View {
         .frame(height: 3)
         .onReceive(timer) { _ in
             let profile = appState.settings.mode.profile
-            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            // Use the same corrected clock LiveEngine schedules RX/TX with (NTP +
+            // manual + auto-DT), so the bar and its parity never show a different
+            // slot than the engine is actually using after a sync.
+            let offsetMs = appState.clock
+                .clockOffset(manualMs: appState.settings.manualClockOffsetMs)
+                .combinedMs
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000) + offsetMs
             let ms = SlotClock.msIntoCycle(atUtcMs: nowMs, cycleMs: profile.cycleMs)
             progress = Double(ms) / Double(profile.cycleMs)
             // Guard band = the mode's message duration to the slot boundary.

--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -18,6 +18,10 @@ struct TxStrip: View {
     var body: some View {
         let tx = appState.tx
         let settings = appState.settings
+        // FT4 is RX + timing only for now (scheduleTx rejects non-FT8), so TX/Hunt
+        // must be inert in non-FT8 modes — otherwise Call CQ arms the sequencer and
+        // shows an active TX state that never produces audio.
+        let txAllowed = settings.mode.profile.isFT8
 
         VStack(spacing: 10) {
             // Info row: status + frequency/mode chips + expand chevron
@@ -44,6 +48,13 @@ struct TxStrip: View {
                         Picker("Mode", selection: Binding(
                             get: { settings.mode },
                             set: { newMode in
+                                // Leaving FT8 for an RX-only mode must stop any armed
+                                // CQ/QSO and Hunt so the engine isn't left "transmitting"
+                                // with no audio (scheduleTx would silently drop the TX).
+                                if !newMode.profile.isFT8 {
+                                    if tx.isActivated { onStop() }
+                                    if tx.huntEnabled { onHunt() }
+                                }
                                 settings.mode = newMode
                                 SettingsPersistence.save(appState.settings)
                             }
@@ -156,8 +167,11 @@ struct TxStrip: View {
                     activeColor: signal,
                     style: .secondary
                 ) { onHunt() }
+                .disabled(!txAllowed)
+                .opacity(txAllowed ? 1 : 0.4)
 
-                // CQ / STOP button
+                // CQ / STOP button. In RX-only modes Call CQ is disabled, but STOP
+                // stays live so an FT8-armed run can still be stopped after a switch.
                 ActionButton(
                     label: tx.isActivated ? "STOP" : "CALL CQ",
                     icon: tx.isActivated ? "xmark" : "antenna.radiowaves.left.and.right",
@@ -171,6 +185,8 @@ struct TxStrip: View {
                         onCallCQ()
                     }
                 }
+                .disabled(!txAllowed && !tx.isActivated)
+                .opacity((!txAllowed && !tx.isActivated) ? 0.4 : 1)
 
                 // TX slot toggle
                 ActionButton(

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -572,8 +572,11 @@ final class LiveEngine {
 
         // Keep the live POTA spot cache warm while an activation is running so
         // park-to-park QSO stamping can resolve worked calls even when the Hunt
-        // tab (the only other refresh driver) isn't visible.
-        maybeRefreshPotaSpotsForActivation(nowMs: nowMs)
+        // tab (the only other refresh driver) isn't visible. Rate-limited against
+        // PotaService.lastRefreshMs, which is stamped from raw Date() — so pass the
+        // raw wall clock (not the NTP/DT-corrected nowMs) or a backwards clock
+        // correction makes the delta negative and suppresses refreshes.
+        maybeRefreshPotaSpotsForActivation(nowMs: Int64(Date().timeIntervalSince1970 * 1000))
 
         // Log incoming RX messages addressed to us for the conversation panel.
         let myCall = settings.myCall.uppercased()

--- a/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/FT8Decoder.swift
@@ -43,6 +43,10 @@ public final class FT8Decoder {
     /// The codec sample rate (needed by the time-domain subtraction, which works
     /// in the raw sample domain rather than the waterfall).
     let sampleRate: Int32
+    /// Whether this decoder is running the FT8 protocol (vs. FT4). The subtract-
+    /// and-redecode deep loop re-synthesizes FT8 tones, so it is only valid for
+    /// FT8; FT4 uses the single decode pass. Exposed read-only for that gate/tests.
+    public let isFT8: Bool
     /// Retained copy of the samples last fed through the monitor. The subtract-
     /// and-redecode loop edits this in place (removing each decoded signal) and
     /// re-runs the STFT over it — mirroring ft8_decoder_state.samples/num_fed in
@@ -68,6 +72,7 @@ public final class FT8Decoder {
     public init(sampleRate: Int32 = FT8.sampleRate, isFT8: Bool = true, hashTable: HashTable = HashTable()) {
         self.hashtable = hashTable
         self.sampleRate = sampleRate
+        self.isFT8 = isFT8
         var cfg = monitor_config_t()
         cfg.f_min = 100
         cfg.f_max = 3500

--- a/ios/FT8AFKit/Sources/FT8DSP/SubtractDecode.swift
+++ b/ios/FT8AFKit/Sources/FT8DSP/SubtractDecode.swift
@@ -48,7 +48,13 @@ public extension FT8Decoder {
     func decodeSlotDeep() -> [DecodedMessage] {
         findSync()
         var all = decodeAll()
-        guard isDeep else { return all }
+        // The subtract-and-redecode loop re-synthesizes FT8 tones (79 tones, BT 2.0,
+        // 0.160 s symbol) via `ft8_subtract_signal_time`, so it is only correct for FT8.
+        // In FT4 mode it would subtract the wrong waveform from the captured slot and
+        // pollute the residual, hurting subsequent weak-signal passes — so FT4 (and any
+        // non-FT8 protocol) runs the single decode pass only until the native routine is
+        // protocol-parameterized. FT8 is unaffected.
+        guard isDeep, isFT8 else { return all }
         runSubtractLoop(into: &all)
         return all
     }

--- a/ios/FT8AFKit/Tests/FT8DSPTests/SubtractDecodeTests.swift
+++ b/ios/FT8AFKit/Tests/FT8DSPTests/SubtractDecodeTests.swift
@@ -160,4 +160,28 @@ final class SubtractDecodeTests: XCTestCase {
 
         XCTAssertEqual(deepOff, single, "deep-off decodeSlotDeep equals a single pass")
     }
+
+    /// The subtract loop re-synthesizes FT8 tones, so it must run for FT8 only.
+    /// The `isFT8` flag the gate keys on is set from the initializer; guard the
+    /// wiring so an FT4 decoder can't silently start FT8-tone subtraction.
+    func testIsFt8FlagGatesSubtraction() {
+        XCTAssertTrue(FT8Decoder(isFT8: true).isFT8, "default/FT8 decoder reports FT8")
+        XCTAssertFalse(FT8Decoder(isFT8: false).isFT8, "FT4 decoder reports non-FT8")
+
+        // An FT4 deep decoder must run the single pass only (subtract loop gated
+        // off), so decodeSlotDeep never diverges from findSync + decodeAll.
+        guard let s = mixedSlot([("CQ K1ABC FN42", 1500, 0.5)]) else { return XCTFail("encode") }
+
+        let deep = FT8Decoder(isFT8: false)
+        deep.setDeep(true)
+        deep.feedSlot(s)
+        let ft4Deep = Set(deep.decodeSlotDeep().map { $0.rawText })
+
+        let single = FT8Decoder(isFT8: false)
+        single.feedSlot(s)
+        single.findSync()
+        let ft4Single = Set(single.decodeAll().map { $0.rawText })
+
+        XCTAssertEqual(ft4Deep, ft4Single, "FT4 decodeSlotDeep is a single pass (subtraction gated off)")
+    }
 }


### PR DESCRIPTION
Fixes the four valid Copilot findings from the dev→staging promotion review (#763). These are pre-existing issues in already-merged iOS features (FT4 RX, NTP, POTA), split out here so the promotion isn't held up and these get proper iOS CI + review.

## Fixes
- **SubtractDecode → FT8 only** (`SubtractDecode.swift`, `FT8Decoder.swift`): the subtract-and-redecode loop re-synthesizes FT8 tones (`ft8_subtract_signal_time`), so running it for FT4 subtracted the wrong waveform and polluted the residual (hurting weak-signal passes). FT4 now runs the single decode pass. `FT8Decoder` gains a read-only `isFT8` flag; new `SubtractDecodeTests` case guards the gate.
- **SlotTimerBar clock** (`SlotTimerBar.swift`): apply the same NTP/manual/auto-DT offset `LiveEngine` schedules RX/TX with, so the bar and its parity can't display a different slot than the engine after a sync (was reading the raw device clock).
- **POTA refresh time source** (`LiveEngine.swift`): rate-limit the activation spot refresh against the raw wall clock, matching `PotaService.lastRefreshMs` (stamped from `Date()`). Using the corrected clock could make the delta negative and suppress refreshes if a correction moved the clock backwards.
- **FT4 TX/Hunt gating** (`TxStrip.swift`): FT4 is RX-only (`scheduleTx` rejects non-FT8), so Call CQ / Hunt are disabled in non-FT8 modes, and switching away from FT8 stops any armed CQ/QSO + Hunt. Previously Call CQ armed the sequencer and showed an active TX state that never produced audio.

## Not changed (false positive)
The SNTP offset formula flagged in the same review (`SntpSyncService.swift`) is left as-is: it intentionally mirrors Android's `UtcTimer.ntpClockOffsetMs` (`reference − now`), and one-way return latency (tens–hundreds of ms) is well within FT8's ~1 s timing tolerance — the full 4-timestamp SNTP calc isn't warranted here and Android doesn't do it either.

## Verification
- `swift test` — FT8DSP suite, 49 tests, 0 failures (incl. the new subtract gate).
- `xcodebuild build` — FT8AF app on iPhone 16 simulator, **BUILD SUCCEEDED**.
- Full runtime behaviour (on-device timing/POTA) not exercised here; changes are compile-verified + logic-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)