### PR TITLE
Bluetooth SCO: track link state, retry, and rebuild the mic on connect (Android 8.x RX dead, #759)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -44,6 +44,7 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -55,6 +56,7 @@ import androidx.lifecycle.ViewModelStoreOwner;
 import com.k1af.ft8af.callsign.CallsignDatabase;
 import com.k1af.ft8af.callsign.CallsignInfo;
 import com.k1af.ft8af.callsign.OnAfterQueryCallsignLocation;
+import com.k1af.ft8af.bluetooth.ScoLinkTracker;
 import com.k1af.ft8af.bluetooth.ScoPolicy;
 import com.k1af.ft8af.connector.BaseRigConnector;
 import com.k1af.ft8af.connector.BluetoothRigConnector;
@@ -126,6 +128,7 @@ import com.k1af.ft8af.timer.OnUtcTimer;
 import com.k1af.ft8af.timer.UtcTimer;
 import com.k1af.ft8af.ui.ToastMessage;
 import com.k1af.ft8af.wave.HamRecorder;
+import com.k1af.ft8af.wave.MicRecorder;
 import com.k1af.ft8af.wave.OnGetVoiceDataDone;
 import com.k1af.ft8af.x6100.X6100Radio;
 
@@ -2335,73 +2338,188 @@ public class MainViewModel extends ViewModel {
     }
 
 
+    // ---- Bluetooth SCO (hands-free audio link) -------------------------------
+    //
+    // All four entry points below go through ScoLinkTracker so that (a) a link
+    // that is already being built is never stopped and restarted underneath
+    // itself, (b) a start that fails or a link that drops is retried, bounded,
+    // and (c) once the link is up the AudioRecord is verified to be capturing
+    // from it. Issue #759 (Android 8.x: Bluetooth RX dead, TX fine).
+
+    private final ScoLinkTracker scoTracker = new ScoLinkTracker();
+    private final Handler scoHandler = new Handler(Looper.getMainLooper());
+    private final Runnable scoRetryRunnable = () -> applyScoAction(scoTracker.onRetryDue(), "retry");
+    private final Runnable scoConnectTimeoutRunnable = () -> {
+        ScoLinkTracker.Update u = scoTracker.onConnectTimeout();
+        if (u.gaveUp) {
+            GeneralVariables.fileLog("SCO: no CONNECTED within "
+                    + ScoLinkTracker.CONNECT_TIMEOUT_MS + "ms and retries exhausted ("
+                    + scoTracker.attempts() + " attempts) - giving up");
+        } else if (u.action != ScoLinkTracker.Action.NONE) {
+            GeneralVariables.fileLog("SCO: no CONNECTED within "
+                    + ScoLinkTracker.CONNECT_TIMEOUT_MS + "ms");
+        }
+        applyScoAction(u.action, "timeout");
+    };
+    private static final long SCO_MIC_ROUTE_CHECK_DELAY_MS = 300;
+
+    private AudioManager scoAudioManager() {
+        Context ctx = GeneralVariables.getMainContext();
+        if (ctx == null) return null;
+        return (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
+    }
+
+    /**
+     * Drive {@code AudioManager} per the tracker's decision. Returns whether
+     * anything was done.
+     */
+    private boolean applyScoAction(ScoLinkTracker.Action action, String why) {
+        if (action == ScoLinkTracker.Action.NONE) return false;
+        AudioManager audioManager = scoAudioManager();
+        if (audioManager == null) return false;
+        GeneralVariables.fileLog("SCO: " + action + " (" + why + ", attempt "
+                + scoTracker.attempts() + ")");
+        scoHandler.removeCallbacks(scoRetryRunnable);
+        scoHandler.removeCallbacks(scoConnectTimeoutRunnable);
+        switch (action) {
+            case STOP:
+                audioManager.setBluetoothScoOn(false);
+                audioManager.stopBluetoothSco();
+                audioManager.setSpeakerphoneOn(true);//exit headset mode
+                break;
+            case RESTART:
+                // A failed/abandoned start can leave AudioService's per-client
+                // start count at 1, where a bare start is a no-op - balance it.
+                audioManager.stopBluetoothSco();
+                // fall through
+            case START:
+                audioManager.setBluetoothScoOn(true);
+                audioManager.startBluetoothSco();//71ms
+                audioManager.setSpeakerphoneOn(false);//enter headset mode
+                scoHandler.postDelayed(scoConnectTimeoutRunnable, ScoLinkTracker.CONNECT_TIMEOUT_MS);
+                break;
+            default:
+                break;
+        }
+        return true;
+    }
+
+    /** Bring SCO up (after TX). Idempotent while a link is pending/up. */
     public void startSco() {
-        AudioManager audioManager = (AudioManager) GeneralVariables.getMainContext()
-                .getSystemService(Context.AUDIO_SERVICE);
+        AudioManager audioManager = scoAudioManager();
         if (audioManager == null) return;
         if (!audioManager.isBluetoothScoAvailableOffCall()) {
             //Bluetooth device does not support recording
             ToastMessage.show(getStringFromResource(R.string.does_not_support_recording));
             return;
         }
-        audioManager.setBluetoothScoOn(true);
-        audioManager.startBluetoothSco();//71ms
-        audioManager.setSpeakerphoneOn(false);//enter headset mode
+        applyScoAction(scoTracker.requestOn(), "startSco");
     }
 
+    /** Take SCO down (before TX). No-op unless we asked for it. */
     public void stopSco() {
-        AudioManager audioManager = (AudioManager) GeneralVariables.getMainContext()
-                .getSystemService(Context.AUDIO_SERVICE);
-        if (audioManager == null) return;
-        if (audioManager.isBluetoothScoOn()) {
-            audioManager.setBluetoothScoOn(false);
-            audioManager.stopBluetoothSco();
-            audioManager.setSpeakerphoneOn(true);//exit headset mode
-        }
-
+        applyScoAction(scoTracker.requestOff(), "stopSco");
     }
 
-
+    /** Enter Bluetooth headset mode: SCO up for RX audio from the rig. */
     public void setBlueToothOn() {
-        AudioManager audioManager = (AudioManager) GeneralVariables.getMainContext()
-                .getSystemService(Context.AUDIO_SERVICE);
+        AudioManager audioManager = scoAudioManager();
         if (audioManager == null) return;
         if (!audioManager.isBluetoothScoAvailableOffCall()) {
             //Bluetooth device does not support recording
             ToastMessage.show(getStringFromResource(R.string.does_not_support_recording));
         }
 
+        ScoLinkTracker.Action action = scoTracker.requestOn();
+        if (action == ScoLinkTracker.Action.NONE) {
+            GeneralVariables.fileLog("SCO: setBlueToothOn ignored, link already "
+                    + ScoLinkTracker.stateName(scoTracker.linkState()));
+            return;
+        }
         /*
         MODE_NORMAL corresponds to music playback. For speaker output, call audioManager.setSpeakerphoneOn(true).
         For headset or earpiece, set mode to MODE_IN_CALL (pre-3.0) or MODE_IN_COMMUNICATION (3.0+).
+        Stays NORMAL on purpose: TX audio goes out over A2DP (SCO is dropped
+        around PTT), and an in-call mode would pull media to the earpiece.
          */
         audioManager.setMode(AudioManager.MODE_NORMAL);//178ms
-        audioManager.setBluetoothScoOn(true);
-        audioManager.stopBluetoothSco();
-        audioManager.startBluetoothSco();//71ms
-        audioManager.setSpeakerphoneOn(false);//enter headset mode
+        applyScoAction(action, "setBlueToothOn");
 
         //entering Bluetooth headset mode
         ToastMessage.show(getStringFromResource(R.string.bluetooth_headset_mode));
-
     }
 
+    /** Leave Bluetooth headset mode. */
     public void setBlueToothOff() {
-
-        AudioManager audioManager = (AudioManager) GeneralVariables.getMainContext()
-                .getSystemService(Context.AUDIO_SERVICE);
+        AudioManager audioManager = scoAudioManager();
         if (audioManager == null) return;
-        if (audioManager.isBluetoothScoOn()) {
-            audioManager.setMode(AudioManager.MODE_NORMAL);
-            audioManager.setBluetoothScoOn(false);
-            audioManager.stopBluetoothSco();
-            audioManager.setSpeakerphoneOn(true);//exit headset mode
-        }
+        ScoLinkTracker.Action action = scoTracker.requestOff();
+        if (action == ScoLinkTracker.Action.NONE) return;
+        audioManager.setMode(AudioManager.MODE_NORMAL);
+        applyScoAction(action, "setBlueToothOff");
         //leaving Bluetooth headset mode
         ToastMessage.show(getStringFromResource(R.string.bluetooth_Headset_mode_cancelled));
-
     }
 
+    /**
+     * {@code AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED} landed (main thread).
+     * Logs every transition, retries a failed/dropped link while we want it,
+     * and once CONNECTED makes sure the mic is really on the headset.
+     */
+    public void onScoAudioStateUpdated(int state, int previousState) {
+        GeneralVariables.fileLog("SCO: state " + ScoLinkTracker.stateName(previousState)
+                + " -> " + ScoLinkTracker.stateName(state)
+                + " wanted=" + scoTracker.isWanted()
+                + " attempt=" + scoTracker.attempts());
+        ScoLinkTracker.Update u = scoTracker.onStateUpdate(state, SystemClock.elapsedRealtime());
+        if (state == AudioManager.SCO_AUDIO_STATE_CONNECTED) {
+            scoHandler.removeCallbacks(scoConnectTimeoutRunnable);
+            scoHandler.removeCallbacks(scoRetryRunnable);
+        }
+        if (u.gaveUp) {
+            GeneralVariables.fileLog("SCO: link failed " + scoTracker.attempts()
+                    + " times - giving up until the next request");
+        }
+        if (u.retryDelayMs > 0) {
+            GeneralVariables.fileLog("SCO: retry in " + u.retryDelayMs + "ms");
+            scoHandler.removeCallbacks(scoRetryRunnable);
+            scoHandler.postDelayed(scoRetryRunnable, u.retryDelayMs);
+        }
+        applyScoAction(u.action, "state");
+        if (u.checkMicRouting) {
+            // The policy re-route runs asynchronously in the audio server; give
+            // it a beat before asking where the record actually landed.
+            scoHandler.postDelayed(this::verifyMicOnScoLink, SCO_MIC_ROUTE_CHECK_DELAY_MS);
+        }
+    }
+
+    /**
+     * SCO is up: is the AudioRecord capturing from it? Android's own recipe is
+     * to create the record only after SCO_AUDIO_STATE_CONNECTED; ours already
+     * exists (opened at app start on the built-in mic), and on some builds -
+     * Oreo in the field - the force-use change never re-routes it. Rebuild it
+     * so the fresh open picks the headset.
+     */
+    private void verifyMicOnScoLink() {
+        if (!scoTracker.isWanted()
+                || scoTracker.linkState() != AudioManager.SCO_AUDIO_STATE_CONNECTED
+                || hamRecorder == null) {
+            return;
+        }
+        MicRecorder mic = hamRecorder.getMicRecorder();
+        int routed = mic.routedInputDeviceType();
+        int chosen = mic.chosenInputDeviceType();
+        boolean reinit = ScoLinkTracker.needsMicReinit(routed, chosen);
+        GeneralVariables.fileLog("SCO: mic routedType=" + routed + " chosenType=" + chosen
+                + (reinit ? " -> rebuilding AudioRecord on the SCO link" : " ok"));
+        if (!reinit) return;
+        reinitializeAudioInput();
+        scoHandler.postDelayed(() -> {
+            if (hamRecorder == null) return;
+            GeneralVariables.fileLog("SCO: mic after rebuild routedType="
+                    + hamRecorder.getMicRecorder().routedInputDeviceType());
+        }, SCO_MIC_ROUTE_CHECK_DELAY_MS);
+    }
 
     /**
      * Check whether Bluetooth is connected

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -44,7 +44,6 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.SystemClock;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -56,6 +55,7 @@ import androidx.lifecycle.ViewModelStoreOwner;
 import com.k1af.ft8af.callsign.CallsignDatabase;
 import com.k1af.ft8af.callsign.CallsignInfo;
 import com.k1af.ft8af.callsign.OnAfterQueryCallsignLocation;
+import com.k1af.ft8af.bluetooth.ScoLinkCoordinator;
 import com.k1af.ft8af.bluetooth.ScoLinkTracker;
 import com.k1af.ft8af.bluetooth.ScoPolicy;
 import com.k1af.ft8af.connector.BaseRigConnector;
@@ -2340,68 +2340,56 @@ public class MainViewModel extends ViewModel {
 
     // ---- Bluetooth SCO (hands-free audio link) -------------------------------
     //
-    // All four entry points below go through ScoLinkTracker so that (a) a link
-    // that is already being built is never stopped and restarted underneath
-    // itself, (b) a start that fails or a link that drops is retried, bounded,
-    // and (c) once the link is up the AudioRecord is verified to be capturing
-    // from it. Issue #759 (Android 8.x: Bluetooth RX dead, TX fine).
+    // All entry points below go through ScoLinkCoordinator (one ScoLinkTracker
+    // driven on the main thread) so that (a) a link that is already being built
+    // is never stopped and restarted underneath itself, (b) a start that fails
+    // or a link that drops is retried, bounded, (c) once the link is up the
+    // AudioRecord is verified to be capturing from it, and (d) requests from
+    // the TX executor and the main-thread broadcasts/timers are applied in
+    // order, never interleaved. Issue #759 (Android 8.x: Bluetooth RX dead).
 
-    private final ScoLinkTracker scoTracker = new ScoLinkTracker();
     private final Handler scoHandler = new Handler(Looper.getMainLooper());
-    private final Runnable scoRetryRunnable = () -> applyScoAction(scoTracker.onRetryDue(), "retry");
-    private final Runnable scoConnectTimeoutRunnable = () -> {
-        ScoLinkTracker.Update u = scoTracker.onConnectTimeout();
-        if (u.gaveUp) {
-            GeneralVariables.fileLog("SCO: no CONNECTED within "
-                    + ScoLinkTracker.CONNECT_TIMEOUT_MS + "ms and retries exhausted ("
-                    + scoTracker.attempts() + " attempts) - giving up");
-        } else if (u.action != ScoLinkTracker.Action.NONE) {
-            GeneralVariables.fileLog("SCO: no CONNECTED within "
-                    + ScoLinkTracker.CONNECT_TIMEOUT_MS + "ms");
-        }
-        applyScoAction(u.action, "timeout");
-    };
-    private static final long SCO_MIC_ROUTE_CHECK_DELAY_MS = 300;
+    private final ScoLinkCoordinator scoLink = ScoLinkCoordinator.onMainThread(
+            new ScoLinkCoordinator.Sink() {
+                @Override
+                public void startSco() {
+                    AudioManager audioManager = scoAudioManager();
+                    if (audioManager == null) return;
+                    audioManager.setBluetoothScoOn(true);
+                    audioManager.startBluetoothSco();//71ms
+                    audioManager.setSpeakerphoneOn(false);//enter headset mode
+                }
+
+                @Override
+                public void stopScoForRestart() {
+                    AudioManager audioManager = scoAudioManager();
+                    if (audioManager != null) audioManager.stopBluetoothSco();
+                }
+
+                @Override
+                public void stopSco() {
+                    AudioManager audioManager = scoAudioManager();
+                    if (audioManager == null) return;
+                    audioManager.setBluetoothScoOn(false);
+                    audioManager.stopBluetoothSco();
+                    audioManager.setSpeakerphoneOn(true);//exit headset mode
+                }
+
+                @Override
+                public void verifyMicRouting() {
+                    verifyMicOnScoLink();
+                }
+
+                @Override
+                public void log(String message) {
+                    GeneralVariables.fileLog(message);
+                }
+            });
 
     private AudioManager scoAudioManager() {
         Context ctx = GeneralVariables.getMainContext();
         if (ctx == null) return null;
         return (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
-    }
-
-    /**
-     * Drive {@code AudioManager} per the tracker's decision. Returns whether
-     * anything was done.
-     */
-    private boolean applyScoAction(ScoLinkTracker.Action action, String why) {
-        if (action == ScoLinkTracker.Action.NONE) return false;
-        AudioManager audioManager = scoAudioManager();
-        if (audioManager == null) return false;
-        GeneralVariables.fileLog("SCO: " + action + " (" + why + ", attempt "
-                + scoTracker.attempts() + ")");
-        scoHandler.removeCallbacks(scoRetryRunnable);
-        scoHandler.removeCallbacks(scoConnectTimeoutRunnable);
-        switch (action) {
-            case STOP:
-                audioManager.setBluetoothScoOn(false);
-                audioManager.stopBluetoothSco();
-                audioManager.setSpeakerphoneOn(true);//exit headset mode
-                break;
-            case RESTART:
-                // A failed/abandoned start can leave AudioService's per-client
-                // start count at 1, where a bare start is a no-op - balance it.
-                audioManager.stopBluetoothSco();
-                // fall through
-            case START:
-                audioManager.setBluetoothScoOn(true);
-                audioManager.startBluetoothSco();//71ms
-                audioManager.setSpeakerphoneOn(false);//enter headset mode
-                scoHandler.postDelayed(scoConnectTimeoutRunnable, ScoLinkTracker.CONNECT_TIMEOUT_MS);
-                break;
-            default:
-                break;
-        }
-        return true;
     }
 
     /** Bring SCO up (after TX). Idempotent while a link is pending/up. */
@@ -2413,12 +2401,12 @@ public class MainViewModel extends ViewModel {
             ToastMessage.show(getStringFromResource(R.string.does_not_support_recording));
             return;
         }
-        applyScoAction(scoTracker.requestOn(), "startSco");
+        scoLink.requestOn("startSco", null);
     }
 
     /** Take SCO down (before TX). No-op unless we asked for it. */
     public void stopSco() {
-        applyScoAction(scoTracker.requestOff(), "stopSco");
+        scoLink.requestOff("stopSco", null);
     }
 
     /** Enter Bluetooth headset mode: SCO up for RX audio from the rig. */
@@ -2429,36 +2417,28 @@ public class MainViewModel extends ViewModel {
             //Bluetooth device does not support recording
             ToastMessage.show(getStringFromResource(R.string.does_not_support_recording));
         }
-
-        ScoLinkTracker.Action action = scoTracker.requestOn();
-        if (action == ScoLinkTracker.Action.NONE) {
-            GeneralVariables.fileLog("SCO: setBlueToothOn ignored, link already "
-                    + ScoLinkTracker.stateName(scoTracker.linkState()));
-            return;
-        }
-        /*
-        MODE_NORMAL corresponds to music playback. For speaker output, call audioManager.setSpeakerphoneOn(true).
-        For headset or earpiece, set mode to MODE_IN_CALL (pre-3.0) or MODE_IN_COMMUNICATION (3.0+).
-        Stays NORMAL on purpose: TX audio goes out over A2DP (SCO is dropped
-        around PTT), and an in-call mode would pull media to the earpiece.
-         */
-        audioManager.setMode(AudioManager.MODE_NORMAL);//178ms
-        applyScoAction(action, "setBlueToothOn");
-
-        //entering Bluetooth headset mode
-        ToastMessage.show(getStringFromResource(R.string.bluetooth_headset_mode));
+        scoLink.requestOn("setBlueToothOn", () -> {
+            /*
+            MODE_NORMAL corresponds to music playback. For speaker output, call audioManager.setSpeakerphoneOn(true).
+            For headset or earpiece, set mode to MODE_IN_CALL (pre-3.0) or MODE_IN_COMMUNICATION (3.0+).
+            Stays NORMAL on purpose: TX audio goes out over A2DP (SCO is dropped
+            around PTT), and an in-call mode would pull media to the earpiece.
+             */
+            audioManager.setMode(AudioManager.MODE_NORMAL);//178ms
+            //entering Bluetooth headset mode
+            ToastMessage.show(getStringFromResource(R.string.bluetooth_headset_mode));
+        });
     }
 
     /** Leave Bluetooth headset mode. */
     public void setBlueToothOff() {
         AudioManager audioManager = scoAudioManager();
         if (audioManager == null) return;
-        ScoLinkTracker.Action action = scoTracker.requestOff();
-        if (action == ScoLinkTracker.Action.NONE) return;
-        audioManager.setMode(AudioManager.MODE_NORMAL);
-        applyScoAction(action, "setBlueToothOff");
-        //leaving Bluetooth headset mode
-        ToastMessage.show(getStringFromResource(R.string.bluetooth_Headset_mode_cancelled));
+        scoLink.requestOff("setBlueToothOff", () -> {
+            audioManager.setMode(AudioManager.MODE_NORMAL);
+            //leaving Bluetooth headset mode
+            ToastMessage.show(getStringFromResource(R.string.bluetooth_Headset_mode_cancelled));
+        });
     }
 
     /**
@@ -2467,30 +2447,7 @@ public class MainViewModel extends ViewModel {
      * and once CONNECTED makes sure the mic is really on the headset.
      */
     public void onScoAudioStateUpdated(int state, int previousState) {
-        GeneralVariables.fileLog("SCO: state " + ScoLinkTracker.stateName(previousState)
-                + " -> " + ScoLinkTracker.stateName(state)
-                + " wanted=" + scoTracker.isWanted()
-                + " attempt=" + scoTracker.attempts());
-        ScoLinkTracker.Update u = scoTracker.onStateUpdate(state, SystemClock.elapsedRealtime());
-        if (state == AudioManager.SCO_AUDIO_STATE_CONNECTED) {
-            scoHandler.removeCallbacks(scoConnectTimeoutRunnable);
-            scoHandler.removeCallbacks(scoRetryRunnable);
-        }
-        if (u.gaveUp) {
-            GeneralVariables.fileLog("SCO: link failed " + scoTracker.attempts()
-                    + " times - giving up until the next request");
-        }
-        if (u.retryDelayMs > 0) {
-            GeneralVariables.fileLog("SCO: retry in " + u.retryDelayMs + "ms");
-            scoHandler.removeCallbacks(scoRetryRunnable);
-            scoHandler.postDelayed(scoRetryRunnable, u.retryDelayMs);
-        }
-        applyScoAction(u.action, "state");
-        if (u.checkMicRouting) {
-            // The policy re-route runs asynchronously in the audio server; give
-            // it a beat before asking where the record actually landed.
-            scoHandler.postDelayed(this::verifyMicOnScoLink, SCO_MIC_ROUTE_CHECK_DELAY_MS);
-        }
+        scoLink.onStateUpdated(state, previousState);
     }
 
     /**
@@ -2501,8 +2458,8 @@ public class MainViewModel extends ViewModel {
      * so the fresh open picks the headset.
      */
     private void verifyMicOnScoLink() {
-        if (!scoTracker.isWanted()
-                || scoTracker.linkState() != AudioManager.SCO_AUDIO_STATE_CONNECTED
+        if (!scoLink.isWanted()
+                || scoLink.linkState() != AudioManager.SCO_AUDIO_STATE_CONNECTED
                 || hamRecorder == null) {
             return;
         }
@@ -2518,7 +2475,7 @@ public class MainViewModel extends ViewModel {
             if (hamRecorder == null) return;
             GeneralVariables.fileLog("SCO: mic after rebuild routedType="
                     + hamRecorder.getMicRecorder().routedInputDeviceType());
-        }, SCO_MIC_ROUTE_CHECK_DELAY_MS);
+        }, ScoLinkCoordinator.MIC_ROUTE_CHECK_DELAY_MS);
     }
 
     /**
@@ -2611,6 +2568,10 @@ public class MainViewModel extends ViewModel {
         // ViewModel is cleared while still "connected" the Timer thread would keep probing
         // the rig indefinitely. Tear it down here too.
         stopCatLivenessWatchdog();
+        // Drop the SCO retry/timeout timers and balance an outstanding start,
+        // else a retained ViewModel keeps restarting SCO after the activity is
+        // gone and AudioService is left holding our request.
+        scoLink.shutdown();
         PskReporterSender.INSTANCE.stop();
         WsjtxUdpService.INSTANCE.stop();
         getQTHThreadPool.shutdown();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothStateBroadcastReceive.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothStateBroadcastReceive.java
@@ -99,6 +99,20 @@ public class BluetoothStateBroadcastReceive extends BroadcastReceiver {
                 }
                 break;
 
+            case AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED:
+                // Registered since day one but never handled: the app had no idea
+                // whether its startBluetoothSco() ever produced a link, so a
+                // failed/dropped SCO was never retried and the AudioRecord was
+                // never rebuilt on top of it (issue #759). Not gated on connect
+                // mode: the tracker only acts when the app asked for SCO, and
+                // the transitions are worth having in debug.log regardless.
+                mainViewModel.onScoAudioStateUpdated(
+                        intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_STATE,
+                                AudioManager.SCO_AUDIO_STATE_ERROR),
+                        intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_PREVIOUS_STATE,
+                                AudioManager.SCO_AUDIO_STATE_ERROR));
+                break;
+
             case AudioManager.ACTION_AUDIO_BECOMING_NOISY:
                 if (shouldHandleBluetoothAudioRouting()) {
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.sound_source_switched));

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinator.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinator.java
@@ -1,0 +1,228 @@
+package com.k1af.ft8af.bluetooth;
+
+import android.media.AudioManager;
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.function.LongSupplier;
+
+/**
+ * Drives a {@link ScoLinkTracker} against the real world: every request,
+ * broadcast, retry and timeout is applied on one {@link Handler} thread, in
+ * order, so the tracker's decision and its {@code AudioManager} side effects
+ * are never interleaved with another caller's.
+ *
+ * <p>Why the single-thread rule (Copilot review on PR #772): TX asks for
+ * {@code stopSco()}/{@code startSco()} from the transmit executor while the
+ * {@code ACTION_SCO_AUDIO_STATE_UPDATED} broadcast and the retry/timeout
+ * callbacks run on the main thread. Without funnelling, a request could change
+ * the tracker between another caller's decision and its application, letting
+ * an obsolete START run after a newer STOP (or vice versa). Calls that arrive
+ * on the handler's own looper run inline; all others are posted.
+ *
+ * <p>Everything Android-specific — the {@code AudioManager} calls, the mic
+ * re-route check, the debug log — goes through {@link Sink}, and the clock is
+ * injected, so the scheduling and cancellation logic is Robolectric-testable
+ * without a rig or a headset.
+ */
+public final class ScoLinkCoordinator {
+
+    /** Side effects the coordinator asks the host to perform. */
+    public interface Sink {
+        /** {@code setBluetoothScoOn(true); startBluetoothSco(); setSpeakerphoneOn(false)}. */
+        void startSco();
+
+        /** Bare {@code stopBluetoothSco()} that balances a start before a fresh one. */
+        void stopScoForRestart();
+
+        /** {@code setBluetoothScoOn(false); stopBluetoothSco(); setSpeakerphoneOn(true)}. */
+        void stopSco();
+
+        /** SCO is CONNECTED and wanted: check that the AudioRecord is on the link. */
+        void verifyMicRouting();
+
+        void log(String message);
+    }
+
+    /** Delay before asking where the record landed after CONNECTED. */
+    public static final long MIC_ROUTE_CHECK_DELAY_MS = 300;
+
+    private final ScoLinkTracker tracker;
+    private final Handler handler;
+    private final Sink sink;
+    private final LongSupplier clock;
+
+    private final Runnable retryRunnable;
+    private final Runnable connectTimeoutRunnable;
+    private final Runnable micCheckRunnable;
+
+    public ScoLinkCoordinator(ScoLinkTracker tracker, Handler handler, Sink sink,
+                              LongSupplier clock) {
+        this.tracker = tracker;
+        this.handler = handler;
+        this.sink = sink;
+        this.clock = clock;
+        this.retryRunnable = () -> apply(this.tracker.onRetryDue(), "retry");
+        this.connectTimeoutRunnable = this::onConnectTimeout;
+        this.micCheckRunnable = this::onMicCheckDue;
+    }
+
+    /** Main-thread coordinator with a monotonic clock. */
+    public static ScoLinkCoordinator onMainThread(Sink sink) {
+        return new ScoLinkCoordinator(new ScoLinkTracker(),
+                new Handler(Looper.getMainLooper()), sink,
+                android.os.SystemClock::elapsedRealtime);
+    }
+
+    // ---- read-only state --------------------------------------------------
+
+    public boolean isWanted() {
+        return tracker.isWanted();
+    }
+
+    public int linkState() {
+        return tracker.linkState();
+    }
+
+    public int attempts() {
+        return tracker.attempts();
+    }
+
+    // ---- entry points (any thread) ----------------------------------------
+
+    /**
+     * The app wants SCO up. {@code onApplied} runs (on the handler thread) only
+     * when the request actually started or restarted the link; a request that
+     * finds the link already pending/up is logged and otherwise ignored.
+     */
+    public void requestOn(String why, Runnable onApplied) {
+        dispatch(() -> {
+            ScoLinkTracker.Action action = tracker.requestOn();
+            if (action == ScoLinkTracker.Action.NONE) {
+                sink.log("SCO: " + why + " ignored, link already "
+                        + ScoLinkTracker.stateName(tracker.linkState()));
+                return;
+            }
+            apply(action, why);
+            if (onApplied != null) onApplied.run();
+        });
+    }
+
+    /** The app wants SCO down. {@code onApplied} runs only if a link was actually stopped. */
+    public void requestOff(String why, Runnable onApplied) {
+        dispatch(() -> {
+            ScoLinkTracker.Action action = tracker.requestOff();
+            if (action == ScoLinkTracker.Action.NONE) return;
+            apply(action, why);
+            if (onApplied != null) onApplied.run();
+        });
+    }
+
+    /** {@code ACTION_SCO_AUDIO_STATE_UPDATED} landed. */
+    public void onStateUpdated(int state, int previousState) {
+        dispatch(() -> {
+            sink.log("SCO: state " + ScoLinkTracker.stateName(previousState)
+                    + " -> " + ScoLinkTracker.stateName(state)
+                    + " wanted=" + tracker.isWanted()
+                    + " attempt=" + tracker.attempts());
+            ScoLinkTracker.Update u = tracker.onStateUpdate(state, clock.getAsLong());
+            if (state == AudioManager.SCO_AUDIO_STATE_CONNECTED) {
+                handler.removeCallbacks(connectTimeoutRunnable);
+                handler.removeCallbacks(retryRunnable);
+            }
+            if (u.gaveUp) {
+                sink.log("SCO: link failed " + tracker.attempts()
+                        + " times - giving up until the next request");
+            }
+            scheduleRetry(u);
+            apply(u.action, "state");
+            if (u.checkMicRouting) {
+                // The policy re-route runs asynchronously in the audio server;
+                // give it a beat before asking where the record actually landed.
+                handler.removeCallbacks(micCheckRunnable);
+                handler.postDelayed(micCheckRunnable, MIC_ROUTE_CHECK_DELAY_MS);
+            }
+        });
+    }
+
+    /**
+     * The owner is going away: drop every pending callback and balance an
+     * outstanding start so a retained-but-torn-down ViewModel can't keep
+     * restarting SCO, or leave AudioService holding our request.
+     */
+    public void shutdown() {
+        dispatch(() -> {
+            handler.removeCallbacks(retryRunnable);
+            handler.removeCallbacks(connectTimeoutRunnable);
+            handler.removeCallbacks(micCheckRunnable);
+            ScoLinkTracker.Action action = tracker.requestOff();
+            if (action != ScoLinkTracker.Action.NONE) {
+                apply(action, "shutdown");
+            }
+        });
+    }
+
+    // ---- handler-thread internals -----------------------------------------
+
+    private void dispatch(Runnable r) {
+        if (Looper.myLooper() == handler.getLooper()) {
+            r.run();
+        } else {
+            handler.post(r);
+        }
+    }
+
+    private void onConnectTimeout() {
+        ScoLinkTracker.Update u = tracker.onConnectTimeout();
+        if (u.gaveUp) {
+            sink.log("SCO: no CONNECTED within " + ScoLinkTracker.CONNECT_TIMEOUT_MS
+                    + "ms and retries exhausted (" + tracker.attempts()
+                    + " attempts) - giving up");
+        } else if (u.retryDelayMs > 0) {
+            sink.log("SCO: no CONNECTED within " + ScoLinkTracker.CONNECT_TIMEOUT_MS + "ms");
+        }
+        scheduleRetry(u);
+        apply(u.action, "timeout");
+    }
+
+    private void onMicCheckDue() {
+        if (!tracker.isWanted()
+                || tracker.linkState() != AudioManager.SCO_AUDIO_STATE_CONNECTED) {
+            return;
+        }
+        sink.verifyMicRouting();
+    }
+
+    private void scheduleRetry(ScoLinkTracker.Update u) {
+        if (u.retryDelayMs <= 0) return;
+        sink.log("SCO: retry in " + u.retryDelayMs + "ms");
+        handler.removeCallbacks(retryRunnable);
+        handler.postDelayed(retryRunnable, u.retryDelayMs);
+    }
+
+    /** Drive the sink per the tracker's decision; returns whether anything was done. */
+    private boolean apply(ScoLinkTracker.Action action, String why) {
+        if (action == ScoLinkTracker.Action.NONE) return false;
+        sink.log("SCO: " + action + " (" + why + ", attempt " + tracker.attempts() + ")");
+        handler.removeCallbacks(retryRunnable);
+        handler.removeCallbacks(connectTimeoutRunnable);
+        switch (action) {
+            case STOP:
+                handler.removeCallbacks(micCheckRunnable);
+                sink.stopSco();
+                break;
+            case RESTART:
+                // A failed/abandoned start can leave AudioService's per-client
+                // start count at 1, where a bare start is a no-op - balance it.
+                sink.stopScoForRestart();
+                // fall through
+            case START:
+                sink.startSco();
+                handler.postDelayed(connectTimeoutRunnable, ScoLinkTracker.CONNECT_TIMEOUT_MS);
+                break;
+            default:
+                break;
+        }
+        return true;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkTracker.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkTracker.java
@@ -198,21 +198,25 @@ public final class ScoLinkTracker {
 
     /**
      * {@link #CONNECT_TIMEOUT_MS} elapsed since the last start with no
-     * CONNECTED. Returns the action to take; {@code gaveUp} in the update is
-     * set when the budget is spent.
+     * CONNECTED. The attempt is counted as failed and — exactly like a
+     * DISCONNECTED/ERROR broadcast — a spaced retry is handed out via
+     * {@code retryDelayMs} for {@link #onRetryDue()} to re-check, so a late
+     * CONNECTING/CONNECTED that lands in the meantime overtakes the retry
+     * instead of being torn down by an immediate restart. {@code gaveUp} is set
+     * when the budget is spent.
      */
     public synchronized Update onConnectTimeout() {
         if (!wanted || linkState != AudioManager.SCO_AUDIO_STATE_CONNECTING) {
             return Update.NONE;
         }
+        linkState = AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
+        connectedAtMs = -1;
         if (attempts >= MAX_ATTEMPTS) {
-            linkState = AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
             return new Update(Action.NONE, 0, false, true);
         }
         attempts++;
-        retryPending = false;
-        markStarted();
-        return new Update(Action.RESTART, 0, false, false);
+        retryPending = true;
+        return new Update(Action.NONE, retryDelayMs(attempts), false, false);
     }
 
     private void markStarted() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkTracker.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkTracker.java
@@ -1,0 +1,262 @@
+package com.k1af.ft8af.bluetooth;
+
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+
+/**
+ * Tracks the phone's Bluetooth SCO (hands-free audio) link on behalf of the
+ * app and decides what to do with {@code AudioManager} at each step. Pure
+ * logic — no Android calls — so the whole state machine is unit-testable.
+ *
+ * <p>Why this exists (issue #759, Android 8.x Bluetooth RX dead): the app used
+ * to fire {@code stopBluetoothSco(); startBluetoothSco();} blindly on every
+ * "turn Bluetooth on" event, and several of those fire back-to-back at launch
+ * (headset-mode gate, rig connect, profile-connected broadcast). Stopping a
+ * request that is still CONNECTING abandons the half-built link in the
+ * Bluetooth stack — on Oreo the stale virtual call then makes every later
+ * start a silent no-op ("Call in progress"). The
+ * {@code ACTION_SCO_AUDIO_STATE_UPDATED} broadcast was registered but never
+ * handled, so a failed or dropped link was never retried, nothing was logged,
+ * and the {@code AudioRecord} created before SCO came up was never re-created
+ * once it did (Android's documented recipe is "start recording after
+ * SCO_AUDIO_STATE_CONNECTED").
+ *
+ * <p>Rules encoded here:
+ * <ul>
+ *   <li>A request to turn SCO on while it is already CONNECTING/CONNECTED is a
+ *       no-op — never restart a link that is being built.</li>
+ *   <li>{@code startBluetoothSco()} is reference-counted per client in
+ *       AudioService, and a start that ends in DISCONNECTED/ERROR can leave the
+ *       count at 1, where a second bare start does nothing. Every retry is
+ *       therefore a stop+start ({@link Action#RESTART}).</li>
+ *   <li>Retries are bounded ({@link #MAX_ATTEMPTS}) and spaced
+ *       ({@link #retryDelayMs}); a link that stayed up for
+ *       {@link #STABLE_LINK_MS} earns a fresh budget when it drops.</li>
+ *   <li>A start that never reports CONNECTED within
+ *       {@link #CONNECT_TIMEOUT_MS} counts as failed.</li>
+ *   <li>Once CONNECTED, the mic must actually be capturing from the SCO device;
+ *       if the OS did not re-route the existing AudioRecord, re-create it
+ *       ({@link #needsMicReinit}).</li>
+ * </ul>
+ */
+public final class ScoLinkTracker {
+
+    /** What the caller should do to {@code AudioManager} right now. */
+    public enum Action {
+        NONE,
+        /** {@code startBluetoothSco()}. */
+        START,
+        /** {@code stopBluetoothSco()} then {@code startBluetoothSco()}. */
+        RESTART,
+        /** {@code stopBluetoothSco()}. */
+        STOP
+    }
+
+    /** Outcome of a state broadcast. */
+    public static final class Update {
+        /** Immediate action, if any. */
+        public final Action action;
+        /** {@code > 0}: schedule {@link #onRetryDue()} after this many ms. */
+        public final long retryDelayMs;
+        /** The link is up and wanted — verify the mic is routed to it. */
+        public final boolean checkMicRouting;
+        /** Retries exhausted; the caller should say so in the log. */
+        public final boolean gaveUp;
+
+        Update(Action action, long retryDelayMs, boolean checkMicRouting, boolean gaveUp) {
+            this.action = action;
+            this.retryDelayMs = retryDelayMs;
+            this.checkMicRouting = checkMicRouting;
+            this.gaveUp = gaveUp;
+        }
+
+        static final Update NONE = new Update(Action.NONE, 0, false, false);
+    }
+
+    /** Total start attempts (initial + retries) per want-session. */
+    static final int MAX_ATTEMPTS = 5;
+    /** No CONNECTED within this many ms of a start = failed attempt. */
+    public static final long CONNECT_TIMEOUT_MS = 6000;
+    /** A link that held this long resets the retry budget when it drops. */
+    static final long STABLE_LINK_MS = 5000;
+    private static final long[] RETRY_DELAYS_MS = {1000, 2000, 3000, 4000};
+
+    private boolean wanted;
+    /** A startBluetoothSco() has been issued and not yet balanced by a stop. */
+    private boolean requested;
+    private int linkState = AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
+    private int attempts;
+    private long connectedAtMs = -1;
+    /** A retry was handed out by {@link #onStateUpdate} and not yet consumed. */
+    private boolean retryPending;
+
+    public synchronized boolean isWanted() {
+        return wanted;
+    }
+
+    public synchronized boolean isRequested() {
+        return requested;
+    }
+
+    public synchronized int linkState() {
+        return linkState;
+    }
+
+    /** Attempts made in the current want-session (1 = the initial start). */
+    public synchronized int attempts() {
+        return attempts;
+    }
+
+    /** Delay before retry number {@code attempt} (2 = first retry). */
+    static long retryDelayMs(int attempt) {
+        int idx = Math.max(0, Math.min(RETRY_DELAYS_MS.length - 1, attempt - 2));
+        return RETRY_DELAYS_MS[idx];
+    }
+
+    private boolean linkUpOrPending() {
+        return linkState == AudioManager.SCO_AUDIO_STATE_CONNECTING
+                || linkState == AudioManager.SCO_AUDIO_STATE_CONNECTED;
+    }
+
+    /** The app wants SCO up (headset mode / after TX). */
+    public synchronized Action requestOn() {
+        wanted = true;
+        if (requested && linkUpOrPending()) {
+            return Action.NONE;
+        }
+        attempts = 1;
+        retryPending = false;
+        Action action = requested ? Action.RESTART : Action.START;
+        markStarted();
+        return action;
+    }
+
+    /** The app wants SCO down (before TX / leaving headset mode). */
+    public synchronized Action requestOff() {
+        wanted = false;
+        attempts = 0;
+        connectedAtMs = -1;
+        retryPending = false;
+        if (!requested) {
+            return Action.NONE;
+        }
+        requested = false;
+        linkState = AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
+        return Action.STOP;
+    }
+
+    /**
+     * An {@code ACTION_SCO_AUDIO_STATE_UPDATED} broadcast arrived.
+     *
+     * @param state {@code AudioManager.SCO_AUDIO_STATE_*}
+     * @param nowMs monotonic clock, for the stable-link check
+     */
+    public synchronized Update onStateUpdate(int state, long nowMs) {
+        int previous = linkState;
+        linkState = state;
+        if (state == AudioManager.SCO_AUDIO_STATE_CONNECTED) {
+            connectedAtMs = nowMs;
+            return wanted ? new Update(Action.NONE, 0, true, false) : Update.NONE;
+        }
+        if (state == AudioManager.SCO_AUDIO_STATE_CONNECTING) {
+            return Update.NONE;
+        }
+        // DISCONNECTED or ERROR. Our own STOP clears `wanted` first, so a
+        // broadcast that lands here while wanted means the link failed or
+        // dropped underneath us. It may also be the *stale* DISCONNECTED from a
+        // stop we issued right before a fresh start — that is why the retry is
+        // deferred and re-checked in onRetryDue() rather than fired now.
+        if (!wanted) {
+            return Update.NONE;
+        }
+        if (previous == AudioManager.SCO_AUDIO_STATE_CONNECTED
+                && connectedAtMs >= 0 && nowMs - connectedAtMs >= STABLE_LINK_MS) {
+            attempts = 0; // the link held; a drop after that gets a fresh budget
+        }
+        connectedAtMs = -1;
+        if (attempts >= MAX_ATTEMPTS) {
+            return new Update(Action.NONE, 0, false, true);
+        }
+        attempts++;
+        retryPending = true;
+        return new Update(Action.NONE, retryDelayMs(attempts), false, false);
+    }
+
+    /** A retry scheduled by {@link #onStateUpdate} is due. */
+    public synchronized Action onRetryDue() {
+        if (!retryPending) {
+            return Action.NONE; // nothing scheduled (e.g. after a give-up)
+        }
+        retryPending = false;
+        if (!wanted || linkUpOrPending()) {
+            return Action.NONE; // a later broadcast overtook the retry
+        }
+        Action action = requested ? Action.RESTART : Action.START;
+        markStarted();
+        return action;
+    }
+
+    /**
+     * {@link #CONNECT_TIMEOUT_MS} elapsed since the last start with no
+     * CONNECTED. Returns the action to take; {@code gaveUp} in the update is
+     * set when the budget is spent.
+     */
+    public synchronized Update onConnectTimeout() {
+        if (!wanted || linkState != AudioManager.SCO_AUDIO_STATE_CONNECTING) {
+            return Update.NONE;
+        }
+        if (attempts >= MAX_ATTEMPTS) {
+            linkState = AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
+            return new Update(Action.NONE, 0, false, true);
+        }
+        attempts++;
+        retryPending = false;
+        markStarted();
+        return new Update(Action.RESTART, 0, false, false);
+    }
+
+    private void markStarted() {
+        requested = true;
+        // Optimistic: the CONNECTING broadcast is asynchronous, and a second
+        // requestOn() a few ms later must already see the link as pending.
+        linkState = AudioManager.SCO_AUDIO_STATE_CONNECTING;
+        connectedAtMs = -1;
+    }
+
+    /**
+     * Whether the capture path must be rebuilt now that SCO is CONNECTED.
+     *
+     * @param routedDeviceType {@code AudioDeviceInfo.TYPE_*} the running
+     *        AudioRecord is actually capturing from; {@code TYPE_UNKNOWN} if the
+     *        OS reports none yet; {@code -1} if there is no AudioRecord at all
+     *        (USB-direct capture or nothing open).
+     * @param chosenDeviceType type of the input the user pinned in Settings, or
+     *        {@code -1} for "system default".
+     */
+    public static boolean needsMicReinit(int routedDeviceType, int chosenDeviceType) {
+        if (routedDeviceType < 0) {
+            return false; // nothing to rebuild (USB direct / no AudioRecord)
+        }
+        if (routedDeviceType == AudioDeviceInfo.TYPE_BLUETOOTH_SCO) {
+            return false; // already capturing from the headset
+        }
+        // The user explicitly pinned a non-Bluetooth input: respect it.
+        return chosenDeviceType < 0 || chosenDeviceType == AudioDeviceInfo.TYPE_BLUETOOTH_SCO;
+    }
+
+    /** Debug-log name for an {@code AudioManager.SCO_AUDIO_STATE_*} value. */
+    public static String stateName(int state) {
+        switch (state) {
+            case AudioManager.SCO_AUDIO_STATE_DISCONNECTED:
+                return "DISCONNECTED";
+            case AudioManager.SCO_AUDIO_STATE_CONNECTED:
+                return "CONNECTED";
+            case AudioManager.SCO_AUDIO_STATE_CONNECTING:
+                return "CONNECTING";
+            case AudioManager.SCO_AUDIO_STATE_ERROR:
+                return "ERROR";
+            default:
+                return "UNKNOWN(" + state + ")";
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/HamRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/HamRecorder.java
@@ -210,6 +210,11 @@ public class HamRecorder {
         isRunning = false;
     }
 
+    /** The underlying mic capture, for routing introspection (issue #759). */
+    public MicRecorder getMicRecorder() {
+        return micRecorder;
+    }
+
     /**
      * Reinitialize the mic recorder to pick up newly connected USB audio devices.
      * Re-wires the data listener after reinit.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -283,6 +283,37 @@ public class MicRecorder {
         return null;
     }
 
+    /**
+     * {@code AudioDeviceInfo.TYPE_*} the running AudioRecord is actually
+     * capturing from right now, {@code TYPE_UNKNOWN} if the OS reports none yet
+     * (not started / not routed), or {@code -1} when there is no AudioRecord to
+     * ask (USB-direct capture, init failure, API &lt; 24). Used after Bluetooth
+     * SCO connects to see whether the capture path followed the link
+     * (issue #759).
+     */
+    public synchronized int routedInputDeviceType() {
+        if (useUsbAudio || audioRecord == null) return -1;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return -1;
+        try {
+            AudioDeviceInfo routed = audioRecord.getRoutedDevice();
+            return routed == null ? AudioDeviceInfo.TYPE_UNKNOWN : routed.getType();
+        } catch (Exception e) {
+            return AudioDeviceInfo.TYPE_UNKNOWN;
+        }
+    }
+
+    /**
+     * {@code AudioDeviceInfo.TYPE_*} of the input the user pinned in Settings,
+     * or {@code -1} for "system default" / USB-direct / a pinned device that is
+     * no longer present.
+     */
+    public int chosenInputDeviceType() {
+        if (GeneralVariables.audioInputDeviceId <= 0) return -1;
+        AudioDeviceInfo chosen = findAudioDeviceById(
+                GeneralVariables.audioInputDeviceId, AudioManager.GET_DEVICES_INPUTS);
+        return chosen == null ? -1 : chosen.getType();
+    }
+
     public synchronized void start(){
         if (isRunning) return;
 

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinatorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinatorTest.java
@@ -1,0 +1,192 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.media.AudioManager;
+import android.os.Handler;
+import android.os.Looper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Drives {@link ScoLinkCoordinator} on Robolectric's paused main looper: the
+ * handler-facing behaviour PR #772's tracker tests leave out — timeout and retry
+ * scheduling/cancellation, the CONNECTED mic-route check, cross-thread
+ * serialization, and teardown.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ScoLinkCoordinatorTest {
+
+    private static final int CONNECTED = AudioManager.SCO_AUDIO_STATE_CONNECTED;
+    private static final int CONNECTING = AudioManager.SCO_AUDIO_STATE_CONNECTING;
+    private static final int DISCONNECTED = AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
+
+    /** Records every side effect in order. */
+    private static final class RecordingSink implements ScoLinkCoordinator.Sink {
+        final List<String> calls = new ArrayList<>();
+        final List<String> log = new ArrayList<>();
+
+        @Override public void startSco() { calls.add("start"); }
+        @Override public void stopScoForRestart() { calls.add("stopForRestart"); }
+        @Override public void stopSco() { calls.add("stop"); }
+        @Override public void verifyMicRouting() { calls.add("verifyMic"); }
+        @Override public void log(String message) { log.add(message); }
+    }
+
+    private RecordingSink sink;
+    private ScoLinkTracker tracker;
+    private ScoLinkCoordinator coordinator;
+    private long nowMs;
+
+    @Before
+    public void setUp() {
+        sink = new RecordingSink();
+        tracker = new ScoLinkTracker();
+        coordinator = new ScoLinkCoordinator(tracker,
+                new Handler(Looper.getMainLooper()), sink, () -> nowMs);
+    }
+
+    private void advance(long ms) {
+        nowMs += ms;
+        shadowOf(Looper.getMainLooper()).idleFor(ms, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void requestOn_onMainThread_startsInline_andArmsTimeout() {
+        coordinator.requestOn("test", null);
+        assertThat(sink.calls).containsExactly("start");
+        // Nothing until the timeout elapses...
+        advance(ScoLinkTracker.CONNECT_TIMEOUT_MS - 1);
+        assertThat(sink.calls).containsExactly("start");
+        // ...then the failed attempt gets a spaced retry, not an instant restart.
+        advance(1);
+        assertThat(sink.calls).containsExactly("start");
+        assertThat(tracker.attempts()).isEqualTo(2);
+        advance(ScoLinkTracker.retryDelayMs(2));
+        assertThat(sink.calls).containsExactly("start", "stopForRestart", "start").inOrder();
+    }
+
+    @Test
+    public void connected_cancelsTimeout_andChecksMicAfterDelay() {
+        coordinator.requestOn("test", null);
+        coordinator.onStateUpdated(CONNECTING, DISCONNECTED);
+        coordinator.onStateUpdated(CONNECTED, CONNECTING);
+        assertThat(sink.calls).containsExactly("start");
+        advance(ScoLinkCoordinator.MIC_ROUTE_CHECK_DELAY_MS);
+        assertThat(sink.calls).containsExactly("start", "verifyMic").inOrder();
+        // The connect timeout must have been dropped: no restart later.
+        advance(ScoLinkTracker.CONNECT_TIMEOUT_MS * 2);
+        assertThat(sink.calls).containsExactly("start", "verifyMic").inOrder();
+    }
+
+    @Test
+    public void micCheck_skippedIfLinkDroppedBeforeItRuns() {
+        coordinator.requestOn("test", null);
+        coordinator.onStateUpdated(CONNECTED, CONNECTING);
+        coordinator.requestOff("test", null);
+        advance(ScoLinkCoordinator.MIC_ROUTE_CHECK_DELAY_MS);
+        assertThat(sink.calls).containsExactly("start", "stop").inOrder();
+    }
+
+    @Test
+    public void droppedLink_retriesAfterDelay_withRestart() {
+        coordinator.requestOn("test", null);
+        coordinator.onStateUpdated(CONNECTED, CONNECTING);
+        advance(100);
+        coordinator.onStateUpdated(DISCONNECTED, CONNECTED);
+        assertThat(sink.log).contains("SCO: retry in " + ScoLinkTracker.retryDelayMs(2) + "ms");
+        advance(ScoLinkTracker.retryDelayMs(2) - 1);
+        assertThat(sink.calls).doesNotContain("stopForRestart");
+        advance(1);
+        assertThat(sink.calls).containsExactly("start", "stopForRestart", "start").inOrder();
+    }
+
+    @Test
+    public void lateConnect_duringRetryDelay_cancelsRetry() {
+        coordinator.requestOn("test", null);
+        advance(ScoLinkTracker.CONNECT_TIMEOUT_MS); // timeout -> retry scheduled
+        coordinator.onStateUpdated(CONNECTED, CONNECTING);
+        advance(ScoLinkTracker.retryDelayMs(2) + 1);
+        assertThat(sink.calls).containsExactly("start", "verifyMic").inOrder();
+    }
+
+    @Test
+    public void requestOn_whileConnecting_isLoggedAsIgnored_notApplied() {
+        List<String> applied = new ArrayList<>();
+        coordinator.requestOn("first", () -> applied.add("first"));
+        coordinator.requestOn("second", () -> applied.add("second"));
+        assertThat(applied).containsExactly("first");
+        assertThat(sink.calls).containsExactly("start");
+        assertThat(sink.log).contains("SCO: second ignored, link already CONNECTING");
+    }
+
+    @Test
+    public void requestOff_withoutStart_doesNothing() {
+        List<String> applied = new ArrayList<>();
+        coordinator.requestOff("test", () -> applied.add("off"));
+        assertThat(applied).isEmpty();
+        assertThat(sink.calls).isEmpty();
+    }
+
+    // Copilot on PR #772: TX calls stopSco()/startSco() from its executor while
+    // broadcasts run on the main thread; every decision + application must land
+    // on the handler thread in submission order.
+    @Test
+    public void requestsFromAnotherThread_arePostedAndAppliedInOrder() throws Exception {
+        CountDownLatch done = new CountDownLatch(1);
+        Thread tx = new Thread(() -> {
+            coordinator.requestOn("tx-end", null);
+            coordinator.requestOff("tx-begin", null);
+            coordinator.requestOn("tx-end", null);
+            done.countDown();
+        });
+        tx.start();
+        assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+        // Nothing applied on the caller's thread.
+        assertThat(sink.calls).isEmpty();
+        shadowOf(Looper.getMainLooper()).idle();
+        assertThat(sink.calls).containsExactly("start", "stop", "start").inOrder();
+    }
+
+    @Test
+    public void shutdown_cancelsTimers_andBalancesOutstandingStart() {
+        coordinator.requestOn("test", null);
+        coordinator.shutdown();
+        assertThat(sink.calls).containsExactly("start", "stop").inOrder();
+        assertThat(tracker.isRequested()).isFalse();
+        // No retry/timeout survives the teardown.
+        advance(ScoLinkTracker.CONNECT_TIMEOUT_MS + ScoLinkTracker.retryDelayMs(2) + 1);
+        assertThat(sink.calls).containsExactly("start", "stop").inOrder();
+    }
+
+    @Test
+    public void shutdown_withNothingOutstanding_isQuiet() {
+        coordinator.shutdown();
+        assertThat(sink.calls).isEmpty();
+    }
+
+    @Test
+    public void retriesExhausted_logsGiveUp_andStopsScheduling() {
+        coordinator.requestOn("test", null);
+        for (int i = 1; i < ScoLinkTracker.MAX_ATTEMPTS; i++) {
+            advance(ScoLinkTracker.CONNECT_TIMEOUT_MS);
+            advance(ScoLinkTracker.retryDelayMs(i + 1));
+        }
+        int starts = (int) sink.calls.stream().filter("start"::equals).count();
+        assertThat(starts).isEqualTo(ScoLinkTracker.MAX_ATTEMPTS);
+        advance(ScoLinkTracker.CONNECT_TIMEOUT_MS);
+        assertThat(sink.log.get(sink.log.size() - 1)).contains("giving up");
+        advance(60_000);
+        assertThat((int) sink.calls.stream().filter("start"::equals).count())
+                .isEqualTo(ScoLinkTracker.MAX_ATTEMPTS);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkTrackerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkTrackerTest.java
@@ -189,15 +189,36 @@ public class ScoLinkTrackerTest {
         assertThat(t.attempts()).isEqualTo(3);
     }
 
+    // A timeout is a failed attempt, handled exactly like DISCONNECTED/ERROR:
+    // a spaced, deferred retry that onRetryDue() re-checks, not an immediate
+    // restart that would tear down a late CONNECTING/CONNECTED.
     @Test
-    public void connectTimeout_whileConnecting_restarts() {
+    public void connectTimeout_whileConnecting_schedulesDeferredRestart() {
         ScoLinkTracker t = new ScoLinkTracker();
         t.requestOn();
         t.onStateUpdate(CONNECTING, 0);
         Update u = t.onConnectTimeout();
-        assertThat(u.action).isEqualTo(Action.RESTART);
+        assertThat(u.action).isEqualTo(Action.NONE);
         assertThat(u.gaveUp).isFalse();
+        assertThat(u.retryDelayMs).isEqualTo(ScoLinkTracker.retryDelayMs(2));
         assertThat(t.attempts()).isEqualTo(2);
+        assertThat(t.linkState()).isEqualTo(DISCONNECTED);
+        // The retry balances the abandoned start with a stop+start.
+        assertThat(t.onRetryDue()).isEqualTo(Action.RESTART);
+        assertThat(t.linkState()).isEqualTo(CONNECTING);
+    }
+
+    @Test
+    public void connectTimeout_thenLateConnect_overtakesRetry() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(CONNECTING, 0);
+        t.onConnectTimeout();
+        // The stack was just slow: CONNECTED lands during the retry delay.
+        Update late = t.onStateUpdate(CONNECTED, 7000);
+        assertThat(late.checkMicRouting).isTrue();
+        assertThat(t.onRetryDue()).isEqualTo(Action.NONE);
+        assertThat(t.linkState()).isEqualTo(CONNECTED);
     }
 
     @Test
@@ -215,7 +236,8 @@ public class ScoLinkTrackerTest {
         ScoLinkTracker t = new ScoLinkTracker();
         t.requestOn();
         for (int i = 1; i < ScoLinkTracker.MAX_ATTEMPTS; i++) {
-            assertThat(t.onConnectTimeout().action).isEqualTo(Action.RESTART);
+            assertThat(t.onConnectTimeout().retryDelayMs).isGreaterThan(0L);
+            assertThat(t.onRetryDue()).isEqualTo(Action.RESTART);
         }
         Update u = t.onConnectTimeout();
         assertThat(u.action).isEqualTo(Action.NONE);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkTrackerTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkTrackerTest.java
@@ -1,0 +1,255 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+
+import com.k1af.ft8af.bluetooth.ScoLinkTracker.Action;
+import com.k1af.ft8af.bluetooth.ScoLinkTracker.Update;
+
+import org.junit.Test;
+
+public class ScoLinkTrackerTest {
+
+    private static final int CONNECTED = AudioManager.SCO_AUDIO_STATE_CONNECTED;
+    private static final int CONNECTING = AudioManager.SCO_AUDIO_STATE_CONNECTING;
+    private static final int DISCONNECTED = AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
+    private static final int ERROR = AudioManager.SCO_AUDIO_STATE_ERROR;
+
+    @Test
+    public void firstRequestOn_starts() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        assertThat(t.requestOn()).isEqualTo(Action.START);
+        assertThat(t.isWanted()).isTrue();
+        assertThat(t.isRequested()).isTrue();
+        assertThat(t.attempts()).isEqualTo(1);
+        // Optimistically pending until the broadcast confirms.
+        assertThat(t.linkState()).isEqualTo(CONNECTING);
+    }
+
+    // Issue #759: at launch the headset-mode gate, the rig connect, and the
+    // profile-connected broadcast each call setBlueToothOn() within a few ms.
+    // The 2nd/3rd must NOT stop+start the link that the 1st is still building.
+    @Test
+    public void requestOn_whileConnecting_isNoOp() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        assertThat(t.requestOn()).isEqualTo(Action.NONE);
+        t.onStateUpdate(CONNECTING, 0);
+        assertThat(t.requestOn()).isEqualTo(Action.NONE);
+        assertThat(t.attempts()).isEqualTo(1);
+    }
+
+    @Test
+    public void requestOn_whileConnected_isNoOp() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(CONNECTED, 0);
+        assertThat(t.requestOn()).isEqualTo(Action.NONE);
+    }
+
+    @Test
+    public void requestOff_afterStart_stops_andIgnoresOwnDisconnect() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(CONNECTED, 0);
+        assertThat(t.requestOff()).isEqualTo(Action.STOP);
+        assertThat(t.isRequested()).isFalse();
+        // The DISCONNECTED our own stop produces must not schedule a retry.
+        Update u = t.onStateUpdate(DISCONNECTED, 100);
+        assertThat(u.action).isEqualTo(Action.NONE);
+        assertThat(u.retryDelayMs).isEqualTo(0);
+        assertThat(u.gaveUp).isFalse();
+    }
+
+    @Test
+    public void requestOff_withoutStart_isNoOp() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        assertThat(t.requestOff()).isEqualTo(Action.NONE);
+        // A sticky CONNECTED from some other app while we don't want SCO: ignore.
+        assertThat(t.onStateUpdate(CONNECTED, 0).checkMicRouting).isFalse();
+    }
+
+    @Test
+    public void connected_whileWanted_asksForMicRoutingCheck() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        Update u = t.onStateUpdate(CONNECTED, 0);
+        assertThat(u.checkMicRouting).isTrue();
+        assertThat(u.action).isEqualTo(Action.NONE);
+    }
+
+    @Test
+    public void failedStart_schedulesDeferredRetry_thenRestarts() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(CONNECTING, 0);
+        Update u = t.onStateUpdate(ERROR, 500);
+        assertThat(u.action).isEqualTo(Action.NONE);
+        assertThat(u.retryDelayMs).isEqualTo(1000);
+        assertThat(t.attempts()).isEqualTo(2);
+        // AudioService may have left our start count at 1: retry = stop+start.
+        assertThat(t.onRetryDue()).isEqualTo(Action.RESTART);
+        assertThat(t.linkState()).isEqualTo(CONNECTING);
+    }
+
+    @Test
+    public void retryDelays_growThenCap() {
+        assertThat(ScoLinkTracker.retryDelayMs(2)).isEqualTo(1000);
+        assertThat(ScoLinkTracker.retryDelayMs(3)).isEqualTo(2000);
+        assertThat(ScoLinkTracker.retryDelayMs(4)).isEqualTo(3000);
+        assertThat(ScoLinkTracker.retryDelayMs(5)).isEqualTo(4000);
+        assertThat(ScoLinkTracker.retryDelayMs(9)).isEqualTo(4000);
+    }
+
+    // stopSco() right before TX, startSco() right after: the DISCONNECTED from
+    // the stop is delivered *after* the new start. It must not tear down the
+    // link being built — the deferred retry sees CONNECTING and stands down.
+    @Test
+    public void staleDisconnectAfterRestart_retryStandsDownOnceConnecting() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(CONNECTED, 0);
+        assertThat(t.requestOff()).isEqualTo(Action.STOP);
+        assertThat(t.requestOn()).isEqualTo(Action.START);
+        Update u = t.onStateUpdate(DISCONNECTED, 10); // stale, from the stop
+        assertThat(u.retryDelayMs).isGreaterThan(0L);
+        t.onStateUpdate(CONNECTING, 20); // the start's own broadcast
+        assertThat(t.onRetryDue()).isEqualTo(Action.NONE);
+        t.onStateUpdate(CONNECTED, 900);
+        assertThat(t.onRetryDue()).isEqualTo(Action.NONE);
+    }
+
+    @Test
+    public void retryDue_afterRequestOff_isNoOp() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(ERROR, 0);
+        t.requestOff();
+        assertThat(t.onRetryDue()).isEqualTo(Action.NONE);
+    }
+
+    @Test
+    public void retries_areBounded_thenGiveUp() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn(); // attempt 1
+        for (int attempt = 2; attempt <= ScoLinkTracker.MAX_ATTEMPTS; attempt++) {
+            Update u = t.onStateUpdate(DISCONNECTED, attempt * 1000L);
+            assertThat(u.gaveUp).isFalse();
+            assertThat(u.retryDelayMs).isGreaterThan(0L);
+            assertThat(t.onRetryDue()).isEqualTo(Action.RESTART);
+            assertThat(t.attempts()).isEqualTo(attempt);
+        }
+        Update last = t.onStateUpdate(DISCONNECTED, 99_000);
+        assertThat(last.gaveUp).isTrue();
+        assertThat(last.retryDelayMs).isEqualTo(0);
+        assertThat(t.onRetryDue()).isEqualTo(Action.NONE);
+    }
+
+    // An explicit new request (next TX cycle, rig reconnect) gets a fresh budget
+    // even after a give-up, and restarts because our start count may be stale.
+    @Test
+    public void requestOn_afterGiveUp_restartsWithFreshBudget() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        for (int i = 0; i < ScoLinkTracker.MAX_ATTEMPTS; i++) {
+            if (t.onStateUpdate(DISCONNECTED, i * 1000L).retryDelayMs > 0) {
+                t.onRetryDue();
+            }
+        }
+        assertThat(t.linkState()).isEqualTo(DISCONNECTED);
+        assertThat(t.requestOn()).isEqualTo(Action.RESTART);
+        assertThat(t.attempts()).isEqualTo(1);
+    }
+
+    @Test
+    public void linkThatHeld_resetsBudgetWhenItDrops() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(DISCONNECTED, 0);   // attempt -> 2
+        t.onRetryDue();
+        t.onStateUpdate(DISCONNECTED, 1000); // attempt -> 3
+        t.onRetryDue();
+        t.onStateUpdate(CONNECTED, 2000);
+        // Held for longer than STABLE_LINK_MS, then dropped: budget resets.
+        Update u = t.onStateUpdate(DISCONNECTED, 2000 + ScoLinkTracker.STABLE_LINK_MS);
+        assertThat(u.retryDelayMs).isEqualTo(1000);
+        assertThat(t.attempts()).isEqualTo(1);
+    }
+
+    @Test
+    public void linkThatFlapped_doesNotResetBudget() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(DISCONNECTED, 0);
+        t.onRetryDue(); // attempts 2
+        t.onStateUpdate(CONNECTED, 1000);
+        t.onStateUpdate(DISCONNECTED, 1200); // up for 200ms only
+        assertThat(t.attempts()).isEqualTo(3);
+    }
+
+    @Test
+    public void connectTimeout_whileConnecting_restarts() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(CONNECTING, 0);
+        Update u = t.onConnectTimeout();
+        assertThat(u.action).isEqualTo(Action.RESTART);
+        assertThat(u.gaveUp).isFalse();
+        assertThat(t.attempts()).isEqualTo(2);
+    }
+
+    @Test
+    public void connectTimeout_afterConnected_orOff_isNoOp() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(CONNECTED, 0);
+        assertThat(t.onConnectTimeout().action).isEqualTo(Action.NONE);
+        t.requestOff();
+        assertThat(t.onConnectTimeout().action).isEqualTo(Action.NONE);
+    }
+
+    @Test
+    public void connectTimeout_withBudgetSpent_givesUp() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        for (int i = 1; i < ScoLinkTracker.MAX_ATTEMPTS; i++) {
+            assertThat(t.onConnectTimeout().action).isEqualTo(Action.RESTART);
+        }
+        Update u = t.onConnectTimeout();
+        assertThat(u.action).isEqualTo(Action.NONE);
+        assertThat(u.gaveUp).isTrue();
+        assertThat(t.linkState()).isEqualTo(DISCONNECTED);
+    }
+
+    @Test
+    public void needsMicReinit_onlyWhenRecordIsOffTheHeadset() {
+        int sco = AudioDeviceInfo.TYPE_BLUETOOTH_SCO;
+        int mic = AudioDeviceInfo.TYPE_BUILTIN_MIC;
+        int wired = AudioDeviceInfo.TYPE_WIRED_HEADSET;
+        int unknown = AudioDeviceInfo.TYPE_UNKNOWN;
+        // Default input still on the built-in mic after SCO came up: rebuild.
+        assertThat(ScoLinkTracker.needsMicReinit(mic, -1)).isTrue();
+        assertThat(ScoLinkTracker.needsMicReinit(unknown, -1)).isTrue();
+        // Already on the headset: leave the running capture alone.
+        assertThat(ScoLinkTracker.needsMicReinit(sco, -1)).isFalse();
+        assertThat(ScoLinkTracker.needsMicReinit(sco, sco)).isFalse();
+        // The user pinned "Bluetooth SCO" in Settings but the OS put the record
+        // elsewhere (the reporter's exact symptom): rebuild.
+        assertThat(ScoLinkTracker.needsMicReinit(mic, sco)).isTrue();
+        // The user pinned a non-Bluetooth input on purpose: respect it.
+        assertThat(ScoLinkTracker.needsMicReinit(mic, wired)).isFalse();
+        // No AudioRecord (USB-direct capture): nothing to rebuild.
+        assertThat(ScoLinkTracker.needsMicReinit(-1, -1)).isFalse();
+    }
+
+    @Test
+    public void stateName_coversAllStates() {
+        assertThat(ScoLinkTracker.stateName(CONNECTED)).isEqualTo("CONNECTED");
+        assertThat(ScoLinkTracker.stateName(CONNECTING)).isEqualTo("CONNECTING");
+        assertThat(ScoLinkTracker.stateName(DISCONNECTED)).isEqualTo("DISCONNECTED");
+        assertThat(ScoLinkTracker.stateName(ERROR)).isEqualTo("ERROR");
+        assertThat(ScoLinkTracker.stateName(42)).isEqualTo("UNKNOWN(42)");
+    }
+}


