### PR TITLE
Detach kernel USB-audio driver so Android sounds can't kill a USB-direct TX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,3 +202,22 @@ duration (12.14 s real time for 12.64 s of audio). Fixed in PR #94 in
 unaffected because the kernel UAC driver does this math automatically;
 the bug only bites the direct-libusb path used for car-dash kernels and
 similar.
+
+**4. The USB-direct path must force-claim the UAC AudioControl interface,
+not just the streaming ones.** Claiming only the AudioStreaming interfaces
+is a silent no-op for the kernel's `snd-usb-audio` driver (it binds the card
+at the AudioControl interface and treats the streaming interfaces as
+owned-but-unused), so the ALSA card survives and Android keeps the rig's
+sound card registered as a `usb_headset` sink+source. Every sound Android
+then routes there — the app's own QSO-complete alert ding, a Bluetooth
+car-kit connecting, a nav prompt — makes the kernel driver flip the playback
+interface's alt-setting under our in-flight iso URBs, which the kernel
+completes with `-ESHUTDOWN`. Tell from log: `libusb native write FAILED
+(rc=5 TRANSFER_NO_DEVICE) after ~280ms` with **no** `usbDetach` and the RX
+capture still running, typically 1.9 s after an `ALERT fire` line. The
+device is still on the bus; only the endpoint was torn down. Fixed by
+`UsbAudioDevice.detachKernelAudioDriver()`, which claims the AudioControl
+interface (that runs the real `usb_audio_disconnect`). A genuine bus drop
+looks different: `usbDetach` for the hub, serial and audio devices together
+and `serial.send: port not open!` — that one is electrical (RF resetting the
+hub), not software.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -76,6 +76,12 @@ public class UsbAudioDevice {
     private int outputSampleRate = 48000;
     private int outputChannels = 2;
 
+    // UAC AudioControl interface (bInterfaceClass 1 / bInterfaceSubclass 1). Force-claiming
+    // it is what actually detaches the kernel's snd-usb-audio driver from the device —
+    // see detachKernelAudioDriver().
+    private UsbInterface controlInterface;
+    private boolean controlInterfaceClaimed;
+
     // Singleton active device for use by MicRecorder / FT8TransmitSignal
     private static UsbAudioDevice activeInputDevice;
     private static UsbAudioDevice activeOutputDevice;
@@ -185,7 +191,93 @@ public class UsbAudioDevice {
         }
 
         findEndpoints();
+        detachKernelAudioDriver();
         return endpointIn != null || endpointOut != null;
+    }
+
+    /**
+     * Detaches the kernel's USB-audio class driver from this device by force-claiming its
+     * AudioControl interface, so Android stops treating the rig's sound card as a headset
+     * while we drive it over libusb.
+     *
+     * <p>Why (2026-08-25 bench log): claiming only the streaming interfaces, as before, is a
+     * silent no-op for {@code snd-usb-audio} — it binds the card to the AudioControl
+     * interface and marks the streaming interfaces owned-but-unused, so the ALSA card
+     * survived our claim and Android kept the device registered as a {@code usb_headset}
+     * sink and source. Every sound Android routed there (our own DX-alert notification ding,
+     * a BT car-kit connect re-route, a nav prompt) made the kernel driver flip the playback
+     * interface's alt-setting under our in-flight iso URBs, which the kernel completes with
+     * {@code -ESHUTDOWN}: {@code nativeWrite} returned {@code rc=5 TRANSFER_NO_DEVICE}
+     * ~280 ms into the TX with the device still on the bus, and the cycle went out as dead
+     * air. 20 of 22 such failures in that log were preceded by a QSO-complete alert 1.9 s
+     * earlier. Disconnecting the driver at the AudioControl interface runs the real
+     * {@code usb_audio_disconnect}, which retires the ALSA card; nothing Android plays can
+     * reach the endpoint any more.
+     *
+     * <p>Side effect, by design: while the app holds the device, phone audio that Android
+     * would have routed into the rig's mic input is dropped instead (it was inaudible to the
+     * operator either way, and could have been keyed on air). The kernel does not rebind the
+     * driver on release; the card comes back on the next unplug/replug.
+     *
+     * <p>Not fatal: a device with no AudioControl interface, or a refused claim, is logged
+     * and the caller proceeds exactly as before.
+     */
+    private void detachKernelAudioDriver() {
+        if (connection == null || usbDevice == null) return;
+        // The per-cycle TX open runs while the session-long RX capture already holds the
+        // AudioControl interface on the same device: the driver is already gone, and a
+        // second force-claim would only steal the claim from the RX connection each cycle.
+        UsbAudioDevice holder = activeInputDevice;
+        if (holder != null && holder != this && holder.controlInterfaceClaimed
+                && usbDevice.equals(holder.usbDevice)) {
+            com.k1af.ft8af.GeneralVariables.fileLog(
+                    "UsbAudioDevice: kernel audio driver already detached by the RX session");
+            return;
+        }
+        int n = usbDevice.getInterfaceCount();
+        int[] classes = new int[n];
+        int[] subclasses = new int[n];
+        for (int i = 0; i < n; i++) {
+            UsbInterface iface = usbDevice.getInterface(i);
+            classes[i] = iface.getInterfaceClass();
+            subclasses[i] = iface.getInterfaceSubclass();
+        }
+        int idx = audioControlInterfaceIndex(classes, subclasses);
+        if (idx < 0) {
+            com.k1af.ft8af.GeneralVariables.fileLog(
+                    "UsbAudioDevice: no AudioControl interface — kernel audio driver left "
+                            + "attached (Android may still route sounds into this device)");
+            return;
+        }
+        controlInterface = usbDevice.getInterface(idx);
+        boolean ok;
+        try {
+            ok = connection.claimInterface(controlInterface, /*force=*/ true);
+        } catch (Exception e) {
+            ok = false;
+        }
+        controlInterfaceClaimed = ok;
+        com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                "UsbAudioDevice: kernel audio driver detach via AudioControl iface %d: %s",
+                controlInterface.getId(), ok ? "OK" : "claimInterface FAILED"));
+    }
+
+    /**
+     * Index of the first UAC AudioControl interface (class {@value #USB_CLASS_AUDIO},
+     * subclass {@value #USB_SUBCLASS_AUDIOCONTROL}) among a device's interfaces, given
+     * their {@code bInterfaceClass} / {@code bInterfaceSubclass} values in interface order;
+     * {@code -1} when there is none. Extra entries in the longer array are ignored.
+     *
+     * <p>Package-visible for tests.
+     */
+    static int audioControlInterfaceIndex(int[] classes, int[] subclasses) {
+        int n = Math.min(classes.length, subclasses.length);
+        for (int i = 0; i < n; i++) {
+            if (classes[i] == USB_CLASS_AUDIO && subclasses[i] == USB_SUBCLASS_AUDIOCONTROL) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private void findEndpoints() {
@@ -1037,6 +1129,12 @@ public class UsbAudioDevice {
                     connection.releaseInterface(streamingInterfaceOut);
                 }
             } catch (Exception ignored) {}
+            try {
+                if (controlInterfaceClaimed && controlInterface != null) {
+                    connection.releaseInterface(controlInterface);
+                }
+            } catch (Exception ignored) {}
+            controlInterfaceClaimed = false;
             connection.close();
             connection = null;
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/UsbAudioDevice.java
@@ -191,8 +191,16 @@ public class UsbAudioDevice {
         }
 
         findEndpoints();
+        if (endpointIn == null && endpointOut == null) {
+            // Nothing we can stream on. Callers treat a false return as "nothing to
+            // close", so release the connection here rather than leaking it — and
+            // don't take Android's audio away from a device we can't use anyway.
+            connection.close();
+            connection = null;
+            return false;
+        }
         detachKernelAudioDriver();
-        return endpointIn != null || endpointOut != null;
+        return true;
     }
 
     /**
@@ -228,38 +236,96 @@ public class UsbAudioDevice {
         // AudioControl interface on the same device: the driver is already gone, and a
         // second force-claim would only steal the claim from the RX connection each cycle.
         UsbAudioDevice holder = activeInputDevice;
-        if (holder != null && holder != this && holder.controlInterfaceClaimed
-                && usbDevice.equals(holder.usbDevice)) {
-            com.k1af.ft8af.GeneralVariables.fileLog(
-                    "UsbAudioDevice: kernel audio driver already detached by the RX session");
-            return;
+        boolean holderAlreadyDetached = holder != null && holder != this
+                && holder.controlInterfaceClaimed && usbDevice.equals(holder.usbDevice);
+
+        final UsbDevice dev = usbDevice;
+        final UsbDeviceConnection conn = connection;
+        KernelDetachResult result = detachKernelAudioDriver(new KernelDetachPort() {
+            @Override public int interfaceCount() { return dev.getInterfaceCount(); }
+            @Override public int interfaceClass(int i) {
+                return dev.getInterface(i).getInterfaceClass();
+            }
+            @Override public int interfaceSubclass(int i) {
+                return dev.getInterface(i).getInterfaceSubclass();
+            }
+            @Override public boolean forceClaim(int i) {
+                UsbInterface iface = dev.getInterface(i);
+                controlInterface = iface;
+                try {
+                    return conn.claimInterface(iface, /*force=*/ true);
+                } catch (Exception e) {
+                    return false;
+                }
+            }
+        }, holderAlreadyDetached);
+
+        controlInterfaceClaimed = result == KernelDetachResult.CLAIMED;
+        switch (result) {
+            case SKIPPED_HOLDER:
+                com.k1af.ft8af.GeneralVariables.fileLog(
+                        "UsbAudioDevice: kernel audio driver already detached by the RX session");
+                break;
+            case NO_CONTROL_INTERFACE:
+                com.k1af.ft8af.GeneralVariables.fileLog(
+                        "UsbAudioDevice: no AudioControl interface — kernel audio driver left "
+                                + "attached (Android may still route sounds into this device)");
+                break;
+            default:
+                com.k1af.ft8af.GeneralVariables.fileLog(String.format(
+                        "UsbAudioDevice: kernel audio driver detach via AudioControl iface %d: %s",
+                        controlInterface != null ? controlInterface.getId() : -1,
+                        result == KernelDetachResult.CLAIMED ? "OK" : "claimInterface FAILED"));
+                break;
         }
