### PR TITLE
Let a manual listings run pick the mode, so the permission probe is reachable

### DIFF
--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -23,7 +23,9 @@ Modes:
   --annotate-verdict N  Print the GitHub Actions annotation for probe exit code
                         N (see probe_annotation) and exit 0. The workflow relays
                         the probe's verdict through this so the mapping is
-                        unit-tested here instead of living in bash.
+                        unit-tested here instead of living in bash. Cannot be
+                        combined with a mode: it formats a verdict, it never
+                        produces one.
   (default)             Push every locale whose text differs from live, then
                         commit the edit so it goes to Play for review.
 
@@ -533,23 +535,28 @@ def main(argv=None):
     ap = build_arg_parser()
     args = ap.parse_args(argv)
 
-    if args.annotate_verdict is not None:
-        # Pure formatting for the workflow: no metadata, no credentials, no
-        # Play. The workflow exits with the probe's own code afterwards.
-        print(format_annotation(*probe_annotation(args.annotate_verdict)))
-        return EXIT_OK
-
     chosen = [
         name
         for name, on in (
             ("--dry-run", args.dry_run),
             ("--pull", args.pull),
             ("--check-permissions", args.check_permissions),
+            # Listed with the modes so `--check-permissions --annotate-verdict 3`
+            # is rejected: the helper only formats a verdict, and letting it
+            # ride along with a mode would print a caller-supplied verdict for
+            # a probe that never ran.
+            ("--annotate-verdict", args.annotate_verdict is not None),
         )
         if on
     ]
     if len(chosen) > 1:
         ap.error("%s are mutually exclusive" % " and ".join(chosen))
+
+    if args.annotate_verdict is not None:
+        # Pure formatting for the workflow: no metadata, no credentials, no
+        # Play. The workflow exits with the probe's own code afterwards.
+        print(format_annotation(*probe_annotation(args.annotate_verdict)))
+        return EXIT_OK
 
     local = None
     if not args.pull:

--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -74,8 +74,10 @@ def probe_annotation(rc):
     against the EXIT_* constants it depends on: swapping the 3/4 arms, or
     reporting a generic 1 as a missing grant, would send an operator to change
     a Console permission that was never wrong, and a bash `case` cannot be
-    unit-tested. Only 3 and 4 are verdicts; everything else means the probe
-    never ran, which is deliberately NOT annotated as anything about the grant.
+    unit-tested. Three outcomes: 0 and 3 are verdicts (the account may / may
+    not edit listings), 4 means the probe ran but reached no verdict, and
+    anything else (1, argparse's 2, ...) means the probe never ran — which is
+    deliberately NOT annotated as anything about the grant.
     """
     if rc == EXIT_OK:
         return "notice", "The service account can edit listings."

--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -16,9 +16,14 @@ Modes:
                         prove the account may edit listings — see below.
   --pull                Overwrite the local tree with what is live on Play
                         (bootstrap / resync after someone edits in the Console).
-  --check-permissions   Patch one listing inside an edit that is then abandoned,
-                        to prove the service account holds the "Manage store
-                        presence" permission. Nothing is committed.
+  --check-permissions   Write one listing (PATCH of one Play already has, or
+                        PUT when Play has none yet) inside an edit that is then
+                        abandoned, to prove the service account holds the
+                        "Manage store presence" permission. Nothing is committed.
+  --annotate-verdict N  Print the GitHub Actions annotation for probe exit code
+                        N (see probe_annotation) and exit 0. The workflow relays
+                        the probe's verdict through this so the mapping is
+                        unit-tested here instead of living in bash.
   (default)             Push every locale whose text differs from live, then
                         commit the edit so it goes to Play for review.
 
@@ -52,6 +57,46 @@ EXIT_OK = 0
 EXIT_ERROR = 1  # generic failure: unpublishable metadata, bad credentials, API error
 EXIT_DENIED = 3  # --check-permissions: Play refused the listing write with 403
 EXIT_INCONCLUSIVE = 4  # --check-permissions: the probe never reached a verdict
+
+# Where the missing grant is set, quoted in every message that names it.
+GRANT_ADVICE = (
+    "Play Console -> Users and permissions -> App permissions -> Store presence "
+    '-> "Manage store presence"'
+)
+
+
+def probe_annotation(rc):
+    """(level, message) the workflow annotates a --check-permissions run with.
+
+    Lives here rather than in the workflow's bash so the mapping is tested
+    against the EXIT_* constants it depends on: swapping the 3/4 arms, or
+    reporting a generic 1 as a missing grant, would send an operator to change
+    a Console permission that was never wrong, and a bash `case` cannot be
+    unit-tested. Only 3 and 4 are verdicts; everything else means the probe
+    never ran, which is deliberately NOT annotated as anything about the grant.
+    """
+    if rc == EXIT_OK:
+        return "notice", "The service account can edit listings."
+    if rc == EXIT_DENIED:
+        return "error", "The service account cannot edit listings. Grant it %s." % GRANT_ADVICE
+    if rc == EXIT_INCONCLUSIVE:
+        return (
+            "warning",
+            "The probe reached no verdict — the API call failed for a reason that says "
+            "nothing about the grant (401: the token was not accepted, a credentials "
+            "problem; or a timeout, rate limit, Play 5xx). Fix the cause and run it again.",
+        )
+    return (
+        "error",
+        "The probe did not run (exit %d) — see the log above. This is not a verdict "
+        "about the grant." % rc,
+    )
+
+
+def format_annotation(level, message):
+    """A GitHub Actions workflow command: `::level::message` on its own line."""
+    return "::%s::%s" % (level, message)
+
 
 # Listing field <-> fastlane filename.
 FIELD_FILES = {
@@ -475,12 +520,24 @@ def build_arg_parser():
     )
     ap.add_argument("--root", default=str(DEFAULT_ROOT), help="metadata root directory")
     ap.add_argument("--package", default=os.environ.get("PACKAGE_NAME", DEFAULT_PACKAGE))
+    ap.add_argument(
+        "--annotate-verdict",
+        type=int,
+        metavar="RC",
+        help="print the GitHub Actions annotation for probe exit code RC and exit 0",
+    )
     return ap
 
 
 def main(argv=None):
     ap = build_arg_parser()
     args = ap.parse_args(argv)
+
+    if args.annotate_verdict is not None:
+        # Pure formatting for the workflow: no metadata, no credentials, no
+        # Play. The workflow exits with the probe's own code afterwards.
+        print(format_annotation(*probe_annotation(args.annotate_verdict)))
+        return EXIT_OK
 
     chosen = [
         name

--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -42,6 +42,17 @@ DEFAULT_ROOT = Path(__file__).resolve().parents[2] / "fastlane" / "metadata" / "
 # check locally first and name the offending file rather than surfacing a 400.
 LIMITS = {"title": 30, "shortDescription": 80, "fullDescription": 4000}
 
+# Exit codes. The probe's result is a verdict, not pass/fail, so it needs codes
+# that nothing else can produce: annotating an unrelated failure as "you are
+# missing the grant" sends someone to fix a permission that was never wrong.
+#
+# 2 is deliberately skipped — argparse exits 2 on a usage error, so a mistyped
+# flag would otherwise be indistinguishable from a probe verdict.
+EXIT_OK = 0
+EXIT_ERROR = 1  # generic failure: unpublishable metadata, bad credentials, API error
+EXIT_DENIED = 3  # --check-permissions: Play refused the listings.patch (401/403)
+EXIT_INCONCLUSIVE = 4  # --check-permissions: the probe never reached a verdict
+
 # Listing field <-> fastlane filename.
 FIELD_FILES = {
     "title": "title.txt",
@@ -312,11 +323,20 @@ def run_check(s, package, edit_id, local):
     The probe writes back the text Play already has wherever possible, so even a
     committed edit (which cannot happen here) would be a no-op.
 
-    Returns 0 if the account may edit listings, 1 if Play refused (401/403), and
-    2 if the call failed for some other reason — a timeout or a 5xx proves
-    nothing either way and must not be reported as a missing grant.
+    Returns EXIT_OK if the account may edit listings, EXIT_DENIED if Play
+    refused (401/403), and EXIT_INCONCLUSIVE if anything else went wrong — a
+    timeout or a 5xx proves nothing either way and must not be reported as a
+    missing grant.
     """
-    remote = fetch_listings(s, package, edit_id)
+    try:
+        remote = fetch_listings(s, package, edit_id)
+    except Exception as e:
+        print(
+            "INCONCLUSIVE: could not read the current listings (%s).\n\nThe probe "
+            "never got as far as testing the grant. Try again." % e,
+            file=sys.stderr,
+        )
+        return EXIT_INCONCLUSIVE
     if remote:
         locale = "en-US" if "en-US" in remote else sorted(remote)[0]
         probe = {f: remote[locale].get(f) or "" for f in FIELD_FILES}
@@ -338,7 +358,7 @@ def run_check(s, package, edit_id, local):
                 '-> "Edit store listing, pricing & distribution".' % (status, e),
                 file=sys.stderr,
             )
