### PR TITLE
iOS: fix 2 follow-up Copilot findings from PR #763

### DIFF
--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -48,13 +48,9 @@ struct TxStrip: View {
                         Picker("Mode", selection: Binding(
                             get: { settings.mode },
                             set: { newMode in
-                                // Leaving FT8 for an RX-only mode must stop any armed
-                                // CQ/QSO and Hunt so the engine isn't left "transmitting"
-                                // with no audio (scheduleTx would silently drop the TX).
-                                if !newMode.profile.isFT8 {
-                                    if tx.isActivated { onStop() }
-                                    if tx.huntEnabled { onHunt() }
-                                }
+                                // Leaving FT8 for an RX-only mode disarms TX/Hunt — via the
+                                // shared engine method so every mode picker behaves the same.
+                                appState.engine?.handleModeChange(to: newMode)
                                 settings.mode = newMode
                                 SettingsPersistence.save(appState.settings)
                             }

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -267,6 +267,17 @@ final class LiveEngine {
         appState.tx.huntEnabled.toggle()
     }
 
+    /// Apply the side effects of switching operating mode. FT4 is RX-only (see
+    /// `scheduleTx`), so leaving FT8 must stop any armed CQ/QSO and disarm Hunt —
+    /// otherwise the sequencer stays "active" while every transmit is rejected,
+    /// showing a silent TX state. Call this from every mode picker (TxStrip and
+    /// Settings) so the transition is identical wherever the mode is changed.
+    func handleModeChange(to newMode: Mode) {
+        guard !newMode.profile.isFT8 else { return }
+        if appState?.tx.isActivated == true { stopTx() }
+        if appState?.tx.huntEnabled == true { toggleHunt() }
+    }
+
     /// Switch TX slot parity (TX1 ↔ TX2).
     func toggleSlotParity() {
         guard let appState else { return }

--- a/ios/FT8AF/FT8AF/Engine/SntpSyncService.swift
+++ b/ios/FT8AF/FT8AF/Engine/SntpSyncService.swift
@@ -86,8 +86,16 @@ enum SntpSyncService {
                                 finish(.failure(.invalidResponse))
                                 return
                             }
-                            finish(.success(Sntp.offsetMs(
-                                referenceUnixMs: refMs, deviceNowMs: deviceNowMs)))
+                            let offset = Sntp.offsetMs(
+                                referenceUnixMs: refMs, deviceNowMs: deviceNowMs)
+                            // Drop an implausible correction (> 1 h) rather than
+                            // shoving the clock by a bad/rogue timestamp — matches
+                            // Android's NtpClockUpdater sane-offset guard.
+                            guard Sntp.isOffsetSane(offset) else {
+                                finish(.failure(.invalidResponse))
+                                return
+                            }
+                            finish(.success(offset))
                         }
                     })
                 case .failed(let err):

--- a/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
@@ -243,7 +243,12 @@ struct TransmissionSettings: View {
         .onChange(of: settings.pttMode) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.txVolume) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.band) { _, _ in SettingsPersistence.save(appState.settings) }
-        .onChange(of: settings.mode) { _, _ in SettingsPersistence.save(appState.settings) }
+        .onChange(of: settings.mode) { _, newMode in
+            // Same RX-only disarm as the TxStrip mode picker: selecting FT4 here must
+            // also stop an armed CQ/QSO + Hunt (shared engine method), not just persist.
+            appState.engine?.handleModeChange(to: newMode)
+            SettingsPersistence.save(appState.settings)
+        }
         .onChange(of: settings.huntCallsCQ) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.autoCallFollow) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.earlyDecode) { _, _ in SettingsPersistence.save(appState.settings) }