-        int n = usbDevice.getInterfaceCount();
+    }
+
+    /**
+     * The slice of {@link UsbDevice}/{@link UsbDeviceConnection} that
+     * {@link #detachKernelAudioDriver(KernelDetachPort, boolean)} needs, so the
+     * claim decision and its effect can be unit-tested without Android USB objects.
+     * Package-visible for tests.
+     */
+    interface KernelDetachPort {
+        int interfaceCount();
+        int interfaceClass(int index);
+        int interfaceSubclass(int index);
+        /** Force-claims interface {@code index}; returns the claim result. */
+        boolean forceClaim(int index);
+    }
+
+    /** Outcome of {@link #detachKernelAudioDriver(KernelDetachPort, boolean)}. */
+    enum KernelDetachResult {
+        /** Another open connection on the same device already holds the claim. */
+        SKIPPED_HOLDER,
+        /** The device exposes no UAC AudioControl interface; nothing was claimed. */
+        NO_CONTROL_INTERFACE,
+        /** The AudioControl interface was force-claimed; the kernel driver is gone. */
+        CLAIMED,
+        /** The claim was refused; the kernel driver may still be attached. */
+        CLAIM_FAILED
+    }
+
+    /**
+     * Decides whether to force-claim the AudioControl interface and does so through
+     * {@code port}. Exactly one {@link KernelDetachPort#forceClaim} call is made, on the
+     * first AudioControl interface, unless {@code holderAlreadyDetached} is set or the
+     * device has none. Package-visible for tests.
+     */
+    static KernelDetachResult detachKernelAudioDriver(KernelDetachPort port,
+                                                      boolean holderAlreadyDetached) {
+        if (holderAlreadyDetached) return KernelDetachResult.SKIPPED_HOLDER;
+        int n = port.interfaceCount();
         int[] classes = new int[n];
         int[] subclasses = new int[n];
         for (int i = 0; i < n; i++) {
-            UsbInterface iface = usbDevice.getInterface(i);
-            classes[i] = iface.getInterfaceClass();
-            subclasses[i] = iface.getInterfaceSubclass();
+            classes[i] = port.interfaceClass(i);
+            subclasses[i] = port.interfaceSubclass(i);
         }
         int idx = audioControlInterfaceIndex(classes, subclasses);
-        if (idx < 0) {
-            com.k1af.ft8af.GeneralVariables.fileLog(
-                    "UsbAudioDevice: no AudioControl interface — kernel audio driver left "
-                            + "attached (Android may still route sounds into this device)");
-            return;
-        }
-        controlInterface = usbDevice.getInterface(idx);
-        boolean ok;
-        try {
-            ok = connection.claimInterface(controlInterface, /*force=*/ true);
-        } catch (Exception e) {
-            ok = false;
-        }
-        controlInterfaceClaimed = ok;
-        com.k1af.ft8af.GeneralVariables.fileLog(String.format(
-                "UsbAudioDevice: kernel audio driver detach via AudioControl iface %d: %s",
-                controlInterface.getId(), ok ? "OK" : "claimInterface FAILED"));
+        if (idx < 0) return KernelDetachResult.NO_CONTROL_INTERFACE;
+        return port.forceClaim(idx)
+                ? KernelDetachResult.CLAIMED : KernelDetachResult.CLAIM_FAILED;
     }
 
     /**
@@ -1198,9 +1264,14 @@ public class UsbAudioDevice {
      * {@code libusb_transfer_status} (positive, stored by
      * {@code onOutputComplete} in {@code usb_audio_capture.cpp}). The positive
      * statuses were previously logged as {@code UNKNOWN}, which hid the actual
-     * field failure mode: {@code rc=5 TRANSFER_NO_DEVICE}, the device falling
-     * off the bus mid-transmission (typically RF into the USB link at TX
-     * power). Naming the code makes a dropped TX cycle diagnosable.
+     * field failure mode: {@code rc=5 TRANSFER_NO_DEVICE}. Despite the name,
+     * that status is the kernel tearing down our endpoint ({@code -ESHUTDOWN})
+     * while the device is usually still on the bus — historically Android
+     * playing a sound through the same card while its class driver was still
+     * attached (see {@link #detachKernelAudioDriver()}); a genuine bus removal
+     * mid-transfer shows up as {@code rc=-4 NO_DEVICE} together with a
+     * {@code usbDetach} in the log. Naming the code makes a dropped TX cycle
+     * diagnosable.
      *
      * <p>Package-visible for testing.
      */