-            return 1
+            return EXIT_DENIED
         # A timeout, a rate limit, or a Play 5xx says nothing about the grant.
         # Calling those "permission denied" would send someone editing Console
         # permissions that were fine all along.
@@ -348,9 +368,9 @@ def run_check(s, package, edit_id, local):
             % ("" if status is None else " (HTTP %s)" % status, e),
             file=sys.stderr,
         )
-        return 2
+        return EXIT_INCONCLUSIVE
     print("OK — the service account can edit listings. The edit is discarded, not committed.")
-    return 0
+    return EXIT_OK
 
 
 def run_push(s, package, edit_id, local, dry_run):
@@ -432,18 +452,30 @@ def main(argv=None):
             local = load_metadata(args.root)
         except MetadataError as e:
             print("Metadata is not publishable:\n%s" % e, file=sys.stderr)
-            return 1
+            return EXIT_ERROR
         print("Loaded %d locale(s) from %s\n" % (len(local), args.root))
 
     try:
         s = play_session()
     except CredentialsError as e:
         print("%s" % e, file=sys.stderr)
-        return 1
+        return EXIT_ERROR
 
-    edit = s.post("%s/applications/%s/edits" % (API, args.package), timeout=30)
-    edit.raise_for_status()
-    edit_id = edit.json()["id"]
+    try:
+        edit = s.post("%s/applications/%s/edits" % (API, args.package), timeout=30)
+        edit.raise_for_status()
+        edit_id = edit.json()["id"]
+    except Exception as e:
+        # In probe mode this must not surface as a traceback: Python would exit
+        # 1, which the workflow would read as a denied verdict.
+        if not args.check_permissions:
+            raise
+        print(
+            "INCONCLUSIVE: could not open an edit (%s).\n\nThe probe never got as "
+            "far as testing the grant. Try again." % e,
+            file=sys.stderr,
+        )
+        return EXIT_INCONCLUSIVE
 
     try:
         if args.pull:
@@ -458,7 +490,7 @@ def main(argv=None):
             c.raise_for_status()
             print("\nCommitted edit %s — %d locale(s) sent to Play." % (edit_id, pushed))
             edit_id = None  # committed; do not delete
-        return 0
+        return EXIT_OK
     finally:
         # A --dry-run / --pull / no-op edit is abandoned so it does not linger as
         # the app's one open edit and block the release publish in android.yml.

--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -389,7 +389,14 @@ def run_push(s, package, edit_id, local, dry_run):
     return len(pending)
 
 
-def main(argv=None):
+def build_arg_parser():
+    """Build the CLI parser.
+
+    Separate from main() so the tests can introspect the real option strings and
+    check them against the modes play-listings.yml offers — renaming a flag here
+    without updating the workflow would otherwise only surface as a failed
+    manual run.
+    """
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--dry-run", action="store_true", help="show the diff, change nothing")
     ap.add_argument("--pull", action="store_true", help="overwrite the local tree from Play")
@@ -400,6 +407,11 @@ def main(argv=None):
     )
     ap.add_argument("--root", default=str(DEFAULT_ROOT), help="metadata root directory")
     ap.add_argument("--package", default=os.environ.get("PACKAGE_NAME", DEFAULT_PACKAGE))
