### PR TITLE
Exclude own-TX echoes from the clock-sync DT pill

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -750,7 +750,13 @@ public class MainViewModel extends ViewModel {
                 }
 
                 publishFt8MessageList();//post an immutable snapshot so the UI recomposes immediately
-                mutableTimerOffset.postValue(time_sec);//this cycle's time offset
+                // Slot-wide mean DT with own-TX echoes already excluded (see
+                // OwnTxEchoFilter.meanTimeOffsetSec). NaN can't happen here — messages
+                // is non-empty, so at least one decode survived — but never post it:
+                // the pill would render it as "unknown".
+                if (!Float.isNaN(time_sec)) {
+                    mutableTimerOffset.postValue(time_sec);//this cycle's time offset
+                }
 
 
                 findIncludedCallsigns(messages);//find matching messages and add to the call list

--- a/ft8af/app/src/main/java/com/k1af/ft8af/OwnTxEchoFilter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/OwnTxEchoFilter.java
@@ -79,6 +79,31 @@ public final class OwnTxEchoFilter {
     }
 
     /**
+     * Mean per-decode time offset (WSJT-style DT, seconds) of the kept messages —
+     * the value the clock-sync pill on the slot bar shows. Own-TX echoes must not
+     * contribute: an echo's DT is the TX chain latency (keyed ~0.5-0.8 s into the
+     * cycle, plus PTT delay, transmit delay and audio buffering), not clock error,
+     * so one echo in a TX slot dragged the raw mean past the "POOR" threshold and
+     * turned the pill red on every over. Junk decodes carry a random DT and are
+     * excluded for the same reason.
+     *
+     * @return the mean DT of {@link #kept}, or {@link Float#NaN} when nothing survived
+     */
+    public float meanTimeOffsetSec() {
+        if (kept.isEmpty()) return Float.NaN;
+        float sum = 0f;
+        for (Ft8Message m : kept) {
+            sum += m.time_sec;
+        }
+        return sum / kept.size();
+    }
+
+    /** {@link #filter} then {@link #meanTimeOffsetSec()} in one call. */
+    public static float meanTimeOffsetSec(List<Ft8Message> decoded) {
+        return filter(decoded).meanTimeOffsetSec();
+    }
+
+    /**
      * Format the per-cycle diagnostic line written to debug.log. Recording the
      * kept count, dropped-echo count, dropped-junk count, whether a reply
      * addressed to us survived, and the slot lets us tell "decoded but

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/FT8SignalListener.java
@@ -14,6 +14,7 @@ import androidx.lifecycle.MutableLiveData;
 import com.k1af.ft8af.FT8Common;
 import com.k1af.ft8af.Ft8Message;
 import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.OwnTxEchoFilter;
 import com.k1af.ft8af.ModeProfile;
 import com.k1af.ft8af.database.DatabaseOpr;
 import com.k1af.ft8af.ft8transmit.GenerateFT8;
@@ -264,7 +265,7 @@ public class FT8SignalListener {
                 decodeTimeSec.postValue(timeSec);// decode elapsed time
                 try {
                     if (onFt8Listen != null) {
-                        onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, false);
+                        onFt8Listen.afterDecode(utc, OwnTxEchoFilter.meanTimeOffsetSec(allMsg), UtcTimer.sequential(utc), msgs, false);
                     }
                 } finally {
                     // Released only after DELIVERY, not merely after decoding: the
@@ -283,7 +284,7 @@ public class FT8SignalListener {
                     timeSec = System.currentTimeMillis() - time;
                     decodeTimeSec.postValue(timeSec);// decode elapsed time
                     if (onFt8Listen != null) {
-                        onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
+                        onFt8Listen.afterDecode(utc, OwnTxEchoFilter.meanTimeOffsetSec(allMsg), UtcTimer.sequential(utc), msgs, true);
                     }
 
                     // The subtract-and-redecode loop runs on the early buffer ONLY when no
@@ -313,7 +314,7 @@ public class FT8SignalListener {
                             timeSec = System.currentTimeMillis() - time;
                             decodeTimeSec.postValue(timeSec);// decode elapsed time
                             if (onFt8Listen != null) {
-                                onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
+                                onFt8Listen.afterDecode(utc, OwnTxEchoFilter.meanTimeOffsetSec(allMsg), UtcTimer.sequential(utc), msgs, true);
                             }
 
                         } while (msgs.size() > 0 );
@@ -426,7 +427,7 @@ public class FT8SignalListener {
             return;
         }
         // isDeep=true: MainViewModel appends these without re-triggering auto-sequence.
-        onFt8Listen.afterDecode(utc, averageOffset(allMsg), UtcTimer.sequential(utc), msgs, true);
+        onFt8Listen.afterDecode(utc, OwnTxEchoFilter.meanTimeOffsetSec(allMsg), UtcTimer.sequential(utc), msgs, true);
     }
 
 
@@ -569,22 +570,6 @@ public class FT8SignalListener {
     private void subtractDecode(long decoder, A91List list, boolean fromSource) {
         if (fromSource) ReBuildSignal.subtractSignalFt2(decoder, list);
         else ReBuildSignal.subtractSignal(decoder, list);
-    }
-
-    /**
-     * Calculate the average time offset value.
-     *
-     * @param messages message list
-     * @return offset value
-     */
-    private float averageOffset(ArrayList<Ft8Message> messages) {
-        if (messages.size() == 0) return 0f;
-        float dt = 0;
-        //int dtAverage = 0;
-        for (Ft8Message msg : messages) {
-            dt += msg.time_sec;
-        }
-        return dt / messages.size();
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/OnFt8Listen.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8listener/OnFt8Listen.java
@@ -19,7 +19,9 @@ public interface OnFt8Listen {
     /**
      * Event triggered after decoding completes.
      * @param utc UTC time of the current cycle
-     * @param time_sec average time offset for this cycle (seconds)
+     * @param time_sec mean time offset (DT, seconds) of the slot's decodes so far,
+     *                 own-TX echoes and junk excluded ({@code OwnTxEchoFilter.meanTimeOffsetSec});
+     *                 NaN when nothing survived the filter
      * @param sequential current sequence number
      * @param messages message list
      */

--- a/ft8af/app/src/test/java/com/k1af/ft8af/OwnTxEchoFilterTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/OwnTxEchoFilterTest.java
@@ -252,4 +252,57 @@ public class OwnTxEchoFilterTest {
         assertThat(result.decodeLogLine(0))
                 .isEqualTo("DECODE: kept=1 ownEcho=0 junk=1 replyToMe=false slot=0");
     }
+
+    /** Stamp a decode with a WSJT-style DT (seconds). */
+    private static Ft8Message withDt(Ft8Message m, float dtSec) {
+        m.time_sec = dtSec;
+        return m;
+    }
+
+    /**
+     * The clock-sync pill's value: the mean DT of the kept decodes. A TX-slot
+     * loopback echo carries the TX chain latency as its DT (here +1.4 s), which
+     * used to drag the raw slot mean to red; it must not contribute.
+     */
+    @Test
+    public void meanTimeOffsetSec_excludesOwnTxEcho() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(withDt(ownEcho("RA3XYZ"), 1.4f));
+        decoded.add(withDt(thirdParty("CQ", "DL1ABC"), 0.1f));
+        decoded.add(withDt(replyToMe("W1AW"), -0.1f));
+
+        assertThat(OwnTxEchoFilter.meanTimeOffsetSec(decoded)).isWithin(1e-6f).of(0f);
+        assertThat(OwnTxEchoFilter.filter(decoded).meanTimeOffsetSec()).isWithin(1e-6f).of(0f);
+    }
+
+    /** Junk decodes carry a random DT and are excluded from the mean as well. */
+    @Test
+    public void meanTimeOffsetSec_excludesJunk() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(withDt(structuredJunk(), 2.3f));
+        decoded.add(withDt(thirdParty("CQ", "DL1ABC"), 0.2f));
+        decoded.add(withDt(thirdParty("CQ", "JA1XYZ"), 0.4f));
+
+        assertThat(OwnTxEchoFilter.meanTimeOffsetSec(decoded)).isWithin(1e-6f).of(0.3f);
+    }
+
+    /** Plain mean over everything kept when nothing was filtered. */
+    @Test
+    public void meanTimeOffsetSec_isPlainMeanOfKept() {
+        List<Ft8Message> decoded = new ArrayList<>();
+        decoded.add(withDt(thirdParty("CQ", "DL1ABC"), -0.5f));
+        decoded.add(withDt(thirdParty("CQ", "JA1XYZ"), 0.1f));
+
+        assertThat(OwnTxEchoFilter.meanTimeOffsetSec(decoded)).isWithin(1e-6f).of(-0.2f);
+    }
+
+    /** Echo-only slot (or empty list): no evidence, so NaN rather than a fake 0.0. */
+    @Test
+    public void meanTimeOffsetSec_isNaNWhenNothingKept() {
+        List<Ft8Message> echoOnly = new ArrayList<>();
+        echoOnly.add(withDt(ownEcho("RA3XYZ"), 1.4f));
+
+        assertThat(OwnTxEchoFilter.meanTimeOffsetSec(echoOnly)).isNaN();
+        assertThat(OwnTxEchoFilter.meanTimeOffsetSec(Collections.emptyList())).isNaN();
+    }
 }