@@ -1245,9 +1316,13 @@ public class UsbAudioDevice {
      * {@link #MAX_FALLBACK_ELAPSED_MS}), part of the FT8 message has already
      * been transmitted; restarting from the beginning mid-slot would key an
      * off-grid, overlapping signal that no receiver can decode — worse than
-     * dropping the cycle. Device-gone ({@code NO_DEVICE}/{@code
-     * TRANSFER_NO_DEVICE}) and cancelled ({@code TRANSFER_CANCELLED}, the user
-     * pressed STOP) failures never retry either, regardless of timing.
+     * dropping the cycle. Endpoint-torn-down failures never retry either,
+     * regardless of timing: {@code rc=-4 NO_DEVICE} means the device really
+     * left the bus, and {@code rc=5 TRANSFER_NO_DEVICE} means the kernel
+     * flushed our endpoint ({@code -ESHUTDOWN}) — usually with the device still
+     * attached, see {@link #detachKernelAudioDriver()} — and in both cases the
+     * audio already streamed can't be un-sent. Cancelled ({@code
+     * TRANSFER_CANCELLED}, the user pressed STOP) never retries.
      *
      * <p>Package-visible for testing.
      *
@@ -1256,7 +1331,7 @@ public class UsbAudioDevice {
      */
     static boolean shouldFallbackToUsbRequest(int rc, long elapsedMs) {
         if (rc == 0) return false;// success — nothing to fall back from
-        if (rc == -4 || rc == 5) return false;// device left the bus
+        if (rc == -4 || rc == 5) return false;// device gone (-4) or endpoint torn down (5)
         if (rc == 3) return false;// cancelled: the user stopped the TX
         return elapsedMs <= MAX_FALLBACK_ELAPSED_MS;
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioControlInterfaceTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioControlInterfaceTest.java
@@ -1,0 +1,86 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link UsbAudioDevice#audioControlInterfaceIndex(int[], int[])} — which interface
+ * {@code detachKernelAudioDriver()} force-claims to get the kernel's {@code snd-usb-audio}
+ * driver off a rig's sound card.
+ *
+ * <p>Background (2026-08-25 bench log): the app used to claim only the UAC AudioStreaming
+ * interfaces. For {@code snd-usb-audio} that is a silent no-op — the card is bound to the
+ * AudioControl interface — so Android kept the CM108 registered as a {@code usb_headset}
+ * and every sound it routed there (the app's own QSO-complete alert ding, a BT car-kit
+ * re-route, a nav prompt) flipped the playback alt-setting under our iso URBs; the TX died
+ * ~280 ms in with {@code rc=5 TRANSFER_NO_DEVICE} while the device stayed on the bus. The
+ * driver only really disconnects (and the ALSA card with it) when the AudioControl
+ * interface is claimed, so picking that interface correctly is the whole fix.
+ */
+public class UsbAudioControlInterfaceTest {
+
+    private static final int AUDIO = UsbAudioDevice.USB_CLASS_AUDIO;
+    private static final int CONTROL = UsbAudioDevice.USB_SUBCLASS_AUDIOCONTROL;
+    private static final int STREAMING = UsbAudioDevice.USB_SUBCLASS_AUDIOSTREAMING;
+    private static final int HID = 0x03;
+
+    /** CM108/CM108B (Digirig, many rig interfaces): AC, AS out, AS in, HID. */
+    @Test
+    public void cm108Layout_controlIsInterfaceZero() {
+        int[] classes = {AUDIO, AUDIO, AUDIO, HID};
+        int[] subclasses = {CONTROL, STREAMING, STREAMING, 0};
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(classes, subclasses)).isEqualTo(0);
+    }
+
+    /** Composite CAT+audio dongles put a CDC/vendor interface first; the AC index moves. */
+    @Test
+    public void compositeDevice_controlNotFirst() {
+        int[] classes = {0x02, 0x0A, AUDIO, AUDIO, AUDIO};
+        int[] subclasses = {0x02, 0x00, CONTROL, STREAMING, STREAMING};
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(classes, subclasses)).isEqualTo(2);
+    }
+
+    /** Only the first AC interface is returned when a device exposes two audio functions. */
+    @Test
+    public void twoAudioFunctions_firstControlWins() {
+        int[] classes = {AUDIO, AUDIO, AUDIO, AUDIO};
+        int[] subclasses = {CONTROL, STREAMING, CONTROL, STREAMING};
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(classes, subclasses)).isEqualTo(0);
+    }
+
+    /** A streaming-only descriptor set (no AC interface) must not be mistaken for control. */
+    @Test
+    public void streamingOnly_returnsMinusOne() {
+        int[] classes = {AUDIO, AUDIO};
+        int[] subclasses = {STREAMING, STREAMING};
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(classes, subclasses)).isEqualTo(-1);
+    }
+
+    /** Subclass 1 on a non-audio class (e.g. HID boot subclass) is not an AC interface. */
+    @Test
+    public void controlSubclassOnOtherClass_ignored() {
+        int[] classes = {HID, 0xFF};
+        int[] subclasses = {CONTROL, CONTROL};
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(classes, subclasses)).isEqualTo(-1);
+    }
+
+    @Test
+    public void noInterfaces_returnsMinusOne() {
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(new int[0], new int[0]))
+                .isEqualTo(-1);
+    }
+
+    /** Mismatched lengths only scan the common prefix rather than throwing. */
+    @Test
+    public void mismatchedLengths_scansCommonPrefix() {
+        int[] classes = {HID, AUDIO, AUDIO};
+        int[] subclasses = {0, CONTROL};
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(classes, subclasses)).isEqualTo(1);
+
+        int[] shortClasses = {HID};
+        int[] longSubclasses = {0, CONTROL, CONTROL};
+        assertThat(UsbAudioDevice.audioControlInterfaceIndex(shortClasses, longSubclasses))
+                .isEqualTo(-1);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioKernelDetachTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioKernelDetachTest.java
@@ -1,0 +1,114 @@
+package com.k1af.ft8af.wave;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.wave.UsbAudioDevice.KernelDetachPort;
+import com.k1af.ft8af.wave.UsbAudioDevice.KernelDetachResult;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests {@link UsbAudioDevice#detachKernelAudioDriver(KernelDetachPort, boolean)} — the
+ * stateful part of the fix for Android sounds killing a USB-direct TX: that the
+ * AudioControl interface actually gets force-claimed, that the claim is skipped when the
+ * RX session on the same device already holds it, and that a refused claim is reported
+ * rather than pretended. {@link UsbAudioControlInterfaceTest} covers only the index
+ * lookup; without this test the {@code forceClaim} call could be deleted and every test
+ * would stay green.
+ */
+public class UsbAudioKernelDetachTest {
+
+    private static final int AUDIO = UsbAudioDevice.USB_CLASS_AUDIO;
+    private static final int CONTROL = UsbAudioDevice.USB_SUBCLASS_AUDIOCONTROL;
+    private static final int STREAMING = UsbAudioDevice.USB_SUBCLASS_AUDIOSTREAMING;
+    private static final int HID = 0x03;
+
+    /** Scripted device: interface (class, subclass) pairs plus a canned claim answer. */
+    private static final class FakePort implements KernelDetachPort {
+        final int[] classes;
+        final int[] subclasses;
+        final boolean claimAnswer;
+        final List<Integer> claimed = new ArrayList<>();
+
+        FakePort(int[] classes, int[] subclasses, boolean claimAnswer) {
+            this.classes = classes;
+            this.subclasses = subclasses;
+            this.claimAnswer = claimAnswer;
+        }
+
+        @Override public int interfaceCount() { return classes.length; }
+        @Override public int interfaceClass(int index) { return classes[index]; }
+        @Override public int interfaceSubclass(int index) { return subclasses[index]; }
+        @Override public boolean forceClaim(int index) {
+            claimed.add(index);
+            return claimAnswer;
+        }
+    }
+
+    private static FakePort cm108(boolean claimAnswer) {
+        return new FakePort(
+                new int[]{AUDIO, AUDIO, AUDIO, HID},
+                new int[]{CONTROL, STREAMING, STREAMING, 0},
+                claimAnswer);
+    }
+
+    @Test
+    public void claimsTheAudioControlInterface_exactlyOnce() {
+        FakePort port = cm108(true);
+        assertThat(UsbAudioDevice.detachKernelAudioDriver(port, false))
+                .isEqualTo(KernelDetachResult.CLAIMED);
+        assertThat(port.claimed).containsExactly(0);
+    }
+
+    /** Composite CAT+audio device: the claim lands on the AC interface, not index 0. */
+    @Test
+    public void claimsControlInterface_whenNotFirst() {
+        FakePort port = new FakePort(
+                new int[]{0x02, 0x0A, AUDIO, AUDIO, AUDIO},
+                new int[]{0x02, 0x00, CONTROL, STREAMING, STREAMING},
+                true);
+        assertThat(UsbAudioDevice.detachKernelAudioDriver(port, false))
+                .isEqualTo(KernelDetachResult.CLAIMED);
+        assertThat(port.claimed).containsExactly(2);
+    }
+
+    /** The per-cycle TX open must not steal the claim the RX session already holds. */
+    @Test
+    public void holderAlreadyDetached_skipsWithoutClaiming() {
+        FakePort port = cm108(true);
+        assertThat(UsbAudioDevice.detachKernelAudioDriver(port, true))
+                .isEqualTo(KernelDetachResult.SKIPPED_HOLDER);
+        assertThat(port.claimed).isEmpty();
+    }
+
+    @Test
+    public void refusedClaim_reportedAsFailure() {
+        FakePort port = cm108(false);
+        assertThat(UsbAudioDevice.detachKernelAudioDriver(port, false))
+                .isEqualTo(KernelDetachResult.CLAIM_FAILED);
+        assertThat(port.claimed).containsExactly(0);
+    }
+
+    /** A streaming-only descriptor set: nothing to claim, and no claim is attempted. */
+    @Test
+    public void noControlInterface_claimsNothing() {
+        FakePort port = new FakePort(
+                new int[]{AUDIO, AUDIO},
+                new int[]{STREAMING, STREAMING},
+                true);
+        assertThat(UsbAudioDevice.detachKernelAudioDriver(port, false))
+                .isEqualTo(KernelDetachResult.NO_CONTROL_INTERFACE);
+        assertThat(port.claimed).isEmpty();
+    }
+
+    @Test
+    public void noInterfacesAtAll_claimsNothing() {
+        FakePort port = new FakePort(new int[0], new int[0], true);
+        assertThat(UsbAudioDevice.detachKernelAudioDriver(port, false))
+                .isEqualTo(KernelDetachResult.NO_CONTROL_INTERFACE);
+        assertThat(port.claimed).isEmpty();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioWriteErrorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/wave/UsbAudioWriteErrorTest.java
@@ -17,8 +17,11 @@ import org.junit.Test;
  * {@code libusb_error} (setup failure), or a positive
  * {@code libusb_transfer_status} when a transfer dies after streaming started —
  * the field failure mode from the 2026-07-03 POTA log was {@code rc=5}
- * TRANSFER_NO_DEVICE (device fell off the bus mid-TX, RF into the USB link),
- * which used to be logged as UNKNOWN.
+ * TRANSFER_NO_DEVICE, which used to be logged as UNKNOWN. That status is the
+ * kernel flushing the endpoint under our URBs: usually Android routing a sound
+ * through the same card while its class driver was still attached (see
+ * {@link UsbAudioControlInterfaceTest}), occasionally the device really falling
+ * off the bus (a hub resetting under RF).
  */
 public class UsbAudioWriteErrorTest {
 


### PR DESCRIPTION
## Problem

USB-direct TX intermittently goes out as dead air: the rig keys, `debug.log` shows
`libusb native write FAILED (rc=5 TRANSFER_NO_DEVICE) after ~280ms`, no `usbDetach`,
and RX capture on the same device keeps running. Reported by users as "TX stops
working until I unplug/replug" (the replug is a coincidence — see below).

## Root cause (2026-08-25 bench log, Pixel 11 Pro XL + CM108 0d8c:0012)

`claimInterface(force)` on the UAC *AudioStreaming* interfaces is a silent no-op for
the kernel's `snd-usb-audio` driver: it binds the card at the *AudioControl* interface
and marks the streaming interfaces owned-but-unused. So the ALSA card survived our
claim and Android kept the rig's sound card registered as a **`usb_headset` sink +
source** (`dumpsys audio` → `setWiredDeviceConnectionState … from UsbAlsaDevice`).

Every sound Android routed there made the kernel driver flip interface 1's
alt-setting under our in-flight iso URBs; the kernel completes those with
`-ESHUTDOWN` → libusb `TRANSFER_NO_DEVICE`. Correlation over the whole log:

| write result | alert ≤6 s before | no alert |
|---|---|---|
| OK | 1 | 302 |
| FAIL (`rc=5`, device still on bus) | **20** (all at dt ≈ 1.9 s) | 2 (BT car-kit connect at 09:08, nav prompt in car) |
| FAIL (`rc=-4`, whole bus dropped) | 0 | 2 (electrical, see below) |

The dominant trigger is the app's **own QSO-complete DX-alert notification ding**
(`ALERT fire … QSO complete` 1.9 s before the TX slot). `rc=-1 IO` at submit is the
same thing when the alt-setting was already flipped back before our submit.

Iso OUT has no device-side handshake, so only host-side actions can fail an OUT URB
while the device stays attached; RX surviving pins it to an interface-1-only action,
i.e. the kernel class driver.

## Fix

`UsbAudioDevice.open()` now calls `detachKernelAudioDriver()`, which force-claims
the AudioControl interface. That runs the real `usb_audio_disconnect`, retiring the
ALSA card, so nothing Android plays can reach the endpoint. The per-cycle TX open
skips the claim when the session-long RX capture already holds it on the same
device. No AudioControl interface / refused claim → logged, behaviour unchanged.

Side effect, by design: phone sounds Android would have routed *into the rig's mic
input* are dropped instead (they were inaudible to the operator anyway and could have
been keyed on air). The kernel doesn't rebind the driver on release; the card
returns on the next replug.

Also: the `UsbAudioWriteErrorTest` Javadoc blamed `rc=5` on RF knocking the device off
the bus — corrected. CLAUDE.md gains TX-pipeline gotcha #4 with the log signatures.

## Not fixed here (electrical)

Two failures today were a real bus drop mid-TX: `usbDetach` for hub + CP2105 + C-Media
together, `serial.send: port not open!`, and `dumpsys batterystats --history` shows
the phone lost hub power (`-plugged`) at the same instant (08:37:02 at 35 % drive on
40 m, 09:00:12). That's the hub resetting under RF — ferrites / powered hub / shorter
cable, not software.

## Tests

- New `UsbAudioControlInterfaceTest` (7 tests) for `audioControlInterfaceIndex()`.
- `testDebugUnitTest --tests com.k1af.ft8af.wave.*`: 19 suites green.

## Hardware verification — TODO before merge

Not yet run on hardware (the bench phone carries the non-debuggable Play build, so a
debug install would wipe its QSO log). To verify: plug in the rig interface, check
`debug.log` for `UsbAudioDevice: kernel audio driver detach via AudioControl iface 0: OK`,
then trigger a QSO-complete alert (or any notification sound) ~2 s before a TX slot
and confirm the next write logs `libusb native write OK`. Also confirm
`dumpsys media.audio_flinger` doesn't misbehave once the ALSA card is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
