### PR TITLE
Promote dev → staging

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -451,7 +451,10 @@ jobs:
           # staging -> main) are not PRs worth listing.
           # Newest first; capped so a very long range can't balloon the prompt —
           # the PR list and size figures carry the overall picture anyway.
-          LOG=$(git log --no-merges --pretty='- %s' "$RANGE" | head -n 400)
+          # `head` closing the pipe early makes the upstream git/sort take
+          # SIGPIPE; under `set -o pipefail` that would fail the whole step, so
+          # drop pipefail inside these truncating substitutions.
+          LOG=$(set +o pipefail; git log --no-merges --pretty='- %s' "$RANGE" | head -n 400)
           LOG_TOTAL=$(git rev-list --no-merges --count "$RANGE")
           if (( LOG_TOTAL > 400 )); then
             LOG+=$'\n'"- … and $((LOG_TOTAL - 400)) older commits not listed"
@@ -469,7 +472,7 @@ jobs:
           STAT=$(git diff --shortstat "$RANGE" -- ft8af/ | sed 's/^ *//')
           TOTAL=$(printf '%s\n' "$ALL" | grep -c . || true)
           ANDROID=$(printf '%s\n' "$ANDROID_FILES" | grep -c . || true)
-          AREAS=$(printf '%s\n' "$ALL" \
+          AREAS=$(set +o pipefail; printf '%s\n' "$ALL" \
             | sed -E 's#^ft8af/app/src/main/(java/com/k1af/ft8af|kotlin/radio/ks3ckc/ft8af)/#app:#; s#^ft8af/app/src/test/(java/com/k1af/ft8af|kotlin/radio/ks3ckc/ft8af)/#app-tests:#; s#^ft8af/app/src/main/cpp/#native:#; s#^ft8af/app/src/main/res/#app-res:#' \
             | awk -F/ '{ print (NF > 1 ? $1 "/" $2 : $1) }' | sort | uniq -c | sort -rn | head -25 \
             | awk '{ printf "- %s (%d files)\n", $2, $1 }')

--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class GeneralVariables {
     private static final String TAG = "GeneralVariables";
     public static String VERSION = BuildConfig.VERSION_NAME;//Version number "0.62 (Beta 4)";
-    public static int VERSION_CODE = BuildConfig.VERSION_CODE;//Monotonic build number (CI: GITHUB_RUN_NUMBER + 100)
+    public static int VERSION_CODE = BuildConfig.VERSION_CODE;//Monotonic build number (CI: GITHUB_RUN_NUMBER + 1000)
     public static String BUILD_DATE = BuildConfig.apkBuildTime;//Build time
     public static int MESSAGE_COUNT = 3000;//Maximum message cache count
     public static boolean saveSWLMessage = false;//Save decoded messages switch

--- a/ios/FT8AF/FT8AF/Components/TxStrip.swift
+++ b/ios/FT8AF/FT8AF/Components/TxStrip.swift
@@ -48,13 +48,9 @@ struct TxStrip: View {
                         Picker("Mode", selection: Binding(
                             get: { settings.mode },
                             set: { newMode in
-                                // Leaving FT8 for an RX-only mode must stop any armed
-                                // CQ/QSO and Hunt so the engine isn't left "transmitting"
-                                // with no audio (scheduleTx would silently drop the TX).
-                                if !newMode.profile.isFT8 {
-                                    if tx.isActivated { onStop() }
-                                    if tx.huntEnabled { onHunt() }
-                                }
+                                // Leaving FT8 for an RX-only mode disarms TX/Hunt — via the
+                                // shared engine method so every mode picker behaves the same.
+                                appState.engine?.handleModeChange(to: newMode)
                                 settings.mode = newMode
                                 SettingsPersistence.save(appState.settings)
                             }

--- a/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
+++ b/ios/FT8AF/FT8AF/Engine/LiveEngine.swift
@@ -267,6 +267,17 @@ final class LiveEngine {
         appState.tx.huntEnabled.toggle()
     }
 
+    /// Apply the side effects of switching operating mode. FT4 is RX-only (see
+    /// `scheduleTx`), so leaving FT8 must stop any armed CQ/QSO and disarm Hunt —
+    /// otherwise the sequencer stays "active" while every transmit is rejected,
+    /// showing a silent TX state. Call this from every mode picker (TxStrip and
+    /// Settings) so the transition is identical wherever the mode is changed.
+    func handleModeChange(to newMode: Mode) {
+        guard !newMode.profile.isFT8 else { return }
+        if appState?.tx.isActivated == true { stopTx() }
+        if appState?.tx.huntEnabled == true { toggleHunt() }
+    }
+
     /// Switch TX slot parity (TX1 ↔ TX2).
     func toggleSlotParity() {
         guard let appState else { return }

--- a/ios/FT8AF/FT8AF/Engine/SntpSyncService.swift
+++ b/ios/FT8AF/FT8AF/Engine/SntpSyncService.swift
@@ -86,8 +86,16 @@ enum SntpSyncService {
                                 finish(.failure(.invalidResponse))
                                 return
                             }
-                            finish(.success(Sntp.offsetMs(
-                                referenceUnixMs: refMs, deviceNowMs: deviceNowMs)))
+                            let offset = Sntp.offsetMs(
+                                referenceUnixMs: refMs, deviceNowMs: deviceNowMs)
+                            // Drop an implausible correction (> 1 h) rather than
+                            // shoving the clock by a bad/rogue timestamp — matches
+                            // Android's NtpClockUpdater sane-offset guard.
+                            guard Sntp.isOffsetSane(offset) else {
+                                finish(.failure(.invalidResponse))
+                                return
+                            }
+                            finish(.success(offset))
                         }
                     })
                 case .failed(let err):

--- a/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
+++ b/ios/FT8AF/FT8AF/Screens/Settings/TransmissionSettings.swift
@@ -243,7 +243,12 @@ struct TransmissionSettings: View {
         .onChange(of: settings.pttMode) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.txVolume) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.band) { _, _ in SettingsPersistence.save(appState.settings) }
-        .onChange(of: settings.mode) { _, _ in SettingsPersistence.save(appState.settings) }
+        .onChange(of: settings.mode) { _, newMode in
+            // Same RX-only disarm as the TxStrip mode picker: selecting FT4 here must
+            // also stop an armed CQ/QSO + Hunt (shared engine method), not just persist.
+            appState.engine?.handleModeChange(to: newMode)
+            SettingsPersistence.save(appState.settings)
+        }
         .onChange(of: settings.huntCallsCQ) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.autoCallFollow) { _, _ in SettingsPersistence.save(appState.settings) }
         .onChange(of: settings.earlyDecode) { _, _ in SettingsPersistence.save(appState.settings) }

--- a/ios/FT8AFKit/Sources/FT8Audio/Sntp.swift
+++ b/ios/FT8AFKit/Sources/FT8Audio/Sntp.swift
@@ -26,9 +26,22 @@ public enum Sntp {
 
     /// Extract the server's Transmit Timestamp (bytes 40..47) from a response
     /// and convert it to Unix epoch milliseconds. Returns `nil` when the packet
-    /// is too short or carries a zero (unset / Kiss-o'-Death) timestamp.
+    /// is too short, fails the header sanity checks, or carries a zero (unset /
+    /// Kiss-o'-Death) timestamp.
+    ///
+    /// The header checks reject anything we can't trust as an authoritative
+    /// server time — otherwise any 48-byte UDP payload with a nonzero seconds
+    /// field would be accepted and could shift the RX/TX/QSO clock by years:
+    ///  - LI (leap indicator) == 3 → the server is unsynchronized ("alarm").
+    ///  - Mode != 4 → not a server-mode reply to our Mode-3 client request.
+    ///  - Stratum 0 → a Kiss-o'-Death packet (no time); 16..255 are reserved.
     public static func transmitTimeUnixMs(fromResponse bytes: [UInt8]) -> Int64? {
         guard bytes.count >= packetSize else { return nil }
+        let leapIndicator = (bytes[0] >> 6) & 0x3
+        let mode = bytes[0] & 0x7
+        let stratum = bytes[1]
+        guard leapIndicator != 3, mode == 4, stratum >= 1, stratum <= 15 else { return nil }
+
         let seconds = beUInt32(bytes, at: 40)
         let fraction = beUInt32(bytes, at: 44)
         if seconds == 0 { return nil } // no valid timestamp in the reply
@@ -47,6 +60,18 @@ public enum Sntp {
     /// `ntpClockOffsetMs`.
     public static func offsetMs(referenceUnixMs: Int64, deviceNowMs: Int64) -> Int64 {
         referenceUnixMs - deviceNowMs
+    }
+
+    /// The largest clock correction (ms) an SNTP reply may apply — one hour,
+    /// mirroring Android's `NtpClockUpdater.MAX_SANE_OFFSET_MS`. A larger jump is
+    /// treated as a bad/rogue response and dropped so a corrupt timestamp can't
+    /// shove the RX/TX/QSO clock by an implausible amount.
+    public static let maxSaneOffsetMs: Int64 = 60 * 60 * 1000
+
+    /// Whether an offset is within the sane bound (`abs(offset) <= maxSaneOffsetMs`).
+    /// Callers reject an out-of-bound offset instead of applying it.
+    public static func isOffsetSane(_ offsetMs: Int64) -> Bool {
+        abs(offsetMs) <= maxSaneOffsetMs
     }
 
     /// Read a big-endian (network byte order) 32-bit unsigned int at `offset`.

--- a/ios/FT8AFKit/Tests/FT8AudioTests/SntpTests.swift
+++ b/ios/FT8AFKit/Tests/FT8AudioTests/SntpTests.swift
@@ -29,11 +29,59 @@ final class SntpTests: XCTestCase {
         let halfSecondFraction: UInt32 = 0x8000_0000 // 0.5 s
 
         var packet = [UInt8](repeating: 0, count: 48)
+        packet[0] = 0x24 // LI=0, VN=4, Mode=4 (server)
+        packet[1] = 1    // stratum 1 (primary)
         putBE(ntpSec, into: &packet, at: 40)
         putBE(halfSecondFraction, into: &packet, at: 44)
 
         let ms = Sntp.transmitTimeUnixMs(fromResponse: packet)
         XCTAssertEqual(ms, unixSec * 1_000 + 500)
+    }
+
+    // MARK: - Header validation
+
+    /// Build an otherwise-valid server response carrying a fixed timestamp, so a
+    /// test can flip one header byte and assert it is rejected.
+    private func validResponse(li: UInt8 = 0, mode: UInt8 = 4, stratum: UInt8 = 2) -> [UInt8] {
+        var packet = [UInt8](repeating: 0, count: 48)
+        packet[0] = (li << 6) | (4 << 3) | mode // VN=4
+        packet[1] = stratum
+        // NTP seconds 0xE8FE6F80 = 1_700_000_000 s Unix, fraction 0.5 s.
+        packet[40] = 0xE8; packet[41] = 0xFE; packet[42] = 0x6F; packet[43] = 0x80
+        packet[44] = 0x80
+        return packet
+    }
+
+    func testValidServerResponseAccepted() {
+        XCTAssertEqual(Sntp.transmitTimeUnixMs(fromResponse: validResponse()), 1_700_000_000_500)
+    }
+
+    func testRejectsUnsynchronizedLeapIndicator() {
+        // LI = 3 ("alarm", clock not synchronized) — even with a plausible timestamp.
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(li: 3)))
+    }
+
+    func testRejectsNonServerMode() {
+        // Mode 3 (client) or 6 (control) is not a server-mode reply to our query.
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(mode: 3)))
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(mode: 6)))
+    }
+
+    func testRejectsKissOfDeathAndReservedStratum() {
+        // Stratum 0 = Kiss-o'-Death (no usable time); 16..255 are reserved.
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(stratum: 0)))
+        XCTAssertNil(Sntp.transmitTimeUnixMs(fromResponse: validResponse(stratum: 16)))
+    }
+
+    // MARK: - Sane-offset bound
+
+    func testOffsetSaneBound() {
+        XCTAssertTrue(Sntp.isOffsetSane(0))
+        XCTAssertTrue(Sntp.isOffsetSane(Sntp.maxSaneOffsetMs))
+        XCTAssertTrue(Sntp.isOffsetSane(-Sntp.maxSaneOffsetMs))
+        XCTAssertFalse(Sntp.isOffsetSane(Sntp.maxSaneOffsetMs + 1))
+        // A year-scale jump (the failure the header/bound guards prevent) is rejected.
+        XCTAssertFalse(Sntp.isOffsetSane(365 * 24 * 60 * 60 * 1000))
     }
 
     // MARK: - Parse (literal captured bytes)


### PR DESCRIPTION
Promotion of `dev` → `staging` to cut a new internal-testing build.

## Included since last promotion (4 commits)

- **#766 — fix: stop SIGPIPE from failing the Android release changelog step** — the primary reason for this promotion. Fixes the `sort: Broken pipe` / exit-2 failure in the *Collect changes since the last production release* step that blocked the previous staging → internal-testing build. Also corrects a stale `versionCode` offset comment.
- **#765 — iOS: fix 2 follow-up Copilot findings from PR #763** — iOS-only; does not affect the Android APK.

## Expected result

The Android release workflow should now clear the *Collect changes* step, decide the semver, build the signed APK/AAB, and upload to the Play internal-testing track. The build's version will surface in **Settings → About** as `X.Y.Z-dev.<runNumber>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)