### PR TITLE
fix: stop SIGPIPE from failing the Android release changelog step

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -451,7 +451,10 @@ jobs:
           # staging -> main) are not PRs worth listing.
           # Newest first; capped so a very long range can't balloon the prompt —
           # the PR list and size figures carry the overall picture anyway.
-          LOG=$(git log --no-merges --pretty='- %s' "$RANGE" | head -n 400)
+          # `head` closing the pipe early makes the upstream git/sort take
+          # SIGPIPE; under `set -o pipefail` that would fail the whole step, so
+          # drop pipefail inside these truncating substitutions.
+          LOG=$(set +o pipefail; git log --no-merges --pretty='- %s' "$RANGE" | head -n 400)
           LOG_TOTAL=$(git rev-list --no-merges --count "$RANGE")
           if (( LOG_TOTAL > 400 )); then
             LOG+=$'\n'"- … and $((LOG_TOTAL - 400)) older commits not listed"
@@ -469,7 +472,7 @@ jobs:
           STAT=$(git diff --shortstat "$RANGE" -- ft8af/ | sed 's/^ *//')
           TOTAL=$(printf '%s\n' "$ALL" | grep -c . || true)
           ANDROID=$(printf '%s\n' "$ANDROID_FILES" | grep -c . || true)
-          AREAS=$(printf '%s\n' "$ALL" \
+          AREAS=$(set +o pipefail; printf '%s\n' "$ALL" \
             | sed -E 's#^ft8af/app/src/main/(java/com/k1af/ft8af|kotlin/radio/ks3ckc/ft8af)/#app:#; s#^ft8af/app/src/test/(java/com/k1af/ft8af|kotlin/radio/ks3ckc/ft8af)/#app-tests:#; s#^ft8af/app/src/main/cpp/#native:#; s#^ft8af/app/src/main/res/#app-res:#' \
             | awk -F/ '{ print (NF > 1 ? $1 "/" $2 : $1) }' | sort | uniq -c | sort -rn | head -25 \
             | awk '{ printf "- %s (%d files)\n", $2, $1 }')

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class GeneralVariables {
     private static final String TAG = "GeneralVariables";
     public static String VERSION = BuildConfig.VERSION_NAME;//Version number "0.62 (Beta 4)";
-    public static int VERSION_CODE = BuildConfig.VERSION_CODE;//Monotonic build number (CI: GITHUB_RUN_NUMBER + 100)
+    public static int VERSION_CODE = BuildConfig.VERSION_CODE;//Monotonic build number (CI: GITHUB_RUN_NUMBER + 1000)
     public static String BUILD_DATE = BuildConfig.apkBuildTime;//Build time
     public static int MESSAGE_COUNT = 3000;//Maximum message cache count
     public static boolean saveSWLMessage = false;//Save decoded messages switch


### PR DESCRIPTION
## Problem

The staging → internal-testing promotion failed in the Android release workflow, in the **Collect changes since the last production release** step, with:

```
sort: fflush failed: 'standard output': Broken pipe
sort: write error
Error: Process completed with exit code 2.
```

The build never reached the APK/Play-upload steps — so the "failed to push to Play Console" symptom was actually the release dying earlier.

## Root cause

The step runs under `set -euo pipefail`. Two pipelines truncate with `head`:

- `AREAS=... | sort -rn | head -25`
- `LOG=$(git log ... | head -n 400)`

When the range has more than 25 distinct areas (or >400 commits), `head` reads its quota and closes the pipe. The upstream `sort`/`git` then receive **SIGPIPE**, exit non-zero, and `pipefail` makes that the pipeline's (and the step's) exit code. It's data-dependent, which is why smaller promotions passed — `head` drained everything before closing, so `sort` never hit a broken pipe. The big `android-v0.149..HEAD` range crossed the threshold.

## Fix

Disable `pipefail` locally inside those two command substitutions (`$(set +o pipefail; ...)`), so the pipeline status comes from the succeeding `head`/`awk` tail rather than the intentionally-severed producer. The rest of the step keeps strict-mode error handling.

## Also included (cosmetic)

Corrected a stale comment in `GeneralVariables.java`: the CI `versionCode` offset is `+1000`, not `+100`.

## Version-display note (no change needed)

While investigating, I confirmed the assigned semver already reaches the user-facing UI correctly:

`workflow step tag → -PVERSION_NAME_OVERRIDE → build.gradle versionName → BuildConfig.VERSION_NAME → GeneralVariables.VERSION → Compose About screen`

The `release` build type adds no `versionNameSuffix`, so production shows the clean semver (e.g. `0.150.0`) and the internal track shows `0.150.0-dev.<runNumber>`.

## Testing

CI-only shell change; verified the workflow YAML still parses. The fix is exercised by the next staging promotion, which should now clear this step and continue to the APK build + Play upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)