### PR TITLE
CI: stop publishing to Play production on staging → main merges

### DIFF
--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -47,7 +47,10 @@ import sys
 START = "<!-- ft8af-notes-start -->"
 END = "<!-- ft8af-notes-end -->"
 
-# Play's what's-new limit; the fallback keeps whole lines under it.
+# Play's what's-new limit, in BYTES: the workflow truncates notes.txt with
+# `head -c 500` before upload, and the API limit is on the encoded text. A
+# character budget would let multibyte titles (Cyrillic, CJK, emoji) pass here
+# and be cut mid-codepoint downstream, sending Play invalid UTF-8.
 PLAY_NOTES_LIMIT = 500
 DEFAULT_NOTES = "Bug fixes and improvements."
 # What the AI step's "Collect changes" writes to its prs output when the range
@@ -56,12 +59,16 @@ DEFAULT_NOTES = "Bug fixes and improvements."
 NO_PRS_SENTINEL = "(no pull-request merges in range)"
 
 
+def utf8_len(text):
+    return len(text.encode("utf-8"))
+
+
 def fallback_notes(pr_list):
     """Release notes from the PR list the AI step collects ("- #123 scope: title").
 
     Whole lines only, stopping before the total would exceed PLAY_NOTES_LIMIT
-    (each line counts its newline), mirroring the sed/awk the workflow's
-    fallback used. Empty input yields DEFAULT_NOTES.
+    bytes of UTF-8 (each line counts its newline), so the downstream `head -c`
+    never lands inside a multibyte character. Empty input yields DEFAULT_NOTES.
     """
     out = []
     n = 0
@@ -70,17 +77,34 @@ def fallback_notes(pr_list):
         line = re.sub(r"^- #[0-9]+ ", "", line)
         if not line.strip() or line.strip() == NO_PRS_SENTINEL:
             continue
-        if n + len(line) + 1 > PLAY_NOTES_LIMIT:
+        if n + utf8_len(line) + 1 > PLAY_NOTES_LIMIT:
             break
         out.append(line)
-        n += len(line) + 1
+        n += utf8_len(line) + 1
     return "\n".join(out) + "\n" if out else DEFAULT_NOTES + "\n"
 
 
+def cap_notes(notes):
+    """Fit any producer's notes into PLAY_NOTES_LIMIT bytes without splitting a
+    character: cut at the last line break inside the budget, else at the last
+    whole codepoint. Claude is asked for <= 400 characters, which multibyte text
+    can push past 500 bytes; the workflow's `head -c 500` would then cut
+    mid-codepoint, so the cap is applied here first and that head is a no-op.
+    """
+    data = notes.encode("utf-8")
+    if len(data) <= PLAY_NOTES_LIMIT:
+        return notes
+    cut = data.rfind(b"\n", 0, PLAY_NOTES_LIMIT + 1)
+    if cut > 0:
+        return data[:cut].decode("utf-8") + "\n"
+    return data[:PLAY_NOTES_LIMIT].decode("utf-8", errors="ignore")
+
+
 def ensure_notes(notes, pr_list):
-    """(notes, used_fallback): nonblank notes come back unchanged."""
+    """(notes, used_fallback): nonblank notes come back unchanged apart from the
+    byte cap; blank ones become the fallback."""
     if notes is not None and notes.strip():
-        return notes, False
+        return cap_notes(notes), False
     return fallback_notes(pr_list), True
 
 
@@ -192,14 +216,18 @@ def run_ensure_notes(args):
         with open(args.notes, encoding="utf-8", errors="replace") as f:
             notes = f.read()
     ensured, used_fallback = ensure_notes(notes, os.environ.get(args.pr_list_env, ""))
-    if used_fallback:
+    if used_fallback or ensured != notes:
         with open(args.notes, "w", encoding="utf-8", newline="\n") as f:
             f.write(ensured)
+    if used_fallback:
         print("::warning title=Release notes fell back::The notes producer left notes.txt "
               "blank — using the fallback text (the PR titles, or the default line when "
               "there were none) so the release stays shippable.")
         print("Notes:")
         print(ensured)
+    elif ensured != notes:
+        print("::warning title=Release notes trimmed::notes.txt exceeded Play's %d-byte "
+              "what's-new limit and was cut at a line boundary." % PLAY_NOTES_LIMIT)
     return 0
 
 
@@ -221,7 +249,7 @@ def main(argv=None):
         with open(args.body_out, "w", encoding="utf-8", newline="\n") as f:
             f.write(out.body if out.body.endswith("\n") else out.body + "\n")
         with open(args.notes_out, "w", encoding="utf-8", newline="\n") as f:
-            f.write(out.notes)
+            f.write(cap_notes(out.notes))
     if args.github_output:
         with open(args.github_output, "a", encoding="utf-8", newline="\n") as f:
             f.write("found=%s\n" % ("true" if out.found else "false"))

--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -1,7 +1,18 @@
 #!/usr/bin/env python3
-"""Restore the release notes of the GitHub Release an android-v* tag already has.
+"""Release-notes helpers for android.yml: `restore` and `ensure-notes`.
 
