### PR TITLE
Address Copilot review on dev → staging promotion (PR #778)

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -2104,13 +2104,15 @@ public class MainViewModel extends ViewModel {
     /**
      * One-time repair for a CI-V address the 2026-05..08 Compose rig picker persisted in
      * decimal (#753). {@link com.k1af.ft8af.database.DatabaseOpr} already un-mangles the
-     * unambiguous cases at load; the two-digit ones ("88" for an IC-706's 0x58) can only be
-     * told apart by comparing with the selected model, which needs the rig list — and only
-     * when the value's provenance is unknown ({@link CivAddressConfig#FORMAT_KEY} absent),
-     * so a deliberate override that a hex-aware writer stored is never touched. Whenever the
-     * marker is missing or the stored text isn't canonical hex, the value is written back
-     * canonically together with the marker, so the repair really is one-time — including
-     * the three-digit decimal case whose decoded address already matched the model.
+     * unambiguous (three-digit) cases at load. The two-digit ones ("88" for an IC-706's
+     * 0x58) are ambiguous: the same text is what a deliberate 0x88 override written by the
+     * legacy hex field looks like, and there is no longer any UI to restore such an override
+     * — so they are never rewritten (Copilot review on #778). Instead, when the value's
+     * provenance is unknown ({@link CivAddressConfig#FORMAT_KEY} absent) and it is the
+     * model's decimal twin, the user is told once to re-select the rig if it uses the
+     * default; the picker then stores hex with the marker. Whenever the marker is missing or
+     * the stored text isn't canonical hex, the value is written back canonically together
+     * with the marker, so the repair (and the hint) really is one-time.
      */
     private void repairCivAddressAgainstModel() {
         if (GeneralVariables.instructionSet != InstructionSet.ICOM
@@ -2131,6 +2133,16 @@ public class MainViewModel extends ViewModel {
                 GeneralVariables.fileLog(String.format(java.util.Locale.US,
                         "CIV: repaired stored address 0x%02X -> 0x%02X (model %s)",
                         before, plan.address, model.modelName));
+            }
+            if (plan.ambiguous) {
+                String hint = String.format(java.util.Locale.US,
+                        getStringFromResource(R.string.civ_address_ambiguous_hint),
+                        plan.address, model.modelName, model.address);
+                GeneralVariables.fileLog(String.format(java.util.Locale.US,
+                        "CIV: stored address 0x%02X is the decimal twin of model %s (0x%02X); "
+                                + "kept as-is, user hinted to re-select the rig",
+                        plan.address, model.modelName, model.address));
+                ToastMessage.show(hint);
             }
             if (plan.writeBack && databaseOpr != null) {
                 String encoded = CivAddressConfig.encode(plan.address);
@@ -2336,12 +2348,18 @@ public class MainViewModel extends ViewModel {
         boolean want = ScoPolicy.shouldEnterHeadsetMode(GeneralVariables.connectMode,
                 isBTConnected(), inputType, outputType);
 
-        // Cross-check the cached flag against the real SCO state: SCO drops by itself when
-        // the headset disconnects (and setBlueToothOn() can fail), so the flag alone would
-        // skip re-entering and leave the selected BT mic/speaker dead until restart.
-        boolean scoOn = audioManager.isBluetoothScoOn();
+        // Cross-check the cached flag against the coordinator's tracked link state: SCO
+        // drops by itself when the headset disconnects (and setBlueToothOn() can fail), so
+        // the flag alone would skip re-entering and leave the selected BT mic/speaker dead
+        // until restart. Not AudioManager.isBluetoothScoOn(): that only mirrors the legacy
+        // force-use flag, which the setSpeakerphoneOn(false) in the SCO sink clears on newer
+        // builds, so it can read false with the link up — and then a "deselect BT headset"
+        // would FORGET instead of LEAVE and the coordinator would keep SCO on (Copilot #778).
+        boolean linkUp = scoLink.isLinkUpOrPending();
+        boolean linkHeld = scoLink.isWanted();
         boolean bluetoothRig = GeneralVariables.connectMode == ConnectMode.BLUE_TOOTH;
-        switch (ScoPolicy.headsetModeAction(want, btHeadsetModeActive, scoOn, bluetoothRig)) {
+        switch (ScoPolicy.headsetModeAction(want, btHeadsetModeActive, linkUp, linkHeld,
+                bluetoothRig)) {
             case ScoPolicy.HEADSET_MODE_ENTER:
                 setBlueToothOn();
                 btHeadsetModeActive = true;
@@ -2357,7 +2375,8 @@ public class MainViewModel extends ViewModel {
                 reinitializeAudioInput();
                 break;
             case ScoPolicy.HEADSET_MODE_FORGET:
-                // SCO already went away on its own; nothing to tear down.
+                // The coordinator no longer holds a request (TX stopSco / shutdown already
+                // took the link down); nothing to tear down.
                 btHeadsetModeActive = false;
                 break;
             default:

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothStateBroadcastReceive.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/BluetoothStateBroadcastReceive.java
@@ -16,6 +16,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.media.AudioManager;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.core.content.ContextCompat;
 
@@ -29,6 +31,11 @@ public class BluetoothStateBroadcastReceive extends BroadcastReceiver {
     private static final String TAG="BluetoothStateBroadcastReceive";
     private Context context;
     private MainViewModel mainViewModel;
+
+    /** How long after a profile change to re-evaluate headset mode for non-Bluetooth rigs. */
+    static final long PROFILE_REFRESH_DELAY_MS = 500;
+    private final Handler refreshHandler = new Handler(Looper.getMainLooper());
+    private final Runnable refreshHeadsetMode = () -> mainViewModel.refreshBluetoothHeadsetMode();
 
     public BluetoothStateBroadcastReceive(Context context, MainViewModel mainViewModel) {
         this.context = context;
@@ -71,17 +78,33 @@ public class BluetoothStateBroadcastReceive extends BroadcastReceiver {
         switch (action) {
             case BluetoothAdapter.ACTION_CONNECTION_STATE_CHANGED:
             case BluetoothAdapter.EXTRA_CONNECTION_STATE:
-            case BluetoothAdapter.EXTRA_STATE:
-                if (shouldHandleBluetoothAudioRouting()) {
-                    if(headset == BluetoothProfile.STATE_CONNECTED ||a2dp==BluetoothProfile.STATE_CONNECTED){
-                    //if(headset == BluetoothProfile.STATE_CONNECTED){
-                    //if(a2dp==BluetoothProfile.STATE_CONNECTED){
+            case BluetoothAdapter.EXTRA_STATE: {
+                boolean profileConnected = headset == BluetoothProfile.STATE_CONNECTED
+                        || a2dp == BluetoothProfile.STATE_CONNECTED;
+                switch (ScoPolicy.profileChangeAction(GeneralVariables.connectMode,
+                        profileConnected)) {
+                    case ScoPolicy.PROFILE_ENTER:
                         mainViewModel.setBlueToothOn();
-                    }else {
+                        break;
+                    case ScoPolicy.PROFILE_LEAVE:
                         mainViewModel.setBlueToothOff();
-                    }
+                        break;
+                    case ScoPolicy.PROFILE_REFRESH:
+                        // USB/VOX rig with a BT headset selected as mic/speaker (#723): a
+                        // headset that comes back after the SCO retry budget ran out must
+                        // re-enter headset mode, and one that goes away must leave it. The
+                        // refresh is selection-aware and idempotent, so a car merely paired
+                        // for music still isn't touched. Deferred a beat: the profile
+                        // broadcast can land before AudioManager lists the SCO endpoint the
+                        // refresh looks the selected device id up against.
+                        refreshHandler.removeCallbacks(refreshHeadsetMode);
+                        refreshHandler.postDelayed(refreshHeadsetMode, PROFILE_REFRESH_DELAY_MS);
+                        break;
+                    default:
+                        break;
                 }
                 break;
+            }
 
             case BluetoothDevice.ACTION_ACL_CONNECTED:
                 if (shouldHandleBluetoothAudioRouting() && device!=null) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinator.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinator.java
@@ -84,6 +84,17 @@ public final class ScoLinkCoordinator {
         return tracker.linkState();
     }
 
+    /**
+     * The link is CONNECTING or CONNECTED as far as the tracker knows — the state the
+     * headset-mode refresh cross-checks instead of {@code AudioManager.isBluetoothScoOn()},
+     * which only mirrors the legacy force-use flag (Copilot review on #778).
+     */
+    public boolean isLinkUpOrPending() {
+        int s = tracker.linkState();
+        return s == AudioManager.SCO_AUDIO_STATE_CONNECTING
+                || s == AudioManager.SCO_AUDIO_STATE_CONNECTED;
+    }
+
     public int attempts() {
         return tracker.attempts();
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoPolicy.java
@@ -85,27 +85,68 @@ public final class ScoPolicy {
     /**
      * What {@code refreshBluetoothHeadsetMode()} should do, given whether headset mode is
      * wanted ({@link #shouldEnterHeadsetMode}), whether we believe we entered it
-     * ({@code enteredByUs}, the cached flag), and whether SCO is <em>actually</em> on right
-     * now ({@code AudioManager.isBluetoothScoOn()}).
+     * ({@code enteredByUs}, the cached flag), and what the app's own SCO coordinator
+     * ({@code ScoLinkCoordinator}) says about the link.
      *
      * <p>The cached flag alone isn't trustworthy: SCO drops on its own when the headset
      * disconnects, and {@code setBlueToothOn()} can fail, so a stale {@code true} would make
      * every later refresh skip re-entering and leave the selected BT mic/speaker dead until
-     * restart (Copilot review on #723). Cross-checking the real SCO state fixes that while
-     * still avoiding the disruptive stop+start on every settings tap when SCO is really up.
+     * restart (Copilot review on #723). The cross-check deliberately uses the coordinator's
+     * tracked state rather than {@code AudioManager.isBluetoothScoOn()}: that getter only
+     * mirrors the legacy force-use flag, which {@code setSpeakerphoneOn(false)} (issued right
+     * after {@code setBluetoothScoOn(true)} in the SCO sink) clears on newer Android builds —
+     * so it can read {@code false} while the link is up. Deciding on it made a USB/VOX user's
+     * "deselect BT headset" pick {@link #HEADSET_MODE_FORGET} instead of
+     * {@link #HEADSET_MODE_LEAVE}, leaving the coordinator wanted and SCO on (Copilot review
+     * on #778).
      *
      * <p>A Bluetooth <em>rig</em> owns SCO for its TX/RX path, so headset mode is never left
      * from here while one is connected — but a headset that dropped and came back still
-     * re-enters, because {@code want && !scoOn} always yields {@link #HEADSET_MODE_ENTER}.
+     * re-enters, because {@code want && !linkUp} always yields {@link #HEADSET_MODE_ENTER}.
+     *
+     * @param want         headset mode is wanted for the current rig + audio selection
+     * @param enteredByUs  the cached "we entered headset mode" flag
+     * @param linkUp       the coordinator has the link CONNECTING or CONNECTED (so a fresh
+     *                     request would only restart a link that is being built)
+     * @param linkHeld     the coordinator still holds an SCO request — up, retrying, or gave
+     *                     up but never told to stop; it must be told to stop to really leave
+     * @param bluetoothRig the rig itself is connected over Bluetooth
      */
-    public static int headsetModeAction(boolean want, boolean enteredByUs, boolean scoOn,
-                                        boolean bluetoothRig) {
+    public static int headsetModeAction(boolean want, boolean enteredByUs, boolean linkUp,
+                                        boolean linkHeld, boolean bluetoothRig) {
         if (want) {
-            return (enteredByUs && scoOn) ? HEADSET_MODE_KEEP : HEADSET_MODE_ENTER;
+            return (enteredByUs && linkUp) ? HEADSET_MODE_KEEP : HEADSET_MODE_ENTER;
         }
         if (!enteredByUs || bluetoothRig) {
             return HEADSET_MODE_KEEP;
         }
-        return scoOn ? HEADSET_MODE_LEAVE : HEADSET_MODE_FORGET;
+        return linkHeld ? HEADSET_MODE_LEAVE : HEADSET_MODE_FORGET;
+    }
+
+    /** {@link #profileChangeAction}: Bluetooth rig — enter headset mode directly. */
+    public static final int PROFILE_ENTER = 0;
+    /** {@link #profileChangeAction}: Bluetooth rig — leave headset mode directly. */
+    public static final int PROFILE_LEAVE = 1;
+    /**
+     * {@link #profileChangeAction}: not a Bluetooth rig — run the selection-aware
+     * {@code refreshBluetoothHeadsetMode()} so a selected BT headset that reconnects (or
+     * goes away) is handled the same way a settings change would be.
+     */
+    public static final int PROFILE_REFRESH = 2;
+
+    /**
+     * What the Bluetooth broadcast receiver should do when a headset/A2DP profile connection
+     * state changes. A Bluetooth rig keeps its original direct on/off behaviour. Any other
+     * rig mode used to ignore profile changes entirely, so for the #723 case (USB/VOX rig +
+     * BT headset selected as mic/speaker) a headset that reconnected after the SCO retry
+     * budget was exhausted never re-entered headset mode and RX stayed dead until restart or
+     * another settings change (Copilot review on #778). Routing it through the refresh keeps
+     * the car-stereo protection: the refresh only acts when a BT-SCO device is selected.
+     */
+    public static int profileChangeAction(int connectMode, boolean profileConnected) {
+        if (connectMode == ConnectMode.BLUE_TOOTH) {
+            return profileConnected ? PROFILE_ENTER : PROFILE_LEAVE;
+        }
+        return PROFILE_REFRESH;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiConnector.java
@@ -39,13 +39,21 @@ public class WifiConnector extends BaseRigConnector{
         // the network path exactly as they do for USB/Bluetooth.
         this.wifiRig.setOnLinkStateChanged(new WifiRig.OnLinkStateChanged() {
             @Override
-            public void onLoginResult(boolean ok) {
-                emit(linkState.onLoginResult(ok), "login " + (ok ? "ok" : "failed"));
+            public void onSessionBegin(int session) {
+                // Fresh state for this attempt, scoped to its session id, at the instant the
+                // rig advances the counter — so an event from the previous session can no
+                // longer be admitted afterwards (Copilot review on #778).
+                linkState.reset(session);
             }
 
             @Override
-            public void onSendError() {
-                emit(linkState.onSendError(), "network send error");
+            public void onLoginResult(int session, boolean ok) {
+                emit(linkState.onLoginResult(session, ok), "login " + (ok ? "ok" : "failed"));
+            }
+
+            @Override
+            public void onSendError(int session) {
+                emit(linkState.onSendError(session), "network send error");
             }
 
             @Override
@@ -82,11 +90,12 @@ public class WifiConnector extends BaseRigConnector{
         super.connect();
         // Announce the attempt so the chip shows "connecting" (amber) immediately; the
         // CONNECTED/ERROR edge follows from the login response. A reconnect reuses this same
-        // connector instance, so start from a fresh link state each attempt — otherwise the
+        // connector instance, so each attempt needs a fresh link state — otherwise the
         // terminal flag from the previous close/error swallows the next login and the chip
-        // never leaves "connecting" (Copilot review on #754). Reset before start(): the login
-        // response can arrive on the receive worker before start() returns.
-        linkState.reset();
+        // never leaves "connecting" (Copilot review on #754). The reset itself happens in
+        // onSessionBegin(), which the rig fires from start() as it advances the session id:
+        // doing it here, before start(), left a window in which a late event from the old
+        // session still matched the current id and hit the reset state (Copilot #778).
         if (getOnConnectorStateChanged() != null) {
             getOnConnectorStateChanged().onConnecting();
         }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiLinkState.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/WifiLinkState.java
@@ -31,6 +31,8 @@ public final class WifiLinkState {
 
     private boolean announcedConnected = false;
     private boolean terminal = false;
+    /** Session id the current state belongs to; events tagged with another id are ignored. */
+    private int session = 0;
 
     /** True between a {@link Emit#CONNECTED} and the following disconnect/error. */
     public synchronized boolean isConnected() {
@@ -38,22 +40,44 @@ public final class WifiLinkState {
     }
 
     /**
-     * Start a fresh attempt. {@link WifiConnector#connect()} calls this before
-     * {@code wifiRig.start()} because a reconnect reuses the same connector instance: without
-     * it the {@code terminal} flag left behind by the previous close/error swallowed the next
-     * successful login, so the chip stuck on "connecting" and {@link #isConnected()} stayed
-     * false for the whole re-established session.
+     * Start a fresh attempt for {@code session}. A reconnect reuses the same connector
+     * instance: without a reset the {@code terminal} flag left behind by the previous
+     * close/error swallowed the next successful login, so the chip stuck on "connecting" and
+     * {@link #isConnected()} stayed false for the whole re-established session.
+     *
+     * <p>Carrying the session id makes the reset and event admission atomic: an event from an
+     * older session that slipped past the rig's own check before the counter advanced is
+     * rejected here under the same monitor, instead of falsely connecting or terminally
+     * failing the new attempt (Copilot review on #778).
      */
-    public synchronized void reset() {
+    public synchronized void reset(int session) {
+        this.session = session;
         announcedConnected = false;
         terminal = false;
     }
 
+    /** Unsessioned reset: keeps the current session id. */
+    public synchronized void reset() {
+        reset(session);
+    }
+
+    /** The session id the state currently belongs to. */
+    public synchronized int session() {
+        return session;
+    }
+
     /**
-     * A 0x60 login response arrived. First success emits {@link Emit#CONNECTED}; later successes
-     * are swallowed (the rig re-sends). A failure (bad user/password) is a terminal
-     * {@link Emit#ERROR}.
+     * A 0x60 login response arrived for {@code session}. First success emits
+     * {@link Emit#CONNECTED}; later successes are swallowed (the rig re-sends). A failure (bad
+     * user/password) is a terminal {@link Emit#ERROR}. An event from another session is
+     * ignored.
      */
+    public synchronized Emit onLoginResult(int session, boolean ok) {
+        if (session != this.session) return null;
+        return onLoginResult(ok);
+    }
+
+    /** Unsessioned form: applies to the current session. */
     public synchronized Emit onLoginResult(boolean ok) {
         if (terminal) return null;
         if (ok) {
@@ -66,10 +90,17 @@ public final class WifiLinkState {
     }
 
     /**
-     * A UDP send failed (network unreachable). After a successful connect this is a link drop
-     * ({@link Emit#DISCONNECTED}); before one it is a failed attempt ({@link Emit#ERROR}). Once
-     * only — the stack fires it per stream.
+     * A UDP send failed (network unreachable) in {@code session}. After a successful connect
+     * this is a link drop ({@link Emit#DISCONNECTED}); before one it is a failed attempt
+     * ({@link Emit#ERROR}). Once only — the stack fires it per stream. An event from another
+     * session is ignored.
      */
+    public synchronized Emit onSendError(int session) {
+        if (session != this.session) return null;
+        return onSendError();
+    }
+
+    /** Unsessioned form: applies to the current session. */
     public synchronized Emit onSendError() {
         if (terminal) return null;
         terminal = true;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IComWifiRig.java
@@ -20,12 +20,26 @@ public class IComWifiRig extends WifiRig{
 
     @Override
     public void start(){
+        // Tear down a previous session first (reconnect without an explicit disconnect,
+        // e.g. the tap-to-reconnect chip): otherwise its timers and sockets stay alive and
+        // keep firing this rig's handlers.
+        ControlUdp previous = controlUdp;
+        if (previous != null) {
+            try {
+                previous.closeAll();
+            } catch (RuntimeException ignored) {
+                // Already closed / never opened: nothing to reclaim.
+            }
+        }
         // Tag this attempt so handlers left over from a previous session can't report
         // into the new one (see WifiRig.beginLinkSession).
         final int session = beginLinkSession();
         opened=true;
         openAudio();//Open audio
-        controlUdp=new IcomControlUdp(userName,password,ip,port);
+        // Local handle for the handlers below: they must only ever tear down *their own*
+        // sockets, never the rig's current controlUdp after a reconnect (Copilot #778).
+        final ControlUdp udp = new IcomControlUdp(userName,password,ip,port);
+        controlUdp=udp;
 
         //Set events; handle radio status and receive audio data from radio
         controlUdp.setOnStreamEvents(new IcomUdpBase.OnStreamEvents() {
@@ -36,6 +50,7 @@ public class IComWifiRig extends WifiRig{
 
             @Override
             public void OnReceivedCivData(byte[] data) {
+                if (!isCurrentSession(session)) return;
                 if (onDataEvents!=null){
                     onDataEvents.onReceivedCivData(data);
                 }
@@ -43,6 +58,7 @@ public class IComWifiRig extends WifiRig{
 
             @Override
             public void OnReceivedAudioData(byte[] audioData) {
+                if (!isCurrentSession(session)) return;
                 if (onDataEvents!=null){
                     onDataEvents.onReceivedWaveData(audioData);
                 }
@@ -52,6 +68,9 @@ public class IComWifiRig extends WifiRig{
 
             @Override
             public void OnUdpSendIOException(IcomUdpStyle style,IOException e) {
+                // Stale session: close only the old sockets, no toast, no close() of the
+                // rig (which would tear down the new session's controlUdp).
+                if (!admitSessionEvent(session, udp::closeAll)) return;
                 ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
                         R.string.network_exception),IcomUdpBase.getUdpStyle(style),e.getMessage()));
                 notifySendError(session);
@@ -60,12 +79,14 @@ public class IComWifiRig extends WifiRig{
 
             @Override
             public void OnLoginResponse(boolean authIsOK) {
+                // Stale session: its sockets must not outlive it whatever the rig said.
+                if (!admitSessionEvent(session, udp::closeAll)) return;
                 notifyLoginResult(session, authIsOK);
                 if (authIsOK){
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.login_succeed));
                 }else {
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.loging_failed));
-                    controlUdp.closeAll();
+                    udp.closeAll();
                 }
             }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/WifiRig.java
@@ -34,9 +34,17 @@ public abstract class WifiRig {
      * handlers via the {@code notify*} helpers below.
      */
     public interface OnLinkStateChanged {
-        void onLoginResult(boolean ok);
+        /**
+         * {@link #start()} opened a new UDP session. Fired from inside
+         * {@link #beginLinkSession()} — i.e. at the same instant the session counter
+         * advances — so a listener that resets per-attempt state here can't be handed an
+         * event from the previous session afterwards (every event carries its session id).
+         */
+        void onSessionBegin(int session);
 
-        void onSendError();
+        void onLoginResult(int session, boolean ok);
+
+        void onSendError(int session);
 
         void onClosed();
     }
@@ -54,9 +62,42 @@ public abstract class WifiRig {
     // and pass it back through the session-checked notify* overloads.
     private final AtomicInteger linkSession = new AtomicInteger();
 
-    /** Called at the top of {@link #start()}; returns the id the new handlers must carry. */
+    /**
+     * Called at the top of {@link #start()}; returns the id the new handlers must carry.
+     * Announces the new session to the link-state listener in the same step so its reset
+     * and the session advance are one edge (Copilot review on #778: resetting the connector
+     * state <em>before</em> {@code start()} left a window where a late event from the old
+     * session still matched the current id and landed on the freshly reset state).
+     */
     protected int beginLinkSession() {
-        return linkSession.incrementAndGet();
+        int session = linkSession.incrementAndGet();
+        if (onLinkStateChanged != null) onLinkStateChanged.onSessionBegin(session);
+        return session;
+    }
+
+    /** Whether an event tagged {@code session} belongs to the current attempt. */
+    protected boolean isCurrentSession(int session) {
+        return isCurrentSession(session, linkSession.get());
+    }
+
+    /**
+     * Gate for a stream-event callback: returns true when {@code session} is current and the
+     * callback should run as usual. For a stale session it runs {@code staleTeardown} (the
+     * orphaned sockets' own close — never the rig's current {@code controlUdp}) and returns
+     * false so the caller skips its toasts, notifications and {@code close()} (Copilot review
+     * on #778: a late send error or failed login from the old sockets used to call
+     * {@code close()} / {@code controlUdp.closeAll()} on the <em>new</em> session's field).
+     */
+    protected boolean admitSessionEvent(int session, Runnable staleTeardown) {
+        if (isCurrentSession(session)) return true;
+        if (staleTeardown != null) {
+            try {
+                staleTeardown.run();
+            } catch (RuntimeException e) {
+                Log.w(TAG, "Stale link session " + session + " teardown failed", e);
+            }
+        }
+        return false;
     }
 
     /** Package-visible for tests. */
@@ -69,23 +110,28 @@ public abstract class WifiRig {
         return session == current;
     }
 
-    /** Concrete rigs call these from their stream-event handlers; null-safe. */
+    /**
+     * Concrete rigs call these from their stream-event handlers; null-safe. The unsessioned
+     * forms apply to whatever session is current (for callers that have no id to carry).
+     */
     protected void notifyLoginResult(boolean ok) {
-        if (onLinkStateChanged != null) onLinkStateChanged.onLoginResult(ok);
+        notifyLoginResult(linkSession.get(), ok);
     }
 
-    /** As {@link #notifyLoginResult(boolean)}, but dropped when {@code session} is stale. */
+    /** Dropped here when {@code session} is stale; the listener re-checks under its own lock. */
     protected void notifyLoginResult(int session, boolean ok) {
-        if (isCurrentSession(session, linkSession.get())) notifyLoginResult(ok);
+        if (!isCurrentSession(session)) return;
+        if (onLinkStateChanged != null) onLinkStateChanged.onLoginResult(session, ok);
     }
 
     protected void notifySendError() {
-        if (onLinkStateChanged != null) onLinkStateChanged.onSendError();
+        notifySendError(linkSession.get());
     }
 
-    /** As {@link #notifySendError()}, but dropped when {@code session} is stale. */
+    /** Dropped here when {@code session} is stale; the listener re-checks under its own lock. */
     protected void notifySendError(int session) {
-        if (isCurrentSession(session, linkSession.get())) notifySendError();
+        if (!isCurrentSession(session)) return;
+        if (onLinkStateChanged != null) onLinkStateChanged.onSendError(session);
     }
 
     protected void notifyClosed() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/XieGuWifiRig.java
@@ -20,12 +20,26 @@ public class XieGuWifiRig extends WifiRig{
 
     @Override
     public void start(){
+        // Tear down a previous session first (reconnect without an explicit disconnect,
+        // e.g. the tap-to-reconnect chip): otherwise its timers and sockets stay alive and
+        // keep firing this rig's handlers.
+        ControlUdp previous = controlUdp;
+        if (previous != null) {
+            try {
+                previous.closeAll();
+            } catch (RuntimeException ignored) {
+                // Already closed / never opened: nothing to reclaim.
+            }
+        }
         // Tag this attempt so handlers left over from a previous session can't report
         // into the new one (see WifiRig.beginLinkSession).
         final int session = beginLinkSession();
         opened=true;
         openAudio();//Open audio
-        controlUdp=new XieGuControlUdp(userName,password,ip,port);
+        // Local handle for the handlers below: they must only ever tear down *their own*
+        // sockets, never the rig's current controlUdp after a reconnect (Copilot #778).
+        final ControlUdp udp = new XieGuControlUdp(userName,password,ip,port);
+        controlUdp=udp;
 
         //Set events; handle radio status and receive audio data from radio
         controlUdp.setOnStreamEvents(new IcomUdpBase.OnStreamEvents() {
@@ -36,6 +50,7 @@ public class XieGuWifiRig extends WifiRig{
 
             @Override
             public void OnReceivedCivData(byte[] data) {
+                if (!isCurrentSession(session)) return;
                 if (onDataEvents!=null){
                     onDataEvents.onReceivedCivData(data);
                 }
@@ -43,6 +58,7 @@ public class XieGuWifiRig extends WifiRig{
 
             @Override
             public void OnReceivedAudioData(byte[] audioData) {
+                if (!isCurrentSession(session)) return;
                 if (onDataEvents!=null){
                     onDataEvents.onReceivedWaveData(audioData);
                 }
@@ -51,6 +67,9 @@ public class XieGuWifiRig extends WifiRig{
 
             @Override
             public void OnUdpSendIOException(IcomUdpStyle style,IOException e) {
+                // Stale session: close only the old sockets, no toast, no close() of the
+                // rig (which would tear down the new session's controlUdp).
+                if (!admitSessionEvent(session, udp::closeAll)) return;
                 ToastMessage.show(String.format(GeneralVariables.getStringFromResource(
                         R.string.network_exception),IcomUdpBase.getUdpStyle(style),e.getMessage()));
                 notifySendError(session);
@@ -59,12 +78,14 @@ public class XieGuWifiRig extends WifiRig{
 
             @Override
             public void OnLoginResponse(boolean authIsOK) {
+                // Stale session: its sockets must not outlive it whatever the rig said.
+                if (!admitSessionEvent(session, udp::closeAll)) return;
                 notifyLoginResult(session, authIsOK);
                 if (authIsOK){
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.login_succeed));
                 }else {
                     ToastMessage.show(GeneralVariables.getStringFromResource(R.string.loging_failed));
-                    controlUdp.closeAll();
+                    udp.closeAll();
                 }
             }
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivAddressConfig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/CivAddressConfig.java
@@ -20,9 +20,14 @@ import java.util.Locale;
  *   <li>{@link #decode}: a hex parse that lands outside {@code 0x00..0xFF} can only be a
  *       decimal string of a real address (all three-digit decimals are ≥ {@code 0x100} as
  *       hex), so it is re-read as decimal.</li>
- *   <li>{@link #reconcileWithModel}: two-digit decimal strings ({@code "88"} for an IC-706's
- *       {@code 0x58}) are valid hex too, so they are resolved against the selected rig
- *       model's address instead.</li>
+ *   <li>Two-digit decimal strings ({@code "88"} for an IC-706's {@code 0x58}) are valid hex
+ *       too, and a value of unknown provenance can't be told from a deliberate hex override
+ *       that happens to be the model's decimal twin ({@code 0x88} typed into the legacy hex
+ *       field on an IC-706). Those are <b>not</b> auto-rewritten — the stored value is kept,
+ *       {@link #planRepair} flags it {@link Repair#ambiguous}, and the app tells the user to
+ *       re-select the rig if it uses the default (Copilot review on #778; the earlier
+ *       silent model reconciliation would have destroyed such an override with no UI left
+ *       to restore it). {@link #reconcileWithModel} is what that detection is built on.</li>
  * </ul>
  * Pure — no Android imports — so it is unit-testable.
  */
@@ -52,10 +57,19 @@ public final class CivAddressConfig {
         public final int address;
         /** True when {@code civ} (canonical hex) and {@link #FORMAT_KEY} must be written. */
         public final boolean writeBack;
+        /**
+         * True when the stored value was unmarked and its digits read in decimal are the
+         * selected model's address — it may be the old picker's decimal write <em>or</em> a
+         * deliberate hex override, and the two can't be told apart, so {@link #address} keeps
+         * the stored (hex) reading and the user should be told to re-select the rig if it
+         * really uses the model default.
+         */
+        public final boolean ambiguous;
 
-        Repair(int address, boolean writeBack) {
+        Repair(int address, boolean writeBack, boolean ambiguous) {
             this.address = address;
             this.writeBack = writeBack;
+            this.ambiguous = ambiguous;
         }
     }
 
@@ -68,18 +82,21 @@ public final class CivAddressConfig {
      * @param modelAddress the selected rig model's default address
      * @return the address to use, and whether to write it (and the marker) back
      *
-     * <p>Rules: a marked value is trusted as-is — no model reconciliation, so user overrides
-     * survive. An unmarked value gets {@link #reconcileWithModel}. A write-back is due when
-     * the marker is missing (settles provenance once and for all, and fixes the three-digit
+     * <p>Rules: the loaded value is always kept — a marked value because its provenance is
+     * known, an unmarked one because a two-digit decimal twin of the model address is
+     * indistinguishable from a deliberate hex override and must not be silently rewritten
+     * (it is reported as {@link Repair#ambiguous} instead). A write-back is due when the
+     * marker is missing (settles provenance once and for all, and fixes the three-digit
      * decimal case whose decoded address already equals the model's) or when the stored
      * text isn't the canonical {@link #encode} form.
      */
     public static Repair planRepair(String storedRaw, boolean formatKnown, int loaded,
                                     int modelAddress) {
-        int resolved = formatKnown ? loaded : reconcileWithModel(loaded, modelAddress);
+        boolean ambiguous = !formatKnown
+                && reconcileWithModel(loaded, modelAddress) != loaded;
         boolean canonical = storedRaw != null
-                && encode(resolved).equals(storedRaw.trim().toLowerCase(Locale.ROOT));
-        return new Repair(resolved, !formatKnown || !canonical);
+                && encode(loaded).equals(storedRaw.trim().toLowerCase(Locale.ROOT));
+        return new Repair(loaded, !formatKnown || !canonical, ambiguous);
     }
 
     /** True when a stored {@link #FORMAT_KEY} value says the {@code civ} key is hex. */
@@ -119,11 +136,12 @@ public final class CivAddressConfig {
     }
 
     /**
-     * Resolves the ambiguity {@link #decode} can't: a loaded address that doesn't match the
-     * selected rig model, but whose digits read in decimal do. Example: an IC-706MKIIG
-     * ({@code 0x58} = 88) saved as {@code "88"}, loaded as {@code 0x88}. Returns
-     * {@code modelAddress} in that case, otherwise {@code loaded} unchanged — a deliberate
-     * user override (rig configured to a non-default address) is left alone.
+     * The model-reconciled reading of a loaded address that doesn't match the selected rig
+     * model but whose digits read in decimal do. Example: an IC-706MKIIG ({@code 0x58} = 88)
+     * saved as {@code "88"}, loaded as {@code 0x88}. Returns {@code modelAddress} in that
+     * case, otherwise {@code loaded} unchanged. {@link #planRepair} uses it only to
+     * <em>detect</em> the ambiguity — it never applies the result, because the same stored
+     * text is also what a deliberate {@code 0x88} override looks like.
      */
     public static int reconcileWithModel(int loaded, int modelAddress) {
         if (!isValid(modelAddress) || loaded == modelAddress) return loaded;

--- a/ft8af/app/src/main/res/values/strings.xml
+++ b/ft8af/app/src/main/res/values/strings.xml
@@ -363,6 +363,7 @@
     <string name="connect_xiegu_ip">Connect XIEGU Radio %s …</string>
     <string name="network_exception">%s : Network transmission exception : %s</string>
     <string name="login_succeed">Login succeeded !</string>
+    <string name="civ_address_ambiguous_hint">CI-V address is 0x%1$02X but the %2$s default is 0x%3$02X. If the rig uses the default, re-select it under Settings › Radio.</string>
     <string name="loging_failed">Login failed, invalid user name or password.</string>
     <string name="data_stream">Data stream</string>
     <string name="control_stream">Control stream</string>

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinatorTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinatorTest.java
@@ -130,6 +130,25 @@ public class ScoLinkCoordinatorTest {
     }
 
     @Test
+    public void isLinkUpOrPending_tracksTheTrackerNotAudioManager() {
+        // The headset-mode refresh cross-checks this instead of isBluetoothScoOn()
+        // (Copilot review on #778).
+        assertThat(coordinator.isLinkUpOrPending()).isFalse();
+        coordinator.requestOn("test", null);
+        assertThat(coordinator.isLinkUpOrPending()).isTrue();   // optimistic CONNECTING
+        coordinator.onStateUpdated(CONNECTED, CONNECTING);
+        assertThat(coordinator.isLinkUpOrPending()).isTrue();
+        // Dropped underneath us: still wanted (held) but no longer up/pending.
+        coordinator.onStateUpdated(DISCONNECTED, CONNECTED);
+        assertThat(coordinator.isLinkUpOrPending()).isFalse();
+        assertThat(coordinator.isWanted()).isTrue();
+        // Released: neither.
+        coordinator.requestOff("test", null);
+        assertThat(coordinator.isLinkUpOrPending()).isFalse();
+        assertThat(coordinator.isWanted()).isFalse();
+    }
+
+    @Test
     public void requestOff_withoutStart_doesNothing() {
         List<String> applied = new ArrayList<>();
         coordinator.requestOff("test", () -> applied.add("off"));

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyAudioDeviceTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/ScoPolicyAudioDeviceTest.java
@@ -28,55 +28,95 @@ public class ScoPolicyAudioDeviceTest {
         assertThat(ScoPolicy.TYPE_BLUETOOTH_SCO).isEqualTo(framework);
     }
 
-    // ---- headsetModeAction: cached flag cross-checked with real SCO state --------------
+    // ---- headsetModeAction: cached flag cross-checked with the coordinator's link state ----
+    // Args: (want, enteredByUs, linkUp, linkHeld, bluetoothRig). linkUp = tracker says
+    // CONNECTING/CONNECTED; linkHeld = coordinator still holds an SCO request (wanted).
 
     @Test
-    public void headsetModeAction_wantedAndReallyOn_keeps() {
-        assertThat(ScoPolicy.headsetModeAction(true, true, true, false))
+    public void headsetModeAction_wantedAndLinkUp_keeps() {
+        assertThat(ScoPolicy.headsetModeAction(true, true, true, true, false))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
     }
 
     @Test
     public void headsetModeAction_wantedButNeverEntered_enters() {
-        assertThat(ScoPolicy.headsetModeAction(true, false, false, false))
+        assertThat(ScoPolicy.headsetModeAction(true, false, false, false, false))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_ENTER);
     }
 
     @Test
-    public void headsetModeAction_wantedButScoDroppedBehindOurBack_reEnters() {
-        // Headset disconnected and came back (or setBlueToothOn() failed): the cached flag
-        // says active but SCO is really off — must not skip re-entering.
-        assertThat(ScoPolicy.headsetModeAction(true, true, false, false))
+    public void headsetModeAction_wantedButLinkDroppedBehindOurBack_reEnters() {
+        // Headset disconnected and came back (or the start failed and retries were
+        // exhausted): the cached flag says active but the link is down — must re-enter,
+        // whether or not the coordinator still nominally holds the request.
+        assertThat(ScoPolicy.headsetModeAction(true, true, false, true, false))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_ENTER);
-        assertThat(ScoPolicy.headsetModeAction(true, true, false, true))
+        assertThat(ScoPolicy.headsetModeAction(true, true, false, false, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_ENTER);
+        assertThat(ScoPolicy.headsetModeAction(true, true, false, false, true))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_ENTER);
     }
 
     @Test
     public void headsetModeAction_notWantedAndNotOurs_keeps() {
         // SCO turned on by someone else (Bluetooth rig path, broadcast receiver): leave it.
-        assertThat(ScoPolicy.headsetModeAction(false, false, true, false))
+        assertThat(ScoPolicy.headsetModeAction(false, false, true, true, false))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
     }
 
     @Test
     public void headsetModeAction_deselectedOnUsbRig_leaves() {
-        assertThat(ScoPolicy.headsetModeAction(false, true, true, false))
+        assertThat(ScoPolicy.headsetModeAction(false, true, true, true, false))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_LEAVE);
     }
 
     @Test
-    public void headsetModeAction_deselectedButScoAlreadyGone_forgets() {
-        assertThat(ScoPolicy.headsetModeAction(false, true, false, false))
+    public void headsetModeAction_deselectedWhileCoordinatorRetrying_stillLeaves() {
+        // Copilot review on #778: the link is momentarily down (retry pending) but the
+        // coordinator still wants it. Deciding on AudioManager.isBluetoothScoOn() here read
+        // "off" and FORGOT, so the coordinator stayed wanted and brought SCO right back.
+        // The held request must be told to stop.
+        assertThat(ScoPolicy.headsetModeAction(false, true, false, true, false))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_LEAVE);
+    }
+
+    @Test
+    public void headsetModeAction_deselectedAndNothingHeld_forgets() {
+        // TX stopSco()/shutdown already released the request: nothing to tear down.
+        assertThat(ScoPolicy.headsetModeAction(false, true, false, false, false))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_FORGET);
     }
 
     @Test
     public void headsetModeAction_neverYanksScoFromBluetoothRig() {
-        assertThat(ScoPolicy.headsetModeAction(false, true, true, true))
+        assertThat(ScoPolicy.headsetModeAction(false, true, true, true, true))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
-        assertThat(ScoPolicy.headsetModeAction(false, true, false, true))
+        assertThat(ScoPolicy.headsetModeAction(false, true, false, true, true))
                 .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
+        assertThat(ScoPolicy.headsetModeAction(false, true, false, false, true))
+                .isEqualTo(ScoPolicy.HEADSET_MODE_KEEP);
+    }
+
+    // ---- profileChangeAction: what the BT broadcast receiver does on a profile change ----
+
+    @Test
+    public void profileChangeAction_bluetoothRig_entersAndLeavesDirectly() {
+        assertThat(ScoPolicy.profileChangeAction(ConnectMode.BLUE_TOOTH, true))
+                .isEqualTo(ScoPolicy.PROFILE_ENTER);
+        assertThat(ScoPolicy.profileChangeAction(ConnectMode.BLUE_TOOTH, false))
+                .isEqualTo(ScoPolicy.PROFILE_LEAVE);
+    }
+
+    @Test
+    public void profileChangeAction_otherRigs_runSelectionAwareRefresh() {
+        // Copilot review on #778: USB/VOX rig + selected BT headset — a headset reconnect
+        // after the SCO retry budget ran out was ignored, so RX stayed dead until restart.
+        assertThat(ScoPolicy.profileChangeAction(ConnectMode.USB_CABLE, true))
+                .isEqualTo(ScoPolicy.PROFILE_REFRESH);
+        assertThat(ScoPolicy.profileChangeAction(ConnectMode.USB_CABLE, false))
+                .isEqualTo(ScoPolicy.PROFILE_REFRESH);
+        assertThat(ScoPolicy.profileChangeAction(ConnectMode.NETWORK, true))
+                .isEqualTo(ScoPolicy.PROFILE_REFRESH);
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorLinkStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorLinkStateTest.java
@@ -26,11 +26,18 @@ public class WifiConnectorLinkStateTest {
             super("192.168.0.1", 50001, "user", "pw");
         }
 
-        @Override public void start() { opened = true; }
+        // Real rigs open every session through beginLinkSession(); the connector resets its
+        // link state on that edge (Copilot review on #778), so the fake must do the same.
+        @Override public void start() { beginLinkSession(); opened = true; }
         @Override public void setPttOn(boolean on) { }
         @Override public void sendCivData(byte[] data) { }
         @Override public void sendWaveData(float[] data) { }
         @Override public void close() { opened = false; notifyClosed(); }
+
+        // The unsessioned notifiers apply to the current session, exactly as a live
+        // handler passing the session it captured in start() would.
+        void login(boolean ok) { notifyLoginResult(ok); }
+        void sendError() { notifySendError(); }
     }
 
     private FakeWifiRig rig;
@@ -63,18 +70,18 @@ public class WifiConnectorLinkStateTest {
     @Test
     public void loginSuccess_emitsConnectedAndReportsConnected() {
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(true);
+        rig.login(true);
         assertThat(events).containsExactly("connecting", "connected").inOrder();
         assertThat(connector.isConnected()).isTrue();
         // Duplicate login packets don't re-announce.
-        rig.onLinkStateChanged.onLoginResult(true);
+        rig.login(true);
         assertThat(events).containsExactly("connecting", "connected").inOrder();
     }
 
     @Test
     public void loginFailure_emitsError() {
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(false);
+        rig.login(false);
         assertThat(events).containsExactly("connecting", "error:login failed").inOrder();
         assertThat(connector.isConnected()).isFalse();
     }
@@ -82,8 +89,8 @@ public class WifiConnectorLinkStateTest {
     @Test
     public void linkDropAfterConnect_emitsDisconnectedOnce() {
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(true);
-        rig.onLinkStateChanged.onSendError(); // network went away
+        rig.login(true);
+        rig.sendError(); // network went away
         rig.close();                          // teardown that follows
         assertThat(events).containsExactly("connecting", "connected", "disconnected").inOrder();
         assertThat(connector.isConnected()).isFalse();
@@ -92,7 +99,7 @@ public class WifiConnectorLinkStateTest {
     @Test
     public void userDisconnect_emitsDisconnected() {
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(true);
+        rig.login(true);
         connector.disconnect(); // -> wifiRig.close() -> notifyClosed()
         assertThat(events).containsExactly("connecting", "connected", "disconnected").inOrder();
     }
@@ -103,14 +110,14 @@ public class WifiConnectorLinkStateTest {
         // previous drop left the link state terminal; without a reset the next login was
         // swallowed and the chip stuck on "connecting" (Copilot review on #754).
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(true);
-        rig.onLinkStateChanged.onSendError();
+        rig.login(true);
+        rig.sendError();
         rig.close();
         assertThat(connector.isConnected()).isFalse();
 
         connector.connect();
         assertThat(connector.isConnected()).isFalse(); // until the new login lands
-        rig.onLinkStateChanged.onLoginResult(true);
+        rig.login(true);
         assertThat(events).containsExactly(
                 "connecting", "connected", "disconnected",
                 "connecting", "connected").inOrder();
@@ -127,9 +134,9 @@ public class WifiConnectorLinkStateTest {
     @Test
     public void reconnectAfterLoginFailure_announcesConnected() {
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(false);
+        rig.login(false);
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(true);
+        rig.login(true);
         assertThat(events).containsExactly(
                 "connecting", "error:login failed", "connecting", "connected").inOrder();
         assertThat(connector.isConnected()).isTrue();
@@ -138,10 +145,10 @@ public class WifiConnectorLinkStateTest {
     @Test
     public void reconnectAfterUserDisconnect_announcesConnected() {
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(true);
+        rig.login(true);
         connector.disconnect();
         connector.connect();
-        rig.onLinkStateChanged.onLoginResult(true);
+        rig.login(true);
         assertThat(events).containsExactly(
                 "connecting", "connected", "disconnected", "connecting", "connected").inOrder();
         assertThat(connector.isConnected()).isTrue();

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorSessionTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiConnectorSessionTest.java
@@ -1,0 +1,124 @@
+package com.k1af.ft8af.connector;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.database.ControlMode;
+import com.k1af.ft8af.icom.WifiRig;
+import com.k1af.ft8af.rigs.OnRigStateChanged;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link WifiConnector} + {@link WifiRig} session wiring (Copilot review on #778): the
+ * connector's per-attempt link state is reset on the rig's {@code onSessionBegin} edge — the
+ * same instant the session counter advances — and every login/send-error event is admitted
+ * by session id, so a late event from the previous UDP session can neither falsely connect
+ * nor terminally fail a fresh attempt. Robolectric only because {@code WifiConnector} touches
+ * {@code android.util.Log}; no sockets are opened.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class WifiConnectorSessionTest {
+
+    /** A rig whose start() begins a session but opens nothing; events are pushed by hand. */
+    private static class FakeRig extends WifiRig {
+        int lastSession;
+
+        FakeRig() {
+            super("192.168.0.1", 50001, "user", "pw");
+        }
+
+        @Override public void start() { lastSession = beginLinkSession(); opened = true; }
+        @Override public void setPttOn(boolean on) { }
+        @Override public void sendCivData(byte[] data) { }
+        @Override public void sendWaveData(float[] data) { }
+        @Override public void close() { opened = false; notifyClosed(); }
+
+        void login(int session, boolean ok) { notifyLoginResult(session, ok); }
+        void sendError(int session) { notifySendError(session); }
+    }
+
+    private static List<String> record(WifiConnector c) {
+        final List<String> events = new ArrayList<>();
+        c.setOnRigStateChanged(new OnRigStateChanged() {
+            @Override public void onDisconnected() { events.add("disconnected"); }
+            @Override public void onConnected() { events.add("connected"); }
+            @Override public void onPttChanged(boolean isOn) { }
+            @Override public void onFreqChanged(long freq) { }
+            @Override public void onRunError(String message) { events.add("error:" + message); }
+            @Override public void onConnecting() { events.add("connecting"); }
+        });
+        return events;
+    }
+
+    @Test
+    public void connect_thenLogin_connects() {
+        FakeRig rig = new FakeRig();
+        WifiConnector c = new WifiConnector(ControlMode.CAT, rig);
+        List<String> events = record(c);
+        c.connect();
+        rig.login(rig.lastSession, true);
+        assertThat(events).containsExactly("connecting", "connected").inOrder();
+        assertThat(c.isConnected()).isTrue();
+    }
+
+    @Test
+    public void reconnect_staleLoginFromOldSession_cannotConnectTheNewAttempt() {
+        FakeRig rig = new FakeRig();
+        WifiConnector c = new WifiConnector(ControlMode.CAT, rig);
+        List<String> events = record(c);
+        c.connect();
+        int old = rig.lastSession;
+        c.disconnect();
+        c.connect();
+        // A late 0x60 from the old sockets, delivered straight to the link state as if it
+        // had slipped past the rig's own check: must not light the chip.
+        rig.login(old, true);
+        assertThat(c.isConnected()).isFalse();
+        assertThat(events).containsExactly("connecting", "connecting").inOrder();
+        // The real login for the new session still connects.
+        rig.login(rig.lastSession, true);
+        assertThat(c.isConnected()).isTrue();
+        assertThat(events).containsExactly("connecting", "connecting", "connected").inOrder();
+    }
+
+    @Test
+    public void reconnect_staleFailureFromOldSession_doesNotSwallowTheNewLogin() {
+        FakeRig rig = new FakeRig();
+        WifiConnector c = new WifiConnector(ControlMode.CAT, rig);
+        List<String> events = record(c);
+        c.connect();
+        int old = rig.lastSession;
+        c.disconnect();
+        c.connect();
+        rig.login(old, false);       // late failed login from the old sockets
+        rig.sendError(old);          // late sender failure from the old streams
+        assertThat(events).doesNotContain("error:login failed");
+        assertThat(events).doesNotContain("error:network send error");
+        rig.login(rig.lastSession, true);
+        assertThat(c.isConnected()).isTrue();
+    }
+
+    @Test
+    public void reconnect_afterDropWithoutDisconnect_startsFreshState() {
+        // Tap-to-reconnect after a link drop reuses the connector without disconnect():
+        // the terminal flag from the drop must not swallow the new login (#754), and the
+        // reset now rides on the session edge rather than preceding start().
+        FakeRig rig = new FakeRig();
+        WifiConnector c = new WifiConnector(ControlMode.CAT, rig);
+        List<String> events = record(c);
+        c.connect();
+        rig.login(rig.lastSession, true);
+        rig.sendError(rig.lastSession);
+        assertThat(events).containsExactly("connecting", "connected", "disconnected").inOrder();
+        c.connect();
+        rig.login(rig.lastSession, true);
+        assertThat(c.isConnected()).isTrue();
+        assertThat(events).containsExactly("connecting", "connected", "disconnected",
+                "connecting", "connected").inOrder();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiLinkStateTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/connector/WifiLinkStateTest.java
@@ -106,6 +106,47 @@ public class WifiLinkStateTest {
         assertThat(s.onClosed()).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
     }
 
+    // ---- session-scoped events (Copilot review on #778) ---------------------------------
+
+    @Test
+    public void reset_withSession_rejectsEventsFromOtherSessions() {
+        WifiLinkState s = new WifiLinkState();
+        s.reset(1);
+        assertThat(s.session()).isEqualTo(1);
+        // A late success from the previous session must not connect the fresh attempt...
+        assertThat(s.onLoginResult(0, true)).isNull();
+        assertThat(s.isConnected()).isFalse();
+        // ...nor terminally fail it, which would swallow the real login that follows.
+        assertThat(s.onLoginResult(0, false)).isNull();
+        assertThat(s.onSendError(0)).isNull();
+        assertThat(s.onLoginResult(1, true)).isEqualTo(WifiLinkState.Emit.CONNECTED);
+        assertThat(s.isConnected()).isTrue();
+    }
+
+    @Test
+    public void reset_withSession_dropsStaleSendErrorAfterReconnect() {
+        WifiLinkState s = new WifiLinkState();
+        s.reset(1);
+        s.onLoginResult(1, true);
+        s.onClosed();
+        s.reset(2);
+        s.onLoginResult(2, true);
+        // Old streams fail late: not a disconnect of the new link.
+        assertThat(s.onSendError(1)).isNull();
+        assertThat(s.isConnected()).isTrue();
+        assertThat(s.onSendError(2)).isEqualTo(WifiLinkState.Emit.DISCONNECTED);
+    }
+
+    @Test
+    public void unsessionedReset_keepsSessionId() {
+        WifiLinkState s = new WifiLinkState();
+        s.reset(5);
+        s.onLoginResult(5, false);
+        s.reset();
+        assertThat(s.session()).isEqualTo(5);
+        assertThat(s.onLoginResult(5, true)).isEqualTo(WifiLinkState.Emit.CONNECTED);
+    }
+
     @Test
     public void concurrentLogins_announceConnectedExactlyOnce() throws Exception {
         // The rig re-fires 0x60/0x50 and the receive worker isn't the only caller; with

--- a/ft8af/app/src/test/java/com/k1af/ft8af/icom/WifiRigLinkSessionTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/icom/WifiRigLinkSessionTest.java
@@ -32,13 +32,16 @@ public class WifiRigLinkSessionTest {
         // Expose the protected session-checked notifiers the concrete rigs' handlers use.
         void login(int session, boolean ok) { notifyLoginResult(session, ok); }
         void sendError(int session) { notifySendError(session); }
+        boolean admit(int session, Runnable teardown) { return admitSessionEvent(session, teardown); }
+        boolean current(int session) { return isCurrentSession(session); }
     }
 
     private static List<String> record(FakeRig rig) {
         final List<String> events = new ArrayList<>();
         rig.setOnLinkStateChanged(new WifiRig.OnLinkStateChanged() {
-            @Override public void onLoginResult(boolean ok) { events.add("login:" + ok); }
-            @Override public void onSendError() { events.add("sendError"); }
+            @Override public void onSessionBegin(int session) { events.add("begin:" + session); }
+            @Override public void onLoginResult(int session, boolean ok) { events.add("login:" + ok + "@" + session); }
+            @Override public void onSendError(int session) { events.add("sendError@" + session); }
             @Override public void onClosed() { events.add("closed"); }
         });
         return events;
@@ -64,13 +67,15 @@ public class WifiRigLinkSessionTest {
     }
 
     @Test
-    public void currentSessionEvents_areDelivered() {
+    public void currentSessionEvents_areDelivered_taggedWithTheirSession() {
         FakeRig rig = new FakeRig();
         List<String> events = record(rig);
         rig.start();
-        rig.login(rig.lastSession, true);
-        rig.sendError(rig.lastSession);
-        assertThat(events).containsExactly("login:true", "sendError").inOrder();
+        int s = rig.lastSession;
+        rig.login(s, true);
+        rig.sendError(s);
+        assertThat(events).containsExactly("begin:" + s, "login:true@" + s, "sendError@" + s)
+                .inOrder();
     }
 
     @Test
@@ -81,25 +86,93 @@ public class WifiRigLinkSessionTest {
         int old = rig.lastSession;
         rig.close();                 // link dropped / user disconnect
         rig.start();                 // reconnect: new ControlUdp, new session
+        int fresh = rig.lastSession;
         rig.login(old, true);        // late 0x60 from the old sockets
         rig.sendError(old);          // late sender failure from the old streams
         rig.login(old, false);
-        assertThat(events).containsExactly("closed");
+        assertThat(events).containsExactly("begin:" + old, "closed", "begin:" + fresh).inOrder();
         // The new session's own events still get through.
-        rig.login(rig.lastSession, true);
-        assertThat(events).containsExactly("closed", "login:true").inOrder();
+        rig.login(fresh, true);
+        assertThat(events).containsExactly("begin:" + old, "closed", "begin:" + fresh,
+                "login:true@" + fresh).inOrder();
     }
 
     @Test
-    public void unsessionedNotifiers_stillDeliver() {
+    public void sessionBegin_isAnnouncedAsTheCounterAdvances() {
+        // Copilot review on #778: the connector resets its per-attempt state in
+        // onSessionBegin(), so the reset and the session advance are one edge — no window
+        // in which an old-session event still matches the current id.
+        FakeRig rig = new FakeRig();
+        List<String> events = record(rig);
+        rig.start();
+        assertThat(events).containsExactly("begin:" + rig.currentLinkSession());
+        rig.start();
+        assertThat(events).containsExactly("begin:1", "begin:2").inOrder();
+    }
+
+    @Test
+    public void unsessionedNotifiers_applyToTheCurrentSession() {
         // The original overloads remain for callers that have no session to carry
         // (close() -> notifyClosed(), and any third-party rig subclass).
         FakeRig rig = new FakeRig();
         List<String> events = record(rig);
+        rig.start();
+        int s = rig.lastSession;
         rig.notifyLoginResult(true);
         rig.notifySendError();
         rig.notifyClosed();
-        assertThat(events).containsExactly("login:true", "sendError", "closed").inOrder();
+        assertThat(events).containsExactly("begin:" + s, "login:true@" + s, "sendError@" + s,
+                "closed").inOrder();
+    }
+
+    @Test
+    public void isCurrentSession_instanceForm() {
+        FakeRig rig = new FakeRig();
+        rig.start();
+        int old = rig.lastSession;
+        assertThat(rig.current(old)).isTrue();
+        rig.start();
+        assertThat(rig.current(old)).isFalse();
+        assertThat(rig.current(rig.lastSession)).isTrue();
+    }
+
+    @Test
+    public void admitSessionEvent_currentSession_admitsWithoutTeardown() {
+        FakeRig rig = new FakeRig();
+        rig.start();
+        final int[] torn = {0};
+        assertThat(rig.admit(rig.lastSession, () -> torn[0]++)).isTrue();
+        assertThat(torn[0]).isEqualTo(0);
+    }
+
+    @Test
+    public void admitSessionEvent_staleSession_tearsDownOnlyThatSessionAndRejects() {
+        // Copilot review on #778: a late send error / failed login from the old sockets
+        // must close *those* sockets, not the reconnected session's controlUdp.
+        FakeRig rig = new FakeRig();
+        List<String> events = record(rig);
+        rig.start();
+        int old = rig.lastSession;
+        rig.start();
+        final int[] torn = {0};
+        assertThat(rig.admit(old, () -> torn[0]++)).isFalse();
+        assertThat(torn[0]).isEqualTo(1);
+        // Nothing reached the listener for the stale session, and the rig wasn't closed.
+        assertThat(events).doesNotContain("closed");
+        assertThat(rig.opened).isTrue();
+    }
+
+    @Test
+    public void admitSessionEvent_staleTeardownFailure_isSwallowed() {
+        // closeAll() on sockets that are already gone can throw; the stale branch must
+        // not let that escape onto the UDP receive worker.
+        FakeRig rig = new FakeRig();
+        rig.start();
+        int old = rig.lastSession;
+        rig.start();
+        assertThat(rig.admit(old, () -> { throw new IllegalStateException("closed"); }))
+                .isFalse();
+        assertThat(rig.admit(old, null)).isFalse();
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivAddressConfigTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/CivAddressConfigTest.java
@@ -81,7 +81,9 @@ public class CivAddressConfigTest {
     }
 
     @Test
-    public void reconcile_twoDigitDecimalTwinOfModel_isRepaired() {
+    public void reconcile_twoDigitDecimalTwinOfModel_resolvesToModel() {
+        // planRepair only uses this to *detect* the ambiguity (Copilot #778); the helper's
+        // own contract is unchanged.
         // Stored "88" for 0x58 (IC-706MKIIG) -> loaded 0x88; digits "88" in decimal == 0x58.
         assertThat(CivAddressConfig.reconcileWithModel(0x88, 0x58)).isEqualTo(0x58);
         // Stored "94" for 0x5E (IC-718).
@@ -116,10 +118,30 @@ public class CivAddressConfigTest {
     }
 
     @Test
-    public void plan_unmarkedTwoDigitDecimalTwin_isRepairedAndWrittenBack() {
+    public void plan_unmarkedTwoDigitDecimalTwin_isKeptFlaggedAmbiguousAndMarked() {
+        // Copilot review on #778: "88" on an IC-706 (0x58) is either the old picker's decimal
+        // write or a deliberate 0x88 override typed into the legacy hex field — with no UI
+        // left to restore an override, it must not be silently rewritten. Keep 0x88, mark
+        // it so this is a one-time event, and flag it so the user gets the re-select hint.
         CivAddressConfig.Repair r = CivAddressConfig.planRepair("88", false, 0x88, 0x58);
-        assertThat(r.address).isEqualTo(0x58);
+        assertThat(r.address).isEqualTo(0x88);
         assertThat(r.writeBack).isTrue();
+        assertThat(r.ambiguous).isTrue();
+    }
+
+    @Test
+    public void plan_unmarkedNonTwinMismatch_isNotAmbiguous() {
+        // 0x5F vs model 0xA4: "5f" can't be a decimal string, so it's a plain override.
+        CivAddressConfig.Repair r = CivAddressConfig.planRepair("5f", false, 0x5F, 0xA4);
+        assertThat(r.address).isEqualTo(0x5F);
+        assertThat(r.writeBack).isTrue();   // marker still gets written
+        assertThat(r.ambiguous).isFalse();
+    }
+
+    @Test
+    public void plan_threeDigitDecimal_isNeverAmbiguous() {
+        // decode() already resolved "164" -> 0xA4 unambiguously; nothing to hint about.
+        assertThat(CivAddressConfig.planRepair("164", false, 0xA4, 0xA4).ambiguous).isFalse();
     }
 
     @Test
@@ -129,6 +151,7 @@ public class CivAddressConfigTest {
         CivAddressConfig.Repair r = CivAddressConfig.planRepair("88", true, 0x88, 0x58);
         assertThat(r.address).isEqualTo(0x88);
         assertThat(r.writeBack).isFalse();
+        assertThat(r.ambiguous).isFalse();   // known provenance: no hint either
     }
 
     @Test
@@ -137,6 +160,7 @@ public class CivAddressConfigTest {
         CivAddressConfig.Repair r = CivAddressConfig.planRepair("a4", false, 0xA4, 0xA4);
         assertThat(r.address).isEqualTo(0xA4);
         assertThat(r.writeBack).isTrue();
+        assertThat(r.ambiguous).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Addresses the six Copilot review threads on the dev → staging promotion PR #778. #778's head is `dev`, which takes no direct commits, so the fixes land here first and flow into #778 on merge.

## Bluetooth SCO (#772 / #776 follow-ups)

- **`refreshBluetoothHeadsetMode()` decided on `AudioManager.isBluetoothScoOn()`** — that getter only mirrors the legacy force-use flag, which the `setSpeakerphoneOn(false)` in the SCO sink clears on newer builds, so it can read *false* with the link up. A USB/VOX user deselecting a BT headset then hit `HEADSET_MODE_FORGET` instead of `LEAVE`, leaving the coordinator wanted and SCO on. `ScoPolicy.headsetModeAction` now takes the coordinator's tracked state (`linkUp` = CONNECTING/CONNECTED via new `ScoLinkCoordinator.isLinkUpOrPending()`, `linkHeld` = `isWanted()`): a held request is always told to stop when deselected, even while retrying.
- **Profile reconnects were only handled in Bluetooth-rig mode** — for the #723 case (USB/VOX rig + BT headset selected), a headset that came back after the SCO retry budget ran out never re-entered headset mode. New `ScoPolicy.profileChangeAction` routes non-BT-rig profile changes through the selection-aware `refreshBluetoothHeadsetMode()` (posted 500 ms later so AudioManager has listed the SCO endpoint). BT-rig behaviour is unchanged.

## Icom / Xiegu WLAN link (#775 follow-ups)

- **Stale-session callbacks tore down the *new* session** — `OnUdpSendIOException`/`OnLoginResponse` on old sockets called `close()` / `controlUdp.closeAll()` on the mutable field after a reconnect. Handlers now capture their own `ControlUdp` and go through `WifiRig.admitSessionEvent(session, teardown)`: a stale event quietly closes only its own sockets and skips toasts, notifications and `close()`. `start()` also closes any previous `ControlUdp` before opening a new one, so a tap-to-reconnect without disconnect no longer leaves the old timers/sockets alive. Data callbacks are session-gated too.
- **`linkState.reset()` before `start()` raced the session advance** — an old-session event could still match the current id and land on the freshly reset state. The reset now rides the new `OnLinkStateChanged.onSessionBegin(session)` edge fired from inside `beginLinkSession()`, and `WifiLinkState` carries the session id so reset and event admission are atomic under its monitor.

## CI-V address (#774 follow-up)

- **Unmarked two-digit values were silently reconciled to the model** — `"88"` on an IC-706 is either the old picker's decimal write *or* a deliberate `0x88` override typed into the legacy hex field, and with the legacy screen unreachable there is no UI left to restore an override. `planRepair` now keeps the stored value, marks it (so this is one-time), and flags it `ambiguous`; `MainViewModel` logs it and toasts a hint to re-select the rig under Settings › Radio if it uses the default (the picker then stores hex + marker). Three-digit decimals stay auto-repaired at load as before.

## Tests

91 tests across the touched classes, all green (`ScoPolicyAudioDeviceTest`, `ScoLinkCoordinatorTest`, `WifiRigLinkSessionTest`, `WifiLinkStateTest`, new `WifiConnectorSessionTest`, `WifiConnectorLinkStateTest`, `CivAddressConfigTest`); full `testDebugUnitTest` run and `installDebug` on the emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