+    return ap
+
+
+def main(argv=None):
+    ap = build_arg_parser()
     args = ap.parse_args(argv)
 
     chosen = [

--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -50,7 +50,7 @@ LIMITS = {"title": 30, "shortDescription": 80, "fullDescription": 4000}
 # flag would otherwise be indistinguishable from a probe verdict.
 EXIT_OK = 0
 EXIT_ERROR = 1  # generic failure: unpublishable metadata, bad credentials, API error
-EXIT_DENIED = 3  # --check-permissions: Play refused the listings.patch (401/403)
+EXIT_DENIED = 3  # --check-permissions: Play refused the listing write with 403
 EXIT_INCONCLUSIVE = 4  # --check-permissions: the probe never reached a verdict
 
 # Listing field <-> fastlane filename.
@@ -345,16 +345,19 @@ def run_check(s, package, edit_id, local):
     A dry run cannot answer this: it only reads. An account with release
     permission but not "Manage store presence" passes a dry
     run and then fails on the first real publish. So do the one thing that
-    exercises the grant — a single listings.patch — inside an edit the caller
-    abandons instead of committing. Nothing reaches the store.
+    exercises the grant — writing a single listing (listings.patch on a language
+    Play already has, listings.put when it has none yet) — inside an edit the
+    caller abandons instead of committing. Nothing reaches the store.
 
     The probe writes back the text Play already has wherever possible, so even a
     committed edit (which cannot happen here) would be a no-op.
 
     Returns EXIT_OK if the account may edit listings, EXIT_DENIED if Play
-    refused (401/403), and EXIT_INCONCLUSIVE if anything else went wrong — a
-    timeout or a 5xx proves nothing either way and must not be reported as a
-    missing grant.
+    refused with 403 (an authenticated account that lacks the grant), and
+    EXIT_INCONCLUSIVE if anything else went wrong. A 401 is inconclusive too:
+    it means the access token was not accepted at all, which is a credentials
+    problem and says nothing about the grant. Likewise a timeout or a 5xx proves
+    nothing either way and must not be reported as a missing grant.
     """
     try:
         remote = fetch_listings(s, package, edit_id)
@@ -374,19 +377,35 @@ def run_check(s, package, edit_id, local):
         probe = local[locale]
         note = "no listings live yet, so using the repo's text"
 
-    print("Probing listings.patch on %s (%s)..." % (locale, note))
+    verb = "listings.patch" if locale in remote else "listings.put"
+    print("Probing %s on %s (%s)..." % (verb, locale, note))
     try:
         upsert_listing(s, package, edit_id, locale, probe, locale in remote)
     except Exception as e:
         status = getattr(getattr(e, "response", None), "status_code", None)
-        if status in (401, 403):
+        if status == 403:
             print(
-                "DENIED (HTTP %s): %s\n\nThe service account cannot edit listings. "
+                "DENIED (HTTP 403): %s\n\nThe service account cannot edit listings. "
                 'Grant it Play Console -> Users and permissions -> App permissions '
-                '-> Store presence -> "Manage store presence".' % (status, e),
+                '-> Store presence -> "Manage store presence".' % e,
                 file=sys.stderr,
             )
             return EXIT_DENIED
+        if status == 401:
+            # Only a 403 is a verdict about the grant: it means Play knew who was
+            # asking and said no. A 401 means the token itself was not accepted
+            # (revoked key, wrong project, clock skew) — the probe never got as
+            # far as the permission check, so sending someone to Console to fix
+            # a grant would be the same false diagnosis this split exists to
+            # prevent.
+            print(
+                "INCONCLUSIVE (HTTP 401): %s\n\nPlay did not accept the access "
+                "token, so the probe never reached the permission check. This is "
+                "a credentials problem, not evidence about the grant: check the "
+                "service-account key and run it again." % e,
+                file=sys.stderr,
+            )
+            return EXIT_INCONCLUSIVE
         # A timeout, a rate limit, or a Play 5xx says nothing about the grant.
         # Calling those "permission denied" would send someone editing Console
         # permissions that were fine all along.

--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -17,8 +17,8 @@ Modes:
   --pull                Overwrite the local tree with what is live on Play
                         (bootstrap / resync after someone edits in the Console).
   --check-permissions   Patch one listing inside an edit that is then abandoned,
-                        to prove the service account holds "Edit store listing,
-                        pricing & distribution". Nothing is committed.
+                        to prove the service account holds the "Manage store
+                        presence" permission. Nothing is committed.
   (default)             Push every locale whose text differs from live, then
                         commit the edit so it goes to Play for review.
 
@@ -315,7 +315,7 @@ def run_check(s, package, edit_id, local):
     """Prove the service account may actually edit listings, without publishing.
 
     A dry run cannot answer this: it only reads. An account with release
-    permission but not "Edit store listing, pricing & distribution" passes a dry
+    permission but not "Manage store presence" passes a dry
     run and then fails on the first real publish. So do the one thing that
     exercises the grant — a single listings.patch — inside an edit the caller
     abandons instead of committing. Nothing reaches the store.
@@ -355,7 +355,7 @@ def run_check(s, package, edit_id, local):
             print(
                 "DENIED (HTTP %s): %s\n\nThe service account cannot edit listings. "
                 'Grant it Play Console -> Users and permissions -> App permissions '
-                '-> "Edit store listing, pricing & distribution".' % (status, e),
+                '-> Store presence -> "Manage store presence".' % (status, e),
                 file=sys.stderr,
             )
             return EXIT_DENIED

--- a/.github/scripts/publish_listings.py
+++ b/.github/scripts/publish_listings.py
@@ -270,7 +270,11 @@ def abandon_edit(s, package, edit_id):
 
 
 def patch_listing(s, package, edit_id, locale, listing):
-    """PATCH one listing. PATCH (not PUT) so an existing promo video is left alone."""
+    """PATCH an EXISTING listing, so a promo video already on it is left alone.
+
+    Only valid for a language Play already has: PATCH is an update, and the API
+    answers 404 for a language with no listing yet. Use put_listing to create.
+    """
     r = s.patch(
         "%s/applications/%s/edits/%s/listings/%s" % (API, package, edit_id, locale),
         json=listing,
@@ -278,6 +282,30 @@ def patch_listing(s, package, edit_id, locale, listing):
     )
     r.raise_for_status()
     return r.json()
+
+
+def put_listing(s, package, edit_id, locale, listing):
+    """PUT one listing, creating it if the language has none yet.
+
+    The body carries `language` because PUT replaces the whole resource. Nothing
+    is lost by replacing here: this is only used for languages Play has never
+    had a listing for, so there is no video or other field to preserve.
+    """
+    body = dict(listing, language=locale)
+    r = s.put(
+        "%s/applications/%s/edits/%s/listings/%s" % (API, package, edit_id, locale),
+        json=body,
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def upsert_listing(s, package, edit_id, locale, listing, exists):
+    """Create or update one listing, whichever the language needs."""
+    if exists:
+        return patch_listing(s, package, edit_id, locale, listing)
+    return put_listing(s, package, edit_id, locale, listing)
 
 
 # --- Modes ------------------------------------------------------------------
@@ -348,7 +376,7 @@ def run_check(s, package, edit_id, local):
 
     print("Probing listings.patch on %s (%s)..." % (locale, note))
     try:
-        patch_listing(s, package, edit_id, locale, probe)
+        upsert_listing(s, package, edit_id, locale, probe, locale in remote)
     except Exception as e:
         status = getattr(getattr(e, "response", None), "status_code", None)
         if status in (401, 403):
@@ -404,8 +432,9 @@ def run_push(s, package, edit_id, local, dry_run):
         return 0
 
     for locale, listing in sorted(pending.items()):
-        patch_listing(s, package, edit_id, locale, listing)
-        print("pushed %s" % locale)
+        existed = locale in remote
+        upsert_listing(s, package, edit_id, locale, listing, existed)
+        print("pushed %s%s" % (locale, "" if existed else " (created)"))
     return len(pending)
 
 

--- a/.github/scripts/test_publish_listings.py
+++ b/.github/scripts/test_publish_listings.py
@@ -98,6 +98,7 @@ class FakeSession:
         self.patch_status = patch_status
         self.patch_exc = patch_exc
         self.patched = {}
+        self.puts = {}
         self.commits = []
         self.deletes = []
 
@@ -118,6 +119,15 @@ class FakeSession:
         if self.patch_exc is not None:
             raise self.patch_exc
         r = FakeResponse(dict(json or {}, language=locale), self.patch_status)
+        r.raise_for_status()
+        return r
+
+    def put(self, url, json=None, timeout=None):
+        locale = url.rsplit("/", 1)[-1]
+        self.puts[locale] = json
+        if self.patch_exc is not None:
+            raise self.patch_exc
+        r = FakeResponse(dict(json or {}), self.patch_status)
         r.raise_for_status()
         return r
 
@@ -387,8 +397,52 @@ class MainArgsTest(unittest.TestCase):
         self.assertEqual(pl.main(["--root", tmp, "--dry-run"]), 1)
 
 
+class UpsertListingTest(unittest.TestCase):
+    """Creating a listing needs PUT; PATCH 404s on a language Play has never had.
+
+    This is the bug that broke the first real publish: 17 of 18 locales did not
+    exist on Play yet, and PATCH answered 404 Not Found on the first one.
+    """
+
+    def test_existing_locale_is_patched(self):
+        s = FakeSession()
+        pl.upsert_listing(s, "pkg", "e1", "en-US", listing(), exists=True)
+        self.assertIn("en-US", s.patched)
+        self.assertEqual(s.puts, {})
+
+    def test_new_locale_is_put(self):
+        s = FakeSession()
+        pl.upsert_listing(s, "pkg", "e1", "ar", listing(), exists=False)
+        self.assertIn("ar", s.puts)
+        self.assertEqual(s.patched, {})
+
+    def test_put_body_carries_the_language(self):
+        # PUT replaces the whole resource, and the API wants the language in it.
+        s = FakeSession()
+        pl.upsert_listing(s, "pkg", "e1", "ja-JP", listing(), exists=False)
+        self.assertEqual(s.puts["ja-JP"]["language"], "ja-JP")
+
+    def test_patch_body_does_not_add_a_language_field(self):
+        # PATCH is a partial update of an existing resource; sending extra
+        # fields risks clobbering what we deliberately preserve.
+        s = FakeSession()
+        pl.upsert_listing(s, "pkg", "e1", "en-US", listing(), exists=True)
+        self.assertNotIn("language", s.patched["en-US"])
+
+
 class RunPushTest(unittest.TestCase):
     LOCAL = {"en-US": listing(), "fr-FR": listing(short="court")}
+
+    def test_first_publish_creates_every_missing_locale(self):
+        # The real store state that broke: only en-US exists.
+        local = {"en-US": listing(short="new"), "ar": listing(), "ja-JP": listing()}
+        s = FakeSession(listings={"en-US": listing(short="old")})
+        with captured() as (out, _):
+            pushed = pl.run_push(s, "pkg", "e1", local, dry_run=False)
+        self.assertEqual(pushed, 3)
+        self.assertEqual(sorted(s.puts), ["ar", "ja-JP"])
+        self.assertEqual(sorted(s.patched), ["en-US"])
+        self.assertIn("(created)", out.getvalue())
 
     def test_identical_text_sends_nothing(self):
         s = FakeSession(listings=dict(self.LOCAL))
@@ -407,12 +461,15 @@ class RunPushTest(unittest.TestCase):
         self.assertEqual(list(s.patched), ["fr-FR"])
         self.assertEqual(s.patched["fr-FR"]["shortDescription"], "court")
 
-    def test_locale_absent_from_play_is_patched(self):
+    def test_locale_absent_from_play_is_created(self):
+        # Created with PUT, not PATCH: PATCH 404s on a language Play has never
+        # had a listing for.
         s = FakeSession(listings={"en-US": listing()})
         with captured():
             pushed = pl.run_push(s, "pkg", "e1", self.LOCAL, dry_run=False)
         self.assertEqual(pushed, 1)
-        self.assertEqual(list(s.patched), ["fr-FR"])
+        self.assertEqual(list(s.puts), ["fr-FR"])
+        self.assertEqual(s.patched, {})
 
     def test_dry_run_reports_but_sends_nothing(self):
         s = FakeSession(listings={"en-US": listing()})
@@ -498,7 +555,11 @@ class RunCheckTest(unittest.TestCase):
         s = FakeSession(listings={})
         with captured() as (out, _):
             self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_OK)
-        self.assertEqual(s.patched["en-US"], self.LOCAL["en-US"])
+        # Nothing is live, so the probe has to create rather than patch.
+        self.assertEqual(
+            {k: v for k, v in s.puts["en-US"].items() if k != "language"},
+            self.LOCAL["en-US"],
+        )
         self.assertIn("no listings live yet", out.getvalue())
 
     def test_denied_patch_reports_the_missing_grant(self):

--- a/.github/scripts/test_publish_listings.py
+++ b/.github/scripts/test_publish_listings.py
@@ -625,6 +625,63 @@ class RunCheckTest(unittest.TestCase):
         self.assertNotIn("Manage store presence", err.getvalue())
 
 
+class ProbeAnnotationTest(unittest.TestCase):
+    """The exit-code -> annotation mapping the workflow shows the operator.
+
+    This is the probe's main operator-facing behaviour, so it is pinned per
+    code: the level, the message, and — just as important — what a message
+    must NOT say (a non-verdict must never name the grant).
+    """
+
+    def test_ok_is_a_notice(self):
+        level, msg = pl.probe_annotation(pl.EXIT_OK)
+        self.assertEqual(level, "notice")
+        self.assertIn("can edit listings", msg)
+
+    def test_denied_is_an_error_naming_the_grant(self):
+        level, msg = pl.probe_annotation(pl.EXIT_DENIED)
+        self.assertEqual(level, "error")
+        self.assertIn("cannot edit listings", msg)
+        self.assertIn("Manage store presence", msg)
+
+    def test_inconclusive_is_a_warning_that_does_not_name_the_grant(self):
+        level, msg = pl.probe_annotation(pl.EXIT_INCONCLUSIVE)
+        self.assertEqual(level, "warning")
+        self.assertIn("no verdict", msg)
+        self.assertIn("401", msg)
+        self.assertNotIn("Manage store presence", msg)
+
+    def test_generic_failure_is_an_error_but_not_a_verdict(self):
+        # A 1 (bad key, unreadable metadata) and argparse's 2 both mean the
+        # probe never ran. Reporting either as a missing grant is the false
+        # diagnosis the exit-code split exists to prevent.
+        for rc in (pl.EXIT_ERROR, 2, 42):
+            level, msg = pl.probe_annotation(rc)
+            self.assertEqual(level, "error", rc)
+            self.assertIn("did not run", msg)
+            self.assertIn("exit %d" % rc, msg)
+            self.assertIn("not a verdict", msg)
+            self.assertNotIn("Manage store presence", msg)
+
+    def test_the_four_outcomes_are_told_apart(self):
+        seen = {pl.probe_annotation(rc) for rc in (0, 1, 3, 4)}
+        self.assertEqual(len(seen), 4)
+
+    def test_format_is_a_workflow_command(self):
+        self.assertEqual(pl.format_annotation("warning", "hi"), "::warning::hi")
+
+    def test_cli_prints_the_annotation_and_touches_nothing_else(self):
+        # The workflow relays the probe's code through this; it must not need
+        # metadata or credentials, and must exit 0 so the workflow can go on to
+        # exit with the probe's own code.
+        with mock.patch.object(pl, "play_session", side_effect=AssertionError("no Play")):
+            with mock.patch.object(pl, "load_metadata", side_effect=AssertionError("no tree")):
+                with captured() as (out, _):
+                    self.assertEqual(pl.main(["--annotate-verdict", "3"]), pl.EXIT_OK)
+        self.assertEqual(out.getvalue().strip(), pl.format_annotation(*pl.probe_annotation(3)))
+        self.assertTrue(out.getvalue().startswith("::error::"))
+
+
 class ExitCodeTest(unittest.TestCase):
     """The probe's verdict codes must not collide with anything else."""
 
@@ -960,6 +1017,31 @@ class WorkflowModesTest(unittest.TestCase):
         for flag in filter(None, self.MODE_FLAGS.values()):
             args = pl.build_arg_parser().parse_args([flag])
             self.assertTrue(getattr(args, flag[2:].replace("-", "_")))
+
+    def run_step(self):
+        """The `run:` block of the Run step, from the MODE case to its exit."""
+        text = self.workflow_text()
+        start = text.index('case "$MODE" in')
+        return text[start : text.index("exit $rc", start) + len("exit $rc")]
+
+    def test_verdict_annotation_is_delegated_to_the_script(self):
+        # The exit-code -> annotation mapping is ProbeAnnotationTest's job; the
+        # workflow must relay the probe's code through --annotate-verdict and
+        # not keep a bash copy that could drift from the EXIT_* constants.
+        step = self.run_step()
+        self.assertIn('--annotate-verdict "$rc"', step)
+        self.assertNotIn('case "$rc"', step)
+        self.assertIn(
+            "--annotate-verdict",
+            {o for a in pl.build_arg_parser()._actions for o in a.option_strings},
+        )
+
+    def test_step_exits_with_the_probes_own_code(self):
+        # The annotation helper exits 0 by design; the step must still end with
+        # the probe's code so a denied verdict fails the run.
+        step = self.run_step()
+        self.assertIn("rc=$?", step)
+        self.assertTrue(step.rstrip().endswith("exit $rc"))
 
 
 class RepoMetadataTest(unittest.TestCase):

--- a/.github/scripts/test_publish_listings.py
+++ b/.github/scripts/test_publish_listings.py
@@ -374,6 +374,18 @@ class MainArgsTest(unittest.TestCase):
                 pl.main(["--check-permissions", other])
             self.assertEqual(cm.exception.code, 2)
 
+    def test_annotate_verdict_cannot_ride_along_with_a_mode(self):
+        # `--check-permissions --annotate-verdict 3` must not skip the probe and
+        # print a caller-supplied denial with exit 0; the helper formats a
+        # verdict, it never produces one.
+        for mode in ("--check-permissions", "--dry-run", "--pull"):
+            with mock.patch.object(pl, "play_session", side_effect=AssertionError("no Play")):
+                with captured() as (out, _):
+                    with self.assertRaises(SystemExit) as cm:
+                        pl.main([mode, "--annotate-verdict", "3"])
+            self.assertEqual(cm.exception.code, 2, mode)
+            self.assertNotIn("::error::", out.getvalue())
+
     def test_an_unusable_key_is_reported_in_one_line_not_a_traceback(self):
         err = pl.CredentialsError(
             "PLAY_SERVICE_ACCOUNT_JSON parsed but is not a usable service account key "

--- a/.github/scripts/test_publish_listings.py
+++ b/.github/scripts/test_publish_listings.py
@@ -8,6 +8,7 @@ Run from the repo root:  python -m unittest discover -s .github/scripts -p 'test
 """
 import contextlib
 import io
+import re
 import shutil
 import tempfile
 import unittest
@@ -480,7 +481,7 @@ class RunCheckTest(unittest.TestCase):
     def test_patches_one_listing_and_never_commits(self):
         s = FakeSession(listings={"en-US": listing(short="live")})
         with captured() as (out, _):
-            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), 0)
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_OK)
         self.assertEqual(list(s.patched), ["en-US"])
         self.assertEqual(s.commits, [], "the probe must never commit")
         self.assertIn("OK", out.getvalue())
@@ -496,14 +497,14 @@ class RunCheckTest(unittest.TestCase):
     def test_falls_back_to_repo_text_when_nothing_is_published(self):
         s = FakeSession(listings={})
         with captured() as (out, _):
-            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), 0)
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_OK)
         self.assertEqual(s.patched["en-US"], self.LOCAL["en-US"])
         self.assertIn("no listings live yet", out.getvalue())
 
     def test_denied_patch_reports_the_missing_grant(self):
         s = FakeSession(listings={"en-US": listing()}, patch_status=403)
         with captured() as (_, err):
-            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), 1)
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_DENIED)
         self.assertIn("DENIED", err.getvalue())
         self.assertIn("cannot edit listings", err.getvalue())
         self.assertIn("Edit store listing", err.getvalue())
@@ -511,7 +512,7 @@ class RunCheckTest(unittest.TestCase):
     def test_unauthenticated_is_also_a_denial(self):
         s = FakeSession(listings={"en-US": listing()}, patch_status=401)
         with captured() as (_, err):
-            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), 1)
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_DENIED)
         self.assertIn("DENIED", err.getvalue())
 
     def test_server_error_is_inconclusive_not_a_grant_diagnosis(self):
@@ -519,23 +520,54 @@ class RunCheckTest(unittest.TestCase):
         # permissions that were fine all along.
         s = FakeSession(listings={"en-US": listing()}, patch_status=500)
         with captured() as (_, err):
-            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), 2)
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_INCONCLUSIVE)
         self.assertIn("INCONCLUSIVE", err.getvalue())
         self.assertNotIn("Edit store listing", err.getvalue())
 
     def test_rate_limit_is_inconclusive(self):
         s = FakeSession(listings={"en-US": listing()}, patch_status=429)
         with captured() as (_, err):
-            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), 2)
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_INCONCLUSIVE)
         self.assertIn("INCONCLUSIVE", err.getvalue())
 
     def test_transport_error_with_no_response_is_inconclusive(self):
         s = FakeSession(listings={"en-US": listing()}, patch_exc=OSError("timed out"))
         with captured() as (_, err):
-            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), 2)
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_INCONCLUSIVE)
         self.assertIn("INCONCLUSIVE", err.getvalue())
         self.assertIn("timed out", err.getvalue())
         self.assertNotIn("Edit store listing", err.getvalue())
+
+
+class ExitCodeTest(unittest.TestCase):
+    """The probe's verdict codes must not collide with anything else."""
+
+    def test_verdict_codes_are_distinct_from_generic_failure(self):
+        codes = [pl.EXIT_OK, pl.EXIT_ERROR, pl.EXIT_DENIED, pl.EXIT_INCONCLUSIVE]
+        self.assertEqual(len(set(codes)), len(codes))
+
+    def test_no_verdict_code_collides_with_argparse_usage_error(self):
+        # argparse exits 2 on a bad flag. If a verdict used 2, a typo in the
+        # workflow would read as a real answer about the grant.
+        self.assertNotIn(2, (pl.EXIT_DENIED, pl.EXIT_INCONCLUSIVE))
+
+    def test_generic_failures_do_not_use_a_verdict_code(self):
+        # A missing key and unpublishable metadata both exit EXIT_ERROR, so the
+        # workflow can tell "the probe did not run" from "Play said no".
+        verdicts = (pl.EXIT_DENIED, pl.EXIT_INCONCLUSIVE)
+        self.assertNotIn(pl.EXIT_ERROR, verdicts)
+
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, True)
+        with captured():
+            self.assertEqual(pl.main(["--root", tmp, "--check-permissions"]), pl.EXIT_ERROR)
+
+        write_locale(tmp, "en-US")
+        with mock.patch.object(pl, "play_session", side_effect=pl.CredentialsError("no key")):
+            with captured():
+                self.assertEqual(
+                    pl.main(["--root", tmp, "--check-permissions"]), pl.EXIT_ERROR
+                )
 
 
 class RunPullTest(TempTreeTest):
@@ -705,10 +737,39 @@ class MainLifecycleTest(TempTreeTest):
         self.assertEqual(s.commits, [], "the probe must never commit")
         self.assertEqual(len(s.deletes), 1, "the probe edit must be abandoned")
 
-    def test_check_permissions_returns_1_when_the_grant_is_missing(self):
+    def test_unreadable_listings_are_inconclusive_not_denied(self):
+        # fetch_listings failing means the probe never tested the grant.
+        s = FakeSession(listings={"en-US": listing()})
+        s.get = lambda url, timeout=None: (_ for _ in ()).throw(OSError("timed out"))
+        code, _, err = self.run_main(s, ["--check-permissions"])
+        self.assertEqual(code, pl.EXIT_INCONCLUSIVE)
+        self.assertIn("never got as far", err)
+        self.assertNotIn("Edit store listing", err)
+        self.assertEqual(len(s.deletes), 1, "the probe edit must still be abandoned")
+
+    def test_unopenable_edit_is_inconclusive_not_denied(self):
+        # A 5xx creating the edit used to escape as a traceback, which Python
+        # exits 1 for — indistinguishable from a denial at the workflow layer.
+        s = FakeSession()
+        s.post = lambda url, timeout=None: (_ for _ in ()).throw(OSError("play is down"))
+        code, _, err = self.run_main(s, ["--check-permissions"])
+        self.assertEqual(code, pl.EXIT_INCONCLUSIVE)
+        self.assertIn("could not open an edit", err)
+        self.assertNotIn("Edit store listing", err)
+
+    def test_a_failed_edit_open_still_raises_outside_probe_mode(self):
+        # Only the probe swallows this; a real publish must still fail loudly.
+        s = FakeSession(listings={"en-US": listing(short="old")})
+        s.post = lambda url, timeout=None: (_ for _ in ()).throw(OSError("play is down"))
+        with mock.patch.object(pl, "play_session", return_value=s):
+            with captured():
+                with self.assertRaises(OSError):
+                    pl.main(["--root", self.tmp])
+
+    def test_check_permissions_returns_denied_when_the_grant_is_missing(self):
         s = FakeSession(listings={"en-US": listing()}, patch_status=403)
         code, _, err = self.run_main(s, ["--check-permissions"])
-        self.assertEqual(code, 1)
+        self.assertEqual(code, pl.EXIT_DENIED)
         self.assertIn("Edit store listing", err)
         self.assertEqual(len(s.deletes), 1)
 
@@ -761,21 +822,47 @@ class WorkflowModesTest(unittest.TestCase):
     def test_workflow_offers_exactly_the_modes_we_support(self):
         self.assertEqual(sorted(self.declared_modes()), sorted(self.MODE_FLAGS))
 
-    def test_every_mode_maps_to_a_real_cli_flag(self):
-        # Renaming a flag in build_arg_parser() without updating the workflow
-        # would otherwise only surface as a failed manual run against Play.
+    def case_arm_flags(self):
+        """{mode: flag-or-None} read out of the run step's case arms.
+
+        The flag has to come from the workflow itself, not from MODE_FLAGS: a
+        typo like `args+=(--check-permissons)` is exactly the drift this guard
+        exists to catch, and comparing the table against itself would miss it.
+        """
+        text = self.workflow_text()
+        run = text[text.index('case "$MODE" in') :]
+        run = run[: run.index("esac")]
+        arms = {}
+        for arm in re.finditer(
+            r"^\s{10,}([a-z][a-z-]*)\)\s*\n(.*?)^\s+;;", run, re.S | re.M
+        ):
+            mode, body = arm.group(1), arm.group(2)
+            flags = re.findall(r"args\+=\(([^)]*)\)", body)
+            self.assertLessEqual(len(flags), 1, "mode %r appends args more than once" % mode)
+            arms[mode] = flags[0].strip() if flags else None
+        return arms
+
+    def test_every_mode_has_a_case_arm(self):
+        self.assertEqual(sorted(self.case_arm_flags()), sorted(self.declared_modes()))
+
+    def test_case_arms_pass_the_flags_we_expect(self):
+        self.assertEqual(self.case_arm_flags(), self.MODE_FLAGS)
+
+    def test_every_flag_the_workflow_passes_is_a_real_cli_flag(self):
+        # Catches both directions of drift: renaming a flag in
+        # build_arg_parser(), and mistyping one in the workflow. Either used to
+        # surface only as a failed manual run against Play.
         known = set()
         for action in pl.build_arg_parser()._actions:
             known.update(action.option_strings)
-        for mode in self.declared_modes():
-            flag = self.MODE_FLAGS[mode]
+        for mode, flag in self.case_arm_flags().items():
             if flag is not None:
                 self.assertIn(flag, known, "mode %r passes unknown flag %s" % (mode, flag))
 
-    def test_workflow_handles_every_mode_it_offers(self):
-        text = self.workflow_text()
-        for mode in self.declared_modes():
-            self.assertIn("%s)" % mode, text, "mode %r has no case branch" % mode)
+    def test_publish_arm_passes_no_flag(self):
+        # Publishing is the script's default; passing a flag for it would mean
+        # the workflow and the CLI disagree about what "no mode" means.
+        self.assertIsNone(self.case_arm_flags()["publish"])
 
     def test_default_mode_is_the_read_only_one(self):
         text = self.workflow_text()

--- a/.github/scripts/test_publish_listings.py
+++ b/.github/scripts/test_publish_listings.py
@@ -477,6 +477,9 @@ class RunPushTest(unittest.TestCase):
             pushed = pl.run_push(s, "pkg", "e1", self.LOCAL, dry_run=True)
         self.assertEqual(pushed, 0)
         self.assertEqual(s.patched, {})
+        # fr-FR is missing on Play, so a real run would PUT it; a dry run must
+        # not create it either.
+        self.assertEqual(s.puts, {})
         self.assertIn("DRY RUN", out.getvalue())
         self.assertIn("fr-FR", out.getvalue())
 
@@ -540,8 +543,12 @@ class RunCheckTest(unittest.TestCase):
         with captured() as (out, _):
             self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_OK)
         self.assertEqual(list(s.patched), ["en-US"])