### PR DESCRIPTION
Fixes #759 — Android 8.x: Bluetooth RX audio never reaches the app (spectrum blank, TX fine).

## What the code was doing

Reviewing the Bluetooth SCO path turned up four defects, none Android-8-specific in themselves but the combination bites hardest on Oreo's AudioService/HeadsetStateMachine:

1. **`ACTION_SCO_AUDIO_STATE_UPDATED` was registered but never handled.** The app fired `startBluetoothSco()` and then had no idea whether a link ever came up. A failed or dropped SCO was never retried, and nothing about it reached `debug.log` — which is why the reporter's log shows nothing at all about SCO.
2. **`setBlueToothOn()` did `stopBluetoothSco(); startBluetoothSco();` unconditionally, and it is called up to three times within a few ms at launch** (headset-mode gate in `initData`, `connectBluetoothRig`'s post, and the `ACTION_CONNECTION_STATE_CHANGED` broadcast). Stopping a request that is still CONNECTING abandons the half-built link inside the Bluetooth stack; on Oreo the stale virtual call then makes every later start a silent no-op (`initiateScoUsingVirtualVoiceCall: Call in progress`).
3. **`stopSco()` was gated on `AudioManager.isBluetoothScoOn()`**, which for an app only reflects a shadow flag that `setSpeakerphoneOn(false)` immediately resets. So stop-before-TX was skipped whenever the link wasn't fully up, and `startBluetoothSco()`'s per-client reference count crept upward, after which further starts do nothing.
4. **The `AudioRecord` is created at app start on the built-in mic and never re-created once SCO connects.** Android's documented recipe is to open the record after `SCO_AUDIO_STATE_CONNECTED`; relying on the force-use re-route of an already-open input is exactly what the reporter describes as "the app selects the wrong device" (and it's why voice-search — which forces a fresh SCO + re-route — made audio appear).

