### PR TITLE
Steer TX to A2DP when Default output shares a BT link with SCO

### DIFF
--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -924,18 +924,24 @@ public class MainViewModel extends ViewModel {
                 boolean keysViaControlPath = GeneralVariables.controlMode == ControlMode.CAT
                         || GeneralVariables.controlMode == ControlMode.RTS
                         || GeneralVariables.controlMode == ControlMode.DTR;
-                // SCO is paused around PTT only for a Bluetooth rig keyed through a
-                // control path — the pre-existing condition, unchanged. The same
-                // flag decides whether the TX path may later steer Default output
-                // to that rig's A2DP: a USB/network rig with a Bluetooth headset
-                // picked as its mic also holds a SCO link of ours, but its TX
-                // audio belongs on the rig, not the headset (Copilot review on
-                // #790). keyDown() takes the snapshot BEFORE it stops SCO — the
-                // TX worker reads it after the PTT settle delay, when the tracker
-                // has already been told to drop the link — and that order lives
-                // in TxScoLatch so it is the tested one.
+                // Two different questions (Copilot review on #790):
+                //  - needControlSco(): is this a Bluetooth RIG whose TX audio must
+                //    not ride SCO? That decides whether the TX path may steer
+                //    Default output to the rig's A2DP. It is true for Bluetooth +
+                //    VOX too — VOX leaves SCO up, so its media stream is on the
+                //    SCO route and needs the steering just as much. A USB/network
+                //    rig with a Bluetooth headset picked as its mic also holds a
+                //    SCO link of ours, but its audio belongs on the rig: false.
+                //  - control-path keying with a rig: the only case that pauses
+                //    SCO around PTT (the pre-existing condition, unchanged).
+                // keyDown() takes the snapshot BEFORE it stops SCO — the TX worker
+                // reads it after the PTT settle delay, when the tracker has already
+                // been told to drop the link — and that order lives in TxScoLatch
+                // so it is the tested one.
+                boolean bluetoothRigTx = needControlSco();
                 txScoLatch.keyDown(
-                        keysViaControlPath && baseRig != null && needControlSco(),
+                        bluetoothRigTx,
+                        keysViaControlPath && baseRig != null && bluetoothRigTx,
                         MainViewModel.this::isScoLinkUpOrPending,
                         MainViewModel.this::routedScoInputAddress,
                         MainViewModel.this::stopSco);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -2492,6 +2492,17 @@ public class MainViewModel extends ViewModel {
     // the TX executor and the main-thread broadcasts/timers are applied in
     // order, never interleaved. Issue #759 (Android 8.x: Bluetooth RX dead).
 
+    /**
+     * Whether this app currently holds a SCO session (CONNECTING or CONNECTED),
+     * per the tracker rather than {@code AudioManager.isBluetoothScoOn()} — see
+     * {@link ScoLinkCoordinator#isLinkUpOrPending()}. Read by the TX path, which
+     * must not steer Default output onto a Bluetooth sink unless our own SCO link
+     * is the thing displacing the media route (see {@code AudioOutputRoutingPolicy}).
+     */
+    public boolean isScoLinkUpOrPending() {
+        return scoLink.isLinkUpOrPending();
+    }
+
     private final Handler scoHandler = new Handler(Looper.getMainLooper());
     private final ScoLinkCoordinator scoLink = ScoLinkCoordinator.onMainThread(
             new ScoLinkCoordinator.Sink() {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -921,22 +921,30 @@ public class MainViewModel extends ViewModel {
              * (VOX), this is a no-op and the audio itself keys the rig.
              */
             private void beginKeying() {
-                // Snapshot BEFORE stopSco() below: the TX worker reads this after
-                // the PTT settle delay, when the tracker has already been told
-                // to drop the link and would answer "no SCO" (TxScoLatch).
-                txScoLatch.onKeying(isScoLinkUpOrPending());
-                if (GeneralVariables.controlMode == ControlMode.CAT
+                boolean keysViaControlPath = GeneralVariables.controlMode == ControlMode.CAT
                         || GeneralVariables.controlMode == ControlMode.RTS
-                        || GeneralVariables.controlMode == ControlMode.DTR) {
-                    if (baseRig != null) {
-                        //if (GeneralVariables.connectMode != ConnectMode.NETWORK) stopSco();
-                        if (needControlSco()) stopSco();
-                        // Arm before the write, not after: if setPTT throws or the
-                        // process dies mid-key, we still recorded that the rig may
-                        // be keyed and the next reconnect settles it.
-                        pttSafetyLatch.onKeyed();
-                        baseRig.setPTT(true);
-                    }
+                        || GeneralVariables.controlMode == ControlMode.DTR;
+                // SCO is paused around PTT only for a Bluetooth rig keyed through a
+                // control path — the pre-existing condition, unchanged. The same
+                // flag decides whether the TX path may later steer Default output
+                // to that rig's A2DP: a USB/network rig with a Bluetooth headset
+                // picked as its mic also holds a SCO link of ours, but its TX
+                // audio belongs on the rig, not the headset (Copilot review on
+                // #790). keyDown() takes the snapshot BEFORE it stops SCO — the
+                // TX worker reads it after the PTT settle delay, when the tracker
+                // has already been told to drop the link — and that order lives
+                // in TxScoLatch so it is the tested one.
+                txScoLatch.keyDown(
+                        keysViaControlPath && baseRig != null && needControlSco(),
+                        MainViewModel.this::isScoLinkUpOrPending,
+                        MainViewModel.this::routedScoInputAddress,
+                        MainViewModel.this::stopSco);
+                if (keysViaControlPath && baseRig != null) {
+                    // Arm before the write, not after: if setPTT throws or the
+                    // process dies mid-key, we still recorded that the rig may
+                    // be keyed and the next reconnect settles it.
+                    pttSafetyLatch.onKeyed();
+                    baseRig.setPTT(true);
                 }
             }
 
@@ -958,7 +966,7 @@ public class MainViewModel extends ViewModel {
                 }
                 // The post-TX restart has been requested; the next over takes a
                 // fresh snapshot in beginKeying().
-                txScoLatch.onUnkeyed();
+                txScoLatch.keyUp();
             }
 
             @Override
@@ -2528,6 +2536,26 @@ public class MainViewModel extends ViewModel {
      */
     public boolean isScoHeldForTx() {
         return txScoLatch.heldForTx();
+    }
+
+    /**
+     * Address of the device our SCO link was on when the current over was
+     * keyed, or null when unknown (see {@link TxScoLatch#scoAddress()}).
+     */
+    public String scoAddressForTx() {
+        return txScoLatch.scoAddress();
+    }
+
+    /**
+     * Address of the SCO device the mic is being captured from right now, or
+     * null when the capture is not on SCO / the platform withholds it. Read at
+     * keying time, before SCO is stopped, so the TX path knows which of several
+     * hands-free devices actually carries our link.
+     */
+    private String routedScoInputAddress() {
+        if (hamRecorder == null) return null;
+        MicRecorder mic = hamRecorder.getMicRecorder();
+        return mic == null ? null : mic.routedScoInputAddress();
     }
 
     private final Handler scoHandler = new Handler(Looper.getMainLooper());

--- a/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java
@@ -56,6 +56,7 @@ import com.k1af.ft8af.callsign.CallsignDatabase;
 import com.k1af.ft8af.callsign.CallsignInfo;
 import com.k1af.ft8af.callsign.OnAfterQueryCallsignLocation;
 import com.k1af.ft8af.bluetooth.ScoLinkCoordinator;
+import com.k1af.ft8af.bluetooth.TxScoLatch;
 import com.k1af.ft8af.bluetooth.ScoLinkTracker;
 import com.k1af.ft8af.bluetooth.ScoPolicy;
 import com.k1af.ft8af.connector.BaseRigConnector;
@@ -252,6 +253,13 @@ public class MainViewModel extends ViewModel {
     // "We keyed the rig and haven't confirmed it back off" — settled by
     // retryPendingUnkey() on reconnect and at slot boundaries.
     private final PttSafetyLatch pttSafetyLatch = new PttSafetyLatch();
+    /**
+     * Whether our SCO link was up when the current over was keyed — snapshotted
+     * in {@code beginKeying()} before {@code stopSco()} tears it down, because
+     * the TX path asks after the PTT settle delay, by which time the tracker
+     * already says "down" (see {@link TxScoLatch}).
+     */
+    private final TxScoLatch txScoLatch = new TxScoLatch();
     public MeterProtectionController meterProtectionController;//ALC auto-volume + SWR halt
     public SpectrumListener spectrumListener;//object for drawing the spectrum
     public boolean markMessage = true;//whether to mark messages toggle
@@ -913,6 +921,10 @@ public class MainViewModel extends ViewModel {
              * (VOX), this is a no-op and the audio itself keys the rig.
              */
             private void beginKeying() {
+                // Snapshot BEFORE stopSco() below: the TX worker reads this after
+                // the PTT settle delay, when the tracker has already been told
+                // to drop the link and would answer "no SCO" (TxScoLatch).
+                txScoLatch.onKeying(isScoLinkUpOrPending());
                 if (GeneralVariables.controlMode == ControlMode.CAT
                         || GeneralVariables.controlMode == ControlMode.RTS
                         || GeneralVariables.controlMode == ControlMode.DTR) {
@@ -944,6 +956,9 @@ public class MainViewModel extends ViewModel {
                         if (needControlSco()) startSco();
                     }
                 }
+                // The post-TX restart has been requested; the next over takes a
+                // fresh snapshot in beginKeying().
+                txScoLatch.onUnkeyed();
             }
 
             @Override
@@ -2495,12 +2510,24 @@ public class MainViewModel extends ViewModel {
     /**
      * Whether this app currently holds a SCO session (CONNECTING or CONNECTED),
      * per the tracker rather than {@code AudioManager.isBluetoothScoOn()} — see
-     * {@link ScoLinkCoordinator#isLinkUpOrPending()}. Read by the TX path, which
-     * must not steer Default output onto a Bluetooth sink unless our own SCO link
-     * is the thing displacing the media route (see {@code AudioOutputRoutingPolicy}).
+     * {@link ScoLinkCoordinator#isLinkUpOrPending()}. Snapshotted by the keying
+     * path into {@link #isScoHeldForTx()}; the TX path must read that snapshot,
+     * not this live value, because keying stops SCO before the audio starts.
      */
     public boolean isScoLinkUpOrPending() {
         return scoLink.isLinkUpOrPending();
+    }
+
+    /**
+     * Whether our own SCO link was up (or coming up) when the current over or
+     * tune carrier was keyed. Read by the TX path, which must not steer Default
+     * output onto a Bluetooth sink unless our own SCO link is the thing
+     * displacing the media route (see {@code AudioOutputRoutingPolicy}). Stable
+     * for the whole over even though {@code beginKeying()} has already asked
+     * the tracker to drop the link (Copilot review on #790, {@link TxScoLatch}).
+     */
+    public boolean isScoHeldForTx() {
+        return txScoLatch.heldForTx();
     }
 
     private final Handler scoHandler = new Handler(Looper.getMainLooper());

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
@@ -14,11 +14,32 @@ package com.k1af.ft8af.bluetooth;
  * hands-free) path while SCO is up, and the paired transceiver only listens on
  * the A2DP profile for the FT8 tone, so TX goes into the void.
  *
- * <p>Rule: when the user chose "Default" output and an A2DP device <em>and</em>
- * a SCO device are both currently in the output list (the tell-tale state where
- * A2DP + SCO share the same paired headset), steer TX to A2DP. When SCO is not
- * present, leave the OS routing alone — a phone paired only for A2DP music has
- * never had this problem and picking A2DP over speakers would be surprising.
+ * <p>Rule: when the user chose "Default" output, <em>this app</em> currently holds
+ * a SCO session, and the output list contains an A2DP endpoint belonging to the
+ * <em>same</em> Bluetooth device as a SCO endpoint, steer TX to that A2DP
+ * endpoint. Otherwise leave the OS routing alone.
+ *
+ * <p>All three conditions matter, and the first version of this class checked
+ * only "an A2DP type and a SCO type are both enumerated" (Copilot review on
+ * #790):
+ * <ul>
+ *   <li>{@code AudioManager} enumerates both profiles for any connected
+ *       hands-free device whether or not a SCO link is actually up, so device
+ *       types alone cannot tell a live SCO session from an idle car kit sitting
+ *       in the list. {@link ScoPolicy} deliberately leaves SCO off outside
+ *       Bluetooth audio modes, and a rig on USB or the network must not have its
+ *       Default output yanked onto a Bluetooth sink because a car is paired
+ *       nearby.</li>
+ *   <li>The enumerated profiles need not belong to the same device — a phone can
+ *       have a car kit on SCO and a speaker on A2DP at once — and steering TX to
+ *       an unrelated A2DP sink sends the FT8 tone somewhere the rig cannot hear
+ *       it, which is the failure being fixed, not a cure for it.</li>
+ * </ul>
+ *
+ * <p>The SCO state must come from the app's own {@code ScoLinkTracker} (via
+ * {@code ScoLinkCoordinator.isLinkUpOrPending()}), not from
+ * {@code AudioManager.isBluetoothScoOn()} — see the note on {@link ScoPolicy}
+ * for why that getter is not trusted anywhere in this codebase.
  */
 public final class AudioOutputRoutingPolicy {
 
@@ -47,23 +68,81 @@ public final class AudioOutputRoutingPolicy {
      * When the user picked "Default" output, decide which enumerated device (by
      * index into {@code deviceTypes}) to hand to {@code AudioTrack.setPreferredDevice}.
      *
-     * @param deviceTypes the {@code AudioDeviceInfo.getType()} of every currently
-     *                    connected output device, in enumeration order
+     * @param deviceTypes        the {@code AudioDeviceInfo.getType()} of every
+     *                           currently connected output device, in enumeration
+     *                           order
+     * @param deviceAddresses    the matching {@code AudioDeviceInfo.getAddress()}
+     *                           values — the Bluetooth MAC for a BT endpoint, and
+     *                           blank for everything else. May be {@code null},
+     *                           and individual entries may be null or blank on
+     *                           platforms that withhold them.
+     * @param appScoSessionActive whether <em>this app</em> currently holds a SCO
+     *                           session, per its own {@code ScoLinkTracker}. False
+     *                           short-circuits: with no SCO of ours stealing the
+     *                           media route there is nothing to steer around.
      * @return the index of the A2DP device to prefer, or {@link #LEAVE_TO_OS}
      *         when the OS's own default routing is fine
      */
-    public static int pickDefaultOutputIndex(int[] deviceTypes) {
-        if (deviceTypes == null) return LEAVE_TO_OS;
-        int a2dpIdx = LEAVE_TO_OS;
-        boolean scoPresent = false;
+    public static int pickDefaultOutputIndex(int[] deviceTypes,
+                                             String[] deviceAddresses,
+                                             boolean appScoSessionActive) {
+        if (!appScoSessionActive || deviceTypes == null) return LEAVE_TO_OS;
+
+        int a2dpCount = 0;
+        int scoCount = 0;
+        int firstA2dpIdx = LEAVE_TO_OS;
+        boolean anyScoAddressKnown = false;
         for (int i = 0; i < deviceTypes.length; i++) {
-            int type = deviceTypes[i];
-            if (type == TYPE_BLUETOOTH_A2DP) {
-                if (a2dpIdx == LEAVE_TO_OS) a2dpIdx = i;
-            } else if (type == TYPE_BLUETOOTH_SCO) {
-                scoPresent = true;
+            if (deviceTypes[i] == TYPE_BLUETOOTH_A2DP) {
+                a2dpCount++;
+                if (firstA2dpIdx == LEAVE_TO_OS) firstA2dpIdx = i;
+            } else if (deviceTypes[i] == TYPE_BLUETOOTH_SCO) {
+                scoCount++;
+                if (isKnownAddress(addressAt(deviceAddresses, i))) anyScoAddressKnown = true;
             }
         }
-        return scoPresent ? a2dpIdx : LEAVE_TO_OS;
+        if (a2dpCount == 0 || scoCount == 0) return LEAVE_TO_OS;
+
+        // Preferred path: an A2DP endpoint on the same Bluetooth device as one of
+        // the SCO endpoints. That is the headset whose hands-free link is holding
+        // the media route hostage, and the only sink the rig is listening on.
+        for (int i = 0; i < deviceTypes.length; i++) {
+            if (deviceTypes[i] != TYPE_BLUETOOTH_A2DP) continue;
+            String a2dpAddr = addressAt(deviceAddresses, i);
+            if (!isKnownAddress(a2dpAddr)) continue;
+            for (int j = 0; j < deviceTypes.length; j++) {
+                if (deviceTypes[j] != TYPE_BLUETOOTH_SCO) continue;
+                if (a2dpAddr.equalsIgnoreCase(addressAt(deviceAddresses, j))) {
+                    return i;
+                }
+            }
+        }
+
+        // Fallback for platforms that withhold endpoint addresses: with exactly
+        // one A2DP and exactly one SCO endpoint the pairing is unambiguous, so
+        // steering is still safe. Only when the addresses genuinely told us
+        // nothing — if both are known and simply differ, they are different
+        // devices and we must not touch the routing.
+        boolean addressesUninformative =
+                !isKnownAddress(addressAt(deviceAddresses, firstA2dpIdx)) || !anyScoAddressKnown;
+        if (a2dpCount == 1 && scoCount == 1 && addressesUninformative) {
+            return firstA2dpIdx;
+        }
+        return LEAVE_TO_OS;
+    }
+
+    /** {@code deviceAddresses[i]}, tolerating a null array or a short one. */
+    private static String addressAt(String[] deviceAddresses, int i) {
+        if (deviceAddresses == null || i < 0 || i >= deviceAddresses.length) return null;
+        return deviceAddresses[i];
+    }
+
+    /**
+     * Whether an address actually identifies a device. Non-Bluetooth endpoints
+     * report {@code ""}, and some builds report blanks even for BT endpoints, so
+     * a blank must never be treated as "matches another blank".
+     */
+    private static boolean isKnownAddress(String address) {
+        return address != null && !address.trim().isEmpty();
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
@@ -76,43 +76,77 @@ public final class AudioOutputRoutingPolicy {
      *                           blank for everything else. May be {@code null},
      *                           and individual entries may be null or blank on
      *                           platforms that withhold them.
-     * @param appScoSessionActive whether <em>this app</em> currently holds a SCO
-     *                           session, per its own {@code ScoLinkTracker}. False
-     *                           short-circuits: with no SCO of ours stealing the
-     *                           media route there is nothing to steer around.
+     * @param appScoSessionActive whether <em>this app</em> held a SCO session for
+     *                           the rig when this over was keyed, per its own
+     *                           {@code ScoLinkTracker} (see {@code TxScoLatch}).
+     *                           False short-circuits: with no SCO of ours
+     *                           stealing the media route there is nothing to
+     *                           steer around.
+     * @param activeScoAddress   the Bluetooth address of the device that SCO link
+     *                           is on (the mic's routed capture device at keying
+     *                           time), or null when the platform withheld it.
+     *                           With it, only that device's A2DP endpoint is
+     *                           ever chosen. Without it, the SCO endpoints must
+     *                           all agree on one device: an idle car kit can
+     *                           enumerate a SCO endpoint next to the rig's, and
+     *                           guessing the first matching pair could send TX
+     *                           to the car (Copilot review on #790).
      * @return the index of the A2DP device to prefer, or {@link #LEAVE_TO_OS}
      *         when the OS's own default routing is fine
      */
     public static int pickDefaultOutputIndex(int[] deviceTypes,
                                              String[] deviceAddresses,
-                                             boolean appScoSessionActive) {
+                                             boolean appScoSessionActive,
+                                             String activeScoAddress) {
         if (!appScoSessionActive || deviceTypes == null) return LEAVE_TO_OS;
 
         int a2dpCount = 0;
         int scoCount = 0;
         int firstA2dpIdx = LEAVE_TO_OS;
         boolean anyScoAddressKnown = false;
+        String soleScoAddress = null;
+        boolean scoDevicesDiffer = false;
         for (int i = 0; i < deviceTypes.length; i++) {
             if (deviceTypes[i] == TYPE_BLUETOOTH_A2DP) {
                 a2dpCount++;
                 if (firstA2dpIdx == LEAVE_TO_OS) firstA2dpIdx = i;
             } else if (deviceTypes[i] == TYPE_BLUETOOTH_SCO) {
                 scoCount++;
-                if (isKnownAddress(addressAt(deviceAddresses, i))) anyScoAddressKnown = true;
+                String scoAddr = addressAt(deviceAddresses, i);
+                if (isKnownAddress(scoAddr)) {
+                    anyScoAddressKnown = true;
+                    if (soleScoAddress == null) {
+                        soleScoAddress = scoAddr;
+                    } else if (!soleScoAddress.equalsIgnoreCase(scoAddr)) {
+                        scoDevicesDiffer = true;
+                    }
+                }
             }
         }
         if (a2dpCount == 0 || scoCount == 0) return LEAVE_TO_OS;
 
-        // Preferred path: an A2DP endpoint on the same Bluetooth device as one of
-        // the SCO endpoints. That is the headset whose hands-free link is holding
-        // the media route hostage, and the only sink the rig is listening on.
-        for (int i = 0; i < deviceTypes.length; i++) {
-            if (deviceTypes[i] != TYPE_BLUETOOTH_A2DP) continue;
-            String a2dpAddr = addressAt(deviceAddresses, i);
-            if (!isKnownAddress(a2dpAddr)) continue;
-            for (int j = 0; j < deviceTypes.length; j++) {
-                if (deviceTypes[j] != TYPE_BLUETOOTH_SCO) continue;
-                if (a2dpAddr.equalsIgnoreCase(addressAt(deviceAddresses, j))) {
+        // Which SCO endpoint is ours. The routed capture device is authoritative;
+        // without it, the identity is only trustworthy when every SCO endpoint
+        // reports the same address, i.e. a single hands-free device is connected.
+        String ourSco;
+        if (isKnownAddress(activeScoAddress)) {
+            ourSco = activeScoAddress;
+        } else if (scoDevicesDiffer) {
+            // Two or more hands-free devices and no word on which carries our
+            // link. Steering to whichever pair enumerates first could put the
+            // FT8 tone into a car kit; leave the routing to the OS instead.
+            return LEAVE_TO_OS;
+        } else {
+            ourSco = soleScoAddress;
+        }
+
+        // Preferred path: the A2DP endpoint on the same Bluetooth device as our
+        // SCO link. That is the device whose hands-free link is holding the media
+        // route hostage, and the only sink the rig is listening on.
+        if (ourSco != null) {
+            for (int i = 0; i < deviceTypes.length; i++) {
+                if (deviceTypes[i] != TYPE_BLUETOOTH_A2DP) continue;
+                if (ourSco.equalsIgnoreCase(addressAt(deviceAddresses, i))) {
                     return i;
                 }
             }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
@@ -107,6 +107,7 @@ public final class AudioOutputRoutingPolicy {
         boolean anyScoAddressKnown = false;
         String soleScoAddress = null;
         boolean scoDevicesDiffer = false;
+        boolean activeSeenOnSco = false;
         for (int i = 0; i < deviceTypes.length; i++) {
             if (deviceTypes[i] == TYPE_BLUETOOTH_A2DP) {
                 a2dpCount++;
@@ -116,6 +117,9 @@ public final class AudioOutputRoutingPolicy {
                 String scoAddr = addressAt(deviceAddresses, i);
                 if (isKnownAddress(scoAddr)) {
                     anyScoAddressKnown = true;
+                    if (isKnownAddress(activeScoAddress) && activeScoAddress.equalsIgnoreCase(scoAddr)) {
+                        activeSeenOnSco = true;
+                    }
                     if (soleScoAddress == null) {
                         soleScoAddress = scoAddr;
                     } else if (!soleScoAddress.equalsIgnoreCase(scoAddr)) {
@@ -157,6 +161,14 @@ public final class AudioOutputRoutingPolicy {
                     return i;
                 }
             }
+        }
+
+        // The capture side named our device but the output side names only
+        // OTHER devices on SCO: the enumeration contradicts the routed capture,
+        // and the withheld-address fallback below would hand TX to a blank A2DP
+        // endpoint that belongs to one of those other devices. Not ours to guess.
+        if (isKnownAddress(activeScoAddress) && anyScoAddressKnown && !activeSeenOnSco) {
+            return LEAVE_TO_OS;
         }
 
         // Fallback for platforms that withhold endpoint addresses: with exactly

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
@@ -1,0 +1,69 @@
+package com.k1af.ft8af.bluetooth;
+
+/**
+ * Decides whether the TX audio path should override a "Default" output selection
+ * with the paired Bluetooth A2DP device. Pure ints — no Android runtime — so the
+ * whole decision is unit-testable.
+ *
+ * <p>Why this exists (issue #759 follow-up on Android 8.1): PR #772 makes the
+ * SCO link come up reliably so the mic captures over Bluetooth. Once it does,
+ * a tester reported that with both audio input and audio output set to
+ * "Default", TX audio no longer reaches the transceiver — but manually picking
+ * the paired device's A2DP profile as the output makes TX work again. Android's
+ * routing keeps the {@code USAGE_MEDIA} stream on the SCO (narrowband
+ * hands-free) path while SCO is up, and the paired transceiver only listens on
+ * the A2DP profile for the FT8 tone, so TX goes into the void.
+ *
+ * <p>Rule: when the user chose "Default" output and an A2DP device <em>and</em>
+ * a SCO device are both currently in the output list (the tell-tale state where
+ * A2DP + SCO share the same paired headset), steer TX to A2DP. When SCO is not
+ * present, leave the OS routing alone — a phone paired only for A2DP music has
+ * never had this problem and picking A2DP over speakers would be surprising.
+ */
+public final class AudioOutputRoutingPolicy {
+
+    private AudioOutputRoutingPolicy() {
+    }
+
+    /**
+     * Mirror of {@code android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP}
+     * (stable framework constant = 8), kept as a literal so this class stays
+     * Android-free.
+     */
+    public static final int TYPE_BLUETOOTH_A2DP = 8;
+
+    /**
+     * Mirror of {@code android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO}
+     * (stable framework constant = 7).
+     */
+    public static final int TYPE_BLUETOOTH_SCO = 7;
+
+    /**
+     * Sentinel from {@link #pickDefaultOutputIndex} for "let the OS pick".
+     */
+    public static final int LEAVE_TO_OS = -1;
+
+    /**
+     * When the user picked "Default" output, decide which enumerated device (by
+     * index into {@code deviceTypes}) to hand to {@code AudioTrack.setPreferredDevice}.
+     *
+     * @param deviceTypes the {@code AudioDeviceInfo.getType()} of every currently
+     *                    connected output device, in enumeration order
+     * @return the index of the A2DP device to prefer, or {@link #LEAVE_TO_OS}
+     *         when the OS's own default routing is fine
+     */
+    public static int pickDefaultOutputIndex(int[] deviceTypes) {
+        if (deviceTypes == null) return LEAVE_TO_OS;
+        int a2dpIdx = LEAVE_TO_OS;
+        boolean scoPresent = false;
+        for (int i = 0; i < deviceTypes.length; i++) {
+            int type = deviceTypes[i];
+            if (type == TYPE_BLUETOOTH_A2DP) {
+                if (a2dpIdx == LEAVE_TO_OS) a2dpIdx = i;
+            } else if (type == TYPE_BLUETOOTH_SCO) {
+                scoPresent = true;
+            }
+        }
+        return scoPresent ? a2dpIdx : LEAVE_TO_OS;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java
@@ -102,6 +102,7 @@ public final class AudioOutputRoutingPolicy {
 
         int a2dpCount = 0;
         int scoCount = 0;
+        int scoUnknownCount = 0;
         int firstA2dpIdx = LEAVE_TO_OS;
         boolean anyScoAddressKnown = false;
         String soleScoAddress = null;
@@ -120,6 +121,8 @@ public final class AudioOutputRoutingPolicy {
                     } else if (!soleScoAddress.equalsIgnoreCase(scoAddr)) {
                         scoDevicesDiffer = true;
                     }
+                } else {
+                    scoUnknownCount++;
                 }
             }
         }
@@ -127,14 +130,18 @@ public final class AudioOutputRoutingPolicy {
 
         // Which SCO endpoint is ours. The routed capture device is authoritative;
         // without it, the identity is only trustworthy when every SCO endpoint
-        // reports the same address, i.e. a single hands-free device is connected.
+        // can be identified as the same device. Two known addresses that differ
+        // are two devices — and so is one known address next to a blank one: the
+        // blank endpoint may well be the rig, and treating the named one as "the"
+        // device would route TX to a car kit (Copilot review on #790).
         String ourSco;
         if (isKnownAddress(activeScoAddress)) {
             ourSco = activeScoAddress;
-        } else if (scoDevicesDiffer) {
-            // Two or more hands-free devices and no word on which carries our
-            // link. Steering to whichever pair enumerates first could put the
-            // FT8 tone into a car kit; leave the routing to the OS instead.
+        } else if (scoDevicesDiffer || (anyScoAddressKnown && scoUnknownCount > 0)) {
+            // Two or more hands-free devices (or endpoints we cannot tell apart)
+            // and no word on which carries our link. Steering to whichever pair
+            // enumerates first could put the FT8 tone into a car kit; leave the
+            // routing to the OS instead.
             return LEAVE_TO_OS;
         } else {
             ourSco = soleScoAddress;

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/DefaultOutputRouting.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/DefaultOutputRouting.java
@@ -1,0 +1,89 @@
+package com.k1af.ft8af.bluetooth;
+
+import android.media.AudioDeviceInfo;
+import android.os.Build;
+
+/**
+ * The Android side of the Default-output A2DP steering: turns the enumerated
+ * output devices into the plain arrays {@link AudioOutputRoutingPolicy} decides
+ * on, and applies its answer to the track through a {@link Sink}.
+ *
+ * <p>Split out of {@code FT8TransmitSignal.applyDefaultOutputRoutingOverride}
+ * so the wiring — device enumeration to policy to
+ * {@code AudioTrack.setPreferredDevice}, including the rejection diagnostic —
+ * is exercised by a Robolectric test instead of only on a rig (Copilot review
+ * on #790). Everything that needs a real {@code AudioTrack} or the app's
+ * {@code GeneralVariables} goes through the sink, so the test can capture it.
+ */
+public final class DefaultOutputRouting {
+
+    private DefaultOutputRouting() {
+    }
+
+    /** The two things the adapter needs from the caller. */
+    public interface Sink {
+        /** {@code AudioTrack.setPreferredDevice(device)}; false when the framework refuses. */
+        boolean setPreferredDevice(AudioDeviceInfo device);
+
+        /** One line for debug.log. */
+        void log(String line);
+    }
+
+    /** debug.log line when the route was applied. */
+    public static final String LOG_STEERED =
+            "playFT8Signal: default output steered to A2DP (app SCO session up)";
+    /** debug.log line when {@code setPreferredDevice} refused the route. */
+    public static final String LOG_REJECTED =
+            "playFT8Signal: A2DP steering REJECTED by setPreferredDevice;"
+                    + " TX audio stays on the OS route";
+
+    /**
+     * Decide and apply. Silent when the policy leaves routing to the OS.
+     *
+     * @param outputs        {@code AudioManager.getDevices(GET_DEVICES_OUTPUTS)}
+     * @param scoHeldForTx   {@code MainViewModel.isScoHeldForTx()} — our SCO link
+     *                       was up when this over was keyed
+     * @param scoAddress     {@code MainViewModel.scoAddressForTx()}, may be null
+     * @param sink           applies the route and logs the outcome
+     * @return true only when a route was applied and accepted
+     */
+    public static boolean apply(AudioDeviceInfo[] outputs, boolean scoHeldForTx,
+                                String scoAddress, Sink sink) {
+        if (outputs == null) return false;
+        int[] types = new int[outputs.length];
+        String[] addresses = new String[outputs.length];
+        for (int i = 0; i < outputs.length; i++) {
+            types[i] = outputs[i].getType();
+            addresses[i] = deviceAddressOrNull(outputs[i]);
+        }
+        int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(
+                types, addresses, scoHeldForTx, scoAddress);
+        if (idx == AudioOutputRoutingPolicy.LEAVE_TO_OS) return false;
+        // setPreferredDevice returns false when the framework refuses the route.
+        // Log what actually happened: an unconditional "steered" line is worse
+        // than no line at all, because the next person debugging a dead TX would
+        // rule this out on the strength of it.
+        boolean applied = sink.setPreferredDevice(outputs[idx]);
+        sink.log(applied ? LOG_STEERED : LOG_REJECTED);
+        return applied;
+    }
+
+    /**
+     * {@code AudioDeviceInfo.getAddress()} exists only from API 28. Calling it
+     * on the Android 8.1 device this steering exists for (issue #759 follow-up)
+     * throws {@link NoSuchMethodError} — a linkage error, which the
+     * {@code catch (Exception)} blocks around TX do not catch — before any
+     * audio plays. On Android 12+ a Bluetooth address additionally needs the
+     * runtime {@code BLUETOOTH_CONNECT} permission, which the user can deny;
+     * that must not abort the over either. In both cases the address is simply
+     * unknown, and the policy's single-pair fallback still performs the fix.
+     */
+    static String deviceAddressOrNull(AudioDeviceInfo device) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return null;
+        try {
+            return device.getAddress();
+        } catch (SecurityException e) {
+            return null;
+        }
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinator.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinator.java
@@ -4,7 +4,6 @@ import android.media.AudioManager;
 import android.os.Handler;
 import android.os.Looper;
 
-import java.util.function.LongSupplier;
 
 /**
  * Drives a {@link ScoLinkTracker} against the real world: every request,
@@ -26,6 +25,19 @@ import java.util.function.LongSupplier;
  * without a rig or a headset.
  */
 public final class ScoLinkCoordinator {
+
+    /**
+     * Monotonic-ish clock in ms. App-local rather than
+     * {@code java.util.function.LongSupplier}: {@code java.util.function} does
+     * not exist before API 24 and the core library is not desugared, so the
+     * {@code System::currentTimeMillis} lambda handed to
+     * {@link #onMainThread} failed to load on Android 6 (minSdk 23) — while
+     * constructing {@code MainViewModel}, i.e. at app start (Copilot review on
+     * #790, same defect as {@code TxScoLatch} had).
+     */
+    public interface Clock {
+        long nowMs();
+    }
 
     /** Side effects the coordinator asks the host to perform. */
     public interface Sink {
@@ -50,14 +62,14 @@ public final class ScoLinkCoordinator {
     private final ScoLinkTracker tracker;
     private final Handler handler;
     private final Sink sink;
-    private final LongSupplier clock;
+    private final Clock clock;
 
     private final Runnable retryRunnable;
     private final Runnable connectTimeoutRunnable;
     private final Runnable micCheckRunnable;
 
     public ScoLinkCoordinator(ScoLinkTracker tracker, Handler handler, Sink sink,
-                              LongSupplier clock) {
+                              Clock clock) {
         this.tracker = tracker;
         this.handler = handler;
         this.sink = sink;
@@ -136,7 +148,7 @@ public final class ScoLinkCoordinator {
                     + " -> " + ScoLinkTracker.stateName(state)
                     + " wanted=" + tracker.isWanted()
                     + " attempt=" + tracker.attempts());
-            ScoLinkTracker.Update u = tracker.onStateUpdate(state, clock.getAsLong());
+            ScoLinkTracker.Update u = tracker.onStateUpdate(state, clock.nowMs());
             if (state == AudioManager.SCO_AUDIO_STATE_CONNECTED) {
                 handler.removeCallbacks(connectTimeoutRunnable);
                 handler.removeCallbacks(retryRunnable);

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
@@ -1,8 +1,5 @@
 package com.k1af.ft8af.bluetooth;
 
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
-
 /**
  * Remembers whether <em>this app</em> held a Bluetooth SCO session for the rig
  * at the moment an over (or the tune carrier) was keyed — and on which device —
@@ -49,6 +46,22 @@ import java.util.function.Supplier;
  */
 public final class TxScoLatch {
 
+    /**
+     * {@code ScoLinkCoordinator.isLinkUpOrPending()} as a callable. App-local
+     * rather than {@code java.util.function.BooleanSupplier}: that package does
+     * not exist before API 24 and the module does not desugar the core library,
+     * so a lambda implementing it fails to load on Android 6 (minSdk 23) — at
+     * keying time, in this case (Copilot review on #790).
+     */
+    public interface LinkState {
+        boolean isUpOrPending();
+    }
+
+    /** The mic's routed SCO device address as a callable; same reason as {@link LinkState}. */
+    public interface DeviceAddress {
+        String get();
+    }
+
     private volatile boolean heldForTx;
     private volatile String scoAddress;
 
@@ -71,10 +84,10 @@ public final class TxScoLatch {
      */
     public void keyDown(boolean bluetoothRigTx,
                         boolean stopsSco,
-                        BooleanSupplier scoUpOrPending,
-                        Supplier<String> scoDeviceAddress,
+                        LinkState scoUpOrPending,
+                        DeviceAddress scoDeviceAddress,
                         Runnable stopSco) {
-        boolean held = bluetoothRigTx && scoUpOrPending.getAsBoolean();
+        boolean held = bluetoothRigTx && scoUpOrPending.isUpOrPending();
         heldForTx = held;
         scoAddress = held ? scoDeviceAddress.get() : null;
         if (stopsSco) {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
@@ -1,15 +1,19 @@
 package com.k1af.ft8af.bluetooth;
 
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
 /**
- * Remembers whether <em>this app</em> held a Bluetooth SCO session at the moment
- * an over (or the tune carrier) was keyed, so the TX audio path can still act on
- * that fact after the keying sequence has already asked for the link to drop.
+ * Remembers whether <em>this app</em> held a Bluetooth SCO session for the rig
+ * at the moment an over (or the tune carrier) was keyed — and on which device —
+ * so the TX audio path can still act on that after the keying sequence has
+ * already asked for the link to drop.
  *
  * <p>Why a latch rather than a live query (Copilot review on #790): the keying
- * path in {@code MainViewModel.beginKeying()} calls {@code stopSco()} <em>before</em>
- * PTT, then the TX worker sleeps the PTT settle delay (100 ms by default) before
- * it builds the {@code AudioTrack} and asks whether to steer Default output to
- * A2DP. {@code stopSco()} posts {@code ScoLinkTracker.requestOff()} to the main
+ * path calls {@code stopSco()} <em>before</em> PTT, then the TX worker sleeps
+ * the PTT settle delay (100 ms by default) before it builds the
+ * {@code AudioTrack} and asks whether to steer Default output to A2DP.
+ * {@code stopSco()} posts {@code ScoLinkTracker.requestOff()} to the main
  * looper, which flips the tracked state to DISCONNECTED as soon as it runs — so
  * by the time the question is asked the honest answer from the tracker is
  * "no", the override never fires in exactly the CAT/RTS/DTR + Bluetooth case it
@@ -18,39 +22,76 @@ package com.k1af.ft8af.bluetooth;
  * {@code USAGE_MEDIA} on the hands-free route (issue #759 follow-up), which is
  * the failure the steering fixes.
  *
- * <p>So the keying path snapshots the tracker's answer here first, the TX path
- * reads the snapshot, and the unkey path clears it once the post-TX SCO restart
- * has been requested. A mid-slot message swap (#704) re-keys nothing, so the
- * latch simply carries across it.
+ * <p>Why the ordering lives here: {@link #keyDown} performs the snapshot and
+ * the stop itself, in that order, so the sequence the TX path depends on is
+ * a single tested call rather than two statements in
+ * {@code MainViewModel.beginKeying()} that could be reordered without any test
+ * noticing.
  *
- * <p>Pure Java, no Android types: the ordering is what matters and it is
- * unit-tested against the real {@link ScoLinkTracker}.
+ * <p>Why {@code controlsSco}: a USB or network rig with a Bluetooth headset
+ * picked as its mic also holds a SCO link of ours
+ * ({@code ScoPolicy.shouldEnterHeadsetMode}), but that TX path neither stops
+ * SCO nor wants its audio moved off the rig onto the headset's A2DP. Only the
+ * path that actually pauses SCO around PTT for a Bluetooth rig may latch.
+ *
+ * <p>A mid-slot message swap (#704) re-keys nothing, so the latch carries
+ * across it. Pure Java, no Android types; the ordering is unit-tested against
+ * the real {@link ScoLinkTracker}.
  */
 public final class TxScoLatch {
 
     private volatile boolean heldForTx;
+    private volatile String scoAddress;
 
     /**
-     * Record the tracker's answer at keying time. Must be called <em>before</em>
-     * {@code stopSco()} is requested, on the thread that keys the rig.
+     * The production keying order: snapshot the link, then stop it.
      *
-     * @param scoUpOrPendingNow {@code ScoLinkCoordinator.isLinkUpOrPending()}
-     *                          as read at this instant
+     * @param controlsSco        whether this keying pauses SCO around PTT for a
+     *                           Bluetooth rig ({@code needControlSco()} on a
+     *                           control-path keying with a rig). When false
+     *                           nothing is latched and {@code stopSco} is not run.
+     * @param scoUpOrPending     {@code ScoLinkCoordinator.isLinkUpOrPending()},
+     *                           read here <em>before</em> {@code stopSco}
+     * @param scoDeviceAddress   Bluetooth address of the device the mic is
+     *                           currently captured from over SCO, or null when
+     *                           unknown; read only when the link is held
+     * @param stopSco            the {@code stopSco()} request, run after the
+     *                           snapshot when {@code controlsSco}
      */
-    public void onKeying(boolean scoUpOrPendingNow) {
-        heldForTx = scoUpOrPendingNow;
+    public void keyDown(boolean controlsSco,
+                        BooleanSupplier scoUpOrPending,
+                        Supplier<String> scoDeviceAddress,
+                        Runnable stopSco) {
+        boolean held = controlsSco && scoUpOrPending.getAsBoolean();
+        heldForTx = held;
+        scoAddress = held ? scoDeviceAddress.get() : null;
+        if (controlsSco) {
+            stopSco.run();
+        }
     }
 
     /**
-     * Whether our SCO link was up (or coming up) when the current over was keyed.
-     * Stable for the whole over regardless of what the tracker says now.
+     * Whether our SCO link for the rig was up (or coming up) when the current
+     * over was keyed. Stable for the whole over regardless of what the tracker
+     * says now.
      */
     public boolean heldForTx() {
         return heldForTx;
     }
 
+    /**
+     * Address of the device that link was on at keying time, or null when the
+     * platform withheld it (or nothing is held). Lets the routing policy pick
+     * <em>that</em> device's A2DP endpoint rather than the first hands-free
+     * device that happens to enumerate one.
+     */
+    public String scoAddress() {
+        return scoAddress;
+    }
+
     /** The over is done and the post-TX {@code startSco()} has been requested. */
-    public void onUnkeyed() {
+    public void keyUp() {
         heldForTx = false;
+        scoAddress = null;
     }
 }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
@@ -1,0 +1,56 @@
+package com.k1af.ft8af.bluetooth;
+
+/**
+ * Remembers whether <em>this app</em> held a Bluetooth SCO session at the moment
+ * an over (or the tune carrier) was keyed, so the TX audio path can still act on
+ * that fact after the keying sequence has already asked for the link to drop.
+ *
+ * <p>Why a latch rather than a live query (Copilot review on #790): the keying
+ * path in {@code MainViewModel.beginKeying()} calls {@code stopSco()} <em>before</em>
+ * PTT, then the TX worker sleeps the PTT settle delay (100 ms by default) before
+ * it builds the {@code AudioTrack} and asks whether to steer Default output to
+ * A2DP. {@code stopSco()} posts {@code ScoLinkTracker.requestOff()} to the main
+ * looper, which flips the tracked state to DISCONNECTED as soon as it runs — so
+ * by the time the question is asked the honest answer from the tracker is
+ * "no", the override never fires in exactly the CAT/RTS/DTR + Bluetooth case it
+ * exists for, and if the main looper happens to be busy the answer becomes a
+ * race. Meanwhile the OS is still tearing the SCO link down and keeps
+ * {@code USAGE_MEDIA} on the hands-free route (issue #759 follow-up), which is
+ * the failure the steering fixes.
+ *
+ * <p>So the keying path snapshots the tracker's answer here first, the TX path
+ * reads the snapshot, and the unkey path clears it once the post-TX SCO restart
+ * has been requested. A mid-slot message swap (#704) re-keys nothing, so the
+ * latch simply carries across it.
+ *
+ * <p>Pure Java, no Android types: the ordering is what matters and it is
+ * unit-tested against the real {@link ScoLinkTracker}.
+ */
+public final class TxScoLatch {
+
+    private volatile boolean heldForTx;
+
+    /**
+     * Record the tracker's answer at keying time. Must be called <em>before</em>
+     * {@code stopSco()} is requested, on the thread that keys the rig.
+     *
+     * @param scoUpOrPendingNow {@code ScoLinkCoordinator.isLinkUpOrPending()}
+     *                          as read at this instant
+     */
+    public void onKeying(boolean scoUpOrPendingNow) {
+        heldForTx = scoUpOrPendingNow;
+    }
+
+    /**
+     * Whether our SCO link was up (or coming up) when the current over was keyed.
+     * Stable for the whole over regardless of what the tracker says now.
+     */
+    public boolean heldForTx() {
+        return heldForTx;
+    }
+
+    /** The over is done and the post-TX {@code startSco()} has been requested. */
+    public void onUnkeyed() {
+        heldForTx = false;
+    }
+}

--- a/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java
@@ -28,11 +28,20 @@ import java.util.function.Supplier;
  * {@code MainViewModel.beginKeying()} that could be reordered without any test
  * noticing.
  *
- * <p>Why {@code controlsSco}: a USB or network rig with a Bluetooth headset
- * picked as its mic also holds a SCO link of ours
- * ({@code ScoPolicy.shouldEnterHeadsetMode}), but that TX path neither stops
- * SCO nor wants its audio moved off the rig onto the headset's A2DP. Only the
- * path that actually pauses SCO around PTT for a Bluetooth rig may latch.
+ * <p>Two separate questions go in, because they have different answers:
+ * <ul>
+ *   <li>{@code bluetoothRigTx} — is this a Bluetooth <em>rig</em> whose TX
+ *       audio must not go over SCO ({@code ScoPolicy.needControlSco()})? That
+ *       is what decides whether Default output gets steered to A2DP. A USB or
+ *       network rig with a Bluetooth headset picked as its mic also holds a SCO
+ *       link of ours ({@code ScoPolicy.shouldEnterHeadsetMode}), but its TX
+ *       audio belongs on the rig, so it answers no.</li>
+ *   <li>{@code stopsSco} — does this keying path actually pause SCO around
+ *       PTT? Only a control-path keying (CAT/RTS/DTR) with a rig does; a
+ *       Bluetooth rig on VOX leaves SCO up and lets the audio key the rig. It
+ *       still needs the steering — its media stream is on the SCO route too —
+ *       so it must latch even though it stops nothing.</li>
+ * </ul>
  *
  * <p>A mid-slot message swap (#704) re-keys nothing, so the latch carries
  * across it. Pure Java, no Android types; the ordering is unit-tested against
@@ -46,26 +55,29 @@ public final class TxScoLatch {
     /**
      * The production keying order: snapshot the link, then stop it.
      *
-     * @param controlsSco        whether this keying pauses SCO around PTT for a
-     *                           Bluetooth rig ({@code needControlSco()} on a
+     * @param bluetoothRigTx     whether this TX goes to a Bluetooth rig whose
+     *                           audio must not ride SCO ({@code needControlSco()}).
+     *                           When false nothing is latched.
+     * @param stopsSco           whether this keying pauses SCO around PTT (a
      *                           control-path keying with a rig). When false
-     *                           nothing is latched and {@code stopSco} is not run.
+     *                           {@code stopSco} is not run; VOX keeps SCO up.
      * @param scoUpOrPending     {@code ScoLinkCoordinator.isLinkUpOrPending()},
      *                           read here <em>before</em> {@code stopSco}
      * @param scoDeviceAddress   Bluetooth address of the device the mic is
      *                           currently captured from over SCO, or null when
      *                           unknown; read only when the link is held
      * @param stopSco            the {@code stopSco()} request, run after the
-     *                           snapshot when {@code controlsSco}
+     *                           snapshot when {@code stopsSco}
      */
-    public void keyDown(boolean controlsSco,
+    public void keyDown(boolean bluetoothRigTx,
+                        boolean stopsSco,
                         BooleanSupplier scoUpOrPending,
                         Supplier<String> scoDeviceAddress,
                         Runnable stopSco) {
-        boolean held = controlsSco && scoUpOrPending.getAsBoolean();
+        boolean held = bluetoothRigTx && scoUpOrPending.getAsBoolean();
         heldForTx = held;
         scoAddress = held ? scoDeviceAddress.get() : null;
-        if (controlsSco) {
+        if (stopsSco) {
             stopSco.run();
         }
     }

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -24,6 +24,7 @@ import androidx.lifecycle.MutableLiveData;
 
 import com.k1af.ft8af.FT8Common;
 import com.k1af.ft8af.ModeProfile;
+import com.k1af.ft8af.bluetooth.AudioOutputRoutingPolicy;
 import com.k1af.ft8af.ft8listener.FastDecodeGate;
 import com.k1af.ft8af.Ft8Message;
 import com.k1af.ft8af.ft8signal.FT8Package;
@@ -1066,6 +1067,8 @@ public class FT8TransmitSignal {
             AudioDeviceInfo deviceInfo = findAudioDeviceById(
                     GeneralVariables.audioOutputDeviceId, AudioManager.GET_DEVICES_OUTPUTS);
             audioTrack.setPreferredDevice(deviceInfo); // null resets to default
+        } else {
+            applyDefaultOutputRoutingOverride(audioTrack);
         }
 
         // Skip leading samples if we started transmitting late, so audio still ends on the cycle boundary.
@@ -3222,6 +3225,8 @@ public class FT8TransmitSignal {
                 AudioDeviceInfo deviceInfo = findAudioDeviceById(
                         GeneralVariables.audioOutputDeviceId, AudioManager.GET_DEVICES_OUTPUTS);
                 track.setPreferredDevice(deviceInfo);
+            } else {
+                applyDefaultOutputRoutingOverride(track);
             }
             track.play();
             track.setVolume(1.0f);
@@ -3310,6 +3315,33 @@ public class FT8TransmitSignal {
             }
         }
         return null;
+    }
+
+    /**
+     * When the user picked "Default" output and a Bluetooth SCO link is up
+     * alongside a paired A2DP device, pin the AudioTrack to the A2DP device.
+     * On Android 8.1 (issue #759 follow-up) the OS routes the USAGE_MEDIA
+     * stream through SCO while the hands-free link is active, leaving TX
+     * inaudible on a rig that only listens for the A2DP music channel — the
+     * tester's exact "audio received, not transmitted" report, cured by
+     * manually picking A2DP. Leaves routing to the OS when there's nothing to
+     * steer to.
+     */
+    private static void applyDefaultOutputRoutingOverride(AudioTrack track) {
+        Context context = GeneralVariables.getMainContext();
+        if (context == null) return;
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager == null) return;
+        AudioDeviceInfo[] outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
+        int[] types = new int[outputs.length];
+        for (int i = 0; i < outputs.length; i++) {
+            types[i] = outputs[i].getType();
+        }
+        int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(types);
+        if (idx == AudioOutputRoutingPolicy.LEAVE_TO_OS) return;
+        track.setPreferredDevice(outputs[idx]);
+        GeneralVariables.fileLog(
+                "playFT8Signal: default output steered to A2DP (SCO link present)");
     }
 
     private static class DoTransmitRunnable implements Runnable {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -23,6 +23,7 @@ import com.k1af.ft8af.wave.UsbAudioNative;
 import androidx.lifecycle.MutableLiveData;
 
 import com.k1af.ft8af.FT8Common;
+import com.k1af.ft8af.MainViewModel;
 import com.k1af.ft8af.ModeProfile;
 import com.k1af.ft8af.bluetooth.AudioOutputRoutingPolicy;
 import com.k1af.ft8af.ft8listener.FastDecodeGate;
@@ -3318,14 +3319,15 @@ public class FT8TransmitSignal {
     }
 
     /**
-     * When the user picked "Default" output and a Bluetooth SCO link is up
-     * alongside a paired A2DP device, pin the AudioTrack to the A2DP device.
-     * On Android 8.1 (issue #759 follow-up) the OS routes the USAGE_MEDIA
-     * stream through SCO while the hands-free link is active, leaving TX
-     * inaudible on a rig that only listens for the A2DP music channel — the
-     * tester's exact "audio received, not transmitted" report, cured by
-     * manually picking A2DP. Leaves routing to the OS when there's nothing to
-     * steer to.
+     * When the user picked "Default" output and <em>this app</em> is holding a
+     * Bluetooth SCO link, pin the AudioTrack to the A2DP endpoint of the same
+     * Bluetooth device. On Android 8.1 (issue #759 follow-up) the OS routes the
+     * USAGE_MEDIA stream through SCO while the hands-free link is active,
+     * leaving TX inaudible on a rig that only listens for the A2DP music
+     * channel — the tester's exact "audio received, not transmitted" report,
+     * cured by manually picking A2DP. Leaves routing to the OS whenever the
+     * conditions aren't met; see {@link AudioOutputRoutingPolicy} for why the
+     * enumerated device types alone are not enough to decide.
      */
     private static void applyDefaultOutputRoutingOverride(AudioTrack track) {
         Context context = GeneralVariables.getMainContext();
@@ -3334,14 +3336,36 @@ public class FT8TransmitSignal {
         if (audioManager == null) return;
         AudioDeviceInfo[] outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
         int[] types = new int[outputs.length];
+        String[] addresses = new String[outputs.length];
         for (int i = 0; i < outputs.length; i++) {
             types[i] = outputs[i].getType();
+            addresses[i] = outputs[i].getAddress();
         }
-        int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(types);
+        int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(
+                types, addresses, appHoldsScoSession());
         if (idx == AudioOutputRoutingPolicy.LEAVE_TO_OS) return;
-        track.setPreferredDevice(outputs[idx]);
-        GeneralVariables.fileLog(
-                "playFT8Signal: default output steered to A2DP (SCO link present)");
+        // setPreferredDevice returns false when the framework refuses the route.
+        // Log what actually happened: an unconditional "steered" line is worse
+        // than no line at all, because the next person debugging a dead TX would
+        // rule this out on the strength of it.
+        boolean applied = track.setPreferredDevice(outputs[idx]);
+        GeneralVariables.fileLog(applied
+                ? "playFT8Signal: default output steered to A2DP (app SCO session up)"
+                : "playFT8Signal: A2DP steering REJECTED by setPreferredDevice;"
+                        + " TX audio stays on the OS route");
+    }
+
+    /**
+     * Whether the app's own SCO link tracker says we currently hold a SCO
+     * session. Deliberately not {@code AudioManager.isBluetoothScoOn()}, which
+     * only mirrors the legacy force-use flag and is not trusted anywhere else in
+     * this codebase — see {@code ScoPolicy} / {@code ScoLinkCoordinator}.
+     * Returns false when the view model isn't up yet, which correctly means "no
+     * SCO session of ours".
+     */
+    private static boolean appHoldsScoSession() {
+        MainViewModel viewModel = MainViewModel.peekInstance();
+        return viewModel != null && viewModel.isScoLinkUpOrPending();
     }
 
     private static class DoTransmitRunnable implements Runnable {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -3342,7 +3342,7 @@ public class FT8TransmitSignal {
             addresses[i] = outputs[i].getAddress();
         }
         int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(
-                types, addresses, appHoldsScoSession());
+                types, addresses, scoHeldForThisTx());
         if (idx == AudioOutputRoutingPolicy.LEAVE_TO_OS) return;
         // setPreferredDevice returns false when the framework refuses the route.
         // Log what actually happened: an unconditional "steered" line is worse
@@ -3356,16 +3356,23 @@ public class FT8TransmitSignal {
     }
 
     /**
-     * Whether the app's own SCO link tracker says we currently hold a SCO
-     * session. Deliberately not {@code AudioManager.isBluetoothScoOn()}, which
-     * only mirrors the legacy force-use flag and is not trusted anywhere else in
-     * this codebase — see {@code ScoPolicy} / {@code ScoLinkCoordinator}.
-     * Returns false when the view model isn't up yet, which correctly means "no
-     * SCO session of ours".
+     * Whether the app's own SCO link was up when this over was keyed, per the
+     * snapshot {@code MainViewModel.beginKeying()} takes before it calls
+     * {@code stopSco()} ({@code TxScoLatch}). Not the tracker's live answer:
+     * by the time this runs — after {@code onBeforeTransmit()} /
+     * {@code onTuneKeyDown()} and the PTT settle sleep — the posted
+     * {@code requestOff()} has normally already flipped the tracker to
+     * DISCONNECTED, so a live query said "no" in exactly the case the steering
+     * exists for, and became a race against the main looper otherwise (Copilot
+     * review on #790). Deliberately not {@code AudioManager.isBluetoothScoOn()}
+     * either, which only mirrors the legacy force-use flag and is not trusted
+     * anywhere else in this codebase — see {@code ScoPolicy} /
+     * {@code ScoLinkCoordinator}. Returns false when the view model isn't up
+     * yet, which correctly means "no SCO session of ours".
      */
-    private static boolean appHoldsScoSession() {
+    private static boolean scoHeldForThisTx() {
         MainViewModel viewModel = MainViewModel.peekInstance();
-        return viewModel != null && viewModel.isScoLinkUpOrPending();
+        return viewModel != null && viewModel.isScoHeldForTx();
     }
 
     private static class DoTransmitRunnable implements Runnable {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -12,6 +12,7 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 import android.media.AudioAttributes;
 import android.media.AudioDeviceInfo;
+import android.os.Build;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
@@ -3339,7 +3340,7 @@ public class FT8TransmitSignal {
         String[] addresses = new String[outputs.length];
         for (int i = 0; i < outputs.length; i++) {
             types[i] = outputs[i].getType();
-            addresses[i] = outputs[i].getAddress();
+            addresses[i] = deviceAddressOrNull(outputs[i]);
         }
         int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(
                 types, addresses, scoHeldForThisTx(), scoAddressForThisTx());
@@ -3353,6 +3354,19 @@ public class FT8TransmitSignal {
                 ? "playFT8Signal: default output steered to A2DP (app SCO session up)"
                 : "playFT8Signal: A2DP steering REJECTED by setPreferredDevice;"
                         + " TX audio stays on the OS route");
+    }
+
+    /**
+     * {@code AudioDeviceInfo.getAddress()} exists only from API 28. Calling it
+     * on the Android 8.1 device this steering exists for (issue #759 follow-up)
+     * throws {@link NoSuchMethodError} — a linkage error, which the
+     * {@code catch (Exception)} blocks around TX do not catch — before any
+     * audio plays. Below Pie the addresses are simply unknown, and the policy's
+     * single-pair fallback still performs the fix there.
+     */
+    private static String deviceAddressOrNull(AudioDeviceInfo device) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return null;
+        return device.getAddress();
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -27,6 +27,7 @@ import com.k1af.ft8af.FT8Common;
 import com.k1af.ft8af.MainViewModel;
 import com.k1af.ft8af.ModeProfile;
 import com.k1af.ft8af.bluetooth.AudioOutputRoutingPolicy;
+import com.k1af.ft8af.bluetooth.DefaultOutputRouting;
 import com.k1af.ft8af.ft8listener.FastDecodeGate;
 import com.k1af.ft8af.Ft8Message;
 import com.k1af.ft8af.ft8signal.FT8Package;
@@ -3330,43 +3331,28 @@ public class FT8TransmitSignal {
      * conditions aren't met; see {@link AudioOutputRoutingPolicy} for why the
      * enumerated device types alone are not enough to decide.
      */
-    private static void applyDefaultOutputRoutingOverride(AudioTrack track) {
+    private static void applyDefaultOutputRoutingOverride(final AudioTrack track) {
         Context context = GeneralVariables.getMainContext();
         if (context == null) return;
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         if (audioManager == null) return;
         AudioDeviceInfo[] outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
-        int[] types = new int[outputs.length];
-        String[] addresses = new String[outputs.length];
-        for (int i = 0; i < outputs.length; i++) {
-            types[i] = outputs[i].getType();
-            addresses[i] = deviceAddressOrNull(outputs[i]);
-        }
-        int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(
-                types, addresses, scoHeldForThisTx(), scoAddressForThisTx());
-        if (idx == AudioOutputRoutingPolicy.LEAVE_TO_OS) return;
-        // setPreferredDevice returns false when the framework refuses the route.
-        // Log what actually happened: an unconditional "steered" line is worse
-        // than no line at all, because the next person debugging a dead TX would
-        // rule this out on the strength of it.
-        boolean applied = track.setPreferredDevice(outputs[idx]);
-        GeneralVariables.fileLog(applied
-                ? "playFT8Signal: default output steered to A2DP (app SCO session up)"
-                : "playFT8Signal: A2DP steering REJECTED by setPreferredDevice;"
-                        + " TX audio stays on the OS route");
-    }
+        // The enumeration-to-policy-to-track wiring (and the address gating for
+        // API < 28 / a denied BLUETOOTH_CONNECT) lives in DefaultOutputRouting so
+        // it is covered by DefaultOutputRoutingTest; only the real track and the
+        // debug log are supplied from here.
+        DefaultOutputRouting.apply(outputs, scoHeldForThisTx(), scoAddressForThisTx(),
+                new DefaultOutputRouting.Sink() {
+                    @Override
+                    public boolean setPreferredDevice(AudioDeviceInfo device) {
+                        return track.setPreferredDevice(device);
+                    }
 
-    /**
-     * {@code AudioDeviceInfo.getAddress()} exists only from API 28. Calling it
-     * on the Android 8.1 device this steering exists for (issue #759 follow-up)
-     * throws {@link NoSuchMethodError} — a linkage error, which the
-     * {@code catch (Exception)} blocks around TX do not catch — before any
-     * audio plays. Below Pie the addresses are simply unknown, and the policy's
-     * single-pair fallback still performs the fix there.
-     */
-    private static String deviceAddressOrNull(AudioDeviceInfo device) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return null;
-        return device.getAddress();
+                    @Override
+                    public void log(String line) {
+                        GeneralVariables.fileLog(line);
+                    }
+                });
     }
 
     /**

--- a/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java
@@ -3342,7 +3342,7 @@ public class FT8TransmitSignal {
             addresses[i] = outputs[i].getAddress();
         }
         int idx = AudioOutputRoutingPolicy.pickDefaultOutputIndex(
-                types, addresses, scoHeldForThisTx());
+                types, addresses, scoHeldForThisTx(), scoAddressForThisTx());
         if (idx == AudioOutputRoutingPolicy.LEAVE_TO_OS) return;
         // setPreferredDevice returns false when the framework refuses the route.
         // Log what actually happened: an unconditional "steered" line is worse
@@ -3373,6 +3373,16 @@ public class FT8TransmitSignal {
     private static boolean scoHeldForThisTx() {
         MainViewModel viewModel = MainViewModel.peekInstance();
         return viewModel != null && viewModel.isScoHeldForTx();
+    }
+
+    /**
+     * Address of the device that SCO link was on at keying time, or null when
+     * the platform withheld it; lets the policy pick <em>that</em> device's A2DP
+     * endpoint when more than one hands-free device is connected.
+     */
+    private static String scoAddressForThisTx() {
+        MainViewModel viewModel = MainViewModel.peekInstance();
+        return viewModel == null ? null : viewModel.scoAddressForTx();
     }
 
     private static class DoTransmitRunnable implements Runnable {

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -303,6 +303,30 @@ public class MicRecorder {
     }
 
     /**
+     * Bluetooth address of the SCO device the running AudioRecord is capturing
+     * from right now, or {@code null} when the capture is not on a SCO endpoint
+     * or there is nothing to ask (USB-direct capture, not started, API &lt; 24,
+     * address withheld by the platform). This is what identifies <em>which</em>
+     * hands-free device carries our SCO link, so the TX path can steer Default
+     * output to that device's A2DP profile and not to another dual-profile
+     * device that merely enumerates a SCO endpoint (Copilot review on #790).
+     */
+    public synchronized String routedScoInputAddress() {
+        if (useUsbAudio || audioRecord == null) return null;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return null;
+        try {
+            AudioDeviceInfo routed = audioRecord.getRoutedDevice();
+            if (routed == null || routed.getType() != AudioDeviceInfo.TYPE_BLUETOOTH_SCO) {
+                return null;
+            }
+            String address = routed.getAddress();
+            return address == null || address.trim().isEmpty() ? null : address;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
      * {@code AudioDeviceInfo.TYPE_*} of the input the user pinned in Settings,
      * or {@code -1} for "system default" / USB-direct / a pinned device that is
      * no longer present.

--- a/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
+++ b/ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java
@@ -313,7 +313,11 @@ public class MicRecorder {
      */
     public synchronized String routedScoInputAddress() {
         if (useUsbAudio || audioRecord == null) return null;
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return null;
+        // getRoutedDevice() is API 24, but getAddress() is API 28: on Android
+        // 8.x (the platform this exists for) the call is a NoSuchMethodError,
+        // which no catch (Exception) below would stop, and it would abort the
+        // keying that snapshots SCO. Below Pie the address is simply unknown.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return null;
         try {
             AudioDeviceInfo routed = audioRecord.getRoutedDevice();
             if (routed == null || routed.getType() != AudioDeviceInfo.TYPE_BLUETOOTH_SCO) {

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
@@ -40,8 +40,70 @@ public class AudioOutputRoutingPolicyTest {
     /** What AudioManager reports for a non-Bluetooth endpoint. */
     private static final String NONE = "";
 
+    /** The platform withheld which device our SCO link is on. */
     private static int pick(int[] types, String[] addresses, boolean scoActive) {
-        return AudioOutputRoutingPolicy.pickDefaultOutputIndex(types, addresses, scoActive);
+        return AudioOutputRoutingPolicy.pickDefaultOutputIndex(types, addresses, scoActive, null);
+    }
+
+    /** The mic's routed capture device told us which device our SCO link is on. */
+    private static int pickOn(int[] types, String[] addresses, String activeSco) {
+        return AudioOutputRoutingPolicy.pickDefaultOutputIndex(types, addresses, true, activeSco);
+    }
+
+    // -- two hands-free devices: only the one carrying our link may win -------
+
+    @Test
+    public void twoDualProfileDevices_withOurLinkIdentified_picksThatDevicesA2dp() {
+        // A car kit enumerated first and the rig second, both exposing SCO and
+        // A2DP. The first matching pair is the car's; only the routed capture
+        // device tells us the rig is the one holding our link.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, OTHER, HEADSET, HEADSET};
+        assertThat(pickOn(types, addrs, HEADSET)).isEqualTo(2);
+        assertThat(pickOn(types, addrs, OTHER)).isEqualTo(0);
+    }
+
+    @Test
+    public void twoDualProfileDevices_withOurLinkUnknown_leavesToOs() {
+        // Same phone, but the platform could not say which device the mic is
+        // captured from. Guessing the first pair could send TX into the car.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, OTHER, HEADSET, HEADSET};
+        assertThat(pick(types, addrs, true)).isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void ourLinkOnADeviceWithoutA2dp_leavesToOs_evenIfAnotherPairExists() {
+        // Our SCO link is on a headset that has no A2DP endpoint; the car kit
+        // next to it pairs perfectly well but is not where the rig listens.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, OTHER, HEADSET};
+        assertThat(pickOn(types, addrs, HEADSET)).isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void identifiedLinkMatchesCaseInsensitively() {
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {HEADSET, HEADSET};
+        assertThat(pickOn(types, addrs, "aa:bb:cc:dd:ee:ff")).isEqualTo(0);
+    }
+
+    @Test
+    public void identifiedLink_withAddressesWithheld_stillUsesTheSinglePairFallback() {
+        // The capture side knew the address but the output enumeration blanked
+        // them all: one A2DP + one SCO is still an unambiguous pairing.
+        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {NONE, NONE, NONE};
+        assertThat(pickOn(types, addrs, HEADSET)).isEqualTo(1);
+    }
+
+    @Test
+    public void sameDeviceEnumeratedTwiceOnSco_isNotAmbiguous() {
+        // Some builds list a hands-free device's SCO endpoint more than once;
+        // identical addresses are one device, not two.
+        int[] types = {TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {HEADSET, HEADSET, "aa:bb:cc:dd:ee:ff"};
+        assertThat(pick(types, addrs, true)).isEqualTo(1);
     }
 
     // -- the case the override exists for -------------------------------------

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
@@ -1,0 +1,86 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for the Default-output override that steers TX to A2DP when a Bluetooth
+ * SCO link is up (issue #759 follow-up). Pure JUnit — the policy takes plain
+ * ints so it never touches the Android runtime.
+ */
+public class AudioOutputRoutingPolicyTest {
+
+    // Framework AudioDeviceInfo type constants used to build test inputs.
+    private static final int TYPE_BUILTIN_SPEAKER = 2;
+    private static final int TYPE_WIRED_HEADSET = 3;
+    private static final int TYPE_BLUETOOTH_SCO = 7;
+    private static final int TYPE_BLUETOOTH_A2DP = 8;
+    private static final int TYPE_USB_DEVICE = 11;
+
+    @Test
+    public void constantsMatchFrameworkValues() throws Exception {
+        int frameworkA2dp = android.media.AudioDeviceInfo.class
+                .getField("TYPE_BLUETOOTH_A2DP").getInt(null);
+        int frameworkSco = android.media.AudioDeviceInfo.class
+                .getField("TYPE_BLUETOOTH_SCO").getInt(null);
+        assertThat(AudioOutputRoutingPolicy.TYPE_BLUETOOTH_A2DP).isEqualTo(frameworkA2dp);
+        assertThat(AudioOutputRoutingPolicy.TYPE_BLUETOOTH_SCO).isEqualTo(frameworkSco);
+    }
+
+    // The issue #759 follow-up: with mic SCO up and the paired transceiver also
+    // reachable via A2DP, "Default" output must be steered to A2DP or TX silently
+    // goes into the SCO speaker instead of on the air.
+    @Test
+    public void a2dpAndScoBothPresent_picksA2dp() {
+        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types)).isEqualTo(1);
+    }
+
+    @Test
+    public void a2dpAndScoBothPresent_picksFirstA2dp() {
+        // Some devices enumerate more than one A2DP node during a profile
+        // transition; the first is the stable choice.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_A2DP};
+        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types)).isEqualTo(0);
+    }
+
+    // No SCO in play: a phone paired to a car/headphones for music must not have
+    // TX yanked off the wired headset or built-in speaker onto the A2DP link —
+    // that's the car-stereo pause-loop regression the two-arg ScoPolicy guards
+    // against on the input side.
+    @Test
+    public void onlyA2dpPresent_leavesToOs() {
+        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_BLUETOOTH_A2DP};
+        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void onlyScoPresent_leavesToOs() {
+        // Nothing better to steer to; the OS's own routing (and the SCO
+        // pipeline itself) is the only choice.
+        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_BLUETOOTH_SCO};
+        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void noBluetoothDevices_leavesToOs() {
+        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_WIRED_HEADSET, TYPE_USB_DEVICE};
+        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void emptyList_leavesToOs() {
+        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(new int[0]))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void nullList_leavesToOs() {
+        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(null))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
@@ -117,6 +117,25 @@ public class AudioOutputRoutingPolicyTest {
     }
 
     @Test
+    public void identifiedLink_contradictedByTheOnlyNamedSco_leavesToOs() {
+        // Partial redaction: the A2DP endpoint's address is withheld but the one
+        // SCO endpoint names a DIFFERENT device than the one the mic is captured
+        // from. The single-pair fallback must not hand TX to that blank A2DP.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {NONE, OTHER};
+        assertThat(pickOn(types, addrs, HEADSET)).isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void identifiedLink_confirmedByTheNamedSco_stillUsesTheSinglePairFallback() {
+        // Same shape, but the SCO endpoint agrees with the capture side: the
+        // blank A2DP is the only candidate and the pairing is unambiguous.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {NONE, HEADSET};
+        assertThat(pickOn(types, addrs, HEADSET)).isEqualTo(0);
+    }
+
+    @Test
     public void sameDeviceEnumeratedTwiceOnSco_isNotAmbiguous() {
         // Some builds list a hands-free device's SCO endpoint more than once;
         // identical addresses are one device, not two.

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
@@ -5,9 +5,14 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.Test;
 
 /**
- * Tests for the Default-output override that steers TX to A2DP when a Bluetooth
- * SCO link is up (issue #759 follow-up). Pure JUnit — the policy takes plain
- * ints so it never touches the Android runtime.
+ * Tests for the Default-output override that steers TX to A2DP when this app is
+ * holding a Bluetooth SCO link (issue #759 follow-up). Pure JUnit — the policy
+ * takes plain ints/Strings so it never touches the Android runtime.
+ *
+ * <p>The second half of these pin the conditions added after the Copilot review
+ * on #790: enumerating both profiles proves neither that a SCO session is ours
+ * nor that the two endpoints are the same physical device, and steering on
+ * either mistaken belief pushes TX audio somewhere the rig cannot hear it.
  */
 public class AudioOutputRoutingPolicyTest {
 
@@ -28,59 +33,166 @@ public class AudioOutputRoutingPolicyTest {
         assertThat(AudioOutputRoutingPolicy.TYPE_BLUETOOTH_SCO).isEqualTo(frameworkSco);
     }
 
-    // The issue #759 follow-up: with mic SCO up and the paired transceiver also
-    // reachable via A2DP, "Default" output must be steered to A2DP or TX silently
-    // goes into the SCO speaker instead of on the air.
+    /** The tester's headset: one paired device exposing both profiles. */
+    private static final String HEADSET = "AA:BB:CC:DD:EE:FF";
+    /** A second, unrelated Bluetooth device - a car kit or a speaker. */
+    private static final String OTHER = "11:22:33:44:55:66";
+    /** What AudioManager reports for a non-Bluetooth endpoint. */
+    private static final String NONE = "";
+
+    private static int pick(int[] types, String[] addresses, boolean scoActive) {
+        return AudioOutputRoutingPolicy.pickDefaultOutputIndex(types, addresses, scoActive);
+    }
+
+    // -- the case the override exists for -------------------------------------
+
+    // Issue #759 follow-up: mic SCO up on the paired transceiver, which is also
+    // reachable via A2DP. "Default" output must be steered to A2DP or TX goes
+    // into the SCO channel instead of on the air.
     @Test
-    public void a2dpAndScoBothPresent_picksA2dp() {
+    public void ourScoSessionOnTheSameDevice_picksThatDevicesA2dp() {
         int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
-        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types)).isEqualTo(1);
+        String[] addrs = {NONE, HEADSET, HEADSET};
+        assertThat(pick(types, addrs, true)).isEqualTo(1);
     }
 
     @Test
-    public void a2dpAndScoBothPresent_picksFirstA2dp() {
-        // Some devices enumerate more than one A2DP node during a profile
-        // transition; the first is the stable choice.
-        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_A2DP};
-        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types)).isEqualTo(0);
+    public void matchingIsCaseInsensitive() {
+        // AudioDeviceInfo.getAddress() casing is not contractual across profiles.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {"aa:bb:cc:dd:ee:ff", HEADSET};
+        assertThat(pick(types, addrs, true)).isEqualTo(0);
     }
 
-    // No SCO in play: a phone paired to a car/headphones for music must not have
-    // TX yanked off the wired headset or built-in speaker onto the A2DP link —
-    // that's the car-stereo pause-loop regression the two-arg ScoPolicy guards
-    // against on the input side.
+    @Test
+    public void picksTheMatchingA2dp_notMerelyTheFirstOne() {
+        // A speaker enumerated ahead of the headset must not win: the rig is
+        // listening on the headset's A2DP, not the speaker's.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, HEADSET, HEADSET};
+        assertThat(pick(types, addrs, true)).isEqualTo(1);
+    }
+
+    // -- no SCO session of ours -----------------------------------------------
+
+    @Test
+    public void noAppScoSession_leavesToOs() {
+        // The regression this guards: AudioManager enumerates both profiles for
+        // any connected hands-free device, up link or not. A rig on USB or the
+        // network must not have Default output yanked onto a Bluetooth sink just
+        // because a car kit is paired nearby - ScoPolicy deliberately left SCO
+        // off in that case.
+        int[] types = {TYPE_USB_DEVICE, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {NONE, HEADSET, HEADSET};
+        assertThat(pick(types, addrs, false))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    // -- different devices ----------------------------------------------------
+
+    @Test
+    public void a2dpOnADifferentDeviceThanTheScoLink_leavesToOs() {
+        // A car kit holding SCO plus an unrelated A2DP speaker. Steering TX to
+        // the speaker is the failure being fixed, not a cure for it.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, HEADSET};
+        assertThat(pick(types, addrs, true))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void multipleCandidatesWithNoMatch_leavesToOs() {
+        // Two A2DP sinks, neither on the SCO device: nothing here is known to be
+        // the rig, and the ambiguity fallback must not kick in.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, OTHER, HEADSET};
+        assertThat(pick(types, addrs, true))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    // -- platforms that withhold addresses ------------------------------------
+
+    @Test
+    public void blankAddressesWithASingleCandidatePair_stillSteers() {
+        // Some builds report blank addresses even for BT endpoints. With exactly
+        // one A2DP and one SCO endpoint the pairing is unambiguous, so the
+        // Android 8.1 fix still works there.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {NONE, NONE};
+        assertThat(pick(types, addrs, true)).isEqualTo(0);
+    }
+
+    @Test
+    public void nullAddressArray_stillSteersForASingleCandidatePair() {
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        assertThat(pick(types, null, true)).isEqualTo(0);
+    }
+
+    @Test
+    public void blankAddressesWithTwoA2dpCandidates_leavesToOs() {
+        // Without addresses there is no way to tell which sink is the rig, so
+        // guessing is not allowed.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {NONE, NONE, NONE};
+        assertThat(pick(types, addrs, true))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void blankIsNeverTreatedAsMatchingAnotherBlank() {
+        // An equality match on "" must never fire: with a blank A2DP, a known
+        // mismatched A2DP and a known SCO, there is nothing legitimate to pick.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {NONE, OTHER, HEADSET};
+        assertThat(pick(types, addrs, true))
+                .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    // -- nothing to steer to --------------------------------------------------
+
     @Test
     public void onlyA2dpPresent_leavesToOs() {
+        // Paired for music only - this has never been broken, and overriding
+        // speakers would be surprising.
         int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_BLUETOOTH_A2DP};
-        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types))
+        String[] addrs = {NONE, HEADSET};
+        assertThat(pick(types, addrs, true))
                 .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
     }
 
     @Test
     public void onlyScoPresent_leavesToOs() {
-        // Nothing better to steer to; the OS's own routing (and the SCO
-        // pipeline itself) is the only choice.
-        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_BLUETOOTH_SCO};
-        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types))
+        int[] types = {TYPE_BLUETOOTH_SCO, TYPE_WIRED_HEADSET};
+        String[] addrs = {HEADSET, NONE};
+        assertThat(pick(types, addrs, true))
                 .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
     }
 
     @Test
     public void noBluetoothDevices_leavesToOs() {
-        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_WIRED_HEADSET, TYPE_USB_DEVICE};
-        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(types))
+        int[] types = {TYPE_BUILTIN_SPEAKER, TYPE_USB_DEVICE, TYPE_WIRED_HEADSET};
+        String[] addrs = {NONE, NONE, NONE};
+        assertThat(pick(types, addrs, true))
                 .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
     }
 
     @Test
     public void emptyList_leavesToOs() {
-        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(new int[0]))
+        assertThat(pick(new int[0], new String[0], true))
                 .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
     }
 
     @Test
     public void nullList_leavesToOs() {
-        assertThat(AudioOutputRoutingPolicy.pickDefaultOutputIndex(null))
+        assertThat(pick(null, null, true))
                 .isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void shortAddressArray_doesNotThrow() {
+        // Defensive: the arrays are built in lockstep by the caller, but an
+        // index-out-of-bounds inside the TX path would kill a transmission.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO};
+        assertThat(pick(types, new String[]{HEADSET}, true)).isEqualTo(0);
     }
 }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicyTest.java
@@ -98,6 +98,25 @@ public class AudioOutputRoutingPolicyTest {
     }
 
     @Test
+    public void knownScoNextToABlankSco_isAmbiguous_leavesToOs() {
+        // The car kit reports its address, the rig's SCO endpoint comes back
+        // blank (some builds withhold it). Only one address is known, but that
+        // is one device out of two — the rig may be the blank one, and steering
+        // to the car's A2DP is exactly the failure being fixed.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, OTHER, NONE};
+        assertThat(pick(types, addrs, true)).isEqualTo(AudioOutputRoutingPolicy.LEAVE_TO_OS);
+    }
+
+    @Test
+    public void knownScoNextToABlankSco_withOurLinkIdentified_stillPicksIt() {
+        // Same enumeration, but the capture side named the car as our link.
+        int[] types = {TYPE_BLUETOOTH_A2DP, TYPE_BLUETOOTH_SCO, TYPE_BLUETOOTH_SCO};
+        String[] addrs = {OTHER, OTHER, NONE};
+        assertThat(pickOn(types, addrs, OTHER)).isEqualTo(0);
+    }
+
+    @Test
     public void sameDeviceEnumeratedTwiceOnSco_isNotAmbiguous() {
         // Some builds list a hands-free device's SCO endpoint more than once;
         // identical addresses are one device, not two.

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/DefaultOutputRoutingTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/DefaultOutputRoutingTest.java
@@ -1,0 +1,133 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.media.AudioDeviceInfo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.AudioDeviceInfoBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Android adapter between the enumerated outputs, the pure
+ * {@link AudioOutputRoutingPolicy}, and {@code AudioTrack.setPreferredDevice}.
+ * Robolectric builds real {@link AudioDeviceInfo} objects (type only — their
+ * addresses come back blank, which is the withheld-address path the policy's
+ * single-pair fallback exists for), and a capturing {@link DefaultOutputRouting.Sink}
+ * stands in for the track and debug.log.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DefaultOutputRoutingTest {
+
+    private static AudioDeviceInfo device(int type) {
+        return AudioDeviceInfoBuilder.newBuilder().setType(type).build();
+    }
+
+    private static final class CapturingSink implements DefaultOutputRouting.Sink {
+        final List<AudioDeviceInfo> preferred = new ArrayList<>();
+        final List<String> log = new ArrayList<>();
+        boolean accept = true;
+
+        @Override
+        public boolean setPreferredDevice(AudioDeviceInfo device) {
+            preferred.add(device);
+            return accept;
+        }
+
+        @Override
+        public void log(String line) {
+            log.add(line);
+        }
+    }
+
+    @Test
+    public void ourScoUp_singlePair_steersToTheA2dpDeviceAndLogsIt() {
+        AudioDeviceInfo speaker = device(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER);
+        AudioDeviceInfo a2dp = device(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP);
+        AudioDeviceInfo sco = device(AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+        CapturingSink sink = new CapturingSink();
+
+        boolean applied = DefaultOutputRouting.apply(
+                new AudioDeviceInfo[] {speaker, a2dp, sco}, true, null, sink);
+
+        assertThat(applied).isTrue();
+        assertThat(sink.preferred).containsExactly(a2dp);
+        assertThat(sink.log).containsExactly(DefaultOutputRouting.LOG_STEERED);
+    }
+
+    @Test
+    public void frameworkRefusesTheRoute_logsTheRejection() {
+        AudioDeviceInfo a2dp = device(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP);
+        AudioDeviceInfo sco = device(AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+        CapturingSink sink = new CapturingSink();
+        sink.accept = false;
+
+        boolean applied = DefaultOutputRouting.apply(
+                new AudioDeviceInfo[] {a2dp, sco}, true, null, sink);
+
+        assertThat(applied).isFalse();
+        assertThat(sink.preferred).containsExactly(a2dp);
+        assertThat(sink.log).containsExactly(DefaultOutputRouting.LOG_REJECTED);
+    }
+
+    @Test
+    public void noScoOfOurs_touchesNothing() {
+        AudioDeviceInfo a2dp = device(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP);
+        AudioDeviceInfo sco = device(AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+        CapturingSink sink = new CapturingSink();
+
+        assertThat(DefaultOutputRouting.apply(new AudioDeviceInfo[] {a2dp, sco}, false, null, sink))
+                .isFalse();
+        assertThat(sink.preferred).isEmpty();
+        assertThat(sink.log).isEmpty();
+    }
+
+    @Test
+    public void noBluetoothOutputs_touchesNothing() {
+        AudioDeviceInfo speaker = device(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER);
+        AudioDeviceInfo usb = device(AudioDeviceInfo.TYPE_USB_DEVICE);
+        CapturingSink sink = new CapturingSink();
+
+        assertThat(DefaultOutputRouting.apply(new AudioDeviceInfo[] {speaker, usb}, true, null, sink))
+                .isFalse();
+        assertThat(sink.preferred).isEmpty();
+        assertThat(sink.log).isEmpty();
+    }
+
+    @Test
+    public void nullEnumeration_touchesNothing() {
+        CapturingSink sink = new CapturingSink();
+        assertThat(DefaultOutputRouting.apply(null, true, null, sink)).isFalse();
+        assertThat(sink.preferred).isEmpty();
+    }
+
+    @Test
+    @Config(sdk = 27)
+    public void belowPie_addressesAreUnknown_andTheFixStillApplies() {
+        // Android 8.1 is the device this exists for; getAddress() does not exist
+        // there, so the adapter must not call it — and the single-pair fallback
+        // must still steer.
+        AudioDeviceInfo a2dp = device(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP);
+        AudioDeviceInfo sco = device(AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+        assertThat(DefaultOutputRouting.deviceAddressOrNull(a2dp)).isNull();
+        CapturingSink sink = new CapturingSink();
+
+        assertThat(DefaultOutputRouting.apply(new AudioDeviceInfo[] {a2dp, sco}, true, null, sink))
+                .isTrue();
+        assertThat(sink.preferred).containsExactly(a2dp);
+    }
+
+    @Test
+    public void onPieAndLater_addressIsReadWithoutThrowing() {
+        AudioDeviceInfo a2dp = device(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP);
+        // Robolectric's builder gives no address; the point is the call path
+        // itself is taken and any blank comes back as a value, not an exception.
+        String address = DefaultOutputRouting.deviceAddressOrNull(a2dp);
+        assertThat(address == null || address.isEmpty()).isTrue();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/TxScoLatchTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/TxScoLatchTest.java
@@ -42,7 +42,7 @@ public class TxScoLatchTest {
         TxScoLatch latch = new TxScoLatch();
 
         // beginKeying() for a Bluetooth rig keyed via CAT/RTS/DTR.
-        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
+        latch.keyDown(true, true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
 
         // The stop really ran (this is what playFT8Signal sees after the PTT
         // settle delay, and what the first version of #790 queried)...
@@ -53,15 +53,33 @@ public class TxScoLatchTest {
     }
 
     @Test
-    public void keyDown_withoutScoControl_latchesNothingAndDoesNotStop() {
-        // USB/network rig with a Bluetooth headset selected as the mic: our SCO
-        // link is up, but this keying does not pause it and TX audio belongs on
-        // the rig, not the headset's A2DP.
+    public void bluetoothRigOnVox_latchesWithoutStopping() {
+        // Bluetooth rig keyed by VOX: needControlSco() is true (the audio must
+        // not ride SCO) but no control path pauses SCO around PTT. The steering
+        // is still needed — the media stream is on the SCO route — so the latch
+        // must engage while stopSco() stays untouched (Copilot review on #790).
         ScoLinkTracker tracker = connectedTracker();
         TxScoLatch latch = new TxScoLatch();
         AtomicInteger stops = new AtomicInteger();
 
-        latch.keyDown(false, () -> upOrPending(tracker), () -> RIG, stops::incrementAndGet);
+        latch.keyDown(true, false, () -> upOrPending(tracker), () -> RIG, stops::incrementAndGet);
+
+        assertThat(latch.heldForTx()).isTrue();
+        assertThat(latch.scoAddress()).isEqualTo(RIG);
+        assertThat(stops.get()).isEqualTo(0);
+        assertThat(upOrPending(tracker)).isTrue();
+    }
+
+    @Test
+    public void nonBluetoothRig_latchesNothingAndDoesNotStop() {
+        // USB/network rig with a Bluetooth headset selected as the mic: our SCO
+        // link is up, but this TX is not to a Bluetooth rig and its audio
+        // belongs on the rig, not the headset's A2DP.
+        ScoLinkTracker tracker = connectedTracker();
+        TxScoLatch latch = new TxScoLatch();
+        AtomicInteger stops = new AtomicInteger();
+
+        latch.keyDown(false, false, () -> upOrPending(tracker), () -> RIG, stops::incrementAndGet);
 
         assertThat(latch.heldForTx()).isFalse();
         assertThat(latch.scoAddress()).isNull();
@@ -77,7 +95,7 @@ public class TxScoLatchTest {
         TxScoLatch latch = new TxScoLatch();
         AtomicInteger stops = new AtomicInteger();
 
-        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, stops::incrementAndGet);
+        latch.keyDown(true, true, () -> upOrPending(tracker), () -> RIG, stops::incrementAndGet);
 
         assertThat(latch.heldForTx()).isFalse();
         assertThat(latch.scoAddress()).isNull();
@@ -93,7 +111,7 @@ public class TxScoLatchTest {
         assertThat(tracker.linkState()).isEqualTo(AudioManager.SCO_AUDIO_STATE_CONNECTING);
         TxScoLatch latch = new TxScoLatch();
 
-        latch.keyDown(true, () -> upOrPending(tracker), () -> null, tracker::requestOff);
+        latch.keyDown(true, true, () -> upOrPending(tracker), () -> null, tracker::requestOff);
 
         assertThat(latch.heldForTx()).isTrue();
         assertThat(latch.scoAddress()).isNull();
@@ -104,7 +122,7 @@ public class TxScoLatchTest {
         ScoLinkTracker tracker = connectedTracker();
         TxScoLatch latch = new TxScoLatch();
 
-        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
+        latch.keyDown(true, true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
         // endKeying(): startSco() requested, then the latch is released.
         tracker.requestOn();
         latch.keyUp();
@@ -114,13 +132,13 @@ public class TxScoLatchTest {
         // Next over: the headset went away in between, so this time the answer
         // is genuinely no and must not be carried over from the last over.
         tracker.requestOff();
-        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
+        latch.keyDown(true, true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
         assertThat(latch.heldForTx()).isFalse();
 
         // ...and comes back once the link is up again.
         tracker.requestOn();
         tracker.onStateUpdate(AudioManager.SCO_AUDIO_STATE_CONNECTED, 2_000L);
-        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
+        latch.keyDown(true, true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
         assertThat(latch.heldForTx()).isTrue();
         assertThat(latch.scoAddress()).isEqualTo(RIG);
     }

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/TxScoLatchTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/TxScoLatchTest.java
@@ -1,0 +1,103 @@
+package com.k1af.ft8af.bluetooth;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.media.AudioManager;
+
+import org.junit.Test;
+
+/**
+ * Ordering regression for the A2DP TX steering (#790): the keying path stops
+ * SCO before the TX worker decides where Default output should go, so the
+ * decision must be made from what the link looked like at keying time, not
+ * from a live tracker query after the stop. Drives the real
+ * {@link ScoLinkTracker} through the same sequence {@code MainViewModel}
+ * uses so the test fails if that ordering ever changes underneath the latch.
+ */
+public class TxScoLatchTest {
+
+    /** {@code ScoLinkCoordinator.isLinkUpOrPending()} without the handler. */
+    private static boolean upOrPending(ScoLinkTracker t) {
+        int s = t.linkState();
+        return s == AudioManager.SCO_AUDIO_STATE_CONNECTING
+                || s == AudioManager.SCO_AUDIO_STATE_CONNECTED;
+    }
+
+    private static ScoLinkTracker connectedTracker() {
+        ScoLinkTracker t = new ScoLinkTracker();
+        t.requestOn();
+        t.onStateUpdate(AudioManager.SCO_AUDIO_STATE_CONNECTED, 1_000L);
+        assertThat(upOrPending(t)).isTrue();
+        return t;
+    }
+
+    @Test
+    public void stopBeforePlayback_latchStillSaysScoWasHeld() {
+        ScoLinkTracker tracker = connectedTracker();
+        TxScoLatch latch = new TxScoLatch();
+
+        // beginKeying(): snapshot first, then stopSco() -> tracker.requestOff().
+        latch.onKeying(upOrPending(tracker));
+        tracker.requestOff();
+
+        // PTT settle delay elapses; playFT8Signal() now asks the question. The
+        // live query is what the first version of #790 used — and it is already
+        // false, so the override never ran. The latch is the answer to use.
+        assertThat(upOrPending(tracker)).isFalse();
+        assertThat(latch.heldForTx()).isTrue();
+    }
+
+    @Test
+    public void noScoAtKeying_latchStaysFalse() {
+        // USB/network rig with no SCO of ours: nothing to steer around, and the
+        // latch must not invent a session.
+        ScoLinkTracker tracker = new ScoLinkTracker();
+        TxScoLatch latch = new TxScoLatch();
+
+        latch.onKeying(upOrPending(tracker));
+        tracker.requestOff();
+
+        assertThat(latch.heldForTx()).isFalse();
+    }
+
+    @Test
+    public void pendingLinkCountsAsHeld() {
+        // A link still CONNECTING when TX starts is ours too; the OS will have
+        // the media route on SCO by the time audio plays.
+        ScoLinkTracker tracker = new ScoLinkTracker();
+        tracker.requestOn();
+        assertThat(tracker.linkState()).isEqualTo(AudioManager.SCO_AUDIO_STATE_CONNECTING);
+        TxScoLatch latch = new TxScoLatch();
+
+        latch.onKeying(upOrPending(tracker));
+        tracker.requestOff();
+
+        assertThat(latch.heldForTx()).isTrue();
+    }
+
+    @Test
+    public void unkeyClearsTheLatch_andTheNextOverReTakesIt() {
+        ScoLinkTracker tracker = connectedTracker();
+        TxScoLatch latch = new TxScoLatch();
+
+        latch.onKeying(upOrPending(tracker));
+        tracker.requestOff();
+        // endKeying(): startSco() requested, then the latch is released.
+        tracker.requestOn();
+        latch.onUnkeyed();
+        assertThat(latch.heldForTx()).isFalse();
+
+        // Next over: the headset went away in between, so this time the answer
+        // is genuinely no and must not be carried over from the last over.
+        tracker.requestOff();
+        latch.onKeying(upOrPending(tracker));
+        assertThat(latch.heldForTx()).isFalse();
+
+        // ...and comes back once the link is up again.
+        tracker.requestOn();
+        tracker.onStateUpdate(AudioManager.SCO_AUDIO_STATE_CONNECTED, 2_000L);
+        latch.onKeying(upOrPending(tracker));
+        tracker.requestOff();
+        assertThat(latch.heldForTx()).isTrue();
+    }
+}

--- a/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/TxScoLatchTest.java
+++ b/ft8af/app/src/test/java/com/k1af/ft8af/bluetooth/TxScoLatchTest.java
@@ -6,15 +6,20 @@ import android.media.AudioManager;
 
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
- * Ordering regression for the A2DP TX steering (#790): the keying path stops
+ * Ordering regression for the A2DP TX steering (#790). The keying path stops
  * SCO before the TX worker decides where Default output should go, so the
- * decision must be made from what the link looked like at keying time, not
- * from a live tracker query after the stop. Drives the real
- * {@link ScoLinkTracker} through the same sequence {@code MainViewModel}
- * uses so the test fails if that ordering ever changes underneath the latch.
+ * decision must come from what the link looked like at keying time. That
+ * order is {@link TxScoLatch#keyDown}'s own — these tests hand it the real
+ * {@link ScoLinkTracker} as both the thing to snapshot and the thing to stop,
+ * so if the snapshot ever moved after the stop the latch would read the
+ * already-dropped link and the first test would fail.
  */
 public class TxScoLatchTest {
+
+    private static final String RIG = "AA:BB:CC:DD:EE:FF";
 
     /** {@code ScoLinkCoordinator.isLinkUpOrPending()} without the handler. */
     private static boolean upOrPending(ScoLinkTracker t) {
@@ -32,32 +37,51 @@ public class TxScoLatchTest {
     }
 
     @Test
-    public void stopBeforePlayback_latchStillSaysScoWasHeld() {
+    public void keyDown_snapshotsBeforeItStopsTheLink() {
         ScoLinkTracker tracker = connectedTracker();
         TxScoLatch latch = new TxScoLatch();
 
-        // beginKeying(): snapshot first, then stopSco() -> tracker.requestOff().
-        latch.onKeying(upOrPending(tracker));
-        tracker.requestOff();
+        // beginKeying() for a Bluetooth rig keyed via CAT/RTS/DTR.
+        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
 
-        // PTT settle delay elapses; playFT8Signal() now asks the question. The
-        // live query is what the first version of #790 used — and it is already
-        // false, so the override never ran. The latch is the answer to use.
+        // The stop really ran (this is what playFT8Signal sees after the PTT
+        // settle delay, and what the first version of #790 queried)...
         assertThat(upOrPending(tracker)).isFalse();
+        // ...but the latch answers for keying time.
         assertThat(latch.heldForTx()).isTrue();
+        assertThat(latch.scoAddress()).isEqualTo(RIG);
     }
 
     @Test
-    public void noScoAtKeying_latchStaysFalse() {
-        // USB/network rig with no SCO of ours: nothing to steer around, and the
-        // latch must not invent a session.
-        ScoLinkTracker tracker = new ScoLinkTracker();
+    public void keyDown_withoutScoControl_latchesNothingAndDoesNotStop() {
+        // USB/network rig with a Bluetooth headset selected as the mic: our SCO
+        // link is up, but this keying does not pause it and TX audio belongs on
+        // the rig, not the headset's A2DP.
+        ScoLinkTracker tracker = connectedTracker();
         TxScoLatch latch = new TxScoLatch();
+        AtomicInteger stops = new AtomicInteger();
 
-        latch.onKeying(upOrPending(tracker));
-        tracker.requestOff();
+        latch.keyDown(false, () -> upOrPending(tracker), () -> RIG, stops::incrementAndGet);
 
         assertThat(latch.heldForTx()).isFalse();
+        assertThat(latch.scoAddress()).isNull();
+        assertThat(stops.get()).isEqualTo(0);
+        assertThat(upOrPending(tracker)).isTrue();
+    }
+
+    @Test
+    public void keyDown_withNoLink_stillStopsButLatchesFalse() {
+        // Bluetooth rig, link never came up: stopSco() is still requested (the
+        // tracker answers NONE), and nothing is latched.
+        ScoLinkTracker tracker = new ScoLinkTracker();
+        TxScoLatch latch = new TxScoLatch();
+        AtomicInteger stops = new AtomicInteger();
+
+        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, stops::incrementAndGet);
+
+        assertThat(latch.heldForTx()).isFalse();
+        assertThat(latch.scoAddress()).isNull();
+        assertThat(stops.get()).isEqualTo(1);
     }
 
     @Test
@@ -69,35 +93,35 @@ public class TxScoLatchTest {
         assertThat(tracker.linkState()).isEqualTo(AudioManager.SCO_AUDIO_STATE_CONNECTING);
         TxScoLatch latch = new TxScoLatch();
 
-        latch.onKeying(upOrPending(tracker));
-        tracker.requestOff();
+        latch.keyDown(true, () -> upOrPending(tracker), () -> null, tracker::requestOff);
 
         assertThat(latch.heldForTx()).isTrue();
+        assertThat(latch.scoAddress()).isNull();
     }
 
     @Test
-    public void unkeyClearsTheLatch_andTheNextOverReTakesIt() {
+    public void keyUpClearsTheLatch_andTheNextOverReTakesIt() {
         ScoLinkTracker tracker = connectedTracker();
         TxScoLatch latch = new TxScoLatch();
 
-        latch.onKeying(upOrPending(tracker));
-        tracker.requestOff();
+        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
         // endKeying(): startSco() requested, then the latch is released.
         tracker.requestOn();
-        latch.onUnkeyed();
+        latch.keyUp();
         assertThat(latch.heldForTx()).isFalse();
+        assertThat(latch.scoAddress()).isNull();
 
         // Next over: the headset went away in between, so this time the answer
         // is genuinely no and must not be carried over from the last over.
         tracker.requestOff();
-        latch.onKeying(upOrPending(tracker));
+        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
         assertThat(latch.heldForTx()).isFalse();
 
         // ...and comes back once the link is up again.
         tracker.requestOn();
         tracker.onStateUpdate(AudioManager.SCO_AUDIO_STATE_CONNECTED, 2_000L);
-        latch.onKeying(upOrPending(tracker));
-        tracker.requestOff();
+        latch.keyDown(true, () -> upOrPending(tracker), () -> RIG, tracker::requestOff);
         assertThat(latch.heldForTx()).isTrue();
+        assertThat(latch.scoAddress()).isEqualTo(RIG);
     }
 }


### PR DESCRIPTION
Closes #759

## What changed
Follow-up to PR #772. That change made the RX side of Bluetooth work reliably on Android 8.1 (the SCO link is now brought up and the mic re-routed to it), and a tester confirmed decoding worked -- but reported a mirror bug on the TX side:

> If I set audio input and output to "Default", audio received, but not transmitted to the transceiver. However, if I leave the audio input as "Default" and select a device with the A2DP profile for the audio output, audio is transmitted and received correctly.

**Root cause.** On Android 8.1, once the SCO (hands-free) link is up for the mic, the OS keeps the `USAGE_MEDIA` stream on the SCO speaker path too. The paired transceiver only listens for the FT8 tone on its A2DP music channel, so TX audio never leaves the phone -- exactly the "audio received, not transmitted" report. Manually picking the paired device's A2DP profile as the output moves TX back to A2DP and cures it.

**Fix.**

- `AudioOutputRoutingPolicy` (pure ints/Strings, unit-tested): when the user chose "Default" output, *our own* SCO link for the rig was up when the over was keyed, and the output list has an A2DP endpoint on the **same** Bluetooth device as that link, steer TX to it. It leaves routing to the OS for a rig on USB/network with a paired car kit nearby, for an A2DP endpoint on a different device, and whenever two hands-free devices are enumerated and it cannot tell which carries our link.
- `TxScoLatch`: the keying path (`MainViewModel.beginKeying`) stops SCO *before* PTT, and the TX worker only asks after the PTT settle delay -- by then the tracker already says "down". So keying snapshots the link state (and the address of the device the mic is captured from over SCO) into the latch *before* `stopSco()`, and the TX path reads the snapshot. The latch engages for any Bluetooth-rig TX (`needControlSco()`, so VOX included) and stops SCO only on the control-path keying that always did.
- `DefaultOutputRouting`: the Android adapter from the enumerated outputs to the policy to `AudioTrack.setPreferredDevice`, with the API < 28 / denied-`BLUETOOTH_CONNECT` address gating. Both TX playback paths in `FT8TransmitSignal` (`playViaAudioTrack()` and `playTuneTone()`) call it on the Default-output branch.

`debug.log` says what happened on each transmit: `playFT8Signal: default output steered to A2DP (app SCO session up)` when the route was applied, or `playFT8Signal: A2DP steering REJECTED by setPreferredDevice; TX audio stays on the OS route` when the framework refused it. No line at all on that branch means the policy left routing to the OS.

Also fixed on the way: `ScoLinkCoordinator` (merged in #772) took a `java.util.function.LongSupplier` clock, which does not exist before API 24 and would have failed to load on Android 6 (minSdk 23) while constructing `MainViewModel`; it now uses an app-local `Clock` interface, as the latch does.

Files changed:
- `ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/AudioOutputRoutingPolicy.java` (new)
- `ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/TxScoLatch.java` (new)
- `ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/DefaultOutputRouting.java` (new)
- `ft8af/app/src/main/java/com/k1af/ft8af/bluetooth/ScoLinkCoordinator.java` (API 23 clock)
- `ft8af/app/src/main/java/com/k1af/ft8af/MainViewModel.java` (keying snapshot, TX accessors)
- `ft8af/app/src/main/java/com/k1af/ft8af/wave/MicRecorder.java` (routed SCO address)
- `ft8af/app/src/main/java/com/k1af/ft8af/ft8transmit/FT8TransmitSignal.java` (both TX playback paths)
- tests: `AudioOutputRoutingPolicyTest` (27 cases), `TxScoLatchTest` (6, drives the real `ScoLinkTracker` through the snapshot-then-stop order), `DefaultOutputRoutingTest` (7, Robolectric, real `AudioDeviceInfo` objects and a capturing sink)

## Caveat
Like #772 this is verified with unit tests, not on an Android 8.1 device. If the tester still sees TX not reaching the rig, a fresh `debug.log` will now say either `default output steered to A2DP (app SCO session up)` (the override fired -- something further downstream is broken), `A2DP steering REJECTED by setPreferredDevice` (the framework refused the route), or nothing at all on that branch (the policy left routing to the OS -- most likely only one of A2DP/SCO enumerated, or our SCO link was not up at keying).

## How to test
- Unit tests: from `ft8af/` run `./gradlew testDebugUnitTest --tests 'com.k1af.ft8af.bluetooth.*'` (JDK 17). Windows: `cmd.exe /c "gradlew.bat testDebugUnitTest --tests com.k1af.ft8af.bluetooth.*"`.
- On-device (Android 8.1 with a BT-audio transceiver, Default I/O selected): confirm TX now reaches the rig and `debug.log` contains `playFT8Signal: default output steered to A2DP (app SCO session up)` on each transmit; RX behaviour from #772 is unchanged.