+        self.assertEqual(s.puts, {})
         self.assertEqual(s.commits, [], "the probe must never commit")
         self.assertIn("OK", out.getvalue())
+        # The log names the call it actually made, so an operator reading it
+        # is not told "patch" when the store was empty and it had to put.
+        self.assertIn("listings.patch", out.getvalue())
 
     def test_probe_writes_back_plays_own_text(self):
         # So that even a committed edit — which cannot happen here — is a no-op.
@@ -561,6 +568,9 @@ class RunCheckTest(unittest.TestCase):
             self.LOCAL["en-US"],
         )
         self.assertIn("no listings live yet", out.getvalue())
+        self.assertEqual(s.patched, {})
+        self.assertIn("listings.put", out.getvalue())
+        self.assertNotIn("listings.patch", out.getvalue())
 
     def test_denied_patch_reports_the_missing_grant(self):
         s = FakeSession(listings={"en-US": listing()}, patch_status=403)
@@ -570,11 +580,26 @@ class RunCheckTest(unittest.TestCase):
         self.assertIn("cannot edit listings", err.getvalue())
         self.assertIn("Manage store presence", err.getvalue())
 
-    def test_unauthenticated_is_also_a_denial(self):
+    def test_unauthenticated_is_inconclusive_not_a_denial(self):
+        # 401 means the token was not accepted, so the probe never reached the
+        # permission check. Calling that "denied" would send someone to fix a
+        # grant that was never tested — the false diagnosis the exit-code split
+        # exists to prevent.
         s = FakeSession(listings={"en-US": listing()}, patch_status=401)
         with captured() as (_, err):
