### PR TITLE
Enter Bluetooth headset (SCO) mode when a BT headset is the selected audio device (#723)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -2281,19 +2281,32 @@ public class MainViewModel extends ViewModel {
         boolean want = ScoPolicy.shouldEnterHeadsetMode(GeneralVariables.connectMode,
                 isBTConnected(), inputType, outputType);
 
-        if (want && !btHeadsetModeActive) {
-            setBlueToothOn();
-            btHeadsetModeActive = true;
-            // Rebuild capture so the AudioRecord binds to the freshly-opened SCO route rather
-            // than the built-in mic it was created on.
-            reinitializeAudioInput();
-        } else if (!want && btHeadsetModeActive
-                && GeneralVariables.connectMode != ConnectMode.BLUE_TOOTH) {
-            // Leave headset mode when the user picks a non-BT device — but never yank SCO out
-            // from under a Bluetooth rig, whose TX/RX path owns it.
-            setBlueToothOff();
-            btHeadsetModeActive = false;
-            reinitializeAudioInput();
+        // Cross-check the cached flag against the real SCO state: SCO drops by itself when
+        // the headset disconnects (and setBlueToothOn() can fail), so the flag alone would
+        // skip re-entering and leave the selected BT mic/speaker dead until restart.
+        boolean scoOn = audioManager.isBluetoothScoOn();
+        boolean bluetoothRig = GeneralVariables.connectMode == ConnectMode.BLUE_TOOTH;
+        switch (ScoPolicy.headsetModeAction(want, btHeadsetModeActive, scoOn, bluetoothRig)) {
+            case ScoPolicy.HEADSET_MODE_ENTER:
+                setBlueToothOn();
+                btHeadsetModeActive = true;
+                // Rebuild capture so the AudioRecord binds to the freshly-opened SCO route
+                // rather than the built-in mic it was created on.
+                reinitializeAudioInput();
+                break;
+            case ScoPolicy.HEADSET_MODE_LEAVE:
+                // Leave headset mode when the user picks a non-BT device — never from under
+                // a Bluetooth rig, whose TX/RX path owns SCO (headsetModeAction guards that).
+                setBlueToothOff();
+                btHeadsetModeActive = false;
+                reinitializeAudioInput();
+                break;
+            case ScoPolicy.HEADSET_MODE_FORGET:
+                // SCO already went away on its own; nothing to tear down.
+                btHeadsetModeActive = false;
+                break;
+            default:
+                break;
         }
     }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -2250,6 +2250,66 @@ public class MainViewModel extends ViewModel {
         }
     }
 