--- a/ios/FT8AFKit/Sources/FT8Audio/Sntp.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/Sntp.swift
@@ -26,9 +26,22 @@ public enum Sntp {
 
     /// Extract the server's Transmit Timestamp (bytes 40..47) from a response
     /// and convert it to Unix epoch milliseconds. Returns `nil` when the packet
-    /// is too short or carries a zero (unset / Kiss-o'-Death) timestamp.
+    /// is too short, fails the header sanity checks, or carries a zero (unset /
+    /// Kiss-o'-Death) timestamp.
+    ///
+    /// The header checks reject anything we can't trust as an authoritative
+    /// server time — otherwise any 48-byte UDP payload with a nonzero seconds
+    /// field would be accepted and could shift the RX/TX/QSO clock by years:
+    ///  - LI (leap indicator) == 3 → the server is unsynchronized ("alarm").
+    ///  - Mode != 4 → not a server-mode reply to our Mode-3 client request.
+    ///  - Stratum 0 → a Kiss-o'-Death packet (no time); 16..255 are reserved.
     public static func transmitTimeUnixMs(fromResponse bytes: [UInt8]) -> Int64? {
         guard bytes.count >= packetSize else { return nil }
+        let leapIndicator = (bytes[0] >> 6) & 0x3
+        let mode = bytes[0] & 0x7
+        let stratum = bytes[1]
+        guard leapIndicator != 3, mode == 4, stratum >= 1, stratum <= 15 else { return nil }
+
         let seconds = beUInt32(bytes, at: 40)
         let fraction = beUInt32(bytes, at: 44)
         if seconds == 0 { return nil } // no valid timestamp in the reply
@@ -47,6 +60,18 @@ public enum Sntp {
     /// `ntpClockOffsetMs`.
     public static func offsetMs(referenceUnixMs: Int64, deviceNowMs: Int64) -> Int64 {
         referenceUnixMs - deviceNowMs
+    }
+
+    /// The largest clock correction (ms) an SNTP reply may apply — one hour,
+    /// mirroring Android's `NtpClockUpdater.MAX_SANE_OFFSET_MS`. A larger jump is
+    /// treated as a bad/rogue response and dropped so a corrupt timestamp can't
+    /// shove the RX/TX/QSO clock by an implausible amount.
+    public static let maxSaneOffsetMs: Int64 = 60 * 60 * 1000
+
+    /// Whether an offset is within the sane bound (`abs(offset) <= maxSaneOffsetMs`).
+    /// Callers reject an out-of-bound offset instead of applying it.
+    public static func isOffsetSane(_ offsetMs: Int64) -> Bool {
+        abs(offsetMs) <= maxSaneOffsetMs
     }
 
     /// Read a big-endian (network byte order) 32-bit unsigned int at `offset`.

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SntpTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SntpTests.swift
@@ -29,11 +29,59 @@ final class SntpTests: XCTestCase {
         let halfSecondFraction: UInt32 = 0x8000_0000 // 0.5 s
 
         var packet = [UInt8](repeating: 0, count: 48)
+        packet[0] = 0x24 // LI=0, VN=4, Mode=4 (server)
+        packet[1] = 1    // stratum 1 (primary)
         putBE(ntpSec, into: &packet, at: 40)
         putBE(halfSecondFraction, into: &packet, at: 44)
 
         let ms = Sntp.transmitTimeUnixMs(fromResponse: packet)
         XCTAssertEqual(ms, unixSec * 1_000 + 500)
+    }
+
+    // MARK: - Header validation
+
+    /// Build an otherwise-valid server response carrying a fixed timestamp, so a
+    /// test can flip one header byte and assert it is rejected.
+    private func validResponse(li: UInt8 = 0, mode: UInt8 = 4, stratum: UInt8 = 2) -> [UInt8] {
+        var packet = [UInt8](repeating: 0, count: 48)
+        packet[0] = (li << 6) | (4 << 3) | mode // VN=4
+        packet[1] = stratum
+        // NTP seconds 0xE8FE6F80 = 1_700_000_000 s Unix, fraction 0.5 s.
+        packet[40] = 0xE8; packet[41] = 0xFE; packet[42] = 0x6F; packet[43] = 0x80
+        packet[44] = 0x80
+        return packet
+    }
+
+    func testValidServerResponseAccepted() {
+        XCTAssertEqual(Sntp.transmitTimeUnixMs(fromResponse: validResponse()), 1_700_000_000_500)
+    }
+
+    func testRejectsUnsynchronizedLeapIndicator() {
+        // LI = 3 ("alarm", clock not synchronized) — even with a plausible timestamp.
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(li: 3)))
+    }
+
+    func testRejectsNonServerMode() {
+        // Mode 3 (client) or 6 (control) is not a server-mode reply to our query.
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(mode: 3)))
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(mode: 6)))
+    }
+
+    func testRejectsKissOfDeathAndReservedStratum() {
+        // Stratum 0 = Kiss-o'-Death (no usable time); 16..255 are reserved.
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(stratum: 0)))
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(stratum: 16)))
+    }
+
+    // MARK: - Sane-offset bound
+
+    func testOffsetSaneBound() {
+        XCTAssertTrue(Sntp.isOffsetSane(0))
+        XCTAssertTrue(Sntp.isOffsetSane(Sntp.maxSaneOffsetMs))
+        XCTAssertTrue(Sntp.isOffsetSane(-Sntp.maxSaneOffsetMs))
+        XCTAssertFalse(Sntp.isOffsetSane(Sntp.maxSaneOffsetMs + 1))
+        // A year-scale jump (the failure the header/bound guards prevent) is rejected.
+        XCTAssertFalse(Sntp.isOffsetSane(365 * 24 * 60 * 60 * 1000))
     }
 
     // MARK: - Parse (literal captured bytes)


### PR DESCRIPTION
Second-pass Copilot review on #763 surfaced two more valid issues in the merged iOS features (both related to the NTP/FT4 work). Fixed here on `dev` so they ship with a later promotion, keeping them out of the in-flight staging cut.

## Fixes
- **SNTP response validation** (`Sntp.swift`, `SntpSyncService.swift`): the parser accepted *any* 48-byte UDP payload with a nonzero seconds field as authoritative time, so an unsynchronized reply (LI=3), a non-server packet, a stratum-0 Kiss-o'-Death, or a corrupt timestamp could shift the RX/TX/QSO clock by **years** — and, unlike Android, iOS applied no sane-offset bound. Now:
  - rejects `LI == 3` (server unsynchronized), `Mode != 4` (not a server reply), and stratum `0` / `16..255`;
  - drops any correction beyond ±1 h via `Sntp.isOffsetSane`, mirroring Android's `NtpClockUpdater.MAX_SANE_OFFSET_MS`.
  New `SntpTests` cover LI/mode/stratum rejection and the offset bound (11 pass).
- **Shared mode-change disarm** (`LiveEngine.handleModeChange`): #764's FT4 RX-only disarm lived only in the *TxStrip* mode picker, so selecting FT4 from **Settings** bypassed it and left an armed CQ/QSO in a silent active-TX state (`scheduleTx` rejects non-FT8). Both pickers now route through one engine method that stops the run and disarms Hunt when leaving FT8.

## Verification
- `swift test` — FT8Audio suite, **153 tests, 0 failures** (incl. the new SNTP cases).
- `xcodebuild build` — FT8AF app on iPhone 16 simulator, **BUILD SUCCEEDED**.

Follow-up to #764; both are pre-existing (non-regression) issues in already-merged iOS features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)