+            self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_INCONCLUSIVE)
+        self.assertIn("INCONCLUSIVE", err.getvalue())
+        self.assertIn("401", err.getvalue())
+        self.assertIn("credentials", err.getvalue())
+        self.assertNotIn("DENIED", err.getvalue())
+        self.assertNotIn("Manage store presence", err.getvalue())
+
+    def test_denied_put_on_an_empty_store_is_still_the_missing_grant(self):
+        # The verdict must not depend on which verb the probe had to use.
+        s = FakeSession(listings={}, patch_status=403)
+        with captured() as (_, err):
             self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_DENIED)
-        self.assertIn("DENIED", err.getvalue())
+        self.assertIn("Manage store presence", err.getvalue())
 
     def test_server_error_is_inconclusive_not_a_grant_diagnosis(self):
         # Calling a 500 "permission denied" would send someone editing Console
@@ -743,6 +768,7 @@ class MainLifecycleTest(TempTreeTest):
         code, out, _ = self.run_main(s, ["--dry-run"])
         self.assertEqual(code, 0)
         self.assertEqual(s.patched, {})
+        self.assertEqual(s.puts, {})
         self.assertEqual(s.commits, [])
         self.assertEqual(len(s.deletes), 1, "a dry-run edit must not be left open")
 

--- a/.github/scripts/test_publish_listings.py
+++ b/.github/scripts/test_publish_listings.py
@@ -731,6 +731,63 @@ class MainLifecycleTest(TempTreeTest):
         self.assertEqual(s.deletes, [])
 
 