-Used by the `tag` lane of android.yml. The manual production ship re-runs the
+`ensure-notes` runs in "Write release notes" for the lanes that produce notes
+(staging and main). The producers can yield a blank file — Claude's structured
+output permits an empty `notes` string, and `jq -r` writes that as a bare
+newline — and a release whose body carries blank markers would later be
+refused by the manual production ship (`restore`, below). So before the notes
+go into the markers, a blank file is replaced with the PR titles (whole lines,
+up to Play's 500-character limit) or, failing that, "Bug fixes and
+improvements." — the same fallback the AI step used when the API was
+unreachable, now applied in one place for every producer.
+
+`restore` restores the release notes of the GitHub Release an android-v* tag
+already has. Used by the `tag` lane. The manual production ship re-runs the
 workflow on an android-v<x.y.z> tag whose GitHub Release the main-merge run
 already created, carrying the promoted staging notes in its body between the
 hidden markers written by "Write release notes":
@@ -29,10 +40,44 @@ Outcomes (`found=...` is appended to --github-output):
                genuine "release not found".
 """
 import argparse
+import os
+import re
 import sys
 
 START = "<!-- ft8af-notes-start -->"
 END = "<!-- ft8af-notes-end -->"
+
+# Play's what's-new limit; the fallback keeps whole lines under it.
+PLAY_NOTES_LIMIT = 500
+DEFAULT_NOTES = "Bug fixes and improvements."
+
+
+def fallback_notes(pr_list):
+    """Release notes from the PR list the AI step collects ("- #123 scope: title").
+
+    Whole lines only, stopping before the total would exceed PLAY_NOTES_LIMIT
+    (each line counts its newline), mirroring the sed/awk the workflow's
+    fallback used. Empty input yields DEFAULT_NOTES.
+    """
+    out = []
+    n = 0
+    for line in (pr_list or "").splitlines():
+        line = re.sub(r"^- #[0-9]+ [^:]*: ?", "", line)
+        line = re.sub(r"^- #[0-9]+ ", "", line)
+        if not line.strip():
+            continue
+        if n + len(line) + 1 > PLAY_NOTES_LIMIT:
+            break
+        out.append(line)
+        n += len(line) + 1
+    return "\n".join(out) + "\n" if out else DEFAULT_NOTES + "\n"
+
+
+def ensure_notes(notes, pr_list):
+    """(notes, used_fallback): nonblank notes come back unchanged."""
+    if notes is not None and notes.strip():
+        return notes, False
+    return fallback_notes(pr_list), True
 
 
 class MalformedMarkers(Exception):
@@ -116,17 +161,47 @@ def decide(event, tag, gh_status, gh_stderr, body):
         "Release %s already exists; keeping its body." % tag))
 
 
-def main(argv=None):
+def build_arg_parser():
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    ap.add_argument("--event", required=True, help="$GITHUB_EVENT_NAME")
-    ap.add_argument("--tag", required=True)
-    ap.add_argument("--gh-status", type=int, required=True, help="exit code of gh release view")
-    ap.add_argument("--gh-stderr", required=True, help="file holding gh's stderr")
-    ap.add_argument("--body", required=True, help="file holding gh's stdout (the body)")
-    ap.add_argument("--notes-out", required=True)
-    ap.add_argument("--body-out", required=True)
-    ap.add_argument("--github-output", help="$GITHUB_OUTPUT; found=true|false is appended")
-    args = ap.parse_args(argv)
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    r = sub.add_parser("restore", help="restore the notes of the release a tag already has")
+    r.add_argument("--event", required=True, help="$GITHUB_EVENT_NAME")
+    r.add_argument("--tag", required=True)
+    r.add_argument("--gh-status", type=int, required=True, help="exit code of gh release view")
+    r.add_argument("--gh-stderr", required=True, help="file holding gh's stderr")
+    r.add_argument("--body", required=True, help="file holding gh's stdout (the body)")
+    r.add_argument("--notes-out", required=True)
+    r.add_argument("--body-out", required=True)
+    r.add_argument("--github-output", help="$GITHUB_OUTPUT; found=true|false is appended")
+
+    e = sub.add_parser("ensure-notes", help="replace a blank notes file with the fallback text")
+    e.add_argument("--notes", required=True, help="notes file; created or rewritten when blank")
+    e.add_argument("--pr-list-env", default="PR_LIST",
+                   help="env var holding the AI step's PR list (default PR_LIST)")
+    return ap
+
+
+def run_ensure_notes(args):
+    notes = None
+    if os.path.exists(args.notes):
+        with open(args.notes, encoding="utf-8", errors="replace") as f:
+            notes = f.read()
+    ensured, used_fallback = ensure_notes(notes, os.environ.get(args.pr_list_env, ""))
+    if used_fallback:
+        with open(args.notes, "w", encoding="utf-8", newline="\n") as f:
+            f.write(ensured)
+        print("::warning title=Release notes fell back::The notes producer left notes.txt "
+              "blank — using the PR titles instead, so the release stays shippable.")
+        print("Notes:")
+        print(ensured)
+    return 0
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    if args.command == "ensure-notes":
+        return run_ensure_notes(args)
 
     with open(args.gh_stderr, encoding="utf-8", errors="replace") as f:
         gh_stderr = f.read()

--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -94,7 +94,7 @@ def cap_notes(notes):
     data = notes.encode("utf-8")
     if len(data) <= PLAY_NOTES_LIMIT:
         return notes
-    cut = data.rfind(b"\n", 0, PLAY_NOTES_LIMIT + 1)
+    cut = data.rfind(b"\n", 0, PLAY_NOTES_LIMIT)
     if cut > 0:
         return data[:cut].decode("utf-8") + "\n"
     return data[:PLAY_NOTES_LIMIT].decode("utf-8", errors="ignore")

--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -50,6 +50,10 @@ END = "<!-- ft8af-notes-end -->"
 # Play's what's-new limit; the fallback keeps whole lines under it.
 PLAY_NOTES_LIMIT = 500
 DEFAULT_NOTES = "Bug fixes and improvements."
+# What the AI step's "Collect changes" writes to its prs output when the range
+# had no PR merges (android.yml: `${PRS:-(no pull-request merges in range)}`).
+# A placeholder for the log, not a release note; must never reach Play.
+NO_PRS_SENTINEL = "(no pull-request merges in range)"
 
 
 def fallback_notes(pr_list):
@@ -64,7 +68,7 @@ def fallback_notes(pr_list):
     for line in (pr_list or "").splitlines():
         line = re.sub(r"^- #[0-9]+ [^:]*: ?", "", line)
         line = re.sub(r"^- #[0-9]+ ", "", line)
-        if not line.strip():
+        if not line.strip() or line.strip() == NO_PRS_SENTINEL:
             continue
         if n + len(line) + 1 > PLAY_NOTES_LIMIT:
             break
@@ -192,7 +196,8 @@ def run_ensure_notes(args):
         with open(args.notes, "w", encoding="utf-8", newline="\n") as f:
             f.write(ensured)
         print("::warning title=Release notes fell back::The notes producer left notes.txt "
-              "blank — using the PR titles instead, so the release stays shippable.")
+              "blank — using the fallback text (the PR titles, or the default line when "
+              "there were none) so the release stays shippable.")
         print("Notes:")
         print(ensured)
     return 0

--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Restore the release notes of the GitHub Release an android-v* tag already has.
+
+Used by the `tag` lane of android.yml. The manual production ship re-runs the
+workflow on an android-v<x.y.z> tag whose GitHub Release the main-merge run
+already created, carrying the promoted staging notes in its body between the
+hidden markers written by "Write release notes":
+
+    <!-- ft8af-notes-start -->
+    ...notes...
+    <!-- ft8af-notes-end -->
+
+The workflow step runs `gh release view` and hands this script the result; the
+decision — existing release / missing release / lookup failure, manual dispatch
+versus tag push, and the marker parsing — lives here so test_release_notes.py
+can cover every branch instead of a bash step nobody can run in CI.
+
+Outcomes (`found=...` is appended to --github-output):
+  found=true   the release exists: --body-out gets its body verbatim (for the
+               release step to hand back to softprops unchanged) and --notes-out
+               gets the text between the markers (for Play's what's-new).
+  found=false  a plain tag push found no release: nothing is written, the
+               workflow falls back to the version string as before.
+  exit 1       the run must stop, with a ::error:: line saying why. Always on a
+               workflow_dispatch that cannot read its release or finds no notes
+               in it (the manual ship is documented to send the promoted notes,
+               and carrying on would overwrite the release body with a
+               placeholder); on a tag push for any lookup failure other than a
+               genuine "release not found".
+"""
+import argparse
+import sys
+
+START = "<!-- ft8af-notes-start -->"
+END = "<!-- ft8af-notes-end -->"
+
+
+class MalformedMarkers(Exception):
+    """The body does not carry exactly one ordered start/end marker pair."""
+
+
+def extract_notes(body):
+    """Text between the markers, line-wise, as the awk extraction produced it.
+
+    Strict about structure: exactly one start marker, exactly one end marker,
+    start before end. Anything else raises MalformedMarkers — with the end
+    marker first, a lenient scan would capture everything after the start
+    marker and ship trailing release text to Play as the what's-new.
+    """
+    starts = body.count(START)
+    ends = body.count(END)
+    if starts == 0 and ends == 0:
+        raise MalformedMarkers("no ft8af-notes markers")
+    if starts != 1 or ends != 1:
+        raise MalformedMarkers(
+            "expected one start and one end marker, found %d and %d" % (starts, ends)
+        )
+    s = body.index(START)
+    e = body.index(END)
+    if e < s:
+        raise MalformedMarkers("end marker comes before the start marker")
+    inner = body[s + len(START):e]
+    # The markers sit on their own lines; drop the line break that follows the
+    # start marker so the notes begin at their first line, like awk's did.
+    if inner.startswith("\n"):
+        inner = inner[1:]
+    return inner
+
+
+class Outcome:
+    def __init__(self, found=None, error=None, notes="", body="", message=""):
+        self.found = found      # True / False, or None when error is set
+        self.error = error      # the ::error:: text, or None
+        self.notes = notes
+        self.body = body
+        self.message = message  # informational stdout line
+
+
+def decide(event, tag, gh_status, gh_stderr, body):
+    """The whole decision, pure so it can be tested without gh or a runner."""
+    dispatch = event == "workflow_dispatch"
+    gh_stderr = (gh_stderr or "").strip()
+    if gh_status != 0:
+        if dispatch:
+            return Outcome(error=(
+                "Could not read the GitHub Release for %s (%s). A manual production "
+                "ship needs the release the main merge created — check the tag and "
+                "rerun." % (tag, gh_stderr)))
+        if "not found" not in gh_stderr.lower():
+            # A tag push with a release we merely failed to read is the same
+            # overwrite risk; only a genuine "no release" may fall through.
+            return Outcome(error=(
+                "Could not read the GitHub Release for %s (%s); refusing to continue "
+                "and risk overwriting it." % (tag, gh_stderr)))
+        return Outcome(found=False, message=(
+            "No existing release for %s (plain tag push) — Play's what's-new falls "
+            "back to the version string." % tag))
+
+    body = (body or "").replace("\r", "")
+    try:
+        notes = extract_notes(body)
+    except MalformedMarkers as m:
+        if dispatch:
+            return Outcome(error=(
+                "The GitHub Release for %s has no usable release notes (%s), so there "
+                "is nothing to send to Play as the what's-new. Put the notes in the "
+                "release body between %s and %s and rerun." % (tag, m, START, END)))
+        # A tag push keeps the body but ships without notes, as it always did.
+        notes = ""
+    if dispatch and not notes.strip():
+        return Outcome(error=(
+            "The GitHub Release for %s has no release notes between the ft8af-notes "
+            "markers, so there is nothing to send to Play as the what's-new. Add "
+            "them to the release body and rerun." % tag))
+    return Outcome(found=True, notes=notes, body=body, message=(
+        "Release %s already exists; keeping its body." % tag))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--event", required=True, help="$GITHUB_EVENT_NAME")
+    ap.add_argument("--tag", required=True)
+    ap.add_argument("--gh-status", type=int, required=True, help="exit code of gh release view")
+    ap.add_argument("--gh-stderr", required=True, help="file holding gh's stderr")
+    ap.add_argument("--body", required=True, help="file holding gh's stdout (the body)")
+    ap.add_argument("--notes-out", required=True)
+    ap.add_argument("--body-out", required=True)
+    ap.add_argument("--github-output", help="$GITHUB_OUTPUT; found=true|false is appended")
+    args = ap.parse_args(argv)
+
+    with open(args.gh_stderr, encoding="utf-8", errors="replace") as f:
+        gh_stderr = f.read()
+    with open(args.body, encoding="utf-8", errors="replace") as f:
+        body = f.read()
+
+    out = decide(args.event, args.tag, args.gh_status, gh_stderr, body)
+    if out.error:
+        print("::error::" + out.error)
+        return 1
+    if out.found:
+        with open(args.body_out, "w", encoding="utf-8", newline="\n") as f:
+            f.write(out.body if out.body.endswith("\n") else out.body + "\n")
+        with open(args.notes_out, "w", encoding="utf-8", newline="\n") as f:
+            f.write(out.notes)
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8", newline="\n") as f:
+            f.write("found=%s\n" % ("true" if out.found else "false"))
+    print(out.message)
+    if out.found:
+        print("Notes:")
+        print(out.notes)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_release_notes.py
+++ b/.github/scripts/test_release_notes.py
@@ -1,0 +1,173 @@
+"""Tests for release_notes.py — the tag lane's release-notes restoration.
+
+Stdlib only, like test_publish_listings.py, so android.yml's test job can run
+it with no extra install. Every branch the workflow step used to carry in bash
+is pinned here: existing / missing release, lookup failure, dispatch versus
+tag push, and the marker structure.
+"""
+import contextlib
+import io
+import os
+import shutil
+import tempfile
+import unittest
+
+import release_notes as rn
+
+BODY = (
+    "## Release notes\r\n\r\n"
+    "<!-- ft8af-notes-start -->\r\n"
+    "New: hamlib CAT support.\r\nFixes for Icom SWR meters.\r\n\r\n"
+    "<!-- ft8af-notes-end -->\r\n\r\n"
+    "<!-- ft8af-version: 0.151.0 -->\r\n"
+    "_Version `0.151.0` — promoted from android-dev.1155._\r\n"
+)
+NOTES = "New: hamlib CAT support.\nFixes for Icom SWR meters.\n\n"
+
+
+class DecideTest(unittest.TestCase):
+    def test_existing_release_on_dispatch_restores_notes_and_body(self):
+        out = rn.decide("workflow_dispatch", "android-v0.151.0", 0, "", BODY)
+        self.assertTrue(out.found)
+        self.assertIsNone(out.error)
+        self.assertEqual(out.notes, NOTES)
+        self.assertNotIn("\r", out.body)
+        self.assertIn("<!-- ft8af-version: 0.151.0 -->", out.body)
+
+    def test_existing_release_on_push_restores_too(self):
+        out = rn.decide("push", "android-v0.151.0", 0, "", BODY)
+        self.assertTrue(out.found)
+        self.assertEqual(out.notes, NOTES)
+
+    def test_missing_release_on_dispatch_is_an_error(self):
+        out = rn.decide("workflow_dispatch", "android-v9.9.9", 1, "release not found", "")
+        self.assertIsNotNone(out.error)
+        self.assertIn("android-v9.9.9", out.error)
+        self.assertIn("release not found", out.error)
+
+    def test_missing_release_on_push_falls_back(self):
+        out = rn.decide("push", "android-v9.9.9", 1, "release not found\n", "")
+        self.assertFalse(out.found)
+        self.assertIsNone(out.error)
+        self.assertIn("plain tag push", out.message)
+
+    def test_lookup_failure_on_push_is_an_error_not_a_fallback(self):
+        # Auth, rate limit, transient API error: the release may well exist and
+        # carrying on would overwrite it.
+        for err in ("HTTP 401: Bad credentials", "HTTP 403: API rate limit exceeded", ""):
+            out = rn.decide("push", "android-v0.151.0", 1, err, "")
+            self.assertIsNotNone(out.error, err)
+            self.assertIn("refusing to continue", out.error)
+
+    def test_lookup_failure_on_dispatch_is_an_error(self):
+        out = rn.decide("workflow_dispatch", "android-v0.151.0", 1, "HTTP 401: Bad credentials", "")
+        self.assertIsNotNone(out.error)
+        self.assertIn("Bad credentials", out.error)
+
+    def test_no_markers_on_dispatch_is_an_error(self):
+        # A release cut by a plain tag push, or one whose body was edited.
+        out = rn.decide("workflow_dispatch", "android-v0.149", 0, "", "## Release\nno markers here\n")
+        self.assertIsNotNone(out.error)
+        self.assertIn("no usable release notes", out.error)
+
+    def test_no_markers_on_push_keeps_body_and_ships_without_notes(self):
+        out = rn.decide("push", "android-v0.149", 0, "", "## Release\nno markers here\n")
+        self.assertTrue(out.found)
+        self.assertEqual(out.notes, "")
+        self.assertIn("no markers here", out.body)
+
+    def test_blank_notes_between_markers_on_dispatch_is_an_error(self):
+        body = "<!-- ft8af-notes-start -->\n\n   \n<!-- ft8af-notes-end -->\n"
+        out = rn.decide("workflow_dispatch", "android-v0.151.0", 0, "", body)
+        self.assertIsNotNone(out.error)
+        self.assertIn("no release notes between", out.error)
+
+    def test_end_marker_before_start_is_malformed(self):
+        # A lenient scan would capture everything after the start marker and
+        # ship the trailing release text to Play.
+        body = "<!-- ft8af-notes-end -->\n<!-- ft8af-notes-start -->\ntrailing text\n"
+        out = rn.decide("workflow_dispatch", "android-v0.151.0", 0, "", body)
+        self.assertIsNotNone(out.error)
+        self.assertIn("end marker comes before", out.error)
+        out = rn.decide("push", "android-v0.151.0", 0, "", body)
+        self.assertTrue(out.found)
+        self.assertEqual(out.notes, "")
+
+    def test_duplicate_markers_are_malformed(self):
+        body = ("<!-- ft8af-notes-start -->\nA\n<!-- ft8af-notes-end -->\n"
+                "<!-- ft8af-notes-start -->\nB\n<!-- ft8af-notes-end -->\n")
+        out = rn.decide("workflow_dispatch", "android-v0.151.0", 0, "", body)
+        self.assertIsNotNone(out.error)
+        self.assertIn("found 2 and 2", out.error)
+
+    def test_only_one_of_the_markers_is_malformed(self):
+        out = rn.decide("workflow_dispatch", "android-v0.151.0", 0, "",
+                        "<!-- ft8af-notes-start -->\nA\n")
+        self.assertIsNotNone(out.error)
+
+
+class ExtractNotesTest(unittest.TestCase):
+    def test_matches_the_old_awk_extraction(self):
+        self.assertEqual(rn.extract_notes(BODY.replace("\r", "")), NOTES)
+
+    def test_no_markers_raises(self):
+        with self.assertRaises(rn.MalformedMarkers):
+            rn.extract_notes("plain body")
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def path(self, name, content=None):
+        p = os.path.join(self.tmp, name)
+        if content is not None:
+            with open(p, "w", encoding="utf-8", newline="") as f:
+                f.write(content)
+        return p
+
+    def run_main(self, event, status, stderr, body):
+        argv = [
+            "--event", event, "--tag", "android-v0.151.0",
+            "--gh-status", str(status),
+            "--gh-stderr", self.path("err.txt", stderr),
+            "--body", self.path("body.raw", body),
+            "--notes-out", self.path("notes.txt"),
+            "--body-out", self.path("existing-release-body.md"),
+            "--github-output", self.path("out.txt", ""),
+        ]
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            code = rn.main(argv)
+        return code, stdout.getvalue()
+
+    def read(self, name):
+        with open(os.path.join(self.tmp, name), encoding="utf-8", newline="") as f:
+            return f.read()
+
+    def test_found_writes_notes_body_and_output(self):
+        code, out = self.run_main("workflow_dispatch", 0, "", BODY)
+        self.assertEqual(code, 0)
+        self.assertEqual(self.read("notes.txt"), NOTES)
+        self.assertNotIn("\r", self.read("existing-release-body.md"))
+        self.assertEqual(self.read("out.txt"), "found=true\n")
+        self.assertIn("hamlib CAT support", out)
+
+    def test_not_found_on_push_writes_no_files(self):
+        code, out = self.run_main("push", 1, "release not found", "")
+        self.assertEqual(code, 0)
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "notes.txt")))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "existing-release-body.md")))
+        self.assertEqual(self.read("out.txt"), "found=false\n")
+
+    def test_error_exits_1_with_an_error_annotation_and_no_files(self):
+        code, out = self.run_main("workflow_dispatch", 1, "release not found", "")
+        self.assertEqual(code, 1)
+        self.assertTrue(out.startswith("::error::"))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "notes.txt")))
+        self.assertEqual(self.read("out.txt"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_release_notes.py
+++ b/.github/scripts/test_release_notes.py
@@ -129,6 +129,7 @@ class MainTest(unittest.TestCase):
 
     def run_main(self, event, status, stderr, body):
         argv = [
+            "restore",
             "--event", event, "--tag", "android-v0.151.0",
             "--gh-status", str(status),
             "--gh-stderr", self.path("err.txt", stderr),
@@ -167,6 +168,98 @@ class MainTest(unittest.TestCase):
         self.assertTrue(out.startswith("::error::"))
         self.assertFalse(os.path.exists(os.path.join(self.tmp, "notes.txt")))
         self.assertEqual(self.read("out.txt"), "")
+
+
+class EnsureNotesTest(unittest.TestCase):
+    PR_LIST = (
+        "- #801 rigs: Follow IC-705 dial changes\n"
+        "- #802 Fix Bluetooth CAT write race\n"
+        "- #803 ci: stop publishing to Play production on main merges\n"
+    )
+
+    def test_nonblank_notes_are_left_alone(self):
+        notes, fell_back = rn.ensure_notes("Real notes.\n", self.PR_LIST)
+        self.assertEqual(notes, "Real notes.\n")
+        self.assertFalse(fell_back)
+
+    def test_blank_notes_become_the_pr_titles(self):
+        # Claude's schema allows an empty string and `jq -r` writes it as a
+        # bare newline: exactly what used to produce blank markers.
+        for blank in ("", "\n", "   \n\n", None):
+            notes, fell_back = rn.ensure_notes(blank, self.PR_LIST)
+            self.assertTrue(fell_back, repr(blank))
+            self.assertEqual(
+                notes,
+                "Follow IC-705 dial changes\n"
+                "Fix Bluetooth CAT write race\n"
+                "stop publishing to Play production on main merges\n",
+            )
+
+    def test_blank_notes_and_no_prs_use_the_default_text(self):
+        notes, fell_back = rn.ensure_notes("\n", "")
+        self.assertTrue(fell_back)
+        self.assertEqual(notes, rn.DEFAULT_NOTES + "\n")
+
+    def test_fallback_keeps_whole_lines_under_plays_limit(self):
+        long_list = "".join("- #%d %s\n" % (i, "x" * 120) for i in range(10))
+        notes = rn.fallback_notes(long_list)
+        self.assertLessEqual(len(notes), rn.PLAY_NOTES_LIMIT)
+        self.assertEqual(notes.count("\n"), 4)  # 4 x 121 = 484 fits, 5 would not
+        self.assertTrue(all(len(l) == 120 for l in notes.splitlines()))
+
+    def test_round_trip_producer_to_manual_ship(self):
+        # The producer/consumer case: notes that went through ensure_notes
+        # land between the markers "Write release notes" emits, and the manual
+        # ship's restore accepts that body — while a blank producer output that
+        # skipped ensure_notes would have been refused.
+        def body_for(notes):
+            return ("## Release notes\n\n%s\n%s\n%s\n\n<!-- ft8af-version: 0.151.0 -->\n"
+                    % (rn.START, notes, rn.END))
+        blank, _ = "\n", None
+        refused = rn.decide("workflow_dispatch", "android-v0.151.0", 0, "", body_for(blank))
+        self.assertIsNotNone(refused.error)
+        ensured, _ = rn.ensure_notes(blank, self.PR_LIST)
+        accepted = rn.decide("workflow_dispatch", "android-v0.151.0", 0, "", body_for(ensured))
+        self.assertTrue(accepted.found)
+        self.assertIn("Follow IC-705 dial changes", accepted.notes)
+
+
+class EnsureNotesMainTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.notes = os.path.join(self.tmp, "notes.txt")
+
+    def run_ensure(self, content, pr_list):
+        if content is not None:
+            with open(self.notes, "w", encoding="utf-8", newline="") as f:
+                f.write(content)
+        os.environ["PR_LIST_TEST"] = pr_list
+        try:
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = rn.main(["ensure-notes", "--notes", self.notes, "--pr-list-env", "PR_LIST_TEST"])
+        finally:
+            del os.environ["PR_LIST_TEST"]
+        with open(self.notes, encoding="utf-8", newline="") as f:
+            return code, stdout.getvalue(), f.read()
+
+    def test_blank_file_is_rewritten_with_a_warning(self):
+        code, out, notes = self.run_ensure("\n", "- #1 A title\n")
+        self.assertEqual(code, 0)
+        self.assertEqual(notes, "A title\n")
+        self.assertIn("::warning", out)
+
+    def test_missing_file_is_created(self):
+        code, out, notes = self.run_ensure(None, "")
+        self.assertEqual(code, 0)
+        self.assertEqual(notes, rn.DEFAULT_NOTES + "\n")
+
+    def test_real_notes_are_untouched_and_silent(self):
+        code, out, notes = self.run_ensure("Real notes.\n", "- #1 A title\n")
+        self.assertEqual(code, 0)
+        self.assertEqual(notes, "Real notes.\n")
+        self.assertEqual(out, "")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_release_notes.py
+++ b/.github/scripts/test_release_notes.py
@@ -147,6 +147,14 @@ class MainTest(unittest.TestCase):
         with open(os.path.join(self.tmp, name), encoding="utf-8", newline="") as f:
             return f.read()
 
+    def test_restored_notes_are_byte_capped_for_play(self):
+        body = "<!-- ft8af-notes-start -->\n" + "\u0416" * 300 + "\n<!-- ft8af-notes-end -->\n"
+        code, out = self.run_main("workflow_dispatch", 0, "", body)
+        self.assertEqual(code, 0)
+        self.assertLessEqual(len(self.read("notes.txt").encode("utf-8")), rn.PLAY_NOTES_LIMIT)
+        # The body itself is untouched: only Play's copy is capped.
+        self.assertIn("\u0416" * 300, self.read("existing-release-body.md"))
+
     def test_found_writes_notes_body_and_output(self):
         code, out = self.run_main("workflow_dispatch", 0, "", BODY)
         self.assertEqual(code, 0)
@@ -219,6 +227,36 @@ class EnsureNotesTest(unittest.TestCase):
         self.assertEqual(notes.count("\n"), 4)  # 4 x 121 = 484 fits, 5 would not
         self.assertTrue(all(len(l) == 120 for l in notes.splitlines()))
 
+    def test_fallback_budgets_bytes_not_characters(self):
+        # 120 emoji is 120 characters but 480 bytes: one line fits, a second
+        # would not. A character budget would have taken four such lines and
+        # left `head -c 500` to cut the second one mid-codepoint.
+        emoji_line = "\U0001F4E1" * 120
+        long_list = "".join("- #%d %s\n" % (i, emoji_line) for i in range(4))
+        notes = rn.fallback_notes(long_list)
+        self.assertEqual(notes, emoji_line + "\n")
+        self.assertLessEqual(len(notes.encode("utf-8")), rn.PLAY_NOTES_LIMIT)
+        # The byte-truncated file must still be valid UTF-8 (a no-op here).
+        notes.encode("utf-8")[: rn.PLAY_NOTES_LIMIT].decode("utf-8")
+
+    def test_cap_notes_cuts_multibyte_text_at_a_line_then_a_codepoint(self):
+        # Claude's notes are asked to stay under 400 characters, which Cyrillic
+        # (2 bytes each) pushes past 500 bytes.
+        line = "\u0416" * 100  # 200 bytes + newline
+        three_lines = (line + "\n") * 3  # 603 bytes
+        capped = rn.cap_notes(three_lines)
+        self.assertEqual(capped, (line + "\n") * 2)  # 402 bytes, cut at a line
+        one_long_line = "\u0416" * 300  # 600 bytes, no line break to cut at
+        capped = rn.cap_notes(one_long_line)
+        self.assertLessEqual(len(capped.encode("utf-8")), rn.PLAY_NOTES_LIMIT)
+        self.assertEqual(capped, "\u0416" * 250)  # whole codepoints only
+        self.assertEqual(rn.cap_notes("short\n"), "short\n")
+
+    def test_ensure_notes_caps_real_notes_too(self):
+        notes, fell_back = rn.ensure_notes("\u0416" * 300 + "\n", "")
+        self.assertFalse(fell_back)
+        self.assertLessEqual(len(notes.encode("utf-8")), rn.PLAY_NOTES_LIMIT)
+
     def test_round_trip_producer_to_manual_ship(self):
         # The producer/consumer case: notes that went through ensure_notes
         # land between the markers "Write release notes" emits, and the manual
@@ -275,6 +313,12 @@ class EnsureNotesMainTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(notes, "Real notes.\n")
         self.assertEqual(out, "")
+
+    def test_oversized_real_notes_are_trimmed_with_a_warning(self):
+        code, out, notes = self.run_ensure(("\u0416" * 100 + "\n") * 3, "")
+        self.assertEqual(code, 0)
+        self.assertLessEqual(len(notes.encode("utf-8")), rn.PLAY_NOTES_LIMIT)
+        self.assertIn("::warning title=Release notes trimmed", out)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_release_notes.py
+++ b/.github/scripts/test_release_notes.py
@@ -196,9 +196,21 @@ class EnsureNotesTest(unittest.TestCase):
             )
 
     def test_blank_notes_and_no_prs_use_the_default_text(self):
-        notes, fell_back = rn.ensure_notes("\n", "")
-        self.assertTrue(fell_back)
-        self.assertEqual(notes, rn.DEFAULT_NOTES + "\n")
+        # The workflow never hands over an empty list: with no PR merges in the
+        # range it writes the "(no pull-request merges in range)" placeholder,
+        # which is a log line, not a release note.
+        for no_prs in ("", rn.NO_PRS_SENTINEL, rn.NO_PRS_SENTINEL + "\n"):
+            notes, fell_back = rn.ensure_notes("\n", no_prs)
+            self.assertTrue(fell_back, repr(no_prs))
+            self.assertEqual(notes, rn.DEFAULT_NOTES + "\n", repr(no_prs))
+            self.assertNotIn("pull-request", notes)
+
+    def test_sentinel_matches_what_the_workflow_writes(self):
+        # Drift guard: the placeholder is spelled in android.yml; if it changes
+        # there, this must change too or Play gets the placeholder as notes.
+        wf = os.path.join(os.path.dirname(__file__), "..", "workflows", "android.yml")
+        with open(wf, encoding="utf-8") as f:
+            self.assertIn(":-" + rn.NO_PRS_SENTINEL + "}", f.read())
 
     def test_fallback_keeps_whole_lines_under_plays_limit(self):
         long_list = "".join("- #%d %s\n" % (i, "x" * 120) for i in range(10))
@@ -251,9 +263,12 @@ class EnsureNotesMainTest(unittest.TestCase):
         self.assertIn("::warning", out)
 
     def test_missing_file_is_created(self):
-        code, out, notes = self.run_ensure(None, "")
+        code, out, notes = self.run_ensure(None, rn.NO_PRS_SENTINEL)
         self.assertEqual(code, 0)
         self.assertEqual(notes, rn.DEFAULT_NOTES + "\n")
+        # The warning must not claim PR titles were used when there were none.
+        self.assertIn("::warning", out)
+        self.assertNotIn("using the PR titles instead", out)
 
     def test_real_notes_are_untouched_and_silent(self):
         code, out, notes = self.run_ensure("Real notes.\n", "- #1 A title\n")

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -72,20 +72,25 @@ permissions:
 
 # Google Play allows only one active "edit" per app, so two release builds
 # publishing at once make the second fail with "This edit has expired, please
-# create a new Edit." Serialize the runs that actually publish to Play (pushes
-# to staging, android-v* tag pushes, and the manual ship run) into a single
-# queue so they never overlap on the Play API. A push to main is NOT in the
-# queue: it cuts the tag and the GitHub Release but no longer touches Play, and
-# holding the play-publish key (shared with play-listings.yml) for a full main
-# build would only stall staging uploads, manual ships and listing updates.
-# cancel-in-progress is false so an in-flight publish finishes rather than
-# being killed mid-upload. Other runs (PRs, dev/main pushes) get a unique group
-# keyed to run id, so they never queue and CI stays fast.
+# create a new Edit." Serialize the release runs (pushes to staging/main,
+# android-v* tag pushes, and the manual ship run) into a single queue so they
+# never overlap on the Play API. A push to main no longer touches Play itself,
+# but it stays in the queue for a second reason: ordering. Its "candidate"
+# step promotes the android-dev.* tag the staging run creates, and if the
+# staging -> main merge lands while that staging run is still building, an
+# unserialized main run would fetch tags before the prerelease exists and
+# re-roll a fresh version and notes instead of promoting what internal
+# testers ran. The cost is that a main build holds the play-publish key
+# (shared with play-listings.yml) for its duration; that is the narrow safe
+# trade. cancel-in-progress is false so an in-flight publish finishes rather
+# than being killed mid-upload. Other runs (PRs, dev pushes) get a unique
+# group keyed to run id, so they never queue and CI stays fast.
 concurrency:
   group: >-
     ${{
       ((github.event_name == 'push'
-        && (github.ref == 'refs/heads/staging'
+        && (github.ref == 'refs/heads/main'
+          || github.ref == 'refs/heads/staging'
           || startsWith(github.ref, 'refs/tags/android-v')))
       || (github.event_name == 'workflow_dispatch'
         && startsWith(github.ref, 'refs/tags/android-v')))

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -112,6 +112,8 @@ jobs:
             android:
               - 'ft8af/**'
               - '.github/workflows/android.yml'
+              - '.github/scripts/release_notes.py'
+              - '.github/scripts/test_release_notes.py'
 
       - name: Decide whether to run
         id: decide
@@ -181,6 +183,11 @@ jobs:
           done
           echo "::error::Failed to install NDK $NDK_VERSION after 3 attempts"
           exit 1
+
+      # The tag lane's release-notes restoration is a Python script so its
+      # branches can be tested here instead of only on a real ship run.
+      - name: Release-script unit tests
+        run: python3 -m unittest discover -s .github/scripts -p 'test_release_notes.py' -v
 
       - name: Run unit tests
         working-directory: ft8af
@@ -447,53 +454,27 @@ jobs:
         # the body's hidden markers for Play, and keep the whole body so the
         # release itself is left exactly as the promotion wrote it. A plain
         # tag push with no release yet finds nothing and behaves as before;
-        # any other lookup failure fails closed rather than risk the overwrite.
+        # any other lookup failure, and a manual ship whose release has no
+        # notes between the markers, fails closed rather than risk the overwrite.
         if: steps.lane.outputs.lane == 'tag'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # pipefail makes the assignment fail when gh does; the error text is
-          # kept so a lookup failure can be told from a missing release.
-          if ! BODY=$(gh release view "$TAG" --json body -q .body 2>gh-release-err.txt | tr -d '\r'); then
-            err=$(cat gh-release-err.txt)
-            if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-              # The manual ship targets a tag whose release the main-merge run
-              # created. Not finding it — or not being able to ask (auth, rate
-              # limit, a transient API error) — must stop the run: carrying on
-              # would let the release step overwrite that release's body with a
-              # placeholder and send a bare version string to Play. Fail closed.
-              echo "::error::Could not read the GitHub Release for $TAG ($err). A manual production ship needs the release the main merge created — check the tag and rerun."
-              exit 1
-            fi
-            if ! grep -qi 'not found' gh-release-err.txt; then
-              # A tag push with a release we merely failed to read is the same
-              # overwrite risk; only a genuine "no release" may fall through.
-              echo "::error::Could not read the GitHub Release for $TAG ($err); refusing to continue and risk overwriting it."
-              exit 1
-            fi
-            echo "No existing release for $TAG (plain tag push) — Play's what's-new falls back to the version string."
-            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          printf '%s\n' "$BODY" > existing-release-body.md
-          awk '/<!-- ft8af-notes-start -->/{f=1; next} /<!-- ft8af-notes-end -->/{f=0} f' <<< "$BODY" > notes.txt
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            # A release existing is not the same as the promoted notes existing:
-            # a release cut by a plain tag push, or one whose body was edited,
-            # has no markers, and awk happily produces an empty notes.txt. The
-            # manual ship is documented to send those notes to Play, so treat
-            # their absence as an error rather than quietly shipping the bare
-            # version string as the what's-new.
-            if ! grep -q '<!-- ft8af-notes-start -->' <<< "$BODY" \
-               || ! grep -q '<!-- ft8af-notes-end -->' <<< "$BODY" \
-               || ! grep -q '[^[:space:]]' notes.txt; then
-              echo "::error::The GitHub Release for $TAG has no release notes between the ft8af-notes markers, so there is nothing to send to Play as the what's-new. Add the notes to the release body between <!-- ft8af-notes-start --> and <!-- ft8af-notes-end --> and rerun."
-              exit 1
-            fi
-          fi
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "Release $TAG already exists; keeping its body. Notes:"; cat notes.txt
+          # This step only runs gh and hands the result over. The decision —
+          # existing / missing release, lookup failure, dispatch versus tag
+          # push, and the marker parsing — is release_notes.py, unit-tested by
+          # test_release_notes.py in the test job above.
+          set +e
+          gh release view "$TAG" --json body -q .body > release-body.raw.md 2> gh-release-err.txt
+          rc=$?
+          set -e
+          python3 .github/scripts/release_notes.py \
+            --event "$GITHUB_EVENT_NAME" --tag "$TAG" \
+            --gh-status "$rc" --gh-stderr gh-release-err.txt --body release-body.raw.md \
+            --notes-out notes.txt --body-out existing-release-body.md \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Collect changes since the last production release
         id: changes

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,11 +16,20 @@ name: Android CI & Release
 #   push to main           -> android-v<x.y.z> release, NO Play publish, reusing
 #                             the semver + notes of the staging build it promotes
 #   android-v* tag push    -> release + Play production
+#   manual run on an       -> release + Play production (the manual ship step;
+#     android-v* tag           see "Shipping to production" below)
 # Feature work lands on dev; the dev build is cut only when dev -> staging
 # merges. A staging -> main merge cuts the versioned GitHub Release but ships
-# NOTHING to Play — shipping to Play production is a deliberate, separate act:
-# push the android-v<x.y.z> tag that the main merge created and the tag lane
-# uploads it.
+# no AAB to Play — shipping to Play production is a deliberate, separate act.
+#
+# Shipping to production: the main-merge run creates the android-v<x.y.z> tag
+# itself (softprops/action-gh-release creates the ref via the Releases API), so
+# there is no tag left to push by hand — `git push origin android-v<x.y.z>`
+# would be a no-op and would fire no push event. Ship it by running this
+# workflow manually (Actions -> "Android CI & Release" -> "Run workflow") with
+# the android-v<x.y.z> tag selected as the ref: that run takes the same `tag`
+# lane a tag push would and uploads to the Play production track. A manual run
+# on a BRANCH is build-only — the lane below requires a tag ref.
 #
 # Versioning + release notes (ported from Sorrel's play-beta.yml): on a staging
 # push the build job collects the PRs, commits and diff size since the latest
@@ -38,10 +47,10 @@ name: Android CI & Release
 # PATH-FILTERED: on pull requests and dev pushes this whole pipeline only runs
 # when Android-relevant files change (ft8af/** — which includes the shared
 # native C core at ft8af/app/src/main/cpp/ — or this workflow file). Pushes to
-# staging/main and android-v* tags always build (a full release snapshot,
-# regardless of what changed). The always-run `android-gate` job is the single
-# required status check so branch protection never gets stuck "pending" when the
-# build jobs are path-skipped.
+# staging/main, android-v* tags, and manual runs on such a tag always build (a
+# full release snapshot, regardless of what changed). The always-run
+# `android-gate` job is the single required status check so branch protection
+# never gets stuck "pending" when the build jobs are path-skipped.
 
 on:
   push:
@@ -50,6 +59,13 @@ on:
       - 'android-v*'
   pull_request:
     branches: [main, staging, dev]
+  # The manual production ship step. Run this workflow with an android-v<x.y.z>
+  # tag selected as the ref to build that tag and upload it to the Play
+  # production track. Needed because the main-merge run creates the tag itself
+  # through the Releases API, leaving nothing to push by hand. No inputs: the
+  # ref picker already names the release, and taking the version from anywhere
+  # else would let a run publish an AAB built from a different commit.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -57,17 +73,20 @@ permissions:
 # Google Play allows only one active "edit" per app, so two release builds
 # publishing at once make the second fail with "This edit has expired, please
 # create a new Edit." Serialize the release-publishing runs (pushes to
-# staging/main and android-v* tags) into a single queue so they never overlap on
-# the Play API. cancel-in-progress is false so an in-flight publish finishes
-# rather than being killed mid-upload. Other runs (PRs, dev pushes) get a unique
-# group keyed to run id, so they never queue and CI stays fast.
+# staging/main, android-v* tags, and the manual ship run) into a single queue so
+# they never overlap on the Play API. cancel-in-progress is false so an
+# in-flight publish finishes rather than being killed mid-upload. Other runs
+# (PRs, dev pushes) get a unique group keyed to run id, so they never queue and
+# CI stays fast.
 concurrency:
   group: >-
     ${{
-      (github.event_name == 'push'
+      ((github.event_name == 'push'
         && (github.ref == 'refs/heads/main'
           || github.ref == 'refs/heads/staging'
           || startsWith(github.ref, 'refs/tags/android-v')))
+      || (github.event_name == 'workflow_dispatch'
+        && startsWith(github.ref, 'refs/tags/android-v')))
       && 'play-publish'
       || format('build-{0}', github.run_id)
     }}
@@ -98,10 +117,12 @@ jobs:
           CHANGED: ${{ steps.filter.outputs.android }}
         run: |
           set -euo pipefail
-          # staging/main pushes and android-v* tags always build the full
-          # release snapshot; otherwise (dev push, PRs) build only when
-          # Android-relevant files changed.
+          # staging/main pushes, android-v* tags, and the manual ship run on such
+          # a tag always build the full release snapshot; otherwise (dev push,
+          # PRs) build only when Android-relevant files changed.
           if [[ "$GITHUB_EVENT_NAME" == "push" && ( "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/staging" || "$GITHUB_REF" == refs/tags/android-v* ) ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$GITHUB_REF" == refs/tags/android-v* ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           elif [[ "$CHANGED" == "true" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
@@ -389,8 +410,12 @@ jobs:
         run: |
           set -euo pipefail
           # Release lanes (everything else — dev push, PRs — is build-only):
-          #   android-v* tag push -> "tag":        production release, Play production
-          #   push to main        -> "production": android-v<x.y.z> tag, Play production
+          #   android-v* tag ref  -> "tag":        production release, Play production.
+          #                                        Reached by a tag push AND by the
+          #                                        manual ship run on that tag, which
+          #                                        is why this arm does not test the
+          #                                        event name.
+          #   push to main        -> "production": android-v<x.y.z> tag, NO Play publish
           #   push to staging     -> "dev":        android-dev.<run#> tag, PRERELEASE,
           #                                        Play internal
           # The dev build is cut on staging, NOT on dev: dev pushes never reach
@@ -656,7 +681,7 @@ jobs:
             tag)
               release_tag="${GITHUB_REF_NAME}"
               version_name="${GITHUB_REF_NAME#android-v}"
-              should_release=true; play_track=production; version_source="pushed tag"
+              should_release=true; play_track=production; version_source="release tag ($GITHUB_EVENT_NAME)"
               ;;
             production|dev)
               if [[ "$ANDROID_CHANGED" != "true" ]]; then
@@ -678,9 +703,12 @@ jobs:
                   release_tag="android-v$version"
                   version_name="$version"
                   # No Play publish on a staging -> main merge: the merge cuts
-                  # the android-v* tag + GitHub Release only. Pushing that tag
-                  # by hand re-runs this job in the `tag` lane, which is what
-                  # uploads to the Play production track.
+                  # the android-v* tag + GitHub Release only. Shipping it is a
+                  # separate manual act — run this workflow by hand with that
+                  # android-v* tag as the ref, which takes the `tag` lane above
+                  # and uploads to the Play production track. (Not "push the
+                  # tag": this run creates the tag itself through the Releases
+                  # API, so there is nothing left to push.)
                   play_track=""
                 else
                   # staging: a run-numbered PRERELEASE on the Play internal track.
@@ -922,8 +950,9 @@ jobs:
           # R8 deobfuscation mapping — clears the Play Console "no deobfuscation
           # file" warning and makes crash/ANR stack traces readable.
           mappingFile: ft8af/app/build/outputs/mapping/release/mapping.txt
-          # staging -> internal track; android-v* tag -> production track. A
-          # push to main leaves the track empty, which skips this step entirely.
+          # staging -> internal track; android-v* tag ref (a tag push or the
+          # manual ship run) -> production track. A push to main leaves the
+          # track empty, which skips this step entirely.
           track: ${{ steps.tag.outputs.play_track }}
           status: completed
           releaseName: ${{ steps.tag.outputs.release_tag }}
@@ -964,7 +993,7 @@ jobs:
             if [[ -n "$PLAY_TRACK" ]]; then
               echo "- **Play track:** \`$PLAY_TRACK\` (publish: $PLAY_OUTCOME)"
             else
-              echo "- **Play track:** _none — not published._ Push \`$RELEASE_TAG\` to ship it to the production track."
+              echo "- **Play track:** _none — not published._ To ship it, run this workflow manually with the \`$RELEASE_TAG\` tag selected as the ref (Actions → Android CI & Release → Run workflow). The tag already exists, so there is nothing to push."
             fi
             echo ""
             echo "### Release notes"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -444,16 +444,34 @@ jobs:
         # replace its body with that placeholder. Pull the notes back out of
         # the body's hidden markers for Play, and keep the whole body so the
         # release itself is left exactly as the promotion wrote it. A plain
-        # tag push with no release yet finds nothing and behaves as before.
+        # tag push with no release yet finds nothing and behaves as before;
+        # any other lookup failure fails closed rather than risk the overwrite.
         if: steps.lane.outputs.lane == 'tag'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          BODY=$(gh release view "$TAG" --json body -q .body 2>/dev/null | tr -d '\r' || true)
-          if [[ -z "$BODY" ]]; then
-            echo "No existing release for $TAG — Play's what's-new falls back to the version string."
+          # pipefail makes the assignment fail when gh does; the error text is
+          # kept so a lookup failure can be told from a missing release.
+          if ! BODY=$(gh release view "$TAG" --json body -q .body 2>gh-release-err.txt | tr -d '\r'); then
+            err=$(cat gh-release-err.txt)
+            if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+              # The manual ship targets a tag whose release the main-merge run
+              # created. Not finding it — or not being able to ask (auth, rate
+              # limit, a transient API error) — must stop the run: carrying on
+              # would let the release step overwrite that release's body with a
+              # placeholder and send a bare version string to Play. Fail closed.
+              echo "::error::Could not read the GitHub Release for $TAG ($err). A manual production ship needs the release the main merge created — check the tag and rerun."
+              exit 1
+            fi
+            if ! grep -qi 'not found' gh-release-err.txt; then
+              # A tag push with a release we merely failed to read is the same
+              # overwrite risk; only a genuine "no release" may fall through.
+              echo "::error::Could not read the GitHub Release for $TAG ($err); refusing to continue and risk overwriting it."
+              exit 1
+            fi
+            echo "No existing release for $TAG (plain tag push) — Play's what's-new falls back to the version string."
             echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           printf '%s\n' "$BODY" > existing-release-body.md

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -433,6 +433,34 @@ jobs:
           echo "Release lane: $lane"
           echo "lane=$lane" >> "$GITHUB_OUTPUT"
 
+      - name: Restore the notes of the release this tag already has
+        id: existing
+        # The manual production ship re-runs this workflow on an android-v* tag
+        # whose GitHub Release the main-merge run already created, carrying the
+        # promoted staging notes in its body. This lane has no candidate step
+        # and no Claude step, so without this "Write release notes" would send
+        # a bare "FT8AF <version>" to Play as the what's-new and
+        # softprops/action-gh-release, updating the existing release, would
+        # replace its body with that placeholder. Pull the notes back out of
+        # the body's hidden markers for Play, and keep the whole body so the
+        # release itself is left exactly as the promotion wrote it. A plain
+        # tag push with no release yet finds nothing and behaves as before.
+        if: steps.lane.outputs.lane == 'tag'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          BODY=$(gh release view "$TAG" --json body -q .body 2>/dev/null | tr -d '\r' || true)
+          if [[ -z "$BODY" ]]; then
+            echo "No existing release for $TAG — Play's what's-new falls back to the version string."
+            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          printf '%s\n' "$BODY" > existing-release-body.md
+          awk '/<!-- ft8af-notes-start -->/{f=1; next} /<!-- ft8af-notes-end -->/{f=0} f' <<< "$BODY" > notes.txt
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "Release $TAG already exists; keeping its body. Notes:"; cat notes.txt
+
       - name: Collect changes since the last production release
         id: changes
         if: steps.lane.outputs.lane == 'production' || steps.lane.outputs.lane == 'dev'
@@ -745,13 +773,22 @@ jobs:
           VERSION_SOURCE: ${{ steps.tag.outputs.version_source }}
         run: |
           set -euo pipefail
-          # notes.txt comes from Claude, the fallback, or the promoted staging
-          # candidate; the android-v* tag-push lane has none.
+          # notes.txt comes from Claude, the fallback, the promoted staging
+          # candidate, or (manual ship) the tag's existing release; a plain
+          # tag push with no release yet has none.
           mkdir -p distribution/whatsnew
           if [[ -s notes.txt ]]; then
             head -c 500 notes.txt > distribution/whatsnew/whatsnew-en-US
           else
             echo "FT8AF $VERSION_NAME" > distribution/whatsnew/whatsnew-en-US
+          fi
+          if [[ -f existing-release-body.md ]]; then
+            # Manual ship on a tag that already has a release: hand softprops
+            # the body it already has, byte for byte, so updating the release
+            # to attach this run's APK does not rewrite the promoted notes.
+            cp existing-release-body.md release-body.md
+            echo "::group::release-body.md (kept from the existing release)"; cat release-body.md; echo "::endgroup::"
+            exit 0
           fi
           {
             if [[ -s notes.txt ]]; then
@@ -920,7 +957,10 @@ jobs:
           # The body (Claude's notes + version markers + signature) is PREPENDED
           # to GitHub's auto-generated "What's Changed" PR list.
           body_path: release-body.md
-          generate_release_notes: true
+          # Off when the body was kept from an existing release (manual ship):
+          # that body already ends in the generated list, and asking for it
+          # again would append a second copy.
+          generate_release_notes: ${{ steps.existing.outputs.found != 'true' }}
           # android-dev.* releases are flagged as prerelease so they sort under
           # the latest android-v* and don't get picked up by downstream tooling
           # that looks for "latest release".
@@ -998,7 +1038,7 @@ jobs:
             echo ""
             echo "### Release notes"
             echo ""
-            if [[ -s notes.txt ]]; then cat notes.txt; else echo "_(none — tag-push lane)_"; fi
+            if [[ -s notes.txt ]]; then cat notes.txt; else echo "_(none — tag push with no existing release)_"; fi
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -470,7 +470,7 @@ jobs:
           gh release view "$TAG" --json body -q .body > release-body.raw.md 2> gh-release-err.txt
           rc=$?
           set -e
-          python3 .github/scripts/release_notes.py \
+          python3 .github/scripts/release_notes.py restore \
             --event "$GITHUB_EVENT_NAME" --tag "$TAG" \
             --gh-status "$rc" --gh-stderr gh-release-err.txt --body release-body.raw.md \
             --notes-out notes.txt --body-out existing-release-body.md \
@@ -626,10 +626,10 @@ jobs:
             echo "::warning title=AI versioning fell back::$1 — using a patch bump and the PR titles as release notes. Set the ANTHROPIC_API_KEY secret / check the step log."
             echo "bump=patch" >> "$GITHUB_OUTPUT"
             echo "source=fallback" >> "$GITHUB_OUTPUT"
-            # PR titles, whole lines only, up to Play's 500-char limit.
-            printf '%s\n' "$PR_LIST" | sed -E 's/^- #[0-9]+ [^:]*: ?//; s/^- #[0-9]+ //' \
-              | awk '{ if (n + length($0) + 1 > 500) exit; print; n += length($0) + 1 }' > notes.txt
-            [[ -s notes.txt ]] || echo "Bug fixes and improvements." > notes.txt
+            # The PR-title notes are produced by `release_notes.py ensure-notes`
+            # in "Write release notes", which runs for every producer (including
+            # a Claude answer whose notes came back blank), so leave nothing here.
+            : > notes.txt
             exit 0
           }
           [[ -n "$ANTHROPIC_API_KEY" ]] || fallback "ANTHROPIC_API_KEY is not set"
@@ -786,11 +786,21 @@ jobs:
           VERSION: ${{ steps.tag.outputs.version }}
           VERSION_NAME: ${{ steps.tag.outputs.version_name }}
           VERSION_SOURCE: ${{ steps.tag.outputs.version_source }}
+          LANE: ${{ steps.lane.outputs.lane }}
+          PR_LIST: ${{ steps.changes.outputs.prs }}
         run: |
           set -euo pipefail
           # notes.txt comes from Claude, the fallback, the promoted staging
           # candidate, or (manual ship) the tag's existing release; a plain
           # tag push with no release yet has none.
+          if [[ "$LANE" != "tag" ]]; then
+            # The producers can leave it blank (Claude's schema allows an empty
+            # notes string; jq -r writes that as a newline), and a release whose
+            # markers enclose nothing would later be refused by the manual
+            # production ship. Guarantee nonblank notes before they go into the
+            # markers: the PR titles, else "Bug fixes and improvements."
+            python3 .github/scripts/release_notes.py ensure-notes --notes notes.txt --pr-list-env PR_LIST
+          fi
           mkdir -p distribution/whatsnew
           if [[ -s notes.txt ]]; then
             head -c 500 notes.txt > distribution/whatsnew/whatsnew-en-US

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Android CI & Release
 # Android pipeline for the ft8af/ app: unit tests + coverage, instrumented
 # emulator tests, static analysis (lint/detekt/ktlint), and the signed
 # APK/AAB build + GitHub Release + Play publish (internal track on staging,
-# production track on main / android-v* tags — see the Release lifecycle below).
+# production track on android-v* tags only — see the Release lifecycle below).
 #
 # Release lifecycle (see docs/release-pipeline.md):
 #   PR to dev/staging/main -> build-only (unsigned), tests
@@ -13,11 +13,14 @@ name: Android CI & Release
 #                             versionName <x.y.z>-dev.<run#> where x.y.z is the
 #                             semver Claude picks from the changes since the
 #                             last production tag (see "Versioning" below)
-#   push to main           -> android-v<x.y.z> release + Play production, reusing
+#   push to main           -> android-v<x.y.z> release, NO Play publish, reusing
 #                             the semver + notes of the staging build it promotes
 #   android-v* tag push    -> release + Play production
 # Feature work lands on dev; the dev build is cut only when dev -> staging
-# merges, and production only when staging -> main merges.
+# merges. A staging -> main merge cuts the versioned GitHub Release but ships
+# NOTHING to Play — shipping to Play production is a deliberate, separate act:
+# push the android-v<x.y.z> tag that the main merge created and the tag lane
+# uploads it.
 #
 # Versioning + release notes (ported from Sorrel's play-beta.yml): on a staging
 # push the build job collects the PRs, commits and diff size since the latest
@@ -674,7 +677,11 @@ jobs:
                   done
                   release_tag="android-v$version"
                   version_name="$version"
-                  play_track=production
+                  # No Play publish on a staging -> main merge: the merge cuts
+                  # the android-v* tag + GitHub Release only. Pushing that tag
+                  # by hand re-runs this job in the `tag` lane, which is what
+                  # uploads to the Play production track.
+                  play_track=""
                 else
                   # staging: a run-numbered PRERELEASE on the Play internal track.
                   # Distinct tag prefix so it sorts separately from android-v*;
@@ -905,7 +912,7 @@ jobs:
       # broken build fails earlier, in "Build APK & AAB".
       - name: Publish AAB to Play
         id: play_publish
-        if: steps.tag.outputs.should_release == 'true'
+        if: steps.tag.outputs.should_release == 'true' && steps.tag.outputs.play_track != ''
         continue-on-error: true
         uses: r0adkll/upload-google-play@v1
         with:
@@ -915,7 +922,8 @@ jobs:
           # R8 deobfuscation mapping — clears the Play Console "no deobfuscation
           # file" warning and makes crash/ANR stack traces readable.
           mappingFile: ft8af/app/build/outputs/mapping/release/mapping.txt
-          # staging -> internal track; main / android-v* tag -> production track.
+          # staging -> internal track; android-v* tag -> production track. A
+          # push to main leaves the track empty, which skips this step entirely.
           track: ${{ steps.tag.outputs.play_track }}
           status: completed
           releaseName: ${{ steps.tag.outputs.release_tag }}
@@ -935,7 +943,7 @@ jobs:
       # Make a swallowed publish failure visible (annotation on the run) without
       # failing the job — the artifact + GitHub Release already succeeded.
       - name: Warn if Play publish failed
-        if: steps.tag.outputs.should_release == 'true' && steps.play_publish.outcome == 'failure'
+        if: steps.tag.outputs.play_track != '' && steps.play_publish.outcome == 'failure'
         run: |
           echo "::warning::Play publish (track=${{ steps.tag.outputs.play_track }}) failed for ${{ steps.tag.outputs.release_tag }} (non-blocking). The signed AAB built and the GitHub Release was created; only the Play upload did not complete. Check the 'Publish AAB to Play' step log — common causes are an upgrade-path rejection or an expired Play edit."
 
@@ -953,7 +961,11 @@ jobs:
             echo ""
             echo "- **versionName:** \`$VERSION_NAME\` ($VERSION_SOURCE)"
             echo "- **versionCode:** $((GITHUB_RUN_NUMBER + 1000))"
-            echo "- **Play track:** \`$PLAY_TRACK\` (publish: $PLAY_OUTCOME)"
+            if [[ -n "$PLAY_TRACK" ]]; then
+              echo "- **Play track:** \`$PLAY_TRACK\` (publish: $PLAY_OUTCOME)"
+            else
+              echo "- **Play track:** _none — not published._ Push \`$RELEASE_TAG\` to ship it to the production track."
+            fi
             echo ""
             echo "### Release notes"
             echo ""

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -72,18 +72,20 @@ permissions:
 
 # Google Play allows only one active "edit" per app, so two release builds
 # publishing at once make the second fail with "This edit has expired, please
-# create a new Edit." Serialize the release-publishing runs (pushes to
-# staging/main, android-v* tags, and the manual ship run) into a single queue so
-# they never overlap on the Play API. cancel-in-progress is false so an
-# in-flight publish finishes rather than being killed mid-upload. Other runs
-# (PRs, dev pushes) get a unique group keyed to run id, so they never queue and
-# CI stays fast.
+# create a new Edit." Serialize the runs that actually publish to Play (pushes
+# to staging, android-v* tag pushes, and the manual ship run) into a single
+# queue so they never overlap on the Play API. A push to main is NOT in the
+# queue: it cuts the tag and the GitHub Release but no longer touches Play, and
+# holding the play-publish key (shared with play-listings.yml) for a full main
+# build would only stall staging uploads, manual ships and listing updates.
+# cancel-in-progress is false so an in-flight publish finishes rather than
+# being killed mid-upload. Other runs (PRs, dev/main pushes) get a unique group
+# keyed to run id, so they never queue and CI stays fast.
 concurrency:
   group: >-
     ${{
       ((github.event_name == 'push'
-        && (github.ref == 'refs/heads/main'
-          || github.ref == 'refs/heads/staging'
+        && (github.ref == 'refs/heads/staging'
           || startsWith(github.ref, 'refs/tags/android-v')))
       || (github.event_name == 'workflow_dispatch'
         && startsWith(github.ref, 'refs/tags/android-v')))
@@ -476,6 +478,20 @@ jobs:
           fi
           printf '%s\n' "$BODY" > existing-release-body.md
           awk '/<!-- ft8af-notes-start -->/{f=1; next} /<!-- ft8af-notes-end -->/{f=0} f' <<< "$BODY" > notes.txt
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            # A release existing is not the same as the promoted notes existing:
+            # a release cut by a plain tag push, or one whose body was edited,
+            # has no markers, and awk happily produces an empty notes.txt. The
+            # manual ship is documented to send those notes to Play, so treat
+            # their absence as an error rather than quietly shipping the bare
+            # version string as the what's-new.
+            if ! grep -q '<!-- ft8af-notes-start -->' <<< "$BODY" \
+               || ! grep -q '<!-- ft8af-notes-end -->' <<< "$BODY" \
+               || ! grep -q '[^[:space:]]' notes.txt; then
+              echo "::error::The GitHub Release for $TAG has no release notes between the ft8af-notes markers, so there is nothing to send to Play as the what's-new. Add the notes to the release body between <!-- ft8af-notes-start --> and <!-- ft8af-notes-end --> and rerun."
+              exit 1
+            fi
+          fi
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "Release $TAG already exists; keeping its body. Notes:"; cat notes.txt
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -11,7 +11,8 @@ others (except a change to the shared native C core under
 ```
 feature/* ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
                   │            │               │
-                  │            │               └─ PRODUCTION build → Releases only (NO Play publish)
+                  │            │               └─ PRODUCTION build → Releases only (no AAB to Play)
+                  │            │                  └─ manual run on the android-v* tag → Play production
                   │            └───────────────── DEV (prerelease) build → Releases + Play internal
                   └────────────────────────────── CI only, NO release
 ```
@@ -23,12 +24,21 @@ feature/* ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
   platform: prerelease GitHub Releases + Play **internal** track for Android.
 - **staging → main** — promote the validated staging build. Merging this PR (a
   push to `main`) cuts the **production** build: full GitHub Releases with the
-  auto-bumped `android-v<x.y.z>` / `desktop-v<x.y.z>` tags. It publishes
-  **nothing to Google Play**.
-- **shipping to Play production is manual.** Push the `android-v<x.y.z>` tag the
-  `main` merge created (`git fetch --tags && git push origin android-v1.2.3`);
-  that tag push re-runs the Android release lane and uploads the AAB to the Play
-  **production** track. A merge to `main` on its own never reaches users.
+  auto-bumped `android-v<x.y.z>` / `desktop-v<x.y.z>` tags. It uploads **no app
+  binary to Google Play** — no AAB reaches any track. (Store *listing* text is a
+  separate pipeline: a `main` push touching `fastlane/metadata/android/**` still
+  runs `play-listings.yml`, which does publish listing changes to Play. See
+  [Store listings](#store-listings) below.)
+- **shipping the app to Play production is manual.** In **Actions → Android CI &
+  Release → Run workflow**, pick the `android-v<x.y.z>` tag the `main` merge
+  created as the ref and run it. That run takes the same release lane an
+  `android-v*` tag push takes and uploads the AAB to the Play **production**
+  track. A merge to `main` on its own never puts a build in front of users.
+
+  It has to be a manual run rather than a tag push: the `main` run creates the
+  `android-v<x.y.z>` ref itself (the GitHub Releases API creates the tag), so
+  `git push origin android-v<x.y.z>` is `Everything up-to-date` — it emits no
+  push event and starts no workflow.
 
 Source gates (enforced as required status checks):
 
@@ -78,7 +88,7 @@ Ported from Sorrel's `play-beta.yml`. On a push to `staging` the Android
 On the later push to `main` the job looks for the newest `android-dev.*` tag
 that is an ancestor of `HEAD` and not already shipped, reads the version and
 notes back out of those markers, and releases `android-v<x.y.z>` with the same
-notes — so when that tag is later pushed to Play, production ships exactly what
+notes — so when that tag is later shipped to Play, production ships exactly what
 the internal testers ran. If no such candidate exists (or it pre-dates the markers) Claude
 decides on `main` instead. An `android-v<x.y.z>` that already exists is stepped
 by a patch until free.
@@ -91,6 +101,17 @@ and has a self-test (`--self-test`).
 **Secret:** `ANTHROPIC_API_KEY` (repository secret). Without it, or if the API
 call fails, the run annotates a warning, takes a **patch** bump, and uses the
 PR titles as the notes — a release is never blocked on the AI step.
+
+## Store listings
+
+Play *store listing* text (title, descriptions, per-locale metadata) lives in
+`fastlane/metadata/android/` and ships through its own workflow,
+`play-listings.yml` — not through the Android release pipeline above. It
+publishes on a push to `main` that touches that directory, and can also be run
+manually (with a dry-run option). So a `main` merge that changes listing text
+does reach Google Play, even though it uploads no app binary; the two are
+deliberately independent, because listing copy and app builds ship on different
+cadences.
 
 ## One-time setup on GitHub (manual)
 
@@ -107,5 +128,5 @@ These cannot be done from a workflow file — do them in the repo settings:
    now lives on `staging`.
 4. **Play Console** → confirm the `PLAY_SERVICE_ACCOUNT_JSON` service account has
    release permission on the **production** track (it previously only needed
-   internal). Only a manually pushed `android-v*` tag publishes there — `main`
-   merges do not.
+   internal). Only a manual workflow run on an `android-v*` tag publishes an AAB
+   there — `main` merges do not.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -29,14 +29,17 @@ feature/* ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
   separate pipeline: a `main` push touching `fastlane/metadata/android/**` still
   runs `play-listings.yml`, which does publish listing changes to Play. See
   [Store listings](#store-listings) below.)
-- **shipping the app to Play production is manual.** In **Actions → Android CI &
-  Release → Run workflow**, pick the `android-v<x.y.z>` tag the `main` merge
-  created as the ref and run it. That run takes the same release lane an
-  `android-v*` tag push takes and uploads the AAB to the Play **production**
-  track. It reuses the release notes already on that tag's GitHub Release
-  (read back through the hidden markers in its body) as Play's what's-new, and
-  leaves the release body as the promotion wrote it. A merge to `main` on its
-  own never puts a build in front of users.
+- **shipping a `main`-cut release to Play production is manual.** In
+  **Actions → Android CI & Release → Run workflow**, pick the `android-v<x.y.z>`
+  tag the `main` merge created as the ref and run it. That run takes the same
+  release lane an `android-v*` tag push takes and uploads the AAB to the Play
+  **production** track. It reuses the release notes already on that tag's
+  GitHub Release (read back through the hidden markers in its body) as Play's
+  what's-new — and refuses to run if they are missing — and leaves the release
+  body as the promotion wrote it. A merge to `main` on its own never puts a
+  build in front of users. (Pushing a brand-new `android-v*` tag by hand is
+  the other, older path: it also enters the tag lane and publishes to
+  production directly, with the version string as the what's-new.)
 
   It has to be a manual run rather than a tag push: the `main` run creates the
   `android-v<x.y.z>` ref itself (the GitHub Releases API creates the tag), so
@@ -131,5 +134,6 @@ These cannot be done from a workflow file — do them in the repo settings:
    now lives on `staging`.
 4. **Play Console** → confirm the `PLAY_SERVICE_ACCOUNT_JSON` service account has
    release permission on the **production** track (it previously only needed
-   internal). Only a manual workflow run on an `android-v*` tag publishes an AAB
-   there — `main` merges do not.
+   internal). Two paths publish an AAB there: the manual workflow run on an
+   `android-v*` tag (the normal path for a release cut by a `main` merge) and a
+   plain `android-v*` tag push. `main` merges do not.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -11,7 +11,7 @@ others (except a change to the shared native C core under
 ```
 feature/* ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
                   │            │               │
-                  │            │               └─ PRODUCTION build → Releases + Play production
+                  │            │               └─ PRODUCTION build → Releases only (NO Play publish)
                   │            └───────────────── DEV (prerelease) build → Releases + Play internal
                   └────────────────────────────── CI only, NO release
 ```
@@ -22,8 +22,13 @@ feature/* ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
   this PR (a push to `staging`) cuts a **dev / prerelease** build of every
   platform: prerelease GitHub Releases + Play **internal** track for Android.
 - **staging → main** — promote the validated staging build. Merging this PR (a
-  push to `main`) cuts the **production** build: full GitHub Releases + Play
-  **production** track for Android.
+  push to `main`) cuts the **production** build: full GitHub Releases with the
+  auto-bumped `android-v<x.y.z>` / `desktop-v<x.y.z>` tags. It publishes
+  **nothing to Google Play**.
+- **shipping to Play production is manual.** Push the `android-v<x.y.z>` tag the
+  `main` merge created (`git fetch --tags && git push origin android-v1.2.3`);
+  that tag push re-runs the Android release lane and uploads the AAB to the Play
+  **production** track. A merge to `main` on its own never reaches users.
 
 Source gates (enforced as required status checks):
 
@@ -73,8 +78,8 @@ Ported from Sorrel's `play-beta.yml`. On a push to `staging` the Android
 On the later push to `main` the job looks for the newest `android-dev.*` tag
 that is an ancestor of `HEAD` and not already shipped, reads the version and
 notes back out of those markers, and releases `android-v<x.y.z>` with the same
-notes on the production track — production ships exactly what the internal
-testers ran. If no such candidate exists (or it pre-dates the markers) Claude
+notes — so when that tag is later pushed to Play, production ships exactly what
+the internal testers ran. If no such candidate exists (or it pre-dates the markers) Claude
 decides on `main` instead. An `android-v<x.y.z>` that already exists is stepped
 by a patch until free.
 
@@ -102,4 +107,5 @@ These cannot be done from a workflow file — do them in the repo settings:
    now lives on `staging`.
 4. **Play Console** → confirm the `PLAY_SERVICE_ACCOUNT_JSON` service account has
    release permission on the **production** track (it previously only needed
-   internal). `main` merges now publish there.
+   internal). Only a manually pushed `android-v*` tag publishes there — `main`
+   merges do not.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -33,7 +33,10 @@ feature/* ──PR──▶ dev ──PR──▶ staging ──PR──▶ main
   Release → Run workflow**, pick the `android-v<x.y.z>` tag the `main` merge
   created as the ref and run it. That run takes the same release lane an
   `android-v*` tag push takes and uploads the AAB to the Play **production**
-  track. A merge to `main` on its own never puts a build in front of users.
+  track. It reuses the release notes already on that tag's GitHub Release
+  (read back through the hidden markers in its body) as Play's what's-new, and
+  leaves the release body as the promotion wrote it. A merge to `main` on its
+  own never puts a build in front of users.
 
   It has to be a manual run rather than a tag push: the `main` run creates the
   `android-v<x.y.z>` ref itself (the GitHub Releases API creates the tag), so


### PR DESCRIPTION
## Why

Merging `staging` → `main` uploaded the signed AAB to the Google Play **production** track as part of the same run, so a promotion PR shipped to users the instant it merged. Production should be a deliberate act, not a side effect of a merge.

## What changed

`.github/workflows/android.yml` — the `production` (push-to-`main`) lane now leaves `play_track` empty:

- The merge still does everything else: auto-bumped `android-v<x.y.z>` tag, signed APK/AAB, full GitHub Release, and the semver + release notes promoted from the staging build it's promoting.
- `Publish AAB to Play` and `Warn if Play publish failed` are gated on a non-empty `play_track`, so the upload step is simply skipped.
- The release summary now prints `Play track: none — not published.` plus how to ship it.

**Shipping to production is now manual, via `workflow_dispatch`:** in **Actions → Android CI & Release → Run workflow**, pick the `android-v<x.y.z>` tag the `main` merge created as the ref and run it. That run takes the same `tag` lane an `android-v*` tag push takes and uploads to the Play production track.

It has to be a manual run rather than a tag push: the `main` run creates the `android-v<x.y.z>` ref itself (softprops/action-gh-release creates the tag through the Releases API), so `git push origin android-v<x.y.z>` is `Everything up-to-date` — it emits no push event and starts no workflow.

The `tag` lane now also restores the release notes from the tag's existing GitHub Release (via the hidden `<!-- ft8af-notes-* -->` markers the promotion wrote) so the manual ship sends the promoted notes to Play as the what's-new, and it hands softprops the existing release body back unchanged (with `generate_release_notes` off) so re-running on the tag does not overwrite the promoted body with a placeholder.

Unchanged: `staging` → Play **internal**, and a plain `android-v*` tag push (a tag with no release yet) → Play **production**.

`docs/release-pipeline.md` updated to match (branch-lifecycle diagram, the staging → main bullet, the manual-ship bullet, and the Play Console setup note).

## Verification

No unit-testable code path here (workflow YAML), so this was exercised directly:

- Ran the `Compute version and release tag` step standalone for all three lanes: `production` → `should_release=true`, `play_track=` (empty), tag `android-v0.151.0`; `staging` → `internal`; `android-v*` tag → `production`.
- Ran the `Release summary` step with an empty and a set track — renders the "not published" line and the normal line respectively.
- Ran the notes-restore step's extraction against a real existing `android-v*` release body and confirmed `notes.txt` comes back with the promoted notes.
- `bash -n` clean on every `run` block; the workflow parses as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pyS6BHUwx1JTWdDijX4Be
