### PR TITLE
Fix Cloudlog/Wavelog Test Connection over cleartext LAN + report the reason (#756)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/FAQActivity.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/FAQActivity.java
@@ -42,7 +42,11 @@ public class FAQActivity extends AppCompatActivity {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 super.shouldOverrideUrlLoading(view, url);
-                view.loadUrl(url);
+                // HTTPS only: the app-wide cleartext allowance exists for the user's LAN
+                // logbook server (issue #756), not for pages this WebView follows links to.
+                if (com.k1af.ft8af.ui.WebNavigationPolicy.isAllowed(url)) {
+                    view.loadUrl(url);
+                }
                 return true;
             }
         };

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/CloudlogEndpoint.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/CloudlogEndpoint.java
@@ -108,7 +108,7 @@ public final class CloudlogEndpoint {
         while (p.startsWith("/")) {
             p = p.substring(1);
         }
-        if (base.toLowerCase(Locale.ROOT).contains("index.php")) {
+        if (endsWithIndexPhpSegment(base)) {
             out.add(base + p);
             return out;
         }
@@ -123,6 +123,22 @@ public final class CloudlogEndpoint {
             out.add(rewritten);
         }
         return Collections.unmodifiableList(out);
+    }
+
+    /**
+     * True when a normalized base URL's <em>path</em> already ends in an {@code index.php/}
+     * segment, i.e. the user typed the no-rewrite form themselves and there is nothing to
+     * fall back to. Only the path is inspected: a host such as {@code index.php.example}
+     * or a directory merely containing the text ({@code /index.php-old/}) doesn't count.
+     */
+    static boolean endsWithIndexPhpSegment(String base) {
+        if (base == null) return false;
+        String rest = base;
+        int scheme = rest.indexOf("://");
+        if (scheme >= 0) rest = rest.substring(scheme + 3);
+        int slash = rest.indexOf('/');
+        String path = slash >= 0 ? rest.substring(slash) : "";
+        return path.toLowerCase(Locale.ROOT).endsWith("/" + INDEX_PHP);
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/CloudlogEndpoint.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/CloudlogEndpoint.java
@@ -1,0 +1,168 @@
+package com.k1af.ft8af.log;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/**
+ * Pure URL plumbing for the Cloudlog / Wavelog / Nextlog API (issue #756).
+ *
+ * <p>Users type the server address by hand and self-hosted installs vary a lot:
+ * <ul>
+ *   <li>{@code 192.168.15.20/cloudlog} — no scheme at all ({@code new URL()} would throw
+ *       {@code MalformedURLException: no protocol});</li>
+ *   <li>{@code http://192.168.186.73/wavelog/} — plain HTTP on a LAN;</li>
+ *   <li>installs without Apache {@code mod_rewrite}/{@code .htaccess}, where the API only
+ *       answers at {@code /wavelog/index.php/api/...} and {@code /wavelog/api/...} is a 404.</li>
+ * </ul>
+ *
+ * <p>This class turns the raw address into a normalized base URL and, for each API path,
+ * the ordered list of candidate URLs to try: the rewritten form first, then the
+ * {@code index.php/} form. Once a variant answers, {@link #rememberWorking} pins it so
+ * later uploads don't pay for a 404 round-trip on every QSO. No Android imports — keep
+ * it that way so it stays unit-testable.
+ */
+public final class CloudlogEndpoint {
+
+    static final String INDEX_PHP = "index.php/";
+
+    private static final Pattern IPV4 = Pattern.compile("^\\d{1,3}(\\.\\d{1,3}){3}$");
+
+    /** Address (as typed, trimmed) → base URL variant that last answered. In-memory only. */
+    private static final Map<String, String> WORKING_BASE = new ConcurrentHashMap<>();
+
+    private CloudlogEndpoint() {
+    }
+
+    /**
+     * Normalizes a user-entered address into a base URL ending in {@code /}.
+     *
+     * <ul>
+     *   <li>Trims surrounding whitespace.</li>
+     *   <li>Adds a scheme when missing: {@code http://} for IPv4 literals, {@code localhost},
+     *       single-label hosts and {@code .local}/{@code .lan}/{@code .home}/{@code .internal}
+     *       names (LAN boxes practically never have a certificate); {@code https://} for
+     *       anything that looks like a public hostname.</li>
+     *   <li>Guarantees exactly one trailing slash.</li>
+     * </ul>
+     *
+     * @return the normalized base, or {@code null} if the address is null/blank.
+     */
+    public static String normalizeBase(String address) {
+        if (address == null) return null;
+        String a = address.trim();
+        if (a.isEmpty()) return null;
+        if (!a.contains("://")) {
+            a = (looksLikeLanHost(hostOf(a)) ? "http://" : "https://") + a;
+        }
+        while (a.endsWith("//")) {
+            a = a.substring(0, a.length() - 1);
+        }
+        if (!a.endsWith("/")) {
+            a += "/";
+        }
+        return a;
+    }
+
+    /** Host part of a scheme-less address, minus any port, path or userinfo. */
+    static String hostOf(String schemeless) {
+        String h = schemeless;
+        int at = h.indexOf('@');
+        if (at >= 0) h = h.substring(at + 1);
+        int slash = h.indexOf('/');
+        if (slash >= 0) h = h.substring(0, slash);
+        if (h.startsWith("[")) {
+            int close = h.indexOf(']');
+            return close >= 0 ? h.substring(0, close + 1) : h;
+        }
+        int colon = h.indexOf(':');
+        if (colon >= 0) h = h.substring(0, colon);
+        return h;
+    }
+
+    static boolean looksLikeLanHost(String host) {
+        if (host == null || host.isEmpty()) return false;
+        String h = host.toLowerCase(Locale.ROOT);
+        if (h.startsWith("[")) return true; // IPv6 literal — almost always a LAN box
+        if (IPV4.matcher(h).matches()) return true;
+        if (h.equals("localhost")) return true;
+        if (!h.contains(".")) return true; // single-label name: "nas", "raspberrypi"
+        return h.endsWith(".local") || h.endsWith(".lan") || h.endsWith(".home")
+                || h.endsWith(".internal");
+    }
+
+    /**
+     * Ordered candidate URLs for {@code path} (e.g. {@code api/auth/KEY}) under a normalized
+     * base. Returns the rewritten form first, then the {@code index.php/} fallback. If the base
+     * already carries {@code index.php}, only that single URL is returned. A variant that
+     * previously answered for this base is moved to the front.
+     */
+    public static List<String> candidates(String base, String path) {
+        List<String> out = new ArrayList<>(2);
+        if (base == null) return out;
+        String p = path == null ? "" : path;
+        while (p.startsWith("/")) {
+            p = p.substring(1);
+        }
+        if (base.toLowerCase(Locale.ROOT).contains("index.php")) {
+            out.add(base + p);
+            return out;
+        }
+        String plain = base + p;
+        String rewritten = base + INDEX_PHP + p;
+        String known = WORKING_BASE.get(base);
+        if (known != null && known.endsWith(INDEX_PHP)) {
+            out.add(rewritten);
+            out.add(plain);
+        } else {
+            out.add(plain);
+            out.add(rewritten);
+        }
+        return Collections.unmodifiableList(out);
+    }
+
+    /**
+     * Records which base variant answered so the next {@link #candidates} call for the same
+     * base tries it first. {@code url} is the full URL that succeeded.
+     */
+    public static void rememberWorking(String base, String url) {
+        if (base == null || url == null) return;
+        if (url.startsWith(base + INDEX_PHP)) {
+            WORKING_BASE.put(base, base + INDEX_PHP);
+        } else if (url.startsWith(base)) {
+            WORKING_BASE.put(base, base);
+        }
+    }
+
+    /** Test hook / settings-change hook: forget every pinned variant. */
+    public static void forgetAll() {
+        WORKING_BASE.clear();
+    }
+
+    /**
+     * Human-readable reason for a failed request, shown next to "Fail" in the settings
+     * dialog and written to debug.log. Never includes the API key (callers pass redacted
+     * URLs only).
+     */
+    public static String describeFailure(String redactedUrl, int httpStatus, Exception e) {
+        if (e != null) {
+            String msg = e.getMessage();
+            String name = e.getClass().getSimpleName();
+            if (msg == null || msg.isEmpty()) return name;
+            // Common java.net messages are clear on their own; keep the class for the rest.
+            if (e instanceof java.net.UnknownHostException) return "Unknown host: " + msg;
+            if (e instanceof java.net.MalformedURLException) return "Bad URL: " + msg;
+            if (e instanceof java.net.SocketTimeoutException) return "Timed out: " + msg;
+            if (e instanceof java.net.ConnectException) return "Connect failed: " + msg;
+            return name + ": " + msg;
+        }
+        if (httpStatus > 0) {
+            return "HTTP " + httpStatus + (redactedUrl != null ? " from " + redactedUrl : "");
+        }
+        return "No response" + (redactedUrl != null ? " from " + redactedUrl : "");
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -760,17 +760,24 @@ public class ThirdPartyService {
     }
 
     /**
-     * Redacts a Cloudlog/Wavelog API key from a URL before it is logged. The key is a
-     * path segment following {@code create_station/}, {@code station_info/}, or
-     * {@code auth/}; this replaces that segment with {@code ***} so the credential never
-     * reaches logcat. Only the LOGGED string is redacted — the real request URL is
-     * unchanged. Returns null unchanged.
+     * Redacts credentials from a URL before it is logged. Two things are masked:
+     * <ul>
+     *   <li>the Cloudlog/Wavelog API key — a path segment following {@code create_station/},
+     *       {@code station_info/}, or {@code auth/} — replaced with {@code ***};</li>
+     *   <li>any authority user-info ({@code http://user:pw@host/…}) — replaced with
+     *       {@code ***@}. Self-hosted logbooks behind basic auth are entered exactly that
+     *       way, and {@link CloudlogEndpoint#normalizeBase} preserves it, so without this
+     *       every {@code Cloudlog: GET/POST} line in debug.log would carry the password.</li>
+     * </ul>
+     * Only the LOGGED string is redacted — the real request URL is unchanged. Returns null
+     * unchanged.
      */
     static String redactUrlApiKey(String url) {
         if (url == null) {
             return null;
         }
-        return url.replaceAll("(create_station/|station_info/|auth/)[^/?#\\s]+", "$1***");
+        String out = url.replaceFirst("^([A-Za-z][A-Za-z0-9+.\\-]*://)[^/?#@\\s]*@", "$1***@");
+        return out.replaceAll("(create_station/|station_info/|auth/)[^/?#\\s]+", "$1***");
     }
 
     public static String sendPostRequest(String url, String json) throws IOException {
@@ -1030,28 +1037,8 @@ public class ThirdPartyService {
      * API key redacted.
      */
     static String cloudlogGet(String base, String path, StringBuilder failureOut) {
-        String lastFailure = null;
-        for (String url : CloudlogEndpoint.candidates(base, path)) {
-            String shown = redactUrlApiKey(url);
-            int[] status = new int[1];
-            try {
-                String body = sendGetRequest(url, status);
-                if (body != null) {
-                    CloudlogEndpoint.rememberWorking(base, url);
-                    GeneralVariables.fileLog("Cloudlog: GET " + shown + " -> HTTP " + status[0]);
-                    return body;
-                }
-                lastFailure = CloudlogEndpoint.describeFailure(shown, status[0], null);
-                GeneralVariables.fileLog("Cloudlog: GET " + shown + " -> " + lastFailure);
-                if (status[0] != HttpURLConnection.HTTP_NOT_FOUND) break;
-            } catch (Exception e) {
-                lastFailure = CloudlogEndpoint.describeFailure(shown, 0, e);
-                GeneralVariables.fileLog("Cloudlog: GET " + shown + " -> " + lastFailure);
-                break;
-            }
-        }
-        appendFailure(failureOut, lastFailure);
-        return null;
+        return cloudlogRequest("GET", base, path, failureOut,
+                (url, status, why) -> sendGetRequest(url, status));
     }
 
     /**
@@ -1059,25 +1046,49 @@ public class ThirdPartyService {
      * fallback, same logging. Returns the body on HTTP 200/201, else null.
      */
     static String cloudlogPost(String base, String path, String json, StringBuilder failureOut) {
+        return cloudlogRequest("POST", base, path, failureOut,
+                (url, status, why) -> sendPostRequest(url, json, why, status));
+    }
+
+    /**
+     * One HTTP attempt against a single candidate URL. Returns the body on success or
+     * {@code null} on a non-success status (reporting the status in {@code statusOut[0]}
+     * and, optionally, a server-supplied reason in {@code why}); throws on transport
+     * failure. Package-private so the candidate walk can be unit-tested with a fake.
+     */
+    interface CloudlogTransport {
+        String call(String url, int[] statusOut, StringBuilder why) throws IOException;
+    }
+
+    /**
+     * The candidate walk shared by {@link #cloudlogGet} and {@link #cloudlogPost}: try each
+     * URL shape from {@link CloudlogEndpoint#candidates} in order; a 404 moves on to the
+     * next shape, any other status or a transport exception stops; the first success pins
+     * its shape via {@link CloudlogEndpoint#rememberWorking}. The reason for the last
+     * failed attempt is appended to {@code failureOut}.
+     */
+    static String cloudlogRequest(String verb, String base, String path,
+                                  StringBuilder failureOut, CloudlogTransport transport) {
         String lastFailure = null;
         for (String url : CloudlogEndpoint.candidates(base, path)) {
             String shown = redactUrlApiKey(url);
             int[] status = new int[1];
             StringBuilder why = new StringBuilder();
             try {
-                String body = sendPostRequest(url, json, why, status);
+                String body = transport.call(url, status, why);
                 if (body != null) {
                     CloudlogEndpoint.rememberWorking(base, url);
-                    GeneralVariables.fileLog("Cloudlog: POST " + shown + " -> HTTP " + status[0]);
+                    GeneralVariables.fileLog("Cloudlog: " + verb + " " + shown
+                            + " -> HTTP " + status[0]);
                     return body;
                 }
                 lastFailure = why.length() > 0 ? why.toString()
                         : CloudlogEndpoint.describeFailure(shown, status[0], null);
-                GeneralVariables.fileLog("Cloudlog: POST " + shown + " -> " + lastFailure);
+                GeneralVariables.fileLog("Cloudlog: " + verb + " " + shown + " -> " + lastFailure);
                 if (status[0] != HttpURLConnection.HTTP_NOT_FOUND) break;
             } catch (Exception e) {
                 lastFailure = CloudlogEndpoint.describeFailure(shown, 0, e);
-                GeneralVariables.fileLog("Cloudlog: POST " + shown + " -> " + lastFailure);
+                GeneralVariables.fileLog("Cloudlog: " + verb + " " + shown + " -> " + lastFailure);
                 break;
             }
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/log/ThirdPartyService.java
@@ -69,15 +69,12 @@ public class ThirdPartyService {
      */
     public static List<StationProfile> FetchCloudlogStations(String address, String apiKey) {
         List<StationProfile> stations = new ArrayList<>();
-        if (address == null || address.isEmpty() || apiKey == null || apiKey.isEmpty()) {
+        String base = CloudlogEndpoint.normalizeBase(address);
+        if (base == null || apiKey == null || apiKey.trim().isEmpty()) {
             return stations;
         }
-        if (!address.endsWith("/")) {
-            address += "/";
-        }
         try {
-            String url = address + "api/station_info/" + apiKey;
-            String result = sendGetRequest(url);
+            String result = cloudlogGet(base, "api/station_info/" + apiKey.trim(), null);
             if (result == null || result.isEmpty()) return stations;
             JSONArray arr = new JSONArray(result);
             for (int i = 0; i < arr.length(); i++) {
@@ -117,11 +114,9 @@ public class ThirdPartyService {
                                                String gridsquare, String callsign,
                                                String city, String dxcc,
                                                boolean linkActiveLogbook) {
-        if (address == null || address.isEmpty() || apiKey == null || apiKey.isEmpty()) {
+        String base = CloudlogEndpoint.normalizeBase(address);
+        if (base == null || apiKey == null || apiKey.trim().isEmpty()) {
             return null;
-        }
-        if (!address.endsWith("/")) {
-            address += "/";
         }
         try {
             String body = buildCreateStationRequestJson(
@@ -132,8 +127,7 @@ public class ThirdPartyService {
                 Log.d(TAG, "createCloudlogStation aborted: could not build request body");
                 return null;
             }
-            String url = address + "api/create_station/" + apiKey;
-            String result = sendPostRequest(url, body);
+            String result = cloudlogPost(base, "api/create_station/" + apiKey.trim(), body, null);
             String id = parseCreateStationResponse(result);
             Log.d(TAG, "createCloudlogStation " + (id != null ? "created id" : "failed/no id"));
             return id;
@@ -337,13 +331,10 @@ public class ThirdPartyService {
      * explanation instead of a bare "0 uploaded".
      */
     public static boolean uploadAdifToCloudlog(String adif, StringBuilder failureOut) {
-        String address = GeneralVariables.getCloudlogServerAddress();
-        if (address == null || address.isEmpty()) {
+        String base = CloudlogEndpoint.normalizeBase(GeneralVariables.getCloudlogServerAddress());
+        if (base == null) {
             appendFailure(failureOut, "no server address configured");
             return false;
-        }
-        if (!address.endsWith("/")){
-            address+="/";
         }
         JSONStringer js = new JSONStringer();
         try {
@@ -352,7 +343,7 @@ public class ThirdPartyService {
             // Cloudlog's documented endpoint is /api/qso (no trailing slash). Wavelog and
             // Nextlog both 308-redirect when the trailing slash is present, which
             // HttpURLConnection won't follow on a POST.
-            String clRes = sendPostRequest(address+"api/qso", result, failureOut);
+            String clRes = cloudlogPost(base, "api/qso", result, failureOut);
             Log.d(TAG, "Cloudlog upload " + (clRes != null ? "succeeded" : "failed"));
             return clRes != null;
         }catch (Exception k){
@@ -362,32 +353,63 @@ public class ThirdPartyService {
             return false;
         }
     }
+
+    /** Outcome of {@link #checkCloudlogConnection()}: pass/fail plus a one-line reason. */
+    public static final class ConnectionCheck {
+        public final boolean ok;
+        /** Why it failed (HTTP status, transport error, bad key…); null when {@link #ok}. */
+        public final String detail;
+
+        ConnectionCheck(boolean ok, String detail) {
+            this.ok = ok;
+            this.detail = detail;
+        }
+    }
+
     public static boolean CheckCloudlogConnection(){
-        String address = GeneralVariables.getCloudlogServerAddress();
+        return checkCloudlogConnection().ok;
+    }
+
+    /**
+     * Verifies the configured Cloudlog/Wavelog/Nextlog address + API key via
+     * {@code api/auth/[key]} and says <em>why</em> when it fails. Before #756 every failure
+     * — a cleartext block, a 404 from a no-rewrite install, a typo, a dead host — collapsed
+     * to a bare "Fail" in the settings dialog with nothing in debug.log.
+     */
+    public static ConnectionCheck checkCloudlogConnection() {
+        String base = CloudlogEndpoint.normalizeBase(GeneralVariables.getCloudlogServerAddress());
         String apiKey = GeneralVariables.getCloudlogServerApiKey();
-        // Check if the address ends with /
-        if (!address.endsWith("/")){
-            address+="/";
+        if (base == null) {
+            return new ConnectionCheck(false, "no server address configured");
         }
-        try{
-            // The Cloudlog auth endpoint takes the key as a path segment, so the constructed
-            // URL is unavoidably credential-bearing. Do not log it.
-            String url = address + "api/auth/"+ apiKey;
-            String result = sendGetRequest(url);
-            if (result == null) {
-                Log.d(TAG, "Cloudlog connection failed: no response");
-                return false;
-            }
-            // Nextlog and Wavelog both implement /api/auth but return slightly different shapes
-            // (XML declaration, extra whitespace, etc.). Match on the meaningful markers so all
-            // three Cloudlog-compatible backends report Pass.
-            String compact = result.replaceAll("\\s+", "");
-            return compact.contains("<status>Valid</status>")
-                    && compact.contains("<rights>rw</rights>");
-        }catch (Exception e){
-            Log.d(TAG, "Cloudlog auth error: " + e.getClass().getSimpleName());
-            return false;
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            return new ConnectionCheck(false, "no API key configured");
         }
+        // The Cloudlog auth endpoint takes the key as a path segment, so the constructed
+        // URL is unavoidably credential-bearing; cloudlogGet redacts it before logging.
+        StringBuilder why = new StringBuilder();
+        String result = cloudlogGet(base, "api/auth/" + apiKey.trim(), why);
+        if (result == null) {
+            return new ConnectionCheck(false, why.length() > 0 ? why.toString() : "no response");
+        }
+        return interpretAuthResponse(result);
+    }
+
+    /**
+     * Interprets the body of {@code api/auth/[key]}. Nextlog and Wavelog both implement it
+     * but return slightly different shapes (XML declaration, extra whitespace, etc.), so
+     * match on the meaningful markers. Pure — unit-tested.
+     */
+    static ConnectionCheck interpretAuthResponse(String body) {
+        String compact = body == null ? "" : body.replaceAll("\\s+", "");
+        boolean valid = compact.contains("<status>Valid</status>");
+        boolean rw = compact.contains("<rights>rw</rights>");
+        if (valid && rw) return new ConnectionCheck(true, null);
+        if (valid) return new ConnectionCheck(false, "API key is read-only (needs rw rights)");
+        if (compact.contains("<status>")) {
+            return new ConnectionCheck(false, "API key rejected by server");
+        }
+        return new ConnectionCheck(false, "unexpected reply (not a Cloudlog API?)");
     }
 
     public static boolean CheckQRZConnection(){
@@ -767,16 +789,27 @@ public class ThirdPartyService {
      */
     static String sendPostRequest(String url, String json, StringBuilder failureOut)
             throws IOException {
+        return sendPostRequest(url, json, failureOut, null);
+    }
+
+    /**
+     * As {@link #sendPostRequest(String, String, StringBuilder)}, additionally reporting the
+     * final HTTP status in {@code statusOut[0]} (0 if none was received).
+     */
+    static String sendPostRequest(String url, String json, StringBuilder failureOut,
+                                  int[] statusOut) throws IOException {
         // HttpURLConnection does not auto-follow 30x on a POST. Walk redirects manually
         // (capped) so deployments that rewrite trailing slashes, http→https, or move
         // the API path still work.
         String currentUrl = url;
+        if (statusOut != null && statusOut.length > 0) statusOut[0] = 0;
         for (int hop = 0; hop < 5; hop++) {
             HttpURLConnection conn = null;
             BufferedReader reader = null;
             try {
                 URL urlObj = new URL(currentUrl);
                 conn = (HttpURLConnection) urlObj.openConnection();
+                applyTimeouts(conn);
                 conn.setDoOutput(true);
                 conn.setInstanceFollowRedirects(false);
                 conn.setRequestMethod("POST");
@@ -788,6 +821,7 @@ public class ThirdPartyService {
                 os.close();
 
                 int responseCode = conn.getResponseCode();
+                if (statusOut != null && statusOut.length > 0) statusOut[0] = responseCode;
                 // Cloudlog uses HTTP_CREATED as the response for successful record creation
                 if (responseCode == HttpURLConnection.HTTP_OK
                         || responseCode == HttpURLConnection.HTTP_CREATED) {
@@ -888,6 +922,7 @@ public class ThirdPartyService {
         try {
             URL urlObj = new URL(url);
             conn = (HttpURLConnection) urlObj.openConnection();
+            applyTimeouts(conn);
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             conn.setDoOutput(true);
@@ -921,12 +956,23 @@ public class ThirdPartyService {
     }
 
     public static String sendGetRequest(String url) throws IOException {
+        return sendGetRequest(url, null);
+    }
+
+    /**
+     * As {@link #sendGetRequest(String)}, but reports the HTTP status in
+     * {@code statusOut[0]} when supplied (0 if the connection never produced one), so the
+     * caller can tell a 404 (try the other URL shape) from a 401/500 (stop).
+     */
+    static String sendGetRequest(String url, int[] statusOut) throws IOException {
         HttpURLConnection conn = null;
         BufferedReader reader = null;
+        if (statusOut != null && statusOut.length > 0) statusOut[0] = 0;
 
         try {
             URL urlObj = new URL(url);
             conn = (HttpURLConnection) urlObj.openConnection();
+            applyTimeouts(conn);
 
             // Set request method to GET
             conn.setRequestMethod("GET");
@@ -935,8 +981,10 @@ public class ThirdPartyService {
 
             // Get server response
             int responseCode = conn.getResponseCode();
+            if (statusOut != null && statusOut.length > 0) statusOut[0] = responseCode;
             if (responseCode == HttpURLConnection.HTTP_OK) {
-                reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                reader = new BufferedReader(new InputStreamReader(conn.getInputStream(),
+                        StandardCharsets.UTF_8));
                 StringBuilder response = new StringBuilder();
                 String line;
                 while ((line = reader.readLine()) != null) {
@@ -944,6 +992,7 @@ public class ThirdPartyService {
                 }
                 return response.toString();
             }
+            Log.d(TAG, "GET " + redactUrlApiKey(url) + " -> HTTP " + responseCode);
         } finally {
             if (conn != null) {
                 conn.disconnect();
@@ -952,6 +1001,87 @@ public class ThirdPartyService {
                 reader.close();
             }
         }
+        return null;
+    }
+
+    /**
+     * Connect/read timeouts for every logbook request. {@code HttpURLConnection} defaults
+     * to "forever", which on a LAN host that is off or firewalled left the Test Connection
+     * spinner running until the OS gave up on the SYN retries (issue #756).
+     */
+    static final int HTTP_CONNECT_TIMEOUT_MS = 10_000;
+    static final int HTTP_READ_TIMEOUT_MS = 20_000;
+
+    private static void applyTimeouts(HttpURLConnection conn) {
+        conn.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS);
+        conn.setReadTimeout(HTTP_READ_TIMEOUT_MS);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Cloudlog / Wavelog / Nextlog request plumbing (issue #756)
+    // ---------------------------------------------------------------------------------
+
+    /**
+     * GET {@code path} under a Cloudlog-compatible base URL, trying each URL shape from
+     * {@link CloudlogEndpoint#candidates} in turn. A 404 moves on to the next shape (an
+     * install without URL rewriting only answers at {@code index.php/api/...}); any other
+     * status, or a transport error, stops. Returns the body on HTTP 200, else null with the
+     * reason appended to {@code failureOut}. Every attempt is written to debug.log with the
+     * API key redacted.
+     */
+    static String cloudlogGet(String base, String path, StringBuilder failureOut) {
+        String lastFailure = null;
+        for (String url : CloudlogEndpoint.candidates(base, path)) {
+            String shown = redactUrlApiKey(url);
+            int[] status = new int[1];
+            try {
+                String body = sendGetRequest(url, status);
+                if (body != null) {
+                    CloudlogEndpoint.rememberWorking(base, url);
+                    GeneralVariables.fileLog("Cloudlog: GET " + shown + " -> HTTP " + status[0]);
+                    return body;
+                }
+                lastFailure = CloudlogEndpoint.describeFailure(shown, status[0], null);
+                GeneralVariables.fileLog("Cloudlog: GET " + shown + " -> " + lastFailure);
+                if (status[0] != HttpURLConnection.HTTP_NOT_FOUND) break;
+            } catch (Exception e) {
+                lastFailure = CloudlogEndpoint.describeFailure(shown, 0, e);
+                GeneralVariables.fileLog("Cloudlog: GET " + shown + " -> " + lastFailure);
+                break;
+            }
+        }
+        appendFailure(failureOut, lastFailure);
+        return null;
+    }
+
+    /**
+     * POST counterpart of {@link #cloudlogGet}: same candidate walk, same 404-only
+     * fallback, same logging. Returns the body on HTTP 200/201, else null.
+     */
+    static String cloudlogPost(String base, String path, String json, StringBuilder failureOut) {
+        String lastFailure = null;
+        for (String url : CloudlogEndpoint.candidates(base, path)) {
+            String shown = redactUrlApiKey(url);
+            int[] status = new int[1];
+            StringBuilder why = new StringBuilder();
+            try {
+                String body = sendPostRequest(url, json, why, status);
+                if (body != null) {
+                    CloudlogEndpoint.rememberWorking(base, url);
+                    GeneralVariables.fileLog("Cloudlog: POST " + shown + " -> HTTP " + status[0]);
+                    return body;
+                }
+                lastFailure = why.length() > 0 ? why.toString()
+                        : CloudlogEndpoint.describeFailure(shown, status[0], null);
+                GeneralVariables.fileLog("Cloudlog: POST " + shown + " -> " + lastFailure);
+                if (status[0] != HttpURLConnection.HTTP_NOT_FOUND) break;
+            } catch (Exception e) {
+                lastFailure = CloudlogEndpoint.describeFailure(shown, 0, e);
+                GeneralVariables.fileLog("Cloudlog: POST " + shown + " -> " + lastFailure);
+                break;
+            }
+        }
+        appendFailure(failureOut, lastFailure);
         return null;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/QRZ_Fragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/QRZ_Fragment.java
@@ -64,7 +64,11 @@ public class QRZ_Fragment extends Fragment {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 super.shouldOverrideUrlLoading(view, url);
-                view.loadUrl(url);
+                // HTTPS only: the app-wide cleartext allowance exists for the user's LAN
+                // logbook server (issue #756), not for pages this WebView follows links to.
+                if (WebNavigationPolicy.isAllowed(url)) {
+                    view.loadUrl(url);
+                }
                 return true;
             }
         };

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/WebNavigationPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/WebNavigationPolicy.java
@@ -1,0 +1,25 @@
+package com.k1af.ft8af.ui;
+
+import java.util.Locale;
+
+/**
+ * Navigation policy for the app's embedded {@code WebView}s (QRZ lookup, FAQ/feedback).
+ *
+ * <p>Why: issue #756 relaxed the network-security {@code base-config} to permit cleartext,
+ * because the user-typed Cloudlog/Wavelog address is very often a plain-HTTP LAN box. That
+ * flag is app-wide, so the WebViews — which follow arbitrary links with JavaScript on —
+ * would silently start honouring {@code http://} navigations too. This keeps them where
+ * they were before: HTTPS only. Pure, no Android types, so it is unit-testable.
+ */
+public final class WebNavigationPolicy {
+
+    private WebNavigationPolicy() {
+    }
+
+    /** True when {@code url} may be loaded inside an app WebView: an {@code https://} URL. */
+    public static boolean isAllowed(String url) {
+        if (url == null) return false;
+        String u = url.trim().toLowerCase(Locale.ROOT);
+        return u.startsWith("https://") && u.length() > "https://".length();
+    }
+}

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/LoggingSettings.kt
@@ -385,6 +385,7 @@ private fun CloudlogSettingsDialog(
 
     // Test connection state: null = idle, true = pass, false = fail
     var testResult by remember { mutableStateOf<Boolean?>(null) }
+    var testDetail by remember { mutableStateOf<String?>(null) }
     var isTesting by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
@@ -553,17 +554,23 @@ private fun CloudlogSettingsDialog(
             ) {
                 TextButton(
                     onClick = {
-                        // Write current input values to GeneralVariables so the test uses them
-                        GeneralVariables.cloudlogServerAddress = addressInput.text
-                        GeneralVariables.cloudlogApiKey = apiKeyInput.text
-                        GeneralVariables.cloudlogStationID = stationIdInput.text
+                        // Write current input values to GeneralVariables so the test uses them.
+                        // Trimmed: a pasted trailing newline used to reach the URL builder
+                        // here while the station fetch below trimmed — two different fates
+                        // for the same field (#756).
+                        GeneralVariables.cloudlogServerAddress = addressInput.text.trim()
+                        GeneralVariables.cloudlogApiKey = apiKeyInput.text.trim()
+                        GeneralVariables.cloudlogStationID = stationIdInput.text.trim()
                         isTesting = true
                         testResult = null
+                        testDetail = null
                         scope.launch {
-                            val result = withContext(Dispatchers.IO) {
-                                ThirdPartyService.CheckCloudlogConnection()
+                            val check = withContext(Dispatchers.IO) {
+                                ThirdPartyService.checkCloudlogConnection()
                             }
+                            val result = check.ok
                             testResult = result
+                            testDetail = check.detail
                             isTesting = false
                             // On success, also fetch station profiles
                             if (result) {
@@ -605,6 +612,18 @@ private fun CloudlogSettingsDialog(
                         fontSize = 14.sp,
                     )
                 }
+            }
+            // Why it failed — HTTP status, host unreachable, key rejected… (#756). Technical
+            // by design: it is the same line that lands in debug.log, so a bug report and
+            // the screen say the same thing.
+            val detail = testDetail
+            if (testResult == false && !detail.isNullOrBlank()) {
+                Text(
+                    text = detail,
+                    color = StatusBad,
+                    fontSize = 12.sp,
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
 
             Row(

--- a/ft8af/app/src/main/res/xml/network_security_config.xml
+++ b/ft8af/app/src/main/res/xml/network_security_config.xml
@@ -8,9 +8,16 @@
   HttpURLConnection throw before a single packet left the phone, so "Test Connection"
   failed with nothing in the server's access log or in tcpdump.
 
-  So: cleartext is permitted by default (that only affects addresses the user typed),
-  and every public API the app itself talks to is pinned to TLS below, so a typo,
-  a captive portal, or a downgrade attempt can't silently move those to http://.
+  A network-security-config can't express "cleartext only for the host the user typed":
+  domain-config entries are literal host names (no wildcards, no IP ranges), and the
+  logbook host is unknown until runtime. So the base-config permits cleartext, and the
+  exposure is contained two ways:
+    - every public API and every page the app itself opens is pinned to TLS below, so a
+      typo, a captive portal, or a downgrade attempt can't silently move those to http://;
+    - the embedded WebViews (QRZ lookup, FAQ) refuse to follow non-https navigations
+      (WebNavigationPolicy), so link-following inside them stays where it was before.
+  Net effect: the only traffic that can be cleartext is a request to the address the
+  user entered in Logging settings.
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true">
@@ -19,7 +26,8 @@
         </trust-anchors>
     </base-config>
 
-    <!-- Public services the app calls with hard-coded https:// URLs: never cleartext. -->
+    <!-- Public services the app calls with hard-coded https:// URLs, and the hosts the
+         embedded WebViews open: never cleartext. -->
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">qrz.com</domain>
         <domain includeSubdomains="true">pota.app</domain>
@@ -28,5 +36,6 @@
         <domain includeSubdomains="true">amazonaws.com</domain>
         <domain includeSubdomains="true">github.com</domain>
         <domain includeSubdomains="true">ft8af.app</domain>
+        <domain includeSubdomains="true">support.qq.com</domain>
     </domain-config>
 </network-security-config>

--- a/ft8af/app/src/main/res/xml/network_security_config.xml
+++ b/ft8af/app/src/main/res/xml/network_security_config.xml
@@ -1,8 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Cleartext policy (issue #756).
+
+  The only user-supplied host in the app is the Cloudlog / Wavelog / Nextlog logbook
+  server, and those are very often self-hosted on a LAN over plain HTTP
+  (http://192.168.x.x/wavelog/). A base-config that forbids cleartext made
+  HttpURLConnection throw before a single packet left the phone, so "Test Connection"
+  failed with nothing in the server's access log or in tcpdump.
+
+  So: cleartext is permitted by default (that only affects addresses the user typed),
+  and every public API the app itself talks to is pinned to TLS below, so a typo,
+  a captive portal, or a downgrade attempt can't silently move those to http://.
+-->
 <network-security-config>
-    <base-config cleartextTrafficPermitted="false">
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
+
+    <!-- Public services the app calls with hard-coded https:// URLs: never cleartext. -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">qrz.com</domain>
+        <domain includeSubdomains="true">pota.app</domain>
+        <domain includeSubdomains="true">pskreporter.info</domain>
+        <domain includeSubdomains="true">amazoncognito.com</domain>
+        <domain includeSubdomains="true">amazonaws.com</domain>
+        <domain includeSubdomains="true">github.com</domain>
+        <domain includeSubdomains="true">ft8af.app</domain>
+    </domain-config>
 </network-security-config>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/CloudlogEndpointIndexPhpTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/CloudlogEndpointIndexPhpTest.java
@@ -1,0 +1,72 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * {@link CloudlogEndpoint#endsWithIndexPhpSegment(String)} and its effect on
+ * {@link CloudlogEndpoint#candidates}: only a base whose <em>path</em> already ends in the
+ * {@code index.php/} segment gets the single-candidate treatment. A hostname or directory
+ * that merely contains the text must still receive the {@code index.php/} fallback,
+ * otherwise a no-rewrite install at such an address can never be reached.
+ */
+public class CloudlogEndpointIndexPhpTest {
+
+    @Before
+    public void reset() {
+        CloudlogEndpoint.forgetAll();
+    }
+
+    @Test
+    public void terminalIndexPhpSegment_detected() {
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("http://192.168.1.5/wavelog/index.php/"))
+                .isTrue();
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("https://log.example.org/index.php/"))
+                .isTrue();
+        // Case-insensitive, like the rest of the URL handling.
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("http://nas/cloudlog/INDEX.PHP/"))
+                .isTrue();
+    }
+
+    @Test
+    public void indexPhpInHostname_notDetected() {
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("https://index.php.example/cloudlog/"))
+                .isFalse();
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("https://index.php.example/"))
+                .isFalse();
+    }
+
+    @Test
+    public void indexPhpAsPartOfAnotherSegment_notDetected() {
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("http://nas/index.php-old/"))
+                .isFalse();
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("http://nas/index.php/wavelog/"))
+                .isFalse();
+    }
+
+    @Test
+    public void nullOrSchemeless_handled() {
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment(null)).isFalse();
+        assertThat(CloudlogEndpoint.endsWithIndexPhpSegment("nas/wavelog/index.php/")).isTrue();
+    }
+
+    @Test
+    public void candidates_hostnameContainingIndexPhp_stillGetsFallback() {
+        List<String> c = CloudlogEndpoint.candidates("https://index.php.example/cloudlog/",
+                "api/auth/KEY");
+        assertThat(c).containsExactly(
+                "https://index.php.example/cloudlog/api/auth/KEY",
+                "https://index.php.example/cloudlog/index.php/api/auth/KEY").inOrder();
+    }
+
+    @Test
+    public void candidates_terminalIndexPhp_singleCandidate() {
+        List<String> c = CloudlogEndpoint.candidates("http://nas/wavelog/index.php/",
+                "api/auth/KEY");
+        assertThat(c).containsExactly("http://nas/wavelog/index.php/api/auth/KEY");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/CloudlogEndpointTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/CloudlogEndpointTest.java
@@ -1,0 +1,196 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.ConnectException;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.List;
+
+/**
+ * Unit tests for {@link CloudlogEndpoint} (issue #756): the pure URL plumbing that turns a
+ * hand-typed Cloudlog / Wavelog / Nextlog address into the candidate API URLs. Pure JUnit —
+ * no network, no Android types.
+ */
+public class CloudlogEndpointTest {
+
+    @Before
+    public void reset() {
+        CloudlogEndpoint.forgetAll();
+    }
+
+    // ---- normalizeBase ------------------------------------------------------------
+
+    @Test
+    public void normalizeBase_nullOrBlank_isNull() {
+        assertThat(CloudlogEndpoint.normalizeBase(null)).isNull();
+        assertThat(CloudlogEndpoint.normalizeBase("")).isNull();
+        assertThat(CloudlogEndpoint.normalizeBase("   \n")).isNull();
+    }
+
+    @Test
+    public void normalizeBase_trimsAndAddsTrailingSlash() {
+        assertThat(CloudlogEndpoint.normalizeBase("  http://192.168.186.73/wavelog \n"))
+                .isEqualTo("http://192.168.186.73/wavelog/");
+    }
+
+    @Test
+    public void normalizeBase_keepsSingleTrailingSlash() {
+        assertThat(CloudlogEndpoint.normalizeBase("http://192.168.15.20/cloudlog/"))
+                .isEqualTo("http://192.168.15.20/cloudlog/");
+        assertThat(CloudlogEndpoint.normalizeBase("http://192.168.15.20/cloudlog//"))
+                .isEqualTo("http://192.168.15.20/cloudlog/");
+    }
+
+    @Test
+    public void normalizeBase_schemelessIpv4_getsHttp() {
+        // The reporter's "ip only" attempt: new URL() used to throw "no protocol".
+        assertThat(CloudlogEndpoint.normalizeBase("192.168.15.20/cloudlog"))
+                .isEqualTo("http://192.168.15.20/cloudlog/");
+        assertThat(CloudlogEndpoint.normalizeBase("192.168.1.3:1234"))
+                .isEqualTo("http://192.168.1.3:1234/");
+    }
+
+    @Test
+    public void normalizeBase_schemelessLanNames_getHttp() {
+        assertThat(CloudlogEndpoint.normalizeBase("localhost:8080/wavelog"))
+                .isEqualTo("http://localhost:8080/wavelog/");
+        assertThat(CloudlogEndpoint.normalizeBase("nas/wavelog"))
+                .isEqualTo("http://nas/wavelog/");
+        assertThat(CloudlogEndpoint.normalizeBase("raspberrypi.local/cloudlog"))
+                .isEqualTo("http://raspberrypi.local/cloudlog/");
+        assertThat(CloudlogEndpoint.normalizeBase("shack.lan"))
+                .isEqualTo("http://shack.lan/");
+    }
+
+    @Test
+    public void normalizeBase_schemelessPublicHostname_getsHttps() {
+        assertThat(CloudlogEndpoint.normalizeBase("log.example.com/wavelog"))
+                .isEqualTo("https://log.example.com/wavelog/");
+    }
+
+    @Test
+    public void normalizeBase_explicitSchemeIsNeverRewritten() {
+        assertThat(CloudlogEndpoint.normalizeBase("https://192.168.1.5/cloudlog"))
+                .isEqualTo("https://192.168.1.5/cloudlog/");
+        assertThat(CloudlogEndpoint.normalizeBase("http://log.example.com"))
+                .isEqualTo("http://log.example.com/");
+    }
+
+    @Test
+    public void hostOf_stripsUserinfoPortAndPath() {
+        assertThat(CloudlogEndpoint.hostOf("user:pw@192.168.1.5:8080/wavelog/"))
+                .isEqualTo("192.168.1.5");
+        assertThat(CloudlogEndpoint.hostOf("log.example.com/x")).isEqualTo("log.example.com");
+        assertThat(CloudlogEndpoint.hostOf("[fe80::1]:80/cl")).isEqualTo("[fe80::1]");
+    }
+
+    // ---- candidates -----------------------------------------------------------------
+
+    @Test
+    public void candidates_rewrittenFormFirst_thenIndexPhp() {
+        List<String> c = CloudlogEndpoint.candidates("http://192.168.186.73/wavelog/",
+                "api/auth/KEY");
+        assertThat(c).containsExactly(
+                "http://192.168.186.73/wavelog/api/auth/KEY",
+                "http://192.168.186.73/wavelog/index.php/api/auth/KEY").inOrder();
+    }
+
+    @Test
+    public void candidates_stripLeadingSlashFromPath() {
+        List<String> c = CloudlogEndpoint.candidates("http://h/", "/api/qso");
+        assertThat(c.get(0)).isEqualTo("http://h/api/qso");
+        assertThat(c.get(1)).isEqualTo("http://h/index.php/api/qso");
+    }
+
+    @Test
+    public void candidates_baseAlreadyHasIndexPhp_singleCandidate() {
+        List<String> c = CloudlogEndpoint.candidates("http://h/wavelog/index.php/", "api/qso");
+        assertThat(c).containsExactly("http://h/wavelog/index.php/api/qso");
+    }
+
+    @Test
+    public void candidates_nullBase_isEmpty() {
+        assertThat(CloudlogEndpoint.candidates(null, "api/qso")).isEmpty();
+    }
+
+    @Test
+    public void rememberWorking_indexPhp_movesItToFront() {
+        String base = "http://192.168.186.73/wavelog/";
+        CloudlogEndpoint.rememberWorking(base, base + "index.php/api/auth/KEY");
+        List<String> c = CloudlogEndpoint.candidates(base, "api/qso");
+        assertThat(c).containsExactly(
+                base + "index.php/api/qso",
+                base + "api/qso").inOrder();
+    }
+
+    @Test
+    public void rememberWorking_plain_keepsPlainFirst() {
+        String base = "http://192.168.186.73/wavelog/";
+        CloudlogEndpoint.rememberWorking(base, base + "index.php/api/auth/KEY");
+        CloudlogEndpoint.rememberWorking(base, base + "api/auth/KEY"); // server got rewriting
+        List<String> c = CloudlogEndpoint.candidates(base, "api/qso");
+        assertThat(c.get(0)).isEqualTo(base + "api/qso");
+    }
+
+    @Test
+    public void rememberWorking_isPerBase() {
+        String a = "http://a/";
+        String b = "http://b/";
+        CloudlogEndpoint.rememberWorking(a, a + "index.php/api/auth/K");
+        assertThat(CloudlogEndpoint.candidates(b, "api/qso").get(0)).isEqualTo(b + "api/qso");
+    }
+
+    @Test
+    public void rememberWorking_ignoresForeignUrl() {
+        String base = "http://a/";
+        CloudlogEndpoint.rememberWorking(base, "http://elsewhere/index.php/api/auth/K");
+        assertThat(CloudlogEndpoint.candidates(base, "api/qso").get(0))
+                .isEqualTo(base + "api/qso");
+    }
+
+    // ---- describeFailure ------------------------------------------------------------
+
+    @Test
+    public void describeFailure_httpStatus() {
+        assertThat(CloudlogEndpoint.describeFailure("http://h/api/auth/***", 404, null))
+                .isEqualTo("HTTP 404 from http://h/api/auth/***");
+    }
+
+    @Test
+    public void describeFailure_noStatusNoException() {
+        assertThat(CloudlogEndpoint.describeFailure("http://h/api/auth/***", 0, null))
+                .isEqualTo("No response from http://h/api/auth/***");
+        assertThat(CloudlogEndpoint.describeFailure(null, 0, null)).isEqualTo("No response");
+    }
+
+    @Test
+    public void describeFailure_wellKnownNetExceptions() {
+        assertThat(CloudlogEndpoint.describeFailure(null, 0, new UnknownHostException("nas")))
+                .isEqualTo("Unknown host: nas");
+        assertThat(CloudlogEndpoint.describeFailure(null, 0,
+                new MalformedURLException("no protocol: 192.168.1.1")))
+                .isEqualTo("Bad URL: no protocol: 192.168.1.1");
+        assertThat(CloudlogEndpoint.describeFailure(null, 0,
+                new SocketTimeoutException("connect timed out")))
+                .isEqualTo("Timed out: connect timed out");
+        assertThat(CloudlogEndpoint.describeFailure(null, 0,
+                new ConnectException("Connection refused")))
+                .isEqualTo("Connect failed: Connection refused");
+    }
+
+    @Test
+    public void describeFailure_genericException_keepsClassAndMessage() {
+        // This is what a cleartext block looked like before the config change — the
+        // message is the whole diagnosis, and it used to be thrown away.
+        assertThat(CloudlogEndpoint.describeFailure(null, 0,
+                new java.io.IOException("Cleartext HTTP traffic to 192.168.186.73 not permitted")))
+                .isEqualTo("IOException: Cleartext HTTP traffic to 192.168.186.73 not permitted");
+        assertThat(CloudlogEndpoint.describeFailure(null, 0, new IllegalStateException()))
+                .isEqualTo("IllegalStateException");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCloudlogAuthTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCloudlogAuthTest.java
@@ -1,0 +1,49 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ThirdPartyService#interpretAuthResponse(String)} — the pure half of
+ * the Cloudlog "Test Connection" check (issue #756). No network, no Android types.
+ */
+public class ThirdPartyServiceCloudlogAuthTest {
+
+    @Test
+    public void validRw_passes() {
+        ThirdPartyService.ConnectionCheck c = ThirdPartyService.interpretAuthResponse(
+                "<?xml version=\"1.0\"?>\n<auth>\n  <status>Valid</status>\n"
+                        + "  <rights>rw</rights>\n</auth>");
+        assertThat(c.ok).isTrue();
+        assertThat(c.detail).isNull();
+    }
+
+    @Test
+    public void validReadOnly_failsWithReason() {
+        ThirdPartyService.ConnectionCheck c = ThirdPartyService.interpretAuthResponse(
+                "<auth><status>Valid</status><rights>r</rights></auth>");
+        assertThat(c.ok).isFalse();
+        assertThat(c.detail).contains("read-only");
+    }
+
+    @Test
+    public void invalidKey_failsWithReason() {
+        ThirdPartyService.ConnectionCheck c = ThirdPartyService.interpretAuthResponse(
+                "<auth><status>Invalid</status><rights></rights></auth>");
+        assertThat(c.ok).isFalse();
+        assertThat(c.detail).contains("rejected");
+    }
+
+    @Test
+    public void notAnApiReply_failsWithReason() {
+        // A no-rewrite Wavelog answering the plain path with its HTML 404 page, or a
+        // reverse proxy landing page.
+        ThirdPartyService.ConnectionCheck c = ThirdPartyService.interpretAuthResponse(
+                "<html><body><h1>404 Not Found</h1></body></html>");
+        assertThat(c.ok).isFalse();
+        assertThat(c.detail).contains("not a Cloudlog API");
+        assertThat(ThirdPartyService.interpretAuthResponse(null).ok).isFalse();
+        assertThat(ThirdPartyService.interpretAuthResponse("").ok).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCloudlogRequestTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/log/ThirdPartyServiceCloudlogRequestTest.java
@@ -1,0 +1,235 @@
+package com.k1af.ft8af.log;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Drives {@link ThirdPartyService#cloudlogRequest} — the candidate walk behind
+ * {@link ThirdPartyService#cloudlogGet} and {@link ThirdPartyService#cloudlogPost} — with a
+ * scripted {@link ThirdPartyService.CloudlogTransport}, so the 404-only fallback, the
+ * stop-on-anything-else rule and the remembered-variant reordering are pinned down
+ * without a network. Also covers the user-info redaction added to
+ * {@link ThirdPartyService#redactUrlApiKey}.
+ */
+public class ThirdPartyServiceCloudlogRequestTest {
+
+    private static final String BASE = "http://192.168.1.5/wavelog/";
+    private static final String PLAIN = BASE + "api/auth/KEY";
+    private static final String REWRITTEN = BASE + "index.php/api/auth/KEY";
+
+    /** One scripted attempt: status to report, body to return (null = failure), or throw. */
+    private static final class Step {
+        final int status;
+        final String body;
+        final IOException error;
+        final String why;
+
+        Step(int status, String body, IOException error, String why) {
+            this.status = status;
+            this.body = body;
+            this.error = error;
+            this.why = why;
+        }
+
+        static Step ok(String body) { return new Step(200, body, null, null); }
+        static Step status(int s) { return new Step(s, null, null, null); }
+        static Step statusWithReason(int s, String why) { return new Step(s, null, null, why); }
+        static Step failing(IOException e) { return new Step(0, null, e, null); }
+    }
+
+    private static final class ScriptedTransport implements ThirdPartyService.CloudlogTransport {
+        final List<Step> script = new ArrayList<>();
+        final List<String> urlsTried = new ArrayList<>();
+
+        ScriptedTransport(Step... steps) {
+            for (Step s : steps) script.add(s);
+        }
+
+        @Override
+        public String call(String url, int[] statusOut, StringBuilder why) throws IOException {
+            urlsTried.add(url);
+            if (script.isEmpty()) throw new AssertionError("unexpected attempt on " + url);
+            Step s = script.remove(0);
+            if (s.error != null) throw s.error;
+            statusOut[0] = s.status;
+            if (s.why != null) why.append(s.why);
+            return s.body;
+        }
+    }
+
+    @Before
+    public void reset() {
+        CloudlogEndpoint.forgetAll();
+    }
+
+    // ---- fallback control flow ---------------------------------------------------
+
+    @Test
+    public void first404_thenSuccessOnIndexPhp() {
+        ScriptedTransport t = new ScriptedTransport(Step.status(404), Step.ok("<auth/>"));
+        StringBuilder why = new StringBuilder();
+
+        String body = ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY", why, t);
+
+        assertThat(body).isEqualTo("<auth/>");
+        assertThat(t.urlsTried).containsExactly(PLAIN, REWRITTEN).inOrder();
+        assertThat(why.toString()).isEmpty();
+    }
+
+    @Test
+    public void firstAttemptSucceeds_noSecondRequest() {
+        ScriptedTransport t = new ScriptedTransport(Step.ok("<auth/>"));
+
+        String body = ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY",
+                new StringBuilder(), t);
+
+        assertThat(body).isEqualTo("<auth/>");
+        assertThat(t.urlsTried).containsExactly(PLAIN);
+    }
+
+    @Test
+    public void non404Status_stopsWithoutTryingFallback() {
+        ScriptedTransport t = new ScriptedTransport(Step.status(401));
+        StringBuilder why = new StringBuilder();
+
+        String body = ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY", why, t);
+
+        assertThat(body).isNull();
+        assertThat(t.urlsTried).containsExactly(PLAIN);
+        assertThat(why.toString()).contains("HTTP 401");
+        // The logged/reported URL never carries the key.
+        assertThat(why.toString()).doesNotContain("KEY");
+        assertThat(why.toString()).contains("auth/***");
+    }
+
+    @Test
+    public void post_serverReasonWins_andStopsOnNon404() {
+        ScriptedTransport t = new ScriptedTransport(
+                Step.statusWithReason(500, "HTTP 500: Unknown column 'foo'"));
+        StringBuilder why = new StringBuilder();
+
+        String body = ThirdPartyService.cloudlogRequest("POST", BASE, "api/qso", why, t);
+
+        assertThat(body).isNull();
+        assertThat(t.urlsTried).containsExactly(BASE + "api/qso");
+        assertThat(why.toString()).contains("Unknown column 'foo'");
+    }
+
+    @Test
+    public void both404_reportsLastFailure() {
+        ScriptedTransport t = new ScriptedTransport(Step.status(404), Step.status(404));
+        StringBuilder why = new StringBuilder();
+
+        String body = ThirdPartyService.cloudlogRequest("POST", BASE, "api/qso", why, t);
+
+        assertThat(body).isNull();
+        assertThat(t.urlsTried).hasSize(2);
+        assertThat(why.toString()).contains("HTTP 404");
+    }
+
+    @Test
+    public void transportException_stopsImmediately() {
+        ScriptedTransport t = new ScriptedTransport(
+                Step.failing(new ConnectException("ECONNREFUSED")), Step.ok("never"));
+        StringBuilder why = new StringBuilder();
+
+        String body = ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY", why, t);
+
+        assertThat(body).isNull();
+        assertThat(t.urlsTried).containsExactly(PLAIN);
+        assertThat(why.toString()).contains("Connect failed: ECONNREFUSED");
+    }
+
+    @Test
+    public void nullFailureOut_tolerated() {
+        ScriptedTransport t = new ScriptedTransport(Step.status(500));
+        assertThat(ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY", null, t))
+                .isNull();
+    }
+
+    // ---- remembered variant ------------------------------------------------------
+
+    @Test
+    public void successOnIndexPhp_isRememberedForNextRequest() {
+        ScriptedTransport first = new ScriptedTransport(Step.status(404), Step.ok("ok"));
+        ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY", new StringBuilder(), first);
+
+        ScriptedTransport second = new ScriptedTransport(Step.ok("{}"));
+        String body = ThirdPartyService.cloudlogRequest("POST", BASE, "api/qso",
+                new StringBuilder(), second);
+
+        assertThat(body).isEqualTo("{}");
+        // No 404 round-trip this time: the index.php/ shape is tried first.
+        assertThat(second.urlsTried).containsExactly(BASE + "index.php/api/qso");
+    }
+
+    @Test
+    public void successOnPlain_keepsPlainFirst() {
+        ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY", new StringBuilder(),
+                new ScriptedTransport(Step.ok("ok")));
+
+        ScriptedTransport second = new ScriptedTransport(Step.ok("{}"));
+        ThirdPartyService.cloudlogRequest("POST", BASE, "api/qso", new StringBuilder(), second);
+
+        assertThat(second.urlsTried).containsExactly(BASE + "api/qso");
+    }
+
+    @Test
+    public void rememberedIndexPhp_stillFallsBackToPlainOn404() {
+        ThirdPartyService.cloudlogRequest("GET", BASE, "api/auth/KEY", new StringBuilder(),
+                new ScriptedTransport(Step.status(404), Step.ok("ok")));
+
+        ScriptedTransport second = new ScriptedTransport(Step.status(404), Step.ok("{}"));
+        String body = ThirdPartyService.cloudlogRequest("POST", BASE, "api/qso",
+                new StringBuilder(), second);
+
+        assertThat(body).isEqualTo("{}");
+        assertThat(second.urlsTried)
+                .containsExactly(BASE + "index.php/api/qso", BASE + "api/qso").inOrder();
+    }
+
+    // ---- redaction of authority user-info -----------------------------------------
+
+    @Test
+    public void redact_hidesUserInfo() {
+        assertThat(ThirdPartyService.redactUrlApiKey("http://alice:s3cret@nas/wavelog/api/qso"))
+                .isEqualTo("http://***@nas/wavelog/api/qso");
+        assertThat(ThirdPartyService.redactUrlApiKey("https://alice@log.example.org/"))
+                .isEqualTo("https://***@log.example.org/");
+    }
+
+    @Test
+    public void redact_hidesUserInfoAndApiKeyTogether() {
+        assertThat(ThirdPartyService.redactUrlApiKey(
+                "http://alice:s3cret@nas/wavelog/index.php/api/auth/KEY123"))
+                .isEqualTo("http://***@nas/wavelog/index.php/api/auth/***");
+    }
+
+    @Test
+    public void redact_leavesUrlsWithoutUserInfoAlone() {
+        assertThat(ThirdPartyService.redactUrlApiKey("http://nas/wavelog/api/qso"))
+                .isEqualTo("http://nas/wavelog/api/qso");
+        // An '@' later in the URL (query/path) is not user-info.
+        assertThat(ThirdPartyService.redactUrlApiKey("http://nas/x?email=a@b.c"))
+                .isEqualTo("http://nas/x?email=a@b.c");
+        assertThat(ThirdPartyService.redactUrlApiKey("http://nas/path/a@b/"))
+                .isEqualTo("http://nas/path/a@b/");
+    }
+
+    @Test
+    public void redact_userInfoInLoggedFailureReason() {
+        ScriptedTransport t = new ScriptedTransport(Step.status(401));
+        StringBuilder why = new StringBuilder();
+        ThirdPartyService.cloudlogRequest("GET", "http://bob:pw@nas/wavelog/", "api/auth/KEY",
+                why, t);
+        assertThat(why.toString()).doesNotContain("pw");
+        assertThat(why.toString()).contains("http://***@nas/wavelog/api/auth/***");
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/ui/WebNavigationPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/ui/WebNavigationPolicyTest.java
@@ -1,0 +1,44 @@
+package com.k1af.ft8af.ui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * {@link WebNavigationPolicy} keeps the embedded WebViews HTTPS-only now that the
+ * network-security base-config permits cleartext for the user's LAN logbook (issue #756).
+ */
+public class WebNavigationPolicyTest {
+
+    @Test
+    public void https_allowed() {
+        assertThat(WebNavigationPolicy.isAllowed("https://www.qrz.com/db/K1AF")).isTrue();
+        assertThat(WebNavigationPolicy.isAllowed("https://support.qq.com/product/415890")).isTrue();
+    }
+
+    @Test
+    public void schemeCaseAndWhitespace_tolerated() {
+        assertThat(WebNavigationPolicy.isAllowed("  HTTPS://example.org/x ")).isTrue();
+    }
+
+    @Test
+    public void http_refused() {
+        assertThat(WebNavigationPolicy.isAllowed("http://example.org/")).isFalse();
+        assertThat(WebNavigationPolicy.isAllowed("http://192.168.1.10/wavelog/")).isFalse();
+    }
+
+    @Test
+    public void otherSchemes_refused() {
+        assertThat(WebNavigationPolicy.isAllowed("file:///sdcard/x.html")).isFalse();
+        assertThat(WebNavigationPolicy.isAllowed("javascript:alert(1)")).isFalse();
+        assertThat(WebNavigationPolicy.isAllowed("intent://x#Intent;end")).isFalse();
+        assertThat(WebNavigationPolicy.isAllowed("content://com.k1af.ft8af/x")).isFalse();
+    }
+
+    @Test
+    public void nullEmptyOrBareScheme_refused() {
+        assertThat(WebNavigationPolicy.isAllowed(null)).isFalse();
+        assertThat(WebNavigationPolicy.isAllowed("")).isFalse();
+        assertThat(WebNavigationPolicy.isAllowed("https://")).isFalse();
+    }
+}


### PR DESCRIPTION
Fixes #756.

## What was wrong
The app disabled cleartext HTTP app-wide (`network_security_config.xml` with `cleartextTrafficPermitted="false"`). The only user-supplied host in the app is the Cloudlog/Wavelog/Nextlog logbook server, which is very often self-hosted on a LAN over plain `http://`. So `HttpURLConnection` threw `Cleartext HTTP traffic … not permitted` **before a single packet left the phone** — matching both reporters exactly: Test Connection fails, the server access log is empty, and `tcpdump` on the server sees no TCP attempt at all.

Two secondary problems compounded it:
- Every failure (cleartext block, 404, wrong key, dead host) collapsed to a bare **"Fail"** with nothing in `debug.log`.
- Installs without URL rewriting only answer at `/index.php/api/...`; the app only ever tried `/api/...`.
- A scheme-less address (`192.168.15.20/cloudlog`) threw `MalformedURLException`, and the Test path didn't `.trim()` a pasted newline.

## The fix
- **network_security_config**: permit cleartext by default (only affects the address the user typed), and pin every hard-coded public API the app itself calls (qrz.com, pota.app, pskreporter.info, cognito/amazonaws, github.com, ft8af.app) to TLS via `domain-config`, so a typo or downgrade can't move those to `http://`.
- **New `CloudlogEndpoint`** (pure/tested): normalizes the address (adds `http://` for IPv4/LAN names, `https://` for public hostnames; trims; one trailing slash) and returns ordered candidate URLs so a no-rewrite install (`/index.php/api/...`) is tried too, pinning whichever variant answered.
- **`ThirdPartyService`**: connect/read timeouts on all logbook HTTP; status-aware GET/POST; a `ConnectionCheck` carrying a human reason (HTTP status, host unreachable, key read-only/rejected); every attempt written to `debug.log` with the API key redacted.
- **LoggingSettings**: shows the failure reason under "Fail"; trims the address/key before testing.

## Tests
- `CloudlogEndpointTest` — normalize / candidate ordering / index.php fallback / remember-working / failure description.
- `ThirdPartyServiceCloudlogAuthTest` — auth-response interpretation (valid rw / read-only / rejected / not-an-API).

Unit tests pass; debug APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)