+class WorkflowModesTest(unittest.TestCase):
+    """The workflow's dispatch modes must match the CLI they invoke.
+
+    Parsed by hand rather than with PyYAML: the validate job installs nothing,
+    and keeping this suite stdlib-only is what lets it stay that way.
+    """
+
+    WORKFLOW = REPO_ROOT / ".github" / "workflows" / "play-listings.yml"
+
+    # mode -> the flag the workflow passes for it. "publish" passes none.
+    MODE_FLAGS = {"dry-run": "--dry-run", "check-permissions": "--check-permissions", "publish": None}
+
+    def workflow_text(self):
+        return self.WORKFLOW.read_text(encoding="utf-8")
+
+    def declared_modes(self):
+        """The `options:` list under the mode input, in file order."""
+        text = self.workflow_text()
+        start = text.index("      mode:")
+        block = text[start : text.index("permissions:", start)]
+        opts = block[block.index("options:") :]
+        return [
+            ln.strip()[2:].strip()
+            for ln in opts.splitlines()
+            if ln.strip().startswith("- ")
+        ]
+
+    def test_workflow_offers_exactly_the_modes_we_support(self):
+        self.assertEqual(sorted(self.declared_modes()), sorted(self.MODE_FLAGS))
+
+    def test_every_mode_maps_to_a_real_cli_flag(self):
+        # Renaming a flag in build_arg_parser() without updating the workflow
+        # would otherwise only surface as a failed manual run against Play.
+        known = set()
+        for action in pl.build_arg_parser()._actions:
+            known.update(action.option_strings)
+        for mode in self.declared_modes():
+            flag = self.MODE_FLAGS[mode]
+            if flag is not None:
+                self.assertIn(flag, known, "mode %r passes unknown flag %s" % (mode, flag))
+
+    def test_workflow_handles_every_mode_it_offers(self):
+        text = self.workflow_text()
+        for mode in self.declared_modes():
+            self.assertIn("%s)" % mode, text, "mode %r has no case branch" % mode)
+
+    def test_default_mode_is_the_read_only_one(self):
+        text = self.workflow_text()
+        block = text[text.index("      mode:") : text.index("options:")]
+        self.assertIn("default: dry-run", block)
+
+    def test_parser_accepts_each_mode_flag(self):
+        for flag in filter(None, self.MODE_FLAGS.values()):
+            args = pl.build_arg_parser().parse_args([flag])
+            self.assertTrue(getattr(args, flag[2:].replace("-", "_")))
+
+
 class RepoMetadataTest(unittest.TestCase):
     """The listings actually checked in must always be publishable."""
 

--- a/.github/scripts/test_publish_listings.py
+++ b/.github/scripts/test_publish_listings.py
@@ -507,7 +507,7 @@ class RunCheckTest(unittest.TestCase):
             self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_DENIED)
         self.assertIn("DENIED", err.getvalue())
         self.assertIn("cannot edit listings", err.getvalue())
-        self.assertIn("Edit store listing", err.getvalue())
+        self.assertIn("Manage store presence", err.getvalue())
 
     def test_unauthenticated_is_also_a_denial(self):
         s = FakeSession(listings={"en-US": listing()}, patch_status=401)
@@ -522,7 +522,7 @@ class RunCheckTest(unittest.TestCase):
         with captured() as (_, err):
             self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_INCONCLUSIVE)
         self.assertIn("INCONCLUSIVE", err.getvalue())
-        self.assertNotIn("Edit store listing", err.getvalue())
+        self.assertNotIn("Manage store presence", err.getvalue())
 
     def test_rate_limit_is_inconclusive(self):
         s = FakeSession(listings={"en-US": listing()}, patch_status=429)
@@ -536,7 +536,7 @@ class RunCheckTest(unittest.TestCase):
             self.assertEqual(pl.run_check(s, "pkg", "e1", self.LOCAL), pl.EXIT_INCONCLUSIVE)
         self.assertIn("INCONCLUSIVE", err.getvalue())
         self.assertIn("timed out", err.getvalue())
-        self.assertNotIn("Edit store listing", err.getvalue())
+        self.assertNotIn("Manage store presence", err.getvalue())
 
 
 class ExitCodeTest(unittest.TestCase):
@@ -744,7 +744,7 @@ class MainLifecycleTest(TempTreeTest):
         code, _, err = self.run_main(s, ["--check-permissions"])
         self.assertEqual(code, pl.EXIT_INCONCLUSIVE)
         self.assertIn("never got as far", err)
-        self.assertNotIn("Edit store listing", err)
+        self.assertNotIn("Manage store presence", err)
         self.assertEqual(len(s.deletes), 1, "the probe edit must still be abandoned")
 
     def test_unopenable_edit_is_inconclusive_not_denied(self):
@@ -755,7 +755,7 @@ class MainLifecycleTest(TempTreeTest):
         code, _, err = self.run_main(s, ["--check-permissions"])
         self.assertEqual(code, pl.EXIT_INCONCLUSIVE)
         self.assertIn("could not open an edit", err)
-        self.assertNotIn("Edit store listing", err)
+        self.assertNotIn("Manage store presence", err)
 
     def test_a_failed_edit_open_still_raises_outside_probe_mode(self):
         # Only the probe swallows this; a real publish must still fail loudly.
@@ -770,7 +770,7 @@ class MainLifecycleTest(TempTreeTest):
         s = FakeSession(listings={"en-US": listing()}, patch_status=403)
         code, _, err = self.run_main(s, ["--check-permissions"])
         self.assertEqual(code, pl.EXIT_DENIED)
-        self.assertIn("Edit store listing", err)
+        self.assertIn("Manage store presence", err)
         self.assertEqual(len(s.deletes), 1)
 
     def test_pull_writes_the_tree_and_abandons_the_edit(self):

--- a/.github/workflows/play-listings.yml
+++ b/.github/workflows/play-listings.yml
@@ -44,8 +44,8 @@ on:
           # Read-only. Prints a unified diff of the repo against the live
           # listings and sends nothing.
           - dry-run
-          # Proves the service account holds "Edit store listing, pricing &
-          # distribution" by patching one listing inside an edit it abandons.
+          # Proves the service account holds "Manage store presence" by
+          # patching one listing inside an edit it abandons.
           # Nothing is committed. A dry run cannot answer this — it only reads.
           - check-permissions
           # The real thing: push every changed locale and commit the edit.
@@ -142,7 +142,7 @@ jobs:
             # never wrong. See the EXIT_* constants in publish_listings.py.
             case "$rc" in
               0) echo "::notice::The service account can edit listings." ;;
-              3) echo "::error::The service account cannot edit listings. Grant it Play Console -> Users and permissions -> App permissions -> 'Edit store listing, pricing & distribution'." ;;
+              3) echo "::error::The service account cannot edit listings. Grant it Play Console -> Users and permissions -> App permissions -> Store presence -> 'Manage store presence'." ;;
               4) echo "::warning::The probe reached no verdict — the API call failed for an unrelated reason (timeout, rate limit, Play 5xx). This says nothing about the grant; run it again." ;;
               *) echo "::error::The probe did not run (exit $rc) — see the log above. This is not a verdict about the grant." ;;
             esac

--- a/.github/workflows/play-listings.yml
+++ b/.github/workflows/play-listings.yml
@@ -117,7 +117,7 @@ jobs:
               ;;
             check-permissions)
               args+=(--check-permissions)
-              echo "::notice::Permission probe — patches one listing inside an edit that is then abandoned. Nothing is published."
+              echo "::notice::Permission probe — writes one listing (patch, or put if Play has none yet) inside an edit that is then abandoned. Nothing is published."
               ;;
             publish)
               ;;