### PR DESCRIPTION
## Bug

With the self-syncing clock on, the DT pill on the slot bar reads near-zero (green) all through RX and flips **red with a large offset the moment we key up**.

## Cause

The pill is fed from `mutableTimerOffset`, posted with the `time_sec` that `FT8SignalListener.averageOffset(allMsg)` computes — a plain mean over the slot's **raw** decode list, before `OwnTxEchoFilter` runs.

In a TX slot the rig's monitor loopback lets the decoder decode our own transmission. That echo's DT is the TX chain latency (keyed ~0.5–0.8 s into the cycle plus PTT/transmit delay and audio buffering), not clock error, so a single echo drags the slot mean past the 1.0 s POOR threshold. Junk (CRC-collision) decodes were averaged in too.

The self-sync estimator (`ClockSelfSync`) was never affected — it already samples the filtered list — so this was display-only.

## Fix

- `OwnTxEchoFilter.meanTimeOffsetSec()` — mean DT of the *kept* decodes, `NaN` when nothing survived; plus a static one-shot overload.
- `FT8SignalListener` uses it for every `afterDecode` delivery instead of the raw average (private `averageOffset` removed).
- `MainViewModel` never posts a `NaN` (unreachable today since an all-filtered slot returns early, but the pill would render it as "unknown").
- `OnFt8Listen` javadoc updated for the new `time_sec` contract.

## Tests

Four new `OwnTxEchoFilterTest` cases: echo excluded, junk excluded, plain mean of kept, NaN when nothing kept. Full unit suite: **3297 tests, 0 failures**.

Built `installDebug` OK; no phone was attached (emulator-5554 refused the install for lack of internal storage), so on-air verification is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
