### PR TITLE
Android-1026: Freq Change won't work via network with IC-705

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -2717,9 +2717,7 @@ public class MainViewModel extends ViewModel {
         // disconnect path run — a cleared ViewModel did not. Without this a
         // non-daemon Timer and the rig it holds stay alive, polling a connector
         // nobody owns any more (Copilot review on #789).
-        if (baseRig != null) {
-            baseRig.onDisconnecting();
-        }
+        releaseRigOnClear(baseRig);
         // Drop the SCO retry/timeout timers and balance an outstanding start,
         // else a retained ViewModel keeps restarting SCO after the activity is
         // gone and AudioService is left holding our request.
@@ -2728,6 +2726,21 @@ public class MainViewModel extends ViewModel {
         WsjtxUdpService.INSTANCE.stop();
         getQTHThreadPool.shutdown();
         sendWaveDataThreadPool.shutdown();
+    }
+
+    /**
+     * The rig half of {@link #onCleared()}: run the rig's teardown hook so its
+     * poll timers stop with the ViewModel. A static seam because this class
+     * cannot be constructed in a unit test (the constructor starts the audio
+     * recorder, the FT8 listener and its thread pools), so
+     * {@code MainViewModelRigCleanupTest} exercises the hook wiring through
+     * this method with a recording rig. Null-safe: nothing to release before a
+     * rig was ever connected.
+     */
+    static void releaseRigOnClear(BaseRig rig) {
+        if (rig != null) {
+            rig.onDisconnecting();
+        }
     }
 
     private static final String ACTION_USB_AUDIO_PERMISSION =

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -2712,6 +2712,14 @@ public class MainViewModel extends ViewModel {
         // ViewModel is cleared while still "connected" the Timer thread would keep probing
         // the rig indefinitely. Tear it down here too.
         stopCatLivenessWatchdog();
+        // The rig's own poll Timers (IcomRig's dial follow and meter polls) are
+        // cancelled only by onDisconnecting(), which connectRig() and the
+        // disconnect path run — a cleared ViewModel did not. Without this a
+        // non-daemon Timer and the rig it holds stay alive, polling a connector
+        // nobody owns any more (Copilot review on #789).
+        if (baseRig != null) {
+            baseRig.onDisconnecting();
+        }
         // Drop the SCO retry/timeout timers and balance an outstanding start,
         // else a retained ViewModel keeps restarting SCO after the activity is
         // gone and AudioService is left holding our request.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
@@ -13,6 +13,15 @@ import com.k1af.ft8af.rigs.OnRigStateChanged;
 
 public class BaseRigConnector {
     private boolean connected;//Whether currently connected
+    /**
+     * Bumped every time the link comes up. Lets a poller that only samples
+     * {@link #isConnected()} periodically tell a link that stayed up from one
+     * that dropped and reopened between two samples (the cable auto-reconnect
+     * retries within 500 ms, well inside a 2 s poll period) — see
+     * {@code IcomRig.runReadFreqTick}. Volatile: written on the connector's
+     * I/O thread, read on rig timer threads.
+     */
+    private volatile int connectionGeneration;
     private OnConnectReceiveData onConnectReceiveData;//Action to take when data is received
     private int controlMode;//Control mode
     private OnRigStateChanged onRigStateChanged;
@@ -27,6 +36,7 @@ public class BaseRigConnector {
 
         @Override
         public void onConnected() {
+            connectionGeneration++;
             if (onRigStateChanged!=null){
                 onRigStateChanged.onConnected();
             }
@@ -174,6 +184,11 @@ public class BaseRigConnector {
     }
     public boolean isConnected(){
         return connected;
+    }
+
+    /** How many times this connector's link has come up; see the field note. */
+    public int connectionGeneration() {
+        return connectionGeneration;
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/connector/BaseRigConnector.java
@@ -12,7 +12,12 @@ import com.k1af.ft8af.rigs.OnRigStateChanged;
 
 
 public class BaseRigConnector {
-    private boolean connected;//Whether currently connected
+    //Whether currently connected. Volatile: written by the connector's I/O
+    //callbacks (onConnected/onDisconnected/onRunError), read by rig poll timers
+    //on their own threads (IcomRig.runReadFreqTick gates every tick on it) —
+    //without it a Timer thread may legally keep seeing a stale value and either
+    //never start polling or keep sending after a drop.
+    private volatile boolean connected;
     /**
      * Bumped every time the link comes up. Lets a poller that only samples
      * {@link #isConnected()} periodically tell a link that stayed up from one

--- a/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomCivUdp.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/icom/IcomCivUdp.java
@@ -61,7 +61,13 @@ public class IcomCivUdp extends IcomUdpBase{
        }
     }
 
-    public void sendOpenClose(boolean open){
+    // sendOpenClose and sendCivData build the packet from civSeq, send it, then
+    // increment civSeq. sendTrackedPacket is synchronized, but the build and the
+    // increment were not, so two senders — the dial poll, the CAT-liveness poll,
+    // a PTT command from the UI — could stamp the same sequence number and have
+    // the rig drop one as a duplicate. Both are synchronized on the same monitor
+    // as sendTrackedPacket (reentrant), so build + send + increment is atomic.
+    public synchronized void sendOpenClose(boolean open){
         if (open) {
             sendTrackedPacket(IComPacketTypes.OpenClosePacket.toBytes((short) 0
                     , localId, remoteId, civSeq,(byte) 0x04));//Open connection
@@ -94,7 +100,7 @@ public class IcomCivUdp extends IcomUdpBase{
         }
     }
 
-    public void sendCivData(byte[] data){
+    public synchronized void sendCivData(byte[] data){
         sendTrackedPacket(IComPacketTypes.CivPacket.setCivData((short) 0,localId,remoteId,civSeq,data));
         civSeq++;
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
@@ -21,7 +21,11 @@ public abstract class BaseRig {
     //rigs' poll timers read it on their Timer threads to stay quiet during TX
     //(ReadTaskAction.decide) — a stale false there means a CAT read mid-over.
     private volatile boolean isPttOn=false;
-    private BaseRigConnector connector = null;//rig connector object
+    //Rig connector object. Volatile: IcomRig starts its poll timers in its
+    //constructor and MainViewModel calls setConnector() afterwards from another
+    //thread, so without it the Timer thread could keep reading null and never
+    //poll (nor see a later reconnect's connector).
+    private volatile BaseRigConnector connector = null;
 
     public abstract boolean isConnected();//check if rig is connected
 

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/BaseRig.java
@@ -17,7 +17,10 @@ public abstract class BaseRig {
     private OnRigStateChanged onRigStateChanged;//callback when rig state changes
     private int civAddress;//CIV address
     private int baudRate;//baud rate
-    private boolean isPttOn=false;//whether PTT is on
+    //Whether PTT is on. Volatile: setPTT() writes it on the TX path, and the
+    //rigs' poll timers read it on their Timer threads to stay quiet during TX
+    //(ReadTaskAction.decide) — a stale false there means a CAT read mid-over.
+    private volatile boolean isPttOn=false;
     private BaseRigConnector connector = null;//rig connector object
 
     public abstract boolean isConnected();//check if rig is connected

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -71,6 +71,12 @@ public class IcomRig extends BaseRig {
     //relative to THIS, not to construction — see READ_FREQ_CONNECT_SETTLE_MS. Volatile:
     //written on the Timer thread, cleared on the disconnect thread (onDisconnecting).
     private volatile long connectedSinceMs = 0L;
+    //The connector's connection generation connectedSinceMs was taken in. A link
+    //that dropped and reopened entirely between two ticks (CableConnector retries
+    //within 500 ms; ticks are 2 s apart) never shows this timer a "down" sample,
+    //so without this the old settle window would be inherited and the first tick
+    //of the new session would poll straight into its connect handshake.
+    private volatile int settleGeneration = -1;
 
     private boolean oldVersion = false;//for older rigs that may not support SWR query
     //private boolean isPttOn = false;
@@ -308,7 +314,12 @@ public class IcomRig extends BaseRig {
      */
     public void startReadFreqTimer() {
         readFreqTimer = new Timer();
-        readFreqTimer.scheduleAtFixedRate(new TimerTask() {
+        // Fixed-delay schedule(), not scheduleAtFixedRate(): the latter catches
+        // up missed executions after a long tick, a GC pause or a device
+        // suspend, which would fire a burst of back-to-back CI-V reads. A
+        // polling backlog has no value and can coalesce CAT traffic; the
+        // sibling pollers (Yaesu38Rig, KenwoodTS590Rig) use fixed delay too.
+        readFreqTimer.schedule(new TimerTask() {
             @Override
             public void run() {
                 runReadFreqTick();
@@ -347,8 +358,15 @@ public class IcomRig extends BaseRig {
                 connectedSinceMs = 0L;
                 return;
             }
-            if (connectedSinceMs == 0L) {
+            //Also start a fresh window when the connector's link came up again since
+            //the window was taken, even though every tick saw it "up": the cable
+            //auto-reconnect reopens within 500 ms, so a drop and reopen can fall
+            //entirely between two 2 s ticks and the new session's connect handshake
+            //would otherwise be polled into. See settleGeneration.
+            int generation = connectionGeneration();
+            if (connectedSinceMs == 0L || generation != settleGeneration) {
                 connectedSinceMs = nowMs;
+                settleGeneration = generation;
             }
             switch (ReadTaskAction.decide(true, isPttOn())) {
                 case SKIP:
@@ -402,6 +420,11 @@ public class IcomRig extends BaseRig {
             return true;
         }
         return nowMs - connectedSinceMs >= READ_FREQ_CONNECT_SETTLE_MS;
+    }
+
+    /** The connector's connection generation, or -1 with no connector. */
+    private int connectionGeneration() {
+        return getConnector() == null ? -1 : getConnector().connectionGeneration();
     }
 
     @Override

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -22,6 +22,23 @@ import java.util.TimerTask;
 public class IcomRig extends BaseRig {
     private static final String TAG = "IcomRig";
 
+    /**
+     * How often the frequency-poll timer asks the rig for its current dial. Sized
+     * to the same 2 s cadence Yaesu38Rig / KenwoodTS590Rig / Elecraft use: fast
+     * enough that a user turning the VFO on the rig sees the app follow within
+     * a slot, slow enough that even a chatty CI-V stream stays comfortably below
+     * the rig's command rate. See {@link #startReadFreqTimer}.
+     */
+    static final long READ_FREQ_PERIOD_MS = 2000;
+    /**
+     * Small delay before the first frequency poll so a fresh connect can finish
+     * its USB-mode + set-frequency handshake ({@code setOperationBand}, ~800 ms
+     * from onConnected) before we start reading — otherwise the very first
+     * observed frequency could be the rig's power-on value, not the one we just
+     * asserted. See {@link #startReadFreqTimer}.
+     */
+    static final long READ_FREQ_START_DELAY_MS = 2000;
+
     private final int ctrAddress = 0xE0;//receive address, default 0xE0; rig reply can also be 0x00
     private byte[] dataBuffer = new byte[0];//data buffer
     private int alc = 0;
@@ -29,6 +46,7 @@ public class IcomRig extends BaseRig {
     private boolean alcMaxAlert = false;
     private boolean swrAlert = false;
     private Timer meterTimer;//Timer for querying meter
+    private Timer readFreqTimer;//Timer for polling frequency (rig->app dial follow)
 
     private boolean oldVersion = false;//for older rigs that may not support SWR query
     //private boolean isPttOn = false;
@@ -249,6 +267,67 @@ public class IcomRig extends BaseRig {
         }, 0, IComPacketTypes.METER_TIMER_PERIOD_MS);
     }
 
+    /**
+     * Poll the rig for its current dial every {@link #READ_FREQ_PERIOD_MS} so the
+     * app follows the operator turning the VFO on the rig itself (issue #753
+     * follow-up: after the CI-V address hex fix the app could command the rig,
+     * but rig&rarr;app dial updates still didn't land — every other CAT rig in
+     * this codebase runs its own frequency poll and IcomRig was the odd one out
+     * relying solely on {@link CatLiveness}'s 3 s liveness poll, which stops
+     * hard on an 8 s quiet timeout).
+     *
+     * <p>Suppressed while transmitting: an unsolicited CI-V read during TX can
+     * clobber the meter poll's SWR/ALC reads that {@link #startMeterTimer} runs
+     * at 500 ms, and a rig can't turn its VFO while keyed anyway. Follows the
+     * {@link ReadTaskAction} pattern already used by
+     * {@link Yaesu38Rig} / {@link KenwoodTS590Rig} / {@link ElecraftRig}.
+     */
+    public void startReadFreqTimer() {
+        readFreqTimer = new Timer();
+        readFreqTimer.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                runReadFreqTick();
+            }
+        }, READ_FREQ_START_DELAY_MS, READ_FREQ_PERIOD_MS);
+    }
+
+    /**
+     * One tick of the frequency-poll timer, factored out so the decision path
+     * can be exercised from tests without waiting on wall-clock time. Package-
+     * private for the same reason.
+     */
+    void runReadFreqTick() {
+        switch (ReadTaskAction.decide(isConnected(), isPttOn())) {
+            case SKIP:
+                return;
+            case READ_METERS:
+                //Meter reads are handled by the dedicated meter timer (500 ms
+                //cadence); don't duplicate them here.
+                return;
+            case READ_FREQ:
+                readFreqFromRig();
+                break;
+        }
+    }
+
+    @Override
+    public void onDisconnecting() {
+        // Cancel our timers so a reconnect (which builds a fresh IcomRig via
+        // MainViewModel.connectRig -> baseRig.onDisconnecting) doesn't leak the
+        // previous instance's polling task or double-poll after re-connect.
+        if (readFreqTimer != null) {
+            readFreqTimer.cancel();
+            readFreqTimer.purge();
+            readFreqTimer = null;
+        }
+        if (meterTimer != null) {
+            meterTimer.cancel();
+            meterTimer.purge();
+            meterTimer = null;
+        }
+    }
+
 
     public String getFrequencyStr() {
         return BaseRigOperation.getFrequencyStr(getFreq());
@@ -260,5 +339,6 @@ public class IcomRig extends BaseRig {
         this.oldVersion = !newRig;//some older rigs do not support SWR query
         setCivAddress(civAddress);
         startMeterTimer();
+        startReadFreqTimer();
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -65,8 +65,55 @@ public class IcomRig extends BaseRig {
     private int swr = 0;
     private boolean alcMaxAlert = false;
     private boolean swrAlert = false;
-    private Timer meterTimer;//Timer for querying meter
-    private Timer readFreqTimer;//Timer for polling frequency (rig->app dial follow)
+    /**
+     * How this rig schedules its repeating polls. A seam so a test can verify
+     * that the constructor schedules the dial poll (task, delay, period, fixed
+     * delay versus fixed rate) and that {@link #onDisconnecting()} cancels it,
+     * without a real {@link Timer} and without sleeping — the tick body alone
+     * being tested would stay green if the constructor stopped scheduling it.
+     */
+    interface PollScheduler {
+        /** Repeating task with a fixed delay between the end of one run and the next. */
+        Cancellable scheduleFixedDelay(Runnable task, long delayMs, long periodMs);
+
+        /** Repeating task at a fixed rate (catches up missed runs). */
+        Cancellable scheduleFixedRate(Runnable task, long delayMs, long periodMs);
+    }
+
+    /** A scheduled poll that can be stopped. */
+    interface Cancellable {
+        void cancel();
+    }
+
+    /** The production scheduler: one {@link Timer} thread per poll. */
+    static final class TimerScheduler implements PollScheduler {
+        @Override
+        public Cancellable scheduleFixedDelay(Runnable task, long delayMs, long periodMs) {
+            Timer timer = new Timer();
+            timer.schedule(wrap(task), delayMs, periodMs);
+            return () -> { timer.cancel(); timer.purge(); };
+        }
+
+        @Override
+        public Cancellable scheduleFixedRate(Runnable task, long delayMs, long periodMs) {
+            Timer timer = new Timer();
+            timer.scheduleAtFixedRate(wrap(task), delayMs, periodMs);
+            return () -> { timer.cancel(); timer.purge(); };
+        }
+
+        private static TimerTask wrap(Runnable task) {
+            return new TimerTask() {
+                @Override
+                public void run() {
+                    task.run();
+                }
+            };
+        }
+    }
+
+    private final PollScheduler scheduler;
+    private Cancellable meterPoll;//querying meters while keyed
+    private Cancellable readFreqPoll;//polling frequency (rig->app dial follow)
     //When this timer first saw the link up, or 0 while it is down. The poll gate is
     //relative to THIS, not to construction — see READ_FREQ_CONNECT_SETTLE_MS. Volatile:
     //written on the Timer thread, cleared on the disconnect thread (onDisconnecting).
@@ -285,14 +332,10 @@ public class IcomRig extends BaseRig {
     }
 
     public void startMeterTimer() {
-        meterTimer = new Timer();
-        meterTimer.scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                if (isPttOn() && !oldVersion) {//measure when PTT is pressed, and rig is not an old version
-                    sendCivData(IcomRigConstant.getSWRState(ctrAddress, getCivAddress()));
-                    sendCivData(IcomRigConstant.getALCState(ctrAddress, getCivAddress()));
-                }
+        meterPoll = scheduler.scheduleFixedRate(() -> {
+            if (isPttOn() && !oldVersion) {//measure when PTT is pressed, and rig is not an old version
+                sendCivData(IcomRigConstant.getSWRState(ctrAddress, getCivAddress()));
+                sendCivData(IcomRigConstant.getALCState(ctrAddress, getCivAddress()));
             }
         }, 0, IComPacketTypes.METER_TIMER_PERIOD_MS);
     }
@@ -313,18 +356,18 @@ public class IcomRig extends BaseRig {
      * {@link Yaesu38Rig} / {@link KenwoodTS590Rig} / {@link ElecraftRig}.
      */
     public void startReadFreqTimer() {
-        readFreqTimer = new Timer();
-        // Fixed-delay schedule(), not scheduleAtFixedRate(): the latter catches
-        // up missed executions after a long tick, a GC pause or a device
-        // suspend, which would fire a burst of back-to-back CI-V reads. A
-        // polling backlog has no value and can coalesce CAT traffic; the
-        // sibling pollers (Yaesu38Rig, KenwoodTS590Rig) use fixed delay too.
-        readFreqTimer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                runReadFreqTick();
-            }
-        }, READ_FREQ_START_DELAY_MS, READ_FREQ_PERIOD_MS);
+        // Fixed delay, not fixed rate: the latter catches up missed executions
+        // after a long tick, a GC pause or a device suspend, which would fire a
+        // burst of back-to-back CI-V reads. A polling backlog has no value and
+        // can coalesce CAT traffic; the sibling pollers (Yaesu38Rig,
+        // KenwoodTS590Rig) use fixed delay too.
+        readFreqPoll = scheduler.scheduleFixedDelay(
+                this::runReadFreqTick, READ_FREQ_START_DELAY_MS, READ_FREQ_PERIOD_MS);
+    }
+
+    /** When this timer first saw the link up (0 while down); for the scheduling test. */
+    long connectedSinceMs() {
+        return connectedSinceMs;
     }
 
     /**
@@ -432,17 +475,15 @@ public class IcomRig extends BaseRig {
         // Cancel our timers so a reconnect (which builds a fresh IcomRig via
         // MainViewModel.connectRig -> baseRig.onDisconnecting) doesn't leak the
         // previous instance's polling task or double-poll after re-connect.
-        if (readFreqTimer != null) {
-            readFreqTimer.cancel();
-            readFreqTimer.purge();
-            readFreqTimer = null;
+        if (readFreqPoll != null) {
+            readFreqPoll.cancel();
+            readFreqPoll = null;
         }
         //A reconnect must serve a fresh settle window, not inherit this one's.
         connectedSinceMs = 0L;
-        if (meterTimer != null) {
-            meterTimer.cancel();
-            meterTimer.purge();
-            meterTimer = null;
+        if (meterPoll != null) {
+            meterPoll.cancel();
+            meterPoll = null;
         }
     }
 
@@ -453,7 +494,13 @@ public class IcomRig extends BaseRig {
 
 
     public IcomRig(int civAddress, boolean newRig) {
+        this(civAddress, newRig, new TimerScheduler());
+    }
+
+    /** Test seam: the polls go through {@code scheduler} instead of real Timers. */
+    IcomRig(int civAddress, boolean newRig, PollScheduler scheduler) {
         Log.d(TAG, "IcomRig: Create.");
+        this.scheduler = scheduler;
         this.oldVersion = !newRig;//some older rigs do not support SWR query
         setCivAddress(civAddress);
         startMeterTimer();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -465,13 +465,17 @@ public class IcomRig extends BaseRig {
      *
      * <p>Two ways to clear it, because neither alone is sufficient:
      * <ul>
-     *   <li>{@code dialDeliveredAtMs != deliveredStampAtConnect} — the delivered
-     *       stamp changed since this window was taken, i.e. {@code setOperationBand}'s
-     *       delayed FA write actually reached the wire on <em>this</em> connection,
-     *       so the rig is on the frequency we asked for and there is nothing left
-     *       to wait for. Session state, not a clock comparison: the stamp is wall
-     *       clock and a correction could otherwise make a previous session's stamp
-     *       look newer than the connection (or this session's look older).</li>
+     *   <li>{@code dialDeliveredAtMs} changed since this window was taken <em>and</em>
+     *       is nonzero — {@code setOperationBand}'s delayed FA write actually reached
+     *       the wire on <em>this</em> connection, so the rig is on the frequency we
+     *       asked for and there is nothing left to wait for. Session state, not a
+     *       clock comparison: the stamp is wall clock and a correction could
+     *       otherwise make a previous session's stamp look newer than the
+     *       connection (or this session's look older). Nonzero, because
+     *       {@code GeneralVariables.operatorChoseDial} resets the stamp to 0 when
+     *       the operator picks a new dial: that is a change, but it means a NEW
+     *       write is pending, not that one landed — polling then would read the
+     *       rig's pre-command dial.</li>
      *   <li>{@link #READ_FREQ_CONNECT_SETTLE_MS} elapsed since the link came up —
      *       the fallback for when that push never lands at all, e.g. RetunePolicy
      *       suppressed it as redundant on a flapping reconnect. Without this the
@@ -492,7 +496,7 @@ public class IcomRig extends BaseRig {
         if (connectedSinceMs <= 0L) {
             return false;
         }
-        if (dialDeliveredAtMs != deliveredStampAtConnect) {
+        if (dialDeliveredAtMs != 0L && dialDeliveredAtMs != deliveredStampAtConnect) {
             return true;
         }
         return nowMs - connectedSinceMs >= READ_FREQ_CONNECT_SETTLE_MS;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -31,13 +31,33 @@ public class IcomRig extends BaseRig {
      */
     static final long READ_FREQ_PERIOD_MS = 2000;
     /**
-     * Small delay before the first frequency poll so a fresh connect can finish
-     * its USB-mode + set-frequency handshake ({@code setOperationBand}, ~800 ms
-     * from onConnected) before we start reading — otherwise the very first
-     * observed frequency could be the rig's power-on value, not the one we just
-     * asserted. See {@link #startReadFreqTimer}.
+     * Delay before the timer's first tick. This is only a cheap way to keep the
+     * poll off the connect path — it is measured from {@code IcomRig}
+     * construction, which happens before the connector logs in, so it cannot on
+     * its own guarantee the connect-time handshake is done. The gate that
+     * actually does that is {@link #READ_FREQ_CONNECT_SETTLE_MS}, applied per
+     * tick in {@link #mayPollDial}. See {@link #startReadFreqTimer}.
      */
     static final long READ_FREQ_START_DELAY_MS = 2000;
+    /**
+     * How long after the link comes up the dial poll stays quiet, when the
+     * connect-time frequency push can't be observed landing.
+     *
+     * <p>{@link #READ_FREQ_START_DELAY_MS} alone is not enough, because a
+     * {@code Timer} start delay runs from {@code IcomRig} construction and the
+     * rig is constructed in {@code MainViewModel.connectRig} <em>before</em> the
+     * connector logs in. The handshake we need to clear finishes at
+     * {@code onConnected + 1500 ms} (the posted {@code setOperationBand})
+     * {@code + 800 ms} (its delayed FA write) — i.e. always later than 2000 ms
+     * after construction, no matter how fast the login is. Polling into that
+     * window reads the rig's power-on dial, which {@code onFreqChanged} then
+     * adopts as {@code commandedBandHz}, and the connect-time retune "preserves"
+     * the wrong frequency.
+     *
+     * <p>2500 ms covers that 2300 ms handshake with margin, measured from when
+     * this timer first observes the link up.
+     */
+    static final long READ_FREQ_CONNECT_SETTLE_MS = 2500;
 
     private final int ctrAddress = 0xE0;//receive address, default 0xE0; rig reply can also be 0x00
     private byte[] dataBuffer = new byte[0];//data buffer
@@ -47,6 +67,10 @@ public class IcomRig extends BaseRig {
     private boolean swrAlert = false;
     private Timer meterTimer;//Timer for querying meter
     private Timer readFreqTimer;//Timer for polling frequency (rig->app dial follow)
+    //When this timer first saw the link up, or 0 while it is down. The poll gate is
+    //relative to THIS, not to construction — see READ_FREQ_CONNECT_SETTLE_MS. Volatile:
+    //written on the Timer thread, cleared on the disconnect thread (onDisconnecting).
+    private volatile long connectedSinceMs = 0L;
 
     private boolean oldVersion = false;//for older rigs that may not support SWR query
     //private boolean isPttOn = false;
@@ -298,17 +322,86 @@ public class IcomRig extends BaseRig {
      * private for the same reason.
      */
     void runReadFreqTick() {
-        switch (ReadTaskAction.decide(isConnected(), isPttOn())) {
-            case SKIP:
+        runReadFreqTick(System.currentTimeMillis(), GeneralVariables.operatorDialDeliveredAtMs);
+    }
+
+    /**
+     * The tick body, with the two time-dependent inputs passed in so tests can
+     * drive the connect-settle gate without sleeping.
+     *
+     * <p>Everything is wrapped in a catch-all: an unchecked exception thrown out
+     * of a {@link TimerTask} kills its {@link Timer} thread outright, which would
+     * silently end dial polling for the rest of the session. The sibling rig
+     * polls ({@link Yaesu38Rig}, {@link KenwoodTS590Rig}) guard theirs the same
+     * way; this one logs the throwable rather than just its message so the stack
+     * trace survives.
+     *
+     * @param nowMs             current wall clock
+     * @param dialDeliveredAtMs {@code GeneralVariables.operatorDialDeliveredAtMs}
+     */
+    void runReadFreqTick(long nowMs, long dialDeliveredAtMs) {
+        try {
+            boolean connected = isConnected();
+            if (!connected) {
+                //Link down: forget the settle window so a reconnect earns a fresh one.
+                connectedSinceMs = 0L;
                 return;
-            case READ_METERS:
-                //Meter reads are handled by the dedicated meter timer (500 ms
-                //cadence); don't duplicate them here.
-                return;
-            case READ_FREQ:
-                readFreqFromRig();
-                break;
+            }
+            if (connectedSinceMs == 0L) {
+                connectedSinceMs = nowMs;
+            }
+            switch (ReadTaskAction.decide(true, isPttOn())) {
+                case SKIP:
+                    return;
+                case READ_METERS:
+                    //Meter reads are handled by the dedicated meter timer (500 ms
+                    //cadence); don't duplicate them here.
+                    return;
+                case READ_FREQ:
+                    if (!mayPollDial(nowMs, connectedSinceMs, dialDeliveredAtMs)) {
+                        return;
+                    }
+                    readFreqFromRig();
+                    break;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "readFreq tick failed", e);
         }
+    }
+
+    /**
+     * Whether the connect-time frequency handshake is far enough along that a
+     * dial reading can be trusted as the operator's dial rather than the rig's
+     * power-on value.
+     *
+     * <p>Two ways to clear it, because neither alone is sufficient:
+     * <ul>
+     *   <li>{@code dialDeliveredAtMs >= connectedSinceMs} — {@code setOperationBand}'s
+     *       delayed FA write actually reached the wire on <em>this</em> connection,
+     *       so the rig is on the frequency we asked for and there is nothing left
+     *       to wait for. A stamp older than the connection is a previous session's
+     *       and doesn't count.</li>
+     *   <li>{@link #READ_FREQ_CONNECT_SETTLE_MS} elapsed since the link came up —
+     *       the fallback for when that push never lands at all, e.g. RetunePolicy
+     *       suppressed it as redundant on a flapping reconnect. Without this the
+     *       poll could stay off for the whole session and the dial-follow feature
+     *       this timer exists for would silently never run.</li>
+     * </ul>
+     *
+     * <p>Pure and static so the gate is unit-testable without a Timer or a clock.
+     *
+     * @param nowMs             current wall clock
+     * @param connectedSinceMs  when this timer first saw the link up, or 0 if down
+     * @param dialDeliveredAtMs {@code GeneralVariables.operatorDialDeliveredAtMs}
+     */
+    static boolean mayPollDial(long nowMs, long connectedSinceMs, long dialDeliveredAtMs) {
+        if (connectedSinceMs <= 0L) {
+            return false;
+        }
+        if (dialDeliveredAtMs >= connectedSinceMs) {
+            return true;
+        }
+        return nowMs - connectedSinceMs >= READ_FREQ_CONNECT_SETTLE_MS;
     }
 
     @Override
@@ -321,6 +414,8 @@ public class IcomRig extends BaseRig {
             readFreqTimer.purge();
             readFreqTimer = null;
         }
+        //A reconnect must serve a fresh settle window, not inherit this one's.
+        connectedSinceMs = 0L;
         if (meterTimer != null) {
             meterTimer.cancel();
             meterTimer.purge();

--- a/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java
@@ -9,6 +9,7 @@ import android.util.Log;
 
 import com.k1af.ft8af.Ft8Message;
 import com.k1af.ft8af.GeneralVariables;
+import android.os.SystemClock;
 import com.k1af.ft8af.R;
 import com.k1af.ft8af.connector.ConnectMode;
 import com.k1af.ft8af.database.ControlMode;
@@ -114,10 +115,17 @@ public class IcomRig extends BaseRig {
     private final PollScheduler scheduler;
     private Cancellable meterPoll;//querying meters while keyed
     private Cancellable readFreqPoll;//polling frequency (rig->app dial follow)
-    //When this timer first saw the link up, or 0 while it is down. The poll gate is
-    //relative to THIS, not to construction — see READ_FREQ_CONNECT_SETTLE_MS. Volatile:
-    //written on the Timer thread, cleared on the disconnect thread (onDisconnecting).
+    //When this timer first saw the link up (SystemClock.elapsedRealtime(), so a
+    //wall-clock correction cannot stretch or shrink the window), or 0 while it is
+    //down. The poll gate is relative to THIS, not to construction — see
+    //READ_FREQ_CONNECT_SETTLE_MS. Volatile: written on the Timer thread, cleared on
+    //the disconnect thread (onDisconnecting).
     private volatile long connectedSinceMs = 0L;
+    //GeneralVariables.operatorDialDeliveredAtMs as it stood when the window was
+    //taken. "The connect-time push landed on THIS connection" is then "the stamp
+    //changed since", which no clock step in either direction can fake or hide —
+    //comparing the wall-clock stamp against a connect time could.
+    private volatile long deliveredStampAtConnect = 0L;
     //The connector's connection generation connectedSinceMs was taken in. A link
     //that dropped and reopened entirely between two ticks (CableConnector retries
     //within 500 ms; ticks are 2 s apart) never shows this timer a "down" sample,
@@ -130,10 +138,28 @@ public class IcomRig extends BaseRig {
 
     @Override
     public void setPTT(boolean on) {
-        super.setPTT(on);
-        //isPttOn = on;
+        // isPttOn() is what the poll timers read to stay quiet during TX, so
+        // publish it BEFORE the key-down goes out and only AFTER the unkey is on
+        // the wire. With the flag flipped to false first, a tick landing between
+        // the flip and the PTT-off command saw "not transmitting" and could send
+        // a frequency read ahead of the unkey — the mid-transmit CI-V read the
+        // gate exists to prevent (Copilot review on #789).
+        if (on) {
+            super.setPTT(true);
+        }
         alcMaxAlert = false;
         swrAlert = false;
+        try {
+            dispatchPtt(on);
+        } finally {
+            if (!on) {
+                super.setPTT(false);
+            }
+        }
+    }
+
+    /** The data-mode fix-up and the PTT command itself; see {@link #setPTT}. */
+    private void dispatchPtt(boolean on) {
         if (on) {
             //fix connection mode: 0x03=WLAN, 0x01=USB, 0x02=USB+MIC, ensuring audio can be sent to rig
             if (GeneralVariables.connectMode == ConnectMode.NETWORK) {
@@ -376,7 +402,7 @@ public class IcomRig extends BaseRig {
      * private for the same reason.
      */
     void runReadFreqTick() {
-        runReadFreqTick(System.currentTimeMillis(), GeneralVariables.operatorDialDeliveredAtMs);
+        runReadFreqTick(SystemClock.elapsedRealtime(), GeneralVariables.operatorDialDeliveredAtMs);
     }
 
     /**
@@ -390,7 +416,7 @@ public class IcomRig extends BaseRig {
      * way; this one logs the throwable rather than just its message so the stack
      * trace survives.
      *
-     * @param nowMs             current wall clock
+     * @param nowMs             a monotonic clock ({@code SystemClock.elapsedRealtime()})
      * @param dialDeliveredAtMs {@code GeneralVariables.operatorDialDeliveredAtMs}
      */
     void runReadFreqTick(long nowMs, long dialDeliveredAtMs) {
@@ -410,6 +436,7 @@ public class IcomRig extends BaseRig {
             if (connectedSinceMs == 0L || generation != settleGeneration) {
                 connectedSinceMs = nowMs;
                 settleGeneration = generation;
+                deliveredStampAtConnect = dialDeliveredAtMs;
             }
             switch (ReadTaskAction.decide(true, isPttOn())) {
                 case SKIP:
@@ -419,7 +446,8 @@ public class IcomRig extends BaseRig {
                     //cadence); don't duplicate them here.
                     return;
                 case READ_FREQ:
-                    if (!mayPollDial(nowMs, connectedSinceMs, dialDeliveredAtMs)) {
+                    if (!mayPollDial(nowMs, connectedSinceMs, deliveredStampAtConnect,
+                            dialDeliveredAtMs)) {
                         return;
                     }
                     readFreqFromRig();
@@ -437,11 +465,13 @@ public class IcomRig extends BaseRig {
      *
      * <p>Two ways to clear it, because neither alone is sufficient:
      * <ul>
-     *   <li>{@code dialDeliveredAtMs >= connectedSinceMs} — {@code setOperationBand}'s
+     *   <li>{@code dialDeliveredAtMs != deliveredStampAtConnect} — the delivered
+     *       stamp changed since this window was taken, i.e. {@code setOperationBand}'s
      *       delayed FA write actually reached the wire on <em>this</em> connection,
      *       so the rig is on the frequency we asked for and there is nothing left
-     *       to wait for. A stamp older than the connection is a previous session's
-     *       and doesn't count.</li>
+     *       to wait for. Session state, not a clock comparison: the stamp is wall
+     *       clock and a correction could otherwise make a previous session's stamp
+     *       look newer than the connection (or this session's look older).</li>
      *   <li>{@link #READ_FREQ_CONNECT_SETTLE_MS} elapsed since the link came up —
      *       the fallback for when that push never lands at all, e.g. RetunePolicy
      *       suppressed it as redundant on a flapping reconnect. Without this the
@@ -451,15 +481,18 @@ public class IcomRig extends BaseRig {
      *
      * <p>Pure and static so the gate is unit-testable without a Timer or a clock.
      *
-     * @param nowMs             current wall clock
-     * @param connectedSinceMs  when this timer first saw the link up, or 0 if down
-     * @param dialDeliveredAtMs {@code GeneralVariables.operatorDialDeliveredAtMs}
+     * @param nowMs                   a monotonic clock, same base as {@code connectedSinceMs}
+     * @param connectedSinceMs        when this timer first saw the link up, or 0 if down
+     * @param deliveredStampAtConnect {@code GeneralVariables.operatorDialDeliveredAtMs}
+     *                                as it stood when the window was taken
+     * @param dialDeliveredAtMs       {@code GeneralVariables.operatorDialDeliveredAtMs} now
      */
-    static boolean mayPollDial(long nowMs, long connectedSinceMs, long dialDeliveredAtMs) {
+    static boolean mayPollDial(long nowMs, long connectedSinceMs,
+                               long deliveredStampAtConnect, long dialDeliveredAtMs) {
         if (connectedSinceMs <= 0L) {
             return false;
         }
-        if (dialDeliveredAtMs >= connectedSinceMs) {
+        if (dialDeliveredAtMs != deliveredStampAtConnect) {
             return true;
         }
         return nowMs - connectedSinceMs >= READ_FREQ_CONNECT_SETTLE_MS;

--- a/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelRigCleanupTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/MainViewModelRigCleanupTest.java
@@ -1,0 +1,47 @@
+package com.k1af.ft8af;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.rigs.BaseRig;
+
+import org.junit.Test;
+
+/**
+ * {@code MainViewModel.onCleared()} must run the rig's teardown hook: the
+ * rig's poll timers are non-daemon and are cancelled nowhere else once the
+ * ViewModel is gone (Copilot review on #789). The ViewModel itself cannot be
+ * constructed here — its constructor starts the audio recorder and the FT8
+ * listener — so the hook wiring is exercised through the static seam
+ * {@code releaseRigOnClear} that {@code onCleared()} delegates to.
+ */
+public class MainViewModelRigCleanupTest {
+
+    /** A rig that only records whether its teardown hook ran. */
+    private static final class RecordingRig extends BaseRig {
+        int disconnecting;
+
+        @Override
+        public void onDisconnecting() {
+            disconnecting++;
+        }
+
+        @Override public boolean isConnected() { return false; }
+        @Override public void setUsbModeToRig() { }
+        @Override public void setFreqToRig() { }
+        @Override public void onReceiveData(byte[] data) { }
+        @Override public void readFreqFromRig() { }
+        @Override public String getName() { return "recording"; }
+    }
+
+    @Test
+    public void clearingTheViewModel_runsTheRigTeardownHook() {
+        RecordingRig rig = new RecordingRig();
+        MainViewModel.releaseRigOnClear(rig);
+        assertThat(rig.disconnecting).isEqualTo(1);
+    }
+
+    @Test
+    public void clearingWithNoRig_isANoOp() {
+        MainViewModel.releaseRigOnClear(null);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigPollSchedulingTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigPollSchedulingTest.java
@@ -1,0 +1,137 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.connector.BaseRigConnector;
+import com.k1af.ft8af.icom.IComPacketTypes;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What the {@link IcomRig} constructor schedules and what
+ * {@link IcomRig#onDisconnecting()} cancels, verified through the
+ * {@link IcomRig.PollScheduler} seam with no real {@code Timer} and no
+ * sleeping. {@link IcomRigReadFreqPollTest} covers the tick body; this class
+ * covers the fact that the constructor actually wires that body up as the
+ * dial poll with the documented delay and period, fixed-delay, so removing
+ * the {@code startReadFreqTimer()} call or scheduling the wrong task could not
+ * leave the suite green (Copilot review on #789).
+ *
+ * <p>Robolectric because the scheduled task is the real
+ * {@code runReadFreqTick()}, which reads {@code GeneralVariables}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class IcomRigPollSchedulingTest {
+
+    private static final class Scheduled {
+        final String kind;
+        final Runnable task;
+        final long delayMs;
+        final long periodMs;
+        boolean cancelled;
+
+        Scheduled(String kind, Runnable task, long delayMs, long periodMs) {
+            this.kind = kind;
+            this.task = task;
+            this.delayMs = delayMs;
+            this.periodMs = periodMs;
+        }
+    }
+
+    private static final class RecordingScheduler implements IcomRig.PollScheduler {
+        final List<Scheduled> scheduled = new ArrayList<>();
+
+        @Override
+        public IcomRig.Cancellable scheduleFixedDelay(Runnable task, long delayMs, long periodMs) {
+            Scheduled s = new Scheduled("fixed-delay", task, delayMs, periodMs);
+            scheduled.add(s);
+            return () -> s.cancelled = true;
+        }
+
+        @Override
+        public IcomRig.Cancellable scheduleFixedRate(Runnable task, long delayMs, long periodMs) {
+            Scheduled s = new Scheduled("fixed-rate", task, delayMs, periodMs);
+            scheduled.add(s);
+            return () -> s.cancelled = true;
+        }
+    }
+
+    private static final class ConnectedConnector extends BaseRigConnector {
+        ConnectedConnector() {
+            super(0);
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+    }
+
+    private Scheduled dialPoll(RecordingScheduler s) {
+        for (Scheduled x : s.scheduled) {
+            if (x.kind.equals("fixed-delay")) return x;
+        }
+        throw new AssertionError("no fixed-delay poll scheduled: " + s.scheduled.size());
+    }
+
+    private Scheduled meterPoll(RecordingScheduler s) {
+        for (Scheduled x : s.scheduled) {
+            if (x.kind.equals("fixed-rate")) return x;
+        }
+        throw new AssertionError("no fixed-rate poll scheduled");
+    }
+
+    @Test
+    public void constructor_schedulesTheDialPollFixedDelayWithTheDocumentedTiming() {
+        RecordingScheduler s = new RecordingScheduler();
+        new IcomRig(0xA4, true, s);
+
+        Scheduled dial = dialPoll(s);
+        assertThat(dial.delayMs).isEqualTo(IcomRig.READ_FREQ_START_DELAY_MS);
+        assertThat(dial.periodMs).isEqualTo(IcomRig.READ_FREQ_PERIOD_MS);
+        assertThat(s.scheduled).hasSize(2); // dial poll + meter poll, nothing else
+    }
+
+    @Test
+    public void constructor_schedulesTheMeterPollAtFixedRate() {
+        RecordingScheduler s = new RecordingScheduler();
+        new IcomRig(0xA4, true, s);
+
+        Scheduled meter = meterPoll(s);
+        assertThat(meter.delayMs).isEqualTo(0);
+        assertThat(meter.periodMs).isEqualTo(IComPacketTypes.METER_TIMER_PERIOD_MS);
+    }
+
+    @Test
+    public void theScheduledDialTaskIsTheTick() {
+        // Running the scheduled task with the link up takes the settle window,
+        // which only the tick body does — so the constructor wired the right
+        // Runnable, not an empty one.
+        RecordingScheduler s = new RecordingScheduler();
+        IcomRig rig = new IcomRig(0xA4, true, s);
+        rig.setConnector(new ConnectedConnector());
+        assertThat(rig.connectedSinceMs()).isEqualTo(0L);
+
+        dialPoll(s).task.run();
+
+        assertThat(rig.connectedSinceMs()).isGreaterThan(0L);
+    }
+
+    @Test
+    public void onDisconnecting_cancelsBothPolls_andIsIdempotent() {
+        RecordingScheduler s = new RecordingScheduler();
+        IcomRig rig = new IcomRig(0xA4, true, s);
+
+        rig.onDisconnecting();
+        rig.onDisconnecting();
+
+        assertThat(dialPoll(s).cancelled).isTrue();
+        assertThat(meterPoll(s).cancelled).isTrue();
+        assertThat(rig.connectedSinceMs()).isEqualTo(0L);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigPttPollOrderingTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigPttPollOrderingTest.java
@@ -1,0 +1,165 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.GeneralVariables;
+import com.k1af.ft8af.connector.BaseRigConnector;
+import com.k1af.ft8af.connector.ConnectMode;
+import com.k1af.ft8af.database.ControlMode;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The dial poll must never send a frequency read while the rig is keyed, and
+ * "keyed" has to include the moments the PTT command itself is on its way out.
+ * {@code IcomRig.setPTT} used to publish {@code isPttOn()} first and dispatch
+ * second, so a tick landing between the flag going false and the PTT-off
+ * command reaching the wire saw "not transmitting" and read the dial ahead of
+ * the unkey (Copilot review on #789). These tests make the connector fire a
+ * settled tick <em>during</em> the PTT dispatch — the Timer thread landing
+ * mid-command, made deterministic — and check what went out, and in what order.
+ *
+ * <p>Robolectric because {@code setPTT} reads {@code GeneralVariables}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class IcomRigPttPollOrderingTest {
+
+    private static final int IC705_CIV = 0xA4;
+    private static final long T0 = 1_700_000_000_000L;
+    private static final byte[] READ_FREQ_FRAME = {
+            (byte) 0xFE, (byte) 0xFE, (byte) 0xA4, (byte) 0xE0, (byte) 0x03, (byte) 0xFD
+    };
+
+    /** Records every send, and runs a settled poll tick inside each PTT dispatch. */
+    private final class InterleavingConnector extends BaseRigConnector {
+        final List<String> events = new ArrayList<>();
+        long now = T0 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS;
+
+        InterleavingConnector() {
+            super(ControlMode.CAT);
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public synchronized void sendData(byte[] data) {
+            events.add(Arrays.equals(data, READ_FREQ_FRAME) ? "READ_FREQ" : "civ");
+        }
+
+        @Override
+        public void setPttOn(byte[] command) {
+            events.add("PTT-command");
+            tickDuringDispatch();
+        }
+
+        @Override
+        public void setPttOn(boolean on) {
+            events.add("PTT-command");
+            tickDuringDispatch();
+        }
+
+        private void tickDuringDispatch() {
+            now += 3_000;
+            rig.runReadFreqTick(now, 0L);
+        }
+    }
+
+    private InterleavingConnector connector;
+    private IcomRig rig;
+    private int savedConnectMode;
+
+    @Before
+    public void setUp() {
+        savedConnectMode = GeneralVariables.connectMode;
+        GeneralVariables.connectMode = ConnectMode.USB_CABLE;
+        connector = new InterleavingConnector();
+        rig = new IcomRig(IC705_CIV, true, new IcomRig.PollScheduler() {
+            @Override
+            public IcomRig.Cancellable scheduleFixedDelay(Runnable task, long delayMs, long periodMs) {
+                return () -> { };
+            }
+
+            @Override
+            public IcomRig.Cancellable scheduleFixedRate(Runnable task, long delayMs, long periodMs) {
+                return () -> { };
+            }
+        });
+        rig.setConnector(connector);
+        rig.setControlMode(ControlMode.CAT);
+        // Take and outlive the settle window so a tick is otherwise free to poll.
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(connector.now, 0L);
+        assertThat(connector.events).containsExactly("READ_FREQ");
+        connector.events.clear();
+    }
+
+    @After
+    public void tearDown() {
+        rig.onDisconnecting();
+        GeneralVariables.connectMode = savedConnectMode;
+    }
+
+    @Test
+    public void tickDuringKeyDown_doesNotReadTheDial() {
+        rig.setPTT(true);
+
+        assertThat(connector.events).contains("PTT-command");
+        assertThat(connector.events).doesNotContain("READ_FREQ");
+        assertThat(rig.isPttOn()).isTrue();
+    }
+
+    @Test
+    public void tickDuringKeyUp_doesNotReadTheDialAheadOfTheUnkey() {
+        rig.setPTT(true);
+        connector.events.clear();
+
+        rig.setPTT(false);
+
+        // The tick that fired while the PTT-off command was being dispatched
+        // must have stayed quiet: the flag is still "keyed" until the command
+        // is on the wire.
+        assertThat(connector.events).containsExactly("PTT-command");
+        assertThat(rig.isPttOn()).isFalse();
+
+        // Once the unkey is out, polling resumes.
+        connector.now += 3_000;
+        rig.runReadFreqTick(connector.now, 0L);
+        assertThat(connector.events).containsExactly("PTT-command", "READ_FREQ").inOrder();
+    }
+
+    @Test
+    public void flagIsPublishedEvenIfTheUnkeyDispatchThrows() {
+        // The finally in setPTT: a transport failure on the way out must not
+        // leave the rig marked keyed forever (which would silence polling).
+        rig.setPTT(true);
+        rig.setConnector(new BaseRigConnector(ControlMode.CAT) {
+            @Override
+            public boolean isConnected() {
+                return true;
+            }
+
+            @Override
+            public void setPttOn(byte[] command) {
+                throw new IllegalStateException("transport exploded");
+            }
+        });
+        rig.setControlMode(ControlMode.CAT);
+        try {
+            rig.setPTT(false);
+        } catch (IllegalStateException expected) {
+            // propagated, as before
+        }
+        assertThat(rig.isPttOn()).isFalse();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
@@ -42,6 +42,16 @@ public class IcomRigReadFreqPollTest {
     /** IC-705's factory address, matching the rest of the ICOM tests. */
     private static final int IC705_CIV = 0xA4;
 
+    /** Arbitrary fixed "now" so the connect-settle gate needs no wall clock. */
+    private static final long T0 = 1_700_000_000_000L;
+
+    /**
+     * A tick far enough past {@link #T0} that the connect-settle window has
+     * elapsed, for tests whose subject is the PTT/connected decision rather
+     * than the gate itself.
+     */
+    private static final long T_SETTLED = T0 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS;
+
     /** CI-V read-frequency frame the app must send: FE FE A4 E0 03 FD. */
     private static final byte[] READ_FREQ_FRAME = {
             (byte) 0xFE, (byte) 0xFE, (byte) 0xA4, (byte) 0xE0,
@@ -75,7 +85,10 @@ public class IcomRigReadFreqPollTest {
         connector.connected = true;
         // PTT off: rig.isPttOn() is false out of the constructor.
 
-        rig.runReadFreqTick();
+        // First tick observes the link coming up and starts the settle window;
+        // the second is past it, so the read goes out.
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(T_SETTLED, 0L);
 
         assertThat(connector.sent).hasSize(1);
         assertThat(connector.sent.get(0)).isEqualTo(READ_FREQ_FRAME);
@@ -87,9 +100,102 @@ public class IcomRigReadFreqPollTest {
         // absent connector with reads it can't deliver anyway.
         connector.connected = false;
 
-        rig.runReadFreqTick();
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(T_SETTLED, 0L);
 
         assertThat(connector.sent).isEmpty();
+    }
+
+    @Test
+    public void firstTickAfterConnect_doesNotPollBeforeTheConnectHandshake() {
+        // The regression this gate exists for: the Timer's start delay runs
+        // from IcomRig construction, but the rig is built before the connector
+        // logs in, so the first tick always lands before setOperationBand's
+        // FA write (onConnected + 1500 ms + 800 ms). Reading there returns the
+        // rig's power-on dial, which onFreqChanged adopts as commandedBandHz.
+        connector.connected = true;
+
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(T0 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS - 1, 0L);
+
+        assertThat(connector.sent).isEmpty();
+    }
+
+    @Test
+    public void connectPushDelivered_pollsWithoutWaitingOutTheSettleWindow() {
+        // setOperationBand's FA write landed on this connection, so the rig is
+        // already on the dial we asked for and there is nothing left to wait
+        // for — no reason to sit out the rest of the window.
+        connector.connected = true;
+
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(T0 + 100, T0 + 50);
+
+        assertThat(countMatching(connector.sent, READ_FREQ_FRAME)).isEqualTo(1);
+    }
+
+    @Test
+    public void reconnect_earnsAFreshSettleWindow() {
+        // A drop resets connectedSinceMs, so the link coming back does not
+        // inherit the previous session's elapsed window and poll immediately
+        // into the new connect handshake.
+        connector.connected = true;
+        rig.runReadFreqTick(T0, 0L);
+        connector.connected = false;
+        rig.runReadFreqTick(T0 + 10_000, 0L);
+
+        connector.connected = true;
+        rig.runReadFreqTick(T0 + 20_000, 0L);
+
+        assertThat(connector.sent).isEmpty();
+    }
+
+    @Test
+    public void tickSurvivesAnUncheckedExceptionFromTheTransport() {
+        // An unchecked exception out of a TimerTask kills the Timer thread, so
+        // one bad tick would end dial polling for the whole session. The tick
+        // has to swallow and log it instead.
+        connector.connected = true;
+        connector.throwOnSend = true;
+
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(T_SETTLED, 0L);
+
+        // Still ticking afterwards: the next poll is attempted, not skipped.
+        connector.throwOnSend = false;
+        rig.runReadFreqTick(T_SETTLED + 2000, 0L);
+        assertThat(countMatching(connector.sent, READ_FREQ_FRAME)).isEqualTo(1);
+    }
+
+    // -- mayPollDial (pure gate) ---------------------------------------------
+
+    @Test
+    public void mayPollDial_linkDown_isFalse() {
+        assertThat(IcomRig.mayPollDial(T0, 0L, T0)).isFalse();
+    }
+
+    @Test
+    public void mayPollDial_staleDeliveredStampFromAPreviousSession_doesNotCount() {
+        // A stamp older than this connection belongs to the last one; it must
+        // not short-circuit the window for the link that just came up.
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, T0 - 5_000)).isFalse();
+    }
+
+    @Test
+    public void mayPollDial_settleWindowBoundaryIsInclusive() {
+        assertThat(IcomRig.mayPollDial(
+                T0 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS - 1, T0, 0L)).isFalse();
+        assertThat(IcomRig.mayPollDial(
+                T0 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS, T0, 0L)).isTrue();
+    }
+
+    @Test
+    public void mayPollDial_settleWindowCoversTheWholeConnectHandshake() {
+        // onConnected posts setOperationBand at +1500 ms and its FA write lands
+        // 800 ms after that. The window must outlast the pair, otherwise this
+        // gate is no better than the construction-relative start delay it
+        // replaced.
+        assertThat(IcomRig.READ_FREQ_CONNECT_SETTLE_MS).isAtLeast(1500L + 800L);
     }
 
     @Test
@@ -101,7 +207,8 @@ public class IcomRigReadFreqPollTest {
         connector.connected = true;
         rig.setPTT(true);
 
-        rig.runReadFreqTick();
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(T_SETTLED, 0L);
 
         // setPTT(true) itself writes a data-mode command on the connector, so
         // filter to just the read-frequency frame we're guarding against.
@@ -157,6 +264,8 @@ public class IcomRigReadFreqPollTest {
     private static final class CapturingConnector extends BaseRigConnector {
         final List<byte[]> sent = new ArrayList<>();
         boolean connected = false;
+        /** Simulates a transport that throws an unchecked exception mid-write. */
+        boolean throwOnSend = false;
 
         CapturingConnector() {
             super(0 /* controlMode — unused by this test */);
@@ -164,6 +273,9 @@ public class IcomRigReadFreqPollTest {
 
         @Override
         public synchronized void sendData(byte[] data) {
+            if (throwOnSend) {
+                throw new IllegalStateException("transport exploded");
+            }
             // Copy so a caller reusing its buffer can't retroactively change
             // what we recorded.
             byte[] copy = new byte[data.length];

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
@@ -135,6 +135,41 @@ public class IcomRigReadFreqPollTest {
     }
 
     @Test
+    public void reconnectBetweenTicks_earnsAFreshSettleWindow() {
+        // CableConnector's auto-reconnect retries within 500 ms, so a drop and
+        // a reopen can both happen between two 2 s ticks: this timer never
+        // samples the link down. The connector's connection generation is what
+        // tells the tick a new session started (Copilot review on #789).
+        connector.connected = true;
+        connector.getOnConnectorStateChanged().onConnected(); // session 1 up
+        rig.runReadFreqTick(T0, 0L);
+        rig.runReadFreqTick(T_SETTLED, 0L);
+        assertThat(connector.sent).hasSize(1); // settled, polled once
+        connector.sent.clear();
+
+        // Drop and reopen with no tick in between: isConnected() reads true on
+        // every sample this timer takes.
+        connector.getOnConnectorStateChanged().onDisconnected();
+        connector.getOnConnectorStateChanged().onConnected(); // session 2 up
+
+        // First tick of session 2 lands inside its connect handshake: no poll.
+        rig.runReadFreqTick(T_SETTLED + 2_000, 0L);
+        assertThat(connector.sent).isEmpty();
+        // ...and polls again once the fresh window has elapsed.
+        rig.runReadFreqTick(T_SETTLED + 2_000 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS, 0L);
+        assertThat(connector.sent).hasSize(1);
+    }
+
+    @Test
+    public void connectionGeneration_countsEveryLinkUp() {
+        assertThat(connector.connectionGeneration()).isEqualTo(0);
+        connector.getOnConnectorStateChanged().onConnected();
+        connector.getOnConnectorStateChanged().onDisconnected();
+        connector.getOnConnectorStateChanged().onConnected();
+        assertThat(connector.connectionGeneration()).isEqualTo(2);
+    }
+
+    @Test
     public void reconnect_earnsAFreshSettleWindow() {
         // A drop resets connectedSinceMs, so the link coming back does not
         // inherit the previous session's elapsed window and poll immediately

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
@@ -69,6 +69,11 @@ public class IcomRigReadFreqPollTest {
         // modern IC-705 / IC-7300 / IC-9700.
         rig = new IcomRig(IC705_CIV, true);
         rig.setConnector(connector);
+        // The constructor starts the real 2 s poll and 500 ms meter Timers.
+        // Cancel them right away so a slow or paused test worker can't get a
+        // background tick appended to `sent` between a manual runReadFreqTick
+        // and its assertion; the manual ticks below need no Timer.
+        rig.onDisconnecting();
     }
 
     @After
@@ -158,6 +163,17 @@ public class IcomRigReadFreqPollTest {
         // ...and polls again once the fresh window has elapsed.
         rig.runReadFreqTick(T_SETTLED + 2_000 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS, 0L);
         assertThat(connector.sent).hasSize(1);
+    }
+
+    @Test
+    public void connectionFlagsAreVolatile() throws Exception {
+        // The tick reads both fields on the Timer thread; the writers are the
+        // connector I/O thread (connected) and the TX path (isPttOn). Without
+        // volatile there is no happens-before edge and a stale read is legal.
+        assertThat(java.lang.reflect.Modifier.isVolatile(
+                BaseRigConnector.class.getDeclaredField("connected").getModifiers())).isTrue();
+        assertThat(java.lang.reflect.Modifier.isVolatile(
+                BaseRig.class.getDeclaredField("isPttOn").getModifiers())).isTrue();
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
@@ -243,33 +243,55 @@ public class IcomRigReadFreqPollTest {
 
     // -- mayPollDial (pure gate) ---------------------------------------------
 
+    private static final long SETTLE = IcomRig.READ_FREQ_CONNECT_SETTLE_MS;
+
     @Test
     public void mayPollDial_linkDown_isFalse() {
-        assertThat(IcomRig.mayPollDial(T0, 0L, T0)).isFalse();
+        assertThat(IcomRig.mayPollDial(T0, 0L, 0L, T0)).isFalse();
     }
 
     @Test
-    public void mayPollDial_staleDeliveredStampFromAPreviousSession_doesNotCount() {
-        // A stamp older than this connection belongs to the last one; it must
-        // not short-circuit the window for the link that just came up.
-        assertThat(IcomRig.mayPollDial(T0 + 100, T0, T0 - 5_000)).isFalse();
+    public void mayPollDial_deliveryIsSessionState_notAClockComparison() {
+        // The stamp as it stood when the window was taken belongs to the last
+        // session (or to nothing); only a stamp that CHANGED since means the
+        // connect-time push landed on this connection.
+        long stale = T0 - 5_000;
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, stale, stale)).isFalse();
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, stale, T0 + 50)).isTrue();
+        // A wall-clock step backwards between connect and delivery makes the
+        // new stamp read EARLIER than the old one; it still changed, so it
+        // still counts — the old ">= connect time" test would have missed it.
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, stale, stale - 60_000)).isTrue();
     }
 
     @Test
     public void mayPollDial_settleWindowBoundaryIsInclusive() {
-        assertThat(IcomRig.mayPollDial(
-                T0 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS - 1, T0, 0L)).isFalse();
-        assertThat(IcomRig.mayPollDial(
-                T0 + IcomRig.READ_FREQ_CONNECT_SETTLE_MS, T0, 0L)).isTrue();
+        assertThat(IcomRig.mayPollDial(T0 + SETTLE - 1, T0, 0L, 0L)).isFalse();
+        assertThat(IcomRig.mayPollDial(T0 + SETTLE, T0, 0L, 0L)).isTrue();
     }
 
     @Test
     public void mayPollDial_settleWindowCoversTheWholeConnectHandshake() {
-        // onConnected posts setOperationBand at +1500 ms and its FA write lands
-        // 800 ms after that. The window must outlast the pair, otherwise this
-        // gate is no better than the construction-relative start delay it
-        // replaced.
-        assertThat(IcomRig.READ_FREQ_CONNECT_SETTLE_MS).isAtLeast(1500L + 800L);
+        // onConnected + 1500 ms (the posted setOperationBand) + 800 ms (its
+        // delayed FA write): the window must outlast that even when the push
+        // is never observed landing.
+        assertThat(SETTLE).isAtLeast(2_300L);
+        assertThat(IcomRig.mayPollDial(T0 + 2_300, T0, 0L, 0L)).isFalse();
+    }
+
+    @Test
+    public void tickUsesTheSnapshotItTookWhenTheLinkCameUp() {
+        // The gate sees the stamp as of the first "up" sample, so a stamp from
+        // the previous session that is numerically later than this window's
+        // start (clock corrected forwards in between) cannot short-circuit it.
+        connector.connected = true;
+        long previousSession = T0 + 999_999;
+        rig.runReadFreqTick(T0, previousSession);
+        rig.runReadFreqTick(T0 + 100, previousSession);
+        assertThat(connector.sent).isEmpty();
+        // ...until the stamp actually changes.
+        rig.runReadFreqTick(T0 + 200, previousSession + 1);
+        assertThat(countMatching(connector.sent, READ_FREQ_FRAME)).isEqualTo(1);
     }
 
     @Test

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
@@ -265,6 +265,35 @@ public class IcomRigReadFreqPollTest {
     }
 
     @Test
+    public void mayPollDial_stampResetByANewSelection_isNotADelivery() {
+        // GeneralVariables.operatorChoseDial() zeroes the delivered stamp when
+        // the operator picks a new dial: the stamp changed, but a new FA write
+        // is now PENDING, and polling would read the rig's pre-command dial.
+        long previous = T0 - 5_000;
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, previous, 0L)).isFalse();
+        // The window still expires on its own...
+        assertThat(IcomRig.mayPollDial(T0 + SETTLE, T0, previous, 0L)).isTrue();
+        // ...and the new selection's own delivery still clears it early.
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, previous, T0 + 90)).isTrue();
+        // A window taken while the stamp was already 0 behaves the same.
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, 0L, 0L)).isFalse();
+        assertThat(IcomRig.mayPollDial(T0 + 100, T0, 0L, T0 + 90)).isTrue();
+    }
+
+    @Test
+    public void newSelectionDuringTheSettleWindow_doesNotOpenTheGate() {
+        // Through the tick: connect, then the operator chooses a dial before
+        // the connect handshake has settled. The reset must not poll.
+        connector.connected = true;
+        long previousSession = T0 - 5_000;
+        rig.runReadFreqTick(T0, previousSession);
+        rig.runReadFreqTick(T0 + 100, 0L); // operatorChoseDial() zeroed it
+        assertThat(connector.sent).isEmpty();
+        rig.runReadFreqTick(T0 + 200, T0 + 150); // that selection's write landed
+        assertThat(countMatching(connector.sent, READ_FREQ_FRAME)).isEqualTo(1);
+    }
+
+    @Test
     public void mayPollDial_settleWindowBoundaryIsInclusive() {
         assertThat(IcomRig.mayPollDial(T0 + SETTLE - 1, T0, 0L, 0L)).isFalse();
         assertThat(IcomRig.mayPollDial(T0 + SETTLE, T0, 0L, 0L)).isTrue();

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
@@ -1,0 +1,179 @@
+package com.k1af.ft8af.rigs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.k1af.ft8af.connector.BaseRigConnector;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Covers {@link IcomRig#runReadFreqTick()} — the tick body of the dedicated
+ * frequency-poll timer added in the follow-up to issue #753.
+ *
+ * <p>After the CI-V address hex/decimal fix (PR #774) the app could COMMAND an
+ * IC-705 correctly, but rig&rarr;app dial updates still didn't land: the user
+ * turned the VFO on the rig and FT8AF stayed on the old frequency. Root cause
+ * was that {@code IcomRig} had no CAT-side frequency poll of its own — every
+ * other CAT rig class runs one (Yaesu38Rig, KenwoodTS590Rig, ElecraftRig, …) —
+ * and relied entirely on {@link CatLiveness}'s 3 s liveness probe, which stops
+ * hard on an 8 s quiet timeout and therefore can't be depended on to keep the
+ * app's dial in sync.
+ *
+ * <p>These tests pin the tick's decision contract using a fake connector that
+ * captures the CI-V bytes {@link IcomRig#readFreqFromRig()} sends, so the
+ * regression can't come back silently:
+ * <ul>
+ *   <li>connected + PTT off &rarr; sends the 6-byte read-frequency frame,</li>
+ *   <li>connected + PTT on  &rarr; sends nothing (meters are handled by the
+ *       500 ms meter timer; polling frequency mid-TX would race it), and</li>
+ *   <li>disconnected         &rarr; sends nothing (no-op even if the transport
+ *       object still exists).</li>
+ * </ul>
+ *
+ * <p>No Android types are touched, so no Robolectric runner is needed.
+ */
+public class IcomRigReadFreqPollTest {
+
+    /** IC-705's factory address, matching the rest of the ICOM tests. */
+    private static final int IC705_CIV = 0xA4;
+
+    /** CI-V read-frequency frame the app must send: FE FE A4 E0 03 FD. */
+    private static final byte[] READ_FREQ_FRAME = {
+            (byte) 0xFE, (byte) 0xFE, (byte) 0xA4, (byte) 0xE0,
+            (byte) 0x03, (byte) 0xFD
+    };
+
+    private CapturingConnector connector;
+    private IcomRig rig;
+
+    @Before
+    public void setUp() {
+        connector = new CapturingConnector();
+        // "newRig=true" avoids the oldVersion meter-suppression path, which is
+        // irrelevant to frequency polling but keeps this rig behaving like a
+        // modern IC-705 / IC-7300 / IC-9700.
+        rig = new IcomRig(IC705_CIV, true);
+        rig.setConnector(connector);
+    }
+
+    @After
+    public void tearDown() {
+        // Cancel the two Timer threads the IcomRig constructor spins up so they
+        // don't outlive the test — otherwise the JVM keeps running them until
+        // Gradle's test worker shuts down, and their sendCivData spam pollutes
+        // any concurrent test's captured bytes.
+        rig.onDisconnecting();
+    }
+
+    @Test
+    public void connectedAndPttOff_sendsReadFreqFrame() {
+        connector.connected = true;
+        // PTT off: rig.isPttOn() is false out of the constructor.
+
+        rig.runReadFreqTick();
+
+        assertThat(connector.sent).hasSize(1);
+        assertThat(connector.sent.get(0)).isEqualTo(READ_FREQ_FRAME);
+    }
+
+    @Test
+    public void disconnected_sendsNothing() {
+        // A dropped Wi-Fi link or an unplugged USB cable must not spam the
+        // absent connector with reads it can't deliver anyway.
+        connector.connected = false;
+
+        rig.runReadFreqTick();
+
+        assertThat(connector.sent).isEmpty();
+    }
+
+    @Test
+    public void connectedAndPttOn_sendsNothing() {
+        // The 500 ms meter timer handles SWR/ALC reads during TX. This poll
+        // deliberately skips: an unsolicited read-frequency mid-transmit can
+        // arrive coalesced with a meter reply and confuse the parser, and the
+        // rig can't turn its VFO while keyed anyway.
+        connector.connected = true;
+        rig.setPTT(true);
+
+        rig.runReadFreqTick();
+
+        // setPTT(true) itself writes a data-mode command on the connector, so
+        // filter to just the read-frequency frame we're guarding against.
+        assertThat(countMatching(connector.sent, READ_FREQ_FRAME)).isEqualTo(0);
+    }
+
+    @Test
+    public void directReadFreqFromRig_sendsFrameEvenWhenConnectorReportsDisconnected() {
+        // readFreqFromRig() itself only null-checks the connector — it does NOT
+        // gate on isConnected(). The tick above is what enforces the connected
+        // guard, so a caller that reaches straight in (CatLiveness during a
+        // brief link blip) still gets its write attempted. Pinning both halves
+        // catches an accidental extra guard slipped into readFreqFromRig.
+        connector.connected = false;
+
+        rig.readFreqFromRig();
+
+        assertThat(connector.sent).hasSize(1);
+        assertThat(connector.sent.get(0)).isEqualTo(READ_FREQ_FRAME);
+    }
+
+    @Test
+    public void onDisconnecting_isIdempotent() {
+        // MainViewModel.connectRig calls baseRig.onDisconnecting() before
+        // replacing the rig instance, and the test's own tearDown calls it
+        // again — cancelling an already-cancelled Timer is fine, but the null-
+        // out means a second call would NPE without the null-check the
+        // implementation added. Belt-and-braces: verify we can call it twice.
+        rig.onDisconnecting();
+        rig.onDisconnecting();
+    }
+
+    /** Counts how many of {@code sent}'s payloads exactly equal {@code frame}. */
+    private static int countMatching(List<byte[]> sent, byte[] frame) {
+        int n = 0;
+        for (byte[] b : sent) {
+            if (b.length != frame.length) continue;
+            boolean same = true;
+            for (int i = 0; i < b.length; i++) {
+                if (b[i] != frame[i]) { same = false; break; }
+            }
+            if (same) n++;
+        }
+        return n;
+    }
+
+    /**
+     * Minimal {@link BaseRigConnector} that records every {@link #sendData}
+     * payload for assertion and lets the test flip {@link #isConnected()}
+     * without a real transport. No superclass wiring is used beyond what the
+     * base constructor sets up.
+     */
+    private static final class CapturingConnector extends BaseRigConnector {
+        final List<byte[]> sent = new ArrayList<>();
+        boolean connected = false;
+
+        CapturingConnector() {
+            super(0 /* controlMode — unused by this test */);
+        }
+
+        @Override
+        public synchronized void sendData(byte[] data) {
+            // Copy so a caller reusing its buffer can't retroactively change
+            // what we recorded.
+            byte[] copy = new byte[data.length];
+            System.arraycopy(data, 0, copy, 0, data.length);
+            sent.add(copy);
+        }
+
+        @Override
+        public boolean isConnected() {
+            return connected;
+        }
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java
@@ -67,21 +67,26 @@ public class IcomRigReadFreqPollTest {
         // "newRig=true" avoids the oldVersion meter-suppression path, which is
         // irrelevant to frequency polling but keeps this rig behaving like a
         // modern IC-705 / IC-7300 / IC-9700.
-        rig = new IcomRig(IC705_CIV, true);
+        // A scheduler that never runs anything: these tests drive the tick by
+        // hand, so no background thread can append to `sent` between a manual
+        // runReadFreqTick and its assertion. IcomRigPollSchedulingTest covers
+        // what the constructor schedules.
+        rig = new IcomRig(IC705_CIV, true, new IcomRig.PollScheduler() {
+            @Override
+            public IcomRig.Cancellable scheduleFixedDelay(Runnable task, long delayMs, long periodMs) {
+                return () -> { };
+            }
+
+            @Override
+            public IcomRig.Cancellable scheduleFixedRate(Runnable task, long delayMs, long periodMs) {
+                return () -> { };
+            }
+        });
         rig.setConnector(connector);
-        // The constructor starts the real 2 s poll and 500 ms meter Timers.
-        // Cancel them right away so a slow or paused test worker can't get a
-        // background tick appended to `sent` between a manual runReadFreqTick
-        // and its assertion; the manual ticks below need no Timer.
-        rig.onDisconnecting();
     }
 
     @After
     public void tearDown() {
-        // Cancel the two Timer threads the IcomRig constructor spins up so they
-        // don't outlive the test — otherwise the JVM keeps running them until
-        // Gradle's test worker shuts down, and their sendCivData spam pollutes
-        // any concurrent test's captured bytes.
         rig.onDisconnecting();
     }
 
@@ -174,6 +179,24 @@ public class IcomRigReadFreqPollTest {
                 BaseRigConnector.class.getDeclaredField("connected").getModifiers())).isTrue();
         assertThat(java.lang.reflect.Modifier.isVolatile(
                 BaseRig.class.getDeclaredField("isPttOn").getModifiers())).isTrue();
+        // The connector itself is set by MainViewModel after the constructor
+        // has already started the polls, from another thread.
+        assertThat(java.lang.reflect.Modifier.isVolatile(
+                BaseRig.class.getDeclaredField("connector").getModifiers())).isTrue();
+    }
+
+    @Test
+    public void wlanCivSendsAreSerialized() throws Exception {
+        // IcomCivUdp builds a packet from civSeq, sends it, then increments the
+        // sequence. sendTrackedPacket alone being synchronized let two senders
+        // (this poll, the CAT-liveness poll, a PTT command) stamp the same
+        // sequence number and have the rig drop one as a duplicate.
+        for (String name : new String[] {"sendCivData", "sendOpenClose"}) {
+            java.lang.reflect.Method m = name.equals("sendCivData")
+                    ? com.k1af.ft8af.icom.IcomCivUdp.class.getDeclaredMethod(name, byte[].class)
+                    : com.k1af.ft8af.icom.IcomCivUdp.class.getDeclaredMethod(name, boolean.class);
+            assertThat(java.lang.reflect.Modifier.isSynchronized(m.getModifiers())).isTrue();
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #753

## What changed

Follow-up to PR #774 (CI-V address hex/decimal fix). After that fix the app
could **command** the IC-705 over CI-V correctly, but the operator's follow-up
report was:

> Frequency update works, but there's no change in FT8AF, if I change the QRG
> on the IC 705.

i.e. rig→app dial-follow was still broken. Root cause was that `IcomRig` had
**no CAT-side frequency poll of its own**. Every other CAT rig class in this
codebase runs one (Yaesu38Rig, Yaesu39Rig, KenwoodTS590Rig, ElecraftRig,
XieGuRig, TrUSDXRig, GuoHeQ900Rig, YaesuDX10Rig, Flex6000Rig, KenwoodKT90Rig,
Wolf_sdr_450Rig, Yaesu2Rig, Yaesu2_847Rig, Yaesu38_450Rig, KenwoodTS2000Rig) —
`IcomRig` was the odd one out, relying solely on `CatLiveness`'s 3 s liveness
probe. That watchdog stops hard on an 8 s quiet timeout, so any transient hush
on the link leaves the app permanently out of sync with the rig's dial until
the operator manually reconnects.

`IcomRig` now runs its own 2 s frequency poll using the shared
`ReadTaskAction` decision (`connected + PTT-off → read frequency`,
`PTT-on → defer to the 500 ms meter timer`, `disconnected → skip`).
`onDisconnecting()` is overridden to cancel both this timer and the existing
meter timer, so a reconnect via `MainViewModel.connectRig` doesn't leak the
previous instance's `Timer` thread or double-poll after re-connect.

Files touched:
- `ft8af/app/src/main/java/com/k1af/ft8af/rigs/IcomRig.java` — new
  `startReadFreqTimer()` / `runReadFreqTick()` + `onDisconnecting()` override.
- `ft8af/app/src/test/java/com/k1af/ft8af/rigs/IcomRigReadFreqPollTest.java` —
  five new tests using a `CapturingConnector` fake so no `Timer` or
  Robolectric is required.

## How to test

**Automated (macOS/Linux with JDK 17, or Windows via the `gradlew.bat`
wrapper — see CLAUDE.md):**

```
cd ft8af && ./gradlew testDebugUnitTest --tests com.k1af.ft8af.rigs.IcomRigReadFreqPollTest
```

Full suite also stays green:

```
cd ft8af && ./gradlew testDebugUnitTest
```

Result on this branch: **3491 tests, 0 failures**.

**On an IC-705 (network / WLAN):**

1. Install the debug APK on a phone that can reach the IC-705's Wi-Fi:
   `cd ft8af && ./gradlew installDebug` (Windows: `gradlew.bat installDebug`).
2. In FT8AF, connect to the IC-705 via the settings screen's network
   connection dialog. Confirm the CAT chip goes green.
3. Turn the VFO on the IC-705 to a new dial (e.g. 14.074 → 14.080 MHz).
4. **Within ~2 s** the app's band indicator should follow to the new dial.
   Before this change it stayed on the old dial until reconnect.
5. Repeat with PTT on during a TX slot: the app should **not** ask for
   frequency mid-transmit (the 500 ms meter poll still runs, so SWR/ALC keep
   updating).

The same follow behaviour also applies to any other ICOM over any transport
(USB serial, Bluetooth, WLAN) — `IcomRig` is the shared class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)