### PR TITLE
Surface IC-705 network connect/disconnect on the CAT status chip (#754)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -1994,12 +1994,15 @@ public class MainViewModel extends ViewModel {
             }
         });
 
-        iComWifiConnector.connect();
         connectRig();//assign baseRig
 
         baseRig.setControlMode(GeneralVariables.controlMode);
         baseRig.setOnRigStateChanged(onRigStateChanged);
         baseRig.setConnector(iComWifiConnector);
+        // Connect AFTER the rig-state listener is wired (setConnector above), otherwise the
+        // onConnecting/onConnected edges the connector now emits (#754) would fire into a
+        // null listener and the CAT chip would never leave grey.
+        iComWifiConnector.connect();
 
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {//connection takes time, wait before setting frequency
             @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiConnector.java
@@ -82,7 +82,11 @@ public class WifiConnector extends BaseRigConnector{
         super.connect();
         // Announce the attempt so the chip shows "connecting" (amber) immediately; the
         // CONNECTED/ERROR edge follows from the login response. A reconnect reuses this same
-        // connector instance, so start from a fresh link state each attempt.
+        // connector instance, so start from a fresh link state each attempt — otherwise the
+        // terminal flag from the previous close/error swallows the next login and the chip
+        // never leaves "connecting" (Copilot review on #754). Reset before start(): the login
+        // response can arrive on the receive worker before start() returns.
+        linkState.reset();
         if (getOnConnectorStateChanged() != null) {
             getOnConnectorStateChanged().onConnecting();
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiConnector.java
@@ -24,11 +24,50 @@ public class WifiConnector extends BaseRigConnector{
     public WifiRig wifiRig;
     public OnWifiDataReceived onWifiDataReceived;
 
+    // Real link state (issue #754). wifiRig.opened flips true the instant start() is called,
+    // before the UDP handshake — reading it as "connected" made the Settings header claim a
+    // connection with the radio off. This tracks the actual login/close edges instead, and
+    // feeds isConnected().
+    private final WifiLinkState linkState = new WifiLinkState();
+
 
     public WifiConnector(int controlMode, WifiRig wifiRig) {
         super(controlMode);
         this.wifiRig=wifiRig;
+        // Forward the rig's link lifecycle to the shared connector-state pipeline so the CAT
+        // status chip, connect/disconnect toasts, and the liveness watchdog all light up for
+        // the network path exactly as they do for USB/Bluetooth.
+        this.wifiRig.setOnLinkStateChanged(new WifiRig.OnLinkStateChanged() {
+            @Override
+            public void onLoginResult(boolean ok) {
+                emit(linkState.onLoginResult(ok), "login " + (ok ? "ok" : "failed"));
+            }
 
+            @Override
+            public void onSendError() {
+                emit(linkState.onSendError(), "network send error");
+            }
+
+            @Override
+            public void onClosed() {
+                emit(linkState.onClosed(), "closed");
+            }
+        });
+    }
+
+    private void emit(WifiLinkState.Emit action, String reason) {
+        if (action == null || getOnConnectorStateChanged() == null) return;
+        switch (action) {
+            case CONNECTED:
+                getOnConnectorStateChanged().onConnected();
+                break;
+            case DISCONNECTED:
+                getOnConnectorStateChanged().onDisconnected();
+                break;
+            case ERROR:
+                getOnConnectorStateChanged().onRunError(reason);
+                break;
+        }
     }
 
     @Override
@@ -41,6 +80,12 @@ public class WifiConnector extends BaseRigConnector{
     @Override
     public void connect() {
         super.connect();
+        // Announce the attempt so the chip shows "connecting" (amber) immediately; the
+        // CONNECTED/ERROR edge follows from the login response. A reconnect reuses this same
+        // connector instance, so start from a fresh link state each attempt.
+        if (getOnConnectorStateChanged() != null) {
+            getOnConnectorStateChanged().onConnecting();
+        }
         wifiRig.start();
     }
 
@@ -72,7 +117,9 @@ public class WifiConnector extends BaseRigConnector{
 
     @Override
     public boolean isConnected() {
-        return wifiRig.opened;
+        // The real link state (post-login, pre-close), not wifiRig.opened which is true the
+        // instant start() runs — see linkState (#754).
+        return linkState.isConnected();
     }
 
     public void setOnWifiDataReceived(OnWifiDataReceived onDataReceived) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiLinkState.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiLinkState.java
@@ -1,0 +1,71 @@
+package com.k1af.ft8af.connector;
+
+/**
+ * Edge-guarded connection-state machine for the Icom/Xiegu network (WLAN) link (issue #754).
+ *
+ * <p>The Icom UDP stack signals its progress through repeated packets — a 0x60 login response
+ * and a 0x50 status packet can each arrive several times (the X6100 in particular re-fires
+ * them), and a dropped link surfaces as a send-side {@code IOException} or an explicit close.
+ * Before #754 none of that reached the UI: the CAT status chip stayed grey the entire session
+ * even with the radio linked, and a Wi-Fi drop just froze the waterfall with no message.
+ *
+ * <p>This class turns that stream of raw events into <em>edges</em> — connected announced once,
+ * disconnected announced once — so the connector can drive the same
+ * {@link OnConnectorStateChanged} pipeline every wired connector already uses. Pure (no Android
+ * imports) so it is unit-testable.
+ */
+public final class WifiLinkState {
+
+    /** What the connector should emit in response to an event; {@code null} means "nothing". */
+    public enum Emit {
+        CONNECTED,
+        DISCONNECTED,
+        ERROR
+    }
+
+    private boolean announcedConnected = false;
+    private boolean terminal = false;
+
+    /** True between a {@link Emit#CONNECTED} and the following disconnect/error. */
+    public boolean isConnected() {
+        return announcedConnected && !terminal;
+    }
+
+    /**
+     * A 0x60 login response arrived. First success emits {@link Emit#CONNECTED}; later successes
+     * are swallowed (the rig re-sends). A failure (bad user/password) is a terminal
+     * {@link Emit#ERROR}.
+     */
+    public Emit onLoginResult(boolean ok) {
+        if (terminal) return null;
+        if (ok) {
+            if (announcedConnected) return null;
+            announcedConnected = true;
+            return Emit.CONNECTED;
+        }
+        terminal = true;
+        return Emit.ERROR;
+    }
+
+    /**
+     * A UDP send failed (network unreachable). After a successful connect this is a link drop
+     * ({@link Emit#DISCONNECTED}); before one it is a failed attempt ({@link Emit#ERROR}). Once
+     * only — the stack fires it per stream.
+     */
+    public Emit onSendError() {
+        if (terminal) return null;
+        terminal = true;
+        return announcedConnected ? Emit.DISCONNECTED : Emit.ERROR;
+    }
+
+    /**
+     * The link was closed (user disconnect, or teardown after an error already reported).
+     * Emits {@link Emit#DISCONNECTED} only if we had announced a connect and haven't already
+     * gone terminal.
+     */
+    public Emit onClosed() {
+        if (terminal) return null;
+        terminal = true;
+        return announcedConnected ? Emit.DISCONNECTED : null;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiLinkState.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiLinkState.java
@@ -13,6 +13,12 @@ package com.k1af.ft8af.connector;
  * disconnected announced once — so the connector can drive the same
  * {@link OnConnectorStateChanged} pipeline every wired connector already uses. Pure (no Android
  * imports) so it is unit-testable.
+ *
+ * <p>Thread-safe: login results arrive on the UDP receive worker, send errors on whichever
+ * stream's sender failed, and a close from the UI thread — every transition and the
+ * {@link #isConnected()} read take the same monitor so two callbacks can't both see
+ * {@code terminal == false} and double-announce an edge, and a close can't interleave with a
+ * login and leave the chip lit after teardown.
  */
 public final class WifiLinkState {
 
@@ -27,8 +33,20 @@ public final class WifiLinkState {
     private boolean terminal = false;
 
     /** True between a {@link Emit#CONNECTED} and the following disconnect/error. */
-    public boolean isConnected() {
+    public synchronized boolean isConnected() {
         return announcedConnected && !terminal;
+    }
+
+    /**
+     * Start a fresh attempt. {@link WifiConnector#connect()} calls this before
+     * {@code wifiRig.start()} because a reconnect reuses the same connector instance: without
+     * it the {@code terminal} flag left behind by the previous close/error swallowed the next
+     * successful login, so the chip stuck on "connecting" and {@link #isConnected()} stayed
+     * false for the whole re-established session.
+     */
+    public synchronized void reset() {
+        announcedConnected = false;
+        terminal = false;
     }
 
     /**
@@ -36,7 +54,7 @@ public final class WifiLinkState {
      * are swallowed (the rig re-sends). A failure (bad user/password) is a terminal
      * {@link Emit#ERROR}.
      */
-    public Emit onLoginResult(boolean ok) {
+    public synchronized Emit onLoginResult(boolean ok) {
         if (terminal) return null;
         if (ok) {
             if (announcedConnected) return null;
@@ -52,7 +70,7 @@ public final class WifiLinkState {
      * ({@link Emit#DISCONNECTED}); before one it is a failed attempt ({@link Emit#ERROR}). Once
      * only — the stack fires it per stream.
      */
-    public Emit onSendError() {
+    public synchronized Emit onSendError() {
         if (terminal) return null;
         terminal = true;
         return announcedConnected ? Emit.DISCONNECTED : Emit.ERROR;
@@ -63,7 +81,7 @@ public final class WifiLinkState {
      * Emits {@link Emit#DISCONNECTED} only if we had announced a connect and haven't already
      * gone terminal.
      */
-    public Emit onClosed() {
+    public synchronized Emit onClosed() {
         if (terminal) return null;
         terminal = true;
         return announcedConnected ? Emit.DISCONNECTED : null;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
@@ -20,6 +20,9 @@ public class IComWifiRig extends WifiRig{
 
     @Override
     public void start(){
+        // Tag this attempt so handlers left over from a previous session can't report
+        // into the new one (see WifiRig.beginLinkSession).
+        final int session = beginLinkSession();
         opened=true;
         openAudio();//Open audio
         controlUdp=new IcomControlUdp(userName,password,ip,port);
@@ -51,13 +54,13 @@ public class IComWifiRig extends WifiRig{
             public void OnUdpSendIOException(IcomUdpStyle style,IOException e) {
                 ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
                         R.string.network_exception),IcomUdpBase.getUdpStyle(style),e.getMessage()));
-                notifySendError();
+                notifySendError(session);
                 close();
             }
 
             @Override
             public void OnLoginResponse(boolean authIsOK) {
-                notifyLoginResult(authIsOK);
+                notifyLoginResult(session, authIsOK);
                 if (authIsOK){
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.login_succeed));
                 }else {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
@@ -51,11 +51,13 @@ public class IComWifiRig extends WifiRig{
             public void OnUdpSendIOException(IcomUdpStyle style,IOException e) {
                 ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
                         R.string.network_exception),IcomUdpBase.getUdpStyle(style),e.getMessage()));
+                notifySendError();
                 close();
             }
 
             @Override
             public void OnLoginResponse(boolean authIsOK) {
+                notifyLoginResult(authIsOK);
                 if (authIsOK){
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.login_succeed));
                 }else {
@@ -92,6 +94,7 @@ public class IComWifiRig extends WifiRig{
     @Override
     public void close(){
         opened=false;
+        notifyClosed();
         controlUdp.closeAll();
         closeAudio();
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
@@ -27,6 +27,38 @@ public abstract class WifiRig {
         void onReceivedWaveData(byte[] data);
     }
 
+    /**
+     * Link lifecycle events, surfaced so the connector can drive the CAT status chip and
+     * connect/disconnect toasts (issue #754). Fired from the concrete rig's stream-event
+     * handlers via the {@code notify*} helpers below.
+     */
+    public interface OnLinkStateChanged {
+        void onLoginResult(boolean ok);
+
+        void onSendError();
+
+        void onClosed();
+    }
+
+    public OnLinkStateChanged onLinkStateChanged;
+
+    public void setOnLinkStateChanged(OnLinkStateChanged onLinkStateChanged) {
+        this.onLinkStateChanged = onLinkStateChanged;
+    }
+
+    /** Concrete rigs call these from their stream-event handlers; null-safe. */
+    protected void notifyLoginResult(boolean ok) {
+        if (onLinkStateChanged != null) onLinkStateChanged.onLoginResult(ok);
+    }
+
+    protected void notifySendError() {
+        if (onLinkStateChanged != null) onLinkStateChanged.onSendError();
+    }
+
+    protected void notifyClosed() {
+        if (onLinkStateChanged != null) onLinkStateChanged.onClosed();
+    }
+
     public ControlUdp controlUdp;
     // volatile: the UDP receive worker reads this to play RX audio while another
     // thread (UI disconnect, or a send-side network error routed through

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
@@ -17,6 +17,7 @@ import com.k1af.ft8af.icom.IcomUdpBase.IcomUdpStyle;
 import com.k1af.ft8af.ui.ToastMessage;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class WifiRig {
     private static final String TAG = "WifiRig";
@@ -46,13 +47,45 @@ public abstract class WifiRig {
         this.onLinkStateChanged = onLinkStateChanged;
     }
 
+    // Monotonic id of the current UDP session. start() creates a new ControlUdp every
+    // attempt but the previous one's stream-event handlers still point at this rig, so a
+    // late login response or send failure from the old sockets would otherwise be applied
+    // to the new attempt's link state. Concrete rigs capture beginLinkSession() in start()
+    // and pass it back through the session-checked notify* overloads.
+    private final AtomicInteger linkSession = new AtomicInteger();
+
+    /** Called at the top of {@link #start()}; returns the id the new handlers must carry. */
+    protected int beginLinkSession() {
+        return linkSession.incrementAndGet();
+    }
+
+    /** Package-visible for tests. */
+    int currentLinkSession() {
+        return linkSession.get();
+    }
+
+    /** Package-visible for tests: whether an event tagged {@code session} is still current. */
+    static boolean isCurrentSession(int session, int current) {
+        return session == current;
+    }
+
     /** Concrete rigs call these from their stream-event handlers; null-safe. */
     protected void notifyLoginResult(boolean ok) {
         if (onLinkStateChanged != null) onLinkStateChanged.onLoginResult(ok);
     }
 
+    /** As {@link #notifyLoginResult(boolean)}, but dropped when {@code session} is stale. */
+    protected void notifyLoginResult(int session, boolean ok) {
+        if (isCurrentSession(session, linkSession.get())) notifyLoginResult(ok);
+    }
+
     protected void notifySendError() {
         if (onLinkStateChanged != null) onLinkStateChanged.onSendError();
+    }
+
+    /** As {@link #notifySendError()}, but dropped when {@code session} is stale. */
+    protected void notifySendError(int session) {
+        if (isCurrentSession(session, linkSession.get())) notifySendError();
     }
 
     protected void notifyClosed() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
@@ -20,6 +20,9 @@ public class XieGuWifiRig extends WifiRig{
 
     @Override
     public void start(){
+        // Tag this attempt so handlers left over from a previous session can't report
+        // into the new one (see WifiRig.beginLinkSession).
+        final int session = beginLinkSession();
         opened=true;
         openAudio();//Open audio
         controlUdp=new XieGuControlUdp(userName,password,ip,port);
@@ -50,13 +53,13 @@ public class XieGuWifiRig extends WifiRig{
             public void OnUdpSendIOException(IcomUdpStyle style,IOException e) {
                 ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
                         R.string.network_exception),IcomUdpBase.getUdpStyle(style),e.getMessage()));
-                notifySendError();
+                notifySendError(session);
                 close();
             }
 
             @Override
             public void OnLoginResponse(boolean authIsOK) {
-                notifyLoginResult(authIsOK);
+                notifyLoginResult(session, authIsOK);
                 if (authIsOK){
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.login_succeed));
                 }else {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
@@ -50,11 +50,13 @@ public class XieGuWifiRig extends WifiRig{
             public void OnUdpSendIOException(IcomUdpStyle style,IOException e) {
                 ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
                         R.string.network_exception),IcomUdpBase.getUdpStyle(style),e.getMessage()));
+                notifySendError();
                 close();
             }
 
             @Override
             public void OnLoginResponse(boolean authIsOK) {
+                notifyLoginResult(authIsOK);
                 if (authIsOK){
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.login_succeed));
                 }else {
@@ -91,6 +93,7 @@ public class XieGuWifiRig extends WifiRig{
     @Override
     public void close(){
         opened=false;
+        notifyClosed();
         controlUdp.closeAll();
         closeAudio();
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorLinkStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorLinkStateTest.java
@@ -96,4 +96,54 @@ public class WifiConnectorLinkStateTest {
         connector.disconnect(); // -> wifiRig.close() -> notifyClosed()
         assertThat(events).containsExactly("connecting", "connected", "disconnected").inOrder();
     }
+
+    @Test
+    public void reconnectAfterLinkDrop_announcesConnectedAgain() {
+        // MainViewModel.reconnectRig() calls connect() on this same connector instance. The
+        // previous drop left the link state terminal; without a reset the next login was
+        // swallowed and the chip stuck on "connecting" (Copilot review on #754).
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(true);
+        rig.onLinkStateChanged.onSendError();
+        rig.close();
+        assertThat(connector.isConnected()).isFalse();
+
+        connector.connect();
+        assertThat(connector.isConnected()).isFalse(); // until the new login lands
+        rig.onLinkStateChanged.onLoginResult(true);
+        assertThat(events).containsExactly(
+                "connecting", "connected", "disconnected",
+                "connecting", "connected").inOrder();
+        assertThat(connector.isConnected()).isTrue();
+
+        // And the re-established session tears down cleanly, once.
+        connector.disconnect();
+        assertThat(events).containsExactly(
+                "connecting", "connected", "disconnected",
+                "connecting", "connected", "disconnected").inOrder();
+        assertThat(connector.isConnected()).isFalse();
+    }
+
+    @Test
+    public void reconnectAfterLoginFailure_announcesConnected() {
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(false);
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(true);
+        assertThat(events).containsExactly(
+                "connecting", "error:login failed", "connecting", "connected").inOrder();
+        assertThat(connector.isConnected()).isTrue();
+    }
+
+    @Test
+    public void reconnectAfterUserDisconnect_announcesConnected() {
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(true);
+        connector.disconnect();
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(true);
+        assertThat(events).containsExactly(
+                "connecting", "connected", "disconnected", "connecting", "connected").inOrder();
+        assertThat(connector.isConnected()).isTrue();
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorLinkStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorLinkStateTest.java
@@ -1,0 +1,99 @@
+package com.k1af.ft8af.connector;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.database.ControlMode;
+import com.k1af.ft8af.icom.WifiRig;
+import com.k1af.ft8af.rigs.OnRigStateChanged;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Verifies {@link WifiConnector} forwards the rig's link lifecycle to the shared
+ * {@link OnConnectorStateChanged}/{@link OnRigStateChanged} pipeline that drives the CAT
+ * status chip (issue #754), and that {@link WifiConnector#isConnected()} reflects the real
+ * post-login state rather than {@code wifiRig.opened}. No Android types are touched.
+ */
+public class WifiConnectorLinkStateTest {
+
+    /** A WifiRig that performs no network I/O; the test drives its link callbacks directly. */
+    private static class FakeWifiRig extends WifiRig {
+        FakeWifiRig() {
+            super("192.168.0.1", 50001, "user", "pw");
+        }
+
+        @Override public void start() { opened = true; }
+        @Override public void setPttOn(boolean on) { }
+        @Override public void sendCivData(byte[] data) { }
+        @Override public void sendWaveData(float[] data) { }
+        @Override public void close() { opened = false; notifyClosed(); }
+    }
+
+    private FakeWifiRig rig;
+    private WifiConnector connector;
+    private final List<String> events = new ArrayList<>();
+
+    @Before
+    public void setUp() {
+        rig = new FakeWifiRig();
+        connector = new WifiConnector(ControlMode.CAT, rig);
+        connector.setOnRigStateChanged(new OnRigStateChanged() {
+            @Override public void onConnected() { events.add("connected"); }
+            @Override public void onDisconnected() { events.add("disconnected"); }
+            @Override public void onConnecting() { events.add("connecting"); }
+            @Override public void onRunError(String message) { events.add("error:" + message); }
+            @Override public void onPttChanged(boolean isOn) { }
+            @Override public void onFreqChanged(long freq) { }
+        });
+    }
+
+    @Test
+    public void connect_isNotConnectedUntilLogin() {
+        connector.connect();
+        assertThat(events).containsExactly("connecting");
+        // wifiRig.opened is already true here — the old isConnected() would have lied.
+        assertThat(rig.opened).isTrue();
+        assertThat(connector.isConnected()).isFalse();
+    }
+
+    @Test
+    public void loginSuccess_emitsConnectedAndReportsConnected() {
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(true);
+        assertThat(events).containsExactly("connecting", "connected").inOrder();
+        assertThat(connector.isConnected()).isTrue();
+        // Duplicate login packets don't re-announce.
+        rig.onLinkStateChanged.onLoginResult(true);
+        assertThat(events).containsExactly("connecting", "connected").inOrder();
+    }
+
+    @Test
+    public void loginFailure_emitsError() {
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(false);
+        assertThat(events).containsExactly("connecting", "error:login failed").inOrder();
+        assertThat(connector.isConnected()).isFalse();
+    }
+
+    @Test
+    public void linkDropAfterConnect_emitsDisconnectedOnce() {
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(true);
+        rig.onLinkStateChanged.onSendError(); // network went away
+        rig.close();                          // teardown that follows
+        assertThat(events).containsExactly("connecting", "connected", "disconnected").inOrder();
+        assertThat(connector.isConnected()).isFalse();
+    }
+
+    @Test
+    public void userDisconnect_emitsDisconnected() {
+        connector.connect();
+        rig.onLinkStateChanged.onLoginResult(true);
+        connector.disconnect(); // -> wifiRig.close() -> notifyClosed()
+        assertThat(events).containsExactly("connecting", "connected", "disconnected").inOrder();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiLinkStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiLinkStateTest.java
@@ -73,4 +73,72 @@ public class WifiLinkStateTest {
         assertThat(s.onClosed()).isNull();
         assertThat(s.isConnected()).isFalse();
     }
+
+    @Test
+    public void reset_clearsTerminalSoNextLoginConnects() {
+        // Reconnect reuses the connector (and this state): after a drop the next login
+        // must announce CONNECTED again instead of being swallowed by the stale terminal flag.
+        WifiLinkState s = new WifiLinkState();
+        s.onLoginResult(true);
+        assertThat(s.onSendError()).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
+        assertThat(s.onLoginResult(true)).isNull(); // still terminal without reset
+        s.reset();
+        assertThat(s.isConnected()).isFalse();
+        assertThat(s.onLoginResult(true)).isEqualTo(WifiLinkState.Emit.CONNECTED);
+        assertThat(s.isConnected()).isTrue();
+    }
+
+    @Test
+    public void reset_afterLoginFailure_allowsRetry() {
+        WifiLinkState s = new WifiLinkState();
+        assertThat(s.onLoginResult(false)).isEqualTo(WifiLinkState.Emit.ERROR);
+        s.reset();
+        assertThat(s.onLoginResult(true)).isEqualTo(WifiLinkState.Emit.CONNECTED);
+    }
+
+    @Test
+    public void reset_afterUserClose_allowsReconnect() {
+        WifiLinkState s = new WifiLinkState();
+        s.onLoginResult(true);
+        assertThat(s.onClosed()).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
+        s.reset();
+        assertThat(s.onLoginResult(true)).isEqualTo(WifiLinkState.Emit.CONNECTED);
+        assertThat(s.onClosed()).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
+    }
+
+    @Test
+    public void concurrentLogins_announceConnectedExactlyOnce() throws Exception {
+        // The rig re-fires 0x60/0x50 and the receive worker isn't the only caller; with
+        // unsynchronized transitions two threads could both see announcedConnected == false
+        // and emit two CONNECTED edges. Hammer it and count.
+        for (int round = 0; round < 50; round++) {
+            final WifiLinkState s = new WifiLinkState();
+            final int threads = 8;
+            final java.util.concurrent.CountDownLatch go =
+                    new java.util.concurrent.CountDownLatch(1);
+            final java.util.concurrent.atomic.AtomicInteger connected =
+                    new java.util.concurrent.atomic.AtomicInteger();
+            final java.util.concurrent.atomic.AtomicInteger disconnected =
+                    new java.util.concurrent.atomic.AtomicInteger();
+            Thread[] ts = new Thread[threads];
+            for (int i = 0; i < threads; i++) {
+                final boolean closer = (i == threads - 1);
+                ts[i] = new Thread(() -> {
+                    try { go.await(); } catch (InterruptedException ignored) { return; }
+                    WifiLinkState.Emit e = closer ? s.onClosed() : s.onLoginResult(true);
+                    if (e == WifiLinkState.Emit.CONNECTED) connected.incrementAndGet();
+                    if (e == WifiLinkState.Emit.DISCONNECTED) disconnected.incrementAndGet();
+                });
+                ts[i].start();
+            }
+            go.countDown();
+            for (Thread t : ts) t.join();
+            assertThat(connected.get()).isAtMost(1);
+            assertThat(disconnected.get()).isAtMost(1);
+            // A close never leaves the chip lit, whichever order the threads won.
+            assertThat(s.isConnected()).isFalse();
+            // DISCONNECTED can only follow a CONNECTED.
+            if (disconnected.get() == 1) assertThat(connected.get()).isEqualTo(1);
+        }
+    }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiLinkStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiLinkStateTest.java
@@ -1,0 +1,76 @@
+package com.k1af.ft8af.connector;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link WifiLinkState} (issue #754): the edge-guard that turns the Icom UDP
+ * stack's repeated login/status packets and its send-error/close events into single
+ * connect/disconnect edges for the CAT status chip. Pure JUnit.
+ */
+public class WifiLinkStateTest {
+
+    @Test
+    public void loginOk_emitsConnectedOnce() {
+        WifiLinkState s = new WifiLinkState();
+        assertThat(s.onLoginResult(true)).isEqualTo(WifiLinkState.Emit.CONNECTED);
+        assertThat(s.isConnected()).isTrue();
+        // The rig re-sends 0x60/0x50; further successes must not re-announce.
+        assertThat(s.onLoginResult(true)).isNull();
+        assertThat(s.onLoginResult(true)).isNull();
+        assertThat(s.isConnected()).isTrue();
+    }
+
+    @Test
+    public void loginFail_isTerminalError() {
+        WifiLinkState s = new WifiLinkState();
+        assertThat(s.onLoginResult(false)).isEqualTo(WifiLinkState.Emit.ERROR);
+        assertThat(s.isConnected()).isFalse();
+        // Nothing after a terminal failure.
+        assertThat(s.onLoginResult(true)).isNull();
+        assertThat(s.onClosed()).isNull();
+    }
+
+    @Test
+    public void sendErrorAfterConnect_isDisconnect() {
+        WifiLinkState s = new WifiLinkState();
+        s.onLoginResult(true);
+        assertThat(s.onSendError()).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
+        assertThat(s.isConnected()).isFalse();
+    }
+
+    @Test
+    public void sendErrorBeforeConnect_isError() {
+        WifiLinkState s = new WifiLinkState();
+        assertThat(s.onSendError()).isEqualTo(WifiLinkState.Emit.ERROR);
+        assertThat(s.isConnected()).isFalse();
+    }
+
+    @Test
+    public void sendErrorThenClose_emitsOnlyOnce() {
+        // OnUdpSendIOException calls notifySendError() then close() -> notifyClosed():
+        // the disconnect must be announced once, not twice.
+        WifiLinkState s = new WifiLinkState();
+        s.onLoginResult(true);
+        assertThat(s.onSendError()).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
+        assertThat(s.onClosed()).isNull();
+    }
+
+    @Test
+    public void userCloseAfterConnect_isDisconnect() {
+        WifiLinkState s = new WifiLinkState();
+        s.onLoginResult(true);
+        assertThat(s.onClosed()).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
+        assertThat(s.isConnected()).isFalse();
+    }
+
+    @Test
+    public void closeBeforeConnect_isSilent() {
+        // Dismissing the login dialog before the handshake completes shouldn't flash a
+        // "disconnected" the chip never showed connected for.
+        WifiLinkState s = new WifiLinkState();
+        assertThat(s.onClosed()).isNull();
+        assertThat(s.isConnected()).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/WifiRigLinkSessionTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/WifiRigLinkSessionTest.java
@@ -1,0 +1,115 @@
+package com.k1af.ft8af.icom;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests the link-session guard in {@link WifiRig} (Copilot review on #754): every
+ * {@code start()} creates a fresh {@code ControlUdp}, but the previous session's stream-event
+ * handlers still point at the rig, so a late login response or send failure from the old
+ * sockets must not be reported into the new attempt's link state. Pure JUnit.
+ */
+public class WifiRigLinkSessionTest {
+
+    /** Minimal rig: start() begins a session the way IComWifiRig/XieGuWifiRig do. */
+    private static class FakeRig extends WifiRig {
+        int lastSession;
+
+        FakeRig() {
+            super("192.168.0.1", 50001, "user", "pw");
+        }
+
+        @Override public void start() { lastSession = beginLinkSession(); opened = true; }
+        @Override public void setPttOn(boolean on) { }
+        @Override public void sendCivData(byte[] data) { }
+        @Override public void sendWaveData(float[] data) { }
+        @Override public void close() { opened = false; notifyClosed(); }
+
+        // Expose the protected session-checked notifiers the concrete rigs' handlers use.
+        void login(int session, boolean ok) { notifyLoginResult(session, ok); }
+        void sendError(int session) { notifySendError(session); }
+    }
+
+    private static List<String> record(FakeRig rig) {
+        final List<String> events = new ArrayList<>();
+        rig.setOnLinkStateChanged(new WifiRig.OnLinkStateChanged() {
+            @Override public void onLoginResult(boolean ok) { events.add("login:" + ok); }
+            @Override public void onSendError() { events.add("sendError"); }
+            @Override public void onClosed() { events.add("closed"); }
+        });
+        return events;
+    }
+
+    @Test
+    public void isCurrentSession_exactMatchOnly() {
+        assertThat(WifiRig.isCurrentSession(3, 3)).isTrue();
+        assertThat(WifiRig.isCurrentSession(2, 3)).isFalse();
+        assertThat(WifiRig.isCurrentSession(4, 3)).isFalse();
+    }
+
+    @Test
+    public void beginLinkSession_incrementsPerStart() {
+        FakeRig rig = new FakeRig();
+        assertThat(rig.currentLinkSession()).isEqualTo(0);
+        rig.start();
+        int first = rig.lastSession;
+        assertThat(first).isEqualTo(rig.currentLinkSession());
+        rig.start();
+        assertThat(rig.lastSession).isEqualTo(first + 1);
+        assertThat(rig.currentLinkSession()).isEqualTo(first + 1);
+    }
+
+    @Test
+    public void currentSessionEvents_areDelivered() {
+        FakeRig rig = new FakeRig();
+        List<String> events = record(rig);
+        rig.start();
+        rig.login(rig.lastSession, true);
+        rig.sendError(rig.lastSession);
+        assertThat(events).containsExactly("login:true", "sendError").inOrder();
+    }
+
+    @Test
+    public void staleSessionEvents_areDropped() {
+        FakeRig rig = new FakeRig();
+        List<String> events = record(rig);
+        rig.start();
+        int old = rig.lastSession;
+        rig.close();                 // link dropped / user disconnect
+        rig.start();                 // reconnect: new ControlUdp, new session
+        rig.login(old, true);        // late 0x60 from the old sockets
+        rig.sendError(old);          // late sender failure from the old streams
+        rig.login(old, false);
+        assertThat(events).containsExactly("closed");
+        // The new session's own events still get through.
+        rig.login(rig.lastSession, true);
+        assertThat(events).containsExactly("closed", "login:true").inOrder();
+    }
+
+    @Test
+    public void unsessionedNotifiers_stillDeliver() {
+        // The original overloads remain for callers that have no session to carry
+        // (close() -> notifyClosed(), and any third-party rig subclass).
+        FakeRig rig = new FakeRig();
+        List<String> events = record(rig);
+        rig.notifyLoginResult(true);
+        rig.notifySendError();
+        rig.notifyClosed();
+        assertThat(events).containsExactly("login:true", "sendError", "closed").inOrder();
+    }
+
+    @Test
+    public void nullListener_isSafe() {
+        FakeRig rig = new FakeRig();
+        rig.start();
+        rig.login(rig.lastSession, true);
+        rig.sendError(rig.lastSession);
+        rig.close();
+        // No NPE is the assertion.
+        assertThat(rig.opened).isFalse();
+    }
+}


### PR DESCRIPTION
Fixes #754.

## What was wrong
Connecting to an IC-705 over WLAN gave no indication the link was up (the user had to guess by watching the waterfall), and losing Wi-Fi to the rig just froze the waterfall with no message.

Root cause: the Icom network connector never fired any of the connector-state callbacks that the USB and Bluetooth connectors use. So the CAT status chip stayed grey the entire session, and the CAT liveness watchdog — which flips the chip when a "connected" link goes silently dead — was never started on the network path. `WifiConnector.isConnected()` also returned `wifiRig.opened`, which is `true` the instant `start()` runs, so the Settings header claimed "connected" with the radio off.

## The fix
- **New `WifiLinkState`** (pure/tested): edge-guards the Icom UDP stack's repeated login/status packets and its send-error/close events into single connect/disconnect edges (the rig re-sends 0x60/0x50; a fault-then-close must not double-report).
- **`WifiRig`** gains an `OnLinkStateChanged` hook; `IComWifiRig`/`XieGuWifiRig` fire it on login response, UDP send error, and close.
- **`WifiConnector`** forwards those edges to the shared `OnConnectorStateChanged` pipeline → chip goes amber→green on connect and red/grey on drop, connect/disconnect toasts fire, and the CAT liveness watchdog runs (giving a silent Wi-Fi drop a detectable "went quiet" signal). `isConnected()` now reflects the real post-login state.
- **`connectWifiRig()`** wires the rig-state listener *before* `connect()` so the new edges aren't lost.
- Removed a stray, incomplete `IcomLinkTracker.java` that was in the tree.

## Note on the silent-drop case
A UDP Wi-Fi drop produces no socket error, so it's the liveness watchdog (now running) that catches it — it probes the rig's frequency and flips to ERROR after it goes quiet. That readback depends on the CI-V address being correct, which is exactly what #753 fixes; the watchdog only arms after the first reply, so if readback is dead it degrades safely (chip stays green rather than falsely red).

## Tests
- `WifiLinkStateTest` — connect-once, login-fail, drop-after-connect, close-before-connect, no double-report.
- `WifiConnectorLinkStateTest` — end-to-end connect/login/drop/disconnect wiring and the `isConnected()` fix.

Unit tests pass; debug APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)