@@ -143,7 +143,7 @@ jobs:
             case "$rc" in
               0) echo "::notice::The service account can edit listings." ;;
               3) echo "::error::The service account cannot edit listings. Grant it Play Console -> Users and permissions -> App permissions -> Store presence -> 'Manage store presence'." ;;
-              4) echo "::warning::The probe reached no verdict — the API call failed for an unrelated reason (timeout, rate limit, Play 5xx). This says nothing about the grant; run it again." ;;
+              4) echo "::warning::The probe reached no verdict — the API call failed for a reason that says nothing about the grant (401: the token was not accepted, a credentials problem; or a timeout, rate limit, Play 5xx). Fix the cause and run it again." ;;
               *) echo "::error::The probe did not run (exit $rc) — see the log above. This is not a verdict about the grant." ;;
             esac
           fi

--- a/.github/workflows/play-listings.yml
+++ b/.github/workflows/play-listings.yml
@@ -135,10 +135,16 @@ jobs:
           set -e
 
           if [[ "$MODE" == "check-permissions" ]]; then
+            # Codes 3 and 4 are the probe's own verdicts; nothing else in the
+            # script produces them. A generic 1 (bad credentials, unreadable
+            # metadata, an unhandled API error) must NOT be reported as a
+            # missing grant — that sends someone to fix a permission that was
+            # never wrong. See the EXIT_* constants in publish_listings.py.
             case "$rc" in
               0) echo "::notice::The service account can edit listings." ;;
-              1) echo "::error::The service account cannot edit listings. Grant it Play Console -> Users and permissions -> App permissions -> 'Edit store listing, pricing & distribution'." ;;
-              *) echo "::warning::The probe reached no verdict — the API call failed for an unrelated reason (timeout, rate limit, Play 5xx). This says nothing about the grant; run it again." ;;
+              3) echo "::error::The service account cannot edit listings. Grant it Play Console -> Users and permissions -> App permissions -> 'Edit store listing, pricing & distribution'." ;;
+              4) echo "::warning::The probe reached no verdict — the API call failed for an unrelated reason (timeout, rate limit, Play 5xx). This says nothing about the grant; run it again." ;;
+              *) echo "::error::The probe did not run (exit $rc) — see the log above. This is not a verdict about the grant." ;;
             esac
           fi
           exit $rc

--- a/.github/workflows/play-listings.yml
+++ b/.github/workflows/play-listings.yml
@@ -45,8 +45,9 @@ on:
           # listings and sends nothing.
           - dry-run
           # Proves the service account holds "Manage store presence" by
-          # patching one listing inside an edit it abandons.
-          # Nothing is committed. A dry run cannot answer this — it only reads.
+          # writing one listing (a patch of one Play already has, or a put if
+          # Play has none yet) inside an edit it abandons. Nothing is
+          # committed. A dry run cannot answer this — it only reads.
           - check-permissions
           # The real thing: push every changed locale and commit the edit.
           - publish
@@ -135,16 +136,10 @@ jobs:
           set -e
 
           if [[ "$MODE" == "check-permissions" ]]; then
-            # Codes 3 and 4 are the probe's own verdicts; nothing else in the
-            # script produces them. A generic 1 (bad credentials, unreadable
-            # metadata, an unhandled API error) must NOT be reported as a
-            # missing grant — that sends someone to fix a permission that was
-            # never wrong. See the EXIT_* constants in publish_listings.py.
-            case "$rc" in
-              0) echo "::notice::The service account can edit listings." ;;
-              3) echo "::error::The service account cannot edit listings. Grant it Play Console -> Users and permissions -> App permissions -> Store presence -> 'Manage store presence'." ;;
-              4) echo "::warning::The probe reached no verdict — the API call failed for a reason that says nothing about the grant (401: the token was not accepted, a credentials problem; or a timeout, rate limit, Play 5xx). Fix the cause and run it again." ;;
-              *) echo "::error::The probe did not run (exit $rc) — see the log above. This is not a verdict about the grant." ;;
-            esac
+            # The code is a verdict (3 = denied, 4 = inconclusive, anything
+            # else = the probe did not run). The code -> annotation mapping
+            # lives in the script (probe_annotation), where it is unit-tested
+            # against the EXIT_* constants; this only relays it.
+            python .github/scripts/publish_listings.py --annotate-verdict "$rc"
           fi
           exit $rc

--- a/.github/workflows/play-listings.yml
+++ b/.github/workflows/play-listings.yml
@@ -6,7 +6,8 @@ name: Play store listings
 #
 #   pull request touching the metadata -> validate only (no secrets, works from forks)
 #   push to main touching the metadata -> publish the changed locales to Play
-#   workflow_dispatch                  -> dry run by default; untick to publish
+#   workflow_dispatch                  -> pick a mode: dry-run (default),
+#                                         check-permissions, or publish
 #
 # Graphics (icon, feature graphic, screenshots) are NOT managed here — Play falls
 # back to the default language's graphics for locales that have none of their
@@ -35,10 +36,20 @@ on:
       - 'ft8af/app/src/main/res/values*/strings_compose.xml'
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: 'Dry run (show the diff against Play, change nothing)'
-        type: boolean
-        default: true
+      mode:
+        description: 'What to run'
+        type: choice
+        default: dry-run
+        options:
+          # Read-only. Prints a unified diff of the repo against the live
+          # listings and sends nothing.
+          - dry-run
+          # Proves the service account holds "Edit store listing, pricing &
+          # distribution" by patching one listing inside an edit it abandons.
+          # Nothing is committed. A dry run cannot answer this — it only reads.
+          - check-permissions
+          # The real thing: push every changed locale and commit the edit.
+          - publish
 
 permissions:
   contents: read
@@ -61,7 +72,7 @@ jobs:
         run: python -m unittest discover -s .github/scripts -p 'test_*.py' -v
 
   publish:
-    name: Publish listings to Play
+    name: Run against Play
     needs: validate
     # Only from the canonical repo — a fork has no PLAY_SERVICE_ACCOUNT_JSON and
     # must never be able to push listing text to the production app.
@@ -85,21 +96,49 @@ jobs:
       - name: Install deps
         run: pip install --quiet google-auth requests
 
-      - name: Publish
+      - name: Run
         env:
           PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           PACKAGE_NAME: radio.ks3ckc.ft8af
-          # workflow_dispatch honours the checkbox; a push to main always publishes.
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          # A push to main always publishes; a manual run does what was picked.
+          MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'publish' }}
         run: |
           set -euo pipefail
           if [[ -z "${PLAY_SERVICE_ACCOUNT_JSON:-}" ]]; then
             echo "::error::PLAY_SERVICE_ACCOUNT_JSON is not set — cannot reach the Play API."
             exit 1
           fi
+
           args=()
-          if [[ "$DRY_RUN" == "true" ]]; then
-            args+=(--dry-run)
-            echo "::notice::Dry run — the diff below is what a real run would send."
-          fi
+          case "$MODE" in
+            dry-run)
+              args+=(--dry-run)
+              echo "::notice::Dry run — the diff below is what a real run would send."
+              ;;
+            check-permissions)
+              args+=(--check-permissions)
+              echo "::notice::Permission probe — patches one listing inside an edit that is then abandoned. Nothing is published."
+              ;;
+            publish)
+              ;;
+            *)
+              echo "::error::Unknown mode '$MODE'."
+              exit 1
+              ;;
+          esac
+
+          # The probe's exit code is a verdict, not just pass/fail, so read it
+          # rather than letting -e swallow the distinction.
+          set +e
           python .github/scripts/publish_listings.py "${args[@]}"
+          rc=$?
+          set -e
+
+          if [[ "$MODE" == "check-permissions" ]]; then
+            case "$rc" in
+              0) echo "::notice::The service account can edit listings." ;;
+              1) echo "::error::The service account cannot edit listings. Grant it Play Console -> Users and permissions -> App permissions -> 'Edit store listing, pricing & distribution'." ;;
+              *) echo "::warning::The probe reached no verdict — the API call failed for an unrelated reason (timeout, rate limit, Play 5xx). This says nothing about the grant; run it again." ;;
+            esac
+          fi
+          exit $rc

--- a/docs/store-listings.md
+++ b/docs/store-listings.md
@@ -105,7 +105,7 @@ changes nothing commits nothing.
 
 `PLAY_SERVICE_ACCOUNT_JSON` was set up for *releases*. Editing listings needs a
 separate grant — **Play Console → Users and permissions → the service account →
-App permissions → "Edit store listing, pricing & distribution"**. Without it the
+App permissions → Store presence → "Manage store presence"**. Without it the
 `listings.patch` call fails with a 403 that names the missing permission, and
 nothing is committed.
 

--- a/docs/store-listings.md
+++ b/docs/store-listings.md
@@ -123,11 +123,19 @@ edit it then abandons rather than commits, so nothing reaches the store. It
 writes back the text Play already has, so the probe is a no-op even in
 principle.
 
