### PR TITLE
Fix ICOM CAT frequency control: civ address stored decimal, read hex (#753)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/GeneralVariables.java
@@ -512,6 +512,8 @@ public class GeneralVariables {
     public static int iaruRegion = 2;//Operator's IARU region (1/2/3), used to gate Message-Creator QSY frequency options to legal band edges. Default 2 (the Americas). See com.k1af.ft8af.message.SpecialMessage.
     public static boolean autoCQAfterQSO = false;//Auto-CQ: keep calling CQ after each completed QSO (chain without re-tapping). Refreshes the TX watchdog per QSO and forces pure CQ (ignores Hunt).
     public static int civAddress = 0xa4;//CI-V address
+    public static String civAddressStored = null;//Raw "civ" config text as hydrated (null = no row); lets the #753 repair see whether the on-disk form is canonical hex.
+    public static boolean civAddressFormatKnown = false;//True when config "civFormat=hex" was present: the stored civ value is trusted verbatim, no model reconciliation (#753).
     public static int baudRate = 19200;//Baud rate
     public static long band = 14074000;//Carrier frequency band
     public static int serialDataBits = 8;//Default is 8

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -2099,8 +2099,12 @@ public class MainViewModel extends ViewModel {
      * One-time repair for a CI-V address the 2026-05..08 Compose rig picker persisted in
      * decimal (#753). {@link com.k1af.ft8af.database.DatabaseOpr} already un-mangles the
      * unambiguous cases at load; the two-digit ones ("88" for an IC-706's 0x58) can only be
-     * told apart by comparing with the selected model, which needs the rig list. When the
-     * value is corrected it is also written back — in hex — so the fix sticks.
+     * told apart by comparing with the selected model, which needs the rig list — and only
+     * when the value's provenance is unknown ({@link CivAddressConfig#FORMAT_KEY} absent),
+     * so a deliberate override that a hex-aware writer stored is never touched. Whenever the
+     * marker is missing or the stored text isn't canonical hex, the value is written back
+     * canonically together with the marker, so the repair really is one-time — including
+     * the three-digit decimal case whose decoded address already matched the model.
      */
     private void repairCivAddressAgainstModel() {
         if (GeneralVariables.instructionSet != InstructionSet.ICOM
@@ -2113,15 +2117,25 @@ public class MainViewModel extends ViewModel {
             RigNameList.RigName model = RigNameList.getInstance(ctx)
                     .getRigNameByIndex(GeneralVariables.modelNo);
             int before = GeneralVariables.civAddress;
-            int after = CivAddressConfig.reconcileWithModel(before, model.address);
-            if (after != before) {
-                GeneralVariables.civAddress = after;
+            CivAddressConfig.Repair plan = CivAddressConfig.planRepair(
+                    GeneralVariables.civAddressStored, GeneralVariables.civAddressFormatKnown,
+                    before, model.address);
+            if (plan.address != before) {
+                GeneralVariables.civAddress = plan.address;
                 GeneralVariables.fileLog(String.format(java.util.Locale.US,
                         "CIV: repaired stored address 0x%02X -> 0x%02X (model %s)",
-                        before, after, model.modelName));
-                if (databaseOpr != null) {
-                    databaseOpr.writeConfig("civ", CivAddressConfig.encode(after), null);
-                }
+                        before, plan.address, model.modelName));
+            }
+            if (plan.writeBack && databaseOpr != null) {
+                String encoded = CivAddressConfig.encode(plan.address);
+                databaseOpr.writeConfig("civ", encoded, null);
+                databaseOpr.writeConfig(CivAddressConfig.FORMAT_KEY,
+                        CivAddressConfig.FORMAT_HEX, null);
+                GeneralVariables.civAddressStored = encoded;
+                GeneralVariables.civAddressFormatKnown = true;
+                GeneralVariables.fileLog(String.format(java.util.Locale.US,
+                        "CIV: stored address canonicalized to \"%s\" (+%s=%s)",
+                        encoded, CivAddressConfig.FORMAT_KEY, CivAddressConfig.FORMAT_HEX));
             }
         } catch (Exception e) {
             GeneralVariables.fileLog("CIV: repair skipped: " + e.getMessage());

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -92,6 +92,7 @@ import com.k1af.ft8af.log.ThirdPartyService;
 import com.k1af.ft8af.rigs.BaseRig;
 import com.k1af.ft8af.rigs.BaseRigOperation;
 import com.k1af.ft8af.rigs.CatConnectionState;
+import com.k1af.ft8af.rigs.CivAddressConfig;
 import com.k1af.ft8af.rigs.RetunePolicy;
 import com.k1af.ft8af.rigs.RigDialTarget;
 import com.k1af.ft8af.rigs.CatLiveness;
@@ -2095,6 +2096,39 @@ public class MainViewModel extends ViewModel {
 
 
     /**
+     * One-time repair for a CI-V address the 2026-05..08 Compose rig picker persisted in
+     * decimal (#753). {@link com.k1af.ft8af.database.DatabaseOpr} already un-mangles the
+     * unambiguous cases at load; the two-digit ones ("88" for an IC-706's 0x58) can only be
+     * told apart by comparing with the selected model, which needs the rig list. When the
+     * value is corrected it is also written back — in hex — so the fix sticks.
+     */
+    private void repairCivAddressAgainstModel() {
+        if (GeneralVariables.instructionSet != InstructionSet.ICOM
+                && GeneralVariables.instructionSet != InstructionSet.ICOM_756) {
+            return;
+        }
+        try {
+            android.content.Context ctx = GeneralVariables.getMainContext();
+            if (ctx == null) return;
+            RigNameList.RigName model = RigNameList.getInstance(ctx)
+                    .getRigNameByIndex(GeneralVariables.modelNo);
+            int before = GeneralVariables.civAddress;
+            int after = CivAddressConfig.reconcileWithModel(before, model.address);
+            if (after != before) {
+                GeneralVariables.civAddress = after;
+                GeneralVariables.fileLog(String.format(java.util.Locale.US,
+                        "CIV: repaired stored address 0x%02X -> 0x%02X (model %s)",
+                        before, after, model.modelName));
+                if (databaseOpr != null) {
+                    databaseOpr.writeConfig("civ", CivAddressConfig.encode(after), null);
+                }
+            }
+        } catch (Exception e) {
+            GeneralVariables.fileLog("CIV: repair skipped: " + e.getMessage());
+        }
+    }
+
+    /**
      * Create different rig models based on the instruction set
      */
     private void connectRig() {
@@ -2103,6 +2137,7 @@ public class MainViewModel extends ViewModel {
             baseRig.onDisconnecting();
         }
         baseRig = null;
+        repairCivAddressAgainstModel();
         //determine the rig type: ICOM, YAESU 2, YAESU 3
         switch (GeneralVariables.instructionSet) {
             case InstructionSet.ICOM:

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2692,6 +2692,12 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                     // rig model in MainViewModel.connectRig().
                     GeneralVariables.civAddress = com.k1af.ft8af.rigs.CivAddressConfig
                             .decode(result, com.k1af.ft8af.rigs.CivAddressConfig.DEFAULT_ADDRESS);
+                    GeneralVariables.civAddressStored = result;
+                }
+                if (name.equalsIgnoreCase(com.k1af.ft8af.rigs.CivAddressConfig.FORMAT_KEY)) {
+                    // Provenance marker: present only when a hex-aware writer stored "civ".
+                    GeneralVariables.civAddressFormatKnown =
+                            com.k1af.ft8af.rigs.CivAddressConfig.isHexFormatMarker(result);
                 }
                 if (name.equalsIgnoreCase("baudRate")) {
                     GeneralVariables.baudRate = parseConfigInt(result, 19200);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/database/DatabaseOpr.java
@@ -2687,7 +2687,11 @@ public class DatabaseOpr extends SQLiteOpenHelper {
                 }
 
                 if (name.equalsIgnoreCase("civ")) {
-                    GeneralVariables.civAddress = parseConfigInt(result, 0xa4, 16);
+                    // Hex on disk; also repairs the decimal strings an earlier Compose
+                    // picker wrote (#753). The two-digit ambiguity is settled against the
+                    // rig model in MainViewModel.connectRig().
+                    GeneralVariables.civAddress = com.k1af.ft8af.rigs.CivAddressConfig
+                            .decode(result, com.k1af.ft8af.rigs.CivAddressConfig.DEFAULT_ADDRESS);
                 }
                 if (name.equalsIgnoreCase("baudRate")) {
                     GeneralVariables.baudRate = parseConfigInt(result, 19200);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivAddressConfig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivAddressConfig.java
@@ -31,7 +31,60 @@ public final class CivAddressConfig {
     /** Default when nothing usable is stored: IC-705 / X6100 style {@code 0xA4}. */
     public static final int DEFAULT_ADDRESS = 0xA4;
 
+    /**
+     * Provenance marker config key. Every writer that stores {@code civ} in hex also writes
+     * {@code civFormat=hex}; the buggy decimal-writing picker never did. Its presence means
+     * the stored value is trusted verbatim — in particular a deliberate two-digit override
+     * that happens to be a decimal twin of the model address ({@code 0x88} on an IC-706)
+     * is never "repaired" away. Its absence marks a value of unknown provenance that gets
+     * the one-time model reconciliation and is then re-written canonically with the marker.
+     */
+    public static final String FORMAT_KEY = "civFormat";
+    /** The only value {@link #FORMAT_KEY} ever carries. */
+    public static final String FORMAT_HEX = "hex";
+
     private CivAddressConfig() {
+    }
+
+    /** Outcome of {@link #planRepair}: the address to use and whether to persist it. */
+    public static final class Repair {
+        /** The address the app should run with. */
+        public final int address;
+        /** True when {@code civ} (canonical hex) and {@link #FORMAT_KEY} must be written. */
+        public final boolean writeBack;
+
+        Repair(int address, boolean writeBack) {
+            this.address = address;
+            this.writeBack = writeBack;
+        }
+    }
+
+    /**
+     * Decides the one-time repair for the loaded CI-V address (#753).
+     *
+     * @param storedRaw    the {@code civ} string as found in the database, or null if absent
+     * @param formatKnown  whether {@link #FORMAT_KEY} was present with {@link #FORMAT_HEX}
+     * @param loaded       the address {@link #decode} produced from {@code storedRaw}
+     * @param modelAddress the selected rig model's default address
+     * @return the address to use, and whether to write it (and the marker) back
+     *
+     * <p>Rules: a marked value is trusted as-is — no model reconciliation, so user overrides
+     * survive. An unmarked value gets {@link #reconcileWithModel}. A write-back is due when
+     * the marker is missing (settles provenance once and for all, and fixes the three-digit
+     * decimal case whose decoded address already equals the model's) or when the stored
+     * text isn't the canonical {@link #encode} form.
+     */
+    public static Repair planRepair(String storedRaw, boolean formatKnown, int loaded,
+                                    int modelAddress) {
+        int resolved = formatKnown ? loaded : reconcileWithModel(loaded, modelAddress);
+        boolean canonical = storedRaw != null
+                && encode(resolved).equals(storedRaw.trim().toLowerCase(Locale.ROOT));
+        return new Repair(resolved, !formatKnown || !canonical);
+    }
+
+    /** True when a stored {@link #FORMAT_KEY} value says the {@code civ} key is hex. */
+    public static boolean isHexFormatMarker(String stored) {
+        return stored != null && FORMAT_HEX.equalsIgnoreCase(stored.trim());
     }
 
     /** True for a value that fits a CI-V address byte. */

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivAddressConfig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivAddressConfig.java
@@ -1,0 +1,94 @@
+package com.k1af.ft8af.rigs;
+
+import java.util.Locale;
+
+/**
+ * Encodes / decodes the ICOM CI-V address for the {@code civ} config key (issue #753).
+ *
+ * <p>The key has always been stored as <b>hex</b> — the legacy settings screen wrote the
+ * text of its hex field, {@code rigaddress.txt} lists addresses in hex, and
+ * {@code DatabaseOpr} parses it with radix 16. The Compose rig picker (2026-05) wrote
+ * {@code Integer.toString(address)} instead, i.e. <b>decimal</b>: an IC-705's {@code 0xA4}
+ * went to disk as {@code "164"}, came back as {@code 0x164}, was truncated to a byte and
+ * became {@code 0x64}. From the next launch on, every frequency command went to a rig that
+ * doesn't exist and every CI-V reply was filtered out — while PTT (which uses the address
+ * the rig announces over WLAN) and audio kept working, which is exactly what #753 looks
+ * like.
+ *
+ * <p>This class writes hex, reads hex, and repairs values a buggy build already wrote:
+ * <ul>
+ *   <li>{@link #decode}: a hex parse that lands outside {@code 0x00..0xFF} can only be a
+ *       decimal string of a real address (all three-digit decimals are ≥ {@code 0x100} as
+ *       hex), so it is re-read as decimal.</li>
+ *   <li>{@link #reconcileWithModel}: two-digit decimal strings ({@code "88"} for an IC-706's
+ *       {@code 0x58}) are valid hex too, so they are resolved against the selected rig
+ *       model's address instead.</li>
+ * </ul>
+ * Pure — no Android imports — so it is unit-testable.
+ */
+public final class CivAddressConfig {
+
+    /** Default when nothing usable is stored: IC-705 / X6100 style {@code 0xA4}. */
+    public static final int DEFAULT_ADDRESS = 0xA4;
+
+    private CivAddressConfig() {
+    }
+
+    /** True for a value that fits a CI-V address byte. */
+    public static boolean isValid(int address) {
+        return address >= 0 && address <= 0xFF;
+    }
+
+    /** The on-disk form: lowercase hex without a prefix, e.g. {@code "a4"}. */
+    public static String encode(int address) {
+        return Integer.toHexString(address & 0xFF);
+    }
+
+    /**
+     * Parses the stored {@code civ} value. Hex first; if that overflows a byte the string was
+     * written in decimal by the old Compose picker and is re-read as such. Anything else
+     * (empty, non-numeric, out of range either way) yields {@code fallback}.
+     */
+    public static int decode(String stored, int fallback) {
+        if (stored == null) return fallback;
+        String s = stored.trim().toLowerCase(Locale.ROOT);
+        if (s.startsWith("0x")) s = s.substring(2);
+        if (s.isEmpty()) return fallback;
+        int hex;
+        try {
+            hex = Integer.parseInt(s, 16);
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+        if (isValid(hex)) return hex;
+        int dec = decimalTwin(s);
+        return isValid(dec) ? dec : fallback;
+    }
+
+    /**
+     * Resolves the ambiguity {@link #decode} can't: a loaded address that doesn't match the
+     * selected rig model, but whose digits read in decimal do. Example: an IC-706MKIIG
+     * ({@code 0x58} = 88) saved as {@code "88"}, loaded as {@code 0x88}. Returns
+     * {@code modelAddress} in that case, otherwise {@code loaded} unchanged — a deliberate
+     * user override (rig configured to a non-default address) is left alone.
+     */
+    public static int reconcileWithModel(int loaded, int modelAddress) {
+        if (!isValid(modelAddress) || loaded == modelAddress) return loaded;
+        int dec = decimalTwin(Integer.toHexString(loaded));
+        return dec == modelAddress ? modelAddress : loaded;
+    }
+
+    /** The digits of {@code s} read in base 10, or -1 if they aren't all decimal digits. */
+    static int decimalTwin(String s) {
+        if (s == null || s.isEmpty()) return -1;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c < '0' || c > '9') return -1;
+        }
+        try {
+            return Integer.parseInt(s, 10);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/ConfigFragment.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/ConfigFragment.java
@@ -324,6 +324,13 @@ public class ConfigFragment extends Fragment {
             if (s.matches("\\b0[xX][0-9a-fA-F]+\\b")) {// Match hexadecimal
                 String temp = editable.toString().substring(0, 2).toUpperCase();
                 writeConfig("civ", temp);
+                // Provenance marker: a hex-aware writer stored this, so the #753 repair
+                // must trust it verbatim (a deliberate override may be a decimal twin of
+                // the model address, e.g. 0x88 on an IC-706).
+                writeConfig(com.k1af.ft8af.rigs.CivAddressConfig.FORMAT_KEY,
+                        com.k1af.ft8af.rigs.CivAddressConfig.FORMAT_HEX);
+                GeneralVariables.civAddressStored = temp;
+                GeneralVariables.civAddressFormatKnown = true;
                 GeneralVariables.civAddress = Integer.parseInt(temp, 16);
                 mainViewModel.setCivAddress();
             }

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -42,6 +42,7 @@ import com.k1af.ft8af.database.ControlMode
 import com.k1af.ft8af.database.OperationBand
 import com.k1af.ft8af.database.RigNameList
 import com.k1af.ft8af.rigs.BaseRigOperation
+import com.k1af.ft8af.rigs.CivAddressConfig
 import com.k1af.ft8af.rigs.InstructionSet
 import com.k1af.ft8af.ui.AudioDeviceSpinnerAdapter
 import radio.ks3ckc.ft8af.PER_BAND_OUTPUT_LEVEL_KEY
@@ -200,8 +201,11 @@ fun RadioAudioSettings(
                 mainViewModel.databaseOpr.writeConfig(
                     "baudRate", GeneralVariables.baudRate.toString(), null,
                 )
+                // "civ" is a HEX key (rigaddress.txt, the legacy screen and the loader all
+                // agree). Writing Int.toString() here stored "164" for an IC-705's 0xA4,
+                // which reloaded as 0x64 and silently killed CAT frequency control (#753).
                 mainViewModel.databaseOpr.writeConfig(
-                    "civ", GeneralVariables.civAddress.toString(), null,
+                    "civ", CivAddressConfig.encode(GeneralVariables.civAddress), null,
                 )
             },
         )

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -204,9 +204,14 @@ fun RadioAudioSettings(
                 // "civ" is a HEX key (rigaddress.txt, the legacy screen and the loader all
                 // agree). Writing Int.toString() here stored "164" for an IC-705's 0xA4,
                 // which reloaded as 0x64 and silently killed CAT frequency control (#753).
+                val encodedCiv = CivAddressConfig.encode(GeneralVariables.civAddress)
+                mainViewModel.databaseOpr.writeConfig("civ", encodedCiv, null)
+                // Provenance marker: tells the #753 repair this value is hex and trusted.
                 mainViewModel.databaseOpr.writeConfig(
-                    "civ", CivAddressConfig.encode(GeneralVariables.civAddress), null,
+                    CivAddressConfig.FORMAT_KEY, CivAddressConfig.FORMAT_HEX, null,
                 )
+                GeneralVariables.civAddressStored = encodedCiv
+                GeneralVariables.civAddressFormatKnown = true
             },
         )
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -46,6 +46,8 @@ public class DatabaseOprConfigHydrationTest {
     private int origSerialParity;
 
     private int origCivAddress;
+    private String origCivAddressStored;
+    private boolean origCivAddressFormatKnown;
     private int origBaudRate;
     private long origBand;
     private int origBandListIndex;
@@ -64,6 +66,8 @@ public class DatabaseOprConfigHydrationTest {
         origSerialParity = GeneralVariables.serialParity;
 
         origCivAddress = GeneralVariables.civAddress;
+        origCivAddressStored = GeneralVariables.civAddressStored;
+        origCivAddressFormatKnown = GeneralVariables.civAddressFormatKnown;
         origBaudRate = GeneralVariables.baudRate;
         origBand = GeneralVariables.band;
         origBandListIndex = GeneralVariables.bandListIndex;
@@ -88,6 +92,8 @@ public class DatabaseOprConfigHydrationTest {
             GeneralVariables.serialParity = origSerialParity;
 
             GeneralVariables.civAddress = origCivAddress;
+            GeneralVariables.civAddressStored = origCivAddressStored;
+            GeneralVariables.civAddressFormatKnown = origCivAddressFormatKnown;
             GeneralVariables.baudRate = origBaudRate;
             GeneralVariables.band = origBand;
             GeneralVariables.bandListIndex = origBandListIndex;
@@ -416,5 +422,38 @@ public class DatabaseOprConfigHydrationTest {
         hydrate();
 
         assertThat(GeneralVariables.civAddress).isEqualTo(0x94);
+    }
+
+    /**
+     * The #753 repair in {@code MainViewModel.connectRig()} needs the raw stored text (to
+     * know whether the on-disk form is canonical) and the {@code civFormat} provenance
+     * marker (to know whether to trust it verbatim). Both must come out of hydration.
+     */
+    @Test
+    public void civRawTextAndFormatMarker_areHydrated() {
+        GeneralVariables.civAddressStored = "stale";
+        GeneralVariables.civAddressFormatKnown = false;
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("civ", "164");
+        config.put("civFormat", "hex");
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.civAddressStored).isEqualTo("164");
+        assertThat(GeneralVariables.civAddressFormatKnown).isTrue();
+    }
+
+    @Test
+    public void civFormatMarker_absentOrForeign_isNotTrusted() {
+        GeneralVariables.civAddressFormatKnown = true;
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("civ", "a4");
+        config.put("civFormat", "dec");     // anything but "hex" is not a hex marker
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.civAddressFormatKnown).isFalse();
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/database/DatabaseOprConfigHydrationTest.java
@@ -388,4 +388,33 @@ public class DatabaseOprConfigHydrationTest {
         assertThat(GeneralVariables.deepDecodeMode).isFalse();
         assertThat(GeneralVariables.keepScreenOn).isFalse();
     }
+
+    /**
+     * Issue #753: the Compose rig picker wrote {@code civ} in DECIMAL for three months
+     * ("164" for an IC-705's 0xA4) while hydration reads HEX, so the address came back as
+     * 0x164 -> truncated 0x64 and CAT frequency control silently died. Hydration must now
+     * recognise the decimal form and land on the real address.
+     */
+    @Test
+    public void decimalCivWrittenByOldPicker_isRepairedOnLoad() {
+        GeneralVariables.civAddress = 0x11;
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("civ", "164");           // IC-705 0xA4 written as decimal
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.civAddress).isEqualTo(0xa4);
+    }
+
+    @Test
+    public void hexCivWithPrefix_isHonored() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("civ", "0x94");          // IC-7300
+        opr.writeConfigSync(config);
+
+        hydrate();
+
+        assertThat(GeneralVariables.civAddress).isEqualTo(0x94);
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivAddressConfigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivAddressConfigTest.java
@@ -104,6 +104,80 @@ public class CivAddressConfigTest {
         assertThat(CivAddressConfig.reconcileWithModel(0x88, 0x100)).isEqualTo(0x88);
     }
 
+    // ---- planRepair (provenance marker + write-back) -----------------------------------
+
+    @Test
+    public void plan_unmarkedThreeDigitDecimal_isWrittenBackEvenThoughAddressMatchesModel() {
+        // Copilot review #774: "164" decodes to 0xA4 == model, so an address-only compare
+        // would never persist the fix and "164" would stay on disk forever.
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("164", false, 0xA4, 0xA4);
+        assertThat(r.address).isEqualTo(0xA4);
+        assertThat(r.writeBack).isTrue();
+    }
+
+    @Test
+    public void plan_unmarkedTwoDigitDecimalTwin_isRepairedAndWrittenBack() {
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("88", false, 0x88, 0x58);
+        assertThat(r.address).isEqualTo(0x58);
+        assertThat(r.writeBack).isTrue();
+    }
+
+    @Test
+    public void plan_markedOverrideThatIsDecimalTwinOfModel_isTrusted() {
+        // Copilot review #774: a user who deliberately set 0x88 on an IC-706 (model 0x58)
+        // through a hex-aware writer must not have it reset on every connectRig().
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("88", true, 0x88, 0x58);
+        assertThat(r.address).isEqualTo(0x88);
+        assertThat(r.writeBack).isFalse();
+    }
+
+    @Test
+    public void plan_unmarkedCanonicalHex_isMarkedOnce() {
+        // Value is fine, but provenance is unknown: write the marker so it's settled.
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("a4", false, 0xA4, 0xA4);
+        assertThat(r.address).isEqualTo(0xA4);
+        assertThat(r.writeBack).isTrue();
+    }
+
+    @Test
+    public void plan_markedCanonicalHex_isSteadyState() {
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("a4", true, 0xA4, 0xA4);
+        assertThat(r.address).isEqualTo(0xA4);
+        assertThat(r.writeBack).isFalse();
+        // Case / whitespace differences don't count as non-canonical.
+        assertThat(CivAddressConfig.planRepair(" A4 ", true, 0xA4, 0xA4).writeBack).isFalse();
+    }
+
+    @Test
+    public void plan_markedButPrefixedHex_isCanonicalized() {
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("0xA4", true, 0xA4, 0xA4);
+        assertThat(r.address).isEqualTo(0xA4);
+        assertThat(r.writeBack).isTrue();
+    }
+
+    @Test
+    public void plan_noStoredRow_isWrittenBackWithDefault() {
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair(null, false, 0xA4, 0xA4);
+        assertThat(r.address).isEqualTo(0xA4);
+        assertThat(r.writeBack).isTrue();
+    }
+
+    @Test
+    public void plan_markedUserOverride_neverReconciled() {
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("5f", true, 0x5F, 0xA4);
+        assertThat(r.address).isEqualTo(0x5F);
+        assertThat(r.writeBack).isFalse();
+    }
+
+    @Test
+    public void isHexFormatMarker() {
+        assertThat(CivAddressConfig.isHexFormatMarker("hex")).isTrue();
+        assertThat(CivAddressConfig.isHexFormatMarker(" HEX ")).isTrue();
+        assertThat(CivAddressConfig.isHexFormatMarker("dec")).isFalse();
+        assertThat(CivAddressConfig.isHexFormatMarker("")).isFalse();
+        assertThat(CivAddressConfig.isHexFormatMarker(null)).isFalse();
+    }
+
     @Test
     public void decimalTwin_helper() {
         assertThat(CivAddressConfig.decimalTwin("88")).isEqualTo(88);

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivAddressConfigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivAddressConfigTest.java
@@ -1,0 +1,114 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CivAddressConfig} (issue #753): the {@code civ} config key is hex,
+ * the Compose rig picker wrote decimal for three months, and the loader has to survive
+ * both. Pure JUnit — no Android types.
+ */
+public class CivAddressConfigTest {
+
+    // ---- encode --------------------------------------------------------------------
+
+    @Test
+    public void encode_isLowercaseHexWithoutPrefix() {
+        assertThat(CivAddressConfig.encode(0xA4)).isEqualTo("a4");
+        assertThat(CivAddressConfig.encode(0x94)).isEqualTo("94");
+        assertThat(CivAddressConfig.encode(0x0E)).isEqualTo("e");
+    }
+
+    @Test
+    public void encode_masksToOneByte() {
+        assertThat(CivAddressConfig.encode(0x1A4)).isEqualTo("a4");
+    }
+
+    @Test
+    public void encode_roundTripsThroughDecode() {
+        for (int a = 0; a <= 0xFF; a++) {
+            assertThat(CivAddressConfig.decode(CivAddressConfig.encode(a), -1)).isEqualTo(a);
+        }
+    }
+
+    // ---- decode --------------------------------------------------------------------
+
+    @Test
+    public void decode_hex_asAlwaysStored() {
+        assertThat(CivAddressConfig.decode("a4", 0)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode("A4", 0)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode(" 5e ", 0)).isEqualTo(0x5E);
+        assertThat(CivAddressConfig.decode("0xA4", 0)).isEqualTo(0xA4);
+    }
+
+    @Test
+    public void decode_repairsDecimalWrittenByOldComposePicker() {
+        // IC-705: 0xA4 == 164 -> stored "164" -> hex 0x164 overflows a byte -> decimal 164.
+        assertThat(CivAddressConfig.decode("164", 0)).isEqualTo(0xA4);
+        // IC-7300 0x94 == 148, IC-7000 0x70 == 112, IC-9700 0xA2 == 162, IC-7100 0x88 == 136
+        assertThat(CivAddressConfig.decode("148", 0)).isEqualTo(0x94);
+        assertThat(CivAddressConfig.decode("112", 0)).isEqualTo(0x70);
+        assertThat(CivAddressConfig.decode("162", 0)).isEqualTo(0xA2);
+        assertThat(CivAddressConfig.decode("136", 0)).isEqualTo(0x88);
+    }
+
+    @Test
+    public void decode_twoDigitDecimal_isAmbiguous_readAsHex() {
+        // "88" (an IC-706MKIIG's 0x58 in decimal) is also valid hex — decode alone can't
+        // tell; reconcileWithModel settles it.
+        assertThat(CivAddressConfig.decode("88", 0)).isEqualTo(0x88);
+    }
+
+    @Test
+    public void decode_fallbacks() {
+        assertThat(CivAddressConfig.decode(null, 0xA4)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode("", 0xA4)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode("   ", 0xA4)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode("zz", 0xA4)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode("0x", 0xA4)).isEqualTo(0xA4);
+        // Too big in both bases.
+        assertThat(CivAddressConfig.decode("999", 0xA4)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode("1a4", 0xA4)).isEqualTo(0xA4);
+        assertThat(CivAddressConfig.decode("-1", 0xA4)).isEqualTo(0xA4);
+    }
+
+    // ---- reconcileWithModel ----------------------------------------------------------
+
+    @Test
+    public void reconcile_matchingModel_unchanged() {
+        assertThat(CivAddressConfig.reconcileWithModel(0xA4, 0xA4)).isEqualTo(0xA4);
+    }
+
+    @Test
+    public void reconcile_twoDigitDecimalTwinOfModel_isRepaired() {
+        // Stored "88" for 0x58 (IC-706MKIIG) -> loaded 0x88; digits "88" in decimal == 0x58.
+        assertThat(CivAddressConfig.reconcileWithModel(0x88, 0x58)).isEqualTo(0x58);
+        // Stored "94" for 0x5E (IC-718).
+        assertThat(CivAddressConfig.reconcileWithModel(0x94, 0x5E)).isEqualTo(0x5E);
+        // Stored "40" for 0x28 (IC-725).
+        assertThat(CivAddressConfig.reconcileWithModel(0x40, 0x28)).isEqualTo(0x28);
+    }
+
+    @Test
+    public void reconcile_userOverride_isLeftAlone() {
+        // Rig re-addressed to 0x5F on purpose while the model says 0xA4: not a decimal twin.
+        assertThat(CivAddressConfig.reconcileWithModel(0x5F, 0xA4)).isEqualTo(0x5F);
+        // Hex digits with a letter can't be a decimal twin at all.
+        assertThat(CivAddressConfig.reconcileWithModel(0x9A, 0x62)).isEqualTo(0x9A);
+    }
+
+    @Test
+    public void reconcile_invalidModelAddress_isIgnored() {
+        assertThat(CivAddressConfig.reconcileWithModel(0x88, -1)).isEqualTo(0x88);
+        assertThat(CivAddressConfig.reconcileWithModel(0x88, 0x100)).isEqualTo(0x88);
+    }
+
+    @Test
+    public void decimalTwin_helper() {
+        assertThat(CivAddressConfig.decimalTwin("88")).isEqualTo(88);
+        assertThat(CivAddressConfig.decimalTwin("a4")).isEqualTo(-1);
+        assertThat(CivAddressConfig.decimalTwin("")).isEqualTo(-1);
+        assertThat(CivAddressConfig.decimalTwin(null)).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
Fixes #753.

## What was wrong
The Compose rig-model picker (added 2026-05) persisted the CI-V address with `Integer.toString()` — **decimal** — while the config loader, `rigaddress.txt`, and the legacy settings screen all treat the `civ` key as **hex**. So an IC-705's `0xA4` was written as `"164"`, reloaded as `0x164`, truncated to a byte, and became `0x64`.

From the next launch on, every `setFreq`/`readFreq` CI-V frame carried a rig address no radio answers to:
- changing frequency in the app (decode window, waterfall, settings) did nothing, and
- turning the dial on the radio never updated FT8AF.

PTT and audio kept working — PTT uses the CI-V address the rig *announces* over WLAN, and audio is a separate UDP stream — which is why the report reads as WLAN-specific. But the corruption hits **every ICOM model** (IC-7300 `0x94`→`0x48`, IC-9700 `0xA2`→…, etc.); WLAN just masks it because PTT/audio still work.

## The fix
- **New `CivAddressConfig`** (pure/tested): `encode()` writes hex; `decode()` reads hex and repairs the decimal strings the buggy build wrote (a hex parse that overflows a byte can only be a 3-digit decimal address); `reconcileWithModel()` settles the 2-digit ambiguity (`"88"` == `0x58` vs `0x88`) against the selected rig model.
- **`RadioAudioSettings`** now writes `CivAddressConfig.encode(...)` (hex).
- **`DatabaseOpr`** hydrates `civ` via `CivAddressConfig.decode(...)`.
- **`MainViewModel.connectRig()`** runs a one-time repair against the selected model and writes the corrected hex back, so an already-mangled install self-heals on the next connect.

## Tests
- `CivAddressConfigTest` — encode/decode, full 0x00–0xFF round-trip, decimal repair, reconcile, user-override left alone.
- `DatabaseOprConfigHydrationTest` — decimal `civ` repaired on load; `0x`-prefixed hex honored.

Unit tests pass; debug APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)