## What this PR does

- New `ScoLinkTracker` (pure Java, fully unit-tested): a small state machine that owns *wanted / requested / link state / attempts* and returns `START` / `RESTART` / `STOP` / `NONE` for `AudioManager`.
  - `requestOn()` is a no-op while a link is CONNECTING/CONNECTED — never restart a link being built.
  - Retries are always stop+start (to balance AudioService's start count), deferred and re-checked so the stale DISCONNECTED from our own pre-TX stop can't tear down the post-TX start, bounded to 5 attempts with 1/2/3/4 s spacing, and a link that held ≥5 s gets a fresh budget when it drops.
  - A start with no CONNECTED within 6 s counts as a failed attempt.
  - `needsMicReinit(routedType, chosenType)`: once CONNECTED, rebuild the `AudioRecord` unless it is already routed to `TYPE_BLUETOOTH_SCO` or the user pinned a non-Bluetooth input on purpose.
- `MainViewModel`: `startSco/stopSco/setBlueToothOn/setBlueToothOff` now go through the tracker; new `onScoAudioStateUpdated()` logs every transition to `debug.log` (`SCO: state CONNECTING -> CONNECTED wanted=true attempt=1`, `SCO: retry in 2000ms`, `SCO: mic routedType=15 chosenType=-1 -> rebuilding AudioRecord on the SCO link`, …), schedules retries/timeouts on the main looper, and verifies mic routing 300 ms after CONNECTED.
- `BluetoothStateBroadcastReceive`: handles `ACTION_SCO_AUDIO_STATE_UPDATED`.
- `MicRecorder`: `routedInputDeviceType()` (via `AudioRecord.getRoutedDevice()`, API 24+) and `chosenInputDeviceType()`; `HamRecorder.getMicRecorder()`.
- `AudioManager.MODE_NORMAL` is kept deliberately: TX goes out over A2DP (SCO is dropped around PTT) and an in-call mode would pull media to the earpiece.

Behaviour on phones where SCO already works is unchanged in the steady state: the link comes up, the record is found routed to SCO, no rebuild happens — the only visible difference is the new `SCO:` lines in `debug.log`.

## Testing

- `ScoLinkTrackerTest` (19 cases) + existing `ScoPolicyTest` pass.
- `installDebug` on an emulator: app launches and runs; no Bluetooth there, so the SCO path itself could not be exercised.
- **Not verified on Android 8.1 hardware** — I don't have a device. The reporter's next `debug.log` will now show exactly where SCO stalls (`SCO: …` lines), so if this doesn't fix it outright we'll at least have the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