-It exits `0` when the account may edit listings, `1` when Play refused
-(401/403 — the missing grant, named), and `2` when the call failed for another
-reason. A timeout or a Play 5xx proves nothing either way, so it is reported as
-inconclusive rather than sending you to edit Console permissions that were fine
-all along.
+Its exit code is a verdict, so the codes are chosen not to collide with
+anything else the script (or argparse) can produce:
+
+| exit | meaning |
+| ---- | ------- |
+| `0`  | the account may edit listings |
+| `1`  | the probe did not run — bad credentials, unpublishable metadata. **Not** a verdict |
+| `3`  | Play refused the patch (401/403). This is the missing grant |
+| `4`  | inconclusive — timeout, rate limit, Play 5xx. Proves nothing either way; run it again |
+
+`2` is skipped on purpose: argparse exits 2 on a usage error, and a mistyped
+flag must not read as an answer about the grant. Anything other than `3` is not
+evidence that a permission is wrong.
 
 Play's one-open-edit-per-app rule means a listing publish and an AAB upload must
 not overlap, or the second fails with *"This edit has expired"*. The publish job

--- a/docs/store-listings.md
+++ b/docs/store-listings.md
@@ -88,9 +88,15 @@ The workflow is `.github/workflows/play-listings.yml`:
 - **Push to `main`** touching the metadata → publishes the changed locales. Since
   all PRs target `dev`, listing changes reach Play on the normal
   dev → staging → main promotion, alongside the release they belong to.
-- **Manual run** (Actions → "Play store listings" → Run workflow) → dry run by
-  default; it prints the diff against what is live and sends nothing. Untick
-  "Dry run" to publish without waiting for a merge to `main`.
+- **Manual run** (Actions → "Play store listings" → Run workflow) → pick a mode:
+  `dry-run` (the default; prints the diff, sends nothing), `check-permissions`
+  (the grant probe below), or `publish` (the real thing, without waiting for a
+  merge to `main`).
+
+Note that `workflow_dispatch` only appears once this workflow file exists on the
+repository's **default branch**, `main`. Until the first promotion carries it
+there, the manual run is not available and the PR-time validation is all that
+runs.
 
 Only locales whose text actually differs from Play are sent, so a rerun that
 changes nothing commits nothing.
@@ -106,7 +112,7 @@ nothing is committed.
 **A dry run does not prove you have this grant.** It only reads listings, and
 reading them needs no edit permission — so an account that can read but not
 write passes the dry run and fails on the first real publish. Use the probe
-instead:
+instead — as a manual run in the `check-permissions` mode, or locally:
 
 ```bash
 python .github/scripts/publish_listings.py --check-permissions

--- a/docs/store-listings.md
+++ b/docs/store-listings.md
@@ -103,16 +103,23 @@ changes nothing commits nothing.
 
 ### Prerequisite: service account permission
 
-`PLAY_SERVICE_ACCOUNT_JSON` was set up for *releases*. Editing listings needs a
-separate grant — **Play Console → Users and permissions → the service account →
-App permissions → Store presence → "Manage store presence"**. Without it the
-`listings.patch` call fails with a 403 that names the missing permission, and
-nothing is committed.
+Editing listings is a different grant from releasing: the two Releases
+permissions cover uploading artifacts, so an account can push an AAB all day and
+still get a 403 on `listings.patch`. What it needs is **Play Console → Users and
+permissions → the service account → App permissions → Store presence → "Manage
+store presence"**.
+
+**For FT8AF this is already granted** (confirmed 2026-09-01), so the first
+publish should go straight through. It is written down because it is not implied
+by the release permission the account was set up with, and because revoking it
+would break listing publishes while leaving releases working — a failure that
+would otherwise be puzzling.
 
 **A dry run does not prove you have this grant.** It only reads listings, and
 reading them needs no edit permission — so an account that can read but not
-write passes the dry run and fails on the first real publish. Use the probe
-instead — as a manual run in the `check-permissions` mode, or locally:
+write passes the dry run and fails on the first real publish. If you ever need
+to check (after a permissions change, or when a publish 403s), use the probe —
+as a manual run in the `check-permissions` mode, or locally:
 
 ```bash
 python .github/scripts/publish_listings.py --check-permissions

--- a/docs/store-listings.md
+++ b/docs/store-listings.md
@@ -125,10 +125,12 @@ as a manual run in the `check-permissions` mode, or locally:
 python .github/scripts/publish_listings.py --check-permissions
 ```
 
-That does the one thing a dry run skips: a single `listings.patch` inside an
+That does the one thing a dry run skips: a single listing write inside an
 edit it then abandons rather than commits, so nothing reaches the store. It
-writes back the text Play already has, so the probe is a no-op even in
-principle.
+writes back the text Play already has (`listings.patch`), so the probe is a
+no-op even in principle; only on an app with no listings at all does it have
+to create one from the repo's text instead (`listings.put`). The log names
+whichever call it made.
 
 Its exit code is a verdict, so the codes are chosen not to collide with
 anything else the script (or argparse) can produce:
@@ -137,8 +139,8 @@ anything else the script (or argparse) can produce:
 | ---- | ------- |
 | `0`  | the account may edit listings |
 | `1`  | the probe did not run — bad credentials, unpublishable metadata. **Not** a verdict |
-| `3`  | Play refused the patch (401/403). This is the missing grant |
-| `4`  | inconclusive — timeout, rate limit, Play 5xx. Proves nothing either way; run it again |
+| `3`  | Play refused the write with **403**. This is the missing grant |
+| `4`  | inconclusive — a 401 (the token was not accepted: a credentials problem, not a grant verdict), timeout, rate limit, Play 5xx. Proves nothing either way; fix the cause and run it again |
 
 `2` is skipped on purpose: argparse exits 2 on a usage error, and a mistyped
 flag must not read as an answer about the grant. Anything other than `3` is not


### PR DESCRIPTION
Follow-up to #784.

## Why

`--check-permissions` shipped in #784, but nothing could actually invoke it. The workflow's only `workflow_dispatch` input was a `dry_run` boolean, so the one command that answers *"can this service account edit listings?"* was reachable only by downloading a private key and running the script by hand — which is exactly what you'd want CI to do for you, since the secret already lives there.

That's the gap this closes.

## What

**`mode` choice input** replacing the boolean: `dry-run` (default), `check-permissions`, `publish`. A push to `main` still always publishes.

**The probe writes one listing, it does not always PATCH.** `listings.patch` 404s on a language Play has never had a listing for, so on an app with no listings yet the probe (and a first publish) `PUT`s instead. The log names whichever call it made.

**The probe's exit code is a verdict**, not pass/fail, so the step reads it instead of letting `set -e` flatten the distinction. The codes are chosen not to collide with anything else the script or argparse can produce (2 is skipped on purpose):

| exit | meaning | annotation |
| --- | --- | --- |
| 0 | the account can edit listings | notice |
| 3 | Play refused the write with **403** — the account is authenticated but lacks "Manage store presence" | error, naming the grant and where to set it |
| 4 | inconclusive — a **401** (the token was not accepted: a credentials problem, not a grant verdict), a timeout, rate limit, or Play 5xx | warning: fix the cause and run it again |
| 1 / anything else | the probe did not run — bad key, unpublishable metadata, argparse usage error | error: "not a verdict about the grant" |

The code → annotation mapping lives in the script (`probe_annotation`, relayed by `--annotate-verdict`) rather than in a bash `case`, so it is unit-tested against the `EXIT_*` constants and a drift test asserts the workflow delegates to it.

**Drift guard.** `build_arg_parser()` is now separate from `main()`, and the tests read the mode list straight out of the YAML, asserting every mode maps to a real option string and has a `case` branch. Renaming a flag without updating the workflow previously surfaced only as a failed manual run against Play; it now fails the PR. Verified by mutation — renaming `--check-permissions` to `--verify-permissions` fails with:

```
AssertionError: '--check-permissions' not found in {...} : mode 'check-permissions' passes unknown flag --check-permissions
```

The YAML is parsed by hand rather than with PyYAML, keeping the suite stdlib-only — which is what lets the `validate` job install nothing and run on forks.

## Tests

103, up from 75. They cover the modes offered, their mapping to real flags, the `case` coverage, the read-only default, the parser accepting each flag, the 401/403 split, the PUT-on-empty-store path (and that a dry run PUTs nothing either), each exit code's annotation, and the workflow's delegation of that annotation to the script.

```
Ran 103 tests in 0.292s

OK
```

## Also documented

The constraint that prompted this: **`workflow_dispatch` does not appear until the workflow file reaches the default branch.** `play-listings.yml` is currently only on `dev`, so there is no "Run workflow" button yet, and there won't be until the first promotion carries it to `main`. Worth knowing before anyone goes looking for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