+    // Tracks whether we've put the phone into Bluetooth headset (SCO) mode for audio, so
+    // refreshBluetoothHeadsetMode() only toggles on an actual change. setBlueToothOn() does a
+    // stop+start of SCO, which is disruptive to re-issue on every settings tap. (#723)
+    private boolean btHeadsetModeActive = false;
+
+    /**
+     * Bring the phone's Bluetooth headset (SCO) link up or down to match the current rig +
+     * audio-device selection (issue #723).
+     *
+     * <p>Before this, SCO was entered only when the <em>rig</em> connection was Bluetooth. A
+     * user on a USB/VOX rig who selected a Bluetooth headset as the FT8 mic got no SCO, so the
+     * app captured the built-in mic instead and the headset never appeared to work — the
+     * documented workaround was to launch FT8CN first purely to turn SCO on. This now also
+     * enters headset mode when the selected input or output device is a Bluetooth-SCO endpoint,
+     * and rebuilds the AudioRecord so capture actually routes over the link.
+     *
+     * <p>Idempotent and safe to call from launch and from each device-picker change.
+     */
+    public void refreshBluetoothHeadsetMode() {
+        AudioManager audioManager = (AudioManager) GeneralVariables.getMainContext()
+                .getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager == null) return;
+
+        int inputType = audioDeviceType(audioManager,
+                GeneralVariables.audioInputDeviceId, AudioManager.GET_DEVICES_INPUTS);
+        int outputType = audioDeviceType(audioManager,
+                GeneralVariables.audioOutputDeviceId, AudioManager.GET_DEVICES_OUTPUTS);
+
+        boolean want = ScoPolicy.shouldEnterHeadsetMode(GeneralVariables.connectMode,
+                isBTConnected(), inputType, outputType);
+
+        if (want && !btHeadsetModeActive) {
+            setBlueToothOn();
+            btHeadsetModeActive = true;
+            // Rebuild capture so the AudioRecord binds to the freshly-opened SCO route rather
+            // than the built-in mic it was created on.
+            reinitializeAudioInput();
+        } else if (!want && btHeadsetModeActive
+                && GeneralVariables.connectMode != ConnectMode.BLUE_TOOTH) {
+            // Leave headset mode when the user picks a non-BT device — but never yank SCO out
+            // from under a Bluetooth rig, whose TX/RX path owns it.
+            setBlueToothOff();
+            btHeadsetModeActive = false;
+            reinitializeAudioInput();
+        }
+    }
+
+    /**
+     * {@link android.media.AudioDeviceInfo#getType()} of the routed device matching
+     * {@code deviceId} among {@code flags} (inputs or outputs), or -1 if none match (Default
+     * row, USB-direct entry, or nothing connected).
+     */
+    private int audioDeviceType(AudioManager audioManager, int deviceId, int flags) {
+        if (deviceId <= 0) return -1;
+        for (android.media.AudioDeviceInfo d : audioManager.getDevices(flags)) {
+            if (d.getId() == deviceId) return d.getType();
+        }
+        return -1;
+    }
+
     /**
      * Check whether the rig is connected. Two cases: rigBaseClass not created, or serial port connection failed.
      *

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
@@ -16,6 +16,23 @@ public final class ScoPolicy {
     }
 
     /**
+     * Mirror of {@code android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO} (a stable framework
+     * constant = 7), kept as a literal so this class stays Android-free and unit-testable.
+     */
+    public static final int TYPE_BLUETOOTH_SCO = 7;
+
+    /**
+     * Whether the operator's chosen audio input/output device is a Bluetooth SCO (hands-free)
+     * endpoint — the signal #723 was missing. Selecting a BT headset as the FT8 mic/speaker is
+     * an explicit request to route audio over it, unlike a car merely paired for music, so it
+     * is safe to bring SCO up in that case even outside Bluetooth <em>rig</em> mode.
+     */
+    public static boolean audioSelectionNeedsHeadsetMode(int inputDeviceType,
+                                                         int outputDeviceType) {
+        return inputDeviceType == TYPE_BLUETOOTH_SCO || outputDeviceType == TYPE_BLUETOOTH_SCO;
+    }
+
+    /**
      * Whether the TX/RX cycle needs to toggle SCO around PTT (stop before
      * transmit, restart after). Only in Bluetooth connect mode; there,
      * non-CAT control always needs it, and CAT control needs it unless the
@@ -39,5 +56,20 @@ public final class ScoPolicy {
      */
     public static boolean shouldEnterHeadsetMode(int connectMode, boolean btAudioProfileConnected) {
         return connectMode == ConnectMode.BLUE_TOOTH && btAudioProfileConnected;
+    }
+
+    /**
+     * Headset-mode decision that also accounts for the selected audio devices (issue #723):
+     * enter SCO when a Bluetooth rig is in use <em>or</em> the operator picked a Bluetooth-SCO
+     * mic/speaker — but only while a Bluetooth audio profile is actually connected, so a
+     * stale device id can't force SCO on with nothing paired.
+     */
+    public static boolean shouldEnterHeadsetMode(int connectMode, boolean btAudioProfileConnected,
+                                                 int inputDeviceType, int outputDeviceType) {
+        if (!btAudioProfileConnected) {
+            return false;
+        }
+        return connectMode == ConnectMode.BLUE_TOOTH
+                || audioSelectionNeedsHeadsetMode(inputDeviceType, outputDeviceType);
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
@@ -72,4 +72,40 @@ public final class ScoPolicy {
         return connectMode == ConnectMode.BLUE_TOOTH
                 || audioSelectionNeedsHeadsetMode(inputDeviceType, outputDeviceType);
     }
+
+    /** {@link #headsetModeAction}: nothing to do. */
+    public static final int HEADSET_MODE_KEEP = 0;
+    /** {@link #headsetModeAction}: bring SCO up and rebuild capture. */
+    public static final int HEADSET_MODE_ENTER = 1;
+    /** {@link #headsetModeAction}: take SCO down and rebuild capture. */
+    public static final int HEADSET_MODE_LEAVE = 2;
+    /** {@link #headsetModeAction}: SCO is already gone — just forget that we entered it. */
+    public static final int HEADSET_MODE_FORGET = 3;
+
+    /**
+     * What {@code refreshBluetoothHeadsetMode()} should do, given whether headset mode is
+     * wanted ({@link #shouldEnterHeadsetMode}), whether we believe we entered it
+     * ({@code enteredByUs}, the cached flag), and whether SCO is <em>actually</em> on right
+     * now ({@code AudioManager.isBluetoothScoOn()}).
+     *
+     * <p>The cached flag alone isn't trustworthy: SCO drops on its own when the headset
+     * disconnects, and {@code setBlueToothOn()} can fail, so a stale {@code true} would make
+     * every later refresh skip re-entering and leave the selected BT mic/speaker dead until
+     * restart (Copilot review on #723). Cross-checking the real SCO state fixes that while
+     * still avoiding the disruptive stop+start on every settings tap when SCO is really up.
+     *
+     * <p>A Bluetooth <em>rig</em> owns SCO for its TX/RX path, so headset mode is never left
+     * from here while one is connected — but a headset that dropped and came back still
+     * re-enters, because {@code want && !scoOn} always yields {@link #HEADSET_MODE_ENTER}.
+     */
+    public static int headsetModeAction(boolean want, boolean enteredByUs, boolean scoOn,
+                                        boolean bluetoothRig) {
+        if (want) {
+            return (enteredByUs && scoOn) ? HEADSET_MODE_KEEP : HEADSET_MODE_ENTER;
+        }
+        if (!enteredByUs || bluetoothRig) {
+            return HEADSET_MODE_KEEP;
+        }
+        return scoOn ? HEADSET_MODE_LEAVE : HEADSET_MODE_FORGET;
+    }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/AudioDeviceSpinnerAdapter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/AudioDeviceSpinnerAdapter.java
@@ -184,6 +184,20 @@ public class AudioDeviceSpinnerAdapter extends BaseAdapter {
         return view;
     }
 
+    /**
+     * {@link AudioDeviceInfo} type at a spinner position, or -1 for the "Default" row and USB
+     * entries (which don't correspond to a routed {@code AudioDeviceInfo}). Used to detect
+     * when the user picked a Bluetooth-SCO headset so SCO can be brought up (issue #723).
+     */
+    public int getDeviceType(int position) {
+        if (position <= 0) return -1;
+        int adPos = position - 1;
+        if (adPos < audioDeviceList.size()) {
+            return audioDeviceList.get(adPos).getType();
+        }
+        return -1;
+    }
+
     public String getDeviceDisplayName(int position) {
         if (position == 0) {
             return mContext.getString(R.string.audio_device_default);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ui/AudioDeviceSpinnerAdapter.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ui/AudioDeviceSpinnerAdapter.java
@@ -185,9 +185,12 @@ public class AudioDeviceSpinnerAdapter extends BaseAdapter {
     }
 
     /**
-     * {@link AudioDeviceInfo} type at a spinner position, or -1 for the "Default" row and USB
-     * entries (which don't correspond to a routed {@code AudioDeviceInfo}). Used to detect
-     * when the user picked a Bluetooth-SCO headset so SCO can be brought up (issue #723).
+     * {@link AudioDeviceInfo} type at a spinner position, or -1 for the "Default" row and the
+     * USB-direct entries appended after {@code audioDeviceList} (those are driven over libusb
+     * and have no routed {@code AudioDeviceInfo}). Android-routed USB devices such as
+     * {@link AudioDeviceInfo#TYPE_USB_DEVICE} are ordinary {@code audioDeviceList} rows and
+     * return their real type. Used to detect when the user picked a Bluetooth-SCO headset so
+     * SCO can be brought up (issue #723).
      */
     public int getDeviceType(int position) {
         if (position <= 0) return -1;

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ComposeMainActivity.kt
@@ -42,7 +42,6 @@ import radio.ks3ckc.ft8af.util.bluetoothAdapter
 import com.k1af.ft8af.service.RxForegroundService
 import com.k1af.ft8af.service.RxServiceController
 import com.k1af.ft8af.bluetooth.BluetoothStateBroadcastReceive
-import com.k1af.ft8af.bluetooth.ScoPolicy
 import com.k1af.ft8af.connector.CableSerialPort
 import com.k1af.ft8af.connector.ConnectMode
 import com.k1af.ft8af.callsign.CallsignDatabase
@@ -448,11 +447,10 @@ class ComposeMainActivity : AppCompatActivity() {
                 // review); gating on connect mode at all keeps a car/headphones paired
                 // for music from being yanked out of A2DP (the original bug).
                 Handler(Looper.getMainLooper()).post {
-                    if (ScoPolicy.shouldEnterHeadsetMode(
-                            GeneralVariables.connectMode, mainViewModel.isBTConnected())
-                    ) {
-                        mainViewModel.setBlueToothOn()
-                    }
+                    // Enter Bluetooth headset (SCO) mode if a Bluetooth rig is in use OR the
+                    // persisted audio device is a Bluetooth-SCO headset (issue #723). The
+                    // decision + AudioRecord rebuild live in the view model.
+                    mainViewModel.refreshBluetoothHeadsetMode()
                 }
 
                 // USB auto-connect is driven by the mutableSerialPorts observer; Bluetooth has

--- a/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
+++ b/ft8af/app/src/main/kotlin/radio/ks3ckc/ft8af/ui/settings/RadioAudioSettings.kt
@@ -504,6 +504,9 @@ fun RadioAudioSettings(
                     mainViewModel.databaseOpr.writeConfig("usbAudioInputPid", "0", null)
                 }
                 audioInputName = audioInputAdapter.getDeviceDisplayName(position)
+                // Selecting a Bluetooth-SCO mic must actually bring SCO up (issue #723);
+                // deselecting it releases SCO unless a Bluetooth rig still needs it.
+                mainViewModel.refreshBluetoothHeadsetMode()
             },
         )
     }
@@ -539,6 +542,8 @@ fun RadioAudioSettings(
                     mainViewModel.databaseOpr.writeConfig("usbAudioOutputPid", "0", null)
                 }
                 audioOutputName = audioOutputAdapter.getDeviceDisplayName(position)
+                // Same for the speaker side: route playback over the BT headset (issue #723).
+                mainViewModel.refreshBluetoothHeadsetMode()
             },
         )
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyAudioDeviceTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyAudioDeviceTest.java
@@ -1,0 +1,80 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.connector.ConnectMode;
+
+import org.junit.Test;
+
+/**
+ * Tests for the audio-device-aware headset-mode decision added for issue #723: SCO must come
+ * up when the operator picks a Bluetooth headset as the FT8 mic/speaker, even on a USB/VOX rig.
+ * Pure JUnit — TYPE_BLUETOOTH_SCO is a compile-time constant.
+ */
+public class ScoPolicyAudioDeviceTest {
+
+    // AudioDeviceInfo type constants (framework values) used by these tests.
+    private static final int TYPE_BLUETOOTH_SCO = 7;
+    private static final int TYPE_BUILTIN_MIC = 15;
+    private static final int TYPE_USB_DEVICE = 11;
+    private static final int NONE = -1;
+
+    @Test
+    public void constantMatchesFrameworkValue() {
+        assertThat(ScoPolicy.TYPE_BLUETOOTH_SCO)
+                .isEqualTo(android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+    }
+
+    @Test
+    public void audioSelectionNeedsHeadsetMode_btScoInput() {
+        assertThat(ScoPolicy.audioSelectionNeedsHeadsetMode(TYPE_BLUETOOTH_SCO, NONE)).isTrue();
+    }
+
+    @Test
+    public void audioSelectionNeedsHeadsetMode_btScoOutput() {
+        assertThat(ScoPolicy.audioSelectionNeedsHeadsetMode(TYPE_BUILTIN_MIC, TYPE_BLUETOOTH_SCO))
+                .isTrue();
+    }
+
+    @Test
+    public void audioSelectionNeedsHeadsetMode_noBtDevice() {
+        assertThat(ScoPolicy.audioSelectionNeedsHeadsetMode(TYPE_BUILTIN_MIC, TYPE_USB_DEVICE))
+                .isFalse();
+        assertThat(ScoPolicy.audioSelectionNeedsHeadsetMode(NONE, NONE)).isFalse();
+    }
+
+    @Test
+    public void shouldEnterHeadsetMode_usbRigWithBtHeadsetMic_entersWhenBtConnected() {
+        // The #723 scenario: USB rig, BT headset picked as mic, headset actually paired.
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(
+                ConnectMode.USB_CABLE, true, TYPE_BLUETOOTH_SCO, NONE)).isTrue();
+    }
+
+    @Test
+    public void shouldEnterHeadsetMode_btHeadsetSelectedButNothingConnected_isFalse() {
+        // A stale saved BT-SCO device id must not force SCO with no headset paired.
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(
+                ConnectMode.USB_CABLE, false, TYPE_BLUETOOTH_SCO, NONE)).isFalse();
+    }
+
+    @Test
+    public void shouldEnterHeadsetMode_bluetoothRig_stillEntersRegardlessOfAudioDevice() {
+        // Existing behaviour preserved: a Bluetooth rig enters headset mode even with the
+        // default (non-BT) audio device selected.
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(
+                ConnectMode.BLUE_TOOTH, true, NONE, NONE)).isTrue();
+    }
+
+    @Test
+    public void shouldEnterHeadsetMode_usbRigDefaultAudio_isFalse() {
+        // The car-stereo protection: USB rig + no BT audio device selected => no SCO.
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(
+                ConnectMode.USB_CABLE, true, TYPE_BUILTIN_MIC, TYPE_BUILTIN_MIC)).isFalse();
+    }
+
+    @Test
+    public void twoArgOverload_unchanged() {
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(ConnectMode.BLUE_TOOTH, true)).isTrue();
+        assertThat(ScoPolicy.shouldEnterHeadsetMode(ConnectMode.USB_CABLE, true)).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyAudioDeviceTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyAudioDeviceTest.java
@@ -20,9 +20,63 @@ public class ScoPolicyAudioDeviceTest {
     private static final int NONE = -1;
 
     @Test
-    public void constantMatchesFrameworkValue() {
-        assertThat(ScoPolicy.TYPE_BLUETOOTH_SCO)
-                .isEqualTo(android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+    public void constantMatchesFrameworkValue() throws Exception {
+        // Read the framework constant reflectively: referencing it directly lets javac inline
+        // the compile-time value, which would turn this into "7 == 7" and never catch drift.
+        int framework = android.media.AudioDeviceInfo.class
+                .getField("TYPE_BLUETOOTH_SCO").getInt(null);
+        assertThat(ScoPolicy.TYPE_BLUETOOTH_SCO).isEqualTo(framework);
+    }
+
+    // ---- headsetModeAction: cached flag cross-checked with real SCO state --------------
+
+    @Test
+    public void headsetModeAction_wantedAndReallyOn_keeps() {
+        assertThat(ScoPolicy.headsetModeAction(true, true, true, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
+    }
+
+    @Test
+    public void headsetModeAction_wantedButNeverEntered_enters() {
+        assertThat(ScoPolicy.headsetModeAction(true, false, false, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_ENTER);
+    }
+
+    @Test
+    public void headsetModeAction_wantedButScoDroppedBehindOurBack_reEnters() {
+        // Headset disconnected and came back (or setBlueToothOn() failed): the cached flag
+        // says active but SCO is really off — must not skip re-entering.
+        assertThat(ScoPolicy.headsetModeAction(true, true, false, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_ENTER);
+        assertThat(ScoPolicy.headsetModeAction(true, true, false, true))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_ENTER);
+    }
+
+    @Test
+    public void headsetModeAction_notWantedAndNotOurs_keeps() {
+        // SCO turned on by someone else (Bluetooth rig path, broadcast receiver): leave it.
+        assertThat(ScoPolicy.headsetModeAction(false, false, true, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
+    }
+
+    @Test
+    public void headsetModeAction_deselectedOnUsbRig_leaves() {
+        assertThat(ScoPolicy.headsetModeAction(false, true, true, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_LEAVE);
+    }
+
+    @Test
+    public void headsetModeAction_deselectedButScoAlreadyGone_forgets() {
+        assertThat(ScoPolicy.headsetModeAction(false, true, false, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_FORGET);
+    }
+
+    @Test
+    public void headsetModeAction_neverYanksScoFromBluetoothRig() {
+        assertThat(ScoPolicy.headsetModeAction(false, true, true, true))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
+        assertThat(ScoPolicy.headsetModeAction(false, true, false, true))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
     }
 
     @Test


### PR DESCRIPTION
Fixes #723.

## What was wrong
FT8AF only started Android's Bluetooth SCO (headset) link when the **rig connection mode** was Bluetooth. A user on a USB or VOX rig who selected a Bluetooth headset as the FT8 mic/speaker got no SCO, so the app captured the built-in mic and the headset never worked. The known workaround was to launch FT8CN first purely to turn SCO on, then start FT8AF.

SCO does need to stay gated — opening it knocks a paired car/headphones out of A2DP music (the original "car stereo pause loop" bug) — but *picking a BT headset as the FT8 audio device* is explicit consent to route over it, which is the signal the old gate was missing.

## The fix
- **`ScoPolicy`**: `audioSelectionNeedsHeadsetMode()` + a 4-arg `shouldEnterHeadsetMode()` that enters SCO when a BT rig is in use **or** a BT-SCO input/output device is selected, but only while a BT audio profile is actually connected (a stale saved device id can't force SCO with nothing paired).
- **`AudioDeviceSpinnerAdapter.getDeviceType(position)`** exposes the `AudioDeviceInfo` type so the picker can detect a BT-SCO choice.
- **`MainViewModel.refreshBluetoothHeadsetMode()`**: brings SCO up/down to match the rig + selected devices and rebuilds the `AudioRecord` so capture binds to the SCO route; guarded so it only toggles on a real change and never yanks SCO from a Bluetooth rig.
- Called at launch (replacing the rig-only gate) and from both audio-device pickers.

## Relationship to PR #772 (issue #759)
#772 reworks *how* SCO is brought up/retried (ScoLinkTracker, retries, AudioRecord rebuild on `SCO_AUDIO_STATE_CONNECTED`). This PR changes *when* SCO is entered. They're complementary; there's a small overlap in `MainViewModel`'s SCO area that whoever merges second resolves.

## Tests
- `ScoPolicyAudioDeviceTest` — device-type detection, all gate combinations, the framework-constant check, and the car-stereo protection (USB rig + default audio ⇒ no SCO).

Unit tests pass; debug APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)