### PR TITLE
Retry the Play publish with the opposite review flag

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1029,20 +1029,59 @@ jobs:
           # Claude's release notes (whatsnew-en-US), written by "Write release
           # notes" above — shows up as the track's "Release notes" in Console.
           whatsNewDirectory: distribution/whatsnew
-          # Let Google auto-send the release for review (the normal path). Do NOT
-          # set this true: that bypass is only accepted while the app has
-          # review-gated changes pending. Once it's a normal reviewed app, Google
-          # auto-sends changes for review and the edit-commit rejects the flag with
-          # "Changes are sent for review automatically. The query parameter
-          # changesNotSentForReview must not be set." — which failed the internal
-          # upload for the android-dev.1026 staging build. Flip back to true only if
-          # a future upload fails demanding it (a new review-gated change is pending).
+          # Let Google auto-send the release for review (the normal path). See
+          # the retry step below: whether Google accepts this flag depends on
+          # Play Console review state, which flips out from under CI, so the
+          # value here is a first guess, not a setting to hand-tune.
           changesNotSentForReview: false
+
+      # The changesNotSentForReview flag is not ours to choose — Google's edit
+      # commit demands one specific value and rejects the other, and which one
+      # it wants depends on Play Console review state that changes outside CI:
+      #
+      #   normal reviewed app   -> Google auto-sends changes for review, and the
+      #                            commit rejects the flag with "Changes are sent
+      #                            for review automatically. The query parameter
+      #                            changesNotSentForReview must not be set."
+      #   review-gated changes  -> the commit refuses to auto-send and demands
+      #     pending in Console      "Please set the query parameter
+      #                            changesNotSentForReview to true."
+      #
+      # We have been burned in BOTH directions (false broke the android-dev.1231
+      # internal upload after an app-level review gate appeared; true broke
+      # android-dev.1026 once the app went back to normal), so don't hand-flip
+      # the literal above — retry once with the opposite value instead. The
+      # first attempt uploaded the AAB into an edit that was never committed, so
+      # the versionCode is still unused and re-uploading it here is fine.
+      - name: Retry Play publish with the opposite review flag
+        id: play_publish_retry
+        if: steps.tag.outputs.should_release == 'true' && steps.tag.outputs.play_track != '' && steps.play_publish.outcome == 'failure'
+        continue-on-error: true
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: radio.ks3ckc.ft8af
+          releaseFiles: ft8af/app/build/outputs/bundle/release/app-release.aab
+          mappingFile: ft8af/app/build/outputs/mapping/release/mapping.txt
+          track: ${{ steps.tag.outputs.play_track }}
+          status: completed
+          releaseName: ${{ steps.tag.outputs.release_tag }}
+          whatsNewDirectory: distribution/whatsnew
+          changesNotSentForReview: true
+
+      # Committed but NOT sent for review: the release is on the track, and a
+      # human has to press "Send for review" (or submit the pending app-level
+      # change) in the Play Console before testers see it. Say so loudly rather
+      # than letting a green run imply the build shipped.
+      - name: Note the review-flag retry
+        if: steps.play_publish_retry.outcome == 'success'
+        run: |
+          echo "::warning::Play publish for ${{ steps.tag.outputs.release_tag }} needed changesNotSentForReview=true — the app has review-gated changes pending in the Play Console. The AAB is committed to the '${{ steps.tag.outputs.play_track }}' track but was NOT auto-sent for review: open the Play Console and send the pending changes for review, or testers will not get this build."
 
       # Make a swallowed publish failure visible (annotation on the run) without
       # failing the job — the artifact + GitHub Release already succeeded.
       - name: Warn if Play publish failed
-        if: steps.tag.outputs.play_track != '' && steps.play_publish.outcome == 'failure'
+        if: steps.tag.outputs.play_track != '' && steps.play_publish.outcome == 'failure' && steps.play_publish_retry.outcome != 'success'
         run: |
           echo "::warning::Play publish (track=${{ steps.tag.outputs.play_track }}) failed for ${{ steps.tag.outputs.release_tag }} (non-blocking). The signed AAB built and the GitHub Release was created; only the Play upload did not complete. Check the 'Publish AAB to Play' step log — common causes are an upgrade-path rejection or an expired Play edit."
 
@@ -1053,7 +1092,9 @@ jobs:
           VERSION_NAME: ${{ steps.tag.outputs.version_name }}
           VERSION_SOURCE: ${{ steps.tag.outputs.version_source }}
           PLAY_TRACK: ${{ steps.tag.outputs.play_track }}
-          PLAY_OUTCOME: ${{ steps.play_publish.outcome }}
+          # The retry step (opposite changesNotSentForReview) is what
+          # decides the real outcome whenever the first attempt failed.
+          PLAY_OUTCOME: ${{ steps.play_publish.outcome == 'success' && 'success' || steps.play_publish_retry.outcome }}
         run: |
           {
             echo "## Android release $RELEASE_TAG"


### PR DESCRIPTION
## Why

The `dev -> staging` promotion (#810) ran green but **no internal release appeared on Play**. The Android run's "Publish AAB to Play" step is `continue-on-error`, so the failure only showed up as an annotation:

```
Uploading ft8af/app/build/outputs/bundle/release/app-release.aab
Successfully uploaded 1 artifacts
Committing the Edit
##[error]Changes cannot be sent for review automatically. Please set the query
parameter changesNotSentForReview to true. Once committed, the changes in this
edit can be sent for review from the Google Play Console UI.
```

The AAB uploaded fine; the *edit was never committed*, so `android-dev.1231` / `0.150.0-dev.1231` never reached the internal track. The Sept 8 staging build (`android-dev.1225`) committed cleanly, so the app's Play Console review state flipped between the two — consistent with the app now having review-gated changes pending.

## What

`changesNotSentForReview` is not really ours to choose. Google's edit commit demands one specific value and rejects the other, and which one it wants depends on Console state that changes outside CI:

| Play Console state | commit behavior |
| --- | --- |
| normal reviewed app | auto-sends for review; rejects the flag ("...must not be set") |
| review-gated changes pending | refuses to auto-send; requires the flag `true` |

We have been burned in **both** directions — `false` broke `android-dev.1231` today, `true` broke `android-dev.1026` once the app went back to normal — and the step comment had turned into a note about which way to hand-flip it next. So instead of flipping the literal again:

- keep `false` (the normal path) as the first attempt;
- add a **retry step** that re-runs the upload with `changesNotSentForReview: true` only when the first commit failed. The failed edit is never committed, so its versionCode stays unused and re-uploading the same AAB is safe;
- when the retry is what succeeded, emit a warning: the release is on the track but was **not** sent for review, so someone has to submit the pending changes in the Play Console before testers get the build;
- the existing failure warning now only fires when the retry also failed, and the run summary's `Play track: ... (publish: ...)` line reflects the retry outcome.

## Testing

Validated that the workflow still parses and that the four steps' `if` conditions and flag values are wired as intended.

No unit test accompanies this — the change is entirely GitHub Actions workflow wiring, which the repo's JVM test suite cannot reach. It gets exercised for real by the next `dev -> staging` promotion.

## Note

This unblocks *future* staging builds. The current `0.150.0` internal build still has to be re-cut (the next promotion run will do it with a fresh run number / versionCode), and if the retry path is what fires, the Play Console will need a manual "send for review".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ht2BB4TWtkmC5EW5GsPXEM
